### PR TITLE
Add Codex plugin compatibility phase 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:team:worker-runtime-identity:compiled": "node --test dist/team/__tests__/worker-runtime-identity.test.js",
     "test:recent-bug-regressions": "npm run build && npm run test:recent-bug-regressions:compiled",
     "test:recent-bug-regressions:compiled": "node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/launch-fallback.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/hardening-e2e.test.js",
+    "test:plugin-boundaries:compiled": "node --test dist/cli/__tests__/codex-plugin-layout.test.js dist/cli/__tests__/package-bin-contract.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js",
     "test:node": "node dist/scripts/run-test-files.js dist",
     "test:node:cross-platform": "npm run test:node",
     "test": "npm run build && npm run test:node && node dist/scripts/generate-catalog-docs.js --check",

--- a/plugins/oh-my-codex/.mcp.json
+++ b/plugins/oh-my-codex/.mcp.json
@@ -1,37 +1,42 @@
 {
   "mcpServers": {
     "omx_state": {
-      "command": "node",
+      "command": "omx",
       "args": [
-        "../../dist/mcp/state-server.js"
+        "mcp-serve",
+        "state-server.js"
       ],
       "enabled": true
     },
     "omx_memory": {
-      "command": "node",
+      "command": "omx",
       "args": [
-        "../../dist/mcp/memory-server.js"
+        "mcp-serve",
+        "memory-server.js"
       ],
       "enabled": true
     },
     "omx_code_intel": {
-      "command": "node",
+      "command": "omx",
       "args": [
-        "../../dist/mcp/code-intel-server.js"
+        "mcp-serve",
+        "code-intel-server.js"
       ],
       "enabled": true
     },
     "omx_trace": {
-      "command": "node",
+      "command": "omx",
       "args": [
-        "../../dist/mcp/trace-server.js"
+        "mcp-serve",
+        "trace-server.js"
       ],
       "enabled": true
     },
     "omx_wiki": {
-      "command": "node",
+      "command": "omx",
       "args": [
-        "../../dist/mcp/wiki-server.js"
+        "mcp-serve",
+        "wiki-server.js"
       ],
       "enabled": true
     }

--- a/plugins/oh-my-codex/.mcp.json
+++ b/plugins/oh-my-codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "omx",
       "args": [
         "mcp-serve",
-        "state-server.js"
+        "state"
       ],
       "enabled": true
     },
@@ -12,7 +12,7 @@
       "command": "omx",
       "args": [
         "mcp-serve",
-        "memory-server.js"
+        "memory"
       ],
       "enabled": true
     },
@@ -20,7 +20,7 @@
       "command": "omx",
       "args": [
         "mcp-serve",
-        "code-intel-server.js"
+        "code-intel"
       ],
       "enabled": true
     },
@@ -28,7 +28,7 @@
       "command": "omx",
       "args": [
         "mcp-serve",
-        "trace-server.js"
+        "trace"
       ],
       "enabled": true
     },
@@ -36,7 +36,7 @@
       "command": "omx",
       "args": [
         "mcp-serve",
-        "wiki-server.js"
+        "wiki"
       ],
       "enabled": true
     }

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -1,8 +1,17 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readdir, readFile, stat } from 'node:fs/promises';
-import { basename, join, relative, resolve, sep } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { chmod, cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, delimiter, join, relative, sep } from 'node:path';
 import { buildMergedConfig } from '../../config/generator.js';
+import {
+  buildOmxPluginMcpManifest,
+  OMX_FIRST_PARTY_MCP_ENTRYPOINTS,
+  OMX_FIRST_PARTY_MCP_SERVER_NAMES,
+  OMX_PLUGIN_MCP_COMMAND,
+  OMX_PLUGIN_MCP_SERVE_SUBCOMMAND,
+} from '../../config/omx-first-party-mcp.js';
 
 type PackageJson = {
   version: string;
@@ -46,6 +55,7 @@ const pluginMcpPath = join(pluginRoot, '.mcp.json');
 const pluginAppsPath = join(pluginRoot, '.app.json');
 const marketplacePath = join(root, '.agents', 'plugins', 'marketplace.json');
 const setupOnlyInstallableSkills = new Set(['wiki']);
+const omxBin = join(root, 'dist', 'cli', 'omx.js');
 
 type PluginMcpManifest = {
   mcpServers?: Record<string, {
@@ -63,7 +73,6 @@ async function readJson<T>(path: string): Promise<T> {
   return JSON.parse(await readFile(path, 'utf-8')) as T;
 }
 
-
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -77,6 +86,55 @@ async function listFiles(dir: string, base = dir): Promise<string[]> {
     return [];
   }));
   return files.flat().sort();
+}
+
+async function writeOmxShim(binDir: string): Promise<void> {
+  await mkdir(binDir, { recursive: true });
+
+  if (process.platform === 'win32') {
+    await writeFile(
+      join(binDir, 'omx.cmd'),
+      `@echo off\r\n"${process.execPath}" "${omxBin}" %*\r\n`,
+      'utf-8',
+    );
+    return;
+  }
+
+  const shimPath = join(binDir, 'omx');
+  await writeFile(
+    shimPath,
+    `#!/bin/sh\nexec "${process.execPath}" "${omxBin}" "$@"\n`,
+    'utf-8',
+  );
+  await chmod(shimPath, 0o755);
+}
+
+async function assertPluginCacheLaunchable(entrypoint: string): Promise<void> {
+  const cacheRoot = await mkdtemp(join(tmpdir(), 'omx-plugin-cache-'));
+  const cachePluginRoot = join(cacheRoot, pluginName, 'local');
+  const shimDir = join(cacheRoot, 'bin');
+  await cp(pluginRoot, cachePluginRoot, { recursive: true });
+  await writeOmxShim(shimDir);
+
+  try {
+    const result = spawnSync(OMX_PLUGIN_MCP_COMMAND, [OMX_PLUGIN_MCP_SERVE_SUBCOMMAND, entrypoint], {
+      cwd: cachePluginRoot,
+      encoding: 'utf-8',
+      input: '',
+      env: {
+        ...process.env,
+        PATH: `${shimDir}${delimiter}${process.env.PATH || ''}`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(result.stderr.trim(), '', `${entrypoint} should not fail when launched from a cache-style plugin root`);
+  } finally {
+    await rm(cacheRoot, { recursive: true, force: true });
+  }
 }
 
 describe('official Codex plugin layout', () => {
@@ -104,50 +162,21 @@ describe('official Codex plugin layout', () => {
       readJson<PluginMcpManifest>(pluginMcpPath),
       readJson<PluginAppsManifest>(pluginAppsPath),
     ]);
+    const expectedPluginMcpManifest = buildOmxPluginMcpManifest();
 
     assert.equal('hooks' in (await readJson<Record<string, unknown>>(pluginManifestPath)), false);
     assert.deepEqual(appsManifest, { apps: {} });
-
-    assert.deepEqual(
-      Object.keys(mcpManifest.mcpServers ?? {}).sort(),
-      ['omx_code_intel', 'omx_memory', 'omx_state', 'omx_trace', 'omx_wiki'],
-    );
-    assert.deepEqual(mcpManifest.mcpServers?.omx_state, {
-      command: 'node',
-      args: ['../../dist/mcp/state-server.js'],
-      enabled: true,
-    });
-    assert.deepEqual(mcpManifest.mcpServers?.omx_memory, {
-      command: 'node',
-      args: ['../../dist/mcp/memory-server.js'],
-      enabled: true,
-    });
-    assert.deepEqual(mcpManifest.mcpServers?.omx_code_intel, {
-      command: 'node',
-      args: ['../../dist/mcp/code-intel-server.js'],
-      enabled: true,
-    });
-    assert.deepEqual(mcpManifest.mcpServers?.omx_trace, {
-      command: 'node',
-      args: ['../../dist/mcp/trace-server.js'],
-      enabled: true,
-    });
-    assert.deepEqual(mcpManifest.mcpServers?.omx_wiki, {
-      command: 'node',
-      args: ['../../dist/mcp/wiki-server.js'],
-      enabled: true,
-    });
+    assert.deepEqual(mcpManifest, expectedPluginMcpManifest);
 
     for (const [serverName, server] of Object.entries(mcpManifest.mcpServers ?? {})) {
-      assert.equal(server.command, 'node', `${serverName} should run via node`);
+      assert.equal(server.command, OMX_PLUGIN_MCP_COMMAND, `${serverName} should run via omx`);
       assert.equal(server.enabled, true, `${serverName} should be enabled`);
-      assert.equal(server.args?.length, 1, `${serverName} should have a single entrypoint arg`);
-      const entrypoint = server.args?.[0];
+      assert.equal(server.args?.length, 2, `${serverName} should have serve subcommand + entrypoint args`);
+      assert.equal(server.args?.[0], OMX_PLUGIN_MCP_SERVE_SUBCOMMAND, `${serverName} should launch through omx mcp-serve`);
+      const entrypoint = server.args?.[1];
       assert.ok(entrypoint, `${serverName} should declare an entrypoint`);
-      assert.equal(entrypoint?.startsWith('../../dist/mcp/'), true, `${serverName} should point back to packaged dist/mcp assets`);
-      const resolvedEntrypoint = resolve(pluginRoot, entrypoint ?? '');
-      const entrypointStat = await stat(resolvedEntrypoint);
-      assert.equal(entrypointStat.isFile(), true, `${serverName} entrypoint should exist at ${resolvedEntrypoint}`);
+      assert.equal(entrypoint?.includes('..'), false, `${serverName} should not depend on path traversal outside the plugin root`);
+      assert.equal(OMX_FIRST_PARTY_MCP_ENTRYPOINTS.includes(entrypoint ?? ''), true, `${serverName} should use a canonical OMX MCP entrypoint`);
     }
   });
 
@@ -158,10 +187,15 @@ describe('official Codex plugin layout', () => {
       .map((match) => match[1])
       .sort();
 
+    assert.deepEqual(
+      setupManagedServers,
+      [...OMX_FIRST_PARTY_MCP_SERVER_NAMES].sort(),
+      'setup should expose the canonical first-party OMX MCP roster',
+    );
     assert.deepEqual(setupManagedServers, Object.keys(mcpManifest.mcpServers ?? {}).sort());
 
     for (const [serverName, server] of Object.entries(mcpManifest.mcpServers ?? {})) {
-      const entrypoint = basename(server.args?.[0] ?? '');
+      const entrypoint = basename(server.args?.[1] ?? '');
       assert.ok(entrypoint, `${serverName} should expose an entrypoint basename`);
       assert.match(
         mergedConfig,
@@ -169,6 +203,20 @@ describe('official Codex plugin layout', () => {
         `${serverName} should stay aligned with the setup-managed MCP entrypoint`,
       );
     }
+  });
+
+  it('launches plugin MCP entrypoints from a cache-style plugin root via the installed omx CLI', async () => {
+    for (const entrypoint of OMX_FIRST_PARTY_MCP_ENTRYPOINTS) {
+      await assertPluginCacheLaunchable(entrypoint);
+    }
+  });
+
+  it('does not stage plugin-scoped hook manifests or runtime hook directories', async () => {
+    const pluginEntries = await readdir(pluginRoot);
+
+    assert.equal(pluginEntries.includes('.codex'), false, 'official plugin should not ship setup-owned .codex hook assets');
+    assert.equal(pluginEntries.includes('.omx'), false, 'official plugin should not ship runtime hook directories');
+    assert.equal(pluginEntries.includes('hooks.json'), false, 'official plugin should not ship a plugin-scoped hooks manifest');
   });
 
   it('registers the plugin in the repo marketplace with explicit source, policy, and category', async () => {

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -3,11 +3,12 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { chmod, cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { basename, delimiter, join, relative, sep } from 'node:path';
+import { delimiter, join, relative, sep } from 'node:path';
 import { buildMergedConfig } from '../../config/generator.js';
 import {
   buildOmxPluginMcpManifest,
   OMX_FIRST_PARTY_MCP_ENTRYPOINTS,
+  OMX_FIRST_PARTY_MCP_PLUGIN_TARGETS,
   OMX_FIRST_PARTY_MCP_SERVER_NAMES,
   OMX_PLUGIN_MCP_COMMAND,
   OMX_PLUGIN_MCP_SERVE_SUBCOMMAND,
@@ -171,12 +172,13 @@ describe('official Codex plugin layout', () => {
     for (const [serverName, server] of Object.entries(mcpManifest.mcpServers ?? {})) {
       assert.equal(server.command, OMX_PLUGIN_MCP_COMMAND, `${serverName} should run via omx`);
       assert.equal(server.enabled, true, `${serverName} should be enabled`);
-      assert.equal(server.args?.length, 2, `${serverName} should have serve subcommand + entrypoint args`);
+      assert.equal(server.args?.length, 2, `${serverName} should have serve subcommand + public target args`);
       assert.equal(server.args?.[0], OMX_PLUGIN_MCP_SERVE_SUBCOMMAND, `${serverName} should launch through omx mcp-serve`);
-      const entrypoint = server.args?.[1];
-      assert.ok(entrypoint, `${serverName} should declare an entrypoint`);
-      assert.equal(entrypoint?.includes('..'), false, `${serverName} should not depend on path traversal outside the plugin root`);
-      assert.equal(OMX_FIRST_PARTY_MCP_ENTRYPOINTS.includes(entrypoint ?? ''), true, `${serverName} should use a canonical OMX MCP entrypoint`);
+      const target = server.args?.[1];
+      assert.ok(target, `${serverName} should declare a public target`);
+      assert.equal(target?.includes('..'), false, `${serverName} should not depend on path traversal outside the plugin root`);
+      assert.equal(OMX_FIRST_PARTY_MCP_PLUGIN_TARGETS.includes(target ?? ''), true, `${serverName} should use a stable public OMX MCP target`);
+      assert.equal(target?.endsWith('-server.js'), false, `${serverName} should not expose internal dist filenames in plugin metadata`);
     }
   });
 
@@ -194,9 +196,14 @@ describe('official Codex plugin layout', () => {
     );
     assert.deepEqual(setupManagedServers, Object.keys(mcpManifest.mcpServers ?? {}).sort());
 
+    const targetToEntrypoint = new Map(
+      OMX_FIRST_PARTY_MCP_PLUGIN_TARGETS.map((target, index) => [target, OMX_FIRST_PARTY_MCP_ENTRYPOINTS[index]]),
+    );
+
     for (const [serverName, server] of Object.entries(mcpManifest.mcpServers ?? {})) {
-      const entrypoint = basename(server.args?.[1] ?? '');
-      assert.ok(entrypoint, `${serverName} should expose an entrypoint basename`);
+      const target = server.args?.[1] ?? '';
+      const entrypoint = targetToEntrypoint.get(target);
+      assert.ok(entrypoint, `${serverName} should expose a canonical public target`);
       assert.match(
         mergedConfig,
         new RegExp(`\\[mcp_servers\\.${escapeRegex(serverName)}\\][\\s\\S]*?${escapeRegex(entrypoint)}`),
@@ -205,9 +212,9 @@ describe('official Codex plugin layout', () => {
     }
   });
 
-  it('launches plugin MCP entrypoints from a cache-style plugin root via the installed omx CLI', async () => {
-    for (const entrypoint of OMX_FIRST_PARTY_MCP_ENTRYPOINTS) {
-      await assertPluginCacheLaunchable(entrypoint);
+  it('launches plugin MCP public targets from a cache-style plugin root via the installed omx CLI', async () => {
+    for (const target of OMX_FIRST_PARTY_MCP_PLUGIN_TARGETS) {
+      await assertPluginCacheLaunchable(target);
     }
   });
 

--- a/src/cli/__tests__/mcp-serve.test.ts
+++ b/src/cli/__tests__/mcp-serve.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MCP_ENTRYPOINT_MARKER_ENV } from "../../mcp/bootstrap.js";
+import { mcpServeCommand } from "../mcp-serve.js";
+
+describe("mcp-serve command", () => {
+	it("passes the selected MCP entrypoint marker to bootstrap before loading the server module", async () => {
+		const env: Record<string, string | undefined> = {};
+		const loaded: string[] = [];
+
+		await mcpServeCommand(["trace"], {
+			env,
+			loaders: {
+				"state-server.js": async () => {
+					loaded.push("state-server.js");
+				},
+				"memory-server.js": async () => {
+					loaded.push("memory-server.js");
+				},
+				"code-intel-server.js": async () => {
+					loaded.push("code-intel-server.js");
+				},
+				"trace-server.js": async () => {
+					loaded.push(env[MCP_ENTRYPOINT_MARKER_ENV] ?? "missing");
+				},
+				"wiki-server.js": async () => {
+					loaded.push("wiki-server.js");
+				},
+			},
+		});
+
+		assert.equal(env[MCP_ENTRYPOINT_MARKER_ENV], "trace-server.js");
+		assert.deepEqual(loaded, ["trace-server.js"]);
+	});
+
+	it("does not mutate the entrypoint marker when argument validation fails before target resolution", async () => {
+		const env: Record<string, string | undefined> = {};
+
+		await assert.rejects(
+			mcpServeCommand(["unknown-entrypoint"], { env }),
+			/Unknown MCP target: unknown-entrypoint/,
+		);
+
+		assert.equal(env[MCP_ENTRYPOINT_MARKER_ENV], undefined);
+	});
+});

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -31,6 +31,7 @@ describe('nested help routing', () => {
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
     [['state', '--help'], /Usage:\s*omx state <read\|write\|clear\|list-active\|get-status>/i],
+    [['mcp-serve', '--help'], /Usage:\s*omx mcp-serve <entrypoint>/i],
     [['tmux-hook', '--help'], /Usage:\s*\n\s*omx tmux-hook init/i],
     [['ralph', '--help'], /omx ralph - Launch Codex with ralph persistence mode active/i],
   ] satisfies Array<[string[], RegExp]>) {

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -31,7 +31,7 @@ describe('nested help routing', () => {
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
     [['state', '--help'], /Usage:\s*omx state <read\|write\|clear\|list-active\|get-status>/i],
-    [['mcp-serve', '--help'], /Usage:\s*omx mcp-serve <entrypoint>/i],
+    [['mcp-serve', '--help'], /Usage:\s*omx mcp-serve <target>/i],
     [['tmux-hook', '--help'], /Usage:\s*\n\s*omx tmux-hook init/i],
     [['ralph', '--help'], /omx ralph - Launch Codex with ralph persistence mode active/i],
   ] satisfies Array<[string[], RegExp]>) {

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -65,9 +65,13 @@ describe('package bin contract', () => {
       pkg.scripts?.['test:ralph-persistence:compiled'],
       'node --test dist/cli/__tests__/session-scoped-runtime.test.js dist/mcp/__tests__/trace-server.test.js dist/hud/__tests__/state.test.js dist/mcp/__tests__/state-server-ralph-phase.test.js dist/ralph/__tests__/persistence.test.js dist/verification/__tests__/ralph-persistence-gate.test.js',
     );
+    assert.equal(
+      pkg.scripts?.['test:plugin-boundaries:compiled'],
+      'node --test dist/cli/__tests__/codex-plugin-layout.test.js dist/cli/__tests__/package-bin-contract.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js',
+    );
     assert.equal(pkg.scripts?.['test:compat:node'], 'npm run build && node dist/scripts/run-test-files.js dist/compat/__tests__');
 
-    for (const scriptName of ['test:node', 'test:ci:compiled', 'coverage:team-critical', 'coverage:team-critical:compiled', 'coverage:ts:full', 'coverage:ts:full:compiled', 'test:ralph-persistence:compiled', 'test:compat:node'] as const) {
+    for (const scriptName of ['test:node', 'test:ci:compiled', 'coverage:team-critical', 'coverage:team-critical:compiled', 'coverage:ts:full', 'coverage:ts:full:compiled', 'test:ralph-persistence:compiled', 'test:plugin-boundaries:compiled', 'test:compat:node'] as const) {
       const script: string | undefined = pkg.scripts?.[scriptName];
       assert.ok(script, `expected ${scriptName} to exist`);
       assert.equal(script.includes('$(find '), false, `${scriptName} should not rely on POSIX command substitution`);
@@ -131,6 +135,11 @@ describe('package bin contract', () => {
     const promptEntry = results[0]?.files?.find((file) => file.path === 'prompts/executor.md');
     const templateEntry = results[0]?.files?.find((file) => file.path === 'templates/AGENTS.md');
     const postinstallEntry = results[0]?.files?.find((file) => file.path === 'src/scripts/postinstall-bootstrap.js');
+    const pluginScopedHooksEntry = results[0]?.files?.find((file) =>
+      file.path === 'plugins/oh-my-codex/hooks.json'
+      || file.path === 'plugins/oh-my-codex/.codex/hooks.json'
+      || file.path === 'plugins/oh-my-codex/.codex-plugin/hooks.json'
+      || file.path.startsWith('plugins/oh-my-codex/.omx/hooks/'));
 
     assert.equal(packagedHarnessEntry, undefined, `did not expect ${packagedHarnessPath} in npm pack output`);
     assert.equal(packagedHarnessMetaEntry, undefined, 'did not expect packaged explore harness metadata in npm pack output');
@@ -143,16 +152,17 @@ describe('package bin contract', () => {
     assert.ok(pluginManifestEntry, 'expected npm pack output to include plugins/oh-my-codex/.codex-plugin/plugin.json');
     assert.ok(pluginMcpEntry, 'expected npm pack output to include plugins/oh-my-codex/.mcp.json');
     assert.ok(pluginAppsEntry, 'expected npm pack output to include plugins/oh-my-codex/.app.json');
-    assert.ok(stateServerEntry, 'expected npm pack output to include dist/mcp/state-server.js for plugin MCP metadata');
-    assert.ok(memoryServerEntry, 'expected npm pack output to include dist/mcp/memory-server.js for plugin MCP metadata');
-    assert.ok(codeIntelServerEntry, 'expected npm pack output to include dist/mcp/code-intel-server.js for plugin MCP metadata');
-    assert.ok(traceServerEntry, 'expected npm pack output to include dist/mcp/trace-server.js for plugin MCP metadata');
-    assert.ok(wikiServerEntry, 'expected npm pack output to include dist/mcp/wiki-server.js for plugin MCP metadata');
+    assert.ok(stateServerEntry, 'expected npm pack output to include dist/mcp/state-server.js for omx mcp-serve');
+    assert.ok(memoryServerEntry, 'expected npm pack output to include dist/mcp/memory-server.js for omx mcp-serve');
+    assert.ok(codeIntelServerEntry, 'expected npm pack output to include dist/mcp/code-intel-server.js for omx mcp-serve');
+    assert.ok(traceServerEntry, 'expected npm pack output to include dist/mcp/trace-server.js for omx mcp-serve');
+    assert.ok(wikiServerEntry, 'expected npm pack output to include dist/mcp/wiki-server.js for omx mcp-serve');
     assert.ok(pluginRalphSkillEntry, 'expected npm pack output to include mirrored plugin ralph skill');
     assert.ok(pluginWorkerSkillEntry, 'expected npm pack output to include mirrored plugin worker skill');
     assert.ok(rootRalphSkillEntry, 'expected npm pack output to keep canonical root skills');
     assert.ok(promptEntry, 'expected npm pack output to keep prompts');
     assert.ok(templateEntry, 'expected npm pack output to keep templates');
     assert.ok(postinstallEntry, 'expected npm pack output to keep postinstall bootstrap script');
+    assert.equal(pluginScopedHooksEntry, undefined, 'did not expect setup-owned hook assets inside the installable plugin bundle');
   });
 });

--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -413,12 +413,14 @@ esac
     const originalResume = process.stdin.resume;
     const originalPause = process.stdin.pause;
     const originalWrite = process.stdout.write.bind(process.stdout);
+    const originalStderrWrite = process.stderr.write.bind(process.stderr);
     const originalCwd = process.cwd();
     const originalTmux = process.env.TMUX;
     const originalTmuxPane = process.env.TMUX_PANE;
     const originalQuestionReturnPane = process.env.OMX_QUESTION_RETURN_PANE;
     const originalLeaderPaneId = process.env.OMX_LEADER_PANE_ID;
     const writes: string[] = [];
+    const stderrWrites: string[] = [];
 
     Object.defineProperty(process, 'platform', { value: 'win32' });
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
@@ -434,6 +436,10 @@ esac
       writes.push(String(chunk));
       return true;
     }) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
     process.chdir(cwd);
 
     try {
@@ -454,12 +460,12 @@ esac
 
       await runPromise;
       const joined = writes.join('');
-      const lastJsonLine = joined.trim().split('\n').reverse().find((line) => line.trim().startsWith('{'));
-      assert.ok(lastJsonLine, `expected JSON output in: ${joined}`);
-      const payload = JSON.parse(lastJsonLine);
+      const stderrJoined = stderrWrites.join('');
+      const payload = JSON.parse(joined);
       assert.equal(payload.ok, true);
       assert.equal(payload.answer.value, 'a');
-      assert.match(joined, /Use ↑\/↓ to move, Enter to select\./);
+      assert.doesNotMatch(joined, /Use ↑\/↓ to move, Enter to select\./);
+      assert.match(stderrJoined, /Use ↑\/↓ to move, Enter to select\./);
 
       const entries = await readdir(join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions'));
       assert.equal(entries.length, 1);
@@ -474,6 +480,7 @@ esac
       process.stdin.resume = originalResume;
       process.stdin.pause = originalPause;
       process.stdout.write = originalWrite as typeof process.stdout.write;
+      process.stderr.write = originalStderrWrite as typeof process.stderr.write;
       process.chdir(originalCwd);
       if (typeof originalTmux === 'string') process.env.TMUX = originalTmux;
       else delete process.env.TMUX;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -20,6 +20,7 @@ import {
 import { getPackageRoot } from '../utils/package.js';
 import { hasLegacyOmxTeamRunTable } from '../config/generator.js';
 import { getMissingManagedCodexHookEvents } from '../config/codex-hooks.js';
+import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from '../config/omx-first-party-mcp.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import { OMX_EXPLORE_CMD_ENV, isExploreCommandRoutingEnabled } from '../hooks/explore-routing.js';
 import { isLeaderRuntimeStale } from '../team/leader-activity.js';
@@ -904,7 +905,7 @@ async function checkMcpServers(configPath: string): Promise<Check> {
           message: `${mcpCount} servers configured, but retired [mcp_servers.omx_team_run] is not supported; run "omx setup --force" to repair the config`,
         };
       }
-      const hasOmx = content.includes('omx_state') || content.includes('omx_memory');
+      const hasOmx = OMX_FIRST_PARTY_MCP_SERVER_NAMES.some((name) => content.includes(name));
       if (hasOmx) {
         return { name: 'MCP Servers', status: 'pass', message: `${mcpCount} servers configured (OMX present)` };
       }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -32,6 +32,7 @@ import { agentsCommand } from "./agents.js";
 import { sessionCommand } from "./session-search.js";
 import { autoresearchCommand } from "./autoresearch.js";
 import { mcpParityCommand } from "./mcp-parity.js";
+import { mcpServeCommand } from "./mcp-serve.js";
 import { adaptCommand } from "./adapt.js";
 import {
   MADMAX_FLAG,
@@ -186,6 +187,7 @@ Usage:
   omx code-intel
                 CLI parity for OMX code-intel MCP tools
   omx wiki      CLI parity for OMX wiki MCP tools
+  omx mcp-serve Launch an OMX stdio MCP server entrypoint (plugin/runtime use)
   omx sparkshell <command> [args...]
   omx sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]
                 Run native sparkshell sidecar for direct command execution or explicit tmux-pane summarization
@@ -292,6 +294,7 @@ type CliCommand =
   | "hud"
   | "state"
   | "wiki"
+  | "mcp-serve"
   | "status"
   | "cancel"
   | "help"
@@ -312,6 +315,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "hud",
   "state",
   "wiki",
+  "mcp-serve",
   "ralph",
   "resume",
   "session",
@@ -618,6 +622,7 @@ export async function main(args: string[]): Promise<void> {
     "hooks",
     "hud",
     "state",
+    "mcp-serve",
     "status",
     "cancel",
     "help",
@@ -737,6 +742,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "wiki":
         await mcpParityCommand("wiki", args.slice(1));
+        break;
+      case "mcp-serve":
+        await mcpServeCommand(args.slice(1));
         break;
       case "tmux-hook":
         await tmuxHookCommand(args.slice(1));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -187,7 +187,7 @@ Usage:
   omx code-intel
                 CLI parity for OMX code-intel MCP tools
   omx wiki      CLI parity for OMX wiki MCP tools
-  omx mcp-serve Launch an OMX stdio MCP server entrypoint (plugin/runtime use)
+  omx mcp-serve Launch an OMX stdio MCP server target (plugin/runtime use)
   omx sparkshell <command> [args...]
   omx sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]
                 Run native sparkshell sidecar for direct command execution or explicit tmux-pane summarization

--- a/src/cli/mcp-serve.ts
+++ b/src/cli/mcp-serve.ts
@@ -1,0 +1,73 @@
+import {
+  OMX_FIRST_PARTY_MCP_ENTRYPOINTS,
+  OMX_PLUGIN_MCP_SERVE_SUBCOMMAND,
+} from "../config/omx-first-party-mcp.js";
+
+type McpServeEntrypoint = (typeof OMX_FIRST_PARTY_MCP_ENTRYPOINTS)[number];
+
+type McpServeLoader = () => Promise<unknown>;
+
+const MCP_SERVE_USAGE = [
+  `Usage: omx ${OMX_PLUGIN_MCP_SERVE_SUBCOMMAND} <entrypoint>`,
+  "",
+  "Launch an OMX stdio MCP server entrypoint via the installed omx CLI.",
+  "Intended for plugin-scoped MCP metadata and other runtime launchers.",
+  "",
+  `Supported entrypoints: ${OMX_FIRST_PARTY_MCP_ENTRYPOINTS.join(", ")}`,
+].join("\n");
+
+const MCP_SERVE_LOADERS: Record<McpServeEntrypoint, McpServeLoader> = {
+  "state-server.js": async () => await import("../mcp/state-server.js"),
+  "memory-server.js": async () => await import("../mcp/memory-server.js"),
+  "code-intel-server.js": async () => await import("../mcp/code-intel-server.js"),
+  "trace-server.js": async () => await import("../mcp/trace-server.js"),
+  "wiki-server.js": async () => await import("../mcp/wiki-server.js"),
+};
+
+const MCP_SERVE_TARGET_ALIASES: Record<string, McpServeEntrypoint> = {
+  state: "state-server.js",
+  "state-server": "state-server.js",
+  "state-server.js": "state-server.js",
+  memory: "memory-server.js",
+  "memory-server": "memory-server.js",
+  "memory-server.js": "memory-server.js",
+  codeintel: "code-intel-server.js",
+  "code-intel": "code-intel-server.js",
+  code_intel: "code-intel-server.js",
+  "code-intel-server": "code-intel-server.js",
+  "code-intel-server.js": "code-intel-server.js",
+  trace: "trace-server.js",
+  "trace-server": "trace-server.js",
+  "trace-server.js": "trace-server.js",
+  wiki: "wiki-server.js",
+  "wiki-server": "wiki-server.js",
+  "wiki-server.js": "wiki-server.js",
+};
+
+export function normalizeOmxMcpServeTarget(
+  rawTarget: string | undefined,
+): McpServeEntrypoint | null {
+  if (typeof rawTarget !== "string") return null;
+  const normalized = rawTarget.trim().toLowerCase();
+  if (!normalized) return null;
+  return MCP_SERVE_TARGET_ALIASES[normalized] ?? null;
+}
+
+export async function mcpServeCommand(args: string[]): Promise<void> {
+  const firstArg = args[0];
+  if (!firstArg || firstArg === "--help" || firstArg === "-h" || firstArg === "help") {
+    console.log(MCP_SERVE_USAGE);
+    return;
+  }
+
+  const target = normalizeOmxMcpServeTarget(firstArg);
+  if (!target) {
+    throw new Error(`Unknown MCP entrypoint: ${firstArg}\n${MCP_SERVE_USAGE}`);
+  }
+
+  if (args.length > 1) {
+    throw new Error(`Unexpected arguments: ${args.slice(1).join(" ")}\n${MCP_SERVE_USAGE}`);
+  }
+
+  await MCP_SERVE_LOADERS[target]();
+}

--- a/src/cli/mcp-serve.ts
+++ b/src/cli/mcp-serve.ts
@@ -1,22 +1,30 @@
 import {
   OMX_FIRST_PARTY_MCP_ENTRYPOINTS,
+  OMX_FIRST_PARTY_MCP_PLUGIN_TARGETS,
   OMX_PLUGIN_MCP_SERVE_SUBCOMMAND,
 } from "../config/omx-first-party-mcp.js";
+import { MCP_ENTRYPOINT_MARKER_ENV } from "../mcp/bootstrap.js";
 
 type McpServeEntrypoint = (typeof OMX_FIRST_PARTY_MCP_ENTRYPOINTS)[number];
 
 type McpServeLoader = () => Promise<unknown>;
+type McpServeLoaderMap = Record<McpServeEntrypoint, McpServeLoader>;
+
+interface McpServeCommandOptions {
+  env?: Record<string, string | undefined>;
+  loaders?: McpServeLoaderMap;
+}
 
 const MCP_SERVE_USAGE = [
-  `Usage: omx ${OMX_PLUGIN_MCP_SERVE_SUBCOMMAND} <entrypoint>`,
+  `Usage: omx ${OMX_PLUGIN_MCP_SERVE_SUBCOMMAND} <target>`,
   "",
-  "Launch an OMX stdio MCP server entrypoint via the installed omx CLI.",
+  "Launch an OMX stdio MCP server target via the installed omx CLI.",
   "Intended for plugin-scoped MCP metadata and other runtime launchers.",
   "",
-  `Supported entrypoints: ${OMX_FIRST_PARTY_MCP_ENTRYPOINTS.join(", ")}`,
+  `Supported targets: ${OMX_FIRST_PARTY_MCP_PLUGIN_TARGETS.join(", ")}`,
 ].join("\n");
 
-const MCP_SERVE_LOADERS: Record<McpServeEntrypoint, McpServeLoader> = {
+const MCP_SERVE_LOADERS: McpServeLoaderMap = {
   "state-server.js": async () => await import("../mcp/state-server.js"),
   "memory-server.js": async () => await import("../mcp/memory-server.js"),
   "code-intel-server.js": async () => await import("../mcp/code-intel-server.js"),
@@ -53,7 +61,10 @@ export function normalizeOmxMcpServeTarget(
   return MCP_SERVE_TARGET_ALIASES[normalized] ?? null;
 }
 
-export async function mcpServeCommand(args: string[]): Promise<void> {
+export async function mcpServeCommand(
+  args: string[],
+  options: McpServeCommandOptions = {},
+): Promise<void> {
   const firstArg = args[0];
   if (!firstArg || firstArg === "--help" || firstArg === "-h" || firstArg === "help") {
     console.log(MCP_SERVE_USAGE);
@@ -62,12 +73,15 @@ export async function mcpServeCommand(args: string[]): Promise<void> {
 
   const target = normalizeOmxMcpServeTarget(firstArg);
   if (!target) {
-    throw new Error(`Unknown MCP entrypoint: ${firstArg}\n${MCP_SERVE_USAGE}`);
+    throw new Error(`Unknown MCP target: ${firstArg}\n${MCP_SERVE_USAGE}`);
   }
 
   if (args.length > 1) {
     throw new Error(`Unexpected arguments: ${args.slice(1).join(" ")}\n${MCP_SERVE_USAGE}`);
   }
 
-  await MCP_SERVE_LOADERS[target]();
+  const env = options.env ?? process.env;
+  const loaders = options.loaders ?? MCP_SERVE_LOADERS;
+  env[MCP_ENTRYPOINT_MARKER_ENV] = target;
+  await loaders[target]();
 }

--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -105,6 +105,17 @@ function extractErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function createJsonSafeInlineQuestionOutput(): { isTTY?: boolean; write(chunk: string): boolean } {
+  return {
+    get isTTY() {
+      return process.stdout.isTTY;
+    },
+    write(chunk: string): boolean {
+      return process.stderr.write(chunk);
+    },
+  };
+}
+
 export async function questionCommand(args: string[]): Promise<void> {
   const parsed = parseQuestionArgs(args);
   if (parsed.help || args.length === 0) {
@@ -153,7 +164,10 @@ export async function questionCommand(args: string[]): Promise<void> {
     });
     await markQuestionPrompting(recordPath, renderer);
     if (renderer.renderer === 'inline-tty') {
-      await runQuestionUi(recordPath);
+      await runQuestionUi(
+        recordPath,
+        parsed.json ? { output: createJsonSafeInlineQuestionOutput() } : {},
+      );
     }
     finalRecord = await waitForQuestionTerminalState(recordPath);
   } catch (error) {

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -22,6 +22,7 @@ import { detectLegacySkillRootOverlap } from "../utils/paths.js";
 import { resolveScopeDirectories, type SetupScope } from "./setup.js";
 import { readPersistedSetupScope } from "./index.js";
 import { isOmxGeneratedAgentsMd } from "../utils/agents-md.js";
+import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 
 export interface UninstallOptions {
   dryRun?: boolean;
@@ -47,14 +48,6 @@ interface UninstallSummary {
   legacySkillRootWarning: string | null;
 }
 
-const OMX_MCP_SERVERS = [
-  "omx_state",
-  "omx_memory",
-  "omx_code_intel",
-  "omx_trace",
-  "omx_wiki",
-];
-
 function detectOmxConfigArtifacts(config: string): {
   hasMcpServers: string[];
   hasAgentEntries: number;
@@ -63,7 +56,7 @@ function detectOmxConfigArtifacts(config: string): {
   hasFeatureFlags: boolean;
   hasExploreRoutingEnv: boolean;
 } {
-  const hasMcpServers = OMX_MCP_SERVERS.filter((name) =>
+  const hasMcpServers = OMX_FIRST_PARTY_MCP_SERVER_NAMES.filter((name) =>
     new RegExp(`\\[mcp_servers\\.${name}\\]`).test(config),
   );
 

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -17,6 +17,7 @@ import TOML from "@iarna/toml";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
+import { getOmxFirstPartySetupMcpServers } from "./omx-first-party-mcp.js";
 
 interface MergeOptions {
   includeTui?: boolean;
@@ -957,63 +958,31 @@ function getSharedMcpRegistryBlock(
  * Contains ONLY [table] sections — no bare keys.
  */
 function getOmxTablesBlock(pkgRoot: string, includeTui = true): string {
-  const stateServerPath = escapeTomlString(
-    join(pkgRoot, "dist", "mcp", "state-server.js"),
-  );
-  const memoryServerPath = escapeTomlString(
-    join(pkgRoot, "dist", "mcp", "memory-server.js"),
-  );
-  const codeIntelServerPath = escapeTomlString(
-    join(pkgRoot, "dist", "mcp", "code-intel-server.js"),
-  );
-  const traceServerPath = escapeTomlString(
-    join(pkgRoot, "dist", "mcp", "trace-server.js"),
-  );
-  const wikiServerPath = escapeTomlString(
-    join(pkgRoot, "dist", "mcp", "wiki-server.js"),
-  );
-
-  return [
+  const lines = [
     "",
     "# ============================================================",
     "# oh-my-codex (OMX) Configuration",
     "# Managed by omx setup - manual edits preserved on next setup",
     "# ============================================================",
-    "",
-    "# OMX State Management MCP Server",
-    "[mcp_servers.omx_state]",
-    'command = "node"',
-    `args = ["${stateServerPath}"]`,
-    "enabled = true",
-    "startup_timeout_sec = 5",
-    "",
-    "# OMX Project Memory MCP Server",
-    "[mcp_servers.omx_memory]",
-    'command = "node"',
-    `args = ["${memoryServerPath}"]`,
-    "enabled = true",
-    "startup_timeout_sec = 5",
-    "",
-    "# OMX Code Intelligence MCP Server (LSP diagnostics, AST search)",
-    "[mcp_servers.omx_code_intel]",
-    'command = "node"',
-    `args = ["${codeIntelServerPath}"]`,
-    "enabled = true",
-    "startup_timeout_sec = 10",
-    "",
-    "# OMX Trace MCP Server (agent flow timeline & statistics)",
-    "[mcp_servers.omx_trace]",
-    'command = "node"',
-    `args = ["${traceServerPath}"]`,
-    "enabled = true",
-    "startup_timeout_sec = 5",
-    "",
-    "# OMX Wiki MCP Server (persistent project knowledge base)",
-    "[mcp_servers.omx_wiki]",
-    'command = "node"',
-    `args = ["${wikiServerPath}"]`,
-    "enabled = true",
-    "startup_timeout_sec = 5",
+  ];
+
+  for (const server of getOmxFirstPartySetupMcpServers(pkgRoot)) {
+    lines.push("");
+    lines.push(server.title);
+    lines.push(`[mcp_servers.${server.name}]`);
+    lines.push('command = "node"');
+    lines.push(
+      `args = [${server.args
+        .map((arg) => `"${escapeTomlString(arg)}"`)
+        .join(", ")}]`,
+    );
+    lines.push(`enabled = ${server.enabled ? "true" : "false"}`);
+    if (typeof server.startupTimeoutSec === "number") {
+      lines.push(`startup_timeout_sec = ${server.startupTimeoutSec}`);
+    }
+  }
+
+  lines.push(
     ...(includeTui
       ? [
           "",
@@ -1022,11 +991,12 @@ function getOmxTablesBlock(pkgRoot: string, includeTui = true): string {
           OMX_TUI_STATUS_LINE,
           "",
         ]
-      : []),
-    "# ============================================================",
-    "# End oh-my-codex",
-    "",
-  ].join("\n");
+      : [""]),
+  );
+  lines.push("# ============================================================");
+  lines.push("# End oh-my-codex");
+  lines.push("");
+  return lines.join("\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config/omx-first-party-mcp.ts
+++ b/src/config/omx-first-party-mcp.ts
@@ -1,0 +1,90 @@
+import { join } from "path";
+import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
+
+export const OMX_PLUGIN_MCP_COMMAND = "omx";
+export const OMX_PLUGIN_MCP_SERVE_SUBCOMMAND = "mcp-serve";
+
+type OmxFirstPartyMcpSpec = {
+  name: string;
+  title: string;
+  entrypoint: string;
+  startupTimeoutSec: number;
+};
+
+const OMX_FIRST_PARTY_MCP_SPECS: readonly OmxFirstPartyMcpSpec[] = [
+  {
+    name: "omx_state",
+    title: "# OMX State Management MCP Server",
+    entrypoint: "state-server.js",
+    startupTimeoutSec: 5,
+  },
+  {
+    name: "omx_memory",
+    title: "# OMX Project Memory MCP Server",
+    entrypoint: "memory-server.js",
+    startupTimeoutSec: 5,
+  },
+  {
+    name: "omx_code_intel",
+    title: "# OMX Code Intelligence MCP Server (LSP diagnostics, AST search)",
+    entrypoint: "code-intel-server.js",
+    startupTimeoutSec: 10,
+  },
+  {
+    name: "omx_trace",
+    title: "# OMX Trace MCP Server (agent flow timeline & statistics)",
+    entrypoint: "trace-server.js",
+    startupTimeoutSec: 5,
+  },
+  {
+    name: "omx_wiki",
+    title: "# OMX Wiki MCP Server (persistent project knowledge base)",
+    entrypoint: "wiki-server.js",
+    startupTimeoutSec: 5,
+  },
+] as const;
+
+export const OMX_FIRST_PARTY_MCP_SERVER_NAMES = OMX_FIRST_PARTY_MCP_SPECS.map(
+  (spec) => spec.name,
+);
+
+export const OMX_FIRST_PARTY_MCP_ENTRYPOINTS = OMX_FIRST_PARTY_MCP_SPECS.map(
+  (spec) => spec.entrypoint,
+);
+
+export function getOmxFirstPartySetupMcpServers(
+  pkgRoot: string,
+): Array<UnifiedMcpRegistryServer & { title: string }> {
+  return OMX_FIRST_PARTY_MCP_SPECS.map((spec) => ({
+    name: spec.name,
+    title: spec.title,
+    command: "node",
+    args: [join(pkgRoot, "dist", "mcp", spec.entrypoint)],
+    enabled: true,
+    startupTimeoutSec: spec.startupTimeoutSec,
+  }));
+}
+
+export function buildOmxPluginMcpManifest(): {
+  mcpServers: Record<
+    string,
+    {
+      command: string;
+      args: string[];
+      enabled: boolean;
+    }
+  >;
+} {
+  return {
+    mcpServers: Object.fromEntries(
+      OMX_FIRST_PARTY_MCP_SPECS.map((spec) => [
+        spec.name,
+        {
+          command: OMX_PLUGIN_MCP_COMMAND,
+          args: [OMX_PLUGIN_MCP_SERVE_SUBCOMMAND, spec.entrypoint],
+          enabled: true,
+        },
+      ]),
+    ),
+  };
+}

--- a/src/config/omx-first-party-mcp.ts
+++ b/src/config/omx-first-party-mcp.ts
@@ -8,6 +8,7 @@ type OmxFirstPartyMcpSpec = {
   name: string;
   title: string;
   entrypoint: string;
+  pluginTarget: string;
   startupTimeoutSec: number;
 };
 
@@ -16,30 +17,35 @@ const OMX_FIRST_PARTY_MCP_SPECS: readonly OmxFirstPartyMcpSpec[] = [
     name: "omx_state",
     title: "# OMX State Management MCP Server",
     entrypoint: "state-server.js",
+    pluginTarget: "state",
     startupTimeoutSec: 5,
   },
   {
     name: "omx_memory",
     title: "# OMX Project Memory MCP Server",
     entrypoint: "memory-server.js",
+    pluginTarget: "memory",
     startupTimeoutSec: 5,
   },
   {
     name: "omx_code_intel",
     title: "# OMX Code Intelligence MCP Server (LSP diagnostics, AST search)",
     entrypoint: "code-intel-server.js",
+    pluginTarget: "code-intel",
     startupTimeoutSec: 10,
   },
   {
     name: "omx_trace",
     title: "# OMX Trace MCP Server (agent flow timeline & statistics)",
     entrypoint: "trace-server.js",
+    pluginTarget: "trace",
     startupTimeoutSec: 5,
   },
   {
     name: "omx_wiki",
     title: "# OMX Wiki MCP Server (persistent project knowledge base)",
     entrypoint: "wiki-server.js",
+    pluginTarget: "wiki",
     startupTimeoutSec: 5,
   },
 ] as const;
@@ -51,6 +57,24 @@ export const OMX_FIRST_PARTY_MCP_SERVER_NAMES = OMX_FIRST_PARTY_MCP_SPECS.map(
 export const OMX_FIRST_PARTY_MCP_ENTRYPOINTS = OMX_FIRST_PARTY_MCP_SPECS.map(
   (spec) => spec.entrypoint,
 );
+
+export const OMX_FIRST_PARTY_MCP_PLUGIN_TARGETS = OMX_FIRST_PARTY_MCP_SPECS.map(
+  (spec) => spec.pluginTarget,
+);
+
+export function resolveOmxFirstPartyMcpEntrypointForPluginTarget(
+  target: string | undefined,
+): string | null {
+  if (typeof target !== "string") return null;
+  const normalized = target.trim().toLowerCase();
+  if (!normalized) return null;
+  const spec = OMX_FIRST_PARTY_MCP_SPECS.find(
+    (candidate) =>
+      candidate.pluginTarget === normalized ||
+      candidate.entrypoint === normalized,
+  );
+  return spec?.entrypoint ?? null;
+}
 
 export function getOmxFirstPartySetupMcpServers(
   pkgRoot: string,
@@ -81,7 +105,7 @@ export function buildOmxPluginMcpManifest(): {
         spec.name,
         {
           command: OMX_PLUGIN_MCP_COMMAND,
-          args: [OMX_PLUGIN_MCP_SERVE_SUBCOMMAND, spec.entrypoint],
+          args: [OMX_PLUGIN_MCP_SERVE_SUBCOMMAND, spec.pluginTarget],
           enabled: true,
         },
       ]),

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -4,9 +4,11 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   analyzeDuplicateSiblingState,
+  MCP_ENTRYPOINT_MARKER_ENV,
   extractMcpEntrypointMarker,
   isParentProcessAlive,
   parseProcessTable,
+  resolveCurrentMcpEntrypointMarker,
   shouldAutoStartMcpServer,
   shouldSelfExitForDuplicateSibling,
   type McpServerName,
@@ -135,7 +137,33 @@ describe('mcp duplicate sibling detection', () => {
       extractMcpEntrypointMarker('node C:\\\\tmp\\\\oh-my-codex\\\\dist\\\\mcp\\\\trace-server.ts'),
       'trace-server.ts',
     );
+    assert.equal(
+      extractMcpEntrypointMarker('node /tmp/dist/cli/omx.js mcp-serve state'),
+      'state-server.js',
+    );
+    assert.equal(
+      extractMcpEntrypointMarker('node /tmp/dist/cli/omx.js mcp-serve code-intel'),
+      'code-intel-server.js',
+    );
     assert.equal(extractMcpEntrypointMarker('node something-else.js'), null);
+  });
+
+
+  it('prefers an explicit MCP entrypoint marker over argv[1]', () => {
+    assert.equal(
+      resolveCurrentMcpEntrypointMarker(
+        { [MCP_ENTRYPOINT_MARKER_ENV]: 'trace-server.js' },
+        '/repo/dist/cli/omx.js',
+      ),
+      'trace-server.js',
+    );
+  });
+
+  it('falls back to argv[1] when no explicit MCP entrypoint marker is set', () => {
+    assert.equal(
+      resolveCurrentMcpEntrypointMarker({}, '/repo/dist/mcp/state-server.js'),
+      'state-server.js',
+    );
   });
 
   it('parses ps output into process table entries', () => {
@@ -172,6 +200,34 @@ describe('mcp duplicate sibling detection', () => {
     const newest = analyzeDuplicateSiblingState(processes, 140, 55, 'state-server.js');
 
     assert.equal(older.status, 'older_duplicate');
+    assert.deepEqual(older.newerSiblingPids, [140]);
+    assert.equal(newest.status, 'newest');
+    assert.deepEqual(newest.newerSiblingPids, []);
+  });
+
+
+  it('detects duplicate plugin-launched mcp-serve public-target siblings', () => {
+    const processes = [
+      { pid: 101, ppid: 55, command: 'node /repo/dist/cli/omx.js mcp-serve state' },
+      { pid: 140, ppid: 55, command: 'node /repo/dist/cli/omx.js mcp-serve state' },
+      { pid: 160, ppid: 55, command: 'node /repo/dist/cli/omx.js mcp-serve memory' },
+    ];
+
+    const older = analyzeDuplicateSiblingState(
+      processes,
+      101,
+      55,
+      'state-server.js',
+    );
+    const newest = analyzeDuplicateSiblingState(
+      processes,
+      140,
+      55,
+      'state-server.js',
+    );
+
+    assert.equal(older.status, 'older_duplicate');
+    assert.deepEqual(older.matchingPids, [101, 140]);
     assert.deepEqual(older.newerSiblingPids, [140]);
     assert.equal(newest.status, 'newest');
     assert.deepEqual(newest.newerSiblingPids, []);

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { resolveOmxFirstPartyMcpEntrypointForPluginTarget } from '../config/omx-first-party-mcp.js';
 
 export type McpServerName = 'state' | 'memory' | 'code_intel' | 'trace' | 'wiki';
 
@@ -17,11 +18,13 @@ const PARENT_WATCHDOG_INTERVAL_ENV = 'OMX_MCP_PARENT_WATCHDOG_INTERVAL_MS';
 const DUPLICATE_SIBLING_WATCHDOG_INTERVAL_ENV = 'OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS';
 const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS';
 const DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS';
+export const MCP_ENTRYPOINT_MARKER_ENV = 'OMX_MCP_ENTRYPOINT_MARKER';
 const DEFAULT_PARENT_WATCHDOG_INTERVAL_MS = 1_000;
 const DEFAULT_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
 const DEFAULT_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
 const DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS = 60_000;
 const MCP_ENTRYPOINT_PATTERN = /\b([a-z0-9-]+-server\.(?:[cm]?js|ts))\b/i;
+const MCP_SERVE_TARGET_PATTERN = /(?:^|\s)mcp-serve\s+([^\s]+)/i;
 
 interface StdioLifecycleServer {
   connect(transport: StdioServerTransport): Promise<unknown>;
@@ -53,8 +56,23 @@ function normalizeCommand(command: string): string {
 }
 
 export function extractMcpEntrypointMarker(command: string): string | null {
-  const match = normalizeCommand(command).match(MCP_ENTRYPOINT_PATTERN);
-  return match?.[1]?.toLowerCase() ?? null;
+  const normalizedCommand = normalizeCommand(command);
+  const entrypointMatch = normalizedCommand.match(MCP_ENTRYPOINT_PATTERN);
+  if (entrypointMatch?.[1]) return entrypointMatch[1].toLowerCase();
+
+  const mcpServeMatch = normalizedCommand.match(MCP_SERVE_TARGET_PATTERN);
+  return resolveOmxFirstPartyMcpEntrypointForPluginTarget(mcpServeMatch?.[1]);
+}
+
+export function resolveCurrentMcpEntrypointMarker(
+  env: Record<string, string | undefined> = process.env,
+  argv1: string | undefined = process.argv[1],
+): string | null {
+  const explicitMarker = extractMcpEntrypointMarker(
+    env[MCP_ENTRYPOINT_MARKER_ENV] ?? '',
+  );
+  if (explicitMarker) return explicitMarker;
+  return extractMcpEntrypointMarker(argv1 ?? '');
 }
 
 export function parseProcessTable(output: string): ProcessTableEntry[] {
@@ -266,7 +284,10 @@ export function autoStartStdioMcpServer(
   const lifecycleDebugEnabled = env[LIFECYCLE_DEBUG_ENV] === '1';
   const lifecycleTiming = resolveLifecycleTimingConfig(env);
   const trackedParentPid = Number.isInteger(process.ppid) ? process.ppid : 0;
-  const trackedEntrypoint = extractMcpEntrypointMarker(process.argv[1] ?? '');
+  const trackedEntrypoint = resolveCurrentMcpEntrypointMarker(
+    env,
+    process.argv[1] ?? '',
+  );
   let lastTrafficAtMs: number | null = null;
   let duplicateObservedAtMs: number | null = null;
 


### PR DESCRIPTION
## Summary

- add the official `plugins/oh-my-codex` bundle and marketplace metadata for Codex plugin compatibility
- keep plugin MCP metadata on stable public targets (`state`, `memory`, `code-intel`, `trace`, `wiki`) while setup/runtime continue to use internal MCP entrypoints
- fix review-found runtime boundaries:
  - `omx question --json` keeps stdout JSON-only for inline TTY rendering
  - `omx mcp-serve` preserves the selected MCP identity for duplicate-sibling lifecycle detection

## Review / Ralph resolution

Resolved the branch code-review findings before opening this PR:

- HIGH: inline question UI could pollute `--json` stdout — fixed by routing inline UI writes to stderr when JSON output is requested.
- MEDIUM: plugin-launched MCP servers lost duplicate-sibling identity — fixed by mapping public `mcp-serve <target>` launches back to internal entrypoint markers.
- WATCH: plugin MCP metadata leaked internal `*-server.js` filenames — fixed by exposing public targets in `.mcp.json`.

## Verification

- `npm run build`
- `node --test dist/cli/__tests__/question.test.js dist/question/__tests__/renderer.test.js dist/mcp/__tests__/bootstrap.test.js dist/cli/__tests__/mcp-serve.test.js dist/cli/__tests__/codex-plugin-layout.test.js dist/cli/__tests__/nested-help-routing.test.js dist/cli/__tests__/package-bin-contract.test.js`
- `npm run lint -- src/cli/question.ts src/cli/mcp-serve.ts src/mcp/bootstrap.ts src/config/omx-first-party-mcp.ts`
- `git diff --check`

## Notes

Full `npm test` was attempted. It still fails in unrelated environment-sensitive watcher/path areas on this machine (`/private/var` vs `/var` temp path canonicalization and a notify-fallback watcher case), while the focused suites covering this PR's changed boundaries pass.
