### PR TITLE
Keep plugin skill mirrors aligned on dev

### DIFF
--- a/plugins/oh-my-codex/skills/help/SKILL.md
+++ b/plugins/oh-my-codex/skills/help/SKILL.md
@@ -7,7 +7,7 @@ description: Guide on using oh-my-codex plugin
 
 Plain English works as best-effort guidance — OMX inspects each prompt and may add advisory routing context to steer the model toward a suitable lane. This is **advisory prompt-routing context**: it does not activate a skill or workflow by itself. Explicit keywords remain the deterministic control surface when you want exact, guaranteed routing.
 
-**Triage lanes** (when no keyword matches): complex/multi-step prompts may receive HEAVY guidance (autopilot-shaped); read-only lookups receive LIGHT/explore guidance; implementation work receives LIGHT/executor guidance; UI work receives LIGHT/designer guidance; simple conversational prompts receive no injection (PASS). To opt out per prompt, include a phrase such as `no workflow`, `just chat`, or `plain answer`.
+**Triage lanes** (when no keyword matches): complex/multi-step prompts may receive HEAVY guidance (autopilot-shaped); repo-local read-only lookups receive LIGHT/explore guidance; implementation work receives LIGHT/executor guidance; UI work receives LIGHT/designer guidance; external official-doc/reference/source-backed lookup receives LIGHT/researcher guidance; simple conversational prompts receive no injection (PASS). To opt out per prompt, include a phrase such as `no workflow`, `just chat`, or `plain answer`.
 
 ## What Happens Automatically
 

--- a/plugins/oh-my-codex/skills/visual-ralph/SKILL.md
+++ b/plugins/oh-my-codex/skills/visual-ralph/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: visual-ralph
+description: Visual Ralph orchestration for frontend UI: generate an approved image reference with $imagegen, then run $ralph with $visual-verdict and pixel-diff evidence until the implementation matches and leaves a reproducible design system.
+---
+
+# Visual Ralph Skill
+
+Use this skill when the user wants Codex to build or restyle frontend UI through a Visual Ralph loop: an approved generated reference image becomes the target, Ralph implements, and Visual Verdict drives measured iteration rather than subjective description alone.
+
+## Purpose
+
+Create a measured frontend delivery loop:
+
+`user description -> $imagegen reference -> explicit approval -> $ralph implementation -> $visual-verdict + pixel diff -> reproducible design system`.
+
+This is an orchestration skill. It composes existing skills and must not add runtime commands, dependencies, or app-specific assumptions by itself.
+
+## Use when
+
+- The user describes a desired web/app UI and wants implementation, not just design advice.
+- A generated raster mockup/reference image would make the target clearer.
+- The task needs pixel-level visual iteration with a pass/fail threshold.
+- The final result should leave reusable design tokens/components, not only a one-off screenshot match.
+
+## Do not use when
+
+- The user only wants design critique or general frontend advice; use `$frontend-ui-ux` or a designer lane.
+- The reference is a live URL; use `$web-clone`.
+- The user already supplied a final static reference image and only needs comparison/fixes; hand directly to `$ralph` with `$visual-verdict` guidance.
+- The requested output is a deterministic SVG/vector/code-native asset rather than a raster reference.
+
+## Workflow
+
+### 1. Ground the target repo
+
+Before stack-specific choices, inspect local evidence:
+- package manager and scripts,
+- frontend framework and routing structure,
+- styling system and design-token conventions,
+- screenshot/test tooling,
+- existing components that should be reused.
+
+Do not hardcode React, Vue, Tailwind, Playwright, or any other stack unless the repository evidence supports it.
+
+### 2. Generate the visual reference with `$imagegen`
+
+Use `$imagegen` to produce the reference from the user's UI description.
+
+Prompt requirements:
+- classify as `ui-mockup`, unless another imagegen taxonomy is clearly better,
+- include viewport/aspect ratio and intended surface,
+- specify layout, hierarchy, typography direction, color mood, and any exact text,
+- forbid logos/watermarks/unrequested brand marks,
+- ask imagegen to avoid impossible UI details or unreadable text.
+
+For project-bound implementation, copy the approved reference into the workspace, for example under `.omx/artifacts/visual-ralph/<slug>/reference.png`. Never leave the implementation reference only in `$CODEX_HOME/generated_images/...`.
+
+### 3. Require explicit user approval
+
+Stop after reference generation and ask the user to approve one reference image or request a targeted regeneration.
+
+Before approval:
+- do not start frontend implementation,
+- do not invoke `$ralph`,
+- do not treat a rough image as final.
+
+After approval, the confirmed image becomes the visual source of truth. Major design pivots, replacing the reference, or changing the design direction require an explicit user request.
+
+### 4. Hand off to `$ralph` for implementation
+
+Invoke `$ralph` with:
+- the approved reference image path,
+- the user description,
+- the detected repo/frontend context,
+- exact screenshot command/viewport requirements,
+- the completion checklist below.
+
+Ralph may iterate autonomously after approval. It should edit code, run the app, capture screenshots, and keep improving until the approved reference is matched or a real blocker exists.
+
+### 5. Use `$visual-verdict` before every next edit
+
+For each visual iteration:
+1. Capture the current generated screenshot with recorded viewport/state.
+2. Run `$visual-verdict` comparing the approved reference and generated screenshot.
+3. Treat the JSON verdict as authoritative.
+4. If `score < 90`, convert `differences[]` and `suggestions[]` into the next edit plan.
+5. Rerun before the next edit.
+
+Required verdict shape is inherited from `$visual-verdict`: `score`, `verdict`, `category_match`, `differences[]`, `suggestions[]`, and `reasoning`.
+
+### 6. Use pixel diff only as secondary debug evidence
+
+When mismatch diagnosis is hard, generate a pixel diff or pixelmatch overlay to locate hotspots. Pixel diff does not replace `$visual-verdict`; it only helps translate visual hotspots into concrete edits.
+
+Record final diff evidence with the reference/screenshot artifacts so the result can be audited.
+
+### 7. Build a reproducible design system
+
+The implementation is incomplete unless the visual match is encoded in repo-native reusable artifacts. Depending on the project, this may mean CSS variables, theme tokens, Tailwind config, component variants, Storybook stories, design docs, or existing equivalents.
+
+Capture at least the applicable:
+- colors,
+- spacing scale,
+- typography scale/weights,
+- radii,
+- shadows/elevation,
+- important component variants and states.
+
+Prefer existing token/component patterns. Do not introduce a new design-system layer if the repo already has one that can be extended.
+
+## Completion checklist
+
+Do not declare done until all are true:
+- Approved reference image is saved in the workspace.
+- Screenshot reproduction command, viewport, route, seed/state, and output paths are documented.
+- `$visual-verdict` final score is `>= 90` against the approved reference.
+- Pixel diff or overlay evidence is recorded as secondary debug evidence.
+- Design-system tokens/components are repo-native and reusable.
+- Build/lint/test or the repo's equivalent verification passes.
+- No unapproved major design pivot occurred after reference approval.
+- Remaining visual differences, if any, are explicitly documented with rationale.
+
+## Handoff template
+
+```text
+$ralph "Implement the approved frontend reference.
+Reference: <workspace-reference-image>
+Route/surface: <route or component>
+Screenshot command: <command and viewport>
+Use $visual-verdict before every next edit; pass threshold score >= 90.
+Use pixel diff only as secondary debug evidence.
+Extract reusable design tokens/components for colors, spacing, typography, radii, shadows, and key variants.
+Run build/lint/test before completion.
+Do not make major design pivots unless explicitly requested."
+```
+
+Task: {{ARGUMENTS}}


### PR DESCRIPTION
## Summary
- restore the missing visual-ralph plugin skill mirror introduced on dev after PR #1858
- resync the plugin help skill copy with the canonical root skill text
- unblock the official Codex plugin layout parity test in dev CI

## Testing
- npm run build
- node --test dist/cli/__tests__/codex-plugin-layout.test.js