### PR TITLE
Propagate configured leader model to subagents

### DIFF
--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -119,7 +119,7 @@ describe("agents/native-config", () => {
     }
   });
 
-  it("keeps standard agents off a custom gpt-5.2 root model", async () => {
+  it("inherits a custom root model for standard agents when no standard override exists", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-native-config-root-model-"));
     const codexHome = join(root, ".codex");
     const promptsDir = join(root, "prompts");
@@ -128,6 +128,33 @@ describe("agents/native-config", () => {
 
     try {
       delete process.env.OMX_DEFAULT_STANDARD_MODEL;
+      process.env.CODEX_HOME = codexHome;
+      await mkdir(promptsDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.2"\n');
+      await writeFile(join(promptsDir, "debugger.md"), "debugger prompt");
+
+      await installNativeAgentConfigs(root, { agentsDir: outDir });
+      const debuggerToml = await readFile(join(outDir, "debugger.toml"), "utf8");
+      assert.match(debuggerToml, /model = "gpt-5\.2"/);
+      assert.doesNotMatch(debuggerToml, /model = "gpt-5\.4-mini"/);
+    } finally {
+      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      process.env.OMX_DEFAULT_STANDARD_MODEL = "gpt-5.4-mini";
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves explicit standard model override for standard agents", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-config-standard-override-"));
+    const codexHome = join(root, ".codex");
+    const promptsDir = join(root, "prompts");
+    const outDir = join(codexHome, "agents");
+    const previousCodexHome = process.env.CODEX_HOME;
+
+    try {
+      process.env.OMX_DEFAULT_STANDARD_MODEL = "gpt-5.4-mini";
       process.env.CODEX_HOME = codexHome;
       await mkdir(promptsDir, { recursive: true });
       await mkdir(codexHome, { recursive: true });

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -650,7 +650,7 @@ describe('buildExploreHarnessArgs', () => {
       '--model-spark',
       'spark-model',
       '--model-fallback',
-      'gpt-5.4-mini',
+      'gpt-5.5',
     ]);
   });
 

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -5,7 +5,6 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   DEFAULT_FRONTIER_MODEL,
-  DEFAULT_STANDARD_MODEL,
   DEFAULT_SPARK_MODEL,
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
@@ -134,6 +133,14 @@ describe('getModelForMode', () => {
     assert.equal(getModelForMode('team'), 'frontier-local');
   });
 
+  it('uses config.toml root model as the main and standard default when env overrides are absent', async () => {
+    await writeFile(join(tempDir, 'config.toml'), 'model = "frontier-config"\n');
+
+    assert.equal(getMainDefaultModel(), 'frontier-config');
+    assert.equal(getStandardDefaultModel(), 'frontier-config');
+    assert.equal(getModelForMode('team'), 'frontier-config');
+  });
+
   it('uses OMX_DEFAULT_STANDARD_MODEL when configured in shell env', () => {
     process.env.OMX_DEFAULT_STANDARD_MODEL = 'gpt-5.4-mini-tuned';
     assert.equal(getEnvConfiguredStandardDefaultModel(), 'gpt-5.4-mini-tuned');
@@ -216,9 +223,15 @@ describe('getModelForMode', () => {
     assert.equal(getTeamLowComplexityModel(), 'gpt-4.1-mini');
   });
 
+  it('inherits the main default for standard agents when no standard override is configured', async () => {
+    process.env.OMX_DEFAULT_FRONTIER_MODEL = 'gpt-5.5-custom';
+    await writeConfig({ models: { team: 'gpt-4.1' } });
+    assert.equal(getStandardDefaultModel(), 'gpt-5.5-custom');
+  });
+
   it('returns canonical spark fallback when not configured', async () => {
     await writeConfig({ models: { team: 'gpt-4.1' } });
-    assert.equal(getStandardDefaultModel(), DEFAULT_STANDARD_MODEL);
+    assert.equal(getStandardDefaultModel(), DEFAULT_FRONTIER_MODEL);
     assert.equal(getSparkDefaultModel(), DEFAULT_SPARK_MODEL);
     assert.equal(getTeamLowComplexityModel(), DEFAULT_SPARK_MODEL);
   });

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -38,6 +38,7 @@ interface OmxConfigFile {
 }
 
 interface CodexConfigFile {
+  model?: unknown;
   model_provider?: unknown;
   model_providers?: Record<string, unknown>;
 }
@@ -159,6 +160,10 @@ export function getEnvConfiguredMainDefaultModel(
     ?? readConfigEnvValue(OMX_DEFAULT_FRONTIER_MODEL_ENV, codexHomeOverride);
 }
 
+function getCodexConfigRootModel(codexHomeOverride?: string): string | undefined {
+  return normalizeConfiguredValue(readCodexConfigFile(codexHomeOverride)?.model);
+}
+
 export function getEnvConfiguredStandardDefaultModel(
   env: NodeJS.ProcessEnv = process.env,
   codexHomeOverride?: string,
@@ -179,20 +184,27 @@ export function getEnvConfiguredSparkDefaultModel(
 
 /**
  * Get the envvar-backed main/default model.
- * Resolution: OMX_DEFAULT_FRONTIER_MODEL > DEFAULT_FRONTIER_MODEL
+ * Resolution: OMX_DEFAULT_FRONTIER_MODEL > config.toml model > DEFAULT_FRONTIER_MODEL
  */
 export function getMainDefaultModel(codexHomeOverride?: string): string {
   return getEnvConfiguredMainDefaultModel(process.env, codexHomeOverride)
+    ?? getCodexConfigRootModel(codexHomeOverride)
     ?? DEFAULT_FRONTIER_MODEL;
 }
 
 /**
  * Get the envvar-backed standard/default subagent model.
- * Resolution: OMX_DEFAULT_STANDARD_MODEL > DEFAULT_STANDARD_MODEL
+ *
+ * Standard-role subagents inherit the configured main/default model unless an
+ * explicit standard-lane override is configured. This keeps spawned agents in
+ * sync with the leader model while preserving OMX_DEFAULT_STANDARD_MODEL as the
+ * opt-in escape hatch for cheaper/specialized standard workers.
+ *
+ * Resolution: OMX_DEFAULT_STANDARD_MODEL > OMX_DEFAULT_FRONTIER_MODEL > config.toml model > DEFAULT_FRONTIER_MODEL
  */
 export function getStandardDefaultModel(codexHomeOverride?: string): string {
   return getEnvConfiguredStandardDefaultModel(process.env, codexHomeOverride)
-    ?? DEFAULT_STANDARD_MODEL;
+    ?? getMainDefaultModel(codexHomeOverride);
 }
 
 /**

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -111,9 +111,9 @@ describe('team model contract', () => {
     assert.equal(resolveAgentReasoningEffort('does-not-exist'), undefined);
   });
 
-  it('maps worker roles to explicit default model lanes', () => {
+  it('maps worker roles to configured default model lanes', () => {
     assert.equal(resolveAgentDefaultModel('explore'), expectedLowComplexityModel());
-    assert.equal(resolveAgentDefaultModel('writer'), 'gpt-5.4-mini');
+    assert.equal(resolveAgentDefaultModel('writer'), 'gpt-5.5');
     assert.equal(resolveAgentDefaultModel('executor'), 'gpt-5.5');
     assert.equal(resolveAgentDefaultModel('architect'), 'gpt-5.5');
     assert.equal(resolveAgentDefaultModel('does-not-exist'), undefined);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -2296,12 +2296,14 @@ process.on('SIGTERM', () => process.exit(0));
     const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const prevCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
+    const prevStandardModel = process.env.OMX_DEFAULT_STANDARD_MODEL;
 
     process.env.PATH = `${binDir}:${prevPath ?? ''}`;
     delete process.env.TMUX;
     process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     process.env.OMX_TEAM_WORKER_CLI = 'codex';
     process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
+    delete process.env.OMX_DEFAULT_STANDARD_MODEL;
 
     let runtime: TeamRuntime | null = null;
     try {
@@ -2339,8 +2341,8 @@ process.on('SIGTERM', () => process.exit(0));
       assert.doesNotMatch(worker1Instructions, /exact gpt-5\.4-mini model/);
       assert.match(worker2Instructions, /You are operating as the \*\*writer\*\* role/);
       assert.match(worker2Instructions, /You are Writer\./);
-      assert.match(worker2Instructions, /exact gpt-5\.4-mini model/);
-      assert.match(worker2Instructions, /strict execution order: inspect -> plan -> act -> verify/);
+      assert.doesNotMatch(worker2Instructions, /exact gpt-5\.4-mini model/);
+      assert.match(worker2Instructions, /resolved_model: gpt-5\.5/);
 
       let worker1Args: string[] | null = null;
       let worker2Args: string[] | null = null;
@@ -2364,7 +2366,7 @@ process.on('SIGTERM', () => process.exit(0));
       assert.match(worker1Joined, /--model gpt-5\.5/);
       assert.match(worker2Joined, /model_reasoning_effort="high"/);
       assert.match(worker2Joined, /model_instructions_file=.*worker-2\/AGENTS\.md/);
-      assert.match(worker2Joined, /--model gpt-5\.4-mini/);
+      assert.match(worker2Joined, /--model gpt-5\.5/);
 
       await shutdownTeam(runtime.teamName, cwd, { force: true });
       runtime = null;
@@ -2382,6 +2384,8 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevCaptureDir === 'string') process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
       else delete process.env.OMX_ARGV_CAPTURE_DIR;
+      if (typeof prevStandardModel === 'string') process.env.OMX_DEFAULT_STANDARD_MODEL = prevStandardModel;
+      else delete process.env.OMX_DEFAULT_STANDARD_MODEL;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -2417,12 +2421,14 @@ process.on('SIGTERM', () => process.exit(0));
     const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const prevCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
     const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+    const prevStandardModel = process.env.OMX_DEFAULT_STANDARD_MODEL;
 
     process.env.PATH = `${binDir}:${prevPath ?? ''}`;
     delete process.env.TMUX;
     process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     process.env.OMX_TEAM_WORKER_CLI = 'codex';
     process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
+    delete process.env.OMX_DEFAULT_STANDARD_MODEL;
     process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--model gpt-5.4-mini-tuned';
 
     let runtime: TeamRuntime | null = null;
@@ -2477,6 +2483,8 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevCaptureDir === 'string') process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
       else delete process.env.OMX_ARGV_CAPTURE_DIR;
+      if (typeof prevStandardModel === 'string') process.env.OMX_DEFAULT_STANDARD_MODEL = prevStandardModel;
+      else delete process.env.OMX_DEFAULT_STANDARD_MODEL;
       if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
       await rm(cwd, { recursive: true, force: true });

--- a/src/utils/__tests__/agents-model-table.test.ts
+++ b/src/utils/__tests__/agents-model-table.test.ts
@@ -58,6 +58,16 @@ describe('agents model table', () => {
     });
   });
 
+  it('uses the configured frontier model as the standard subagent default when no standard override exists', () => {
+    const context = resolveAgentsModelTableContext('model = "frontier-config"\n');
+
+    assert.deepEqual(context, {
+      frontierModel: 'frontier-config',
+      sparkModel: 'gpt-5.3-codex-spark',
+      subagentDefaultModel: 'frontier-config',
+    });
+  });
+
   it('builds table rows for summary roles and posture/modelClass-driven agent recommendations', () => {
     const table = buildAgentsModelTable({
       frontierModel: 'gpt-frontier',

--- a/src/utils/agents-model-table.ts
+++ b/src/utils/agents-model-table.ts
@@ -2,13 +2,11 @@ import { AGENT_DEFINITIONS, type AgentDefinition } from '../agents/definitions.j
 import { getRootModelName } from '../config/generator.js';
 import {
   DEFAULT_FRONTIER_MODEL,
-  DEFAULT_STANDARD_MODEL,
   DEFAULT_SPARK_MODEL,
   getEnvConfiguredSparkDefaultModel,
   getEnvConfiguredMainDefaultModel,
   getEnvConfiguredStandardDefaultModel,
   getSparkDefaultModel,
-  getStandardDefaultModel,
 } from '../config/models.js';
 
 export const OMX_MODELS_START_MARKER = '<!-- OMX:MODELS:START -->';
@@ -80,8 +78,7 @@ export function resolveAgentsModelTableContext(
     DEFAULT_SPARK_MODEL;
   const subagentDefaultModel =
     getEnvConfiguredStandardDefaultModel(env, codexHomeOverride) ??
-    getStandardDefaultModel(codexHomeOverride) ??
-    DEFAULT_STANDARD_MODEL;
+    frontierModel;
 
   return {
     frontierModel,


### PR DESCRIPTION
## Summary

- Make the standard subagent default inherit the configured leader/default model when no explicit standard override is set.
- Read the Codex `config.toml` root `model` as part of main/default model resolution so native subagent TOML generation follows the configured leader model.
- Keep explicit override precedence intact for `OMX_DEFAULT_STANDARD_MODEL` and `OMX_TEAM_WORKER_LAUNCH_ARGS --model`.
- Update the generated AGENTS model table and focused regressions for native subagents and team workers.

Fixes #1879

## Verification

- `npm run check:no-unused`
- `npm run build`
- `npm run lint`
- `node --test dist/config/__tests__/models.test.js dist/agents/__tests__/native-config.test.js dist/team/__tests__/model-contract.test.js dist/utils/__tests__/agents-model-table.test.js`
- `timeout 180s node --test --test-name-pattern 'resolveWorkerLaunchArgsFromEnv|startTeam preserves routed task roles|startTeam does not apply mini guidance' dist/team/__tests__/runtime.test.js`
- `timeout 180s node --test dist/cli/__tests__/index.test.js`

## Notes

The combined command `node --test dist/team/__tests__/runtime.test.js dist/cli/__tests__/index.test.js` was stopped after it hung. The lingering Node process was terminated, the full runtime test file was identified as the long-running part, and verification was split into the non-hanging focused commands above.

— Generated with OpenAI Codex
