### PR TITLE
fix: ignore stale dead-session Ralph state in native Stop hook

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3522,6 +3522,55 @@ esac
     }
   });
 
+  it("does not block Stop from stale current-session Ralph state when session.json points to a dead owner", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-current-session-ralph-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-dead"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: "sess-dead",
+        cwd,
+        pid: Number.MAX_SAFE_INTEGER,
+        started_at: "2026-01-01T00:00:00.000Z",
+      });
+      await writeJson(join(stateDir, "sessions", "sess-dead", "ralph-state.json"), {
+        active: true,
+        current_phase: "verifying",
+        session_id: "sess-dead",
+      });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: true,
+        skill: "team",
+        phase: "team-exec",
+        active_skills: [{ skill: "team", phase: "team-exec", active: true, session_id: "sess-dead" }],
+      });
+      await writeJson(join(stateDir, "native-stop-state.json"), {
+        sessions: {
+          "sess-dead": {
+            last_signature: "ralph-stop|sess-dead|thread-1|no-message|verifying",
+            updated_at: "2026-04-20T21:00:00.000Z",
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-dead",
+          thread_id: "thread-1",
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block Stop from another session-scoped Ralph state when an explicit session_id has no active Ralph state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-explicit-session-ralph-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -10,7 +10,12 @@ import {
 } from "../state/skill-active.js";
 import { readSubagentSessionSummary } from "../subagents/tracker.js";
 import { resolveCanonicalTeamStateRoot } from "../team/state-root.js";
-import { readUsableSessionState, reconcileNativeSessionStart } from "../hooks/session.js";
+import {
+  isSessionStateUsable,
+  readSessionState,
+  readUsableSessionState,
+  reconcileNativeSessionStart,
+} from "../hooks/session.js";
 import {
   appendTeamEvent,
   readTeamLeaderAttention,
@@ -278,8 +283,14 @@ async function readActiveRalphState(
   preferredSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
   const cwd = resolve(stateDir, "..", "..");
-  const sessionInfo = await readUsableSessionState(cwd);
-  const currentOmxSessionId = safeString(sessionInfo?.session_id).trim();
+  const [rawSessionInfo, usableSessionInfo] = await Promise.all([
+    readSessionState(cwd),
+    readUsableSessionState(cwd),
+  ]);
+  const currentOmxSessionId = safeString(usableSessionInfo?.session_id).trim();
+  const staleCurrentSessionId = rawSessionInfo && !isSessionStateUsable(rawSessionInfo, cwd)
+    ? safeString(rawSessionInfo.session_id).trim()
+    : "";
   const sessionCandidates = [...new Set([
     safeString(preferredSessionId).trim(),
     currentOmxSessionId,
@@ -289,6 +300,9 @@ async function readActiveRalphState(
   // That is intentionally stricter than generic state MCP reads: do not scan sibling
   // session scopes or fall back to root when a current/explicit session is in play.
   for (const sessionId of sessionCandidates) {
+    if (staleCurrentSessionId && sessionId === staleCurrentSessionId) {
+      continue;
+    }
     const sessionScoped = await readStopSessionPinnedState("ralph-state.json", cwd, sessionId);
     if (sessionScoped?.active === true && shouldContinueRun(sessionScoped)) {
       return sessionScoped;


### PR DESCRIPTION
## Summary
- ignore session-scoped Ralph stop state when `session.json` points at an unusable/dead current session owner
- keep the native Stop hook from reviving stale Ralph/verifying warnings after real work has stopped
- add a regression test for the stale-current-session shape from issue #1788

## Testing
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js
- npm run test:explicit-terminal-contract:compiled
- manual repro of stale dead-session Ralph Stop returning null after fix

Closes #1788
