### PR TITLE
Catch Korean ulw keyboard drift before routing

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -242,6 +242,15 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(detectPrimaryKeyword('PASS runs assertions in parallel when sharding is enabled'), null);
     assert.equal(detectPrimaryKeyword('running 8 tests in parallel across 4 workers'), null);
   });
+
+  it('normalizes the Korean keyboard typo for ulw to ultrawork only', () => {
+    const match = detectPrimaryKeyword('ㅕㅣㅈ로 이 작업 처리해줘');
+
+    assert.ok(match);
+    assert.equal(match.skill, 'ultrawork');
+    assert.equal(match.keyword, 'ulw');
+    assert.equal(detectPrimaryKeyword('ㅁㅔㅔ로 처리해줘'), null);
+  });
 });
 
 describe('autoresearch keyword detection', () => {
@@ -544,6 +553,37 @@ describe('keyword detector skill-active-state lifecycle', () => {
         await readFile(join(stateDir, 'sessions', 'sess-visible', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
       ) as { active_skills?: Array<{ skill: string }> };
       assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team', 'ralph', 'ultrawork']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('activates ultrawork mode from the Korean keyboard typo for ulw', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ulw-ko-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'ㅕㅣㅈ로 병렬 처리해줘',
+        sessionId: 'sess-ulw-ko',
+        threadId: 'thread-ulw-ko',
+        turnId: 'turn-ulw-ko',
+        nowIso: '2026-04-21T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'ultrawork');
+      assert.equal(result.keyword, 'ulw');
+      assert.equal(result.initialized_mode, 'ultrawork');
+      assert.equal(result.initialized_state_path, '.omx/state/sessions/sess-ulw-ko/ultrawork-state.json');
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-ulw-ko', 'ultrawork-state.json'), 'utf-8'),
+      ) as { mode: string; active: boolean; current_phase: string };
+      assert.equal(modeState.mode, 'ultrawork');
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'planning');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -469,6 +469,17 @@ function hasExplicitPromptsInvocation(text: string): boolean {
   return /(?:^|\s)\/prompts:[\w.-]+(?=[\s.,!?;:]|$)/i.test(text);
 }
 
+/**
+ * Korean 2-set keyboard typo aliases for workflow keywords.
+ *
+ * Keep this intentionally narrow: only the `ulw` ultrawork shorthand is
+ * normalized so users who forget to switch IMEs get the same activation path
+ * as the canonical keyword without introducing broad transliteration surprises.
+ */
+function normalizeWorkflowKeyboardTypos(text: string): string {
+  return text.replace(/ㅕㅣㅈ/g, 'ulw');
+}
+
 function hasExplicitSkillLikeInvocation(text: string): boolean {
   return /(?:^|[^\w])\$([a-z][a-z0-9-]*)\b/i.test(text);
 }
@@ -522,11 +533,12 @@ function hasIntentContextForKeyword(text: string, keyword: string): boolean {
  * then appends implicit keyword matches sorted by priority.
  */
 export function detectKeywords(text: string): KeywordMatch[] {
-  const explicit = extractExplicitSkillInvocations(text);
-  if (hasExplicitPromptsInvocation(text) && explicit.length === 0) {
+  const normalizedText = normalizeWorkflowKeyboardTypos(text);
+  const explicit = extractExplicitSkillInvocations(normalizedText);
+  if (hasExplicitPromptsInvocation(normalizedText) && explicit.length === 0) {
     return [];
   }
-  if (explicit.length === 0 && hasExplicitSkillLikeInvocation(text)) {
+  if (explicit.length === 0 && hasExplicitSkillLikeInvocation(normalizedText)) {
     return [];
   }
   if (explicit.length > 0) {
@@ -536,9 +548,9 @@ export function detectKeywords(text: string): KeywordMatch[] {
   const implicit: KeywordMatch[] = [];
 
   for (const { pattern, skill, priority } of KEYWORD_MAP) {
-    const match = text.match(pattern);
+    const match = normalizedText.match(pattern);
     if (match) {
-      if (!hasIntentContextForKeyword(text, match[0].toLowerCase())) continue;
+      if (!hasIntentContextForKeyword(normalizedText, match[0].toLowerCase())) continue;
       implicit.push({
         keyword: match[0],
         skill,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -606,6 +606,35 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("normalizes the Korean keyboard typo for ulw during UserPromptSubmit activation", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ulw-ko-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-ulw-ko",
+          thread_id: "thread-ulw-ko",
+          turn_id: "turn-ulw-ko",
+          prompt: "ㅕㅣㅈ로 병렬 처리해줘",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "ultrawork");
+      assert.equal(result.skillState?.keyword, "ulw");
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(additionalContext, /workflow keyword \"ulw\" -> ultrawork/);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-ulw-ko", "ultrawork-state.json")), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not activate Ralph workflow state from a plain conversational mention", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-plain-text-"));
     try {


### PR DESCRIPTION
## Summary

Fixes Korean 2-set keyboard drift for the `ulw` ultrawork shorthand. When a Korean user forgets to switch input languages, typing `ulw` becomes `ㅕㅣㅈ`; the native prompt keyword path previously missed that input and did not activate ultrawork.

## Changes

- Add a narrow keyword-detector normalization step that maps `ㅕㅣㅈ` to the canonical `ulw` shorthand before existing keyword matching and intent checks run.
- Keep the alias intentionally scoped to `ulw` only instead of adding broad keyboard transliteration.
- Add regression coverage for direct keyword detection, ultrawork state seeding, and the native `UserPromptSubmit` activation path.

## Validation

- [x] `npm run build`
- [x] `node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- [x] `npx biome lint src/hooks/keyword-detector.ts src/hooks/__tests__/keyword-detector.test.ts src/scripts/__tests__/codex-native-hook.test.ts`
- [x] `npm run check:no-unused`
- [ ] `npm test` — attempted, but this workspace still has unrelated tmux/local-path environment failures (for example tmux target/log timeouts and `/private/var` vs `/var` path assertions). The focused tests for this change pass.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Backward-compatibility impact considered — canonical `ulw`/`$ultrawork` behavior is unchanged; the new alias only normalizes the Korean keyboard drift form
- [x] False-positive scope considered — no broad transliteration, no aliases for other workflow keywords
