### PR TITLE
fix: stop Codex App hook lifecycle noise

### DIFF
--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -71,18 +71,13 @@ export function buildManagedCodexHooksConfig(
       PreToolUse: [
         buildCommandHook(command, {
           matcher: "Bash",
-          statusMessage: "Running OMX Bash preflight",
         }),
       ],
       PostToolUse: [
-        buildCommandHook(command, {
-          statusMessage: "Running OMX tool review",
-        }),
+        buildCommandHook(command),
       ],
       UserPromptSubmit: [
-        buildCommandHook(command, {
-          statusMessage: "Applying OMX prompt routing",
-        }),
+        buildCommandHook(command),
       ],
       Stop: [
         buildCommandHook(command, {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -151,6 +151,7 @@ describe("codex native hook config", () => {
       String(preToolUse.hooks?.[0]?.command || ""),
       /codex-native-hook\.js"?$/,
     );
+    assert.equal(preToolUse.hooks?.[0]?.statusMessage, undefined);
 
     const postToolUse = config.hooks.PostToolUse[0] as {
       matcher?: string;
@@ -161,7 +162,18 @@ describe("codex native hook config", () => {
       String(postToolUse.hooks?.[0]?.command || ""),
       /codex-native-hook\.js"?$/,
     );
-    assert.equal(postToolUse.hooks?.[0]?.statusMessage, "Running OMX tool review");
+    assert.equal(postToolUse.hooks?.[0]?.statusMessage, undefined);
+
+    const userPromptSubmit = config.hooks.UserPromptSubmit[0] as {
+      matcher?: string;
+      hooks?: Array<Record<string, unknown>>;
+    };
+    assert.equal(userPromptSubmit.matcher, undefined);
+    assert.match(
+      String(userPromptSubmit.hooks?.[0]?.command || ""),
+      /codex-native-hook\.js"?$/,
+    );
+    assert.equal(userPromptSubmit.hooks?.[0]?.statusMessage, undefined);
 
     const stop = config.hooks.Stop[0] as {
       hooks?: Array<Record<string, unknown>>;


### PR DESCRIPTION
## Summary
- stop managed OMX native hook lifecycle labels from surfacing as noisy App-facing status rows
- keep real hook ownership/management behavior intact while making App presentation safer
- add regression coverage for managed hook metadata and shared hook setup behavior

## Testing
- npm run build
- node --test dist/config/__tests__/codex-hooks.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js

## Issue
- closes #1866