### PR TITLE
Enhance code-review skill with architect blocker synthesis

### DIFF
--- a/prompts/architect.md
+++ b/prompts/architect.md
@@ -33,6 +33,7 @@ You are Architect (Oracle). Diagnose, analyze, and recommend with file-backed ev
 - Recommendations are concrete and implementable.
 - Tradeoffs are acknowledged.
 - In ralplan consensus reviews, include antithesis, tradeoff tension, and synthesis.
+- In `code-review` dual-lane reviews, emit an explicit architectural status: `CLEAR`, `WATCH`, or `BLOCK`.
 </success_criteria>
 
 <verification_loop>
@@ -69,6 +70,9 @@ Default final-output shape: quality-first and evidence-dense; add as much detail
 ## Recommendations
 1. [Highest priority] - [effort level] - [impact]
 2. [Next priority] - [effort level] - [impact]
+
+## Architectural Status (code-review dual-lane only)
+`CLEAR` / `WATCH` / `BLOCK`
 
 ## Trade-offs
 | Option | Pros | Cons |

--- a/prompts/code-reviewer.md
+++ b/prompts/code-reviewer.md
@@ -6,6 +6,7 @@ argument-hint: "task description"
 You are Code Reviewer. Your mission is to ensure code quality and security through systematic, severity-rated review.
 You are responsible for spec compliance verification, security checks, code quality assessment, performance review, and best practice enforcement.
 You are not responsible for implementing fixes (executor), architecture design (architect), or writing tests (test-engineer).
+When paired with an `architect` lane in the `code-review` workflow, you own the code/spec/security lane and must report architectural concerns upward instead of turning them into the final design verdict yourself.
 
 Code review is the last line of defense before bugs and vulnerabilities reach production. These rules exist because reviews that miss security issues cause real damage, and reviews that only nitpick style waste everyone's time.
 </identity>
@@ -44,6 +45,7 @@ Do not ask about requirements. Read the spec, PR description, or issue tracker t
 - Each issue includes a concrete fix suggestion
 - lsp_diagnostics run on all modified files (no type errors approved)
 - Clear verdict: APPROVE, REQUEST CHANGES, or COMMENT
+- In dual-lane reviews, architecture concerns are surfaced upward to `architect` instead of being absorbed into this lane's verdict
 </success_criteria>
 
 <verification_loop>
@@ -70,6 +72,7 @@ Never stop at the first finding when broader coverage is needed.
 When an additional review angle would improve quality:
 - Summarize the missing review dimension and report it upward so the leader can decide whether broader review is warranted.
 - For large-context or design-heavy concerns, package the relevant evidence and questions for leader review instead of routing externally yourself.
+- In `code-review` dual-lane mode, treat `architect` as the authoritative design/devil's-advocate lane and keep your own verdict focused on code/spec/security evidence.
 Never block on extra consultation; continue with the best grounded review you can provide.
 </tools>
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -15,8 +15,6 @@ This skill activates when:
 - After implementing a major feature
 - User wants quality assessment
 
-## What It Does
-
 ## GPT-5.4 Guidance Alignment
 
 - Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail.
@@ -24,29 +22,48 @@ This skill activates when:
 - If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the review is grounded.
 - Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, or preference-dependent.
 
-Delegates to the `code-reviewer` agent (THOROUGH tier) for deep analysis:
+Delegates to the `code-reviewer` and `architect` agents in parallel for a two-lane review:
 
 1. **Identify Changes**
    - Run `git diff` to find changed files
    - Determine scope of review (specific files or entire PR)
 
-2. **Review Categories**
+2. **Launch Parallel Review Lanes**
+   - **`code-reviewer` lane** - owns spec compliance, security, code quality, performance, and maintainability findings
+   - **`architect` lane** - owns the devil's-advocate / design-tradeoff perspective
+   - Both lanes run in parallel and produce distinct outputs before final synthesis
+
+3. **Review Categories**
    - **Security** - Hardcoded secrets, injection risks, XSS, CSRF
    - **Code Quality** - Function size, complexity, nesting depth
    - **Performance** - Algorithm efficiency, N+1 queries, caching
    - **Best Practices** - Naming, documentation, error handling
    - **Maintainability** - Duplication, coupling, testability
 
-3. **Severity Rating**
+4. **Severity Rating**
    - **CRITICAL** - Security vulnerability (must fix before merge)
    - **HIGH** - Bug or major code smell (should fix before merge)
    - **MEDIUM** - Minor issue (fix when possible)
    - **LOW** - Style/suggestion (consider fixing)
 
-4. **Specific Recommendations**
+5. **Architectural Status Contract**
+   - **CLEAR** - No unresolved architectural blocker was found
+   - **WATCH** - Non-blocking design/tradeoff concern that must appear in the final synthesis
+   - **BLOCK** - Unresolved design concern that prevents a merge-ready verdict
+
+6. **Specific Recommendations**
    - File:line locations for each issue
    - Concrete fix suggestions
    - Code examples where applicable
+
+7. **Final Synthesis**
+   - Combine the `code-reviewer` recommendation and the architect status into one final verdict
+   - Deterministic merge gating rules:
+     - If architect status is **BLOCK**, final recommendation is **REQUEST CHANGES**
+     - Else if `code-reviewer` recommendation is **REQUEST CHANGES**, final recommendation is **REQUEST CHANGES**
+     - Else if architect status is **WATCH**, final recommendation is **COMMENT**
+     - Else final recommendation follows the `code-reviewer` lane
+   - The final report must make architect blockers impossible to miss
 
 ## Agent Delegation
 
@@ -57,6 +74,8 @@ delegate(
   prompt="CODE REVIEW TASK
 
 Review code changes for quality, security, and maintainability.
+
+This is the code/spec/security lane. Do not absorb architectural ownership.
 
 Scope: [git diff or specific files]
 
@@ -74,6 +93,29 @@ Output: Code review report with:
 - Fix recommendations
 - Approval recommendation (APPROVE / REQUEST CHANGES / COMMENT)"
 )
+
+delegate(
+  role="architect",
+  tier="THOROUGH",
+  prompt="ARCHITECTURE / DEVIL'S-ADVOCATE REVIEW TASK
+
+Review the same code changes from the architecture/tradeoff perspective.
+
+Scope: [git diff or specific files]
+
+Focus:
+- System boundaries and interfaces
+- Hidden coupling or long-term maintainability risks
+- Tradeoff tension the main reviewer might miss
+- Strongest counterargument against approving as-is
+
+Output:
+- Architectural Status: CLEAR / WATCH / BLOCK
+- File:line evidence for each concern
+- Concrete tradeoff or design recommendation"
+)
+
+Run both lanes in parallel, then synthesize them with the deterministic rules above.
 ```
 
 ## External Model Consultation (Preferred)
@@ -112,45 +154,59 @@ CODE REVIEW REPORT
 ==================
 
 Files Reviewed: 8
-Total Issues: 15
+Total Issues: 12
+Architectural Status: WATCH
 
 CRITICAL (0)
 -----------
 (none)
 
-HIGH (3)
+HIGH (0)
 --------
-1. src/api/auth.ts:42
-   Issue: User input not sanitized before SQL query
-   Risk: SQL injection vulnerability
-   Fix: Use parameterized queries or ORM
-
-2. src/components/UserProfile.tsx:89
-   Issue: Password displayed in plain text in logs
-   Risk: Credential exposure
-   Fix: Remove password from log statements
-
-3. src/utils/validation.ts:15
-   Issue: Email regex allows invalid formats
-   Risk: Accepts malformed emails
-   Fix: Use proven email validation library
+(none)
 
 MEDIUM (7)
 ----------
-...
+1. src/api/auth.ts:42
+   Issue: Email normalization logic is duplicated instead of reusing the shared helper
+   Risk: Validation rules can drift between authentication paths
+   Fix: Route both paths through the shared normalization helper
+
+2. src/components/UserProfile.tsx:89
+   Issue: Derived permissions are recalculated on every render
+   Risk: Avoidable work during profile refreshes
+   Fix: Memoize the derived permissions list or compute it upstream
+
+3. src/utils/validation.ts:15
+   Issue: Form-layer and server-layer validation messages are defined separately
+   Risk: User-facing validation guidance can become inconsistent
+   Fix: Share one validation message helper across both call sites
 
 LOW (5)
 -------
 ...
 
-RECOMMENDATION: REQUEST CHANGES
+ARCHITECTURE WATCHLIST
+----------------------
+- src/review/orchestrator.ts:88
+  Concern: Review result synthesis relies on implicit ordering rather than an explicit blocker contract
+  Status: WATCH
+  Recommendation: Define deterministic merge gating before expanding reviewers
 
-Critical security issues must be addressed before merge.
+SYNTHESIS
+---------
+- code-reviewer recommendation: COMMENT
+- architect status: WATCH
+- final recommendation: COMMENT
+
+RECOMMENDATION: COMMENT
+
+Address any WATCH concerns before treating the change as merge-ready.
 ```
 
 ## Review Checklist
 
-The code-reviewer agent checks:
+The `code-reviewer` lane checks:
 
 ### Security
 - [ ] No hardcoded secrets (API keys, passwords, tokens)
@@ -180,11 +236,21 @@ The code-reviewer agent checks:
 - [ ] Tests for critical paths
 - [ ] No commented-out code
 
+## Architect Lane Checklist
+
+The `architect` lane checks:
+
+- [ ] Boundary or interface changes are explicit
+- [ ] New coupling/tradeoff risks are surfaced
+- [ ] Long-horizon maintainability concerns are evidence-backed
+- [ ] Architectural status is one of `CLEAR`, `WATCH`, or `BLOCK`
+- [ ] Any `BLOCK` concern cites the reason merge-ready status should be withheld
+
 ## Approval Criteria
 
-**APPROVE** - No CRITICAL or HIGH issues, minor improvements only
-**REQUEST CHANGES** - CRITICAL or HIGH issues present
-**COMMENT** - Only LOW/MEDIUM issues, no blocking concerns
+**APPROVE** - `code-reviewer` returns APPROVE and architect status is `CLEAR`
+**REQUEST CHANGES** - `code-reviewer` returns REQUEST CHANGES or architect status is `BLOCK`
+**COMMENT** - `code-reviewer` returns COMMENT with architect status `CLEAR`, architect status is `WATCH`, or only LOW/MEDIUM improvements remain
 
 
 ## Scenario Examples
@@ -207,7 +273,7 @@ Includes coordinated review execution across specialized agents.
 ```
 /ralph code-review then fix all issues
 ```
-Review code, get feedback, fix until approved.
+On the explicit Ralph path, review findings should flow into automatic fix follow-up without another permission prompt. Plain `code-review` itself remains read-only and does **not** promise auto-fix.
 
 **With Ultrawork:**
 ```

--- a/src/hooks/__tests__/code-review-skill-contract.test.ts
+++ b/src/hooks/__tests__/code-review-skill-contract.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const codeReviewSkill = readFileSync(
+  join(__dirname, '../../../skills/code-review/SKILL.md'),
+  'utf-8',
+);
+
+describe('code-review skill contract', () => {
+  it('requires parallel code-reviewer and architect lanes', () => {
+    assert.match(codeReviewSkill, /`code-reviewer` and `architect` agents in parallel/i);
+    assert.match(codeReviewSkill, /Both lanes run in parallel/i);
+    assert.match(codeReviewSkill, /`code-reviewer` lane/i);
+    assert.match(codeReviewSkill, /`architect` lane/i);
+  });
+
+  it('frames architect as the devil’s-advocate lane with deterministic blocker status', () => {
+    assert.match(codeReviewSkill, /devil['’]s-advocate/i);
+    assert.match(codeReviewSkill, /Architectural Status Contract/i);
+    assert.match(codeReviewSkill, /CLEAR/i);
+    assert.match(codeReviewSkill, /WATCH/i);
+    assert.match(codeReviewSkill, /BLOCK/i);
+    assert.match(codeReviewSkill, /If architect status is \*\*BLOCK\*\*, final recommendation is \*\*REQUEST CHANGES\*\*/i);
+  });
+
+  it('requires final synthesis across both lanes', () => {
+    assert.match(codeReviewSkill, /Final Synthesis/i);
+    assert.match(codeReviewSkill, /Combine the `code-reviewer` recommendation and the architect status/i);
+    assert.match(codeReviewSkill, /final report must make architect blockers impossible to miss/i);
+  });
+
+  it('keeps approval criteria aligned with the deterministic synthesis contract', () => {
+    assert.match(codeReviewSkill, /\*\*APPROVE\*\* - `code-reviewer` returns APPROVE and architect status is `CLEAR`/i);
+    assert.match(codeReviewSkill, /\*\*REQUEST CHANGES\*\* - `code-reviewer` returns REQUEST CHANGES or architect status is `BLOCK`/i);
+    assert.match(codeReviewSkill, /\*\*COMMENT\*\* - `code-reviewer` returns COMMENT with architect status `CLEAR`, architect status is `WATCH`, or only LOW\/MEDIUM improvements remain/i);
+  });
+
+  it('bounds auto-fix wording to the explicit ralph path only', () => {
+    assert.match(codeReviewSkill, /On the explicit Ralph path/i);
+    assert.match(codeReviewSkill, /automatic fix follow-up without another permission prompt/i);
+    assert.match(codeReviewSkill, /Plain `code-review` itself remains read-only and does \*\*not\*\* promise auto-fix/i);
+  });
+
+  it('keeps the sample output consistent with a WATCH and COMMENT outcome', () => {
+    const totalIssues = codeReviewSkill.match(/Total Issues: (\d+)/i);
+    const criticalCount = codeReviewSkill.match(/CRITICAL \((\d+)\)/i);
+    assert.match(codeReviewSkill, /HIGH \(0\)/i);
+    const highCount = codeReviewSkill.match(/HIGH \((\d+)\)/i);
+    const mediumCount = codeReviewSkill.match(/MEDIUM \((\d+)\)/i);
+    const lowCount = codeReviewSkill.match(/LOW \((\d+)\)/i);
+    assert.match(codeReviewSkill, /- code-reviewer recommendation: COMMENT/i);
+    assert.match(codeReviewSkill, /RECOMMENDATION: COMMENT/i);
+    assert.doesNotMatch(codeReviewSkill, /Risk: SQL injection vulnerability/i);
+    assert.doesNotMatch(codeReviewSkill, /Risk: Credential exposure/i);
+    assert.ok(totalIssues && criticalCount && highCount && mediumCount && lowCount);
+    assert.equal(
+      Number(totalIssues[1]),
+      Number(criticalCount[1]) +
+        Number(highCount[1]) +
+        Number(mediumCount[1]) +
+        Number(lowCount[1]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- run `code-reviewer` and `architect` in parallel in the `code-review` skill
- add deterministic `CLEAR` / `WATCH` / `BLOCK` synthesis and keep plain `code-review` read-only
- add a dedicated contract test for the dual-lane review and Ralph handoff wording

## Testing
- npm run build
- node --test dist/hooks/__tests__/code-review-skill-contract.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js dist/hooks/__tests__/consensus-execution-handoff.test.js
- npx biome lint src/hooks/__tests__/code-review-skill-contract.test.ts
- lsp_diagnostics on src/hooks/__tests__/code-review-skill-contract.test.ts
