### PR TITLE
feat(team): add worker subagent delegation contract

### DIFF
--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -6,11 +6,13 @@ import { tmpdir } from 'os';
 import {
   DEFAULT_FRONTIER_MODEL,
   DEFAULT_SPARK_MODEL,
+  DEFAULT_TEAM_CHILD_MODEL,
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
   getModelForMode,
   getSparkDefaultModel,
   getStandardDefaultModel,
+  getTeamChildModel,
   getTeamLowComplexityModel,
   readConfiguredEnvOverrides,
 } from '../models.js';
@@ -21,6 +23,7 @@ describe('getModelForMode', () => {
   let originalDefaultFrontierModel: string | undefined;
   let originalDefaultStandardModel: string | undefined;
   let originalDefaultSparkModel: string | undefined;
+  let originalTeamChildModel: string | undefined;
   let originalSparkModel: string | undefined;
 
   beforeEach(async () => {
@@ -29,11 +32,13 @@ describe('getModelForMode', () => {
     originalDefaultFrontierModel = process.env.OMX_DEFAULT_FRONTIER_MODEL;
     originalDefaultStandardModel = process.env.OMX_DEFAULT_STANDARD_MODEL;
     originalDefaultSparkModel = process.env.OMX_DEFAULT_SPARK_MODEL;
+    originalTeamChildModel = process.env.OMX_TEAM_CHILD_MODEL;
     originalSparkModel = process.env.OMX_SPARK_MODEL;
     process.env.CODEX_HOME = tempDir;
     delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
     delete process.env.OMX_DEFAULT_STANDARD_MODEL;
     delete process.env.OMX_DEFAULT_SPARK_MODEL;
+    delete process.env.OMX_TEAM_CHILD_MODEL;
     delete process.env.OMX_SPARK_MODEL;
   });
 
@@ -57,6 +62,11 @@ describe('getModelForMode', () => {
       process.env.OMX_DEFAULT_SPARK_MODEL = originalDefaultSparkModel;
     } else {
       delete process.env.OMX_DEFAULT_SPARK_MODEL;
+    }
+    if (typeof originalTeamChildModel === 'string') {
+      process.env.OMX_TEAM_CHILD_MODEL = originalTeamChildModel;
+    } else {
+      delete process.env.OMX_TEAM_CHILD_MODEL;
     }
     if (typeof originalSparkModel === 'string') {
       process.env.OMX_SPARK_MODEL = originalSparkModel;
@@ -169,6 +179,24 @@ describe('getModelForMode', () => {
     process.env.OMX_DEFAULT_FRONTIER_MODEL = 'gpt-5.4-mini';
     await writeConfig({ models: { team: 'gpt-4.1', default: 'o4-mini' } });
     assert.equal(getModelForMode('team'), 'gpt-4.1');
+  });
+
+
+
+  it('defaults team child model to standard mini independent of frontier defaults', () => {
+    process.env.OMX_DEFAULT_FRONTIER_MODEL = 'frontier-expensive';
+    assert.equal(DEFAULT_TEAM_CHILD_MODEL, 'gpt-5.4-mini');
+    assert.equal(getTeamChildModel(), 'gpt-5.4-mini');
+  });
+
+  it('uses OMX_TEAM_CHILD_MODEL shell override for team child model', () => {
+    process.env.OMX_TEAM_CHILD_MODEL = 'team-child-custom';
+    assert.equal(getTeamChildModel(), 'team-child-custom');
+  });
+
+  it('uses .omx-config.json env.OMX_TEAM_CHILD_MODEL when shell env is absent', async () => {
+    await writeConfig({ env: { OMX_TEAM_CHILD_MODEL: 'team-child-local' } });
+    assert.equal(getTeamChildModel(), 'team-child-local');
   });
 
   it('returns low-complexity team model when configured', async () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -47,6 +47,7 @@ export const OMX_DEFAULT_FRONTIER_MODEL_ENV = 'OMX_DEFAULT_FRONTIER_MODEL';
 export const OMX_DEFAULT_STANDARD_MODEL_ENV = 'OMX_DEFAULT_STANDARD_MODEL';
 export const OMX_DEFAULT_SPARK_MODEL_ENV = 'OMX_DEFAULT_SPARK_MODEL';
 export const OMX_SPARK_MODEL_ENV = 'OMX_SPARK_MODEL';
+export const OMX_TEAM_CHILD_MODEL_ENV = 'OMX_TEAM_CHILD_MODEL';
 
 function readOmxConfigFile(codexHomeOverride?: string): OmxConfigFile | null {
   const configPath = join(codexHomeOverride || codexHome(), '.omx-config.json');
@@ -86,6 +87,7 @@ function readModelsBlock(codexHomeOverride?: string): ModelsConfig | null {
 export const DEFAULT_FRONTIER_MODEL = 'gpt-5.5';
 export const DEFAULT_STANDARD_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_SPARK_MODEL = 'gpt-5.3-codex-spark';
+export const DEFAULT_TEAM_CHILD_MODEL = DEFAULT_STANDARD_MODEL;
 
 function normalizeConfiguredValue(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -180,6 +182,13 @@ export function getEnvConfiguredSparkDefaultModel(
     ?? normalizeConfiguredValue(env[OMX_SPARK_MODEL_ENV])
     ?? readConfigEnvValue(OMX_DEFAULT_SPARK_MODEL_ENV, codexHomeOverride)
     ?? readConfigEnvValue(OMX_SPARK_MODEL_ENV, codexHomeOverride);
+}
+
+
+export function getTeamChildModel(codexHomeOverride?: string): string {
+  return normalizeConfiguredValue(process.env[OMX_TEAM_CHILD_MODEL_ENV])
+    ?? readConfigEnvValue(OMX_TEAM_CHILD_MODEL_ENV, codexHomeOverride)
+    ?? DEFAULT_TEAM_CHILD_MODEL;
 }
 
 /**

--- a/src/team/__tests__/delegation-policy.test.ts
+++ b/src/team/__tests__/delegation-policy.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { synthesizeDelegationPlan } from '../delegation-policy.js';
+import type { TeamTask } from '../state.js';
+
+function task(overrides: Partial<TeamTask>): TeamTask {
+  return {
+    id: '1',
+    subject: 'subject',
+    description: 'description',
+    status: 'pending',
+    created_at: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe('synthesizeDelegationPlan', () => {
+  let originalChildModel: string | undefined;
+  let originalFrontierModel: string | undefined;
+
+  beforeEach(() => {
+    originalChildModel = process.env.OMX_TEAM_CHILD_MODEL;
+    originalFrontierModel = process.env.OMX_DEFAULT_FRONTIER_MODEL;
+    delete process.env.OMX_TEAM_CHILD_MODEL;
+    delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
+  });
+
+  afterEach(() => {
+    if (typeof originalChildModel === 'string') process.env.OMX_TEAM_CHILD_MODEL = originalChildModel;
+    else delete process.env.OMX_TEAM_CHILD_MODEL;
+    if (typeof originalFrontierModel === 'string') process.env.OMX_DEFAULT_FRONTIER_MODEL = originalFrontierModel;
+    else delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
+  });
+
+  it('auto-delegates broad investigation tasks to gpt-5.4-mini child agents', () => {
+    process.env.OMX_DEFAULT_FRONTIER_MODEL = 'frontier-expensive';
+    const plan = synthesizeDelegationPlan(task({
+      subject: 'Investigate flaky runtime behavior',
+      description: 'Search the repo, debug root cause, and propose tests across runtime modules',
+      role: 'debugger',
+    }));
+
+    assert.equal(plan.mode, 'auto');
+    assert.equal(plan.max_parallel_subtasks, 3);
+    assert.equal(plan.required_parallel_probe, true);
+    assert.equal(plan.spawn_before_serial_search_threshold, 3);
+    assert.equal(plan.child_model_policy, 'standard');
+    assert.equal(plan.child_model, 'gpt-5.4-mini');
+    assert.equal(plan.child_report_format, 'bullets');
+    assert.equal(plan.skip_allowed_reason_required, true);
+    assert.ok((plan.subtask_candidates ?? []).some((candidate) => /debug|root-cause/i.test(candidate)));
+  });
+
+  it('keeps narrow typo/copy tasks quiet', () => {
+    const plan = synthesizeDelegationPlan(task({
+      subject: 'Fix typo',
+      description: 'Fix one typo in README.md',
+    }));
+
+    assert.deepEqual(plan, { mode: 'none' });
+  });
+
+  it('falls back to optional delegation for ordinary implementation work and honors child override', () => {
+    process.env.OMX_TEAM_CHILD_MODEL = 'standard-child-override';
+    const plan = synthesizeDelegationPlan(task({
+      subject: 'Add parser option',
+      description: 'Implement parser option and update docs',
+    }));
+
+    assert.equal(plan.mode, 'optional');
+    assert.equal(plan.max_parallel_subtasks, 2);
+    assert.equal(plan.child_model_policy, 'standard');
+    assert.equal(plan.child_model, 'standard-child-override');
+  });
+});

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -5173,18 +5173,27 @@ esac
 
   it('startTeam persists synthesized delegation plans for broad tasks', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    await mkdir(binDir, { recursive: true });
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    let runtime: TeamRuntime | null = null;
     try {
-      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-      process.env.OMX_TEAM_WORKER_CLI = 'gemini';
-      await startTeam(
-        'team-delegation-persist',
-        'delegation persistence test',
-        'executor',
-        1,
-        [{ subject: 'Investigate runtime assignment', description: 'Search runtime and debug assignTask behavior', owner: 'worker-1' }],
-        cwd,
+      runtime = await withPromptModeCodexEnv(binDir, {}, () =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-delegation-persist',
+            'delegation persistence test',
+            'executor',
+            1,
+            [{ subject: 'Investigate runtime assignment', description: 'Search runtime and debug assignTask behavior' }],
+            cwd,
+          ),
+        ),
       );
 
       const task = await readTask('team-delegation-persist', '1', cwd);
@@ -5192,8 +5201,9 @@ esac
       assert.equal(task?.delegation?.child_model, 'gpt-5.4-mini');
       assert.equal(task?.delegation?.required_parallel_probe, true);
     } finally {
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -10,6 +10,7 @@ import {
   initTeamState,
   createTask,
   writeWorkerIdentity,
+  writeWorkerInbox,
   readTeamConfig,
   saveTeamConfig,
   listMailboxMessages,
@@ -994,8 +995,6 @@ sleep 5
       else delete process.env.OMX_TEAM_LEADER_CWD;
       if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -1015,6 +1014,7 @@ sleep 5
     } finally {
       if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      delete process.env.OMX_TEAM_WORKER_CLI;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -5164,6 +5164,67 @@ esac
         () => assignTask('team-approval', 'worker-1', task.id, cwd),
         /plan_approval_required/,
       );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+
+  it('startTeam persists synthesized delegation plans for broad tasks', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    try {
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+      await startTeam(
+        'team-delegation-persist',
+        'delegation persistence test',
+        'executor',
+        1,
+        [{ subject: 'Investigate runtime assignment', description: 'Search runtime and debug assignTask behavior', owner: 'worker-1' }],
+        cwd,
+      );
+
+      const task = await readTask('team-delegation-persist', '1', cwd);
+      assert.equal(task?.delegation?.mode, 'auto');
+      assert.equal(task?.delegation?.child_model, 'gpt-5.4-mini');
+      assert.equal(task?.delegation?.required_parallel_probe, true);
+    } finally {
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('assignTask synthesizes delegation before follow-up dispatch rollback', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
+    try {
+      await initTeamState('team-assign-delegation', 'assignment delegation test', 'executor', 1, cwd);
+      const config = await readTeamConfig('team-assign-delegation', cwd);
+      assert.ok(config);
+      config.worker_launch_mode = 'prompt';
+      await saveTeamConfig(config, cwd);
+      const task = await createTask(
+        'team-assign-delegation',
+        { subject: 'Investigate follow-up assignment', description: 'Search repo and debug follow-up assignment behavior', status: 'pending' },
+        cwd,
+      );
+
+      await writeWorkerInbox('team-assign-delegation', 'worker-1', 'existing inbox', cwd);
+      await assert.rejects(
+        () => assignTask('team-assign-delegation', 'worker-1', task.id, cwd),
+        /worker_notify_failed/,
+      );
+
+      const reread = await readTask('team-assign-delegation', task.id, cwd);
+      assert.equal(reread?.delegation?.mode, 'auto');
+      assert.equal(reread?.delegation?.child_model, 'gpt-5.4-mini');
+
+      const inbox = await readFile(join(cwd, '.omx', 'state', 'team', 'team-assign-delegation', 'workers', 'worker-1', 'inbox.md'), 'utf-8');
+      assert.match(inbox, /Assignment Cancelled/);
+      assert.match(inbox, /worker_notify_failed/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -390,6 +390,56 @@ describe("worker bootstrap", () => {
     assert.match(inbox, /Role: test-engineer/);
   });
 
+
+
+  it("generateInitialInbox includes Native Subagent Delegation Contract for broad delegated tasks", () => {
+    const tasks: TeamTask[] = [{
+      id: "7",
+      subject: "Investigate runtime failure",
+      description: "Search runtime and debug flaky assignment behavior",
+      status: "pending",
+      created_at: new Date(0).toISOString(),
+      delegation: {
+        mode: "auto",
+        max_parallel_subtasks: 3,
+        required_parallel_probe: true,
+        spawn_before_serial_search_threshold: 3,
+        child_model_policy: "standard",
+        child_model: "gpt-5.4-mini",
+        subtask_candidates: ["Map runtime assignment flow", "Inspect bootstrap tests"],
+        child_report_format: "bullets",
+        skip_allowed_reason_required: true,
+      },
+    }];
+
+    const inbox = generateInitialInbox("worker-1", "team-delegation", "executor", tasks);
+
+    assert.match(inbox, /Native Subagent Delegation Contract/);
+    assert.match(inbox, /Task 7/);
+    assert.match(inbox, /before doing more than 3 serial repo-search\/read commands/i);
+    assert.match(inbox, /spawn up to 3 Codex native subagents/i);
+    assert.match(inbox, /gpt-5\.4-mini/);
+    assert.match(inbox, /Map runtime assignment flow/);
+    assert.match(inbox, /Subagent evidence reporting fields/);
+    assert.match(inbox, /Subagent skip reason:/);
+  });
+
+  it("generateInitialInbox keeps mode none tasks quiet about delegation contract", () => {
+    const tasks: TeamTask[] = [{
+      id: "8",
+      subject: "Fix typo",
+      description: "Fix one typo in README.md",
+      status: "pending",
+      created_at: new Date(0).toISOString(),
+      delegation: { mode: "none" },
+    }];
+
+    const inbox = generateInitialInbox("worker-1", "team-narrow", "executor", tasks);
+
+    assert.doesNotMatch(inbox, /Native Subagent Delegation Contract/);
+    assert.doesNotMatch(inbox, /gpt-5\.4-mini/);
+  });
+
   it("generateTaskAssignmentInbox includes task ID and description", () => {
     const inbox = generateTaskAssignmentInbox(
       "worker-3",
@@ -411,6 +461,39 @@ describe("worker bootstrap", () => {
     );
     assert.match(inbox, /Verification Requirements/);
     assert.match(inbox, /PASS\/FAIL/);
+  });
+
+
+
+  it("generateTaskAssignmentInbox includes delegation contract for follow-up task object", () => {
+    const inbox = generateTaskAssignmentInbox(
+      "worker-3",
+      "team-followup",
+      {
+        id: "42",
+        subject: "Investigate parser regression",
+        description: "Investigate parser regression across tests",
+        status: "pending",
+        created_at: new Date(0).toISOString(),
+        delegation: {
+          mode: "auto",
+          max_parallel_subtasks: 3,
+          required_parallel_probe: true,
+          spawn_before_serial_search_threshold: 3,
+          child_model_policy: "standard",
+          child_model: "gpt-5.4-mini",
+          subtask_candidates: ["Search parser references", "Review parser tests"],
+          child_report_format: "bullets",
+          skip_allowed_reason_required: true,
+        },
+      },
+    );
+
+    assert.match(inbox, /Native Subagent Delegation Contract/);
+    assert.match(inbox, /spawn up to 3 Codex native subagents/i);
+    assert.match(inbox, /gpt-5\.4-mini/);
+    assert.match(inbox, /Search parser references/);
+    assert.match(inbox, /Subagent skip reason:/);
   });
 
   it("generateShutdownInbox contains exit instruction and concrete ack path", () => {

--- a/src/team/delegation-policy.ts
+++ b/src/team/delegation-policy.ts
@@ -1,0 +1,96 @@
+import { getTeamChildModel } from '../config/models.js';
+import type { TeamTask, TeamTaskDelegationPlan } from './state.js';
+
+const BROAD_TASK_PATTERNS = [
+  /\b(broad|large|cross[-\s]?cutting|end[-\s]?to[-\s]?end)\b/i,
+  /\bdebug|root[-\s]?cause|flaky|failure|regression|bug\b/i,
+  /\breview|audit|assess|validate\b/i,
+  /\bsearch|map|trace|find references|repo[-\s]?wide\b/i,
+  /\btest|coverage|verify|qa\b/i,
+  /\brefactor|cleanup|deslop|simplif(?:y|ication)\b/i,
+  /\bmigrat(?:e|ion)|upgrade|port\b/i,
+  /\binvestigat(?:e|ion)|analy[sz]e|diagnos(?:e|is)\b/i,
+];
+
+const NARROW_TASK_PATTERNS = [
+  /\btypo\b/i,
+  /\bcopy\b/i,
+  /\bsingle[-\s]?file\b/i,
+  /\bone[-\s]?(line|word|sentence|file)\b/i,
+  /\breadme\b.*\btypo\b/i,
+];
+
+const SIMPLE_SCOPE_PATTERNS = [
+  /\bfix\b.*\btypo\b/i,
+  /\bupdate\b.*\bcopy\b/i,
+  /\brename\b.*\bsingle\b/i,
+];
+
+function taskText(task: Pick<TeamTask, 'subject' | 'description' | 'role'>): string {
+  return [task.subject, task.description, task.role].filter(Boolean).join('\n');
+}
+
+function isNarrowTask(text: string): boolean {
+  return NARROW_TASK_PATTERNS.some((pattern) => pattern.test(text))
+    && (SIMPLE_SCOPE_PATTERNS.some((pattern) => pattern.test(text)) || !/\b(search|debug|investigate|refactor|migration|review|test)\b/i.test(text));
+}
+
+function isBroadTask(text: string): boolean {
+  return BROAD_TASK_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function roleAwareSubtaskCandidates(task: Pick<TeamTask, 'subject' | 'description' | 'role'>): string[] {
+  const text = taskText(task);
+  const candidates: string[] = [];
+
+  if (/\bdebug|root[-\s]?cause|flaky|failure|regression|bug|investigat/i.test(text)) {
+    candidates.push('Debug/root-cause probe: trace likely failure paths and summarize evidence.');
+  }
+  if (/\bsearch|map|find references|repo[-\s]?wide|investigat/i.test(text)) {
+    candidates.push('Repository map probe: find relevant files, symbols, and ownership boundaries.');
+  }
+  if (/\breview|audit|security|quality/i.test(text)) {
+    candidates.push('Review probe: inspect risks, edge cases, and contract violations.');
+  }
+  if (/\btest|coverage|verify|qa/i.test(text)) {
+    candidates.push('Test probe: identify existing coverage and missing regression checks.');
+  }
+  if (/\brefactor|cleanup|deslop|simplif|migrat|upgrade|port/i.test(text)) {
+    candidates.push('Change-slice probe: isolate safe implementation slices and migration hazards.');
+  }
+
+  if (candidates.length === 0) {
+    candidates.push('Context probe: map the relevant code paths and summarize recommended next steps.');
+  }
+
+  return candidates.slice(0, 4);
+}
+
+export function synthesizeDelegationPlan(task: Pick<TeamTask, 'subject' | 'description' | 'role'>): TeamTaskDelegationPlan {
+  const text = taskText(task);
+
+  if (isNarrowTask(text)) {
+    return { mode: 'none' };
+  }
+
+  if (isBroadTask(text)) {
+    return {
+      mode: 'auto',
+      max_parallel_subtasks: 3,
+      required_parallel_probe: true,
+      spawn_before_serial_search_threshold: 3,
+      child_model_policy: 'standard',
+      child_model: getTeamChildModel(),
+      subtask_candidates: roleAwareSubtaskCandidates(task),
+      child_report_format: 'bullets',
+      skip_allowed_reason_required: true,
+    };
+  }
+
+  return {
+    mode: 'optional',
+    max_parallel_subtasks: 2,
+    child_model_policy: 'standard',
+    child_model: getTeamChildModel(),
+  };
+}

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -43,6 +43,7 @@ import {
   teamCreateTask as createStateTask,
   teamReadTask as readTask,
   teamListTasks as listTasks,
+  teamUpdateTask as updateTask,
   teamReadManifest as readTeamManifestV2,
   teamNormalizeGovernance as normalizeTeamGovernance,
   teamNormalizePolicy as normalizeTeamPolicy,
@@ -102,6 +103,7 @@ import {
   buildLeaderMailboxTriggerDirective,
   writeWorkerRoleInstructionsFile,
 } from './worker-bootstrap.js';
+import { synthesizeDelegationPlan } from './delegation-policy.js';
 import { loadRolePrompt } from './role-router.js';
 import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
@@ -1992,7 +1994,7 @@ export async function startTeam(
   task: string,
   agentType: string,
   workerCount: number,
-  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[]; role?: string }>,
+  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[]; role?: string; delegation?: TeamTask['delegation'] }>,
   cwd: string,
   options: TeamStartOptions = {},
 ): Promise<TeamRuntime> {
@@ -2122,6 +2124,7 @@ export async function startTeam(
         owner: t.owner,
         blocked_by: t.blocked_by,
         role: t.role,
+        delegation: t.delegation ?? synthesizeDelegationPlan(t),
       }, leaderCwd);
     }
 
@@ -2873,7 +2876,10 @@ export async function assignTask(
 
   try {
     // Retry dispatch up to 2 times to handle trust prompts during assignment (fixes #393).
-    const inbox = generateTaskAssignmentInbox(workerName, sanitized, taskId, task.description);
+    const taskForInbox = task.delegation
+      ? task
+      : (await updateTask(sanitized, taskId, { delegation: synthesizeDelegationPlan(task) }, cwd)) ?? task;
+    const inbox = generateTaskAssignmentInbox(workerName, sanitized, taskForInbox);
     const maxAssignRetries = 2;
     const assignRetryDelayS = 2;
     let outcome: DispatchOutcome = { ok: false, transport: 'none', reason: 'not_attempted' };

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -129,6 +129,21 @@ export interface WorkerStatus {
   updated_at: string;
 }
 
+export type TeamTaskDelegationMode = 'none' | 'optional' | 'auto' | 'required';
+export type TeamTaskChildModelPolicy = 'standard' | 'fast' | 'inherit' | 'frontier';
+
+export interface TeamTaskDelegationPlan {
+  mode: TeamTaskDelegationMode;
+  max_parallel_subtasks?: number;
+  required_parallel_probe?: boolean;
+  spawn_before_serial_search_threshold?: number;
+  child_model_policy?: TeamTaskChildModelPolicy;
+  child_model?: string;
+  subtask_candidates?: string[];
+  child_report_format?: 'bullets' | 'json';
+  skip_allowed_reason_required?: boolean;
+}
+
 export interface TeamTask {
   id: string;
   subject: string;
@@ -145,6 +160,7 @@ export interface TeamTask {
   claim?: TeamTaskClaim;
   created_at: string;
   completed_at?: string;
+  delegation?: TeamTaskDelegationPlan;
 }
 
 export interface TeamTaskClaim {

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -57,6 +57,21 @@ export interface WorkerStatus {
   updated_at: string;
 }
 
+export type TeamTaskDelegationMode = 'none' | 'optional' | 'auto' | 'required';
+export type TeamTaskChildModelPolicy = 'standard' | 'fast' | 'inherit' | 'frontier';
+
+export interface TeamTaskDelegationPlan {
+  mode: TeamTaskDelegationMode;
+  max_parallel_subtasks?: number;
+  required_parallel_probe?: boolean;
+  spawn_before_serial_search_threshold?: number;
+  child_model_policy?: TeamTaskChildModelPolicy;
+  child_model?: string;
+  subtask_candidates?: string[];
+  child_report_format?: 'bullets' | 'json';
+  skip_allowed_reason_required?: boolean;
+}
+
 export interface TeamTask {
   id: string;
   subject: string;
@@ -73,6 +88,7 @@ export interface TeamTask {
   claim?: TeamTaskClaim;
   created_at: string;
   completed_at?: string;
+  delegation?: TeamTaskDelegationPlan;
 }
 
 export interface TeamTaskClaim {

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -632,6 +632,50 @@ async function withAgentsMdLock<T>(
   }
 }
 
+
+function renderDelegationContract(task: TeamTask): string {
+  const plan = task.delegation;
+  if (!plan || plan.mode === "none") return "";
+
+  const threshold = plan.spawn_before_serial_search_threshold ?? 3;
+  const maxParallel = plan.max_parallel_subtasks ?? 2;
+  const childModel = plan.child_model ?? "gpt-5.4-mini";
+  const candidates = (plan.subtask_candidates ?? [])
+    .map((candidate) => `- ${candidate}`)
+    .join("\n");
+  const requiredProbe = plan.required_parallel_probe
+    ? "- A parallel probe is required unless there is a documented skip reason.\n"
+    : "";
+  const skipLine = plan.skip_allowed_reason_required
+    ? "- If skipped, include `Subagent skip reason:` in your result and explain why serial work was safer or sufficient.\n"
+    : "";
+  const reportFormat = plan.child_report_format ?? "bullets";
+
+  return `
+### Native Subagent Delegation Contract — Task ${task.id}
+
+- Delegation mode: ${plan.mode}
+- Before doing more than ${threshold} serial repo-search/read commands, spawn up to ${maxParallel} Codex native subagents using model ${childModel}, wait for them, then integrate their findings before continuing.
+${requiredProbe}- Keep subagent work independent, bounded, and inside this worker's task scope.
+- Use child report format: ${reportFormat}.
+${skipLine}${candidates ? `\nRole/probe subtask candidates:\n${candidates}\n` : ""}
+Subagent evidence reporting fields:
+- Subagents spawned: <count and task names>
+- Subagent model: ${childModel}
+- Findings integrated: <brief bullets>
+- Serial searches before spawn: <number>
+`;
+}
+
+function renderDelegationContracts(tasks: TeamTask[]): string {
+  const sections = tasks.map(renderDelegationContract).filter((section) => section.trim().length > 0);
+  if (sections.length === 0) return "";
+  return `
+## Native Subagent Delegation Contract
+
+${sections.join("\n")}`;
+}
+
 /**
  * Generate initial inbox file content for worker bootstrap.
  * This is written to .omx/state/team/{team}/workers/{worker}/inbox.md by the lead.
@@ -665,6 +709,7 @@ export function generateInitialInbox(
   const teamStateRoot = options.teamStateRoot || "<team_state_root>";
   const leaderCwd = options.leaderCwd || "<leader_cwd>";
   const displayRole = options.workerRole ?? agentType;
+  const delegationSection = renderDelegationContracts(tasks);
 
   const specializationSection = options.worktreeRootAgentsCanonical === true
     ? ""
@@ -726,6 +771,7 @@ When using \`omx team api send-message\`, ALWAYS include from_worker with YOUR w
 
 Example: omx team api send-message --input "{\"team_name\":\"${teamName}\",\"from_worker\":\"${workerName}\",\"to_worker\":\"leader-fixed\",\"body\":\"ACK: initialized\"}" --json
 
+${delegationSection}
 ${buildVerificationSection("each assigned task")}
 
 ## Scope Rules
@@ -743,9 +789,27 @@ ${specializationSection}`;
 export function generateTaskAssignmentInbox(
   workerName: string,
   teamName: string,
+  task: TeamTask,
+): string;
+export function generateTaskAssignmentInbox(
+  workerName: string,
+  teamName: string,
   taskId: string,
   taskDescription: string,
+): string;
+export function generateTaskAssignmentInbox(
+  workerName: string,
+  teamName: string,
+  taskOrId: TeamTask | string,
+  taskDescriptionArg?: string,
 ): string {
+  const task = typeof taskOrId === "string"
+    ? { id: taskOrId, description: taskDescriptionArg ?? "" }
+    : taskOrId;
+  const taskId = task.id;
+  const taskDescription = task.description;
+  const delegationSection = renderDelegationContracts([task as TeamTask]);
+
   return `# New Task Assignment
 
 **Worker:** ${workerName}
@@ -769,6 +833,7 @@ ${taskDescription}
 7. Use \`omx team api release-task-claim --json\` only for rollback to \`pending\`
 8. Write \`{"state": "idle", "updated_at": "<current ISO timestamp>"}\` to your status file
 
+${delegationSection}
 ${buildVerificationSection(taskDescription)}
 `;
 }


### PR DESCRIPTION
## Summary

This PR adds a first-class team-worker delegation contract so broad OMX team tasks can carry explicit guidance for worker-local Codex native subagent use.

The change introduces a structured `TeamTask.delegation` plan, synthesizes that plan from task subject/description/role, persists it into team task state, and renders a concrete Native Subagent Delegation Contract into both initial worker inboxes and follow-up task assignment inboxes.

## Problem statement

OMX team workers already had role prompts and generic guidance saying they may spawn native subagents, but the actual task payload did not carry an execution contract.

That made subagent use easy to miss in practice:
- worker inbox text treated subagents as optional throughput help
- follow-up assignment inboxes did not preserve richer delegation guidance
- `TeamTask` had no field for delegation mode, max subtasks, required probe, child model, or skip-reason reporting
- runtime assignment could only dispatch a plain task description, not a spawn policy

## Root cause

The runtime had role routing and worker model routing, but not a task-level supervisor contract for worker-local delegation.

As a result, broad investigation/search/debug tasks were still mostly executed serially by a worker even when the work was naturally parallelizable.

## What changed

### 1. Added a structured task delegation plan

`TeamTask` now supports a `delegation` payload with:
- `mode: none | optional | auto | required`
- `max_parallel_subtasks`
- `required_parallel_probe`
- `spawn_before_serial_search_threshold`
- `child_model_policy`
- `child_model`
- `subtask_candidates`
- `child_report_format`
- `skip_allowed_reason_required`

### 2. Added delegation-policy synthesis

New `src/team/delegation-policy.ts` classifies tasks by text/role:
- broad debug/search/review/test/refactor/migration tasks get `mode: auto`
- narrow typo/copy/single-file tasks get `mode: none`
- other tasks get `mode: optional`

Broad tasks default to:
- `max_parallel_subtasks: 3`
- `required_parallel_probe: true`
- `spawn_before_serial_search_threshold: 3`
- `child_model_policy: standard`
- `child_model: gpt-5.4-mini`

### 3. Added a dedicated team child-model lane

`getTeamChildModel()` resolves worker-local child model selection through:
1. `OMX_TEAM_CHILD_MODEL`
2. `.omx-config.json` env override
3. `DEFAULT_TEAM_CHILD_MODEL`

`DEFAULT_TEAM_CHILD_MODEL` is set to `DEFAULT_STANDARD_MODEL`, currently `gpt-5.4-mini`.

This keeps team-worker child agents on a stable standard/mini lane instead of inheriting the leader/frontier model by accident.

### 4. Persisted and rendered the contract

Team startup now writes synthesized delegation plans into task JSON. Follow-up assignment dispatch also backfills the plan when missing.

Worker inboxes now include a concrete Native Subagent Delegation Contract telling workers:
- when to spawn native subagents
- how many to spawn
- which model to use
- what subtask candidates to consider
- what evidence fields to report
- when a skip reason is required

### 5. Added focused tests

Coverage was added for:
- child-model defaults and override behavior
- delegation-policy classification
- state persistence of task delegation fields
- worker inbox rendering for initial and follow-up assignments
- runtime assignment backfill/dispatch behavior

## Why this design

Prompt wording alone is not enough for reliable worker-local subagent use. The worker needs a task-scoped execution contract that survives task creation, persistence, assignment, and inbox rendering.

This PR keeps the design narrow:
- no broad team scheduler rewrite
- no new worker process type
- no forced child execution from the leader
- no claim that runtime logs now prove workers always spawn subagents

Instead, it makes the worker contract explicit and reviewable at the point where workers actually receive work.

## Overlap assessment

Classification: **Follow-up / adjacent but distinct**

Related work:
- #885 added native Codex subagent integration and team interop surfaces.
- #1018 tightened root prompt guidance so child agents inherit current frontier defaults unless explicitly overridden.

This PR is different because it targets **team worker task delivery**, not root prompt inheritance or the existence of native subagent support. It adds a structured task-level delegation policy and renders it into worker assignments.

## Validation

Ran on this branch after rebasing on `upstream/dev`:

```bash
npm run build
node --test dist/team/__tests__/worker-bootstrap.test.js
node --test dist/team/__tests__/delegation-policy.test.js
node --test dist/config/__tests__/models.test.js --test-name-pattern 'team child|OMX_TEAM_CHILD_MODEL|standard mini'
node --test dist/team/__tests__/runtime.test.js --test-name-pattern 'delegation|assignTask|role routing'
```

Result: all focused verification passed, including `runtime` 107/107 tests.

Additional manual smoke evidence:
- a prompt-mode team run rendered `Native Subagent Delegation Contract` into the worker inbox
- generated task JSON contained `delegation.child_model = "gpt-5.4-mini"`
- the inbox instructed workers to spawn up to 3 native subagents using `gpt-5.4-mini`

Important limitation: historical Codex state inspection did not show a successful worker `spawn_agent` call using `gpt-5.4-mini` yet. This PR lands the task/inbox contract; runtime behavior should be monitored in follow-up real team runs.

## Risks / compatibility

Risk level: medium-low.

Compatibility notes:
- existing task JSON remains valid because `delegation` is optional
- missing delegation plans are synthesized/backfilled on assignment
- narrow tasks can opt out via `mode: none`
- `OMX_TEAM_CHILD_MODEL` allows overriding the default child lane

Known risk:
- workers may still skip or fail to call `spawn_agent` despite the contract; this PR makes the expectation explicit but does not add retrospective enforcement/eval yet.

## Changed files

- `src/config/models.ts`
- `src/config/__tests__/models.test.ts`
- `src/team/state/types.ts`
- `src/team/state.ts`
- `src/team/delegation-policy.ts`
- `src/team/__tests__/delegation-policy.test.ts`
- `src/team/worker-bootstrap.ts`
- `src/team/__tests__/worker-bootstrap.test.ts`
- `src/team/runtime.ts`
- `src/team/__tests__/runtime.test.ts`

## Target-base diff classification

Net-new behavior change: team tasks now carry and render explicit worker-local native subagent delegation contracts.
