### PR TITLE
fix(setup): preserve customized status line

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -355,7 +355,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
-  it("skips OMX-managed [tui] writes for Codex CLI >= 0.107.0 and preserves an existing [tui] table", async () => {
+  it("seeds [tui].status_line for Codex CLI >= 0.107.0 while preserving an existing customization", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       await mkdir(join(wd, ".omx", "state"), { recursive: true });
@@ -376,7 +376,28 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       assert.match(config, /^status_line = \["git-branch"\]$/m);
       assert.match(
         output,
-        /Codex CLI >= 0\.107\.0 manages \[tui\]; OMX left that section untouched\./,
+        /StatusLine configured in config\.toml via \[tui\] section\./,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("seeds default [tui].status_line on fresh setup for Codex CLI >= 0.107.0", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        codexVersionProbe: () => "codex-cli 0.107.0",
+      });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.equal(config.match(/^\[tui\]$/gm)?.length ?? 0, 1);
+      assert.match(
+        config,
+        /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -71,7 +71,6 @@ import {
   resolveAgentsModelTableContext,
   upsertAgentsModelTable,
 } from "../utils/agents-model-table.js";
-import { spawnPlatformCommandSync } from "../utils/platform-command.js";
 
 interface SetupOptions {
   codexVersionProbe?: () => string | null;
@@ -224,7 +223,6 @@ const DEFAULT_SETUP_INSTALL_MODE: SetupInstallMode = "legacy";
 const LEGACY_SETUP_MODEL = "gpt-5.3-codex";
 const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
 const OBSOLETE_NATIVE_AGENT_FIELD = ["skill", "ref"].join("_");
-const TUI_OWNED_BY_CODEX_VERSION = [0, 107, 0] as const;
 
 function createEmptyCategorySummary(): SetupCategorySummary {
   return {
@@ -628,40 +626,6 @@ async function promptForModelUpgrade(
   } finally {
     rl.close();
   }
-}
-
-function parseSemverTriplet(version: string): [number, number, number] | null {
-  const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
-  if (!match) return null;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function semverGte(
-  version: [number, number, number],
-  minimum: readonly [number, number, number],
-): boolean {
-  if (version[0] !== minimum[0]) return version[0] > minimum[0];
-  if (version[1] !== minimum[1]) return version[1] > minimum[1];
-  return version[2] >= minimum[2];
-}
-
-function probeInstalledCodexVersion(): string | null {
-  const { result } = spawnPlatformCommandSync("codex", ["--version"], {
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-  if (result.error || result.status !== 0) return null;
-  const stdout = (result.stdout || "").trim();
-  return stdout === "" ? null : stdout;
-}
-
-function shouldOmxManageTuiFromCodexVersion(
-  versionOutput: string | null,
-): boolean {
-  if (!versionOutput) return true;
-  const parsed = parseSemverTriplet(versionOutput);
-  if (!parsed) return true;
-  return !semverGte(parsed, TUI_OWNED_BY_CODEX_VERSION);
 }
 
 async function promptForAgentsOverwrite(
@@ -1715,7 +1679,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
       summary.config,
       backupContext,
       {
-        codexVersionProbe: options.codexVersionProbe,
         dryRun,
         modelUpgradePrompt,
         verbose,
@@ -1981,10 +1944,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   }
   if (omxManagesTui) {
     console.log("  StatusLine configured in config.toml via [tui] section.");
-  } else {
-    console.log(
-      "  Codex CLI >= 0.107.0 manages [tui]; OMX left that section untouched.",
-    );
   }
   console.log();
 
@@ -2674,7 +2633,7 @@ async function updateManagedConfig(
   backupContext: SetupBackupContext,
   options: Pick<
     SetupOptions,
-    "codexVersionProbe" | "dryRun" | "verbose" | "modelUpgradePrompt"
+    "dryRun" | "verbose" | "modelUpgradePrompt"
   >,
 ): Promise<ManagedConfigResult> {
   const existing = existsSync(configPath)
@@ -2683,9 +2642,7 @@ async function updateManagedConfig(
   const hadLegacyTeamRunTable = hasLegacyOmxTeamRunTable(existing);
   const currentModel = getRootModelName(existing);
   let modelOverride: string | undefined;
-  const codexVersion =
-    options.codexVersionProbe?.() ?? probeInstalledCodexVersion();
-  const omxManagesTui = shouldOmxManageTuiFromCodexVersion(codexVersion);
+  const omxManagesTui = true;
 
   if (currentModel === LEGACY_SETUP_MODEL) {
     const shouldPrompt =

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -358,7 +358,7 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
-  it("merges OMX status_line into an existing user [tui] section without duplicating the table", async () => {
+  it("preserves a user-owned status_line in an existing [tui] section", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
       const configPath = join(wd, "config.toml");
@@ -371,18 +371,51 @@ describe("config generator idempotency (#384)", () => {
       await writeFile(configPath, userTui);
 
       await mergeConfig(configPath, wd);
+      await mergeConfig(configPath, wd);
       const toml = await readFile(configPath, "utf-8");
 
       assert.equal(count(toml, /^\[tui\]$/gm), 1, "[tui] should appear once");
       assert.match(toml, /^theme = "night"$/m, "user tui key preserved");
       assert.match(
         toml,
-        /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
-        "status_line updated in-place",
+        /^status_line = \["git-branch"\]$/m,
+        "user status_line preserved",
       );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
+  });
+
+  it("seeds the default status_line into a fresh [tui] section", () => {
+    const toml = buildMergedConfig("", "/tmp/omx");
+
+    assert.equal(count(toml, /^\[tui\]$/gm), 1, "[tui] should appear once");
+    assert.match(
+      toml,
+      /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
+    );
+  });
+
+  it("preserves a customized managed-block status_line when refreshing setup", () => {
+    const firstRun = buildMergedConfig("", "/tmp/omx");
+    const customized = firstRun.replace(
+      /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
+      'status_line = ["git-branch", "context-remaining"]',
+    );
+
+    const refreshed = buildMergedConfig(customized, "/tmp/omx");
+
+    assert.equal(count(refreshed, /^\[tui\]$/gm), 1, "[tui] should appear once");
+    assert.match(
+      refreshed,
+      /^status_line = \["git-branch", "context-remaining"\]$/m,
+      "customized status_line should survive managed-block stripping",
+    );
+    assert.doesNotMatch(
+      refreshed,
+      /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
+      "default status_line should not overwrite customization",
+    );
   });
 
   it("skips emitting an OMX [tui] table when includeTui is disabled", () => {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -64,6 +64,8 @@ const OMX_TUI_STATUS_LINE =
   'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"]';
 const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
   /^\s*\[mcp_servers\.(?:"omx_team_run"|omx_team_run)\]\s*$/m;
+const OMX_CONFIG_MARKER = "oh-my-codex (OMX) Configuration";
+const OMX_CONFIG_END_MARKER = "# End oh-my-codex";
 
 export function hasLegacyOmxTeamRunTable(config: string): boolean {
   return LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(config);
@@ -675,6 +677,51 @@ function stripOrphanedOmxSections(config: string): string {
   return result.join("\n");
 }
 
+function extractCustomizedTuiSectionsFromOmxBlocks(config: string): string[] {
+  const sections: string[] = [];
+  let searchStart = 0;
+
+  while (true) {
+    const markerIdx = config.indexOf(OMX_CONFIG_MARKER, searchStart);
+    if (markerIdx < 0) break;
+
+    const endIdx = config.indexOf(OMX_CONFIG_END_MARKER, markerIdx);
+    if (endIdx < 0) break;
+
+    const blockLines = config.slice(markerIdx, endIdx).split(/\r?\n/);
+
+    for (let i = 0; i < blockLines.length; i++) {
+      if (!/^\s*\[tui\]\s*$/.test(blockLines[i])) continue;
+
+      const tuiLines = [blockLines[i].trim()];
+      let hasCustomizedStatusLine = false;
+
+      for (let j = i + 1; j < blockLines.length; j++) {
+        if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(blockLines[j])) break;
+
+        const trimmed = blockLines[j].trim();
+        if (!trimmed) continue;
+
+        tuiLines.push(trimmed);
+        if (
+          /^status_line\s*=/.test(trimmed) &&
+          trimmed !== OMX_TUI_STATUS_LINE
+        ) {
+          hasCustomizedStatusLine = true;
+        }
+      }
+
+      if (hasCustomizedStatusLine) {
+        sections.push(tuiLines.join("\n"));
+      }
+    }
+
+    searchStart = endIdx + OMX_CONFIG_END_MARKER.length;
+  }
+
+  return sections;
+}
+
 function upsertTuiStatusLine(config: string): {
   cleaned: string;
   hadExistingTui: boolean;
@@ -702,6 +749,7 @@ function upsertTuiStatusLine(config: string): {
 
   const preservedKeyLines: string[] = [];
   const seenKeys = new Set<string>();
+  let preservedStatusLine: string | undefined;
 
   for (const section of sections) {
     for (let i = section.start + 1; i < section.end; i++) {
@@ -713,13 +761,21 @@ function upsertTuiStatusLine(config: string): {
       if (!keyMatch) continue;
 
       const key = keyMatch[1];
-      if (key === "status_line" || seenKeys.has(key)) continue;
+      if (key === "status_line") {
+        preservedStatusLine ??= trimmed;
+        continue;
+      }
+      if (seenKeys.has(key)) continue;
       seenKeys.add(key);
       preservedKeyLines.push(trimmed);
     }
   }
 
-  const mergedSection = ["[tui]", ...preservedKeyLines, OMX_TUI_STATUS_LINE];
+  const mergedSection = [
+    "[tui]",
+    ...preservedKeyLines,
+    preservedStatusLine ?? OMX_TUI_STATUS_LINE,
+  ];
   const firstStart = sections[0].start;
   const rebuilt: string[] = [];
 
@@ -754,13 +810,11 @@ export function stripExistingOmxBlocks(config: string): {
   cleaned: string;
   removed: number;
 } {
-  const marker = "oh-my-codex (OMX) Configuration";
-  const endMarker = "# End oh-my-codex";
   let cleaned = config;
   let removed = 0;
 
   while (true) {
-    const markerIdx = cleaned.indexOf(marker);
+    const markerIdx = cleaned.indexOf(OMX_CONFIG_MARKER);
     if (markerIdx < 0) break;
 
     let blockStart = cleaned.lastIndexOf("\n", markerIdx);
@@ -779,7 +833,7 @@ export function stripExistingOmxBlocks(config: string): {
     }
 
     let blockEnd = cleaned.length;
-    const endIdx = cleaned.indexOf(endMarker, markerIdx);
+    const endIdx = cleaned.indexOf(OMX_CONFIG_END_MARKER, markerIdx);
     if (endIdx >= 0) {
       const endLineBreak = cleaned.indexOf("\n", endIdx);
       blockEnd = endLineBreak >= 0 ? endLineBreak + 1 : cleaned.length;
@@ -1076,10 +1130,15 @@ export function buildMergedConfig(
 ): string {
   let existing = existingConfig;
   const includeTui = options.includeTui !== false;
+  const customizedManagedTuiSections =
+    extractCustomizedTuiSectionsFromOmxBlocks(existing);
 
-  if (existing.includes("oh-my-codex (OMX) Configuration")) {
+  if (existing.includes(OMX_CONFIG_MARKER)) {
     const stripped = stripExistingOmxBlocks(existing);
     existing = stripped.cleaned;
+    if (customizedManagedTuiSections.length > 0) {
+      existing = `${existing.trimEnd()}\n\n${customizedManagedTuiSections.join("\n\n")}\n`;
+    }
   }
   if (existing.includes(SHARED_MCP_REGISTRY_MARKER)) {
     const stripped = stripExistingSharedMcpRegistryBlock(existing);


### PR DESCRIPTION
## Summary

- seed the default `[tui].status_line` on fresh setup, including modern Codex CLI installs
- preserve existing user-owned `[tui].status_line` values on repeat setup/refresh
- preserve an edited generated managed-block `status_line` by extracting it before the managed block is stripped and regenerated

Fixes #1891

## Verification

- `npm ci`
- `npm run build`
- `node --test dist/cli/__tests__/setup-refresh.test.js dist/config/__tests__/generator-idempotent.test.js` (`56/56`)
- `npm run lint`
- `npm run check:no-unused`
- Ralph STANDARD architect verification: APPROVED
