### PR TITLE
fix: avoid misclassifying empty bash exits as setup failures

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1912,6 +1912,28 @@ esac
     }
   });
 
+  it("does not classify empty-output exit-1 Bash commands as setup failures", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-empty-exit-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-empty-exit",
+          tool_input: { command: "rg -n missing pattern file" },
+          tool_response: '{"exit_code":1,"stdout":"","stderr":""}',
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns PostToolUse MCP transport fallback guidance for clear MCP transport death", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mcp-transport-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1934,6 +1934,40 @@ esac
     }
   });
 
+  it("still classifies setup failures when stdout contains the shell error and stderr is only noise", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mixed-hard-failure-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-mixed-hard-failure",
+          tool_input: { command: "foo --version" },
+          tool_response: JSON.stringify({
+            exit_code: 127,
+            stdout: "bash: foo: command not found",
+            stderr: "prelude",
+          }),
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: "The Bash output indicates a command/setup failure that should be fixed before retrying.",
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext:
+            "Bash reported `command not found`, `permission denied`, or a missing file/path. Verify the command, dependency installation, PATH, file permissions, and referenced paths before retrying.",
+        },
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns PostToolUse MCP transport fallback guidance for clear MCP transport death", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mcp-transport-"));
     try {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -586,8 +586,8 @@ function containsHardFailure(stderrText: string, stdoutText = "", exitCode: numb
     return false;
   }
   const stderr = String(stderrText ?? "").trim();
-  if (stderr) {
-    return /command not found|permission denied|no such file or directory/i.test(stderr);
+  if (stderr && /command not found|permission denied|no such file or directory/i.test(stderr)) {
+    return true;
   }
   const stdout = String(stdoutText ?? "").trim();
   if (!stdout) {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -85,7 +85,8 @@ export function normalizePostToolUsePayload(
     ?? safeInteger(parsedToolResponse?.exitCode)
     ?? null;
   const rawText = safeString(rawToolResponse).trim();
-  const stdoutText = safeString(parsedToolResponse?.stdout).trim() || rawText;
+  const stdoutText = safeString(parsedToolResponse?.stdout).trim()
+    || (parsedToolResponse ? "" : rawText);
   const stderrText = safeString(parsedToolResponse?.stderr).trim();
 
   return {
@@ -580,8 +581,19 @@ export function buildNativePreToolUseOutput(
   };
 }
 
-function containsHardFailure(text: string): boolean {
-  return /command not found|permission denied|no such file or directory/i.test(text);
+function containsHardFailure(stderrText: string, stdoutText = "", exitCode: number | null = null): boolean {
+  if (exitCode === 0) {
+    return false;
+  }
+  const stderr = String(stderrText ?? "").trim();
+  if (stderr) {
+    return /command not found|permission denied|no such file or directory/i.test(stderr);
+  }
+  const stdout = String(stdoutText ?? "").trim();
+  if (!stdout) {
+    return false;
+  }
+  return /(?:^|\n)\s*(?:bash|sh|zsh|node|python|python3|env|git|rg|grep|sed|cat|tail|head|find|npm|pnpm|yarn|flutter|dart|omx)?[^\n]*?(?:command not found|permission denied|no such file or directory)/i.test(stdout);
 }
 
 export function buildNativePostToolUseOutput(
@@ -608,7 +620,7 @@ export function buildNativePostToolUseOutput(
   if (!normalized.isBash) return null;
 
   const combined = `${normalized.stderrText}\n${normalized.stdoutText}`.trim();
-  if (containsHardFailure(combined)) {
+  if (containsHardFailure(normalized.stderrText, normalized.stdoutText, normalized.exitCode)) {
     return {
       decision: "block",
       reason: "The Bash output indicates a command/setup failure that should be fixed before retrying.",
@@ -624,7 +636,7 @@ export function buildNativePostToolUseOutput(
     normalized.exitCode !== null
     && normalized.exitCode !== 0
     && combined.length > 0
-    && !containsHardFailure(combined)
+    && !containsHardFailure(normalized.stderrText, normalized.stdoutText, normalized.exitCode)
   ) {
     return {
       decision: "block",


### PR DESCRIPTION
## Summary
- stop treating parsed-but-empty non-zero Bash tool responses as command/setup failures
- only fall back to raw tool output when the response was not parsed into stdout/stderr fields
- add a regression test for exit-1 Bash commands with empty stdout/stderr

## Why
Commands like `rg` legitimately return exit code 1 when no matches are found. Their tool payload can be parsed successfully with empty stdout/stderr, but the previous classifier fell back to the raw JSON string and treated that as informative output, which then surfaced misleading PostToolUse guidance.

## Testing
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js
