### PR TITLE
fix: back up AGENTS.md before accepted setup overwrite

### DIFF
--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -101,7 +101,7 @@ describe('omx setup AGENTS refresh behavior', () => {
     }
   });
 
-  it('overwrites existing AGENTS.md in TTY after confirmation and creates a backup first', async () => {
+  it('overwrites existing AGENTS.md in TTY after confirmation and moves the old file to a deterministic sibling backup', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
     const restoreTty = setMockTty(true);
     const home = join(wd, 'home');
@@ -117,18 +117,44 @@ describe('omx setup AGENTS refresh behavior', () => {
       });
 
       const agentsContent = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+      const backupPath = join(wd, '.AGENTS.md.bkup');
       assert.match(output, /Generated AGENTS\.md in project root\./);
+      assert.match(output, new RegExp(`Backed up existing AGENTS\\.md to ${backupPath.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}\\.`));
       assert.match(output, /agents_md: updated=1, unchanged=0, backed_up=1, skipped=0, removed=0/);
       assert.match(agentsContent, /^<!-- AUTONOMY DIRECTIVE — DO NOT REMOVE -->/);
       assert.match(agentsContent, /# oh-my-codex - Intelligent Multi-Agent Orchestration/);
       assert.doesNotMatch(agentsContent, /User-owned guidance\./);
-
-      const backupsRoot = join(wd, '.omx', 'backups', 'setup');
-      assert.equal(existsSync(backupsRoot), true);
-      const timestamps = await readdir(backupsRoot);
-      assert.equal(timestamps.length, 1);
-      const backupContent = await readFile(join(backupsRoot, timestamps[0], 'AGENTS.md'), 'utf-8');
+      assert.equal(existsSync(backupPath), true);
+      assert.equal(existsSync(join(wd, '.omx', 'backups', 'setup')), false);
+      const backupContent = await readFile(backupPath, 'utf-8');
       assert.equal(backupContent, existing);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('increments the deterministic sibling backup name when prior AGENTS backups already exist', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(true);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const existing = '# keep me\n';
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+      await writeFile(join(wd, '.AGENTS.md.bkup'), 'older backup\n');
+      await writeFile(join(wd, '.AGENTS.md.bkup1'), 'older backup 1\n');
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        agentsOverwritePrompt: async () => true,
+      });
+
+      const backupPath = join(wd, '.AGENTS.md.bkup2');
+      assert.match(output, new RegExp(`Backed up existing AGENTS\\.md to ${backupPath.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}\\.`));
+      assert.equal(await readFile(backupPath, 'utf-8'), existing);
     } finally {
       restoreHome();
       restoreTty();

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -8,11 +8,12 @@ import {
   copyFile,
   readdir,
   readFile,
+  rename,
   writeFile,
   stat,
   rm,
 } from "fs/promises";
-import { join, dirname, relative } from "path";
+import { join, dirname, relative, basename } from "path";
 import { existsSync } from "fs";
 import { spawnSync } from "child_process";
 import { createInterface } from "readline/promises";
@@ -234,6 +235,29 @@ async function ensureBackup(
     console.log(`  backup ${destinationPath} -> ${backupPath}`);
   }
   return true;
+}
+
+async function moveExistingAgentsToDeterministicBackup(
+  destinationPath: string,
+  options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<string | null> {
+  if (!existsSync(destinationPath)) return null;
+
+  const backupBaseName = `.${basename(destinationPath)}.bkup`;
+  let backupPath = join(dirname(destinationPath), backupBaseName);
+  let suffix = 1;
+
+  while (existsSync(backupPath)) {
+    backupPath = join(dirname(destinationPath), `${backupBaseName}${suffix}`);
+    suffix += 1;
+  }
+
+  if (!options.dryRun) {
+    await rename(destinationPath, backupPath);
+  }
+
+  console.log(`  Backed up existing AGENTS.md to ${backupPath}.`);
+  return backupPath;
 }
 
 async function filesDiffer(src: string, dst: string): Promise<boolean> {
@@ -1213,6 +1237,7 @@ async function syncManagedAgentsContent(
   const destinationExists = existsSync(dstPath);
   let existing = "";
   let changed = true;
+  let acceptedInteractiveOverwrite = false;
 
   if (destinationExists) {
     existing = await readFile(dstPath, "utf-8");
@@ -1247,9 +1272,18 @@ async function syncManagedAgentsContent(
       }
       return "skipped";
     }
+
+    acceptedInteractiveOverwrite = true;
   }
 
-  if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
+  if (
+    acceptedInteractiveOverwrite &&
+    (await moveExistingAgentsToDeterministicBackup(dstPath, options))
+  ) {
+    summary.backedUp += 1;
+  } else if (
+    await ensureBackup(dstPath, destinationExists, backupContext, options)
+  ) {
     summary.backedUp += 1;
   }
 


### PR DESCRIPTION
## Summary
- move an existing `AGENTS.md` to a deterministic sibling backup path when `omx setup` gets an accepted overwrite
- keep the change scoped to the exact setup AGENTS write path in `src/cli/setup.ts`
- add focused tests for the initial backup name and incremented backup suffix behavior

## Verification
- `npm run build && node --test dist/cli/__tests__/setup-agents-overwrite.test.js`
- `npx biome lint src/cli/setup.ts src/cli/__tests__/setup-agents-overwrite.test.ts`
- `npm run check:no-unused`

Closes #1782
