### PR TITLE
Sync ultrawork protocol with upstream

### DIFF
--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -4,58 +4,80 @@ description: Parallel execution engine for high-throughput task completion
 ---
 
 <Purpose>
-Ultrawork is a parallel execution engine that runs multiple agents simultaneously for independent tasks. It is a component, not a standalone persistence mode -- it provides parallelism and smart model routing but not persistence, verification loops, or state management.
+Ultrawork is a parallel execution engine for high-throughput task completion. It is a component, not a standalone persistence mode: it provides parallelism, context discipline, and smart delegation guidance, but not Ralph's persistence loop, architect sign-off, or long-running completion guarantees.
 </Purpose>
 
 <Use_When>
 - Multiple independent tasks can run simultaneously
-- User says "ulw", "ultrawork", or wants parallel execution
-- You need to delegate work to multiple agents at once
-- Task benefits from concurrent execution but the user will manage completion themselves
+- User says "ulw", "ultrawork", or explicitly wants parallel execution
+- Task benefits from concurrent execution plus lightweight evidence before wrap-up
+- You need a direct-tool lane plus optional background evidence lanes without entering Ralph
 </Use_When>
 
 <Do_Not_Use_When>
-- Task requires guaranteed completion with verification -- use `ralph` instead (ralph includes ultrawork)
-- Task requires a full autonomous pipeline -- use `autopilot` instead (autopilot includes ralph which includes ultrawork)
-- There is only one sequential task with no parallelism opportunity -- delegate directly to an executor agent
-- User needs session persistence for resume -- use `ralph` which adds persistence on top of ultrawork
+- Task requires guaranteed completion with persistence, architect verification, or deslop/reverification -- use `ralph` instead (Ralph includes ultrawork)
+- Task requires a full autonomous pipeline -- use `autopilot` instead (autopilot includes Ralph which includes ultrawork)
+- There is only one sequential task with no parallelism opportunity -- execute directly or delegate to a single `executor`
+- The request is still in plan-consensus mode -- keep planning artifacts in `ralplan` until execution is explicitly authorized
+- User needs session persistence for resume -- use `ralph`, which adds persistence on top of ultrawork
 </Do_Not_Use_When>
 
 <Why_This_Exists>
-Sequential task execution wastes time when tasks are independent. Ultrawork enables firing multiple agents simultaneously and routing each to the right model tier, reducing total execution time while controlling token costs. It is designed as a composable component that ralph and autopilot layer on top of.
+Sequential task execution wastes time when tasks are independent. Ultrawork keeps the execution branch fast while tightening the protocol: gather enough context first, define pass/fail acceptance criteria before editing, decide deliberately between local execution and delegation, and finish with evidence rather than vibes.
 </Why_This_Exists>
 
 <Execution_Policy>
-- Fire all independent agent calls simultaneously -- never serialize independent work
-- Always pass the `model` parameter explicitly when delegating
-- Read `docs/shared/agent-tiers.md` before first delegation for agent selection guidance
-- Auto-delegate `researcher` when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect task correctness; treat it as an evidence lane, not a replacement primary workflow
-- Use `run_in_background: true` for operations over ~30 seconds (installs, builds, tests)
-- Run quick commands (git status, file reads, simple checks) in the foreground
+- Gather enough context before implementation. Start with the task intent, desired outcome, constraints, likely touchpoints, and any uncertainty that would change the execution path.
+- If uncertainty is still material after a quick repo read, do a focused evidence pass first instead of immediately editing.
+- Define pass/fail acceptance criteria before launching execution lanes. Include the command, artifact, or manual check that will prove success.
+- Prefer direct tool work when the task is small, coupled, or blocked on immediate local context. Delegate only when the work is independent enough to benefit from parallel execution.
+- When useful, run a direct-tool lane and one or more background evidence lanes at the same time. Evidence lanes can cover docs, tests, regression mapping, or bounded repo analysis.
+- Fire independent agent calls simultaneously -- never serialize independent work.
+- Always pass the `model` parameter explicitly when delegating.
+- Read `docs/shared/agent-tiers.md` before first delegation for agent selection guidance.
+- Auto-delegate `researcher` when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect task correctness; treat it as an evidence lane, not a replacement primary workflow.
+- Use `run_in_background: true` for operations over ~30 seconds (installs, builds, tests).
+- Run quick commands (git status, file reads, simple checks) in the foreground.
+- Default to concise, evidence-dense progress and completion reporting. If a lane is speculative or blocked, say so explicitly.
+- Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints.
+- If the user says `continue` after ultrawork already has a clear next step, continue the current execution branch instead of restarting planning or asking for reconfirmation.
 </Execution_Policy>
 
 <Steps>
-1. **Read agent reference**: Load `docs/shared/agent-tiers.md` for tier selection
-2. **Classify tasks by independence**: Identify which tasks can run in parallel vs which have dependencies
-3. **Route to correct tiers**:
-   - Simple lookups/definitions: LOW tier
-   - Standard implementation: STANDARD tier
-   - Complex analysis/refactoring: THOROUGH tier
-4. **Fire independent tasks simultaneously**: Launch all parallel-safe tasks at once
-5. **Run dependent tasks sequentially**: Wait for prerequisites before launching dependent work
-6. **Background long operations**: Builds, installs, and test suites use `run_in_background: true`
-7. **Verify when all tasks complete** (lightweight):
-   - Build/typecheck passes
-   - Affected tests pass
-   - No new errors introduced
+1. **Read agent reference**: Load `docs/shared/agent-tiers.md` for tier selection.
+2. **Context + certainty check**:
+   - State the task intent in one sentence.
+   - List the constraints and unknowns that could invalidate a quick fix.
+   - If confidence is low, explore first and narrow the task before editing.
+3. **Define acceptance criteria before execution**:
+   - What must be true at the end?
+   - Which command or artifact proves it?
+   - Which manual QA check is required, if any?
+4. **Classify the work by dependency shape**:
+   - Independent tasks -> parallel lanes.
+   - Shared-file or prerequisite-heavy tasks -> local execution or staged lanes.
+5. **Choose self vs delegate deliberately**:
+   - Work locally when the next step depends on immediate repo context, shared files, or tight iteration.
+   - Delegate when the task slice is bounded, independent, and materially improves throughput.
+6. **Run execution lanes**:
+   - Direct-tool lane for immediate implementation or verification work.
+   - Background evidence lanes for tests, docs, repo analysis, or regression checks.
+7. **Run dependent tasks sequentially**: Wait for prerequisites before launching dependent work.
+8. **Close with lightweight evidence**:
+   - Build/typecheck passes when relevant.
+   - Affected tests pass.
+   - Manual QA notes are recorded when the task needs a human-visible or behavior-level check.
+   - No new errors introduced.
 </Steps>
 
 <Tool_Usage>
-- Use LOW-tier delegation for simple changes
-- Use STANDARD-tier delegation for standard work
-- Use THOROUGH-tier delegation for complex work
-- Use `run_in_background: true` for package installs, builds, and test suites
-- Use foreground execution for quick status checks and file operations
+- Use LOW-tier delegation for simple lookups and bounded evidence gathering.
+- Use STANDARD-tier delegation for standard implementation and regression work.
+- Use THOROUGH-tier delegation for complex analysis, architectural review, or risky multi-file changes.
+- Prefer a direct-tool lane when the immediate next step is blocked on local context.
+- Prefer background evidence lanes when you can learn something useful in parallel with implementation.
+- Use `run_in_background: true` for package installs, builds, and test suites.
+- Use foreground execution for quick status checks and file operations.
 </Tool_Usage>
 
 ## State Management
@@ -73,64 +95,74 @@ Use `omx_state` MCP tools for ultrawork lifecycle state.
 
 <Examples>
 <Good>
-Three independent tasks fired simultaneously:
+Two-track execution with acceptance criteria up front:
 ```
-delegate(role="executor", tier="LOW", task="Add missing type export for Config interface")
-delegate(role="executor", tier="STANDARD", task="Implement the /api/users endpoint with validation")
-delegate(role="test-engineer", tier="STANDARD", task="Add integration tests for the auth middleware")
+Acceptance criteria:
+- `npm run build` passes
+- `node --test dist/scripts/__tests__/codex-native-hook.test.js` passes
+- Manual QA: verify `$ultrawork` activation message still points to the session state file
+
+Direct-tool lane:
+- update `skills/ultrawork/SKILL.md`
+
+Background evidence lane:
+- delegate(role="test-engineer", tier="STANDARD", task="Map which hook tests cover ultrawork activation messaging", model="...")
 ```
-Why good: Independent tasks at appropriate tiers, all fired at once.
+Why good: Context is grounded first, acceptance criteria are explicit, and the direct-tool lane runs alongside a bounded evidence lane.
 </Good>
 
 <Good>
-Correct use of background execution:
+Correct use of self-vs-delegate judgment:
 ```
-delegate(role="executor", tier="STANDARD", task="npm install && npm run build", run_in_background=true)
-delegate(role="writer", tier="LOW", task="Update the README with new API endpoints")
+Shared-file edit in progress across `src/scripts/codex-native-hook.ts` and its test -> keep implementation local.
+Independent regression mapping for keyword-detector coverage -> delegate to a test-engineer lane.
 ```
-Why good: Long build runs in background while short task runs in foreground.
+Why good: Shared-file work stays local; independent evidence work fans out.
 </Good>
 
 <Bad>
-Sequential execution of independent work:
+Parallelizing before the task is grounded:
 ```
-result1 = delegate(executor, LOW, "Add type export")  # wait...
-result2 = delegate(executor, STANDARD, "Implement endpoint")     # wait...
-result3 = delegate(test-engineer, STANDARD, "Add tests")              # wait...
+delegate(role="executor", tier="STANDARD", task="Implement whatever seems necessary", model="...")
+delegate(role="test-engineer", tier="STANDARD", task="Figure out how to test it later", model="...")
 ```
-Why bad: These tasks are independent. Running them sequentially wastes time.
+Why bad: No context snapshot, no pass/fail target, and delegation starts before the work is shaped.
 </Bad>
 
 <Bad>
-Wrong tier selection:
+Claiming success without evidence or manual QA:
 ```
-delegate(role="executor", tier="THOROUGH", task="Add a missing semicolon")
+Made the changes. Ultrawork should be updated now.
 ```
-Why bad: THOROUGH tier is expensive overkill for a trivial fix. Use LOW-tier execution instead.
+Why bad: No verification output, no acceptance evidence, and no manual QA note when the behavior is user-visible.
 </Bad>
 </Examples>
 
 <Escalation_And_Stop_Conditions>
-- When ultrawork is invoked directly (not via ralph), apply lightweight verification only -- build passes, tests pass, no new errors
-- For full persistence and comprehensive architect verification, recommend switching to `ralph` mode
-- If a task fails repeatedly across retries, report the issue rather than retrying indefinitely
-- Escalate to the user when tasks have unclear dependencies or conflicting requirements
+- When ultrawork is invoked directly (not via Ralph), apply lightweight verification only -- build/typecheck passes when relevant, affected tests pass, and manual QA notes are captured when needed.
+- Ralph owns persistence, architect verification, deslop, and the full verified-completion promise. Do not claim those guarantees from direct ultrawork alone.
+- If a task fails repeatedly across retries, report the issue rather than retrying indefinitely.
+- Escalate to the user when tasks have unclear dependencies, conflicting requirements, or a materially branching acceptance target.
 </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>
-- [ ] All parallel tasks completed
-- [ ] Build/typecheck passes
+- [ ] Task intent and constraints were grounded before editing
+- [ ] Pass/fail acceptance criteria were stated before execution
+- [ ] Parallel lanes were used only for independent work
+- [ ] Build/typecheck passes when relevant
 - [ ] Affected tests pass
+- [ ] Manual QA notes recorded when behavior is user-visible
 - [ ] No new errors introduced
+- [ ] Completion claim stays inside ultrawork's lightweight-verification boundary
 </Final_Checklist>
 
 <Advanced>
 ## Relationship to Other Modes
 
 ```
-ralph (persistence wrapper)
+ralph (persistence + verified completion wrapper)
  \-- includes: ultrawork (this skill)
-     \-- provides: parallel execution only
+     \-- provides: high-throughput execution + lightweight evidence
 
 autopilot (autonomous execution)
  \-- includes: ralph
@@ -140,5 +172,5 @@ ecomode (token efficiency)
  \-- modifies: ultrawork's model selection
 ```
 
-Ultrawork is the parallelism layer. Ralph adds persistence and verification. Autopilot adds the full lifecycle pipeline. Ecomode adjusts ultrawork's model routing to favor cheaper models.
+Ultrawork is the parallelism and execution-discipline layer. Ralph adds persistence, architect verification, deslop, and retry-until-done behavior. Autopilot adds the broader autonomous lifecycle pipeline. Ecomode adjusts ultrawork's model routing to favor cheaper models.
 </Advanced>

--- a/src/hooks/__tests__/skill-guidance-contract.test.ts
+++ b/src/hooks/__tests__/skill-guidance-contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import { SKILL_CONTRACTS } from '../prompt-guidance-contract.js';
-import { assertContractSurface } from './prompt-guidance-test-helpers.js';
+import { assertContractSurface, loadSurface } from './prompt-guidance-test-helpers.js';
 
 describe('execution-heavy skill guidance contract', () => {
   for (const contract of SKILL_CONTRACTS) {
@@ -8,4 +9,11 @@ describe('execution-heavy skill guidance contract', () => {
       assertContractSurface(contract);
     });
   }
+
+  it('ultrawork guidance stays OMX-native and avoids upstream-only runtime taxonomy', () => {
+    const content = loadSurface('skills/ultrawork/SKILL.md');
+    assert.doesNotMatch(content, /@opencode-ai\/plugin|bun:sqlite|\.sisyphus/i);
+    assert.doesNotMatch(content, /\boracle\b|\blibrarian\b|\bartistry\b|\bPrometheus\b/i);
+    assert.match(content, /Ralph owns persistence, architect verification, deslop, and the full verified-completion promise/i);
+  });
 });

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -94,6 +94,16 @@ const SKILL_PATTERNS = [
   rx('user says `continue`'),
 ];
 
+const ULTRAWORK_SKILL_PATTERNS = [
+  ...SKILL_PATTERNS,
+  rx('Gather enough context before implementation'),
+  rx('Define pass/fail acceptance criteria before launching execution lanes'),
+  rx('run a direct-tool lane and one or more background evidence lanes'),
+  rx('Choose self vs delegate deliberately'),
+  rx('Manual QA notes are recorded when the task needs a human-visible or behavior-level check'),
+  rx('Ralph owns persistence, architect verification, deslop, and the full verified-completion promise'),
+];
+
 export const ROOT_TEMPLATE_CONTRACTS: GuidanceSurfaceContract[] = [
   { id: 'agents-template', path: 'templates/AGENTS.md', requiredPatterns: ROOT_TEMPLATE_PATTERNS },
 ];
@@ -202,18 +212,25 @@ export const SPECIALIZED_PROMPT_CONTRACTS: GuidanceSurfaceContract[] = [
 ];
 
 export const SKILL_CONTRACTS: GuidanceSurfaceContract[] = [
-  'analyze',
-  'autopilot',
-  'build-fix',
-  'code-review',
-  'plan',
-  'ralph',
-  'ralplan',
-  'security-review',
-  'team',
-  'ultraqa',
-].map((name) => ({
-  id: name,
-  path: `skills/${name}/SKILL.md`,
-  requiredPatterns: SKILL_PATTERNS,
-}));
+  ...[
+    'analyze',
+    'autopilot',
+    'build-fix',
+    'code-review',
+    'plan',
+    'ralph',
+    'ralplan',
+    'security-review',
+    'team',
+    'ultraqa',
+  ].map((name) => ({
+    id: name,
+    path: `skills/${name}/SKILL.md`,
+    requiredPatterns: SKILL_PATTERNS,
+  })),
+  {
+    id: 'ultrawork',
+    path: 'skills/ultrawork/SKILL.md',
+    requiredPatterns: ULTRAWORK_SKILL_PATTERNS,
+  },
+];

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -636,6 +636,37 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("adds ultrawork-specific activation guidance only for true ultrawork workflow activation", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultrawork-routing-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-ultrawork-msg",
+          thread_id: "thread-ultrawork-msg",
+          turn_id: "turn-ultrawork-msg",
+          prompt: "$ultrawork fan out the regression checks",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "ultrawork");
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /\$ultrawork" -> ultrawork/);
+      assert.match(message, /ground the task before editing/i);
+      assert.match(message, /define pass\/fail acceptance criteria/i);
+      assert.match(message, /direct-tool plus background evidence lanes/i);
+      assert.match(message, /Ralph owns persistence and the full verified-completion promise/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not activate Ralph workflow state from a plain conversational mention", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-plain-text-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -631,6 +631,9 @@ function buildAdditionalContextMessage(
   const deepInterviewPromptActivationNote = skillState?.initialized_mode === "deep-interview"
     ? buildDeepInterviewQuestionBridgeInstruction(cwd, payload)
     : null;
+  const ultraworkPromptActivationNote = skillState?.initialized_mode === "ultrawork"
+    ? "Ultrawork protocol: ground the task before editing, define pass/fail acceptance criteria, keep shared-file work local, and use direct-tool plus background evidence lanes only for truly independent work. Direct ultrawork provides lightweight verification only; Ralph owns persistence and the full verified-completion promise."
+    : null;
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;
     if (matches.length <= 1 || activeSkills.length <= 1) return skillState.transition_message;
@@ -681,6 +684,7 @@ function buildAdditionalContextMessage(
       promptPriorityMessage,
       initializedStateMessage,
       deepInterviewPromptActivationNote,
+      ultraworkPromptActivationNote,
       "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout.",
       "If you need runtime syntax, run `omx team --help` yourself.",
       "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
@@ -697,6 +701,7 @@ function buildAdditionalContextMessage(
       promptPriorityMessage,
       `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
       deepInterviewPromptActivationNote,
+      ultraworkPromptActivationNote,
       ralphPromptActivationNote,
       "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
     ].join(" ");


### PR DESCRIPTION
## Summary
- Sync `skills/ultrawork` with upstream oh-my-openagent protocol concepts in OMX-native language.
- Add ultrawork-specific prompt guidance contracts for context-first execution, pass/fail acceptance criteria, evidence lanes, manual QA, and the Ralph boundary.
- Add narrow UserPromptSubmit ultrawork activation guidance plus regression coverage.

## Code review
- Reviewer lane: no CRITICAL/HIGH/MEDIUM blockers found in local review; spawned reviewer agents were attempted but timed out without findings.
- Architectural status: CLEAR in local review; the change stays on existing skill/contract/hook seams and does not add upstream runtime/model override machinery.

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/hooks/__tests__/skill-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js` → 281 pass, 0 fail
- `npm run test` → 3887 pass, 0 fail
- `./node_modules/.bin/biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts src/hooks/prompt-guidance-contract.ts src/hooks/__tests__/skill-guidance-contract.test.ts`
- `node dist/scripts/generate-catalog-docs.js --check`
- Manual hook dispatch confirmed `$ultrawork` context includes grounding, acceptance, and Ralph-boundary guidance.

## Notes
- Intentionally rejects OpenCode/Bun/SQLite/model-override parity from upstream.
- Direct ultrawork remains lightweight verification; Ralph remains the full persistence/verified-completion path.
