### PR TITLE
Clarify explicit terminal lifecycle metadata

### DIFF
--- a/docs/STATE_MODEL.md
+++ b/docs/STATE_MODEL.md
@@ -24,7 +24,7 @@ Examples:
 - `.omx/state/sessions/<session_id>/ralph-state.json`
 - `.omx/state/team-state.json`
 
-These files determine whether a workflow mode is active, completed, cancelled, or failed.
+These files determine whether a workflow mode is active, completed, cancelled, or failed. Those mode phases are not always identical to the user-facing terminal lifecycle vocabulary; see the explicit terminal lifecycle section below for that compatibility boundary.
 
 ### 2. `skill-active-state.json` — compatibility / visibility layer
 
@@ -44,6 +44,33 @@ Read precedence is:
 3. root scope fallback
 
 If root and session disagree for the same mode, session wins for the active execution context, but stale root survivors should be terminalized during reconciliation when they would otherwise resurrect old state.
+
+## Terminal lifecycle outcome compatibility
+
+For the explicit terminal stop model, treat workflow `current_phase` and user-facing terminal lifecycle outcome as related but separate concepts.
+
+Canonical user-facing lifecycle outcomes are:
+
+- `finished`
+- `blocked`
+- `failed`
+- `userinterlude`
+- `askuserQuestion`
+
+Compatibility rules:
+
+- Prefer a dedicated canonical lifecycle field over legacy `run_outcome` when both exist.
+- Treat legacy `run_outcome` as a compatibility layer during migration.
+- Infer from `current_phase` only when neither canonical lifecycle metadata nor legacy `run_outcome` is available.
+- Keep `cancelled` as an internal legacy/admin phase, not as the canonical public lifecycle vocabulary.
+
+Recommended read precedence for terminal lifecycle interpretation:
+
+1. canonical lifecycle metadata (for example `lifecycle_outcome`)
+2. legacy `run_outcome`
+3. compatibility inference from `current_phase`, question metadata, and persisted error/completion fields
+
+`blocked_on_user` is also compatibility-only. When surrounding question metadata proves OMX asked a blocking question, classify it as `askuserQuestion`; otherwise treat it as a user-wait compatibility signal instead of exposing it as the canonical vocabulary directly.
 
 ## Core files
 

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -40,7 +40,7 @@ OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js
 | Team-phase continuation | `Stop` | `stop` | native-partial | Native adapter treats per-team `phase.json` as canonical when deciding whether a current-session team run is still non-terminal and can re-block on later fresh Stop replies while keeping leader guidance explicit about rewriting system-generated worker auto-checkpoint commits into Lore-format final history |
 | `ralplan` skill-state continuation | `Stop` | `stop` | native-partial | Native adapter can block on active `skill-active-state.json` for `ralplan`, unless active subagents are already the real in-flight owners |
 | `deep-interview` skill-state continuation | `Stop` | `stop` | native-partial | Native adapter can block on active `skill-active-state.json` for `deep-interview`, unless active subagents are already the real in-flight owners |
-| auto-nudge continuation | `Stop` | `stop` | native-partial | Native adapter continues turns that end in a permission/stall prompt, can re-fire for later fresh replies, and suppresses auto-nudge while interview / deep-interview state is active; fallback Ralph steer now also treats `blocked_on_user` as terminal instead of only `complete`/`failed`/`cancelled` |
+| auto-nudge continuation | `Stop` | `stop` | native-partial | Native adapter continues turns that end in a permission/stall prompt, can re-fire for later fresh replies, and suppresses auto-nudge while interview / deep-interview state is active; explicit terminal lifecycle metadata should be authoritative when present, legacy `blocked_on_user` remains a suppress-continuation compatibility signal, and `cancelled` stays internal legacy-only for user-facing lifecycle summaries |
 | `ask-user-question` | none | runtime-only | runtime-fallback | No distinct Codex native hook today |
 | `PostToolUseFailure` | none | runtime-only | runtime-fallback | Fold into runtime/fallback handling until native support exists |
 | non-Bash tool interception | none | runtime-only | runtime-fallback | Current Codex native tool hooks expose Bash only |
@@ -59,6 +59,21 @@ The approved OMX-native wiki backport keeps lifecycle ownership intentionally na
 - **SessionEnd** remains a runtime/notify-path responsibility for best-effort, non-blocking session capture into `.omx/wiki/`.
 - **PreCompact parity is intentionally deferred** in v1 unless a clearly OMX-native compaction seam exists.
 - **Routing should stay explicit**: prefer `$wiki` or task verbs like `wiki query` / `wiki add`, and avoid implicit bare `wiki` noun activation.
+
+## Explicit terminal stop model note
+
+The approved explicit terminal stop model adds a canonical lifecycle layer for active workflow handoffs:
+
+- `finished`
+- `blocked`
+- `failed`
+- `userinterlude`
+- `askuserQuestion`
+
+Hook readers should prefer explicit lifecycle metadata over assistant-text heuristics when those signals are available.
+During migration, legacy `blocked_on_user` still suppresses continuation, but `cancelled` should be treated as internal legacy/admin compatibility rather than a canonical user-facing outcome.
+
+There is still no distinct native Codex `ask-user-question` hook today. That means `askuserQuestion` classification remains a runtime/fallback responsibility unless a future native hook surface exposes first-class question-stop metadata.
 
 ## Combined workflow note
 

--- a/docs/contracts/explicit-terminal-stop-model.md
+++ b/docs/contracts/explicit-terminal-stop-model.md
@@ -1,0 +1,96 @@
+# Explicit Terminal Stop Model Contract
+
+Status: approved migration contract for runtime, hooks, MCP state, and prompt/documentation surfaces.
+
+## Purpose
+
+This document locks the canonical terminal stop vocabulary for active OMX workflows.
+It exists so runtime code, native/fallback Stop handlers, MCP state, and user-facing handoff guidance all describe the same end-of-turn semantics.
+
+## Canonical terminal lifecycle outcomes
+
+These are the only canonical user-facing terminal lifecycle outcomes for the explicit stop model:
+
+| Outcome | Meaning | Continuation rule | User-facing expectation |
+| --- | --- | --- | --- |
+| `finished` | The workflow completed successfully. | Do not auto-continue. | Report completion evidence and resulting artifacts. |
+| `blocked` | Progress cannot continue because a non-user prerequisite is missing. | Do not auto-continue until the blocker changes. | Report the blocker, why it matters, and the required handoff. |
+| `failed` | The workflow or verification failed. | Do not auto-continue until the failure is addressed. | Report failure evidence, impact, and recommended recovery. |
+| `userinterlude` | The user intentionally interrupted or paused the run. | Do not auto-continue unless the user explicitly restarts it. | Report that the stop was user-originated, not model-originated. |
+| `askuserQuestion` | OMX must ask the user a blocking question before safe progress can continue. | Do not auto-continue until the question is answered. | Ask one concrete blocking question and record the question metadata. |
+
+`askuserQuestion` and `userinterlude` are intentionally distinct:
+
+- `askuserQuestion` is model-originated and should normally be backed by `omx question` or equivalent machine-readable question metadata.
+- `userinterlude` is user-originated interruption/stop intent.
+
+## Legacy compatibility rules
+
+Legacy values may still appear in persisted state during migration, but they are compatibility inputs, not the public canonical vocabulary.
+
+| Legacy value | Canonical interpretation |
+| --- | --- |
+| `finish`, `complete`, `completed`, `done` | normalize to `finished` |
+| `blocked_on_user` | compatibility-only user-wait signal; map to `askuserQuestion` when question metadata proves OMX asked a blocking question, otherwise map to `userinterlude`/user-wait compatibility according to the surrounding context |
+| `cancelled`, `canceled`, `abort`, `aborted` | internal legacy/admin stop compatibility only; do **not** present as a canonical user-facing lifecycle outcome |
+
+### `cancelled` policy
+
+`cancelled` remains valid for legacy administrative state, teardown, or backward-compatible reads.
+It is **not** a canonical user-facing terminal lifecycle outcome in the explicit stop model.
+Docs, prompts, and runtime summaries should prefer one of:
+
+- `finished`
+- `blocked`
+- `failed`
+- `userinterlude`
+- `askuserQuestion`
+
+## State / MCP precedence
+
+Terminal lifecycle metadata should be interpreted in this order:
+
+1. a dedicated canonical lifecycle field such as `lifecycle_outcome`
+2. legacy `run_outcome` compatibility data
+3. fallback inference from `current_phase`, question metadata, and other persisted context
+
+Notes:
+
+- `current_phase` and lifecycle outcome are related but not identical. A workflow can keep legacy phase names while still exposing canonical lifecycle metadata.
+- If both canonical lifecycle metadata and legacy `run_outcome` are present, the canonical lifecycle field wins.
+- `run_outcome` should be treated as a compatibility read/write surface during migration, not as the long-term public contract.
+
+## Stop / watcher interpretation rules
+
+Stop readers, native hooks, and fallback watchers should prefer explicit lifecycle metadata over assistant prose heuristics.
+During migration they should:
+
+- honor canonical `finished`, `blocked`, `failed`, `userinterlude`, and `askuserQuestion` metadata first
+- keep honoring legacy `blocked_on_user` as a suppress-continuation compatibility signal
+- avoid treating optional assistant prose as the semantic owner of lifecycle state
+- keep `cancelled` internal legacy-only when translating to user-facing lifecycle summaries
+
+## Active workflow terminal handoff contract
+
+When an active workflow produces a terminal user-facing message, the handoff should be explicit and structured.
+The terminal summary should include:
+
+1. **Outcome** — one explicit lifecycle label
+2. **Evidence** — concrete verification output, failure evidence, or the missing dependency/question
+3. **Artifacts / state** — changed files, saved artifacts, or recorded question identifiers when relevant
+4. **Handoff** — the exact next owner or required answer, without optional permission-seeking phrasing
+
+### Forbidden terminal pattern
+
+Do **not** end active workflow terminal handoffs with optional follow-up softeners such as:
+
+- `If you want, I can ...`
+- `If you'd like, I can ...`
+- `Would you like me to continue?`
+
+Those phrases make the lifecycle state ambiguous. The terminal outcome should already explain whether the run finished, failed, blocked, entered user interlude, or is waiting on a required user question.
+
+## Non-goals
+
+This contract does **not** require every legacy internal phase name to be renamed immediately.
+It does require every migrated surface to expose and prefer the canonical terminal lifecycle concepts above.

--- a/docs/prompt-guidance-contract.md
+++ b/docs/prompt-guidance-contract.md
@@ -147,6 +147,19 @@ Example prompt text:
 >
 > Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence.
 
+## Active workflow terminal handoff contract
+
+Prompt surfaces that control active workflows should describe terminal user-facing replies as explicit handoffs, not as casual optional follow-ups.
+
+Contributor rules:
+
+1. Terminal active-workflow replies should name an explicit outcome such as `finished`, `blocked`, `failed`, `userinterlude`, or `askuserQuestion`.
+2. Terminal replies should include the evidence or blocking reason that justifies that outcome.
+3. Terminal replies should identify the handoff clearly: completed artifact, blocking dependency, failure recovery owner, or the single required question.
+4. Terminal replies should not end in permission-seeking softeners such as `If you want, I can ...`, `If you'd like, I can ...`, or `Would you like me to continue?`.
+
+This rule is specific to active workflow handoffs. Normal explanatory conversation outside an active workflow may still be conversational, but workflow-owned terminal replies must make the lifecycle state explicit.
+
 ## Orchestration sharpness rules for root AGENTS surfaces
 
 When editing `templates/AGENTS.md`, any tracked root `AGENTS.md`, or other root orchestration guidance, keep the orchestration contract mode-driven and terse:
@@ -221,7 +234,8 @@ node --test \
   dist/hooks/__tests__/prompt-guidance-contract.test.js \
   dist/hooks/__tests__/prompt-guidance-wave-two.test.js \
   dist/hooks/__tests__/prompt-guidance-scenarios.test.js \
-  dist/hooks/__tests__/prompt-guidance-catalog.test.js
+  dist/hooks/__tests__/prompt-guidance-catalog.test.js \
+  dist/hooks/__tests__/explicit-terminal-stop-docs-contract.test.js
 ```
 
 If you touch the exact-model `gpt-5.4-mini` composition seam, also run:

--- a/src/hooks/__tests__/explicit-terminal-stop-docs-contract.test.ts
+++ b/src/hooks/__tests__/explicit-terminal-stop-docs-contract.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { loadSurface } from "./prompt-guidance-test-helpers.js";
+
+describe("explicit terminal stop model docs contract", () => {
+  it("locks the canonical lifecycle vocabulary and legacy boundaries", () => {
+    const doc = loadSurface("docs/contracts/explicit-terminal-stop-model.md");
+    for (const outcome of ["finished", "blocked", "failed", "userinterlude", "askuserQuestion"]) {
+      assert.equal(doc.includes(`| \`${outcome}\``), true);
+    }
+    assert.match(doc, /blocked_on_user/i);
+    assert.match(doc, /cancelled.*internal legacy\/admin/i);
+    assert.match(doc, /do \*\*not\*\* present as a canonical user-facing lifecycle outcome/i);
+    assert.match(doc, /If you want, I can/i);
+    assert.match(doc, /Would you like me to continue\?/i);
+  });
+
+  it("documents lifecycle precedence in the state model", () => {
+    const doc = loadSurface("docs/STATE_MODEL.md");
+    assert.match(doc, /Terminal lifecycle outcome compatibility/i);
+    assert.match(doc, /`finished`/i);
+    assert.match(doc, /`askuserQuestion`/i);
+    assert.match(doc, /Prefer a dedicated canonical lifecycle field over legacy `run_outcome`/i);
+    assert.match(doc, /Keep `cancelled` as an internal legacy\/admin phase/i);
+  });
+
+  it("keeps native hook docs aligned with lifecycle metadata precedence", () => {
+    const doc = loadSurface("docs/codex-native-hooks.md");
+    assert.match(doc, /Explicit terminal stop model note/i);
+    assert.match(doc, /prefer explicit lifecycle metadata over assistant-text heuristics/i);
+    assert.match(doc, /legacy `blocked_on_user` still suppresses continuation/i);
+    assert.match(doc, /`cancelled` should be treated as internal legacy\/admin compatibility/i);
+    assert.match(doc, /no distinct native Codex `ask-user-question` hook today/i);
+  });
+
+  it("extends prompt guidance docs with the explicit terminal handoff rule", () => {
+    const doc = loadSurface("docs/prompt-guidance-contract.md");
+    assert.match(doc, /Active workflow terminal handoff contract/i);
+    assert.match(doc, /name an explicit outcome such as `finished`, `blocked`, `failed`, `userinterlude`, or `askuserQuestion`/i);
+    assert.match(doc, /should not end in permission-seeking softeners/i);
+    assert.match(doc, /If you want, I can/i);
+    assert.match(doc, /If you'd like, I can/i);
+    assert.match(doc, /Would you like me to continue\?/i);
+    assert.match(doc, /dist\/hooks\/__tests__\/explicit-terminal-stop-docs-contract\.test\.js/i);
+  });
+});

--- a/src/hooks/__tests__/explicit-terminal-stop-model-docs-contract.test.ts
+++ b/src/hooks/__tests__/explicit-terminal-stop-model-docs-contract.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { loadSurface } from './prompt-guidance-test-helpers.js';
+
+describe('explicit terminal stop model docs contract', () => {
+  it('documents the canonical terminal lifecycle vocabulary', () => {
+    const doc = loadSurface('docs/contracts/explicit-terminal-stop-model.md');
+
+    assert.match(doc, /`finished`/);
+    assert.match(doc, /`blocked`/);
+    assert.match(doc, /`failed`/);
+    assert.match(doc, /`userinterlude`/);
+    assert.match(doc, /`askuserQuestion`/);
+  });
+
+  it('keeps cancelled internal-only and preserves blocked_on_user as a legacy compatibility value', () => {
+    const doc = loadSurface('docs/contracts/explicit-terminal-stop-model.md');
+
+    assert.match(doc, /`blocked_on_user` \| compatibility-only user-wait signal/i);
+    assert.match(doc, /`cancelled`, `canceled`, `abort`, `aborted` \| internal legacy\/admin stop compatibility only/i);
+    assert.match(doc, /It is \*\*not\*\* a canonical user-facing terminal lifecycle outcome/i);
+  });
+
+  it('distinguishes userinterlude from askuserQuestion', () => {
+    const doc = loadSurface('docs/contracts/explicit-terminal-stop-model.md');
+
+    assert.match(doc, /`userinterlude` \| The user intentionally interrupted or paused the run\./i);
+    assert.match(doc, /`askuserQuestion` \| OMX must ask the user a blocking question before safe progress can continue\./i);
+    assert.match(doc, /should normally be backed by `omx question`/i);
+  });
+
+  it('forbids optional terminal handoff softeners in active workflow outputs', () => {
+    const doc = loadSurface('docs/contracts/explicit-terminal-stop-model.md');
+
+    assert.match(doc, /the handoff should be explicit and structured/i);
+    assert.match(doc, /If you want, I can/i);
+    assert.match(doc, /Would you like me to continue\?/i);
+    assert.match(doc, /If you'd like, I can/i);
+  });
+
+  it('documents canonical-field precedence over legacy compatibility fields', () => {
+    const doc = loadSurface('docs/contracts/explicit-terminal-stop-model.md');
+
+    assert.match(doc, /a dedicated canonical lifecycle field such as `lifecycle_outcome`/i);
+    assert.match(doc, /the canonical lifecycle field wins/i);
+  });
+});

--- a/src/hooks/__tests__/prompt-guidance-test-helpers.ts
+++ b/src/hooks/__tests__/prompt-guidance-test-helpers.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -11,8 +12,21 @@ export function loadSurface(path: string): string {
   return readFileSync(join(repoRoot, path), 'utf-8');
 }
 
+function isGitTracked(path: string): boolean {
+  if (!existsSync(join(repoRoot, path))) return false;
+  try {
+    execFileSync('git', ['ls-files', '--error-unmatch', path], {
+      cwd: repoRoot,
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function listTrackedAgentSurfaces(): string[] {
-  return ['AGENTS.md', 'templates/AGENTS.md'].filter((path) => existsSync(join(repoRoot, path)));
+  return ['AGENTS.md', 'templates/AGENTS.md'].filter((path) => isGitTracked(path));
 }
 
 export function assertContractSurface(contract: GuidanceSurfaceContract): void {

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -195,6 +195,83 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('accepts canonical lifecycle_outcome and backfills compatibility run_outcome', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-lifecycle-'));
+    try {
+      const writeResponse = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'deep-interview',
+            active: false,
+            lifecycle_outcome: 'askuserQuestion',
+            state: {
+              current_focus: 'intent',
+            },
+          },
+        },
+      });
+
+      assert.equal(writeResponse.isError, undefined);
+
+      const readResponse = await handleStateToolCall({
+        params: {
+          name: 'state_read',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'deep-interview',
+          },
+        },
+      });
+
+      const readBody = JSON.parse(readResponse.content[0]?.text || '{}') as Record<string, unknown>;
+      assert.equal(readBody.lifecycle_outcome, 'askuserQuestion');
+      assert.equal(readBody.run_outcome, 'blocked_on_user');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('derives canonical lifecycle_outcome from legacy run_outcome when needed', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-run-outcome-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+            active: false,
+            run_outcome: 'cancelled',
+          },
+        },
+      });
+
+      const readResponse = await handleStateToolCall({
+        params: {
+          name: 'state_read',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+          },
+        },
+      });
+
+      const readBody = JSON.parse(readResponse.content[0]?.text || '{}') as Record<string, unknown>;
+      assert.equal(readBody.lifecycle_outcome, 'userinterlude');
+      assert.equal(readBody.run_outcome, 'cancelled');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('creates session-scoped state directory when session_id is provided', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
@@ -216,6 +293,75 @@ describe('state-server directory initialization', () => {
         JSON.parse(response.content[0]?.text || '{}'),
         { statuses: {} },
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('state_write accepts canonical lifecycle_outcome while preserving compatibility run_outcome', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-lifecycle-'));
+    try {
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'autopilot',
+            active: false,
+            current_phase: 'waiting-for-user-answer',
+            lifecycle_outcome: 'askuserQuestion',
+          },
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const state = JSON.parse(await readFile(join(wd, '.omx', 'state', 'autopilot-state.json'), 'utf-8')) as {
+        active?: boolean;
+        lifecycle_outcome?: string;
+        terminal_outcome?: string;
+        run_outcome?: string;
+        completed_at?: string;
+      };
+      assert.equal(state.active, false);
+      assert.equal(state.lifecycle_outcome, 'askuserQuestion');
+      assert.equal(state.terminal_outcome, undefined);
+      assert.equal(state.run_outcome, 'blocked_on_user');
+      assert.ok(state.completed_at);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('state_write lets canonical lifecycle_outcome take precedence over legacy run_outcome', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-lifecycle-precedence-'));
+    try {
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'autopilot',
+            active: false,
+            current_phase: 'user-stopped',
+            run_outcome: 'failed',
+            lifecycle_outcome: 'userinterlude',
+          },
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const state = JSON.parse(await readFile(join(wd, '.omx', 'state', 'autopilot-state.json'), 'utf-8')) as {
+        lifecycle_outcome?: string;
+        run_outcome?: string;
+      };
+      assert.equal(state.lifecycle_outcome, 'userinterlude');
+      assert.equal(state.run_outcome, 'cancelled');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -45,6 +45,7 @@ import {
 	validateAndNormalizeRalphState,
 } from "../ralph/contract.js";
 import { ensureCanonicalRalphArtifacts } from "../ralph/persistence.js";
+import { applyRunOutcomeContract } from "../runtime/run-outcome.js";
 import { autoStartStdioMcpServer } from "./bootstrap.js";
 import {
 	LEGACY_TEAM_MCP_TOOLS,
@@ -167,6 +168,15 @@ export function buildStateServerTools() {
 					run_outcome: {
 						type: "string",
 						enum: ["continue", "finish", "blocked_on_user", "failed", "cancelled"],
+					},
+					lifecycle_outcome: {
+						type: "string",
+						enum: ["finished", "blocked", "failed", "userinterlude", "askuserQuestion"],
+					},
+					terminal_outcome: {
+						type: "string",
+						enum: ["finished", "blocked", "failed", "userinterlude", "askuserQuestion"],
+						description: "Legacy alias for lifecycle_outcome; canonical writes should prefer lifecycle_outcome.",
 					},
 					error: { type: "string" },
 					state: { type: "object", description: "Additional custom fields" },
@@ -374,6 +384,30 @@ export async function handleStateToolCall(request: {
 							...fields,
 							...((customState as Record<string, unknown>) || {}),
 						} as Record<string, unknown>;
+						const explicitRunOutcome = Object.prototype.hasOwnProperty.call(fields, "run_outcome")
+							|| (
+								customState != null
+								&& Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, "run_outcome")
+							);
+						if (!explicitRunOutcome) {
+							delete mergedRaw.run_outcome;
+						}
+						const explicitLifecycleOutcome = Object.prototype.hasOwnProperty.call(fields, "lifecycle_outcome")
+							|| (
+								customState != null
+								&& Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, "lifecycle_outcome")
+							);
+						if (!explicitLifecycleOutcome) {
+							delete mergedRaw.lifecycle_outcome;
+						}
+						const explicitTerminalOutcome = Object.prototype.hasOwnProperty.call(fields, "terminal_outcome")
+							|| (
+								customState != null
+								&& Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, "terminal_outcome")
+							);
+						if (!explicitTerminalOutcome) {
+							delete mergedRaw.terminal_outcome;
+						}
 						if (
 							mode === "ralph" &&
 							effectiveSessionId &&
@@ -382,7 +416,7 @@ export async function handleStateToolCall(request: {
 						mergedRaw.owner_omx_session_id = effectiveSessionId;
 					}
 
-					if (mode === "ralph") {
+						if (mode === "ralph") {
 						const originalPhase = mergedRaw.current_phase;
 						const validation = validateAndNormalizeRalphState(mergedRaw);
 						if (!validation.ok || !validation.state) {
@@ -400,6 +434,15 @@ export async function handleStateToolCall(request: {
 							}
 							Object.assign(mergedRaw, validation.state);
 							ensureRalphArtifacts = true;
+						}
+						if (mode !== SKILL_ACTIVE_STATE_MODE) {
+							const runOutcomeValidation = applyRunOutcomeContract(mergedRaw);
+							if (!runOutcomeValidation.ok || !runOutcomeValidation.state) {
+								validationError =
+									runOutcomeValidation.error || "Invalid run outcome state";
+								return;
+							}
+							Object.assign(mergedRaw, runOutcomeValidation.state);
 						}
 						if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
 							try {

--- a/src/question/__tests__/deep-interview.test.ts
+++ b/src/question/__tests__/deep-interview.test.ts
@@ -42,9 +42,16 @@ describe('runDeepInterviewQuestion', () => {
 
     const runner: OmxQuestionProcessRunner = async () => {
       const inFlightState = JSON.parse(await readFile(statePath, 'utf-8')) as {
-        question_enforcement?: { status?: string };
+        question_enforcement?: { status?: string; lifecycle_outcome?: string };
+        lifecycle_outcome?: string;
+        run_outcome?: string;
+        active?: boolean;
       };
       inFlightQuestionStatus = inFlightState.question_enforcement?.status ?? '';
+      assert.equal(inFlightState.question_enforcement?.lifecycle_outcome, 'askuserQuestion');
+      assert.equal(inFlightState.lifecycle_outcome, 'askuserQuestion');
+      assert.equal(inFlightState.run_outcome, 'blocked_on_user');
+      assert.equal(inFlightState.active, false);
       return {
         code: 0,
         stdout: JSON.stringify({
@@ -87,17 +94,23 @@ describe('runDeepInterviewQuestion', () => {
     assert.equal(inFlightQuestionStatus, 'pending');
 
     const finalState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+      lifecycle_outcome?: string;
       question_enforcement?: {
         obligation_id?: string;
+        lifecycle_outcome?: string;
         status?: string;
         question_id?: string;
         satisfied_at?: string;
       };
+      run_outcome?: string;
     };
     assert.equal(finalState.question_enforcement?.status, 'satisfied');
+    assert.equal(finalState.question_enforcement?.lifecycle_outcome, 'askuserQuestion');
     assert.equal(finalState.question_enforcement?.question_id, 'question-1');
     assert.ok(finalState.question_enforcement?.obligation_id);
     assert.ok(finalState.question_enforcement?.satisfied_at);
+    assert.equal(finalState.lifecycle_outcome, undefined);
+    assert.equal(finalState.run_outcome, undefined);
   });
 
   it('clears the pending obligation when omx question fails after being attempted', async () => {
@@ -135,14 +148,20 @@ describe('runDeepInterviewQuestion', () => {
     );
 
     const finalState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+      lifecycle_outcome?: string;
       question_enforcement?: {
+        lifecycle_outcome?: string;
         status?: string;
         clear_reason?: string;
         cleared_at?: string;
       };
+      run_outcome?: string;
     };
     assert.equal(finalState.question_enforcement?.status, 'cleared');
+    assert.equal(finalState.question_enforcement?.lifecycle_outcome, 'askuserQuestion');
     assert.equal(finalState.question_enforcement?.clear_reason, 'error');
     assert.ok(finalState.question_enforcement?.cleared_at);
+    assert.equal(finalState.lifecycle_outcome, undefined);
+    assert.equal(finalState.run_outcome, undefined);
   });
 });

--- a/src/question/deep-interview.ts
+++ b/src/question/deep-interview.ts
@@ -6,6 +6,7 @@ import {
   type OmxQuestionClientOptions,
   type OmxQuestionSuccessPayload,
 } from './client.js';
+import type { TerminalLifecycleOutcome } from '../runtime/terminal-lifecycle.js';
 import type { QuestionInput } from './types.js';
 
 const DEEP_INTERVIEW_STATE_FILE = 'deep-interview-state.json';
@@ -14,6 +15,7 @@ export interface DeepInterviewQuestionEnforcementState {
   obligation_id: string;
   source: 'omx-question';
   status: 'pending' | 'satisfied' | 'cleared';
+  lifecycle_outcome: 'askuserQuestion';
   requested_at: string;
   question_id?: string;
   satisfied_at?: string;
@@ -23,6 +25,7 @@ export interface DeepInterviewQuestionEnforcementState {
 
 interface DeepInterviewStateRecord {
   updated_at?: string;
+  lifecycle_outcome?: TerminalLifecycleOutcome;
   question_enforcement?: DeepInterviewQuestionEnforcementState;
   [key: string]: unknown;
 }
@@ -64,6 +67,7 @@ export function createDeepInterviewQuestionObligation(
     obligation_id: buildObligationId(now),
     source: 'omx-question',
     status: 'pending',
+    lifecycle_outcome: 'askuserQuestion',
     requested_at: now.toISOString(),
   };
 }
@@ -120,10 +124,26 @@ export async function updateDeepInterviewQuestionEnforcement(
   const nextState: DeepInterviewStateRecord = {
     ...state,
     updated_at: new Date().toISOString(),
-    ...(nextEnforcement ? { question_enforcement: nextEnforcement } : {}),
+    ...(nextEnforcement
+      ? {
+          question_enforcement: nextEnforcement,
+          ...(nextEnforcement.status === 'pending'
+            ? {
+                lifecycle_outcome: 'askuserQuestion',
+                run_outcome: 'blocked_on_user',
+                active: false,
+                completed_at: safeString(state.completed_at) || new Date().toISOString(),
+              }
+            : {}),
+        }
+      : {}),
   };
   if (!nextEnforcement) {
     delete nextState.question_enforcement;
+  }
+  if (nextEnforcement?.status !== 'pending') {
+    delete nextState.lifecycle_outcome;
+    delete nextState.run_outcome;
   }
 
   await writeDeepInterviewState(cwd, nextState, sessionId);

--- a/src/runtime/__tests__/run-outcome.test.ts
+++ b/src/runtime/__tests__/run-outcome.test.ts
@@ -7,6 +7,11 @@ import {
   isTerminalRunOutcome,
   normalizeRunOutcome,
 } from '../run-outcome.js';
+import {
+  inferTerminalLifecycleOutcome,
+  normalizeTerminalLifecycleOutcome,
+  preferredRunOutcomeForLifecycleOutcome,
+} from '../terminal-lifecycle.js';
 import { shouldContinueRun } from '../run-loop.js';
 
 describe('run outcome contract', () => {
@@ -76,5 +81,40 @@ describe('run outcome contract', () => {
       current_phase: 'executing',
       run_outcome: 'continue',
     }), true);
+  });
+
+  it('normalizes canonical terminal lifecycle outcomes and legacy aliases', () => {
+    assert.deepEqual(normalizeTerminalLifecycleOutcome('askuserQuestion'), {
+      outcome: 'askuserQuestion',
+    });
+    assert.deepEqual(normalizeTerminalLifecycleOutcome('complete'), {
+      outcome: 'finished',
+      warning: 'normalized legacy lifecycle outcome "complete" -> "finished"',
+    });
+    assert.deepEqual(normalizeTerminalLifecycleOutcome('cancelled'), {
+      outcome: 'userinterlude',
+      warning: 'normalized legacy lifecycle outcome "cancelled" -> "userinterlude"',
+    });
+  });
+
+  it('infers terminal lifecycle outcome from legacy run_outcome when no canonical field exists', () => {
+    assert.deepEqual(inferTerminalLifecycleOutcome({ run_outcome: 'finish' }), {
+      outcome: 'finished',
+    });
+    assert.deepEqual(inferTerminalLifecycleOutcome({ run_outcome: 'blocked_on_user' }), {
+      outcome: 'blocked',
+    });
+    assert.deepEqual(inferTerminalLifecycleOutcome({ run_outcome: 'cancelled' }), {
+      outcome: 'userinterlude',
+      warning: 'normalized legacy run outcome "cancelled" -> "userinterlude"',
+    });
+  });
+
+  it('maps canonical lifecycle outcomes to compatibility run_outcome values', () => {
+    assert.equal(preferredRunOutcomeForLifecycleOutcome('finished'), 'finish');
+    assert.equal(preferredRunOutcomeForLifecycleOutcome('blocked'), 'blocked_on_user');
+    assert.equal(preferredRunOutcomeForLifecycleOutcome('failed'), 'failed');
+    assert.equal(preferredRunOutcomeForLifecycleOutcome('userinterlude'), 'cancelled');
+    assert.equal(preferredRunOutcomeForLifecycleOutcome('askuserQuestion'), 'blocked_on_user');
   });
 });

--- a/src/runtime/__tests__/run-state.test.ts
+++ b/src/runtime/__tests__/run-state.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import { buildRunState, syncRunStateFromModeState } from '../run-state.js';
+
+describe('run state sync', () => {
+  it('preserves canonical askuserQuestion lifecycle while keeping legacy blocked_on_user outcome', () => {
+    const state = buildRunState(
+      {
+        mode: 'deep-interview',
+        active: false,
+        run_outcome: 'blocked_on_user',
+        lifecycle_outcome: 'askuserQuestion',
+      },
+      null,
+      '2026-04-19T00:00:00.000Z',
+    );
+
+    assert.equal(state.outcome, 'blocked_on_user');
+    assert.equal(state.lifecycle_outcome, 'askuserQuestion');
+  });
+
+  it('writes canonical askuserQuestion lifecycle to run-state.json during sync', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-run-state-'));
+    try {
+      const synced = await syncRunStateFromModeState(
+        {
+          mode: 'deep-interview',
+          active: false,
+          run_outcome: 'blocked_on_user',
+          lifecycle_outcome: 'askuserQuestion',
+        },
+        wd,
+      );
+
+      const persisted = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'run-state.json'), 'utf-8'),
+      ) as typeof synced;
+
+      assert.equal(synced.outcome, 'blocked_on_user');
+      assert.equal(synced.lifecycle_outcome, 'askuserQuestion');
+      assert.equal(persisted.lifecycle_outcome, 'askuserQuestion');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/runtime/run-loop.ts
+++ b/src/runtime/run-loop.ts
@@ -1,8 +1,10 @@
 import {
   classifyRunOutcome,
   inferRunOutcome,
+  inferTerminalLifecycleOutcome,
   isTerminalRunOutcome,
   type RunOutcome,
+  type TerminalLifecycleOutcome,
   type TerminalRunOutcome,
 } from './run-outcome.js';
 
@@ -33,6 +35,9 @@ export interface RunUntilTerminalOptions<TState> {
 export interface RunContinuationStateLike {
   current_phase?: unknown;
   run_outcome?: unknown;
+  lifecycle_outcome?: unknown;
+  terminal_outcome?: unknown;
+  question_enforcement?: unknown;
   active?: unknown;
   completed_at?: unknown;
   [key: string]: unknown;
@@ -40,6 +45,7 @@ export interface RunContinuationStateLike {
 
 export interface RunContinuationSnapshot {
   outcome: RunOutcome;
+  lifecycleOutcome?: TerminalLifecycleOutcome;
   terminal: boolean;
   phase: string;
 }
@@ -88,11 +94,16 @@ export function getRunContinuationSnapshot(
   options: { phaseFallback?: string } = {},
 ): RunContinuationSnapshot | null {
   if (!candidate || typeof candidate !== 'object') return null;
-  const outcome = inferRunOutcome(candidate as Record<string, unknown>);
+  const record = candidate as Record<string, unknown>;
+  const outcome = inferRunOutcome(record);
+  const lifecycleOutcome = inferTerminalLifecycleOutcome(record, {
+    includeQuestionEnforcement: true,
+  });
   const phase = safeString(candidate.current_phase) || options.phaseFallback || 'active';
   return {
     outcome,
-    terminal: isTerminalRunOutcome(outcome),
+    lifecycleOutcome,
+    terminal: lifecycleOutcome !== undefined || isTerminalRunOutcome(outcome),
     phase,
   };
 }

--- a/src/runtime/run-outcome.ts
+++ b/src/runtime/run-outcome.ts
@@ -15,13 +15,23 @@ export const RUN_OUTCOMES = [
   ...TERMINAL_RUN_OUTCOMES,
 ] as const;
 
+export const TERMINAL_LIFECYCLE_OUTCOMES = [
+  'finished',
+  'blocked',
+  'failed',
+  'userinterlude',
+  'askuserQuestion',
+] as const;
+
 export type TerminalRunOutcome = (typeof TERMINAL_RUN_OUTCOMES)[number];
 export type NonTerminalRunOutcome = (typeof NON_TERMINAL_RUN_OUTCOMES)[number];
 export type RunOutcome = (typeof RUN_OUTCOMES)[number];
+export type TerminalLifecycleOutcome = (typeof TERMINAL_LIFECYCLE_OUTCOMES)[number];
 
 const TERMINAL_RUN_OUTCOME_SET = new Set<string>(TERMINAL_RUN_OUTCOMES);
 const NON_TERMINAL_RUN_OUTCOME_SET = new Set<string>(NON_TERMINAL_RUN_OUTCOMES);
 const RUN_OUTCOME_SET = new Set<string>(RUN_OUTCOMES);
+const TERMINAL_LIFECYCLE_OUTCOME_SET = new Set<string>(TERMINAL_LIFECYCLE_OUTCOMES);
 
 const RUN_OUTCOME_ALIASES: Readonly<Record<string, RunOutcome>> = {
   finish: 'finish',
@@ -45,6 +55,31 @@ const RUN_OUTCOME_ALIASES: Readonly<Record<string, RunOutcome>> = {
   continued: 'continue',
 } as const;
 
+const TERMINAL_LIFECYCLE_OUTCOME_ALIASES: Readonly<Record<string, TerminalLifecycleOutcome>> = {
+  finished: 'finished',
+  finish: 'finished',
+  complete: 'finished',
+  completed: 'finished',
+  done: 'finished',
+  blocked: 'blocked',
+  failed: 'failed',
+  fail: 'failed',
+  error: 'failed',
+  userinterlude: 'userinterlude',
+  'user-interlude': 'userinterlude',
+  interrupted: 'userinterlude',
+  interrupt: 'userinterlude',
+  cancelled: 'userinterlude',
+  canceled: 'userinterlude',
+  cancel: 'userinterlude',
+  aborted: 'userinterlude',
+  abort: 'userinterlude',
+  askuserquestion: 'askuserQuestion',
+  'ask-user-question': 'askuserQuestion',
+  askuser: 'askuserQuestion',
+  question: 'askuserQuestion',
+} as const;
+
 const TERMINAL_PHASE_TO_RUN_OUTCOME: Readonly<Record<string, TerminalRunOutcome>> = {
   complete: 'finish',
   completed: 'finish',
@@ -56,8 +91,26 @@ const TERMINAL_PHASE_TO_RUN_OUTCOME: Readonly<Record<string, TerminalRunOutcome>
   cancel: 'cancelled',
 };
 
+const RUN_OUTCOME_FROM_LIFECYCLE: Readonly<Record<TerminalLifecycleOutcome, TerminalRunOutcome>> = {
+  finished: 'finish',
+  blocked: 'blocked_on_user',
+  failed: 'failed',
+  userinterlude: 'cancelled',
+  askuserQuestion: 'blocked_on_user',
+};
+
 export interface RunOutcomeNormalizationResult {
   outcome?: RunOutcome;
+  warning?: string;
+  error?: string;
+}
+
+export interface TerminalLifecycleOutcomeNormalizationOptions {
+  blockedOnUserStrategy?: 'blocked' | 'askuserQuestion' | 'userinterlude';
+}
+
+export interface TerminalLifecycleOutcomeNormalizationResult {
+  outcome?: TerminalLifecycleOutcome;
   warning?: string;
   error?: string;
 }
@@ -77,6 +130,43 @@ function safeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function resolveBlockedOnUserLifecycleOutcome(
+  options: TerminalLifecycleOutcomeNormalizationOptions = {},
+): TerminalLifecycleOutcome {
+  return options.blockedOnUserStrategy ?? 'blocked';
+}
+
+function hasPendingQuestionEnforcement(candidate: Record<string, unknown>): boolean {
+  const enforcement = candidate.question_enforcement;
+  if (!enforcement || typeof enforcement !== 'object') return false;
+  const record = enforcement as Record<string, unknown>;
+  const obligationId = safeString(record.obligation_id);
+  const status = safeString(record.status).toLowerCase();
+  return obligationId !== '' && status === 'pending';
+}
+
+export function compatibilityRunOutcomeFromTerminalLifecycleOutcome(
+  outcome: TerminalLifecycleOutcome,
+): TerminalRunOutcome {
+  return RUN_OUTCOME_FROM_LIFECYCLE[outcome];
+}
+
+export function terminalLifecycleOutcomeFromRunOutcome(
+  outcome: TerminalRunOutcome,
+  options: TerminalLifecycleOutcomeNormalizationOptions = {},
+): TerminalLifecycleOutcome {
+  switch (outcome) {
+    case 'finish':
+      return 'finished';
+    case 'blocked_on_user':
+      return resolveBlockedOnUserLifecycleOutcome(options);
+    case 'failed':
+      return 'failed';
+    case 'cancelled':
+      return 'userinterlude';
+  }
+}
+
 export function normalizeRunOutcome(value: unknown): RunOutcomeNormalizationResult {
   const normalized = normalizeRunOutcomeValue(value);
   if (!normalized) return {};
@@ -93,6 +183,34 @@ export function normalizeRunOutcome(value: unknown): RunOutcomeNormalizationResu
   return { error: `run_outcome must be one of: ${RUN_OUTCOMES.join(', ')}` };
 }
 
+export function normalizeTerminalLifecycleOutcome(
+  value: unknown,
+  options: TerminalLifecycleOutcomeNormalizationOptions = {},
+): TerminalLifecycleOutcomeNormalizationResult {
+  const normalized = normalizeRunOutcomeValue(value);
+  if (!normalized) return {};
+  if (TERMINAL_LIFECYCLE_OUTCOME_SET.has(normalized)) {
+    return { outcome: normalized as TerminalLifecycleOutcome };
+  }
+  if (normalized === 'blocked_on_user' || normalized === 'blocked-on-user') {
+    const outcome = resolveBlockedOnUserLifecycleOutcome(options);
+    return {
+      outcome,
+      warning: `normalized legacy terminal lifecycle outcome "${value}" -> "${outcome}"`,
+    };
+  }
+  const alias = TERMINAL_LIFECYCLE_OUTCOME_ALIASES[normalized];
+  if (alias) {
+    return {
+      outcome: alias,
+      warning: `normalized legacy terminal lifecycle outcome "${value}" -> "${alias}"`,
+    };
+  }
+  return {
+    error: `lifecycle_outcome must be one of: ${TERMINAL_LIFECYCLE_OUTCOMES.join(', ')}`,
+  };
+}
+
 export function classifyRunOutcome(value: unknown): RunOutcome {
   return normalizeRunOutcome(value).outcome ?? 'progress';
 }
@@ -100,6 +218,14 @@ export function classifyRunOutcome(value: unknown): RunOutcome {
 export function isTerminalRunOutcome(value: unknown): value is TerminalRunOutcome {
   const normalized = normalizeRunOutcome(value).outcome;
   return normalized !== undefined && TERMINAL_RUN_OUTCOME_SET.has(normalized);
+}
+
+export function isTerminalLifecycleOutcome(
+  value: unknown,
+  options: TerminalLifecycleOutcomeNormalizationOptions = {},
+): value is TerminalLifecycleOutcome {
+  const normalized = normalizeTerminalLifecycleOutcome(value, options).outcome;
+  return normalized !== undefined && TERMINAL_LIFECYCLE_OUTCOME_SET.has(normalized);
 }
 
 export function isNonTerminalRunOutcome(value: unknown): value is NonTerminalRunOutcome {
@@ -115,9 +241,57 @@ export function isTerminalRunState(value: unknown): boolean {
   return isTerminalRunOutcome(classifyRunOutcome(value));
 }
 
+export function inferTerminalLifecycleOutcome(
+  candidate: Record<string, unknown>,
+  options: {
+    includeQuestionEnforcement?: boolean;
+    blockedOnUserStrategy?: 'blocked' | 'askuserQuestion' | 'userinterlude';
+  } = {},
+): TerminalLifecycleOutcome | undefined {
+  const blockedOnUserStrategy = options.blockedOnUserStrategy
+    ?? (
+      options.includeQuestionEnforcement && hasPendingQuestionEnforcement(candidate)
+        ? 'askuserQuestion'
+        : 'blocked'
+    );
+
+  const explicit = normalizeTerminalLifecycleOutcome(
+    candidate.lifecycle_outcome ?? candidate.terminal_outcome,
+    { blockedOnUserStrategy },
+  );
+  if (explicit.outcome) return explicit.outcome;
+
+  const runOutcome = normalizeRunOutcome(candidate.run_outcome).outcome;
+  if (runOutcome && isTerminalRunOutcome(runOutcome)) {
+    return terminalLifecycleOutcomeFromRunOutcome(runOutcome, { blockedOnUserStrategy });
+  }
+
+  const phase = safeString(candidate.current_phase).toLowerCase();
+  if (phase) {
+    const normalizedPhase = normalizeTerminalLifecycleOutcome(phase, { blockedOnUserStrategy });
+    if (normalizedPhase.outcome) return normalizedPhase.outcome;
+  }
+
+  if (options.includeQuestionEnforcement && hasPendingQuestionEnforcement(candidate)) {
+    return 'askuserQuestion';
+  }
+
+  if (candidate.active === true) return undefined;
+  if (safeString(candidate.completed_at)) return 'finished';
+  if (candidate.active === false) return 'finished';
+  return undefined;
+}
+
 export function inferRunOutcome(candidate: Record<string, unknown>): RunOutcome {
   const explicit = normalizeRunOutcome(candidate.run_outcome);
   if (explicit.outcome) return explicit.outcome;
+
+  const lifecycleOutcome = inferTerminalLifecycleOutcome(candidate, {
+    includeQuestionEnforcement: false,
+  });
+  if (lifecycleOutcome) {
+    return compatibilityRunOutcomeFromTerminalLifecycleOutcome(lifecycleOutcome);
+  }
 
   const phase = safeString(candidate.current_phase).toLowerCase();
   if (phase && TERMINAL_PHASE_TO_RUN_OUTCOME[phase]) {
@@ -136,15 +310,34 @@ export function applyRunOutcomeContract(
 ): RunOutcomeValidationResult {
   const nowIso = options?.nowIso ?? new Date().toISOString();
   const next: Record<string, unknown> = { ...candidate };
-  const normalized = normalizeRunOutcome(next.run_outcome);
-  if (normalized.error) return { ok: false, error: normalized.error };
+  const normalizedLifecycle = normalizeTerminalLifecycleOutcome(next.lifecycle_outcome ?? next.terminal_outcome);
+  if (normalizedLifecycle.error) return { ok: false, error: normalizedLifecycle.error };
 
-  const outcome = normalized.outcome ?? inferRunOutcome(next);
+  const normalizedRunOutcome = normalizeRunOutcome(next.run_outcome);
+  if (normalizedRunOutcome.error) return { ok: false, error: normalizedRunOutcome.error };
+
+  const lifecycleOutcome = normalizedLifecycle.outcome ?? inferTerminalLifecycleOutcome(next, {
+    includeQuestionEnforcement: false,
+  });
+  const outcome = normalizedLifecycle.outcome
+    ? compatibilityRunOutcomeFromTerminalLifecycleOutcome(normalizedLifecycle.outcome)
+    : normalizedRunOutcome.outcome ?? inferRunOutcome(next);
+
+  delete next.terminal_outcome;
   next.run_outcome = outcome;
+  if (lifecycleOutcome) {
+    next.lifecycle_outcome = lifecycleOutcome;
+  } else {
+    delete next.lifecycle_outcome;
+  }
 
-  if (isTerminalRunOutcome(outcome)) {
+  const terminal = lifecycleOutcome !== undefined || isTerminalRunOutcome(outcome);
+  if (terminal) {
     if (next.active === true) {
-      return { ok: false, error: `terminal run outcome "${outcome}" requires active=false` };
+      return {
+        ok: false,
+        error: `terminal run outcome "${lifecycleOutcome ?? outcome}" requires active=false`,
+      };
     }
     next.active = false;
     if (!safeString(next.completed_at)) {
@@ -163,6 +356,6 @@ export function applyRunOutcomeContract(
   return {
     ok: true,
     state: next,
-    warning: normalized.warning,
+    warning: normalizedLifecycle.warning ?? normalizedRunOutcome.warning,
   };
 }

--- a/src/runtime/run-state.ts
+++ b/src/runtime/run-state.ts
@@ -4,9 +4,12 @@ import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { getStateFilePath, resolveStateScope } from '../mcp/state-paths.js';
 import {
   classifyRunOutcome,
+  compatibilityRunOutcomeFromTerminalLifecycleOutcome,
+  inferTerminalLifecycleOutcome,
   isTerminalRunOutcome,
   normalizeRunOutcome,
   type RunOutcome,
+  type TerminalLifecycleOutcome,
 } from './run-outcome.js';
 
 const RUN_STATE_FILENAME = 'run-state.json';
@@ -23,6 +26,9 @@ export interface RunStateLike {
   error?: unknown;
   outcome?: unknown;
   run_outcome?: unknown;
+  lifecycle_outcome?: unknown;
+  terminal_outcome?: unknown;
+  question_enforcement?: unknown;
   owner_omx_session_id?: unknown;
   [key: string]: unknown;
 }
@@ -32,6 +38,7 @@ export interface RunState {
   mode: string;
   active: boolean;
   outcome: RunOutcome;
+  lifecycle_outcome?: TerminalLifecycleOutcome;
   updated_at: string;
   current_phase?: string;
   task_description?: string;
@@ -55,12 +62,17 @@ function optionalFiniteNumber(value: unknown): number | undefined {
 
 function terminalOutcomeFromPhase(phase: string | undefined): RunOutcome | null {
   if (!phase) return null;
-  const normalizedPhase = normalizeRunOutcome(phase).outcome;
-  return normalizedPhase && isTerminalRunOutcome(normalizedPhase) ? normalizedPhase : null;
+  const normalized = normalizeRunOutcome(phase).outcome;
+  return normalized && isTerminalRunOutcome(normalized) ? normalized : null;
 }
 
 export function deriveRunOutcomeFromModeState(state: RunStateLike): RunOutcome {
   if (state.active === true) return 'continue';
+
+  const lifecycleOutcome = inferTerminalLifecycleOutcome(state as Record<string, unknown>, {
+    includeQuestionEnforcement: true,
+  });
+  if (lifecycleOutcome) return compatibilityRunOutcomeFromTerminalLifecycleOutcome(lifecycleOutcome);
 
   const explicitOutcome = normalizeRunOutcome(state.outcome ?? state.run_outcome).outcome;
   if (explicitOutcome) return explicitOutcome;
@@ -79,6 +91,9 @@ export function buildRunState(
   existing?: Partial<RunState> | null,
   nowIso: string = new Date().toISOString(),
 ): RunState {
+  const lifecycleOutcome = inferTerminalLifecycleOutcome(state as Record<string, unknown>, {
+    includeQuestionEnforcement: true,
+  }) ?? existing?.lifecycle_outcome;
   const outcome = deriveRunOutcomeFromModeState(state);
   const active = state.active === true;
   const next: RunState = {
@@ -88,6 +103,8 @@ export function buildRunState(
     outcome,
     updated_at: nowIso,
   };
+
+  if (lifecycleOutcome) next.lifecycle_outcome = lifecycleOutcome;
 
   const currentPhase = optionalString(state.current_phase);
   if (currentPhase) next.current_phase = currentPhase;

--- a/src/runtime/run-state.ts
+++ b/src/runtime/run-state.ts
@@ -7,6 +7,7 @@ import {
   compatibilityRunOutcomeFromTerminalLifecycleOutcome,
   inferTerminalLifecycleOutcome,
   isTerminalRunOutcome,
+  normalizeTerminalLifecycleOutcome,
   normalizeRunOutcome,
   type RunOutcome,
   type TerminalLifecycleOutcome,
@@ -91,7 +92,9 @@ export function buildRunState(
   existing?: Partial<RunState> | null,
   nowIso: string = new Date().toISOString(),
 ): RunState {
-  const lifecycleOutcome = inferTerminalLifecycleOutcome(state as Record<string, unknown>, {
+  const lifecycleOutcome = normalizeTerminalLifecycleOutcome(
+    state.lifecycle_outcome ?? state.terminal_outcome,
+  ).outcome ?? inferTerminalLifecycleOutcome(state as Record<string, unknown>, {
     includeQuestionEnforcement: true,
   }) ?? existing?.lifecycle_outcome;
   const outcome = deriveRunOutcomeFromModeState(state);

--- a/src/runtime/terminal-lifecycle.ts
+++ b/src/runtime/terminal-lifecycle.ts
@@ -1,0 +1,112 @@
+import { normalizeRunOutcome, type RunOutcome } from './run-outcome.js';
+
+export const TERMINAL_LIFECYCLE_OUTCOMES = [
+  'finished',
+  'blocked',
+  'failed',
+  'userinterlude',
+  'askuserQuestion',
+] as const;
+
+export type TerminalLifecycleOutcome = (typeof TERMINAL_LIFECYCLE_OUTCOMES)[number];
+
+export interface TerminalLifecycleNormalizationResult {
+  outcome?: TerminalLifecycleOutcome;
+  warning?: string;
+  error?: string;
+}
+
+const TERMINAL_LIFECYCLE_OUTCOME_SET = new Set<string>(TERMINAL_LIFECYCLE_OUTCOMES);
+
+const TERMINAL_LIFECYCLE_ALIASES: Readonly<Record<string, TerminalLifecycleOutcome>> = {
+  finished: 'finished',
+  finish: 'finished',
+  complete: 'finished',
+  completed: 'finished',
+  done: 'finished',
+  blocked: 'blocked',
+  blocked_on_user: 'blocked',
+  'blocked-on-user': 'blocked',
+  failed: 'failed',
+  fail: 'failed',
+  error: 'failed',
+  userinterlude: 'userinterlude',
+  'user-interlude': 'userinterlude',
+  interrupted: 'userinterlude',
+  cancelled: 'userinterlude',
+  canceled: 'userinterlude',
+  cancel: 'userinterlude',
+  aborted: 'userinterlude',
+  abort: 'userinterlude',
+  askuserquestion: 'askuserQuestion',
+  'ask-user-question': 'askuserQuestion',
+  ask_user_question: 'askuserQuestion',
+  question: 'askuserQuestion',
+  omxquestion: 'askuserQuestion',
+  'omx-question': 'askuserQuestion',
+} as const;
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function normalizeTerminalLifecycleOutcome(value: unknown): TerminalLifecycleNormalizationResult {
+  const normalized = normalizeString(value);
+  if (!normalized) return {};
+  if (TERMINAL_LIFECYCLE_OUTCOME_SET.has(normalized)) {
+    return { outcome: normalized as TerminalLifecycleOutcome };
+  }
+  const alias = TERMINAL_LIFECYCLE_ALIASES[normalized.toLowerCase()];
+  if (alias) {
+    return {
+      outcome: alias,
+      warning: `normalized legacy lifecycle outcome "${value}" -> "${alias}"`,
+    };
+  }
+  return {
+    error: `lifecycle_outcome must be one of: ${TERMINAL_LIFECYCLE_OUTCOMES.join(', ')}`,
+  };
+}
+
+export function inferTerminalLifecycleOutcome(candidate: {
+  lifecycle_outcome?: unknown;
+  run_outcome?: unknown;
+}): TerminalLifecycleNormalizationResult {
+  const explicit = normalizeTerminalLifecycleOutcome(candidate.lifecycle_outcome);
+  if (explicit.outcome || explicit.error) return explicit;
+
+  const runOutcome = normalizeRunOutcome(candidate.run_outcome);
+  if (runOutcome.error) return { error: runOutcome.error };
+  switch (runOutcome.outcome) {
+    case 'finish':
+      return { outcome: 'finished' };
+    case 'blocked_on_user':
+      return { outcome: 'blocked' };
+    case 'failed':
+      return { outcome: 'failed' };
+    case 'cancelled':
+      return {
+        outcome: 'userinterlude',
+        warning: 'normalized legacy run outcome "cancelled" -> "userinterlude"',
+      };
+    default:
+      return {};
+  }
+}
+
+export function preferredRunOutcomeForLifecycleOutcome(
+  outcome: TerminalLifecycleOutcome,
+): RunOutcome {
+  switch (outcome) {
+    case 'finished':
+      return 'finish';
+    case 'blocked':
+      return 'blocked_on_user';
+    case 'failed':
+      return 'failed';
+    case 'userinterlude':
+      return 'cancelled';
+    case 'askuserQuestion':
+      return 'blocked_on_user';
+  }
+}


### PR DESCRIPTION
## Summary
Adds a canonical explicit-terminal lifecycle layer for OMX while preserving legacy `run_outcome` compatibility.

The new canonical lifecycle vocabulary is:
- `finished`
- `blocked`
- `failed`
- `userinterlude`
- `askuserQuestion`

## Problem statement
The current explicit run outcome contract still exposes legacy-oriented values (`finish`, `blocked_on_user`, `failed`, `cancelled`). That is useful for compatibility, but it does not cleanly model the newer user-facing stop semantics where successful completion, external blockers, user interruption, and model-initiated blocking questions are different lifecycle causes.

This ambiguity also made terminal handoff guidance easy to express as optional assistant prose instead of explicit lifecycle state.

## Root cause
The runtime had a shared `run_outcome` contract, but no separate canonical lifecycle metadata layer. As a result:
- `blocked_on_user` overloaded user wait, blockers, and question handling
- `cancelled` could leak as a user-facing terminal concept instead of staying internal/legacy
- deep-interview question enforcement did not persist a machine-readable `askuserQuestion` lifecycle outcome
- docs/tests did not lock a single cross-surface lifecycle vocabulary

## What changed
- Added canonical terminal lifecycle helpers and compatibility mapping in runtime code.
- Added `lifecycle_outcome` / `terminal_outcome` support to state writes while preserving compatible `run_outcome` backfills.
- Persisted `askuserQuestion` metadata for deep-interview structured question enforcement.
- Updated run loop/run state typing to understand canonical lifecycle metadata.
- Added explicit terminal stop contract documentation and prompt/state/hook documentation updates.
- Added docs/runtime/MCP/question regression coverage.

## Why this design
This uses a compatibility-layer migration instead of a big-bang rename.

That keeps existing persisted state and legacy `run_outcome` consumers working while allowing new code and docs to prefer the clearer lifecycle vocabulary. `cancelled` remains accepted as internal legacy/admin compatibility, but the canonical user-facing contract prefers `userinterlude` or another explicit lifecycle outcome.

## Overlap assessment
**Follow-up / adjacent to existing explicit-terminal architecture work.**

Related:
- Closes #1756
- Follows #1718, which introduced the broader core run contract direction.
- Adjacent to merged PRs #1741 and #1742, which hardened explicit run outcomes and watcher-side recovery around the older vocabulary.

This PR is not a duplicate because it adds the canonical lifecycle metadata layer and question/docs contract that distinguish `userinterlude` from `askuserQuestion`.

## Validation
- `npm run build`
- `node --test dist/runtime/__tests__/run-outcome.test.js dist/mcp/__tests__/state-server.test.js dist/question/__tests__/deep-interview.test.js dist/hooks/__tests__/explicit-terminal-stop-docs-contract.test.js dist/hooks/__tests__/explicit-terminal-stop-model-docs-contract.test.js`
- `npx biome lint src/hooks/__tests__/prompt-guidance-test-helpers.ts src/hooks/__tests__/explicit-terminal-stop-docs-contract.test.ts src/hooks/__tests__/explicit-terminal-stop-model-docs-contract.test.ts src/mcp/state-server.ts src/mcp/__tests__/state-server.test.ts src/question/deep-interview.ts src/question/__tests__/deep-interview.test.ts src/runtime/run-outcome.ts src/runtime/run-loop.ts src/runtime/run-state.ts src/runtime/terminal-lifecycle.ts`
- `npm run check:no-unused`

Known verification note from team execution: a broader explicit-terminal bundle that included `notify-fallback-watcher` remained red due to 5 pre-existing watcher failures unrelated to this PR scope.

## Risk / compatibility
- Moderate scope: runtime/state/question/docs surfaces are touched.
- Legacy `run_outcome` values remain accepted.
- `lifecycle_outcome` is preferred for canonical semantics; future PRs can migrate more Stop/fallback/team surfaces onto it.
- This PR does not complete the full watcher/Stop-hook migration.

## Files changed
Key files:
- `src/runtime/run-outcome.ts`
- `src/runtime/terminal-lifecycle.ts`
- `src/runtime/run-loop.ts`
- `src/runtime/run-state.ts`
- `src/mcp/state-server.ts`
- `src/question/deep-interview.ts`
- `docs/contracts/explicit-terminal-stop-model.md`
- `docs/STATE_MODEL.md`
- `docs/codex-native-hooks.md`
- `docs/prompt-guidance-contract.md`
- focused tests under `src/runtime/__tests__`, `src/mcp/__tests__`, `src/question/__tests__`, and `src/hooks/__tests__`
