### PR TITLE
Count plugin cleanup backups in setup summary

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { setup } from "../setup.js";
@@ -443,10 +443,43 @@ describe("omx setup install mode behavior", () => {
           assert.equal(existsSync(helpSkillDir), true);
           assert.equal(existsSync(wikiSkillDir), true);
 
-          await setup({ scope: "user", installMode: "plugin" });
+          const outputLines: string[] = [];
+          const previousLog = console.log;
+          console.log = (...args: unknown[]) => {
+            outputLines.push(args.join(" "));
+          };
+          try {
+            await setup({ scope: "user", installMode: "plugin" });
+          } finally {
+            console.log = previousLog;
+          }
 
+          const setupOutput = outputLines.join("\n");
           assert.equal(existsSync(helpSkillDir), false);
           assert.equal(existsSync(wikiSkillDir), false);
+          assert.match(
+            setupOutput,
+            /skills: updated=0, unchanged=0, backed_up=\d+, skipped=0, removed=\d+/,
+          );
+
+          const backupSetupRoot = join(wd, "home", ".omx", "backups", "setup");
+          const backupTimestamps = await readdir(backupSetupRoot);
+          assert.equal(backupTimestamps.length, 1);
+          const backupSkillsDir = join(
+            backupSetupRoot,
+            backupTimestamps[0],
+            ".codex",
+            "skills",
+          );
+          const backedUpSkillNames = await readdir(backupSkillsDir);
+          assert.ok(backedUpSkillNames.includes("help"));
+          assert.ok(backedUpSkillNames.includes("wiki"));
+          assert.match(
+            setupOutput,
+            new RegExp(
+              `skills: updated=0, unchanged=0, backed_up=${backedUpSkillNames.length}, skipped=0, removed=${backedUpSkillNames.length}`,
+            ),
+          );
         });
       });
     } finally {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1558,6 +1558,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
       );
       summary.skills.removed += cleanup.removedSkillNames.length;
       summary.skills.skipped += cleanup.skippedSkillNames.length;
+      summary.skills.backedUp += cleanup.backedUpSkillNames.length;
       for (const warning of cleanup.warnings) {
         console.log(`  warning: ${warning}`);
       }
@@ -2599,6 +2600,7 @@ async function removeDirectoryCopyAware(
 interface LegacySkillCleanupResult {
   removedSkillNames: string[];
   skippedSkillNames: string[];
+  backedUpSkillNames: string[];
   warnings: string[];
 }
 
@@ -2611,6 +2613,7 @@ async function cleanupLegacyManagedSkills(
   const result: LegacySkillCleanupResult = {
     removedSkillNames: [],
     skippedSkillNames: [],
+    backedUpSkillNames: [],
     warnings: [],
   };
   if (!existsSync(dstDir) || !existsSync(srcDir)) {
@@ -2650,6 +2653,7 @@ async function cleanupLegacyManagedSkills(
     );
     if (removed) {
       result.removedSkillNames.push(skillName);
+      result.backedUpSkillNames.push(skillName);
     }
   }
 


### PR DESCRIPTION
## Summary
- Track backed-up legacy skill names from plugin-mode cleanup
- Include those backups in setup summary `skills.backed_up`
- Add regression coverage that checks backup names and summary counts

Fixes #1910

## Verification
- npm run build
- node --test dist/cli/__tests__/setup-install-mode.test.js
- npm run lint
- lsp diagnostics on affected files: 0 errors

## Notes
- Architect verification: APPROVED
