### PR TITLE
Reinforce regression coverage for prompt-worker terminal guards

### DIFF
--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -105,8 +105,14 @@ describe('runtime-cli helpers', () => {
     const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
     const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     delete process.env.OMX_TEAM_STATE_ROOT;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     try {
       await initTeamState('runtime-cli-complete', 'task', 'executor', 1, cwd);
+      const config = await readTeamConfig('runtime-cli-complete', cwd);
+      assert.ok(config);
+      if (!config) return;
+      config.workers[0]!.pid = process.pid;
+      await saveTeamConfig(config, cwd);
       await createTask('runtime-cli-complete', {
         subject: 'done task',
         description: 'already complete',

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1848,9 +1848,16 @@ process.on('SIGTERM', () => {
   it('monitorTeam withholds terminal phase while a live worker still reports active status', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-live-worker-terminal-'));
     const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     delete process.env.OMX_TEAM_STATE_ROOT;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     try {
       await initTeamState('team-live-worker-terminal', 'live worker terminal guard', 'executor', 1, cwd);
+      const config = await readTeamConfig('team-live-worker-terminal', cwd);
+      assert.ok(config);
+      if (!config) return;
+      config.workers[0]!.pid = process.pid;
+      await saveTeamConfig(config, cwd);
       const task = await createTask(
         'team-live-worker-terminal',
         {
@@ -1897,6 +1904,8 @@ process.on('SIGTERM', () => {
     } finally {
       if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
       else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2060,7 +2060,6 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
       .map((worker) => `${worker.name}:${worker.status.state}`);
     recommendations.push(`Terminal phase withheld while live worker signals remain active: ${blockingWorkers.join(', ')}`);
   }
-
   const deadWorkerStall =
     config.worker_launch_mode === 'prompt'
     && config.workers.length > 0

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2060,6 +2060,7 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
       .map((worker) => `${worker.name}:${worker.status.state}`);
     recommendations.push(`Terminal phase withheld while live worker signals remain active: ${blockingWorkers.join(', ')}`);
   }
+
   const deadWorkerStall =
     config.worker_launch_mode === 'prompt'
     && config.workers.length > 0


### PR DESCRIPTION
## Summary
Retitle and reframe this PR as regression coverage only for the existing prompt-worker terminal guard behavior.

## Scope
This PR does **not** introduce a new production/runtime completion guard.

The live-worker terminal guard already exists on the base branch in `monitorTeam()`:
- `terminalBlockedByLiveWorkers` is derived from live worker status
- that signal is passed into `inferPhaseTargetFromTaskCounts(...)`
- the phase is held at `team-verify` while a live worker still reports an active runtime state

This branch only updates regression coverage so the tests match the real prompt-worker liveness contract used by that existing runtime path.

## Why the previous framing was misleading
The previous title/body implied that this branch added the production behavior that prevents terminal completion while live workers are still active.

After re-checking the diff against `pr/base-local-dev-upstream`, that is not what this branch changes. Relative to the PR base, the branch is a small follow-up that tightens tests around behavior already present on the base.

## What actually changed
- updated the prompt-worker regression setup so prompt workers are treated as alive using the same contract the runtime uses in production
- explicitly enabled prompt launch mode in the affected tests
- seeded worker pid/heartbeat/state so the tests exercise the real liveness gate instead of an under-specified fixture
- kept the existing runtime behavior assertions:
  - `monitorTeam()` stays at `team-verify` while a live prompt worker is still `working`
  - runtime CLI helper coverage keeps that state from being treated as an immediate shutdown condition

## Files changed
- `src/team/__tests__/runtime-cli.test.ts`
- `src/team/__tests__/runtime.test.ts`

## Validation
- `npm run build`
- `node --test dist/team/__tests__/runtime-cli.test.js`
- `node --test --test-name-pattern="monitorTeam withholds terminal phase while a live worker still reports active status" dist/team/__tests__/runtime.test.js`

## Reviewer note
This PR should be reviewed as **regression coverage reinforcement for existing runtime behavior**, not as a new production runtime fix.
