### PR TITLE
Keep deep-interview question bridge usable in reused sessions

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -752,6 +752,8 @@ describe("codex native hook dispatch", () => {
       assert.match(message, /skill: deep-interview activated and initial state initialized at \.omx\/state\/sessions\/sess-deep-interview-msg\/deep-interview-state\.json; write subsequent updates via omx_state MCP\./);
       assert.match(message, /Deep-interview must ask each interview round via `omx question`/);
       assert.match(message, /do not fall back to `request_user_input` or plain-text questioning/i);
+      assert.match(message, /If bare `omx question` is unavailable in this reused session, use the current-session CLI bridge command:/);
+      assert.match(message, /`'.+' '.+dist\/cli\/omx\.js' question`/);
       assert.match(message, /Stop remains blocked while a deep-interview question obligation is pending\./);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -44,6 +44,7 @@ import {
 import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
 import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
+import { shellEscapeSingle } from "../hud/tmux.js";
 import { onSessionStart as buildWikiSessionStartContext } from "../wiki/lifecycle.js";
 import { readAutoresearchCompletionStatus, readAutoresearchModeState } from "../autoresearch/skill-validation.js";
 import { shouldContinueRun } from "../runtime/run-loop.js";
@@ -57,6 +58,7 @@ import {
   type TriageStateFile,
 } from "../hooks/triage-state.js";
 import { isPendingDeepInterviewQuestionEnforcement } from "../question/deep-interview.js";
+import { resolveOmxCliEntryPath } from "../utils/paths.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -527,7 +529,17 @@ async function buildSessionStartContext(
   return sections.length > 0 ? sections.join("\n\n") : null;
 }
 
-function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveState | null): string | null {
+function buildDeepInterviewQuestionBridgeInstruction(cwd: string): string {
+  const omxBin = resolveOmxCliEntryPath({ cwd }) || process.argv[1] || "omx";
+  const bridgeCommand = `${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} question`;
+  return `Deep-interview must ask each interview round via \`omx question\`; do not fall back to \`request_user_input\` or plain-text questioning. If bare \`omx question\` is unavailable in this reused session, use the current-session CLI bridge command: \`${bridgeCommand}\`. Stop remains blocked while a deep-interview question obligation is pending.`;
+}
+
+function buildAdditionalContextMessage(
+  prompt: string,
+  skillState?: SkillActiveState | null,
+  cwd: string = process.cwd(),
+): string | null {
   if (!prompt) return null;
   const promptPriorityMessage = buildPromptPriorityMessage(prompt);
   const matches = detectKeywords(prompt);
@@ -547,7 +559,7 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
     ? "Prompt-side `$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`. Use `omx ralph --prd ...` only when you explicitly want the PRD-gated CLI startup path."
     : null;
   const deepInterviewPromptActivationNote = skillState?.initialized_mode === "deep-interview"
-    ? "Deep-interview must ask each interview round via `omx question`; do not fall back to `request_user_input` or plain-text questioning. Stop remains blocked while a deep-interview question obligation is pending."
+    ? buildDeepInterviewQuestionBridgeInstruction(cwd)
     : null;
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;
@@ -1730,7 +1742,7 @@ export async function dispatchCodexNativeHook(
   if (hookEventName === "SessionStart" || hookEventName === "UserPromptSubmit") {
     const additionalContext = hookEventName === "SessionStart"
       ? await buildSessionStartContext(cwd, canonicalSessionId || nativeSessionId)
-      : (buildAdditionalContextMessage(readPromptText(payload), skillState) ?? triageAdditionalContext);
+      : (buildAdditionalContextMessage(readPromptText(payload), skillState, cwd) ?? triageAdditionalContext);
     if (additionalContext) {
       outputJson = {
         hookSpecificOutput: {


### PR DESCRIPTION
## Summary

Fixes issue #1801 by keeping the deep-interview structured-question path reachable in reused sessions where bare `omx question` may resolve to a stale or mismatched CLI shim.

The CLI command is already registered on `dev`; the failing path is the prompt/runtime bridge. The hook required agents to use bare `omx question`, but the runtime bridge already resolves the current package CLI entry with `resolveOmxCliEntryPath()`. This PR surfaces that resolved bridge command in the deep-interview hook guidance while preserving the no-plain-text/no-`request_user_input` contract.

## Changes

- Add a deep-interview question bridge instruction that includes `node <resolved omx cli> question` for reused sessions where bare `omx question` is unavailable.
- Pass hook `cwd` into the additional-context builder so bridge resolution uses the current worktree/session context.
- Add focused regression coverage asserting the hook still enforces `omx question` and now emits the current-session bridge command.

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npm run check:no-unused`
- [x] `npm run lint -- src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts`
- [x] `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/nested-help-routing.test.js dist/cli/__tests__/question.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — not needed; runtime hook guidance only
- [x] Backward-compatibility impact considered — preserves bare `omx question` guidance and only adds a resolved fallback bridge command for reused sessions

## Related

Closes #1801
