### PR TITLE
Fix macOS launcher path test canonicalization

### DIFF
--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -20,6 +20,7 @@ import {
   omxAdaptersDir,
   omxLogsDir,
   packageRoot,
+  canonicalizeComparablePath,
   OMX_ENTRY_PATH_ENV,
   OMX_STARTUP_CWD_ENV,
   rememberOmxLaunchContext,
@@ -442,7 +443,7 @@ describe("OMX launcher path resolution", () => {
         },
       });
 
-      assert.equal(resolved, launcherPath);
+      assert.equal(resolved, canonicalizeComparablePath(launcherPath));
     } finally {
       await rm(startupCwd, { recursive: true, force: true });
       await rm(laterCwd, { recursive: true, force: true });
@@ -466,7 +467,7 @@ describe("OMX launcher path resolution", () => {
       });
 
       assert.equal(process.env[OMX_STARTUP_CWD_ENV], startupCwd);
-      assert.equal(process.env[OMX_ENTRY_PATH_ENV], launcherPath);
+      assert.equal(process.env[OMX_ENTRY_PATH_ENV], canonicalizeComparablePath(launcherPath));
     } finally {
       await rm(startupCwd, { recursive: true, force: true });
     }
@@ -490,7 +491,7 @@ describe("OMX launcher path resolution", () => {
         },
       });
 
-      assert.equal(resolved, launcherPath);
+      assert.equal(resolved, canonicalizeComparablePath(launcherPath));
     } finally {
       await rm(startupCwd, { recursive: true, force: true });
     }
@@ -515,7 +516,7 @@ describe("OMX launcher path resolution", () => {
       });
 
       assert.equal(process.env[OMX_STARTUP_CWD_ENV], startupCwd);
-      assert.equal(process.env[OMX_ENTRY_PATH_ENV], launcherPath);
+      assert.equal(process.env[OMX_ENTRY_PATH_ENV], canonicalizeComparablePath(launcherPath));
     } finally {
       process.argv[1] = originalArgv1;
       await rm(startupCwd, { recursive: true, force: true });
@@ -545,7 +546,7 @@ describe("OMX launcher path resolution", () => {
         packageRootDir,
       });
 
-      assert.equal(resolved, cliPath);
+      assert.equal(resolved, canonicalizeComparablePath(cliPath));
     } finally {
       await rm(startupCwd, { recursive: true, force: true });
       await rm(packageRootDir, { recursive: true, force: true });
@@ -569,7 +570,7 @@ describe("OMX launcher path resolution", () => {
         },
       });
 
-      assert.equal(resolved, cliPath);
+      assert.equal(resolved, canonicalizeComparablePath(cliPath));
     } finally {
       await rm(startupCwd, { recursive: true, force: true });
     }
@@ -596,7 +597,7 @@ describe("OMX launcher path resolution", () => {
         packageRootDir,
       });
 
-      assert.equal(resolved, cliPath);
+      assert.equal(resolved, canonicalizeComparablePath(cliPath));
     } finally {
       await rm(startupCwd, { recursive: true, force: true });
       await rm(packageRootDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes #1911.

This keeps the runtime launcher path contract unchanged and narrows the fix to the launcher path tests. Expected test paths now use the same `canonicalizeComparablePath` realpath policy as the implementation before strict equality checks, avoiding macOS `/var` vs `/private/var` alias mismatches.

## Verification

- `npm run build` ✅
- `node --test dist/utils/__tests__/paths.test.js` ✅ (30 tests)
- `npm run test:ci:compiled` ✅ (4068 tests)
- `npm run lint -- src/utils/__tests__/paths.test.ts` ✅
- LSP/TypeScript diagnostics on `src/utils/__tests__/paths.test.ts` ✅ (0 errors)
- Architect verification ✅ approved

Note: A later redundant full compiled rerun was stopped after the prior full run had already passed, per session instruction.
