### PR TITLE
Expose Visual Ralph as a default frontend workflow skill

### DIFF
--- a/docs/skills.html
+++ b/docs/skills.html
@@ -56,6 +56,7 @@
         <li><code>$build-fix</code></li>
         <li><code>$code-review</code></li>
         <li><code>$security-review</code></li>
+        <li><code>$visual-ralph</code></li>
         <li><code>$frontend-ui-ux</code></li>
         <li><code>$git-master</code></li>
         <li><code>$review</code></li>

--- a/skills/visual-ralph/SKILL.md
+++ b/skills/visual-ralph/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: visual-ralph
+description: Visual Ralph orchestration for frontend UI: generate an approved image reference with $imagegen, then run $ralph with $visual-verdict and pixel-diff evidence until the implementation matches and leaves a reproducible design system.
+---
+
+# Visual Ralph Skill
+
+Use this skill when the user wants Codex to build or restyle frontend UI through a Visual Ralph loop: an approved generated reference image becomes the target, Ralph implements, and Visual Verdict drives measured iteration rather than subjective description alone.
+
+## Purpose
+
+Create a measured frontend delivery loop:
+
+`user description -> $imagegen reference -> explicit approval -> $ralph implementation -> $visual-verdict + pixel diff -> reproducible design system`.
+
+This is an orchestration skill. It composes existing skills and must not add runtime commands, dependencies, or app-specific assumptions by itself.
+
+## Use when
+
+- The user describes a desired web/app UI and wants implementation, not just design advice.
+- A generated raster mockup/reference image would make the target clearer.
+- The task needs pixel-level visual iteration with a pass/fail threshold.
+- The final result should leave reusable design tokens/components, not only a one-off screenshot match.
+
+## Do not use when
+
+- The user only wants design critique or general frontend advice; use `$frontend-ui-ux` or a designer lane.
+- The reference is a live URL; use `$web-clone`.
+- The user already supplied a final static reference image and only needs comparison/fixes; hand directly to `$ralph` with `$visual-verdict` guidance.
+- The requested output is a deterministic SVG/vector/code-native asset rather than a raster reference.
+
+## Workflow
+
+### 1. Ground the target repo
+
+Before stack-specific choices, inspect local evidence:
+- package manager and scripts,
+- frontend framework and routing structure,
+- styling system and design-token conventions,
+- screenshot/test tooling,
+- existing components that should be reused.
+
+Do not hardcode React, Vue, Tailwind, Playwright, or any other stack unless the repository evidence supports it.
+
+### 2. Generate the visual reference with `$imagegen`
+
+Use `$imagegen` to produce the reference from the user's UI description.
+
+Prompt requirements:
+- classify as `ui-mockup`, unless another imagegen taxonomy is clearly better,
+- include viewport/aspect ratio and intended surface,
+- specify layout, hierarchy, typography direction, color mood, and any exact text,
+- forbid logos/watermarks/unrequested brand marks,
+- ask imagegen to avoid impossible UI details or unreadable text.
+
+For project-bound implementation, copy the approved reference into the workspace, for example under `.omx/artifacts/visual-ralph/<slug>/reference.png`. Never leave the implementation reference only in `$CODEX_HOME/generated_images/...`.
+
+### 3. Require explicit user approval
+
+Stop after reference generation and ask the user to approve one reference image or request a targeted regeneration.
+
+Before approval:
+- do not start frontend implementation,
+- do not invoke `$ralph`,
+- do not treat a rough image as final.
+
+After approval, the confirmed image becomes the visual source of truth. Major design pivots, replacing the reference, or changing the design direction require an explicit user request.
+
+### 4. Hand off to `$ralph` for implementation
+
+Invoke `$ralph` with:
+- the approved reference image path,
+- the user description,
+- the detected repo/frontend context,
+- exact screenshot command/viewport requirements,
+- the completion checklist below.
+
+Ralph may iterate autonomously after approval. It should edit code, run the app, capture screenshots, and keep improving until the approved reference is matched or a real blocker exists.
+
+### 5. Use `$visual-verdict` before every next edit
+
+For each visual iteration:
+1. Capture the current generated screenshot with recorded viewport/state.
+2. Run `$visual-verdict` comparing the approved reference and generated screenshot.
+3. Treat the JSON verdict as authoritative.
+4. If `score < 90`, convert `differences[]` and `suggestions[]` into the next edit plan.
+5. Rerun before the next edit.
+
+Required verdict shape is inherited from `$visual-verdict`: `score`, `verdict`, `category_match`, `differences[]`, `suggestions[]`, and `reasoning`.
+
+### 6. Use pixel diff only as secondary debug evidence
+
+When mismatch diagnosis is hard, generate a pixel diff or pixelmatch overlay to locate hotspots. Pixel diff does not replace `$visual-verdict`; it only helps translate visual hotspots into concrete edits.
+
+Record final diff evidence with the reference/screenshot artifacts so the result can be audited.
+
+### 7. Build a reproducible design system
+
+The implementation is incomplete unless the visual match is encoded in repo-native reusable artifacts. Depending on the project, this may mean CSS variables, theme tokens, Tailwind config, component variants, Storybook stories, design docs, or existing equivalents.
+
+Capture at least the applicable:
+- colors,
+- spacing scale,
+- typography scale/weights,
+- radii,
+- shadows/elevation,
+- important component variants and states.
+
+Prefer existing token/component patterns. Do not introduce a new design-system layer if the repo already has one that can be extended.
+
+## Completion checklist
+
+Do not declare done until all are true:
+- Approved reference image is saved in the workspace.
+- Screenshot reproduction command, viewport, route, seed/state, and output paths are documented.
+- `$visual-verdict` final score is `>= 90` against the approved reference.
+- Pixel diff or overlay evidence is recorded as secondary debug evidence.
+- Design-system tokens/components are repo-native and reusable.
+- Build/lint/test or the repo's equivalent verification passes.
+- No unapproved major design pivot occurred after reference approval.
+- Remaining visual differences, if any, are explicitly documented with rationale.
+
+## Handoff template
+
+```text
+$ralph "Implement the approved frontend reference.
+Reference: <workspace-reference-image>
+Route/surface: <route or component>
+Screenshot command: <command and viewport>
+Use $visual-verdict before every next edit; pass threshold score >= 90.
+Use pixel diff only as secondary debug evidence.
+Extract reusable design tokens/components for colors, spacing, typography, radii, shadows, and key variants.
+Run build/lint/test before completion.
+Do not make major design pivots unless explicitly requested."
+```
+
+Task: {{ARGUMENTS}}

--- a/src/catalog/__tests__/generator.test.ts
+++ b/src/catalog/__tests__/generator.test.ts
@@ -45,6 +45,7 @@ describe('catalog reader/contract', () => {
     assert.ok(contract.skills.some((s) => s.name === 'ask-claude' && s.status === 'active'));
     assert.ok(contract.skills.some((s) => s.name === 'ask-gemini' && s.status === 'active'));
     assert.ok(contract.skills.some((s) => s.name === 'ai-slop-cleaner' && s.status === 'active'));
+    assert.ok(contract.skills.some((s) => s.name === 'visual-ralph' && s.status === 'active'));
   });
 
   it('template manifest can be synced from source manifest', async () => {

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-04-18T08:54:56.317Z",
+  "generatedAt": "2026-04-23T07:12:22.060Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 40,
+    "skillCount": 41,
     "promptCount": 30,
-    "activeSkillCount": 26,
+    "activeSkillCount": 27,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -162,6 +162,14 @@
       "category": "shortcut",
       "status": "active",
       "canonical": "vision",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "visual-ralph",
+      "category": "shortcut",
+      "status": "active",
+      "canonical": "designer",
       "core": false,
       "internalRequired": false
     },

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -118,6 +118,12 @@
       "canonical": "vision"
     },
     {
+      "name": "visual-ralph",
+      "category": "shortcut",
+      "status": "active",
+      "canonical": "designer"
+    },
+    {
       "name": "frontend-ui-ux",
       "category": "shortcut",
       "status": "alias",

--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -73,6 +73,7 @@ describe('omx setup skills overwrite behavior', () => {
       assert.equal(installed.has('ecomode'), false);
       assert.equal(installed.has('ultraqa'), true);
       assert.equal(installed.has('ralph-init'), false);
+      assert.equal(installed.has('visual-ralph'), true);
       assert.equal(installed.has('frontend-ui-ux'), false);
       assert.equal(installed.has('pipeline'), false);
       assert.equal(installed.has('configure-notifications'), true);

--- a/src/hooks/__tests__/visual-ralph-skill.test.ts
+++ b/src/hooks/__tests__/visual-ralph-skill.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const skill = readFileSync(join(__dirname, '../../../skills/visual-ralph/SKILL.md'), 'utf-8');
+
+describe('visual-ralph skill contract', () => {
+  it('defines the image approval to Ralph workflow', () => {
+    assert.match(skill, /^---\nname: visual-ralph/m);
+    assert.match(skill, /description: Visual Ralph orchestration/i);
+    assert.match(skill, /\$imagegen/);
+    assert.match(skill, /explicit user approval|explicit user confirmation/i);
+    assert.match(skill, /\$ralph/);
+    assert.match(skill, /\$visual-verdict/);
+  });
+
+  it('keeps visual-verdict authoritative and pixel diff secondary', () => {
+    assert.match(skill, /score\s*>?=\s*90|90\+/i);
+    assert.match(skill, /pixel diff|pixelmatch/i);
+    assert.match(skill, /does not replace \$visual-verdict|secondary debug evidence/i);
+  });
+
+  it('requires reproducibility and repo-native design system artifacts', () => {
+    assert.match(skill, /screenshot reproduction command|viewport|output paths/i);
+    assert.match(skill, /repo-native reusable artifacts|repo-native and reusable/i);
+    for (const token of ['colors', 'spacing', 'typography', 'radii', 'shadows']) {
+      assert.match(skill, new RegExp(token, 'i'));
+    }
+  });
+
+  it('forbids hardcoded stack assumptions and unapproved pivots', () => {
+    assert.match(skill, /Do not hardcode React, Vue, Tailwind/i);
+    assert.match(skill, /Major design pivots.*explicit user request|Do not make major design pivots unless explicitly requested/i);
+  });
+});

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -153,6 +153,14 @@
       "internalRequired": false
     },
     {
+      "name": "visual-ralph",
+      "category": "shortcut",
+      "status": "active",
+      "canonical": "designer",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "frontend-ui-ux",
       "category": "shortcut",
       "status": "alias",


### PR DESCRIPTION
## Summary
- add the new `$visual-ralph` skill for imagegen-approved frontend implementation loops
- register it as an active catalog skill so `omx setup` installs it by default
- add docs/catalog/setup/skill contract coverage for the new skill

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/visual-ralph-skill.test.js dist/hooks/__tests__/visual-verdict-loop.test.js dist/catalog/__tests__/generator.test.js dist/cli/__tests__/setup-skills-overwrite.test.js`
- `node dist/scripts/generate-catalog-docs.js --check`
- `npx biome lint src/hooks/__tests__/visual-ralph-skill.test.ts src/catalog/__tests__/generator.test.ts src/cli/__tests__/setup-skills-overwrite.test.ts`
- `npm run check:no-unused`

## Review notes
- `$code-review` returned COMMENT with no critical/high/medium issues.
- Architectural watch item: `visual-ralph` is currently cataloged as a designer shortcut even though it is a composite workflow surface; this PR keeps the existing catalog model and records that taxonomy risk in the commit directive.
