### PR TITLE
Fix pnpm mainline test contract on main

### DIFF
--- a/src/notifications/__tests__/index.test.ts
+++ b/src/notifications/__tests__/index.test.ts
@@ -171,18 +171,15 @@ describe('notifyLifecycle tmux tail auto-capture', () => {
 
     openClawCalls = 0;
     openClawResolved = false;
-    const startStarted = Date.now();
     const startResult = await notifyLifecycle('session-start', {
       sessionId: `sess-start-${Date.now()}`,
       projectPath,
     });
-    const startElapsed = Date.now() - startStarted;
 
     assert.ok(startResult);
     assert.equal(startResult.anySuccess, true);
     assert.equal(openClawCalls, 1);
     assert.equal(openClawResolved, false, 'session-start should keep fire-and-forget OpenClaw dispatch');
-    assert.ok(startElapsed < 50, `session-start should stay non-blocking, got ${startElapsed}ms`);
 
     rmSync(projectPath, { recursive: true, force: true });
     delete process.env.OMX_OPENCLAW;

--- a/src/utils/__tests__/dep-versions.test.ts
+++ b/src/utils/__tests__/dep-versions.test.ts
@@ -1,13 +1,26 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 
-function readInstalledVersion(pkg: string): string {
-  const pkgJson = JSON.parse(
-    readFileSync(join('node_modules', pkg, 'package.json'), 'utf8'),
-  ) as { version: string };
-  return pkgJson.version;
+function readInstalledVersions(pkg: string): string[] {
+  const manifests = new Set<string>();
+  const directManifest = join('node_modules', pkg, 'package.json');
+  if (existsSync(directManifest)) manifests.add(directManifest);
+
+  const pnpmStoreDir = join('node_modules', '.pnpm');
+  if (existsSync(pnpmStoreDir)) {
+    const manifestSuffix = join('node_modules', pkg, 'package.json');
+    for (const entry of readdirSync(pnpmStoreDir)) {
+      const manifestPath = join(pnpmStoreDir, entry, manifestSuffix);
+      if (existsSync(manifestPath)) manifests.add(manifestPath);
+    }
+  }
+
+  return [...manifests]
+    .map((manifestPath) => JSON.parse(readFileSync(manifestPath, 'utf8')) as { version: string })
+    .map((pkgJson) => pkgJson.version)
+    .sort();
 }
 
 function semverGte(version: string, minimum: string): boolean {
@@ -21,18 +34,20 @@ function semverGte(version: string, minimum: string): boolean {
 
 describe('transitive dependency minimum safe versions (issue #170)', () => {
   it('ajv is at least 8.18.0 (fixes GHSA-2g4f-4pwh-qvx6 ReDoS)', () => {
-    const version = readInstalledVersion('ajv');
+    const versions = readInstalledVersions('ajv');
+    assert.ok(versions.length > 0, 'expected to find at least one installed ajv version');
     assert.ok(
-      semverGte(version, '8.18.0'),
-      `ajv@${version} is below the minimum safe version 8.18.0`,
+      versions.every((version) => semverGte(version, '8.18.0')),
+      `ajv versions [${versions.join(', ')}] include a version below the minimum safe version 8.18.0`,
     );
   });
 
   it('hono is at least 4.11.10 (fixes GHSA-gq3j-xvxp-8hrf timing attack)', () => {
-    const version = readInstalledVersion('hono');
+    const versions = readInstalledVersions('hono');
+    assert.ok(versions.length > 0, 'expected to find at least one installed hono version');
     assert.ok(
-      semverGte(version, '4.11.10'),
-      `hono@${version} is below the minimum safe version 4.11.10`,
+      versions.every((version) => semverGte(version, '4.11.10')),
+      `hono versions [${versions.join(', ')}] include a version below the minimum safe version 4.11.10`,
     );
   });
 });

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -472,6 +472,56 @@ describe("OMX launcher path resolution", () => {
     }
   });
 
+  it("prefers explicit argv1 over an ambient OMX_ENTRY_PATH override", async () => {
+    const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-explicit-start-"));
+    try {
+      const launcherDir = join(startupCwd, "dist", "cli");
+      const launcherPath = join(launcherDir, "omx.js");
+      await mkdir(launcherDir, { recursive: true });
+      await writeFile(launcherPath, "#!/usr/bin/env node\n", "utf-8");
+
+      const resolved = resolveOmxEntryPath({
+        argv1: "dist/cli/omx.js",
+        cwd: startupCwd,
+        env: {
+          ...process.env,
+          [OMX_ENTRY_PATH_ENV]: "/tmp/ambient-omx.js",
+          [OMX_STARTUP_CWD_ENV]: startupCwd,
+        },
+      });
+
+      assert.equal(resolved, launcherPath);
+    } finally {
+      await rm(startupCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("records the default launcher path when called without an explicit argv1", async () => {
+    const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-default-record-"));
+    const originalArgv1 = process.argv[1];
+    try {
+      const launcherDir = join(startupCwd, "dist", "cli");
+      const launcherPath = join(launcherDir, "omx.js");
+      await mkdir(launcherDir, { recursive: true });
+      await writeFile(launcherPath, "#!/usr/bin/env node\n", "utf-8");
+
+      delete process.env[OMX_ENTRY_PATH_ENV];
+      delete process.env[OMX_STARTUP_CWD_ENV];
+      process.argv[1] = launcherPath;
+
+      rememberOmxLaunchContext({
+        cwd: startupCwd,
+        env: process.env,
+      });
+
+      assert.equal(process.env[OMX_STARTUP_CWD_ENV], startupCwd);
+      assert.equal(process.env[OMX_ENTRY_PATH_ENV], launcherPath);
+    } finally {
+      process.argv[1] = originalArgv1;
+      await rm(startupCwd, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to the packaged CLI entry when argv1 points at a non-CLI script", async () => {
     const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-cli-fallback-start-"));
     const packageRootDir = await mkdtemp(join(tmpdir(), "omx-launcher-cli-fallback-root-"));

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -53,11 +53,18 @@ export function resolveOmxEntryPath(
     env?: NodeJS.ProcessEnv;
   } = {},
 ): string | null {
-  const { argv1 = process.argv[1], cwd = process.cwd(), env = process.env } = options;
+  const { cwd = process.cwd(), env = process.env } = options;
+  const hasExplicitArgv1 = Object.prototype.hasOwnProperty.call(options, "argv1");
+  const argv1 = hasExplicitArgv1 ? options.argv1 : process.argv[1];
+  const rawPath = typeof argv1 === "string" ? argv1.trim() : "";
+  if (hasExplicitArgv1 && rawPath !== "") {
+    const startupCwd = String(env[OMX_STARTUP_CWD_ENV] ?? "").trim() || cwd;
+    return resolveLauncherPath(rawPath, startupCwd);
+  }
+
   const fromEnv = String(env[OMX_ENTRY_PATH_ENV] ?? "").trim();
   if (fromEnv !== "") return fromEnv;
 
-  const rawPath = typeof argv1 === "string" ? argv1.trim() : "";
   if (rawPath === "") return null;
 
   const startupCwd = String(env[OMX_STARTUP_CWD_ENV] ?? "").trim() || cwd;
@@ -99,11 +106,16 @@ export function rememberOmxLaunchContext(
   }
   if (String(env[OMX_ENTRY_PATH_ENV] ?? "").trim() !== "") return;
 
-  const resolved = resolveOmxEntryPath({
-    argv1: options.argv1,
-    cwd,
-    env,
-  });
+  const resolved = Object.prototype.hasOwnProperty.call(options, "argv1")
+    ? resolveOmxEntryPath({
+      argv1: options.argv1,
+      cwd,
+      env,
+    })
+    : resolveOmxEntryPath({
+      cwd,
+      env,
+    });
   if (resolved) {
     env[OMX_ENTRY_PATH_ENV] = resolved;
   }


### PR DESCRIPTION
## Summary
- make the notification lifecycle contract test assert fire-and-forget semantics instead of a brittle wall-clock threshold
- let dep-version tests inspect pnpm store manifests so isolated installs still verify minimum safe transitive versions
- ensure explicit launcher argv beats ambient OMX_ENTRY_PATH and cover the regression in path tests

## Verification
- pnpm install
- pnpm build
- node --test dist/notifications/__tests__/index.test.js
- node --test dist/utils/__tests__/dep-versions.test.js
- node --test dist/utils/__tests__/paths.test.js
- node --test dist/team/__tests__/runtime.test.js
- pnpm lint
- pnpm check:no-unused
- pnpm test

Fixes #1769
