### PR TITLE
Fix codex-native-hook main-module guard for space-containing paths

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { buildManagedCodexHooksConfig } from "../../config/codex-hooks.js";
 import {
@@ -14,6 +15,7 @@ import {
 } from "../../team/state.js";
 import {
   dispatchCodexNativeHook,
+  isCodexNativeHookMainModule,
   mapCodexHookEventToOmxEvent,
   resolveSessionOwnerPidFromAncestry,
 } from "../codex-native-hook.js";
@@ -143,6 +145,25 @@ describe("codex native hook config", () => {
 });
 
 describe("codex native hook dispatch", () => {
+  it("treats space-containing argv entry paths as the main module", () => {
+    const entryPath = "/tmp/omx native/codex-native-hook.js";
+
+    assert.equal(
+      isCodexNativeHookMainModule(pathToFileURL(entryPath).href, entryPath),
+      true,
+    );
+  });
+
+  it("does not treat a different module url as the main module", () => {
+    assert.equal(
+      isCodexNativeHookMainModule(
+        pathToFileURL("/tmp/omx native/other-script.js").href,
+        "/tmp/omx native/codex-native-hook.js",
+      ),
+      false,
+    );
+  });
+
   it("emits deterministic JSON stdout when CLI stdin is malformed", () => {
     const stdout = execFileSync(
       process.execPath,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { join, resolve } from "path";
+import { pathToFileURL } from "url";
 import { readModeState, readModeStateForSession, updateModeState } from "../modes/base.js";
 import {
   listActiveSkills,
@@ -1742,6 +1743,14 @@ interface NativeHookCliReadResult {
   parseError: Error | null;
 }
 
+export function isCodexNativeHookMainModule(
+  moduleUrl: string,
+  argv1: string | undefined,
+): boolean {
+  if (!argv1) return false;
+  return moduleUrl === pathToFileURL(argv1).href;
+}
+
 async function readStdinJson(): Promise<NativeHookCliReadResult> {
   const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) {
@@ -1786,7 +1795,7 @@ export async function runCodexNativeHookCli(): Promise<void> {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isCodexNativeHookMainModule(import.meta.url, process.argv[1])) {
   runCodexNativeHookCli().catch((error) => {
     process.stderr.write(
       `[omx] codex-native-hook failed: ${


### PR DESCRIPTION
Summary
- normalize the codex-native-hook CLI main-module guard with pathToFileURL(process.argv[1]).href
- keep the change narrow by isolating the comparison in a helper
- add regression tests covering a space-containing entry path and a mismatched-url control

Verification
- passed: npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts
- passed: npx tsc --noEmit --pretty false --project tsconfig.json
- passed: node --test dist/scripts/__tests__/codex-native-hook.test.js
- passed: npm run test:recent-bug-regressions:compiled

Notes
- node_modules/@types/node was missing in this worktree, so npm install was required before build and typecheck verification.