### PR TITLE
Prevent partial fallback watcher state reads

### DIFF
--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -94,6 +94,19 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+let atomicJsonWriteCounter = 0;
+
+async function writeJsonObjectAtomically(path: string, value: unknown): Promise<void> {
+  const tempPath = `${path}.${process.pid}.${Date.now()}.${++atomicJsonWriteCounter}.tmp`;
+  try {
+    await writeFile(tempPath, JSON.stringify(value, null, 2));
+    await rename(tempPath, path);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
 async function waitForPidExit(pid: number, timeoutMs = 3000, stepMs = 50): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -1336,7 +1349,7 @@ async function writeState(extra: Record<string, unknown> = {}): Promise<void> {
     },
     ...extra,
   };
-  await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
+  await writeJsonObjectAtomically(statePath, state).catch(() => {});
 }
 
 async function writeAuthorityBackoffState(): Promise<void> {
@@ -1345,7 +1358,7 @@ async function writeAuthorityBackoffState(): Promise<void> {
   const state = existing && typeof existing === 'object'
     ? { ...existing, authority_backoff: lastAuthorityBackoff }
     : { authority_backoff: lastAuthorityBackoff };
-  await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
+  await writeJsonObjectAtomically(statePath, state).catch(() => {});
 }
 
 async function readJsonObject(path: string): Promise<Record<string, unknown> | null> {


### PR DESCRIPTION
## Summary
- write `notify-fallback-state.json` via same-directory temp file + rename
- keep watcher state payloads and authority backoff merge behavior unchanged
- preserve PR #1905 byte-bounded rollout reads while preventing readers from seeing partial JSON

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/notify-fallback-watcher.test.js`
- `for i in $(seq 1 5); do node --test --test-name-pattern "backs off idle polling and resets to the base cadence after fresh rollout activity" dist/hooks/__tests__/notify-fallback-watcher.test.js; done`
- `npm run lint`
- `npm run check:no-unused`
- `npm run test:explicit-terminal-contract:compiled`

## Notes
- Architect review approved the narrow atomic-write fix.
- Full `coverage:ts:full` was not run locally; the targeted compiled watcher test and related explicit-terminal contract suite passed.
