### PR TITLE
Clarify deep-interview omx question payload guidance

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -154,6 +154,96 @@ Round {n} | Target: {weakest_dimension} | Ambiguity: {score}%
 {question}
 ```
 
+`omx question` payload guidance for interview rounds:
+- Use canonical `type` values instead of authoring raw `multi_select` flags by hand. `type: "single-answerable"` is the default for one-path decisions; `type: "multi-answerable"` is the canonical shape for bounded multi-select rounds. The runtime will keep `multi_select` aligned with `type`.
+- Use `single-answerable` when exactly one answer should drive the next branch, the options are mutually exclusive, or selecting more than one answer would blur the decision boundary. Typical cases: handoff lane selection, choosing the primary failure mode, or confirming which of several competing interpretations is correct.
+- Use `multi-answerable` when multiple options may all be true at once and you need to capture a bounded set of coexisting constraints, non-goals, risks, or acceptance checks in one round. Typical cases: selecting all out-of-scope items, all success metrics that must hold, or all deployment constraints that apply together.
+- If one selected option would immediately require a follow-up question to disambiguate the others, prefer a `single-answerable` round now and ask the follow-up next. Do not hide a branching interview tree inside one overloaded multi-select prompt.
+- Keep interview options bounded and concrete. If the valid answers are already known, set `allow_other: false`; only leave `allow_other: true` when the interview genuinely needs one user-supplied option that cannot be enumerated in advance.
+- Read answers structurally. For `single-answerable`, expect one decisive selection in `answer.value` plus `answer.selected_values`. For `multi-answerable`, treat `answer.selected_values` as the source of truth for all chosen constraints/non-goals and preserve the full set in the transcript/spec.
+
+Canonical bounded single-choice payload:
+
+```json
+{
+  "question": "Which execution lane should own this once the interview is complete?",
+  "type": "single-answerable",
+  "options": [
+    {
+      "label": "Plan first",
+      "value": "ralplan",
+      "description": "Need architecture and test-shape review before execution"
+    },
+    {
+      "label": "Execute directly",
+      "value": "autopilot",
+      "description": "Requirements are already explicit enough for planning plus execution"
+    },
+    {
+      "label": "Refine further",
+      "value": "refine",
+      "description": "Clarification is still needed before any handoff"
+    }
+  ],
+  "allow_other": false,
+  "other_label": "Other",
+  "source": "deep-interview"
+}
+```
+
+Canonical bounded multi-select payload:
+
+```json
+{
+  "question": "Which non-goals must stay out of scope for the first pass?",
+  "type": "multi-answerable",
+  "options": [
+    {
+      "label": "No UI redesign",
+      "value": "no-ui-redesign",
+      "description": "Keep layout and styling unchanged"
+    },
+    {
+      "label": "No new dependencies",
+      "value": "no-new-dependencies",
+      "description": "Work within the existing toolchain"
+    },
+    {
+      "label": "No API contract changes",
+      "value": "no-api-contract-changes",
+      "description": "Preserve external request and response shapes"
+    }
+  ],
+  "allow_other": false,
+  "other_label": "Other",
+  "source": "deep-interview"
+}
+```
+
+Canonical answer-shape reminders:
+
+```json
+{
+  "answer": {
+    "kind": "option",
+    "value": "ralplan",
+    "selected_labels": ["Plan first"],
+    "selected_values": ["ralplan"]
+  }
+}
+```
+
+```json
+{
+  "answer": {
+    "kind": "multi",
+    "value": ["no-new-dependencies", "no-api-contract-changes"],
+    "selected_labels": ["No new dependencies", "No API contract changes"],
+    "selected_values": ["no-new-dependencies", "no-api-contract-changes"]
+  }
+}
+```
+
 ### 2c) Score ambiguity
 Score each weighted dimension in `[0.0, 1.0]` with justification + gap.
 

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -173,6 +173,73 @@ describe("deep-interview Ouroboros contract", () => {
 		);
 	});
 
+	it("teaches canonical single-choice vs multi-answerable omx question payloads", () => {
+		assert.match(
+			deepInterviewSkill,
+			/Use canonical `type` values instead of authoring raw `multi_select` flags by hand/i,
+		);
+		assert.match(deepInterviewSkill, /type: "single-answerable"/i);
+		assert.match(deepInterviewSkill, /type: "multi-answerable"/i);
+		assert.match(
+			deepInterviewSkill,
+			/Use `single-answerable` when exactly one answer should drive the next branch/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Use `multi-answerable` when multiple options may all be true at once/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/If one selected option would immediately require a follow-up question to disambiguate the others, prefer a `single-answerable` round now/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Keep interview options bounded and concrete\./i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Canonical bounded single-choice payload:/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Which execution lane should own this once the interview is complete\?/i,
+		);
+		assert.match(deepInterviewSkill, /"value": "ralplan"/i);
+		assert.match(deepInterviewSkill, /"value": "autopilot"/i);
+		assert.match(deepInterviewSkill, /"value": "refine"/i);
+		assert.match(
+			deepInterviewSkill,
+			/Canonical bounded multi-select payload:/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Which non-goals must stay out of scope for the first pass\?/i,
+		);
+		assert.match(deepInterviewSkill, /"value": "no-ui-redesign"/i);
+		assert.match(deepInterviewSkill, /"value": "no-new-dependencies"/i);
+		assert.match(deepInterviewSkill, /"value": "no-api-contract-changes"/i);
+	});
+
+	it("locks canonical omx question answer shapes for single and multi rounds", () => {
+		assert.match(deepInterviewSkill, /Canonical answer-shape reminders:/i);
+		assert.match(deepInterviewSkill, /"kind": "option"/i);
+		assert.match(deepInterviewSkill, /"value": "ralplan"/i);
+		assert.match(deepInterviewSkill, /"selected_values": \["ralplan"\]/i);
+		assert.match(deepInterviewSkill, /"kind": "multi"/i);
+		assert.match(
+			deepInterviewSkill,
+			/"value": \["no-new-dependencies", "no-api-contract-changes"\]/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/"selected_values": \["no-new-dependencies", "no-api-contract-changes"\]/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/For `multi-answerable`, treat `answer\.selected_values` as the source of truth/i,
+		);
+	});
+
 	it("preserves clarified intent and boundary constraints across execution handoff", () => {
 		assert.match(
 			deepInterviewSkill,


### PR DESCRIPTION
## Summary
- add explicit deep-interview guidance for when interview rounds should use bounded `single-answerable` versus `multi-answerable` `omx question` payloads
- include canonical payload examples plus canonical answer-shape reminders so the contract is concrete and reusable
- lock the guidance into `deep-interview` contract tests so regressions fail if the examples or heuristics disappear

## Verification
- `npm install`
- `npm run build`
- `npx biome lint src/hooks/__tests__/deep-interview-contract.test.ts`
- `node --test dist/hooks/__tests__/deep-interview-contract.test.js dist/question/__tests__/types.test.js dist/question/__tests__/deep-interview.test.js dist/question/__tests__/client.test.js dist/cli/__tests__/question.test.js`

## Notes
- `npm run build` initially failed because this worktree did not have `node_modules`; after `npm install`, the targeted build and tests passed.
- Scope stayed on guidance and contract surfaces only.
