### PR TITLE
fix: keep omx question panes alive under tmux Nushell shells

### DIFF
--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -60,6 +60,16 @@ describe('launchQuestionRenderer', () => {
     assert.equal(calls.length, 2);
     assert.equal(calls[0]?.[0], 'split-window');
     assert.ok(!calls[0]?.includes('-d'));
+    assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
+    assert.equal(calls[0]?.[calls[0]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(calls[0]?.slice(-4), [
+      'question',
+      '--ui',
+      '--state-path',
+      '/repo/.omx/state/sessions/s1/questions/question-1.json',
+    ]);
+    assert.ok(calls[0]?.includes('-e'));
+    assert.ok(calls[0]?.includes('OMX_SESSION_ID=s1'));
     assert.deepEqual(calls[1], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
   });
 
@@ -89,7 +99,49 @@ describe('launchQuestionRenderer', () => {
 
     assert.equal(calls.length, 2);
     assert.equal(calls[0]?.[0], 'split-window');
+    assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
+    assert.equal(calls[0]?.[calls[0]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(calls[0]?.slice(-4), [
+      'question',
+      '--ui',
+      '--state-path',
+      '/repo/.omx/state/sessions/s1/questions/question-1.json',
+    ]);
     assert.deepEqual(calls[1], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
+  });
+
+  it('passes direct tmux argv so non-POSIX default shells do not parse a shell string', () => {
+    const calls: string[][] = [];
+    launchQuestionRenderer(
+      {
+        cwd: '/repo',
+        recordPath: '/repo/question with spaces.json',
+        sessionId: 'sess-123',
+        env: { TMUX: '/tmp/tmux-demo' } as NodeJS.ProcessEnv,
+      },
+      {
+        strategy: 'inside-tmux',
+        execTmux: (args) => {
+          calls.push(args);
+          if (args[0] === 'split-window') return '%77\n';
+          if (args[0] === 'list-panes') return '0\t%77\n';
+          return '';
+        },
+        sleepSync: () => {},
+      },
+    );
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0]?.some((part) => /question --ui --state-path/.test(part)), false);
+    assert.equal(calls[0]?.some((part) => /^'.*'$/.test(part)), false);
+    assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
+    assert.equal(calls[0]?.[calls[0]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(calls[0]?.slice(-4), [
+      'question',
+      '--ui',
+      '--state-path',
+      '/repo/question with spaces.json',
+    ]);
   });
 
   it('uses detached sessions outside tmux', () => {
@@ -99,6 +151,7 @@ describe('launchQuestionRenderer', () => {
         cwd: '/repo',
         recordPath: '/repo/.omx/state/sessions/s1/questions/question-2.json',
         nowIso: '2026-04-19T00:00:00.000Z',
+        env: {} as NodeJS.ProcessEnv,
       },
       {
         strategy: 'detached-tmux',
@@ -113,6 +166,14 @@ describe('launchQuestionRenderer', () => {
     assert.equal(calls.length, 1);
     assert.equal(calls[0]?.[0], 'new-session');
     assert.ok(calls[0]?.includes('-d'));
+    assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
+    assert.equal(calls[0]?.[calls[0]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(calls[0]?.slice(-4), [
+      'question',
+      '--ui',
+      '--state-path',
+      '/repo/.omx/state/sessions/s1/questions/question-2.json',
+    ]);
   });
 
   it('prefers the current launcher path over a stale ambient OMX_ENTRY_PATH when spawning the UI', () => {
@@ -145,9 +206,8 @@ describe('launchQuestionRenderer', () => {
       );
 
       assert.equal(result.target, '%42');
-      const command = calls[0]?.[calls[0].length - 1] || '';
-      assert.match(command, /\/repo\/dist\/cli\/omx\.js/);
-      assert.doesNotMatch(command, /\/stale\/global\/dist\/cli\/omx\.js/);
+      assert.equal(calls[0]?.includes('/repo/dist/cli/omx.js'), true);
+      assert.equal(calls[0]?.includes('/stale/global/dist/cli/omx.js'), false);
     } finally {
       process.argv[1] = originalArgv1;
     }

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { basename } from 'node:path';
-import { parsePaneIdFromTmuxOutput, shellEscapeSingle } from '../hud/tmux.js';
+import { parsePaneIdFromTmuxOutput } from '../hud/tmux.js';
 import { sleepSync } from '../utils/sleep.js';
 import { sanitizeReplyInput } from '../notifications/reply-listener.js';
 import { getCurrentTmuxPaneId } from '../notifications/tmux.js';
@@ -43,22 +43,29 @@ export function resolveQuestionRendererStrategy(
   return 'unsupported';
 }
 
-function buildQuestionUiCommand(
+function buildQuestionUiTmuxArgs(
   recordPath: string,
   options: {
     cwd: string;
     env?: NodeJS.ProcessEnv;
     sessionId?: string;
   },
-): string {
+): string[] {
   const omxBin = resolveOmxCliEntryPath({
     argv1: process.argv[1],
     cwd: options.cwd,
     env: options.env,
   }) || process.argv[1];
   if (!omxBin) throw new Error('Unable to resolve OMX CLI entry path for question UI launch.');
-  const sessionPrefix = options.sessionId ? `OMX_SESSION_ID=${shellEscapeSingle(options.sessionId)} ` : '';
-  return `${sessionPrefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} question --ui --state-path ${shellEscapeSingle(recordPath)}`;
+  return [
+    ...(options.sessionId ? ['-e', `OMX_SESSION_ID=${options.sessionId}`] : []),
+    process.execPath,
+    omxBin,
+    'question',
+    '--ui',
+    '--state-path',
+    recordPath,
+  ];
 }
 
 function defaultExecTmux(args: string[]): string {
@@ -84,9 +91,14 @@ function isLaunchedQuestionPaneAlive(
   if (!isPaneId(paneId)) return false;
   try {
     const status = execTmux(['list-panes', '-t', paneId, '-F', '#{pane_dead}\t#{pane_id}']);
-    const firstLine = status.split('\n')[0]?.trim() || '';
-    const [paneDead = '', resolvedPaneId = ''] = firstLine.split('\t');
-    return paneDead !== '1' && resolvedPaneId === paneId;
+    return status
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .some((line) => {
+        const [paneDead = '', resolvedPaneId = ''] = line.split('\t');
+        return resolvedPaneId === paneId && paneDead !== '1';
+      });
   } catch {
     return false;
   }
@@ -136,7 +148,7 @@ export function launchQuestionRenderer(
   const execTmux = deps.execTmux ?? defaultExecTmux;
   const sleepImpl = deps.sleepSync ?? sleepSync;
   const launchedAt = options.nowIso ?? new Date().toISOString();
-  const command = buildQuestionUiCommand(options.recordPath, {
+  const commandArgs = buildQuestionUiTmuxArgs(options.recordPath, {
     cwd: options.cwd,
     env: options.env,
     sessionId: options.sessionId,
@@ -153,7 +165,7 @@ export function launchQuestionRenderer(
       '#{pane_id}',
       '-c',
       options.cwd,
-      command,
+      ...commandArgs,
     ]);
     const paneId = parsePaneIdFromTmuxOutput(rawPane);
     if (!paneId) throw new Error('Failed to create tmux split pane for omx question UI.');
@@ -183,7 +195,7 @@ export function launchQuestionRenderer(
       sessionName,
       '-c',
       options.cwd,
-      command,
+      ...commandArgs,
     ]).trim();
     return {
       renderer: 'tmux-session',


### PR DESCRIPTION
## Summary
- stop launching `omx question --ui` as one POSIX-quoted tmux shell-command string
- pass the question UI launch as direct tmux argv plus `-e OMX_SESSION_ID=...`
- add regression coverage that asserts tmux receives argv segments instead of one shell string

## Root cause
`src/question/renderer.ts` built a POSIX-quoted command string and passed it as the final `split-window`/`new-session` argument. tmux runs that string through the configured `default-shell`. When `default-shell` was Nushell, Nushell rejected the POSIX quoting and the question pane exited immediately.

## Verification
- `npm run build`
- `node --test dist/question/__tests__/renderer.test.js`
- `npx biome lint src/question/renderer.ts src/question/__tests__/renderer.test.ts`
- live repro with tmux `default-shell` set to `nu 0.112.2`: the question pane stayed alive and `omx question --json` returned `{"ok":true,...}`

## Issue
- Fixes #1795
