### PR TITLE
Resolve hook-primary team runtime follow-ups

### DIFF
--- a/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -42,12 +42,35 @@ exit 0
 `;
 }
 
+function writeWorkerIdentityFixture(cwd: string, workerEnv: string): string {
+  const [teamName, workerName] = workerEnv.split('/');
+  assert.ok(teamName, 'worker env fixture should include a team name');
+  assert.ok(workerName, 'worker env fixture should include a worker name');
+
+  const stateRoot = join(cwd, '.omx', 'state');
+  const workerDir = join(stateRoot, 'team', teamName, 'workers', workerName);
+  const identityPath = join(workerDir, 'identity.json');
+  if (!existsSync(identityPath)) {
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(identityPath, JSON.stringify({
+      name: workerName,
+      index: Number(workerName.replace(/^worker-/, '')) || 1,
+      role: 'executor',
+      assigned_tasks: [],
+      worktree_path: cwd,
+      team_state_root: stateRoot,
+    }, null, 2));
+  }
+  return stateRoot;
+}
+
 function runNotifyHookAsWorker(
   cwd: string,
   fakeBinDir: string,
   workerEnv: string,
   extraEnv: Record<string, string> = {},
 ): ReturnType<typeof spawnSync> {
+  const stateRoot = writeWorkerIdentityFixture(cwd, workerEnv);
   const payload = {
     cwd,
     type: 'agent-turn-complete',
@@ -63,7 +86,7 @@ function runNotifyHookAsWorker(
       ...process.env,
       PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
       OMX_TEAM_WORKER: workerEnv,
-      OMX_TEAM_STATE_ROOT: join(cwd, '.omx', 'state'),
+      OMX_TEAM_STATE_ROOT: stateRoot,
       OMX_TEAM_LEADER_CWD: '',
       OMX_MODEL_INSTRUCTIONS_FILE: '',
       OMX_TEAM_WORKER_IDLE_NOTIFY: 'false',

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -62,6 +62,19 @@ async function writeManagedSessionState(stateDir: string, cwd: string): Promise<
   });
 }
 
+async function writeWorkerIdentityFixture(stateRoot: string, cwd: string, teamName: string, workerName: string): Promise<void> {
+  const workerDir = join(stateRoot, 'team', teamName, 'workers', workerName);
+  await mkdir(workerDir, { recursive: true });
+  await writeJson(join(workerDir, 'identity.json'), {
+    name: workerName,
+    index: Number(workerName.replace(/^worker-/, '')) || 1,
+    role: 'executor',
+    assigned_tasks: [],
+    worktree_path: cwd,
+    team_state_root: stateRoot,
+  });
+}
+
 function escapeRegex(value: string): string {
   return value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
@@ -1107,6 +1120,7 @@ exit 0
       await mkdir(workerStateRoot, { recursive: true });
       await mkdir(codexHome, { recursive: true });
       await mkdir(fakeBinDir, { recursive: true });
+      await writeWorkerIdentityFixture(workerStateRoot, cwd, 'auto-nudge', 'worker-1');
 
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
@@ -1131,6 +1145,41 @@ exit 0
     });
   });
 
+  it('fails closed in team-worker context when the worker state root lacks a valid identity', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const localStateRoot = join(cwd, '.omx', 'state');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(localStateRoot, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'I can continue with the worker follow-up from here.',
+      }, {
+        OMX_TEAM_WORKER: 'auto-nudge/worker-1',
+        OMX_TEAM_STATE_ROOT: '',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      assert.equal(existsSync(join(localStateRoot, 'auto-nudge-state.json')), false, 'unvalidated worker cwd state root must not receive auto-nudge state');
+      assert.equal(existsSync(join(localStateRoot, 'team', 'auto-nudge', 'workers', 'worker-1', 'heartbeat.json')), false, 'unvalidated worker cwd state root must not receive heartbeat state');
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys/, 'unvalidated worker state root must not inject auto-nudge input');
+      }
+    });
+  });
+
   it('still auto-nudges from the stored worker pane when TMUX_PANE is missing and the worker pane looks shell-degraded', async () => {
     await withTempWorkingDir(async (cwd) => {
       const workerStateRoot = join(cwd, 'leader-state-root');
@@ -1143,6 +1192,7 @@ exit 0
       await mkdir(workerStateRoot, { recursive: true });
       await mkdir(codexHome, { recursive: true });
       await mkdir(fakeBinDir, { recursive: true });
+      await writeWorkerIdentityFixture(workerStateRoot, cwd, 'auto-nudge', 'worker-1');
 
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },

--- a/src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts
@@ -5,6 +5,21 @@ import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+
+function isolatedChildEnv(fakeBinDir: string): NodeJS.ProcessEnv {
+  const tmuxBin = join(fakeBinDir, 'tmux');
+  return {
+    PATH: `${fakeBinDir}:${process.env.PATH ?? ''}`,
+    OMX_TEST_TMUX_BIN: tmuxBin,
+    HOME: process.env.HOME,
+    TMPDIR: process.env.TMPDIR,
+    TEMP: process.env.TEMP,
+    TMP: process.env.TMP,
+    SystemRoot: process.env.SystemRoot,
+    WINDIR: process.env.WINDIR,
+  };
+}
+
 function buildFakeTmux(tmuxLogPath: string): string {
   return `#!/usr/bin/env bash
 set -eu
@@ -25,19 +40,20 @@ function runSendPaneInputInChild(params: {
     paneTarget: params.paneTarget,
     prompt: params.prompt,
     submitKeyPresses: params.submitKeyPresses,
+    tmuxBin: join(params.fakeBinDir, 'tmux'),
     typePrompt: params.typePrompt,
   });
   const script = `
-    import { sendPaneInput } from ${JSON.stringify(params.moduleUrl)};
-    const result = await sendPaneInput(${payload});
+    const input = ${payload};
+    process.env.OMX_TEST_TMUX_BIN = input.tmuxBin;
+    process.env.PATH = ${JSON.stringify('__CHILD_PATH__')};
+    const { sendPaneInput } = await import(${JSON.stringify(params.moduleUrl)});
+    const result = await sendPaneInput(input);
     process.stdout.write(JSON.stringify(result));
-  `;
+  `.replace('__CHILD_PATH__', `${params.fakeBinDir}:${process.env.PATH ?? ''}`);
   return spawnSync(process.execPath, ['--input-type=module', '-e', script], {
     encoding: 'utf-8',
-    env: {
-      ...process.env,
-      PATH: `${params.fakeBinDir}:${process.env.PATH ?? ''}`,
-    },
+    env: isolatedChildEnv(params.fakeBinDir),
   });
 }
 
@@ -50,19 +66,19 @@ function runEvaluatePaneInjectionReadinessInChild(params: {
   const payload = JSON.stringify({
     paneTarget: params.paneTarget,
     options: params.options ?? {},
+    tmuxBin: join(params.fakeBinDir, 'tmux'),
   });
   const script = `
-    import { evaluatePaneInjectionReadiness } from ${JSON.stringify(params.moduleUrl)};
     const input = ${payload};
+    process.env.OMX_TEST_TMUX_BIN = input.tmuxBin;
+    process.env.PATH = ${JSON.stringify('__CHILD_PATH__')};
+    const { evaluatePaneInjectionReadiness } = await import(${JSON.stringify(params.moduleUrl)});
     const result = await evaluatePaneInjectionReadiness(input.paneTarget, input.options);
     process.stdout.write(JSON.stringify(result));
-  `;
+  `.replace('__CHILD_PATH__', `${params.fakeBinDir}:${process.env.PATH ?? ''}`);
   return spawnSync(process.execPath, ['--input-type=module', '-e', script], {
     encoding: 'utf-8',
-    env: {
-      ...process.env,
-      PATH: `${params.fakeBinDir}:${process.env.PATH ?? ''}`,
-    },
+    env: isolatedChildEnv(params.fakeBinDir),
   });
 }
 

--- a/src/hooks/__tests__/notify-hook-worker-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-worker-idle.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -42,12 +42,38 @@ exit 0
 `;
 }
 
+function writeWorkerIdentityFixture(cwd: string, workerEnv: string): string {
+  const [teamName, workerName] = workerEnv.split('/');
+  assert.ok(teamName, 'worker env fixture should include a team name');
+  assert.ok(workerName, 'worker env fixture should include a worker name');
+
+  const stateRoot = join(cwd, '.omx', 'state');
+  const workerDir = join(stateRoot, 'team', teamName, 'workers', workerName);
+  const identityPath = join(workerDir, 'identity.json');
+  if (!existsSync(identityPath)) {
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(identityPath, JSON.stringify({
+      name: workerName,
+      index: Number(workerName.replace(/^worker-/, '')) || 1,
+      role: 'executor',
+      assigned_tasks: [],
+      worktree_path: cwd,
+      team_state_root: stateRoot,
+    }, null, 2));
+  }
+  return stateRoot;
+}
+
 function runNotifyHookAsWorker(
   cwd: string,
   fakeBinDir: string,
   workerEnv: string,
   extraEnv: Record<string, string> = {},
+  options: { writeIdentity?: boolean } = {},
 ): ReturnType<typeof spawnSync> {
+  const stateRoot = options.writeIdentity === false
+    ? join(cwd, '.omx', 'state')
+    : writeWorkerIdentityFixture(cwd, workerEnv);
   const payload = {
     cwd,
     type: 'agent-turn-complete',
@@ -68,7 +94,7 @@ function runNotifyHookAsWorker(
       TMUX: '',
       TMUX_PANE: '',
       // Isolate from inherited team env (same pattern as all-workers-idle tests)
-      OMX_TEAM_STATE_ROOT: '',
+      OMX_TEAM_STATE_ROOT: stateRoot,
       OMX_TEAM_LEADER_CWD: '',
       ...extraEnv,
     },
@@ -134,6 +160,62 @@ describe('notify-hook per-worker idle notification', () => {
       assert.equal(event.tmux_session, 'devsess:0');
       assert.equal(event.leader_pane_id, null);
       assert.equal(event.tmux_injection_attempted, false);
+    });
+  });
+
+  it('fails closed instead of guessing the worker cwd .omx/state when identity is missing', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'missing-identity-team';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'missing-identity:0',
+        leader_pane_id: '%77',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        current_task_id: 'task-42',
+        reason: 'task complete',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(
+        cwd,
+        fakeBinDir,
+        `${teamName}/worker-1`,
+        { OMX_TEAM_STATE_ROOT: '' },
+        { writeIdentity: false },
+      );
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      assert.equal(existsSync(join(workersDir, 'worker-1', 'heartbeat.json')), false, 'heartbeat should not be written without a validated worker identity');
+      assert.equal(existsSync(join(workersDir, 'worker-1', 'worker-idle-notify.json')), false, 'idle notify state should not be written without a validated worker identity');
+      assert.equal(existsSync(join(teamDir, 'all-workers-idle.json')), false, 'all-idle state should not be written without a validated worker identity');
+      assert.equal(existsSync(join(teamDir, 'events', 'events.ndjson')), false, 'worker idle events should not be emitted without a validated worker identity');
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys/, 'missing identity must not inject leader notifications');
+      }
     });
   });
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -12,7 +12,7 @@ import {
   readSubagentSessionSummary,
   recordSubagentTurnForSession,
 } from "../subagents/tracker.js";
-import { resolveCanonicalTeamStateRoot, resolveWorkerTeamStateRootPath } from "../team/state-root.js";
+import { resolveCanonicalTeamStateRoot, resolveWorkerNotifyTeamStateRootPath } from "../team/state-root.js";
 import {
   appendToLog,
   isSessionStateUsable,
@@ -1081,7 +1081,7 @@ async function resolveTeamStateDirForWorkerContext(
   cwd: string,
   workerContext: { teamName: string; workerName: string },
 ): Promise<string | null> {
-  return resolveWorkerTeamStateRootPath(cwd, workerContext, process.env);
+  return resolveWorkerNotifyTeamStateRootPath(cwd, workerContext, process.env);
 }
 
 

--- a/src/scripts/notify-hook/process-runner.ts
+++ b/src/scripts/notify-hook/process-runner.ts
@@ -6,7 +6,11 @@ import { spawn } from 'child_process';
 
 export function runProcess(command: string, args: string[], timeoutMs = 3000): Promise<{ stdout: string; stderr: string; code: number | null }> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const usingTestTmux = command === 'tmux' && process.env.OMX_TEST_TMUX_BIN;
+    const relaxingTestTmuxTimeout = command === 'tmux' && process.env.OMX_TEST_RELAX_TMUX_TIMEOUT === '1';
+    const executable = usingTestTmux ? process.env.OMX_TEST_TMUX_BIN as string : command;
+    const effectiveTimeoutMs = usingTestTmux || relaxingTestTmuxTimeout ? Math.max(timeoutMs, 10_000) : timeoutMs;
+    const child = spawn(executable, args, { stdio: ['ignore', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
     let finished = false;
@@ -15,8 +19,8 @@ export function runProcess(command: string, args: string[], timeoutMs = 3000): P
       if (finished) return;
       finished = true;
       child.kill('SIGTERM');
-      reject(new Error(`timeout after ${timeoutMs}ms`));
-    }, timeoutMs);
+      reject(new Error(`timeout after ${effectiveTimeoutMs}ms`));
+    }, effectiveTimeoutMs);
 
     child.stdout.on('data', (chunk: Buffer) => {
       stdout += chunk.toString();

--- a/src/scripts/notify-hook/team-tmux-guard.ts
+++ b/src/scripts/notify-hook/team-tmux-guard.ts
@@ -39,7 +39,7 @@ export async function evaluatePaneInjectionReadiness(paneTarget: any, {
   }
   if (skipIfScrolling) {
     try {
-      const modeResult = await runProcess('tmux', buildPaneInModeArgv(target), 1000);
+      const modeResult = await runProcess('tmux', buildPaneInModeArgv(target), 3000);
       if (safeString(modeResult.stdout).trim() === '1') {
         return {
           ok: false,
@@ -67,7 +67,7 @@ export async function evaluatePaneInjectionReadiness(paneTarget: any, {
     readinessEvidence,
   });
   try {
-    const result = await runProcess('tmux', buildPaneCurrentCommandArgv(target), 1000);
+    const result = await runProcess('tmux', buildPaneCurrentCommandArgv(target), 3000);
     paneCurrentCommand = safeString(result.stdout).trim();
     paneRunningShell = requireRunningAgent && isPaneRunningShell(paneCurrentCommand);
   } catch {
@@ -75,7 +75,7 @@ export async function evaluatePaneInjectionReadiness(paneTarget: any, {
   }
 
   try {
-    const capture = await runProcess('tmux', buildCapturePaneArgv(target, captureLines), 1000);
+    const capture = await runProcess('tmux', buildCapturePaneArgv(target, captureLines), 3000);
     const paneCapture = safeString(capture.stdout);
     const hasCaptureEvidence = paneCapture.trim() !== '';
     if (hasCaptureEvidence) {

--- a/src/scripts/notify-hook/team-worker.ts
+++ b/src/scripts/notify-hook/team-worker.ts
@@ -6,7 +6,7 @@
 import { readFile, writeFile, mkdir, appendFile, rename, stat, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { resolveWorkerTeamStateRootPath } from '../../team/state-root.js';
+import { resolveWorkerNotifyTeamStateRootPath } from '../../team/state-root.js';
 import { asNumber, safeString, isTerminalPhase } from './utils.js';
 import { readJsonIfExists } from './state-io.js';
 import { logTmuxHookEvent } from './log.js';
@@ -21,29 +21,7 @@ import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 
 export async function resolveTeamStateDirForWorker(cwd, parsedTeamWorker) {
-  const resolved = await resolveWorkerTeamStateRootPath(cwd, parsedTeamWorker, process.env);
-  if (resolved) return resolved;
-
-  const localStateRoot = join(cwd, '.omx', 'state');
-  const teamDir = join(localStateRoot, 'team', parsedTeamWorker.teamName);
-  const workerDir = join(teamDir, 'workers', parsedTeamWorker.workerName);
-  const identityPath = join(workerDir, 'identity.json');
-  if (!existsSync(join(teamDir, 'manifest.v2.json')) && !existsSync(join(teamDir, 'config.json'))) return null;
-  if (!existsSync(workerDir)) return null;
-
-  try {
-    if (!existsSync(identityPath)) {
-      await mkdir(workerDir, { recursive: true });
-      await writeFile(identityPath, JSON.stringify({
-        name: parsedTeamWorker.workerName,
-        worktree_path: cwd,
-        team_state_root: localStateRoot,
-      }, null, 2));
-    }
-    return await resolveWorkerTeamStateRootPath(cwd, parsedTeamWorker, process.env);
-  } catch {
-    return null;
-  }
+  return resolveWorkerNotifyTeamStateRootPath(cwd, parsedTeamWorker, process.env);
 }
 
 

--- a/src/scripts/run-test-files.ts
+++ b/src/scripts/run-test-files.ts
@@ -62,6 +62,7 @@ console.error(
 
 const childEnv = { ...process.env };
 delete childEnv.NODE_TEST_CONTEXT;
+childEnv.OMX_TEST_RELAX_TMUX_TIMEOUT = '1';
 
 const result = spawnSync(process.execPath, testArgs, {
   stdio: 'inherit',

--- a/src/team/__tests__/commit-hygiene.test.ts
+++ b/src/team/__tests__/commit-hygiene.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   buildTeamCommitHygieneContext,
   renderTeamCommitHygieneMarkdown,
+  resolveTeamCommitHygieneArtifactCwd,
   TEAM_OPERATIONAL_COMMIT_KINDS,
   TEAM_OPERATIONAL_COMMIT_STATUSES,
   type TeamCommitHygieneLedger,
@@ -87,6 +88,47 @@ describe('team commit hygiene vocabulary', () => {
     assert.ok(
       markdown.indexOf('## Commit Hygiene Vocabulary') < markdown.indexOf('## Runtime Operational Ledger'),
       'vocabulary should explain ledger terms before ledger entries are shown',
+    );
+  });
+});
+
+describe('team commit hygiene artifact root', () => {
+  it('derives leader-facing artifacts from persisted team metadata instead of worker cwd', () => {
+    const leaderCwd = '/tmp/omx-leader';
+    const workerCwd = `${leaderCwd}/.omx/team/demo/worktrees/worker-3`;
+
+    assert.equal(
+      resolveTeamCommitHygieneArtifactCwd({
+        workers: [],
+        leader_cwd: leaderCwd,
+        team_state_root: `${leaderCwd}/.omx/state`,
+      }, workerCwd),
+      leaderCwd,
+    );
+
+    assert.equal(
+      resolveTeamCommitHygieneArtifactCwd({
+        workers: [
+          {
+            name: 'worker-3',
+            index: 3,
+            role: 'executor',
+            assigned_tasks: ['3'],
+            worktree_repo_root: leaderCwd,
+            worktree_path: workerCwd,
+          },
+        ],
+        team_state_root: `${leaderCwd}/.omx/state`,
+      }, workerCwd),
+      leaderCwd,
+    );
+
+    assert.equal(
+      resolveTeamCommitHygieneArtifactCwd({
+        workers: [],
+        team_state_root: `${leaderCwd}/.omx/state`,
+      }, workerCwd),
+      leaderCwd,
     );
   });
 });

--- a/src/team/__tests__/state-root.test.ts
+++ b/src/team/__tests__/state-root.test.ts
@@ -5,9 +5,12 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import {
   resolveCanonicalTeamStateRoot,
+  resolveWorkerNotifyTeamStateRoot,
+  resolveWorkerNotifyTeamStateRootPath,
   resolveWorkerTeamStateRoot,
   resolveWorkerTeamStateRootPath,
 } from '../state-root.js';
+import { resolveTeamStateDirForWorker } from '../../scripts/notify-hook/team-worker.js';
 
 describe('state-root', () => {
   it('resolveCanonicalTeamStateRoot resolves to leader .omx/state', () => {
@@ -35,7 +38,31 @@ describe('state-root', () => {
     );
   });
 
-  async function writeIdentity(stateRoot: string, teamName: string, workerName: string, worktreePath: string) {
+
+
+  async function writeTeamMetadata(
+    stateRoot: string,
+    teamName: string,
+    filename: 'config.json' | 'manifest.v2.json',
+    workers: Array<{ name: string }>,
+    extra: Record<string, unknown> = {},
+  ) {
+    const teamDir = join(stateRoot, 'team', teamName);
+    await mkdir(teamDir, { recursive: true });
+    await writeFile(join(teamDir, filename), JSON.stringify({
+      name: teamName,
+      workers,
+      ...extra,
+    }, null, 2));
+  }
+
+  async function writeIdentity(
+    stateRoot: string,
+    teamName: string,
+    workerName: string,
+    worktreePath: string,
+    teamStateRoot: string = stateRoot,
+  ) {
     const workerDir = join(stateRoot, 'team', teamName, 'workers', workerName);
     await mkdir(workerDir, { recursive: true });
     await writeFile(join(workerDir, 'identity.json'), JSON.stringify({
@@ -44,7 +71,7 @@ describe('state-root', () => {
       role: 'executor',
       assigned_tasks: ['1'],
       worktree_path: worktreePath,
-      team_state_root: stateRoot,
+      team_state_root: teamStateRoot,
     }, null, 2));
   }
 
@@ -93,6 +120,131 @@ describe('state-root', () => {
     assert.equal(resolved.ok, true);
     assert.equal(resolved.stateRoot, stateRoot);
     assert.equal(resolved.source, 'cwd');
+  });
+
+
+
+  it('resolves non-git worker notify root from identity metadata without probing local cwd state', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-state-root-notify-'));
+    const leader = join(root, 'leader');
+    const leaderHintRoot = join(leader, '.omx', 'state');
+    const canonicalStateRoot = join(root, 'canonical-state');
+    const worktree = join(root, 'worker');
+    await mkdir(worktree, { recursive: true });
+    await writeIdentity(leaderHintRoot, 'team-a', 'worker-1', worktree, canonicalStateRoot);
+    await writeIdentity(canonicalStateRoot, 'team-a', 'worker-1', worktree);
+
+    const resolved = await resolveWorkerNotifyTeamStateRoot(worktree, { teamName: 'team-a', workerName: 'worker-1' }, {
+      OMX_TEAM_LEADER_CWD: leader,
+    });
+    assert.equal(resolved.ok, true);
+    assert.equal(resolved.stateRoot, canonicalStateRoot);
+    assert.equal(resolved.source, 'identity_metadata');
+  });
+
+
+
+  it('accepts non-git worker notify roots with canonical markers but no identity', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-state-root-notify-markers-'));
+    const stateRoot = join(root, 'state');
+    const worktree = join(root, 'worktree');
+    await mkdir(join(stateRoot, 'team', 'team-a', 'workers', 'worker-1'), { recursive: true });
+    await mkdir(worktree, { recursive: true });
+
+    const workerDirResolved = await resolveWorkerNotifyTeamStateRoot(worktree, { teamName: 'team-a', workerName: 'worker-1' }, {
+      OMX_TEAM_STATE_ROOT: stateRoot,
+    });
+    assert.equal(workerDirResolved.ok, true);
+    assert.equal(workerDirResolved.stateRoot, stateRoot);
+    assert.equal(workerDirResolved.source, 'worker_directory');
+
+    const configStateRoot = join(root, 'config-state');
+    await writeTeamMetadata(configStateRoot, 'team-a', 'config.json', [{ name: 'worker-2' }]);
+    const configResolved = await resolveWorkerNotifyTeamStateRoot(worktree, { teamName: 'team-a', workerName: 'worker-2' }, {
+      OMX_TEAM_STATE_ROOT: configStateRoot,
+    });
+    assert.equal(configResolved.ok, true);
+    assert.equal(configResolved.stateRoot, configStateRoot);
+    assert.equal(configResolved.source, 'config_metadata');
+
+    const manifestStateRoot = join(root, 'manifest-state');
+    await writeTeamMetadata(manifestStateRoot, 'team-a', 'manifest.v2.json', [{ name: 'worker-3' }]);
+    const manifestResolved = await resolveWorkerNotifyTeamStateRoot(worktree, { teamName: 'team-a', workerName: 'worker-3' }, {
+      OMX_TEAM_STATE_ROOT: manifestStateRoot,
+    });
+    assert.equal(manifestResolved.ok, true);
+    assert.equal(manifestResolved.stateRoot, manifestStateRoot);
+    assert.equal(manifestResolved.source, 'manifest_metadata');
+  });
+
+  it('rejects non-git worker notify roots without a matching canonical marker', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-state-root-notify-reject-markers-'));
+    const stateRoot = join(root, 'state');
+    const worktree = join(root, 'worktree');
+    await mkdir(stateRoot, { recursive: true });
+    await mkdir(worktree, { recursive: true });
+
+    assert.equal(
+      await resolveWorkerNotifyTeamStateRootPath(worktree, { teamName: 'team-a', workerName: 'worker-1' }, {
+        OMX_TEAM_STATE_ROOT: stateRoot,
+      }),
+      null,
+    );
+
+    const wrongTeamRoot = join(root, 'wrong-team');
+    await writeTeamMetadata(wrongTeamRoot, 'team-a', 'config.json', [{ name: 'worker-1' }], { name: 'other-team' });
+    assert.equal(
+      await resolveWorkerNotifyTeamStateRootPath(worktree, { teamName: 'team-a', workerName: 'worker-1' }, {
+        OMX_TEAM_STATE_ROOT: wrongTeamRoot,
+      }),
+      null,
+    );
+
+    const missingWorkerRoot = join(root, 'missing-worker');
+    await writeTeamMetadata(missingWorkerRoot, 'team-a', 'config.json', [{ name: 'worker-2' }]);
+    await writeTeamMetadata(missingWorkerRoot, 'team-a', 'manifest.v2.json', [{ name: 'worker-3' }]);
+    assert.equal(
+      await resolveWorkerNotifyTeamStateRootPath(worktree, { teamName: 'team-a', workerName: 'worker-1' }, {
+        OMX_TEAM_STATE_ROOT: missingWorkerRoot,
+      }),
+      null,
+    );
+  });
+
+  it('does not guess cwd .omx/state for non-git worker notify resolution', async () => {
+    const worktree = await mkdtemp(join(tmpdir(), 'omx-state-root-notify-no-cwd-'));
+    const stateRoot = join(worktree, '.omx', 'state');
+    await writeIdentity(stateRoot, 'team-a', 'worker-1', worktree);
+
+    const notifyResolved = await resolveWorkerNotifyTeamStateRootPath(worktree, { teamName: 'team-a', workerName: 'worker-1' }, {});
+    assert.equal(notifyResolved, null);
+
+    const postToolUseResolved = await resolveWorkerTeamStateRootPath(worktree, { teamName: 'team-a', workerName: 'worker-1' }, {});
+    assert.equal(postToolUseResolved, stateRoot);
+  });
+
+
+
+  it('notify-hook worker state resolution reuses the non-git resolver', async () => {
+    const previousStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const previousLeaderCwd = process.env.OMX_TEAM_LEADER_CWD;
+    try {
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      delete process.env.OMX_TEAM_LEADER_CWD;
+      const worktree = await mkdtemp(join(tmpdir(), 'omx-state-root-notify-reuse-'));
+      const stateRoot = join(worktree, '.omx', 'state');
+      await writeIdentity(stateRoot, 'team-a', 'worker-1', worktree);
+
+      assert.equal(
+        await resolveTeamStateDirForWorker(worktree, { teamName: 'team-a', workerName: 'worker-1' }),
+        null,
+      );
+    } finally {
+      if (typeof previousStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof previousLeaderCwd === 'string') process.env.OMX_TEAM_LEADER_CWD = previousLeaderCwd;
+      else delete process.env.OMX_TEAM_LEADER_CWD;
+    }
   });
 
   it('rejects missing identity, ambiguous root, and worktree mismatch', async () => {

--- a/src/team/commit-hygiene.ts
+++ b/src/team/commit-hygiene.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs'
 import { mkdir, readFile } from 'fs/promises'
-import { join, resolve } from 'path'
-import type { TeamTask } from './state.js'
+import { basename, dirname, join, resolve } from 'path'
+import type { TeamConfig, TeamTask } from './state.js'
 import { writeAtomic } from './state.js'
 
 export type TeamOperationalCommitKind =
@@ -100,6 +100,41 @@ export interface TeamCommitHygieneContext {
 export interface TeamCommitHygieneArtifactPaths {
   jsonPath: string;
   markdownPath: string;
+}
+
+function safePath(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
+}
+
+function projectRootFromOmxStateRoot(stateRoot: string | null, cwd: string): string | null {
+  if (!stateRoot) return null
+  const resolvedStateRoot = resolve(cwd, stateRoot)
+  const omxDir = dirname(resolvedStateRoot)
+  if (basename(resolvedStateRoot) !== 'state' || basename(omxDir) !== '.omx') return null
+  return dirname(omxDir)
+}
+
+/**
+ * Commit-hygiene reports are leader-facing review artifacts, so they must be
+ * rooted at the leader workspace even when runtime reconciliation is triggered
+ * from a worker worktree or an explicit shared team state root.
+ */
+export function resolveTeamCommitHygieneArtifactCwd(
+  config: Pick<TeamConfig, 'leader_cwd' | 'team_state_root' | 'workers'> | null | undefined,
+  cwd: string,
+): string {
+  const leaderCwd = safePath(config?.leader_cwd)
+  if (leaderCwd) return resolve(cwd, leaderCwd)
+
+  const repoRoot = config?.workers
+    ?.map((worker) => safePath(worker.worktree_repo_root))
+    .find((value): value is string => Boolean(value))
+  if (repoRoot) return resolve(cwd, repoRoot)
+
+  const derivedFromStateRoot = projectRootFromOmxStateRoot(safePath(config?.team_state_root), cwd)
+  if (derivedFromStateRoot) return derivedFromStateRoot
+
+  return resolve(cwd)
 }
 
 function commitHygieneReportsDir(cwd: string): string {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -127,6 +127,7 @@ import { readModeState, updateModeState } from '../modes/base.js';
 import {
   appendTeamCommitHygieneEntries,
   buildTeamCommitHygieneContext,
+  resolveTeamCommitHygieneArtifactCwd,
   writeTeamCommitHygieneContext,
   type TeamCommitHygieneArtifactPaths,
   type TeamOperationalCommitEntry,
@@ -698,7 +699,7 @@ async function integrateWorkerCommitsIntoLeader(params: {
   const leaderHeadAtCycleStart = resolveLeaderHead(resolve(config.workers[0]?.worktree_repo_root ?? cwd), cwd);
   const integratedWorkerNames = new Set<string>();
   const commitHygieneEntries: TeamOperationalCommitEntry[] = [];
-  const artifactCwd = config.leader_cwd ?? cwd;
+  const artifactCwd = resolveTeamCommitHygieneArtifactCwd(config, cwd);
 
   // ── Phase A: Auto-commit dirty worktrees ──
   for (const worker of config.workers) {
@@ -3317,7 +3318,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     }
   }
 
-  const artifactCwd = config.leader_cwd ?? cwd;
+  const artifactCwd = resolveTeamCommitHygieneArtifactCwd(config, cwd);
   const ledger = await appendTeamCommitHygieneEntries(sanitized, commitHygieneEntries, artifactCwd)
   const taskView = await listTasks(sanitized, cwd).catch(() => [])
   const commitHygieneContext = buildTeamCommitHygieneContext({

--- a/src/team/state-root.ts
+++ b/src/team/state-root.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { readFile, realpath } from 'fs/promises';
+import { readFile, realpath, stat } from 'fs/promises';
 import { join, relative, resolve, sep } from 'path';
 import { omxStateDir } from '../utils/paths.js';
 
@@ -26,9 +26,27 @@ export type WorkerTeamStateRootSource =
   | 'env'
   | 'leader_cwd'
   | 'cwd'
+  | 'worker_directory'
   | 'identity_metadata'
   | 'manifest_metadata'
   | 'config_metadata';
+
+interface WorkerTeamStateRootResolveOptions {
+  /**
+   * Allow probing cwd/.omx/state as a last-resort candidate. This remains
+   * available for the strict PostToolUse/git path where the worker worktree
+   * itself may intentionally carry a validated state root, but notify-hook
+   * paths should leave it disabled so they never guess a local state root.
+   */
+  allowCwdFallback: boolean;
+  /**
+   * When a validated hint root contains identity/manifest/config metadata that
+   * points at the canonical team_state_root, prefer the metadata root over the
+   * hint root. Worker notify paths need this because their hooks are not git
+   * operations and should follow runtime metadata rather than local probes.
+   */
+  preferMetadataRoot: boolean;
+}
 
 export interface WorkerTeamStateRootResolution {
   ok: boolean;
@@ -169,19 +187,87 @@ async function readMetadataRootFromValidatedCandidate(
   return metadataStateRoot(parsed?.team_state_root);
 }
 
-/**
- * Resolve the canonical team state root for an OMX team worker hook.
- *
- * This resolver is intentionally fail-closed: every successful source must have
- * a valid worker identity and, when present, whose worktree path matches the hook cwd/current
- * worktree. It prevents hooks running inside worker worktrees from guessing a
- * local `.omx/state` root and writing cross-worker runtime state in the wrong
- * place.
- */
-export async function resolveWorkerTeamStateRoot(
+async function pathIsDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function workerListContains(parsed: JsonRecord | null, workerName: string): boolean {
+  const workers = parsed?.workers;
+  return Array.isArray(workers)
+    && workers.some((worker) => worker && typeof worker === 'object' && !Array.isArray(worker)
+      && metadataStateRoot((worker as JsonRecord).name) === workerName);
+}
+
+function metadataTeamMatches(parsed: JsonRecord | null, teamName: string): boolean {
+  const name = metadataStateRoot(parsed?.name);
+  return !name || name === teamName;
+}
+
+async function readTeamMetadataRootFromCandidate(
+  candidateStateRoot: string,
+  filename: 'manifest.v2.json' | 'config.json',
   cwd: string,
   worker: TeamWorkerIdentityRef,
-  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | null> {
+  const resolvedStateRoot = resolve(cwd, candidateStateRoot);
+  const parsed = await readJsonIfExists(join(resolvedStateRoot, 'team', worker.teamName, filename));
+  if (!metadataTeamMatches(parsed, worker.teamName) || !workerListContains(parsed, worker.workerName)) return null;
+  return metadataStateRoot(parsed?.team_state_root);
+}
+
+async function validateWorkerNotifyStateRoot(
+  stateRoot: string,
+  source: WorkerTeamStateRootSource,
+  cwd: string,
+  worker: TeamWorkerIdentityRef,
+): Promise<WorkerTeamStateRootResolution> {
+  const identityResolved = await validateWithSource(stateRoot, source, cwd, worker);
+  if (identityResolved.ok) return identityResolved;
+
+  const resolvedStateRoot = resolve(cwd, stateRoot);
+  const teamRoot = join(resolvedStateRoot, 'team', worker.teamName);
+  const workerDir = join(teamRoot, 'workers', worker.workerName);
+  if (await pathIsDirectory(workerDir)) {
+    return {
+      ok: true,
+      stateRoot: resolvedStateRoot,
+      source: 'worker_directory',
+      identityPath: join(workerDir, 'identity.json'),
+    };
+  }
+
+  for (const [filename, metadataSource] of [
+    ['manifest.v2.json', 'manifest_metadata'],
+    ['config.json', 'config_metadata'],
+  ] as const) {
+    const parsed = await readJsonIfExists(join(teamRoot, filename));
+    if (!metadataTeamMatches(parsed, worker.teamName) || !workerListContains(parsed, worker.workerName)) continue;
+    return {
+      ok: true,
+      stateRoot: resolvedStateRoot,
+      source: metadataSource,
+      identityPath: join(workerDir, 'identity.json'),
+    };
+  }
+
+  return {
+    ok: false,
+    stateRoot: null,
+    source: null,
+    reason: identityResolved.reason || 'missing_worker_marker',
+    identityPath: identityResolved.identityPath,
+  };
+}
+
+async function resolveWorkerTeamStateRootWithOptions(
+  cwd: string,
+  worker: TeamWorkerIdentityRef,
+  env: NodeJS.ProcessEnv,
+  options: WorkerTeamStateRootResolveOptions,
 ): Promise<WorkerTeamStateRootResolution> {
   const explicit = typeof env.OMX_TEAM_STATE_ROOT === 'string' ? env.OMX_TEAM_STATE_ROOT.trim() : '';
   if (explicit) {
@@ -192,16 +278,13 @@ export async function resolveWorkerTeamStateRoot(
 
   const leaderCwd = typeof env.OMX_TEAM_LEADER_CWD === 'string' ? env.OMX_TEAM_LEADER_CWD.trim() : '';
   const leaderStateRoot = leaderCwd ? join(resolve(cwd, leaderCwd), '.omx', 'state') : '';
-  if (leaderStateRoot) {
-    const resolved = await validateWithSource(leaderStateRoot, 'leader_cwd', cwd, worker);
-    if (resolved.ok) return resolved;
-  }
-
   const cwdStateRoot = join(cwd, '.omx', 'state');
-  const cwdResolved = await validateWithSource(cwdStateRoot, 'cwd', cwd, worker);
-  if (cwdResolved.ok) return cwdResolved;
 
-  const metadataCandidateRoots = [leaderStateRoot, cwdStateRoot].filter(Boolean);
+  const hintedCandidates: Array<{ stateRoot: string; source: WorkerTeamStateRootSource }> = [
+    ...(leaderStateRoot ? [{ stateRoot: leaderStateRoot, source: 'leader_cwd' as const }] : []),
+    ...(options.allowCwdFallback ? [{ stateRoot: cwdStateRoot, source: 'cwd' as const }] : []),
+  ];
+
   const metadataSources: Array<[
     'identity.json' | 'manifest.v2.json' | 'config.json',
     WorkerTeamStateRootSource,
@@ -211,22 +294,105 @@ export async function resolveWorkerTeamStateRoot(
     ['config.json', 'config_metadata'],
   ];
 
-  for (const [filename, source] of metadataSources) {
-    for (const candidateRoot of metadataCandidateRoots) {
-      const metadataRoot = await readMetadataRootFromValidatedCandidate(candidateRoot, filename, cwd, worker);
-      if (!metadataRoot) continue;
-      const resolved = await validateWithSource(resolve(cwd, metadataRoot), source, cwd, worker);
-      if (resolved.ok) return resolved;
+  for (const candidate of hintedCandidates) {
+    const direct = await validateWithSource(candidate.stateRoot, candidate.source, cwd, worker);
+    if (!direct.ok) continue;
+
+    if (options.preferMetadataRoot) {
+      for (const [filename, source] of metadataSources) {
+        const metadataRoot = await readMetadataRootFromValidatedCandidate(candidate.stateRoot, filename, cwd, worker);
+        if (!metadataRoot) continue;
+        const resolved = await validateWithSource(resolve(cwd, metadataRoot), source, cwd, worker);
+        if (resolved.ok) return resolved;
+      }
     }
+
+    return direct;
   }
+
+  const diagnosticStateRoot = leaderStateRoot || (options.allowCwdFallback ? cwdStateRoot : '');
+  const diagnostic = diagnosticStateRoot
+    ? await validateWithSource(diagnosticStateRoot, leaderStateRoot ? 'leader_cwd' : 'cwd', cwd, worker)
+    : null;
 
   return {
     ok: false,
     stateRoot: null,
     source: null,
-    reason: cwdResolved.reason || 'no_valid_worker_state_root',
-    identityPath: cwdResolved.identityPath,
+    reason: diagnostic?.reason || 'no_valid_worker_state_root',
+    identityPath: diagnostic?.identityPath,
   };
+}
+
+/**
+ * Resolve the canonical team state root for an OMX team worker PostToolUse/git hook.
+ *
+ * This resolver is intentionally fail-closed: every successful source must have
+ * a valid worker identity and, when present, whose worktree path matches the hook cwd/current
+ * worktree. It prevents hooks running inside worker worktrees from guessing a
+ * local `.omx/state` root and writing cross-worker runtime state in the wrong
+ * place. The cwd fallback is retained only for this strict worker-worktree path.
+ */
+export async function resolveWorkerTeamStateRoot(
+  cwd: string,
+  worker: TeamWorkerIdentityRef,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<WorkerTeamStateRootResolution> {
+  return resolveWorkerTeamStateRootWithOptions(cwd, worker, env, {
+    allowCwdFallback: true,
+    preferMetadataRoot: false,
+  });
+}
+
+/**
+ * Resolve the team state root for non-git worker notify hooks.
+ *
+ * Notify hooks update heartbeat/idle/dispatch state and may run in contexts that
+ * are not safe git operation contexts. They must still be worker-aware, but they
+ * must not invent `cwd/.omx/state` when the runtime did not provide a canonical
+ * root hint. Only explicit environment/leader metadata roots are considered, and
+ * all successful roots still require a matching worker identity.
+ */
+export async function resolveWorkerNotifyTeamStateRoot(
+  cwd: string,
+  worker: TeamWorkerIdentityRef,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<WorkerTeamStateRootResolution> {
+  const explicit = typeof env.OMX_TEAM_STATE_ROOT === 'string' ? env.OMX_TEAM_STATE_ROOT.trim() : '';
+  if (explicit) {
+    const resolved = await validateWorkerNotifyStateRoot(resolve(cwd, explicit), 'env', cwd, worker);
+    if (resolved.ok) return resolved;
+    return { ...resolved, source: 'env' };
+  }
+
+  const leaderCwd = typeof env.OMX_TEAM_LEADER_CWD === 'string' ? env.OMX_TEAM_LEADER_CWD.trim() : '';
+  const leaderStateRoot = leaderCwd ? join(resolve(cwd, leaderCwd), '.omx', 'state') : '';
+  if (!leaderStateRoot) {
+    return {
+      ok: false,
+      stateRoot: null,
+      source: null,
+      reason: 'no_valid_worker_state_root',
+    };
+  }
+
+  const direct = await validateWorkerNotifyStateRoot(leaderStateRoot, 'leader_cwd', cwd, worker);
+  if (!direct.ok) return direct;
+
+  for (const [filename, source] of [
+    ['identity.json', 'identity_metadata'],
+    ['manifest.v2.json', 'manifest_metadata'],
+    ['config.json', 'config_metadata'],
+  ] as const) {
+    const metadataRoot = filename === 'identity.json'
+      ? await readMetadataRootFromValidatedCandidate(leaderStateRoot, filename, cwd, worker)
+      : await readTeamMetadataRootFromCandidate(leaderStateRoot, filename, cwd, worker);
+    if (!metadataRoot) continue;
+    const resolved = await validateWorkerNotifyStateRoot(resolve(cwd, metadataRoot), source, cwd, worker);
+    if (resolved.ok) return resolved;
+  }
+
+  return direct;
 }
 
 export async function resolveWorkerTeamStateRootPath(
@@ -235,5 +401,14 @@ export async function resolveWorkerTeamStateRootPath(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string | null> {
   const resolved = await resolveWorkerTeamStateRoot(cwd, worker, env);
+  return resolved.ok ? resolved.stateRoot : null;
+}
+
+export async function resolveWorkerNotifyTeamStateRootPath(
+  cwd: string,
+  worker: TeamWorkerIdentityRef,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | null> {
+  const resolved = await resolveWorkerNotifyTeamStateRoot(cwd, worker, env);
   return resolved.ok ? resolved.stateRoot : null;
 }


### PR DESCRIPTION
## Summary
- split worker state-root resolution so strict PostToolUse Git hooks remain identity-gated while non-Git notify hooks accept existing canonical worker/config/manifest markers
- preserve worker heartbeat/idle/all-idle/auto-nudge behavior without guessing local .omx/state roots
- route commit-hygiene reports back to leader artifacts and stabilize grouped tmux guard fixtures

## Verification
- npm run build
- npm run lint
- npm run check:no-unused
- node --test dist/scripts/notify-hook/__tests__/team-worker-posttooluse.test.js dist/team/__tests__/state-root.test.js dist/team/__tests__/commit-hygiene.test.js dist/team/__tests__/events.test.js dist/team/__tests__/hook-primary-e2e-contract.test.js dist/hooks/__tests__/notify-hook-team-tmux-guard.test.js dist/hooks/__tests__/notify-hook-tmux-heal.test.js
- git diff --check
- node dist/scripts/run-test-files.js dist/hooks/__tests__ dist/hooks/code-simplifier/__tests__ dist/hooks/extensibility/__tests__ dist/notifications/__tests__ dist/mcp/__tests__ dist/hud/__tests__ dist/verification/__tests__ dist/openclaw/__tests__ (1867 pass)
