### PR TITLE
feat(ask): add MiniMax M2.7 as third ask provider via OpenAI-compatible API

### DIFF
--- a/skills/ask-minimax/SKILL.md
+++ b/skills/ask-minimax/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ask-minimax
+description: Ask MiniMax M2.7 via OpenAI-compatible API and capture a reusable artifact
+---
+
+# Ask MiniMax (API)
+
+Use the MiniMax API as a direct external advisor for focused questions, reviews, or second opinions.
+Unlike Claude and Gemini providers, MiniMax requires no local CLI binary — it calls the MiniMax
+OpenAI-compatible HTTP API directly.
+
+## Usage
+
+```bash
+/ask-minimax <question or task>
+```
+
+## Requirements
+
+Set the `MINIMAX_API_KEY` environment variable before invoking:
+
+```bash
+export MINIMAX_API_KEY=your_api_key_here
+```
+
+Optional environment overrides:
+
+| Variable | Default | Description |
+|---|---|---|
+| `MINIMAX_API_KEY` | *(required)* | MiniMax API key |
+| `MINIMAX_BASE_URL` | `https://api.minimax.io/v1` | API base URL |
+| `MINIMAX_MODEL` | `MiniMax-M2.7` | Model name |
+
+## Routing
+
+### Preferred: OMX CLI execution
+
+Run MiniMax through the canonical OMX CLI command path:
+
+```bash
+omx ask minimax "{{ARGUMENTS}}"
+```
+
+This calls the MiniMax `/v1/chat/completions` endpoint directly via `fetch` (no CLI binary needed).
+
+### Missing API key behavior
+
+If `MINIMAX_API_KEY` is not set, do **not** fall back to another provider.
+Instead:
+1. Explain that `MINIMAX_API_KEY` is required for this skill.
+2. Ask the user to set the environment variable.
+3. Provide a quick verification command:
+
+```bash
+omx ask minimax "hello" # should work once MINIMAX_API_KEY is set
+```
+
+## Artifact requirement
+
+After execution, an artifact is saved to:
+
+```text
+.omx/artifacts/minimax-<slug>-<timestamp>.md
+```
+
+Minimum artifact sections:
+1. Original user task
+2. Final prompt sent to MiniMax API
+3. MiniMax output (raw)
+4. Concise summary
+5. Action items / next steps
+
+Task: {{ARGUMENTS}}

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -92,6 +92,20 @@ describe('parseAskArgs', () => {
     assert.throws(() => parseAskArgs(['openai', 'hello']), /Invalid provider/);
   });
 
+  it('parses minimax provider', () => {
+    assert.deepEqual(parseAskArgs(['minimax', 'hello', 'world']), {
+      provider: 'minimax',
+      prompt: 'hello world',
+    });
+  });
+
+  it('parses minimax with -p flag', () => {
+    assert.deepEqual(parseAskArgs(['minimax', '-p', 'what is MiniMax?']), {
+      provider: 'minimax',
+      prompt: 'what is MiniMax?',
+    });
+  });
+
   it('throws when prompt is missing', () => {
     assert.throws(() => parseAskArgs(['claude']), /Missing prompt text/);
   });
@@ -111,6 +125,22 @@ describe('omx ask', () => {
       assert.equal(res.status, 1, res.stderr || res.stdout);
       assert.match(res.stderr, /claude --print/);
       assert.match(res.stderr, /gemini --prompt/);
+      assert.match(res.stderr, /minimax/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('minimax provider writes artifact and returns 1 without MINIMAX_API_KEY', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-ask-minimax-no-key-'));
+    try {
+      const res = runOmx(wd, ['ask', 'minimax', 'hello minimax'], {
+        MINIMAX_API_KEY: '',
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+
+      assert.equal(res.status, 1, res.stderr || res.stdout);
+      assert.match(res.stderr, /MINIMAX_API_KEY/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -7,15 +7,16 @@ import { getPackageRoot } from '../utils/package.js';
 import { codexPromptsDir } from '../utils/paths.js';
 
 export const ASK_USAGE = [
-  'Usage: omx ask <claude|gemini> <question or task>',
-  '   or: omx ask <claude|gemini> -p "<prompt>"',
+  'Usage: omx ask <claude|gemini|minimax> <question or task>',
+  '   or: omx ask <claude|gemini|minimax> -p "<prompt>"',
   '   or: omx ask claude --print "<prompt>"',
   '   or: omx ask gemini --prompt "<prompt>"',
-  '   or: omx ask <claude|gemini> --agent-prompt <role> "<prompt>"',
-  '   or: omx ask <claude|gemini> --agent-prompt=<role> --prompt "<prompt>"',
+  '   or: omx ask minimax "<prompt>"  (requires MINIMAX_API_KEY)',
+  '   or: omx ask <claude|gemini|minimax> --agent-prompt <role> "<prompt>"',
+  '   or: omx ask <claude|gemini|minimax> --agent-prompt=<role> --prompt "<prompt>"',
 ].join('\n');
 
-const ASK_PROVIDERS = ['claude', 'gemini'] as const;
+const ASK_PROVIDERS = ['claude', 'gemini', 'minimax'] as const;
 type AskProvider = typeof ASK_PROVIDERS[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 const ASK_ADVISOR_SCRIPT_ENV = 'OMX_ASK_ADVISOR_SCRIPT';

--- a/src/scripts/run-provider-advisor.ts
+++ b/src/scripts/run-provider-advisor.ts
@@ -5,11 +5,14 @@ import process from 'process';
 import { spawnSync } from 'child_process';
 import { CLAUDE_SKIP_PERMISSIONS_FLAG } from '../cli/constants.js';
 
-const PROVIDER_BINARIES: Record<string, string> = {
+const PROVIDER_BINARIES: Record<string, string | null> = {
   claude: 'claude',
   gemini: 'gemini',
+  minimax: null,
 };
 const ASK_ORIGINAL_TASK_ENV = 'OMX_ASK_ORIGINAL_TASK';
+const MINIMAX_BASE_URL_DEFAULT = 'https://api.minimax.io/v1';
+const MINIMAX_MODEL_DEFAULT = 'MiniMax-M2.7';
 const ISSUE_WORK_PROMPT_PATTERNS = [
   /\bgh\s+issue\b/i,
   /\b(?:fix|work on|work|investigate|implement|triage|debug|review|handle)\s+issue\s*#?\d+\b/i,
@@ -17,10 +20,11 @@ const ISSUE_WORK_PROMPT_PATTERNS = [
 ];
 
 function usage(): void {
-  console.error('Usage: omx ask <claude|gemini> "<prompt>"');
-  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|gemini> <prompt...>');
+  console.error('Usage: omx ask <claude|gemini|minimax> "<prompt>"');
+  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|gemini|minimax> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
+  console.error('Env: MINIMAX_API_KEY required for minimax provider');
 }
 
 function slugify(value: string): string {
@@ -81,6 +85,48 @@ function shouldUseClaudeIssuePermissionsBypass(provider: string, prompt: string)
   const trimmed = prompt.trim();
   if (trimmed === '') return false;
   return ISSUE_WORK_PROMPT_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+async function callMiniMaxAPI(prompt: string): Promise<{ output: string; exitCode: number }> {
+  const apiKey = process.env.MINIMAX_API_KEY;
+  if (!apiKey) {
+    console.error('[ask-minimax] Missing MINIMAX_API_KEY environment variable');
+    console.error('[ask-minimax] Set MINIMAX_API_KEY to your MiniMax API key and retry');
+    return { output: '', exitCode: 1 };
+  }
+
+  const baseUrl = (process.env.MINIMAX_BASE_URL || MINIMAX_BASE_URL_DEFAULT).replace(/\/$/, '');
+  const model = process.env.MINIMAX_MODEL || MINIMAX_MODEL_DEFAULT;
+
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 1.0,
+      }),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[ask-minimax] Network error: ${msg}`);
+    return { output: msg, exitCode: 1 };
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    console.error(`[ask-minimax] API error (${response.status}): ${errorText}`);
+    return { output: errorText, exitCode: 1 };
+  }
+
+  const data = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
+  const content = data.choices?.[0]?.message?.content ?? '';
+  return { output: content, exitCode: 0 };
 }
 
 function buildSummary(exitCode: number, output: string): string {
@@ -160,25 +206,38 @@ async function writeArtifact({ provider, originalTask, finalPrompt, rawOutput, e
 
 async function main(): Promise<void> {
   const { provider, prompt } = parseArgs(process.argv.slice(2));
-  const binary = PROVIDER_BINARIES[provider];
   const originalTask = process.env[ASK_ORIGINAL_TASK_ENV] ?? prompt;
 
-  ensureBinary(binary);
+  let rawOutput: string;
+  let exitCode: number;
+  let spawnError: string | undefined;
 
-  const launchArgs = shouldUseClaudeIssuePermissionsBypass(provider, originalTask)
-    ? [CLAUDE_SKIP_PERMISSIONS_FLAG, '-p', prompt]
-    : ['-p', prompt];
+  if (provider === 'minimax') {
+    const result = await callMiniMaxAPI(prompt);
+    rawOutput = result.output;
+    exitCode = result.exitCode;
+  } else {
+    const binary = PROVIDER_BINARIES[provider] as string;
+    ensureBinary(binary);
 
-  const run = spawnSync(binary, launchArgs, {
-    encoding: 'utf8',
-    maxBuffer: 10 * 1024 * 1024,
-      windowsHide: true,
-    });
+    const launchArgs = shouldUseClaudeIssuePermissionsBypass(provider, originalTask)
+      ? [CLAUDE_SKIP_PERMISSIONS_FLAG, '-p', prompt]
+      : ['-p', prompt];
 
-  const stdout = run.stdout || '';
-  const stderr = run.stderr || '';
-  const rawOutput = [stdout, stderr].filter(Boolean).join(stdout && stderr ? '\n\n' : '');
-  const exitCode = typeof run.status === 'number' ? run.status : 1;
+    const run = spawnSync(binary, launchArgs, {
+      encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
+        windowsHide: true,
+      });
+
+    const stdout = run.stdout || '';
+    const stderr = run.stderr || '';
+    rawOutput = [stdout, stderr].filter(Boolean).join(stdout && stderr ? '\n\n' : '');
+    exitCode = typeof run.status === 'number' ? run.status : 1;
+    if (run.error) {
+      spawnError = run.error.message;
+    }
+  }
 
   const artifactPath = await writeArtifact({
     provider,
@@ -190,8 +249,8 @@ async function main(): Promise<void> {
 
   console.log(artifactPath);
 
-  if (run.error) {
-    console.error(`[ask-${provider}] ${run.error.message}`);
+  if (spawnError) {
+    console.error(`[ask-${provider}] ${spawnError}`);
   }
 
   if (exitCode !== 0) {


### PR DESCRIPTION
## Summary

- Adds `minimax` as a first-class provider for `omx ask minimax "..."`, alongside `claude` and `gemini`
- Calls MiniMax's OpenAI-compatible `/v1/chat/completions` endpoint directly via `fetch` (no local CLI binary required)
- Default model: `MiniMax-M2.7` (configurable via `MINIMAX_MODEL` env var)
- Default base URL: `https://api.minimax.io/v1` (configurable via `MINIMAX_BASE_URL`)
- Requires `MINIMAX_API_KEY` environment variable

## Changes

- `src/cli/ask.ts`: Add `minimax` to `ASK_PROVIDERS` and update `ASK_USAGE` documentation
- `src/scripts/run-provider-advisor.ts`: Add `callMiniMaxAPI()` that calls MiniMax's OpenAI-compat endpoint via native `fetch`; update `parseArgs` and `main()` to dispatch minimax separately from binary-based providers
- `src/cli/__tests__/ask.test.ts`: Add tests for minimax provider parsing, missing API key behavior, and usage text coverage
- `skills/ask-minimax/SKILL.md`: Add skill definition for `omx ask minimax` invocation

## Test plan

- [x] `parseAskArgs(['minimax', 'hello world'])` returns correct result
- [x] `parseAskArgs(['minimax', '-p', '...'])` parses correctly
- [x] Running `omx ask minimax hello` without `MINIMAX_API_KEY` exits with code 1 and mentions `MINIMAX_API_KEY`
- [x] Usage output mentions `minimax` provider
- [x] All 20 existing ask tests pass