### PR TITLE
Keep native Stop replay dedupe inside dispatcher semantics for #1771 follow-up

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -27,6 +27,30 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+async function writeHookCounterPlugin(cwd: string): Promise<string> {
+  const markerPath = join(cwd, ".omx", "stop-hook-counter.json");
+  await mkdir(join(cwd, ".omx", "hooks"), { recursive: true });
+  await writeFile(
+    join(cwd, ".omx", "hooks", "count-stop-hook.mjs"),
+    `import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export async function onHookEvent(event) {
+  if (event.event !== "stop") return;
+  const outPath = join(process.cwd(), ".omx", "stop-hook-counter.json");
+  await mkdir(dirname(outPath), { recursive: true });
+  let count = 0;
+  try {
+    count = JSON.parse(await readFile(outPath, "utf-8")).count || 0;
+  } catch {}
+  await writeFile(outPath, JSON.stringify({ count: count + 1 }, null, 2));
+}
+`,
+    "utf-8",
+  );
+  return markerPath;
+}
+
 async function writeReleaseReadinessLeaderAttention(
   teamName: string,
   sessionId: string,
@@ -3664,6 +3688,117 @@ esac
     }
   });
 
+  it("lets dispatcher dedupe identical native stop hook replays after Stop payload normalization", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-hook-dedupe-"));
+    const previousOmxSessionId = process.env.OMX_SESSION_ID;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-ralph-hook-dedupe"), { recursive: true });
+      await writeHookCounterPlugin(cwd);
+      await writeFile(
+        join(stateDir, "sessions", "sess-stop-ralph-hook-dedupe", "ralph-state.json"),
+        JSON.stringify({
+          active: true,
+          current_phase: "executing",
+          session_id: "sess-stop-ralph-hook-dedupe",
+        }),
+      );
+
+      process.env.OMX_SESSION_ID = "sess-stop-ralph-hook-dedupe";
+      const payload = {
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-stop-ralph-hook-dedupe",
+        thread_id: "thread-stop-ralph-hook-dedupe",
+        turn_id: "turn-stop-ralph-hook-dedupe-1",
+        last_assistant_message: "Next active targets:\n\n1. scheduler integration\n\nI am continuing.",
+      };
+
+      await dispatchCodexNativeHook(payload, { cwd });
+      await dispatchCodexNativeHook(
+        {
+          ...payload,
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
+
+      const marker = JSON.parse(
+        await readFile(join(cwd, ".omx", "stop-hook-counter.json"), "utf-8"),
+      ) as { count: number };
+      assert.equal(marker.count, 1);
+    } finally {
+      if (typeof previousOmxSessionId === "string") process.env.OMX_SESSION_ID = previousOmxSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves per-turn native stop hook delivery even when stop_hook_active remains true", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-hook-refire-"));
+    const previousOmxSessionId = process.env.OMX_SESSION_ID;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-ralph-hook-refire"), { recursive: true });
+      await writeHookCounterPlugin(cwd);
+      await writeFile(
+        join(stateDir, "sessions", "sess-stop-ralph-hook-refire", "ralph-state.json"),
+        JSON.stringify({
+          active: true,
+          current_phase: "executing",
+          session_id: "sess-stop-ralph-hook-refire",
+        }),
+      );
+
+      process.env.OMX_SESSION_ID = "sess-stop-ralph-hook-refire";
+      const payload = {
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-stop-ralph-hook-refire",
+        thread_id: "thread-stop-ralph-hook-refire",
+        turn_id: "turn-stop-ralph-hook-refire-1",
+        last_assistant_message: "Continuing current task.",
+      };
+
+      await dispatchCodexNativeHook(payload, { cwd });
+      await dispatchCodexNativeHook(
+        {
+          ...payload,
+          turn_id: "turn-stop-ralph-hook-refire-2",
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
+
+      await writeFile(
+        join(stateDir, "sessions", "sess-stop-ralph-hook-refire", "ralph-state.json"),
+        JSON.stringify({
+          active: true,
+          current_phase: "executing",
+          session_id: "sess-stop-ralph-hook-refire",
+        }),
+      );
+
+      await dispatchCodexNativeHook(
+        {
+          ...payload,
+          turn_id: "turn-stop-ralph-hook-refire-3",
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
+
+      const marker = JSON.parse(
+        await readFile(join(cwd, ".omx", "stop-hook-counter.json"), "utf-8"),
+      ) as { count: number };
+      assert.equal(marker.count, 3);
+    } finally {
+      if (typeof previousOmxSessionId === "string") process.env.OMX_SESSION_ID = previousOmxSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
 
   it("returns Stop continuation output for native auto-nudge stall prompts", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-"));
@@ -3789,6 +3924,69 @@ esac
         await readFile(join(stateDir, "native-stop-state.json"), "utf-8"),
       ) as { sessions?: Record<string, unknown> };
       assert.deepEqual(Object.keys(persisted.sessions ?? {}), ["omx-canonical"]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("dedupes native stop hook replay across owner launch SessionStart reconciliation drift", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-dispatch-session-drift-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "omx-canonical"), { recursive: true });
+      await writeHookCounterPlugin(cwd);
+      process.env.OMX_SESSION_ID = "omx-canonical";
+      await writeSessionStart(cwd, "omx-canonical");
+      await writeJson(join(stateDir, "sessions", "omx-canonical", "ralph-state.json"), {
+        active: true,
+        current_phase: "executing",
+        session_id: "omx-canonical",
+      });
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "codex-native-new",
+        },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "codex-native-new",
+          thread_id: "thread-stop-hook-drift",
+          turn_id: "turn-stop-hook-drift-1",
+          last_assistant_message: "Keep going and finish the cleanup.",
+        },
+        { cwd },
+      );
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "omx-canonical",
+          thread_id: "thread-stop-hook-drift",
+          turn_id: "turn-stop-hook-drift-1",
+          stop_hook_active: true,
+          last_assistant_message: "Keep going and finish the cleanup.",
+        },
+        { cwd },
+      );
+
+      const marker = JSON.parse(
+        await readFile(join(cwd, ".omx", "stop-hook-counter.json"), "utf-8"),
+      ) as { count: number };
+      assert.equal(marker.count, 1);
+
+      const sessionState = JSON.parse(
+        await readFile(join(stateDir, "session.json"), "utf-8"),
+      ) as { session_id?: string; native_session_id?: string };
+      assert.equal(sessionState.session_id, "omx-canonical");
+      assert.equal(sessionState.native_session_id, "codex-native-new");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -204,15 +204,26 @@ function readPromptText(payload: CodexHookPayload): string {
 function sanitizePayloadForHookContext(
   payload: CodexHookPayload,
   hookEventName: CodexHookEventName,
+  canonicalSessionId = "",
 ): CodexHookPayload {
-  if (hookEventName !== "UserPromptSubmit") return payload;
-
   const sanitized = { ...payload };
-  delete sanitized.prompt;
-  delete sanitized.input;
-  delete sanitized.user_prompt;
-  delete sanitized.userPrompt;
-  delete sanitized.text;
+
+  if (hookEventName === "UserPromptSubmit") {
+    delete sanitized.prompt;
+    delete sanitized.input;
+    delete sanitized.user_prompt;
+    delete sanitized.userPrompt;
+    delete sanitized.text;
+    return sanitized;
+  }
+
+  if (hookEventName === "Stop") {
+    delete sanitized.stop_hook_active;
+    delete sanitized.stopHookActive;
+    delete sanitized.sessionId;
+    sanitized.session_id = canonicalSessionId.trim() || safeString(payload.session_id ?? payload.sessionId).trim();
+  }
+
   return sanitized;
 }
 
@@ -220,13 +231,14 @@ function buildBaseContext(
   cwd: string,
   payload: CodexHookPayload,
   hookEventName: CodexHookEventName,
+  canonicalSessionId = "",
 ): Record<string, unknown> {
   return {
     cwd,
     project_path: cwd,
     transcript_path: safeString(payload.transcript_path ?? payload.transcriptPath) || null,
     source: safeString(payload.source),
-    payload: sanitizePayloadForHookContext(payload, hookEventName),
+    payload: sanitizePayloadForHookContext(payload, hookEventName, canonicalSessionId),
   };
 }
 
@@ -1579,19 +1591,37 @@ export async function dispatchCodexNativeHook(
   const nativeSessionId = safeString(payload.session_id ?? payload.sessionId).trim();
   const threadId = safeString(payload.thread_id ?? payload.threadId).trim();
   const turnId = safeString(payload.turn_id ?? payload.turnId).trim();
-  let canonicalSessionId = safeString((await readUsableSessionState(cwd))?.session_id).trim();
+  const currentSessionState = await readUsableSessionState(cwd);
+  let canonicalSessionId = safeString(currentSessionState?.session_id).trim();
+  let resolvedNativeSessionId = nativeSessionId;
 
   if (hookEventName === "SessionStart" && nativeSessionId) {
     const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {
       pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
     });
     canonicalSessionId = safeString(sessionState.session_id).trim();
+    resolvedNativeSessionId = safeString(sessionState.native_session_id).trim() || nativeSessionId;
   } else if (!canonicalSessionId) {
-    canonicalSessionId = safeString((await readUsableSessionState(cwd))?.session_id).trim();
+    canonicalSessionId = safeString(currentSessionState?.session_id).trim();
+  }
+
+  if (hookEventName === "Stop") {
+    const stopCanonicalSessionId = await resolveInternalSessionIdForPayload(
+      cwd,
+      readPayloadSessionId(payload),
+    );
+    if (stopCanonicalSessionId) {
+      canonicalSessionId = stopCanonicalSessionId;
+    }
+    if (canonicalSessionId && safeString(currentSessionState?.session_id).trim() === canonicalSessionId) {
+      resolvedNativeSessionId =
+        safeString(currentSessionState?.native_session_id).trim() || resolvedNativeSessionId;
+    }
   }
 
   const eventSessionId = canonicalSessionId || nativeSessionId || undefined;
   const sessionIdForState = canonicalSessionId || nativeSessionId;
+  let outputJson: Record<string, unknown> | null = null;
 
   if (hookEventName === "UserPromptSubmit") {
     const prompt = readPromptText(payload);
@@ -1676,10 +1706,10 @@ export async function dispatchCodexNativeHook(
   }
 
   if (omxEventName) {
-    const baseContext = buildBaseContext(cwd, payload, hookEventName!);
-    if (nativeSessionId) {
-      baseContext.native_session_id = nativeSessionId;
-      baseContext.codex_session_id = nativeSessionId;
+    const baseContext = buildBaseContext(cwd, payload, hookEventName!, canonicalSessionId);
+    if (resolvedNativeSessionId) {
+      baseContext.native_session_id = resolvedNativeSessionId;
+      baseContext.codex_session_id = resolvedNativeSessionId;
     }
     if (canonicalSessionId) {
       baseContext.omx_session_id = canonicalSessionId;
@@ -1697,7 +1727,6 @@ export async function dispatchCodexNativeHook(
     await dispatchHookEvent(event, { cwd });
   }
 
-  let outputJson: Record<string, unknown> | null = null;
   if (hookEventName === "SessionStart" || hookEventName === "UserPromptSubmit") {
     const additionalContext = hookEventName === "SessionStart"
       ? await buildSessionStartContext(cwd, canonicalSessionId || nativeSessionId)


### PR DESCRIPTION
## Summary
- normalize native `Stop` hook payload context so replayed `stop_hook_active` events collapse onto the existing dispatcher fingerprint instead of adding a second Stop-only dedupe layer
- preserve fresh per-turn Stop delivery by leaving dispatcher semantics intact and only stripping replay-only payload variance
- add targeted regressions for identical replay dedupe, fresh-turn redispatch, and owner-launch SessionStart reconciliation drift

## Root cause
The duplicate flood came from `dispatchCodexNativeHook()` sending native `stop` hook events with replay-variant payload context. Replayed owner-launch Stop turns kept `stop_hook_active` in the payload context and could switch between native and canonical session ids for the same semantic stop reply, so the dispatcher fingerprint changed and downstream consumers saw fresh `stopped (repo=oh-my-codex)` events.

## Fix
The Stop path now normalizes native hook context before dispatch: replay-only `stop_hook_active` is removed, Stop payload `session_id` is canonicalized, and owner-launch reconciliation reuses the resolved native session id in hook context. That lets the existing dispatcher fingerprint dedupe suppress true replay duplicates while preserving normal per-turn Stop delivery.

## Testing
- `npm run build`
- `./node_modules/.bin/biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js`
- `npx tsc --noEmit --pretty false --project tsconfig.json`

Related: #1771
