### PR TITLE
Honor persisted project plugin setup mode

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -42,6 +42,38 @@ async function withIsolatedUserHome<T>(
   }
 }
 
+async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {
+  const hooks = await readFile(join(wd, ".codex", "hooks.json"), "utf-8");
+  assert.match(hooks, /codex-native-hook\.js/);
+  const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+  assert.match(config, /^codex_hooks = true$/m);
+  assert.doesNotMatch(
+    config,
+    /developer_instructions|notify-hook|mcp_servers/,
+  );
+  assert.equal(
+    existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
+    false,
+  );
+  assert.equal(
+    existsSync(join(wd, ".codex", "agents", "planner.toml")),
+    false,
+  );
+  assert.equal(
+    existsSync(join(wd, ".codex", "prompts", "executor.md")),
+    false,
+  );
+  assert.equal(existsSync(join(wd, "AGENTS.md")), false);
+
+  const persisted = JSON.parse(
+    await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+  ) as { scope: string; installMode?: string };
+  assert.deepEqual(persisted, {
+    scope: "project",
+    installMode: "plugin",
+  });
+}
+
 async function seedPluginCacheFromInstalledSkills(
   codexHomeDir: string,
 ): Promise<void> {
@@ -155,6 +187,29 @@ describe("omx setup install mode behavior", () => {
         await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
       ) as { scope: string; installMode?: string };
       assert.deepEqual(persisted, { scope: "project" });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not carry user plugin mode into non-plugin project setup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async () => {
+        await withTempCwd(wd, async () => {
+          await setup({ scope: "user", installMode: "plugin" });
+          await setup({ scope: "project" });
+
+          const persisted = JSON.parse(
+            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+          ) as { scope: string; installMode?: string };
+          assert.deepEqual(persisted, { scope: "project" });
+          assert.equal(
+            existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
+            true,
+          );
+        });
+      });
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -346,37 +401,21 @@ describe("omx setup install mode behavior", () => {
       await withTempCwd(wd, async () => {
         await setup({ scope: "project", installMode: "plugin" });
 
-        const hooks = await readFile(join(wd, ".codex", "hooks.json"), "utf-8");
-        assert.match(hooks, /codex-native-hook\.js/);
-        const config = await readFile(
-          join(wd, ".codex", "config.toml"),
-          "utf-8",
-        );
-        assert.match(config, /^codex_hooks = true$/m);
-        assert.doesNotMatch(
-          config,
-          /developer_instructions|notify-hook|mcp_servers/,
-        );
-        assert.equal(
-          existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
-          false,
-        );
-        assert.equal(
-          existsSync(join(wd, ".codex", "agents", "planner.toml")),
-          false,
-        );
-        assert.equal(
-          existsSync(join(wd, ".codex", "prompts", "executor.md")),
-          false,
-        );
-        assert.equal(existsSync(join(wd, "AGENTS.md")), false);
-        const persisted = JSON.parse(
-          await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-        ) as { scope: string; installMode?: string };
-        assert.deepEqual(persisted, {
-          scope: "project",
-          installMode: "plugin",
-        });
+        await assertProjectPluginModeArtifacts(wd);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("honors persisted project plugin mode on repeat setup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withTempCwd(wd, async () => {
+        await setup({ scope: "project", installMode: "plugin" });
+        await setup();
+
+        await assertProjectPluginModeArtifacts(wd);
       });
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -849,12 +849,16 @@ async function resolveSetupInstallMode(
   if (requestedInstallMode) {
     return { installMode: requestedInstallMode, source: "cli" };
   }
-  if (scope !== "user") return null;
 
   const persisted = await readPersistedSetupPreferences(projectRoot);
-  if (persisted?.installMode) {
+  if (
+    persisted?.installMode &&
+    (!persisted.scope || persisted.scope === scope)
+  ) {
     return { installMode: persisted.installMode, source: "persisted" };
   }
+
+  if (scope !== "user") return null;
 
   const discoveredPluginCacheDir = await discoverOmxPluginCacheDir();
   const defaultMode = discoveredPluginCacheDir
@@ -1390,7 +1394,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     installModePrompt,
   );
   const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
-  const persistedPreferences = await readPersistedSetupPreferences(projectRoot);
   const scopeSourceMessage =
     resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
   const backupContext = getBackupContext(resolvedScope.scope, projectRoot);
@@ -1423,7 +1426,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
         ? " (from .omx/setup-scope.json)"
         : "";
     console.log(
-      `Using user-scope skill delivery mode: ${resolvedInstallMode.installMode}${installModeSourceMessage}\n`,
+      `Using ${resolvedScope.scope}-scope skill delivery mode: ${resolvedInstallMode.installMode}${installModeSourceMessage}\n`,
     );
   }
 
@@ -1458,10 +1461,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
           scope: resolvedScope.scope,
           installMode: resolvedInstallMode.installMode,
         }
-      : {
-          ...persistedPreferences,
-          scope: resolvedScope.scope,
-        },
+      : { scope: resolvedScope.scope },
     {
       dryRun,
       verbose,


### PR DESCRIPTION
## Summary

- Honor persisted, scope-compatible `installMode: "plugin"` for project-scoped setup repeats.
- Drop stale persisted install mode when a setup run changes to a scope/path that did not resolve an install mode, so user plugin mode is not accidentally carried into non-plugin project setup.
- Add regressions for repeat project plugin setup and scope-mismatch persistence.

Closes #1908

## Verification

- `npm run lint`
- `npm run check:no-unused`
- `npm run build`
- `node --test dist/cli/__tests__/setup-install-mode.test.js`
