### PR TITLE
Fix MCP duplicate-sibling watchdog self-kill in multi-window

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -203,51 +203,17 @@ describe('mcp duplicate sibling detection', () => {
       newerSiblingPids: [140],
     };
 
-    // Well within the 5-minute post-traffic idle window — must stay alive.
     assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 35_000, 1_000, 10_000),
       false,
     );
     assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 40_500, 1_000, 10_000),
-      false,
-    );
-  });
-
-  it('self-exits after traffic once the post-traffic idle window elapses', () => {
-    const observation = {
-      status: 'older_duplicate' as const,
-      entrypoint: 'state-server.js',
-      matchingPids: [101, 140],
-      newerSiblingPids: [140],
-    };
-
-    // lastTraffic=10_000, duplicateObserved=1_000, now=311_000
-    // idle since lastTraffic: 301_000 ms (> 300_000 ms default)
-    // idle since duplicateObserved: 310_000 ms (> 300_000 ms)
-    assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 311_000, 1_000, 10_000),
-      true,
-    );
-  });
-
-  it('stays alive when post-traffic idle window has not fully elapsed', () => {
-    const observation = {
-      status: 'older_duplicate' as const,
-      entrypoint: 'state-server.js',
-      matchingPids: [101, 140],
-      newerSiblingPids: [140],
-    };
-
-    // lastTraffic=10_000, duplicateObserved=1_000, now=309_000
-    // idle since lastTraffic: 299_000 ms (< 300_000 ms default)
-    assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 309_000, 1_000, 10_000),
       false,
     );
   });
 
-  it('uses the later of lastTraffic and duplicateObserved as the idle anchor', () => {
+  it('never self-exits after traffic even after a long idle window', () => {
     const observation = {
       status: 'older_duplicate' as const,
       entrypoint: 'state-server.js',
@@ -255,17 +221,27 @@ describe('mcp duplicate sibling detection', () => {
       newerSiblingPids: [140],
     };
 
-    // duplicateObserved=200_000 (later than lastTraffic=10_000)
-    // idle anchor = max(10_000, 200_000) = 200_000
-    // now=499_000 → idle since anchor: 299_000 ms (< 300_000 ms)
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 600_000, 1_000, 10_000),
+      false,
+    );
+  });
+
+  it('treats any observed client traffic as a do-not-self-kill marker', () => {
+    const observation = {
+      status: 'older_duplicate' as const,
+      entrypoint: 'state-server.js',
+      matchingPids: [101, 140],
+      newerSiblingPids: [140],
+    };
+
     assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 499_000, 200_000, 10_000),
       false,
     );
-    // now=501_000 → idle since anchor: 301_000 ms (> 300_000 ms)
     assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 501_000, 200_000, 10_000),
-      true,
+      shouldSelfExitForDuplicateSibling(observation, 900_000, 200_000, 200_001),
+      false,
     );
   });
 

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -16,7 +16,6 @@ const LIFECYCLE_DEBUG_ENV = 'OMX_MCP_TRANSPORT_DEBUG';
 const PARENT_WATCHDOG_INTERVAL_MS = 25;
 const DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
 const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
-const DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS = 300_000;
 const MCP_ENTRYPOINT_PATTERN = /\b([a-z0-9-]+-server\.(?:[cm]?js|ts))\b/i;
 
 interface StdioLifecycleServer {
@@ -159,7 +158,6 @@ export function shouldSelfExitForDuplicateSibling(
   duplicateObservedAtMs: number | null,
   lastTrafficAtMs: number | null,
   preTrafficGraceMs = DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS,
-  postTrafficIdleMs = DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
 ): boolean {
   if (observation.status !== 'older_duplicate') {
     return false;
@@ -171,13 +169,7 @@ export function shouldSelfExitForDuplicateSibling(
   if (lastTrafficAtMs === null) {
     return nowMs - duplicateObservedAtMs >= preTrafficGraceMs;
   }
-
-  if (!Number.isFinite(lastTrafficAtMs) || lastTrafficAtMs > nowMs) {
-    return false;
-  }
-
-  const safeIdleAnchorMs = Math.max(lastTrafficAtMs, duplicateObservedAtMs);
-  return nowMs - safeIdleAnchorMs >= postTrafficIdleMs;
+  return false;
 }
 
 export function isParentProcessAlive(
@@ -266,10 +258,7 @@ export function autoStartStdioMcpServer(
         return;
       }
 
-      const reason = lastTrafficAtMs === null
-        ? 'superseded_duplicate_before_traffic'
-        : 'superseded_duplicate_idle';
-      void shutdown(reason);
+      void shutdown('superseded_duplicate_before_traffic');
     }, DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS)
     : null;
   duplicateSiblingWatchdog?.unref();


### PR DESCRIPTION
## Summary
- stop the duplicate-sibling watchdog from self-exiting once an MCP server has seen client traffic
- keep the existing parent-loss and stdin/transport shutdown paths for orphan prevention and normal teardown
- tighten regression coverage around the post-traffic sibling case that Codex Desktop multi-window triggers

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/bootstrap.test.js dist/mcp/__tests__/server-lifecycle.test.js`
- `npx biome lint src/mcp/bootstrap.ts src/mcp/__tests__/bootstrap.test.ts`

## Notes
- this is the minimal fix: shared-parent duplicate self-exit is still allowed before any client traffic, but never after traffic because shared parent + entrypoint is not a strong enough ownership signal under Desktop multi-window