### PR TITLE
Recover from stale tmux socket on detached launch

### DIFF
--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -165,6 +165,157 @@ exit 0
     }
   });
 
+  it('falls back directly when tmux is installed but the server socket is unusable', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-stale-socket-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const fakeTmuxPath = join(fakeBin, 'tmux');
+      const tmuxLogPath = join(wd, 'tmux.log');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        fakeCodexPath,
+        '#!/bin/sh\nprintf \'fake-codex:%s\\n\' "$*"\n',
+      );
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+      await writeFile(
+        fakeTmuxPath,
+        `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    printf 'tmux 3.6a\n'
+    exit 0
+    ;;
+  list-sessions)
+    printf 'error connecting to /tmp/tmux-1000/default (Operation not permitted)\n' >&2
+    exit 1
+    ;;
+esac
+printf 'unexpected tmux command: %s\n' "$*" >&2
+exit 1
+`,
+      );
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runOmx(
+        wd,
+        ['--madmax', '--tmux'],
+        {
+          HOME: home,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
+      assert.match(result.stderr, /server\/socket is unusable/);
+      assert.doesNotMatch(tmuxLog, /new-session|attach-session/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rolls back and falls back directly when attaching the detached tmux session fails', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-attach-fail-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const fakeTmuxPath = join(fakeBin, 'tmux');
+      const tmuxLogPath = join(wd, 'tmux.log');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        fakeCodexPath,
+        '#!/bin/sh\nprintf \'fake-codex:%s\\n\' "$*"\n',
+      );
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+      await writeFile(
+        fakeTmuxPath,
+        `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V|list-sessions)
+    exit 0
+    ;;
+  new-session)
+    printf 'leader-pane\n'
+    exit 0
+    ;;
+  split-window)
+    printf 'hud-pane\n'
+    exit 0
+    ;;
+  display-message)
+    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\n'
+    else
+      printf '0\n'
+    fi
+    exit 0
+    ;;
+  show-options)
+    printf 'off\n'
+    exit 0
+    ;;
+  attach-session)
+    printf 'error connecting to /tmp/tmux-1000/default (Operation not permitted)\n' >&2
+    exit 1
+    ;;
+  set-option|set-hook|kill-session|run-shell|resize-pane|select-pane)
+    exit 0
+    ;;
+esac
+exit 0
+`,
+      );
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runOmx(
+        wd,
+        ['--madmax', '--tmux'],
+        {
+          HOME: home,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
+      assert.match(tmuxLog, /tmux:attach-session -t /);
+      assert.match(tmuxLog, /tmux:kill-session -t /);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves the requested cwd through detached tmux launch when an unsupported SHELL value falls back away from rc-driven cwd drift', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-cwd-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -484,6 +484,82 @@ function hasErrnoCode(error: unknown, code: string): boolean {
   );
 }
 
+function tmuxFailureMessage(error: unknown): string {
+  if (!error || typeof error !== "object") return String(error);
+  const err = error as ExecFileSyncFailure & {
+    stdout?: Buffer | string;
+    stderr?: Buffer | string;
+  };
+  const stderr =
+    typeof err.stderr === "string" ? err.stderr : err.stderr?.toString();
+  const stdout =
+    typeof err.stdout === "string" ? err.stdout : err.stdout?.toString();
+  const detail = (stderr || stdout || err.message || String(error)).trim();
+  return detail.replace(/\s+/g, " ");
+}
+
+function isBenignMissingTmuxServerMessage(message: string): boolean {
+  return /no server running/i.test(message);
+}
+
+export interface TmuxLaunchHealth {
+  usable: boolean;
+  reason?: string;
+}
+
+export function checkDetachedTmuxLaunchHealth(): TmuxLaunchHealth {
+  try {
+    execTmuxFileSync(["list-sessions"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    return { usable: true };
+  } catch (err) {
+    const reason = tmuxFailureMessage(err);
+    if (isBenignMissingTmuxServerMessage(reason)) {
+      return { usable: true };
+    }
+    return { usable: false, reason };
+  }
+}
+
+function warnDetachedTmuxFallback(reason?: string): void {
+  const suffix = reason ? ` (${reason})` : "";
+  console.warn(
+    `[omx] warning: tmux is installed but its server/socket is unusable${suffix}. Falling back to direct Codex launch.`,
+  );
+}
+
+function resolveTmuxAwareLaunchPolicy(
+  explicitLaunchPolicy: CodexLaunchPolicy | undefined,
+  nativeWindows: boolean,
+): {
+  launchPolicy: CodexLaunchPolicy;
+  effectiveExplicitLaunchPolicy: CodexLaunchPolicy | undefined;
+} {
+  const launchPolicy = resolveCodexLaunchPolicy(
+    process.env,
+    process.platform,
+    undefined,
+    nativeWindows,
+    undefined,
+    undefined,
+    explicitLaunchPolicy,
+  );
+
+  if (launchPolicy !== "detached-tmux") {
+    return { launchPolicy, effectiveExplicitLaunchPolicy: explicitLaunchPolicy };
+  }
+
+  const tmuxHealth = checkDetachedTmuxLaunchHealth();
+  if (tmuxHealth.usable) {
+    return { launchPolicy, effectiveExplicitLaunchPolicy: explicitLaunchPolicy };
+  }
+
+  warnDetachedTmuxFallback(tmuxHealth.reason);
+  return { launchPolicy: "direct", effectiveExplicitLaunchPolicy: "direct" };
+}
+
 export interface CodexExecFailureClassification {
   kind: "exit" | "launch-error";
   code?: string;
@@ -911,15 +987,8 @@ export async function launchWithHud(args: string[]): Promise<void> {
     notifyTempResult.passthroughArgs,
   );
   const codexHomeOverride = resolveCodexHomeForLaunch(launchCwd, process.env);
-  const launchPolicy = resolveCodexLaunchPolicy(
-    process.env,
-    process.platform,
-    undefined,
-    isNativeWindows(),
-    undefined,
-    undefined,
-    explicitLaunchPolicy,
-  );
+  const { launchPolicy, effectiveExplicitLaunchPolicy } =
+    resolveTmuxAwareLaunchPolicy(explicitLaunchPolicy, isNativeWindows());
   const enableNotifyFallbackAuthority = launchPolicy === "direct";
   const workerSparkModel = resolveWorkerSparkModel(
     notifyTempResult.passthroughArgs,
@@ -1008,7 +1077,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
       workerSparkModel,
       codexHomeOverride,
       notifyTempContractRaw,
-      explicitLaunchPolicy,
+      effectiveExplicitLaunchPolicy,
     );
   } finally {
     // ── Phase 3: postLaunch ─────────────────────────────────────────────
@@ -2428,14 +2497,9 @@ function runCodex(
     ? { ...codexEnv, [OMX_NOTIFY_TEMP_CONTRACT_ENV]: notifyTempContractRaw }
     : codexEnv;
 
-  const launchPolicy = resolveCodexLaunchPolicy(
-    process.env,
-    process.platform,
-    undefined,
-    nativeWindows,
-    undefined,
-    undefined,
+  const { launchPolicy } = resolveTmuxAwareLaunchPolicy(
     explicitLaunchPolicy,
+    nativeWindows,
   );
 
   if (isCodexVersionRequest(launchArgs)) {


### PR DESCRIPTION
## Summary

Closes #1899.

- add a launch-time tmux server/socket health probe before choosing the detached tmux path
- fall back to direct Codex launch when `tmux -V` succeeds but `tmux list-sessions` reports an unusable socket/server
- preserve the benign no-server case so fresh detached tmux sessions can still be created
- add regression coverage for stale socket fallback and attach-time rollback/fallback

## Verification

- `npm run build`
- `node --test dist/cli/__tests__/launch-fallback.test.js`
- `npm run lint`
- `npm run check:no-unused`
- LSP diagnostics: 0 errors on `src/cli/index.ts` and `src/cli/__tests__/launch-fallback.test.ts`

## Notes

`npm run test:recent-bug-regressions:compiled` was attempted but stopped after hanging in the team runtime tests; the targeted launch fallback tests above pass and cover this bug directly.
