### PR TITLE
Add ralplan conversational mention regression coverage

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -147,6 +147,11 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(match, null);
   });
 
+  it('does not trigger ralplan from plain conversational mention', () => {
+    const match = detectPrimaryKeyword('why does ralplan keep blocking stop?');
+    assert.equal(match, null);
+  });
+
   it('still triggers ralph for explicit $ralph invocation', () => {
     const match = detectPrimaryKeyword('$ralph continue verification');
     assert.ok(match);
@@ -390,6 +395,36 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.mode, 'autopilot');
       assert.equal(modeState.active, true);
       assert.equal(modeState.current_phase, 'planning');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not persist ralplan state from plain conversational mention', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralplan-conversation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'why does ralplan keep blocking stop?',
+        sessionId: 'sess-ralplan-conversation',
+        threadId: 'thread-ralplan-conversation',
+        turnId: 'turn-ralplan-conversation',
+        nowIso: '2026-04-24T00:00:00.000Z',
+      });
+
+      assert.equal(result, null);
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-ralplan-conversation', SKILL_ACTIVE_STATE_FILE)),
+        false,
+      );
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-ralplan-conversation', 'ralplan-state.json')),
+        false,
+      );
+      assert.equal(existsSync(join(stateDir, SKILL_ACTIVE_STATE_FILE)), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add a keyword-detector regression test for plain conversational `ralplan` mentions
- assert prompt-submit activation does not seed `skill-active-state` or `ralplan-state` for that prose-only case
- lock down the current mainline behavior so future keyword-detector changes cannot silently reintroduce Stop-hook blockers

## Why
Current `main` already avoids treating a bare conversational `ralplan` mention as a workflow activation, but that guarantee was not covered by regression tests. This PR codifies the behavior so future registry or activation changes do not accidentally seed planning state from incidental prose.

## Testing
- `npm run build`
- `npm run lint -- src/hooks/__tests__/keyword-detector.test.ts`
- `node --test dist/hooks/__tests__/keyword-detector.test.js`
- `npm run check:no-unused`
