### PR TITLE
fix(setup): enable StatusLine by default after install

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -355,14 +355,38 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
-  it("skips OMX-managed [tui] writes for Codex CLI >= 0.107.0 and preserves an existing [tui] table", async () => {
+  it("configures OMX status_line by default for Codex CLI >= 0.107.0", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: "project",
+        codexVersionProbe: () => "codex-cli 0.107.0",
+      });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.equal(config.match(/^\[tui\]$/gm)?.length ?? 0, 1);
+      assert.match(
+        config,
+        /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
+      );
+      assert.match(output, /StatusLine configured in config\.toml via \[tui\] section\./);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves user status_line during Codex CLI >= 0.107.0 setup refresh", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       await mkdir(join(wd, ".omx", "state"), { recursive: true });
       await mkdir(join(wd, ".codex"), { recursive: true });
       await writeFile(
         join(wd, ".codex", "config.toml"),
-        ['model = "gpt-5.5"', "", "[tui]", 'theme = "night"', 'status_line = ["git-branch"]', ""].join("\n"),
+        ["[tui]", 'theme = "night"', 'status_line = ["git-branch"]', ""].join(
+          "\n",
+        ),
       );
 
       const output = await runSetupWithCapturedLogs(wd, {
@@ -374,10 +398,11 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       assert.equal(config.match(/^\[tui\]$/gm)?.length ?? 0, 1);
       assert.match(config, /^theme = "night"$/m);
       assert.match(config, /^status_line = \["git-branch"\]$/m);
-      assert.match(
-        output,
-        /Codex CLI >= 0\.107\.0 manages \[tui\]; OMX left that section untouched\./,
+      assert.doesNotMatch(
+        config,
+        /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
       );
+      assert.match(output, /StatusLine configured in config\.toml via \[tui\] section\./);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -71,9 +71,12 @@ import {
   resolveAgentsModelTableContext,
   upsertAgentsModelTable,
 } from "../utils/agents-model-table.js";
-import { spawnPlatformCommandSync } from "../utils/platform-command.js";
 
 interface SetupOptions {
+  /**
+   * Deprecated no-op: setup now seeds `[tui].status_line` for every supported
+   * Codex version so fresh installs show the built-in status line by default.
+   */
   codexVersionProbe?: () => string | null;
   force?: boolean;
   dryRun?: boolean;
@@ -142,7 +145,6 @@ interface SetupBackupContext {
 
 interface ManagedConfigResult {
   finalConfig: string;
-  omxManagesTui: boolean;
   repairedLegacyTeamRunTable: boolean;
 }
 
@@ -224,7 +226,6 @@ const DEFAULT_SETUP_INSTALL_MODE: SetupInstallMode = "legacy";
 const LEGACY_SETUP_MODEL = "gpt-5.3-codex";
 const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
 const OBSOLETE_NATIVE_AGENT_FIELD = ["skill", "ref"].join("_");
-const TUI_OWNED_BY_CODEX_VERSION = [0, 107, 0] as const;
 
 function createEmptyCategorySummary(): SetupCategorySummary {
   return {
@@ -628,40 +629,6 @@ async function promptForModelUpgrade(
   } finally {
     rl.close();
   }
-}
-
-function parseSemverTriplet(version: string): [number, number, number] | null {
-  const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
-  if (!match) return null;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function semverGte(
-  version: [number, number, number],
-  minimum: readonly [number, number, number],
-): boolean {
-  if (version[0] !== minimum[0]) return version[0] > minimum[0];
-  if (version[1] !== minimum[1]) return version[1] > minimum[1];
-  return version[2] >= minimum[2];
-}
-
-function probeInstalledCodexVersion(): string | null {
-  const { result } = spawnPlatformCommandSync("codex", ["--version"], {
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-  if (result.error || result.status !== 0) return null;
-  const stdout = (result.stdout || "").trim();
-  return stdout === "" ? null : stdout;
-}
-
-function shouldOmxManageTuiFromCodexVersion(
-  versionOutput: string | null,
-): boolean {
-  if (!versionOutput) return true;
-  const parsed = parseSemverTriplet(versionOutput);
-  if (!parsed) return true;
-  return !semverGte(parsed, TUI_OWNED_BY_CODEX_VERSION);
 }
 
 async function promptForAgentsOverwrite(
@@ -1624,7 +1591,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   // Step 5: Update config.toml
   console.log("[5/8] Updating config.toml...");
   let resolvedConfig = "";
-  let omxManagesTui = false;
   if (isPluginInstallMode) {
     const configCleaned = await cleanupPluginModeLegacyConfig(
       scopeDirs.codexConfigFile,
@@ -1721,7 +1687,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
       },
     );
     resolvedConfig = managedConfig.finalConfig;
-    omxManagesTui = managedConfig.omxManagesTui;
     if (managedConfig.repairedLegacyTeamRunTable) {
       console.log(
         "  Removed retired [mcp_servers.omx_team_run] config during refresh.",
@@ -1978,13 +1943,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   } else {
     console.log("  HUD config already exists (use --force to overwrite).");
   }
-  if (omxManagesTui) {
-    console.log("  StatusLine configured in config.toml via [tui] section.");
-  } else {
-    console.log(
-      "  Codex CLI >= 0.107.0 manages [tui]; OMX left that section untouched.",
-    );
-  }
+  console.log("  StatusLine configured in config.toml via [tui] section.");
   console.log();
 
   console.log("Setup refresh summary:");
@@ -2673,9 +2632,6 @@ async function updateManagedConfig(
   const hadLegacyTeamRunTable = hasLegacyOmxTeamRunTable(existing);
   const currentModel = getRootModelName(existing);
   let modelOverride: string | undefined;
-  const codexVersion =
-    options.codexVersionProbe?.() ?? probeInstalledCodexVersion();
-  const omxManagesTui = shouldOmxManageTuiFromCodexVersion(codexVersion);
 
   if (currentModel === LEGACY_SETUP_MODEL) {
     const shouldPrompt =
@@ -2692,7 +2648,9 @@ async function updateManagedConfig(
   }
 
   const finalConfig = buildMergedConfig(existing, pkgRoot, {
-    includeTui: omxManagesTui,
+    // Modern Codex CLI still accepts `[tui].status_line`; skipping it for
+    // newer versions left fresh OMX installs without the default footer.
+    includeTui: true,
     modelOverride,
     sharedMcpServers: sharedMcpRegistry.servers,
     sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
@@ -2704,7 +2662,6 @@ async function updateManagedConfig(
     summary.unchanged += 1;
     return {
       finalConfig,
-      omxManagesTui,
       repairedLegacyTeamRunTable: false,
     };
   }
@@ -2743,7 +2700,6 @@ async function updateManagedConfig(
   }
   return {
     finalConfig,
-    omxManagesTui,
     repairedLegacyTeamRunTable:
       hadLegacyTeamRunTable && !hasLegacyOmxTeamRunTable(finalConfig),
   };

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -358,7 +358,7 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
-  it("merges OMX status_line into an existing user [tui] section without duplicating the table", async () => {
+  it("preserves an existing user status_line in [tui]", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
       const configPath = join(wd, "config.toml");
@@ -377,8 +377,34 @@ describe("config generator idempotency (#384)", () => {
       assert.match(toml, /^theme = "night"$/m, "user tui key preserved");
       assert.match(
         toml,
+        /^status_line = \["git-branch"\]$/m,
+        "user status_line preserved",
+      );
+      assert.doesNotMatch(
+        toml,
         /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
-        "status_line updated in-place",
+        "OMX default should not replace a user status_line",
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("adds the OMX status_line when an existing user [tui] section does not define one", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      await writeFile(configPath, ["[tui]", 'theme = "night"', ""].join("\n"));
+
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, "utf-8");
+
+      assert.equal(count(toml, /^\[tui\]$/gm), 1, "[tui] should appear once");
+      assert.match(toml, /^theme = "night"$/m, "user tui key preserved");
+      assert.match(
+        toml,
+        /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
+        "OMX default status_line added when missing",
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -701,6 +701,7 @@ function upsertTuiStatusLine(config: string): {
   }
 
   const preservedKeyLines: string[] = [];
+  let preservedStatusLine: string[] | undefined;
   const seenKeys = new Set<string>();
 
   for (const section of sections) {
@@ -713,13 +714,34 @@ function upsertTuiStatusLine(config: string): {
       if (!keyMatch) continue;
 
       const key = keyMatch[1];
-      if (key === "status_line" || seenKeys.has(key)) continue;
+      const entryLines = [trimmed];
+      while (
+        !parseStandaloneToml(`[tui]\n${entryLines.join("\n")}`) &&
+        i + entryLines.length < section.end
+      ) {
+        entryLines.push(lines[i + entryLines.length].trim());
+      }
+
+      if (key === "status_line") {
+        preservedStatusLine ??= entryLines;
+        i += entryLines.length - 1;
+        continue;
+      }
+      if (seenKeys.has(key)) {
+        i += entryLines.length - 1;
+        continue;
+      }
       seenKeys.add(key);
-      preservedKeyLines.push(trimmed);
+      preservedKeyLines.push(...entryLines);
+      i += entryLines.length - 1;
     }
   }
 
-  const mergedSection = ["[tui]", ...preservedKeyLines, OMX_TUI_STATUS_LINE];
+  const mergedSection = [
+    "[tui]",
+    ...preservedKeyLines,
+    ...(preservedStatusLine ?? [OMX_TUI_STATUS_LINE]),
+  ];
   const firstStart = sections[0].start;
   const rebuilt: string[] = [];
 


### PR DESCRIPTION
Closes #1891
Replaces #1892 (retargeted from `main` to `dev` per maintainer request).

## Summary

- always seed the OMX-managed `[tui].status_line` during legacy `omx setup`
- remove the obsolete Codex-version gate that skipped StatusLine config for modern Codex CLI
- update setup regression coverage so Codex CLI >= 0.107.0 still gets the default StatusLine

## Verification

- `npm run build`
- `node --test dist/cli/__tests__/setup-refresh.test.js dist/config/__tests__/generator-idempotent.test.js`
- `npm run lint && npm run check:no-unused`

## Notes

The prior PR was closed because it targeted `main`; this PR targets `dev` as requested in https://github.com/Yeachan-Heo/oh-my-codex/pull/1892#issuecomment-4312111881.
