### PR TITLE
Fix deep-interview omx question fallback for Windows non-attached sessions

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, it } from 'node:test';
+import { questionCommand } from '../question.js';
 import { markQuestionAnswered, readQuestionRecord } from '../../question/state.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -401,6 +402,88 @@ esac
     const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
     assert.match(tmuxLog, /split-window -v -l 12 -t %44 -P -F #\{pane_id\}/);
     assert.doesNotMatch(tmuxLog, /new-session/);
+  });
+
+  it('runs inline in interactive Windows non-attached sessions instead of hard-failing on missing TMUX', async () => {
+    const cwd = await makeRepo();
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    const originalStdinIsTTY = process.stdin.isTTY;
+    const originalStdoutIsTTY = process.stdout.isTTY;
+    const originalSetRawMode = process.stdin.setRawMode;
+    const originalResume = process.stdin.resume;
+    const originalPause = process.stdin.pause;
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    const originalCwd = process.cwd();
+    const originalTmux = process.env.TMUX;
+    const originalTmuxPane = process.env.TMUX_PANE;
+    const originalQuestionReturnPane = process.env.OMX_QUESTION_RETURN_PANE;
+    const originalLeaderPaneId = process.env.OMX_LEADER_PANE_ID;
+    const writes: string[] = [];
+
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    delete process.env.TMUX;
+    delete process.env.TMUX_PANE;
+    delete process.env.OMX_QUESTION_RETURN_PANE;
+    delete process.env.OMX_LEADER_PANE_ID;
+    process.stdin.setRawMode = ((_: boolean) => process.stdin) as unknown as typeof process.stdin.setRawMode;
+    process.stdin.resume = (() => process.stdin) as unknown as typeof process.stdin.resume;
+    process.stdin.pause = (() => process.stdin) as unknown as typeof process.stdin.pause;
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.chdir(cwd);
+
+    try {
+      const runPromise = questionCommand([
+        '--input',
+        JSON.stringify({
+          question: 'Pick one',
+          options: [{ label: 'A', value: 'a' }],
+          allow_other: false,
+          session_id: 'sess-q',
+        }),
+        '--json',
+      ]);
+
+      setTimeout(() => {
+        process.stdin.emit('keypress', '', { name: 'enter' });
+      }, 25);
+
+      await runPromise;
+      const joined = writes.join('');
+      const lastJsonLine = joined.trim().split('\n').reverse().find((line) => line.trim().startsWith('{'));
+      assert.ok(lastJsonLine, `expected JSON output in: ${joined}`);
+      const payload = JSON.parse(lastJsonLine);
+      assert.equal(payload.ok, true);
+      assert.equal(payload.answer.value, 'a');
+      assert.match(joined, /Use ↑\/↓ to move, Enter to select\./);
+
+      const entries = await readdir(join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions'));
+      assert.equal(entries.length, 1);
+      const record = await readQuestionRecord(join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions', entries[0]!));
+      assert.equal(record?.status, 'answered');
+      assert.equal(record?.renderer?.renderer, 'inline-tty');
+    } finally {
+      if (originalPlatformDescriptor) Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, configurable: true });
+      process.stdin.setRawMode = originalSetRawMode;
+      process.stdin.resume = originalResume;
+      process.stdin.pause = originalPause;
+      process.stdout.write = originalWrite as typeof process.stdout.write;
+      process.chdir(originalCwd);
+      if (typeof originalTmux === 'string') process.env.TMUX = originalTmux;
+      else delete process.env.TMUX;
+      if (typeof originalTmuxPane === 'string') process.env.TMUX_PANE = originalTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof originalQuestionReturnPane === 'string') process.env.OMX_QUESTION_RETURN_PANE = originalQuestionReturnPane;
+      else delete process.env.OMX_QUESTION_RETURN_PANE;
+      if (typeof originalLeaderPaneId === 'string') process.env.OMX_LEADER_PANE_ID = originalLeaderPaneId;
+      else delete process.env.OMX_LEADER_PANE_ID;
+    }
   });
 
 });

--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -152,6 +152,9 @@ export async function questionCommand(args: string[]): Promise<void> {
       sessionId: policy.sessionId,
     });
     await markQuestionPrompting(recordPath, renderer);
+    if (renderer.renderer === 'inline-tty') {
+      await runQuestionUi(recordPath);
+    }
     finalRecord = await waitForQuestionTerminalState(recordPath);
   } catch (error) {
     const message = extractErrorMessage(error);

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -26,6 +26,17 @@ describe('resolveQuestionRendererStrategy', () => {
     );
   });
 
+  it('uses inline-tty on Windows when no tmux bridge exists but the current terminal is interactive', () => {
+    assert.equal(
+      resolveQuestionRendererStrategy(
+        {} as NodeJS.ProcessEnv,
+        '/usr/bin/tmux',
+        { platform: 'win32', stdinIsTTY: true, stdoutIsTTY: true },
+      ),
+      'inline-tty',
+    );
+  });
+
   it('supports explicit host-pane bridge hints when TMUX is absent', () => {
     assert.equal(
       resolveQuestionRendererStrategy({ OMX_QUESTION_RETURN_PANE: '%77' } as NodeJS.ProcessEnv, '/usr/bin/tmux'),
@@ -307,6 +318,33 @@ describe('launchQuestionRenderer', () => {
       '/repo/.omx/state/sessions/s1/questions/question-1.json',
     ]);
     assert.deepEqual(calls[2], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
+  });
+
+  it('uses inline-tty on Windows without invoking tmux when no attached tmux pane is available', () => {
+    const calls: string[][] = [];
+    const result = launchQuestionRenderer(
+      {
+        cwd: '/repo',
+        recordPath: '/repo/.omx/state/sessions/s1/questions/question-inline.json',
+        sessionId: 's1',
+        nowIso: '2026-04-23T00:00:00.000Z',
+        env: {} as NodeJS.ProcessEnv,
+        platform: 'win32',
+        stdinIsTTY: true,
+        stdoutIsTTY: true,
+      },
+      {
+        execTmux: (args) => {
+          calls.push(args);
+          return '';
+        },
+        sleepSync: () => {},
+      },
+    );
+
+    assert.equal(result.renderer, 'inline-tty');
+    assert.equal(result.target, 'inline-tty');
+    assert.deepEqual(calls, []);
   });
 
   it('falls back to the persisted session mode pane when Bash/tool env lost TMUX_PANE', () => {

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { basename } from 'node:path';
+import { stdin as processStdin, stdout as processStdout } from 'node:process';
 import { parsePaneIdFromTmuxOutput } from '../hud/tmux.js';
 import { buildSendPaneArgvs } from '../notifications/tmux-detector.js';
 import { sleepSync } from '../utils/sleep.js';
@@ -12,7 +13,7 @@ import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
 import type { QuestionAnswer, QuestionRendererState } from './types.js';
 
-export type QuestionRendererStrategy = 'inside-tmux' | 'detached-tmux' | 'test-noop' | 'unsupported';
+export type QuestionRendererStrategy = 'inside-tmux' | 'detached-tmux' | 'inline-tty' | 'test-noop' | 'unsupported';
 
 export interface LaunchQuestionRendererOptions {
   cwd: string;
@@ -20,6 +21,9 @@ export interface LaunchQuestionRendererOptions {
   sessionId?: string;
   env?: NodeJS.ProcessEnv;
   nowIso?: string;
+  platform?: NodeJS.Platform;
+  stdinIsTTY?: boolean;
+  stdoutIsTTY?: boolean;
 }
 
 export type ExecTmuxSync = (args: string[]) => string;
@@ -42,6 +46,15 @@ function hasExplicitQuestionPaneTarget(env: NodeJS.ProcessEnv): boolean {
   return isPaneId(safeString(env.OMX_QUESTION_RETURN_PANE || env.OMX_LEADER_PANE_ID).trim());
 }
 
+function hasInteractiveQuestionTty(options?: {
+  stdinIsTTY?: boolean;
+  stdoutIsTTY?: boolean;
+}): boolean {
+  const stdinIsTTY = options?.stdinIsTTY ?? Boolean(processStdin.isTTY);
+  const stdoutIsTTY = options?.stdoutIsTTY ?? Boolean(processStdout.isTTY);
+  return stdinIsTTY && stdoutIsTTY;
+}
+
 export function resolveQuestionRendererStrategy(
   env: NodeJS.ProcessEnv = process.env,
   // Kept for callers/tests that used to pass detected tmux availability; default
@@ -50,12 +63,18 @@ export function resolveQuestionRendererStrategy(
   options?: {
     cwd?: string;
     sessionId?: string;
+    platform?: NodeJS.Platform;
+    stdinIsTTY?: boolean;
+    stdoutIsTTY?: boolean;
   },
 ): QuestionRendererStrategy {
   if (safeString(env.OMX_QUESTION_TEST_RENDERER).trim() === 'noop') return 'test-noop';
   if (safeString(env.TMUX).trim() !== '') return 'inside-tmux';
   if (hasExplicitQuestionPaneTarget(env)) return 'inside-tmux';
   if (options?.cwd && readPersistedQuestionReturnTarget(options.cwd, options.sessionId)) return 'inside-tmux';
+  if ((options?.platform ?? process.platform) === 'win32' && hasInteractiveQuestionTty(options)) {
+    return 'inline-tty';
+  }
   return 'unsupported';
 }
 
@@ -256,6 +275,9 @@ export function launchQuestionRenderer(
   const strategy = deps.strategy ?? resolveQuestionRendererStrategy(options.env ?? process.env, undefined, {
     cwd: options.cwd,
     sessionId: options.sessionId,
+    platform: options.platform,
+    stdinIsTTY: options.stdinIsTTY,
+    stdoutIsTTY: options.stdoutIsTTY,
   });
   const execTmux = deps.execTmux ?? defaultExecTmux;
   const sleepImpl = deps.sleepSync ?? sleepSync;
@@ -314,6 +336,14 @@ export function launchQuestionRenderer(
       target: paneId,
       launched_at: launchedAt,
       ...(returnTarget ? { return_target: returnTarget, return_transport: 'tmux-send-keys' } : {}),
+    };
+  }
+
+  if (strategy === 'inline-tty') {
+    return {
+      renderer: 'inline-tty',
+      target: 'inline-tty',
+      launched_at: launchedAt,
     };
   }
 

--- a/src/question/types.ts
+++ b/src/question/types.ts
@@ -18,7 +18,7 @@ export interface QuestionInput {
   session_id?: string;
 }
 
-export type QuestionRendererKind = 'tmux-pane' | 'tmux-session';
+export type QuestionRendererKind = 'tmux-pane' | 'tmux-session' | 'inline-tty';
 
 export interface QuestionAnswer {
   kind: 'option' | 'other' | 'multi';


### PR DESCRIPTION
## Summary
- add a Windows inline-TTY renderer path for omx question - OMX-owned blocking user question entrypoint

Usage:
  omx question --input '<json>' [--json]
  omx question --ui --state-path <absolute-or-relative-record-path>

Options:
  --help, -h           Show this help message
  --input <json>       JSON object with question/options schema; blocks until answered
  --input=<json>       Same as --input
  --json               Emit compact JSON on stdout for machine callers
  --ui                 Internal renderer mode; renders the OMX question UI for an existing state record
  --state-path <path>  Question record path used by --ui mode

Input schema:
  {
    "header": "Optional short heading",
    "question": "What should OMX do next?",
    "options": [
      {"label": "Proceed", "value": "proceed", "description": "Continue"},
      {"label": "Revise", "value": "revise"}
    ],
    "allow_other": true,
    "other_label": "Other",
    "type": "single-answerable",
    "multi_select": false,
    "source": "deep-interview",
    "session_id": "optional-session-id"
  }

Notes:
  - 'type' accepts 'single-answerable' or 'multi-answerable'; legacy 'multi_select' is still accepted.
  - options may be [] only when allow_other is true, for a free-text-only prompt.
  - machine callers should use --json and read stdout; the command does not return
    until the user selected a predefined option or submitted Other text. when no attached/persisted tmux pane is available
- keep the existing tmux-backed behavior for attached or bridged sessions unchanged
- add regression coverage for renderer selection and the non-attached Windows CLI flow

## Testing
- npm run build
- node --test dist/question/__tests__/renderer.test.js dist/cli/__tests__/question.test.js
- npm run check:no-unused

Closes #1860