### PR TITLE
Prevent Stop from leaking sibling Ralph state

### DIFF
--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -265,17 +265,19 @@ async function readActiveRalphState(
   stateDir: string,
   preferredSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
-  const sessionInfo = await readUsableSessionState(resolve(stateDir, "..", ".."));
+  const cwd = resolve(stateDir, "..", "..");
+  const sessionInfo = await readUsableSessionState(cwd);
   const currentOmxSessionId = safeString(sessionInfo?.session_id).trim();
   const sessionCandidates = [...new Set([
     safeString(preferredSessionId).trim(),
     currentOmxSessionId,
   ].filter(Boolean))];
 
+  // Ralph Stop stays authoritative-scope-only once the Stop payload is session-bound.
+  // That is intentionally stricter than generic state MCP reads: do not scan sibling
+  // session scopes or fall back to root when a current/explicit session is in play.
   for (const sessionId of sessionCandidates) {
-    const sessionScoped = await readJsonIfExists(
-      join(stateDir, "sessions", sessionId, "ralph-state.json"),
-    );
+    const sessionScoped = await readStopSessionPinnedState("ralph-state.json", cwd, sessionId);
     if (sessionScoped?.active === true && shouldContinueRun(sessionScoped)) {
       return sessionScoped;
     }
@@ -286,17 +288,6 @@ async function readActiveRalphState(
   const direct = await readJsonIfExists(join(stateDir, "ralph-state.json"));
   if (direct?.active === true && shouldContinueRun(direct)) {
     return direct;
-  }
-
-  const sessionsRoot = join(stateDir, "sessions");
-  if (!existsSync(sessionsRoot)) return null;
-  const entries = await readdir(sessionsRoot, { withFileTypes: true }).catch(() => []);
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const candidate = await readJsonIfExists(join(sessionsRoot, entry.name, "ralph-state.json"));
-    if (candidate?.active === true && shouldContinueRun(candidate)) {
-      return candidate;
-    }
   }
 
   return null;

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -197,6 +197,29 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('lists active modes from the explicit session scope without leaking a sibling Ralph session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-foreign-ralph-scope-'));
+    try {
+      const currentSessionDir = join(wd, '.omx', 'state', 'sessions', 'sess-current');
+      const foreignSessionDir = join(wd, '.omx', 'state', 'sessions', 'sess-foreign');
+      await mkdir(currentSessionDir, { recursive: true });
+      await mkdir(foreignSessionDir, { recursive: true });
+      await writeFile(
+        join(foreignSessionDir, 'ralph-state.json'),
+        JSON.stringify({ active: true, current_phase: 'executing' }, null, 2),
+      );
+
+      const response = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: 'sess-current',
+      });
+
+      assert.deepEqual(response.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('creates session-scoped state directory when session_id is provided', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-session-'));
     try {


### PR DESCRIPTION
## Summary
- scope Ralph Stop-hook Ralph-state reads to the explicit/current session candidates only
- remove the sibling-session Ralph scan that could keep Stop blocked after MCP state tools reported no active modes
- add a state operations regression proving explicit session scope does not leak a foreign active Ralph session

## Testing
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/state/__tests__/operations.test.js

## Risk
- low; this keeps existing session-bound no-root-fallback Ralph Stop behavior and only removes the foreign-session leakage path