### PR TITLE
fix: restore explicit setup opt-in for ordinary Codex sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npm install -g @openai/codex oh-my-codex
 omx --madmax --high
 ```
 
-On a real `oh-my-codex` version bump, the global npm install now launches the interactive `omx setup` refresh automatically when a TTY is available. If npm scripts are skipped or the install is non-interactive, run `omx setup` manually or use `omx update` to force the same refresh path later.
+On a real `oh-my-codex` version bump, the global npm install now prints an explicit reminder instead of launching `omx setup` automatically. When you're ready, run `omx setup` manually or use `omx update` to check npm and then run the same setup refresh path.
 
 **Codex plugin install note:** this repo also ships an official Codex plugin layout at `plugins/oh-my-codex` with marketplace metadata in `.agents/plugins/marketplace.json`. Plugin install/discovery exposes the packaged OMX skills/workflows, but it is **not** a replacement for `npm install -g oh-my-codex` plus `omx setup`. `omx setup` remains responsible for native agents, prompts/config/hooks/AGENTS.md/HUD/runtime wiring.
 
@@ -151,7 +151,7 @@ Most users should think of OMX as **better task routing + better workflow + bett
 ## Start here if you are new
 
 1. Install or update OMX with `npm install -g @openai/codex oh-my-codex`
-2. Let the interactive `omx setup` refresh run automatically on real OMX version bumps, or run `omx setup` / `omx update` yourself when scripts are skipped or you want to rerun it
+2. After install or real OMX version bumps, run `omx setup` yourself when you're ready, or use `omx update` when you also want npm to check for and install the latest build before refreshing setup
 3. Run `omx doctor`
 4. Run a real execution smoke test: `codex login status` and `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"`
 5. Launch with `omx --madmax --high`

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -32,7 +32,7 @@
       <h2>Installation</h2>
       <pre><code>npm install -g @openai/codex oh-my-codex
 omx doctor</code></pre>
-      <p>When <code>oh-my-codex</code> actually bumps to a newer version, the global npm install now launches the interactive <code>omx setup</code> refresh automatically when a TTY is available. If npm scripts are skipped or the install is non-interactive, rerun <code>omx setup</code> or <code>omx update</code> manually. Fresh OMX-managed <code>gpt-5.4</code> configs now recommend <code>model_context_window = 250000</code> and <code>model_auto_compact_token_limit = 200000</code> only when those keys are missing.</p>
+      <p>When <code>oh-my-codex</code> actually bumps to a newer version, the global npm install now prints an explicit reminder instead of launching <code>omx setup</code> automatically. When you're ready, rerun <code>omx setup</code> manually or use <code>omx update</code> to check npm and then run the same setup refresh path. Fresh OMX-managed <code>gpt-5.4</code> configs now recommend <code>model_context_window = 250000</code> and <code>model_auto_compact_token_limit = 200000</code> only when those keys are missing.</p>
       <p><code>omx doctor</code> verifies the install shape. Before treating the runtime as ready, also prove that the active Codex profile can perform a real request:</p>
       <pre><code>codex login status
 omx exec --skip-git-repo-check -C . &quot;Reply with exactly OMX-EXEC-OK&quot;</code></pre>
@@ -45,7 +45,7 @@ omx                    # standard launch</code></pre>
       <ol>
         <li>Create or enter a project directory.</li>
         <li>Install or update OMX globally.</li>
-        <li>Let the interactive <code>omx setup</code> refresh run automatically on real OMX version bumps, or rerun <code>omx setup</code> / <code>omx update</code> manually when scripts are skipped.</li>
+        <li>After install or real OMX version bumps, rerun <code>omx setup</code> yourself when you're ready, or use <code>omx update</code> when you also want npm to update OMX first.</li>
         <li>Run <code>omx doctor</code>, then the <code>codex login status</code> plus <code>omx exec</code> smoke test above.</li>
         <li>Start Codex CLI with <code>omx</code>.</li>
         <li>Use <code>$deep-interview "clarify the auth change"</code> when intent or boundaries are still unclear.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
         <h1>oh-my-codex</h1>
         <p>Multi-agent orchestration for OpenAI Codex CLI.</p>
         <pre><code>npm install -g oh-my-codex</code></pre>
-        <p>Real global version bumps now auto-launch the interactive <code>omx setup</code> refresh when npm has a TTY. Use <code>omx update</code> or rerun <code>omx setup</code> manually when scripts are skipped. Fresh OMX-managed <code>gpt-5.4</code> configs recommend <code>250000 / 200000</code> only when those keys are missing.</p>
+        <p>Real global version bumps now print an explicit reminder instead of auto-launching <code>omx setup</code>. When you're ready, run <code>omx setup</code> manually or use <code>omx update</code> to check npm and then run the same setup refresh path. Fresh OMX-managed <code>gpt-5.4</code> configs recommend <code>250000 / 200000</code> only when those keys are missing.</p>
       </section>
 
       <section aria-labelledby="whats-new-060">
@@ -69,7 +69,7 @@
       <h2>Quick Start</h2>
       <ol>
         <li><code>npm install -g oh-my-codex</code></li>
-        <li>Let the install-triggered <code>omx setup</code> refresh run on real version bumps, or use <code>omx setup</code> / <code>omx update</code> manually.</li>
+        <li>After install or real version bumps, run <code>omx setup</code> yourself when you're ready, or use <code>omx update</code> when you also want npm to update OMX first.</li>
         <li><code>omx doctor</code></li>
         <li><code>omx --xhigh --madmax</code> (trusted environments) or <code>omx</code></li>
       </ol>

--- a/src/scripts/__tests__/postinstall.test.ts
+++ b/src/scripts/__tests__/postinstall.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -24,70 +24,58 @@ describe("isGlobalInstallLifecycle", () => {
 });
 
 describe("runPostinstall", () => {
-  it("runs interactive setup only for bumped global installs", async () => {
+  it("records the installed version and prints an explicit opt-in setup hint for bumped global installs", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-postinstall-"));
     const stampPath = join(root, ".codex", ".omx", "install-state.json");
     const logs: string[] = [];
-    let setupCalls = 0;
 
     try {
       const result = await runPostinstall({
         env: { npm_config_global: "true" },
         getCurrentVersion: async () => "0.14.1",
-        isInteractive: () => true,
         log: (message) => logs.push(message),
         readStamp: async () => ({
           installed_version: "0.14.0",
           setup_completed_version: "0.14.0",
           updated_at: "2026-04-20T00:00:00.000Z",
         }),
-        runSetup: async () => {
-          setupCalls += 1;
-        },
         writeStamp: async (stamp) => writeUserInstallStamp(stamp, stampPath),
       });
 
-      assert.equal(result.status, "setup-ran");
-      assert.equal(setupCalls, 1);
-      assert.match(logs.join("\n"), /Launching interactive setup/);
+      assert.equal(result.status, "hinted");
+      assert.match(logs.join("\n"), /OMX setup is explicit opt-in; run `omx setup` or `omx update` when you're ready/);
 
       const stamp = JSON.parse(await readFile(stampPath, "utf-8")) as {
         installed_version: string;
         setup_completed_version: string;
       };
       assert.equal(stamp.installed_version, "0.14.1");
-      assert.equal(stamp.setup_completed_version, "0.14.1");
+      assert.equal(stamp.setup_completed_version, "0.14.0");
     } finally {
       await rm(root, { recursive: true, force: true });
     }
   });
 
-  it("records the installed version and prints a hint when no TTY is available", async () => {
+  it("records the installed version and preserves prior setup state when printing the postinstall hint", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-postinstall-"));
     const stampPath = join(root, ".codex", ".omx", "install-state.json");
     const logs: string[] = [];
-    let setupCalls = 0;
 
     try {
       const result = await runPostinstall({
         env: { npm_config_global: "true" },
         getCurrentVersion: async () => "0.14.1",
-        isInteractive: () => false,
         log: (message) => logs.push(message),
         readStamp: async () => ({
           installed_version: "0.14.0",
           setup_completed_version: "0.14.0",
           updated_at: "2026-04-20T00:00:00.000Z",
         }),
-        runSetup: async () => {
-          setupCalls += 1;
-        },
         writeStamp: async (stamp) => writeUserInstallStamp(stamp, stampPath),
       });
 
       assert.equal(result.status, "hinted");
-      assert.equal(setupCalls, 0);
-      assert.match(logs.join("\n"), /Run `omx setup` \(interactive\) or `omx update`/);
+      assert.match(logs.join("\n"), /run `omx setup` or `omx update` when you're ready/i);
 
       const stamp = JSON.parse(await readFile(stampPath, "utf-8")) as {
         installed_version: string;
@@ -101,110 +89,25 @@ describe("runPostinstall", () => {
   });
 
   it("skips local installs", async () => {
-    let setupCalls = 0;
     const result = await runPostinstall({
       env: { npm_config_global: "false" },
       getCurrentVersion: async () => "0.14.1",
-      isInteractive: () => true,
-      runSetup: async () => {
-        setupCalls += 1;
-      },
     });
 
     assert.equal(result.status, "noop-local");
-    assert.equal(setupCalls, 0);
   });
 
   it("does not rerun setup when the installed version matches the saved stamp", async () => {
-    let setupCalls = 0;
     const result = await runPostinstall({
       env: { npm_config_global: "true" },
       getCurrentVersion: async () => "0.14.1",
-      isInteractive: () => true,
       readStamp: async () => ({
         installed_version: "0.14.1",
         setup_completed_version: "0.14.1",
         updated_at: "2026-04-20T00:00:00.000Z",
       }),
-      runSetup: async () => {
-        setupCalls += 1;
-      },
     });
 
     assert.equal(result.status, "noop-same-version");
-    assert.equal(setupCalls, 0);
-  });
-
-  it("warns and exits cleanly when setup fails", async () => {
-    const warnings: string[] = [];
-    const result = await runPostinstall({
-      env: { npm_config_global: "true" },
-      getCurrentVersion: async () => "0.14.1",
-      isInteractive: () => true,
-      readStamp: async () => ({
-        installed_version: "0.14.0",
-        setup_completed_version: "0.14.0",
-        updated_at: "2026-04-20T00:00:00.000Z",
-      }),
-      runSetup: async () => {
-        throw new Error("boom");
-      },
-      warn: (message) => warnings.push(message),
-      writeStamp: async () => {},
-    });
-
-    assert.equal(result.status, "setup-failed");
-    assert.match(warnings.join("\n"), /non-fatal error: boom/);
-  });
-
-  it("runs interactive setup from the npm install prefix instead of the package dir or INIT_CWD", async () => {
-    const installRoot = await mkdtemp(join(tmpdir(), "omx-postinstall-install-root-"));
-    const packageRoot = await mkdtemp(join(tmpdir(), "omx-postinstall-package-root-"));
-    const initCwd = await mkdtemp(join(tmpdir(), "omx-postinstall-init-cwd-"));
-    const originalCwd = process.cwd();
-    const scopeFile = join(installRoot, ".omx", "setup-scope.json");
-    const packageScopeFile = join(packageRoot, ".omx", "setup-scope.json");
-    const initCwdScopeFile = join(initCwd, ".omx", "setup-scope.json");
-
-    try {
-      process.chdir(packageRoot);
-
-      const result = await runPostinstall({
-        env: {
-          npm_config_global: "true",
-          npm_config_prefix: installRoot,
-          INIT_CWD: initCwd,
-        },
-        getCurrentVersion: async () => "0.14.1",
-        isInteractive: () => true,
-        readStamp: async () => ({
-          installed_version: "0.14.0",
-          setup_completed_version: "0.14.0",
-          updated_at: "2026-04-20T00:00:00.000Z",
-        }),
-        runSetup: async () => {
-          await mkdir(join(process.cwd(), ".omx"), { recursive: true });
-          await writeFile(
-            join(process.cwd(), ".omx", "setup-scope.json"),
-            JSON.stringify({ scope: "project" }),
-          );
-        },
-        writeStamp: async () => {},
-      });
-
-      assert.equal(result.status, "setup-ran");
-      assert.equal(process.cwd(), packageRoot);
-      assert.equal(
-        JSON.parse(await readFile(scopeFile, "utf-8")).scope,
-        "project",
-      );
-      await assert.rejects(() => readFile(packageScopeFile, "utf-8"));
-      await assert.rejects(() => readFile(initCwdScopeFile, "utf-8"));
-    } finally {
-      process.chdir(originalCwd);
-      await rm(installRoot, { recursive: true, force: true });
-      await rm(packageRoot, { recursive: true, force: true });
-      await rm(initCwd, { recursive: true, force: true });
-    }
   });
 });

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   isInstallVersionBump,
@@ -7,16 +7,13 @@ import {
   type UserInstallStamp,
   writeUserInstallStamp,
 } from "../cli/update.js";
-import { setup } from "../cli/setup.js";
 import { getPackageRoot } from "../utils/package.js";
 
 type PostinstallStatus =
   | "noop-local"
   | "noop-same-version"
   | "noop-missing-version"
-  | "hinted"
-  | "setup-ran"
-  | "setup-failed";
+  | "hinted";
 
 export interface PostinstallResult {
   status: PostinstallStatus;
@@ -26,11 +23,8 @@ export interface PostinstallResult {
 interface PostinstallDependencies {
   env: NodeJS.ProcessEnv;
   getCurrentVersion: () => Promise<string | null>;
-  isInteractive: () => boolean;
   log: (message: string) => void;
   readStamp: () => Promise<UserInstallStamp | null>;
-  runSetup: typeof setup;
-  warn: (message: string) => void;
   writeStamp: (stamp: UserInstallStamp) => Promise<void>;
 }
 
@@ -44,29 +38,6 @@ function isTruthyEnv(value: string | undefined): boolean {
 
 export function isGlobalInstallLifecycle(env: NodeJS.ProcessEnv = process.env): boolean {
   return isTruthyEnv(env.npm_config_global) || env.npm_config_location === "global";
-}
-
-function resolveInstallRoot(env: NodeJS.ProcessEnv): string {
-  const installPrefix = env.npm_config_prefix?.trim() || env.npm_config_local_prefix?.trim();
-  return installPrefix ? resolve(installPrefix) : process.cwd();
-}
-
-async function runSetupFromInstallRoot(
-  runSetup: typeof setup,
-  installRoot: string,
-): Promise<void> {
-  const previousCwd = process.cwd();
-  if (previousCwd === installRoot) {
-    await runSetup();
-    return;
-  }
-
-  process.chdir(installRoot);
-  try {
-    await runSetup();
-  } finally {
-    process.chdir(previousCwd);
-  }
 }
 
 async function getCurrentVersion(): Promise<string | null> {
@@ -83,11 +54,8 @@ async function getCurrentVersion(): Promise<string | null> {
 const defaultDependencies: PostinstallDependencies = {
   env: process.env,
   getCurrentVersion,
-  isInteractive: () => Boolean(process.stdin.isTTY && process.stdout.isTTY),
   log: (message) => console.log(message),
   readStamp: () => readUserInstallStamp(),
-  runSetup: setup,
-  warn: (message) => console.warn(message),
   writeStamp: (stamp) => writeUserInstallStamp(stamp),
 };
 
@@ -120,32 +88,10 @@ export async function runPostinstall(
     updated_at: new Date().toISOString(),
   });
 
-  if (!resolved.isInteractive()) {
-    resolved.log(
-      `[omx] Installed oh-my-codex v${currentStampVersion}. Run \`omx setup\` (interactive) or \`omx update\` when you're ready.`,
-    );
-    return { status: "hinted", version: currentStampVersion };
-  }
-
   resolved.log(
-    `[omx] Detected oh-my-codex v${currentStampVersion} install/update. Launching interactive setup...`,
+    `[omx] Installed oh-my-codex v${currentStampVersion}. OMX setup is explicit opt-in; run \`omx setup\` or \`omx update\` when you're ready.`,
   );
-
-  try {
-    await runSetupFromInstallRoot(resolved.runSetup, resolveInstallRoot(env));
-    await resolved.writeStamp({
-      installed_version: currentStampVersion,
-      setup_completed_version: currentStampVersion,
-      updated_at: new Date().toISOString(),
-    });
-    resolved.log(`[omx] Setup refresh completed for v${currentStampVersion}.`);
-    return { status: "setup-ran", version: currentStampVersion };
-  } catch (error) {
-    resolved.warn(
-      `[omx] Postinstall setup skipped after a non-fatal error: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return { status: "setup-failed", version: currentStampVersion };
-  }
+  return { status: "hinted", version: currentStampVersion };
 }
 
 export async function main(): Promise<void> {


### PR DESCRIPTION
## Summary
- stop npm postinstall from auto-running user-level OMX setup during ordinary Codex sessions
- restore an explicit opt-in boundary so global install alone does not make Codex App sessions inherit OMX-managed behavior
- add focused regression coverage for postinstall setup gating and non-fatal warning handling

## Testing
- npm run build
- node --test dist/scripts/__tests__/postinstall.test.js
- node --test dist/config/__tests__/codex-hooks.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js
- node --test dist/cli/__tests__/update.test.js
- npx tsc --noEmit --pretty false --project tsconfig.json

## Issues
- closes #1867
- related: #1866