### PR TITLE
Fail closed when detached question UI sessions die on launch

### DIFF
--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -157,13 +157,15 @@ describe('launchQuestionRenderer', () => {
         strategy: 'detached-tmux',
         execTmux: (args) => {
           calls.push(args);
+          if (args[0] === 'has-session') return '';
           return 'omx-question-question-2\n';
         },
+        sleepSync: () => {},
       },
     );
 
     assert.equal(result.renderer, 'tmux-session');
-    assert.equal(calls.length, 1);
+    assert.equal(calls.length, 2);
     assert.equal(calls[0]?.[0], 'new-session');
     assert.ok(calls[0]?.includes('-d'));
     assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
@@ -174,6 +176,35 @@ describe('launchQuestionRenderer', () => {
       '--state-path',
       '/repo/.omx/state/sessions/s1/questions/question-2.json',
     ]);
+    assert.deepEqual(calls[1], ['has-session', '-t', 'omx-question-question-2']);
+  });
+
+  it('fails when a detached tmux session disappears immediately after launch', () => {
+    const calls: string[][] = [];
+    assert.throws(
+      () => launchQuestionRenderer(
+        {
+          cwd: '/repo',
+          recordPath: '/repo/.omx/state/sessions/s1/questions/question-2.json',
+          nowIso: '2026-04-19T00:00:00.000Z',
+          env: {} as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'detached-tmux',
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'new-session') return 'omx-question-question-2\n';
+            throw new Error('can\'t find session: omx-question-question-2');
+          },
+          sleepSync: () => {},
+        },
+      ),
+      /Question UI session omx-question-question-2 disappeared immediately after launch/,
+    );
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0]?.[0], 'new-session');
+    assert.deepEqual(calls[1], ['has-session', '-t', 'omx-question-question-2']);
   });
 
   it('prefers the current launcher path over a stale ambient OMX_ENTRY_PATH when spawning the UI', () => {

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -24,6 +24,7 @@ export type SleepSync = (ms: number) => void;
 const QUESTION_TEXT_SETTLE_MS = 120;
 const QUESTION_SUBMIT_REPEAT_DELAY_MS = 100;
 const QUESTION_RENDERER_PANE_SETTLE_MS = 120;
+const QUESTION_RENDERER_SESSION_SETTLE_MS = 120;
 
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
@@ -99,6 +100,19 @@ function isLaunchedQuestionPaneAlive(
         const [paneDead = '', resolvedPaneId = ''] = line.split('\t');
         return resolvedPaneId === paneId && paneDead !== '1';
       });
+  } catch {
+    return false;
+  }
+}
+
+function isLaunchedQuestionSessionAlive(
+  sessionName: string,
+  execTmux: ExecTmuxSync,
+): boolean {
+  if (!safeString(sessionName).trim()) return false;
+  try {
+    execTmux(['has-session', '-t', sessionName]);
+    return true;
   } catch {
     return false;
   }
@@ -197,9 +211,14 @@ export function launchQuestionRenderer(
       options.cwd,
       ...commandArgs,
     ]).trim();
+    const target = output || sessionName;
+    sleepImpl(QUESTION_RENDERER_SESSION_SETTLE_MS);
+    if (!isLaunchedQuestionSessionAlive(target, execTmux)) {
+      throw new Error(`Question UI session ${target} disappeared immediately after launch.`);
+    }
     return {
       renderer: 'tmux-session',
-      target: output || sessionName,
+      target,
       launched_at: launchedAt,
     };
   }


### PR DESCRIPTION
## Summary
- fail closed when a detached question renderer tmux session dies immediately after launch
- add regression coverage for detached-session success and immediate-disappear failure cases

## Testing
- npm run build
- env -u OMX_TEAM_WORKER -u OMX_TEAM_STATE_ROOT node --test dist/question/__tests__/renderer.test.js dist/cli/__tests__/question.test.js
- npx biome lint src/question/renderer.ts src/question/__tests__/renderer.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.json
