### PR TITLE
Fail closed for detached tmux question UI

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -130,7 +130,11 @@ case "$1" in
     printf '%%0\\t1\\n%%2\\t0\\n'
     ;;
   display-message)
-    printf '%%0\\n'
+    if [ "$5" = "#{session_attached}" ]; then
+      printf '1\n'
+    else
+      printf '%%0\n'
+    fi
     ;;
 esac
 `, { mode: 0o755 });
@@ -244,4 +248,73 @@ exit 0
     } catch {}
     assert.doesNotMatch(tmuxLog, /new-session/);
   });
+
+  it('fails closed inside a detached tmux session with no attached client', async () => {
+    const cwd = await makeRepo();
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(join(fakeBinDir, 'tmux'), `#!/bin/sh
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  display-message)
+    printf '0\n'
+    ;;
+  split-window)
+    printf '%%5\n'
+    ;;
+esac
+exit 0
+`, { mode: 0o755 });
+
+    const input = JSON.stringify({
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      session_id: 'sess-q',
+    });
+
+    const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
+      const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          TMUX: '/tmp/fake',
+          TMUX_PANE: '%0',
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+      child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+      child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, 'question_runtime_failed');
+    assert.match(payload.error.message, /visible renderer/i);
+    assert.match(payload.error.message, /no attached client/i);
+    assert.match(payload.error.message, /attached tmux pane/i);
+
+    const entries = await readdir(join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions'));
+    assert.equal(entries.length, 1);
+    const recordPath = join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions', entries[0]!);
+    const record = JSON.parse(await readFile(recordPath, 'utf-8')) as { status: string; error?: { code?: string; message?: string } };
+    assert.equal(record.status, 'error');
+    assert.equal(record.error?.code, 'question_runtime_failed');
+    assert.match(record.error?.message || '', /no attached client/i);
+
+    const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+    assert.match(tmuxLog, /display-message -p -t %0 #\{session_attached\}/);
+    assert.doesNotMatch(tmuxLog, /split-window/);
+    assert.doesNotMatch(tmuxLog, /new-session/);
+  });
+
 });

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -41,6 +41,7 @@ describe('resolveQuestionRendererStrategy', () => {
   });
 });
 
+
 describe('launchQuestionRenderer', () => {
   it('fails before building UI argv or invoking tmux when no visible renderer is available', () => {
     const calls: string[][] = [];
@@ -79,7 +80,7 @@ describe('launchQuestionRenderer', () => {
     assert.deepEqual(calls, []);
   });
 
-  it('opens an interactive foreground split when already inside tmux', () => {
+  it('opens an interactive foreground split when already inside an attached tmux session', () => {
     const calls: string[][] = [];
     const result = launchQuestionRenderer(
       {
@@ -93,6 +94,7 @@ describe('launchQuestionRenderer', () => {
         strategy: 'inside-tmux',
         execTmux: (args) => {
           calls.push(args);
+          if (args[0] === 'display-message') return '1\n';
           if (args[0] === 'split-window') return '%42\n';
           if (args[0] === 'list-panes') return '0\t%42\n';
           return '';
@@ -105,20 +107,54 @@ describe('launchQuestionRenderer', () => {
     assert.equal(result.target, '%42');
     assert.equal(result.return_target, '%11');
     assert.equal(result.return_transport, 'tmux-send-keys');
-    assert.equal(calls.length, 2);
-    assert.equal(calls[0]?.[0], 'split-window');
-    assert.ok(!calls[0]?.includes('-d'));
-    assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
-    assert.equal(calls[0]?.[calls[0]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
-    assert.deepEqual(calls[0]?.slice(-4), [
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%11', '#{session_attached}']);
+    assert.equal(calls[1]?.[0], 'split-window');
+    assert.ok(!calls[1]?.includes('-d'));
+    assert.equal(calls[1]?.[calls[1]!.length - 6], process.execPath);
+    assert.equal(calls[1]?.[calls[1]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(calls[1]?.slice(-4), [
       'question',
       '--ui',
       '--state-path',
       '/repo/.omx/state/sessions/s1/questions/question-1.json',
     ]);
-    assert.ok(calls[0]?.includes('-e'));
-    assert.ok(calls[0]?.includes('OMX_SESSION_ID=s1'));
-    assert.deepEqual(calls[1], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
+    assert.ok(calls[1]?.includes('-e'));
+    assert.ok(calls[1]?.includes('OMX_SESSION_ID=s1'));
+    assert.deepEqual(calls[2], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
+  });
+
+  it('fails closed before splitting when inside a detached tmux session', () => {
+    const calls: string[][] = [];
+    assert.throws(
+      () => launchQuestionRenderer(
+        {
+          cwd: '/repo',
+          recordPath: '/repo/.omx/state/sessions/s1/questions/question-detached.json',
+          sessionId: 's1',
+          env: { TMUX: '/tmp/tmux-demo', TMUX_PANE: '%11' } as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'inside-tmux',
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'display-message') return '0\n';
+            if (args[0] === 'split-window') return '%99\n';
+            return '';
+          },
+          sleepSync: () => {},
+        },
+      ),
+      (error) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /visible renderer/i);
+        assert.match(error.message, /no attached client/i);
+        assert.match(error.message, /attached tmux pane/i);
+        return true;
+      },
+    );
+
+    assert.deepEqual(calls, [['display-message', '-p', '-t', '%11', '#{session_attached}']]);
   });
 
   it('fails before prompting state when a reported split pane is already gone', () => {
@@ -136,6 +172,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%42\n';
             throw new Error("can't find pane: %42");
           },
@@ -145,17 +182,18 @@ describe('launchQuestionRenderer', () => {
       /Question UI pane %42 disappeared immediately after launch/,
     );
 
-    assert.equal(calls.length, 2);
-    assert.equal(calls[0]?.[0], 'split-window');
-    assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
-    assert.equal(calls[0]?.[calls[0]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
-    assert.deepEqual(calls[0]?.slice(-4), [
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%11', '#{session_attached}']);
+    assert.equal(calls[1]?.[0], 'split-window');
+    assert.equal(calls[1]?.[calls[1]!.length - 6], process.execPath);
+    assert.equal(calls[1]?.[calls[1]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(calls[1]?.slice(-4), [
       'question',
       '--ui',
       '--state-path',
       '/repo/.omx/state/sessions/s1/questions/question-1.json',
     ]);
-    assert.deepEqual(calls[1], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
+    assert.deepEqual(calls[2], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
   });
 
   it('falls back to the persisted session mode pane when Bash/tool env lost TMUX_PANE', () => {
@@ -182,6 +220,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%77\n';
             if (args[0] === 'list-panes') return '0\t%77\n';
             return '';
@@ -192,7 +231,7 @@ describe('launchQuestionRenderer', () => {
 
       assert.equal(result.return_target, '%91');
       assert.equal(result.return_transport, 'tmux-send-keys');
-      assert.equal(calls[0]?.[0], 'split-window');
+      assert.equal(calls[1]?.[0], 'split-window');
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
@@ -227,6 +266,7 @@ describe('launchQuestionRenderer', () => {
         {
           strategy: 'inside-tmux',
           execTmux: (args) => {
+            if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%77\n';
             if (args[0] === 'list-panes') return '0\t%77\n';
             return '';
@@ -254,6 +294,7 @@ describe('launchQuestionRenderer', () => {
         strategy: 'inside-tmux',
         execTmux: (args) => {
           calls.push(args);
+          if (args[0] === 'display-message') return '1\n';
           if (args[0] === 'split-window') return '%77\n';
           if (args[0] === 'list-panes') return '0\t%77\n';
           return '';
@@ -262,12 +303,13 @@ describe('launchQuestionRenderer', () => {
       },
     );
 
-    assert.equal(calls.length, 2);
-    assert.equal(calls[0]?.some((part) => /question --ui --state-path/.test(part)), false);
-    assert.equal(calls[0]?.some((part) => /^'.*'$/.test(part)), false);
-    assert.equal(calls[0]?.[calls[0]!.length - 6], process.execPath);
-    assert.equal(calls[0]?.[calls[0]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
-    assert.deepEqual(calls[0]?.slice(-4), [
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls[0], ['display-message', '-p', '#{session_attached}']);
+    assert.equal(calls[1]?.some((part) => /question --ui --state-path/.test(part)), false);
+    assert.equal(calls[1]?.some((part) => /^'.*'$/.test(part)), false);
+    assert.equal(calls[1]?.[calls[1]!.length - 6], process.execPath);
+    assert.equal(calls[1]?.[calls[1]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(calls[1]?.slice(-4), [
       'question',
       '--ui',
       '--state-path',
@@ -293,6 +335,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') {
               process.env.TMUX_PANE = '%201';
               return '%201\n';
@@ -305,6 +348,7 @@ describe('launchQuestionRenderer', () => {
       );
 
       assert.equal(result.return_target, '%200');
+      assert.deepEqual(calls[0], ['display-message', '-p', '#{session_attached}']);
     } finally {
       if (typeof originalTmuxPane === 'string') process.env.TMUX_PANE = originalTmuxPane;
       else delete process.env.TMUX_PANE;
@@ -397,6 +441,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%42\n';
             if (args[0] === 'list-panes') return '0\t%42\n';
             return '';
@@ -406,8 +451,9 @@ describe('launchQuestionRenderer', () => {
       );
 
       assert.equal(result.target, '%42');
-      assert.equal(calls[0]?.includes('/repo/dist/cli/omx.js'), true);
-      assert.equal(calls[0]?.includes('/stale/global/dist/cli/omx.js'), false);
+      assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%11', '#{session_attached}']);
+      assert.equal(calls[1]?.includes('/repo/dist/cli/omx.js'), true);
+      assert.equal(calls[1]?.includes('/stale/global/dist/cli/omx.js'), false);
     } finally {
       process.argv[1] = originalArgv1;
     }

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -149,6 +149,20 @@ function resolveReturnTarget(options: {
   return isPaneId(detectedPane) ? detectedPane : undefined;
 }
 
+function isCurrentTmuxSessionAttached(
+  execTmux: ExecTmuxSync = defaultExecTmux,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const paneTarget = safeString(env.TMUX_PANE).trim();
+  const targetArgs = isPaneId(paneTarget) ? ['-t', paneTarget] : [];
+  try {
+    const attached = execTmux(['display-message', '-p', ...targetArgs, '#{session_attached}']).trim();
+    return Number.parseInt(attached, 10) > 0;
+  } catch {
+    return false;
+  }
+}
+
 function isLaunchedQuestionPaneAlive(
   paneId: string,
   execTmux: ExecTmuxSync,
@@ -240,6 +254,12 @@ export function launchQuestionRenderer(
   });
 
   if (strategy === 'inside-tmux') {
+    if (!isCurrentTmuxSessionAttached(execTmux, options.env ?? process.env)) {
+      throw new Error(
+        'omx question cannot open a visible renderer because this tmux session has no attached client. Run omx question from an attached tmux pane.',
+      );
+    }
+
     const returnTarget = resolveReturnTarget({
       cwd: options.cwd,
       env: options.env ?? process.env,


### PR DESCRIPTION
## Summary
- Check tmux `#{session_attached}` before launching the inside-tmux `omx question` renderer.
- Fail closed with the visible-renderer error when the current tmux session has no attached client.
- Add renderer and CLI regressions proving detached sessions do not call `split-window` or `new-session`.

Closes #1832

## Verification
- `npm run check:no-unused`
- `npx biome lint src/question/renderer.ts src/question/__tests__/renderer.test.ts src/cli/__tests__/question.test.ts`
- `npm run build`
- `node --test dist/question/__tests__/renderer.test.js dist/cli/__tests__/question.test.js`
- Manual detached-tmux repro from #1832 now exits with `question_runtime_failed` instead of leaving a hidden UI pane.

## Notes
- Full `npm run lint` still reports the pre-existing missing `bin` path internal Biome IO diagnostic in this worktree.
- I accidentally invoked `npm run test:node -- ...`, which runs the full suite because the script ignores file args; I stopped it after unrelated tests had started and reran the targeted command above.
