### PR TITLE
Make OMX setup reruns review persisted choices

### DIFF
--- a/plugins/oh-my-codex/skills/omx-setup/SKILL.md
+++ b/plugins/oh-my-codex/skills/omx-setup/SKILL.md
@@ -29,11 +29,12 @@ Supported setup flags (current implementation):
 1. Resolve setup scope:
    - `--scope` explicit value
    - else persisted `./.omx/setup-scope.json` (with automatic migration of legacy values)
+   - if a TTY user has persisted setup preferences, `omx setup` first summarizes the recorded choices and asks whether to **keep**, **review/change**, or **reset** them
    - else interactive prompt on TTY (default `user`)
    - else default `user` (safe for CI/tests)
 2. If scope is `user`, resolve user skill delivery mode:
    - explicit `--plugin`, if present
-   - persisted install mode in `./.omx/setup-scope.json`, if present
+   - persisted install mode in `./.omx/setup-scope.json`, if present and the TTY review decision is `keep`
    - else discovered installed plugin cache under `${CODEX_HOME:-~/.codex}/plugins/cache/**/.codex-plugin/plugin.json` with `name: oh-my-codex` makes `plugin` the default
    - else interactive prompt on TTY (`legacy` by default, or `plugin` when a plugin cache is discovered)
    - else default `legacy` unless a plugin cache is discovered
@@ -45,8 +46,9 @@ Supported setup flags (current implementation):
 
 ## Important behavior notes
 
-- `omx setup` only prompts for scope when no scope is provided/persisted and stdin/stdout are TTY.
-- In `user` scope, `omx setup` also prompts for skill delivery mode when no prior install mode is persisted; installed plugin cache discovery makes plugin mode the default prompt/non-interactive choice.
+- `omx setup` prompts for scope when no scope is provided and stdin/stdout are TTY. If `./.omx/setup-scope.json` already exists, setup now summarizes the saved choices first and asks whether to keep them, review/change them, or reset and behave like a fresh setup run.
+- Non-interactive setup never blocks for this review prompt: it keeps deterministic CLI/persisted/default behavior for CI and scripted installs.
+- In `user` scope, `omx setup` also prompts for skill delivery mode when no prior install mode is kept; installed plugin cache discovery makes plugin mode the default prompt/non-interactive choice.
 - Local project orchestration file is `./AGENTS.md` (project root).
 - If `AGENTS.md` exists and `--force` is not used, interactive TTY runs ask whether to overwrite. Non-interactive runs preserve the file.
 - Scope targets:
@@ -60,6 +62,30 @@ Supported setup flags (current implementation):
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
 - With `--force`, AGENTS overwrite may still be skipped if an active OMX session is detected (safety guard).
 - Legacy persisted scope values (`project-local`) are automatically migrated to `project` with a one-time warning.
+
+## Setup-owned configuration surfaces
+
+Use this map when reconciling setup behavior or debugging a confusing install:
+
+| Surface | Owner | Notes |
+| --- | --- | --- |
+| `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
+| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content. |
+| `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
+| prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery and cleans matching legacy OMX-managed copies. |
+| `AGENTS.md` | `omx setup` with overwrite safety | Generated defaults or managed refreshes are guarded by force/session checks. |
+| `./.omx/hud-config.json` | `omx setup` / `$hud` | Setup creates the focused default; `$hud` can adjust it later. |
+| notification hooks | `omx setup` / `$configure-notifications` | Setup wires defaults outside plugin skill delivery; notification skill owns deeper provider configuration. |
+
+## If `$omx-setup` is missing or stale
+
+The source repo ships `skills/omx-setup/SKILL.md` and the catalog marks it active. If Codex does not show `$omx-setup`, treat it as an installation/discovery issue rather than a missing source skill:
+
+1. Run `omx setup --verbose` in the intended scope.
+2. Run `omx doctor` and check the reported setup scope, Codex home, skill root, and hook/config status.
+3. If using project scope, confirm `./.codex/skills/omx-setup/SKILL.md` exists.
+4. If using user scope, confirm `${CODEX_HOME:-~/.codex}/skills/omx-setup/SKILL.md` exists in legacy mode, or that the oh-my-codex plugin is installed/discovered in plugin mode.
+5. If duplicate/stale skills appear, check for legacy `~/.agents/skills` overlap and follow the cleanup hint printed by setup/doctor.
 
 ## Recommended workflow
 

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -29,11 +29,12 @@ Supported setup flags (current implementation):
 1. Resolve setup scope:
    - `--scope` explicit value
    - else persisted `./.omx/setup-scope.json` (with automatic migration of legacy values)
+   - if a TTY user has persisted setup preferences, `omx setup` first summarizes the recorded choices and asks whether to **keep**, **review/change**, or **reset** them
    - else interactive prompt on TTY (default `user`)
    - else default `user` (safe for CI/tests)
 2. If scope is `user`, resolve user skill delivery mode:
    - explicit `--plugin`, if present
-   - persisted install mode in `./.omx/setup-scope.json`, if present
+   - persisted install mode in `./.omx/setup-scope.json`, if present and the TTY review decision is `keep`
    - else discovered installed plugin cache under `${CODEX_HOME:-~/.codex}/plugins/cache/**/.codex-plugin/plugin.json` with `name: oh-my-codex` makes `plugin` the default
    - else interactive prompt on TTY (`legacy` by default, or `plugin` when a plugin cache is discovered)
    - else default `legacy` unless a plugin cache is discovered
@@ -45,8 +46,9 @@ Supported setup flags (current implementation):
 
 ## Important behavior notes
 
-- `omx setup` only prompts for scope when no scope is provided/persisted and stdin/stdout are TTY.
-- In `user` scope, `omx setup` also prompts for skill delivery mode when no prior install mode is persisted; installed plugin cache discovery makes plugin mode the default prompt/non-interactive choice.
+- `omx setup` prompts for scope when no scope is provided and stdin/stdout are TTY. If `./.omx/setup-scope.json` already exists, setup now summarizes the saved choices first and asks whether to keep them, review/change them, or reset and behave like a fresh setup run.
+- Non-interactive setup never blocks for this review prompt: it keeps deterministic CLI/persisted/default behavior for CI and scripted installs.
+- In `user` scope, `omx setup` also prompts for skill delivery mode when no prior install mode is kept; installed plugin cache discovery makes plugin mode the default prompt/non-interactive choice.
 - Local project orchestration file is `./AGENTS.md` (project root).
 - If `AGENTS.md` exists and `--force` is not used, interactive TTY runs ask whether to overwrite. Non-interactive runs preserve the file.
 - Scope targets:
@@ -60,6 +62,30 @@ Supported setup flags (current implementation):
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
 - With `--force`, AGENTS overwrite may still be skipped if an active OMX session is detected (safety guard).
 - Legacy persisted scope values (`project-local`) are automatically migrated to `project` with a one-time warning.
+
+## Setup-owned configuration surfaces
+
+Use this map when reconciling setup behavior or debugging a confusing install:
+
+| Surface | Owner | Notes |
+| --- | --- | --- |
+| `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
+| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content. |
+| `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
+| prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery and cleans matching legacy OMX-managed copies. |
+| `AGENTS.md` | `omx setup` with overwrite safety | Generated defaults or managed refreshes are guarded by force/session checks. |
+| `./.omx/hud-config.json` | `omx setup` / `$hud` | Setup creates the focused default; `$hud` can adjust it later. |
+| notification hooks | `omx setup` / `$configure-notifications` | Setup wires defaults outside plugin skill delivery; notification skill owns deeper provider configuration. |
+
+## If `$omx-setup` is missing or stale
+
+The source repo ships `skills/omx-setup/SKILL.md` and the catalog marks it active. If Codex does not show `$omx-setup`, treat it as an installation/discovery issue rather than a missing source skill:
+
+1. Run `omx setup --verbose` in the intended scope.
+2. Run `omx doctor` and check the reported setup scope, Codex home, skill root, and hook/config status.
+3. If using project scope, confirm `./.codex/skills/omx-setup/SKILL.md` exists.
+4. If using user scope, confirm `${CODEX_HOME:-~/.codex}/skills/omx-setup/SKILL.md` exists in legacy mode, or that the oh-my-codex plugin is installed/discovered in plugin mode.
+5. If duplicate/stale skills appear, check for legacy `~/.agents/skills` overlap and follow the cleanup hint printed by setup/doctor.
 
 ## Recommended workflow
 

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -62,6 +62,7 @@ async function withIsolatedUserHome<T>(
   }
 }
 
+
 async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {
   const hooks = await readFile(join(wd, ".codex", "hooks.json"), "utf-8");
   assert.match(hooks, /codex-native-hook\.js/);
@@ -149,6 +150,218 @@ async function seedPluginCacheFromInstalledSkills(
 }
 
 describe("omx setup install mode behavior", () => {
+  it("summarizes and keeps persisted setup preferences when review chooses keep", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async () => {
+        await withTempCwd(wd, async () => {
+          await mkdir(join(wd, ".omx"), { recursive: true });
+          await writeFile(
+            join(wd, ".omx", "setup-scope.json"),
+            JSON.stringify({ scope: "user", installMode: "legacy" }),
+          );
+
+          const output = await captureConsoleOutput(async () => {
+            await setup({
+              persistedSetupReviewPrompt: async (preferences) => {
+                assert.deepEqual(preferences, {
+                  scope: "user",
+                  installMode: "legacy",
+                });
+                return "keep";
+              },
+            });
+          });
+
+          assert.match(
+            output,
+            /Setup preference review: keep \(scope=user, installMode=legacy\)/,
+          );
+          assert.match(
+            output,
+            /Using setup scope: user \(from \.omx\/setup-scope\.json\)/,
+          );
+          assert.match(
+            output,
+            /Using setup install mode: legacy \(from \.omx\/setup-scope\.json\)/,
+          );
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("uses persisted choices as defaults when review changes setup preferences", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async () => {
+        await withTempCwd(wd, async () => {
+          await mkdir(join(wd, ".omx"), { recursive: true });
+          await writeFile(
+            join(wd, ".omx", "setup-scope.json"),
+            JSON.stringify({ scope: "user", installMode: "legacy" }),
+          );
+
+          await setup({
+            persistedSetupReviewPrompt: async () => "review",
+            setupScopePrompt: async (defaultScope) => {
+              assert.equal(defaultScope, "user");
+              return "user";
+            },
+            installModePrompt: async (defaultMode) => {
+              assert.equal(defaultMode, "legacy");
+              return "plugin";
+            },
+          });
+
+          const persisted = JSON.parse(
+            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+          ) as { scope: string; installMode?: string };
+          assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("clears user-scope install mode when review switches setup to project scope", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async () => {
+        await withTempCwd(wd, async () => {
+          await mkdir(join(wd, ".omx"), { recursive: true });
+          await writeFile(
+            join(wd, ".omx", "setup-scope.json"),
+            JSON.stringify({ scope: "user", installMode: "plugin" }),
+          );
+
+          await setup({
+            persistedSetupReviewPrompt: async () => "review",
+            setupScopePrompt: async (defaultScope) => {
+              assert.equal(defaultScope, "user");
+              return "project";
+            },
+          });
+
+          const persisted = JSON.parse(
+            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+          ) as { scope: string; installMode?: string };
+          assert.deepEqual(persisted, { scope: "project" });
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("reviews persisted scope when only install mode is provided", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async () => {
+        await withTempCwd(wd, async () => {
+          await mkdir(join(wd, ".omx"), { recursive: true });
+          await writeFile(
+            join(wd, ".omx", "setup-scope.json"),
+            JSON.stringify({ scope: "project" }),
+          );
+
+          let reviewed = false;
+          await setup({
+            installMode: "plugin",
+            persistedSetupReviewPrompt: async () => {
+              reviewed = true;
+              return "reset";
+            },
+            setupScopePrompt: async (defaultScope) => {
+              assert.equal(defaultScope, "user");
+              return "user";
+            },
+          });
+
+          assert.equal(reviewed, true);
+          const persisted = JSON.parse(
+            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+          ) as { scope: string; installMode?: string };
+          assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("reviews persisted install mode when only user scope is provided", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async () => {
+        await withTempCwd(wd, async () => {
+          await mkdir(join(wd, ".omx"), { recursive: true });
+          await writeFile(
+            join(wd, ".omx", "setup-scope.json"),
+            JSON.stringify({ scope: "user", installMode: "legacy" }),
+          );
+
+          let reviewed = false;
+          await setup({
+            scope: "user",
+            persistedSetupReviewPrompt: async () => {
+              reviewed = true;
+              return "review";
+            },
+            installModePrompt: async (defaultMode) => {
+              assert.equal(defaultMode, "legacy");
+              return "plugin";
+            },
+          });
+
+          assert.equal(reviewed, true);
+          const persisted = JSON.parse(
+            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+          ) as { scope: string; installMode?: string };
+          assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores persisted setup preferences when review chooses reset", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async () => {
+        await withTempCwd(wd, async () => {
+          await mkdir(join(wd, ".omx"), { recursive: true });
+          await writeFile(
+            join(wd, ".omx", "setup-scope.json"),
+            JSON.stringify({ scope: "project", installMode: "plugin" }),
+          );
+
+          await setup({
+            persistedSetupReviewPrompt: async () => "reset",
+            setupScopePrompt: async (defaultScope) => {
+              assert.equal(defaultScope, "user");
+              return "user";
+            },
+            installModePrompt: async (defaultMode) => {
+              assert.equal(defaultMode, "legacy");
+              return "legacy";
+            },
+          });
+
+          const persisted = JSON.parse(
+            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+          ) as { scope: string; installMode?: string };
+          assert.deepEqual(persisted, { scope: "user", installMode: "legacy" });
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("prints plugin-mode next steps without claiming native agent TOML files were written", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
     try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -81,6 +81,10 @@ interface SetupOptions {
   scope?: SetupScope;
   verbose?: boolean;
   agentsOverwritePrompt?: (destinationPath: string) => Promise<boolean>;
+  setupScopePrompt?: (defaultScope: SetupScope) => Promise<SetupScope>;
+  persistedSetupReviewPrompt?: (
+    preferences: Partial<PersistedSetupScope>,
+  ) => Promise<PersistedSetupReviewDecision>;
   installModePrompt?: (
     defaultMode: SetupInstallMode,
   ) => Promise<SetupInstallMode>;
@@ -212,6 +216,8 @@ interface ResolvedSetupInstallMode {
   installMode: SetupInstallMode;
   source: "cli" | "persisted" | "prompt" | "default";
 }
+
+type PersistedSetupReviewDecision = "keep" | "review" | "reset";
 
 const REQUIRED_TEAM_CLI_API_MARKERS = [
   "if (subcommand === 'api')",
@@ -557,15 +563,23 @@ async function promptForSetupScope(
     output: process.stdout,
   });
   try {
+    const userDefaultMarker = defaultScope === "user" ? " (default)" : "";
+    const projectDefaultMarker = defaultScope === "project" ? " (default)" : "";
+    const defaultChoice = defaultScope === "project" ? "2" : "1";
     console.log("Select setup scope:");
     console.log(
-      `  1) user (default) — installs to ${codexHome()} (skills default to ${userSkillsDir()})`,
+      `  1) user${userDefaultMarker} — installs to ${codexHome()} (skills default to ${userSkillsDir()})`,
     );
-    console.log("  2) project — installs to ./.codex (local to project)");
-    const answer = (await rl.question("Scope [1-2] (default: 1): "))
+    console.log(
+      `  2) project${projectDefaultMarker} — installs to ./.codex (local to project)`,
+    );
+    const answer = (
+      await rl.question(`Scope [1-2] (default: ${defaultChoice}): `)
+    )
       .trim()
       .toLowerCase();
     if (answer === "2" || answer === "project") return "project";
+    if (answer === "1" || answer === "user") return "user";
     return defaultScope;
   } finally {
     rl.close();
@@ -599,6 +613,54 @@ async function promptForSetupInstallMode(
     if (answer === "2" || answer === "plugin") return "plugin";
     if (answer === "1" || answer === "legacy") return "legacy";
     return defaultMode;
+  } finally {
+    rl.close();
+  }
+}
+
+function hasPersistedSetupPreferences(
+  preferences: Partial<PersistedSetupScope> | undefined,
+): preferences is Partial<PersistedSetupScope> {
+  return Boolean(preferences?.scope || preferences?.installMode);
+}
+
+function formatPersistedSetupPreferenceSummary(
+  preferences: Partial<PersistedSetupScope>,
+): string {
+  return [
+    `scope=${preferences.scope ?? "not recorded"}`,
+    `installMode=${preferences.installMode ?? "not recorded"}`,
+  ].join(", ");
+}
+
+async function promptForPersistedSetupReview(
+  preferences: Partial<PersistedSetupScope>,
+): Promise<PersistedSetupReviewDecision> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return "keep";
+  }
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    console.log("Existing OMX setup preferences detected:");
+    console.log(`  ${formatPersistedSetupPreferenceSummary(preferences)}`);
+    console.log("  1) keep   — reuse these choices for this setup run");
+    console.log("  2) review — review/change choices, using these values as defaults");
+    console.log("  3) reset  — ignore saved choices and run setup as if fresh");
+    const answer = (
+      await rl.question("Setup preferences [1-3] (default: 1 keep): ")
+    )
+      .trim()
+      .toLowerCase();
+    if (answer === "2" || answer === "review" || answer === "change") {
+      return "review";
+    }
+    if (answer === "3" || answer === "reset" || answer === "fresh") {
+      return "reset";
+    }
+    return "keep";
   } finally {
     rl.close();
   }
@@ -728,16 +790,29 @@ async function promptForPluginDeveloperInstructionsOverwrite(
 async function resolveSetupScope(
   projectRoot: string,
   requestedScope?: SetupScope,
+  persistedReviewDecision: PersistedSetupReviewDecision = "keep",
+  persistedPreferences?: Partial<PersistedSetupScope>,
+  setupScopePrompt?: (defaultScope: SetupScope) => Promise<SetupScope>,
 ): Promise<ResolvedSetupScope> {
   if (requestedScope) {
     return { scope: requestedScope, source: "cli" };
   }
-  const persisted = await readPersistedSetupPreferences(projectRoot);
-  if (persisted?.scope) {
+  const persisted =
+    persistedPreferences ?? (await readPersistedSetupPreferences(projectRoot));
+  if (persisted?.scope && persistedReviewDecision === "keep") {
     return { scope: persisted.scope, source: "persisted" };
   }
-  if (process.stdin.isTTY && process.stdout.isTTY) {
-    const scope = await promptForSetupScope(DEFAULT_SETUP_SCOPE);
+  if (
+    typeof setupScopePrompt === "function" ||
+    (process.stdin.isTTY && process.stdout.isTTY)
+  ) {
+    const defaultScope =
+      persistedReviewDecision === "review" && persisted?.scope
+        ? persisted.scope
+        : DEFAULT_SETUP_SCOPE;
+    const scope = setupScopePrompt
+      ? await setupScopePrompt(defaultScope)
+      : await promptForSetupScope(defaultScope);
     return { scope, source: "prompt" };
   }
   return { scope: DEFAULT_SETUP_SCOPE, source: "default" };
@@ -810,24 +885,37 @@ async function resolveSetupInstallMode(
   installModePrompt?: (
     defaultMode: SetupInstallMode,
   ) => Promise<SetupInstallMode>,
+  persistedReviewDecision: PersistedSetupReviewDecision = "keep",
+  persistedPreferences?: Partial<PersistedSetupScope>,
 ): Promise<ResolvedSetupInstallMode | null> {
   if (requestedInstallMode) {
     return { installMode: requestedInstallMode, source: "cli" };
   }
 
-  const persisted = await readPersistedSetupPreferences(projectRoot);
-  if (persisted?.installMode && persisted.scope === scope) {
+  const persisted =
+    persistedPreferences ?? (await readPersistedSetupPreferences(projectRoot));
+  if (
+    persisted?.installMode &&
+    persistedReviewDecision === "keep" &&
+    persisted.scope === scope
+  ) {
     return { installMode: persisted.installMode, source: "persisted" };
   }
 
   if (scope !== "user") return null;
 
   const discoveredPluginCacheDir = await discoverOmxPluginCacheDir();
-  const defaultMode = discoveredPluginCacheDir
-    ? "plugin"
-    : DEFAULT_SETUP_INSTALL_MODE;
+  const defaultMode =
+    persistedReviewDecision === "review" && persisted?.installMode
+      ? persisted.installMode
+      : discoveredPluginCacheDir
+        ? "plugin"
+        : DEFAULT_SETUP_INSTALL_MODE;
 
-  if (process.stdin.isTTY && process.stdout.isTTY) {
+  if (
+    typeof installModePrompt === "function" ||
+    (process.stdin.isTTY && process.stdout.isTTY)
+  ) {
     if (discoveredPluginCacheDir) {
       console.log(
         `Detected installed oh-my-codex Codex plugin cache at ${discoveredPluginCacheDir}.`,
@@ -1347,6 +1435,8 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     installMode: requestedInstallMode,
     scope: requestedScope,
     verbose = false,
+    setupScopePrompt,
+    persistedSetupReviewPrompt,
     installModePrompt,
     modelUpgradePrompt,
     pluginAgentsMdPrompt,
@@ -1355,12 +1445,44 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   } = options;
   const pkgRoot = getPackageRoot();
   const projectRoot = process.cwd();
-  const resolvedScope = await resolveSetupScope(projectRoot, requestedScope);
+  const persistedPreferences = await readPersistedSetupPreferences(projectRoot);
+  let persistedReviewDecision: PersistedSetupReviewDecision = "keep";
+  const effectiveScopeForInstallMode =
+    requestedScope ?? persistedPreferences?.scope ?? DEFAULT_SETUP_SCOPE;
+  const wouldUsePersistedScope =
+    !requestedScope && Boolean(persistedPreferences?.scope);
+  const wouldUsePersistedInstallMode =
+    !requestedInstallMode &&
+    Boolean(persistedPreferences?.installMode) &&
+    (!persistedPreferences?.scope ||
+      persistedPreferences.scope === effectiveScopeForInstallMode);
+  const shouldReviewPersistedSetup =
+    hasPersistedSetupPreferences(persistedPreferences) &&
+    (wouldUsePersistedScope || wouldUsePersistedInstallMode) &&
+    (typeof persistedSetupReviewPrompt === "function" ||
+      (process.stdin.isTTY && process.stdout.isTTY));
+  if (shouldReviewPersistedSetup) {
+    persistedReviewDecision = persistedSetupReviewPrompt
+      ? await persistedSetupReviewPrompt(persistedPreferences)
+      : await promptForPersistedSetupReview(persistedPreferences);
+    console.log(
+      `Setup preference review: ${persistedReviewDecision} (${formatPersistedSetupPreferenceSummary(persistedPreferences)})\n`,
+    );
+  }
+  const resolvedScope = await resolveSetupScope(
+    projectRoot,
+    requestedScope,
+    persistedReviewDecision,
+    persistedPreferences,
+    setupScopePrompt,
+  );
   const resolvedInstallMode = await resolveSetupInstallMode(
     projectRoot,
     resolvedScope.scope,
     requestedInstallMode,
     installModePrompt,
+    persistedReviewDecision,
+    persistedPreferences,
   );
   const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
   const scopeSourceMessage =


### PR DESCRIPTION
## Summary
- add an interactive persisted setup review step so TTY reruns summarize saved scope/install-mode choices before reuse
- keep non-TTY/CI setup deterministic and non-blocking
- normalize persisted setup preferences so project scope does not retain user-only installMode
- document the setup-owned configuration surfaces in the `$omx-setup` skill and plugin mirror

## Verification
- `npx tsc --noEmit -p tsconfig.json && npx biome lint src/cli/setup.ts src/cli/__tests__/setup-install-mode.test.ts && git diff --check`
- `npm run build && npm run verify:plugin-bundle && node --test dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/setup-skill-validation.test.js`
- manual TTY dry-run review path with persisted project/plugin preferences
- code review re-check: architect CLEAR, code-reviewer APPROVE

## Notes
- Pre-existing untracked `node_modules` was left untouched.
