### PR TITLE
fix: honor project-local CODEX_HOME in explore sessions

### DIFF
--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -19,6 +19,7 @@ import {
   repoBuiltExploreHarnessCommand,
   resolveExploreHarnessCommand,
   resolveExploreHarnessCommandWithHydration,
+  resolveExploreEnv,
   resolveExploreSparkShellRoute,
   resolvePackagedExploreHarnessCommand,
 } from '../explore.js';
@@ -682,6 +683,39 @@ describe('buildExploreHarnessArgs', () => {
       await rm(codexHome, { recursive: true, force: true });
     }
   });
+
+  it('applies persisted project CODEX_HOME fallback before reading explore config overrides', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-project-codex-home-'));
+    const badHome = join(wd, 'home-as-file');
+    await writeFile(badHome, 'not-a-directory');
+    await mkdir(join(wd, '.omx'), { recursive: true });
+    await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+    await mkdir(join(wd, '.codex'), { recursive: true });
+    await writeFile(join(wd, '.codex', '.omx-config.json'), JSON.stringify({
+      env: {
+        OMX_DEFAULT_STANDARD_MODEL: 'standard-project',
+        OMX_DEFAULT_SPARK_MODEL: 'spark-project',
+      },
+    }));
+
+    try {
+      const env = resolveExploreEnv(wd, { HOME: badHome } as NodeJS.ProcessEnv);
+      assert.equal(env.CODEX_HOME, join(wd, '.codex'));
+      const args = buildExploreHarnessArgs('find auth', wd, env, '/pkg');
+      assert.deepEqual(args.slice(4), [
+        '--prompt-file',
+        '/pkg/prompts/explore-harness.md',
+        '--instructions-file',
+        '/pkg/templates/model-instructions/explore-lightweight-AGENTS.md',
+        '--model-spark',
+        'spark-project',
+        '--model-fallback',
+        'standard-project',
+      ]);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('resolveExploreSparkShellRoute', () => {
@@ -861,6 +895,34 @@ describe('exploreCommand', () => {
       if (shouldSkipForSpawnPermissions(result.error)) return;
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.equal(result.stdout, '# Answer\nReady to proceed\n');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('passes project-local CODEX_HOME to the harness when persisted setup scope is project', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-project-codex-home-e2e-'));
+    try {
+      const stub = join(wd, 'explore-stub.sh');
+      const capturePath = join(wd, 'capture.txt');
+      const badHome = join(wd, 'home-as-file');
+      await writeFile(badHome, 'not-a-directory');
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(
+        stub,
+        `#!/bin/sh\nprintf 'CODEX_HOME=%s\\n' \"$CODEX_HOME\" > ${JSON.stringify(capturePath)}\nprintf '# Answer\\nReady to proceed\\n'\n`,
+      );
+      await chmod(stub, 0o755);
+
+      const result = runOmx(wd, ['explore', '--prompt', 'find auth'], {
+        HOME: badHome,
+        OMX_EXPLORE_BIN: stub,
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stdout, '# Answer\nReady to proceed\n');
+      assert.equal(await readFile(capturePath, 'utf-8'), `CODEX_HOME=${join(wd, '.codex')}\n`);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1129,6 +1129,26 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("uses project CODEX_HOME when persisted scope is project even if HOME is unusable", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      const badHome = join(wd, "home-as-file");
+      await writeFile(badHome, "not-a-directory");
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      assert.equal(resolveCodexHomeForLaunch(wd, { HOME: badHome }), join(wd, ".codex"));
+      assert.equal(
+        resolveCodexConfigPathForLaunch(wd, { HOME: badHome }),
+        join(wd, ".codex", "config.toml"),
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("uses project config.toml for launch repair when persisted scope is project", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
     try {
@@ -1472,6 +1492,27 @@ describe("detached tmux new-session sequencing", () => {
     assert.equal(
       newSession!.args.includes("-e") &&
         newSession!.args.some((arg) => arg === "OMX_SESSION_ID=sess-detached-managed"),
+      true,
+    );
+  });
+
+  it("buildDetachedSessionBootstrapSteps forwards CODEX_HOME override to detached tmux session", () => {
+    const steps = buildDetachedSessionBootstrapSteps(
+      "omx-demo",
+      "/tmp/project",
+      "'codex' '--model' 'gpt-5'",
+      "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null,
+      "/tmp/project/.codex",
+      null,
+      false,
+      "sess-detached-managed",
+    );
+    const newSession = steps.find((step) => step.name === "new-session");
+    assert.ok(newSession);
+    assert.equal(
+      newSession!.args.includes("-e") &&
+        newSession!.args.some((arg) => arg === "CODEX_HOME=/tmp/project/.codex"),
       true,
     );
   });

--- a/src/cli/codex-home.ts
+++ b/src/cli/codex-home.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { codexConfigPath } from "../utils/paths.js";
+import { SETUP_SCOPES, type SetupScope } from "./setup.js";
+
+/**
+ * Legacy scope values that may appear in persisted setup-scope.json files.
+ * Both 'project-local' (renamed) and old 'project' (minimal, removed) are
+ * migrated to the current 'project' scope on read.
+ */
+const LEGACY_SCOPE_MIGRATION_SYNC: Record<string, SetupScope> = {
+  "project-local": "project",
+};
+
+export function readPersistedSetupScope(cwd: string): SetupScope | undefined {
+  return readPersistedSetupPreferences(cwd)?.scope;
+}
+
+export function readPersistedSetupPreferences(
+  cwd: string,
+): Partial<{ scope: SetupScope }> | undefined {
+  const scopePath = join(cwd, ".omx", "setup-scope.json");
+  if (!existsSync(scopePath)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(scopePath, "utf-8")) as Partial<{
+      scope: string;
+    }>;
+    const persisted: Partial<{ scope: SetupScope }> = {};
+    if (typeof parsed.scope === "string") {
+      if (SETUP_SCOPES.includes(parsed.scope as SetupScope)) {
+        persisted.scope = parsed.scope as SetupScope;
+      }
+      const migrated = LEGACY_SCOPE_MIGRATION_SYNC[parsed.scope];
+      if (migrated) persisted.scope = migrated;
+    }
+    return Object.keys(persisted).length > 0 ? persisted : undefined;
+  } catch (err) {
+    process.stderr.write(`[cli/codex-home] operation failed: ${err}\n`);
+    // Ignore malformed persisted scope and use defaults.
+  }
+  return undefined;
+}
+
+export function resolveCodexHomeForLaunch(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return env.CODEX_HOME;
+  const persistedScope = readPersistedSetupScope(cwd);
+  if (persistedScope === "project") {
+    return join(cwd, ".codex");
+  }
+  return undefined;
+}
+
+export function resolveCodexConfigPathForLaunch(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, env);
+  return codexHomeOverride
+    ? join(codexHomeOverride, "config.toml")
+    : codexConfigPath();
+}

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -25,6 +25,7 @@ import {
   getPackageVersion,
 } from './native-assets.js';
 import { getWikiDir, queryWiki } from '../wiki/index.js';
+import { resolveCodexHomeForLaunch } from './codex-home.js';
 
 export const EXPLORE_USAGE = [
   'Usage: omx explore --prompt "<prompt>"',
@@ -433,6 +434,16 @@ export function buildExploreHarnessArgs(
   ];
 }
 
+export function resolveExploreEnv(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, env);
+  return codexHomeOverride
+    ? { ...env, CODEX_HOME: codexHomeOverride }
+    : env;
+}
+
 export async function loadExplorePrompt(parsed: ParsedExploreArgs): Promise<string> {
   if (parsed.prompt) return parsed.prompt;
   if (!parsed.promptFile) throw exploreUsageError('Missing prompt. Provide --prompt or --prompt-file.');
@@ -445,10 +456,12 @@ export async function loadExplorePrompt(parsed: ParsedExploreArgs): Promise<stri
 export async function exploreCommand(args: string[]): Promise<void> {
   const parsed = parseExploreArgs(args);
   const prompt = await loadExplorePrompt(parsed);
+  const cwd = process.cwd();
+  const exploreEnv = resolveExploreEnv(cwd, process.env);
   const sparkShellRoute = resolveExploreSparkShellRoute(prompt);
   if (sparkShellRoute) {
     try {
-      await runExploreViaSparkShell(sparkShellRoute, process.env);
+      await runExploreViaSparkShell(sparkShellRoute, exploreEnv);
       return;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -457,13 +470,13 @@ export async function exploreCommand(args: string[]): Promise<void> {
   }
 
   const packageRoot = getPackageRoot();
-  assertBuiltinExploreHarnessSupported(process.platform, process.env);
-  const harness = await resolveExploreHarnessCommandWithHydration(packageRoot, process.env);
-  const harnessArgs = [...harness.args, ...buildExploreHarnessArgs(prompt, process.cwd(), process.env, packageRoot)];
+  assertBuiltinExploreHarnessSupported(process.platform, exploreEnv);
+  const harness = await resolveExploreHarnessCommandWithHydration(packageRoot, exploreEnv);
+  const harnessArgs = [...harness.args, ...buildExploreHarnessArgs(prompt, cwd, exploreEnv, packageRoot)];
 
   const { result } = spawnPlatformCommandSync(harness.command, harnessArgs, {
-    cwd: process.cwd(),
-    env: process.env,
+    cwd,
+    env: exploreEnv,
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -48,6 +48,19 @@ import {
   getStateDir,
   listModeStateFilesWithScopePreference,
 } from "../mcp/state-paths.js";
+import {
+  readPersistedSetupPreferences,
+  readPersistedSetupScope,
+  resolveCodexConfigPathForLaunch,
+  resolveCodexHomeForLaunch,
+} from "./codex-home.js";
+
+export {
+  readPersistedSetupPreferences,
+  readPersistedSetupScope,
+  resolveCodexConfigPathForLaunch,
+  resolveCodexHomeForLaunch,
+} from "./codex-home.js";
 import { SKILL_ACTIVE_STATE_MODE, syncCanonicalSkillStateForMode } from "../state/skill-active.js";
 import { isTrackedWorkflowMode } from "../state/workflow-transition.js";
 import { maybeCheckAndPromptUpdate, runImmediateUpdate } from "./update.js";
@@ -312,66 +325,6 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
 export interface ResolvedCliInvocation {
   command: CliCommand;
   launchArgs: string[];
-}
-
-/**
- * Legacy scope values that may appear in persisted setup-scope.json files.
- * Both 'project-local' (renamed) and old 'project' (minimal, removed) are
- * migrated to the current 'project' scope on read.
- */
-const LEGACY_SCOPE_MIGRATION_SYNC: Record<string, SetupScope> = {
-  "project-local": "project",
-};
-
-export function readPersistedSetupScope(cwd: string): SetupScope | undefined {
-  return readPersistedSetupPreferences(cwd)?.scope;
-}
-
-export function readPersistedSetupPreferences(
-  cwd: string,
-): Partial<{ scope: SetupScope }> | undefined {
-  const scopePath = join(cwd, ".omx", "setup-scope.json");
-  if (!existsSync(scopePath)) return undefined;
-  try {
-    const parsed = JSON.parse(readFileSync(scopePath, "utf-8")) as Partial<{
-      scope: string;
-    }>;
-    const persisted: Partial<{ scope: SetupScope }> = {};
-    if (typeof parsed.scope === "string") {
-      if (SETUP_SCOPES.includes(parsed.scope as SetupScope)) {
-        persisted.scope = parsed.scope as SetupScope;
-      }
-      const migrated = LEGACY_SCOPE_MIGRATION_SYNC[parsed.scope];
-      if (migrated) persisted.scope = migrated;
-    }
-    return Object.keys(persisted).length > 0 ? persisted : undefined;
-  } catch (err) {
-    process.stderr.write(`[cli/index] operation failed: ${err}\n`);
-    // Ignore malformed persisted scope and use defaults.
-  }
-  return undefined;
-}
-
-export function resolveCodexHomeForLaunch(
-  cwd: string,
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-  if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return env.CODEX_HOME;
-  const persistedScope = readPersistedSetupScope(cwd);
-  if (persistedScope === "project") {
-    return join(cwd, ".codex");
-  }
-  return undefined;
-}
-
-export function resolveCodexConfigPathForLaunch(
-  cwd: string,
-  env: NodeJS.ProcessEnv = process.env,
-): string {
-  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, env);
-  return codexHomeOverride
-    ? join(codexHomeOverride, "config.toml")
-    : codexConfigPath();
 }
 
 export function resolveSetupScopeArg(args: string[]): SetupScope | undefined {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,8 +49,6 @@ import {
   listModeStateFilesWithScopePreference,
 } from "../mcp/state-paths.js";
 import {
-  readPersistedSetupPreferences,
-  readPersistedSetupScope,
   resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
 } from "./codex-home.js";


### PR DESCRIPTION
## Summary\n- reuse the same project-scope CODEX_HOME resolution helper for  as the main launch path\n- inject the resolved CODEX_HOME before reading config overrides and before launching sparkshell / harness flows\n- add targeted regressions for persisted project-local CODEX_HOME resolution and detached bootstrap forwarding\n\n## Verification\n- npm run build\n- cargo test -p omx-explore-harness\n- node --test dist/cli/__tests__/explore.test.js dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js\n- npx biome lint src/cli/codex-home.ts src/cli/explore.ts src/cli/index.ts src/cli/__tests__/explore.test.ts src/cli/__tests__/index.test.ts\n\nCloses #1816