### PR TITLE
Keep bwrap discoverable for omx explore sandbox startup

### DIFF
--- a/crates/omx-explore/src/main.rs
+++ b/crates/omx-explore/src/main.rs
@@ -1362,7 +1362,12 @@ exec node "$basedir/../@openai/codex/bin/codex.js" "$@"
     fn prepare_allowlist_environment_adds_controlled_bwrap_without_host_path() {
         let _guard = env_lock();
         let mut commands = vec!["bash", "sh"];
-        commands.extend(ALLOWED_DIRECT_COMMANDS.iter().copied());
+        commands.extend(
+            ALLOWED_DIRECT_COMMANDS
+                .iter()
+                .copied()
+                .filter(|command| *command != "rg"),
+        );
         let (_root, host_bin) = create_host_bin_with_commands(&commands);
         let fake_bwrap = host_bin.join("bwrap");
         write_executable(&fake_bwrap, "#!/bin/sh\nexit 0\n").expect("write fake bwrap");
@@ -1392,7 +1397,12 @@ exec node "$basedir/../@openai/codex/bin/codex.js" "$@"
     fn prepare_allowlist_environment_leaves_path_allowlist_only_without_bwrap() {
         let _guard = env_lock();
         let mut commands = vec!["bash", "sh"];
-        commands.extend(ALLOWED_DIRECT_COMMANDS.iter().copied());
+        commands.extend(
+            ALLOWED_DIRECT_COMMANDS
+                .iter()
+                .copied()
+                .filter(|command| *command != "rg"),
+        );
         let (_root, host_bin) = create_host_bin_with_commands(&commands);
 
         let allowlist =

--- a/crates/omx-explore/src/main.rs
+++ b/crates/omx-explore/src/main.rs
@@ -42,6 +42,7 @@ struct AttemptResult {
 struct AllowlistEnvironment {
     bin_dir: PathBuf,
     shell_path: PathBuf,
+    sandbox_bin_dir: Option<PathBuf>,
     _root: TempDirGuard,
 }
 
@@ -243,7 +244,11 @@ fn invoke_codex(args: &Args, model: &str, prompt_contract: &str) -> io::Result<A
         .arg(&output_path)
         .arg(&final_prompt)
         .env(HARNESS_ROOT_ENV, &args.cwd)
-        .env("PATH", &allowlist.bin_dir)
+        .env(
+            "PATH",
+            build_codex_path(&allowlist.bin_dir, allowlist.sandbox_bin_dir.as_deref())
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?,
+        )
         .env("SHELL", &allowlist.shell_path);
     sanitize_explore_subprocess_env(&mut command);
     let output = command.output()?;
@@ -533,11 +538,47 @@ fn prepare_allowlist_environment() -> Result<AllowlistEnvironment, String> {
     write_executable(&shell_path, &bash_wrapper)?;
     write_executable(&bin_dir.join("sh"), &sh_wrapper)?;
 
+    let sandbox_bin_dir = prepare_sandbox_dependency_bin(&root.path)?;
+
     Ok(AllowlistEnvironment {
         bin_dir,
         shell_path,
+        sandbox_bin_dir,
         _root: root,
     })
+}
+
+fn build_codex_path(
+    allowlist_bin_dir: &Path,
+    sandbox_bin_dir: Option<&Path>,
+) -> Result<OsString, String> {
+    let mut entries = vec![allowlist_bin_dir.to_path_buf()];
+    if let Some(sandbox_bin_dir) = sandbox_bin_dir {
+        entries.push(sandbox_bin_dir.to_path_buf());
+    }
+    env::join_paths(entries).map_err(|err| format!("failed to construct restricted PATH: {err}"))
+}
+
+fn prepare_sandbox_dependency_bin(root: &Path) -> Result<Option<PathBuf>, String> {
+    let Some(bwrap_path) = resolve_host_command("bwrap") else {
+        return Ok(None);
+    };
+
+    let sandbox_bin_dir = root.join("sandbox-bin");
+    create_dir_all(&sandbox_bin_dir).map_err(|err| {
+        format!(
+            "failed to create sandbox dependency bin dir {}: {err}",
+            sandbox_bin_dir.display()
+        )
+    })?;
+    write_executable(
+        &sandbox_bin_dir.join("bwrap"),
+        &format!(
+            "#!/bin/sh\nexec {} \"$@\"\n",
+            shell_quote(&bwrap_path.display().to_string())
+        ),
+    )?;
+    Ok(Some(sandbox_bin_dir))
 }
 
 fn allowlist_platform_diagnostic(os: &str) -> Option<&'static str> {
@@ -1290,6 +1331,78 @@ exec node "$basedir/../@openai/codex/bin/codex.js" "$@"
             None => unsafe { env::remove_var("PATH") },
         }
         result
+    }
+
+    #[test]
+    fn build_codex_path_keeps_allowlist_first_and_only_adds_sandbox_bin() {
+        let allowlist_bin = Path::new("/tmp/omx-explore-allowlist/bin");
+        let sandbox_bin = Path::new("/tmp/omx-explore-sandbox-bin");
+
+        let path = build_codex_path(allowlist_bin, Some(sandbox_bin)).expect("restricted path");
+        let entries: Vec<PathBuf> = env::split_paths(&path).collect();
+
+        assert_eq!(
+            entries,
+            vec![allowlist_bin.to_path_buf(), sandbox_bin.to_path_buf()]
+        );
+    }
+
+    #[test]
+    fn build_codex_path_omits_sandbox_bin_when_bwrap_is_absent() {
+        let allowlist_bin = Path::new("/tmp/omx-explore-allowlist/bin");
+
+        let path = build_codex_path(allowlist_bin, None).expect("restricted path");
+        let entries: Vec<PathBuf> = env::split_paths(&path).collect();
+
+        assert_eq!(entries, vec![allowlist_bin.to_path_buf()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_allowlist_environment_adds_controlled_bwrap_without_host_path() {
+        let _guard = env_lock();
+        let mut commands = vec!["bash", "sh"];
+        commands.extend(ALLOWED_DIRECT_COMMANDS.iter().copied());
+        let (_root, host_bin) = create_host_bin_with_commands(&commands);
+        let fake_bwrap = host_bin.join("bwrap");
+        write_executable(&fake_bwrap, "#!/bin/sh\nexit 0\n").expect("write fake bwrap");
+
+        let allowlist =
+            with_path(&host_bin, prepare_allowlist_environment).expect("allowlist environment");
+        let sandbox_bin = allowlist
+            .sandbox_bin_dir
+            .as_ref()
+            .expect("sandbox bin when bwrap exists");
+        let path = build_codex_path(&allowlist.bin_dir, allowlist.sandbox_bin_dir.as_deref())
+            .expect("codex path");
+        let entries: Vec<PathBuf> = env::split_paths(&path).collect();
+
+        assert_eq!(
+            entries,
+            vec![allowlist.bin_dir.clone(), sandbox_bin.clone()]
+        );
+        assert!(!entries.contains(&host_bin));
+        let controlled_bwrap =
+            read_to_string(sandbox_bin.join("bwrap")).expect("read controlled bwrap");
+        assert!(controlled_bwrap.contains(&fake_bwrap.display().to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_allowlist_environment_leaves_path_allowlist_only_without_bwrap() {
+        let _guard = env_lock();
+        let mut commands = vec!["bash", "sh"];
+        commands.extend(ALLOWED_DIRECT_COMMANDS.iter().copied());
+        let (_root, host_bin) = create_host_bin_with_commands(&commands);
+
+        let allowlist =
+            with_path(&host_bin, prepare_allowlist_environment).expect("allowlist environment");
+        let path = build_codex_path(&allowlist.bin_dir, allowlist.sandbox_bin_dir.as_deref())
+            .expect("codex path");
+        let entries: Vec<PathBuf> = env::split_paths(&path).collect();
+
+        assert!(allowlist.sandbox_bin_dir.is_none());
+        assert_eq!(entries, vec![allowlist.bin_dir]);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary\n- Fixes #1934.\n- Keeps the omx explore model command PATH constrained to allowlist wrappers while adding a controlled sandbox dependency bin for bwrap discovery.\n- Adds regression tests covering restricted PATH construction with and without bwrap.\n\n## Verification\n- git diff --check\n- cargo fmt --all --check\n- cargo test -p omx-explore-harness\n- cargo clippy -p omx-explore-harness --all-targets -- -D warnings