### PR TITLE
Prevent foreign session skill-active fallback from leaking into status reads

### DIFF
--- a/src/notifications/__tests__/session-status.test.ts
+++ b/src/notifications/__tests__/session-status.test.ts
@@ -53,6 +53,14 @@ describe('session-status helper', () => {
         updated_at: '2026-03-20T00:04:30.000Z',
         session_id: 'sess-1',
       });
+      await writeJson(join(wd, '.omx', 'state', 'sessions', 'sess-1', 'run-state.json'), {
+        version: 1,
+        mode: 'ralph',
+        active: true,
+        outcome: 'continue',
+        current_phase: 'executing',
+        updated_at: '2026-03-20T00:04:30.000Z',
+      });
 
       let tracking = createSubagentTrackingState();
       for (const [threadId, turnId] of [
@@ -84,6 +92,31 @@ describe('session-status helper', () => {
       assert.match(status, /Updated: 2026-03-20T00:04:30.000Z/);
       assert.match(status, /Freshness: Fresh/);
       assert.match(status, /Subagents: 4 active \(a1b2c3, d4e5f6, g7h8i9, \+1 more\)/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not report prompt-seeded ralph skill-active state as running without a live run-state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-session-status-prompt-seeded-'));
+    try {
+      await writeSessionStart(wd, 'sess-seeded', { nativeSessionId: 'native-seeded' });
+      await writeJson(join(wd, '.omx', 'state', 'sessions', 'sess-seeded', 'skill-active-state.json'), {
+        active: true,
+        skill: 'ralph',
+        phase: 'planning',
+        updated_at: '2026-03-20T00:04:30.000Z',
+        session_id: 'sess-seeded',
+      });
+
+      const status = await buildDiscordSessionStatusReply(createMapping(wd, 'sess-seeded'), {
+        now: '2026-03-20T00:05:00.000Z',
+      });
+
+      assert.match(status, /Session: sess-seeded/);
+      assert.match(status, /Native: native-seeded/);
+      assert.match(status, /State: running$/m);
+      assert.doesNotMatch(status, /ralph\/planning/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/notifications/__tests__/session-status.test.ts
+++ b/src/notifications/__tests__/session-status.test.ts
@@ -182,4 +182,68 @@ describe('session-status helper', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('filters root skill-active fallback to entries visible to the requested session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-session-status-foreign-root-'));
+    try {
+      await writeJson(join(wd, '.omx', 'state', 'skill-active-state.json'), {
+        active: true,
+        skill: 'team',
+        phase: 'running',
+        updated_at: '2026-03-20T00:04:30.000Z',
+        active_skills: [
+          {
+            skill: 'ralph',
+            phase: 'executing',
+            active: true,
+            session_id: 'sess-foreign',
+            updated_at: '2026-03-20T00:04:30.000Z',
+          },
+          {
+            skill: 'team',
+            phase: 'running',
+            active: true,
+            updated_at: '2026-03-20T00:04:30.000Z',
+          },
+        ],
+      });
+
+      const status = await buildDiscordSessionStatusReply(createMapping(wd, 'sess-main'), {
+        now: '2026-03-20T00:05:00.000Z',
+      });
+
+      assert.match(status, /State: team\/running/);
+      assert.doesNotMatch(status, /ralph\/executing/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores root skill-active fallback when all active entries belong to another session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-session-status-root-only-foreign-'));
+    try {
+      await writeJson(join(wd, '.omx', 'state', 'skill-active-state.json'), {
+        active: true,
+        skill: 'ralph',
+        phase: 'executing',
+        updated_at: '2026-03-20T00:04:30.000Z',
+        active_skills: [{
+          skill: 'ralph',
+          phase: 'executing',
+          active: true,
+          session_id: 'sess-foreign',
+          updated_at: '2026-03-20T00:04:30.000Z',
+        }],
+      });
+
+      const status = await buildDiscordSessionStatusReply(createMapping(wd, 'sess-main'), {
+        now: '2026-03-20T00:05:00.000Z',
+      });
+
+      assert.equal(status, STATUS_DATA_UNAVAILABLE_MESSAGE);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/notifications/session-status.ts
+++ b/src/notifications/session-status.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isSessionStateUsable, readSessionState, readUsableSessionState } from '../hooks/session.js';
 import { getSkillActiveStatePaths, listActiveSkills, readSkillActiveState } from '../state/skill-active.js';
+import { readRunState } from '../runtime/run-state.js';
 import {
   readSubagentSessionSummary,
   type SubagentSessionSummary,
@@ -37,6 +38,7 @@ export interface SessionStatusDeps {
   readSubagentSessionSummaryImpl?: typeof readSubagentSessionSummary;
   getSkillActiveStatePathsImpl?: typeof getSkillActiveStatePaths;
   readSkillActiveStateImpl?: typeof readSkillActiveState;
+  readRunStateImpl?: typeof readRunState;
 }
 
 export function isDiscordStatusCommand(input: string): boolean {
@@ -84,12 +86,13 @@ async function readRelevantSkillState(
   sessionId: string,
   deps: Pick<
     SessionStatusDeps,
-    'existsSyncImpl' | 'getSkillActiveStatePathsImpl' | 'readSkillActiveStateImpl'
+    'existsSyncImpl' | 'getSkillActiveStatePathsImpl' | 'readSkillActiveStateImpl' | 'readRunStateImpl'
   >,
 ): Promise<SkillStateSummary | null> {
   const existsSyncImpl = deps.existsSyncImpl ?? existsSync;
   const getSkillActiveStatePathsImpl = deps.getSkillActiveStatePathsImpl ?? getSkillActiveStatePaths;
   const readSkillActiveStateImpl = deps.readSkillActiveStateImpl ?? readSkillActiveState;
+  const readRunStateImpl = deps.readRunStateImpl ?? readRunState;
   const { rootPath, sessionPath } = getSkillActiveStatePathsImpl(projectPath, sessionId);
   const candidatePaths = [sessionPath, rootPath].filter((value): value is string => typeof value === 'string');
 
@@ -116,10 +119,19 @@ async function readRelevantSkillState(
     const skill = primary?.skill || (typeof state.skill === 'string' ? state.skill.trim() : '');
     const phase = primary?.phase || (typeof state.phase === 'string' ? state.phase.trim() : '');
     const updatedAt = typeof state.updated_at === 'string' ? state.updated_at.trim() : '';
+    const requiresDurableRuntime = candidatePath === sessionPath && skill.length > 0;
+    const runState = requiresDurableRuntime ? await readRunStateImpl(projectPath, sessionId) : null;
+    const hasDurableRuntime = !requiresDurableRuntime || (
+      runState?.active === true
+      && typeof runState.mode === 'string'
+      && runState.mode.trim() === skill
+    );
 
     return {
-      ...(skill ? { skill } : {}),
-      ...(phase ? { phase } : {}),
+      ...(hasDurableRuntime && skill ? { skill } : {}),
+      ...(hasDurableRuntime
+        ? { phase: (runState?.current_phase?.trim() || phase || undefined) }
+        : {}),
       ...(updatedAt ? { updatedAt } : {}),
     };
   }

--- a/src/notifications/session-status.ts
+++ b/src/notifications/session-status.ts
@@ -99,11 +99,20 @@ async function readRelevantSkillState(
     if (!state) continue;
 
     const stateSessionId = typeof state.session_id === 'string' ? state.session_id.trim() : '';
-    if (candidatePath === rootPath && stateSessionId && stateSessionId !== sessionId) {
+    const entries = listActiveSkills(state);
+    const visibleEntries = entries.filter((entry) => {
+      const entrySessionId = typeof entry.session_id === 'string' ? entry.session_id.trim() : '';
+      return entrySessionId.length === 0 || entrySessionId === sessionId;
+    });
+
+    if (candidatePath === rootPath && (
+      (stateSessionId && stateSessionId !== sessionId)
+      || (entries.length > 0 && visibleEntries.length === 0)
+    )) {
       continue;
     }
 
-    const primary = listActiveSkills(state)[0];
+    const primary = visibleEntries[0];
     const skill = primary?.skill || (typeof state.skill === 'string' ? state.skill.trim() : '');
     const phase = primary?.phase || (typeof state.phase === 'string' ? state.phase.trim() : '');
     const updatedAt = typeof state.updated_at === 'string' ? state.updated_at.trim() : '';


### PR DESCRIPTION
## Summary
- filter root `skill-active-state.json` fallback entries by the requested session before exposing workflow status
- keep globally visible entries usable while ignoring foreign-session-only active skill rows
- add regressions for mixed visible/foreign root entries and foreign-only root fallback

## Testing
- npm run build && npx biome lint src/notifications/session-status.ts src/notifications/__tests__/session-status.test.ts && node --test dist/notifications/__tests__/session-status.test.js dist/state/__tests__/skill-active.test.js

Fixes #1766