### PR TITLE
Reduce watcher rollout polling overhead

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import { once } from 'node:events';
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { appendFile, chmod, mkdtemp, mkdir, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
@@ -392,6 +392,20 @@ function buildCleanNotifyEnv(
 }
 
 describe('notify-fallback watcher', () => {
+  it('uses offset-bounded rollout reads instead of re-reading whole tracked files', async () => {
+    const source = await readFile(new URL('../../scripts/notify-fallback-watcher.js', import.meta.url), 'utf-8');
+
+    assert.match(source, /async function readFileDelta/);
+    assert.match(source, /while \(totalBytesRead < length\)/);
+    assert.match(source, /nextOffset: offset \+ totalBytesRead/);
+    assert.match(source, /new StringDecoder\('utf8'\)/);
+    assert.match(source, /decoder\.write\(bytes\)/);
+    assert.match(source, /const fileStat = await stat\(path\)\.catch\(\(\) => null\);\s*if \(!fileStat\)\s*continue;/);
+    assert.match(source, /if \(currentSize < meta\.offset\) \{\s*meta\.offset = 0;\s*meta\.partial = '';/);
+    assert.doesNotMatch(source, /const content = await readFile\(path, 'utf-8'\)[\s\S]*const delta = content\.slice\(meta\.offset\)/);
+    assert.doesNotMatch(source, /stat\(path\)\.catch\(\(\) => \(\{ size: 0 \}\)\)/);
+  });
+
   it('one-shot mode forwards only recent task_complete events', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-once-'));
     const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-home-'));
@@ -596,6 +610,94 @@ describe('notify-fallback watcher', () => {
       const turnLines = await readLines(turnLog);
       assert.equal(turnLines.length, 1);
       assert.match(turnLines[0], new RegExp(partialTurn));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+      await rm(rolloutPath, { force: true });
+    }
+  });
+
+  it('streaming mode preserves multibyte text split across polling reads', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-stream-utf8-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-home-'));
+    const sid = randomUUID();
+    const sessionDir = todaySessionDir(tempHome);
+    const rolloutPath = join(sessionDir, `rollout-test-fallback-stream-utf8-${sid}.jsonl`);
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+
+      const nowIso = new Date().toISOString();
+      const threadId = `thread-${sid}`;
+      const utf8Turn = `turn-utf8-${sid}`;
+      const emojiMessage = 'split emoji 🧪 preserved';
+
+      await writeFile(
+        rolloutPath,
+        `${JSON.stringify({
+          timestamp: nowIso,
+          type: 'session_meta',
+          payload: { id: threadId, cwd: wd },
+        })}\n`
+      );
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+      const turnLog = join(wd, '.omx', 'logs', `turns-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const child = spawn(
+        process.execPath,
+        [watcherScript, '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '75'],
+        { cwd: wd, stdio: 'ignore', env: buildCleanNotifyEnv({ HOME: tempHome }) }
+      );
+
+      await waitFor(async () => {
+        try {
+          const state = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+          return state.tracked_files === 1;
+        } catch {
+          return false;
+        }
+      });
+
+      const eventLine = `${JSON.stringify({
+        timestamp: new Date(Date.now() + 500).toISOString(),
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: utf8Turn,
+          last_agent_message: emojiMessage,
+        },
+      })}\n`;
+      const bytes = Buffer.from(eventLine, 'utf8');
+      const emojiOffset = bytes.indexOf(Buffer.from('🧪', 'utf8'));
+      assert.ok(emojiOffset > 0, 'expected test payload to contain emoji bytes');
+
+      await appendFile(rolloutPath, bytes.subarray(0, emojiOffset + 1));
+      await sleep(250);
+      assert.equal((await readLines(turnLog)).length, 0, 'incomplete UTF-8 and JSON line should not emit');
+
+      const hiddenRolloutPath = `${rolloutPath}.missing`;
+      await rename(rolloutPath, hiddenRolloutPath);
+      await sleep(250);
+      assert.equal((await readLines(turnLog)).length, 0, 'transient missing file should preserve buffered bytes');
+      await rename(hiddenRolloutPath, rolloutPath);
+
+      await appendFile(rolloutPath, bytes.subarray(emojiOffset + 1));
+      await waitFor(async () => {
+        const turnLines = await readLines(turnLog);
+        return turnLines.length === 1 && turnLines[0]!.includes(utf8Turn) && turnLines[0]!.includes(emojiMessage);
+      }, 4000, 75);
+
+      child.kill('SIGTERM');
+      await once(child, 'exit');
+
+      const turnLines = await readLines(turnLog);
+      assert.equal(turnLines.length, 1);
+      assert.match(turnLines[0], new RegExp(utf8Turn));
+      assert.match(turnLines[0], /split emoji 🧪 preserved/);
     } finally {
       await rm(wd, { recursive: true, force: true });
       await rm(tempHome, { recursive: true, force: true });

--- a/src/scripts/__tests__/hook-derived-watcher.test.ts
+++ b/src/scripts/__tests__/hook-derived-watcher.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
 import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -18,7 +19,34 @@ function todaySessionDir(baseHome: string): string {
   );
 }
 
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(predicate: () => Promise<boolean>, timeoutMs: number = 3000, stepMs: number = 50): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await sleep(stepMs);
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}
+
 describe('hook-derived-watcher', () => {
+  it('uses offset-bounded rollout reads instead of re-reading whole tracked files', async () => {
+    const source = await readFile(new URL('../hook-derived-watcher.js', import.meta.url), 'utf-8');
+
+    assert.match(source, /async function readFileDelta/);
+    assert.match(source, /while \(totalBytesRead < length\)/);
+    assert.match(source, /nextOffset: offset \+ totalBytesRead/);
+    assert.match(source, /new StringDecoder\('utf8'\)/);
+    assert.match(source, /decoder\.write\(bytes\)/);
+    assert.match(source, /const fileStat = await stat\(path\)\.catch\(\(\) => null\);\s*if \(!fileStat\)\s*continue;/);
+    assert.match(source, /if \(currentSize < meta\.offset\) \{\s*meta\.offset = 0;\s*meta\.partial = '';/);
+    assert.doesNotMatch(source, /const content = await readFile\(path, 'utf-8'\)[\s\S]*const delta = content\.slice\(meta\.offset\)/);
+    assert.doesNotMatch(source, /stat\(path\)\.catch\(\(\) => \(\{ size: 0 \}\)\)/);
+  });
+
   it('dispatches needs-input for assistant_message content arrays', async () => {
     const base = await mkdtemp(join(tmpdir(), 'omx-hook-derived-array-'));
     const homeDir = join(base, 'home');
@@ -104,6 +132,108 @@ export async function onHookEvent(event) {
       assert.equal(events[0].source, 'derived');
       assert.equal(events[0].parser_reason, 'assistant_message_heuristic_question');
       assert.match(String((events[0].context as Record<string, unknown>)?.preview ?? ''), /Would you like me to continue/i);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves multibyte assistant text split across polling reads', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'omx-hook-derived-utf8-'));
+    const homeDir = join(base, 'home');
+    const cwd = join(base, 'cwd');
+    const hookLogPath = join(cwd, '.omx', 'hook-events.jsonl');
+
+    try {
+      await mkdir(todaySessionDir(homeDir), { recursive: true });
+      await mkdir(join(cwd, '.omx', 'hooks'), { recursive: true });
+
+      await writeFile(
+        join(cwd, '.omx', 'hooks', 'capture-needs-input.mjs'),
+        `import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+export async function onHookEvent(event) {
+  await mkdir(dirname(${JSON.stringify(hookLogPath)}), { recursive: true });
+  await appendFile(${JSON.stringify(hookLogPath)}, JSON.stringify(event) + '\\n');
+}
+`,
+      );
+
+      const rolloutPath = join(todaySessionDir(homeDir), 'rollout-hook-derived-utf8.jsonl');
+      await writeFile(
+        rolloutPath,
+        `${JSON.stringify({
+          type: 'session_meta',
+          payload: {
+            id: 'thread-hook-utf8',
+            cwd,
+          },
+        })}\n`,
+      );
+
+      const watcherScript = new URL('../hook-derived-watcher.js', import.meta.url).pathname;
+      const child = spawn(
+        process.execPath,
+        [watcherScript, '--cwd', cwd, '--poll-ms', '75'],
+        {
+          cwd,
+          stdio: 'ignore',
+          env: {
+            ...process.env,
+            HOME: homeDir,
+            OMX_HOOK_DERIVED_SIGNALS: '1',
+            OMX_HOOK_PLUGINS: '1',
+          },
+        },
+      );
+
+      const watcherStatePath = join(cwd, '.omx', 'state', 'hook-derived-watcher-state.json');
+      await waitFor(async () => {
+        try {
+          const state = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+          return state.tracked_files === 1;
+        } catch {
+          return false;
+        }
+      });
+
+      const questionText = 'Can you preserve split emoji 🧪 please?';
+      const eventLine = `${JSON.stringify({
+        timestamp: new Date().toISOString(),
+        type: 'event_msg',
+        payload: {
+          type: 'assistant_message',
+          turn_id: 'turn-hook-utf8',
+          content: [{ type: 'output_text', text: questionText }],
+        },
+      })}\n`;
+      const bytes = Buffer.from(eventLine, 'utf8');
+      const emojiOffset = bytes.indexOf(Buffer.from('🧪', 'utf8'));
+      assert.ok(emojiOffset > 0, 'expected test payload to contain emoji bytes');
+
+      await appendFile(rolloutPath, bytes.subarray(0, emojiOffset + 1));
+      await sleep(250);
+      assert.equal(existsSync(hookLogPath), false, 'incomplete UTF-8 and JSON line should not dispatch');
+
+      const hiddenRolloutPath = `${rolloutPath}.missing`;
+      await rename(rolloutPath, hiddenRolloutPath);
+      await sleep(250);
+      assert.equal(existsSync(hookLogPath), false, 'transient missing file should preserve buffered bytes');
+      await rename(hiddenRolloutPath, rolloutPath);
+
+      await appendFile(rolloutPath, bytes.subarray(emojiOffset + 1));
+      await waitFor(async () => {
+        if (!existsSync(hookLogPath)) return false;
+        const raw = await readFile(hookLogPath, 'utf-8');
+        return raw.includes('turn-hook-utf8') && raw.includes(questionText);
+      }, 4000, 75);
+
+      child.kill('SIGTERM');
+      await once(child, 'exit');
+
+      const raw = await readFile(hookLogPath, 'utf-8');
+      assert.match(raw, /turn-hook-utf8/);
+      assert.match(raw, /Can you preserve split emoji 🧪 please\?/);
     } finally {
       await rm(base, { recursive: true, force: true });
     }

--- a/src/scripts/hook-derived-watcher.ts
+++ b/src/scripts/hook-derived-watcher.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 import { existsSync } from 'fs';
-import { appendFile, mkdir, readFile, readdir, stat, writeFile } from 'fs/promises';
+import { appendFile, mkdir, open, readFile, readdir, stat, writeFile } from 'fs/promises';
 import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
+import { StringDecoder } from 'string_decoder';
 import {
   buildOperationalContext,
   classifyExecCommand,
@@ -40,6 +41,7 @@ interface FileMeta {
   partial: string;
   dispatched: number;
   currentTurnId: string;
+  decoder: StringDecoder;
 }
 
 interface PendingCall {
@@ -415,7 +417,9 @@ async function ensureTrackedFiles(): Promise<void> {
     const firstLine = await readFirstLine(path).catch(() => '');
     const meta = shouldTrackSessionMeta(firstLine);
     if (!meta) continue;
-    const size = (await stat(path).catch(() => ({ size: 0 }))).size || 0;
+    const fileStat = await stat(path).catch(() => null);
+    if (!fileStat) continue;
+    const size = fileStat.size || 0;
     const offset = runOnce ? 0 : size;
     fileState.set(path, {
       ...meta,
@@ -423,6 +427,7 @@ async function ensureTrackedFiles(): Promise<void> {
       partial: '',
       dispatched: 0,
       currentTurnId: '',
+      decoder: new StringDecoder('utf8'),
     });
   }
 }
@@ -504,16 +509,54 @@ async function processLine(meta: FileMeta, line: string): Promise<void> {
   meta.dispatched += 1;
 }
 
+async function readFileDelta(
+  path: string,
+  offset: number,
+  currentSize: number,
+): Promise<{ bytes: Buffer; nextOffset: number }> {
+  const length = currentSize - offset;
+  if (length <= 0) return { bytes: Buffer.alloc(0), nextOffset: offset };
+  const handle = await open(path, 'r');
+  try {
+    const buffer = Buffer.allocUnsafe(length);
+    let totalBytesRead = 0;
+    while (totalBytesRead < length) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        totalBytesRead,
+        length - totalBytesRead,
+        offset + totalBytesRead,
+      );
+      if (bytesRead === 0) break;
+      totalBytesRead += bytesRead;
+    }
+    return {
+      bytes: buffer.subarray(0, totalBytesRead),
+      nextOffset: offset + totalBytesRead,
+    };
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
 async function pollFiles(): Promise<void> {
   for (const [path, meta] of fileState.entries()) {
-    const currentSize = (await stat(path).catch(() => ({ size: 0 }))).size || 0;
+    const fileStat = await stat(path).catch(() => null);
+    if (!fileStat) continue;
+    const currentSize = fileStat.size || 0;
+    if (currentSize < meta.offset) {
+      meta.offset = 0;
+      meta.partial = '';
+      meta.decoder = new StringDecoder('utf8');
+    }
     if (currentSize <= meta.offset) continue;
 
-    const content = await readFile(path, 'utf-8').catch(() => '');
-    if (!content) continue;
-
-    const delta = content.slice(meta.offset);
-    meta.offset = currentSize;
+    const read = await readFileDelta(path, meta.offset, currentSize).catch(() => null);
+    if (!read || read.bytes.length === 0) continue;
+    const { bytes, nextOffset } = read;
+    meta.offset = nextOffset;
+    const delta = meta.decoder.write(bytes);
+    if (!delta) continue;
     const merged = meta.partial + delta;
     const lines = merged.split('\n');
     meta.partial = lines.pop() || '';

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -5,6 +5,7 @@ import { appendFile, mkdir, open, readFile, readdir, rename, rm, stat, unlink, w
 import { spawnSync } from 'child_process';
 import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
+import { StringDecoder } from 'string_decoder';
 import { spawnPlatformCommandSync } from '../utils/platform-command.js';
 import { drainPendingTeamDispatch } from './notify-hook/team-dispatch.js';
 import {
@@ -156,6 +157,7 @@ interface WatcherFileMeta {
   offset: number;
   size: number;
   partial: string;
+  decoder: StringDecoder;
 }
 
 interface RalphContinueSteerState {
@@ -1683,9 +1685,11 @@ async function ensureTrackedFiles(): Promise<void> {
     const line = await readFirstLine(path).catch(() => '');
     const threadId = shouldTrackSessionMeta(line);
     if (!threadId) continue;
-    const size = (await stat(path).catch(() => ({ size: 0 }))).size || 0;
+    const fileStat = await stat(path).catch(() => null);
+    if (!fileStat) continue;
+    const size = fileStat.size || 0;
     const offset = runOnce ? 0 : size;
-    fileState.set(path, { threadId, offset, size, partial: '' });
+    fileState.set(path, { threadId, offset, size, partial: '', decoder: new StringDecoder('utf8') });
   }
 }
 
@@ -1698,15 +1702,54 @@ function splitBufferedLines(partial: string, delta: string): { lines: string[]; 
   };
 }
 
+async function readFileDelta(
+  path: string,
+  offset: number,
+  currentSize: number,
+): Promise<{ bytes: Buffer; nextOffset: number }> {
+  const length = currentSize - offset;
+  if (length <= 0) return { bytes: Buffer.alloc(0), nextOffset: offset };
+  const handle = await open(path, 'r');
+  try {
+    const buffer = Buffer.allocUnsafe(length);
+    let totalBytesRead = 0;
+    while (totalBytesRead < length) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        totalBytesRead,
+        length - totalBytesRead,
+        offset + totalBytesRead,
+      );
+      if (bytesRead === 0) break;
+      totalBytesRead += bytesRead;
+    }
+    return {
+      bytes: buffer.subarray(0, totalBytesRead),
+      nextOffset: offset + totalBytesRead,
+    };
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
 async function pollFiles(): Promise<number> {
   let processedCount = 0;
   for (const [path, meta] of fileState.entries()) {
-    const currentSize = (await stat(path).catch(() => ({ size: 0 }))).size || 0;
+    const fileStat = await stat(path).catch(() => null);
+    if (!fileStat) continue;
+    const currentSize = fileStat.size || 0;
+    if (currentSize < meta.offset) {
+      meta.offset = 0;
+      meta.partial = '';
+      meta.decoder = new StringDecoder('utf8');
+    }
     if (currentSize <= meta.offset) continue;
-    const content = await readFile(path, 'utf-8').catch(() => '');
-    if (!content) continue;
-    const delta = content.slice(meta.offset);
-    meta.offset = currentSize;
+    const read = await readFileDelta(path, meta.offset, currentSize).catch(() => null);
+    if (!read || read.bytes.length === 0) continue;
+    const { bytes, nextOffset } = read;
+    meta.offset = nextOffset;
+    const delta = meta.decoder.write(bytes);
+    if (!delta) continue;
     const buffered = splitBufferedLines(meta.partial, delta);
     const lines = buffered.lines;
     meta.partial = buffered.partial;


### PR DESCRIPTION
## Summary
- replace full-file rollout rereads in notify fallback and hook-derived watchers with byte-bounded delta reads
- preserve split UTF-8 sequences with per-file StringDecoder state
- keep partial buffered state across transient stat/read visibility gaps and reset only on confirmed truncation
- add regression coverage for offset-bounded reads, split multibyte payloads, and transient missing rollout files

## Validation
- npm run build
- node --test dist/hooks/__tests__/notify-fallback-watcher.test.js dist/scripts/__tests__/hook-derived-watcher.test.js dist/mcp/__tests__/server-lifecycle.test.js dist/mcp/__tests__/code-intel-server.test.js dist/team/__tests__/mcp-comm.test.js
- npm run check:no-unused
- git diff --check
- npx biome lint src/scripts/notify-fallback-watcher.ts src/scripts/hook-derived-watcher.ts src/hooks/__tests__/notify-fallback-watcher.test.ts src/scripts/__tests__/hook-derived-watcher.test.ts
- code review: APPROVE; architect review: CLEAR