### PR TITLE
Add missing GitHub link for Lor in contributor tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It keeps Codex as the execution engine and makes it easier to:
 | HaD0Yun | [@HaD0Yun](https://github.com/HaD0Yun) |
 | Junho Yeo | [@junhoyeo](https://github.com/junhoyeo) |
 | JiHongKim98 | [@JiHongKim98](https://github.com/JiHongKim98) |
-| Lor | — |
+| Lor | [@gobylor](https://github.com/gobylor) |
 | HyunjunJeon | [@HyunjunJeon](https://github.com/HyunjunJeon) |
 
 ## Recommended default flow

--- a/docs/readme/README.uk.md
+++ b/docs/readme/README.uk.md
@@ -43,7 +43,7 @@ OMX — це шар робочих процесів для [OpenAI Codex CLI](ht
 | HaD0Yun | [@HaD0Yun](https://github.com/HaD0Yun) |
 | Junho Yeo | [@junhoyeo](https://github.com/junhoyeo) |
 | JiHongKim98 | [@JiHongKim98](https://github.com/JiHongKim98) |
-| Lor | — |
+| Lor | [@gobylor](https://github.com/gobylor) |
 | HyunjunJeon | [@HyunjunJeon](https://github.com/HyunjunJeon) |
 
 ## Рекомендований стандартний процес


### PR DESCRIPTION
## Summary

- Add Lor's missing GitHub profile link in the README Top Collaborators table
- Keep the Ukrainian README mirror in sync with the same contributor link

## Verification

- Confirmed Lor now links to https://github.com/gobylor
- Confirmed no remaining `| Lor | — |` placeholder in README files

## Notes

Docs-only change.
