### PR TITLE
fix: reconcile answered deep-interview question state before Stop re-prompts

### DIFF
--- a/src/question/__tests__/deep-interview.test.ts
+++ b/src/question/__tests__/deep-interview.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, it } from 'node:test';
 import { OmxQuestionError, type OmxQuestionProcessRunner } from '../client.js';
-import { runDeepInterviewQuestion } from '../deep-interview.js';
+import {
+  reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords,
+  runDeepInterviewQuestion,
+} from '../deep-interview.js';
 
 const tempDirs: string[] = [];
 
@@ -213,6 +216,85 @@ describe('runDeepInterviewQuestion', () => {
     assert.equal(finalState.question_enforcement?.lifecycle_outcome, 'askuserQuestion');
     assert.equal(finalState.question_enforcement?.clear_reason, 'error');
     assert.ok(finalState.question_enforcement?.cleared_at);
+    assert.equal(finalState.lifecycle_outcome, undefined);
+    assert.equal(finalState.run_outcome, undefined);
+  });
+
+  it('reconciles a pending obligation from an already-answered same-session question record', async () => {
+    const cwd = await makeRepo();
+    const statePath = join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'deep-interview-state.json');
+    const questionsDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'questions');
+    await mkdir(questionsDir, { recursive: true });
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        active: false,
+        mode: 'deep-interview',
+        current_phase: 'intent-first',
+        started_at: '2026-04-19T00:00:00.000Z',
+        updated_at: '2026-04-19T00:00:00.000Z',
+        completed_at: '2026-04-19T00:00:30.000Z',
+        session_id: 'sess-di',
+        lifecycle_outcome: 'askuserQuestion',
+        run_outcome: 'blocked_on_user',
+        question_enforcement: {
+          obligation_id: 'obligation-answered-record',
+          source: 'omx-question',
+          status: 'pending',
+          lifecycle_outcome: 'askuserQuestion',
+          requested_at: '2026-04-19T00:00:10.000Z',
+        },
+      }, null, 2),
+    );
+    await writeFile(
+      join(questionsDir, 'question-answered.json'),
+      JSON.stringify({
+        kind: 'omx.question/v1',
+        question_id: 'question-answered',
+        session_id: 'sess-di',
+        created_at: '2026-04-19T00:00:12.000Z',
+        updated_at: '2026-04-19T00:00:20.000Z',
+        status: 'answered',
+        question: 'What should happen next?',
+        options: [{ label: 'Launch', value: 'launch' }],
+        allow_other: false,
+        other_label: 'Other',
+        multi_select: false,
+        type: 'single-answerable',
+        source: 'deep-interview',
+        answer: {
+          kind: 'option',
+          value: 'launch',
+          selected_labels: ['Launch'],
+          selected_values: ['launch'],
+        },
+      }, null, 2),
+    );
+
+    const reconciled = await reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords(
+      cwd,
+      'sess-di',
+      new Date('2026-04-19T00:00:21.000Z'),
+    );
+
+    assert.equal(reconciled?.question_enforcement?.status, 'satisfied');
+    assert.equal(reconciled?.question_enforcement?.question_id, 'question-answered');
+    assert.equal(reconciled?.question_enforcement?.satisfied_at, '2026-04-19T00:00:21.000Z');
+    assert.equal(reconciled?.lifecycle_outcome, undefined);
+    assert.equal(reconciled?.run_outcome, undefined);
+
+    const finalState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+      lifecycle_outcome?: string;
+      question_enforcement?: {
+        status?: string;
+        question_id?: string;
+        satisfied_at?: string;
+      };
+      run_outcome?: string;
+    };
+    assert.equal(finalState.question_enforcement?.status, 'satisfied');
+    assert.equal(finalState.question_enforcement?.question_id, 'question-answered');
+    assert.equal(finalState.question_enforcement?.satisfied_at, '2026-04-19T00:00:21.000Z');
     assert.equal(finalState.lifecycle_outcome, undefined);
     assert.equal(finalState.run_outcome, undefined);
   });

--- a/src/question/deep-interview.ts
+++ b/src/question/deep-interview.ts
@@ -1,13 +1,18 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { getStateFilePath, readCurrentSessionId } from '../mcp/state-paths.js';
 import {
   runOmxQuestion,
   type OmxQuestionClientOptions,
   type OmxQuestionSuccessPayload,
 } from './client.js';
+import {
+  getQuestionRecordPath,
+  getQuestionStateDir,
+  readQuestionRecord,
+} from './state.js';
 import type { TerminalLifecycleOutcome } from '../runtime/terminal-lifecycle.js';
-import type { QuestionInput } from './types.js';
+import type { QuestionInput, QuestionRecord } from './types.js';
 
 const DEEP_INTERVIEW_STATE_FILE = 'deep-interview-state.json';
 
@@ -32,6 +37,13 @@ interface DeepInterviewStateRecord {
 
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
+}
+
+function parseTimestampMs(value: unknown): number | null {
+  const raw = safeString(value).trim();
+  if (!raw) return null;
+  const timestamp = Date.parse(raw);
+  return Number.isFinite(timestamp) ? timestamp : null;
 }
 
 function buildObligationId(now = new Date()): string {
@@ -109,6 +121,71 @@ export function clearDeepInterviewQuestionObligation(
   };
 }
 
+function isSameSessionQuestionRecord(record: QuestionRecord, sessionId: string): boolean {
+  const recordSessionId = safeString(record.session_id).trim();
+  return !recordSessionId || recordSessionId === sessionId;
+}
+
+function isAnsweredDeepInterviewRecordForObligation(
+  record: QuestionRecord | null,
+  sessionId: string,
+  enforcement: DeepInterviewQuestionEnforcementState,
+): record is QuestionRecord {
+  if (!record) return false;
+  if (!isSameSessionQuestionRecord(record, sessionId)) return false;
+  if (safeString(record.source).trim() !== 'deep-interview') return false;
+  if (record.status !== 'answered' || !record.answer) return false;
+
+  const requestedAtMs = parseTimestampMs(enforcement.requested_at);
+  const createdAtMs = parseTimestampMs(record.created_at);
+  if (requestedAtMs !== null && (createdAtMs === null || createdAtMs < requestedAtMs)) {
+    return false;
+  }
+
+  return true;
+}
+
+async function findAnsweredDeepInterviewRecordForObligation(
+  cwd: string,
+  sessionId: string,
+  enforcement: DeepInterviewQuestionEnforcementState,
+): Promise<QuestionRecord | null> {
+  const exactQuestionId = safeString(enforcement.question_id).trim();
+  if (exactQuestionId) {
+    const exactRecord = await readQuestionRecord(
+      getQuestionRecordPath(cwd, exactQuestionId, sessionId),
+    );
+    if (isAnsweredDeepInterviewRecordForObligation(exactRecord, sessionId, enforcement)) {
+      return exactRecord;
+    }
+  }
+
+  let entries: string[];
+  try {
+    entries = await readdir(getQuestionStateDir(cwd, sessionId));
+  } catch {
+    return null;
+  }
+
+  const candidates: QuestionRecord[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue;
+    const record = await readQuestionRecord(join(getQuestionStateDir(cwd, sessionId), entry));
+    if (isAnsweredDeepInterviewRecordForObligation(record, sessionId, enforcement)) {
+      candidates.push(record);
+    }
+  }
+
+  candidates.sort((left, right) => {
+    const leftCreatedAt = parseTimestampMs(left.created_at) ?? 0;
+    const rightCreatedAt = parseTimestampMs(right.created_at) ?? 0;
+    if (leftCreatedAt !== rightCreatedAt) return leftCreatedAt - rightCreatedAt;
+    return left.question_id.localeCompare(right.question_id);
+  });
+
+  return candidates[0] ?? null;
+}
+
 export async function updateDeepInterviewQuestionEnforcement(
   cwd: string,
   sessionId: string | undefined,
@@ -148,6 +225,39 @@ export async function updateDeepInterviewQuestionEnforcement(
 
   await writeDeepInterviewState(cwd, nextState, sessionId);
   return nextState;
+}
+
+export async function reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords(
+  cwd: string,
+  sessionId: string | undefined,
+  now = new Date(),
+): Promise<DeepInterviewStateRecord | null> {
+  const normalizedSessionId = safeString(sessionId).trim();
+  if (!normalizedSessionId) return null;
+
+  const state = await readDeepInterviewStateIfExists(cwd, normalizedSessionId);
+  const enforcement = state?.question_enforcement;
+  if (!state || !isPendingDeepInterviewQuestionEnforcement(enforcement)) {
+    return state;
+  }
+
+  const answeredRecord = await findAnsweredDeepInterviewRecordForObligation(
+    cwd,
+    normalizedSessionId,
+    enforcement,
+  );
+  if (!answeredRecord) return state;
+
+  return await updateDeepInterviewQuestionEnforcement(
+    cwd,
+    normalizedSessionId,
+    (current) => (
+      current?.obligation_id === enforcement.obligation_id
+        && isPendingDeepInterviewQuestionEnforcement(current)
+        ? satisfyDeepInterviewQuestionObligation(current, answeredRecord.question_id, now)
+        : current
+    ),
+  );
 }
 
 export async function runDeepInterviewQuestion(

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3479,6 +3479,91 @@ esac
     }
   });
 
+  it("does not re-block Stop after a same-session deep-interview question record is already answered", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-question-answered-"));
+    try {
+      const sessionId = "sess-stop-deep-interview-question-answered";
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionDir = join(stateDir, "sessions", sessionId);
+      await mkdir(join(sessionDir, "questions"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: sessionId,
+        thread_id: "thread-stop-deep-interview-question-answered",
+      });
+      await writeJson(join(sessionDir, "deep-interview-state.json"), {
+        active: false,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        lifecycle_outcome: "askuserQuestion",
+        run_outcome: "blocked_on_user",
+        completed_at: "2026-04-19T03:20:30.000Z",
+        session_id: sessionId,
+        thread_id: "thread-stop-deep-interview-question-answered",
+        question_enforcement: {
+          obligation_id: "obligation-answered",
+          source: "omx-question",
+          status: "pending",
+          lifecycle_outcome: "askuserQuestion",
+          requested_at: "2026-04-19T03:20:00.000Z",
+        },
+      });
+      await writeJson(join(sessionDir, "questions", "question-answered.json"), {
+        kind: "omx.question/v1",
+        question_id: "question-answered",
+        session_id: sessionId,
+        created_at: "2026-04-19T03:20:05.000Z",
+        updated_at: "2026-04-19T03:20:10.000Z",
+        status: "answered",
+        question: "What should happen next?",
+        options: [{ label: "Continue", value: "continue" }],
+        allow_other: false,
+        other_label: "Other",
+        multi_select: false,
+        type: "single-answerable",
+        source: "deep-interview",
+        answer: {
+          kind: "option",
+          value: "continue",
+          selected_labels: ["Continue"],
+          selected_values: ["continue"],
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-stop-deep-interview-question-answered",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+
+      const state = JSON.parse(
+        await readFile(join(sessionDir, "deep-interview-state.json"), "utf-8"),
+      ) as {
+        lifecycle_outcome?: string;
+        question_enforcement?: { status?: string; question_id?: string; satisfied_at?: string };
+        run_outcome?: string;
+      };
+      assert.equal(state.question_enforcement?.status, "satisfied");
+      assert.equal(state.question_enforcement?.question_id, "question-answered");
+      assert.ok(state.question_enforcement?.satisfied_at);
+      assert.equal(state.lifecycle_outcome, undefined);
+      assert.equal(state.run_outcome, undefined);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps blocking pending deep-interview question Stop replays until the obligation changes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-question-replay-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -62,7 +62,10 @@ import {
   promptSignature,
   type TriageStateFile,
 } from "../hooks/triage-state.js";
-import { isPendingDeepInterviewQuestionEnforcement } from "../question/deep-interview.js";
+import {
+  isPendingDeepInterviewQuestionEnforcement,
+  reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords,
+} from "../question/deep-interview.js";
 import { resolveOmxCliEntryPath } from "../utils/paths.js";
 
 type CodexHookEventName =
@@ -1082,6 +1085,7 @@ async function buildDeepInterviewQuestionStopOutput(
   sessionId: string,
   threadId: string,
 ): Promise<{ output: Record<string, unknown>; obligationId: string } | null> {
+  await reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords(cwd, sessionId);
   const modeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId);
   if (!modeState) return null;
 


### PR DESCRIPTION
## Summary
- reconcile pending deep-interview question obligations from already-answered same-session question records
- clear stale `askuserQuestion` / `blocked_on_user` state before native Stop decides to block again
- add regression coverage for both the deep-interview reconciliation helper and the Stop-hook replay path

## Testing
- `npm run build`
- `node --test dist/question/__tests__/deep-interview.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npx biome lint src/question/deep-interview.ts src/question/__tests__/deep-interview.test.ts src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts`
- `git diff --check`

Refs #1828
