### PR TITLE
Fix Docker host-tmux question rendering with explicit pane evidence

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -317,4 +317,90 @@ exit 0
     assert.doesNotMatch(tmuxLog, /new-session/);
   });
 
+  it('uses an explicit return pane to launch from a container-like shell without TMUX', async () => {
+    const cwd = await makeRepo();
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(join(fakeBinDir, 'tmux'), `#!/bin/sh
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  split-window)
+    printf '%%45\n'
+    ;;
+  list-panes)
+    printf '0\t%%45\n'
+    ;;
+esac
+`, { mode: 0o755 });
+
+    const input = JSON.stringify({
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      session_id: 'sess-q',
+    });
+
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      OMX_QUESTION_RETURN_PANE: '%44',
+      OMX_AUTO_UPDATE: '0',
+      OMX_NOTIFY_FALLBACK: '0',
+      OMX_HOOK_DERIVED_SIGNALS: '0',
+    };
+    delete childEnv.TMUX;
+    delete childEnv.TMUX_PANE;
+    delete childEnv.OMX_QUESTION_TEST_RENDERER;
+
+    const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
+      cwd,
+      env: childEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+    child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+
+    const questionsDir = join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions');
+    let recordFile = '';
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const entries = await readdir(questionsDir);
+      recordFile = entries.find((entry) => entry.endsWith('.json')) || '';
+      if (recordFile) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    assert.notEqual(recordFile, '', `expected question record file, stderr=${stderr}`);
+    const recordPath = join(questionsDir, recordFile);
+
+    let record = null;
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      record = await readQuestionRecord(recordPath);
+      if (record?.status === 'prompting') break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    assert.equal(record?.status, 'prompting', `expected prompting question record, stderr=${stderr}`);
+    assert.equal(record?.renderer?.renderer, 'tmux-pane');
+    assert.equal(record?.renderer?.target, '%45');
+    assert.equal(record?.renderer?.return_target, '%44');
+
+    await markQuestionAnswered(recordPath, {
+      kind: 'option',
+      value: 'a',
+      selected_labels: ['A'],
+      selected_values: ['a'],
+    });
+
+    const exitCode = await new Promise<number | null>((resolve) => child.on('close', resolve));
+    assert.equal(exitCode, 0, stderr || stdout);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.answer.value, 'a');
+
+    const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+    assert.match(tmuxLog, /split-window -v -l 12 -t %44 -P -F #\{pane_id\}/);
+    assert.doesNotMatch(tmuxLog, /new-session/);
+  });
+
 });

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -26,6 +26,45 @@ describe('resolveQuestionRendererStrategy', () => {
     );
   });
 
+  it('supports explicit host-pane bridge hints when TMUX is absent', () => {
+    assert.equal(
+      resolveQuestionRendererStrategy({ OMX_QUESTION_RETURN_PANE: '%77' } as NodeJS.ProcessEnv, '/usr/bin/tmux'),
+      'inside-tmux',
+    );
+    assert.equal(
+      resolveQuestionRendererStrategy({ OMX_LEADER_PANE_ID: '%88' } as NodeJS.ProcessEnv, '/usr/bin/tmux'),
+      'inside-tmux',
+    );
+  });
+
+  it('supports persisted workflow pane bridges when TMUX is absent', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-question-renderer-strategy-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state', 'sessions', 'sess-stateful');
+      mkdirSync(stateDir, { recursive: true });
+      writeFileSync(join(stateDir, 'deep-interview-state.json'), JSON.stringify({
+        active: true,
+        mode: 'deep-interview',
+        current_phase: 'intent-first',
+        tmux_pane_id: '%91',
+      }, null, 2));
+
+      assert.equal(
+        resolveQuestionRendererStrategy({} as NodeJS.ProcessEnv, '/usr/bin/tmux', { cwd, sessionId: 'sess-stateful' }),
+        'inside-tmux',
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects malformed explicit host-pane bridge hints', () => {
+    assert.equal(
+      resolveQuestionRendererStrategy({ OMX_QUESTION_RETURN_PANE: 'not-a-pane' } as NodeJS.ProcessEnv, '/usr/bin/tmux'),
+      'unsupported',
+    );
+  });
+
   it('uses noop test renderer override when requested', () => {
     assert.equal(
       resolveQuestionRendererStrategy({ OMX_QUESTION_TEST_RENDERER: 'noop' } as NodeJS.ProcessEnv, '/usr/bin/tmux'),
@@ -157,6 +196,78 @@ describe('launchQuestionRenderer', () => {
     );
 
     assert.deepEqual(calls, [['display-message', '-p', '-t', '%11', '#{session_attached}']]);
+  });
+
+  it('targets an explicit host pane when launching from a container without TMUX', () => {
+    const calls: string[][] = [];
+    const result = launchQuestionRenderer(
+      {
+        cwd: '/repo',
+        recordPath: '/repo/.omx/state/sessions/s1/questions/question-bridge.json',
+        sessionId: 's1',
+        nowIso: '2026-04-19T00:00:00.000Z',
+        env: { OMX_QUESTION_RETURN_PANE: '%77' } as NodeJS.ProcessEnv,
+      },
+      {
+        execTmux: (args) => {
+          calls.push(args);
+          if (args[0] === 'split-window') return '%78\n';
+          if (args[0] === 'list-panes') return '0\t%78\n';
+          return '';
+        },
+        sleepSync: () => {},
+      },
+    );
+
+    assert.equal(result.renderer, 'tmux-pane');
+    assert.equal(result.target, '%78');
+    assert.equal(result.return_target, '%77');
+    assert.equal(result.return_transport, 'tmux-send-keys');
+    assert.equal(calls[0]?.[0], 'split-window');
+    assert.ok(!calls[0]?.includes('-d'));
+    assert.deepEqual(calls[0]?.slice(0, 7), ['split-window', '-v', '-l', '12', '-t', '%77', '-P']);
+    assert.deepEqual(calls[1], ['list-panes', '-t', '%78', '-F', '#{pane_dead}\t#{pane_id}']);
+  });
+
+  it('targets a persisted workflow pane when launching from a container without TMUX', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-question-renderer-persisted-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state', 'sessions', 'sess-stateful');
+      mkdirSync(stateDir, { recursive: true });
+      writeFileSync(join(stateDir, 'deep-interview-state.json'), JSON.stringify({
+        active: true,
+        mode: 'deep-interview',
+        current_phase: 'intent-first',
+        tmux_pane_id: '%91',
+      }, null, 2));
+
+      const calls: string[][] = [];
+      const result = launchQuestionRenderer(
+        {
+          cwd,
+          recordPath: join(stateDir, 'questions', 'question-bridge.json'),
+          sessionId: 'sess-stateful',
+          env: {} as NodeJS.ProcessEnv,
+        },
+        {
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'split-window') return '%92\n';
+            if (args[0] === 'list-panes') return '0\t%92\n';
+            return '';
+          },
+          sleepSync: () => {},
+        },
+      );
+
+      assert.equal(result.renderer, 'tmux-pane');
+      assert.equal(result.target, '%92');
+      assert.equal(result.return_target, '%91');
+      assert.equal(result.return_transport, 'tmux-send-keys');
+      assert.deepEqual(calls[0]?.slice(0, 7), ['split-window', '-v', '-l', '12', '-t', '%91', '-P']);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it('fails before prompting state when a reported split pane is already gone', () => {

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -38,14 +38,24 @@ function isPaneId(value: string | null | undefined): value is string {
   return typeof value === 'string' && /^%\d+$/.test(value.trim());
 }
 
+function hasExplicitQuestionPaneTarget(env: NodeJS.ProcessEnv): boolean {
+  return isPaneId(safeString(env.OMX_QUESTION_RETURN_PANE || env.OMX_LEADER_PANE_ID).trim());
+}
+
 export function resolveQuestionRendererStrategy(
   env: NodeJS.ProcessEnv = process.env,
   // Kept for callers/tests that used to pass detected tmux availability; default
   // strategy selection now depends only on renderer visibility signals.
   _tmuxBinary?: string | null,
+  options?: {
+    cwd?: string;
+    sessionId?: string;
+  },
 ): QuestionRendererStrategy {
   if (safeString(env.OMX_QUESTION_TEST_RENDERER).trim() === 'noop') return 'test-noop';
   if (safeString(env.TMUX).trim() !== '') return 'inside-tmux';
+  if (hasExplicitQuestionPaneTarget(env)) return 'inside-tmux';
+  if (options?.cwd && readPersistedQuestionReturnTarget(options.cwd, options.sessionId)) return 'inside-tmux';
   return 'unsupported';
 }
 
@@ -243,7 +253,10 @@ export function launchQuestionRenderer(
     sleepSync?: SleepSync;
   } = {},
 ): QuestionRendererState {
-  const strategy = deps.strategy ?? resolveQuestionRendererStrategy(options.env ?? process.env);
+  const strategy = deps.strategy ?? resolveQuestionRendererStrategy(options.env ?? process.env, undefined, {
+    cwd: options.cwd,
+    sessionId: options.sessionId,
+  });
   const execTmux = deps.execTmux ?? defaultExecTmux;
   const sleepImpl = deps.sleepSync ?? sleepSync;
   const launchedAt = options.nowIso ?? new Date().toISOString();
@@ -268,7 +281,10 @@ export function launchQuestionRenderer(
   });
 
   if (strategy === 'inside-tmux') {
-    if (!isCurrentTmuxSessionAttached(execTmux, env)) {
+    const splitTarget = returnTarget && !safeString(env.TMUX).trim()
+      ? ['-t', returnTarget]
+      : [];
+    if (splitTarget.length === 0 && !isCurrentTmuxSessionAttached(execTmux, env)) {
       throw new Error(
         'omx question cannot open a visible renderer because this tmux session has no attached client. Run omx question from an attached tmux pane.',
       );
@@ -279,6 +295,7 @@ export function launchQuestionRenderer(
       '-v',
       '-l',
       '12',
+      ...splitTarget,
       '-P',
       '-F',
       '#{pane_id}',


### PR DESCRIPTION
## Summary
- allow `omx question` to use a host tmux pane from container-like shells when OMX has explicit pane evidence (`OMX_QUESTION_RETURN_PANE` / `OMX_LEADER_PANE_ID`) or active persisted workflow `tmux_pane_id`
- target the known pane with `tmux split-window -t <pane>` when `$TMUX` is absent, preserving visible renderer behavior without detached fallback
- add renderer and CLI regressions for explicit/persisted pane bridges while retaining fail-closed behavior when no pane evidence exists

Fixes #1846.

## Problem
Inside a Docker container, OMX deep-interview could fail to render `omx question` even when the user was effectively operating from a host tmux session. The existing detection path treated missing `$TMUX` as unsupported, even when OMX already had concrete pane evidence that could safely target a visible host pane.

## What changed
- treat `OMX_QUESTION_RETURN_PANE`, `OMX_LEADER_PANE_ID`, or active persisted workflow `tmux_pane_id` as valid visible-renderer evidence when `$TMUX` is absent
- use `tmux split-window -t <known-pane>` for this container/host bridge path
- preserve the existing unsupported error when no pane evidence exists
- add explicit-pane, persisted-pane, malformed-pane, and CLI regression coverage for the bridge path

## Validation
- `npm run build`
- `node --test dist/question/__tests__/renderer.test.js dist/cli/__tests__/question.test.js`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/biome lint src/question/renderer.ts src/question/__tests__/renderer.test.ts src/cli/__tests__/question.test.ts`
- `git diff --check`

## Risk / contract
- this is intentionally narrow: it does **not** claim generic host-tmux discovery from arbitrary containers
- the bridge path is enabled only when OMX has concrete pane evidence; otherwise OMX still fails closed with the existing unsupported error
- if the container cannot actually reach the host tmux socket/binary path, fail-closed behavior remains the correct outcome
