### PR TITLE
fix: preserve explicit deep-interview intent and scoped clear authority

### DIFF
--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -48,6 +48,45 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('status does not report a root fallback mode as active after current-session clear', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-session-clear-fallback-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-clear';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'deep-interview-state.json'), JSON.stringify({
+        active: true,
+        mode: 'deep-interview',
+        current_phase: 'legacy-root',
+      }));
+      await writeFile(join(sessionDir, 'deep-interview-state.json'), JSON.stringify({
+        active: true,
+        mode: 'deep-interview',
+        current_phase: 'session-active',
+      }));
+
+      const clearResult = runOmx(
+        wd,
+        'state',
+        'clear',
+        '--input',
+        '{"mode":"deep-interview"}',
+        '--json',
+      );
+      assert.equal(clearResult.status, 0, clearResult.stderr || clearResult.stdout);
+      assert.match(clearResult.stdout, /"cleared":true/);
+
+      const statusResult = runOmx(wd, 'status');
+      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      assert.doesNotMatch(statusResult.stdout, /deep-interview: ACTIVE/);
+      assert.match(statusResult.stdout, /deep-interview: inactive \(phase: cleared\)/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('cancels linked ultrawork when Ralph is active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-link-'));
     try {

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -177,6 +177,12 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(match.keyword.toLowerCase(), 'deep interview');
   });
 
+  it('does not trigger deep-interview from cleanup or state-management mentions', () => {
+    assert.equal(detectPrimaryKeyword('clear deep interview state before continuing'), null);
+    assert.equal(detectPrimaryKeyword('cleanup stale deep-interview state after session clear'), null);
+    assert.equal(detectPrimaryKeyword('remove the stale deep interview lock from .omx/state'), null);
+  });
+
   it('maps "gather requirements" to deep-interview skill', () => {
     const match = detectPrimaryKeyword('let us gather requirements first');
 

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -401,6 +401,17 @@ const KEYWORDS_REQUIRING_INTENT = new Set(['ralph', 'team', 'swarm', 'stop', 'ab
 
 type IntentKeyword = 'ralph' | 'team' | 'swarm' | 'stop' | 'abort' | 'parallel' | 'autoresearch';
 
+const DEEP_INTERVIEW_ACTIVATION_PATTERNS: RegExp[] = [
+  /(?:^|[^\w])\$(?:deep-interview)\b/i,
+  /\/prompts:deep-interview\b/i,
+  /\b(?:use|run|start|enable|launch|invoke|activate|do|begin)\s+(?:a\s+|an\s+|the\s+)?deep(?:[- ]+)interview\b/i,
+  /^(?:please\s+)?deep(?:[- ]+)interview\b/i,
+  /\bdeep(?:[- ]+)interview\s+(?:this|first|before|me|now)\b/i,
+  /\binterview\s+(?:me|this|the\s+(?:request|task|problem))\b/i,
+];
+
+const DEEP_INTERVIEW_MANAGEMENT_MENTION_PATTERN = /\b(?:clear|cleanup|clean\s+up|remove|reset|delete|fix|debug|report|reported|status|state|lock|unlock|active|inactive|session(?:-scoped)?|scope|scoped|global|legacy|root|mode|workflow)\b/i;
+
 /**
  * Per-keyword intent patterns used when a keyword is in KEYWORDS_REQUIRING_INTENT.
  *
@@ -522,6 +533,13 @@ function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
 
 function hasIntentContextForKeyword(text: string, keyword: string): boolean {
   const k = keyword.toLowerCase();
+  if (
+    (k === 'deep interview' || k === 'interview')
+    && DEEP_INTERVIEW_MANAGEMENT_MENTION_PATTERN.test(text)
+    && !DEEP_INTERVIEW_ACTIVATION_PATTERNS.some((pattern) => pattern.test(text))
+  ) {
+    return false;
+  }
   if (!KEYWORDS_REQUIRING_INTENT.has(k)) return true;
   const patterns = KEYWORD_INTENT_PATTERNS[k as IntentKeyword];
   return patterns.some((pattern) => pattern.test(text));

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -455,6 +455,70 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('writes a session-scoped inactive tombstone when clearing a mode under an active session', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-clear-root-fallback-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-clear';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(
+        join(stateDir, 'deep-interview-state.json'),
+        JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'legacy-root' }, null, 2),
+      );
+      await writeFile(
+        join(sessionDir, 'deep-interview-state.json'),
+        JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'session-active' }, null, 2),
+      );
+
+      await handleStateToolCall({
+        params: {
+          name: 'state_clear',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'deep-interview',
+          },
+        },
+      });
+
+      const sessionState = JSON.parse(
+        await readFile(join(sessionDir, 'deep-interview-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(sessionState.active, false);
+      assert.equal(sessionState.current_phase, 'cleared');
+      assert.equal(sessionState.session_id, sessionId);
+
+      const listResponse = await handleStateToolCall({
+        params: {
+          name: 'state_list_active',
+          arguments: {
+            workingDirectory: wd,
+          },
+        },
+      });
+      assert.deepEqual(JSON.parse(listResponse.content[0]?.text || '{}'), { active_modes: [] });
+
+      const readResponse = await handleStateToolCall({
+        params: {
+          name: 'state_read',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'deep-interview',
+          },
+        },
+      });
+      const readBody = JSON.parse(readResponse.content[0]?.text || '{}') as Record<string, unknown>;
+      assert.equal(readBody.active, false);
+      assert.equal(readBody.current_phase, 'cleared');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('allows approved overlaps and preserves the remaining canonical state on clear', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -119,6 +119,23 @@ async function writeAtomicFile(path: string, data: string): Promise<void> {
 	}
 }
 
+async function writeClearedSessionScopedModeState(
+	path: string,
+	mode: string,
+	sessionId: string,
+): Promise<void> {
+	const nowIso = new Date().toISOString();
+	const clearedState = withModeRuntimeContext({}, {
+		mode,
+		active: false,
+		current_phase: "cleared",
+		updated_at: nowIso,
+		completed_at: nowIso,
+		session_id: sessionId,
+	});
+	await writeAtomicFile(path, JSON.stringify(clearedState, null, 2));
+}
+
 const server = new Server(
 	{ name: "omx-state", version: "0.1.0" },
 	{ capabilities: { tools: {} } },
@@ -522,7 +539,13 @@ export async function handleStateToolCall(request: {
 
 				if (!allSessions) {
 					const path = getStatePath(mode, cwd, effectiveSessionId);
-					if (existsSync(path)) {
+					if (
+						mode !== SKILL_ACTIVE_STATE_MODE &&
+						effectiveSessionId &&
+						existsSync(getStatePath(mode, cwd))
+					) {
+						await writeClearedSessionScopedModeState(path, mode, effectiveSessionId);
+					} else if (existsSync(path)) {
 						await unlink(path);
 					}
 					if (mode !== SKILL_ACTIVE_STATE_MODE) {

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -264,6 +264,64 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('does not report a legacy root mode active after clearing the current session scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-clear-root-fallback-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-clear';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(
+        join(stateDir, 'deep-interview-state.json'),
+        JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'legacy-root' }, null, 2),
+      );
+      await writeFile(
+        join(sessionDir, 'deep-interview-state.json'),
+        JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'session-active' }, null, 2),
+      );
+
+      await executeStateOperation('state_clear', {
+        workingDirectory: wd,
+        mode: 'deep-interview',
+      });
+
+      assert.equal(existsSync(join(sessionDir, 'deep-interview-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'deep-interview-state.json')), true);
+
+      const sessionState = JSON.parse(
+        await readFile(join(sessionDir, 'deep-interview-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(sessionState.active, false);
+      assert.equal(sessionState.current_phase, 'cleared');
+
+      const activeResponse = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(activeResponse.payload, { active_modes: [] });
+
+      const statusResponse = await executeStateOperation('state_get_status', {
+        workingDirectory: wd,
+        mode: 'deep-interview',
+      });
+      const statuses = (statusResponse.payload as {
+        statuses?: Record<string, { active?: boolean; phase?: string }>;
+      }).statuses || {};
+      assert.equal(statuses['deep-interview']?.active, false);
+      assert.equal(statuses['deep-interview']?.phase, 'cleared');
+
+      const readResponse = await executeStateOperation('state_read', {
+        workingDirectory: wd,
+        mode: 'deep-interview',
+      });
+      const readBody = readResponse.payload as Record<string, unknown>;
+      assert.equal(readBody.active, false);
+      assert.equal(readBody.current_phase, 'cleared');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('syncs canonical skill-active state for tracked mode writes and clears', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-canonical-'));
     try {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -83,6 +83,23 @@ async function writeAtomicFile(path: string, data: string): Promise<void> {
   }
 }
 
+async function writeClearedSessionScopedModeState(
+  path: string,
+  mode: string,
+  sessionId: string,
+): Promise<void> {
+  const nowIso = new Date().toISOString();
+  const clearedState = withModeRuntimeContext({}, {
+    mode,
+    active: false,
+    current_phase: 'cleared',
+    updated_at: nowIso,
+    completed_at: nowIso,
+    session_id: sessionId,
+  });
+  await writeAtomicFile(path, JSON.stringify(clearedState, null, 2));
+}
+
 function readModeSupportsStrictValidation(mode: string): mode is SupportedStateReadMode {
   return SUPPORTED_STATE_READ_MODES.includes(mode as SupportedStateReadMode);
 }
@@ -342,7 +359,13 @@ export async function executeStateOperation(
 
         if (!allSessions) {
           const path = getStatePath(mode, cwd, effectiveSessionId);
-          if (existsSync(path)) {
+          if (
+            mode !== SKILL_ACTIVE_STATE_MODE
+            && effectiveSessionId
+            && existsSync(getStatePath(mode, cwd))
+          ) {
+            await writeClearedSessionScopedModeState(path, mode, effectiveSessionId);
+          } else if (existsSync(path)) {
             await unlink(path);
           }
           if (mode !== SKILL_ACTIVE_STATE_MODE) {


### PR DESCRIPTION
## Summary\n- suppress implicit deep-interview activation on cleanup/state-management mentions unless activation intent is explicit\n- preserve session-scoped clear authority with an inactive tombstone when legacy root compatibility state exists\n- add targeted regressions for keyword routing, scoped clear behavior, MCP parity, and CLI session-scoped reporting\n\n## Verification\n- npm run build\n- node --test dist/hooks/__tests__/keyword-detector.test.js dist/state/__tests__/operations.test.js dist/mcp/__tests__/state-server.test.js dist/cli/__tests__/session-scoped-runtime.test.js\n- npm run lint\n- npm run check:no-unused\n\nCloses #1807