### PR TITLE
test: fix explore hydration fixture on arm64

### DIFF
--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -534,7 +534,9 @@ describe('resolveExploreHarnessCommand', () => {
       await writeFile(binaryPath, '#!/bin/sh\necho hydrated-explore\n');
       await chmod(binaryPath, 0o755);
 
-      const archivePath = join(assetRoot, 'omx-explore-harness-x86_64-unknown-linux-musl.tar.gz');
+      const linuxTargetArch = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
+      const archiveName = `omx-explore-harness-${linuxTargetArch}-unknown-linux-musl.tar.gz`;
+      const archivePath = join(assetRoot, archiveName);
       const archive = spawnSync('tar', ['-czf', archivePath, '-C', stagingDir, packagedExploreHarnessBinaryName()], { encoding: 'utf-8' });
       assert.equal(archive.status, 0, archive.stderr || archive.stdout);
       const archiveBuffer = await readFile(archivePath);
@@ -569,13 +571,14 @@ describe('resolveExploreHarnessCommand', () => {
             product: 'omx-explore-harness',
             version: '0.8.15',
             platform: 'linux',
-            arch: 'x64',
-            archive: 'omx-explore-harness-x86_64-unknown-linux-musl.tar.gz',
+            arch: process.arch,
+            target: `${linuxTargetArch}-unknown-linux-musl`,
+            archive: archiveName,
             binary: 'omx-explore-harness',
             binary_path: 'omx-explore-harness',
             sha256: checksum,
             size: archiveBuffer.length,
-            download_url: `${server.baseUrl}/omx-explore-harness-x86_64-unknown-linux-musl.tar.gz`,
+            download_url: `${server.baseUrl}/${archiveName}`,
           }],
         }, null, 2));
 


### PR DESCRIPTION
## Summary
- replay the verified ARM64 explore hydration fixture fix from `1907032b` onto fresh `upstream/main`
- keep the tracked diff scoped to `src/cli/__tests__/explore.test.ts` only
- replace the hard-coded x64/x86_64 fixture metadata with arch-aware test expectations

## Verification
- `npm run build`
- `npm run test:explore`
  - Rust harness: `30 passed / 0 failed`
  - Node suites: `46 passed / 0 failed`

## Notes
- landed as a narrow patch replay on top of `upstream/main`
- source/replay patch-id matched exactly: `7c5bb3d3daf6eb10b320895cd0037802e419e44c`
- host card / evidence lane: CH-123
