### PR TITLE
Add canonical explicit-terminal lifecycle metadata for #1756

### DIFF
--- a/docs/STATE_MODEL.md
+++ b/docs/STATE_MODEL.md
@@ -26,6 +26,14 @@ Examples:
 
 These files determine whether a workflow mode is active, completed, cancelled, or failed.
 
+Terminal mode state now exposes two layers:
+
+- `explicit_terminal` — canonical explicit-terminal lifecycle metadata for newer readers.
+- `run_outcome` — legacy compatibility field retained for existing hooks, watchers, and state consumers.
+
+See `docs/contracts/explicit-terminal-lifecycle.md` for the canonical vocabulary
+and compatibility mapping.
+
 ### 2. `skill-active-state.json` — compatibility / visibility layer
 
 `skill-active-state.json` is still used as a compatibility surface for hooks/HUD/native messaging, but transition reconciliation should be driven from the shared transition/reconciliation helpers rather than re-deriving semantics ad hoc.

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -60,6 +60,19 @@ The approved OMX-native wiki backport keeps lifecycle ownership intentionally na
 - **PreCompact parity is intentionally deferred** in v1 unless a clearly OMX-native compaction seam exists.
 - **Routing should stay explicit**: prefer `$wiki` or task verbs like `wiki query` / `wiki add`, and avoid implicit bare `wiki` noun activation.
 
+## Explicit terminal compatibility
+
+OMX runtime/state surfaces now expose canonical terminal metadata through
+`explicit_terminal` while preserving legacy `run_outcome` compatibility.
+
+- Canonical statuses: `finished`, `blocked`, `failed`, `userinterlude`, `askuserQuestion`
+- Legacy compatibility remains: `finish`, `blocked_on_user`, `failed`, `cancelled`
+- `cancelled` remains a legacy/internal compatibility string; canonical docs
+  should prefer `userinterlude`
+- Deep-interview pending OMX question obligations persist the narrower
+  `deep_interview_question_lifecycle.status=askuserQuestion` contract without
+  forcing a big-bang migration of the whole mode state
+
 ## Combined workflow note
 
 Stop/continuation readers must interpret approved combined workflow state from

--- a/docs/contracts/explicit-terminal-lifecycle.md
+++ b/docs/contracts/explicit-terminal-lifecycle.md
@@ -1,0 +1,75 @@
+# Explicit Terminal Lifecycle Contract
+
+This document defines the first-pass canonical explicit-terminal vocabulary for
+OMX runtime/state/question surfaces.
+
+## Goal
+
+Expose one narrow metadata layer that can express the newer terminal semantics
+without breaking legacy `run_outcome` readers.
+
+Canonical metadata lives in `explicit_terminal`. Legacy compatibility remains in
+`run_outcome`.
+
+## Canonical statuses
+
+`explicit_terminal.status` may be one of:
+
+- `finished`
+- `blocked`
+- `failed`
+- `userinterlude`
+- `askuserQuestion`
+
+## Compatibility mapping
+
+The first pass is intentionally compatibility-first.
+
+| Canonical `explicit_terminal.status` | Legacy `run_outcome` | Meaning |
+| --- | --- | --- |
+| `finished` | `finish` | Successful terminal completion |
+| `blocked` | `blocked_on_user` | Terminal blocked state without claiming the blocker is a structured OMX question |
+| `failed` | `failed` | Terminal failure |
+| `userinterlude` | `cancelled` | User-originated interruption / interlude; `cancelled` remains the legacy compatibility string |
+| `askuserQuestion` | `blocked_on_user` | OMX is blocked on a model-originated structured question |
+
+## Contract rules
+
+1. `run_outcome` remains the compatibility field for brownfield readers.
+2. `explicit_terminal` is canonical only for terminal semantics.
+3. Non-terminal outcomes such as `continue` and `progress` must not carry
+   `explicit_terminal`.
+4. `explicit_terminal.status` and `run_outcome` must agree on the compatibility
+   mapping above.
+5. `cancelled` remains legacy/internal compatibility vocabulary in state files.
+   Cancelled remains legacy/internal compatibility vocabulary for brownfield readers.
+   User-facing canonical docs should prefer `userinterlude`.
+
+## State and MCP exposure
+
+`state_write` may accept:
+
+- legacy `run_outcome`
+- canonical `explicit_terminal`
+- both together, as long as they are compatible
+
+Persisted state should expose both fields for terminal states so newer and older
+consumers can coexist.
+
+## Deep-interview question lifecycle
+
+Deep-interview does not migrate its main mode state to `askuserQuestion`.
+Instead, it persists a narrow question-lifecycle compatibility surface:
+
+- pending OMX-owned question obligation -> `deep_interview_question_lifecycle.status=askuserQuestion`
+- satisfied question obligation -> `deep_interview_question_lifecycle.status=question_asked`
+- cleared/aborted/error obligation -> `deep_interview_question_lifecycle.status=userinterlude`
+
+This keeps the initial rollout narrow while still exposing the canonical
+question-vs-user-interruption distinction.
+
+## Out of scope
+
+- Replacing every legacy `run_outcome` consumer in one change
+- Redefining existing phase enums across Ralph/team/CLI
+- A broad Stop-hook or watcher lifecycle redesign

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -40,6 +40,10 @@ const templateAgents = readFileSync(
 	join(__dirname, "../../../templates/AGENTS.md"),
 	"utf-8",
 );
+const explicitTerminalContract = readFileSync(
+	join(__dirname, "../../../docs/contracts/explicit-terminal-lifecycle.md"),
+	"utf-8",
+);
 const rootAgentsPath = join(__dirname, "../../../AGENTS.md");
 const rootAgents = existsSync(rootAgentsPath)
 	? readProjectAgents(join(__dirname, "../../.."))
@@ -170,6 +174,21 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.doesNotMatch(
 			deepInterviewSkill,
 			/fall back to concise plain-text one-question turns/i,
+		);
+	});
+
+	it("documents canonical explicit terminal lifecycle vocabulary for deep-interview question persistence", () => {
+		assert.match(explicitTerminalContract, /askuserQuestion/);
+		assert.match(explicitTerminalContract, /userinterlude/);
+		assert.match(explicitTerminalContract, /cancelled remains legacy\/internal compatibility/i);
+		assert.match(explicitTerminalContract, /`cancelled` remains legacy\/internal compatibility/i);
+		assert.match(
+			explicitTerminalContract,
+			/deep_interview_question_lifecycle\.status=askuserQuestion/i,
+		);
+		assert.match(
+			explicitTerminalContract,
+			/deep_interview_question_lifecycle\.status=userinterlude/i,
 		);
 	});
 

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -190,6 +190,51 @@ describe('state-server directory initialization', () => {
       assert.equal(readBody.current_phase, 'deep-interview');
       assert.equal(readBody.current_focus, 'intent');
       assert.equal(readBody.threshold, 0.2);
+      assert.equal(readBody.run_outcome, 'continue');
+      assert.equal(readBody.explicit_terminal, undefined);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts canonical explicit_terminal writes and preserves legacy run_outcome compatibility', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-explicit-terminal-'));
+    try {
+      const writeResponse = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'deep-interview',
+            active: false,
+            explicit_terminal: 'askuserQuestion',
+          },
+        },
+      });
+
+      assert.equal(writeResponse.isError, undefined);
+
+      const readResponse = await handleStateToolCall({
+        params: {
+          name: 'state_read',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'deep-interview',
+          },
+        },
+      });
+
+      const readBody = JSON.parse(readResponse.content[0]?.text || '{}') as Record<string, unknown>;
+      assert.equal(readBody.active, false);
+      assert.equal(readBody.run_outcome, 'blocked_on_user');
+      assert.deepEqual(readBody.explicit_terminal, {
+        status: 'askuserQuestion',
+        legacy_run_outcome: 'blocked_on_user',
+      });
+      assert.equal(typeof readBody.completed_at, 'string');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -733,11 +778,16 @@ describe('state-server directory initialization', () => {
         completed_at?: string;
         auto_completed_reason?: string;
         run_outcome?: string;
+        explicit_terminal?: { status?: string; legacy_run_outcome?: string };
       };
       assert.equal(completed.active, false);
       assert.equal(completed.current_phase, 'completed');
       assert.equal(typeof completed.completed_at, 'string');
       assert.equal(completed.run_outcome, 'finish');
+      assert.deepEqual(completed.explicit_terminal, {
+        status: 'finished',
+        legacy_run_outcome: 'finish',
+      });
       assert.match(completed.auto_completed_reason || '', /mode transiting: deep-interview -> ralplan/);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -50,6 +50,7 @@ import {
 	LEGACY_TEAM_MCP_TOOLS,
 	buildLegacyTeamDeprecationHint,
 } from "../team/api-interop.js";
+import { applyRunOutcomeContract, EXPLICIT_TERMINAL_LIFECYCLE_STATUSES } from "../runtime/run-outcome.js";
 
 const SUPPORTED_MODES = [
 	"autopilot",
@@ -167,6 +168,31 @@ export function buildStateServerTools() {
 					run_outcome: {
 						type: "string",
 						enum: ["continue", "finish", "blocked_on_user", "failed", "cancelled"],
+					},
+					explicit_terminal: {
+						oneOf: [
+							{
+								type: "string",
+								enum: [...EXPLICIT_TERMINAL_LIFECYCLE_STATUSES],
+							},
+							{
+								type: "object",
+								properties: {
+									status: {
+										type: "string",
+										enum: [...EXPLICIT_TERMINAL_LIFECYCLE_STATUSES],
+									},
+									legacy_run_outcome: {
+										type: "string",
+										enum: ["finish", "blocked_on_user", "failed", "cancelled"],
+									},
+								},
+								required: ["status"],
+								additionalProperties: true,
+							},
+						],
+						description:
+							"Canonical explicit-terminal lifecycle metadata. Legacy run_outcome remains the compatibility surface.",
 					},
 					error: { type: "string" },
 					state: { type: "object", description: "Additional custom fields" },
@@ -374,6 +400,15 @@ export async function handleStateToolCall(request: {
 							...fields,
 							...((customState as Record<string, unknown>) || {}),
 						} as Record<string, unknown>;
+						const explicitRunOutcome =
+							Object.prototype.hasOwnProperty.call(fields, "run_outcome") ||
+							(
+								customState != null &&
+								Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, "run_outcome")
+							);
+						if (!explicitRunOutcome) {
+							delete mergedRaw.run_outcome;
+						}
 						if (
 							mode === "ralph" &&
 							effectiveSessionId &&
@@ -400,6 +435,14 @@ export async function handleStateToolCall(request: {
 							}
 							Object.assign(mergedRaw, validation.state);
 							ensureRalphArtifacts = true;
+						}
+						if (mode !== SKILL_ACTIVE_STATE_MODE) {
+							const runOutcomeValidation = applyRunOutcomeContract(mergedRaw);
+							if (!runOutcomeValidation.ok || !runOutcomeValidation.state) {
+								validationError = runOutcomeValidation.error || "Invalid run outcome state";
+								return;
+							}
+							Object.assign(mergedRaw, runOutcomeValidation.state);
 						}
 						if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
 							try {

--- a/src/question/__tests__/deep-interview.test.ts
+++ b/src/question/__tests__/deep-interview.test.ts
@@ -93,11 +93,19 @@ describe('runDeepInterviewQuestion', () => {
         question_id?: string;
         satisfied_at?: string;
       };
+      deep_interview_question_lifecycle?: {
+        status?: string;
+        legacy_run_outcome?: string;
+        question_id?: string;
+      };
     };
     assert.equal(finalState.question_enforcement?.status, 'satisfied');
     assert.equal(finalState.question_enforcement?.question_id, 'question-1');
     assert.ok(finalState.question_enforcement?.obligation_id);
     assert.ok(finalState.question_enforcement?.satisfied_at);
+    assert.equal(finalState.deep_interview_question_lifecycle?.status, 'question_asked');
+    assert.equal(finalState.deep_interview_question_lifecycle?.legacy_run_outcome, 'blocked_on_user');
+    assert.equal(finalState.deep_interview_question_lifecycle?.question_id, 'question-1');
   });
 
   it('clears the pending obligation when omx question fails after being attempted', async () => {
@@ -140,9 +148,19 @@ describe('runDeepInterviewQuestion', () => {
         clear_reason?: string;
         cleared_at?: string;
       };
+      deep_interview_question_lifecycle?: {
+        status?: string;
+        legacy_run_outcome?: string;
+        clear_reason?: string;
+        cleared_at?: string;
+      };
     };
     assert.equal(finalState.question_enforcement?.status, 'cleared');
     assert.equal(finalState.question_enforcement?.clear_reason, 'error');
     assert.ok(finalState.question_enforcement?.cleared_at);
+    assert.equal(finalState.deep_interview_question_lifecycle?.status, 'userinterlude');
+    assert.equal(finalState.deep_interview_question_lifecycle?.legacy_run_outcome, 'blocked_on_user');
+    assert.equal(finalState.deep_interview_question_lifecycle?.clear_reason, 'error');
+    assert.ok(finalState.deep_interview_question_lifecycle?.cleared_at);
   });
 });

--- a/src/question/deep-interview.ts
+++ b/src/question/deep-interview.ts
@@ -7,6 +7,7 @@ import {
   type OmxQuestionSuccessPayload,
 } from './client.js';
 import type { QuestionInput } from './types.js';
+import type { ExplicitTerminalLifecycle } from '../runtime/run-outcome.js';
 
 const DEEP_INTERVIEW_STATE_FILE = 'deep-interview-state.json';
 
@@ -21,9 +22,27 @@ export interface DeepInterviewQuestionEnforcementState {
   clear_reason?: 'handoff' | 'abort' | 'error';
 }
 
+type DeepInterviewQuestionLifecycleStatus =
+  | ExplicitTerminalLifecycle['status']
+  | 'question_asked';
+
+export interface DeepInterviewQuestionLifecycle {
+  status: DeepInterviewQuestionLifecycleStatus;
+  legacy_run_outcome: 'blocked_on_user';
+  obligation_id: string;
+  source: 'omx-question';
+  requested_at: string;
+  question_id?: string;
+  satisfied_at?: string;
+  cleared_at?: string;
+  clear_reason?: 'handoff' | 'abort' | 'error';
+}
+
 interface DeepInterviewStateRecord {
   updated_at?: string;
   question_enforcement?: DeepInterviewQuestionEnforcementState;
+  explicit_terminal?: ExplicitTerminalLifecycle;
+  deep_interview_question_lifecycle?: DeepInterviewQuestionLifecycle;
   [key: string]: unknown;
 }
 
@@ -66,6 +85,32 @@ export function createDeepInterviewQuestionObligation(
     status: 'pending',
     requested_at: now.toISOString(),
   };
+}
+
+function buildDeepInterviewQuestionLifecycle(
+  enforcement: DeepInterviewQuestionEnforcementState,
+): DeepInterviewQuestionLifecycle {
+  const lifecycle: DeepInterviewQuestionLifecycle = {
+    status: 'askuserQuestion',
+    legacy_run_outcome: 'blocked_on_user',
+    obligation_id: enforcement.obligation_id,
+    source: enforcement.source,
+    requested_at: enforcement.requested_at,
+  };
+
+  if (enforcement.status === 'satisfied') {
+    lifecycle.status = 'question_asked';
+    lifecycle.question_id = enforcement.question_id;
+    lifecycle.satisfied_at = enforcement.satisfied_at;
+  } else if (enforcement.status === 'cleared') {
+    lifecycle.status = 'userinterlude';
+    lifecycle.cleared_at = enforcement.cleared_at;
+    lifecycle.clear_reason = enforcement.clear_reason;
+    if (enforcement.question_id) lifecycle.question_id = enforcement.question_id;
+    if (enforcement.satisfied_at) lifecycle.satisfied_at = enforcement.satisfied_at;
+  }
+
+  return lifecycle;
 }
 
 export function isPendingDeepInterviewQuestionEnforcement(
@@ -120,10 +165,16 @@ export async function updateDeepInterviewQuestionEnforcement(
   const nextState: DeepInterviewStateRecord = {
     ...state,
     updated_at: new Date().toISOString(),
-    ...(nextEnforcement ? { question_enforcement: nextEnforcement } : {}),
+    ...(nextEnforcement
+      ? {
+        question_enforcement: nextEnforcement,
+        deep_interview_question_lifecycle: buildDeepInterviewQuestionLifecycle(nextEnforcement),
+      }
+      : {}),
   };
   if (!nextEnforcement) {
     delete nextState.question_enforcement;
+    delete nextState.deep_interview_question_lifecycle;
   }
 
   await writeDeepInterviewState(cwd, nextState, sessionId);

--- a/src/runtime/__tests__/run-outcome.test.ts
+++ b/src/runtime/__tests__/run-outcome.test.ts
@@ -3,8 +3,10 @@ import assert from 'node:assert/strict';
 
 import {
   applyRunOutcomeContract,
+  explicitTerminalLifecycleFromRunOutcome,
   inferRunOutcome,
   isTerminalRunOutcome,
+  normalizeExplicitTerminalLifecycle,
   normalizeRunOutcome,
 } from '../run-outcome.js';
 import { shouldContinueRun } from '../run-loop.js';
@@ -14,6 +16,20 @@ describe('run outcome contract', () => {
     assert.deepEqual(normalizeRunOutcome('completed'), {
       outcome: 'finish',
       warning: 'normalized legacy run outcome "completed" -> "finish"',
+    });
+  });
+
+  it('normalizes explicit terminal lifecycle aliases and preserves legacy compatibility mapping', () => {
+    assert.deepEqual(normalizeExplicitTerminalLifecycle('cancelled'), {
+      lifecycle: {
+        status: 'userinterlude',
+        legacy_run_outcome: 'cancelled',
+      },
+      warning: 'normalized explicit_terminal "cancelled" -> "userinterlude"',
+    });
+    assert.deepEqual(explicitTerminalLifecycleFromRunOutcome('blocked_on_user'), {
+      status: 'blocked',
+      legacy_run_outcome: 'blocked_on_user',
     });
   });
 
@@ -49,8 +65,36 @@ describe('run outcome contract', () => {
     assert.equal(result.ok, true);
     assert.equal(result.state?.active, false);
     assert.equal(result.state?.run_outcome, 'blocked_on_user');
+    assert.deepEqual(result.state?.explicit_terminal, {
+      status: 'blocked',
+      legacy_run_outcome: 'blocked_on_user',
+    });
     assert.equal(result.state?.completed_at, '2026-04-18T12:00:00.000Z');
     assert.equal(isTerminalRunOutcome(result.state?.run_outcome as never), true);
+  });
+
+  it('accepts askuserQuestion as canonical explicit terminal metadata while preserving blocked_on_user', () => {
+    const result = applyRunOutcomeContract({
+      active: false,
+      explicit_terminal: 'askuserQuestion',
+    }, { nowIso: '2026-04-18T13:00:00.000Z' });
+    assert.equal(result.ok, true);
+    assert.equal(result.state?.run_outcome, 'blocked_on_user');
+    assert.deepEqual(result.state?.explicit_terminal, {
+      status: 'askuserQuestion',
+      legacy_run_outcome: 'blocked_on_user',
+    });
+    assert.equal(result.state?.completed_at, '2026-04-18T13:00:00.000Z');
+  });
+
+  it('rejects contradictory explicit terminal and run_outcome pairs', () => {
+    const result = applyRunOutcomeContract({
+      active: false,
+      run_outcome: 'failed',
+      explicit_terminal: 'finished',
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error || '', /incompatible/i);
   });
 
   it('rejects contradictory terminal/active combinations', () => {

--- a/src/runtime/run-outcome.ts
+++ b/src/runtime/run-outcome.ts
@@ -19,9 +19,26 @@ export type TerminalRunOutcome = (typeof TERMINAL_RUN_OUTCOMES)[number];
 export type NonTerminalRunOutcome = (typeof NON_TERMINAL_RUN_OUTCOMES)[number];
 export type RunOutcome = (typeof RUN_OUTCOMES)[number];
 
+export const EXPLICIT_TERMINAL_LIFECYCLE_STATUSES = [
+  'finished',
+  'blocked',
+  'failed',
+  'userinterlude',
+  'askuserQuestion',
+] as const;
+
+export type ExplicitTerminalLifecycleStatus =
+  (typeof EXPLICIT_TERMINAL_LIFECYCLE_STATUSES)[number];
+
+export interface ExplicitTerminalLifecycle {
+  status: ExplicitTerminalLifecycleStatus;
+  legacy_run_outcome: TerminalRunOutcome;
+}
+
 const TERMINAL_RUN_OUTCOME_SET = new Set<string>(TERMINAL_RUN_OUTCOMES);
 const NON_TERMINAL_RUN_OUTCOME_SET = new Set<string>(NON_TERMINAL_RUN_OUTCOMES);
 const RUN_OUTCOME_SET = new Set<string>(RUN_OUTCOMES);
+const EXPLICIT_TERMINAL_LIFECYCLE_STATUS_SET = new Set<string>(EXPLICIT_TERMINAL_LIFECYCLE_STATUSES);
 
 const RUN_OUTCOME_ALIASES: Readonly<Record<string, RunOutcome>> = {
   finish: 'finish',
@@ -56,8 +73,56 @@ const TERMINAL_PHASE_TO_RUN_OUTCOME: Readonly<Record<string, TerminalRunOutcome>
   cancel: 'cancelled',
 };
 
+const EXPLICIT_TERMINAL_LIFECYCLE_ALIASES: Readonly<Record<string, ExplicitTerminalLifecycleStatus>> = {
+  finished: 'finished',
+  finish: 'finished',
+  complete: 'finished',
+  completed: 'finished',
+  done: 'finished',
+  blocked: 'blocked',
+  blocked_on_user: 'blocked',
+  'blocked-on-user': 'blocked',
+  failed: 'failed',
+  fail: 'failed',
+  error: 'failed',
+  userinterlude: 'userinterlude',
+  user_interlude: 'userinterlude',
+  'user-interlude': 'userinterlude',
+  cancelled: 'userinterlude',
+  canceled: 'userinterlude',
+  cancel: 'userinterlude',
+  aborted: 'userinterlude',
+  abort: 'userinterlude',
+  askuserquestion: 'askuserQuestion',
+  ask_user_question: 'askuserQuestion',
+  'ask-user-question': 'askuserQuestion',
+  omxquestion: 'askuserQuestion',
+  'omx-question': 'askuserQuestion',
+} as const;
+
+const EXPLICIT_TERMINAL_LIFECYCLE_TO_RUN_OUTCOME: Readonly<Record<ExplicitTerminalLifecycleStatus, TerminalRunOutcome>> = {
+  finished: 'finish',
+  blocked: 'blocked_on_user',
+  failed: 'failed',
+  userinterlude: 'cancelled',
+  askuserQuestion: 'blocked_on_user',
+} as const;
+
+const RUN_OUTCOME_TO_EXPLICIT_TERMINAL_LIFECYCLE: Readonly<Record<TerminalRunOutcome, ExplicitTerminalLifecycleStatus>> = {
+  finish: 'finished',
+  blocked_on_user: 'blocked',
+  failed: 'failed',
+  cancelled: 'userinterlude',
+} as const;
+
 export interface RunOutcomeNormalizationResult {
   outcome?: RunOutcome;
+  warning?: string;
+  error?: string;
+}
+
+export interface ExplicitTerminalLifecycleNormalizationResult {
+  lifecycle?: ExplicitTerminalLifecycle;
   warning?: string;
   error?: string;
 }
@@ -77,6 +142,23 @@ function safeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function normalizeExplicitTerminalLifecycleStatusValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function normalizeTerminalRunOutcome(
+  value: unknown,
+): { outcome?: TerminalRunOutcome; warning?: string; error?: string } {
+  const normalized = normalizeRunOutcome(value);
+  if (!normalized.outcome) {
+    return normalized.error ? { error: normalized.error } : {};
+  }
+  if (!isTerminalRunOutcome(normalized.outcome)) {
+    return { error: `explicit_terminal legacy_run_outcome must be terminal, got "${normalized.outcome}"` };
+  }
+  return { outcome: normalized.outcome, warning: normalized.warning };
+}
+
 export function normalizeRunOutcome(value: unknown): RunOutcomeNormalizationResult {
   const normalized = normalizeRunOutcomeValue(value);
   if (!normalized) return {};
@@ -91,6 +173,95 @@ export function normalizeRunOutcome(value: unknown): RunOutcomeNormalizationResu
     };
   }
   return { error: `run_outcome must be one of: ${RUN_OUTCOMES.join(', ')}` };
+}
+
+export function explicitTerminalLifecycleFromRunOutcome(
+  value: unknown,
+): ExplicitTerminalLifecycle | undefined {
+  const normalized = normalizeTerminalRunOutcome(value).outcome;
+  if (!normalized) return undefined;
+  return {
+    status: RUN_OUTCOME_TO_EXPLICIT_TERMINAL_LIFECYCLE[normalized],
+    legacy_run_outcome: normalized,
+  };
+}
+
+export function normalizeExplicitTerminalLifecycle(
+  value: unknown,
+): ExplicitTerminalLifecycleNormalizationResult {
+  if (value == null) return {};
+
+  if (typeof value === 'string') {
+    const normalized = normalizeExplicitTerminalLifecycleStatusValue(value);
+    if (!normalized) return {};
+    if (EXPLICIT_TERMINAL_LIFECYCLE_STATUS_SET.has(normalized)) {
+      const status = normalized as ExplicitTerminalLifecycleStatus;
+      return {
+        lifecycle: {
+          status,
+          legacy_run_outcome: EXPLICIT_TERMINAL_LIFECYCLE_TO_RUN_OUTCOME[status],
+        },
+      };
+    }
+    const alias = EXPLICIT_TERMINAL_LIFECYCLE_ALIASES[normalized];
+    if (alias) {
+      return {
+        lifecycle: {
+          status: alias,
+          legacy_run_outcome: EXPLICIT_TERMINAL_LIFECYCLE_TO_RUN_OUTCOME[alias],
+        },
+        warning: `normalized explicit_terminal "${value}" -> "${alias}"`,
+      };
+    }
+    return {
+      error: `explicit_terminal.status must be one of: ${EXPLICIT_TERMINAL_LIFECYCLE_STATUSES.join(', ')}`,
+    };
+  }
+
+  if (typeof value !== 'object') {
+    return {
+      error: `explicit_terminal must be a string or object with status/legacy_run_outcome`,
+    };
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const statusValue = candidate.status;
+  const legacyValue = candidate.legacy_run_outcome ?? candidate.run_outcome;
+
+  const normalizedStatus = normalizeExplicitTerminalLifecycle(statusValue);
+  const normalizedLegacy = normalizeTerminalRunOutcome(legacyValue);
+
+  if (normalizedStatus.error) return normalizedStatus;
+  if (normalizedLegacy.error) return normalizedLegacy;
+
+  const status = normalizedStatus.lifecycle?.status;
+  const legacyRunOutcome = normalizedLegacy.outcome;
+
+  if (!status && !legacyRunOutcome) return {};
+
+  const derivedLifecycle = status
+    ? {
+      status,
+      legacy_run_outcome: EXPLICIT_TERMINAL_LIFECYCLE_TO_RUN_OUTCOME[status],
+    }
+    : explicitTerminalLifecycleFromRunOutcome(legacyRunOutcome);
+
+  if (!derivedLifecycle) {
+    return {
+      error: `explicit_terminal must include status or legacy_run_outcome`,
+    };
+  }
+
+  if (legacyRunOutcome && derivedLifecycle.legacy_run_outcome !== legacyRunOutcome) {
+    return {
+      error: `explicit_terminal.status "${derivedLifecycle.status}" maps to legacy run_outcome "${derivedLifecycle.legacy_run_outcome}", not "${legacyRunOutcome}"`,
+    };
+  }
+
+  return {
+    lifecycle: derivedLifecycle,
+    warning: normalizedStatus.warning ?? normalizedLegacy.warning,
+  };
 }
 
 export function classifyRunOutcome(value: unknown): RunOutcome {
@@ -138,8 +309,14 @@ export function applyRunOutcomeContract(
   const next: Record<string, unknown> = { ...candidate };
   const normalized = normalizeRunOutcome(next.run_outcome);
   if (normalized.error) return { ok: false, error: normalized.error };
+  const normalizedExplicitTerminal = normalizeExplicitTerminalLifecycle(next.explicit_terminal);
+  if (normalizedExplicitTerminal.error) {
+    return { ok: false, error: normalizedExplicitTerminal.error };
+  }
 
-  const outcome = normalized.outcome ?? inferRunOutcome(next);
+  const outcome = normalized.outcome
+    ?? normalizedExplicitTerminal.lifecycle?.legacy_run_outcome
+    ?? inferRunOutcome(next);
   next.run_outcome = outcome;
 
   if (isTerminalRunOutcome(outcome)) {
@@ -160,9 +337,24 @@ export function applyRunOutcomeContract(
     }
   }
 
+  const explicitTerminal = normalizedExplicitTerminal.lifecycle
+    ?? explicitTerminalLifecycleFromRunOutcome(outcome);
+
+  if (explicitTerminal) {
+    if (isTerminalRunOutcome(outcome) && explicitTerminal.legacy_run_outcome !== outcome) {
+      return {
+        ok: false,
+        error: `explicit_terminal.status "${explicitTerminal.status}" is incompatible with run_outcome "${outcome}"`,
+      };
+    }
+    next.explicit_terminal = explicitTerminal;
+  } else {
+    delete next.explicit_terminal;
+  }
+
   return {
     ok: true,
     state: next,
-    warning: normalized.warning,
+    warning: normalized.warning ?? normalizedExplicitTerminal.warning,
   };
 }

--- a/src/runtime/run-state.ts
+++ b/src/runtime/run-state.ts
@@ -4,8 +4,10 @@ import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { getStateFilePath, resolveStateScope } from '../mcp/state-paths.js';
 import {
   classifyRunOutcome,
+  explicitTerminalLifecycleFromRunOutcome,
   isTerminalRunOutcome,
   normalizeRunOutcome,
+  type ExplicitTerminalLifecycle,
   type RunOutcome,
 } from './run-outcome.js';
 
@@ -32,6 +34,7 @@ export interface RunState {
   mode: string;
   active: boolean;
   outcome: RunOutcome;
+  explicit_terminal?: ExplicitTerminalLifecycle;
   updated_at: string;
   current_phase?: string;
   task_description?: string;
@@ -88,6 +91,8 @@ export function buildRunState(
     outcome,
     updated_at: nowIso,
   };
+  const explicitTerminal = explicitTerminalLifecycleFromRunOutcome(outcome);
+  if (explicitTerminal) next.explicit_terminal = explicitTerminal;
 
   const currentPhase = optionalString(state.current_phase);
   if (currentPhase) next.current_phase = currentPhase;


### PR DESCRIPTION
## Summary
- add shared explicit-terminal lifecycle normalization helpers on top of legacy `run_outcome`
- expose canonical terminal metadata through MCP state writes and run-state sync without breaking compatibility readers
- persist deep-interview question lifecycle metadata for `askuserQuestion` vs `userinterlude`, and lock the contract with docs/tests

## Testing
- `npm run build`
- `node --test dist/runtime/__tests__/run-outcome.test.js dist/question/__tests__/deep-interview.test.js dist/mcp/__tests__/state-server.test.js dist/hooks/__tests__/deep-interview-contract.test.js`

## Notes
- keeps `run_outcome` as the brownfield compatibility field
- keeps the rollout narrow and avoids a big-bang migration of watcher/Stop-hook consumers
