### PR TITLE
Deduplicate lifecycle normalization around the shared run outcome contract

### DIFF
--- a/src/runtime/__tests__/run-outcome.test.ts
+++ b/src/runtime/__tests__/run-outcome.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeRunOutcome,
 } from '../run-outcome.js';
 import {
+  compatibilityRunOutcomeFromTerminalLifecycleOutcome,
   inferTerminalLifecycleOutcome,
   normalizeTerminalLifecycleOutcome,
   preferredRunOutcomeForLifecycleOutcome,
@@ -116,5 +117,14 @@ describe('run outcome contract', () => {
     assert.equal(preferredRunOutcomeForLifecycleOutcome('failed'), 'failed');
     assert.equal(preferredRunOutcomeForLifecycleOutcome('userinterlude'), 'cancelled');
     assert.equal(preferredRunOutcomeForLifecycleOutcome('askuserQuestion'), 'blocked_on_user');
+  });
+
+  it('keeps terminal lifecycle compatibility helpers aligned with the shared run outcome contract', () => {
+    for (const outcome of ['finished', 'blocked', 'failed', 'userinterlude', 'askuserQuestion'] as const) {
+      assert.equal(
+        preferredRunOutcomeForLifecycleOutcome(outcome),
+        compatibilityRunOutcomeFromTerminalLifecycleOutcome(outcome),
+      );
+    }
   });
 });

--- a/src/runtime/terminal-lifecycle.ts
+++ b/src/runtime/terminal-lifecycle.ts
@@ -1,70 +1,41 @@
-import { normalizeRunOutcome, type RunOutcome } from './run-outcome.js';
+import {
+  TERMINAL_LIFECYCLE_OUTCOMES,
+  compatibilityRunOutcomeFromTerminalLifecycleOutcome,
+  normalizeRunOutcome,
+  normalizeTerminalLifecycleOutcome as normalizeTerminalLifecycleOutcomeContract,
+  terminalLifecycleOutcomeFromRunOutcome,
+  type RunOutcome,
+  type TerminalLifecycleOutcome,
+  type TerminalLifecycleOutcomeNormalizationResult,
+} from './run-outcome.js';
 
-export const TERMINAL_LIFECYCLE_OUTCOMES = [
-  'finished',
-  'blocked',
-  'failed',
-  'userinterlude',
-  'askuserQuestion',
-] as const;
+export {
+  TERMINAL_LIFECYCLE_OUTCOMES,
+  compatibilityRunOutcomeFromTerminalLifecycleOutcome,
+};
+export type { TerminalLifecycleOutcome };
+export type TerminalLifecycleNormalizationResult = TerminalLifecycleOutcomeNormalizationResult;
 
-export type TerminalLifecycleOutcome = (typeof TERMINAL_LIFECYCLE_OUTCOMES)[number];
-
-export interface TerminalLifecycleNormalizationResult {
-  outcome?: TerminalLifecycleOutcome;
-  warning?: string;
-  error?: string;
+function rewriteWarning(warning: string | undefined): string | undefined {
+  return warning?.replace('legacy terminal lifecycle outcome', 'legacy lifecycle outcome');
 }
 
-const TERMINAL_LIFECYCLE_OUTCOME_SET = new Set<string>(TERMINAL_LIFECYCLE_OUTCOMES);
-
-const TERMINAL_LIFECYCLE_ALIASES: Readonly<Record<string, TerminalLifecycleOutcome>> = {
-  finished: 'finished',
-  finish: 'finished',
-  complete: 'finished',
-  completed: 'finished',
-  done: 'finished',
-  blocked: 'blocked',
-  blocked_on_user: 'blocked',
-  'blocked-on-user': 'blocked',
-  failed: 'failed',
-  fail: 'failed',
-  error: 'failed',
-  userinterlude: 'userinterlude',
-  'user-interlude': 'userinterlude',
-  interrupted: 'userinterlude',
-  cancelled: 'userinterlude',
-  canceled: 'userinterlude',
-  cancel: 'userinterlude',
-  aborted: 'userinterlude',
-  abort: 'userinterlude',
-  askuserquestion: 'askuserQuestion',
-  'ask-user-question': 'askuserQuestion',
-  ask_user_question: 'askuserQuestion',
-  question: 'askuserQuestion',
-  omxquestion: 'askuserQuestion',
-  'omx-question': 'askuserQuestion',
-} as const;
-
-function normalizeString(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : '';
+function isCanonicalTerminalLifecycleOutcome(value: unknown): value is TerminalLifecycleOutcome {
+  return typeof value === 'string' && (TERMINAL_LIFECYCLE_OUTCOMES as readonly string[]).includes(value.trim());
 }
 
 export function normalizeTerminalLifecycleOutcome(value: unknown): TerminalLifecycleNormalizationResult {
-  const normalized = normalizeString(value);
-  if (!normalized) return {};
-  if (TERMINAL_LIFECYCLE_OUTCOME_SET.has(normalized)) {
-    return { outcome: normalized as TerminalLifecycleOutcome };
+  if (isCanonicalTerminalLifecycleOutcome(value)) {
+    return { outcome: value.trim() as TerminalLifecycleOutcome };
   }
-  const alias = TERMINAL_LIFECYCLE_ALIASES[normalized.toLowerCase()];
-  if (alias) {
-    return {
-      outcome: alias,
-      warning: `normalized legacy lifecycle outcome "${value}" -> "${alias}"`,
-    };
-  }
+
+  const result = normalizeTerminalLifecycleOutcomeContract(value, {
+    blockedOnUserStrategy: 'blocked',
+  });
   return {
-    error: `lifecycle_outcome must be one of: ${TERMINAL_LIFECYCLE_OUTCOMES.join(', ')}`,
+    ...(result.outcome ? { outcome: result.outcome } : {}),
+    ...(result.warning ? { warning: rewriteWarning(result.warning) } : {}),
+    ...(result.error ? { error: result.error } : {}),
   };
 }
 
@@ -79,14 +50,18 @@ export function inferTerminalLifecycleOutcome(candidate: {
   if (runOutcome.error) return { error: runOutcome.error };
   switch (runOutcome.outcome) {
     case 'finish':
-      return { outcome: 'finished' };
     case 'blocked_on_user':
-      return { outcome: 'blocked' };
     case 'failed':
-      return { outcome: 'failed' };
+      return {
+        outcome: terminalLifecycleOutcomeFromRunOutcome(runOutcome.outcome, {
+          blockedOnUserStrategy: 'blocked',
+        }),
+      };
     case 'cancelled':
       return {
-        outcome: 'userinterlude',
+        outcome: terminalLifecycleOutcomeFromRunOutcome('cancelled', {
+          blockedOnUserStrategy: 'blocked',
+        }),
         warning: 'normalized legacy run outcome "cancelled" -> "userinterlude"',
       };
     default:
@@ -97,16 +72,5 @@ export function inferTerminalLifecycleOutcome(candidate: {
 export function preferredRunOutcomeForLifecycleOutcome(
   outcome: TerminalLifecycleOutcome,
 ): RunOutcome {
-  switch (outcome) {
-    case 'finished':
-      return 'finish';
-    case 'blocked':
-      return 'blocked_on_user';
-    case 'failed':
-      return 'failed';
-    case 'userinterlude':
-      return 'cancelled';
-    case 'askuserQuestion':
-      return 'blocked_on_user';
-  }
+  return compatibilityRunOutcomeFromTerminalLifecycleOutcome(outcome);
 }


### PR DESCRIPTION
## Summary
- make `src/runtime/terminal-lifecycle.ts` a thinner compatibility wrapper over the shared run-outcome contract
- add regression coverage that compatibility lifecycle helpers stay aligned with canonical run-outcome mappings

## Testing
- npm run build
- node --test dist/runtime/__tests__/run-outcome.test.js dist/mcp/__tests__/state-server.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/notify-hook-ralph-resume.test.js
- npx biome lint src/runtime/terminal-lifecycle.ts src/runtime/__tests__/run-outcome.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.json
