### PR TITLE
fix: prevent invisible omx question prompts outside attached tmux

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -177,4 +177,71 @@ esac
     assert.equal(record.error?.code, 'question_runtime_failed');
     assert.match(record.error?.message || '', /pane %5 disappeared immediately after launch/i);
   });
+
+  it('fails closed outside an attached tmux pane without creating a detached session', async () => {
+    const cwd = await makeRepo();
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(join(fakeBinDir, 'tmux'), `#!/bin/sh
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+exit 0
+`, { mode: 0o755 });
+
+    const input = JSON.stringify({
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      session_id: 'sess-q',
+    });
+
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      OMX_AUTO_UPDATE: '0',
+      OMX_NOTIFY_FALLBACK: '0',
+      OMX_HOOK_DERIVED_SIGNALS: '0',
+    };
+    delete childEnv.TMUX;
+    delete childEnv.TMUX_PANE;
+    delete childEnv.OMX_QUESTION_TEST_RENDERER;
+
+    const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
+      const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
+        cwd,
+        env: childEnv,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+      child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+      child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, 'question_runtime_failed');
+    assert.match(payload.error.message, /visible renderer/i);
+    assert.match(payload.error.message, /attached tmux pane/i);
+    assert.match(payload.error.message, /Run omx question from inside tmux/i);
+    assert.doesNotMatch(payload.error.message, /tmux is unavailable/i);
+
+    const entries = await readdir(join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions'));
+    assert.equal(entries.length, 1);
+    const recordPath = join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions', entries[0]!);
+    const record = JSON.parse(await readFile(recordPath, 'utf-8')) as { status: string; error?: { code?: string; message?: string } };
+    assert.equal(record.status, 'error');
+    assert.equal(record.error?.code, 'question_runtime_failed');
+    assert.match(record.error?.message || '', /visible renderer/i);
+    assert.match(record.error?.message || '', /attached tmux pane/i);
+    assert.doesNotMatch(record.error?.message || '', /tmux is unavailable/i);
+
+    let tmuxLog = '';
+    try {
+      tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+    } catch {}
+    assert.doesNotMatch(tmuxLog, /new-session/);
+  });
 });

--- a/src/question/__tests__/deep-interview.test.ts
+++ b/src/question/__tests__/deep-interview.test.ts
@@ -164,4 +164,56 @@ describe('runDeepInterviewQuestion', () => {
     assert.equal(finalState.lifecycle_outcome, undefined);
     assert.equal(finalState.run_outcome, undefined);
   });
+
+  it('clears the pending obligation when question renderer launch fails', async () => {
+    const cwd = await makeRepo();
+    const statePath = join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'deep-interview-state.json');
+
+    await assert.rejects(
+      runDeepInterviewQuestion(
+        {
+          question: 'What should happen next?',
+          options: [{ label: 'Launch', value: 'launch' }],
+          allow_other: false,
+        },
+        {
+          cwd,
+          argv1: '/repo/dist/cli/omx.js',
+          runner: async () => ({
+            code: 1,
+            stdout: JSON.stringify({
+              ok: false,
+              error: {
+                code: 'question_runtime_failed',
+                message: 'omx question cannot open a visible renderer because this process is not running inside an attached tmux pane.',
+              },
+            }),
+            stderr: '',
+          }),
+        },
+      ),
+      (error) => {
+        assert.ok(error instanceof OmxQuestionError);
+        assert.equal(error.code, 'question_runtime_failed');
+        return true;
+      },
+    );
+
+    const finalState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+      lifecycle_outcome?: string;
+      question_enforcement?: {
+        lifecycle_outcome?: string;
+        status?: string;
+        clear_reason?: string;
+        cleared_at?: string;
+      };
+      run_outcome?: string;
+    };
+    assert.equal(finalState.question_enforcement?.status, 'cleared');
+    assert.equal(finalState.question_enforcement?.lifecycle_outcome, 'askuserQuestion');
+    assert.equal(finalState.question_enforcement?.clear_reason, 'error');
+    assert.ok(finalState.question_enforcement?.cleared_at);
+    assert.equal(finalState.lifecycle_outcome, undefined);
+    assert.equal(finalState.run_outcome, undefined);
+  });
 });

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -15,10 +15,10 @@ describe('resolveQuestionRendererStrategy', () => {
     );
   });
 
-  it('falls back to detached-tmux when tmux exists but TMUX is absent', () => {
+  it('fails closed when tmux exists but TMUX is absent', () => {
     assert.equal(
       resolveQuestionRendererStrategy({} as NodeJS.ProcessEnv, '/usr/bin/tmux'),
-      'detached-tmux',
+      'unsupported',
     );
   });
 
@@ -28,9 +28,53 @@ describe('resolveQuestionRendererStrategy', () => {
       'test-noop',
     );
   });
+
+  it('fails closed when neither attached tmux nor tmux binary exists', () => {
+    assert.equal(
+      resolveQuestionRendererStrategy({} as NodeJS.ProcessEnv, undefined),
+      'unsupported',
+    );
+  });
 });
 
 describe('launchQuestionRenderer', () => {
+  it('fails before building UI argv or invoking tmux when no visible renderer is available', () => {
+    const calls: string[][] = [];
+    const originalArgv1 = process.argv[1];
+    process.argv[1] = '';
+    try {
+      assert.throws(
+        () => launchQuestionRenderer(
+          {
+            cwd: '/repo',
+            recordPath: '/repo/.omx/state/sessions/s1/questions/question-1.json',
+            env: {} as NodeJS.ProcessEnv,
+          },
+          {
+            strategy: 'unsupported',
+            execTmux: (args) => {
+              calls.push(args);
+              return '';
+            },
+            sleepSync: () => {},
+          },
+        ),
+        (error) => {
+          assert.ok(error instanceof Error);
+          assert.match(error.message, /visible renderer/i);
+          assert.match(error.message, /attached tmux pane/i);
+          assert.match(error.message, /Run omx question from inside tmux/i);
+          assert.doesNotMatch(error.message, /tmux is unavailable/i);
+          return true;
+        },
+      );
+    } finally {
+      process.argv[1] = originalArgv1;
+    }
+
+    assert.deepEqual(calls, []);
+  });
+
   it('opens an interactive foreground split when already inside tmux', () => {
     const calls: string[][] = [];
     const result = launchQuestionRenderer(

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -36,11 +36,12 @@ function isPaneId(value: string | null | undefined): value is string {
 
 export function resolveQuestionRendererStrategy(
   env: NodeJS.ProcessEnv = process.env,
-  tmuxBinary = resolveTmuxBinaryForPlatform(),
+  // Kept for callers/tests that used to pass detected tmux availability; default
+  // strategy selection now depends only on renderer visibility signals.
+  _tmuxBinary?: string | null,
 ): QuestionRendererStrategy {
   if (safeString(env.OMX_QUESTION_TEST_RENDERER).trim() === 'noop') return 'test-noop';
   if (safeString(env.TMUX).trim() !== '') return 'inside-tmux';
-  if (tmuxBinary) return 'detached-tmux';
   return 'unsupported';
 }
 
@@ -162,6 +163,13 @@ export function launchQuestionRenderer(
   const execTmux = deps.execTmux ?? defaultExecTmux;
   const sleepImpl = deps.sleepSync ?? sleepSync;
   const launchedAt = options.nowIso ?? new Date().toISOString();
+
+  if (strategy === 'unsupported') {
+    throw new Error(
+      'omx question cannot open a visible renderer because this process is not running inside an attached tmux pane. Run omx question from inside tmux.',
+    );
+  }
+
   const commandArgs = buildQuestionUiTmuxArgs(options.recordPath, {
     cwd: options.cwd,
     env: options.env,
@@ -231,5 +239,6 @@ export function launchQuestionRenderer(
     };
   }
 
-  throw new Error('omx question requires tmux for OMX-owned question UI rendering in this session.');
+  const exhaustiveStrategy: never = strategy;
+  throw new Error(`Unsupported omx question renderer strategy: ${exhaustiveStrategy}`);
 }


### PR DESCRIPTION
## Summary

Prevent `omx question` from silently launching an invisible detached tmux renderer when the calling process is not inside an attached tmux pane.

The root cause was that `resolveQuestionRendererStrategy()` treated ambient tmux binary availability as enough to choose `detached-tmux`. That could create an `omx-question-*` detached session that the caller could not see, leaving automation blocked on a hidden question UI.

## Changes

- Default question renderer strategy now returns `unsupported` when `TMUX` is absent, regardless of tmux binary availability.
- Unsupported renderer launch now fails before building UI tmux argv or invoking tmux.
- Preserved attached tmux split-pane rendering, test noop rendering, and explicit `strategy: 'detached-tmux'` support.
- Added renderer, CLI, and deep-interview regressions for the non-attached failure path and cleanup behavior.

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Additional validation performed:

- [x] `node --test dist/question/__tests__/renderer.test.js dist/cli/__tests__/question.test.js dist/question/__tests__/deep-interview.test.js` (20/20)
- [x] `npx tsc --noEmit --pretty false --project tsconfig.json`
- [x] `npx biome lint src/question/renderer.ts src/question/__tests__/renderer.test.ts src/cli/__tests__/question.test.ts src/question/__tests__/deep-interview.test.ts`
- [x] `git diff --check`
- [x] Manual attached-tmux smoke test via `tmux capture-pane`: split-pane rendered the question UI, selecting `Yes` returned `ok:true`, and the record used `renderer: "tmux-pane"`.

Note: I also ran `npm run test:node`; it failed in unrelated environment-sensitive suites outside this change, including `/private/var` vs `/var` temp path expectations, missing `rustc` for sparkshell packaging, and tmux/team hook behavior. The touched `omx question CLI` suite passed during that run.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
