### PR TITLE
fix(team): reap orphaned OMX MCP processes before spawning team workers

### DIFF
--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -545,3 +545,46 @@ export async function cleanupCommand(
   if (args.includes('--help') || args.includes('-h')) return;
   await cleanupTmpDirectories(args);
 }
+
+export async function cleanupLaunchOrphanedMcpProcesses(
+  dependencies: CleanupDependencies = {},
+): Promise<CleanupResult> {
+  return cleanupOmxMcpProcesses([], {
+    ...dependencies,
+    selectCandidates: dependencies.selectCandidates ?? findLaunchSafeCleanupCandidates,
+    writeLine: dependencies.writeLine ?? (() => {}),
+  });
+}
+
+export interface PostLaunchCleanupDependencies {
+  cleanup?: () => Promise<CleanupResult>;
+  writeInfo?: (line: string) => void;
+  writeWarn?: (line: string) => void;
+  writeError?: (line: string) => void;
+}
+
+export async function reapPostLaunchOrphanedMcpProcesses(
+  dependencies: PostLaunchCleanupDependencies = {},
+): Promise<void> {
+  const cleanup = dependencies.cleanup ?? cleanupLaunchOrphanedMcpProcesses;
+  const writeInfo = dependencies.writeInfo ?? console.log;
+  const writeWarn = dependencies.writeWarn ?? console.warn;
+  const writeError =
+    dependencies.writeError ?? ((line: string) => process.stderr.write(line));
+
+  try {
+    const result = await cleanup();
+    if (result.terminatedCount > 0) {
+      writeInfo(
+        `[omx] postLaunch: reaped ${result.terminatedCount} orphaned OMX MCP process(es).`,
+      );
+    }
+    if (result.failedPids.length > 0) {
+      writeWarn(
+        `[omx] postLaunch: failed to reap ${result.failedPids.length} orphaned OMX MCP process(es); continuing cleanup.`,
+      );
+    }
+  } catch (err) {
+    writeError(`[cli/index] postLaunch MCP cleanup failed: ${err}\n`);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,11 +20,16 @@ import { questionCommand } from "./question.js";
 import { stateCommand } from "./state.js";
 import {
   cleanupCommand,
-  cleanupOmxMcpProcesses,
-  findLaunchSafeCleanupCandidates,
-  type CleanupDependencies,
-  type CleanupResult,
+  cleanupLaunchOrphanedMcpProcesses,
+  reapPostLaunchOrphanedMcpProcesses,
+  type PostLaunchCleanupDependencies,
 } from "./cleanup.js";
+
+export {
+  cleanupLaunchOrphanedMcpProcesses,
+  reapPostLaunchOrphanedMcpProcesses,
+  type PostLaunchCleanupDependencies,
+};
 import { exploreCommand } from "./explore.js";
 import { sparkshellCommand } from "./sparkshell.js";
 import { agentsInitCommand } from "./agents-init.js";
@@ -1987,23 +1992,6 @@ export function shouldEnableNotifyFallbackWatcher(
   return toggle !== "0";
 }
 
-export async function cleanupLaunchOrphanedMcpProcesses(
-  dependencies: CleanupDependencies = {},
-): Promise<CleanupResult> {
-  return cleanupOmxMcpProcesses([], {
-    ...dependencies,
-    selectCandidates: dependencies.selectCandidates ?? findLaunchSafeCleanupCandidates,
-    writeLine: dependencies.writeLine ?? (() => {}),
-  });
-}
-
-interface PostLaunchCleanupDependencies {
-  cleanup?: () => Promise<CleanupResult>;
-  writeInfo?: (line: string) => void;
-  writeWarn?: (line: string) => void;
-  writeError?: (line: string) => void;
-}
-
 interface PostLaunchModeCleanupDependencies {
   readdir?: typeof import("fs/promises").readdir;
   readFile?: typeof import("fs/promises").readFile;
@@ -2211,32 +2199,6 @@ export async function cleanupPostLaunchModeStateFiles(
         );
       }
     }
-  }
-}
-
-export async function reapPostLaunchOrphanedMcpProcesses(
-  dependencies: PostLaunchCleanupDependencies = {},
-): Promise<void> {
-  const cleanup = dependencies.cleanup ?? cleanupLaunchOrphanedMcpProcesses;
-  const writeInfo = dependencies.writeInfo ?? console.log;
-  const writeWarn = dependencies.writeWarn ?? console.warn;
-  const writeError =
-    dependencies.writeError ?? ((line: string) => process.stderr.write(line));
-
-  try {
-    const result = await cleanup();
-    if (result.terminatedCount > 0) {
-      writeInfo(
-        `[omx] postLaunch: reaped ${result.terminatedCount} orphaned OMX MCP process(es).`,
-      );
-    }
-    if (result.failedPids.length > 0) {
-      writeWarn(
-        `[omx] postLaunch: failed to reap ${result.failedPids.length} orphaned OMX MCP process(es); continuing cleanup.`,
-      );
-    }
-  } catch (err) {
-    writeError(`[cli/index] postLaunch MCP cleanup failed: ${err}\n`);
   }
 }
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -960,6 +960,78 @@ sleep 5
     }
   });
 
+  it('startTeam reaps launch-safe OMX MCP orphans before spawning workers', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-reap-mcp-'));
+    const binDir = join(cwd, 'bin');
+    const fakeGeminiPath = join(binDir, 'gemini');
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      fakeGeminiPath,
+      `#!/usr/bin/env bash
+sleep 5
+`,
+      { mode: 0o755 },
+    );
+
+    const prevPath = process.env.PATH;
+    const prevTmux = process.env.TMUX;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+
+    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
+    delete process.env.TMUX;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+    process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+
+    let reapCallCount = 0;
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withoutTeamWorkerEnv(() =>
+        startTeam(
+          'reap-mcp',
+          'task',
+          'explore',
+          1,
+          [{ subject: 's', description: 'd', owner: 'worker-1' }],
+          cwd,
+          {
+            reapOrphanedMcpProcesses: async () => {
+              reapCallCount += 1;
+              return {
+                dryRun: false,
+                candidates: [],
+                terminatedCount: 0,
+                forceKilledCount: 0,
+                failedPids: [],
+              };
+            },
+          },
+        ),
+      );
+      assert.equal(
+        reapCallCount,
+        1,
+        'startTeam must invoke the launch-safe MCP reap exactly once before worker spawn',
+      );
+      await shutdownTeam(runtime.teamName, cwd, { force: true });
+      runtime = null;
+    } finally {
+      const runtimeToShutdown = runtime as TeamRuntime | null;
+      if (runtimeToShutdown) {
+        await shutdownTeam(runtimeToShutdown.teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam throws when tmux is not available', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
     const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -121,6 +121,10 @@ import { getTeamTmuxSessions } from '../notifications/tmux.js';
 import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
 import { buildRebalanceDecisions } from './rebalance-policy.js';
 import { getStatePath } from '../mcp/state-paths.js';
+import {
+  cleanupLaunchOrphanedMcpProcesses,
+  type CleanupResult,
+} from '../cli/cleanup.js';
 import { readModeState, updateModeState } from '../modes/base.js';
 import {
   appendTeamCommitHygieneEntries,
@@ -1189,6 +1193,13 @@ export interface StaleTeamSummary {
 export interface TeamStartOptions {
   worktreeMode?: WorktreeMode;
   confirmStaleCleanup?: (summary: StaleTeamSummary) => Promise<boolean>;
+  /**
+   * Injected best-effort reap for detached OMX MCP orphans before worker
+   * launch. Defaults to `cleanupLaunchOrphanedMcpProcesses`, which is the same
+   * launch-safe reap used by `launchWithHud`. Tests override this to observe
+   * invocation without touching real processes.
+   */
+  reapOrphanedMcpProcesses?: () => Promise<CleanupResult>;
 }
 
 interface ShutdownGateCounts {
@@ -2269,6 +2280,34 @@ export async function startTeam(
       await writeWorkerIdentity(sanitized, bootstrapPlan.workerName, identity, leaderCwd);
       await writeWorkerInbox(sanitized, bootstrapPlan.workerName, bootstrapPlan.inbox, leaderCwd);
     };
+
+    // 5.5. Best-effort launch-safe orphan cleanup for detached OMX MCP
+    // processes before worker codex instances are spawned. Matches the
+    // invariant established by `launchWithHud` (#1345 / 994b161e) so team
+    // workers do not bleed MCP orphans from prior crashed/aborted sessions.
+    // `findLaunchSafeCleanupCandidates` preserves the live leader ancestry,
+    // so the current team leader's MCP children are never at risk.
+    const reapOrphanedMcpProcesses =
+      options.reapOrphanedMcpProcesses ?? cleanupLaunchOrphanedMcpProcesses;
+    try {
+      const cleanup = await reapOrphanedMcpProcesses();
+      if (cleanup.terminatedCount > 0) {
+        console.log(
+          `[omx] team: reaped ${cleanup.terminatedCount} orphaned OMX MCP process(es) before worker launch.`,
+        );
+      }
+      if (cleanup.failedPids.length > 0) {
+        console.warn(
+          `[omx] team: failed to reap ${cleanup.failedPids.length} orphaned OMX MCP process(es); continuing launch.`,
+        );
+      }
+    } catch (err) {
+      // Non-fatal: team launch must still proceed even if the reap probe
+      // (e.g. `ps axww`) is unavailable in the current environment.
+      process.stderr.write(
+        `[team/runtime] pre-worker MCP reap failed: ${err}\n`,
+      );
+    }
 
     // 6. Create worker runtime (interactive tmux panes or prompt-mode child processes)
     if (workerLaunchMode === 'interactive') {


### PR DESCRIPTION
## Summary

- Extend the launch-safe MCP reap from `launchWithHud` (introduced by PR #1345 / `994b161e`) to the `omx team` spawn paths so `$team`-heavy workflows no longer leak OMX MCP orphans across iterations.
- Relocate the reap helpers (`cleanupLaunchOrphanedMcpProcesses`, `reapPostLaunchOrphanedMcpProcesses`, `PostLaunchCleanupDependencies`) from `src/cli/index.ts` into `src/cli/cleanup.ts`, where all of their dependencies already live, and re-export them from `index.ts` for backwards-compatible imports.
- Add a regression test in `src/team/__tests__/runtime.test.ts` that asserts `startTeam` fires the reap exactly once before worker spawn.

## Root cause

Grep on upstream `main` at v0.14.3 shows the reap helpers have exactly three non-test call sites, all inside `src/cli/index.ts`:

```
src/cli/index.ts:970   // launchWithHud direct-attach → preLaunch(...)
src/cli/index.ts:1064  // launchWithHud detached     → preLaunch(...)
src/cli/index.ts:2764  // top-level exit             → reapPostLaunchOrphanedMcpProcesses()
```

The team module has zero call sites. `src/team/runtime.ts:1847-1881` (`spawnPromptWorker`) and `src/team/tmux-session.ts:1003` (`createTeamSession`) invoke the `codex`/`claude`/`gemini` binary directly — `spawn()` for prompt mode, `tmux split-window` for interactive mode — without calling the reap. Ralph is unaffected because `src/cli/ralph.ts:293-303` funnels into `launchWithHud`.

Under `$team`-heavy operator flows, each team iteration bleeds MCP orphans from the previous iteration, and the next reap only fires when the operator eventually runs a top-level `omx codex` / `omx launch` / `omx ralph` — which, inside a long-lived session, may not happen at all.

## Changes

- `src/cli/cleanup.ts`
  - Add `cleanupLaunchOrphanedMcpProcesses`, `reapPostLaunchOrphanedMcpProcesses`, and the `PostLaunchCleanupDependencies` interface. The moved bodies are identical to the previous definitions in `src/cli/index.ts`; log strings (`[omx] postLaunch: reaped …`, `[cli/index] postLaunch MCP cleanup failed: …`) are preserved verbatim so the existing regression tests keep matching.

- `src/cli/index.ts`
  - Replace the three local definitions with an import-and-re-export of the helpers from `./cleanup.js`. Remove now-unused imports of `cleanupOmxMcpProcesses`, `findLaunchSafeCleanupCandidates`, `CleanupDependencies`, and `CleanupResult`. Existing tests that import the helpers from `"../index.js"` continue to resolve through the re-export.

- `src/team/runtime.ts`
  - Import the reap helper directly from `../cli/cleanup.js` (the relocation commit is a prerequisite to avoid a `cli/index.ts → cli/team.ts → team/runtime.ts → cli/index.ts` circular ESM cycle).
  - Add an injectable `reapOrphanedMcpProcesses` field to `TeamStartOptions` so tests can observe invocations; it defaults to `cleanupLaunchOrphanedMcpProcesses`.
  - Fire the reap at the top of the "Create worker runtime" block, immediately before the `if (workerLaunchMode === 'interactive')` branch, so the single insertion point covers both the interactive tmux and the prompt-mode spawn path. The call is wrapped in `try/catch` so a missing or restricted `ps` (e.g. BusyBox-minimal environments handled by PR #1836) remains non-fatal.

- `src/team/__tests__/runtime.test.ts`
  - Add `startTeam reaps launch-safe OMX MCP orphans before spawning workers`, modeled on the existing `startTeam allows nested team invocation when parent governance enables it` test. Uses the same fake-`gemini` binary + prompt-mode pattern, injects a spy via `reapOrphanedMcpProcesses`, and asserts the reap fires exactly once during a successful `startTeam`.

## Why a two-commit structure

The relocation commit is mechanically separate from the behavior change:

1. **`fix(cli): relocate launch-time MCP reap helpers to cleanup.ts`** is a pure code move — zero behavior change, zero log-line change, zero public-signature change. It exists to unblock the team import without closing a circular module cycle.
2. **`fix(team): reap orphaned OMX MCP processes before spawning team workers`** is the single-line-of-reasoning behavior change. All of the orphan-prevention logic and tests live here.

Shipping both as one commit would conflate the relocation with the behavior change and make revert harder if the team-side change ever regresses.

## Why only a pre-launch reap (not post-launch) on the team path

`launchWithHud` holds the codex session in the foreground and fires `reapPostLaunchOrphanedMcpProcesses` after codex exits (`src/cli/index.ts:2764`). `startTeam` returns while worker codex processes are still running (detached or tmux-panes), so the equivalent "post-launch" moment is team *shutdown*, which is a separate entrypoint (`shutdownTeam`). Wiring a post-launch reap there is a meaningful follow-up but is deliberately out of scope for this focused PR — adding it would double the surface area and blur the "match the `launchWithHud preLaunch` invariant" framing.

## Why the reap cannot terminate healthy processes

`findLaunchSafeCleanupCandidates` (`src/cli/cleanup.ts`) walks the process ancestry via `ps` and preserves any OMX MCP whose ancestor chain contains a live codex or omx launch process. The current team leader is, by construction, a live codex/omx process, so its MCP children (and any peer team's children under their own leader) are filtered out before any signal is sent. The new call site cannot regress healthy siblings under realistic conditions — the same invariant already protects concurrent `launchWithHud` launches today.

## Validation

- [x] `npm run build`
- [x] `npm run check:no-unused`
- [x] `node --test dist/cli/__tests__/cleanup.test.js` — `17 passed, 0 failed`
- [x] `node --test dist/cli/__tests__/index.test.js` — `189 passed, 2 failed`; the 2 pre-existing tmux-detached tests also fail on pristine `origin/dev` without this PR's changes
- [x] `node --test --test-name-pattern="startTeam reaps launch-safe OMX MCP orphans" dist/team/__tests__/runtime.test.js` — `1 passed`
- [x] `node --test dist/team/__tests__/runtime.test.js` — `102 passed, 0 failed`
- [ ] `omx doctor` (setup/config behavior unchanged)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — not needed; this is an internal lifecycle fix with no operator-facing config surface
- [x] Backward-compatibility impact considered — reap helpers remain importable from `src/cli/index.js` via re-export; log lines and public signatures unchanged; the new `TeamStartOptions.reapOrphanedMcpProcesses` field is optional with a safe default

## Related

Closes #1850
Extends #1345 (`994b161e`) to the team spawn path.
Complementary to #1666 and #1811, which harden duplicate-sibling reconciliation in the same subsystem but do not address the team-launch scope gap.
