### PR TITLE
Fix plugin-mode setup next steps

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -18,6 +18,26 @@ async function withTempCwd(wd: string, fn: () => Promise<void>): Promise<void> {
   }
 }
 
+async function runSetupWithCapturedLogs(
+  wd: string,
+  options: Parameters<typeof setup>[0],
+): Promise<string> {
+  const previousCwd = process.cwd();
+  const originalLog = console.log;
+  const logs: string[] = [];
+  process.chdir(wd);
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((arg) => String(arg)).join(" "));
+  };
+  try {
+    await setup(options);
+    return logs.join("\n");
+  } finally {
+    console.log = originalLog;
+    process.chdir(previousCwd);
+  }
+}
+
 async function withIsolatedUserHome<T>(
   wd: string,
   fn: (codexHomeDir: string) => Promise<T>,
@@ -78,6 +98,47 @@ async function seedPluginCacheFromInstalledSkills(
 }
 
 describe("omx setup install mode behavior", () => {
+  it("prints plugin-mode next steps without claiming native agent TOML files were written", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async () => {
+        const output = await runSetupWithCapturedLogs(wd, {
+          scope: "user",
+          installMode: "plugin",
+        });
+
+        assert.match(output, /Next steps:/);
+        assert.match(
+          output,
+          /Plugin mode uses Codex plugin discovery for skills\/prompts\/agents/,
+        );
+        assert.doesNotMatch(output, /TOML files written to \.codex\/agents\//);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps legacy-mode next steps describing native agent TOML output", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async () => {
+        const output = await runSetupWithCapturedLogs(wd, {
+          scope: "user",
+          installMode: "legacy",
+        });
+
+        assert.match(output, /Next steps:/);
+        assert.match(
+          output,
+          /Native agent defaults configured in config\.toml \[agents\] and TOML files written to \.codex\/agents\//,
+        );
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("persists user install mode choices alongside setup scope", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
     try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -2020,9 +2020,15 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     "  3. Browse skills with /skills; AGENTS keyword routing can also activate them implicitly",
   );
   console.log("  4. The AGENTS.md orchestration brain is loaded automatically");
-  console.log(
-    "  5. Native agent defaults configured in config.toml [agents] and TOML files written to .codex/agents/",
-  );
+  if (isPluginInstallMode) {
+    console.log(
+      "  5. Plugin mode uses Codex plugin discovery for skills/prompts/agents; setup refreshed native hooks and did not write native agent TOML files.",
+    );
+  } else {
+    console.log(
+      "  5. Native agent defaults configured in config.toml [agents] and TOML files written to .codex/agents/",
+    );
+  }
   console.log(
     '  6. "omx explore" and "omx sparkshell" can hydrate native release binaries on first use; source installs still allow repo-local fallbacks and OMX_EXPLORE_BIN / OMX_SPARKSHELL_BIN overrides',
   );


### PR DESCRIPTION
Fixes #1909

## Summary
- branch setup completion next steps for plugin install mode
- avoid claiming native-agent TOML files were written when plugin mode skips/removes them
- add regression coverage for plugin and legacy setup output

## Verification
- npm run build
- node --test dist/cli/__tests__/setup-install-mode.test.js
- npm run lint
- npm run verify:native-agents
- npm run verify:plugin-bundle
- git diff --check
- npx tsc --noEmit --pretty false --project tsconfig.json

## Notes
- Setup skill docs already describe plugin mode as removing matching legacy prompts/skills/native agents while keeping hooks, so no doc change was needed.