### PR TITLE
Fix postinstall setup refresh install-root regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ If you want the default OMX experience, start here:
 
 ```bash
 npm install -g @openai/codex oh-my-codex
-omx setup
 omx --madmax --high
 ```
+
+On a real `oh-my-codex` version bump, the global npm install now launches the interactive `omx setup` refresh automatically when a TTY is available. If npm scripts are skipped or the install is non-interactive, run `omx setup` manually or use `omx update` to force the same refresh path later.
 
 Then work normally inside Codex:
 
@@ -145,13 +146,14 @@ Most users should think of OMX as **better task routing + better workflow + bett
 
 ## Start here if you are new
 
-1. Run `omx setup`
-2. Run `omx doctor`
-3. Run a real execution smoke test: `codex login status` and `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"`
-4. Launch with `omx --madmax --high`
-5. Use `$deep-interview "..."` when the request or boundaries are still unclear
-6. Use `$ralplan "..."` to approve the plan and review tradeoffs
-7. Choose `$team` for coordinated parallel execution or `$ralph` for persistent completion loops
+1. Install or update OMX with `npm install -g @openai/codex oh-my-codex`
+2. Let the interactive `omx setup` refresh run automatically on real OMX version bumps, or run `omx setup` / `omx update` yourself when scripts are skipped or you want to rerun it
+3. Run `omx doctor`
+4. Run a real execution smoke test: `codex login status` and `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"`
+5. Launch with `omx --madmax --high`
+6. Use `$deep-interview "..."` when the request or boundaries are still unclear
+7. Use `$ralplan "..."` to approve the plan and review tradeoffs
+8. Choose `$team` for coordinated parallel execution or `$ralph` for persistent completion loops
 
 ## Recommended workflow
 
@@ -190,6 +192,8 @@ These are operator/support surfaces:
 - `omx setup` installs prompts, skills, AGENTS scaffolding, `.codex/config.toml`, and OMX-managed native Codex hooks in `.codex/hooks.json`
   - setup refresh preserves non-OMX hook entries in `.codex/hooks.json` and only rewrites OMX-managed wrappers
   - `omx uninstall` removes OMX-managed wrappers from `.codex/hooks.json` but keeps the file when user hooks remain
+- `omx update` checks npm immediately, installs the newest global OMX build, then reruns the same interactive setup refresh path
+- fresh OMX-managed `gpt-5.4` config seeding now recommends `model_context_window = 250000` and `model_auto_compact_token_limit = 200000`, but only when those keys are missing
 - `omx doctor` verifies the install when something seems wrong; it does not prove that the active Codex profile can make an authenticated model call
 - `omx hud --watch` is a monitoring/status surface, not the primary user workflow
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -31,8 +31,8 @@
 
       <h2>Installation</h2>
       <pre><code>npm install -g @openai/codex oh-my-codex
-omx setup
 omx doctor</code></pre>
+      <p>When <code>oh-my-codex</code> actually bumps to a newer version, the global npm install now launches the interactive <code>omx setup</code> refresh automatically when a TTY is available. If npm scripts are skipped or the install is non-interactive, rerun <code>omx setup</code> or <code>omx update</code> manually. Fresh OMX-managed <code>gpt-5.4</code> configs now recommend <code>model_context_window = 250000</code> and <code>model_auto_compact_token_limit = 200000</code> only when those keys are missing.</p>
       <p><code>omx doctor</code> verifies the install shape. Before treating the runtime as ready, also prove that the active Codex profile can perform a real request:</p>
       <pre><code>codex login status
 omx exec --skip-git-repo-check -C . &quot;Reply with exactly OMX-EXEC-OK&quot;</code></pre>
@@ -44,7 +44,8 @@ omx                    # standard launch</code></pre>
       <h2>First Run Walkthrough</h2>
       <ol>
         <li>Create or enter a project directory.</li>
-        <li>Run <code>omx setup</code> to install prompts, skills, AGENTS.md, and configuration.</li>
+        <li>Install or update OMX globally.</li>
+        <li>Let the interactive <code>omx setup</code> refresh run automatically on real OMX version bumps, or rerun <code>omx setup</code> / <code>omx update</code> manually when scripts are skipped.</li>
         <li>Run <code>omx doctor</code>, then the <code>codex login status</code> plus <code>omx exec</code> smoke test above.</li>
         <li>Start Codex CLI with <code>omx</code>.</li>
         <li>Use <code>$deep-interview "clarify the auth change"</code> when intent or boundaries are still unclear.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,7 @@
         <h1>oh-my-codex</h1>
         <p>Multi-agent orchestration for OpenAI Codex CLI.</p>
         <pre><code>npm install -g oh-my-codex</code></pre>
+        <p>Real global version bumps now auto-launch the interactive <code>omx setup</code> refresh when npm has a TTY. Use <code>omx update</code> or rerun <code>omx setup</code> manually when scripts are skipped. Fresh OMX-managed <code>gpt-5.4</code> configs recommend <code>250000 / 200000</code> only when those keys are missing.</p>
       </section>
 
       <section aria-labelledby="whats-new-060">
@@ -68,7 +69,7 @@
       <h2>Quick Start</h2>
       <ol>
         <li><code>npm install -g oh-my-codex</code></li>
-        <li><code>omx setup</code></li>
+        <li>Let the install-triggered <code>omx setup</code> refresh run on real version bumps, or use <code>omx setup</code> / <code>omx update</code> manually.</li>
         <li><code>omx doctor</code></li>
         <li><code>omx --xhigh --madmax</code> (trusted environments) or <code>omx</code></li>
       </ol>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev": "tsc --watch",
     "lint": "biome lint src bin",
     "prepack": "npm run build && npm run clean:native-package-assets",
+    "postinstall": "node src/scripts/postinstall-bootstrap.js",
     "setup": "node dist/cli/omx.js setup",
     "doctor": "node dist/cli/omx.js doctor",
     "ask:claude": "./src/scripts/ask-claude.sh",

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { once } from "node:events";
 import {
+  HELP,
   normalizeCodexLaunchArgs,
   buildTmuxShellCommand,
   buildTmuxPaneCommand,
@@ -902,7 +903,7 @@ describe("commandOwnsLocalHelp", () => {
   });
 
   it("returns false for top-level help-only commands", () => {
-    for (const command of ["help", "launch", "version"]) {
+    for (const command of ["help", "launch", "version", "update"]) {
       assert.equal(
         commandOwnsLocalHelp(command),
         false,
@@ -981,6 +982,13 @@ describe("resolveCliInvocation", () => {
     );
   });
 
+  it("resolves update to update command", () => {
+    assert.deepEqual(resolveCliInvocation(["update"]), {
+      command: "update",
+      launchArgs: [],
+    });
+  });
+
   it("resolves hooks to hooks command", () => {
     assert.deepEqual(resolveCliInvocation(["hooks"]), {
       command: "hooks",
@@ -1028,6 +1036,10 @@ describe("resolveCliInvocation", () => {
       command: "launch",
       launchArgs: ["--model", "gpt-5"],
     });
+  });
+
+  it("advertises the explicit update command in top-level help", () => {
+    assert.match(HELP, /omx update\s+Check npm now, update the global install immediately, then refresh setup/);
   });
 });
 

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -39,6 +39,7 @@ describe('package bin contract', () => {
     assert.equal(pkg.scripts?.['build:full'], 'npm run build && npm run build:explore:release && npm run build:sparkshell');
     assert.equal(pkg.scripts?.['clean:native-package-assets'], 'node dist/scripts/cleanup-explore-harness.js');
     assert.equal(pkg.scripts?.prepack, 'npm run build && npm run clean:native-package-assets');
+    assert.equal(pkg.scripts?.postinstall, 'node src/scripts/postinstall-bootstrap.js');
     assert.equal(pkg.scripts?.postpack, 'npm run clean:native-package-assets');
     assert.equal(pkg.scripts?.['test:explore'], 'cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js');
     assert.equal(pkg.scripts?.['test:team:cross-rebase-smoke:compiled'], 'node --test dist/team/__tests__/cross-rebase-smoke.test.js');
@@ -80,9 +81,13 @@ describe('package bin contract', () => {
     assert.ok(pkg.files?.includes('crates/'));
 
     const binPath = join(process.cwd(), 'dist', 'cli', 'omx.js');
+    const compiledCliPath = join(process.cwd(), 'dist', 'cli', 'index.js');
 
     const binSource = readFileSync(binPath, 'utf-8');
+    const compiledCliSource = readFileSync(compiledCliPath, 'utf-8');
     assert.match(binSource, /^#!\/usr\/bin\/env node/);
+    assert.match(compiledCliSource, /omx update\s+Check npm now, update the global install immediately, then refresh setup/);
+    assert.match(compiledCliSource, /case "update"/);
 
     rmSync(packagedSparkShellPath, { force: true });
 

--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, it } from 'node:test';
-import { readdir } from 'node:fs/promises';
+import { markQuestionAnswered, readQuestionRecord } from '../../question/state.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..', '..', '..');
@@ -86,29 +86,22 @@ describe('omx question CLI', () => {
 
     assert.notEqual(recordFile, '', `expected question record file, stderr=${stderr}`);
     const recordPath = join(questionsDir, recordFile);
-    const record = JSON.parse(await readFile(recordPath, 'utf-8')) as { question_id: string };
-    await writeFile(recordPath, JSON.stringify({
-      kind: 'omx.question/v1',
-      question_id: record.question_id,
-      session_id: 'sess-q',
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      status: 'answered',
-      question: 'Pick one',
-      options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }],
-      allow_other: true,
-      other_label: 'Other',
-      type: 'multi-answerable',
-      multi_select: true,
-      source: 'deep-interview',
-      answer: {
-        kind: 'other',
-        value: 'free text answer',
-        selected_labels: ['Other'],
-        selected_values: ['free text answer'],
-        other_text: 'free text answer',
-      },
-    }, null, 2));
+
+    let record = null;
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      record = await readQuestionRecord(recordPath);
+      if (record?.status === 'prompting') break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+
+    assert.equal(record?.status, 'prompting', `expected prompting question record, stderr=${stderr}`);
+    await markQuestionAnswered(recordPath, {
+      kind: 'other',
+      value: 'free text answer',
+      selected_labels: ['Other'],
+      selected_values: ['free text answer'],
+      other_text: 'free text answer',
+    });
 
     const exitCode = await new Promise<number | null>((resolve) => child.on('close', resolve));
     assert.equal(exitCode, 0, stderr || stdout);

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -250,8 +250,13 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       assert.equal(promptCalls, 1);
       assert.match(config, /^model = "gpt-5\.4"$/m);
       assert.doesNotMatch(config, /^model = "gpt-5\.3-codex"$/m);
-      assert.match(config, /^model_context_window = 250000$/m);
-      assert.match(config, /^model_auto_compact_token_limit = 200000$/m);
+      assert.match(
+        config,
+        /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/m,
+      );
+      assert.match(config, /^model_context_window = 1000000$/m);
+      assert.match(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(config, /^# End oh-my-codex seeded behavioral defaults$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -275,8 +280,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
       assert.match(config, /^model = "gpt-5\.3-codex"$/m);
       assert.doesNotMatch(config, /^model = "gpt-5\.4"$/m);
-      assert.doesNotMatch(config, /^model_context_window = 250000$/m);
-      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 200000$/m);
+      assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
+      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -297,8 +302,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
       assert.match(config, /^model = "gpt-5\.3-codex"$/m);
       assert.doesNotMatch(config, /^model = "gpt-5\.4"$/m);
-      assert.doesNotMatch(config, /^model_context_window = 250000$/m);
-      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 200000$/m);
+      assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
+      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -250,8 +250,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       assert.equal(promptCalls, 1);
       assert.match(config, /^model = "gpt-5\.4"$/m);
       assert.doesNotMatch(config, /^model = "gpt-5\.3-codex"$/m);
-      assert.match(config, /^model_context_window = 1000000$/m);
-      assert.match(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(config, /^model_context_window = 250000$/m);
+      assert.match(config, /^model_auto_compact_token_limit = 200000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -275,8 +275,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
       assert.match(config, /^model = "gpt-5\.3-codex"$/m);
       assert.doesNotMatch(config, /^model = "gpt-5\.4"$/m);
-      assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
-      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.doesNotMatch(config, /^model_context_window = 250000$/m);
+      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 200000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -297,8 +297,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
       assert.match(config, /^model = "gpt-5\.3-codex"$/m);
       assert.doesNotMatch(config, /^model = "gpt-5\.4"$/m);
-      assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
-      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
+      assert.doesNotMatch(config, /^model_context_window = 250000$/m);
+      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 200000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1,17 +1,20 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   isInstallVersionBump,
   isNewerVersion,
   maybeCheckAndPromptUpdate,
   readUserInstallStamp,
+  resolveInstalledCliEntry,
   runImmediateUpdate,
   shouldCheckForUpdates,
   writeUserInstallStamp,
 } from '../update.js';
+
+const PACKAGE_NAME = 'oh-my-codex';
 
 describe('isNewerVersion', () => {
   it('returns true when latest has higher major', () => {
@@ -166,7 +169,7 @@ describe('maybeCheckAndPromptUpdate', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
     const originalLog = console.log;
     const prompts: string[] = [];
-    const setupCalls: unknown[] = [];
+    const setupRefreshCalls: string[] = [];
     console.log = (...args: unknown[]) => {
       prompts.push(args.map((arg) => String(arg)).join(' '));
     };
@@ -178,13 +181,14 @@ describe('maybeCheckAndPromptUpdate', () => {
           fetchLatestVersion: async () => '0.9.0',
           askYesNo: async () => true,
           runGlobalUpdate: () => ({ ok: true, stderr: '' }),
-          setup: async (options) => {
-            setupCalls.push(options ?? {});
+          runSetupRefresh: async (refreshCwd) => {
+            setupRefreshCalls.push(refreshCwd);
+            return { ok: true, stderr: '' };
           },
         });
       });
 
-      assert.deepEqual(setupCalls, [{}]);
+      assert.deepEqual(setupRefreshCalls, [cwd]);
       assert.match(prompts.join('\n'), /Updated to v0\.9\.0/);
     } finally {
       console.log = originalLog;
@@ -194,7 +198,7 @@ describe('maybeCheckAndPromptUpdate', () => {
 
   it('preserves local config semantics by avoiding force setup during auto-update', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
-    let receivedOptions: unknown;
+    const receivedCwds: string[] = [];
 
     try {
       await withInteractiveTty(async () => {
@@ -203,19 +207,14 @@ describe('maybeCheckAndPromptUpdate', () => {
           fetchLatestVersion: async () => '0.13.1',
           askYesNo: async () => true,
           runGlobalUpdate: () => ({ ok: true, stderr: '' }),
-          setup: async (options) => {
-            receivedOptions = options ?? {};
+          runSetupRefresh: async (refreshCwd) => {
+            receivedCwds.push(refreshCwd);
+            return { ok: true, stderr: '' };
           },
         });
       });
 
-      assert.deepEqual(receivedOptions, {});
-      assert.equal(
-        typeof receivedOptions === 'object' &&
-          receivedOptions !== null &&
-          'force' in receivedOptions,
-        false,
-      );
+      assert.deepEqual(receivedCwds, [cwd]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -224,7 +223,7 @@ describe('maybeCheckAndPromptUpdate', () => {
   it('does not update or refresh setup when the prompt is declined', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
     let updateAttempts = 0;
-    let setupCalls = 0;
+    let setupRefreshCalls = 0;
 
     try {
       await withInteractiveTty(async () => {
@@ -236,14 +235,15 @@ describe('maybeCheckAndPromptUpdate', () => {
             updateAttempts += 1;
             return { ok: true, stderr: '' };
           },
-          setup: async () => {
-            setupCalls += 1;
+          runSetupRefresh: async () => {
+            setupRefreshCalls += 1;
+            return { ok: true, stderr: '' };
           },
         });
       });
 
       assert.equal(updateAttempts, 0);
-      assert.equal(setupCalls, 0);
+      assert.equal(setupRefreshCalls, 0);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -253,7 +253,7 @@ describe('maybeCheckAndPromptUpdate', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
     const originalLog = console.log;
     const logs: string[] = [];
-    let setupCalls = 0;
+    let setupRefreshCalls = 0;
 
     console.log = (...args: unknown[]) => {
       logs.push(args.map((arg) => String(arg)).join(' '));
@@ -266,13 +266,14 @@ describe('maybeCheckAndPromptUpdate', () => {
           fetchLatestVersion: async () => '0.9.0',
           askYesNo: async () => true,
           runGlobalUpdate: () => ({ ok: false, stderr: 'npm exited 1' }),
-          setup: async () => {
-            setupCalls += 1;
+          runSetupRefresh: async () => {
+            setupRefreshCalls += 1;
+            return { ok: true, stderr: '' };
           },
         });
       });
 
-      assert.equal(setupCalls, 0);
+      assert.equal(setupRefreshCalls, 0);
       assert.match(logs.join('\n'), /Update failed\. Run manually: npm install -g oh-my-codex@latest/);
     } finally {
       console.log = originalLog;
@@ -298,8 +299,8 @@ describe('maybeCheckAndPromptUpdate', () => {
             updateAttempts += 1;
             return { ok: true, stderr: '' };
           },
-          setup: async () => {
-            throw new Error('setup should not run when already up to date');
+          runSetupRefresh: async () => {
+            throw new Error('setup refresh should not run when already up to date');
           },
         });
       });
@@ -349,6 +350,7 @@ describe('runImmediateUpdate', () => {
     const originalLog = console.log;
     const logs: string[] = [];
     let setupCalls = 0;
+    const refreshCwds: string[] = [];
     let updateCalls = 0;
     let latestCalls = 0;
 
@@ -375,9 +377,10 @@ describe('runImmediateUpdate', () => {
           updateCalls += 1;
           return { ok: true, stderr: '' };
         },
-        setup: async (options) => {
+        runSetupRefresh: async (refreshCwd) => {
           setupCalls += 1;
-          assert.deepEqual(options ?? {}, {});
+          refreshCwds.push(refreshCwd);
+          return { ok: true, stderr: '' };
         },
       });
 
@@ -385,6 +388,7 @@ describe('runImmediateUpdate', () => {
       assert.equal(latestCalls, 1);
       assert.equal(updateCalls, 1);
       assert.equal(setupCalls, 1);
+      assert.deepEqual(refreshCwds, [cwd]);
       assert.match(logs.join('\n'), /Running: npm install -g oh-my-codex@latest/);
       assert.match(logs.join('\n'), /Updated to v0\.14\.1/);
 
@@ -430,6 +434,94 @@ describe('runImmediateUpdate', () => {
       assert.match(logs.join('\n'), /already up to date \(v0\.14\.0\)/);
     } finally {
       console.log = originalLog;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails without writing the success stamp when the fresh setup handoff fails', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
+    const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
+    const originalCodexHome = process.env.CODEX_HOME;
+    const originalLog = console.log;
+    const logs: string[] = [];
+    let refreshCalls = 0;
+
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+
+    process.env.CODEX_HOME = join(cwd, '.codex');
+
+    try {
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.14.0',
+        fetchLatestVersion: async () => '0.14.1',
+        runGlobalUpdate: () => ({ ok: true, stderr: '' }),
+        runSetupRefresh: async () => {
+          refreshCalls += 1;
+          return { ok: false, stderr: 'updated setup exited 17' };
+        },
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.equal(refreshCalls, 1);
+      assert.match(logs.join('\n'), /Update installed, but the setup refresh failed/);
+      await assert.rejects(readFile(stampPath, 'utf-8'));
+    } finally {
+      console.log = originalLog;
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('post-update setup refresh handoff', () => {
+  it('uses the installed package bin entry when resolving the refreshed CLI', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-bin-contract-'));
+    const globalRoot = join(cwd, 'global-root');
+    const packageRoot = join(globalRoot, PACKAGE_NAME);
+    const cliRelativePath = join('dist', 'custom', 'omx-entry.js');
+    const cliEntry = join(packageRoot, cliRelativePath);
+
+    try {
+      await mkdir(dirname(cliEntry), { recursive: true });
+      await writeFile(
+        join(packageRoot, 'package.json'),
+        JSON.stringify({ name: PACKAGE_NAME, version: '0.14.1', bin: { omx: cliRelativePath } }, null, 2),
+      );
+      await writeFile(cliEntry, '#!/usr/bin/env node\n');
+
+      assert.equal(await resolveInstalledCliEntry(globalRoot), cliEntry);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the current published CLI layout when package metadata is unavailable', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-bin-fallback-'));
+    const globalRoot = join(cwd, 'global-root');
+    const cliEntry = join(globalRoot, PACKAGE_NAME, 'dist', 'cli', 'omx.js');
+
+    try {
+      await mkdir(dirname(cliEntry), { recursive: true });
+      await writeFile(cliEntry, '#!/usr/bin/env node\n');
+
+      assert.equal(await resolveInstalledCliEntry(globalRoot), cliEntry);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when neither package bin nor fallback CLI entry exists', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-bin-missing-'));
+
+    try {
+      assert.equal(await resolveInstalledCliEntry(join(cwd, 'global-root')), null);
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1,12 +1,16 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
+  isInstallVersionBump,
   isNewerVersion,
   maybeCheckAndPromptUpdate,
+  readUserInstallStamp,
+  runImmediateUpdate,
   shouldCheckForUpdates,
+  writeUserInstallStamp,
 } from '../update.js';
 
 describe('isNewerVersion', () => {
@@ -82,9 +86,51 @@ describe('shouldCheckForUpdates', () => {
 
   it('respects custom interval', () => {
     const now = Date.now();
-    const customInterval = 60 * 1000; // 1 min
-    const recentCheck = new Date(now - 30 * 1000).toISOString(); // 30s ago
+    const customInterval = 60 * 1000;
+    const recentCheck = new Date(now - 30 * 1000).toISOString();
     assert.equal(shouldCheckForUpdates(now, { last_checked_at: recentCheck }, customInterval), false);
+  });
+});
+
+describe('install stamp helpers', () => {
+  it('treats missing prior stamp as a version bump', () => {
+    assert.equal(isInstallVersionBump('0.14.0', null), true);
+  });
+
+  it('treats matching installed_version as not a bump', () => {
+    assert.equal(
+      isInstallVersionBump('0.14.0', {
+        installed_version: '0.14.0',
+        setup_completed_version: '0.14.0',
+        updated_at: '2026-04-20T00:00:00.000Z',
+      }),
+      false,
+    );
+  });
+
+  it('writes and reads the user-scope install stamp schema', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-install-stamp-'));
+    const stampPath = join(root, '.codex', '.omx', 'install-state.json');
+
+    try {
+      await writeUserInstallStamp(
+        {
+          installed_version: '0.14.0',
+          setup_completed_version: '0.14.0',
+          updated_at: '2026-04-20T00:00:00.000Z',
+        },
+        stampPath,
+      );
+
+      const parsed = await readUserInstallStamp(stampPath);
+      assert.deepEqual(parsed, {
+        installed_version: '0.14.0',
+        setup_completed_version: '0.14.0',
+        updated_at: '2026-04-20T00:00:00.000Z',
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });
 
@@ -261,6 +307,129 @@ describe('maybeCheckAndPromptUpdate', () => {
       assert.equal(promptCalls, 0);
       assert.equal(updateAttempts, 0);
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('respects the passive launch-time cadence before checking npm', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
+    const statePath = join(cwd, '.omx', 'state', 'update-check.json');
+    let latestCalls = 0;
+
+    try {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeFile(statePath, JSON.stringify({
+        last_checked_at: new Date().toISOString(),
+        last_seen_latest: '9.9.9',
+      }, null, 2));
+
+      await withInteractiveTty(async () => {
+        await maybeCheckAndPromptUpdate(cwd, {
+          fetchLatestVersion: async () => {
+            latestCalls += 1;
+            return '9.9.9';
+          },
+          getCurrentVersion: async () => '0.14.0',
+        });
+      });
+
+      assert.equal(latestCalls, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runImmediateUpdate', () => {
+  it('bypasses the passive cadence and updates immediately on explicit request', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
+    const statePath = join(cwd, '.omx', 'state', 'update-check.json');
+    const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
+    const originalCodexHome = process.env.CODEX_HOME;
+    const originalLog = console.log;
+    const logs: string[] = [];
+    let setupCalls = 0;
+    let updateCalls = 0;
+    let latestCalls = 0;
+
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+
+    process.env.CODEX_HOME = join(cwd, '.codex');
+
+    try {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeFile(statePath, JSON.stringify({
+        last_checked_at: new Date().toISOString(),
+        last_seen_latest: '0.14.1',
+      }, null, 2));
+
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.14.0',
+        fetchLatestVersion: async () => {
+          latestCalls += 1;
+          return '0.14.1';
+        },
+        runGlobalUpdate: () => {
+          updateCalls += 1;
+          return { ok: true, stderr: '' };
+        },
+        setup: async (options) => {
+          setupCalls += 1;
+          assert.deepEqual(options ?? {}, {});
+        },
+      });
+
+      assert.equal(result.status, 'updated');
+      assert.equal(latestCalls, 1);
+      assert.equal(updateCalls, 1);
+      assert.equal(setupCalls, 1);
+      assert.match(logs.join('\n'), /Running: npm install -g oh-my-codex@latest/);
+      assert.match(logs.join('\n'), /Updated to v0\.14\.1/);
+
+      const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
+        installed_version: string;
+        setup_completed_version: string;
+      };
+      assert.equal(stamp.installed_version, '0.14.1');
+      assert.equal(stamp.setup_completed_version, '0.14.1');
+    } finally {
+      console.log = originalLog;
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports up-to-date status for explicit update when npm is already current', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
+    const originalLog = console.log;
+    const logs: string[] = [];
+    let updateCalls = 0;
+
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+
+    try {
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.14.0',
+        fetchLatestVersion: async () => '0.14.0',
+        runGlobalUpdate: () => {
+          updateCalls += 1;
+          return { ok: true, stderr: '' };
+        },
+      });
+
+      assert.equal(result.status, 'up-to-date');
+      assert.equal(updateCalls, 0);
+      assert.match(logs.join('\n'), /already up to date \(v0\.14\.0\)/);
+    } finally {
+      console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,7 +50,7 @@ import {
 } from "../mcp/state-paths.js";
 import { SKILL_ACTIVE_STATE_MODE, syncCanonicalSkillStateForMode } from "../state/skill-active.js";
 import { isTrackedWorkflowMode } from "../state/workflow-transition.js";
-import { maybeCheckAndPromptUpdate } from "./update.js";
+import { maybeCheckAndPromptUpdate, runImmediateUpdate } from "./update.js";
 import { maybePromptGithubStar } from "./star-prompt.js";
 import {
   generateOverlay,
@@ -137,13 +137,14 @@ function resolveDistScript(pkgRoot: string, scriptName: string): string {
   return join(pkgRoot, "dist", "scripts", scriptName);
 }
 
-const HELP = `
+export const HELP = `
 oh-my-codex (omx) - Multi-agent orchestration for Codex CLI
 
 Usage:
   omx           Launch Codex CLI (HUD auto-attaches only when already inside tmux)
   omx exec      Run codex exec non-interactively with OMX AGENTS/overlay injection
   omx setup     Install skills, prompts, MCP servers, and scope-specific AGENTS.md
+  omx update    Check npm now, update the global install immediately, then refresh setup
   omx uninstall Remove OMX configuration and clean up installed artifacts
   omx doctor    Check installation health
   omx cleanup   Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories
@@ -259,6 +260,7 @@ type CliCommand =
   | "launch"
   | "exec"
   | "setup"
+  | "update"
   | "agents"
   | "agents-init"
   | "deepinit"
@@ -644,6 +646,7 @@ export async function main(args: string[]): Promise<void> {
     "launch",
     "exec",
     "setup",
+    "update",
     "agents",
     "agents-init",
     "deepinit",
@@ -700,6 +703,9 @@ export async function main(args: string[]): Promise<void> {
           verbose: options.verbose,
           scope: resolveSetupScopeArg(args.slice(1)),
         });
+        break;
+      case "update":
+        await runImmediateUpdate(process.cwd());
         break;
       case "agents":
         await agentsCommand(args.slice(1));

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -13,7 +13,6 @@ import { spawnSync } from 'child_process';
 import { createInterface } from 'readline/promises';
 import { getPackageRoot } from '../utils/package.js';
 import { omxUserInstallStampPath } from '../utils/paths.js';
-import { setup } from './setup.js';
 
 export interface UpdateState {
   last_checked_at: string;
@@ -30,6 +29,11 @@ interface LatestPackageInfo {
   version?: string;
 }
 
+interface PackageManifest {
+  bin?: string | Record<string, string>;
+  version?: string;
+}
+
 export interface UpdateExecutionResult {
   status: 'updated' | 'up-to-date' | 'declined' | 'failed' | 'unavailable';
   currentVersion: string | null;
@@ -37,6 +41,7 @@ export interface UpdateExecutionResult {
 }
 
 type RunGlobalUpdateResult = { ok: boolean; stderr: string };
+type RunSetupRefreshResult = { ok: boolean; stderr: string };
 
 const PACKAGE_NAME = 'oh-my-codex';
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12h
@@ -148,7 +153,7 @@ interface UpdateDependencies {
   fetchLatestVersion: typeof fetchLatestVersion;
   getCurrentVersion: typeof getCurrentVersion;
   runGlobalUpdate: typeof runGlobalUpdate;
-  setup: typeof setup;
+  runSetupRefresh: (cwd: string) => Promise<RunSetupRefreshResult>;
 }
 
 const defaultUpdateDependencies: UpdateDependencies = {
@@ -156,7 +161,7 @@ const defaultUpdateDependencies: UpdateDependencies = {
   fetchLatestVersion,
   getCurrentVersion,
   runGlobalUpdate,
-  setup,
+  runSetupRefresh,
 };
 
 function stripLeadingV(version: string): string {
@@ -212,6 +217,87 @@ export function isInstallVersionBump(
   return stripLeadingV(currentVersion) !== stripLeadingV(stamp.installed_version);
 }
 
+function resolveGlobalInstallRoot(): string | null {
+  const result = spawnSync('npm', ['root', '-g'], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 15000,
+    windowsHide: true,
+  });
+
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+
+  const root = (result.stdout || '').trim();
+  return root === '' ? null : root;
+}
+
+export async function resolveInstalledCliEntry(globalInstallRoot: string): Promise<string | null> {
+  const packageRoot = join(globalInstallRoot, PACKAGE_NAME);
+  const packageJsonPath = join(packageRoot, 'package.json');
+  let cliRelativePath = join('dist', 'cli', 'omx.js');
+
+  try {
+    const content = await readFile(packageJsonPath, 'utf-8');
+    const pkg = JSON.parse(content) as PackageManifest;
+    if (typeof pkg.bin === 'string' && pkg.bin.trim() !== '') {
+      cliRelativePath = pkg.bin;
+    } else if (
+      pkg.bin &&
+      typeof pkg.bin === 'object' &&
+      typeof pkg.bin.omx === 'string' &&
+      pkg.bin.omx.trim() !== ''
+    ) {
+      cliRelativePath = pkg.bin.omx;
+    }
+  } catch {
+    // Fall back to the published contract used in package.json today.
+  }
+
+  const cliEntry = join(packageRoot, cliRelativePath);
+  return existsSync(cliEntry) ? cliEntry : null;
+}
+
+async function runSetupRefresh(cwd: string): Promise<RunSetupRefreshResult> {
+  const globalInstallRoot = resolveGlobalInstallRoot();
+  if (!globalInstallRoot) {
+    return {
+      ok: false,
+      stderr: 'Unable to resolve the npm global install root after updating.',
+    };
+  }
+
+  const cliEntry = await resolveInstalledCliEntry(globalInstallRoot);
+  if (!cliEntry) {
+    return {
+      ok: false,
+      stderr: `Unable to find the updated OMX CLI entry under ${join(globalInstallRoot, PACKAGE_NAME)}.`,
+    };
+  }
+
+  const result = spawnSync(process.execPath, [cliEntry, 'setup'], {
+    cwd,
+    env: process.env,
+    stdio: 'inherit',
+    timeout: 120000,
+    windowsHide: true,
+  });
+
+  if (result.error) {
+    return { ok: false, stderr: result.error.message };
+  }
+
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      stderr: `The updated setup refresh exited with status ${result.status}.`,
+    };
+  }
+
+  return { ok: true, stderr: '' };
+}
+
 async function executeUpdate(
   options: {
     cwd: string;
@@ -263,7 +349,14 @@ async function executeUpdate(
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
 
-  await dependencies.setup();
+  const setupRefreshResult = await dependencies.runSetupRefresh(cwd);
+  if (!setupRefreshResult.ok) {
+    console.log(
+      `[omx] Update installed, but the setup refresh failed. Run \`omx setup\` with the new install. (${setupRefreshResult.stderr})`,
+    );
+    return { status: 'failed', currentVersion: current, latestVersion: latest };
+  }
+
   await writeSuccessfulInstallStamp(latest);
   console.log(`[omx] Updated to v${latest}. Restart to use new code.`);
   return { status: 'updated', currentVersion: current, latestVersion: latest };

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,24 +1,42 @@
 /**
- * Launch-time update checks for oh-my-codex.
- * Non-fatal and throttled; can be disabled via OMX_AUTO_UPDATE=0.
+ * Update orchestration for oh-my-codex.
+ *
+ * The launch-time checker is intentionally passive, non-fatal, and throttled.
+ * The explicit `omx update` command uses the same executor but bypasses the
+ * launch-time cadence so a user request always checks npm immediately.
  */
 
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { spawnSync } from 'child_process';
 import { createInterface } from 'readline/promises';
 import { getPackageRoot } from '../utils/package.js';
+import { omxUserInstallStampPath } from '../utils/paths.js';
 import { setup } from './setup.js';
 
-interface UpdateState {
+export interface UpdateState {
   last_checked_at: string;
   last_seen_latest?: string;
+}
+
+export interface UserInstallStamp {
+  installed_version: string;
+  setup_completed_version?: string;
+  updated_at: string;
 }
 
 interface LatestPackageInfo {
   version?: string;
 }
+
+export interface UpdateExecutionResult {
+  status: 'updated' | 'up-to-date' | 'declined' | 'failed' | 'unavailable';
+  currentVersion: string | null;
+  latestVersion: string | null;
+}
+
+type RunGlobalUpdateResult = { ok: boolean; stderr: string };
 
 const PACKAGE_NAME = 'oh-my-codex';
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12h
@@ -97,7 +115,7 @@ async function getCurrentVersion(): Promise<string | null> {
   }
 }
 
-function runGlobalUpdate(): { ok: boolean; stderr: string } {
+function runGlobalUpdate(): RunGlobalUpdateResult {
   const result = spawnSync('npm', ['install', '-g', `${PACKAGE_NAME}@latest`], {
     encoding: 'utf-8',
     stdio: ['ignore', 'ignore', 'pipe'],
@@ -141,6 +159,129 @@ const defaultUpdateDependencies: UpdateDependencies = {
   setup,
 };
 
+function stripLeadingV(version: string): string {
+  return version.trim().replace(/^v/i, '');
+}
+
+async function writeSuccessfulInstallStamp(
+  installedVersion: string,
+): Promise<void> {
+  await writeUserInstallStamp({
+    installed_version: stripLeadingV(installedVersion),
+    setup_completed_version: stripLeadingV(installedVersion),
+    updated_at: new Date().toISOString(),
+  });
+}
+
+export async function readUserInstallStamp(
+  path = omxUserInstallStampPath(),
+): Promise<UserInstallStamp | null> {
+  if (!existsSync(path)) return null;
+  try {
+    const content = await readFile(path, 'utf-8');
+    const parsed = JSON.parse(content) as Partial<UserInstallStamp>;
+    if (typeof parsed.installed_version !== 'string' || typeof parsed.updated_at !== 'string') {
+      return null;
+    }
+    return {
+      installed_version: parsed.installed_version,
+      ...(typeof parsed.setup_completed_version === 'string'
+        ? { setup_completed_version: parsed.setup_completed_version }
+        : {}),
+      updated_at: parsed.updated_at,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function writeUserInstallStamp(
+  stamp: UserInstallStamp,
+  path = omxUserInstallStampPath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(stamp, null, 2));
+}
+
+export function isInstallVersionBump(
+  currentVersion: string | null | undefined,
+  stamp: UserInstallStamp | null,
+): boolean {
+  if (!currentVersion) return false;
+  if (!stamp?.installed_version) return true;
+  return stripLeadingV(currentVersion) !== stripLeadingV(stamp.installed_version);
+}
+
+async function executeUpdate(
+  options: {
+    cwd: string;
+    dependencies: UpdateDependencies;
+    prompt: boolean;
+    immediate: boolean;
+    nowMs?: number;
+  },
+): Promise<UpdateExecutionResult> {
+  const { cwd, dependencies, prompt, immediate, nowMs = Date.now() } = options;
+  const [current, latest] = await Promise.all([
+    dependencies.getCurrentVersion(),
+    dependencies.fetchLatestVersion(),
+  ]);
+
+  await writeUpdateState(cwd, {
+    last_checked_at: new Date(nowMs).toISOString(),
+    last_seen_latest: latest ?? undefined,
+  });
+
+  if (!current || !latest) {
+    if (immediate) {
+      console.log('[omx] Unable to determine the latest oh-my-codex version. Try again later.');
+    }
+    return { status: 'unavailable', currentVersion: current, latestVersion: latest };
+  }
+
+  if (!isNewerVersion(current, latest)) {
+    if (immediate) {
+      console.log(`[omx] oh-my-codex is already up to date (v${current}).`);
+    }
+    return { status: 'up-to-date', currentVersion: current, latestVersion: latest };
+  }
+
+  if (prompt) {
+    const approved = await dependencies.askYesNo(
+      `[omx] Update available: v${current} → v${latest}. Update now? [Y/n] `,
+    );
+    if (!approved) {
+      return { status: 'declined', currentVersion: current, latestVersion: latest };
+    }
+  }
+
+  console.log(`[omx] Running: npm install -g ${PACKAGE_NAME}@latest`);
+  const result = dependencies.runGlobalUpdate();
+
+  if (!result.ok) {
+    console.log('[omx] Update failed. Run manually: npm install -g oh-my-codex@latest');
+    return { status: 'failed', currentVersion: current, latestVersion: latest };
+  }
+
+  await dependencies.setup();
+  await writeSuccessfulInstallStamp(latest);
+  console.log(`[omx] Updated to v${latest}. Restart to use new code.`);
+  return { status: 'updated', currentVersion: current, latestVersion: latest };
+}
+
+export async function runImmediateUpdate(
+  cwd = process.cwd(),
+  dependencies: Partial<UpdateDependencies> = {},
+): Promise<UpdateExecutionResult> {
+  const updateDependencies = { ...defaultUpdateDependencies, ...dependencies };
+  return executeUpdate({
+    cwd,
+    dependencies: updateDependencies,
+    prompt: false,
+    immediate: true,
+  });
+}
+
 export async function maybeCheckAndPromptUpdate(
   cwd: string,
   dependencies: Partial<UpdateDependencies> = {},
@@ -153,30 +294,11 @@ export async function maybeCheckAndPromptUpdate(
   const state = await readUpdateState(cwd);
   if (!shouldCheckForUpdates(now, state)) return;
 
-  const [current, latest] = await Promise.all([
-    updateDependencies.getCurrentVersion(),
-    updateDependencies.fetchLatestVersion(),
-  ]);
-
-  await writeUpdateState(cwd, {
-    last_checked_at: new Date(now).toISOString(),
-    last_seen_latest: latest || state?.last_seen_latest,
+  await executeUpdate({
+    cwd,
+    dependencies: updateDependencies,
+    prompt: true,
+    immediate: false,
+    nowMs: now,
   });
-
-  if (!current || !latest || !isNewerVersion(current, latest)) return;
-
-  const approved = await updateDependencies.askYesNo(
-    `[omx] Update available: v${current} → v${latest}. Update now? [Y/n] `,
-  );
-  if (!approved) return;
-
-  console.log(`[omx] Running: npm install -g ${PACKAGE_NAME}@latest`);
-  const result = updateDependencies.runGlobalUpdate();
-
-  if (result.ok) {
-    await updateDependencies.setup();
-    console.log(`[omx] Updated to v${latest}. Restart to use new code.`);
-  } else {
-    console.log('[omx] Update failed. Run manually: npm install -g oh-my-codex@latest');
-  }
 }

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -18,24 +18,38 @@ describe('config generator', () => {
       const reasoningIdx = toml.indexOf('model_reasoning_effort =');
       const devInstrIdx = toml.indexOf('developer_instructions =');
       const modelIdx = toml.indexOf('model = "gpt-5.4"');
-      const contextIdx = toml.indexOf('model_context_window = 250000');
-      const compactIdx = toml.indexOf('model_auto_compact_token_limit = 200000');
+      const seededStartIdx = toml.indexOf(
+        '# oh-my-codex seeded behavioral defaults (uninstall removes unchanged defaults)',
+      );
+      const contextIdx = toml.indexOf('model_context_window = 1000000');
+      const compactIdx = toml.indexOf('model_auto_compact_token_limit = 900000');
+      const seededEndIdx = toml.indexOf('# End oh-my-codex seeded behavioral defaults');
       const featuresIdx = toml.indexOf('[features]');
 
       assert.ok(notifyIdx >= 0, 'notify not found');
       assert.ok(reasoningIdx >= 0, 'model_reasoning_effort not found');
       assert.ok(devInstrIdx >= 0, 'developer_instructions not found');
       assert.ok(modelIdx >= 0, 'model not found');
+      assert.ok(seededStartIdx >= 0, 'seeded defaults start marker not found');
       assert.ok(contextIdx >= 0, 'model_context_window not found');
       assert.ok(compactIdx >= 0, 'model_auto_compact_token_limit not found');
+      assert.ok(seededEndIdx >= 0, 'seeded defaults end marker not found');
       assert.ok(featuresIdx >= 0, '[features] not found');
 
       assert.ok(notifyIdx < featuresIdx, 'notify must come before [features]');
       assert.ok(reasoningIdx < featuresIdx, 'model_reasoning_effort must come before [features]');
       assert.ok(devInstrIdx < featuresIdx, 'developer_instructions must come before [features]');
       assert.ok(modelIdx < featuresIdx, 'model must come before [features]');
+      assert.ok(
+        seededStartIdx < featuresIdx,
+        'seeded defaults start marker must come before [features]',
+      );
       assert.ok(contextIdx < featuresIdx, 'model_context_window must come before [features]');
       assert.ok(compactIdx < featuresIdx, 'model_auto_compact_token_limit must come before [features]');
+      assert.ok(
+        seededEndIdx < featuresIdx,
+        'seeded defaults end marker must come before [features]',
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -63,8 +77,13 @@ describe('config generator', () => {
       const toml = await readFile(configPath, 'utf-8');
 
       assert.match(toml, /^model = "gpt-5\.4"$/m);
-      assert.match(toml, /^model_context_window = 250000$/m);
-      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
+      assert.match(
+        toml,
+        /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/m,
+      );
+      assert.match(toml, /^model_context_window = 1000000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^# End oh-my-codex seeded behavioral defaults$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -78,8 +97,13 @@ describe('config generator', () => {
       const toml = await readFile(configPath, 'utf-8');
 
       assert.match(toml, /^model = "gpt-5\.4"$/m);
-      assert.match(toml, /^model_context_window = 250000$/m);
-      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
+      assert.match(
+        toml,
+        /^# oh-my-codex seeded behavioral defaults \(uninstall removes unchanged defaults\)$/m,
+      );
+      assert.match(toml, /^model_context_window = 1000000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^# End oh-my-codex seeded behavioral defaults$/m);
 
       const modelIdx = toml.indexOf('model = "gpt-5.4"');
       const featuresIdx = toml.indexOf('[features]');
@@ -182,7 +206,7 @@ describe('config generator', () => {
 
       assert.match(toml, /^model = "gpt-5\.4"$/m);
       assert.match(toml, /^model_context_window = 640000$/m);
-      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
+      assert.doesNotMatch(toml, /^model_auto_compact_token_limit = 900000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -18,8 +18,8 @@ describe('config generator', () => {
       const reasoningIdx = toml.indexOf('model_reasoning_effort =');
       const devInstrIdx = toml.indexOf('developer_instructions =');
       const modelIdx = toml.indexOf('model = "gpt-5.4"');
-      const contextIdx = toml.indexOf('model_context_window = 1000000');
-      const compactIdx = toml.indexOf('model_auto_compact_token_limit = 900000');
+      const contextIdx = toml.indexOf('model_context_window = 250000');
+      const compactIdx = toml.indexOf('model_auto_compact_token_limit = 200000');
       const featuresIdx = toml.indexOf('[features]');
 
       assert.ok(notifyIdx >= 0, 'notify not found');
@@ -63,8 +63,8 @@ describe('config generator', () => {
       const toml = await readFile(configPath, 'utf-8');
 
       assert.match(toml, /^model = "gpt-5\.4"$/m);
-      assert.match(toml, /^model_context_window = 1000000$/m);
-      assert.match(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^model_context_window = 250000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -78,8 +78,8 @@ describe('config generator', () => {
       const toml = await readFile(configPath, 'utf-8');
 
       assert.match(toml, /^model = "gpt-5\.4"$/m);
-      assert.match(toml, /^model_context_window = 1000000$/m);
-      assert.match(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.match(toml, /^model_context_window = 250000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
 
       const modelIdx = toml.indexOf('model = "gpt-5.4"');
       const featuresIdx = toml.indexOf('[features]');
@@ -168,7 +168,27 @@ describe('config generator', () => {
     }
   });
 
-  it('does not seed 1M context keys for non-gpt-5.4 models', async () => {
+  it('seeds only the missing gpt-5.4 context key while preserving an existing partner value', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      await writeFile(
+        configPath,
+        ['model = "gpt-5.4"', 'model_context_window = 640000', ''].join('\n'),
+      );
+
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.match(toml, /^model = "gpt-5\.4"$/m);
+      assert.match(toml, /^model_context_window = 640000$/m);
+      assert.match(toml, /^model_auto_compact_token_limit = 200000$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not seed 250k context keys for non-gpt-5.4 models', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
     try {
       const configPath = join(wd, 'config.toml');
@@ -178,8 +198,8 @@ describe('config generator', () => {
       const toml = await readFile(configPath, 'utf-8');
 
       assert.match(toml, /^model = "o3"$/m);
-      assert.doesNotMatch(toml, /^model_context_window = 1000000$/m);
-      assert.doesNotMatch(toml, /^model_auto_compact_token_limit = 900000$/m);
+      assert.doesNotMatch(toml, /^model_context_window = 250000$/m);
+      assert.doesNotMatch(toml, /^model_auto_compact_token_limit = 200000$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/postinstall.test.ts
+++ b/src/scripts/__tests__/postinstall.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -155,5 +155,48 @@ describe("runPostinstall", () => {
 
     assert.equal(result.status, "setup-failed");
     assert.match(warnings.join("\n"), /non-fatal error: boom/);
+  });
+
+  it("runs interactive setup from INIT_CWD so setup scope state stays under the install root", async () => {
+    const installRoot = await mkdtemp(join(tmpdir(), "omx-postinstall-install-root-"));
+    const packageRoot = await mkdtemp(join(tmpdir(), "omx-postinstall-package-root-"));
+    const originalCwd = process.cwd();
+    const scopeFile = join(installRoot, ".omx", "setup-scope.json");
+    const packageScopeFile = join(packageRoot, ".omx", "setup-scope.json");
+
+    try {
+      process.chdir(packageRoot);
+
+      const result = await runPostinstall({
+        env: { npm_config_global: "true", INIT_CWD: installRoot },
+        getCurrentVersion: async () => "0.14.1",
+        isInteractive: () => true,
+        readStamp: async () => ({
+          installed_version: "0.14.0",
+          setup_completed_version: "0.14.0",
+          updated_at: "2026-04-20T00:00:00.000Z",
+        }),
+        runSetup: async () => {
+          await mkdir(join(process.cwd(), ".omx"), { recursive: true });
+          await writeFile(
+            join(process.cwd(), ".omx", "setup-scope.json"),
+            JSON.stringify({ scope: "project" }),
+          );
+        },
+        writeStamp: async () => {},
+      });
+
+      assert.equal(result.status, "setup-ran");
+      assert.equal(process.cwd(), packageRoot);
+      assert.equal(
+        JSON.parse(await readFile(scopeFile, "utf-8")).scope,
+        "project",
+      );
+      await assert.rejects(() => readFile(packageScopeFile, "utf-8"));
+    } finally {
+      process.chdir(originalCwd);
+      await rm(installRoot, { recursive: true, force: true });
+      await rm(packageRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/scripts/__tests__/postinstall.test.ts
+++ b/src/scripts/__tests__/postinstall.test.ts
@@ -157,18 +157,24 @@ describe("runPostinstall", () => {
     assert.match(warnings.join("\n"), /non-fatal error: boom/);
   });
 
-  it("runs interactive setup from INIT_CWD so setup scope state stays under the install root", async () => {
+  it("runs interactive setup from the npm install prefix instead of the package dir or INIT_CWD", async () => {
     const installRoot = await mkdtemp(join(tmpdir(), "omx-postinstall-install-root-"));
     const packageRoot = await mkdtemp(join(tmpdir(), "omx-postinstall-package-root-"));
+    const initCwd = await mkdtemp(join(tmpdir(), "omx-postinstall-init-cwd-"));
     const originalCwd = process.cwd();
     const scopeFile = join(installRoot, ".omx", "setup-scope.json");
     const packageScopeFile = join(packageRoot, ".omx", "setup-scope.json");
+    const initCwdScopeFile = join(initCwd, ".omx", "setup-scope.json");
 
     try {
       process.chdir(packageRoot);
 
       const result = await runPostinstall({
-        env: { npm_config_global: "true", INIT_CWD: installRoot },
+        env: {
+          npm_config_global: "true",
+          npm_config_prefix: installRoot,
+          INIT_CWD: initCwd,
+        },
         getCurrentVersion: async () => "0.14.1",
         isInteractive: () => true,
         readStamp: async () => ({
@@ -193,10 +199,12 @@ describe("runPostinstall", () => {
         "project",
       );
       await assert.rejects(() => readFile(packageScopeFile, "utf-8"));
+      await assert.rejects(() => readFile(initCwdScopeFile, "utf-8"));
     } finally {
       process.chdir(originalCwd);
       await rm(installRoot, { recursive: true, force: true });
       await rm(packageRoot, { recursive: true, force: true });
+      await rm(initCwd, { recursive: true, force: true });
     }
   });
 });

--- a/src/scripts/__tests__/postinstall.test.ts
+++ b/src/scripts/__tests__/postinstall.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { writeUserInstallStamp } from "../../cli/update.js";
+import {
+  isGlobalInstallLifecycle,
+  runPostinstall,
+} from "../postinstall.js";
+
+describe("isGlobalInstallLifecycle", () => {
+  it("accepts npm_config_global=true", () => {
+    assert.equal(isGlobalInstallLifecycle({ npm_config_global: "true" }), true);
+  });
+
+  it("accepts npm_config_location=global", () => {
+    assert.equal(isGlobalInstallLifecycle({ npm_config_location: "global" }), true);
+  });
+
+  it("rejects local installs", () => {
+    assert.equal(isGlobalInstallLifecycle({ npm_config_global: "false" }), false);
+  });
+});
+
+describe("runPostinstall", () => {
+  it("runs interactive setup only for bumped global installs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-postinstall-"));
+    const stampPath = join(root, ".codex", ".omx", "install-state.json");
+    const logs: string[] = [];
+    let setupCalls = 0;
+
+    try {
+      const result = await runPostinstall({
+        env: { npm_config_global: "true" },
+        getCurrentVersion: async () => "0.14.1",
+        isInteractive: () => true,
+        log: (message) => logs.push(message),
+        readStamp: async () => ({
+          installed_version: "0.14.0",
+          setup_completed_version: "0.14.0",
+          updated_at: "2026-04-20T00:00:00.000Z",
+        }),
+        runSetup: async () => {
+          setupCalls += 1;
+        },
+        writeStamp: async (stamp) => writeUserInstallStamp(stamp, stampPath),
+      });
+
+      assert.equal(result.status, "setup-ran");
+      assert.equal(setupCalls, 1);
+      assert.match(logs.join("\n"), /Launching interactive setup/);
+
+      const stamp = JSON.parse(await readFile(stampPath, "utf-8")) as {
+        installed_version: string;
+        setup_completed_version: string;
+      };
+      assert.equal(stamp.installed_version, "0.14.1");
+      assert.equal(stamp.setup_completed_version, "0.14.1");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("records the installed version and prints a hint when no TTY is available", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-postinstall-"));
+    const stampPath = join(root, ".codex", ".omx", "install-state.json");
+    const logs: string[] = [];
+    let setupCalls = 0;
+
+    try {
+      const result = await runPostinstall({
+        env: { npm_config_global: "true" },
+        getCurrentVersion: async () => "0.14.1",
+        isInteractive: () => false,
+        log: (message) => logs.push(message),
+        readStamp: async () => ({
+          installed_version: "0.14.0",
+          setup_completed_version: "0.14.0",
+          updated_at: "2026-04-20T00:00:00.000Z",
+        }),
+        runSetup: async () => {
+          setupCalls += 1;
+        },
+        writeStamp: async (stamp) => writeUserInstallStamp(stamp, stampPath),
+      });
+
+      assert.equal(result.status, "hinted");
+      assert.equal(setupCalls, 0);
+      assert.match(logs.join("\n"), /Run `omx setup` \(interactive\) or `omx update`/);
+
+      const stamp = JSON.parse(await readFile(stampPath, "utf-8")) as {
+        installed_version: string;
+        setup_completed_version: string;
+      };
+      assert.equal(stamp.installed_version, "0.14.1");
+      assert.equal(stamp.setup_completed_version, "0.14.0");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips local installs", async () => {
+    let setupCalls = 0;
+    const result = await runPostinstall({
+      env: { npm_config_global: "false" },
+      getCurrentVersion: async () => "0.14.1",
+      isInteractive: () => true,
+      runSetup: async () => {
+        setupCalls += 1;
+      },
+    });
+
+    assert.equal(result.status, "noop-local");
+    assert.equal(setupCalls, 0);
+  });
+
+  it("does not rerun setup when the installed version matches the saved stamp", async () => {
+    let setupCalls = 0;
+    const result = await runPostinstall({
+      env: { npm_config_global: "true" },
+      getCurrentVersion: async () => "0.14.1",
+      isInteractive: () => true,
+      readStamp: async () => ({
+        installed_version: "0.14.1",
+        setup_completed_version: "0.14.1",
+        updated_at: "2026-04-20T00:00:00.000Z",
+      }),
+      runSetup: async () => {
+        setupCalls += 1;
+      },
+    });
+
+    assert.equal(result.status, "noop-same-version");
+    assert.equal(setupCalls, 0);
+  });
+
+  it("warns and exits cleanly when setup fails", async () => {
+    const warnings: string[] = [];
+    const result = await runPostinstall({
+      env: { npm_config_global: "true" },
+      getCurrentVersion: async () => "0.14.1",
+      isInteractive: () => true,
+      readStamp: async () => ({
+        installed_version: "0.14.0",
+        setup_completed_version: "0.14.0",
+        updated_at: "2026-04-20T00:00:00.000Z",
+      }),
+      runSetup: async () => {
+        throw new Error("boom");
+      },
+      warn: (message) => warnings.push(message),
+      writeStamp: async () => {},
+    });
+
+    assert.equal(result.status, "setup-failed");
+    assert.match(warnings.join("\n"), /non-fatal error: boom/);
+  });
+});

--- a/src/scripts/postinstall-bootstrap.js
+++ b/src/scripts/postinstall-bootstrap.js
@@ -1,0 +1,23 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const distScriptPath = join(__dirname, "..", "..", "dist", "scripts", "postinstall.js");
+
+if (!existsSync(distScriptPath)) {
+  process.exit(0);
+}
+
+const moduleUrl = pathToFileURL(distScriptPath).href;
+try {
+  const postinstallModule = await import(moduleUrl);
+  if (typeof postinstallModule.main === "function") {
+    await postinstallModule.main();
+  }
+} catch (error) {
+  console.warn(
+    `[omx] Postinstall bootstrap skipped after a non-fatal error: ${error instanceof Error ? error.message : String(error)}`,
+  );
+}

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   isInstallVersionBump,
@@ -44,6 +44,29 @@ function isTruthyEnv(value: string | undefined): boolean {
 
 export function isGlobalInstallLifecycle(env: NodeJS.ProcessEnv = process.env): boolean {
   return isTruthyEnv(env.npm_config_global) || env.npm_config_location === "global";
+}
+
+function resolveInstallRoot(env: NodeJS.ProcessEnv): string {
+  const initCwd = env.INIT_CWD?.trim();
+  return initCwd ? resolve(initCwd) : process.cwd();
+}
+
+async function runSetupFromInstallRoot(
+  runSetup: typeof setup,
+  installRoot: string,
+): Promise<void> {
+  const previousCwd = process.cwd();
+  if (previousCwd === installRoot) {
+    await runSetup();
+    return;
+  }
+
+  process.chdir(installRoot);
+  try {
+    await runSetup();
+  } finally {
+    process.chdir(previousCwd);
+  }
 }
 
 async function getCurrentVersion(): Promise<string | null> {
@@ -109,7 +132,7 @@ export async function runPostinstall(
   );
 
   try {
-    await resolved.runSetup();
+    await runSetupFromInstallRoot(resolved.runSetup, resolveInstallRoot(env));
     await resolved.writeStamp({
       installed_version: currentStampVersion,
       setup_completed_version: currentStampVersion,

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -47,8 +47,8 @@ export function isGlobalInstallLifecycle(env: NodeJS.ProcessEnv = process.env): 
 }
 
 function resolveInstallRoot(env: NodeJS.ProcessEnv): string {
-  const initCwd = env.INIT_CWD?.trim();
-  return initCwd ? resolve(initCwd) : process.cwd();
+  const installPrefix = env.npm_config_prefix?.trim() || env.npm_config_local_prefix?.trim();
+  return installPrefix ? resolve(installPrefix) : process.cwd();
 }
 
 async function runSetupFromInstallRoot(

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -1,0 +1,138 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  isInstallVersionBump,
+  readUserInstallStamp,
+  type UserInstallStamp,
+  writeUserInstallStamp,
+} from "../cli/update.js";
+import { setup } from "../cli/setup.js";
+import { getPackageRoot } from "../utils/package.js";
+
+type PostinstallStatus =
+  | "noop-local"
+  | "noop-same-version"
+  | "noop-missing-version"
+  | "hinted"
+  | "setup-ran"
+  | "setup-failed";
+
+export interface PostinstallResult {
+  status: PostinstallStatus;
+  version: string | null;
+}
+
+interface PostinstallDependencies {
+  env: NodeJS.ProcessEnv;
+  getCurrentVersion: () => Promise<string | null>;
+  isInteractive: () => boolean;
+  log: (message: string) => void;
+  readStamp: () => Promise<UserInstallStamp | null>;
+  runSetup: typeof setup;
+  warn: (message: string) => void;
+  writeStamp: (stamp: UserInstallStamp) => Promise<void>;
+}
+
+function stripLeadingV(version: string): string {
+  return version.trim().replace(/^v/i, "");
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  return value === "1" || value === "true";
+}
+
+export function isGlobalInstallLifecycle(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isTruthyEnv(env.npm_config_global) || env.npm_config_location === "global";
+}
+
+async function getCurrentVersion(): Promise<string | null> {
+  try {
+    const packageJsonPath = join(getPackageRoot(), "package.json");
+    const content = await readFile(packageJsonPath, "utf-8");
+    const parsed = JSON.parse(content) as { version?: string };
+    return typeof parsed.version === "string" ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+const defaultDependencies: PostinstallDependencies = {
+  env: process.env,
+  getCurrentVersion,
+  isInteractive: () => Boolean(process.stdin.isTTY && process.stdout.isTTY),
+  log: (message) => console.log(message),
+  readStamp: () => readUserInstallStamp(),
+  runSetup: setup,
+  warn: (message) => console.warn(message),
+  writeStamp: (stamp) => writeUserInstallStamp(stamp),
+};
+
+export async function runPostinstall(
+  dependencies: Partial<PostinstallDependencies> = {},
+): Promise<PostinstallResult> {
+  const resolved = { ...defaultDependencies, ...dependencies };
+  const { env } = resolved;
+
+  if (!isGlobalInstallLifecycle(env)) {
+    return { status: "noop-local", version: null };
+  }
+
+  const currentVersion = await resolved.getCurrentVersion();
+  if (!currentVersion) {
+    return { status: "noop-missing-version", version: null };
+  }
+
+  const currentStampVersion = stripLeadingV(currentVersion);
+  const existingStamp = await resolved.readStamp();
+  if (!isInstallVersionBump(currentVersion, existingStamp)) {
+    return { status: "noop-same-version", version: currentStampVersion };
+  }
+
+  await resolved.writeStamp({
+    installed_version: currentStampVersion,
+    ...(typeof existingStamp?.setup_completed_version === "string"
+      ? { setup_completed_version: existingStamp.setup_completed_version }
+      : {}),
+    updated_at: new Date().toISOString(),
+  });
+
+  if (!resolved.isInteractive()) {
+    resolved.log(
+      `[omx] Installed oh-my-codex v${currentStampVersion}. Run \`omx setup\` (interactive) or \`omx update\` when you're ready.`,
+    );
+    return { status: "hinted", version: currentStampVersion };
+  }
+
+  resolved.log(
+    `[omx] Detected oh-my-codex v${currentStampVersion} install/update. Launching interactive setup...`,
+  );
+
+  try {
+    await resolved.runSetup();
+    await resolved.writeStamp({
+      installed_version: currentStampVersion,
+      setup_completed_version: currentStampVersion,
+      updated_at: new Date().toISOString(),
+    });
+    resolved.log(`[omx] Setup refresh completed for v${currentStampVersion}.`);
+    return { status: "setup-ran", version: currentStampVersion };
+  } catch (error) {
+    resolved.warn(
+      `[omx] Postinstall setup skipped after a non-fatal error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { status: "setup-failed", version: currentStampVersion };
+  }
+}
+
+export async function main(): Promise<void> {
+  await runPostinstall();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.warn(
+      `[omx] Postinstall setup skipped after a non-fatal error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  });
+}

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -694,6 +694,9 @@ describe('runtime', () => {
     const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const prevSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+    const prevStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+    const prevStartupDispatchRetries = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+    const prevStartupDispatchRetryDelay = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
     let receiptFailer: NodeJS.Timeout | null = null;
 
     try {
@@ -774,6 +777,9 @@ esac
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
           process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
 
           receiptFailer = setInterval(() => {
             void (async () => {
@@ -832,6 +838,21 @@ esac
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevSkipReadyWait === 'string') process.env.OMX_TEAM_SKIP_READY_WAIT = prevSkipReadyWait;
       else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+      if (typeof prevStartupEvidenceTimeout === 'string') {
+        process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = prevStartupEvidenceTimeout;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+      }
+      if (typeof prevStartupDispatchRetries === 'string') {
+        process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = prevStartupDispatchRetries;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+      }
+      if (typeof prevStartupDispatchRetryDelay === 'string') {
+        process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = prevStartupDispatchRetryDelay;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
+      }
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -1335,6 +1356,9 @@ esac
     const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const previousSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
     const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+    const previousStartupDispatchRetries = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+    const previousStartupDispatchRetryDelay = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
+    let receiptFailer: NodeJS.Timeout | null = null;
     let runtime: TeamRuntime | null = null;
     const teamName = 'team-no-startup-evidence';
 
@@ -1421,6 +1445,25 @@ process.on('SIGTERM', () => process.exit(0));
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
           process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
           process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
+
+          receiptFailer = setInterval(() => {
+            void (async () => {
+              const requests = await listDispatchRequests(teamName, cwd, { kind: 'inbox' }).catch(() => []);
+              for (const request of requests) {
+                if (request.status !== 'pending') continue;
+                await transitionDispatchRequest(
+                  teamName,
+                  request.request_id,
+                  'pending',
+                  'failed',
+                  { last_reason: 'test_failed_receipt' },
+                  cwd,
+                ).catch(() => {});
+              }
+            })();
+          }, 20);
 
           runtime = await withoutTeamWorkerEnv(() =>
             startTeam(
@@ -1449,6 +1492,7 @@ process.on('SIGTERM', () => process.exit(0));
         },
       );
     } finally {
+      if (receiptFailer) clearInterval(receiptFailer);
       if (runtime) {
         await shutdownTeam(teamName, cwd, { force: true }).catch(() => {});
       }
@@ -1467,6 +1511,16 @@ process.on('SIGTERM', () => process.exit(0));
       } else {
         delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
       }
+      if (typeof previousStartupDispatchRetries === 'string') {
+        process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = previousStartupDispatchRetries;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+      }
+      if (typeof previousStartupDispatchRetryDelay === 'string') {
+        process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = previousStartupDispatchRetryDelay;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
+      }
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -1477,7 +1531,10 @@ process.on('SIGTERM', () => process.exit(0));
     const previousTmuxPane = process.env.TMUX_PANE;
     const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousReadyTimeout = process.env.OMX_TEAM_READY_TIMEOUT_MS;
     const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+    const previousStartupDispatchRetries = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+    const previousStartupDispatchRetryDelay = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
 
     try {
       await withMockTmuxFixture(
@@ -1539,7 +1596,10 @@ esac
           process.env.TMUX_PANE = '%1';
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
+          process.env.OMX_TEAM_READY_TIMEOUT_MS = '5000';
           process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
 
           await assert.rejects(
             () => withoutTeamWorkerEnv(() =>
@@ -1564,10 +1624,25 @@ esac
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
       if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
       else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousReadyTimeout === 'string') {
+        process.env.OMX_TEAM_READY_TIMEOUT_MS = previousReadyTimeout;
+      } else {
+        delete process.env.OMX_TEAM_READY_TIMEOUT_MS;
+      }
       if (typeof previousStartupEvidenceTimeout === 'string') {
         process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = previousStartupEvidenceTimeout;
       } else {
         delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+      }
+      if (typeof previousStartupDispatchRetries === 'string') {
+        process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = previousStartupDispatchRetries;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+      }
+      if (typeof previousStartupDispatchRetryDelay === 'string') {
+        process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = previousStartupDispatchRetryDelay;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
       }
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1581,6 +1656,9 @@ esac
     const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const previousSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
     const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+    const previousStartupDispatchRetries = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+    const previousStartupDispatchRetryDelay = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
+    let receiptFailer: NodeJS.Timeout | null = null;
 
     try {
       await withMockTmuxFixture(
@@ -1677,6 +1755,25 @@ process.on('SIGTERM', () => process.exit(0));
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
           process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
           process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
+
+          receiptFailer = setInterval(() => {
+            void (async () => {
+              const requests = await listDispatchRequests('team-materialize-before-evidence', cwd, { kind: 'inbox' }).catch(() => []);
+              for (const request of requests) {
+                if (request.status !== 'pending') continue;
+                await transitionDispatchRequest(
+                  'team-materialize-before-evidence',
+                  request.request_id,
+                  'pending',
+                  'failed',
+                  { last_reason: 'test_failed_receipt' },
+                  cwd,
+                ).catch(() => {});
+              }
+            })();
+          }, 20);
 
           const teamPromise = withoutTeamWorkerEnv(() =>
             startTeam(
@@ -1700,7 +1797,7 @@ process.on('SIGTERM', () => process.exit(0));
           const workerTwoInbox = join(cwd, '.omx', 'state', 'team', sanitizedTeamName, 'workers', 'worker-2', 'inbox.md');
 
           let materializedAllWorkers = false;
-          for (let attempt = 0; attempt < 450; attempt += 1) {
+          for (let attempt = 0; attempt < 200; attempt += 1) {
             if (
               existsSync(workerOneIdentity)
               && existsSync(workerTwoIdentity)
@@ -1709,7 +1806,7 @@ process.on('SIGTERM', () => process.exit(0));
               materializedAllWorkers = true;
               break;
             }
-            await new Promise((resolve) => setTimeout(resolve, 100));
+            await new Promise((resolve) => setTimeout(resolve, 25));
           }
 
           assert.equal(
@@ -1729,6 +1826,7 @@ process.on('SIGTERM', () => process.exit(0));
         },
       );
     } finally {
+      if (receiptFailer) clearInterval(receiptFailer);
       if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
       else delete process.env.TMUX;
       if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
@@ -1743,6 +1841,16 @@ process.on('SIGTERM', () => process.exit(0));
         process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = previousStartupEvidenceTimeout;
       } else {
         delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+      }
+      if (typeof previousStartupDispatchRetries === 'string') {
+        process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = previousStartupDispatchRetries;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+      }
+      if (typeof previousStartupDispatchRetryDelay === 'string') {
+        process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = previousStartupDispatchRetryDelay;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
       }
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1283,6 +1283,8 @@ const previousModelInstructionsFileByTeam = new Map<string, string | undefined>(
 const PROMPT_WORKER_SIGTERM_WAIT_MS = 3_000;
 const PROMPT_WORKER_SIGKILL_WAIT_MS = 2_000;
 const PROMPT_WORKER_EXIT_POLL_MS = 100;
+const STARTUP_DISPATCH_RETRIES = 3;
+const STARTUP_DISPATCH_RETRY_DELAY_S = 3;
 const PROMPT_MODE_CODEX_UNSUPPORTED_REASON = 'prompt_mode_codex_requires_tty';
 // Test-only escape hatch for fake prompt workers that intentionally do not require a real TTY.
 const PROMPT_MODE_CODEX_TEST_ALLOW_ENV = 'OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT';
@@ -1319,6 +1321,18 @@ function resolveWorkerStartupEvidenceTimeoutMs(
     STARTUP_EVIDENCE_TIMEOUT_MS,
     Math.min(workerReadyTimeoutMs, STARTUP_EVIDENCE_LAUNCH_TIMEOUT_MS),
   );
+}
+
+function resolveStartupDispatchRetries(env: NodeJS.ProcessEnv): number {
+  const parsed = Number.parseInt(String(env.OMX_TEAM_STARTUP_DISPATCH_RETRIES ?? ''), 10);
+  if (!Number.isFinite(parsed)) return STARTUP_DISPATCH_RETRIES;
+  return Math.max(1, Math.min(STARTUP_DISPATCH_RETRIES, Math.floor(parsed)));
+}
+
+function resolveStartupDispatchRetryDelayS(env: NodeJS.ProcessEnv): number {
+  const parsed = Number.parseInt(String(env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS ?? ''), 10);
+  if (!Number.isFinite(parsed)) return STARTUP_DISPATCH_RETRY_DELAY_S;
+  return Math.max(0, Math.min(STARTUP_DISPATCH_RETRY_DELAY_S, Math.floor(parsed) / 1000));
 }
 
 function parseTeamWorkerContext(raw: string | undefined): { teamName: string; workerName: string } | null {
@@ -2018,6 +2032,8 @@ export async function startTeam(
     process.env,
     workerReadyTimeoutMs,
   );
+  const startupDispatchRetries = resolveStartupDispatchRetries(process.env);
+  const startupRetryDelayS = resolveStartupDispatchRetryDelayS(process.env);
   const skipWorkerReadyWait = shouldSkipWorkerReadyWait(process.env);
 
   try {
@@ -2324,13 +2340,11 @@ export async function startTeam(
       // Queue inbox via MCP/state then notify worker via tmux transport.
       // Retry dispatch up to 3 times to handle Codex trust prompts that may
       // block the worker pane during startup (fixes #393).
-      const maxStartupDispatchRetries = 3;
-      const startupRetryDelayS = 3;
       let dispatchOutcome: DispatchOutcome = initialPrompt
         ? { ok: true, transport: 'none', reason: 'startup_prompt_delivered_at_launch' }
         : { ok: false, transport: 'none', reason: 'not_attempted' };
       if (!initialPrompt) {
-        for (let attempt = 1; attempt <= maxStartupDispatchRetries; attempt++) {
+        for (let attempt = 1; attempt <= startupDispatchRetries; attempt++) {
           dispatchOutcome = await dispatchCriticalInboxInstruction({
             teamName: sanitized,
             config: config!,
@@ -2348,7 +2362,7 @@ export async function startTeam(
             startupEvidenceTimeoutMs: workerStartupEvidenceTimeoutMs,
           });
           if (dispatchOutcome.ok) break;
-          if (attempt < maxStartupDispatchRetries) {
+          if (attempt < startupDispatchRetries) {
             // Check for trust prompt blocking the worker and dismiss it before retry
             if (workerLaunchMode === 'interactive') {
               if (dismissTrustPromptIfPresent(sessionName, i, paneId)) {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -318,6 +318,11 @@ export function omxLogsDir(projectRoot?: string): string {
   return join(projectRoot || process.cwd(), ".omx", "logs");
 }
 
+/** User-scope install/update stamp path ($CODEX_HOME/.omx/install-state.json) */
+export function omxUserInstallStampPath(codexHomeDir?: string): string {
+  return join(codexHomeDir || codexHome(), ".omx", "install-state.json");
+}
+
 /** Get the package root directory (where agents/, skills/, prompts/ live) */
 export function packageRoot(): string {
   try {


### PR DESCRIPTION
## Summary

Fix the PR #1771 blocker where the automatic postinstall refresh path wrote setup state relative to the global install directory instead of the actual install root.

## Changes

- run the postinstall-triggered setup refresh from `INIT_CWD` when npm provides it
- restore the previous install-root behavior without changing general setup scope semantics
- add a focused regression test covering the postinstall install-root path

## Verification

- [x] `npm run build`
- [x] `npm run check:no-unused`
- [x] manual regression harness against `dist/scripts/postinstall.js` with `INIT_CWD` pointing at the install root
- [ ] direct targeted `node --test` invocation in this CLI environment

## Notes

This is intentionally minimal and preserves the smoothing introduced by #1771 while avoiding broader install/update semantic changes.

## Related

- fixes blocker found while reviewing #1771
- follow-up to #1771
