### PR TITLE
Fix question UI answer return race

### DIFF
--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -121,6 +121,8 @@ describe('launchQuestionRenderer', () => {
     ]);
     assert.ok(calls[1]?.includes('-e'));
     assert.ok(calls[1]?.includes('OMX_SESSION_ID=s1'));
+    assert.ok(calls[1]?.includes('OMX_QUESTION_RETURN_TARGET=%11'));
+    assert.ok(calls[1]?.includes('OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys'));
     assert.deepEqual(calls[2], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
   });
 

--- a/src/question/__tests__/state.test.ts
+++ b/src/question/__tests__/state.test.ts
@@ -95,4 +95,34 @@ describe('question state', () => {
     assert.equal(loaded?.error?.code, 'question_runtime_failed');
     assert.match(loaded?.error?.message || '', /pane %42 disappeared immediately after launch/);
   });
+
+  it('does not regress an already answered record back to prompting when renderer metadata arrives late', async () => {
+    const cwd = await makeRepo();
+    const { recordPath } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-4');
+
+    await markQuestionAnswered(recordPath, {
+      kind: 'option',
+      value: 'a',
+      selected_labels: ['A'],
+      selected_values: ['a'],
+    });
+    await markQuestionPrompting(recordPath, {
+      renderer: 'tmux-pane',
+      target: '%42',
+      launched_at: '2026-04-19T00:00:00.000Z',
+      return_target: '%11',
+      return_transport: 'tmux-send-keys',
+    });
+
+    const loaded = await readQuestionRecord(recordPath);
+    assert.equal(loaded?.status, 'answered');
+    assert.equal(loaded?.answer?.value, 'a');
+    assert.equal(loaded?.renderer?.return_target, '%11');
+  });
 });

--- a/src/question/__tests__/ui.test.ts
+++ b/src/question/__tests__/ui.test.ts
@@ -209,4 +209,154 @@ describe('question ui arrow navigation', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('injects using fresh renderer metadata when the UI read a pre-prompting record', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-stale-record-'));
+    try {
+      const { recordPath } = await createQuestionRecord(
+        cwd,
+        {
+          question: 'Pick one',
+          options: [
+            { label: 'A', value: 'a' },
+            { label: 'B', value: 'b' },
+          ],
+          allow_other: false,
+          other_label: 'Other',
+          multi_select: false,
+          type: 'single-answerable',
+        },
+        'sess-ui-stale',
+      );
+
+      const injected: Array<{ paneId: string; value: string | string[] }> = [];
+      const input = new FakeTtyInput();
+      const output = new FakeTtyOutput();
+      const runPromise = runQuestionUi(recordPath, {
+        input,
+        output,
+        injectAnswerToPane: (paneId, answer) => {
+          injected.push({ paneId, value: answer.value });
+          return true;
+        },
+      });
+
+      setTimeout(() => {
+        void (async () => {
+          await markQuestionPrompting(recordPath, {
+            renderer: 'tmux-pane',
+            target: '%42',
+            launched_at: '2026-04-19T00:00:00.000Z',
+            return_target: '%11',
+            return_transport: 'tmux-send-keys',
+          });
+          input.emit('keypress', '', { name: 'down' });
+          input.emit('keypress', '', { name: 'enter' });
+        })();
+      }, 25);
+
+      await runPromise;
+      assert.deepEqual(injected, [{ paneId: '%11', value: 'b' }]);
+      const loaded = await readQuestionRecord(recordPath);
+      assert.equal(loaded?.status, 'answered');
+      assert.equal(loaded?.renderer?.return_target, '%11');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to launcher-provided return-target env when prompting metadata races the UI answer', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-env-return-'));
+    try {
+      const { recordPath } = await createQuestionRecord(
+        cwd,
+        {
+          question: 'Pick one',
+          options: [{ label: 'A', value: 'a' }],
+          allow_other: false,
+          other_label: 'Other',
+          multi_select: false,
+          type: 'single-answerable',
+        },
+        'sess-ui-env',
+      );
+
+      const injected: Array<{ paneId: string; value: string | string[] }> = [];
+      const input = new FakeTtyInput();
+      const output = new FakeTtyOutput();
+      const runPromise = runQuestionUi(recordPath, {
+        input,
+        output,
+        env: {
+          OMX_QUESTION_RETURN_TARGET: '%11',
+          OMX_QUESTION_RETURN_TRANSPORT: 'tmux-send-keys',
+        } as NodeJS.ProcessEnv,
+        injectAnswerToPane: (paneId, answer) => {
+          injected.push({ paneId, value: answer.value });
+          return true;
+        },
+      });
+
+      setTimeout(() => {
+        input.emit('keypress', '', { name: 'enter' });
+      }, 25);
+
+      await runPromise;
+      assert.deepEqual(injected, [{ paneId: '%11', value: 'a' }]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('submits multi-answerable checkbox selections through the env return-target fallback', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-multi-env-return-'));
+    try {
+      const { recordPath } = await createQuestionRecord(
+        cwd,
+        {
+          question: 'Pick all that apply',
+          options: [
+            { label: 'A', value: 'a' },
+            { label: 'B', value: 'b' },
+          ],
+          allow_other: false,
+          other_label: 'Other',
+          multi_select: true,
+          type: 'multi-answerable',
+        },
+        'sess-ui-multi-env',
+      );
+
+      const injected: Array<{ paneId: string; value: string | string[] }> = [];
+      const input = new FakeTtyInput();
+      const output = new FakeTtyOutput();
+      const runPromise = runQuestionUi(recordPath, {
+        input,
+        output,
+        env: {
+          OMX_QUESTION_RETURN_TARGET: '%11',
+          OMX_QUESTION_RETURN_TRANSPORT: 'tmux-send-keys',
+        } as NodeJS.ProcessEnv,
+        injectAnswerToPane: (paneId, answer) => {
+          injected.push({ paneId, value: answer.value });
+          return true;
+        },
+      });
+
+      setTimeout(() => {
+        input.emit('keypress', '', { name: 'space' });
+        input.emit('keypress', '', { name: 'down' });
+        input.emit('keypress', '', { name: 'space' });
+        input.emit('keypress', '', { name: 'enter' });
+      }, 25);
+
+      await runPromise;
+      assert.deepEqual(injected, [{ paneId: '%11', value: ['a', 'b'] }]);
+      const loaded = await readQuestionRecord(recordPath);
+      assert.equal(loaded?.status, 'answered');
+      assert.deepEqual(loaded?.answer?.selected_values, ['a', 'b']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -55,6 +55,7 @@ function buildQuestionUiTmuxArgs(
     cwd: string;
     env?: NodeJS.ProcessEnv;
     sessionId?: string;
+    returnTarget?: string;
   },
 ): string[] {
   const omxBin = resolveOmxCliEntryPath({
@@ -65,6 +66,12 @@ function buildQuestionUiTmuxArgs(
   if (!omxBin) throw new Error('Unable to resolve OMX CLI entry path for question UI launch.');
   return [
     ...(options.sessionId ? ['-e', `OMX_SESSION_ID=${options.sessionId}`] : []),
+    ...(options.returnTarget ? [
+      '-e',
+      `OMX_QUESTION_RETURN_TARGET=${options.returnTarget}`,
+      '-e',
+      'OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys',
+    ] : []),
     process.execPath,
     omxBin,
     'question',
@@ -240,6 +247,7 @@ export function launchQuestionRenderer(
   const execTmux = deps.execTmux ?? defaultExecTmux;
   const sleepImpl = deps.sleepSync ?? sleepSync;
   const launchedAt = options.nowIso ?? new Date().toISOString();
+  const env = options.env ?? process.env;
 
   if (strategy === 'unsupported') {
     throw new Error(
@@ -247,24 +255,25 @@ export function launchQuestionRenderer(
     );
   }
 
+  const returnTarget = resolveReturnTarget({
+    cwd: options.cwd,
+    env,
+    sessionId: options.sessionId,
+  });
   const commandArgs = buildQuestionUiTmuxArgs(options.recordPath, {
     cwd: options.cwd,
     env: options.env,
     sessionId: options.sessionId,
+    returnTarget,
   });
 
   if (strategy === 'inside-tmux') {
-    if (!isCurrentTmuxSessionAttached(execTmux, options.env ?? process.env)) {
+    if (!isCurrentTmuxSessionAttached(execTmux, env)) {
       throw new Error(
         'omx question cannot open a visible renderer because this tmux session has no attached client. Run omx question from an attached tmux pane.',
       );
     }
 
-    const returnTarget = resolveReturnTarget({
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      sessionId: options.sessionId,
-    });
     const rawPane = execTmux([
       'split-window',
       '-v',

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -85,7 +85,7 @@ export async function markQuestionPrompting(
 ): Promise<QuestionRecord> {
   return updateQuestionRecord(recordPath, (record) => ({
     ...record,
-    status: 'prompting',
+    status: isTerminalQuestionStatus(record.status) ? record.status : 'prompting',
     updated_at: new Date().toISOString(),
     renderer,
   }));

--- a/src/question/ui.ts
+++ b/src/question/ui.ts
@@ -23,6 +23,8 @@ interface QuestionUiOutput {
 interface QuestionUiDeps {
   input?: QuestionUiInput;
   output?: QuestionUiOutput;
+  env?: NodeJS.ProcessEnv;
+  injectAnswerToPane?: (paneId: string, answer: QuestionAnswer) => boolean;
 }
 
 interface InteractiveSelectionState {
@@ -110,12 +112,22 @@ function buildAnswer(record: QuestionRecord, selections: number[], otherText?: s
   };
 }
 
-function maybeInjectAnswer(record: QuestionRecord, answer: QuestionAnswer): void {
-  const target = record.renderer?.return_target;
-  const transport = record.renderer?.return_transport;
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function maybeInjectAnswer(
+  record: QuestionRecord,
+  answer: QuestionAnswer,
+  deps: Pick<QuestionUiDeps, 'env' | 'injectAnswerToPane'> = {},
+): void {
+  const env = deps.env ?? process.env;
+  const envTransport = safeString(env.OMX_QUESTION_RETURN_TRANSPORT).trim();
+  const target = record.renderer?.return_target ?? safeString(env.OMX_QUESTION_RETURN_TARGET).trim();
+  const transport = record.renderer?.return_transport ?? (envTransport === 'tmux-send-keys' ? envTransport : undefined);
   if (!target || transport !== 'tmux-send-keys') return;
   try {
-    injectQuestionAnswerToPane(target, answer);
+    (deps.injectAnswerToPane ?? injectQuestionAnswerToPane)(target, answer);
   } catch {
     // Best-effort continuation nudge only; stdout return path remains canonical.
   }
@@ -385,8 +397,11 @@ export async function runQuestionUi(recordPath: string, deps: QuestionUiDeps = {
     }
 
     const answer = buildAnswer(record, selections, otherText);
-    await markQuestionAnswered(recordPath, answer);
-    maybeInjectAnswer(record, answer);
+    const answeredRecord = await markQuestionAnswered(recordPath, answer);
+    maybeInjectAnswer(answeredRecord, answer, {
+      env: deps.env,
+      injectAnswerToPane: deps.injectAnswerToPane,
+    });
   } catch (error) {
     await markQuestionTerminalError(
       recordPath,


### PR DESCRIPTION
## Summary

- Fixes a question UI race where a user could answer before the launcher had finished persisting renderer return metadata, leaving the requester pane without the automatic continuation nudge.
- Carries the return target into the spawned UI process as launcher-provided environment metadata, then re-reads the answered record before attempting best-effort tmux injection.
- Preserves PR #1835's detached-tmux fail-closed behavior while making fast answers reliable in attached tmux sessions.

## Changes

- Added `OMX_QUESTION_RETURN_TARGET` and `OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys` to the question UI tmux argv when a return target is known.
- Updated the UI answer path to prefer persisted renderer metadata but fall back to the launcher-provided environment metadata when prompting metadata races the user's answer.
- Changed `markQuestionPrompting` so late renderer metadata can be recorded without regressing an already terminal `answered`, `aborted`, or `error` question record back to `prompting`.
- Added regression coverage for:
  - late prompting metadata arriving after an answer,
  - stale UI reads that become answerable after renderer metadata is persisted,
  - env-based return-target fallback for single-answerable and multi-answerable prompts,
  - compatibility with the attached-session guard added by #1835.

## Side Effects / Compatibility

- No new dependencies or public CLI flags are introduced.
- The canonical answer path remains the question state record/stdout response; tmux `send-keys` injection is still best-effort and silently ignored on failure.
- Terminal question records may receive late renderer metadata and a refreshed `updated_at`, but their terminal status and existing answer/error payload are preserved.
- The env fallback is only used when the transport is exactly `tmux-send-keys`; invalid/missing targets still no-op through the existing pane validation.
- This branch is based on `dev` after #1835, so it should not reintroduce hidden detached tmux question panes.

## Validation

- [x] `npm run build`
- [ ] `npm test` (not rerun in full; targeted question/CLI regression suites passed)
- [x] `npm run check:no-unused`
- [x] `npx biome lint src/question/renderer.ts src/question/state.ts src/question/ui.ts src/question/__tests__/renderer.test.ts src/question/__tests__/state.test.ts src/question/__tests__/ui.test.ts`
- [x] `node --test dist/question/__tests__/renderer.test.js dist/question/__tests__/state.test.js dist/question/__tests__/ui.test.js`
- [x] `node --test dist/cli/__tests__/question.test.js`
- [ ] `omx doctor` (setup/config behavior unchanged)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — not needed for this internal question runtime fix
- [x] Backward-compatibility impact considered

## Related

- Builds on, but does not duplicate, #1835.
