### PR TITLE
Fix false-positive PostToolUse failure detection from stdout text

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1912,6 +1912,58 @@ esac
     }
   });
 
+  it("stays silent when successful Bash stdout merely mentions command-not-found text", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-command-not-found-stdout-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-stdout-hard-failure-text",
+          tool_input: { command: "echo command not found" },
+          tool_response: JSON.stringify({
+            exit_code: 0,
+            stdout: "command not found",
+            stderr: "",
+          }),
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not flag successful MCP stdout that only mentions transport closure text", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mcp-transport-stdout-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-mcp-transport-stdout",
+          tool_input: { mode: "team", active: true },
+          tool_response: JSON.stringify({
+            exit_code: 0,
+            stdout: "mcp transport closed",
+            stderr: "",
+          }),
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns PostToolUse MCP transport fallback guidance for clear MCP transport death", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mcp-transport-"));
     try {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -134,9 +134,8 @@ export function detectMcpTransportFailure(
   payload: CodexHookPayload,
 ): McpTransportFailureSignal | null {
   const normalized = normalizePostToolUsePayload(payload);
-  const combined = [
+  const diagnosticText = [
     normalized.stderrText,
-    normalized.stdoutText,
     safeString(normalized.parsedToolResponse?.error),
     safeString(normalized.parsedToolResponse?.message),
     safeString(normalized.parsedToolResponse?.details),
@@ -146,17 +145,17 @@ export function detectMcpTransportFailure(
     .trim();
 
   const mcpContextDetected = isMcpLikeToolName(normalized.toolName)
-    || /\bmcp\b/i.test(combined)
-    || /\bomx-(?:state|memory|trace|code-intel)-server\b/i.test(combined);
+    || /\bmcp\b/i.test(diagnosticText)
+    || /\bomx-(?:state|memory|trace|code-intel)-server\b/i.test(diagnosticText);
   if (!mcpContextDetected) return null;
-  if (!combined) return null;
-  if (!MCP_TRANSPORT_FAILURE_PATTERNS.some((pattern) => pattern.test(combined))) {
+  if (!diagnosticText) return null;
+  if (!MCP_TRANSPORT_FAILURE_PATTERNS.some((pattern) => pattern.test(diagnosticText))) {
     return null;
   }
 
   return {
     toolName: normalized.toolName,
-    summary: combined,
+    summary: diagnosticText,
   };
 }
 
@@ -608,7 +607,18 @@ export function buildNativePostToolUseOutput(
   if (!normalized.isBash) return null;
 
   const combined = `${normalized.stderrText}\n${normalized.stdoutText}`.trim();
-  if (containsHardFailure(combined)) {
+  const hardFailureSignal = normalized.exitCode !== null && normalized.exitCode !== 0
+    ? [
+      normalized.stderrText,
+      safeString(normalized.parsedToolResponse?.error),
+      safeString(normalized.parsedToolResponse?.message),
+      safeString(normalized.parsedToolResponse?.details),
+    ]
+      .filter(Boolean)
+      .join("\n")
+      .trim()
+    : "";
+  if (containsHardFailure(hardFailureSignal)) {
     return {
       decision: "block",
       reason: "The Bash output indicates a command/setup failure that should be fixed before retrying.",
@@ -624,7 +634,7 @@ export function buildNativePostToolUseOutput(
     normalized.exitCode !== null
     && normalized.exitCode !== 0
     && combined.length > 0
-    && !containsHardFailure(combined)
+    && !containsHardFailure(hardFailureSignal)
   ) {
     return {
       decision: "block",


### PR DESCRIPTION
## Summary
- stop `PostToolUse` from treating successful stdout text as authoritative failure diagnostics
- restrict MCP transport-death detection to error/diagnostic channels instead of stdout payloads
- add regressions for successful Bash/MCP outputs that happen to contain `command not found` / transport-closure wording

## Why
The current hook logic can misclassify benign tool output as a hard failure. In practice that means successful commands can trigger noisy `PreToolUse/PostToolUse hook (failed)` or misleading recovery guidance when stdout merely echoes phrases like `command not found` or `mcp transport closed`.

## Verification
- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js`

## Risk
- narrow behavior change in native hook post-processing only
- preserves existing remediation guidance for real stderr / structured-error failure paths
