### PR TITLE
fix: prevent stale MCP duplicates from accumulating under one parent

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -195,7 +195,7 @@ describe('mcp duplicate sibling detection', () => {
     );
   });
 
-  it('does not self-exit after traffic until the duplicate has remained safely idle long enough', () => {
+  it('does not self-exit after post-duplicate traffic until the duplicate has remained safely idle long enough', () => {
     const observation = {
       status: 'older_duplicate' as const,
       entrypoint: 'state-server.js',
@@ -209,11 +209,11 @@ describe('mcp duplicate sibling detection', () => {
     );
     assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 311_000, 1_000, 10_000),
-      false,
+      true,
     );
   });
 
-  it('never self-exits after traffic even after a long idle window', () => {
+  it('uses the duplicate grace window when last traffic predates duplicate observation', () => {
     const observation = {
       status: 'older_duplicate' as const,
       entrypoint: 'state-server.js',
@@ -222,12 +222,16 @@ describe('mcp duplicate sibling detection', () => {
     };
 
     assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 600_000, 1_000, 10_000),
+      shouldSelfExitForDuplicateSibling(observation, 10_500, 9_000, 1_000),
       false,
+    );
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 11_100, 9_000, 1_000),
+      true,
     );
   });
 
-  it('treats any observed client traffic as a do-not-self-kill marker', () => {
+  it('treats future or non-finite traffic timestamps as a do-not-self-kill marker', () => {
     const observation = {
       status: 'older_duplicate' as const,
       entrypoint: 'state-server.js',
@@ -236,11 +240,11 @@ describe('mcp duplicate sibling detection', () => {
     };
 
     assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 499_000, 200_000, 10_000),
+      shouldSelfExitForDuplicateSibling(observation, 499_000, 200_000, 500_000),
       false,
     );
     assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 900_000, 200_000, 200_001),
+      shouldSelfExitForDuplicateSibling(observation, 900_000, 200_000, Number.NaN),
       false,
     );
   });

--- a/src/mcp/__tests__/server-lifecycle.test.ts
+++ b/src/mcp/__tests__/server-lifecycle.test.ts
@@ -130,6 +130,19 @@ async function forceCleanup(child: ChildProcess): Promise<void> {
   await once(child, 'exit').catch(() => {});
 }
 
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs: number,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await delay(25);
+  }
+  if (!predicate()) throw new Error(message);
+}
+
 describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
   for (const entrypoint of IDLE_ENTRYPOINTS) {
     const label = 'caveat' in entrypoint
@@ -199,4 +212,64 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
       }
     });
   }
+
+  it('older duplicate entrypoints self-exit after post-duplicate idle while the newest sibling survives', async () => {
+    const entrypoint = IDLE_ENTRYPOINTS[0];
+    const sharedEnv = {
+      ...process.env,
+      OMX_MCP_PARENT_WATCHDOG_INTERVAL_MS: '250',
+      OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS: '250',
+      OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS: '750',
+    };
+    const older = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
+      cwd: process.cwd(),
+      env: sharedEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let newer: ChildProcess | null = null;
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const attachLogs = (child: ChildProcess) => {
+      child.stdout?.setEncoding('utf8');
+      child.stderr?.setEncoding('utf8');
+      child.stdout?.on('data', (chunk: string) => stdout.push(chunk));
+      child.stderr?.on('data', (chunk: string) => stderr.push(chunk));
+    };
+    attachLogs(older);
+
+    try {
+      await waitForSpawn(older, entrypoint, stderr, stdout);
+      await assertChildAliveBeforeTeardown(older, entrypoint, stderr, stdout);
+
+      older.stdin?.write('pre-duplicate-traffic');
+      await delay(100);
+
+      newer = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
+        cwd: process.cwd(),
+        env: sharedEnv,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      attachLogs(newer);
+      await waitForSpawn(newer, entrypoint, stderr, stdout);
+      await assertChildAliveBeforeTeardown(newer, entrypoint, stderr, stdout);
+
+      await delay(400);
+      older.stdin?.write('post-duplicate-traffic');
+      await waitForCondition(
+        () => !isChildAlive(older),
+        2_500,
+        `older duplicate failed to self-exit: ${formatFailureContext(entrypoint, stderr, stdout)}`,
+      );
+
+      assert.equal(isChildAlive(newer), true, `newest duplicate should survive: ${formatFailureContext(entrypoint, stderr, stdout)}`);
+      const olderExit = await waitForExit(older, entrypoint, stderr, stdout);
+      assert.notEqual(olderExit.signal, 'SIGKILL');
+    } finally {
+      await forceCleanup(older);
+      if (newer) {
+        await forceCleanup(newer);
+      }
+    }
+  });
 });

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -13,9 +13,14 @@ const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
 
 const GLOBAL_DISABLE_ENV = 'OMX_MCP_SERVER_DISABLE_AUTO_START';
 const LIFECYCLE_DEBUG_ENV = 'OMX_MCP_TRANSPORT_DEBUG';
-const PARENT_WATCHDOG_INTERVAL_MS = 25;
-const DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
-const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
+const PARENT_WATCHDOG_INTERVAL_ENV = 'OMX_MCP_PARENT_WATCHDOG_INTERVAL_MS';
+const DUPLICATE_SIBLING_WATCHDOG_INTERVAL_ENV = 'OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS';
+const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS';
+const DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS';
+const DEFAULT_PARENT_WATCHDOG_INTERVAL_MS = 1_000;
+const DEFAULT_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
+const DEFAULT_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
+const DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS = 60_000;
 const MCP_ENTRYPOINT_PATTERN = /\b([a-z0-9-]+-server\.(?:[cm]?js|ts))\b/i;
 
 interface StdioLifecycleServer {
@@ -34,6 +39,13 @@ export interface DuplicateSiblingObservation {
   entrypoint: string | null;
   matchingPids: number[];
   newerSiblingPids: number[];
+}
+
+interface LifecycleTimingConfig {
+  parentWatchdogIntervalMs: number;
+  duplicateSiblingWatchdogIntervalMs: number;
+  duplicateSiblingPreTrafficGraceMs: number;
+  duplicateSiblingPostTrafficIdleMs: number;
 }
 
 function normalizeCommand(command: string): string {
@@ -152,12 +164,51 @@ export function analyzeDuplicateSiblingState(
   };
 }
 
+function readPositiveIntegerEnv(
+  env: Record<string, string | undefined>,
+  name: string,
+  fallback: number,
+): number {
+  const raw = env[name];
+  if (typeof raw !== 'string' || raw.trim() === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolveLifecycleTimingConfig(
+  env: Record<string, string | undefined>,
+): LifecycleTimingConfig {
+  return {
+    parentWatchdogIntervalMs: readPositiveIntegerEnv(
+      env,
+      PARENT_WATCHDOG_INTERVAL_ENV,
+      DEFAULT_PARENT_WATCHDOG_INTERVAL_MS,
+    ),
+    duplicateSiblingWatchdogIntervalMs: readPositiveIntegerEnv(
+      env,
+      DUPLICATE_SIBLING_WATCHDOG_INTERVAL_ENV,
+      DEFAULT_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS,
+    ),
+    duplicateSiblingPreTrafficGraceMs: readPositiveIntegerEnv(
+      env,
+      DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_ENV,
+      DEFAULT_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS,
+    ),
+    duplicateSiblingPostTrafficIdleMs: readPositiveIntegerEnv(
+      env,
+      DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_ENV,
+      DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
+    ),
+  };
+}
+
 export function shouldSelfExitForDuplicateSibling(
   observation: DuplicateSiblingObservation,
   nowMs: number,
   duplicateObservedAtMs: number | null,
   lastTrafficAtMs: number | null,
-  preTrafficGraceMs = DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS,
+  preTrafficGraceMs = DEFAULT_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS,
+  postTrafficIdleMs = DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
 ): boolean {
   if (observation.status !== 'older_duplicate') {
     return false;
@@ -166,10 +217,14 @@ export function shouldSelfExitForDuplicateSibling(
     return false;
   }
 
-  if (lastTrafficAtMs === null) {
+  if (lastTrafficAtMs !== null && (!Number.isFinite(lastTrafficAtMs) || lastTrafficAtMs > nowMs)) {
+    return false;
+  }
+
+  if (lastTrafficAtMs === null || lastTrafficAtMs <= duplicateObservedAtMs) {
     return nowMs - duplicateObservedAtMs >= preTrafficGraceMs;
   }
-  return false;
+  return nowMs - lastTrafficAtMs >= postTrafficIdleMs;
 }
 
 export function isParentProcessAlive(
@@ -209,6 +264,7 @@ export function autoStartStdioMcpServer(
   const transport = new StdioServerTransport();
   let shuttingDown = false;
   const lifecycleDebugEnabled = env[LIFECYCLE_DEBUG_ENV] === '1';
+  const lifecycleTiming = resolveLifecycleTimingConfig(env);
   const trackedParentPid = Number.isInteger(process.ppid) ? process.ppid : 0;
   const trackedEntrypoint = extractMcpEntrypointMarker(process.argv[1] ?? '');
   let lastTrafficAtMs: number | null = null;
@@ -225,7 +281,7 @@ export function autoStartStdioMcpServer(
       if (!isParentProcessAlive(trackedParentPid)) {
         void shutdown('parent_gone');
       }
-    }, PARENT_WATCHDOG_INTERVAL_MS)
+    }, lifecycleTiming.parentWatchdogIntervalMs)
     : null;
   parentWatchdog?.unref();
   const duplicateSiblingWatchdog = trackedParentPid > 1 && trackedEntrypoint
@@ -254,12 +310,18 @@ export function autoStartStdioMcpServer(
         Date.now(),
         duplicateObservedAtMs,
         lastTrafficAtMs,
+        lifecycleTiming.duplicateSiblingPreTrafficGraceMs,
+        lifecycleTiming.duplicateSiblingPostTrafficIdleMs,
       )) {
         return;
       }
 
-      void shutdown('superseded_duplicate_before_traffic');
-    }, DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS)
+      void shutdown(
+        lastTrafficAtMs !== null && lastTrafficAtMs > duplicateObservedAtMs
+          ? 'superseded_duplicate_after_idle'
+          : 'superseded_duplicate_before_traffic',
+      );
+    }, lifecycleTiming.duplicateSiblingWatchdogIntervalMs)
     : null;
   duplicateSiblingWatchdog?.unref();
 


### PR DESCRIPTION
## Summary\n- make stale same-parent duplicate MCP children self-exit after a post-duplicate idle window instead of lingering forever\n- throttle the default parent watchdog interval to reduce sys CPU pressure while keeping env overrides for tests/debugging\n- add regression coverage for duplicate-child lifecycle behavior\n\n## Verification\n- npm run build\n- node --test dist/mcp/__tests__/bootstrap.test.js dist/mcp/__tests__/server-lifecycle.test.js\n- node --test dist/cli/__tests__/cleanup.test.js dist/cli/__tests__/index.test.js\n- manual duplicate-child repro with OMX_MCP_TRANSPORT_DEBUG=1\n\nCloses #1809