### PR TITLE
Support $oh-my-codex:skill routing in UserPromptSubmit hooks

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -45,6 +45,66 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(primary, null);
   });
 
+  it('recognizes plugin-prefixed explicit skill tokens', () => {
+    const matches = detectKeywords('$oh-my-codex:ralplan implement issue #1307');
+    assert.deepEqual(matches.map((m) => m.skill), ['ralplan']);
+    assert.equal(matches[0]?.keyword, '$oh-my-codex:ralplan');
+  });
+
+  it('supports mixed-form explicit multi-skill invocation ordering and dedupe', () => {
+    const matches = detectKeywords('$oh-my-codex:ralplan $ralph $oh-my-codex:ralplan ship this');
+    assert.deepEqual(matches.map((m) => m.skill), ['ralplan', 'ralph']);
+    assert.deepEqual(matches.map((m) => m.keyword), ['$oh-my-codex:ralplan', '$ralph']);
+  });
+
+  it('keeps recognized tokens on both sides of an unknown plugin-prefixed token in the same contiguous block', () => {
+    const matches = detectKeywords('$oh-my-codex:ralplan $oh-my-codex:unknown $ralph');
+    assert.deepEqual(matches.map((m) => m.skill), ['ralplan', 'ralph']);
+    assert.deepEqual(matches.map((m) => m.keyword), ['$oh-my-codex:ralplan', '$ralph']);
+  });
+
+  it('limits mixed-form explicit invocation to the first contiguous block', () => {
+    const matches = detectKeywords('$oh-my-codex:ralplan text $ralph');
+    assert.deepEqual(matches.map((m) => m.skill), ['ralplan']);
+  });
+
+  it('normalizes plugin-prefixed alias tokens', () => {
+    const swarm = detectPrimaryKeyword('$oh-my-codex:swarm handle this');
+    assert.ok(swarm);
+    assert.equal(swarm.skill, 'team');
+    assert.equal(swarm.keyword, '$oh-my-codex:swarm');
+
+    const ulw = detectPrimaryKeyword('$oh-my-codex:ulw continue');
+    assert.ok(ulw);
+    assert.equal(ulw.skill, 'ultrawork');
+    assert.equal(ulw.keyword, '$oh-my-codex:ulw');
+  });
+
+  it('supports plugin-prefixed hyphenated workflow tokens', () => {
+    const deepInterview = detectPrimaryKeyword('$oh-my-codex:deep-interview gather requirements');
+    assert.ok(deepInterview);
+    assert.equal(deepInterview.skill, 'deep-interview');
+    assert.equal(deepInterview.keyword, '$oh-my-codex:deep-interview');
+
+    const codeReview = detectPrimaryKeyword('$oh-my-codex:code-review before merge');
+    assert.ok(codeReview);
+    assert.equal(codeReview.skill, 'code-review');
+    assert.equal(codeReview.keyword, '$oh-my-codex:code-review');
+  });
+
+  it('does not fall back to implicit keyword detection when an unknown plugin-prefixed $token is present', () => {
+    const matches = detectKeywords('$oh-my-codex:maer-thinking 다시 설명해봐 keep going');
+    assert.deepEqual(matches, []);
+    const primary = detectPrimaryKeyword('$oh-my-codex:maer-thinking 다시 설명해봐 keep going');
+    assert.equal(primary, null);
+  });
+
+  it('suppresses implicit detection when an unknown plugin-prefixed token is present with other keyword text', () => {
+    const matches = detectKeywords('$oh-my-codex:unknown analyze this issue');
+    assert.deepEqual(matches, []);
+    assert.equal(detectPrimaryKeyword('$oh-my-codex:unknown analyze this issue'), null);
+  });
+
   it('does not auto-detect keywords for explicit /prompts invocation without $skills', () => {
     const matches = detectKeywords('/prompts:architect analyze this issue');
     assert.deepEqual(matches, []);
@@ -1653,6 +1713,50 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.current_phase, 'verifying');
       assert.equal(modeState.iteration, 7);
       assert.equal(modeState.max_iterations, 50);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not reuse active workflow continuation when prompt contains an unknown plugin-prefixed explicit token', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-unknown-prefixed-explicit-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(stateDir, 'sessions', 'sess-unknown-prefixed'), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-unknown-prefixed', SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'ralph',
+          keyword: '$ralph',
+          phase: 'executing',
+          activated_at: '2026-04-19T00:00:00.000Z',
+          updated_at: '2026-04-19T00:10:00.000Z',
+          source: 'keyword-detector',
+          session_id: 'sess-unknown-prefixed',
+          active_skills: [
+            {
+              skill: 'ralph',
+              phase: 'executing',
+              active: true,
+              activated_at: '2026-04-19T00:00:00.000Z',
+              updated_at: '2026-04-19T00:10:00.000Z',
+              session_id: 'sess-unknown-prefixed',
+            },
+          ],
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$oh-my-codex:unknown continue',
+        sessionId: 'sess-unknown-prefixed',
+        nowIso: '2026-04-19T00:15:00.000Z',
+      });
+
+      assert.equal(result, null);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-unknown-prefixed', 'ralph-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -509,13 +509,18 @@ function normalizeWorkflowKeyboardTypos(text: string): string {
   return text.replace(/ㅕㅣㅈ/g, 'ulw');
 }
 
-function hasExplicitSkillLikeInvocation(text: string): boolean {
-  return /(?:^|[^\w])\$([a-z][a-z0-9-]*)\b/i.test(text);
+interface ExplicitSkillParseResult {
+  matches: KeywordMatch[];
+  sawExplicitLikeInvocation: boolean;
 }
 
-function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
+function normalizeExplicitSkillToken(token: string): string {
+  return token === 'swarm' ? 'team' : token === 'ulw' ? 'ultrawork' : token;
+}
+
+function parseExplicitSkillInvocations(text: string): ExplicitSkillParseResult {
   const results: KeywordMatch[] = [];
-  const regex = /(?:^|[^\w])\$([a-z][a-z0-9-]*)\b/gi;
+  const regex = /(?:^|[^\w])\$(?:(?:oh-my-codex:)?([a-z][a-z0-9-]*))\b/gi;
   let match: RegExpExecArray | null;
   let captureStarted = false;
   let lastMatchEnd = -1;
@@ -523,11 +528,9 @@ function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
   while ((match = regex.exec(text)) !== null) {
     const token = (match[1] ?? '').toLowerCase();
     if (!token) continue;
-
-    const normalizedSkill = token === 'swarm' ? 'team' : token === 'ulw' ? 'ultrawork' : token;
+    const rawKeyword = match[0].slice(match[0].lastIndexOf('$')).toLowerCase();
+    const normalizedSkill = normalizeExplicitSkillToken(token);
     const registryEntry = KEYWORD_TRIGGER_DEFINITIONS.find((entry) => entry.skill.toLowerCase() === normalizedSkill);
-    if (!registryEntry) continue;
-
     const matchStart = match.index + match[0].lastIndexOf('$');
     if (captureStarted) {
       const between = text.slice(lastMatchEnd, matchStart);
@@ -535,18 +538,22 @@ function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
     }
 
     captureStarted = true;
-    lastMatchEnd = matchStart + token.length + 1;
+    lastMatchEnd = matchStart + rawKeyword.length;
+    if (!registryEntry) continue;
 
     if (results.some((item) => item.skill === normalizedSkill)) continue;
 
     results.push({
-      keyword: `$${token}`,
+      keyword: rawKeyword,
       skill: normalizedSkill,
       priority: registryEntry.priority,
     });
   }
 
-  return results;
+  return {
+    matches: results,
+    sawExplicitLikeInvocation: captureStarted,
+  };
 }
 
 function hasIntentContextForKeyword(text: string, keyword: string): boolean {
@@ -570,11 +577,12 @@ function hasIntentContextForKeyword(text: string, keyword: string): boolean {
  */
 export function detectKeywords(text: string): KeywordMatch[] {
   const normalizedText = normalizeWorkflowKeyboardTypos(text);
-  const explicit = extractExplicitSkillInvocations(normalizedText);
+  const explicitParse = parseExplicitSkillInvocations(normalizedText);
+  const explicit = explicitParse.matches;
   if (hasExplicitPromptsInvocation(normalizedText) && explicit.length === 0) {
     return [];
   }
-  if (explicit.length === 0 && hasExplicitSkillLikeInvocation(normalizedText)) {
+  if (explicit.length === 0 && explicitParse.sawExplicitLikeInvocation) {
     return [];
   }
   if (explicit.length > 0) {
@@ -651,7 +659,7 @@ function resolveContinuationKeywordMatch(
     return fallbackMatch;
   }
 
-  if (extractExplicitSkillInvocations(normalizeWorkflowKeyboardTypos(text)).length > 0) {
+  if (parseExplicitSkillInvocations(normalizeWorkflowKeyboardTypos(text)).sawExplicitLikeInvocation) {
     return fallbackMatch;
   }
 
@@ -773,7 +781,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 
   if (isTrackedWorkflowMode(match.skill)) {
     const normalizedInputText = normalizeWorkflowKeyboardTypos(input.text);
-    const workflowMatches = extractExplicitSkillInvocations(normalizedInputText)
+    const workflowMatches = parseExplicitSkillInvocations(normalizedInputText).matches
       .map((entry) => entry.skill)
       .filter(isTrackedWorkflowMode);
     const { requestedSkills: requestedWorkflowSkills, deferredSkills } = resolveRequestedWorkflowSkills(

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -608,6 +608,35 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("records plugin-prefixed keyword activation from UserPromptSubmit payloads", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-plugin-prefixed-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-plugin-1",
+          thread_id: "thread-plugin-1",
+          turn_id: "turn-plugin-1",
+          prompt: "$oh-my-codex:ralplan implement issue #1307",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "ralplan");
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /\$oh-my-codex:ralplan" -> ralplan/);
+      assert.match(message, /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-plugin-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-plugin-1", "ralplan-state.json")), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("normalizes the Korean keyboard typo for ulw during UserPromptSubmit activation", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ulw-ko-"));
     try {
@@ -788,6 +817,35 @@ describe("codex native hook dispatch", () => {
       assert.match(message, /skill: ralph activated and initial state initialized at \.omx\/state\/sessions\/sess-ralph-msg\/ralph-state\.json; write subsequent updates via omx_state MCP\./);
       assert.match(message, /Prompt-side `\$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`\./);
       assert.match(message, /Use `omx ralph --prd \.\.\.` only when you explicitly want the PRD-gated CLI startup path\./);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("clarifies that plugin-prefixed prompt-side $ralph activation does not invoke the PRD-gated CLI path", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-plugin-ralph-routing-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-plugin-ralph-msg",
+          thread_id: "thread-plugin-ralph-msg",
+          turn_id: "turn-plugin-ralph-msg",
+          prompt: "$oh-my-codex:ralph continue verification",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "ralph");
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /\$oh-my-codex:ralph" -> ralph/);
+      assert.match(message, /skill: ralph activated and initial state initialized at \.omx\/state\/sessions\/sess-plugin-ralph-msg\/ralph-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.match(message, /Prompt-side `\$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`\./);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1091,6 +1149,31 @@ export async function onHookEvent(event) {
     }
   });
 
+  it("does not emit UserPromptSubmit routing context for unknown plugin-prefixed $tokens", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-unknown-plugin-token-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-unknown-plugin-1",
+          thread_id: "thread-unknown-plugin-1",
+          turn_id: "turn-unknown-plugin-1",
+          prompt: "$oh-my-codex:maer-thinking 다시 설명해봐",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState, null);
+      assert.equal(result.outputJson, null);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "skill-active-state.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("nudges $team prompt-submit routing toward omx team runtime usage", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-"));
     try {
@@ -1237,6 +1320,37 @@ export async function onHookEvent(event) {
       assert.match(message, /planning preserved over simultaneous execution follow-up; deferred skills: team, ralph\./);
       assert.match(message, /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-multi-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
       assert.doesNotMatch(message, /Use the durable OMX team runtime via `omx team \.\.\.`/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the planning skill active for mixed plugin-prefixed and bare workflow invocations together", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-plugin-planning-precedence-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-plugin-multi-1",
+          thread_id: "thread-plugin-multi-1",
+          turn_id: "turn-plugin-multi-1",
+          prompt: "$oh-my-codex:ralplan $team $oh-my-codex:ralph ship this fix",
+        },
+        { cwd },
+      );
+
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || '',
+      );
+      assert.match(message, /\$oh-my-codex:ralplan" -> ralplan/);
+      assert.match(message, /\$team" -> team/);
+      assert.match(message, /\$oh-my-codex:ralph" -> ralph/);
+      assert.doesNotMatch(message, /mode transiting:/);
+      assert.match(message, /planning preserved over simultaneous execution follow-up; deferred skills: team, ralph\./);
+      assert.match(message, /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-plugin-multi-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- teach native UserPromptSubmit keyword parsing to accept both `$skill` and `$oh-my-codex:skill`
- keep unknown explicit-like tokens inert so they do not fall through to implicit routing or continuation reuse
- add regression coverage for plugin-prefixed activation, alias normalization, mixed explicit blocks, and unknown-token no-ops

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`
- `npx tsc --noEmit --pretty false --project tsconfig.json`

## Notes
- I started `npm test`, but it surfaced unrelated existing failures in other repo areas (ask/plugin/explore/tmux/team), so the PR relies on targeted verification for the touched routing path.
