### PR TITLE
Fix CI rust-toolchain action resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: stable
           components: rustfmt
       - name: Check Rust formatting
         run: cargo fmt --all --check
@@ -31,8 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: stable
           components: clippy
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
@@ -268,8 +270,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: stable
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -337,7 +340,9 @@ jobs:
           node-version: 20
           cache: npm
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
       - run: npm ci
       - name: Download prebuilt dist artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
       - name: Install Linux musl toolchain
         if: runner.os == 'Linux'
@@ -164,7 +165,9 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
       - name: Install cargo-dist
         run: cargo install cargo-dist --locked --version "$CARGO_DIST_VERSION"
       - name: Generate release manifest from cargo-dist plan

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -29,7 +29,7 @@ describe('CI Rust gates', () => {
 
     assert.match(
       workflow,
-      /build:\s*\n(?:.*\n)*?\s+- name: Setup Rust\s*\n\s+uses: dtolnay\/rust-toolchain@stable(?:.*\n)*?\s+- name: Download prebuilt dist artifact\s*\n\s+uses: actions\/download-artifact@v8(?:.*\n)*?\s+- run: npm run build:explore:release(?:.*\n)*?\s+- run: npm run build:sparkshell/m,
+      /build:\s*\n(?:.*\n)*?\s+- name: Setup Rust\s*\n\s+uses: dtolnay\/rust-toolchain@v1\s*\n\s+with:\s*\n\s+toolchain: stable(?:.*\n)*?\s+- name: Download prebuilt dist artifact\s*\n\s+uses: actions\/download-artifact@v8(?:.*\n)*?\s+- run: npm run build:explore:release(?:.*\n)*?\s+- run: npm run build:sparkshell/m,
     );
   });
 


### PR DESCRIPTION
## Summary\n- switch workflow uses of `dtolnay/rust-toolchain` from the failing moving `stable` ref to immutable `v1`\n- pass `toolchain: stable` explicitly so CI/release behavior stays on the stable Rust channel\n- limit the change to workflow setup steps in CI and release jobs\n\n## Verification\n- parsed updated workflow YAML locally\n- confirmed current upstream refs: `stable` -> `29eef336d9b2848a0b548edc03f92a220660cdb8`, `v1` -> `e97e2d8cc328f1b50210efc529dca0028893a2d9`\n- verified all workflow consumers now reference `dtolnay/rust-toolchain@v1`\n\n## Context\nPR #1771 is currently failing CI in the Rust Clippy setup step because GitHub Actions cannot resolve the existing pinned tarball for the moving `stable` action ref. This PR isolates the workflow fix against `dev`.