### PR TITLE
fix(runtime): guard RuntimeBridge JSON.parse against partial output

### DIFF
--- a/src/runtime/__tests__/bridge.test.ts
+++ b/src/runtime/__tests__/bridge.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveRuntimeBinaryPath } from '../bridge.js';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RuntimeBridge, RuntimeBridgeError, resolveRuntimeBinaryPath } from '../bridge.js';
 
 describe('resolveRuntimeBinaryPath', () => {
   it('prefers explicit OMX_RUNTIME_BINARY override', () => {
@@ -48,5 +51,165 @@ describe('resolveRuntimeBinaryPath', () => {
       exists: () => false,
     });
     assert.equal(actual, 'omx-runtime');
+  });
+});
+
+describe('RuntimeBridgeError', () => {
+  it('preserves command and stdoutPreview context for typed catches', () => {
+    const cause = new SyntaxError('Unexpected token } in JSON at position 0');
+    const err = new RuntimeBridgeError('exec failed', {
+      command: 'AcquireAuthority',
+      stdoutPreview: '}',
+      cause,
+    });
+    assert.ok(err instanceof Error);
+    assert.ok(err instanceof RuntimeBridgeError);
+    assert.equal(err.name, 'RuntimeBridgeError');
+    assert.equal(err.context.command, 'AcquireAuthority');
+    assert.equal(err.context.stdoutPreview, '}');
+    assert.equal(err.context.cause, cause);
+    assert.match(err.message, /exec failed/);
+  });
+
+  it('defaults context to an empty object when omitted', () => {
+    const err = new RuntimeBridgeError('bare message');
+    assert.deepEqual(err.context, {});
+  });
+});
+
+describe('RuntimeBridge.readCompatFile (parse guard)', () => {
+  function withBridge(run: (stateDir: string, bridge: RuntimeBridge) => void): void {
+    const stateDir = mkdtempSync(join(tmpdir(), 'omx-bridge-compat-'));
+    try {
+      run(stateDir, new RuntimeBridge({ stateDir, binaryPath: '/nonexistent-binary' }));
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  }
+
+  it('returns null when stateDir is unset', () => {
+    const bridge = new RuntimeBridge({ binaryPath: '/nonexistent-binary' });
+    assert.equal(bridge.readCompatFile('snapshot.json'), null);
+  });
+
+  it('returns null when the compat file is absent', () => {
+    withBridge((_dir, bridge) => {
+      assert.equal(bridge.readCompatFile('snapshot.json'), null);
+    });
+  });
+
+  it('returns null on truncated JSON instead of throwing SyntaxError', () => {
+    withBridge((stateDir, bridge) => {
+      writeFileSync(join(stateDir, 'snapshot.json'), '{');
+      assert.equal(bridge.readCompatFile('snapshot.json'), null);
+    });
+  });
+
+  it('returns null on empty content (truncate-then-write race)', () => {
+    withBridge((stateDir, bridge) => {
+      writeFileSync(join(stateDir, 'snapshot.json'), '');
+      assert.equal(bridge.readCompatFile('snapshot.json'), null);
+    });
+  });
+
+  it('parses well-formed JSON normally', () => {
+    withBridge((stateDir, bridge) => {
+      writeFileSync(join(stateDir, 'snapshot.json'), JSON.stringify({ schema_version: 1 }));
+      assert.deepEqual(
+        bridge.readCompatFile<{ schema_version: number }>('snapshot.json'),
+        { schema_version: 1 },
+      );
+    });
+  });
+});
+
+describe('RuntimeBridge.execCommand / readSnapshot (parse guard)', () => {
+  // The bridge's `validateSchemaOnce` is a module-level singleton: a single
+  // fake-binary that returns the same string regardless of subcommand would
+  // make test ordering matter. Branch on $1 so the schema probe always sees
+  // a valid manifest while exec/snapshot return the test-supplied stdout.
+  const validSchema = JSON.stringify({
+    commands: [
+      'acquire-authority', 'renew-authority', 'queue-dispatch',
+      'mark-notified', 'mark-delivered', 'mark-failed',
+      'request-replay', 'capture-snapshot',
+    ],
+  });
+
+  function withFakeBinary(stdout: string, run: (bridge: RuntimeBridge) => void): void {
+    const stateDir = mkdtempSync(join(tmpdir(), 'omx-bridge-exec-'));
+    const binaryPath = join(stateDir, 'fake-runtime.sh');
+    const script = `#!/bin/sh
+case "$1" in
+  schema)
+    printf '%s' ${JSON.stringify(validSchema)}
+    ;;
+  *)
+    printf '%s' ${JSON.stringify(stdout)}
+    ;;
+esac
+`;
+    writeFileSync(binaryPath, script, 'utf-8');
+    chmodSync(binaryPath, 0o755);
+    try {
+      run(new RuntimeBridge({ stateDir, binaryPath }));
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  }
+
+  it('execCommand surfaces RuntimeBridgeError when stdout is non-JSON', () => {
+    withFakeBinary('not-json-at-all', (bridge) => {
+      assert.throws(
+        () =>
+          bridge.execCommand({
+            command: 'AcquireAuthority',
+            owner: 'leader',
+            lease_id: 'L1',
+            leased_until: '2026-01-01T00:00:00Z',
+          }),
+        (err: unknown) => {
+          assert.ok(err instanceof RuntimeBridgeError, 'expected RuntimeBridgeError');
+          const typed = err as RuntimeBridgeError;
+          assert.equal(typed.context.command, 'AcquireAuthority');
+          assert.match(typed.message, /non-JSON output/);
+          assert.ok(typed.context.cause instanceof SyntaxError);
+          return true;
+        },
+      );
+    });
+  });
+
+  it('execCommand parses well-formed RuntimeEvent stdout', () => {
+    const event = {
+      event: 'AuthorityAcquired',
+      owner: 'leader',
+      lease_id: 'L1',
+      leased_until: '2026-01-01T00:00:00Z',
+    };
+    withFakeBinary(JSON.stringify(event), (bridge) => {
+      const actual = bridge.execCommand({
+        command: 'AcquireAuthority',
+        owner: 'leader',
+        lease_id: 'L1',
+        leased_until: '2026-01-01T00:00:00Z',
+      });
+      assert.deepEqual(actual, event);
+    });
+  });
+
+  it('readSnapshot surfaces RuntimeBridgeError when stdout is non-JSON', () => {
+    withFakeBinary('snapshot panic', (bridge) => {
+      assert.throws(
+        () => bridge.readSnapshot(),
+        (err: unknown) => {
+          assert.ok(err instanceof RuntimeBridgeError, 'expected RuntimeBridgeError');
+          const typed = err as RuntimeBridgeError;
+          assert.equal(typed.context.command, 'snapshot');
+          assert.match(typed.message, /non-JSON output/);
+          return true;
+        },
+      );
+    });
   });
 });

--- a/src/runtime/bridge.ts
+++ b/src/runtime/bridge.ts
@@ -11,6 +11,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveCanonicalTeamStateRoot } from '../team/state-root.js';
+import { safeJsonParse } from '../utils/safe-json.js';
 
 const __bridge_dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -107,6 +108,28 @@ export interface MailboxRecord {
 // Bridge class
 // ---------------------------------------------------------------------------
 
+/**
+ * Raised when the omx-runtime binary returns output that fails JSON decoding.
+ *
+ * Distinguishing parse failure from spawn failure (which `run()` already wraps
+ * in a generic `Error`) lets callers — e.g. dispatch loops in
+ * `team/state/dispatch.ts` — react with a typed `instanceof` check instead of
+ * inspecting error messages, and to mark the affected command failed without
+ * tearing down the surrounding watcher loop.
+ */
+export class RuntimeBridgeError extends Error {
+  readonly context: { command?: string; stdoutPreview?: string; cause?: unknown };
+
+  constructor(
+    message: string,
+    context: { command?: string; stdoutPreview?: string; cause?: unknown } = {},
+  ) {
+    super(message);
+    this.name = 'RuntimeBridgeError';
+    this.context = context;
+  }
+}
+
 let schemaValidated = false;
 
 export interface RuntimeBinaryDiscoveryOptions {
@@ -158,7 +181,18 @@ export class RuntimeBridge {
     if (this.stateDir) args.push(`--state-dir=${this.stateDir}`);
     if (options?.compact) args.push('--compact');
     const stdout = this.run(args);
-    return JSON.parse(stdout) as RuntimeEvent;
+    // Non-JSON stdout means the runtime contract was violated (truncated pipe,
+    // schema drift, panic before flush). Surface a typed error so dispatch
+    // callers can mark the command failed instead of bubbling SyntaxError up
+    // through unrelated layers.
+    try {
+      return JSON.parse(stdout) as RuntimeEvent;
+    } catch (cause) {
+      throw new RuntimeBridgeError(
+        `omx-runtime exec returned non-JSON output for ${cmd.command}`,
+        { command: cmd.command, stdoutPreview: stdout.slice(0, 200), cause },
+      );
+    }
   }
 
   /** Read the current RuntimeSnapshot. */
@@ -166,7 +200,17 @@ export class RuntimeBridge {
     const args = ['snapshot', '--json'];
     if (this.stateDir) args.push(`--state-dir=${this.stateDir}`);
     const stdout = this.run(args);
-    return JSON.parse(stdout) as RuntimeSnapshot;
+    // Same parse hazard as execCommand: a partial snapshot pipe surfaces
+    // here as a SyntaxError that the caller almost never expects.
+    try {
+      return JSON.parse(stdout) as RuntimeSnapshot;
+    } catch (cause) {
+      throw new RuntimeBridgeError('omx-runtime snapshot returned non-JSON output', {
+        command: 'snapshot',
+        stdoutPreview: stdout.slice(0, 200),
+        cause,
+      });
+    }
   }
 
   /** Initialize a fresh state directory. */
@@ -180,8 +224,19 @@ export class RuntimeBridge {
     if (!this.stateDir) return null;
     const filePath = join(this.stateDir, filename);
     if (!existsSync(filePath)) return null;
-    const content = readFileSync(filePath, 'utf-8');
-    return JSON.parse(content) as T;
+    // Compat files cross a Rust→JS boundary and can be observed mid-rename
+    // (`writeAtomic` swaps a tmp file into place) or empty (truncate-then-write).
+    // The only sane recovery is to return null so HUD/dispatch fall through to
+    // their JS-inferred state for this tick — throwing here would abort the
+    // entire query path. `readFileSync` itself can also raise EACCES/EISDIR
+    // on edge cases; treat those identically.
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch {
+      return null;
+    }
+    return safeJsonParse<T | null>(content, null);
   }
 
   /** Read authority snapshot from compatibility file. */


### PR DESCRIPTION
## Summary

`RuntimeBridge.execCommand`, `readSnapshot`, and `readCompatFile` each call `JSON.parse` with no try/catch. A partial Rust write (mid-rename, `kill -9`, schema drift, panic-before-flush) surfaces as a `SyntaxError` that aborts the HUD render path or the dispatch watcher loop instead of degrading gracefully.

This builds on #548 (`fix(quality): safe JSON.parse, …`) and #506. `RuntimeBridge` was not in #548's 16-file scope but exhibits the same hazard.

## Reproducer

```bash
OMX_RUNTIME_BRIDGE=1 omx team run alpha
# In another shell, while the dispatcher is writing:
printf '{' > .omx/state/team/alpha/.omx-runtime/snapshot.json
omx hud
```

**Before**: `SyntaxError: Unexpected end of JSON input` aborts the entire `buildAllState` query at `src/hud/state.ts:458`.
**After**: HUD falls through to JS-inferred state for this tick.

## Fix

| Method | Behaviour on parse failure |
|---|---|
| `execCommand` | Throws typed `RuntimeBridgeError` so dispatch callers (`src/team/state/dispatch.ts:169`, `src/team/state/mailbox.ts:44`) can recognise parse failure with `instanceof` and mark the command failed without tearing down the surrounding watcher. |
| `readSnapshot` | Same typed error — preserves the failing command name plus a 200-byte `stdoutPreview` and the underlying `cause`. |
| `readCompatFile` | Returns `null`. The two production callers (`src/hud/state.ts:454-458`, `src/team/state.ts:1488`) already initialise to `null` (`runtimeSnapshot`) or use optional chaining (`existing?.records`) and treat `null` as the legacy-path fallback, so this is behaviour-compatible. |

`safeJsonParse` from `src/utils/safe-json.ts` (introduced by #548) is reused for the compat-reader path; `execCommand` / `readSnapshot` use direct try/catch because they need to surface a typed error, not a fallback.

## Tests added

`src/runtime/__tests__/bridge.test.ts` (+165 lines, 14 new assertions across 3 suites):
- `RuntimeBridgeError`: `instanceof`, `.name`, context fields (`command`, `stdoutPreview`, `cause`), default empty context
- `RuntimeBridge.readCompatFile (parse guard)`: missing `stateDir`, missing file, truncated `{`, empty content, well-formed JSON
- `RuntimeBridge.execCommand / readSnapshot (parse guard)`: non-JSON stdout → typed error with `command='AcquireAuthority'` + `cause instanceof SyntaxError`, well-formed `RuntimeEvent` → parses normally, `readSnapshot` non-JSON → typed error with `command='snapshot'`

The exec/snapshot tests use a temp shell script as the runtime binary, branching on `$1` so the `validateSchemaOnce` probe always sees a valid manifest (the `schemaValidated` module singleton would otherwise make test ordering significant).

## Verification

- [x] `npm run build`
- [x] `npm run lint` (553 files)
- [x] `npm run check:no-unused`
- [x] `node --test dist/runtime/__tests__/bridge.test.js` — 14/14 pass
- [x] `npm test` — pre-existing failures observed are all `gpt-5.5` frontier-default fixture mismatches from the recent 0.14.4 cut (e.g. `dist/team/__tests__/runtime.test.js:312` expects `gpt-5.5`, gets `gpt-5.4`); none are in `runtime/bridge.ts` and the bridge test suites all pass.

## Backward compatibility

- `RuntimeBridgeError extends Error`. Existing `try { … } catch (err) { … }` blocks at any call site still catch identically; only `instanceof` adopters see new typing.
- `execCommand` / `readSnapshot` previously threw a vanilla `SyntaxError` on this input; now throw `RuntimeBridgeError`. Both production exec call sites (`team/state/dispatch.ts`, `team/state/mailbox.ts`) ignore the return value and the throw propagates the same way.
- `readCompatFile` previously threw on parse failure; now returns `null`. Both callers already handled `null`, so this strictly reduces the failure surface.

## Test plan

- [x] Unit tests cover all three guarded paths plus the typed-error contract
- [x] Verified callers (`hud/state.ts`, `team/state.ts`) tolerate `null` returns
- [x] No platform-specific behaviour beyond the existing `execFileSync` (POSIX shell fixture for binary mock; same OS scope as existing bridge tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)