### PR TITLE
Preserve leader-pane omx question replies

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -654,6 +654,58 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('captures tmux_pane_id in seeded ralplan prompt-submit state when TMUX_PANE is present', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralplan-pane-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const previousPane = process.env.TMUX_PANE;
+    try {
+      await mkdir(stateDir, { recursive: true });
+      process.env.TMUX_PANE = '%88';
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan tighten the plan',
+        sessionId: 'sess-ralplan-pane',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-ralplan-pane', 'ralplan-state.json'), 'utf-8'),
+      ) as { tmux_pane_id?: string };
+      assert.equal(modeState.tmux_pane_id, '%88');
+    } finally {
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('captures tmux_pane_id in deep-interview prompt-submit state when TMUX_PANE is present', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-pane-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const previousPane = process.env.TMUX_PANE;
+    try {
+      await mkdir(stateDir, { recursive: true });
+      process.env.TMUX_PANE = '%89';
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$deep-interview tighten the requirements',
+        sessionId: 'sess-deep-interview-pane',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-deep-interview-pane', 'deep-interview-state.json'), 'utf-8'),
+      ) as { tmux_pane_id?: string };
+      assert.equal(modeState.tmux_pane_id, '%89');
+    } finally {
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds first-class state for ralplan prompt-submit activation', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralplan-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -706,6 +706,48 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('preserves an existing deep-interview tmux_pane_id when prompt-submit re-seeds state without TMUX_PANE', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-preserve-pane-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-deep-interview-preserve-pane';
+    const previousPane = process.env.TMUX_PANE;
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      delete process.env.TMUX_PANE;
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'deep-interview-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'deep-interview',
+          current_phase: 'intent-first',
+          started_at: '2026-02-25T00:00:00.000Z',
+          updated_at: '2026-02-25T00:00:00.000Z',
+          session_id: sessionId,
+          tmux_pane_id: '%89',
+          tmux_pane_set_at: '2026-02-25T00:00:00.000Z',
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$deep-interview tighten the requirements',
+        sessionId,
+        nowIso: '2026-02-25T00:05:00.000Z',
+      });
+
+      assert.ok(result);
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'deep-interview-state.json'), 'utf-8'),
+      ) as { tmux_pane_id?: string; tmux_pane_set_at?: string };
+      assert.equal(modeState.tmux_pane_id, '%89');
+      assert.equal(modeState.tmux_pane_set_at, '2026-02-25T00:00:00.000Z');
+    } finally {
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds first-class state for ralplan prompt-submit activation', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralplan-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -11,6 +11,7 @@
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { withModeRuntimeContext } from '../state/mode-state-context.js';
 import { dirname, join } from 'node:path';
 import { classifyTaskSize, isHeavyMode, type TaskSizeResult, type TaskSizeThresholds } from './task-size-detector.js';
 import { isApprovedExecutionFollowupShortcut, type FollowupMode } from '../team/followup-planner.js';
@@ -142,6 +143,8 @@ const STATEFUL_SKILL_SEED_CONFIG: Record<StatefulSkillMode, StatefulSkillSeedCon
 export interface DeepInterviewModeState {
   active: boolean;
   mode: 'deep-interview';
+  tmux_pane_id?: string;
+  tmux_pane_set_at?: string;
   current_phase: string;
   started_at: string;
   updated_at: string;
@@ -151,6 +154,7 @@ export interface DeepInterviewModeState {
   turn_id?: string;
   input_lock?: DeepInterviewInputLock;
   question_enforcement?: DeepInterviewQuestionEnforcementState;
+  [key: string]: unknown;
 }
 
 function createDeepInterviewInputLock(nowIso: string, previous?: DeepInterviewInputLock): DeepInterviewInputLock {
@@ -247,18 +251,22 @@ export async function persistDeepInterviewModeState(
       'handoff',
       new Date(nowIso),
     );
-    const nextState: DeepInterviewModeState = {
-      active: true,
-      mode: 'deep-interview',
-      current_phase: previousModeState?.active ? previousModeState.current_phase || 'intent-first' : 'intent-first',
-      started_at: previousModeState?.active ? previousModeState.started_at || nowIso : nowIso,
-      updated_at: nowIso,
-      session_id: input.sessionId ?? previousModeState?.session_id,
-      thread_id: input.threadId ?? previousModeState?.thread_id,
-      turn_id: input.turnId ?? previousModeState?.turn_id,
-      ...(nextSkill.input_lock ? { input_lock: nextSkill.input_lock } : {}),
-      ...(nextQuestionEnforcement ? { question_enforcement: nextQuestionEnforcement } : {}),
-    };
+    const nextState = withModeRuntimeContext<DeepInterviewModeState>(
+      previousModeState ?? {},
+      {
+        active: true,
+        mode: 'deep-interview',
+        current_phase: previousModeState?.active ? previousModeState.current_phase || 'intent-first' : 'intent-first',
+        started_at: previousModeState?.active ? previousModeState.started_at || nowIso : nowIso,
+        updated_at: nowIso,
+        session_id: input.sessionId ?? previousModeState?.session_id,
+        thread_id: input.threadId ?? previousModeState?.thread_id,
+        turn_id: input.turnId ?? previousModeState?.turn_id,
+        ...(nextSkill.input_lock ? { input_lock: nextSkill.input_lock } : {}),
+        ...(nextQuestionEnforcement ? { question_enforcement: nextQuestionEnforcement } : {}),
+      },
+      { nowIso },
+    );
     await writeFile(statePath, JSON.stringify(nextState, null, 2));
     return;
   }
@@ -269,6 +277,8 @@ export async function persistDeepInterviewModeState(
   const releasedInputLock = nextSkill?.skill === 'deep-interview' ? nextSkill.input_lock : previousSkill?.input_lock;
   const questionExitReason = nextSkill?.skill === 'deep-interview' && nextSkill.active === false ? 'abort' : 'handoff';
   const nextState: DeepInterviewModeState = {
+    ...(previousModeState?.tmux_pane_id ? { tmux_pane_id: previousModeState.tmux_pane_id } : {}),
+    ...(previousModeState?.tmux_pane_set_at ? { tmux_pane_set_at: previousModeState.tmux_pane_set_at } : {}),
     active: false,
     mode: 'deep-interview',
     current_phase: preserveCompletedDeepInterviewPhase(previousModeState) || 'completing',
@@ -345,19 +355,23 @@ async function persistStatefulSkillSeedState(
       ? safeString(existingModeState?.started_at).trim() || nowIso
     : nowIso;
 
-  const baseState: Record<string, unknown> = {
-    ...(preserveExistingModeState ? existingModeState : {}),
-    active: true,
-    mode: config.mode,
-    current_phase: preserveExistingModeState
-      ? existingPhase || config.initialPhase
-      : config.initialPhase,
-    started_at: startedAt,
-    updated_at: nowIso,
-    session_id: nextSkill.session_id || safeString(existingModeState?.session_id).trim() || undefined,
-    thread_id: nextSkill.thread_id || safeString(existingModeState?.thread_id).trim() || undefined,
-    turn_id: nextSkill.turn_id || safeString(existingModeState?.turn_id).trim() || undefined,
-  };
+  const baseState: Record<string, unknown> = withModeRuntimeContext(
+    (preserveExistingModeState ? existingModeState : {}) ?? {},
+    {
+      ...(preserveExistingModeState ? existingModeState : {}),
+      active: true,
+      mode: config.mode,
+      current_phase: preserveExistingModeState
+        ? existingPhase || config.initialPhase
+        : config.initialPhase,
+      started_at: startedAt,
+      updated_at: nowIso,
+      session_id: nextSkill.session_id || safeString(existingModeState?.session_id).trim() || undefined,
+      thread_id: nextSkill.thread_id || safeString(existingModeState?.thread_id).trim() || undefined,
+      turn_id: nextSkill.turn_id || safeString(existingModeState?.turn_id).trim() || undefined,
+    },
+    { nowIso },
+  );
 
   if (config.includeIteration) {
     baseState.iteration = typeof existingModeState?.iteration === 'number' ? existingModeState.iteration : 0;

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -254,6 +254,8 @@ export async function persistDeepInterviewModeState(
     const nextState = withModeRuntimeContext<DeepInterviewModeState>(
       previousModeState ?? {},
       {
+        ...(previousModeState?.tmux_pane_id ? { tmux_pane_id: previousModeState.tmux_pane_id } : {}),
+        ...(previousModeState?.tmux_pane_set_at ? { tmux_pane_set_at: previousModeState.tmux_pane_set_at } : {}),
         active: true,
         mode: 'deep-interview',
         current_phase: previousModeState?.active ? previousModeState.current_phase || 'intent-first' : 'intent-first',
@@ -359,6 +361,8 @@ async function persistStatefulSkillSeedState(
     (preserveExistingModeState ? existingModeState : {}) ?? {},
     {
       ...(preserveExistingModeState ? existingModeState : {}),
+      ...(existingModeState?.tmux_pane_id ? { tmux_pane_id: existingModeState.tmux_pane_id } : {}),
+      ...(existingModeState?.tmux_pane_set_at ? { tmux_pane_set_at: existingModeState.tmux_pane_set_at } : {}),
       active: true,
       mode: config.mode,
       current_phase: preserveExistingModeState

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import {
   formatQuestionAnswerForInjection,
@@ -155,6 +158,89 @@ describe('launchQuestionRenderer', () => {
     assert.deepEqual(calls[1], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
   });
 
+  it('falls back to the persisted session mode pane when Bash/tool env lost TMUX_PANE', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-question-renderer-state-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state', 'sessions', 'sess-stateful');
+      mkdirSync(stateDir, { recursive: true });
+      writeFileSync(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        active: true,
+        mode: 'ralplan',
+        current_phase: 'planning',
+        tmux_pane_id: '%91',
+      }, null, 2));
+
+      const calls: string[][] = [];
+      const result = launchQuestionRenderer(
+        {
+          cwd,
+          recordPath: join(cwd, '.omx', 'state', 'sessions', 'sess-stateful', 'questions', 'question-3.json'),
+          sessionId: 'sess-stateful',
+          env: { TMUX: '/tmp/tmux-demo' } as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'inside-tmux',
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'split-window') return '%77\n';
+            if (args[0] === 'list-panes') return '0\t%77\n';
+            return '';
+          },
+          sleepSync: () => {},
+        },
+      );
+
+      assert.equal(result.return_target, '%91');
+      assert.equal(result.return_transport, 'tmux-send-keys');
+      assert.equal(calls[0]?.[0], 'split-window');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers session-scoped persisted panes over root workflow fallback panes', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-question-renderer-precedence-'));
+    try {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionStateDir = join(rootStateDir, 'sessions', 'sess-stateful');
+      mkdirSync(sessionStateDir, { recursive: true });
+      writeFileSync(join(rootStateDir, 'team-state.json'), JSON.stringify({
+        active: true,
+        mode: 'team',
+        current_phase: 'executing',
+        tmux_pane_id: '%10',
+      }, null, 2));
+      writeFileSync(join(sessionStateDir, 'ralplan-state.json'), JSON.stringify({
+        active: true,
+        mode: 'ralplan',
+        current_phase: 'planning',
+        tmux_pane_id: '%91',
+      }, null, 2));
+
+      const result = launchQuestionRenderer(
+        {
+          cwd,
+          recordPath: join(sessionStateDir, 'questions', 'question-4.json'),
+          sessionId: 'sess-stateful',
+          env: { TMUX: '/tmp/tmux-demo' } as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'inside-tmux',
+          execTmux: (args) => {
+            if (args[0] === 'split-window') return '%77\n';
+            if (args[0] === 'list-panes') return '0\t%77\n';
+            return '';
+          },
+          sleepSync: () => {},
+        },
+      );
+
+      assert.equal(result.return_target, '%91');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('passes direct tmux argv so non-POSIX default shells do not parse a shell string', () => {
     const calls: string[][] = [];
     launchQuestionRenderer(
@@ -187,6 +273,44 @@ describe('launchQuestionRenderer', () => {
       '--state-path',
       '/repo/question with spaces.json',
     ]);
+  });
+
+  it('resolves the leader return target before opening the question pane', () => {
+    const calls: string[][] = [];
+    const originalTmuxPane = process.env.TMUX_PANE;
+    const originalTmux = process.env.TMUX;
+    process.env.TMUX_PANE = '%200';
+    process.env.TMUX = '/tmp/tmux-leader';
+    try {
+      const result = launchQuestionRenderer(
+        {
+          cwd: '/repo',
+          recordPath: '/repo/question-4.json',
+          sessionId: 'sess-123',
+          env: { TMUX: '/tmp/tmux-demo' } as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'inside-tmux',
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'split-window') {
+              process.env.TMUX_PANE = '%201';
+              return '%201\n';
+            }
+            if (args[0] === 'list-panes') return '0\t%201\n';
+            return '';
+          },
+          sleepSync: () => {},
+        },
+      );
+
+      assert.equal(result.return_target, '%200');
+    } finally {
+      if (typeof originalTmuxPane === 'string') process.env.TMUX_PANE = originalTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof originalTmux === 'string') process.env.TMUX = originalTmux;
+      else delete process.env.TMUX;
+    }
   });
 
   it('uses detached sessions outside tmux', () => {

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -1,10 +1,13 @@
 import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
 import { basename } from 'node:path';
 import { parsePaneIdFromTmuxOutput } from '../hud/tmux.js';
 import { buildSendPaneArgvs } from '../notifications/tmux-detector.js';
 import { sleepSync } from '../utils/sleep.js';
 import { sanitizeReplyInput } from '../notifications/reply-listener.js';
 import { getCurrentTmuxPaneId } from '../notifications/tmux.js';
+import { getStatePath } from '../mcp/state-paths.js';
+import { TRACKED_WORKFLOW_MODES } from '../state/workflow-transition.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
 import type { QuestionAnswer, QuestionRendererState } from './types.js';
@@ -80,9 +83,68 @@ function defaultExecTmux(args: string[]): string {
   });
 }
 
-function resolveReturnTarget(env: NodeJS.ProcessEnv = process.env): string | undefined {
+function readJsonFileIfExists(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readPersistedQuestionReturnTarget(
+  cwd: string,
+  sessionId?: string,
+): string | undefined {
+  const candidatePaths: string[] = [];
+  if (sessionId) {
+    for (const mode of TRACKED_WORKFLOW_MODES) {
+      try {
+        candidatePaths.push(getStatePath(mode, cwd, sessionId));
+      } catch {
+        // Ignore invalid/absent state scopes and keep best-effort fallbacks.
+      }
+    }
+  }
+  for (const mode of TRACKED_WORKFLOW_MODES) {
+    try {
+      candidatePaths.push(getStatePath(mode, cwd));
+    } catch {
+      // Ignore invalid/absent state scopes and keep best-effort fallbacks.
+    }
+  }
+
+  const seen = new Set<string>();
+  for (const path of candidatePaths) {
+    if (seen.has(path)) continue;
+    seen.add(path);
+    const state = readJsonFileIfExists(path);
+    if (state?.active !== true) continue;
+    const pane = safeString(state.tmux_pane_id).trim();
+    if (isPaneId(pane)) return pane;
+  }
+
+  return undefined;
+}
+
+function resolveReturnTarget(options: {
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  sessionId?: string;
+}): string | undefined {
+  const env = options.env ?? process.env;
+  const explicitPane = safeString(env.OMX_QUESTION_RETURN_PANE || env.OMX_LEADER_PANE_ID).trim();
+  if (isPaneId(explicitPane)) return explicitPane;
+
   const envPane = safeString(env.TMUX_PANE).trim();
   if (isPaneId(envPane)) return envPane;
+
+  const persistedPane = readPersistedQuestionReturnTarget(options.cwd, options.sessionId);
+  if (persistedPane) return persistedPane;
+
   const detectedPane = getCurrentTmuxPaneId();
   return isPaneId(detectedPane) ? detectedPane : undefined;
 }
@@ -178,6 +240,11 @@ export function launchQuestionRenderer(
   });
 
   if (strategy === 'inside-tmux') {
+    const returnTarget = resolveReturnTarget({
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      sessionId: options.sessionId,
+    });
     const rawPane = execTmux([
       'split-window',
       '-v',
@@ -196,7 +263,6 @@ export function launchQuestionRenderer(
     if (!isLaunchedQuestionPaneAlive(paneId, execTmux)) {
       throw new Error(`Question UI pane ${paneId} disappeared immediately after launch.`);
     }
-    const returnTarget = resolveReturnTarget(options.env ?? process.env);
     return {
       renderer: 'tmux-pane',
       target: paneId,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -840,7 +840,9 @@ describe("codex native hook dispatch", () => {
       assert.match(message, /do not fall back to `request_user_input` or plain-text questioning/i);
       assert.match(message, /After starting `omx question` in a background terminal, wait for that terminal to finish and read the JSON answer before continuing the interview\./);
       assert.match(message, /If bare `omx question` is unavailable in this reused session, use the current-session CLI bridge command:/);
-      assert.match(message, /`'.+' '.+dist\/cli\/omx\.js' question`/);
+      assert.match(message, /OMX_QUESTION_RETURN_PANE=/);
+      assert.match(message, /preserve the leader pane/i);
+      assert.match(message, /`OMX_QUESTION_RETURN_PANE='?%\d+'? '.+' '.+dist\/cli\/omx\.js' question`/);
       assert.match(message, /Stop remains blocked while a deep-interview question obligation is pending\./);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -1237,6 +1239,91 @@ esac
       }
       process.env.PATH = originalPath;
       process.argv = originalArgv;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks Bash omx question when no leader-pane return hint is preserved", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-question-enforce-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-question-block",
+          tool_input: { command: `omx question --json --input '{"question":"Q?","options":["A"],"allow_other":true}'` },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((result.outputJson as { systemMessage?: string } | null)?.systemMessage || ""), /OMX_QUESTION_RETURN_PANE=\$TMUX_PANE/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows Bash omx question when the command preserves the leader-pane return hint", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-question-allow-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-question-allow",
+          tool_input: { command: `OMX_QUESTION_RETURN_PANE=$TMUX_PANE omx question --json --input '{"question":"Q?","options":["A"],"allow_other":true}'` },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows the quoted pane env assignment emitted by the deep-interview bridge command", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-question-quoted-allow-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-question-quoted-allow",
+          tool_input: { command: `OMX_QUESTION_RETURN_PANE='%42' node ./dist/cli/omx.js question --json --input '{"question":"Q?","options":["A"],"allow_other":true}'` },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks Bash node omx.js question when the command does not preserve the leader-pane return hint", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-question-node-block-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-question-node-block",
+          tool_input: { command: `node ./dist/cli/omx.js question --json --input '{"question":"Q?","options":["A"],"allow_other":true}'` },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -101,6 +101,7 @@ const TEAM_ENV_KEYS = [
   "OMX_TEAM_STATE_ROOT",
   "OMX_TEAM_LEADER_CWD",
   "OMX_SESSION_ID",
+  "TMUX_PANE",
 ] as const;
 
 const priorTeamEnv = new Map<(typeof TEAM_ENV_KEYS)[number], string | undefined>();
@@ -840,10 +841,51 @@ describe("codex native hook dispatch", () => {
       assert.match(message, /do not fall back to `request_user_input` or plain-text questioning/i);
       assert.match(message, /After starting `omx question` in a background terminal, wait for that terminal to finish and read the JSON answer before continuing the interview\./);
       assert.match(message, /If bare `omx question` is unavailable in this reused session, use the current-session CLI bridge command:/);
-      assert.match(message, /OMX_QUESTION_RETURN_PANE=/);
-      assert.match(message, /preserve the leader pane/i);
-      assert.match(message, /`OMX_QUESTION_RETURN_PANE='?%\d+'? '.+' '.+dist\/cli\/omx\.js' question`/);
+      assert.match(message, /'.+' '.+dist\/cli\/omx\.js' question/);
+      assert.doesNotMatch(message, /OMX_QUESTION_RETURN_PANE=/);
+      assert.doesNotMatch(message, /preserve the leader pane/i);
       assert.match(message, /Stop remains blocked while a deep-interview question obligation is pending\./);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("includes leader-pane preservation guidance when a pane hint is available", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-pane-hint-"));
+    try {
+      const sessionId = "sess-deep-interview-pane-hint";
+      const sessionDir = join(cwd, ".omx", "state", "sessions", sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(sessionDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        started_at: "2026-04-21T10:00:00.000Z",
+        updated_at: "2026-04-21T10:00:00.000Z",
+        tmux_pane_id: "%77",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-deep-interview-pane-hint",
+          turn_id: "turn-deep-interview-pane-hint",
+          prompt: "$deep-interview gather requirements",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "deep-interview");
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /OMX_QUESTION_RETURN_PANE='%77'/);
+      assert.match(message, /preserve the leader pane/i);
+      assert.match(message, /OMX_QUESTION_RETURN_PANE=%77/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -566,10 +566,40 @@ async function buildSessionStartContext(
   return sections.length > 0 ? sections.join("\n\n") : null;
 }
 
+function resolveQuestionLeaderPaneHint(cwd: string): string {
+  const sessionId = safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID || process.env.SESSION_ID).trim();
+  const candidatePaths = [
+    ...(sessionId ? [getStatePath('deep-interview', cwd, sessionId), getStatePath('ralplan', cwd, sessionId), getStatePath('ralph', cwd, sessionId)] : []),
+    getStatePath('deep-interview', cwd),
+    getStatePath('ralplan', cwd),
+    getStatePath('ralph', cwd),
+  ];
+
+  for (const path of candidatePaths) {
+    try {
+      if (!existsSync(path)) continue;
+      const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+      const pane = safeString(parsed?.tmux_pane_id).trim();
+      if (/^%\d+$/.test(pane)) return pane;
+    } catch {
+      // best effort only
+    }
+  }
+
+  const envPane = safeString(process.env.TMUX_PANE).trim();
+  return /^%\d+$/.test(envPane) ? envPane : '';
+}
+
 function buildDeepInterviewQuestionBridgeInstruction(cwd: string): string {
   const omxBin = resolveOmxCliEntryPath({ cwd }) || process.argv[1] || "omx";
-  const bridgeCommand = `${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} question`;
-  return `Deep-interview must ask each interview round via \`omx question\`; do not fall back to \`request_user_input\` or plain-text questioning. After starting \`omx question\` in a background terminal, wait for that terminal to finish and read the JSON answer before continuing the interview. If bare \`omx question\` is unavailable in this reused session, use the current-session CLI bridge command: \`${bridgeCommand}\`. Stop remains blocked while a deep-interview question obligation is pending.`;
+  const leaderPaneHint = resolveQuestionLeaderPaneHint(cwd);
+  const bridgeCommand = leaderPaneHint
+    ? `OMX_QUESTION_RETURN_PANE=${shellEscapeSingle(leaderPaneHint)} ${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} question`
+    : `${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} question`;
+  const enforcementNote = leaderPaneHint
+    ? ` When using Bash/background-terminal tool paths, preserve the leader pane by exporting \`OMX_QUESTION_RETURN_PANE=${leaderPaneHint}\` (or equivalent) before invoking \`omx question\`.`
+    : '';
+  return `Deep-interview must ask each interview round via \`omx question\`; do not fall back to \`request_user_input\` or plain-text questioning. After starting \`omx question\` in a background terminal, wait for that terminal to finish and read the JSON answer before continuing the interview. If bare \`omx question\` is unavailable in this reused session, use the current-session CLI bridge command: \`${bridgeCommand}\`.${enforcementNote} Stop remains blocked while a deep-interview question obligation is pending.`;
 }
 
 function buildAdditionalContextMessage(

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -566,8 +566,10 @@ async function buildSessionStartContext(
   return sections.length > 0 ? sections.join("\n\n") : null;
 }
 
-function resolveQuestionLeaderPaneHint(cwd: string): string {
-  const sessionId = safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID || process.env.SESSION_ID).trim();
+function resolveQuestionLeaderPaneHint(cwd: string, payload?: CodexHookPayload): string {
+  const payloadSessionId = safeString(payload?.session_id).trim();
+  const envSessionId = safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID || process.env.SESSION_ID).trim();
+  const sessionId = payloadSessionId || envSessionId;
   const candidatePaths = [
     ...(sessionId ? [getStatePath('deep-interview', cwd, sessionId), getStatePath('ralplan', cwd, sessionId), getStatePath('ralph', cwd, sessionId)] : []),
     getStatePath('deep-interview', cwd),
@@ -590,9 +592,9 @@ function resolveQuestionLeaderPaneHint(cwd: string): string {
   return /^%\d+$/.test(envPane) ? envPane : '';
 }
 
-function buildDeepInterviewQuestionBridgeInstruction(cwd: string): string {
+function buildDeepInterviewQuestionBridgeInstruction(cwd: string, payload?: CodexHookPayload): string {
   const omxBin = resolveOmxCliEntryPath({ cwd }) || process.argv[1] || "omx";
-  const leaderPaneHint = resolveQuestionLeaderPaneHint(cwd);
+  const leaderPaneHint = resolveQuestionLeaderPaneHint(cwd, payload);
   const bridgeCommand = leaderPaneHint
     ? `OMX_QUESTION_RETURN_PANE=${shellEscapeSingle(leaderPaneHint)} ${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} question`
     : `${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} question`;
@@ -606,6 +608,7 @@ function buildAdditionalContextMessage(
   prompt: string,
   skillState?: SkillActiveState | null,
   cwd: string = process.cwd(),
+  payload?: CodexHookPayload,
 ): string | null {
   if (!prompt) return null;
   const promptPriorityMessage = buildPromptPriorityMessage(prompt);
@@ -626,7 +629,7 @@ function buildAdditionalContextMessage(
     ? "Prompt-side `$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`. Use `omx ralph --prd ...` only when you explicitly want the PRD-gated CLI startup path."
     : null;
   const deepInterviewPromptActivationNote = skillState?.initialized_mode === "deep-interview"
-    ? buildDeepInterviewQuestionBridgeInstruction(cwd)
+    ? buildDeepInterviewQuestionBridgeInstruction(cwd, payload)
     : null;
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;
@@ -1814,7 +1817,7 @@ export async function dispatchCodexNativeHook(
   if (hookEventName === "SessionStart" || hookEventName === "UserPromptSubmit") {
     const additionalContext = hookEventName === "SessionStart"
       ? await buildSessionStartContext(cwd, canonicalSessionId || nativeSessionId)
-      : (buildAdditionalContextMessage(readPromptText(payload), skillState, cwd) ?? triageAdditionalContext);
+      : (buildAdditionalContextMessage(readPromptText(payload), skillState, cwd, payload) ?? triageAdditionalContext);
     if (additionalContext) {
       outputJson = {
         hookSpecificOutput: {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -562,6 +562,49 @@ function buildGitCommitEnforcementOutput(commandText: string): Record<string, un
   };
 }
 
+function commandInvokesOmxQuestion(command: string): boolean {
+  const tokens = tokenizeShellCommand(command)?.map((token) => token.toLowerCase()) ?? [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    const rawToken = tokens[index] || '';
+    const token = rawToken.replace(/\\/g, '/').split('/').pop() || '';
+    if ((token === 'omx' || token === 'omx.js') && tokens[index + 1] === 'question') return true;
+    if ((token === 'node' || token === 'node.exe') && /(?:^|\/)omx\.js$/.test(tokens[index + 1] || '') && tokens[index + 2] === 'question') return true;
+  }
+  return /\bomx\s+question\b/i.test(command) || /\bomx\.js['"]?\s+question\b/i.test(command);
+}
+
+function isQuestionReturnPaneAssignment(token: string): boolean {
+  const equalsIndex = token.indexOf('=');
+  if (equalsIndex <= 0) return false;
+  const name = token.slice(0, equalsIndex);
+  if (!['OMX_QUESTION_RETURN_PANE', 'OMX_LEADER_PANE_ID', 'TMUX_PANE'].includes(name)) return false;
+  const value = token.slice(equalsIndex + 1);
+  return /^%\d+$/.test(value) || /^\$\{?TMUX_PANE\}?$/.test(value);
+}
+
+function commandHasQuestionReturnPane(command: string): boolean {
+  return (tokenizeShellCommand(command) ?? []).some(isQuestionReturnPaneAssignment);
+}
+
+function buildOmxQuestionPreToolUseEnforcementOutput(command: string): Record<string, unknown> | null {
+  if (!commandInvokesOmxQuestion(command)) return null;
+  if (commandHasQuestionReturnPane(command)) return null;
+
+  return {
+    decision: "block",
+    reason: "omx question Bash invocations must preserve the leader pane return target.",
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: [
+        "omx question leader-pane enforcement triggered.",
+        "Prefix the Bash command with `OMX_QUESTION_RETURN_PANE=$TMUX_PANE` (or a concrete `%pane` value) so `[omx question answered]` returns to the leader pane even when the tool path drops/stales TMUX_PANE.",
+        `Original command: ${command}`,
+      ].join("\n"),
+    },
+    systemMessage: "omx question is blocked from Bash until the command preserves the leader pane with `OMX_QUESTION_RETURN_PANE=$TMUX_PANE` or an explicit `%pane` value.",
+  };
+}
+
 export function buildNativePreToolUseOutput(
   payload: CodexHookPayload,
 ): Record<string, unknown> | null {
@@ -569,6 +612,8 @@ export function buildNativePreToolUseOutput(
   if (!normalized.isBash) return null;
   const gitCommitEnforcement = buildGitCommitEnforcementOutput(normalized.normalizedCommand);
   if (gitCommitEnforcement) return gitCommitEnforcement;
+  const questionEnforcement = buildOmxQuestionPreToolUseEnforcementOutput(normalized.normalizedCommand);
+  if (questionEnforcement) return questionEnforcement;
   if (!matchesDestructiveFixture(normalized.normalizedCommand)) return null;
 
   return {


### PR DESCRIPTION
## Summary
- persist prompt-seeded workflow tmux pane context so tool-launched `omx question` can recover when `TMUX_PANE` is missing
- resolve question return targets before opening the question split and prefer session-scoped pane state before root fallbacks
- add deep-interview bridge guidance plus PreToolUse Bash enforcement requiring explicit leader-pane preservation, including quoted bridge env assignments

## Verification
- `npm run build`
- `node --test dist/question/__tests__/renderer.test.js dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npx biome lint src/question/renderer.ts src/question/__tests__/renderer.test.ts src/hooks/keyword-detector.ts src/hooks/__tests__/keyword-detector.test.ts src/scripts/codex-native-hook.ts src/scripts/codex-native-pre-post.ts src/scripts/__tests__/codex-native-hook.test.ts`
- `npm run test:recent-bug-regressions:compiled`

## Review
- Code-review lane initially requested changes for quoted env handling and session-vs-root precedence.
- Follow-up code-review lane approved after fixes.
- Architect lane: WATCH (longer-term recommendation to centralize question return-target resolution / session-level leader pane contract).