### PR TITLE
Fix deep-interview question-card resume races

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -130,11 +130,11 @@ case "$1" in
     printf '%%0\\t1\\n%%2\\t0\\n'
     ;;
   display-message)
-    if [ "$5" = "#{session_attached}" ]; then
+    if [ "$2" = "-p" ] && [ "$3" = "-t" ] && [ "$4" = "%0" ] && [ "$5" = "#{session_attached}" ]; then
       printf '1\n'
-    else
-      printf '%%0\n'
+      exit 0
     fi
+    printf '%%0\n'
     ;;
 esac
 `, { mode: 0o755 });

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -233,6 +233,7 @@ describe('launchQuestionRenderer', () => {
 
       assert.equal(result.return_target, '%91');
       assert.equal(result.return_transport, 'tmux-send-keys');
+      assert.deepEqual(calls[0], ['display-message', '-p', '#{session_attached}']);
       assert.equal(calls[1]?.[0], 'split-window');
     } finally {
       rmSync(cwd, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- prevent `omx question` answers from missing their requester-pane continuation when renderer metadata lands after the UI answers
- pass the launcher return target directly into the UI process as an env fallback and re-read the answered record before best-effort injection
- keep late `markQuestionPrompting` updates from regressing already-answered question records, with focused regression coverage for renderer/ui/CLI paths

## Testing
- npm run build
- npm run check:no-unused
- npx biome lint src/question/renderer.ts src/question/state.ts src/question/ui.ts src/question/__tests__/renderer.test.ts src/question/__tests__/state.test.ts src/question/__tests__/ui.test.ts src/cli/__tests__/question.test.ts
- node --test dist/question/__tests__/renderer.test.js dist/question/__tests__/state.test.js dist/question/__tests__/ui.test.js dist/cli/__tests__/question.test.js

Closes #1841
