### PR TITLE
Fix uninstall cleanup for OMX-seeded config keys

### DIFF
--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -114,8 +114,43 @@ function buildConfigWithSeededModelContext(): string {
     'model_reasoning_effort = "high"',
     'developer_instructions = "You have oh-my-codex installed."',
     'model = "gpt-5.4"',
+    '# oh-my-codex seeded behavioral defaults (uninstall removes unchanged defaults)',
     'model_context_window = 1000000',
     'model_auto_compact_token_limit = 900000',
+    '# End oh-my-codex seeded behavioral defaults',
+    '',
+    '[features]',
+    'multi_agent = true',
+    'child_agents_md = true',
+    'codex_hooks = true',
+    '',
+    '# ============================================================',
+    '# oh-my-codex (OMX) Configuration',
+    '# Managed by omx setup - manual edits preserved on next setup',
+    '# ============================================================',
+    '',
+    '[mcp_servers.omx_state]',
+    'command = "node"',
+    'args = ["/path/to/state-server.js"]',
+    'enabled = true',
+    '',
+    '# ============================================================',
+    '# End oh-my-codex',
+    '',
+  ].join('\n');
+}
+
+function buildConfigWithEditedSeededModelContext(): string {
+  return [
+    '# oh-my-codex top-level settings (must be before any [table])',
+    'notify = ["node", "/path/to/notify-hook.js"]',
+    'model_reasoning_effort = "high"',
+    'developer_instructions = "You have oh-my-codex installed."',
+    'model = "gpt-5.4"',
+    '# oh-my-codex seeded behavioral defaults (uninstall removes unchanged defaults)',
+    'model_context_window = 123456',
+    'model_auto_compact_token_limit = 900000',
+    '# End oh-my-codex seeded behavioral defaults',
     '',
     '[features]',
     'multi_agent = true',
@@ -341,8 +376,7 @@ describe('omx uninstall', () => {
     }
   });
 
-
-  it('preserves seeded model/context keys during uninstall', async () => {
+  it('removes unchanged OMX-seeded model/context keys during uninstall', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
     try {
       const home = join(wd, 'home');
@@ -356,8 +390,35 @@ describe('omx uninstall', () => {
 
       const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
       assert.match(config, /^model = "gpt-5\.4"$/m);
-      assert.match(config, /^model_context_window = 1000000$/m);
+      assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
+      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.doesNotMatch(config, /seeded behavioral defaults/);
+      assert.doesNotMatch(config, /notify\s*=/);
+      assert.doesNotMatch(config, /model_reasoning_effort\s*=/);
+      assert.doesNotMatch(config, /developer_instructions\s*=/);
+      assert.doesNotMatch(config, /oh-my-codex \(OMX\) Configuration/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves user-edited seeded model/context keys during uninstall', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), buildConfigWithEditedSeededModelContext());
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      assert.match(config, /^model = "gpt-5\.4"$/m);
+      assert.match(config, /^model_context_window = 123456$/m);
       assert.match(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.doesNotMatch(config, /seeded behavioral defaults/);
       assert.doesNotMatch(config, /notify\s*=/);
       assert.doesNotMatch(config, /model_reasoning_effort\s*=/);
       assert.doesNotMatch(config, /developer_instructions\s*=/);

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -10,6 +10,7 @@ import {
   stripOmxEnvSettings,
   stripOmxTopLevelKeys,
   stripOmxFeatureFlags,
+  stripOmxSeededBehavioralDefaults,
 } from "../config/generator.js";
 import {
   parseCodexHooksConfig,
@@ -144,6 +145,9 @@ async function cleanConfig(
 
   // Strip top-level keys
   config = stripOmxTopLevelKeys(config);
+
+  // Strip OMX-seeded behavioral defaults only when the seeded pair is unchanged.
+  config = stripOmxSeededBehavioralDefaults(config);
 
   // Strip feature flags
   config = stripOmxFeatureFlags(config);

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -22,7 +22,7 @@ function assertSingleOmxBlock(toml: string): void {
     "OMX marker should appear once",
   );
   assert.equal(
-    count(toml, /# End oh-my-codex/g),
+    count(toml, /^# End oh-my-codex$/gm),
     1,
     "End marker should appear once",
   );
@@ -451,8 +451,13 @@ describe("config generator idempotency (#384)", () => {
       const toml = await readFile(configPath, "utf-8");
 
       assert.match(toml, /^model = "gpt-5.4"$/m);
+      assert.match(
+        toml,
+        /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/m,
+      );
       assert.match(toml, /^model_context_window = 1000000$/m);
       assert.match(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^# End oh-my-codex seeded behavioral defaults$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -467,8 +472,13 @@ describe("config generator idempotency (#384)", () => {
 
       assert.match(toml, /^model = "gpt-5\.4"$/m);
       assert.doesNotMatch(toml, /^model = "gpt-5\.3-codex"$/m);
+      assert.match(
+        toml,
+        /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/m,
+      );
       assert.match(toml, /^model_context_window = 1000000$/m);
       assert.match(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^# End oh-my-codex seeded behavioral defaults$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -533,6 +543,19 @@ describe("config generator idempotency (#384)", () => {
         1,
         "seeded auto compact limit should appear once",
       );
+      assert.equal(
+        count(
+          toml,
+          /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/gm,
+        ),
+        1,
+        "seeded defaults start marker should appear once",
+      );
+      assert.equal(
+        count(toml, /^# End oh-my-codex seeded behavioral defaults$/gm),
+        1,
+        "seeded defaults end marker should appear once",
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -595,7 +618,7 @@ describe("config generator idempotency (#384)", () => {
       const toml = buildMergedConfig(broken, wd);
       assert.equal(count(toml, /^\[tui\]$/gm), 1, "[tui] should appear once");
       assert.equal(
-        count(toml, /# End oh-my-codex/g),
+        count(toml, /^# End oh-my-codex$/gm),
         1,
         "End marker should appear once",
       );

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -145,7 +145,7 @@ describe('config generator', () => {
         (rerun.match(/# oh-my-codex \(OMX\) Configuration/g) ?? []).length,
         1
       );
-      assert.equal((rerun.match(/# End oh-my-codex/g) ?? []).length, 1);
+      assert.equal((rerun.match(/^# End oh-my-codex$/gm) ?? []).length, 1);
 
       // Features correct
       assert.equal((rerun.match(/^\[features\]$/gm) ?? []).length, 1);

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -44,6 +44,10 @@ const OMX_TOP_LEVEL_KEYS = [
 const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
 const DEFAULT_SETUP_MODEL_CONTEXT_WINDOW = 1000000;
 const DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT = 900000;
+const OMX_SEEDED_BEHAVIORAL_DEFAULTS_START_MARKER =
+  "# oh-my-codex seeded behavioral defaults (uninstall removes unchanged defaults)";
+const OMX_SEEDED_BEHAVIORAL_DEFAULTS_END_MARKER =
+  "# End oh-my-codex seeded behavioral defaults";
 const SHARED_MCP_REGISTRY_MARKER = "oh-my-codex (OMX) Shared MCP Registry Sync";
 const SHARED_MCP_REGISTRY_END_MARKER =
   "# End oh-my-codex shared MCP registry sync";
@@ -112,13 +116,77 @@ function getOmxTopLevelLines(
     !existingContextWindow &&
     !existingAutoCompact
   ) {
+    lines.push(OMX_SEEDED_BEHAVIORAL_DEFAULTS_START_MARKER);
     lines.push(`model_context_window = ${DEFAULT_SETUP_MODEL_CONTEXT_WINDOW}`);
     lines.push(
       `model_auto_compact_token_limit = ${DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT}`,
     );
+    lines.push(OMX_SEEDED_BEHAVIORAL_DEFAULTS_END_MARKER);
   }
 
   return lines;
+}
+
+function isUnchangedOmxSeededBehavioralDefaultsBlock(lines: string[]): boolean {
+  const relevant = lines.filter((line) => {
+    const trimmed = line.trim();
+    return trimmed.length > 0 && !trimmed.startsWith("#");
+  });
+  if (relevant.length !== 2) return false;
+
+  const parsed = parseRootKeyValues(relevant.join("\n"));
+  return (
+    parsed.size === 2 &&
+    parsed.get("model_context_window") ===
+      String(DEFAULT_SETUP_MODEL_CONTEXT_WINDOW) &&
+    parsed.get("model_auto_compact_token_limit") ===
+      String(DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT)
+  );
+}
+
+export function stripOmxSeededBehavioralDefaults(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const firstTable = lines.findIndex((line) => /^\s*\[/.test(line));
+  const boundary = firstTable >= 0 ? firstTable : lines.length;
+  const result: string[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const trimmed = lines[index].trim();
+
+    if (
+      index < boundary &&
+      trimmed === OMX_SEEDED_BEHAVIORAL_DEFAULTS_START_MARKER
+    ) {
+      const endIndex = lines.findIndex(
+        (line, candidateIndex) =>
+          candidateIndex > index &&
+          candidateIndex < boundary &&
+          line.trim() === OMX_SEEDED_BEHAVIORAL_DEFAULTS_END_MARKER,
+      );
+
+      if (endIndex < 0) {
+        continue;
+      }
+
+      const blockLines = lines.slice(index + 1, endIndex);
+      if (!isUnchangedOmxSeededBehavioralDefaultsBlock(blockLines)) {
+        result.push(...blockLines);
+      }
+      index = endIndex;
+      continue;
+    }
+
+    if (
+      index < boundary &&
+      trimmed === OMX_SEEDED_BEHAVIORAL_DEFAULTS_END_MARKER
+    ) {
+      continue;
+    }
+
+    result.push(lines[index]);
+  }
+
+  return result.join("\n");
 }
 
 function stripRootLevelKeys(config: string, keys: readonly string[]): string {


### PR DESCRIPTION
## Summary
- tag OMX-seeded behavioral defaults in generated config so uninstall can identify them precisely
- remove unchanged seeded context defaults during uninstall while preserving user-edited values
- add focused setup/uninstall regression coverage for seeded-key cleanup semantics

## Testing
- npm run build
- node --test --test-reporter=spec dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/uninstall.test.js

Closes #1777