### PR TITLE
Fix BusyBox ps fallback for MCP cleanup

### DIFF
--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -186,6 +186,39 @@ describe('listOmxProcesses', () => {
     }
   });
 
+  it('falls back to BusyBox-compatible args field when command field is unsupported', () => {
+    const calls: Array<{ file: string; args: readonly string[] }> = [];
+    const processes = listOmxProcesses((file, args) => {
+      calls.push({ file, args });
+      if (args.join(' ') === 'axww -o pid=,ppid=,command=') {
+        throw new Error("ps: bad -o argument 'command'");
+      }
+      assert.deepEqual(args, ['axww', '-o', 'pid=,ppid=,args=']);
+      return [
+        '  800     1 node /tmp/oh-my-codex/dist/mcp/memory-server.js',
+        '  810    42 node /tmp/oh-my-codex/dist/mcp/trace-server.js --verbose',
+      ].join('\n');
+    });
+
+    assert.deepEqual(processes, [
+      { pid: 800, ppid: 1, command: 'node /tmp/oh-my-codex/dist/mcp/memory-server.js' },
+      { pid: 810, ppid: 42, command: 'node /tmp/oh-my-codex/dist/mcp/trace-server.js --verbose' },
+    ]);
+    assert.deepEqual(calls, [
+      { file: 'ps', args: ['axww', '-o', 'pid=,ppid=,command='] },
+      { file: 'ps', args: ['axww', '-o', 'pid=,ppid=,args='] },
+    ]);
+  });
+
+  it('rethrows unrelated ps failures without masking them behind the BusyBox fallback', () => {
+    assert.throws(
+      () => listOmxProcesses(() => {
+        throw new Error('spawn ps ENOENT');
+      }),
+      /spawn ps ENOENT/,
+    );
+  });
+
   it('feeds parsed Windows rows through existing cleanup candidate selection unchanged', () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -170,12 +170,27 @@ function listWindowsOmxProcesses(
   return parseWindowsProcessOutput(output);
 }
 
+function isBusyBoxPsCommandFieldError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /bad -o argument ['"]command['"]|unsupported arguments:.*\bargs\b/i.test(error.message);
+}
+
 export function listOmxProcesses(
   runCommand: ProcessListCommandRunner = defaultProcessListCommandRunner,
 ): ProcessEntry[] {
   if (process.platform === 'win32') return listWindowsOmxProcesses(runCommand);
-  const output = runCommand('ps', ['axww', '-o', 'pid=,ppid=,command='], PROCESS_LIST_COMMAND_OPTIONS);
-  return parsePsOutput(output);
+
+  try {
+    const output = runCommand('ps', ['axww', '-o', 'pid=,ppid=,command='], PROCESS_LIST_COMMAND_OPTIONS);
+    return parsePsOutput(output);
+  } catch (err) {
+    if (!isBusyBoxPsCommandFieldError(err)) throw err;
+    // BusyBox ps (Alpine's default) rejects the procps `command` field name
+    // but accepts the equivalent `args` field. Retry only that exact
+    // incompatibility so unrelated ps failures still surface normally.
+    const output = runCommand('ps', ['axww', '-o', 'pid=,ppid=,args='], PROCESS_LIST_COMMAND_OPTIONS);
+    return parsePsOutput(output);
+  }
 }
 
 function isCodexSessionProcess(command: string): boolean {


### PR DESCRIPTION
## Summary

Fix postLaunch MCP cleanup on Alpine BusyBox by retrying process discovery with BusyBox's supported `args` field when `ps` rejects the procps `command` field.

## Changes

- Keep the existing `ps axww -o pid=,ppid=,command=` process-listing path as the primary non-Windows implementation.
- Detect the specific BusyBox `command` field incompatibility and retry with `ps axww -o pid=,ppid=,args=`.
- Add regression coverage for the BusyBox fallback and for preserving unrelated `ps` errors.

## Validation

- [x] `npm run build`
- [x] `node --test dist/cli/__tests__/cleanup.test.js dist/cli/__tests__/index.test.js`
- [x] `npx biome lint src/cli/cleanup.ts src/cli/__tests__/cleanup.test.ts`
- [x] `docker run --rm -v "$PWD":/work -w /work node:24-alpine node --input-type=module -e "import { listOmxProcesses } from './dist/cli/cleanup.js'; const rows = listOmxProcesses(); console.log(JSON.stringify({count: rows.length, first: rows[0] ?? null}));"`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — not needed
- [x] Backward-compatibility impact considered

## Related

Closes #1834
