### PR TITLE
fix: fail closed when `omx question` runs under detached tmux sessions

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -119,6 +119,13 @@ describe('omx question CLI', () => {
     await writeFile(join(fakeBinDir, 'tmux'), `#!/bin/sh
 printf '%s\\n' "$*" >> "${join(cwd, 'tmux.log')}"
 case "$1" in
+  display-message)
+    if [ "$2" = "-p" ] && [ "$3" = "-t" ] && [ "$4" = "%0" ] && [ "$5" = "#{session_attached}" ]; then
+      printf '1\\n'
+      exit 0
+    fi
+    printf '%%0\\n'
+    ;;
   split-window)
     printf '%%5\\n'
     ;;
@@ -128,9 +135,6 @@ case "$1" in
       exit 1
     fi
     printf '%%0\\t1\\n%%2\\t0\\n'
-    ;;
-  display-message)
-    printf '%%0\\n'
     ;;
 esac
 `, { mode: 0o755 });
@@ -242,6 +246,69 @@ exit 0
     try {
       tmuxLog = await readFile(tmuxLogPath, 'utf-8');
     } catch {}
+    assert.doesNotMatch(tmuxLog, /new-session/);
+  });
+
+  it('fails closed inside a detached tmux session without creating a hidden question pane', async () => {
+    const cwd = await makeRepo();
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(join(fakeBinDir, 'tmux'), `#!/bin/sh
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  display-message)
+    if [ "$2" = "-p" ] && [ "$3" = "-t" ] && [ "$4" = "%0" ] && [ "$5" = "#{session_attached}" ]; then
+      printf '0\\n'
+      exit 0
+    fi
+    printf '%%0\\n'
+    ;;
+esac
+exit 0
+`, { mode: 0o755 });
+
+    const input = JSON.stringify({
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      session_id: 'sess-q',
+    });
+
+    const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
+      const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          TMUX: '/tmp/fake',
+          TMUX_PANE: '%0',
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+      child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+      child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, 'question_runtime_failed');
+    assert.match(payload.error.message, /visible renderer/i);
+    assert.match(payload.error.message, /attached tmux pane/i);
+
+    let tmuxLog = '';
+    try {
+      tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+    } catch {}
+    assert.match(tmuxLog, /display-message -p -t %0 #\{session_attached\}/);
+    assert.doesNotMatch(tmuxLog, /split-window/);
     assert.doesNotMatch(tmuxLog, /new-session/);
   });
 });

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -93,6 +93,7 @@ describe('launchQuestionRenderer', () => {
         strategy: 'inside-tmux',
         execTmux: (args) => {
           calls.push(args);
+          if (args[0] === 'display-message') return '1\n';
           if (args[0] === 'split-window') return '%42\n';
           if (args[0] === 'list-panes') return '0\t%42\n';
           return '';
@@ -105,20 +106,21 @@ describe('launchQuestionRenderer', () => {
     assert.equal(result.target, '%42');
     assert.equal(result.return_target, '%11');
     assert.equal(result.return_transport, 'tmux-send-keys');
-    assert.equal(calls.length, 2);
-    assert.equal(calls[0]?.[0], 'split-window');
-    assert.ok(!calls[0]?.includes('-d'));
-    assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
-    assert.equal(calls[0]?.[calls[0]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
-    assert.deepEqual(calls[0]?.slice(-4), [
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%11', '#{session_attached}']);
+    assert.equal(calls[1]?.[0], 'split-window');
+    assert.ok(!calls[1]?.includes('-d'));
+    assert.equal(calls[1]?.[calls[1]!.length - 6], process.execPath);
+    assert.equal(calls[1]?.[calls[1]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(calls[1]?.slice(-4), [
       'question',
       '--ui',
       '--state-path',
       '/repo/.omx/state/sessions/s1/questions/question-1.json',
     ]);
-    assert.ok(calls[0]?.includes('-e'));
-    assert.ok(calls[0]?.includes('OMX_SESSION_ID=s1'));
-    assert.deepEqual(calls[1], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
+    assert.ok(calls[1]?.includes('-e'));
+    assert.ok(calls[1]?.includes('OMX_SESSION_ID=s1'));
+    assert.deepEqual(calls[2], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
   });
 
   it('fails before prompting state when a reported split pane is already gone', () => {
@@ -136,6 +138,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%42\n';
             throw new Error("can't find pane: %42");
           },
@@ -145,17 +148,18 @@ describe('launchQuestionRenderer', () => {
       /Question UI pane %42 disappeared immediately after launch/,
     );
 
-    assert.equal(calls.length, 2);
-    assert.equal(calls[0]?.[0], 'split-window');
-    assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
-    assert.equal(calls[0]?.[calls[0]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
-    assert.deepEqual(calls[0]?.slice(-4), [
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%11', '#{session_attached}']);
+    assert.equal(calls[1]?.[0], 'split-window');
+    assert.equal(calls[1]?.[calls[1]!.length - 6], process.execPath);
+    assert.equal(calls[1]?.[calls[1]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(calls[1]?.slice(-4), [
       'question',
       '--ui',
       '--state-path',
       '/repo/.omx/state/sessions/s1/questions/question-1.json',
     ]);
-    assert.deepEqual(calls[1], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
+    assert.deepEqual(calls[2], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
   });
 
   it('falls back to the persisted session mode pane when Bash/tool env lost TMUX_PANE', () => {
@@ -182,6 +186,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%77\n';
             if (args[0] === 'list-panes') return '0\t%77\n';
             return '';
@@ -192,7 +197,8 @@ describe('launchQuestionRenderer', () => {
 
       assert.equal(result.return_target, '%91');
       assert.equal(result.return_transport, 'tmux-send-keys');
-      assert.equal(calls[0]?.[0], 'split-window');
+      assert.deepEqual(calls[0], ['display-message', '-p', '#{session_attached}']);
+      assert.equal(calls[1]?.[0], 'split-window');
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
@@ -227,6 +233,7 @@ describe('launchQuestionRenderer', () => {
         {
           strategy: 'inside-tmux',
           execTmux: (args) => {
+            if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%77\n';
             if (args[0] === 'list-panes') return '0\t%77\n';
             return '';
@@ -254,6 +261,7 @@ describe('launchQuestionRenderer', () => {
         strategy: 'inside-tmux',
         execTmux: (args) => {
           calls.push(args);
+          if (args[0] === 'display-message') return '1\n';
           if (args[0] === 'split-window') return '%77\n';
           if (args[0] === 'list-panes') return '0\t%77\n';
           return '';
@@ -262,17 +270,44 @@ describe('launchQuestionRenderer', () => {
       },
     );
 
-    assert.equal(calls.length, 2);
-    assert.equal(calls[0]?.some((part) => /question --ui --state-path/.test(part)), false);
-    assert.equal(calls[0]?.some((part) => /^'.*'$/.test(part)), false);
-    assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
-    assert.equal(calls[0]?.[calls[0]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
-    assert.deepEqual(calls[0]?.slice(-4), [
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls[0], ['display-message', '-p', '#{session_attached}']);
+    assert.equal(calls[1]?.some((part) => /question --ui --state-path/.test(part)), false);
+    assert.equal(calls[1]?.some((part) => /^'.*'$/.test(part)), false);
+    assert.equal(calls[1]?.[calls[1]!.length - 6], process.execPath);
+    assert.equal(calls[1]?.[calls[1]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(calls[1]?.slice(-4), [
       'question',
       '--ui',
       '--state-path',
       '/repo/question with spaces.json',
     ]);
+  });
+
+  it('fails closed when tmux is present but the current session has no attached client', () => {
+    const calls: string[][] = [];
+    assert.throws(
+      () => launchQuestionRenderer(
+        {
+          cwd: '/repo',
+          recordPath: '/repo/.omx/state/sessions/s1/questions/question-detached.json',
+          sessionId: 's1',
+          env: { TMUX: '/tmp/tmux-demo', TMUX_PANE: '%11' } as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'inside-tmux',
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'display-message') return '0\n';
+            throw new Error(`unexpected tmux call: ${args.join(' ')}`);
+          },
+          sleepSync: () => {},
+        },
+      ),
+      /attached tmux pane/i,
+    );
+
+    assert.deepEqual(calls, [['display-message', '-p', '-t', '%11', '#{session_attached}']]);
   });
 
   it('resolves the leader return target before opening the question pane', () => {
@@ -293,6 +328,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') {
               process.env.TMUX_PANE = '%201';
               return '%201\n';
@@ -397,6 +433,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%42\n';
             if (args[0] === 'list-panes') return '0\t%42\n';
             return '';
@@ -406,8 +443,9 @@ describe('launchQuestionRenderer', () => {
       );
 
       assert.equal(result.target, '%42');
-      assert.equal(calls[0]?.includes('/repo/dist/cli/omx.js'), true);
-      assert.equal(calls[0]?.includes('/stale/global/dist/cli/omx.js'), false);
+      assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%11', '#{session_attached}']);
+      assert.equal(calls[1]?.includes('/repo/dist/cli/omx.js'), true);
+      assert.equal(calls[1]?.includes('/stale/global/dist/cli/omx.js'), false);
     } finally {
       process.argv[1] = originalArgv1;
     }

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -38,6 +38,24 @@ function isPaneId(value: string | null | undefined): value is string {
   return typeof value === 'string' && /^%\d+$/.test(value.trim());
 }
 
+function hasVisibleAttachedTmuxSession(
+  env: NodeJS.ProcessEnv,
+  execTmux: ExecTmuxSync,
+): boolean {
+  if (safeString(env.TMUX).trim() === '') return false;
+
+  const paneTarget = safeString(env.TMUX_PANE).trim();
+  const args = isPaneId(paneTarget)
+    ? ['display-message', '-p', '-t', paneTarget, '#{session_attached}']
+    : ['display-message', '-p', '#{session_attached}'];
+
+  try {
+    return execTmux(args).trim() === '1';
+  } catch {
+    return false;
+  }
+}
+
 export function resolveQuestionRendererStrategy(
   env: NodeJS.ProcessEnv = process.env,
   // Kept for callers/tests that used to pass detected tmux availability; default
@@ -226,8 +244,12 @@ export function launchQuestionRenderer(
   const execTmux = deps.execTmux ?? defaultExecTmux;
   const sleepImpl = deps.sleepSync ?? sleepSync;
   const launchedAt = options.nowIso ?? new Date().toISOString();
+  const env = options.env ?? process.env;
 
-  if (strategy === 'unsupported') {
+  if (
+    strategy === 'unsupported'
+    || (strategy === 'inside-tmux' && !hasVisibleAttachedTmuxSession(env, execTmux))
+  ) {
     throw new Error(
       'omx question cannot open a visible renderer because this process is not running inside an attached tmux pane. Run omx question from inside tmux.',
     );
@@ -235,7 +257,7 @@ export function launchQuestionRenderer(
 
   const commandArgs = buildQuestionUiTmuxArgs(options.recordPath, {
     cwd: options.cwd,
-    env: options.env,
+    env,
     sessionId: options.sessionId,
   });
 


### PR DESCRIPTION
## Summary
- fail closed when `omx question` is launched from a tmux session with no attached client
- keep the existing attached-tmux split-pane flow unchanged for normal interactive usage
- add renderer and CLI regressions so detached sessions no longer create hidden question panes

## Verification
- `npm run build`
- `node --test dist/question/__tests__/renderer.test.js dist/cli/__tests__/question.test.js`
- `npx biome lint src/question/renderer.ts src/question/__tests__/renderer.test.ts src/cli/__tests__/question.test.ts`
- `git diff --check`
- manual detached tmux repro: `tmux new-session -d ... node dist/cli/omx.js question ... --json` now returns `question_runtime_failed` JSON instead of spawning a hidden pane

## Why this scope
PR #1808 correctly fixed the non-tmux case, but detached tmux sessions still satisfy the current `TMUX`-only gate. This patch keeps the same fail-closed direction and narrows the gap by checking whether the current tmux session actually has an attached client.

Closes #1832
