### PR TITLE
Require summary gates for oversized deep interviews

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -49,6 +49,10 @@ If no flag is provided, use **Standard**.
 - Gather codebase facts via `explore` before asking user about internals
 - When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only brownfield fact gathering; keep prompts narrow and concrete, and keep ambiguous or non-shell-only investigation on the richer normal path and fall back normally if `omx explore` is unavailable.
 - Always run a preflight context intake before the first interview question
+- If initial context is oversized or would exceed the prompt budget, do not paste or forward the raw payload into interview prompts; request and record a prompt-safe initial-context summary first
+- The oversized initial-context summary gate is blocking: wait for the concise summary before ambiguity scoring, crystallizing artifacts, or any downstream execution handoff
+- The summary must preserve goals, constraints, success criteria, non-goals, decision boundaries, and references to any full source documents so downstream consumers receive a prompt-safe but faithful context
+- Keep total prompt payloads within a safe budget by summarizing or trimming retained history; preserve newest/highest-signal answers and never let raw oversized context crowd out the current question
 - Reduce user effort: ask only the highest-leverage unresolved question, and never ask the user for codebase facts that can be discovered directly
 - For brownfield work, prefer evidence-backed confirmation questions such as "I found X in Y. Should this change follow that pattern?"
 - In Codex CLI, deep-interview uses `omx question` as the required OMX-owned structured questioning path for every interview round
@@ -67,7 +71,8 @@ If no flag is provided, use **Standard**.
 
 1. Parse `{{ARGUMENTS}}` and derive a short task slug.
 2. Attempt to load the latest relevant context snapshot from `.omx/context/{slug}-*.md`.
-3. If no snapshot exists, create a minimum context snapshot with:
+3. Check whether the provided initial context or loaded snapshot is too large for safe prompt use. If it is oversized, the first interview round must ask for a concise prompt-safe summary instead of scoring ambiguity or continuing to downstream handoff.
+4. If no snapshot exists, create a minimum context snapshot with:
    - Task statement
    - Desired outcome
    - Stated solution (what the user asked for)
@@ -77,7 +82,8 @@ If no flag is provided, use **Standard**.
    - Unknowns/open questions
    - Decision-boundary unknowns
    - Likely codebase touchpoints
-4. Save snapshot to `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) and reference it in mode state.
+   - Prompt-safe initial-context summary status (`not_needed`, `needed`, or `recorded`)
+5. Save snapshot to `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) and reference it in mode state.
 
 ## Phase 1: Initialize
 
@@ -116,6 +122,8 @@ If no flag is provided, use **Standard**.
 Repeat until ambiguity `<= threshold`, the pressure pass is complete, the readiness gates are explicit, the user exits with warning, or max rounds are reached.
 
 ### 2a) Generate next question
+If the initial context is oversized and no prompt-safe summary has been recorded yet, the next question must be only a summary request. Do not score ambiguity, do not run readiness gates, and do not hand off to `$ralplan`, `$autopilot`, `$ralph`, or `$team` until that summary answer is captured.
+
 Use:
 - Original idea
 - Prior Q&A rounds
@@ -293,6 +301,7 @@ When threshold is met (or user exits with warning / hard cap):
 Spec should include:
 - Metadata (profile, rounds, final ambiguity, threshold, context type)
 - Context snapshot reference/path (for ralplan/team reuse)
+- Prompt-safe initial-context summary when oversized context was provided, plus references to any full source documents
 - Clarity breakdown table
 - Intent (why the user wants this)
 - Desired Outcome
@@ -392,6 +401,7 @@ Present execution options after artifact generation using explicit handoff contr
 - If `omx question` is unavailable in the current runtime, stop and surface that deep-interview requires the OMX question tool rather than falling back to another questioning path
 - Use `state_write` / `state_read` for resumable mode state
 - Read/write context snapshots under `.omx/context/`
+- Record whether the oversized-context summary gate is not needed, pending, or satisfied before any scoring or handoff step
 - Save transcript/spec artifacts under `.omx/interviews/` and `.omx/specs/`
 </Tool_Usage>
 
@@ -404,6 +414,7 @@ Present execution options after artifact generation using explicit handoff contr
 
 <Final_Checklist>
 - [ ] Preflight context snapshot exists under `.omx/context/{slug}-{timestamp}.md`
+- [ ] Oversized initial context, if present, has a prompt-safe summary recorded before ambiguity scoring or downstream handoff
 - [ ] Ambiguity score shown each round
 - [ ] Intent-first stage priority used before implementation detail
 - [ ] Weakest-dimension targeting used within the active stage

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -258,6 +258,25 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.match(deepInterviewSkill, /\.omx\/specs\//);
 	});
 
+	it("requires prompt-safe summary gating for oversized initial context", () => {
+		assert.match(deepInterviewSkill, /prompt-safe initial-context summary/i);
+		assert.match(deepInterviewSkill, /oversized initial context/i);
+		assert.match(deepInterviewSkill, /do not paste or forward the raw payload/i);
+		assert.match(deepInterviewSkill, /wait for the concise summary before ambiguity scoring, crystallizing artifacts, or any downstream execution handoff/i);
+		assert.match(deepInterviewSkill, /The oversized initial-context summary gate is blocking/i);
+		assert.match(deepInterviewSkill, /Do not score ambiguity, do not run readiness gates, and do not hand off to `\$ralplan`, `\$autopilot`, `\$ralph`, or `\$team` until that summary answer is captured/i);
+		assert.match(deepInterviewSkill, /goals, constraints, success criteria, non-goals, decision boundaries/i);
+	});
+
+	it("documents total prompt-budget hardening for retained context", () => {
+		assert.match(deepInterviewSkill, /Keep total prompt payloads within a safe budget/i);
+		assert.match(deepInterviewSkill, /summarizing or trimming retained history/i);
+		assert.match(deepInterviewSkill, /preserve newest\/highest-signal answers/i);
+		assert.match(deepInterviewSkill, /Prompt-safe initial-context summary when oversized context was provided/i);
+		assert.match(deepInterviewSkill, /summary gate is not needed, pending, or satisfied/i);
+		assert.match(deepInterviewSkill, /before any scoring or handoff step/i);
+	});
+
 	it("requires preflight context intake before interview rounds", () => {
 		assert.match(deepInterviewSkill, /Phase 0: Preflight Context Intake/i);
 		assert.match(


### PR DESCRIPTION
## Summary
- Align deep-interview skill guidance with Ouroboros prompt-budget hardening.
- Require prompt-safe oversized initial-context summaries before ambiguity scoring and downstream handoff.
- Add contract coverage for summary-before-scoring/downstream prompt-budget behavior while preserving `omx question` semantics.

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/deep-interview-contract.test.js`
- `npx biome lint src/hooks/__tests__/deep-interview-contract.test.ts`

## Notes
- Runtime hook behavior was not changed; this PR updates the workflow contract and tests only.
