### PR TITLE
Fail closed when omx question loses its tmux pane

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { mkdtemp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -111,4 +111,70 @@ describe('omx question CLI', () => {
     assert.equal(payload.prompt.source, 'deep-interview');
     assert.equal(payload.prompt.type, 'multi-answerable');
   });
+
+  it('fails closed when tmux reports a split pane that does not actually exist', async () => {
+    const cwd = await makeRepo();
+    const fakeBinDir = join(cwd, 'fake-bin');
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(join(fakeBinDir, 'tmux'), `#!/bin/sh
+printf '%s\\n' "$*" >> "${join(cwd, 'tmux.log')}"
+case "$1" in
+  split-window)
+    printf '%%5\\n'
+    ;;
+  list-panes)
+    if [ "$2" = "-t" ] && [ "$3" = "%5" ]; then
+      echo "can't find pane: %5" >&2
+      exit 1
+    fi
+    printf '%%0\\t1\\n%%2\\t0\\n'
+    ;;
+  display-message)
+    printf '%%0\\n'
+    ;;
+esac
+`, { mode: 0o755 });
+
+    const input = JSON.stringify({
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      session_id: 'sess-q',
+    });
+
+    const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
+      const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          TMUX: '/tmp/fake',
+          TMUX_PANE: '%0',
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+      child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+      child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, 'question_runtime_failed');
+    assert.match(payload.error.message, /pane %5 disappeared immediately after launch/i);
+
+    const entries = await readdir(join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions'));
+    assert.equal(entries.length, 1);
+    const recordPath = join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions', entries[0]!);
+    const record = JSON.parse(await readFile(recordPath, 'utf-8')) as { status: string; error?: { code?: string; message?: string } };
+    assert.equal(record.status, 'error');
+    assert.equal(record.error?.code, 'question_runtime_failed');
+    assert.match(record.error?.message || '', /pane %5 disappeared immediately after launch/i);
+  });
 });

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -45,8 +45,11 @@ describe('launchQuestionRenderer', () => {
         strategy: 'inside-tmux',
         execTmux: (args) => {
           calls.push(args);
-          return '%42\n';
+          if (args[0] === 'split-window') return '%42\n';
+          if (args[0] === 'list-panes') return '0\t%42\n';
+          return '';
         },
+        sleepSync: () => {},
       },
     );
 
@@ -54,9 +57,39 @@ describe('launchQuestionRenderer', () => {
     assert.equal(result.target, '%42');
     assert.equal(result.return_target, '%11');
     assert.equal(result.return_transport, 'tmux-send-keys');
-    assert.equal(calls.length, 1);
+    assert.equal(calls.length, 2);
     assert.equal(calls[0]?.[0], 'split-window');
     assert.ok(!calls[0]?.includes('-d'));
+    assert.deepEqual(calls[1], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
+  });
+
+  it('fails before prompting state when a reported split pane is already gone', () => {
+    const calls: string[][] = [];
+    assert.throws(
+      () => launchQuestionRenderer(
+        {
+          cwd: '/repo',
+          recordPath: '/repo/.omx/state/sessions/s1/questions/question-1.json',
+          sessionId: 's1',
+          nowIso: '2026-04-19T00:00:00.000Z',
+          env: { TMUX: '/tmp/tmux-demo', TMUX_PANE: '%11' } as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'inside-tmux',
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'split-window') return '%42\n';
+            throw new Error("can't find pane: %42");
+          },
+          sleepSync: () => {},
+        },
+      ),
+      /Question UI pane %42 disappeared immediately after launch/,
+    );
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0]?.[0], 'split-window');
+    assert.deepEqual(calls[1], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
   });
 
   it('uses detached sessions outside tmux', () => {
@@ -80,6 +113,44 @@ describe('launchQuestionRenderer', () => {
     assert.equal(calls.length, 1);
     assert.equal(calls[0]?.[0], 'new-session');
     assert.ok(calls[0]?.includes('-d'));
+  });
+
+  it('prefers the current launcher path over a stale ambient OMX_ENTRY_PATH when spawning the UI', () => {
+    const calls: string[][] = [];
+    const originalArgv1 = process.argv[1];
+    process.argv[1] = '/repo/dist/cli/omx.js';
+    try {
+      const result = launchQuestionRenderer(
+        {
+          cwd: '/repo',
+          recordPath: '/repo/.omx/state/sessions/s1/questions/question-3.json',
+          sessionId: 's1',
+          nowIso: '2026-04-19T00:00:00.000Z',
+          env: {
+            TMUX: '/tmp/tmux-demo',
+            TMUX_PANE: '%11',
+            OMX_ENTRY_PATH: '/stale/global/dist/cli/omx.js',
+          } as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'inside-tmux',
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'split-window') return '%42\n';
+            if (args[0] === 'list-panes') return '0\t%42\n';
+            return '';
+          },
+          sleepSync: () => {},
+        },
+      );
+
+      assert.equal(result.target, '%42');
+      const command = calls[0]?.[calls[0].length - 1] || '';
+      assert.match(command, /\/repo\/dist\/cli\/omx\.js/);
+      assert.doesNotMatch(command, /\/stale\/global\/dist\/cli\/omx\.js/);
+    } finally {
+      process.argv[1] = originalArgv1;
+    }
   });
 });
 

--- a/src/question/__tests__/state.test.ts
+++ b/src/question/__tests__/state.test.ts
@@ -7,6 +7,8 @@ import {
   createQuestionRecord,
   getQuestionRecordPath,
   markQuestionAnswered,
+  markQuestionPrompting,
+  markQuestionTerminalError,
   readQuestionRecord,
   waitForQuestionTerminalState,
 } from '../state.js';
@@ -64,5 +66,33 @@ describe('question state', () => {
     const finalRecord = await waiter;
     assert.equal(finalRecord.answer?.value, 'custom text');
     assert.equal(finalRecord.status, 'answered');
+  });
+
+  it('persists explicit terminal errors after prompting begins', async () => {
+    const cwd = await makeRepo();
+    const { recordPath } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-3');
+
+    await markQuestionPrompting(recordPath, {
+      renderer: 'tmux-pane',
+      target: '%42',
+      launched_at: new Date().toISOString(),
+    });
+    await markQuestionTerminalError(
+      recordPath,
+      'error',
+      'question_runtime_failed',
+      'Question UI pane %42 disappeared immediately after launch.',
+    );
+
+    const loaded = await readQuestionRecord(recordPath);
+    assert.equal(loaded?.status, 'error');
+    assert.equal(loaded?.error?.code, 'question_runtime_failed');
+    assert.match(loaded?.error?.message || '', /pane %42 disappeared immediately after launch/);
   });
 });

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -23,6 +23,7 @@ export type SleepSync = (ms: number) => void;
 
 const QUESTION_TEXT_SETTLE_MS = 120;
 const QUESTION_SUBMIT_REPEAT_DELAY_MS = 100;
+const QUESTION_RENDERER_PANE_SETTLE_MS = 120;
 
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
@@ -42,10 +43,21 @@ export function resolveQuestionRendererStrategy(
   return 'unsupported';
 }
 
-function buildQuestionUiCommand(recordPath: string, sessionId?: string): string {
-  const omxBin = resolveOmxCliEntryPath() || process.argv[1];
+function buildQuestionUiCommand(
+  recordPath: string,
+  options: {
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+    sessionId?: string;
+  },
+): string {
+  const omxBin = resolveOmxCliEntryPath({
+    argv1: process.argv[1],
+    cwd: options.cwd,
+    env: options.env,
+  }) || process.argv[1];
   if (!omxBin) throw new Error('Unable to resolve OMX CLI entry path for question UI launch.');
-  const sessionPrefix = sessionId ? `OMX_SESSION_ID=${shellEscapeSingle(sessionId)} ` : '';
+  const sessionPrefix = options.sessionId ? `OMX_SESSION_ID=${shellEscapeSingle(options.sessionId)} ` : '';
   return `${sessionPrefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} question --ui --state-path ${shellEscapeSingle(recordPath)}`;
 }
 
@@ -63,6 +75,21 @@ function resolveReturnTarget(env: NodeJS.ProcessEnv = process.env): string | und
   if (isPaneId(envPane)) return envPane;
   const detectedPane = getCurrentTmuxPaneId();
   return isPaneId(detectedPane) ? detectedPane : undefined;
+}
+
+function isLaunchedQuestionPaneAlive(
+  paneId: string,
+  execTmux: ExecTmuxSync,
+): boolean {
+  if (!isPaneId(paneId)) return false;
+  try {
+    const status = execTmux(['list-panes', '-t', paneId, '-F', '#{pane_dead}\t#{pane_id}']);
+    const firstLine = status.split('\n')[0]?.trim() || '';
+    const [paneDead = '', resolvedPaneId = ''] = firstLine.split('\t');
+    return paneDead !== '1' && resolvedPaneId === paneId;
+  } catch {
+    return false;
+  }
 }
 
 export function formatQuestionAnswerForInjection(answer: QuestionAnswer): string {
@@ -102,12 +129,18 @@ export function launchQuestionRenderer(
   deps: {
     strategy?: QuestionRendererStrategy;
     execTmux?: ExecTmuxSync;
+    sleepSync?: SleepSync;
   } = {},
 ): QuestionRendererState {
   const strategy = deps.strategy ?? resolveQuestionRendererStrategy(options.env ?? process.env);
   const execTmux = deps.execTmux ?? defaultExecTmux;
+  const sleepImpl = deps.sleepSync ?? sleepSync;
   const launchedAt = options.nowIso ?? new Date().toISOString();
-  const command = buildQuestionUiCommand(options.recordPath, options.sessionId);
+  const command = buildQuestionUiCommand(options.recordPath, {
+    cwd: options.cwd,
+    env: options.env,
+    sessionId: options.sessionId,
+  });
 
   if (strategy === 'inside-tmux') {
     const rawPane = execTmux([
@@ -124,6 +157,10 @@ export function launchQuestionRenderer(
     ]);
     const paneId = parsePaneIdFromTmuxOutput(rawPane);
     if (!paneId) throw new Error('Failed to create tmux split pane for omx question UI.');
+    sleepImpl(QUESTION_RENDERER_PANE_SETTLE_MS);
+    if (!isLaunchedQuestionPaneAlive(paneId, execTmux)) {
+      throw new Error(`Question UI pane ${paneId} disappeared immediately after launch.`);
+    }
     const returnTarget = resolveReturnTarget(options.env ?? process.env);
     return {
       renderer: 'tmux-pane',


### PR DESCRIPTION
## Summary
- verify the split-window pane before marking `omx question` as `prompting`
- fail closed with `question_runtime_failed` when tmux reports a vanished pane
- keep the UI launch command anchored to the current invocation path and cover both regressions with tests

## Testing
- npm run build
- node --test dist/question/__tests__/renderer.test.js
- node --test dist/question/__tests__/state.test.js
- node --test dist/cli/__tests__/question.test.js
- reproduced the fake-tmux nonexistent-pane scenario before and after the fix

## Issue
- Closes #1793
