### PR TITLE
Guarantee native agent setup assets stay catalog-rooted

### DIFF
--- a/docs/plugin-bundle-ssot.md
+++ b/docs/plugin-bundle-ssot.md
@@ -28,3 +28,23 @@ npm run sync:plugin:check     # compatibility alias for the same non-mutating ch
 4. Run `npm run verify:plugin-bundle`.
 
 Root skill directories that should not appear in the plugin must be represented in the catalog as `alias` or `merged`; otherwise the plugin bundle verifier fails because the root directory is neither installable nor explicitly excluded.
+
+## Native agent SSOT
+
+Native agents are setup-owned assets, not plugin-scoped bundle assets. Their source-of-truth chain is:
+
+1. `templates/catalog-manifest.json` and `src/catalog/manifest.json` select installable native agents with `active` or `internal` status.
+2. `src/agents/definitions.ts` defines each native agent's metadata, model lane, posture, routing role, and tooling posture.
+3. `prompts/<name>.md` supplies the prompt body for each installable native agent.
+4. `src/agents/native-config.ts` generates native Codex TOML from the definition plus prompt.
+5. `omx setup` writes generated TOML to `.codex/agents/<name>.toml` for the selected scope.
+
+Run the non-mutating native-agent verifier before review or release:
+
+```bash
+npm run verify:native-agents
+```
+
+The verifier fails when installable catalog agents are missing definitions or prompts, when definitions are missing catalog rows, when merged/alias canonical targets do not resolve directly to installable agents, when prompt files are neither cataloged native agents nor explicit setup prompt assets, or when generated TOML loses required metadata.
+
+The official plugin manifest must continue to omit `agents`, `prompts`, and `hooks`; those remain installed by `omx setup`, not by the plugin bundle.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean:native-package-assets": "node dist/scripts/cleanup-explore-harness.js",
     "dev": "tsc --watch",
     "lint": "biome lint src",
-    "prepack": "npm run build && npm run sync:plugin && npm run verify:plugin-bundle && npm run clean:native-package-assets",
+    "prepack": "npm run build && npm run verify:native-agents && npm run sync:plugin && npm run verify:plugin-bundle && npm run clean:native-package-assets",
     "postinstall": "node src/scripts/postinstall-bootstrap.js",
     "setup": "node dist/cli/omx.js setup",
     "doctor": "node dist/cli/omx.js doctor",
@@ -32,8 +32,8 @@
     "test:plugin-boundaries:compiled": "node --test dist/cli/__tests__/codex-plugin-layout.test.js dist/cli/__tests__/package-bin-contract.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js",
     "test:node": "node dist/scripts/run-test-files.js dist",
     "test:node:cross-platform": "npm run test:node",
-    "test": "npm run build && npm run verify:plugin-bundle && npm run test:node && node dist/scripts/generate-catalog-docs.js --check",
-    "test:ci:compiled": "npm run verify:plugin-bundle && npm run test:node && node dist/scripts/generate-catalog-docs.js --check",
+    "test": "npm run build && npm run verify:native-agents && npm run verify:plugin-bundle && npm run test:node && node dist/scripts/generate-catalog-docs.js --check",
+    "test:ci:compiled": "npm run verify:native-agents && npm run verify:plugin-bundle && npm run test:node && node dist/scripts/generate-catalog-docs.js --check",
     "coverage:team-critical": "npm run build && c8 --all --src dist/team --src dist/state --include 'dist/team/**/*.js' --include 'dist/state/**/*.js' --exclude '**/__tests__/**' --reporter=text-summary --reporter=lcov --reporter=json-summary --report-dir coverage/team --check-coverage --lines=78 --functions=90 --branches=70 --statements=78 node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__",
     "coverage:team-critical:compiled": "c8 --all --src dist/team --src dist/state --include 'dist/team/**/*.js' --include 'dist/state/**/*.js' --exclude '**/__tests__/**' --reporter=text-summary --reporter=lcov --reporter=json-summary --report-dir coverage/team --check-coverage --lines=78 --functions=90 --branches=70 --statements=78 node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__",
     "coverage:team-critical:cross-platform": "npm run build && c8 --all --src dist/team --src dist/state --include 'dist/team/**/*.js' --include 'dist/state/**/*.js' --exclude '**/__tests__/**' --reporter=text-summary --reporter=lcov --reporter=json-summary --report-dir coverage/team --check-coverage --lines=78 --functions=90 --branches=70 --statements=78 node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__",
@@ -52,7 +52,8 @@
     "postpack": "npm run clean:native-package-assets",
     "sync:plugin": "node dist/scripts/sync-plugin-mirror.js",
     "sync:plugin:check": "node dist/scripts/sync-plugin-mirror.js --check",
-    "verify:plugin-bundle": "node dist/scripts/sync-plugin-mirror.js --check"
+    "verify:plugin-bundle": "node dist/scripts/sync-plugin-mirror.js --check",
+    "verify:native-agents": "node dist/scripts/verify-native-agents.js"
   },
   "engines": {
     "node": ">=20"
@@ -62,7 +63,6 @@
     "Cargo.lock",
     "dist/",
     "crates/",
-    "agents/",
     "skills/",
     "prompts/",
     "templates/",

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -5,10 +5,26 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import type { AgentDefinition } from "../definitions.js";
+import type { CatalogManifest } from "../../catalog/schema.js";
 import {
   generateAgentToml,
   installNativeAgentConfigs,
 } from "../native-config.js";
+
+function manifestWithAgents(names: string[]): CatalogManifest {
+  return {
+    schemaVersion: 1,
+    catalogVersion: "test",
+    skills: [
+      { name: "ralplan", category: "planning", status: "active", core: true },
+      { name: "team", category: "execution", status: "active", core: true },
+      { name: "ralph", category: "execution", status: "active", core: true },
+      { name: "ultrawork", category: "execution", status: "active", core: true },
+      { name: "autopilot", category: "execution", status: "active", core: true },
+    ],
+    agents: names.map((name) => ({ name, category: "build", status: "active" })),
+  };
+}
 
 const originalStandardModel = process.env.OMX_DEFAULT_STANDARD_MODEL;
 
@@ -86,7 +102,7 @@ describe("agents/native-config", () => {
     assert.doesNotMatch(tunedToml, /exact gpt-5\.4-mini model/);
   });
 
-  it("installs only agents with prompt files and skips existing files without force", async () => {
+  it("installs only catalog-installable agents and skips existing files without force", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-native-config-"));
     const promptsDir = join(root, "prompts");
     const outDir = join(root, "agents-out");
@@ -95,13 +111,16 @@ describe("agents/native-config", () => {
       await mkdir(promptsDir, { recursive: true });
       await writeFile(join(promptsDir, "executor.md"), "executor prompt");
       await writeFile(join(promptsDir, "planner.md"), "planner prompt");
+      await writeFile(join(promptsDir, "style-reviewer.md"), "merged prompt");
 
       const created = await installNativeAgentConfigs(root, {
         agentsDir: outDir,
+        catalogManifest: manifestWithAgents(["executor", "planner"]),
       });
       assert.equal(created, 2);
       assert.equal(existsSync(join(outDir, "executor.toml")), true);
       assert.equal(existsSync(join(outDir, "planner.toml")), true);
+      assert.equal(existsSync(join(outDir, "style-reviewer.toml")), false);
 
       const executorToml = await readFile(
         join(outDir, "executor.toml"),
@@ -112,6 +131,7 @@ describe("agents/native-config", () => {
 
       const skipped = await installNativeAgentConfigs(root, {
         agentsDir: outDir,
+        catalogManifest: manifestWithAgents(["executor", "planner"]),
       });
       assert.equal(skipped, 0);
     } finally {
@@ -134,7 +154,10 @@ describe("agents/native-config", () => {
       await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.2"\n');
       await writeFile(join(promptsDir, "debugger.md"), "debugger prompt");
 
-      await installNativeAgentConfigs(root, { agentsDir: outDir });
+      await installNativeAgentConfigs(root, {
+        agentsDir: outDir,
+        catalogManifest: manifestWithAgents(["debugger"]),
+      });
       const debuggerToml = await readFile(join(outDir, "debugger.toml"), "utf8");
       assert.match(debuggerToml, /model = "gpt-5\.2"/);
       assert.doesNotMatch(debuggerToml, /model = "gpt-5\.4-mini"/);
@@ -161,7 +184,10 @@ describe("agents/native-config", () => {
       await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.2"\n');
       await writeFile(join(promptsDir, "debugger.md"), "debugger prompt");
 
-      await installNativeAgentConfigs(root, { agentsDir: outDir });
+      await installNativeAgentConfigs(root, {
+        agentsDir: outDir,
+        catalogManifest: manifestWithAgents(["debugger"]),
+      });
       const debuggerToml = await readFile(join(outDir, "debugger.toml"), "utf8");
       assert.match(debuggerToml, /model = "gpt-5\.4-mini"/);
       assert.doesNotMatch(debuggerToml, /model = "gpt-5\.2"/);
@@ -188,7 +214,10 @@ describe("agents/native-config", () => {
       await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.2"\n');
       await writeFile(join(promptsDir, "executor.md"), "executor prompt");
 
-      await installNativeAgentConfigs(root, { agentsDir: outDir });
+      await installNativeAgentConfigs(root, {
+        agentsDir: outDir,
+        catalogManifest: manifestWithAgents(["executor"]),
+      });
       const executorToml = await readFile(join(outDir, "executor.toml"), "utf8");
       assert.match(executorToml, /model = "gpt-5\.2"/);
     } finally {

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -7,6 +7,9 @@ import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { AGENT_DEFINITIONS, AgentDefinition } from "./definitions.js";
+import { readCatalogManifest } from "../catalog/reader.js";
+import type { CatalogManifest } from "../catalog/schema.js";
+import { getInstallableNativeAgentNames } from "./policy.js";
 import {
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
@@ -317,6 +320,8 @@ export async function installNativeAgentConfigs(
     dryRun?: boolean;
     verbose?: boolean;
     agentsDir?: string;
+    catalogManifest?: CatalogManifest;
+    allowUncatalogedDefinitions?: boolean;
   } = {},
 ): Promise<number> {
   const {
@@ -324,6 +329,8 @@ export async function installNativeAgentConfigs(
     dryRun = false,
     verbose = false,
     agentsDir = codexAgentsDir(),
+    catalogManifest,
+    allowUncatalogedDefinitions = false,
   } = options;
   const codexHomeOverride = join(agentsDir, "..");
 
@@ -333,7 +340,16 @@ export async function installNativeAgentConfigs(
 
   let count = 0;
 
-  for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
+  const installableAgentNames = allowUncatalogedDefinitions
+    ? new Set(Object.keys(AGENT_DEFINITIONS))
+    : getInstallableNativeAgentNames(catalogManifest ?? readCatalogManifest(pkgRoot));
+
+  for (const name of [...installableAgentNames].sort()) {
+    const agent = AGENT_DEFINITIONS[name];
+    if (!agent) {
+      if (verbose) console.log(`  skip ${name} (no agent definition)`);
+      continue;
+    }
     const promptPath = join(pkgRoot, "prompts", `${name}.md`);
     if (!existsSync(promptPath)) {
       if (verbose) console.log(`  skip ${name} (no prompt file)`);

--- a/src/agents/policy.ts
+++ b/src/agents/policy.ts
@@ -1,0 +1,93 @@
+import type {
+  CatalogAgentEntry,
+  CatalogEntryStatus,
+  CatalogManifest,
+} from "../catalog/schema.js";
+
+export const NON_NATIVE_AGENT_PROMPT_ASSETS = new Set([
+  "explore-harness",
+  "sisyphus-lite",
+  "team-orchestrator",
+]);
+
+export function isNativeAgentInstallableStatus(
+  status: CatalogEntryStatus | string | undefined,
+): boolean {
+  return status === "active" || status === "internal";
+}
+
+export function getCatalogAgentStatusByName(
+  manifest: Pick<CatalogManifest, "agents">,
+): Map<string, CatalogEntryStatus> {
+  return new Map(manifest.agents.map((agent) => [agent.name, agent.status]));
+}
+
+export function getCatalogAgentByName(
+  manifest: Pick<CatalogManifest, "agents">,
+): Map<string, CatalogAgentEntry> {
+  return new Map(manifest.agents.map((agent) => [agent.name, agent]));
+}
+
+export function getInstallableNativeAgentNames(
+  manifest: Pick<CatalogManifest, "agents">,
+): Set<string> {
+  return new Set(
+    manifest.agents
+      .filter((agent) => isNativeAgentInstallableStatus(agent.status))
+      .map((agent) => agent.name),
+  );
+}
+
+export function getNonInstallableNativeAgentNames(
+  manifest: Pick<CatalogManifest, "agents">,
+): Set<string> {
+  return new Set(
+    manifest.agents
+      .filter((agent) => !isNativeAgentInstallableStatus(agent.status))
+      .map((agent) => agent.name),
+  );
+}
+
+export function assertNativeAgentCanonicalTargets(
+  manifest: Pick<CatalogManifest, "agents">,
+): void {
+  const byName = getCatalogAgentByName(manifest);
+
+  for (const agent of manifest.agents) {
+    if (agent.status !== "alias" && agent.status !== "merged") continue;
+
+    if (!agent.canonical) {
+      throw new Error(
+        [
+          "native_agent_canonical_invalid",
+          `agent=${agent.name}`,
+          "message=alias/merged native agents must declare a canonical target",
+        ].join("\n"),
+      );
+    }
+
+    const canonical = byName.get(agent.canonical);
+    if (!canonical) {
+      throw new Error(
+        [
+          "native_agent_canonical_invalid",
+          `agent=${agent.name}`,
+          `canonical=${agent.canonical}`,
+          "message=canonical native agent target is not listed in the catalog",
+        ].join("\n"),
+      );
+    }
+
+    if (!isNativeAgentInstallableStatus(canonical.status)) {
+      throw new Error(
+        [
+          "native_agent_canonical_invalid",
+          `agent=${agent.name}`,
+          `canonical=${agent.canonical}`,
+          `canonical_status=${canonical.status}`,
+          "message=canonical native agent target must be directly installable",
+        ].join("\n"),
+      );
+    }
+  }
+}

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -4,6 +4,7 @@ import { readFileSync, rmSync } from 'node:fs';
 import { arch, platform } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { getInstallableNativeAgentNames } from '../../agents/policy.js';
 import { getSetupInstallableSkillNames } from '../../catalog/installable.js';
 import { readCatalogManifest } from '../../catalog/reader.js';
 
@@ -43,14 +44,15 @@ describe('package bin contract', () => {
     assert.equal(pkg.scripts?.['sync:plugin'], 'node dist/scripts/sync-plugin-mirror.js');
     assert.equal(pkg.scripts?.['sync:plugin:check'], 'node dist/scripts/sync-plugin-mirror.js --check');
     assert.equal(pkg.scripts?.['verify:plugin-bundle'], 'node dist/scripts/sync-plugin-mirror.js --check');
-    assert.equal(pkg.scripts?.prepack, 'npm run build && npm run sync:plugin && npm run verify:plugin-bundle && npm run clean:native-package-assets');
+    assert.equal(pkg.scripts?.['verify:native-agents'], 'node dist/scripts/verify-native-agents.js');
+    assert.equal(pkg.scripts?.prepack, 'npm run build && npm run verify:native-agents && npm run sync:plugin && npm run verify:plugin-bundle && npm run clean:native-package-assets');
     assert.equal(pkg.scripts?.postinstall, 'node src/scripts/postinstall-bootstrap.js');
     assert.equal(pkg.scripts?.postpack, 'npm run clean:native-package-assets');
     assert.equal(pkg.scripts?.['test:explore'], 'cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js');
     assert.equal(pkg.scripts?.['test:team:cross-rebase-smoke:compiled'], 'node --test dist/team/__tests__/cross-rebase-smoke.test.js');
     assert.equal(pkg.scripts?.['test:node'], 'node dist/scripts/run-test-files.js dist');
-    assert.equal(pkg.scripts?.test, 'npm run build && npm run verify:plugin-bundle && npm run test:node && node dist/scripts/generate-catalog-docs.js --check');
-    assert.equal(pkg.scripts?.['test:ci:compiled'], 'npm run verify:plugin-bundle && npm run test:node && node dist/scripts/generate-catalog-docs.js --check');
+    assert.equal(pkg.scripts?.test, 'npm run build && npm run verify:native-agents && npm run verify:plugin-bundle && npm run test:node && node dist/scripts/generate-catalog-docs.js --check');
+    assert.equal(pkg.scripts?.['test:ci:compiled'], 'npm run verify:native-agents && npm run verify:plugin-bundle && npm run test:node && node dist/scripts/generate-catalog-docs.js --check');
     assert.equal(
       pkg.scripts?.['coverage:team-critical'],
       "npm run build && c8 --all --src dist/team --src dist/state --include 'dist/team/**/*.js' --include 'dist/state/**/*.js' --exclude '**/__tests__/**' --reporter=text-summary --reporter=lcov --reporter=json-summary --report-dir coverage/team --check-coverage --lines=78 --functions=90 --branches=70 --statements=78 node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__",
@@ -86,6 +88,7 @@ describe('package bin contract', () => {
 
     assert.equal(pkg.files?.includes('dist/'), true, 'expected package files allowlist to include dist/');
     assert.equal(pkg.files?.includes('bin/'), false, 'did not expect broad bin/ allowlist in package files');
+    assert.equal(pkg.files?.includes('agents/'), false, 'native agent TOMLs are setup output, not package input');
     assert.ok(pkg.files?.includes('Cargo.toml'));
     assert.ok(pkg.files?.includes('Cargo.lock'));
     assert.ok(pkg.files?.includes('crates/'));
@@ -139,6 +142,7 @@ describe('package bin contract', () => {
     const promptEntry = results[0]?.files?.find((file) => file.path === 'prompts/executor.md');
     const templateEntry = results[0]?.files?.find((file) => file.path === 'templates/AGENTS.md');
     const postinstallEntry = results[0]?.files?.find((file) => file.path === 'src/scripts/postinstall-bootstrap.js');
+    const rootNativeAgentEntry = results[0]?.files?.find((file) => file.path === 'agents' || file.path.startsWith('agents/'));
     const pluginScopedHooksEntry = results[0]?.files?.find((file) =>
       file.path === 'plugins/oh-my-codex/hooks.json'
       || file.path === 'plugins/oh-my-codex/.codex/hooks.json'
@@ -162,7 +166,8 @@ describe('package bin contract', () => {
     assert.ok(traceServerEntry, 'expected npm pack output to include dist/mcp/trace-server.js for omx mcp-serve');
     assert.ok(wikiServerEntry, 'expected npm pack output to include dist/mcp/wiki-server.js for omx mcp-serve');
     const packedFilePaths = new Set((results[0]?.files ?? []).map((file) => file.path));
-    const installableSkillNames = [...getSetupInstallableSkillNames(readCatalogManifest(process.cwd()))].sort();
+    const manifest = readCatalogManifest(process.cwd());
+    const installableSkillNames = [...getSetupInstallableSkillNames(manifest)].sort();
     for (const skillName of installableSkillNames) {
       assert.equal(
         packedFilePaths.has(`plugins/oh-my-codex/skills/${skillName}/SKILL.md`),
@@ -170,10 +175,19 @@ describe('package bin contract', () => {
         `expected npm pack output to include mirrored plugin ${skillName} skill`,
       );
     }
+    const installableNativeAgentNames = [...getInstallableNativeAgentNames(manifest)].sort();
+    for (const agentName of installableNativeAgentNames) {
+      assert.equal(
+        packedFilePaths.has(`prompts/${agentName}.md`),
+        true,
+        `expected npm pack output to include prompt for native agent ${agentName}`,
+      );
+    }
     assert.ok(rootRalphSkillEntry, 'expected npm pack output to keep canonical root skills');
     assert.ok(promptEntry, 'expected npm pack output to keep prompts');
     assert.ok(templateEntry, 'expected npm pack output to keep templates');
     assert.ok(postinstallEntry, 'expected npm pack output to keep postinstall bootstrap script');
+    assert.equal(rootNativeAgentEntry, undefined, 'did not expect generated root native agent TOMLs in package output');
     assert.equal(pluginScopedHooksEntry, undefined, 'did not expect setup-owned hook assets inside the installable plugin bundle');
   });
 });

--- a/src/cli/__tests__/setup-prompts-overwrite.test.ts
+++ b/src/cli/__tests__/setup-prompts-overwrite.test.ts
@@ -5,6 +5,8 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { setup } from '../setup.js';
+import { readCatalogManifest } from '../../catalog/reader.js';
+import { getInstallableNativeAgentNames } from '../../agents/policy.js';
 
 describe('omx setup prompt/native-agent overwrite behavior', () => {
   const obsoleteNativeAgentField = ['skill', 'ref'].join('_');
@@ -37,9 +39,14 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       assert.equal(installedPrompts.has('sisyphus-lite.md'), false);
       assert.equal(installedPrompts.has('code-simplifier.md'), true);
 
-      assert.equal(installedNativeAgents.has('executor.toml'), true);
-      assert.equal(installedNativeAgents.has('team-executor.toml'), true);
-      assert.equal(installedNativeAgents.has('code-reviewer.toml'), true);
+      const installableNativeAgents = getInstallableNativeAgentNames(readCatalogManifest());
+      for (const agentName of installableNativeAgents) {
+        assert.equal(
+          installedNativeAgents.has(`${agentName}.toml`),
+          true,
+          `expected setup to install native agent ${agentName}.toml`,
+        );
+      }
       assert.equal(installedNativeAgents.has('code-review.toml'), false);
       assert.equal(installedNativeAgents.has('plan.toml'), false);
       assert.equal(installedNativeAgents.has('style-reviewer.toml'), false);
@@ -50,7 +57,6 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       assert.equal(installedNativeAgents.has('ux-researcher.toml'), false);
       assert.equal(installedNativeAgents.has('information-architect.toml'), false);
       assert.equal(installedNativeAgents.has('product-analyst.toml'), false);
-      assert.equal(installedNativeAgents.has('code-simplifier.toml'), true);
 
       const codeReviewerToml = await readFile(join(wd, '.codex', 'agents', 'code-reviewer.toml'), 'utf-8');
       assert.match(codeReviewerToml, /^name = "code-reviewer"$/m);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -52,6 +52,11 @@ import {
 } from "../config/mcp-registry.js";
 import { generateAgentToml } from "../agents/native-config.js";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
+import {
+  getCatalogAgentStatusByName,
+  getInstallableNativeAgentNames,
+  isNativeAgentInstallableStatus,
+} from "../agents/policy.js";
 import { getPackageRoot } from "../utils/package.js";
 import { readSessionState, isSessionStale } from "../hooks/session.js";
 import { getCatalogHeadlineCounts } from "./catalog-contract.js";
@@ -1012,14 +1017,14 @@ async function cleanupPluginModeLegacyPrompts(
 
   const manifest = tryReadCatalogManifest();
   const agentStatusByName = manifest
-    ? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
+    ? getCatalogAgentStatusByName(manifest)
     : null;
 
   for (const file of await readdir(srcDir)) {
     if (!file.endsWith(".md")) continue;
     const promptName = file.slice(0, -3);
     const status = agentStatusByName?.get(promptName);
-    if (agentStatusByName && !isCatalogInstallableStatus(status)) continue;
+    if (agentStatusByName && !isNativeAgentInstallableStatus(status)) continue;
 
     const src = join(srcDir, file);
     const dst = join(dstDir, file);
@@ -1068,12 +1073,12 @@ async function cleanupPluginModeLegacyNativeAgents(
 
   const manifest = tryReadCatalogManifest();
   const agentStatusByName = manifest
-    ? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
+    ? getCatalogAgentStatusByName(manifest)
     : null;
 
   for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
     const status = agentStatusByName?.get(name);
-    if (agentStatusByName && !isCatalogInstallableStatus(status)) continue;
+    if (agentStatusByName && !isNativeAgentInstallableStatus(status)) continue;
 
     const dst = join(agentsDir, `${name}.toml`);
     const promptPath = join(pkgRoot, "prompts", `${name}.md`);
@@ -2236,7 +2241,7 @@ async function installPrompts(
 
   const manifest = tryReadCatalogManifest();
   const agentStatusByName = manifest
-    ? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
+    ? getCatalogAgentStatusByName(manifest)
     : null;
 
   const files = await readdir(srcDir);
@@ -2250,7 +2255,7 @@ async function installPrompts(
     staleCandidatePromptNames.add(promptName);
 
     const status = agentStatusByName?.get(promptName);
-    if (agentStatusByName && !isCatalogInstallableStatus(status)) {
+    if (agentStatusByName && !isNativeAgentInstallableStatus(status)) {
       summary.skipped += 1;
       if (options.verbose) {
         const label = status ?? "unlisted";
@@ -2279,7 +2284,7 @@ async function installPrompts(
       if (!file.endsWith(".md")) continue;
       const promptName = file.slice(0, -3);
       const status = agentStatusByName?.get(promptName);
-      if (isCatalogInstallableStatus(status)) continue;
+      if (isNativeAgentInstallableStatus(status)) continue;
       if (!staleCandidatePromptNames.has(promptName) && status === undefined)
         continue;
 
@@ -2317,19 +2322,22 @@ async function refreshNativeAgentConfigs(
 
   const manifest = tryReadCatalogManifest();
   const agentStatusByName = manifest
-    ? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
+    ? getCatalogAgentStatusByName(manifest)
     : null;
   const staleCandidateNativeAgentNames = new Set(
     manifest?.agents.map((agent) => agent.name) ?? [],
   );
 
-  for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
+  const nativeAgentNames = manifest
+    ? [...getInstallableNativeAgentNames(manifest)].sort()
+    : Object.keys(AGENT_DEFINITIONS).sort();
+
+  for (const name of nativeAgentNames) {
     staleCandidateNativeAgentNames.add(name);
-    const status = agentStatusByName?.get(name);
-    if (agentStatusByName && !isCatalogInstallableStatus(status)) {
+    const agent = AGENT_DEFINITIONS[name];
+    if (!agent) {
       if (options.verbose) {
-        const label = status ?? "unlisted";
-        console.log(`  skipped native agent ${name}.toml (status: ${label})`);
+        console.log(`  skipped native agent ${name}.toml (missing definition)`);
       }
       summary.skipped += 1;
       continue;
@@ -2367,7 +2375,7 @@ async function refreshNativeAgentConfigs(
       if (!file.endsWith(".toml")) continue;
       const agentName = file.slice(0, -5);
       const agentStatus = agentStatusByName?.get(agentName);
-      if (isCatalogInstallableStatus(agentStatus)) continue;
+      if (isNativeAgentInstallableStatus(agentStatus)) continue;
       if (
         !staleCandidateNativeAgentNames.has(agentName) &&
         agentStatus === undefined

--- a/src/scripts/__tests__/verify-native-agents.test.ts
+++ b/src/scripts/__tests__/verify-native-agents.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AgentDefinition } from "../../agents/definitions.js";
+import {
+  getInstallableNativeAgentNames,
+  isNativeAgentInstallableStatus,
+} from "../../agents/policy.js";
+import type { CatalogAgentEntry, CatalogManifest } from "../../catalog/schema.js";
+import { verifyNativeAgents } from "../verify-native-agents.js";
+
+const definition: AgentDefinition = {
+  name: "executor",
+  description: "Code implementation",
+  reasoningEffort: "medium",
+  posture: "deep-worker",
+  modelClass: "frontier",
+  routingRole: "executor",
+  tools: "execution",
+  category: "build",
+};
+
+function manifest(agents: CatalogAgentEntry[]): CatalogManifest {
+  return {
+    schemaVersion: 1,
+    catalogVersion: "test",
+    skills: [],
+    agents,
+  };
+}
+
+async function rejectsWithCode(
+  code: string,
+  action: () => Promise<unknown>,
+): Promise<void> {
+  await assert.rejects(action, (error) => {
+    assert.ok(error instanceof Error);
+    assert.match(error.message, new RegExp(`^${code}`));
+    return true;
+  });
+}
+
+describe("verify-native-agents", () => {
+  it("passes for an installable agent and explicit non-native prompt assets", async () => {
+    const result = await verifyNativeAgents({
+      manifest: manifest([
+        { name: "executor", category: "build", status: "active" },
+        {
+          name: "style-reviewer",
+          category: "review",
+          status: "merged",
+          canonical: "executor",
+        },
+      ]),
+      definitions: { executor: definition, "style-reviewer": { ...definition, name: "style-reviewer" } },
+      promptNames: new Set(["executor", "style-reviewer", "explore-harness"]),
+      pluginManifest: { skills: "./skills/" },
+    });
+
+    assert.deepEqual(result.installableAgentNames, ["executor"]);
+  });
+
+  it("fails when an installable catalog agent lacks a definition", async () => {
+    await rejectsWithCode("native_agent_definition_missing", () =>
+      verifyNativeAgents({
+        manifest: manifest([{ name: "executor", category: "build", status: "active" }]),
+        definitions: {},
+        promptNames: new Set(["executor"]),
+        pluginManifest: {},
+      }),
+    );
+  });
+
+  it("fails when an installable catalog agent lacks a prompt", async () => {
+    await rejectsWithCode("native_agent_prompt_missing", () =>
+      verifyNativeAgents({
+        manifest: manifest([{ name: "executor", category: "build", status: "internal" }]),
+        definitions: { executor: definition },
+        promptNames: new Set(),
+        pluginManifest: {},
+      }),
+    );
+  });
+
+  it("fails when a definition is missing from catalog agents", async () => {
+    await rejectsWithCode("native_agent_catalog_out_of_sync", () =>
+      verifyNativeAgents({
+        manifest: manifest([]),
+        definitions: { executor: definition },
+        promptNames: new Set(),
+        pluginManifest: {},
+      }),
+    );
+  });
+
+  it("fails when a merged canonical target is missing or non-installable", async () => {
+    await rejectsWithCode("native_agent_canonical_invalid", () =>
+      verifyNativeAgents({
+        manifest: manifest([
+          {
+            name: "style-reviewer",
+            category: "review",
+            status: "merged",
+            canonical: "code-reviewer",
+          },
+        ]),
+        definitions: { "style-reviewer": { ...definition, name: "style-reviewer" } },
+        promptNames: new Set(["style-reviewer"]),
+        pluginManifest: {},
+      }),
+    );
+
+    await rejectsWithCode("native_agent_canonical_invalid", () =>
+      verifyNativeAgents({
+        manifest: manifest([
+          {
+            name: "style-reviewer",
+            category: "review",
+            status: "merged",
+            canonical: "code-reviewer",
+          },
+          {
+            name: "code-reviewer",
+            category: "review",
+            status: "deprecated",
+          },
+        ]),
+        definitions: {
+          "style-reviewer": { ...definition, name: "style-reviewer" },
+          "code-reviewer": { ...definition, name: "code-reviewer" },
+        },
+        promptNames: new Set(["style-reviewer", "code-reviewer"]),
+        pluginManifest: {},
+      }),
+    );
+  });
+
+  it("validates alias canonical targets through the same direct-installable policy", async () => {
+    await rejectsWithCode("native_agent_canonical_invalid", () =>
+      verifyNativeAgents({
+        manifest: manifest([
+          {
+            name: "style-reviewer",
+            category: "review",
+            status: "alias",
+            canonical: "quality-reviewer",
+          },
+          {
+            name: "quality-reviewer",
+            category: "review",
+            status: "merged",
+            canonical: "executor",
+          },
+          { name: "executor", category: "build", status: "active" },
+        ]),
+        definitions: {
+          executor: definition,
+          "style-reviewer": { ...definition, name: "style-reviewer" },
+          "quality-reviewer": { ...definition, name: "quality-reviewer" },
+        },
+        promptNames: new Set(["executor", "style-reviewer", "quality-reviewer"]),
+        pluginManifest: {},
+      }),
+    );
+  });
+
+  it("fails for unclassified prompt assets", async () => {
+    await rejectsWithCode("native_agent_prompt_unclassified", () =>
+      verifyNativeAgents({
+        manifest: manifest([{ name: "executor", category: "build", status: "active" }]),
+        definitions: { executor: definition },
+        promptNames: new Set(["executor", "mystery"]),
+        pluginManifest: {},
+      }),
+    );
+  });
+
+  it("fails if the plugin manifest declares setup-owned native-agent fields", async () => {
+    await rejectsWithCode("native_agent_plugin_boundary_violation", () =>
+      verifyNativeAgents({
+        manifest: manifest([{ name: "executor", category: "build", status: "active" }]),
+        definitions: { executor: definition },
+        promptNames: new Set(["executor"]),
+        pluginManifest: { agents: "./agents/" },
+      }),
+    );
+  });
+
+  it("keeps merged prompt-backed agents out of the installable set", () => {
+    const nativeManifest = manifest([
+      { name: "executor", category: "build", status: "active" },
+      {
+        name: "style-reviewer",
+        category: "review",
+        status: "merged",
+        canonical: "executor",
+      },
+    ]);
+
+    assert.equal(isNativeAgentInstallableStatus("active"), true);
+    assert.equal(isNativeAgentInstallableStatus("internal"), true);
+    assert.equal(isNativeAgentInstallableStatus("merged"), false);
+    assert.deepEqual([...getInstallableNativeAgentNames(nativeManifest)], ["executor"]);
+  });
+});

--- a/src/scripts/verify-native-agents.ts
+++ b/src/scripts/verify-native-agents.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import process from "node:process";
+import TOML from "@iarna/toml";
+import { AGENT_DEFINITIONS, type AgentDefinition } from "../agents/definitions.js";
+import { generateAgentToml } from "../agents/native-config.js";
+import {
+  NON_NATIVE_AGENT_PROMPT_ASSETS,
+  assertNativeAgentCanonicalTargets,
+  getCatalogAgentByName,
+  getInstallableNativeAgentNames,
+  isNativeAgentInstallableStatus,
+} from "../agents/policy.js";
+import { readCatalogManifest } from "../catalog/reader.js";
+import type { CatalogManifest } from "../catalog/schema.js";
+
+export interface VerifyNativeAgentsOptions {
+  root?: string;
+  manifest?: CatalogManifest;
+  definitions?: Record<string, AgentDefinition>;
+  promptNames?: Set<string>;
+  pluginManifest?: Record<string, unknown>;
+}
+
+export interface VerifyNativeAgentsResult {
+  installableAgentNames: string[];
+  promptAssetNames: string[];
+}
+
+function errorBlock(code: string, fields: Record<string, unknown>): Error {
+  return new Error(
+    [
+      code,
+      ...Object.entries(fields).map(
+        ([key, value]) => `${key}=${JSON.stringify(value)}`,
+      ),
+    ].join("\n"),
+  );
+}
+
+async function readPromptNames(root: string): Promise<Set<string>> {
+  const promptsDir = join(root, "prompts");
+  const entries = await readdir(promptsDir, { withFileTypes: true });
+  return new Set(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+      .map((entry) => entry.name.slice(0, -3)),
+  );
+}
+
+async function readPluginManifest(
+  root: string,
+): Promise<Record<string, unknown> | null> {
+  const pluginManifestPath = join(
+    root,
+    "plugins",
+    "oh-my-codex",
+    ".codex-plugin",
+    "plugin.json",
+  );
+  if (!existsSync(pluginManifestPath)) return null;
+  return JSON.parse(await readFile(pluginManifestPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+function assertTomlStructure(
+  agentName: string,
+  agent: AgentDefinition,
+  toml: string,
+): void {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = TOML.parse(toml) as Record<string, unknown>;
+  } catch (cause) {
+    throw errorBlock("native_agent_toml_invalid", {
+      agent: agentName,
+      message: cause instanceof Error ? cause.message : String(cause),
+    });
+  }
+
+  if (parsed.name !== agentName) {
+    throw errorBlock("native_agent_toml_invalid", {
+      agent: agentName,
+      field: "name",
+      expected: agentName,
+      actual: parsed.name,
+    });
+  }
+  if (parsed.description !== agent.description) {
+    throw errorBlock("native_agent_toml_invalid", {
+      agent: agentName,
+      field: "description",
+      expected: agent.description,
+      actual: parsed.description,
+    });
+  }
+  if (parsed.model_reasoning_effort !== agent.reasoningEffort) {
+    throw errorBlock("native_agent_toml_invalid", {
+      agent: agentName,
+      field: "model_reasoning_effort",
+      expected: agent.reasoningEffort,
+      actual: parsed.model_reasoning_effort,
+    });
+  }
+
+  const instructions = parsed.developer_instructions;
+  if (typeof instructions !== "string" || instructions.trim() === "") {
+    throw errorBlock("native_agent_toml_invalid", {
+      agent: agentName,
+      field: "developer_instructions",
+      message: "developer instructions must be non-empty",
+    });
+  }
+
+  for (const expected of [
+    `- role: ${agentName}`,
+    `- posture: ${agent.posture}`,
+    `- model_class: ${agent.modelClass}`,
+    `- routing_role: ${agent.routingRole}`,
+  ]) {
+    if (!instructions.includes(expected)) {
+      throw errorBlock("native_agent_toml_invalid", {
+        agent: agentName,
+        field: "developer_instructions",
+        missing: expected,
+      });
+    }
+  }
+}
+
+export async function verifyNativeAgents(
+  options: VerifyNativeAgentsOptions = {},
+): Promise<VerifyNativeAgentsResult> {
+  const root = resolve(options.root ?? process.cwd());
+  const manifest = options.manifest ?? readCatalogManifest(root);
+  const definitions = options.definitions ?? AGENT_DEFINITIONS;
+  const promptNames = options.promptNames ?? (await readPromptNames(root));
+  const catalogByName = getCatalogAgentByName(manifest);
+  const installableAgentNames = [...getInstallableNativeAgentNames(manifest)].sort();
+
+  assertNativeAgentCanonicalTargets(manifest);
+
+  for (const agent of manifest.agents) {
+    if (!isNativeAgentInstallableStatus(agent.status)) continue;
+    if (!definitions[agent.name]) {
+      throw errorBlock("native_agent_definition_missing", {
+        agent: agent.name,
+        status: agent.status,
+      });
+    }
+    if (!promptNames.has(agent.name)) {
+      throw errorBlock("native_agent_prompt_missing", {
+        agent: agent.name,
+        status: agent.status,
+        path: `prompts/${agent.name}.md`,
+      });
+    }
+  }
+
+  for (const name of Object.keys(definitions).sort()) {
+    if (!catalogByName.has(name)) {
+      throw errorBlock("native_agent_catalog_out_of_sync", {
+        agent: name,
+        message: "agent definition must be listed in catalog agents",
+      });
+    }
+  }
+
+  for (const name of [...promptNames].sort()) {
+    if (catalogByName.has(name)) continue;
+    if (NON_NATIVE_AGENT_PROMPT_ASSETS.has(name)) continue;
+    throw errorBlock("native_agent_prompt_unclassified", {
+      prompt: name,
+      path: `prompts/${name}.md`,
+      message:
+        "prompt files must be cataloged native agents or explicit non-native prompt assets",
+    });
+  }
+
+  for (const name of installableAgentNames) {
+    const agent = definitions[name];
+    if (!agent) continue;
+    const promptPath = join(root, "prompts", `${name}.md`);
+    const promptContent = options.promptNames
+      ? `${name} prompt fixture`
+      : await readFile(promptPath, "utf-8");
+    const toml = generateAgentToml(agent, promptContent);
+    assertTomlStructure(name, agent, toml);
+  }
+
+  const pluginManifest =
+    options.pluginManifest === undefined
+      ? await readPluginManifest(root)
+      : options.pluginManifest;
+  if (pluginManifest) {
+    for (const field of ["agents", "prompts", "hooks"]) {
+      if (pluginManifest[field] !== undefined) {
+        throw errorBlock("native_agent_plugin_boundary_violation", {
+          field,
+          message: "native agents/prompts/hooks are setup-owned, not plugin-scoped",
+        });
+      }
+    }
+  }
+
+  return {
+    installableAgentNames,
+    promptAssetNames: [...promptNames].sort(),
+  };
+}
+
+function parseArgs(argv: string[]): { root: string } {
+  let root = process.cwd();
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--root") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("missing --root value");
+      root = value;
+      i += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+  return { root };
+}
+
+async function main(): Promise<void> {
+  const { root } = parseArgs(process.argv.slice(2));
+  const result = await verifyNativeAgents({ root });
+  console.log(
+    `verified ${result.installableAgentNames.length} installable native agents and ${result.promptAssetNames.length} setup prompt assets`,
+  );
+}
+
+if (process.argv[1]?.endsWith("verify-native-agents.js")) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- add a shared native-agent policy for catalog-derived installability, canonical merge/alias validation, and explicit non-native prompt assets
- add `verify:native-agents` and wire it into prepack/test/CI gates
- make native agent install generation catalog-aware so merged prompt-backed agents cannot bypass setup policy
- strengthen package/setup tests so prompts are packaged as canonical inputs while generated root `agents/` TOMLs are excluded
- document the setup-owned native-agent SSOT chain and plugin boundary

## Verification

- [x] `npm run build`
- [x] `npm run verify:native-agents`
- [x] `npm run verify:plugin-bundle`
- [x] `node --test dist/scripts/__tests__/verify-native-agents.test.js dist/agents/__tests__/native-config.test.js dist/cli/__tests__/setup-prompts-overwrite.test.js`
- [x] `npm run test:plugin-boundaries:compiled`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `git diff --check`

## Notes

Native agents remain setup-owned. The official plugin still omits `agents`, `prompts`, and `hooks`; the verifier now explicitly fails if those setup-owned fields appear in plugin metadata.
