### PR TITLE
Fix prompt-seeded Ralph status from looking like a live run

### DIFF
--- a/src/notifications/__tests__/session-status.test.ts
+++ b/src/notifications/__tests__/session-status.test.ts
@@ -53,6 +53,14 @@ describe('session-status helper', () => {
         updated_at: '2026-03-20T00:04:30.000Z',
         session_id: 'sess-1',
       });
+      await writeJson(join(wd, '.omx', 'state', 'sessions', 'sess-1', 'run-state.json'), {
+        version: 1,
+        mode: 'ralph',
+        active: true,
+        outcome: 'continue',
+        current_phase: 'executing',
+        updated_at: '2026-03-20T00:04:30.000Z',
+      });
 
       let tracking = createSubagentTrackingState();
       for (const [threadId, turnId] of [
@@ -84,6 +92,31 @@ describe('session-status helper', () => {
       assert.match(status, /Updated: 2026-03-20T00:04:30.000Z/);
       assert.match(status, /Freshness: Fresh/);
       assert.match(status, /Subagents: 4 active \(a1b2c3, d4e5f6, g7h8i9, \+1 more\)/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not report prompt-seeded ralph skill-active state as running without a live run-state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-session-status-prompt-seeded-'));
+    try {
+      await writeSessionStart(wd, 'sess-seeded', { nativeSessionId: 'native-seeded' });
+      await writeJson(join(wd, '.omx', 'state', 'sessions', 'sess-seeded', 'skill-active-state.json'), {
+        active: true,
+        skill: 'ralph',
+        phase: 'planning',
+        updated_at: '2026-03-20T00:04:30.000Z',
+        session_id: 'sess-seeded',
+      });
+
+      const status = await buildDiscordSessionStatusReply(createMapping(wd, 'sess-seeded'), {
+        now: '2026-03-20T00:05:00.000Z',
+      });
+
+      assert.match(status, /Session: sess-seeded/);
+      assert.match(status, /Native: native-seeded/);
+      assert.match(status, /State: running$/m);
+      assert.doesNotMatch(status, /ralph\/planning/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/notifications/session-status.ts
+++ b/src/notifications/session-status.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isSessionStateUsable, readSessionState, readUsableSessionState } from '../hooks/session.js';
 import { getSkillActiveStatePaths, listActiveSkills, readSkillActiveState } from '../state/skill-active.js';
+import { readRunState } from '../runtime/run-state.js';
 import {
   readSubagentSessionSummary,
   type SubagentSessionSummary,
@@ -37,6 +38,7 @@ export interface SessionStatusDeps {
   readSubagentSessionSummaryImpl?: typeof readSubagentSessionSummary;
   getSkillActiveStatePathsImpl?: typeof getSkillActiveStatePaths;
   readSkillActiveStateImpl?: typeof readSkillActiveState;
+  readRunStateImpl?: typeof readRunState;
 }
 
 export function isDiscordStatusCommand(input: string): boolean {
@@ -84,12 +86,13 @@ async function readRelevantSkillState(
   sessionId: string,
   deps: Pick<
     SessionStatusDeps,
-    'existsSyncImpl' | 'getSkillActiveStatePathsImpl' | 'readSkillActiveStateImpl'
+    'existsSyncImpl' | 'getSkillActiveStatePathsImpl' | 'readSkillActiveStateImpl' | 'readRunStateImpl'
   >,
 ): Promise<SkillStateSummary | null> {
   const existsSyncImpl = deps.existsSyncImpl ?? existsSync;
   const getSkillActiveStatePathsImpl = deps.getSkillActiveStatePathsImpl ?? getSkillActiveStatePaths;
   const readSkillActiveStateImpl = deps.readSkillActiveStateImpl ?? readSkillActiveState;
+  const readRunStateImpl = deps.readRunStateImpl ?? readRunState;
   const { rootPath, sessionPath } = getSkillActiveStatePathsImpl(projectPath, sessionId);
   const candidatePaths = [sessionPath, rootPath].filter((value): value is string => typeof value === 'string');
 
@@ -107,10 +110,19 @@ async function readRelevantSkillState(
     const skill = primary?.skill || (typeof state.skill === 'string' ? state.skill.trim() : '');
     const phase = primary?.phase || (typeof state.phase === 'string' ? state.phase.trim() : '');
     const updatedAt = typeof state.updated_at === 'string' ? state.updated_at.trim() : '';
+    const runState = skill ? await readRunStateImpl(projectPath, sessionId) : null;
+    const hasDurableRuntime = Boolean(
+      skill
+      && runState?.active === true
+      && typeof runState.mode === 'string'
+      && runState.mode.trim() === skill,
+    );
 
     return {
-      ...(skill ? { skill } : {}),
-      ...(phase ? { phase } : {}),
+      ...(hasDurableRuntime && skill ? { skill } : {}),
+      ...(hasDurableRuntime
+        ? { phase: (runState?.current_phase?.trim() || phase || undefined) }
+        : {}),
       ...(updatedAt ? { updatedAt } : {}),
     };
   }


### PR DESCRIPTION
## Summary
- require a matching active run-state before session-status reports workflow/phase labels from skill-active
- keep the running session summary, but stop labeling prompt-seeded `$ralph` planning state as durable active execution
- add a regression test for prompt-seeded Ralph without a live run-state

## Testing
- npm run build && node --test dist/notifications/__tests__/session-status.test.js

Fixes #1765