### PR TITLE
fix(setup): enable StatusLine by default after install

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -309,15 +309,10 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
-  it("skips OMX-managed [tui] writes for Codex CLI >= 0.107.0 and preserves an existing [tui] table", async () => {
+  it("configures OMX status_line by default for Codex CLI >= 0.107.0", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      await mkdir(join(wd, ".codex"), { recursive: true });
-      await writeFile(
-        join(wd, ".codex", "config.toml"),
-        ['model = "gpt-5.5"', "", "[tui]", 'theme = "night"', 'status_line = ["git-branch"]', ""].join("\n"),
-      );
 
       const output = await runSetupWithCapturedLogs(wd, {
         scope: "project",
@@ -326,12 +321,11 @@ describe("omx setup refresh summary and dry-run behavior", () => {
 
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
       assert.equal(config.match(/^\[tui\]$/gm)?.length ?? 0, 1);
-      assert.match(config, /^theme = "night"$/m);
-      assert.match(config, /^status_line = \["git-branch"\]$/m);
       assert.match(
-        output,
-        /Codex CLI >= 0\.107\.0 manages \[tui\]; OMX left that section untouched\./,
+        config,
+        /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
       );
+      assert.match(output, /StatusLine configured in config\.toml via \[tui\] section\./);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -58,9 +58,12 @@ import {
   resolveAgentsModelTableContext,
   upsertAgentsModelTable,
 } from "../utils/agents-model-table.js";
-import { spawnPlatformCommandSync } from "../utils/platform-command.js";
 
 interface SetupOptions {
+  /**
+   * Deprecated no-op: setup now seeds `[tui].status_line` for every supported
+   * Codex version so fresh installs show the built-in status line by default.
+   */
   codexVersionProbe?: () => string | null;
   force?: boolean;
   dryRun?: boolean;
@@ -118,7 +121,6 @@ interface SetupBackupContext {
 
 interface ManagedConfigResult {
   finalConfig: string;
-  omxManagesTui: boolean;
   repairedLegacyTeamRunTable: boolean;
 }
 
@@ -173,7 +175,6 @@ const DEFAULT_SETUP_SCOPE: SetupScope = "user";
 const LEGACY_SETUP_MODEL = "gpt-5.3-codex";
 const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
 const OBSOLETE_NATIVE_AGENT_FIELD = ["skill", "ref"].join("_");
-const TUI_OWNED_BY_CODEX_VERSION = [0, 107, 0] as const;
 
 function createEmptyCategorySummary(): SetupCategorySummary {
   return {
@@ -537,38 +538,6 @@ async function promptForModelUpgrade(
   } finally {
     rl.close();
   }
-}
-
-function parseSemverTriplet(version: string): [number, number, number] | null {
-  const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
-  if (!match) return null;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function semverGte(
-  version: [number, number, number],
-  minimum: readonly [number, number, number],
-): boolean {
-  if (version[0] !== minimum[0]) return version[0] > minimum[0];
-  if (version[1] !== minimum[1]) return version[1] > minimum[1];
-  return version[2] >= minimum[2];
-}
-
-function probeInstalledCodexVersion(): string | null {
-  const { result } = spawnPlatformCommandSync("codex", ["--version"], {
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-  if (result.error || result.status !== 0) return null;
-  const stdout = (result.stdout || "").trim();
-  return stdout === "" ? null : stdout;
-}
-
-function shouldOmxManageTuiFromCodexVersion(versionOutput: string | null): boolean {
-  if (!versionOutput) return true;
-  const parsed = parseSemverTriplet(versionOutput);
-  if (!parsed) return true;
-  return !semverGte(parsed, TUI_OWNED_BY_CODEX_VERSION);
 }
 
 async function promptForAgentsOverwrite(
@@ -1056,11 +1025,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   } else {
     console.log("  HUD config already exists (use --force to overwrite).");
   }
-  if (managedConfig.omxManagesTui) {
-    console.log("  StatusLine configured in config.toml via [tui] section.");
-  } else {
-    console.log("  Codex CLI >= 0.107.0 manages [tui]; OMX left that section untouched.");
-  }
+  console.log("  StatusLine configured in config.toml via [tui] section.");
   console.log();
 
   console.log("Setup refresh summary:");
@@ -1654,9 +1619,6 @@ async function updateManagedConfig(
   const hadLegacyTeamRunTable = hasLegacyOmxTeamRunTable(existing);
   const currentModel = getRootModelName(existing);
   let modelOverride: string | undefined;
-  const codexVersion =
-    options.codexVersionProbe?.() ?? probeInstalledCodexVersion();
-  const omxManagesTui = shouldOmxManageTuiFromCodexVersion(codexVersion);
 
   if (currentModel === LEGACY_SETUP_MODEL) {
     const shouldPrompt =
@@ -1673,7 +1635,9 @@ async function updateManagedConfig(
   }
 
   const finalConfig = buildMergedConfig(existing, pkgRoot, {
-    includeTui: omxManagesTui,
+    // Modern Codex CLI still accepts `[tui].status_line`; skipping it for
+    // newer versions left fresh OMX installs without the default footer.
+    includeTui: true,
     modelOverride,
     sharedMcpServers: sharedMcpRegistry.servers,
     sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
@@ -1685,7 +1649,6 @@ async function updateManagedConfig(
     summary.unchanged += 1;
     return {
       finalConfig,
-      omxManagesTui,
       repairedLegacyTeamRunTable: false,
     };
   }
@@ -1724,7 +1687,6 @@ async function updateManagedConfig(
   }
   return {
     finalConfig,
-    omxManagesTui,
     repairedLegacyTeamRunTable:
       hadLegacyTeamRunTable && !hasLegacyOmxTeamRunTable(finalConfig),
   };


### PR DESCRIPTION
Closes #1891

## Summary

- always seed the OMX-managed `[tui].status_line` during `omx setup`
- remove the obsolete Codex-version gate that skipped StatusLine config for modern Codex CLI
- update setup regression coverage so Codex CLI >= 0.107.0 still gets the default StatusLine

## Verification

- `npm run build`
- `node --test dist/cli/__tests__/setup-refresh.test.js dist/config/__tests__/generator-idempotent.test.js`
- `npm run lint && npm run check:no-unused`

## Notes

I also attempted `npm run test:ci:compiled`; it is blocked in this local environment by unrelated/pre-existing failures including an old Cargo that cannot parse lockfile v4, missing tmux, `/private/var` vs `/var` temp-path assertions, and unrelated team/explore/ask test failures.
