### PR TITLE
Fix repeated ultrawork Stop-hook block replays

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4548,71 +4548,62 @@ esac
     }
   });
 
-  it("re-blocks active execution modes on repeated Stop hooks", async () => {
-    const cases = [
-      {
-        mode: "autopilot",
-        phase: "execution",
-        reason:
-          "OMX autopilot is still active (phase: execution); continue the task and gather fresh verification evidence before stopping.",
-      },
-      {
-        mode: "ultrawork",
-        phase: "executing",
-        reason:
-          "OMX ultrawork is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
-      },
-      {
-        mode: "ultraqa",
-        phase: "diagnose",
-        reason:
-          "OMX ultraqa is still active (phase: diagnose); continue the task and gather fresh verification evidence before stopping.",
-      },
-    ] as const;
+  it("suppresses duplicate ultrawork Stop replays while stop_hook_active stays true", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ultrawork-repeat-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "ultrawork-state.json"), {
+        active: true,
+        current_phase: "executing",
+      });
 
-    for (const testCase of cases) {
-      const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-stop-${testCase.mode}-repeat-`));
-      try {
-        const stateDir = join(cwd, ".omx", "state");
-        await mkdir(stateDir, { recursive: true });
-        await writeJson(join(stateDir, `${testCase.mode}-state.json`), {
-          active: true,
-          current_phase: testCase.phase,
-        });
+      const first = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-ultrawork-repeat",
+          thread_id: "thread-stop-ultrawork-repeat",
+          turn_id: "turn-stop-ultrawork-repeat-1",
+        },
+        { cwd },
+      );
 
-        await dispatchCodexNativeHook(
-          {
-            hook_event_name: "Stop",
-            cwd,
-            session_id: `sess-stop-${testCase.mode}-repeat`,
-            thread_id: `thread-stop-${testCase.mode}-repeat`,
-            turn_id: `turn-stop-${testCase.mode}-repeat-1`,
-          },
-          { cwd },
-        );
+      const repeated = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-ultrawork-repeat",
+          thread_id: "thread-stop-ultrawork-repeat",
+          turn_id: "turn-stop-ultrawork-repeat-1",
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
 
-        const repeated = await dispatchCodexNativeHook(
-          {
-            hook_event_name: "Stop",
-            cwd,
-            session_id: `sess-stop-${testCase.mode}-repeat`,
-            thread_id: `thread-stop-${testCase.mode}-repeat`,
-            turn_id: `turn-stop-${testCase.mode}-repeat-1`,
-            stop_hook_active: true,
-          },
-          { cwd },
-        );
+      const fresh = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-ultrawork-repeat",
+          thread_id: "thread-stop-ultrawork-repeat",
+          turn_id: "turn-stop-ultrawork-repeat-2",
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
 
-        assert.equal(repeated.omxEventName, "stop");
-        assert.deepEqual(repeated.outputJson, {
-          decision: "block",
-          reason: testCase.reason,
-          stopReason: `${testCase.mode}_${testCase.phase}`,
-          systemMessage: `OMX ${testCase.mode} is still active (phase: ${testCase.phase}).`,
-        });
-      } finally {
-        await rm(cwd, { recursive: true, force: true });
-      }
+      assert.equal(first.omxEventName, "stop");
+      assert.deepEqual(repeated.outputJson, null);
+      assert.equal(fresh.omxEventName, "stop");
+      assert.deepEqual(fresh.outputJson, {
+        decision: "block",
+        reason: "OMX ultrawork is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ultrawork_executing",
+        systemMessage: "OMX ultrawork is still active (phase: executing).",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
     }
   });
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1152,6 +1152,7 @@ async function returnPersistentStopBlock(
   signatureValue: string,
   output: Record<string, unknown> | null,
   canonicalSessionId?: string,
+  options: { allowRepeatDuringStopHook?: boolean } = { allowRepeatDuringStopHook: true },
 ): Promise<Record<string, unknown> | null> {
   return await maybeReturnRepeatableStopOutput(
     payload,
@@ -1159,7 +1160,7 @@ async function returnPersistentStopBlock(
     buildRepeatableStopSignature(payload, signatureKind, signatureValue, canonicalSessionId),
     output,
     canonicalSessionId,
-    { allowRepeatDuringStopHook: true },
+    options,
   );
 }
 
@@ -1442,6 +1443,7 @@ async function buildStopHookOutput(
         safeString(ultraworkOutput.stopReason),
         ultraworkOutput,
         canonicalSessionId,
+        { allowRepeatDuringStopHook: false },
       );
     }
 


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Fixes #1790 by restoring replay suppression for identical ultrawork Stop-hook block payloads. The shared persistent Stop helper kept opting every caller into `allowRepeatDuringStopHook`, so ultrawork bypassed the existing native-stop signature dedupe and re-emitted the same block on every turn while `stop_hook_active=true`.

## Changes

- add an explicit replay-policy option to `returnPersistentStopBlock(...)` while preserving the current repeatable default for existing callers
- make the ultrawork Stop path opt into dedupe during `stop_hook_active` replays
- replace the broad execution-mode replay test with a focused ultrawork regression covering first block / identical replay suppression / later fresh-turn re-block

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [x] `node --test dist/scripts/__tests__/codex-native-hook.test.js`
- [x] direct local dist/scripts/codex-native-hook.js repro for first ultrawork block, identical replay suppression, and fresh-turn re-block
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1790