### PR TITLE
fix: keep hook-driven HUD reconciliation in the emitting tmux window

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -61,6 +61,7 @@ import { ensureReusableNodeModules } from "../../utils/repo-deps.js";
 import { readAllState } from "../../hud/state.js";
 import { generateOverlay } from "../../hooks/agents-overlay.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../../hud/constants.js";
+import { createHudWatchPane as createSharedHudWatchPane, listCurrentWindowHudPaneIds } from "../../hud/tmux.js";
 import {
   DEFAULT_FRONTIER_MODEL,
   getTeamLowComplexityModel,
@@ -1405,6 +1406,56 @@ describe("tmux HUD pane helpers", () => {
 
   it("buildHudPaneCleanupTargets is a no-op guard when leaderPaneId is absent", () => {
     assert.deepEqual(buildHudPaneCleanupTargets(["%3"], "%4"), ["%3", "%4"]);
+  });
+
+  it("listCurrentWindowHudPaneIds scopes tmux pane listing to the emitting pane", () => {
+    const calls: string[][] = [];
+    const panes = listCurrentWindowHudPaneIds("%leader", (args) => {
+      calls.push(args);
+      return [
+        "%leader\tcodex\tcodex",
+        "%hud\tnode\tnode /tmp/bin/omx.js hud --watch",
+      ].join("\n");
+    });
+
+    assert.deepEqual(panes, ["%hud"]);
+    assert.deepEqual(calls[0], [
+      "list-panes",
+      "-t",
+      "%leader",
+      "-F",
+      "#{pane_id}\t#{pane_current_command}\t#{pane_start_command}",
+    ]);
+  });
+
+  it("createHudWatchPane splits from the emitting pane target when provided", () => {
+    const calls: string[][] = [];
+    const paneId = createSharedHudWatchPane(
+      "/repo",
+      "node /repo/dist/cli/omx.js hud --watch",
+      { heightLines: 3, targetPaneId: "%leader" },
+      (args) => {
+        calls.push(args);
+        return "%hud\n";
+      },
+    );
+
+    assert.equal(paneId, "%hud");
+    assert.deepEqual(calls[0], [
+      "split-window",
+      "-v",
+      "-l",
+      "3",
+      "-d",
+      "-t",
+      "%leader",
+      "-c",
+      "/repo",
+      "-P",
+      "-F",
+      "#{pane_id}",
+      "node /repo/dist/cli/omx.js hud --watch",
+    ]);
   });
 });
 

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -12,7 +12,7 @@ describe('reconcileHudForPromptSubmit', () => {
   });
 
   it('recreates a missing HUD in tmux', async () => {
-    const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; fullWidth?: boolean } }> = [];
+    const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
@@ -61,6 +61,31 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(created.length, 1);
     assert.match(created[0]?.cmd || '', /^OMX_SESSION_ID='sess-canonical' node '.*omx\.js' hud --watch/);
     assert.doesNotMatch(created[0]?.cmd || '', /sess-stale/);
+  });
+
+  it('targets the emitting pane window when listing and creating HUD panes', async () => {
+    const listArgs: Array<string | undefined> = [];
+    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%leader' },
+      listCurrentWindowPanes: (currentPaneId) => {
+        listArgs.push(currentPaneId);
+        return [
+          { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        ];
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%hud';
+      },
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'recreated');
+    assert.deepEqual(listArgs, ['%leader']);
+    assert.equal(created[0]?.options?.targetPaneId, '%leader');
   });
 
   it('kills duplicate HUD panes and recreates one full-width pane', async () => {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -28,11 +28,11 @@ export interface ReconcileHudForPromptSubmitResult {
 export interface ReconcileHudForPromptSubmitDeps {
   env?: NodeJS.ProcessEnv;
   sessionId?: string;
-  listCurrentWindowPanes?: () => TmuxPaneSnapshot[];
+  listCurrentWindowPanes?: (currentPaneId?: string) => TmuxPaneSnapshot[];
   createHudWatchPane?: (
     cwd: string,
     hudCmd: string,
-    options?: { heightLines?: number; fullWidth?: boolean },
+    options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string },
   ) => string | null;
   killTmuxPane?: (paneId: string) => boolean;
   resizeTmuxPane?: (paneId: string, heightLines: number) => boolean;
@@ -65,13 +65,13 @@ export async function reconcileHudForPromptSubmit(
     };
   }
 
-  const listPanes = deps.listCurrentWindowPanes ?? (() => listCurrentWindowPanes());
+  const listPanes = deps.listCurrentWindowPanes ?? ((paneId) => listCurrentWindowPanes(undefined, paneId));
   const createPane = deps.createHudWatchPane ?? ((hudCwd, hudCmd, options) => createHudWatchPane(hudCwd, hudCmd, options));
   const killPane = deps.killTmuxPane ?? ((paneId) => killTmuxPane(paneId));
   const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
 
-  const panes = listPanes();
   const currentPaneId = env.TMUX_PANE?.trim();
+  const panes = listPanes(currentPaneId);
   const hudPaneIds = findHudWatchPaneIds(panes, currentPaneId);
   const duplicateCount = Math.max(0, hudPaneIds.length - 1);
   const nonHudPaneCount = panes.filter((pane) => !isHudWatchPane(pane)).length;
@@ -100,6 +100,7 @@ export async function reconcileHudForPromptSubmit(
   const paneId = createPane(cwd, hudCmd, {
     heightLines: desiredHeight,
     fullWidth: nonHudPaneCount > 1,
+    targetPaneId: currentPaneId,
   });
   if (!paneId) {
     return {

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -72,11 +72,13 @@ export function buildHudWatchCommand(omxBin: string, preset?: string, sessionId?
 
 export function listCurrentWindowPanes(
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+  currentPaneId?: string,
 ): TmuxPaneSnapshot[] {
   try {
     return parseTmuxPaneSnapshot(
       execTmuxSync([
         'list-panes',
+        ...(currentPaneId ? ['-t', currentPaneId] : []),
         '-F',
         '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}',
       ]),
@@ -90,14 +92,20 @@ export function listCurrentWindowHudPaneIds(
   currentPaneId?: string,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): string[] {
-  return findHudWatchPaneIds(listCurrentWindowPanes(execTmuxSync), currentPaneId);
+  return findHudWatchPaneIds(listCurrentWindowPanes(execTmuxSync, currentPaneId), currentPaneId);
 }
 
 export function readCurrentWindowSize(
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+  currentPaneId?: string,
 ): { width: number | null; height: number | null } {
   try {
-    const raw = execTmuxSync(['display-message', '-p', '#{window_width}\t#{window_height}']);
+    const raw = execTmuxSync([
+      'display-message',
+      '-p',
+      ...(currentPaneId ? ['-t', currentPaneId] : []),
+      '#{window_width}\t#{window_height}',
+    ]);
     const [widthRaw = '', heightRaw = ''] = raw.split('\t');
     const width = Number.parseInt(widthRaw.trim(), 10);
     const height = Number.parseInt(heightRaw.trim(), 10);
@@ -116,6 +124,7 @@ export function createHudWatchPane(
   options: {
     heightLines?: number;
     fullWidth?: boolean;
+    targetPaneId?: string;
   } = {},
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): string | null {
@@ -129,6 +138,7 @@ export function createHudWatchPane(
     '-l',
     String(heightLines),
     '-d',
+    ...(options.targetPaneId ? ['-t', options.targetPaneId] : []),
     '-c',
     cwd,
     '-P',

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1263,8 +1263,8 @@ esac
 
       assert.equal(result.omxEventName, "keyword-detector");
       const tmuxCalls = await readFile(tmuxLog, "utf-8");
-      assert.match(tmuxCalls, /list-panes/);
-      assert.match(tmuxCalls, /split-window/);
+      assert.match(tmuxCalls, /list-panes -t %1 -F/);
+      assert.match(tmuxCalls, /split-window -v -l 3 -d -t %1 -c/);
       assert.match(tmuxCalls, /resize-pane -t %9 -y 3/);
       assert.match(tmuxCalls, /dist\/cli\/omx\.js' hud --watch --preset=focused/);
       assert.doesNotMatch(tmuxCalls, /\/tmp\/codex-host-binary' hud --watch/);


### PR DESCRIPTION
## Summary\n- thread  through HUD reconciliation so hook-time pane discovery and split creation stay anchored to the emitting tmux window\n- update shared tmux helpers to support explicit pane-targeted list/split operations\n- add regression coverage for helper argv targeting, reconcile propagation, and native hook integration\n\n## Verification\n- npm run build\n- node --test dist/hud/__tests__/reconcile.test.js dist/cli/__tests__/index.test.js dist/scripts/__tests__/codex-native-hook.test.js\n- ./node_modules/.bin/biome lint src/hud/tmux.ts src/hud/reconcile.ts src/hud/__tests__/reconcile.test.ts src/cli/__tests__/index.test.ts src/scripts/__tests__/codex-native-hook.test.ts\n- architect review approved\n\nCloses #1820