### PR TITLE
Make install/update setup smoother and lower seeded context defaults

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -254,8 +254,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
         config,
         /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/m,
       );
-      assert.match(config, /^model_context_window = 1000000$/m);
-      assert.match(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(config, /^model_context_window = 250000$/m);
+      assert.match(config, /^model_auto_compact_token_limit = 200000$/m);
       assert.match(config, /^# End oh-my-codex seeded behavioral defaults$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -280,8 +280,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
       assert.match(config, /^model = "gpt-5\.3-codex"$/m);
       assert.doesNotMatch(config, /^model = "gpt-5\.4"$/m);
-      assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
-      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.doesNotMatch(config, /^model_context_window = 250000$/m);
+      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 200000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -302,8 +302,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
       assert.match(config, /^model = "gpt-5\.3-codex"$/m);
       assert.doesNotMatch(config, /^model = "gpt-5\.4"$/m);
-      assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
-      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.doesNotMatch(config, /^model_context_window = 250000$/m);
+      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 200000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -115,8 +115,8 @@ function buildConfigWithSeededModelContext(): string {
     'developer_instructions = "You have oh-my-codex installed."',
     'model = "gpt-5.4"',
     '# oh-my-codex seeded behavioral defaults (uninstall removes unchanged defaults)',
-    'model_context_window = 1000000',
-    'model_auto_compact_token_limit = 900000',
+    'model_context_window = 250000',
+    'model_auto_compact_token_limit = 200000',
     '# End oh-my-codex seeded behavioral defaults',
     '',
     '[features]',
@@ -149,7 +149,7 @@ function buildConfigWithEditedSeededModelContext(): string {
     'model = "gpt-5.4"',
     '# oh-my-codex seeded behavioral defaults (uninstall removes unchanged defaults)',
     'model_context_window = 123456',
-    'model_auto_compact_token_limit = 900000',
+    'model_auto_compact_token_limit = 200000',
     '# End oh-my-codex seeded behavioral defaults',
     '',
     '[features]',
@@ -390,8 +390,8 @@ describe('omx uninstall', () => {
 
       const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
       assert.match(config, /^model = "gpt-5\.4"$/m);
-      assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
-      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.doesNotMatch(config, /^model_context_window = 250000$/m);
+      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 200000$/m);
       assert.doesNotMatch(config, /seeded behavioral defaults/);
       assert.doesNotMatch(config, /notify\s*=/);
       assert.doesNotMatch(config, /model_reasoning_effort\s*=/);
@@ -417,7 +417,7 @@ describe('omx uninstall', () => {
       const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
       assert.match(config, /^model = "gpt-5\.4"$/m);
       assert.match(config, /^model_context_window = 123456$/m);
-      assert.match(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(config, /^model_auto_compact_token_limit = 200000$/m);
       assert.doesNotMatch(config, /seeded behavioral defaults/);
       assert.doesNotMatch(config, /notify\s*=/);
       assert.doesNotMatch(config, /model_reasoning_effort\s*=/);

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -455,15 +455,15 @@ describe("config generator idempotency (#384)", () => {
         toml,
         /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/m,
       );
-      assert.match(toml, /^model_context_window = 1000000$/m);
-      assert.match(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^model_context_window = 250000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
       assert.match(toml, /^# End oh-my-codex seeded behavioral defaults$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it("can override gpt-5.3-codex to gpt-5.4 and seed 1M context defaults", async () => {
+  it("can override gpt-5.3-codex to gpt-5.4 and seed 250k context defaults", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
       const toml = buildMergedConfig('model = \"gpt-5.3-codex\"\n', wd, {
@@ -476,14 +476,14 @@ describe("config generator idempotency (#384)", () => {
         toml,
         /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/m,
       );
-      assert.match(toml, /^model_context_window = 1000000$/m);
-      assert.match(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^model_context_window = 250000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
       assert.match(toml, /^# End oh-my-codex seeded behavioral defaults$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
-  it("does not seed 1M context defaults for non-gpt-5.4 models", async () => {
+  it("does not seed 250k context defaults for non-gpt-5.4 models", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
       const configPath = join(wd, "config.toml");
@@ -493,14 +493,14 @@ describe("config generator idempotency (#384)", () => {
       const toml = await readFile(configPath, "utf-8");
 
       assert.match(toml, /^model = "o3"$/m, "user model preserved");
-      assert.doesNotMatch(toml, /^model_context_window = 1000000$/m);
-      assert.doesNotMatch(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.doesNotMatch(toml, /^model_context_window = 250000$/m);
+      assert.doesNotMatch(toml, /^model_auto_compact_token_limit = 200000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it("preserves partial user context config without backfilling the missing partner key", async () => {
+  it("seeds missing auto compact limit without overwriting an existing context window", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
       const configPath = join(wd, "config.toml");
@@ -514,7 +514,48 @@ describe("config generator idempotency (#384)", () => {
 
       assert.match(toml, /^model = "gpt-5\.4"$/m);
       assert.match(toml, /^model_context_window = 640000$/m);
-      assert.doesNotMatch(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("seeds missing context window without overwriting an existing auto compact limit", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      await writeFile(
+        configPath,
+        ['model = "gpt-5.4"', "model_auto_compact_token_limit = 150000", ""].join("\n"),
+      );
+
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, "utf-8");
+
+      assert.match(toml, /^model = "gpt-5\.4"$/m);
+      assert.match(toml, /^model_context_window = 250000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 150000$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not duplicate independently seeded defaults across reruns", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      await writeFile(
+        configPath,
+        ['model = "gpt-5.4"', "model_context_window = 640000", ""].join("\n"),
+      );
+
+      await mergeConfig(configPath, wd);
+      await mergeConfig(configPath, wd);
+
+      const toml = await readFile(configPath, "utf-8");
+      assert.equal(count(toml, /^model_context_window = 640000$/gm), 1);
+      assert.equal(count(toml, /^model_auto_compact_token_limit = 200000$/gm), 1);
+      assert.doesNotMatch(toml, /^model_context_window = 250000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -534,12 +575,12 @@ describe("config generator idempotency (#384)", () => {
         "seeded model should appear once",
       );
       assert.equal(
-        count(toml, /^model_context_window = 1000000$/gm),
+        count(toml, /^model_context_window = 250000$/gm),
         1,
         "seeded context window should appear once",
       );
       assert.equal(
-        count(toml, /^model_auto_compact_token_limit = 900000$/gm),
+        count(toml, /^model_auto_compact_token_limit = 200000$/gm),
         1,
         "seeded auto compact limit should appear once",
       );

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -21,8 +21,8 @@ describe('config generator', () => {
       const seededStartIdx = toml.indexOf(
         '# oh-my-codex seeded behavioral defaults (uninstall removes unchanged defaults)',
       );
-      const contextIdx = toml.indexOf('model_context_window = 1000000');
-      const compactIdx = toml.indexOf('model_auto_compact_token_limit = 900000');
+      const contextIdx = toml.indexOf('model_context_window = 250000');
+      const compactIdx = toml.indexOf('model_auto_compact_token_limit = 200000');
       const seededEndIdx = toml.indexOf('# End oh-my-codex seeded behavioral defaults');
       const featuresIdx = toml.indexOf('[features]');
 
@@ -81,8 +81,8 @@ describe('config generator', () => {
         toml,
         /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/m,
       );
-      assert.match(toml, /^model_context_window = 1000000$/m);
-      assert.match(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^model_context_window = 250000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
       assert.match(toml, /^# End oh-my-codex seeded behavioral defaults$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -101,8 +101,8 @@ describe('config generator', () => {
         toml,
         /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/m,
       );
-      assert.match(toml, /^model_context_window = 1000000$/m);
-      assert.match(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^model_context_window = 250000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
       assert.match(toml, /^# End oh-my-codex seeded behavioral defaults$/m);
 
       const modelIdx = toml.indexOf('model = "gpt-5.4"');
@@ -206,7 +206,7 @@ describe('config generator', () => {
 
       assert.match(toml, /^model = "gpt-5\.4"$/m);
       assert.match(toml, /^model_context_window = 640000$/m);
-      assert.doesNotMatch(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -42,8 +42,8 @@ const OMX_TOP_LEVEL_KEYS = [
 ] as const;
 
 const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
-const DEFAULT_SETUP_MODEL_CONTEXT_WINDOW = 1000000;
-const DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT = 900000;
+const DEFAULT_SETUP_MODEL_CONTEXT_WINDOW = 250000;
+const DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT = 200000;
 const OMX_SEEDED_BEHAVIORAL_DEFAULTS_START_MARKER =
   "# oh-my-codex seeded behavioral defaults (uninstall removes unchanged defaults)";
 const OMX_SEEDED_BEHAVIORAL_DEFAULTS_END_MARKER =
@@ -111,17 +111,21 @@ function getOmxTopLevelLines(
     lines.push(`model = "${selectedModel}"`);
   }
 
-  if (
-    selectedModel === DEFAULT_SETUP_MODEL &&
-    !existingContextWindow &&
-    !existingAutoCompact
-  ) {
-    lines.push(OMX_SEEDED_BEHAVIORAL_DEFAULTS_START_MARKER);
-    lines.push(`model_context_window = ${DEFAULT_SETUP_MODEL_CONTEXT_WINDOW}`);
-    lines.push(
-      `model_auto_compact_token_limit = ${DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT}`,
-    );
-    lines.push(OMX_SEEDED_BEHAVIORAL_DEFAULTS_END_MARKER);
+  if (selectedModel === DEFAULT_SETUP_MODEL) {
+    const seededBehavioralDefaults: string[] = [];
+    if (!existingContextWindow) {
+      seededBehavioralDefaults.push(`model_context_window = ${DEFAULT_SETUP_MODEL_CONTEXT_WINDOW}`);
+    }
+    if (!existingAutoCompact) {
+      seededBehavioralDefaults.push(
+        `model_auto_compact_token_limit = ${DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT}`,
+      );
+    }
+    if (seededBehavioralDefaults.length > 0) {
+      lines.push(OMX_SEEDED_BEHAVIORAL_DEFAULTS_START_MARKER);
+      lines.push(...seededBehavioralDefaults);
+      lines.push(OMX_SEEDED_BEHAVIORAL_DEFAULTS_END_MARKER);
+    }
   }
 
   return lines;


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Reduce setup friction after OMX upgrades.
A real global version bump now triggers the interactive setup refresh through a thin best-effort postinstall path, `omx update` exposes the same refresh path explicitly, and fresh OMX-managed `gpt-5.4` configs now seed `250000 / 200000` only when those keys are missing.

## Changes

- add `omx update` help/dispatch and immediate update executor wiring
- add user-scope install stamp tracking and best-effort postinstall bootstrap for real global version bumps
- keep overwrite prompts in `setup.ts` as the sole overwrite authority
- lower seeded `gpt-5.4` defaults to `model_context_window = 250000` and `model_auto_compact_token_limit = 200000`, preserving existing values and backfilling missing partner keys only
- update install/setup docs and add postinstall/update regression coverage

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Additional verification:
- `npm run check:no-unused`
- `npm run lint` (with temporary empty `bin/` dir to satisfy existing Biome path expectation)
- `npm run smoke:packed-install`
- architect verification: APPROVED

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
