### PR TITLE
Keep explicit update reliable when setup still needs refresh

### DIFF
--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -11,6 +11,7 @@ import {
   resolveInstalledCliEntry,
   runImmediateUpdate,
   shouldCheckForUpdates,
+  spawnInstalledSetupRefresh,
   writeUserInstallStamp,
 } from '../update.js';
 
@@ -411,9 +412,119 @@ describe('runImmediateUpdate', () => {
 
   it('reports up-to-date status for explicit update when npm is already current', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
+    const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
+    const originalCodexHome = process.env.CODEX_HOME;
     const originalLog = console.log;
     const logs: string[] = [];
     let updateCalls = 0;
+    let refreshCalls = 0;
+
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+    process.env.CODEX_HOME = join(cwd, '.codex');
+
+    try {
+      await writeUserInstallStamp(
+        {
+          installed_version: '0.14.0',
+          setup_completed_version: '0.14.0',
+          updated_at: '2026-04-20T00:00:00.000Z',
+        },
+        stampPath,
+      );
+
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.14.0',
+        fetchLatestVersion: async () => '0.14.0',
+        runGlobalUpdate: () => {
+          updateCalls += 1;
+          return { ok: true, stderr: '' };
+        },
+        runSetupRefresh: async () => {
+          refreshCalls += 1;
+          return { ok: true, stderr: '' };
+        },
+      });
+
+      assert.equal(result.status, 'up-to-date');
+      assert.equal(updateCalls, 0);
+      assert.equal(refreshCalls, 0);
+      assert.match(logs.join('\n'), /already up to date \(v0\.14\.0\)/);
+    } finally {
+      console.log = originalLog;
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('runs setup refresh for explicit update when current version matches but setup stamp is stale', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
+    const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
+    const originalCodexHome = process.env.CODEX_HOME;
+    const originalLog = console.log;
+    const logs: string[] = [];
+    let refreshCalls = 0;
+
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+    process.env.CODEX_HOME = join(cwd, '.codex');
+
+    try {
+      await writeUserInstallStamp(
+        {
+          installed_version: '0.14.0',
+          setup_completed_version: '0.13.9',
+          updated_at: '2026-04-20T00:00:00.000Z',
+        },
+        stampPath,
+      );
+
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.14.0',
+        fetchLatestVersion: async () => '0.14.0',
+        runGlobalUpdate: () => {
+          throw new Error('global update should not run when already current');
+        },
+        runSetupRefresh: async () => {
+          refreshCalls += 1;
+          return { ok: true, stderr: '' };
+        },
+      });
+
+      assert.equal(result.status, 'up-to-date');
+      assert.equal(refreshCalls, 1);
+      assert.match(logs.join('\n'), /Running setup refresh/);
+      assert.match(logs.join('\n'), /Setup refresh completed for v0\.14\.0/);
+
+      const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
+        installed_version: string;
+        setup_completed_version: string;
+      };
+      assert.equal(stamp.installed_version, '0.14.0');
+      assert.equal(stamp.setup_completed_version, '0.14.0');
+    } finally {
+      console.log = originalLog;
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('continues explicit update when update-check state cannot be written', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
+    const originalLog = console.log;
+    const logs: string[] = [];
+    let updateCalls = 0;
+    let refreshCalls = 0;
 
     console.log = (...args: unknown[]) => {
       logs.push(args.map((arg) => String(arg)).join(' '));
@@ -422,16 +533,24 @@ describe('runImmediateUpdate', () => {
     try {
       const result = await runImmediateUpdate(cwd, {
         getCurrentVersion: async () => '0.14.0',
-        fetchLatestVersion: async () => '0.14.0',
+        fetchLatestVersion: async () => '0.14.1',
+        writeUpdateState: async () => {
+          throw new Error('EACCES');
+        },
         runGlobalUpdate: () => {
           updateCalls += 1;
           return { ok: true, stderr: '' };
         },
+        runSetupRefresh: async () => {
+          refreshCalls += 1;
+          return { ok: true, stderr: '' };
+        },
       });
 
-      assert.equal(result.status, 'up-to-date');
-      assert.equal(updateCalls, 0);
-      assert.match(logs.join('\n'), /already up to date \(v0\.14\.0\)/);
+      assert.equal(result.status, 'updated');
+      assert.equal(updateCalls, 1);
+      assert.equal(refreshCalls, 1);
+      assert.match(logs.join('\n'), /Updated to v0\.14\.1/);
     } finally {
       console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
@@ -524,5 +643,20 @@ describe('post-update setup refresh handoff', () => {
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it('does not impose a timeout on the interactive setup refresh handoff', () => {
+    let receivedTimeout: unknown = Symbol('unset');
+    const result = spawnInstalledSetupRefresh(
+      '/tmp/omx.js',
+      '/tmp/project',
+      ((_command, _args, options) => {
+        receivedTimeout = options?.timeout;
+        return { status: 0, error: undefined };
+      }) as typeof import('node:child_process').spawnSync,
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(receivedTimeout, undefined);
   });
 });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -42,6 +42,7 @@ export interface UpdateExecutionResult {
 
 type RunGlobalUpdateResult = { ok: boolean; stderr: string };
 type RunSetupRefreshResult = { ok: boolean; stderr: string };
+type SpawnSyncLike = typeof spawnSync;
 
 const PACKAGE_NAME = 'oh-my-codex';
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12h
@@ -152,16 +153,20 @@ interface UpdateDependencies {
   askYesNo: typeof askYesNo;
   fetchLatestVersion: typeof fetchLatestVersion;
   getCurrentVersion: typeof getCurrentVersion;
+  readUserInstallStamp: typeof readUserInstallStamp;
   runGlobalUpdate: typeof runGlobalUpdate;
   runSetupRefresh: (cwd: string) => Promise<RunSetupRefreshResult>;
+  writeUpdateState: typeof writeUpdateState;
 }
 
 const defaultUpdateDependencies: UpdateDependencies = {
   askYesNo,
   fetchLatestVersion,
   getCurrentVersion,
+  readUserInstallStamp,
   runGlobalUpdate,
   runSetupRefresh,
+  writeUpdateState,
 };
 
 function stripLeadingV(version: string): string {
@@ -217,6 +222,13 @@ export function isInstallVersionBump(
   return stripLeadingV(currentVersion) !== stripLeadingV(stamp.installed_version);
 }
 
+function doesSetupStampMatchVersion(
+  currentVersion: string,
+  stamp: UserInstallStamp | null,
+): boolean {
+  return stripLeadingV(stamp?.setup_completed_version ?? '') === stripLeadingV(currentVersion);
+}
+
 function resolveGlobalInstallRoot(): string | null {
   const result = spawnSync('npm', ['root', '-g'], {
     encoding: 'utf-8',
@@ -259,28 +271,15 @@ export async function resolveInstalledCliEntry(globalInstallRoot: string): Promi
   return existsSync(cliEntry) ? cliEntry : null;
 }
 
-async function runSetupRefresh(cwd: string): Promise<RunSetupRefreshResult> {
-  const globalInstallRoot = resolveGlobalInstallRoot();
-  if (!globalInstallRoot) {
-    return {
-      ok: false,
-      stderr: 'Unable to resolve the npm global install root after updating.',
-    };
-  }
-
-  const cliEntry = await resolveInstalledCliEntry(globalInstallRoot);
-  if (!cliEntry) {
-    return {
-      ok: false,
-      stderr: `Unable to find the updated OMX CLI entry under ${join(globalInstallRoot, PACKAGE_NAME)}.`,
-    };
-  }
-
-  const result = spawnSync(process.execPath, [cliEntry, 'setup'], {
+export function spawnInstalledSetupRefresh(
+  cliEntry: string,
+  cwd: string,
+  spawnProcess: SpawnSyncLike = spawnSync,
+): RunSetupRefreshResult {
+  const result = spawnProcess(process.execPath, [cliEntry, 'setup'], {
     cwd,
     env: process.env,
     stdio: 'inherit',
-    timeout: 120000,
     windowsHide: true,
   });
 
@@ -298,6 +297,26 @@ async function runSetupRefresh(cwd: string): Promise<RunSetupRefreshResult> {
   return { ok: true, stderr: '' };
 }
 
+async function runSetupRefresh(cwd: string): Promise<RunSetupRefreshResult> {
+  const globalInstallRoot = resolveGlobalInstallRoot();
+  if (!globalInstallRoot) {
+    return {
+      ok: false,
+      stderr: 'Unable to resolve the npm global install root after updating.',
+    };
+  }
+
+  const cliEntry = await resolveInstalledCliEntry(globalInstallRoot);
+  if (!cliEntry) {
+    return {
+      ok: false,
+      stderr: `Unable to find the updated OMX CLI entry under ${join(globalInstallRoot, PACKAGE_NAME)}.`,
+    };
+  }
+
+  return spawnInstalledSetupRefresh(cliEntry, cwd);
+}
+
 async function executeUpdate(
   options: {
     cwd: string;
@@ -313,10 +332,15 @@ async function executeUpdate(
     dependencies.fetchLatestVersion(),
   ]);
 
-  await writeUpdateState(cwd, {
-    last_checked_at: new Date(nowMs).toISOString(),
-    last_seen_latest: latest ?? undefined,
-  });
+  try {
+    await dependencies.writeUpdateState(cwd, {
+      last_checked_at: new Date(nowMs).toISOString(),
+      last_seen_latest: latest ?? undefined,
+    });
+  } catch {
+    // Update-check state is advisory only. Do not fail installs or explicit updates
+    // just because the current working directory is read-only or unavailable.
+  }
 
   if (!current || !latest) {
     if (immediate) {
@@ -326,6 +350,25 @@ async function executeUpdate(
   }
 
   if (!isNewerVersion(current, latest)) {
+    if (immediate) {
+      const installStamp = await dependencies.readUserInstallStamp();
+      if (!doesSetupStampMatchVersion(current, installStamp)) {
+        console.log(
+          `[omx] oh-my-codex is already up to date (v${current}). Running setup refresh...`,
+        );
+        const setupRefreshResult = await dependencies.runSetupRefresh(cwd);
+        if (!setupRefreshResult.ok) {
+          console.log(
+            `[omx] Update installed, but the setup refresh failed. Run \`omx setup\` with the new install. (${setupRefreshResult.stderr})`,
+          );
+          return { status: 'failed', currentVersion: current, latestVersion: latest };
+        }
+        await writeSuccessfulInstallStamp(current);
+        console.log(`[omx] Setup refresh completed for v${current}. Restart to use current code.`);
+        return { status: 'up-to-date', currentVersion: current, latestVersion: latest };
+      }
+    }
+
     if (immediate) {
       console.log(`[omx] oh-my-codex is already up to date (v${current}).`);
     }


### PR DESCRIPTION
## Summary
- refresh setup during explicit `omx update` when the installed version matches but the setup-completed stamp is stale
- treat update-state writes as advisory so read-only cwd failures do not abort explicit updates
- remove the fixed timeout from the interactive updated-CLI setup handoff and cover the flow with tests

## Testing
- npm run build
- node --test dist/cli/__tests__/update.test.js dist/scripts/__tests__/postinstall.test.js
- npx biome lint src/cli/update.ts src/cli/__tests__/update.test.ts
- npm run check:no-unused
- npx tsc --noEmit --pretty false --project tsconfig.json
