### PR TITLE
Keep omx question injection aligned with tmux submit semantics

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -52,6 +52,7 @@ If no flag is provided, use **Standard**.
 - Reduce user effort: ask only the highest-leverage unresolved question, and never ask the user for codebase facts that can be discovered directly
 - For brownfield work, prefer evidence-backed confirmation questions such as "I found X in Y. Should this change follow that pattern?"
 - In Codex CLI, deep-interview uses `omx question` as the required OMX-owned structured questioning path for every interview round
+- If you launch `omx question` in a background terminal, immediately wait for that background terminal to finish and read its JSON answer before scoring ambiguity, asking another round, or handing off
 - If `omx question` is unavailable in the current runtime, treat that as a blocker/error for deep-interview rather than falling back to `request_user_input` or plain-text questioning
 - Re-score ambiguity after each answer and show progress transparently
 - Do not hand off to execution while ambiguity remains above threshold unless user explicitly opts to proceed with warning

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -171,6 +171,10 @@ describe("deep-interview Ouroboros contract", () => {
 			deepInterviewSkill,
 			/fall back to concise plain-text one-question turns/i,
 		);
+		assert.match(
+			deepInterviewSkill,
+			/wait for that background terminal to finish and read its JSON answer before scoring ambiguity, asking another round, or handing off/i,
+		);
 	});
 
 	it("teaches canonical single-choice vs multi-answerable omx question payloads", () => {
@@ -317,6 +321,7 @@ describe("cross-skill and AGENTS coherence for deep-interview", () => {
 
 	it("makes template AGENTS explicit about omx question for deep-interview", () => {
 		assert.match(templateAgents, /deep-interview is active.*`omx question`/i);
+		assert.match(templateAgents, /after launching `omx question` in a background terminal, wait for that terminal to finish and read the JSON answer before continuing/i);
 		assert.match(templateAgents, /do not substitute `request_user_input` or ad hoc plain-text questioning/i);
 	});
 });

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -6,6 +6,7 @@ import {
   launchQuestionRenderer,
   resolveQuestionRendererStrategy,
 } from '../renderer.js';
+import { buildSendPaneArgvs } from '../../notifications/tmux-detector.js';
 
 describe('resolveQuestionRendererStrategy', () => {
   it('prefers inside-tmux when TMUX is present', () => {
@@ -280,11 +281,7 @@ describe('question answer injection', () => {
     );
 
     assert.equal(ok, true);
-    assert.deepEqual(calls, [
-      ['send-keys', '-t', '%11', '-l', '--', '[omx question answered] proceed'],
-      ['send-keys', '-t', '%11', 'C-m'],
-      ['send-keys', '-t', '%11', 'C-m'],
-    ]);
+    assert.deepEqual(calls, buildSendPaneArgvs('%11', '[omx question answered] proceed', true));
     assert.deepEqual(sleeps, [120, 100]);
     assert.equal(calls.some((argv) => argv.includes('Enter')), false);
   });

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { basename } from 'node:path';
 import { parsePaneIdFromTmuxOutput } from '../hud/tmux.js';
+import { buildSendPaneArgvs } from '../notifications/tmux-detector.js';
 import { sleepSync } from '../utils/sleep.js';
 import { sanitizeReplyInput } from '../notifications/reply-listener.js';
 import { getCurrentTmuxPaneId } from '../notifications/tmux.js';
@@ -140,13 +141,13 @@ export function injectQuestionAnswerToPane(
   const text = formatQuestionAnswerForInjection(answer);
   if (!text) return false;
 
-  execTmux(['send-keys', '-t', paneId, '-l', '--', text]);
-  // Match the repo-standard Codex raw-mode submit sequence: let literal text
-  // settle, then send isolated C-m submits rather than Enter key names.
-  sleepImpl(QUESTION_TEXT_SETTLE_MS);
-  execTmux(['send-keys', '-t', paneId, 'C-m']);
-  sleepImpl(QUESTION_SUBMIT_REPEAT_DELAY_MS);
-  execTmux(['send-keys', '-t', paneId, 'C-m']);
+  const argvs = buildSendPaneArgvs(paneId, text, true);
+  for (const [index, argv] of argvs.entries()) {
+    execTmux(argv);
+    const hasNextArgv = index < argvs.length - 1;
+    if (!hasNextArgv) continue;
+    sleepImpl(index === 0 ? QUESTION_TEXT_SETTLE_MS : QUESTION_SUBMIT_REPEAT_DELAY_MS);
+  }
   return true;
 }
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -809,6 +809,7 @@ describe("codex native hook dispatch", () => {
       assert.match(message, /skill: deep-interview activated and initial state initialized at \.omx\/state\/sessions\/sess-deep-interview-msg\/deep-interview-state\.json; write subsequent updates via omx_state MCP\./);
       assert.match(message, /Deep-interview must ask each interview round via `omx question`/);
       assert.match(message, /do not fall back to `request_user_input` or plain-text questioning/i);
+      assert.match(message, /After starting `omx question` in a background terminal, wait for that terminal to finish and read the JSON answer before continuing the interview\./);
       assert.match(message, /If bare `omx question` is unavailable in this reused session, use the current-session CLI bridge command:/);
       assert.match(message, /`'.+' '.+dist\/cli\/omx\.js' question`/);
       assert.match(message, /Stop remains blocked while a deep-interview question obligation is pending\./);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -569,7 +569,7 @@ async function buildSessionStartContext(
 function buildDeepInterviewQuestionBridgeInstruction(cwd: string): string {
   const omxBin = resolveOmxCliEntryPath({ cwd }) || process.argv[1] || "omx";
   const bridgeCommand = `${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} question`;
-  return `Deep-interview must ask each interview round via \`omx question\`; do not fall back to \`request_user_input\` or plain-text questioning. If bare \`omx question\` is unavailable in this reused session, use the current-session CLI bridge command: \`${bridgeCommand}\`. Stop remains blocked while a deep-interview question obligation is pending.`;
+  return `Deep-interview must ask each interview round via \`omx question\`; do not fall back to \`request_user_input\` or plain-text questioning. After starting \`omx question\` in a background terminal, wait for that terminal to finish and read the JSON answer before continuing the interview. If bare \`omx question\` is unavailable in this reused session, use the current-session CLI bridge command: \`${bridgeCommand}\`. Stop remains blocked while a deep-interview question obligation is pending.`;
 }
 
 function buildAdditionalContextMessage(

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -234,7 +234,7 @@ Runtime availability gate:
 - Treat `autopilot`, `ralph`, `ultrawork`, `ultraqa`, `team`/`swarm`, and `ecomode` as **OMX runtime workflows**, not generic prompt aliases.
 - Auto-activate runtime workflows only when the current session is actually running under OMX CLI/runtime (for example, launched via `omx`, with OMX session overlay/runtime state available, or when the user explicitly asks to run `omx ...` in the shell).
 - In Codex App or plain Codex sessions without OMX runtime, do **not** treat those keywords alone as activation. Explain that they require OMX CLI runtime support, and continue with the nearest App-safe surface (`deep-interview`, `ralplan`, `plan`, or native subagents) unless the user explicitly wants you to launch OMX from the shell.
-- When deep-interview is active in OMX CLI/runtime, ask interview rounds via `omx question`; do not substitute `request_user_input` or ad hoc plain-text questioning, and respect Stop-hook blocking while a deep-interview question obligation is pending.
+- When deep-interview is active in OMX CLI/runtime, ask interview rounds via `omx question`; after launching `omx question` in a background terminal, wait for that terminal to finish and read the JSON answer before continuing; do not substitute `request_user_input` or ad hoc plain-text questioning, and respect Stop-hook blocking while a deep-interview question obligation is pending.
 
 <triage_routing>
 ## Triage: advisory prompt-routing context


### PR DESCRIPTION
## Summary
- reuse the shared tmux send-keys argv builder for omx question answer injection
- require deep-interview guidance to wait for a background omx question terminal and read the JSON answer before continuing
- lock the injection/guidance behavior with renderer, hook, and deep-interview contract tests

## Tests
- npm run build
- node --test dist/question/__tests__/renderer.test.js dist/hooks/__tests__/deep-interview-contract.test.js dist/scripts/__tests__/codex-native-hook.test.js

## Risks
- Not live-tested in a repeated long-running tmux/Codex session; coverage is targeted regression/contract coverage.