### PR TITLE
Preserve prompt assets while converging generated native agents

### DIFF
--- a/docs/plugin-bundle-ssot.md
+++ b/docs/plugin-bundle-ssot.md
@@ -31,13 +31,13 @@ Root skill directories that should not appear in the plugin must be represented 
 
 ## Native agent SSOT
 
-Native agents are setup-owned assets, not plugin-scoped bundle assets. Their source-of-truth chain is:
+Native agents are setup-owned assets, not plugin-scoped bundle assets. Generated native-agent TOMLs and prompt files intentionally use different setup policies:
 
-1. `templates/catalog-manifest.json` and `src/catalog/manifest.json` select installable native agents with `active` or `internal` status.
+1. `templates/catalog-manifest.json` and `src/catalog/manifest.json` select installable native agent TOMLs with `active` or `internal` status.
 2. `src/agents/definitions.ts` defines each native agent's metadata, model lane, posture, routing role, and tooling posture.
-3. `prompts/<name>.md` supplies the prompt body for each installable native agent.
-4. `src/agents/native-config.ts` generates native Codex TOML from the definition plus prompt.
-5. `omx setup` writes generated TOML to `.codex/agents/<name>.toml` for the selected scope.
+3. `prompts/<name>.md` supplies prompt guidance. Cataloged prompt files remain setup-owned prompt assets even when their agent status is `merged`, `alias`, or `deprecated`; explicit non-native prompt assets such as harness/orchestrator prompts are also setup-owned.
+4. `src/agents/native-config.ts` generates native Codex TOML from the definition plus prompt for active/internal native agents only.
+5. `omx setup` writes generated TOML to `.codex/agents/<name>.toml` for the selected scope and installs setup-owned prompts to `.codex/prompts/<name>.md`.
 
 Run the non-mutating native-agent verifier before review or release:
 
@@ -46,5 +46,7 @@ npm run verify:native-agents
 ```
 
 The verifier fails when installable catalog agents are missing definitions or prompts, when definitions are missing catalog rows, when merged/alias canonical targets do not resolve directly to installable agents, when prompt files are neither cataloged native agents nor explicit setup prompt assets, or when generated TOML loses required metadata.
+
+`omx setup` converges generated native-agent TOMLs safely: normal setup removes stale non-installable TOMLs only when they carry the exact `# oh-my-codex agent: <name>` generated marker for the same cataloged agent name. User-authored or ambiguous TOMLs are preserved during normal setup; `--force` remains the explicit destructive cleanup path for stale non-installable native-agent files. Prompt cleanup uses the prompt asset policy, so cataloged prompt files and explicit setup prompt assets are preserved even when they are not installable native-agent TOMLs.
 
 The official plugin manifest must continue to omit `agents`, `prompts`, and `hooks`; those remain installed by `omx setup`, not by the plugin bundle.

--- a/src/agents/policy.ts
+++ b/src/agents/policy.ts
@@ -48,6 +48,16 @@ export function getNonInstallableNativeAgentNames(
   );
 }
 
+export function isSetupPromptAssetName(
+  promptName: string,
+  manifest: Pick<CatalogManifest, "agents">,
+): boolean {
+  return (
+    manifest.agents.some((agent) => agent.name === promptName) ||
+    NON_NATIVE_AGENT_PROMPT_ASSETS.has(promptName)
+  );
+}
+
 export function assertNativeAgentCanonicalTargets(
   manifest: Pick<CatalogManifest, "agents">,
 ): void {

--- a/src/cli/__tests__/setup-prompts-overwrite.test.ts
+++ b/src/cli/__tests__/setup-prompts-overwrite.test.ts
@@ -6,12 +6,15 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { setup } from '../setup.js';
 import { readCatalogManifest } from '../../catalog/reader.js';
-import { getInstallableNativeAgentNames } from '../../agents/policy.js';
+import {
+  NON_NATIVE_AGENT_PROMPT_ASSETS,
+  getInstallableNativeAgentNames,
+} from '../../agents/policy.js';
 
 describe('omx setup prompt/native-agent overwrite behavior', () => {
   const obsoleteNativeAgentField = ['skill', 'ref'].join('_');
 
-  it('installs only active/internal catalog prompts and native agents', async () => {
+  it('installs setup-owned prompts separately from active/internal native agents', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
     const previousCwd = process.cwd();
     try {
@@ -28,16 +31,34 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       assert.equal(installedPrompts.has('executor.md'), true);
       assert.equal(installedPrompts.has('team-executor.md'), true);
       assert.equal(installedPrompts.has('code-reviewer.md'), true);
-      assert.equal(installedPrompts.has('style-reviewer.md'), false);
-      assert.equal(installedPrompts.has('quality-reviewer.md'), false);
-      assert.equal(installedPrompts.has('api-reviewer.md'), false);
-      assert.equal(installedPrompts.has('performance-reviewer.md'), false);
-      assert.equal(installedPrompts.has('product-manager.md'), false);
-      assert.equal(installedPrompts.has('ux-researcher.md'), false);
-      assert.equal(installedPrompts.has('information-architect.md'), false);
-      assert.equal(installedPrompts.has('product-analyst.md'), false);
-      assert.equal(installedPrompts.has('sisyphus-lite.md'), false);
       assert.equal(installedPrompts.has('code-simplifier.md'), true);
+
+      for (const promptOnlyAgent of [
+        'style-reviewer',
+        'quality-reviewer',
+        'api-reviewer',
+        'performance-reviewer',
+        'product-manager',
+        'ux-researcher',
+        'information-architect',
+        'product-analyst',
+        'qa-tester',
+        'quality-strategist',
+      ]) {
+        assert.equal(
+          installedPrompts.has(`${promptOnlyAgent}.md`),
+          true,
+          `expected setup to preserve prompt-only role ${promptOnlyAgent}.md`,
+        );
+      }
+
+      for (const promptAsset of NON_NATIVE_AGENT_PROMPT_ASSETS) {
+        assert.equal(
+          installedPrompts.has(`${promptAsset}.md`),
+          true,
+          `expected setup to preserve explicit prompt asset ${promptAsset}.md`,
+        );
+      }
 
       const installableNativeAgents = getInstallableNativeAgentNames(readCatalogManifest());
       for (const agentName of installableNativeAgents) {
@@ -67,7 +88,7 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
     }
   });
 
-  it('removes stale merged/unlisted prompts on --force', async () => {
+  it('preserves setup-owned prompt assets and removes unknown prompts on --force', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
     const previousCwd = process.cwd();
     try {
@@ -76,24 +97,28 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
 
       await setup({ scope: 'project' });
 
-      const stalePrompts = ['style-reviewer.md', 'quality-reviewer.md', 'sisyphus-lite.md'];
-      for (const stalePrompt of stalePrompts) {
-        const stalePath = join(wd, '.codex', 'prompts', stalePrompt);
-        await writeFile(stalePath, `# stale ${stalePrompt}\n`);
-        assert.equal(existsSync(stalePath), true);
+      const validPrompts = ['style-reviewer.md', 'quality-reviewer.md', 'sisyphus-lite.md'];
+      for (const validPrompt of validPrompts) {
+        assert.equal(existsSync(join(wd, '.codex', 'prompts', validPrompt)), true);
       }
+
+      const unknownPromptPath = join(wd, '.codex', 'prompts', 'unclassified-local.md');
+      await writeFile(unknownPromptPath, '# unclassified local prompt\n');
+      assert.equal(existsSync(unknownPromptPath), true);
 
       await setup({ scope: 'project', force: true });
 
-      for (const stalePrompt of stalePrompts) {
-        assert.equal(existsSync(join(wd, '.codex', 'prompts', stalePrompt)), false);
+      for (const validPrompt of validPrompts) {
+        assert.equal(existsSync(join(wd, '.codex', 'prompts', validPrompt)), true);
       }
+      assert.equal(existsSync(unknownPromptPath), false);
       assert.equal(existsSync(join(wd, '.codex', 'prompts', 'executor.md')), true);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
     }
   });
+
   it('removes stale merged native agents on --force', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
     const previousCwd = process.cwd();
@@ -115,6 +140,69 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       for (const staleAgent of staleAgents) {
         assert.equal(existsSync(join(wd, '.codex', 'agents', staleAgent)), false);
       }
+      assert.equal(existsSync(join(wd, '.codex', 'agents', 'executor.toml')), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes generated non-installable native agents during normal setup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const stalePath = join(wd, '.codex', 'agents', 'style-reviewer.toml');
+      await writeFile(
+        stalePath,
+        [
+          '# oh-my-codex agent: style-reviewer',
+          'name = "style-reviewer"',
+          'description = "old generated merged role"',
+          'developer_instructions = """old"""',
+          '',
+        ].join('\n'),
+      );
+      assert.equal(existsSync(stalePath), true);
+
+      await setup({ scope: 'project' });
+
+      assert.equal(existsSync(stalePath), false);
+      assert.equal(existsSync(join(wd, '.codex', 'agents', 'executor.toml')), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves user-authored non-installable native agents during normal setup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const userAuthoredPath = join(wd, '.codex', 'agents', 'style-reviewer.toml');
+      await writeFile(
+        userAuthoredPath,
+        [
+          '# user-authored local agent',
+          'name = "style-reviewer"',
+          'description = "custom local role"',
+          '',
+        ].join('\n'),
+      );
+      assert.equal(existsSync(userAuthoredPath), true);
+
+      await setup({ scope: 'project' });
+
+      assert.equal(existsSync(userAuthoredPath), true);
       assert.equal(existsSync(join(wd, '.codex', 'agents', 'executor.toml')), true);
     } finally {
       process.chdir(previousCwd);
@@ -152,5 +240,4 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
-
 });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -56,6 +56,7 @@ import {
   getCatalogAgentStatusByName,
   getInstallableNativeAgentNames,
   isNativeAgentInstallableStatus,
+  isSetupPromptAssetName,
 } from "../agents/policy.js";
 import { getPackageRoot } from "../utils/package.js";
 import { readSessionState, isSessionStale } from "../hooks/session.js";
@@ -1016,15 +1017,11 @@ async function cleanupPluginModeLegacyPrompts(
   if (!existsSync(srcDir) || !existsSync(dstDir)) return summary;
 
   const manifest = tryReadCatalogManifest();
-  const agentStatusByName = manifest
-    ? getCatalogAgentStatusByName(manifest)
-    : null;
 
   for (const file of await readdir(srcDir)) {
     if (!file.endsWith(".md")) continue;
     const promptName = file.slice(0, -3);
-    const status = agentStatusByName?.get(promptName);
-    if (agentStatusByName && !isNativeAgentInstallableStatus(status)) continue;
+    if (manifest && !isSetupPromptAssetName(promptName, manifest)) continue;
 
     const src = join(srcDir, file);
     const dst = join(dstDir, file);
@@ -1111,6 +1108,17 @@ async function cleanupPluginModeLegacyNativeAgents(
         `  ${options.dryRun ? "would remove" : "removed"} legacy native agent ${name}.toml`,
       );
     }
+  }
+
+  if (manifest) {
+    const generatedCleanup = await cleanupGeneratedNonInstallableNativeAgents(
+      agentsDir,
+      manifest,
+      backupContext,
+      options,
+    );
+    summary.backedUp += generatedCleanup.backedUp;
+    summary.removed += generatedCleanup.removed;
   }
 
   await removeEmptyDirectoryIfPresent(agentsDir, options);
@@ -2245,20 +2253,16 @@ async function installPrompts(
     : null;
 
   const files = await readdir(srcDir);
-  const staleCandidatePromptNames = new Set(
-    manifest?.agents.map((agent) => agent.name) ?? [],
-  );
 
   for (const file of files) {
     if (!file.endsWith(".md")) continue;
     const promptName = file.slice(0, -3);
-    staleCandidatePromptNames.add(promptName);
 
     const status = agentStatusByName?.get(promptName);
-    if (agentStatusByName && !isNativeAgentInstallableStatus(status)) {
+    if (manifest && !isSetupPromptAssetName(promptName, manifest)) {
       summary.skipped += 1;
       if (options.verbose) {
-        const label = status ?? "unlisted";
+        const label = status ?? "unclassified";
         console.log(`  skipped ${file} (status: ${label})`);
       }
       continue;
@@ -2284,13 +2288,14 @@ async function installPrompts(
       if (!file.endsWith(".md")) continue;
       const promptName = file.slice(0, -3);
       const status = agentStatusByName?.get(promptName);
-      if (isNativeAgentInstallableStatus(status)) continue;
-      if (!staleCandidatePromptNames.has(promptName) && status === undefined)
-        continue;
+      if (isSetupPromptAssetName(promptName, manifest)) continue;
 
       const stalePromptPath = join(dstDir, file);
       if (!existsSync(stalePromptPath)) continue;
 
+      if (await ensureBackup(stalePromptPath, true, backupContext, options)) {
+        summary.backedUp += 1;
+      }
       if (!options.dryRun) {
         await rm(stalePromptPath, { force: true });
       }
@@ -2302,6 +2307,72 @@ async function installPrompts(
         const label = status ?? "unlisted";
         console.log(`  ${prefix} ${file} (status: ${label})`);
       }
+    }
+  }
+
+  return summary;
+}
+
+function isGeneratedOmxNativeAgentToml(
+  content: string,
+  agentName: string,
+): boolean {
+  const firstLine = content.split(/\r?\n/, 1)[0]?.trim();
+  return firstLine === `# oh-my-codex agent: ${agentName}`;
+}
+
+async function cleanupGeneratedNonInstallableNativeAgents(
+  agentsDir: string,
+  manifest: NonNullable<ReturnType<typeof tryReadCatalogManifest>>,
+  backupContext: SetupBackupContext,
+  options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<SetupCategorySummary> {
+  const summary = createEmptyCategorySummary();
+  if (!existsSync(agentsDir)) return summary;
+
+  const agentStatusByName = getCatalogAgentStatusByName(manifest);
+  const installedFiles = await readdir(agentsDir);
+
+  for (const file of installedFiles) {
+    if (!file.endsWith(".toml")) continue;
+    const agentName = file.slice(0, -5);
+    const agentStatus = agentStatusByName.get(agentName);
+    if (
+      agentStatus === undefined ||
+      isNativeAgentInstallableStatus(agentStatus)
+    ) {
+      continue;
+    }
+
+    const staleAgentPath = join(agentsDir, file);
+    let content = "";
+    try {
+      content = await readFile(staleAgentPath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    if (!isGeneratedOmxNativeAgentToml(content, agentName)) {
+      if (options.verbose) {
+        console.log(
+          `  skipped stale native agent ${file}: not an OMX-generated native agent`,
+        );
+      }
+      continue;
+    }
+
+    if (await ensureBackup(staleAgentPath, true, backupContext, options)) {
+      summary.backedUp += 1;
+    }
+    if (!options.dryRun) {
+      await rm(staleAgentPath, { force: true });
+    }
+    summary.removed += 1;
+    if (options.verbose) {
+      const prefix = options.dryRun
+        ? "would remove stale generated native agent"
+        : "removed stale generated native agent";
+      console.log(`  ${prefix} ${file} (status: ${agentStatus})`);
     }
   }
 
@@ -2369,6 +2440,17 @@ async function refreshNativeAgentConfigs(
     options,
   );
 
+  if (manifest) {
+    const generatedCleanup = await cleanupGeneratedNonInstallableNativeAgents(
+      agentsDir,
+      manifest,
+      backupContext,
+      options,
+    );
+    summary.backedUp += generatedCleanup.backedUp;
+    summary.removed += generatedCleanup.removed;
+  }
+
   if (options.force && manifest && existsSync(agentsDir)) {
     const installedFiles = await readdir(agentsDir);
     for (const file of installedFiles) {
@@ -2385,6 +2467,9 @@ async function refreshNativeAgentConfigs(
       const staleAgentPath = join(agentsDir, file);
       if (!existsSync(staleAgentPath)) continue;
 
+      if (await ensureBackup(staleAgentPath, true, backupContext, options)) {
+        summary.backedUp += 1;
+      }
       if (!options.dryRun) {
         await rm(staleAgentPath, { force: true });
       }


### PR DESCRIPTION
## Summary
- split setup prompt installation from native-agent TOML installability so cataloged prompt files and explicit non-native prompt assets stay installed
- add marker-aware normal cleanup for generated stale non-installable native-agent TOMLs while preserving user-authored/ambiguous TOMLs
- update setup regression coverage and SSOT docs for prompt-vs-agent cleanup semantics

## Verification
- `npm run build`
- `npm run verify:native-agents`
- `node --test dist/cli/__tests__/setup-prompts-overwrite.test.js dist/scripts/__tests__/verify-native-agents.test.js dist/agents/__tests__/native-config.test.js`
- `npm run verify:plugin-bundle`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- LSP diagnostics: 0 errors on modified TS files

## Context
Follow-up to the review of #1889. That PR was already merged before this fix could be attached, so this PR carries the review-fix commit on top of current `dev`.
