### PR TITLE
fix: prevent omx setup from orphaning multiline root TOML strings

### DIFF
--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import TOML from "@iarna/toml";
 import { buildMergedConfig, mergeConfig, repairConfigIfNeeded } from "../generator.js";
 
 /** Count occurrences of a pattern in text */
@@ -902,6 +903,57 @@ describe("config generator idempotency (#384)", () => {
 
     assert.match(merged, /^\[mcp_servers\.seq\]$/m);
     assert.match(merged, /^startup_timeout_sec = 15$/m);
+  });
+
+  it("removes an existing multiline developer_instructions assignment as one root entry", () => {
+    const existing = [
+      'model = "gpt-5.4"',
+      'developer_instructions = """Custom instructions survive as valid TOML.',
+      'This line used to be orphaned by setup.',
+      'This closing line used to break parsing."""',
+      "",
+      "[features]",
+      "web_search = true",
+      "",
+    ].join("\n");
+
+    const merged = buildMergedConfig(existing, "/tmp/omx");
+
+    assert.doesNotMatch(merged, /This line used to be orphaned/);
+    assert.doesNotMatch(merged, /This closing line used to break parsing/);
+    assert.equal(count(merged, /^developer_instructions\s*=/gm), 1);
+    assert.doesNotThrow(() => TOML.parse(merged));
+  });
+
+  it("preserves root model values when mergeConfig sees multiline root strings", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      await writeFile(
+        configPath,
+        [
+          'developer_instructions = """Custom instructions.',
+          'Multiple lines.',
+          'Done."""',
+          'model = "o3"',
+          "model_context_window = 123456",
+          "",
+          "[features]",
+          "web_search = true",
+          "",
+        ].join("\n"),
+      );
+
+      await mergeConfig(configPath, wd);
+      const merged = await readFile(configPath, "utf-8");
+
+      assert.match(merged, /^model = "o3"$/m);
+      assert.match(merged, /^model_context_window = 123456$/m);
+      assert.doesNotMatch(merged, /^model_auto_compact_token_limit = 200000$/m);
+      assert.doesNotThrow(() => TOML.parse(merged));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
   });
 
   it("repairConfigIfNeeded backfills launcher-backed MCP startup timeouts", async () => {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -73,15 +73,70 @@ export function getRootModelName(config: string): string | undefined {
   return unwrapTomlString(parseRootKeyValues(config).get("model"));
 }
 
+const ROOT_TABLE_HEADER_PATTERN = /^\s*\[\[?[^\]]+\]?\]\s*$/;
+const ROOT_KEY_ASSIGNMENT_PATTERN = /^\s*([A-Za-z0-9_-]+)\s*=\s*(.*)$/;
+
+type RootLevelEntry = {
+  key?: string;
+  lines: string[];
+};
+
+function parseStandaloneToml(snippet: string): boolean {
+  try {
+    TOML.parse(snippet);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function splitRootLevelEntries(config: string): {
+  entries: RootLevelEntry[];
+  remainder: string[];
+} {
+  const lines = config.split(/\r?\n/);
+  const entries: RootLevelEntry[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    if (ROOT_TABLE_HEADER_PATTERN.test(line)) break;
+
+    const match = line.match(ROOT_KEY_ASSIGNMENT_PATTERN);
+    if (!match) {
+      entries.push({ lines: [line] });
+      index += 1;
+      continue;
+    }
+
+    const entryLines = [line];
+    while (
+      !parseStandaloneToml(entryLines.join("\n")) &&
+      index + entryLines.length < lines.length
+    ) {
+      entryLines.push(lines[index + entryLines.length]);
+    }
+
+    entries.push({ key: match[1], lines: entryLines });
+    index += entryLines.length;
+  }
+
+  return { entries, remainder: lines.slice(index) };
+}
+
 function parseRootKeyValues(config: string): Map<string, string> {
   const values = new Map<string, string>();
-  const lines = config.split(/\r?\n/);
-  for (const line of lines) {
-    if (/^\s*\[/.test(line)) break;
-    const match = line.match(/^\s*([A-Za-z0-9_-]+)\s*=\s*(.+?)\s*$/);
+  const { entries } = splitRootLevelEntries(config);
+
+  for (const entry of entries) {
+    if (!entry.key) continue;
+    const [firstLine, ...rest] = entry.lines;
+    const match = firstLine.match(ROOT_KEY_ASSIGNMENT_PATTERN);
     if (!match) continue;
-    values.set(match[1], match[2]);
+    const value = [match[2], ...rest].join("\n").trim();
+    values.set(entry.key, value);
   }
+
   return values;
 }
 
@@ -194,32 +249,30 @@ export function stripOmxSeededBehavioralDefaults(config: string): string {
 }
 
 function stripRootLevelKeys(config: string, keys: readonly string[]): string {
-  let lines = config.split(/\r?\n/);
+  const { entries, remainder } = splitRootLevelEntries(config);
 
-  if (
-    keys.some((key) =>
-      OMX_TOP_LEVEL_KEYS.includes(key as (typeof OMX_TOP_LEVEL_KEYS)[number]),
-    )
-  ) {
-    lines = lines.filter(
-      (l) =>
-        l.trim() !==
-        "# oh-my-codex top-level settings (must be before any [table])",
-    );
-  }
-
-  const firstTable = lines.findIndex((l) => /^\s*\[/.test(l));
-  const boundary = firstTable >= 0 ? firstTable : lines.length;
-
-  const result: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    if (i < boundary) {
-      const isManagedKey = keys.some((key) =>
-        new RegExp(`^\\s*${key}\\s*=`).test(lines[i]),
-      );
-      if (isManagedKey) continue;
+  const filteredEntries = entries.filter((entry) => {
+    if (
+      keys.some((key) =>
+        OMX_TOP_LEVEL_KEYS.includes(key as (typeof OMX_TOP_LEVEL_KEYS)[number]),
+      ) &&
+      entry.lines.length === 1 &&
+      entry.lines[0].trim() ===
+        "# oh-my-codex top-level settings (must be before any [table])"
+    ) {
+      return false;
     }
-    result.push(lines[i]);
+
+    return !entry.key || !keys.includes(entry.key);
+  });
+
+  const result = [
+    ...filteredEntries.flatMap((entry) => entry.lines),
+    ...remainder,
+  ];
+
+  if (result.length === 0) {
+    return "";
   }
 
   return result.join("\n");


### PR DESCRIPTION
## Summary\n- group multiline root-level TOML assignments as single logical entries before managed-key stripping/parsing\n- prevent multiline  bodies from being orphaned above the next table header during oh-my-codex setup
=================

Using setup scope: project (from .omx/setup-scope.json)

[1/8] Creating directories...
  Done.

[2/8] Installing agent prompts...
  Prompt refresh complete (catalog baseline: 20).

[3/8] Installing skills...
  Skill refresh complete (catalog baseline: 27).

[4/8] Installing native agent configs...
  Native agent refresh complete (/home/bellman/clawd/.codex/agents).

[5/8] Updating config.toml...
  Config refresh complete (/home/bellman/clawd/.codex/config.toml).

  Native Codex hooks refresh complete (/home/bellman/clawd/.codex/hooks.json).

[5.5/8] Verifying Team CLI API interop...
  omx team api command detected (CLI-first interop ready)

[6/8] Generating AGENTS.md...
  Skipped AGENTS.md overwrite for /home/bellman/clawd/AGENTS.md. Re-run interactively to confirm or use --force.

[7/8] Configuring notification hook...
  Done.

[8/8] Configuring HUD...
  HUD config already exists (use --force to overwrite).
  Codex CLI >= 0.107.0 manages [tui]; OMX left that section untouched.

Setup refresh summary:
  prompts: updated=0, unchanged=20, backed_up=0, skipped=13, removed=0
  skills: updated=0, unchanged=28, backed_up=0, skipped=10, removed=0
  native_agents: updated=0, unchanged=20, backed_up=0, skipped=10, removed=0
  agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0
  config: updated=1, unchanged=1, backed_up=1, skipped=0, removed=0

Setup complete! Run "omx doctor" to verify installation.

Next steps:
  1. Start Codex CLI in your project directory
  2. Use role/workflow keywords like $architect, $executor, and $plan in Codex
  3. Browse skills with /skills; AGENTS keyword routing can also activate them implicitly
  4. The AGENTS.md orchestration brain is loaded automatically
  5. Native agent defaults configured in config.toml [agents] and TOML files written to .codex/agents/
  6. "omx explore" and "omx sparkshell" can hydrate native release binaries on first use; source installs still allow repo-local fallbacks and OMX_EXPLORE_BIN / OMX_SPARKSHELL_BIN overrides

Support the project: gh repo star Yeachan-Heo/oh-my-codex refresh\n- add idempotency regressions covering multiline root strings and merged config parse validity\n\n## Verification\n- npm run build && node --test dist/config/__tests__/generator-idempotent.test.js\n- npm test\n- npm run check:no-unused\n- npm run lint\n- architect review approved\n\nCloses #1817