### PR TITLE
Use Codex-safe C-m submits for omx question answer injection

### DIFF
--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -97,8 +97,9 @@ describe('question answer injection', () => {
     );
   });
 
-  it('injects the answered text back into the requester pane and submits separately', () => {
+  it('injects the answered text back into the requester pane and submits with isolated double C-m', () => {
     const calls: string[][] = [];
+    const sleeps: number[] = [];
     const ok = injectQuestionAnswerToPane(
       '%11',
       {
@@ -111,14 +112,18 @@ describe('question answer injection', () => {
         calls.push(args);
         return '';
       },
+      (ms) => {
+        sleeps.push(ms);
+      },
     );
 
     assert.equal(ok, true);
     assert.deepEqual(calls, [
       ['send-keys', '-t', '%11', '-l', '--', '[omx question answered] proceed'],
-      ['send-keys', '-t', '%11', 'Enter'],
-      ['send-keys', '-t', '%11', 'Enter'],
-      ['send-keys', '-t', '%11', 'Enter'],
+      ['send-keys', '-t', '%11', 'C-m'],
+      ['send-keys', '-t', '%11', 'C-m'],
     ]);
+    assert.deepEqual(sleeps, [120, 100]);
+    assert.equal(calls.some((argv) => argv.includes('Enter')), false);
   });
 });

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { basename } from 'node:path';
 import { parsePaneIdFromTmuxOutput, shellEscapeSingle } from '../hud/tmux.js';
+import { sleepSync } from '../utils/sleep.js';
 import { sanitizeReplyInput } from '../notifications/reply-listener.js';
 import { getCurrentTmuxPaneId } from '../notifications/tmux.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
@@ -18,6 +19,10 @@ export interface LaunchQuestionRendererOptions {
 }
 
 export type ExecTmuxSync = (args: string[]) => string;
+export type SleepSync = (ms: number) => void;
+
+const QUESTION_TEXT_SETTLE_MS = 120;
+const QUESTION_SUBMIT_REPEAT_DELAY_MS = 100;
 
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
@@ -76,15 +81,19 @@ export function injectQuestionAnswerToPane(
   paneId: string,
   answer: QuestionAnswer,
   execTmux: ExecTmuxSync = defaultExecTmux,
+  sleepImpl: SleepSync = sleepSync,
 ): boolean {
   if (!isPaneId(paneId)) return false;
   const text = formatQuestionAnswerForInjection(answer);
   if (!text) return false;
 
   execTmux(['send-keys', '-t', paneId, '-l', '--', text]);
-  execTmux(['send-keys', '-t', paneId, 'Enter']);
-  execTmux(['send-keys', '-t', paneId, 'Enter']);
-  execTmux(['send-keys', '-t', paneId, 'Enter']);
+  // Match the repo-standard Codex raw-mode submit sequence: let literal text
+  // settle, then send isolated C-m submits rather than Enter key names.
+  sleepImpl(QUESTION_TEXT_SETTLE_MS);
+  execTmux(['send-keys', '-t', paneId, 'C-m']);
+  sleepImpl(QUESTION_SUBMIT_REPEAT_DELAY_MS);
+  execTmux(['send-keys', '-t', paneId, 'C-m']);
   return true;
 }
 


### PR DESCRIPTION
## Summary
- switch `omx question` answer injection from `Enter` key names to isolated double `C-m`
- add the same settle delays OMX already uses for other Codex tmux submit paths
- update renderer tests to lock the Codex-safe submit contract

## Why
Deep-interview answers are injected back into the requesting Codex pane via tmux. That path was still using `Enter` key names while other OMX Codex submit paths already use isolated `C-m` because Codex panes run in raw input mode. When the submit key translation goes wrong, the text lands in the chat box but does not send.

This keeps the fix narrow: the question flow and state model stay the same, but the return-to-pane submit behavior now matches the repo-standard Codex-safe tmux contract.

## Verification
- `npm run build`
- `node --test dist/question/__tests__/renderer.test.js dist/question/__tests__/ui.test.js dist/cli/__tests__/question.test.js`