### PR TITLE
Respect local .omx ignore rules for issue #1780

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -26,6 +26,17 @@ const EXPECTED_PROJECT_GITIGNORE = [
   "!.codex/prompts/**",
 ].join("\n") + "\n";
 
+const EXPECTED_PROJECT_GITIGNORE_WITHOUT_OMX = [
+  ".codex/*",
+  "!.codex/agents/",
+  "!.codex/agents/**",
+  "!.codex/skills/",
+  "!.codex/skills/**",
+  ".codex/skills/.system/**",
+  "!.codex/prompts/",
+  "!.codex/prompts/**",
+].join("\n") + "\n";
+
 async function runSetupWithCapturedLogs(
   cwd: string,
   options: Parameters<typeof setup>[0],
@@ -135,6 +146,24 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       assert.equal(gitignore, `node_modules/\n${EXPECTED_PROJECT_GITIGNORE}`);
       assert.equal(gitignore.match(/^\.omx\/$/gm)?.length ?? 0, 1);
       assert.equal(gitignore.match(/^\.codex\/\*$/gm)?.length ?? 0, 1);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not add .omx/ to project .gitignore when Git already ignores it locally", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-local-ignore-"));
+    try {
+      const initResult = spawnSync("git", ["init", "-q"], { cwd: wd });
+      assert.equal(initResult.status, 0);
+      await writeFile(join(wd, ".gitignore"), "node_modules/\n");
+      await writeFile(join(wd, ".git", "info", "exclude"), ".omx/\n");
+
+      await runSetupInTempDir(wd, { scope: "project" });
+
+      const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
+      assert.equal(gitignore, `node_modules/\n${EXPECTED_PROJECT_GITIGNORE_WITHOUT_OMX}`);
+      assert.equal(gitignore.match(/^\.omx\/$/gm)?.length ?? 0, 0);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -169,6 +169,23 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("creates .gitignore without .omx/ when only local Git excludes already ignore it", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-local-ignore-"));
+    try {
+      const initResult = spawnSync("git", ["init", "-q"], { cwd: wd });
+      assert.equal(initResult.status, 0);
+      await writeFile(join(wd, ".git", "info", "exclude"), ".omx/\n");
+
+      await runSetupInTempDir(wd, { scope: "project" });
+
+      const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
+      assert.equal(gitignore, EXPECTED_PROJECT_GITIGNORE_WITHOUT_OMX);
+      assert.equal(gitignore.match(/^\.omx\/$/gm)?.length ?? 0, 0);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("ignores project-local config while keeping .codex agents, skills, and prompts trackable", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -620,6 +620,25 @@ function hasGitignoreEntry(content: string, entry: string): boolean {
     .some((line) => line === entry);
 }
 
+function isProjectPathIgnoredByGit(projectRoot: string, path: string): boolean {
+  const result = spawnSync("git", ["check-ignore", "--no-index", "-q", path], {
+    cwd: projectRoot,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  return result.status === 0;
+}
+
+function shouldAddProjectGitignoreEntry(projectRoot: string, content: string, entry: string): boolean {
+  if (hasGitignoreEntry(content, entry)) return false;
+
+  if (entry === ".omx/" && isProjectPathIgnoredByGit(projectRoot, entry)) {
+    return false;
+  }
+
+  return true;
+}
+
 function stripLegacyGitignoreEntries(
   content: string,
   legacyEntries: readonly string[],
@@ -650,8 +669,8 @@ async function ensureProjectGitignore(
     LEGACY_PROJECT_GITIGNORE_ENTRIES,
   );
 
-  const missingEntries = PROJECT_GITIGNORE_ENTRIES.filter(
-    (entry) => !hasGitignoreEntry(normalized.content, entry),
+  const missingEntries = PROJECT_GITIGNORE_ENTRIES.filter((entry) =>
+    shouldAddProjectGitignoreEntry(projectRoot, normalized.content, entry),
   );
 
   if (missingEntries.length === 0 && !normalized.removed) {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -679,7 +679,7 @@ async function ensureProjectGitignore(
 
   const nextContent = destinationExists
     ? `${normalized.content}${normalized.content.endsWith("\n") || normalized.content.length === 0 ? "" : "\n"}${missingEntries.join("\n")}${missingEntries.length > 0 ? "\n" : ""}`
-    : `${PROJECT_GITIGNORE_ENTRIES.join("\n")}\n`;
+    : `${missingEntries.join("\n")}\n`;
 
   if (
     await ensureBackup(gitignorePath, destinationExists, backupContext, options)

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -445,6 +445,38 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("respects global Git ignore resolution for indexed .omx paths during SessionStart", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-global-indexed-ignore-"));
+    const excludesFile = join(cwd, "global-ignore");
+    try {
+      await writeFile(join(cwd, ".gitignore"), "node_modules\n");
+      await mkdir(join(cwd, ".omx"), { recursive: true });
+      await writeFile(join(cwd, ".omx", "state.json"), "{}\n");
+      await writeFile(excludesFile, ".omx/\n");
+      execFileSync("git", ["init"], { cwd, stdio: "pipe" });
+      execFileSync("git", ["add", ".omx/state.json"], { cwd, stdio: "pipe" });
+      execFileSync("git", ["config", "core.excludesfile", excludesFile], { cwd, stdio: "pipe" });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "sess-gitignore-global-indexed",
+        },
+        { cwd, sessionOwnerPid: 43210 },
+      );
+
+      assert.equal(result.omxEventName, "session-start");
+      const gitignore = await readFile(join(cwd, ".gitignore"), "utf-8");
+      assert.equal(gitignore, "node_modules\n");
+      const exclude = await readFile(join(cwd, ".git", "info", "exclude"), "utf-8");
+      assert.doesNotMatch(exclude, /(?:^|\n)\.omx\/\n/);
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /Added \.omx\//);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("includes persisted project-memory summary in SessionStart context", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-memory-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -443,7 +443,7 @@ function tryReadGitValue(cwd: string, args: string[]): string | null {
 
 function isPathIgnoredByGit(cwd: string, path: string): boolean {
   try {
-    execFileSync("git", ["check-ignore", "-q", path], {
+    execFileSync("git", ["check-ignore", "--no-index", "-q", path], {
       cwd,
       stdio: ["ignore", "ignore", "ignore"],
       windowsHide: true,


### PR DESCRIPTION
## Summary
- make SessionStart Git ignore checks use `git check-ignore --no-index` so local/global excludes still count for indexed `.omx` paths
- skip adding `.omx/` to project `.gitignore` during setup when Git already ignores it via local/global ignore resolution
- add regression coverage for SessionStart and setup local-ignore cases

Fixes #1780

## Tests
- npm run build && node --test dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/setup-refresh.test.js
- npm run lint
- npm test