### PR TITLE
Fix native Windows + psmux worker pane bootstrap

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1083,7 +1083,14 @@ case "\${1:-}" in
     exit 0
     ;;
   list-panes)
-    printf "%%1\\tnode\\t'codex'\\n"
+    case "$*" in
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n%%2\\tgemini\\t'gemini'\\n%%3\\tnode\\t'node omx hud --watch'\\n"
+        ;;
+      *)
+        printf "%%1\\n%%2\\n%%3\\n"
+        ;;
+    esac
     exit 0
     ;;
   split-window)

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1430,6 +1430,130 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+  it('uses the resolved PowerShell executable path in native Windows startup commands', async () => {
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-worker-startup-win32-powershell-'));
+    const prevPath = process.env.PATH;
+    const prevPathext = process.env.PATHEXT;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevLeaderNodePath = process.env.OMX_LEADER_NODE_PATH;
+    const prevMsystem = process.env.MSYSTEM;
+    const prevOstype = process.env.OSTYPE;
+    const prevWsl = process.env.WSL_DISTRO_NAME;
+    const prevWslInterop = process.env.WSL_INTEROP;
+    const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    process.env.PATH = fakeBin;
+    process.env.PATHEXT = '.EXE;.PS1';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.OMX_LEADER_NODE_PATH = 'C:\\Program Files\\nodejs\\node.exe';
+    delete process.env.MSYSTEM;
+    delete process.env.OSTYPE;
+    delete process.env.WSL_DISTRO_NAME;
+    delete process.env.WSL_INTEROP;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      const codexPs1Path = join(fakeBin, 'codex.ps1');
+      const powershellExePath = join(fakeBin, 'powershell.exe');
+      await writeFile(codexPs1Path, '');
+      await writeFile(powershellExePath, '');
+
+      const cmd = buildWorkerStartupCommand('alpha', 1, ['--model', 'gpt-5'], 'C:\\repo');
+      const prefix = `${powershellExePath} -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand `;
+      assert.ok(cmd.startsWith(prefix), cmd);
+    } finally {
+      if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevPathext === 'string') process.env.PATHEXT = prevPathext;
+      else delete process.env.PATHEXT;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevLeaderNodePath === 'string') process.env.OMX_LEADER_NODE_PATH = prevLeaderNodePath;
+      else delete process.env.OMX_LEADER_NODE_PATH;
+      if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
+      else delete process.env.MSYSTEM;
+      if (typeof prevOstype === 'string') process.env.OSTYPE = prevOstype;
+      else delete process.env.OSTYPE;
+      if (typeof prevWsl === 'string') process.env.WSL_DISTRO_NAME = prevWsl;
+      else delete process.env.WSL_DISTRO_NAME;
+      if (typeof prevWslInterop === 'string') process.env.WSL_INTEROP = prevWslInterop;
+      else delete process.env.WSL_INTEROP;
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers a no-space native Windows PowerShell path when one is available', async () => {
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-worker-startup-win32-nospace-powershell-'));
+    const prevPath = process.env.PATH;
+    const prevPathext = process.env.PATHEXT;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevLeaderNodePath = process.env.OMX_LEADER_NODE_PATH;
+    const prevSystemRoot = process.env.SystemRoot;
+    const prevSYSTEMROOT = process.env.SYSTEMROOT;
+    const prevWindir = process.env.windir;
+    const prevWINDIR = process.env.WINDIR;
+    const prevMsystem = process.env.MSYSTEM;
+    const prevOstype = process.env.OSTYPE;
+    const prevWsl = process.env.WSL_DISTRO_NAME;
+    const prevWslInterop = process.env.WSL_INTEROP;
+    const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    process.env.PATH = fakeBin;
+    process.env.PATHEXT = '.EXE;.PS1';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.OMX_LEADER_NODE_PATH = 'C:\\Program Files\\nodejs\\node.exe';
+    process.env.SystemRoot = 'C:\\Windows';
+    delete process.env.SYSTEMROOT;
+    delete process.env.windir;
+    delete process.env.WINDIR;
+    delete process.env.MSYSTEM;
+    delete process.env.OSTYPE;
+    delete process.env.WSL_DISTRO_NAME;
+    delete process.env.WSL_INTEROP;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      const codexPs1Path = join(fakeBin, 'codex.ps1');
+      const pathPowerShellExe = join(fakeBin, 'powershell.exe');
+      const windowsPowerShellExe = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+      await writeFile(codexPs1Path, '');
+      await writeFile(pathPowerShellExe, '');
+
+      const cmd = withMockedExistsSync((candidate) =>
+        candidate === windowsPowerShellExe
+        || candidate === pathPowerShellExe
+        || candidate === codexPs1Path,
+      () => buildWorkerStartupCommand('alpha', 1, ['--model', 'gpt-5'], 'C:\\repo'));
+      const prefix = `${windowsPowerShellExe} -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand `;
+      assert.ok(cmd.startsWith(prefix), cmd);
+      assert.ok(!cmd.startsWith(`${pathPowerShellExe} `), cmd);
+    } finally {
+      if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevPathext === 'string') process.env.PATHEXT = prevPathext;
+      else delete process.env.PATHEXT;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevLeaderNodePath === 'string') process.env.OMX_LEADER_NODE_PATH = prevLeaderNodePath;
+      else delete process.env.OMX_LEADER_NODE_PATH;
+      if (typeof prevSystemRoot === 'string') process.env.SystemRoot = prevSystemRoot;
+      else delete process.env.SystemRoot;
+      if (typeof prevSYSTEMROOT === 'string') process.env.SYSTEMROOT = prevSYSTEMROOT;
+      else delete process.env.SYSTEMROOT;
+      if (typeof prevWindir === 'string') process.env.windir = prevWindir;
+      else delete process.env.windir;
+      if (typeof prevWINDIR === 'string') process.env.WINDIR = prevWINDIR;
+      else delete process.env.WINDIR;
+      if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
+      else delete process.env.MSYSTEM;
+      if (typeof prevOstype === 'string') process.env.OSTYPE = prevOstype;
+      else delete process.env.OSTYPE;
+      if (typeof prevWsl === 'string') process.env.WSL_DISTRO_NAME = prevWsl;
+      else delete process.env.WSL_DISTRO_NAME;
+      if (typeof prevWslInterop === 'string') process.env.WSL_INTEROP = prevWslInterop;
+      else delete process.env.WSL_INTEROP;
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
   it('uses the resolved node-hosted Codex launcher in native Windows startup commands', async () => {
     const fakeRoot = await mkdtemp(join(tmpdir(), 'omx-worker-startup-win32-node-hosted-'));
     const fakeBin = join(fakeRoot, 'node_modules', '.bin');
@@ -2431,7 +2555,14 @@ case "\${1:-}" in
     exit 0
     ;;
   list-panes)
-    printf "%%1\\tnode\\t'codex'\\n"
+    case "$*" in
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n%%2\\tgemini\\t'gemini'\\n%%3\\tnode\\t'node omx hud --watch'\\n"
+        ;;
+      *)
+        printf "%%1\\n%%2\\n%%3\\n"
+        ;;
+    esac
     exit 0
     ;;
   split-window)
@@ -2534,7 +2665,14 @@ case "\${1:-}" in
     exit 0
     ;;
   list-panes)
-    printf "%%1\\tnode\\t'codex'\\n"
+    case "$*" in
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n%%2\\tgemini\\t'gemini'\\n%%3\\tnode\\t'node omx hud --watch'\\n"
+        ;;
+      *)
+        printf "%%1\\n%%2\\n%%3\\n"
+        ;;
+    esac
     exit 0
     ;;
   split-window)
@@ -2585,6 +2723,117 @@ esac
           assert.doesNotMatch(tmuxLog, /set-hook -t leader:0 client-attached\[\d+\]/);
           assert.doesNotMatch(tmuxLog, /run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/);
           assert.doesNotMatch(tmuxLog, /run-shell tmux resize-pane -t %3 -y \d+ >/);
+        },
+      );
+    } finally {
+      if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
+      else delete process.env.MSYSTEM;
+      if (typeof prevOstype === 'string') process.env.OSTYPE = prevOstype;
+      else delete process.env.OSTYPE;
+      if (typeof prevWsl === 'string') process.env.WSL_DISTRO_NAME = prevWsl;
+      else delete process.env.WSL_DISTRO_NAME;
+      if (typeof prevWslInterop === 'string') process.env.WSL_INTEROP = prevWslInterop;
+      else delete process.env.WSL_INTEROP;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects synthetic worker and HUD pane ids that never materialize on native Windows', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-win32-synthetic-pane-'));
+    const prevTmux = process.env.TMUX;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevMsystem = process.env.MSYSTEM;
+    const prevOstype = process.env.OSTYPE;
+    const prevWsl = process.env.WSL_DISTRO_NAME;
+    const prevWslInterop = process.env.WSL_INTEROP;
+    const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-win32-synthetic-pane-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.3.2"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *)
+        printf "%%1\\n"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|select-layout|set-window-option|select-pane|resize-pane|set-hook|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          const fakeBinDir = join(logPath, '..');
+          const geminiPath = join(fakeBinDir, 'gemini');
+          const powershellExePath = join(fakeBinDir, 'powershell.exe');
+          await writeFile(geminiPath, '#!/bin/sh\nexit 0\n');
+          await chmod(geminiPath, 0o755);
+          await writeFile(powershellExePath, '');
+
+          process.env.TMUX = 'leader-session,stub,0';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+          delete process.env.MSYSTEM;
+          delete process.env.OSTYPE;
+          delete process.env.WSL_DISTRO_NAME;
+          delete process.env.WSL_INTEROP;
+          Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+          assert.throws(
+            () => createTeamSession('Windows Team', 1, cwd),
+            /worker pane 1 did not remain present/,
+          );
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          const listPaneCalls = tmuxLog.match(/list-panes -t leader:0 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}/g) || [];
+          assert.ok(listPaneCalls.length >= 2, tmuxLog);
+          assert.match(tmuxLog, /kill-pane -t %2/);
         },
       );
     } finally {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -80,6 +80,9 @@ const TMUX_COPY_MODE_STYLE_OPTIONS = [
   'mode-style',
   'copy-mode-selection-style',
 ] as const;
+const TMUX_PANE_STABILITY_POLL_MS = 60;
+const TMUX_PANE_STABILITY_POLLS_REQUIRED = 2;
+const TMUX_PANE_STABILITY_TIMEOUT_MS = 750;
 
 export type TeamWorkerCli = 'codex' | 'claude' | 'gemini';
 type TeamWorkerCliMode = 'auto' | TeamWorkerCli;
@@ -233,6 +236,38 @@ export function listPaneIds(target: string): string[] {
   return listPanes(target).map((pane) => pane.paneId);
 }
 
+function paneExistsInTarget(target: string, paneId: string): boolean {
+  if (!paneId.startsWith('%')) return false;
+  return listPaneIds(target).includes(paneId);
+}
+
+function waitForPaneToRemainPresent(
+  target: string,
+  paneId: string,
+  timeoutMs: number = TMUX_PANE_STABILITY_TIMEOUT_MS,
+): boolean {
+  if (!paneId.startsWith('%')) return false;
+
+  const stablePollsRequired = Math.max(1, TMUX_PANE_STABILITY_POLLS_REQUIRED);
+  const startedAt = Date.now();
+  let stablePolls = 0;
+
+  while (Date.now() - startedAt <= timeoutMs) {
+    if (paneExistsInTarget(target, paneId)) {
+      stablePolls += 1;
+      if (stablePolls >= stablePollsRequired) return true;
+    } else {
+      stablePolls = 0;
+    }
+
+    const remaining = timeoutMs - (Date.now() - startedAt);
+    if (remaining <= 0) break;
+    sleepFractionalSeconds(Math.max(0, Math.min(TMUX_PANE_STABILITY_POLL_MS, remaining)) / 1000);
+  }
+
+  return false;
+}
+
 function isHudWatchPane(pane: TmuxPaneInfo): boolean {
   const start = pane.startCommand || '';
   return /\bomx\b.*\bhud\b.*--watch/i.test(start);
@@ -348,6 +383,30 @@ function quotePowerShellArg(value: string): string {
 
 function encodePowerShellCommand(commandText: string): string {
   return Buffer.from(commandText, 'utf16le').toString('base64');
+}
+
+function resolveNativeWindowsPowerShellPath(env: NodeJS.ProcessEnv = process.env): string {
+  const rootCandidates = [
+    env.SystemRoot,
+    env.SYSTEMROOT,
+    env.windir,
+    env.WINDIR,
+  ]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .filter((value, index, values) => value !== '' && values.indexOf(value) === index);
+  const systemPowerShellCandidates = rootCandidates.map(
+    (root) => `${root.replace(/[\\/]+$/, '')}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
+  );
+  const resolvedFromPath = resolveCommandPathForPlatform('powershell', process.platform, env);
+  const existingCandidates = [
+    ...systemPowerShellCandidates,
+    resolvedFromPath,
+  ].filter((candidate): candidate is string => Boolean(candidate && existsSync(candidate)));
+
+  return existingCandidates.find((candidate) => !/\s/.test(candidate))
+    ?? existingCandidates[0]
+    ?? resolvedFromPath
+    ?? 'powershell.exe';
 }
 
 function normalizeTmuxHookToken(value: string): string {
@@ -804,6 +863,7 @@ export function buildWorkerStartupCommand(
     ? resolvedLeaderNodePath.replace(/[\\/][^\\/]+$/, '')
     : '';
   if (isNativeWindows()) {
+    const powershellPath = resolveNativeWindowsPowerShellPath();
     const pathBootstrap = leaderNodeDir
       ? `$env:PATH = ${quotePowerShellArg(`${leaderNodeDir};`)} + $env:PATH`
       : '';
@@ -819,7 +879,7 @@ export function buildWorkerStartupCommand(
         invocation,
       ].filter(Boolean).join('; '),
     );
-    return `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`;
+    return `${powershellPath} -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`;
   }
 
   const launchSpec = buildWorkerLaunchSpec(process.env.SHELL);
@@ -1042,8 +1102,11 @@ export function createTeamSession(
       if (!paneId || !paneId.startsWith('%')) {
         throw new Error(`failed to capture worker pane id for worker ${i}`);
       }
-      workerPaneIds.push(paneId);
       rollbackPaneIds.push(paneId);
+      if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, paneId)) {
+        throw new Error(`worker pane ${i} did not remain present after tmux split-window returned ${paneId}`);
+      }
+      workerPaneIds.push(paneId);
       if (i === 1) rightStackRootPaneId = paneId;
     }
 
@@ -1078,8 +1141,11 @@ export function createTeamSession(
       if (hudResult.ok) {
         const id = hudResult.stdout.split('\n')[0]?.trim() ?? '';
         if (id.startsWith('%')) {
+          rollbackPaneIds.push(id);
+          if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, id)) {
+            throw new Error(`HUD pane did not remain present after tmux split-window returned ${id}`);
+          }
           hudPaneId = id;
-          rollbackPaneIds.push(hudPaneId);
 
           if (isNativeWindows()) {
             // Native Windows tmux support may flow through psmux; issuing a


### PR DESCRIPTION
## Summary
Fix the remaining native Windows + `psmux` worker-pane bootstrap failures by resolving a concrete PowerShell launcher path and refusing to persist synthetic worker/HUD pane ids that never actually materialize.

Closes #1843.

## Problem
On native Windows with `psmux`, `omx team` could record worker/HUD pane ids and enter `team-exec` even when the panes never became real tmux panes. The bootstrap path was still brittle around PowerShell executable resolution, and runtime state could trust pane ids before durability was verified.

## What changed
- resolve a concrete PowerShell executable for native Windows worker bootstrap instead of relying on bare `powershell.exe`
- prefer an existing no-space system PowerShell path when available for `psmux`-sensitive split-window launches
- verify worker pane ids actually remain present after `tmux split-window` before persisting them
- verify HUD pane ids the same way
- roll back synthetic pane ids when durability checks fail
- add focused regressions for resolved PowerShell path selection, no-space PowerShell preference, and synthetic worker/HUD pane ids that never materialize
- update native Windows runtime fixtures to model live worker/HUD panes for the new durability checks

## Validation
- `npm ci`
- `npm run build`
- `node --test dist/team/__tests__/tmux-session.test.js --test-name-pattern 'resolved PowerShell executable|no-space native Windows PowerShell|native Windows HUD reconciliation|synthetic worker and HUD'`
- `node --test dist/team/__tests__/runtime.test.js --test-name-pattern 'native Windows tmux clients'`
- `node --test dist/utils/__tests__/platform-command.test.js --test-name-pattern 'PowerShell|psmux'`
- `npx biome lint src/team/tmux-session.ts src/team/__tests__/tmux-session.test.ts src/team/__tests__/runtime.test.ts`
- `git diff --check`

## Notes
- no live native Windows + `psmux` smoke run was possible from this Linux workspace, so verification is contract/regression based
- focused `biome lint` on touched files passes; broader `biome check` still wants pre-existing full-file formatting/import organization outside the narrow fix scope
