### PR TITLE
Warn agents when spec-driven docs may be stale

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,43 @@ That document defines the GPT-5.4 behavior contract contributors should preserve
 2. Run `omx setup --force` to install it to `~/.codex/skills/`
 3. Use `$my-skill` in Codex CLI
 
+
+### Document refresh warnings
+
+OMX has an agent-only document-refresh warning MVP for spec-driven changes. It
+warns Codex/OMX agents when mapped product or test-contract code changes appear
+without a rule-scoped planning-spec or product-doc refresh. This is warning-only:
+it does not add a generic CI failure, does not install a pre-commit framework,
+and must not hard-block `git commit` for document-refresh reasons.
+
+Current mapped refresh examples:
+
+- Native hook behavior (`src/scripts/codex-native-hook.ts`,
+  `src/scripts/codex-native-pre-post.ts`, `src/config/codex-hooks.ts`, and
+  related native-hook tests) should refresh `docs/codex-native-hooks.md` or a
+  native-hook-scoped planning/spec file.
+- Document-refresh enforcer behavior (`src/document-refresh/**`) should refresh
+  `docs/codex-native-hooks.md` or a document-refresh-scoped planning/spec file.
+- CLI/operator behavior (`src/cli/**`) should refresh `README.md`,
+  `docs/getting-started.html`, or a relevant planning/spec file.
+- Prompt-guidance behavior (`src/hooks/**` rule-owned guidance surfaces) should
+  refresh `docs/prompt-guidance-contract.md` or a relevant planning/spec file.
+
+Commit-path warnings are Bash `git commit` scoped and read only the staged diff.
+Because `.omx/` is gitignored, `.omx/plans/**` and `.omx/specs/**` count for
+commit-path suppression only when tracked or force-staged and rule-owned.
+Final-handoff warnings run only on terminal-looking handoff attempts, read staged
+plus unstaged changes, and can count fresh local rule-owned `.omx` planning/spec
+files. That mtime-based local freshness is heuristic evidence, not proof of a
+semantic refresh.
+
+If no document refresh is needed, include an explicit acknowledgement with a
+reason in the commit message or final handoff:
+
+```text
+Document-refresh: not-needed | <reason>
+```
+
 ## Workflow
 
 1. Create a branch from `dev` for normal contributions.

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -31,8 +31,8 @@ OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js
 | `session-start` | `SessionStart` | `session-start` | native | Native adapter refreshes session bookkeeping, restores startup developer context, and ensures `.omx/` is gitignored at the repo root |
 | wiki startup context | `SessionStart` | `session-start` | native | Wiki session-start context can append a compact `.omx/wiki/` summary when wiki pages exist; startup writes stay config-gated |
 | `keyword-detector` | `UserPromptSubmit` | `keyword-detector` | native | Persists skill activation state and can add prompt-side developer context; `$ralph` prompt routing seeds workflow state only and does not launch `omx ralph --prd ...` |
-| `pre-tool-use` | `PreToolUse` (`Bash`) | `pre-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior cautions on `rm -rf dist` and blocks inspectable inline `git commit` commands until Lore-format structure + the required `Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer are present |
-| `post-tool-use` | `PostToolUse` (`Bash`) | `post-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior covers command-not-found / permission-denied / missing-path guidance and informative non-zero-output review |
+| `pre-tool-use` | `PreToolUse` (`Bash`) | `pre-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior cautions on `rm -rf dist`, blocks inspectable inline `git commit` commands until Lore-format structure + the required `Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer are present, and emits non-blocking document-refresh warnings for mapped staged commit changes that lack rule-scoped docs/spec refresh evidence |
+| `post-tool-use` | `PostToolUse` (`Bash`) | `post-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior covers command-not-found / permission-denied / missing-path guidance and informative non-zero-output review; document-refresh commit warnings use PreToolUse advisory output, with PostToolUse reserved as a future fallback if Codex advisory semantics change |
 | Ralph/persistence stop handling | `Stop` | `stop` | native-partial | Native adapter uses the documented native Stop continuation contract (`decision: "block"` + `reason`) for active Ralph runs and avoids re-blocking once `stop_hook_active` is set |
 | Autopilot continuation | `Stop` | `stop` | native-partial | Native adapter continues non-terminal autopilot sessions from active session/root mode state |
 | Ultrawork continuation | `Stop` | `stop` | native-partial | Native adapter continues non-terminal ultrawork sessions from active session/root mode state |
@@ -49,6 +49,50 @@ OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js
 | `session-end` | none | `session-end` | runtime-fallback | Still emitted from runtime/notify path, not native Codex hooks |
 | wiki session capture | none | `session-end` | runtime-fallback | Wiki session-log capture runs from the existing runtime session-end cleanup path, not from a native Codex hook |
 | `session-idle` | none | `session-idle` | runtime-fallback | Still emitted from runtime/notify path, not native Codex hooks |
+
+
+## Document-refresh warning MVP
+
+The native hook adapter includes an agent-only document-refresh warning MVP for
+spec-driven development hygiene. It does **not** install a generic CI gate, does
+**not** add a repo-wide pre-commit framework, and must not hard-block `git
+commit` for document-refresh reasons. Existing Lore commit blocking remains
+separate and still wins when an inline commit message is not Lore-compliant.
+
+Warning scope is intentionally narrow and rule-scoped:
+
+- **Commit path:** `PreToolUse` is Bash-only in this MVP and evaluates only
+  inspectable `git commit` commands. It reads `git diff --cached --name-status`,
+  so only staged changes count. Staged product docs such as
+  `docs/codex-native-hooks.md` can suppress a native-hook rule warning.
+  Rule-owned `.omx/plans/**` and `.omx/specs/**` targets suppress commit-path
+  warnings only when they are tracked or force-staged despite `.omx/` being
+  gitignored. Local-only ignored planning files do not suppress commit warnings.
+- **Final handoff path:** `Stop` evaluates only terminal-looking final handoff
+  attempts, after active-mode blockers and auto-nudge recovery. It reads staged
+  plus unstaged diffs and can count fresh local rule-owned `.omx/plans/**` or
+  `.omx/specs/**` files when their mtimes are newer than the mapped source
+  change. This is an agent-local heuristic freshness check for final handoff,
+  not commit evidence or proof of semantic refresh.
+- **Mappings:** rules live in `src/document-refresh/config.ts`; unrelated doc
+  or `.omx` edits do not suppress warnings for another rule. Initial rules cover
+  native hook behavior, document-refresh enforcer behavior, CLI/operator
+  behavior, and prompt-guidance behavior only.
+- **Exclusions:** tooling-only changes, release collateral, rename-only changes,
+  and explicitly ignored non-user-facing internal tests are ignored
+  conservatively. Ambiguous refactors should use the explicit exemption if no
+  product/spec refresh is needed.
+
+To acknowledge a legitimate no-refresh case, include this exact line in the
+commit message or final handoff text with a concrete reason:
+
+```text
+Document-refresh: not-needed | <reason>
+```
+
+The warning output names the mapped triggering path(s) and expected refresh
+target group(s), so agents can refresh the right product docs or planning specs
+instead of using an unrelated docs edit as a blanket suppression.
 
 ## Project wiki addendum (approved v1 backport)
 

--- a/src/document-refresh/__tests__/enforcer.test.ts
+++ b/src/document-refresh/__tests__/enforcer.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { utimes, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  DOCUMENT_REFRESH_EXEMPTION_PREFIX,
+  evaluateDocumentRefresh,
+  findFreshLocalPlanningTargets,
+  isFinalHandoffDocumentRefreshCandidate,
+  parseGitNameStatus,
+  type ChangedPathRecord,
+} from "../enforcer.js";
+
+function warningFor(changes: ChangedPathRecord[], options: {
+  scope?: "commit" | "final-handoff";
+  exemptionText?: string;
+  localFreshTargets?: string[];
+} = {}) {
+  return evaluateDocumentRefresh({
+    scope: options.scope ?? "commit",
+    changes,
+    exemptionText: options.exemptionText,
+    localFreshTargets: options.localFreshTargets,
+  });
+}
+
+describe("document refresh evaluator", () => {
+  it("triggers on mapped native-hook source without docs/spec refresh", () => {
+    const warning = warningFor([{ status: "M", path: "src/scripts/codex-native-hook.ts" }]);
+
+    assert.ok(warning);
+    assert.match(warning.message, /Document-refresh warning/);
+    assert.deepEqual(warning.triggeringPaths, ["src/scripts/codex-native-hook.ts"]);
+    assert.ok(warning.expectedTargets.includes("docs/codex-native-hooks.md"));
+  });
+
+  it("commit path suppresses when tracked or force-staged rule-scoped planning spec appears in the diff", () => {
+    const warning = warningFor([
+      { status: "M", path: "src/document-refresh/enforcer.ts" },
+      { status: "A", path: ".omx/plans/prd-document-refresh-enforcer.md" },
+    ]);
+
+    assert.equal(warning, null);
+  });
+
+  it("does not suppress native-hook changes with document-refresh-only planning specs", () => {
+    const warning = warningFor([
+      { status: "M", path: "src/scripts/codex-native-hook.ts" },
+      { status: "A", path: ".omx/plans/prd-document-refresh-enforcer.md" },
+    ]);
+
+    assert.ok(warning);
+    assert.deepEqual(warning.rules.map((rule) => rule.ruleId), ["native-hook-behavior"]);
+  });
+
+  it("commit path does not suppress on ignored local-only planning spec evidence", () => {
+    const warning = warningFor(
+      [{ status: "M", path: "src/scripts/codex-native-hook.ts" }],
+      { scope: "commit", localFreshTargets: [".omx/plans/prd-document-refresh-enforcer.md"] },
+    );
+
+    assert.ok(warning);
+  });
+
+  it("commit path suppresses when relevant product doc changed", () => {
+    const warning = warningFor([
+      { status: "M", path: "src/scripts/codex-native-hook.ts" },
+      { status: "M", path: "docs/codex-native-hooks.md" },
+    ]);
+
+    assert.equal(warning, null);
+  });
+
+  it("does not suppress on unrelated doc change", () => {
+    const warning = warningFor([
+      { status: "M", path: "src/scripts/codex-native-hook.ts" },
+      { status: "M", path: "docs/release-notes-0.14.3.md" },
+    ]);
+
+    assert.ok(warning);
+    assert.deepEqual(warning.triggeringPaths, ["src/scripts/codex-native-hook.ts"]);
+  });
+
+  it("suppresses explicit exemption", () => {
+    const warning = warningFor(
+      [{ status: "M", path: "src/scripts/codex-native-hook.ts" }],
+      { exemptionText: `${DOCUMENT_REFRESH_EXEMPTION_PREFIX} internal-only behavior verified` },
+    );
+
+    assert.equal(warning, null);
+  });
+
+  it("ignores tooling-only changes", () => {
+    const warning = warningFor([
+      { status: "M", path: "package.json" },
+      { status: "M", path: "tsconfig.json" },
+      { status: "M", path: "biome.json" },
+      { status: "M", path: ".github/workflows/ci.yml" },
+    ]);
+
+    assert.equal(warning, null);
+  });
+
+  it("ignores release/docs collateral trigger-only changes", () => {
+    const warning = warningFor([
+      { status: "M", path: "CHANGELOG.md" },
+      { status: "M", path: "RELEASE_BODY.md" },
+      { status: "M", path: "docs/release-notes-0.14.3.md" },
+      { status: "M", path: "docs/qa/release-readiness-20260423.md" },
+    ]);
+
+    assert.equal(warning, null);
+  });
+
+  it("ignores rename-only changes", () => {
+    const warning = warningFor([
+      { status: "R100", previousPath: "src/cli/old.ts", path: "src/cli/new.ts" },
+    ]);
+
+    assert.equal(warning, null);
+  });
+
+  it("ignores non-user-facing internal test-only change", () => {
+    const warning = warningFor([
+      { status: "M", path: "src/cli/__tests__/internal.test.ts" },
+    ]);
+
+    assert.equal(warning, null);
+  });
+
+  it("parses git name-status rename records", () => {
+    assert.deepEqual(parseGitNameStatus("M\tsrc/scripts/codex-native-hook.ts\nR100\tsrc/cli/old.ts\tsrc/cli/new.ts\n"), [
+      { status: "M", path: "src/scripts/codex-native-hook.ts" },
+      { status: "R100", previousPath: "src/cli/old.ts", path: "src/cli/new.ts" },
+    ]);
+  });
+
+  it("recognizes only terminal-looking final handoff text for Stop warnings", () => {
+    assert.equal(isFinalHandoffDocumentRefreshCandidate("Launch-ready: yes"), true);
+    assert.equal(isFinalHandoffDocumentRefreshCandidate("All verification passed; ready to merge."), true);
+    assert.equal(isFinalHandoffDocumentRefreshCandidate("Task completed with green verification."), true);
+    assert.equal(isFinalHandoffDocumentRefreshCandidate("I am done inspecting and will edit next."), false);
+    assert.equal(isFinalHandoffDocumentRefreshCandidate("I will keep working on the implementation."), false);
+    assert.equal(isFinalHandoffDocumentRefreshCandidate(""), false);
+  });
+
+  it("final handoff local .omx freshness suppresses when planning spec is newer than source", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-document-refresh-fresh-"));
+    try {
+      const sourcePath = join(cwd, "src", "scripts", "codex-native-hook.ts");
+      const planPath = join(cwd, ".omx", "plans", "prd-native-hook-behavior.md");
+      await mkdir(join(cwd, "src", "scripts"), { recursive: true });
+      await mkdir(join(cwd, ".omx", "plans"), { recursive: true });
+      await writeFile(sourcePath, "source", "utf-8");
+      await writeFile(planPath, "plan", "utf-8");
+      const oldDate = new Date("2026-04-23T00:00:00Z");
+      const newDate = new Date("2026-04-23T01:00:00Z");
+      await utimes(sourcePath, oldDate, oldDate);
+      await utimes(planPath, newDate, newDate);
+
+      const changes = [{ status: "M", path: "src/scripts/codex-native-hook.ts" }];
+      const freshTargets = findFreshLocalPlanningTargets(cwd, changes);
+      assert.deepEqual(freshTargets, [".omx/plans/prd-native-hook-behavior.md"]);
+      assert.equal(warningFor(changes, { scope: "final-handoff", localFreshTargets: freshTargets }), null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/document-refresh/config.ts
+++ b/src/document-refresh/config.ts
@@ -1,0 +1,77 @@
+export interface DocumentRefreshRule {
+  id: string;
+  description: string;
+  sourceGlobs: string[];
+  refreshTargets: string[];
+  ignoredGlobs?: string[];
+}
+
+export const DEFAULT_DOCUMENT_REFRESH_RULES: DocumentRefreshRule[] = [
+  {
+    id: "native-hook-behavior",
+    description: "Codex native hook behavior and managed hook configuration",
+    sourceGlobs: [
+      "src/scripts/codex-native-hook.ts",
+      "src/scripts/codex-native-pre-post.ts",
+      "src/scripts/__tests__/codex-native-hook.test.ts",
+      "src/config/codex-hooks.ts",
+      "src/config/__tests__/codex-hooks.test.ts",
+    ],
+    refreshTargets: [
+      "docs/codex-native-hooks.md",
+      ".omx/plans/*codex-native*",
+      ".omx/specs/*codex-native*",
+      ".omx/plans/*native-hook*",
+      ".omx/specs/*native-hook*",
+    ],
+  },
+  {
+    id: "document-refresh-enforcer",
+    description: "Document-refresh warning classifier and rule behavior",
+    sourceGlobs: [
+      "src/document-refresh/**",
+    ],
+    refreshTargets: [
+      "docs/codex-native-hooks.md",
+      ".omx/plans/*document-refresh*",
+      ".omx/specs/*document-refresh*",
+    ],
+  },
+  {
+    id: "cli-operator-behavior",
+    description: "CLI and operator-facing behavior",
+    sourceGlobs: [
+      "src/cli/**",
+    ],
+    refreshTargets: [
+      "README.md",
+      "docs/getting-started.html",
+      ".omx/plans/*cli*",
+      ".omx/specs/*cli*",
+      ".omx/plans/*operator*",
+      ".omx/specs/*operator*",
+    ],
+    ignoredGlobs: [
+      "src/cli/**/__tests__/**",
+      "src/cli/**/*.test.ts",
+    ],
+  },
+  {
+    id: "prompt-guidance-behavior",
+    description: "Prompt guidance and hook routing behavior",
+    sourceGlobs: [
+      "src/hooks/keyword-detector.ts",
+      "src/hooks/triage-config.ts",
+      "src/hooks/triage-heuristic.ts",
+      "src/hooks/__tests__/prompt-guidance-*.test.ts",
+      "src/hooks/__tests__/analyze-*-contract.test.ts",
+    ],
+    refreshTargets: [
+      "docs/prompt-guidance-contract.md",
+      ".omx/plans/*prompt*",
+      ".omx/specs/*prompt*",
+      ".omx/plans/*guidance*",
+      ".omx/specs/*guidance*",
+    ],
+  },
+];

--- a/src/document-refresh/enforcer.ts
+++ b/src/document-refresh/enforcer.ts
@@ -1,0 +1,386 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { DEFAULT_DOCUMENT_REFRESH_RULES, type DocumentRefreshRule } from "./config.js";
+
+export type DocumentRefreshScope = "commit" | "final-handoff";
+export type DocumentRefreshHookEventName = "PreToolUse" | "Stop";
+
+export interface ChangedPathRecord {
+  status: string;
+  path: string;
+  previousPath?: string;
+}
+
+export interface DocumentRefreshEvaluationInput {
+  scope: DocumentRefreshScope;
+  changes: ChangedPathRecord[];
+  rules?: DocumentRefreshRule[];
+  exemptionText?: string | null;
+  localFreshTargets?: string[];
+}
+
+export interface DocumentRefreshRuleWarning {
+  ruleId: string;
+  description: string;
+  changedPaths: string[];
+  refreshTargets: string[];
+}
+
+export interface DocumentRefreshWarning {
+  scope: DocumentRefreshScope;
+  rules: DocumentRefreshRuleWarning[];
+  triggeringPaths: string[];
+  expectedTargets: string[];
+  message: string;
+}
+
+export const DOCUMENT_REFRESH_EXEMPTION_PREFIX = "Document-refresh: not-needed |";
+
+const RELEASE_COLLATERAL_GLOBS = [
+  "CHANGELOG.md",
+  "RELEASE_BODY.md",
+  "docs/release-notes-*.md",
+  "docs/release-body-*.md",
+  "docs/qa/release-readiness-*.md",
+];
+
+const TOOLING_ONLY_GLOBS = [
+  "package.json",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "tsconfig.json",
+  "tsconfig.*.json",
+  "biome.json",
+  ".github/workflows/**",
+  ".gitignore",
+];
+
+function normalizeRepoPath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//u, "");
+}
+
+function escapeRegex(char: string): string {
+  return /[|\\{}()[\]^$+?.]/u.test(char) ? `\\${char}` : char;
+}
+
+export function globToRegExp(glob: string): RegExp {
+  const normalized = normalizeRepoPath(glob);
+  let source = "^";
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index] ?? "";
+    const next = normalized[index + 1];
+    if (char === "*" && next === "*") {
+      index += 1;
+      if (normalized[index + 1] === "/") {
+        index += 1;
+        source += "(?:.*?/)?";
+      } else {
+        source += ".*";
+      }
+      continue;
+    }
+    if (char === "*") {
+      source += "[^/]*";
+      continue;
+    }
+    if (char === "?") {
+      source += "[^/]";
+      continue;
+    }
+    source += escapeRegex(char);
+  }
+  source += "$";
+  return new RegExp(source, "u");
+}
+
+export function pathMatchesGlob(path: string, glob: string): boolean {
+  return globToRegExp(glob).test(normalizeRepoPath(path));
+}
+
+function pathMatchesAny(path: string, globs: readonly string[] | undefined): boolean {
+  return (globs ?? []).some((glob) => pathMatchesGlob(path, glob));
+}
+
+function isRenameOnly(record: ChangedPathRecord): boolean {
+  return /^R100$/u.test(record.status.trim());
+}
+
+function isTriggerOnlyExcluded(record: ChangedPathRecord): boolean {
+  const path = normalizeRepoPath(record.path);
+  return pathMatchesAny(path, TOOLING_ONLY_GLOBS) || pathMatchesAny(path, RELEASE_COLLATERAL_GLOBS);
+}
+
+function unique(values: Iterable<string>): string[] {
+  return [...new Set([...values].map(normalizeRepoPath))].sort();
+}
+
+export function hasDocumentRefreshExemption(text: string | null | undefined): boolean {
+  if (!text) return false;
+  return text.split(/\r?\n/u).some((line) => line.trim().startsWith(DOCUMENT_REFRESH_EXEMPTION_PREFIX));
+}
+
+export function parseGitNameStatus(text: string): ChangedPathRecord[] {
+  const records: ChangedPathRecord[] = [];
+  for (const rawLine of text.split(/\r?\n/u)) {
+    const line = rawLine.trimEnd();
+    if (!line.trim()) continue;
+    const parts = line.split("\t").filter((part) => part.length > 0);
+    if (parts.length < 2) continue;
+    const status = parts[0] ?? "";
+    if (/^R\d+$/u.test(status) || /^C\d+$/u.test(status)) {
+      if (parts.length >= 3) {
+        records.push({
+          status,
+          previousPath: normalizeRepoPath(parts[1] ?? ""),
+          path: normalizeRepoPath(parts[2] ?? ""),
+        });
+      }
+      continue;
+    }
+    records.push({ status, path: normalizeRepoPath(parts[1] ?? "") });
+  }
+  return records;
+}
+
+function changedPathCandidates(record: ChangedPathRecord): string[] {
+  return unique([record.path, record.previousPath ?? ""].filter(Boolean));
+}
+
+function recordMatchesRuleSource(record: ChangedPathRecord, rule: DocumentRefreshRule): boolean {
+  if (isRenameOnly(record)) return false;
+  if (isTriggerOnlyExcluded(record)) return false;
+  const candidates = changedPathCandidates(record);
+  return candidates.some((path) => pathMatchesAny(path, rule.sourceGlobs))
+    && !candidates.every((path) => pathMatchesAny(path, rule.ignoredGlobs));
+}
+
+function hasRuleRefresh(
+  changes: ChangedPathRecord[],
+  localFreshTargets: readonly string[],
+  rule: DocumentRefreshRule,
+): boolean {
+  const changedRefresh = changes.some((record) => {
+    if (isRenameOnly(record)) return false;
+    return changedPathCandidates(record).some((path) => pathMatchesAny(path, rule.refreshTargets));
+  });
+  if (changedRefresh) return true;
+  return localFreshTargets.some((path) => pathMatchesAny(path, rule.refreshTargets));
+}
+
+export function evaluateDocumentRefresh(
+  input: DocumentRefreshEvaluationInput,
+): DocumentRefreshWarning | null {
+  if (hasDocumentRefreshExemption(input.exemptionText)) return null;
+
+  const changes = input.changes.filter((record) => record.path.trim() !== "");
+  if (changes.length === 0) return null;
+
+  const rules = input.rules ?? DEFAULT_DOCUMENT_REFRESH_RULES;
+  const localFreshTargets = input.scope === "final-handoff"
+    ? unique(input.localFreshTargets ?? [])
+    : [];
+  const warnings: DocumentRefreshRuleWarning[] = [];
+
+  for (const rule of rules) {
+    const triggering = changes
+      .filter((record) => recordMatchesRuleSource(record, rule))
+      .flatMap(changedPathCandidates);
+    const changedPaths = unique(triggering.filter((path) => pathMatchesAny(path, rule.sourceGlobs)));
+    if (changedPaths.length === 0) continue;
+    if (hasRuleRefresh(changes, localFreshTargets, rule)) continue;
+    warnings.push({
+      ruleId: rule.id,
+      description: rule.description,
+      changedPaths,
+      refreshTargets: [...rule.refreshTargets],
+    });
+  }
+
+  if (warnings.length === 0) return null;
+
+  const triggeringPaths = unique(warnings.flatMap((warning) => warning.changedPaths));
+  const expectedTargets = unique(warnings.flatMap((warning) => warning.refreshTargets));
+  return {
+    scope: input.scope,
+    rules: warnings,
+    triggeringPaths,
+    expectedTargets,
+    message: formatDocumentRefreshWarning({
+      scope: input.scope,
+      rules: warnings,
+      triggeringPaths,
+      expectedTargets,
+      message: "",
+    }),
+  };
+}
+
+
+const FINAL_HANDOFF_MARKER_PATTERNS = [
+  /\b(?:final handoff|handoff|merge-ready|launch-ready|ready to merge|ready for dev|shippable)\b/iu,
+  /\b(?:task|work|implementation|feature|change|verification)\b[\s\S]{0,80}\b(?:complete|completed|done|finished)\b/iu,
+  /\b(?:verification|tests?|build|lint)\b[\s\S]{0,120}\b(?:pass|passed|green|success|succeeded)\b/iu,
+];
+
+export function isFinalHandoffDocumentRefreshCandidate(text: string | null | undefined): boolean {
+  const message = text?.trim() ?? "";
+  if (!message) return false;
+  if (hasDocumentRefreshExemption(message)) return true;
+  return FINAL_HANDOFF_MARKER_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export function buildDocumentRefreshAdvisoryOutput(
+  warning: DocumentRefreshWarning,
+  hookEventName: DocumentRefreshHookEventName,
+): Record<string, unknown> {
+  return {
+    hookSpecificOutput: {
+      hookEventName,
+      additionalContext: warning.message,
+    },
+    systemMessage: warning.message,
+  };
+}
+
+export function formatDocumentRefreshWarning(warning: DocumentRefreshWarning): string {
+  const seam = warning.scope === "commit"
+    ? "Bash git commit uses the staged diff only"
+    : "final handoff uses staged + unstaged changes and fresh local .omx planning/spec files";
+  const ruleLines = warning.rules.map((rule) => `- ${rule.ruleId}: ${rule.description}`).join("\n");
+  const pathLines = warning.triggeringPaths.slice(0, 8).map((path) => `- ${path}`).join("\n");
+  const targetLines = warning.expectedTargets.slice(0, 10).map((path) => `- ${path}`).join("\n");
+  return [
+    "Document-refresh warning: mapped code or test-contract changes may need a planning-spec/product-doc refresh.",
+    `Scope: ${seam}. This warning is agent-only and does not add CI/pre-commit hard blocking.`,
+    "Triggered rule(s):",
+    ruleLines,
+    "Changed path(s):",
+    pathLines,
+    "Expected refresh target(s):",
+    targetLines,
+    `If no refresh is needed, acknowledge explicitly with: ${DOCUMENT_REFRESH_EXEMPTION_PREFIX} <reason>`,
+  ].join("\n");
+}
+
+function readGitNameStatus(cwd: string, args: string[]): ChangedPathRecord[] | null {
+  try {
+    const output = execFileSync("git", args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return parseGitNameStatus(output);
+  } catch {
+    return null;
+  }
+}
+
+export function readStagedGitChanges(cwd: string): ChangedPathRecord[] | null {
+  return readGitNameStatus(cwd, ["diff", "--cached", "--name-status"]);
+}
+
+export function readStagedAndUnstagedGitChanges(cwd: string): ChangedPathRecord[] | null {
+  const staged = readGitNameStatus(cwd, ["diff", "--cached", "--name-status"]);
+  const unstaged = readGitNameStatus(cwd, ["diff", "--name-status"]);
+  if (!staged || !unstaged) return null;
+  return [...staged, ...unstaged];
+}
+
+function collectFiles(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const files: string[] = [];
+  const entries = readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) files.push(...collectFiles(path));
+    else if (entry.isFile()) files.push(path);
+  }
+  return files;
+}
+
+function repoRelative(cwd: string, path: string): string {
+  return normalizeRepoPath(relative(cwd, path));
+}
+
+function latestExistingMtimeMs(cwd: string, paths: readonly string[]): number {
+  let latest = 0;
+  for (const path of paths) {
+    const fullPath = join(cwd, path);
+    try {
+      const stat = statSync(fullPath);
+      latest = Math.max(latest, stat.mtimeMs);
+    } catch {
+      // Missing/deleted paths do not contribute freshness evidence.
+    }
+  }
+  return latest;
+}
+
+export function findFreshLocalPlanningTargets(
+  cwd: string,
+  changes: readonly ChangedPathRecord[],
+  rules: readonly DocumentRefreshRule[] = DEFAULT_DOCUMENT_REFRESH_RULES,
+): string[] {
+  const triggeringPathsByRule = new Map<string, string[]>();
+  for (const rule of rules) {
+    const triggering = changes
+      .filter((record) => recordMatchesRuleSource(record, rule))
+      .flatMap(changedPathCandidates)
+      .filter((path) => pathMatchesAny(path, rule.sourceGlobs));
+    if (triggering.length > 0) triggeringPathsByRule.set(rule.id, unique(triggering));
+  }
+  if (triggeringPathsByRule.size === 0) return [];
+
+  const localPlanningFiles = [
+    ...collectFiles(join(cwd, ".omx", "plans")),
+    ...collectFiles(join(cwd, ".omx", "specs")),
+  ].map((path) => repoRelative(cwd, path));
+  if (localPlanningFiles.length === 0) return [];
+
+  const fresh = new Set<string>();
+  for (const rule of rules) {
+    const triggering = triggeringPathsByRule.get(rule.id);
+    if (!triggering) continue;
+    const latestTriggerMtime = latestExistingMtimeMs(cwd, triggering);
+    if (latestTriggerMtime === 0) continue;
+    for (const target of localPlanningFiles) {
+      if (!pathMatchesAny(target, rule.refreshTargets)) continue;
+      try {
+        const targetMtime = statSync(join(cwd, target)).mtimeMs;
+        if (targetMtime >= latestTriggerMtime) fresh.add(target);
+      } catch {
+        // Ignore races with local file cleanup.
+      }
+    }
+  }
+  return unique(fresh);
+}
+
+export function evaluateStagedDocumentRefresh(
+  cwd: string,
+  exemptionText?: string | null,
+): DocumentRefreshWarning | null {
+  const changes = readStagedGitChanges(cwd);
+  if (!changes) return null;
+  return evaluateDocumentRefresh({
+    scope: "commit",
+    changes,
+    exemptionText,
+  });
+}
+
+export function evaluateFinalHandoffDocumentRefresh(
+  cwd: string,
+  exemptionText?: string | null,
+): DocumentRefreshWarning | null {
+  const changes = readStagedAndUnstagedGitChanges(cwd);
+  if (!changes) return null;
+  return evaluateDocumentRefresh({
+    scope: "final-handoff",
+    changes,
+    exemptionText,
+    localFreshTargets: findFreshLocalPlanningTargets(cwd, changes),
+  });
+}

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7,6 +7,7 @@ import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { buildManagedCodexHooksConfig } from "../../config/codex-hooks.js";
+import { DOCUMENT_REFRESH_EXEMPTION_PREFIX } from "../../document-refresh/enforcer.js";
 import {
   initTeamState,
   readTeamLeaderAttention,
@@ -2042,6 +2043,181 @@ esac
     }
   });
 
+  it("warns on PreToolUse git commit when mapped source changes lack staged docs refresh", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-document-refresh-warn-"));
+    try {
+      execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd, stdio: "ignore" });
+      await mkdir(join(cwd, "src", "scripts"), { recursive: true });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 1;\n", "utf-8");
+      await writeFile(join(cwd, "README.md"), "base\n", "utf-8");
+      execFileSync("git", ["add", "README.md", "src/scripts/codex-native-hook.ts"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 2;\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts"], { cwd, stdio: "ignore" });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-doc-refresh-warn",
+          tool_input: {
+            command: [
+              'git commit',
+              '-m "Keep native hooks aligned with docs"',
+              '-m "Update the stop hook internals without refreshing the operator docs yet."',
+              '-m "Constraint: native hook warning MVP must remain non-blocking on commit path"',
+              '-m "Tested: node --test dist/scripts/__tests__/codex-native-hook.test.js"',
+              '-m "Co-authored-by: OmX <omx@oh-my-codex.dev>"',
+            ].join(" "),
+          },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, undefined);
+      assert.equal((result.outputJson as { hookSpecificOutput?: { hookEventName?: string } } | null)?.hookSpecificOutput?.hookEventName, "PreToolUse");
+      assert.match(JSON.stringify(result.outputJson), /Document-refresh warning/);
+      assert.match(JSON.stringify(result.outputJson), /docs\/codex-native-hooks\.md/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not warn on PreToolUse when relevant docs are staged", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-document-refresh-docs-"));
+    try {
+      await mkdir(join(cwd, "src", "scripts"), { recursive: true });
+      await mkdir(join(cwd, "docs"), { recursive: true });
+      execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 1;\n", "utf-8");
+      await writeFile(join(cwd, "docs", "codex-native-hooks.md"), "initial\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts", "docs/codex-native-hooks.md"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 2;\n", "utf-8");
+      await writeFile(join(cwd, "docs", "codex-native-hooks.md"), "updated\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts", "docs/codex-native-hooks.md"], { cwd, stdio: "ignore" });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-doc-refresh-docs",
+          tool_input: {
+            command: [
+              'git commit',
+              '-m "Keep native hooks aligned with docs"',
+              '-m "Update the stop hook internals and refresh the native hook docs together."',
+              '-m "Constraint: native hook warning MVP must remain non-blocking on commit path"',
+              '-m "Tested: node --test dist/scripts/__tests__/codex-native-hook.test.js"',
+              '-m "Co-authored-by: OmX <omx@oh-my-codex.dev>"',
+            ].join(" "),
+          },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not run commit-path document-refresh against payload cwd when git -C targets another repo", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-document-refresh-chdir-"));
+    const otherRepo = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-document-refresh-other-"));
+    try {
+      await mkdir(join(cwd, "src", "scripts"), { recursive: true });
+      execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 1;\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 2;\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts"], { cwd, stdio: "ignore" });
+
+      execFileSync("git", ["init"], { cwd: otherRepo, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: otherRepo, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd: otherRepo, stdio: "ignore" });
+      await writeFile(join(otherRepo, "README.md"), "base\n", "utf-8");
+      execFileSync("git", ["add", "README.md"], { cwd: otherRepo, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: otherRepo, stdio: "ignore" });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-doc-refresh-chdir",
+          tool_input: {
+            command: [
+              `git -C ${JSON.stringify(otherRepo)}`,
+              'commit',
+              '-m "Keep native hooks aligned with docs"',
+              '-m "Document-refresh check should not inspect the caller cwd when commit targets another repo."',
+              '-m "Constraint: alternate git targets are skipped unless hook-side repo resolution is added explicitly"',
+              '-m "Tested: node --test dist/scripts/__tests__/codex-native-hook.test.js"',
+              '-m "Co-authored-by: OmX <omx@oh-my-codex.dev>"',
+            ].join(" "),
+          },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(otherRepo, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses PreToolUse document-refresh warning when commit message includes an exemption", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-document-refresh-exempt-"));
+    try {
+      await mkdir(join(cwd, "src", "scripts"), { recursive: true });
+      execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 1;\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 2;\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts"], { cwd, stdio: "ignore" });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-doc-refresh-exempt",
+          tool_input: {
+            command: [
+              'git commit',
+              '-m "Keep native hooks aligned with docs"',
+              '-m "Update the stop hook internals without docs refresh because behavior is internal-only."',
+              '-m "Constraint: native hook warning MVP must remain non-blocking on commit path"',
+              `-m "${DOCUMENT_REFRESH_EXEMPTION_PREFIX} internal-only behavior verified"`,
+              '-m "Tested: node --test dist/scripts/__tests__/codex-native-hook.test.js"',
+              '-m "Co-authored-by: OmX <omx@oh-my-codex.dev>"',
+            ].join(" "),
+          },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns PostToolUse remediation guidance for command-not-found output", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-failure-"));
     try {
@@ -3873,6 +4049,123 @@ esac
           cwd,
           session_id: "sess-stop-main",
           thread_id: "main-thread",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a non-blocking Stop document-refresh warning before auto-nudge when Ralph is not active", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-document-refresh-"));
+    try {
+      await mkdir(join(cwd, "src", "scripts"), { recursive: true });
+      execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 1;\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 2;\n", "utf-8");
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-doc-refresh",
+          last_assistant_message: "Launch-ready: yes",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, undefined);
+      assert.equal((result.outputJson as { hookSpecificOutput?: { hookEventName?: string } } | null)?.hookSpecificOutput?.hookEventName, "Stop");
+      assert.match(JSON.stringify(result.outputJson), /Document-refresh warning/);
+      assert.match(JSON.stringify(result.outputJson), /staged \+ unstaged changes/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not warn on ordinary non-terminal Stop attempts before auto-nudge", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-document-refresh-nonterminal-"));
+    try {
+      await mkdir(join(cwd, "src", "scripts"), { recursive: true });
+      execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 1;\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 2;\n", "utf-8");
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-doc-refresh-nonterminal",
+          last_assistant_message: "Continuing implementation; next I will run focused tests.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("dedupes identical Stop document-refresh warnings during active Stop-hook replays", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-document-refresh-dedupe-"));
+    try {
+      await mkdir(join(cwd, "src", "scripts"), { recursive: true });
+      execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 1;\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 2;\n", "utf-8");
+
+      const payload = {
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-stop-doc-refresh-dedupe",
+        last_assistant_message: "Launch-ready: yes",
+      } as const;
+
+      const first = await dispatchCodexNativeHook(payload, { cwd });
+      const replay = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+
+      assert.match(JSON.stringify(first.outputJson), /Document-refresh warning/);
+      assert.equal(replay.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses Stop document-refresh warning when the final handoff message includes an exemption", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-document-refresh-exempt-"));
+    try {
+      await mkdir(join(cwd, "src", "scripts"), { recursive: true });
+      execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 1;\n", "utf-8");
+      execFileSync("git", ["add", "src/scripts/codex-native-hook.ts"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd, stdio: "ignore" });
+      await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 2;\n", "utf-8");
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-doc-refresh-exempt",
+          last_assistant_message: `${DOCUMENT_REFRESH_EXEMPTION_PREFIX} internal-only behavior verified`,
         },
         { cwd },
       );

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -67,6 +67,11 @@ import {
   reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords,
 } from "../question/deep-interview.js";
 import { resolveOmxCliEntryPath } from "../utils/paths.js";
+import {
+  buildDocumentRefreshAdvisoryOutput,
+  evaluateFinalHandoffDocumentRefresh,
+  isFinalHandoffDocumentRefreshCandidate,
+} from "../document-refresh/enforcer.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -1647,6 +1652,25 @@ async function buildStopHookOutput(
         },
         canonicalSessionId,
       );
+    }
+
+    if (isFinalHandoffDocumentRefreshCandidate(lastAssistantMessage)) {
+      const documentRefreshWarning = evaluateFinalHandoffDocumentRefresh(cwd, lastAssistantMessage);
+      if (documentRefreshWarning) {
+        return await maybeReturnRepeatableStopOutput(
+          payload,
+          stateDir,
+          buildRepeatableStopSignature(
+            payload,
+            "document-refresh-stop",
+            documentRefreshWarning.triggeringPaths.join("|"),
+            canonicalSessionId,
+          ),
+          buildDocumentRefreshAdvisoryOutput(documentRefreshWarning, "Stop"),
+          canonicalSessionId,
+          { allowRepeatDuringStopHook: false },
+        );
+      }
     }
 
     return null;

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -1,4 +1,11 @@
+import {
+  buildDocumentRefreshAdvisoryOutput,
+  evaluateStagedDocumentRefresh,
+} from "../document-refresh/enforcer.js";
+
 type CodexHookPayload = Record<string, unknown>;
+
+type GitRepositorySelection = "current-cwd" | "explicit-target";
 
 export interface NormalizedPreToolUsePayload {
   toolName: string;
@@ -268,6 +275,7 @@ function tokenizeShellCommand(commandText: string): string[] | null {
 interface GitCommitCommandParseResult {
   isGitCommit: boolean;
   inlineMessage: string | null;
+  repositorySelection: GitRepositorySelection;
   requiresExternalMessageSource: boolean;
 }
 
@@ -348,6 +356,14 @@ function gitOptionConsumesNextValue(token: string): boolean {
     || token === "--attr-source";
 }
 
+function gitOptionSelectsRepository(token: string): boolean {
+  return token === "-C"
+    || token === "--git-dir"
+    || token === "--work-tree"
+    || token.startsWith("--git-dir=")
+    || token.startsWith("--work-tree=");
+}
+
 function gitOptionStopsBeforeSubcommand(token: string): boolean {
   return token === "-h"
     || token === "--help"
@@ -382,12 +398,22 @@ function findGitSubcommandIndex(tokens: string[], gitTokenIndex: number): number
   return index < tokens.length ? index : -1;
 }
 
-function parseGitCommitCommand(commandText: string): GitCommitCommandParseResult {
+function readGitRepositorySelection(tokens: string[], gitTokenIndex: number, subcommandIndex: number): GitRepositorySelection {
+  for (let index = gitTokenIndex + 1; index < subcommandIndex; index += 1) {
+    const token = tokens[index] ?? "";
+    if (gitOptionSelectsRepository(token)) return "explicit-target";
+    if (gitOptionConsumesNextValue(token)) index += 1;
+  }
+  return "current-cwd";
+}
+
+export function parseGitCommitCommand(commandText: string): GitCommitCommandParseResult {
   const tokens = tokenizeShellCommand(commandText);
   if (!tokens) {
     return {
       isGitCommit: false,
       inlineMessage: null,
+      repositorySelection: "current-cwd",
       requiresExternalMessageSource: false,
     };
   }
@@ -397,6 +423,7 @@ function parseGitCommitCommand(commandText: string): GitCommitCommandParseResult
     return {
       isGitCommit: false,
       inlineMessage: null,
+      repositorySelection: "current-cwd",
       requiresExternalMessageSource: false,
     };
   }
@@ -406,10 +433,12 @@ function parseGitCommitCommand(commandText: string): GitCommitCommandParseResult
     return {
       isGitCommit: false,
       inlineMessage: null,
+      repositorySelection: "current-cwd",
       requiresExternalMessageSource: false,
     };
   }
 
+  const repositorySelection = readGitRepositorySelection(tokens, gitTokenIndex, subcommandIndex);
   const messageParts: string[] = [];
   let requiresExternalMessageSource = false;
   const args = tokens.slice(subcommandIndex + 1);
@@ -452,6 +481,7 @@ function parseGitCommitCommand(commandText: string): GitCommitCommandParseResult
   return {
     isGitCommit: true,
     inlineMessage: messageParts.length > 0 ? messageParts.join("\n\n").trim() : null,
+    repositorySelection,
     requiresExternalMessageSource,
   };
 }
@@ -562,6 +592,22 @@ function buildGitCommitEnforcementOutput(commandText: string): Record<string, un
   };
 }
 
+
+function buildDocumentRefreshPreToolUseOutput(
+  commandText: string,
+  cwd: string,
+): Record<string, unknown> | null {
+  const parsed = parseGitCommitCommand(commandText);
+  if (!parsed.isGitCommit) return null;
+
+  if (parsed.repositorySelection !== "current-cwd") return null;
+
+  const warning = evaluateStagedDocumentRefresh(cwd, parsed.inlineMessage);
+  if (!warning) return null;
+
+  return buildDocumentRefreshAdvisoryOutput(warning, "PreToolUse");
+}
+
 function commandInvokesOmxQuestion(command: string): boolean {
   const tokens = tokenizeShellCommand(command)?.map((token) => token.toLowerCase()) ?? [];
   for (let index = 0; index < tokens.length; index += 1) {
@@ -614,6 +660,11 @@ export function buildNativePreToolUseOutput(
   if (gitCommitEnforcement) return gitCommitEnforcement;
   const questionEnforcement = buildOmxQuestionPreToolUseEnforcementOutput(normalized.normalizedCommand);
   if (questionEnforcement) return questionEnforcement;
+  const documentRefreshWarning = buildDocumentRefreshPreToolUseOutput(
+    normalized.normalizedCommand,
+    safeString(payload.cwd).trim() || process.cwd(),
+  );
+  if (documentRefreshWarning) return documentRefreshWarning;
   if (!matchesDestructiveFixture(normalized.normalizedCommand)) return null;
 
   return {


### PR DESCRIPTION
## Summary

Adds an agent-only document-refresh warning MVP so mapped product/test-contract changes nudge agents to refresh the relevant planning spec or product docs before commit/final handoff.

## Changes

- Add a centralized document-refresh classifier/rule map with rule-scoped refresh targets and exclusions.
- Warn non-blockingly on Bash `git commit` when staged mapped changes lack staged docs/spec refresh evidence.
- Warn non-blockingly on terminal-looking Stop/final-handoff attempts using staged+unstaged diffs plus heuristic local `.omx` freshness.
- Add explicit exemption support: `Document-refresh: not-needed | <reason>`.
- Document contributor/native-hook behavior and the heuristic limits.
- Add regression coverage for staged-only commit behavior, final-handoff behavior, rule-scoped `.omx` suppression, exclusions, exemptions, and Stop replay dedupe.

## Validation

- [x] `npm run build`
- [x] `node --test dist/document-refresh/__tests__/enforcer.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `git diff --check`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `npm run test:ci:compiled` — 3931 tests, 0 failures
- [ ] `omx doctor` (not run; setup/config behavior not changed)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed
- [x] Backward-compatibility impact considered

## Notes

- Document-refresh warnings are intentionally warning-only and never hard-block `git commit`; existing Lore commit enforcement remains separate.
- Final-handoff local `.omx` freshness is heuristic evidence, not semantic proof of refreshed specs.
- Code-reviewer approved; architect status was WATCH (no blockers) for heuristic/future fallback tuning.

## Related

Closes #
