### PR TITLE
Revert PR #1824 skill namespace contract change

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -66,7 +66,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       await mkdir(join(wd, ".omx", "state"), { recursive: true });
       await runSetupInTempDir(wd, { scope: "project" });
 
-      const skillPath = join(wd, ".codex", "skills", "omx", "help", "SKILL.md");
+      const skillPath = join(wd, ".codex", "skills", "help", "SKILL.md");
       await writeFile(skillPath, "# locally modified help\n");
 
       const output = await runSetupWithCapturedLogs(wd, {
@@ -91,7 +91,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       await mkdir(join(wd, ".omx", "state"), { recursive: true });
       await runSetupInTempDir(wd, { scope: "project" });
 
-      const skillPath = join(wd, ".codex", "skills", "omx", "help", "SKILL.md");
+      const skillPath = join(wd, ".codex", "skills", "help", "SKILL.md");
       const customized = "# locally modified help\n";
       await writeFile(skillPath, customized);
 
@@ -164,7 +164,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
           ".codex/config.toml",
           ".codex/agents/local.toml",
           ".codex/prompts/local.md",
-          ".codex/skills/omx/help/SKILL.md",
+          ".codex/skills/help/SKILL.md",
           ".codex/skills/.system/cache.json",
         ],
         { cwd: wd, encoding: "utf-8" },
@@ -173,7 +173,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       assert.match(status.stdout, /^!! \.codex\/config\.toml$/m);
       assert.match(status.stdout, /^\?\? \.codex\/agents\/local\.toml$/m);
       assert.match(status.stdout, /^\?\? \.codex\/prompts\/local\.md$/m);
-      assert.match(status.stdout, /^\?\? \.codex\/skills\/omx\/help\/SKILL\.md$/m);
+      assert.match(status.stdout, /^\?\? \.codex\/skills\/help\/SKILL\.md$/m);
       assert.match(status.stdout, /^!! \.codex\/skills\/\.system\/cache\.json$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -192,22 +192,15 @@ describe("omx setup scope behavior", () => {
       assert.equal(existsSync(localAgents), true);
       assert.equal(existsSync(join(localAgents, "executor.toml")), true);
       assert.equal(
-        existsSync(join(localSkills, "omx", "omx-setup", "SKILL.md")),
-        true,
-      );
-      const omxPluginManifest = JSON.parse(
-        await readFile(
-          join(localSkills, "omx", ".codex-plugin", "plugin.json"),
-          "utf-8",
-        ),
-      );
-      assert.equal(omxPluginManifest.name, "omx");
-      assert.equal(
-        existsSync(join(localSkills, "omx", "ask-claude", "SKILL.md")),
+        existsSync(join(localSkills, "omx-setup", "SKILL.md")),
         true,
       );
       assert.equal(
-        existsSync(join(localSkills, "omx", "ask-gemini", "SKILL.md")),
+        existsSync(join(localSkills, "ask-claude", "SKILL.md")),
+        true,
+      );
+      assert.equal(
+        existsSync(join(localSkills, "ask-gemini", "SKILL.md")),
         true,
       );
       assert.ok(

--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -16,7 +16,7 @@ describe('omx setup skills overwrite behavior', () => {
 
       await setup({ scope: 'project' });
 
-      const wikiSkill = join(wd, '.codex', 'skills', 'omx', 'wiki', 'SKILL.md');
+      const wikiSkill = join(wd, '.codex', 'skills', 'wiki', 'SKILL.md');
       assert.equal(existsSync(wikiSkill), true);
       assert.ok((await readFile(wikiSkill, 'utf-8')).includes('description: "[OMX] '));
     } finally {
@@ -34,7 +34,7 @@ describe('omx setup skills overwrite behavior', () => {
 
       await setup({ scope: 'project' });
 
-      const installedHelpSkill = join(wd, '.codex', 'skills', 'omx', 'help', 'SKILL.md');
+      const installedHelpSkill = join(wd, '.codex', 'skills', 'help', 'SKILL.md');
       const shippedHelpSkill = join(previousCwd, 'skills', 'help', 'SKILL.md');
 
       assert.ok(
@@ -64,35 +64,31 @@ describe('omx setup skills overwrite behavior', () => {
 
       const skillsDir = join(wd, '.codex', 'skills');
       const installed = new Set(await readdir(skillsDir));
-      const omxInstalled = new Set(await readdir(join(skillsDir, 'omx')));
 
-      assert.equal(installed.has('omx'), true);
-      assert.equal(installed.has('analyze'), false);
-      assert.equal(omxInstalled.has('analyze'), true);
-      assert.equal(omxInstalled.has('team'), true);
-      assert.equal(omxInstalled.has('worker'), true);
-      assert.equal(omxInstalled.has('autoresearch'), true);
-      assert.equal(omxInstalled.has('swarm'), false);
-      assert.equal(omxInstalled.has('ecomode'), false);
-      assert.equal(omxInstalled.has('ultraqa'), true);
-      assert.equal(omxInstalled.has('ralph-init'), false);
-      assert.equal(omxInstalled.has('frontend-ui-ux'), false);
-      assert.equal(omxInstalled.has('pipeline'), false);
-      assert.equal(omxInstalled.has('configure-notifications'), true);
-      assert.equal(omxInstalled.has('wiki'), true);
-      assert.equal(omxInstalled.has('configure-discord'), false);
-      assert.equal(omxInstalled.has('configure-telegram'), false);
-      assert.equal(omxInstalled.has('configure-slack'), false);
-      assert.equal(omxInstalled.has('configure-openclaw'), false);
+      assert.equal(installed.has('analyze'), true);
+      assert.equal(installed.has('team'), true);
+      assert.equal(installed.has('worker'), true);
+      assert.equal(installed.has('autoresearch'), true);
+      assert.equal(installed.has('swarm'), false);
+      assert.equal(installed.has('ecomode'), false);
+      assert.equal(installed.has('ultraqa'), true);
+      assert.equal(installed.has('ralph-init'), false);
+      assert.equal(installed.has('frontend-ui-ux'), false);
+      assert.equal(installed.has('pipeline'), false);
+      assert.equal(installed.has('configure-notifications'), true);
+      assert.equal(installed.has('wiki'), true);
+      assert.equal(installed.has('configure-discord'), false);
+      assert.equal(installed.has('configure-telegram'), false);
+      assert.equal(installed.has('configure-slack'), false);
+      assert.equal(installed.has('configure-openclaw'), false);
       assert.match(
-        await readFile(join(skillsDir, 'omx', 'analyze', 'SKILL.md'), 'utf-8'),
+        await readFile(join(skillsDir, 'analyze', 'SKILL.md'), 'utf-8'),
         /^---\nname: analyze/m,
       );
       assert.match(
-        await readFile(join(skillsDir, 'omx', 'autoresearch', 'SKILL.md'), 'utf-8'),
+        await readFile(join(skillsDir, 'autoresearch', 'SKILL.md'), 'utf-8'),
         /^---\nname: autoresearch/m,
       );
-
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -110,7 +106,7 @@ describe('omx setup skills overwrite behavior', () => {
 
       const staleSkills = ['swarm', 'ecomode', 'configure-discord', 'configure-telegram', 'configure-slack', 'configure-openclaw'];
       for (const staleSkill of staleSkills) {
-        const staleDir = join(wd, '.codex', 'skills', 'omx', staleSkill);
+        const staleDir = join(wd, '.codex', 'skills', staleSkill);
         await mkdir(staleDir, { recursive: true });
         await writeFile(join(staleDir, 'SKILL.md'), `# stale ${staleSkill}\n`);
         assert.equal(existsSync(staleDir), true);
@@ -119,9 +115,9 @@ describe('omx setup skills overwrite behavior', () => {
       await setup({ scope: 'project', force: true });
 
       for (const staleSkill of staleSkills) {
-        assert.equal(existsSync(join(wd, '.codex', 'skills', 'omx', staleSkill)), false);
+        assert.equal(existsSync(join(wd, '.codex', 'skills', staleSkill)), false);
       }
-      assert.equal(existsSync(join(wd, '.codex', 'skills', 'omx', 'team')), true);
+      assert.equal(existsSync(join(wd, '.codex', 'skills', 'team')), true);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -138,15 +134,15 @@ describe('omx setup skills overwrite behavior', () => {
       await setup({ scope: 'project' });
 
       const staleSkill = 'pipeline';
-      const staleDir = join(wd, '.codex', 'skills', 'omx', staleSkill);
+      const staleDir = join(wd, '.codex', 'skills', staleSkill);
       await mkdir(staleDir, { recursive: true });
       await writeFile(join(staleDir, 'SKILL.md'), `# stale ${staleSkill}\n`);
       assert.equal(existsSync(staleDir), true);
 
       await setup({ scope: 'project', force: true });
 
-      assert.equal(existsSync(join(wd, '.codex', 'skills', 'omx', staleSkill)), false);
-      assert.equal(existsSync(join(wd, '.codex', 'skills', 'omx', 'team')), true);
+      assert.equal(existsSync(join(wd, '.codex', 'skills', staleSkill)), false);
+      assert.equal(existsSync(join(wd, '.codex', 'skills', 'team')), true);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -162,8 +158,8 @@ describe('omx setup skills overwrite behavior', () => {
 
       await setup({ scope: 'project' });
 
-      const wikiDir = join(wd, '.codex', 'skills', 'omx', 'wiki');
-      const stalePipelineDir = join(wd, '.codex', 'skills', 'omx', 'pipeline');
+      const wikiDir = join(wd, '.codex', 'skills', 'wiki');
+      const stalePipelineDir = join(wd, '.codex', 'skills', 'pipeline');
       assert.equal(existsSync(wikiDir), true);
 
       await mkdir(stalePipelineDir, { recursive: true });
@@ -189,7 +185,7 @@ describe('omx setup skills overwrite behavior', () => {
 
       await setup({ scope: 'project' });
 
-      const skillPath = join(wd, '.codex', 'skills', 'omx', 'help', 'SKILL.md');
+      const skillPath = join(wd, '.codex', 'skills', 'help', 'SKILL.md');
       assert.equal(existsSync(skillPath), true);
 
       const installed = await readFile(skillPath, 'utf-8');
@@ -245,7 +241,7 @@ describe('omx setup skills overwrite behavior', () => {
       await setup({ scope: 'project' });
       await setup({ scope: 'project' });
 
-      const installedHelpSkill = join(wd, '.codex', 'skills', 'omx', 'help', 'SKILL.md');
+      const installedHelpSkill = join(wd, '.codex', 'skills', 'help', 'SKILL.md');
       const content = await readFile(installedHelpSkill, 'utf-8');
       const matches = content.match(/\[OMX\] Guide on using oh-my-codex plugin/g) ?? [];
       assert.equal(matches.length, 1);
@@ -269,13 +265,13 @@ describe('omx setup skills overwrite behavior', () => {
       };
 
       await setup({ scope: 'project', verbose: true });
-      await mkdir(join(wd, '.codex', 'skills', 'omx', 'swarm'), { recursive: true });
-      await writeFile(join(wd, '.codex', 'skills', 'omx', 'swarm', 'SKILL.md'), '# stale swarm\n');
+      await mkdir(join(wd, '.codex', 'skills', 'swarm'), { recursive: true });
+      await writeFile(join(wd, '.codex', 'skills', 'swarm', 'SKILL.md'), '# stale swarm\n');
       await setup({ scope: 'project', force: true, verbose: true });
 
       const output = logs.join('\n');
       assert.match(output, /skipped swarm\/ \(status: alias\)/);
-      assert.match(output, /removed stale skill omx\/swarm\/ \(status: alias\)/);
+      assert.match(output, /removed stale skill swarm\/ \(status: alias\)/);
       assert.match(output, /skills: updated=/);
     } finally {
       console.log = originalLog;
@@ -284,7 +280,7 @@ describe('omx setup skills overwrite behavior', () => {
     }
   });
 
-  it('prints a generic migration hint when legacy ~/.agents/skills exists without overlapping namespaced OMX skills', async () => {
+  it('prints a migration hint when legacy ~/.agents/skills overlaps canonical user skills', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
     const previousCwd = process.cwd();
     const previousHome = process.env.HOME;
@@ -307,8 +303,8 @@ describe('omx setup skills overwrite behavior', () => {
       await setup({ scope: 'user' });
 
       const output = logs.join('\n');
-      assert.match(output, /Migration hint: Legacy ~\/.agents\/skills still exists \(1 skills\) alongside canonical .*\.codex\/skills\./);
-      assert.match(output, /archive or remove ~\/.agents\/skills if Enable\/Disable Skills shows duplicates\./);
+      assert.match(output, /Migration hint: Detected 1 overlapping skill names between canonical .*\.codex\/skills and legacy .*\.agents\/skills\./);
+      assert.match(output, /Remove or archive ~\/\.agents\/skills after confirming .*\.codex\/skills is the version you want Codex to load\./);
     } finally {
       console.log = originalLog;
       process.chdir(previousCwd);

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -539,30 +539,6 @@ describe('omx uninstall', () => {
     }
   });
 
-  it('removes namespaced OMX skills and namespace manifest during uninstall', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
-    try {
-      const home = join(wd, 'home');
-      await mkdir(home, { recursive: true });
-
-      const setup = runOmx(wd, ['setup', '--scope', 'project'], { HOME: home });
-      if (shouldSkipForSpawnPermissions(setup.error)) return;
-      assert.equal(setup.status, 0, setup.stderr || setup.stdout);
-
-      const skillsDir = join(wd, '.codex', 'skills');
-      assert.equal(existsSync(join(skillsDir, 'omx', 'help', 'SKILL.md')), true);
-      assert.equal(existsSync(join(skillsDir, 'omx', '.codex-plugin', 'plugin.json')), true);
-
-      const res = runOmx(wd, ['uninstall', '--keep-config'], { HOME: home });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-
-      assert.equal(existsSync(join(skillsDir, 'omx')), false);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
   it('warns when overlapping legacy ~/.agents/skills remains after user-scope uninstall', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
     try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -8,7 +8,6 @@ import { join } from 'path';
 import {
   codexHome, codexConfigPath, codexPromptsDir,
   userSkillsDir, projectSkillsDir, omxStateDir, detectLegacySkillRootOverlap,
-  listInstalledSkillDirectories,
 } from '../utils/paths.js';
 import { classifySpawnError, spawnPlatformCommandSync } from '../utils/platform-command.js';
 import { getCatalogExpectations } from './catalog-contract.js';
@@ -812,12 +811,12 @@ async function checkSkills(dir: string): Promise<Check> {
     return { name: 'Skills', status: 'warn', message: 'skills directory not found' };
   }
   try {
-    const skills = (await listInstalledSkillDirectories(process.cwd()))
-      .filter((skill) => skill.path.startsWith(dir));
-    if (skills.length >= expectations.skillMin) {
-      return { name: 'Skills', status: 'pass', message: `${skills.length} skills installed` };
+    const entries = await readdir(dir, { withFileTypes: true });
+    const skillDirs = entries.filter(e => e.isDirectory());
+    if (skillDirs.length >= expectations.skillMin) {
+      return { name: 'Skills', status: 'pass', message: `${skillDirs.length} skills installed` };
     }
-    return { name: 'Skills', status: 'warn', message: `${skills.length} skills (expected >= ${expectations.skillMin})` };
+    return { name: 'Skills', status: 'warn', message: `${skillDirs.length} skills (expected >= ${expectations.skillMin})` };
   } catch {
     return { name: 'Skills', status: 'fail', message: 'cannot read skills directory' };
   }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -145,7 +145,6 @@ const PROJECT_GITIGNORE_ENTRIES = [
 ] as const;
 const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".codex/"] as const;
 const SETUP_ONLY_INSTALLABLE_SKILLS = new Set(["wiki"]);
-const OMX_SKILL_NAMESPACE = "omx";
 
 function applyScopePathRewritesToAgentsTemplate(
   content: string,
@@ -1089,7 +1088,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   console.log("\nNext steps:");
   console.log("  1. Start Codex CLI in your project directory");
   console.log(
-    "  2. Use role/workflow keywords like $architect, $executor, and $omx:plan in Codex",
+    "  2. Use role/workflow keywords like $architect, $executor, and $plan in Codex",
   );
   console.log("  3. Browse skills with /skills; AGENTS keyword routing can also activate them implicitly");
   console.log("  4. The AGENTS.md orchestration brain is loaded automatically");
@@ -1541,7 +1540,6 @@ export async function installSkills(
   ): boolean =>
     isInstallableStatus(status) || SETUP_ONLY_INSTALLABLE_SKILLS.has(skillName);
   const entries = await readdir(srcDir, { withFileTypes: true });
-  const namespacedDstDir = join(dstDir, OMX_SKILL_NAMESPACE);
   const staleCandidateSkillNames = new Set(
     manifest?.skills.map((skill) => skill.name) ?? [],
   );
@@ -1559,7 +1557,7 @@ export async function installSkills(
     }
 
     const skillSrc = join(srcDir, entry.name);
-    const skillDst = join(namespacedDstDir, entry.name);
+    const skillDst = join(dstDir, entry.name);
     const skillMd = join(skillSrc, "SKILL.md");
     if (!existsSync(skillMd)) continue;
 
@@ -1614,29 +1612,12 @@ export async function installSkills(
     }
   }
 
-  await ensureOmxSkillNamespaceManifest(
-    namespacedDstDir,
-    summary,
-    backupContext,
-    options,
-  );
-
-  const legacyFlatSkillNames = new Set(
-    [...staleCandidateSkillNames, ...installableSkills.map((skill) => skill.name)],
-  );
-  summary.removed += await cleanupLegacyFlatOmxSkills(
-    dstDir,
-    legacyFlatSkillNames,
-    backupContext,
-    options,
-  );
-
-  if (options.force && manifest && existsSync(namespacedDstDir)) {
+  if (options.force && manifest && existsSync(dstDir)) {
     for (const staleSkill of staleCandidateSkillNames) {
       const status = skillStatusByName?.get(staleSkill);
       if (isSetupInstallableSkill(staleSkill, status)) continue;
 
-      const staleSkillDir = join(namespacedDstDir, staleSkill);
+      const staleSkillDir = join(dstDir, staleSkill);
       if (!existsSync(staleSkillDir)) continue;
 
       if (!options.dryRun) {
@@ -1648,73 +1629,12 @@ export async function installSkills(
           ? "would remove stale skill"
           : "removed stale skill";
         const label = status ?? "unlisted";
-        console.log(`  ${prefix} ${OMX_SKILL_NAMESPACE}/${staleSkill}/ (status: ${label})`);
+        console.log(`  ${prefix} ${staleSkill}/ (status: ${label})`);
       }
     }
   }
 
   return summary;
-}
-
-async function cleanupLegacyFlatOmxSkills(
-  skillsDir: string,
-  skillNames: Set<string>,
-  backupContext: SetupBackupContext,
-  options: SetupOptions,
-): Promise<number> {
-  if (!existsSync(skillsDir)) return 0;
-
-  let removed = 0;
-  for (const skillName of skillNames) {
-    if (skillName === OMX_SKILL_NAMESPACE) continue;
-    const legacySkillDir = join(skillsDir, skillName);
-    if (!existsSync(legacySkillDir)) continue;
-    if (!existsSync(join(legacySkillDir, "SKILL.md"))) continue;
-
-    await ensureBackup(
-      join(legacySkillDir, "SKILL.md"),
-      true,
-      backupContext,
-      options,
-    );
-    if (!options.dryRun) {
-      await rm(legacySkillDir, { recursive: true, force: true });
-    }
-    removed += 1;
-    if (options.verbose) {
-      const prefix = options.dryRun
-        ? "would remove legacy flat OMX skill"
-        : "removed legacy flat OMX skill";
-      console.log(`  ${prefix} ${skillName}/`);
-    }
-  }
-  return removed;
-}
-
-async function ensureOmxSkillNamespaceManifest(
-  namespacedSkillsDir: string,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: SetupOptions,
-): Promise<void> {
-  const manifestPath = join(namespacedSkillsDir, ".codex-plugin", "plugin.json");
-  const manifest = JSON.stringify(
-    {
-      name: OMX_SKILL_NAMESPACE,
-      description: "oh-my-codex workflow skills",
-      version: "0.1.0",
-    },
-    null,
-    2,
-  ) + "\n";
-  await syncManagedContent(
-    manifest,
-    manifestPath,
-    summary,
-    backupContext,
-    options,
-    `${OMX_SKILL_NAMESPACE} skill namespace manifest`,
-  );
 }
 
 async function updateManagedConfig(

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -4,7 +4,7 @@
 
 import { readFile, writeFile, readdir, rm } from "fs/promises";
 import { existsSync } from "fs";
-import { join, basename, relative } from "path";
+import { join, basename } from "path";
 import {
   stripExistingOmxBlocks,
   stripOmxEnvSettings,
@@ -46,8 +46,6 @@ interface UninstallSummary {
   cacheDirectoryRemoved: boolean;
   legacySkillRootWarning: string | null;
 }
-
-const OMX_SKILL_NAMESPACE = "omx";
 
 const OMX_MCP_SERVERS = [
   "omx_state",
@@ -219,43 +217,17 @@ async function removeInstalledSkills(
 
   for (const entry of sourceEntries) {
     if (!entry.isDirectory()) continue;
-    const installed = join(skillsDir, OMX_SKILL_NAMESPACE, entry.name);
-    const legacyFlatInstalled = join(skillsDir, entry.name);
+    const installed = join(skillsDir, entry.name);
+    if (!existsSync(installed)) continue;
 
-    for (const candidate of [installed, legacyFlatInstalled]) {
-      if (!existsSync(candidate)) continue;
-
-      if (!options.dryRun) {
-        await rm(candidate, { recursive: true, force: true });
-      }
-      if (options.verbose)
-        console.log(
-          `  ${options.dryRun ? "Would remove" : "Removed"} skill: ${relative(skillsDir, candidate)}/`,
-        );
-      removed++;
+    if (!options.dryRun) {
+      await rm(installed, { recursive: true, force: true });
     }
-  }
-
-  const namespaceDir = join(skillsDir, OMX_SKILL_NAMESPACE);
-  if (existsSync(namespaceDir)) {
-    const manifestDir = join(namespaceDir, ".codex-plugin");
-    if (existsSync(manifestDir)) {
-      if (!options.dryRun) {
-        await rm(manifestDir, { recursive: true, force: true });
-      }
-      if (options.verbose) {
-        console.log(
-          `  ${options.dryRun ? "Would remove" : "Removed"} skill namespace manifest: ${relative(skillsDir, manifestDir)}/`,
-        );
-      }
-    }
-
-    const remaining = await readdir(namespaceDir).catch(() => []);
-    if (remaining.length === 0) {
-      if (!options.dryRun) {
-        await rm(namespaceDir, { recursive: true, force: true });
-      }
-    }
+    if (options.verbose)
+      console.log(
+        `  ${options.dryRun ? "Would remove" : "Removed"} skill: ${entry.name}/`,
+      );
+    removed++;
   }
 
   return removed;

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -123,8 +123,7 @@ describe('config generator', () => {
       assert.match(toml, /^model_reasoning_effort = "high"$/m);
       assert.match(toml, /^developer_instructions = "You have oh-my-codex installed/m);
       assert.match(toml, /AGENTS\.md is your orchestration brain and the main orchestration surface/);
-      assert.match(toml, /Use skill\/keyword routing like \$omx:name for OMX workflows plus spawned role-specialized subagents for specialized work/);
-      assert.match(toml, /legacy \$name remains accepted by hooks for compatibility/);
+      assert.match(toml, /Use skill\/keyword routing like \$name plus spawned role-specialized subagents for specialized work/);
       assert.match(toml, /Codex native subagents are available via \.codex\/agents/);
       assert.match(toml, /Treat installed prompts as narrower internal execution surfaces under AGENTS\.md authority/);
     } finally {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -153,7 +153,7 @@ function getOmxTopLevelLines(
     "# oh-my-codex top-level settings (must be before any [table])",
     `notify = ["node", "${escapedPath}"]`,
     'model_reasoning_effort = "high"',
-    `developer_instructions = "You have oh-my-codex installed. AGENTS.md is your orchestration brain and the main orchestration surface. Use skill/keyword routing like $omx:name for OMX workflows plus spawned role-specialized subagents for specialized work. Codex native subagents are available via .codex/agents and may be used for independent parallel subtasks within a single session or team pane. Skills are loaded from installed SKILL.md files under .codex/skills, not from native agent TOMLs. Use OMX workflow skills via $omx:name when explicitly invoked or clearly routed by AGENTS.md; legacy $name remains accepted by hooks for compatibility. Treat installed prompts as narrower internal execution surfaces under AGENTS.md authority, even when user-facing docs prefer $name keywords."`,
+    `developer_instructions = "You have oh-my-codex installed. AGENTS.md is your orchestration brain and the main orchestration surface. Use skill/keyword routing like $name plus spawned role-specialized subagents for specialized work. Codex native subagents are available via .codex/agents and may be used for independent parallel subtasks within a single session or team pane. Skills are loaded from installed SKILL.md files under .codex/skills, not from native agent TOMLs. Use workflow skills via $name when explicitly invoked or clearly routed by AGENTS.md. Treat installed prompts as narrower internal execution surfaces under AGENTS.md authority, even when user-facing docs prefer $name keywords."`,
   ];
 
   const existingModel = rootValues.get("model");

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -28,12 +28,6 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.deepEqual(matches.map((m) => m.skill), ['analyze']);
   });
 
-  it('normalizes explicit $omx-prefixed skill tokens to internal skill names', () => {
-    const matches = detectKeywords('$omx:plan $omx:team ship it');
-    assert.deepEqual(matches.map((m) => m.skill), ['plan', 'team']);
-    assert.deepEqual(matches.map((m) => m.keyword), ['$omx:plan', '$omx:team']);
-  });
-
   it('limits explicit multi-skill invocation to the first contiguous $skill block', () => {
     const matches = detectKeywords('$ralplan Fix issue #1030 and ensure other directives ($ralph, $team, $deep-interview) are not affected');
     assert.deepEqual(matches.map((m) => m.skill), ['ralplan']);

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -510,12 +510,12 @@ function normalizeWorkflowKeyboardTypos(text: string): string {
 }
 
 function hasExplicitSkillLikeInvocation(text: string): boolean {
-  return /(?:^|[^\w])\$(?:omx:)?([a-z][a-z0-9-]*)\b/i.test(text);
+  return /(?:^|[^\w])\$([a-z][a-z0-9-]*)\b/i.test(text);
 }
 
 function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
   const results: KeywordMatch[] = [];
-  const regex = /(?:^|[^\w])\$(?:omx:)?([a-z][a-z0-9-]*)\b/gi;
+  const regex = /(?:^|[^\w])\$([a-z][a-z0-9-]*)\b/gi;
   let match: RegExpExecArray | null;
   let captureStarted = false;
   let lastMatchEnd = -1;
@@ -535,14 +535,12 @@ function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
     }
 
     captureStarted = true;
-    lastMatchEnd = regex.lastIndex;
+    lastMatchEnd = matchStart + token.length + 1;
 
     if (results.some((item) => item.skill === normalizedSkill)) continue;
 
-    const invocationPrefix = match[0].includes('$omx:') ? '$omx:' : '$';
-
     results.push({
-      keyword: `${invocationPrefix}${token}`,
+      keyword: `$${token}`,
       skill: normalizedSkill,
       priority: registryEntry.priority,
     });

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -240,19 +240,16 @@ describe("listInstalledSkillDirectories", () => {
       );
       const userHelpDir = join(codexHomeRoot, "skills", "help");
       const userOnlyDir = join(codexHomeRoot, "skills", "user-only");
-      const userNamespacedPlanDir = join(codexHomeRoot, "skills", "omx", "plan");
 
       await mkdir(projectHelpDir, { recursive: true });
       await mkdir(projectOnlyDir, { recursive: true });
       await mkdir(userHelpDir, { recursive: true });
       await mkdir(userOnlyDir, { recursive: true });
-      await mkdir(userNamespacedPlanDir, { recursive: true });
 
       await writeFile(join(projectHelpDir, "SKILL.md"), "# project help\n");
       await writeFile(join(projectOnlyDir, "SKILL.md"), "# project only\n");
       await writeFile(join(userHelpDir, "SKILL.md"), "# user help\n");
       await writeFile(join(userOnlyDir, "SKILL.md"), "# user only\n");
-      await writeFile(join(userNamespacedPlanDir, "SKILL.md"), "# user namespaced plan\n");
 
       const skills = await listInstalledSkillDirectories(projectRoot);
 
@@ -264,7 +261,6 @@ describe("listInstalledSkillDirectories", () => {
         [
           { name: "help", scope: "project" },
           { name: "project-only", scope: "project" },
-          { name: "omx:plan", scope: "user" },
           { name: "user-only", scope: "user" },
         ],
       );

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -185,31 +185,15 @@ async function readInstalledSkillsFromDir(
   if (!existsSync(dir)) return [];
 
   const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
-  const skills: InstalledSkillDirectory[] = [];
-
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const entryPath = join(dir, entry.name);
-    if (existsSync(join(entryPath, "SKILL.md"))) {
-      skills.push({ name: entry.name, path: entryPath, scope });
-      continue;
-    }
-    if (entry.name.startsWith(".")) continue;
-
-    const nestedEntries = await readdir(entryPath, { withFileTypes: true }).catch(() => []);
-    for (const nestedEntry of nestedEntries) {
-      if (!nestedEntry.isDirectory()) continue;
-      const nestedPath = join(entryPath, nestedEntry.name);
-      if (!existsSync(join(nestedPath, "SKILL.md"))) continue;
-      skills.push({
-        name: `${entry.name}:${nestedEntry.name}`,
-        path: nestedPath,
-        scope,
-      });
-    }
-  }
-
-  return skills.sort((a, b) => a.name.localeCompare(b.name));
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      name: entry.name,
+      path: join(dir, entry.name),
+      scope,
+    }))
+    .filter((entry) => existsSync(join(entry.path, "SKILL.md")))
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /**

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -226,8 +226,8 @@ Specialists remain available through the role catalog and native child-agent sur
 Keyword routing is implemented primarily by native `UserPromptSubmit` hooks and the generated keyword registry. Treat hook-injected routing context as authoritative for the current turn, then load the named `SKILL.md` or prompt file as instructed.
 
 Fallback behavior when hook context is unavailable:
-- Explicit `$omx:name` invocations run left-to-right and override implicit keywords; legacy `$name` remains accepted for backward compatibility.
-- Bare skill names do not activate skills by themselves; skill-name activation requires explicit `$skill` invocation. Natural-language routing phrases may still map to a workflow when they are not just the bare skill name. Examples: `analyze` / `investigate` → `$analyze` for read-only deep analysis with ranked synthesis, explicit confidence, and concrete file references; `deep interview`, `interview`, `don't assume`, or `ouroboros` → `$omx:deep-interview`; `ralplan` / `consensus plan` → `$omx:ralplan`; `cancel`, `stop`, or `abort` → `$omx:cancel`.
+- Explicit `$name` invocations run left-to-right and override implicit keywords.
+- Bare skill names do not activate skills by themselves; skill-name activation requires explicit `$skill` invocation. Natural-language routing phrases may still map to a workflow when they are not just the bare skill name. Examples: `analyze` / `investigate` → `$analyze` for read-only deep analysis with ranked synthesis, explicit confidence, and concrete file references; `deep interview`, `interview`, `don't assume`, or `ouroboros` → `$deep-interview`; `ralplan` / `consensus plan` → `$ralplan`; `cancel`, `stop`, or `abort` → `$cancel`.
 - Keep the detailed keyword list in `src/hooks/keyword-registry.ts`; do not duplicate that table here.
 
 Runtime availability gate:


### PR DESCRIPTION
## Summary
- Reverts merge commit `7e97504a1a168ba5fbf536fc834a6d63ea3064b8` from PR #1824.
- Restores the approved user-facing OMX skill namespace/install contract.
- Records the owner directive that user-facing orchestration contract changes require explicit owner confirmation.

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/setup-skills-overwrite.test.js dist/cli/__tests__/uninstall.test.js dist/config/__tests__/generator-notify.test.js dist/hooks/__tests__/keyword-detector.test.js dist/utils/__tests__/paths.test.js`
