### PR TITLE
Fix Windows psmux question renderer hangs

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -183,6 +183,116 @@ esac
     assert.match(record.error?.message || '', /pane %5 disappeared immediately after launch/i);
   });
 
+  it('fails instead of hanging when a renderer pane dies after prompting starts', async () => {
+    const cwd = await makeRepo();
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+    const countPath = join(cwd, 'list-panes-count');
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(join(fakeBinDir, 'tmux'), `#!/bin/sh
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  display-message)
+    printf '1\n'
+    ;;
+  split-window)
+    printf '%%45\n'
+    ;;
+  list-panes)
+    count=0
+    if [ -f "${countPath}" ]; then count=$(cat "${countPath}"); fi
+    count=$((count + 1))
+    printf '%s' "$count" > "${countPath}"
+    if [ "$count" = "1" ]; then
+      printf '0\t%%45\n'
+      exit 0
+    fi
+    echo "can't find pane: %45" >&2
+    exit 1
+    ;;
+esac
+`, { mode: 0o755 });
+
+    const input = JSON.stringify({
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      session_id: 'sess-q',
+    });
+
+    const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
+      const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          TMUX: '/tmp/fake',
+          TMUX_PANE: '%0',
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          OMX_QUESTION_WAIT_TIMEOUT_MS: '5000',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+      child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+      child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, 'question_runtime_failed');
+    assert.match(payload.error.message, /renderer tmux-pane %45 exited before answering/i);
+
+    const entries = await readdir(join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions'));
+    assert.equal(entries.length, 1);
+    const recordPath = join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions', entries[0]!);
+    const record = JSON.parse(await readFile(recordPath, 'utf-8')) as { status: string; error?: { code?: string; message?: string } };
+    assert.equal(record.status, 'error');
+    assert.equal(record.error?.code, 'question_runtime_failed');
+    assert.match(record.error?.message || '', /exited before answering/i);
+  });
+
+  it('times out unanswered test renderers instead of waiting forever', async () => {
+    const cwd = await makeRepo();
+    const input = JSON.stringify({
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      session_id: 'sess-q',
+    });
+
+    const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
+      const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
+        cwd,
+        env: {
+          ...process.env,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          OMX_QUESTION_TEST_RENDERER: 'noop',
+          OMX_QUESTION_WAIT_TIMEOUT_MS: '50',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+      child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+      child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, 'question_runtime_failed');
+    assert.match(payload.error.message, /Timed out waiting for question answer after 50ms/i);
+  });
+
   it('fails closed outside an attached tmux pane without creating a detached session', async () => {
     const cwd = await makeRepo();
     const fakeBinDir = join(cwd, 'fake-bin');

--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -5,9 +5,18 @@ import {
   markQuestionPrompting,
   waitForQuestionTerminalState,
 } from '../question/state.js';
-import { launchQuestionRenderer } from '../question/renderer.js';
+import { isQuestionRendererAlive, launchQuestionRenderer } from '../question/renderer.js';
 import { normalizeQuestionInput } from '../question/types.js';
 import { runQuestionUi } from '../question/ui.js';
+
+const DEFAULT_QUESTION_WAIT_TIMEOUT_MS = 30 * 60 * 1000;
+
+function parseQuestionWaitTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = String(env.OMX_QUESTION_WAIT_TIMEOUT_MS ?? '').trim();
+  if (!raw) return DEFAULT_QUESTION_WAIT_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_QUESTION_WAIT_TIMEOUT_MS;
+}
 
 export const QUESTION_HELP = `omx question - OMX-owned blocking user question entrypoint
 
@@ -169,7 +178,13 @@ export async function questionCommand(args: string[]): Promise<void> {
         parsed.json ? { output: createJsonSafeInlineQuestionOutput() } : {},
       );
     }
-    finalRecord = await waitForQuestionTerminalState(recordPath);
+    finalRecord = await waitForQuestionTerminalState(recordPath, {
+      timeoutMs: parseQuestionWaitTimeoutMs(),
+      rendererAlive: (currentRecord) => isQuestionRendererAlive(currentRecord.renderer),
+      rendererDeathMessage: (currentRecord) => (
+        `Question renderer ${currentRecord.renderer?.renderer ?? renderer.renderer} ${currentRecord.renderer?.target ?? renderer.target} exited before answering.`
+      ),
+    });
   } catch (error) {
     const message = extractErrorMessage(error);
     await markQuestionTerminalError(

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -48,6 +48,25 @@ describe('resolveQuestionRendererStrategy', () => {
     );
   });
 
+  it('uses a detached Windows console for native psmux return bridges', () => {
+    assert.equal(
+      resolveQuestionRendererStrategy(
+        { TMUX: 'psmux-session', TMUX_PANE: '%44' } as NodeJS.ProcessEnv,
+        'C:/Program Files/psmux/psmux.exe',
+        { platform: 'win32' },
+      ),
+      'windows-console',
+    );
+    assert.equal(
+      resolveQuestionRendererStrategy(
+        { OMX_QUESTION_RETURN_PANE: '%45' } as NodeJS.ProcessEnv,
+        'C:/Program Files/psmux/psmux.exe',
+        { platform: 'win32' },
+      ),
+      'windows-console',
+    );
+  });
+
   it('supports persisted workflow pane bridges when TMUX is absent', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'omx-question-renderer-strategy-'));
     try {
@@ -238,6 +257,52 @@ describe('launchQuestionRenderer', () => {
     assert.ok(!calls[0]?.includes('-d'));
     assert.deepEqual(calls[0]?.slice(0, 7), ['split-window', '-v', '-l', '12', '-t', '%77', '-P']);
     assert.deepEqual(calls[1], ['list-panes', '-t', '%78', '-F', '#{pane_dead}\t#{pane_id}']);
+  });
+
+  it('opens a detached Windows console instead of a psmux split pane when a return bridge is present', () => {
+    const tmuxCalls: string[][] = [];
+    const spawnCalls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+    const result = launchQuestionRenderer(
+      {
+        cwd: 'C:/repo',
+        recordPath: 'C:/repo/.omx/state/sessions/s1/questions/question-bridge.json',
+        sessionId: 's1',
+        nowIso: '2026-04-24T00:00:00.000Z',
+        env: { TMUX: 'psmux-session', TMUX_PANE: '%44' } as NodeJS.ProcessEnv,
+        platform: 'win32',
+      },
+      {
+        execTmux: (args) => {
+          tmuxCalls.push(args);
+          return '';
+        },
+        spawnDetachedRenderer: (command, args, options) => {
+          spawnCalls.push({ command, args, options: options as Record<string, unknown> });
+          return { pid: 1234, unref: () => {} };
+        },
+        sleepSync: () => {},
+      },
+    );
+
+    assert.equal(result.renderer, 'windows-console');
+    assert.equal(result.target, 'pid:1234');
+    assert.equal(result.pid, 1234);
+    assert.equal(result.return_target, '%44');
+    assert.equal(result.return_transport, 'tmux-send-keys');
+    assert.deepEqual(tmuxCalls, []);
+    assert.equal(spawnCalls.length, 1);
+    assert.equal(spawnCalls[0]?.command, 'cmd.exe');
+    assert.deepEqual(spawnCalls[0]?.args.slice(0, 3), ['/d', '/s', '/c']);
+    assert.match(spawnCalls[0]?.args[3] || '', /start "OMX Question" \/wait/);
+    assert.match(spawnCalls[0]?.args[3] || '', /"question" "--ui" "--state-path"/);
+    assert.match(spawnCalls[0]?.args[3] || '', /question-bridge\.json"/);
+    assert.equal(spawnCalls[0]?.options.cwd, 'C:/repo');
+    assert.equal(spawnCalls[0]?.options.detached, true);
+    assert.equal(spawnCalls[0]?.options.windowsHide, true);
+    const env = spawnCalls[0]?.options.env as NodeJS.ProcessEnv;
+    assert.equal(env.OMX_SESSION_ID, 's1');
+    assert.equal(env.OMX_QUESTION_RETURN_TARGET, '%44');
+    assert.equal(env.OMX_QUESTION_RETURN_TRANSPORT, 'tmux-send-keys');
   });
 
   it('targets a persisted workflow pane when launching from a container without TMUX', () => {

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { basename } from 'node:path';
 import { stdin as processStdin, stdout as processStdout } from 'node:process';
@@ -13,7 +13,7 @@ import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
 import type { QuestionAnswer, QuestionRendererState } from './types.js';
 
-export type QuestionRendererStrategy = 'inside-tmux' | 'detached-tmux' | 'inline-tty' | 'test-noop' | 'unsupported';
+export type QuestionRendererStrategy = 'inside-tmux' | 'detached-tmux' | 'inline-tty' | 'windows-console' | 'test-noop' | 'unsupported';
 
 export interface LaunchQuestionRendererOptions {
   cwd: string;
@@ -28,6 +28,7 @@ export interface LaunchQuestionRendererOptions {
 
 export type ExecTmuxSync = (args: string[]) => string;
 export type SleepSync = (ms: number) => void;
+export type SpawnDetachedRenderer = (command: string, args: string[], options: SpawnOptions) => Pick<ChildProcess, 'pid' | 'unref'>;
 
 const QUESTION_TEXT_SETTLE_MS = 120;
 const QUESTION_SUBMIT_REPEAT_DELAY_MS = 100;
@@ -55,6 +56,17 @@ function hasInteractiveQuestionTty(options?: {
   return stdinIsTTY && stdoutIsTTY;
 }
 
+function hasWindowsPsmuxReturnBridge(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): boolean {
+  if (platform !== 'win32') return false;
+  if (hasExplicitQuestionPaneTarget(env)) return true;
+  const tmux = safeString(env.TMUX).trim().toLowerCase();
+  const tmuxPane = safeString(env.TMUX_PANE).trim();
+  return tmux !== '' && (tmux.includes('psmux') || isPaneId(tmuxPane));
+}
+
 export function resolveQuestionRendererStrategy(
   env: NodeJS.ProcessEnv = process.env,
   // Kept for callers/tests that used to pass detected tmux availability; default
@@ -68,14 +80,32 @@ export function resolveQuestionRendererStrategy(
     stdoutIsTTY?: boolean;
   },
 ): QuestionRendererStrategy {
+  const platform = options?.platform ?? process.platform;
   if (safeString(env.OMX_QUESTION_TEST_RENDERER).trim() === 'noop') return 'test-noop';
+  if (hasWindowsPsmuxReturnBridge(env, platform)) return 'windows-console';
   if (safeString(env.TMUX).trim() !== '') return 'inside-tmux';
   if (hasExplicitQuestionPaneTarget(env)) return 'inside-tmux';
   if (options?.cwd && readPersistedQuestionReturnTarget(options.cwd, options.sessionId)) return 'inside-tmux';
-  if ((options?.platform ?? process.platform) === 'win32' && hasInteractiveQuestionTty(options)) {
+  if (platform === 'win32' && hasInteractiveQuestionTty(options)) {
     return 'inline-tty';
   }
   return 'unsupported';
+}
+
+function resolveQuestionUiProcessArgs(
+  recordPath: string,
+  options: {
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+  },
+): string[] {
+  const omxBin = resolveOmxCliEntryPath({
+    argv1: process.argv[1],
+    cwd: options.cwd,
+    env: options.env,
+  }) || process.argv[1];
+  if (!omxBin) throw new Error('Unable to resolve OMX CLI entry path for question UI launch.');
+  return [omxBin, 'question', '--ui', '--state-path', recordPath];
 }
 
 function buildQuestionUiTmuxArgs(
@@ -87,12 +117,6 @@ function buildQuestionUiTmuxArgs(
     returnTarget?: string;
   },
 ): string[] {
-  const omxBin = resolveOmxCliEntryPath({
-    argv1: process.argv[1],
-    cwd: options.cwd,
-    env: options.env,
-  }) || process.argv[1];
-  if (!omxBin) throw new Error('Unable to resolve OMX CLI entry path for question UI launch.');
   return [
     ...(options.sessionId ? ['-e', `OMX_SESSION_ID=${options.sessionId}`] : []),
     ...(options.returnTarget ? [
@@ -102,12 +126,43 @@ function buildQuestionUiTmuxArgs(
       'OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys',
     ] : []),
     process.execPath,
-    omxBin,
-    'question',
-    '--ui',
-    '--state-path',
-    recordPath,
+    ...resolveQuestionUiProcessArgs(recordPath, options),
   ];
+}
+
+function buildQuestionUiProcessEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  options: {
+    sessionId?: string;
+    returnTarget?: string;
+  },
+): NodeJS.ProcessEnv {
+  return {
+    ...baseEnv,
+    ...(options.sessionId ? { OMX_SESSION_ID: options.sessionId } : {}),
+    ...(options.returnTarget ? {
+      OMX_QUESTION_RETURN_TARGET: options.returnTarget,
+      OMX_QUESTION_RETURN_TRANSPORT: 'tmux-send-keys',
+    } : {}),
+  };
+}
+
+function quoteCmdArg(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function buildWindowsConsoleStartCommand(command: string, args: string[]): string {
+  return [
+    'start',
+    '"OMX Question"',
+    '/wait',
+    quoteCmdArg(command),
+    ...args.map(quoteCmdArg),
+  ].join(' ');
+}
+
+function defaultSpawnDetachedRenderer(command: string, args: string[], options: SpawnOptions): Pick<ChildProcess, 'pid' | 'unref'> {
+  return spawn(command, args, options);
 }
 
 function defaultExecTmux(args: string[]): string {
@@ -199,7 +254,7 @@ function isCurrentTmuxSessionAttached(
   }
 }
 
-function isLaunchedQuestionPaneAlive(
+export function isLaunchedQuestionPaneAlive(
   paneId: string,
   execTmux: ExecTmuxSync,
 ): boolean {
@@ -219,7 +274,7 @@ function isLaunchedQuestionPaneAlive(
   }
 }
 
-function isLaunchedQuestionSessionAlive(
+export function isLaunchedQuestionSessionAlive(
   sessionName: string,
   execTmux: ExecTmuxSync,
 ): boolean {
@@ -230,6 +285,30 @@ function isLaunchedQuestionSessionAlive(
   } catch {
     return false;
   }
+}
+
+export function isWindowsConsoleRendererAlive(pid: number | undefined): boolean {
+  if (!Number.isInteger(pid) || Number(pid) <= 0) return true;
+  try {
+    process.kill(Number(pid), 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isQuestionRendererAlive(
+  renderer: QuestionRendererState | undefined,
+  execTmux: ExecTmuxSync = defaultExecTmux,
+): boolean {
+  if (!renderer) return true;
+  if (renderer.renderer === 'tmux-pane') return isLaunchedQuestionPaneAlive(renderer.target, execTmux);
+  if (renderer.renderer === 'tmux-session') {
+    if (renderer.target === 'test-noop-renderer') return true;
+    return isLaunchedQuestionSessionAlive(renderer.target, execTmux);
+  }
+  if (renderer.renderer === 'windows-console') return isWindowsConsoleRendererAlive(renderer.pid);
+  return true;
 }
 
 export function formatQuestionAnswerForInjection(answer: QuestionAnswer): string {
@@ -270,6 +349,7 @@ export function launchQuestionRenderer(
     strategy?: QuestionRendererStrategy;
     execTmux?: ExecTmuxSync;
     sleepSync?: SleepSync;
+    spawnDetachedRenderer?: SpawnDetachedRenderer;
   } = {},
 ): QuestionRendererState {
   const strategy = deps.strategy ?? resolveQuestionRendererStrategy(options.env ?? process.env, undefined, {
@@ -281,6 +361,7 @@ export function launchQuestionRenderer(
   });
   const execTmux = deps.execTmux ?? defaultExecTmux;
   const sleepImpl = deps.sleepSync ?? sleepSync;
+  const spawnDetachedRenderer = deps.spawnDetachedRenderer ?? defaultSpawnDetachedRenderer;
   const launchedAt = options.nowIso ?? new Date().toISOString();
   const env = options.env ?? process.env;
 
@@ -335,6 +416,29 @@ export function launchQuestionRenderer(
       renderer: 'tmux-pane',
       target: paneId,
       launched_at: launchedAt,
+      ...(returnTarget ? { return_target: returnTarget, return_transport: 'tmux-send-keys' } : {}),
+    };
+  }
+
+  if (strategy === 'windows-console') {
+    const uiArgs = resolveQuestionUiProcessArgs(options.recordPath, { cwd: options.cwd, env: options.env });
+    const child = spawnDetachedRenderer(
+      env.ComSpec || 'cmd.exe',
+      ['/d', '/s', '/c', buildWindowsConsoleStartCommand(process.execPath, uiArgs)],
+      {
+        cwd: options.cwd,
+        env: buildQuestionUiProcessEnv(env, { sessionId: options.sessionId, returnTarget }),
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+      },
+    );
+    child.unref();
+    return {
+      renderer: 'windows-console',
+      target: child.pid ? `pid:${child.pid}` : 'windows-console',
+      launched_at: launchedAt,
+      ...(Number.isInteger(child.pid) ? { pid: child.pid } : {}),
       ...(returnTarget ? { return_target: returnTarget, return_transport: 'tmux-send-keys' } : {}),
     };
   }

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -131,6 +131,8 @@ export async function waitForQuestionTerminalState(
   options: {
     pollIntervalMs?: number;
     timeoutMs?: number;
+    rendererAlive?: (record: QuestionRecord) => boolean;
+    rendererDeathMessage?: (record: QuestionRecord) => string;
   } = {},
 ): Promise<QuestionRecord> {
   const pollIntervalMs = Math.max(10, options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
@@ -141,6 +143,12 @@ export async function waitForQuestionTerminalState(
     const record = await readQuestionRecord(recordPath);
     if (!record) throw new Error(`Question record not found while waiting: ${recordPath}`);
     if (isTerminalQuestionStatus(record.status)) return record;
+    if (options.rendererAlive && !options.rendererAlive(record)) {
+      throw new Error(
+        options.rendererDeathMessage?.(record)
+          ?? `Question renderer ${record.renderer?.renderer ?? 'unknown'} exited before answering.`,
+      );
+    }
     if (typeof timeoutMs === 'number' && timeoutMs >= 0 && Date.now() - startedAt > timeoutMs) {
       throw new Error(`Timed out waiting for question answer after ${timeoutMs}ms`);
     }

--- a/src/question/types.ts
+++ b/src/question/types.ts
@@ -18,7 +18,7 @@ export interface QuestionInput {
   session_id?: string;
 }
 
-export type QuestionRendererKind = 'tmux-pane' | 'tmux-session' | 'inline-tty';
+export type QuestionRendererKind = 'tmux-pane' | 'tmux-session' | 'inline-tty' | 'windows-console';
 
 export interface QuestionAnswer {
   kind: 'option' | 'other' | 'multi';
@@ -36,6 +36,7 @@ export interface QuestionRendererState {
   launched_at: string;
   return_target?: string;
   return_transport?: 'tmux-send-keys';
+  pid?: number;
 }
 
 export interface QuestionRecord {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1739,6 +1739,35 @@ esac
     }
   });
 
+  it("allows PowerShell env bridge forms for omx question return panes", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-question-powershell-allow-"));
+    try {
+      const commands = [
+        `$env:OMX_QUESTION_RETURN_PANE=$env:TMUX_PANE; omx question --json --input '{"question":"Q?","options":["A"],"allow_other":true}'`,
+        `$env:OMX_QUESTION_RETURN_PANE='%42'; node ./dist/cli/omx.js question --json --input '{"question":"Q?","options":["A"],"allow_other":true}'`,
+        `$env:OMX_LEADER_PANE_ID="%43"; omx question --json --input '{"question":"Q?","options":["A"],"allow_other":true}'`,
+      ];
+
+      for (const [index, command] of commands.entries()) {
+        const result = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            tool_name: "Bash",
+            tool_use_id: `tool-question-powershell-allow-${index}`,
+            tool_input: { command },
+          },
+          { cwd },
+        );
+
+        assert.equal(result.omxEventName, "pre-tool-use");
+        assert.equal(result.outputJson, null);
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("allows Bash omx question when a valid inherited OMX_QUESTION_RETURN_PANE bridge is already exported", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-question-env-allow-"));
     const originalReturnPane = process.env.OMX_QUESTION_RETURN_PANE;

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -649,8 +649,14 @@ function hasInheritedQuestionReturnPaneBridge(): boolean {
   return /^%\d+$/.test(explicitPane);
 }
 
+function commandHasPowerShellQuestionReturnPane(command: string): boolean {
+  return /\$env:(?:OMX_QUESTION_RETURN_PANE|OMX_LEADER_PANE_ID)\s*=\s*(?:['"]?%\d+['"]?|\$env:TMUX_PANE)\b/i.test(command)
+    || /\$env:TMUX_PANE\s*=\s*['"]?%\d+['"]?/i.test(command);
+}
+
 function commandHasQuestionReturnPane(command: string): boolean {
   if (hasInheritedQuestionReturnPaneBridge()) return true;
+  if (commandHasPowerShellQuestionReturnPane(command)) return true;
   return (tokenizeShellCommand(command) ?? []).some(isQuestionReturnPaneAssignment);
 }
 


### PR DESCRIPTION
## Summary
- Fixes #1871 by routing native Windows/psmux question return bridges to a detached Windows console renderer instead of defaulting to tmux split-pane.
- Preserves optional return-pane nudging for the UI process via `OMX_QUESTION_RETURN_TARGET` / `OMX_QUESTION_RETURN_TRANSPORT`.
- Adds renderer liveness checks and a bounded wait timeout so `omx question --json` fails cleanly if the renderer dies or never answers.

## Tests
- `npm run build`
- `node --test dist/question/__tests__/renderer.test.js dist/cli/__tests__/question.test.js`
- `node --test --test-name-pattern "PowerShell env bridge" dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`
- `npm run check:no-unused`

## Notes
- Not live-tested on Windows 11 + psmux in this Linux workspace.
