### PR TITLE
Support MacPorts zsh for tmux launches

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2571,6 +2571,23 @@ describe("buildTmuxPaneCommand", () => {
     assert.ok(result.includes("source ~/.zshrc"), "should source .zshrc");
   });
 
+  it("keeps MacPorts zsh instead of downgrading to /bin/sh", () => {
+    const result = buildTmuxPaneCommand(
+      "codex",
+      ["--model", "gpt-5"],
+      "/opt/local/bin/zsh",
+    );
+    assert.ok(
+      result.startsWith("'/opt/local/bin/zsh' -c "),
+      "should preserve MacPorts zsh when SHELL points to it",
+    );
+    assert.ok(
+      !result.startsWith("'/bin/sh' -c "),
+      "should not fall back to /bin/sh for supported MacPorts zsh",
+    );
+    assert.ok(result.includes("source ~/.zshrc"), "should source .zshrc");
+  });
+
   it("wraps command with bash profile sourcing while preserving tmux cwd", () => {
     const result = buildTmuxPaneCommand("codex", [], "/bin/bash");
     assert.ok(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -259,6 +259,7 @@ const ALLOWED_SHELLS = new Set([
   "/usr/local/bin/bash",
   "/usr/local/bin/zsh",
   "/usr/local/bin/fish",
+  "/opt/local/bin/zsh",
   "/opt/homebrew/bin/zsh",
 ]);
 const WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS = 2500;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -938,6 +938,26 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+  it('accepts MacPorts zsh as a supported worker shell without falling back', () => {
+    const prevShell = process.env.SHELL;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.SHELL = '/opt/local/bin/zsh';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const cmd = withMockedExistsSync((candidate) => candidate === '/opt/local/bin/zsh', () =>
+        buildWorkerStartupCommand('alpha', 2),
+      );
+      assert.match(cmd, /'\/opt\/local\/bin\/zsh' -c/);
+      assert.doesNotMatch(cmd, /'\/bin\/sh' -c/);
+      assert.match(cmd, /source ~\/\.zshrc/);
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
   it('uses bash with ~/.bashrc and preserves launch args', () => {
     const prevShell = process.env.SHELL;
     process.env.SHELL = '/bin/bash';

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -566,7 +566,7 @@ export function buildReconcileHudResizeArgs(
   return ['run-shell', buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)))];
 }
 
-const ZSH_CANDIDATE_PATHS = ['/bin/zsh', '/usr/bin/zsh', '/usr/local/bin/zsh', '/opt/homebrew/bin/zsh'];
+const ZSH_CANDIDATE_PATHS = ['/bin/zsh', '/usr/bin/zsh', '/usr/local/bin/zsh', '/opt/local/bin/zsh', '/opt/homebrew/bin/zsh'];
 const BASH_CANDIDATE_PATHS = ['/bin/bash', '/usr/bin/bash'];
 
 function buildShellLaunchSpec(shell: string, rcFile: string | null): WorkerLaunchSpec {


### PR DESCRIPTION
## Summary

Adds `/opt/local/bin/zsh` as a supported zsh path for tmux-launched OMX sessions.

## Root cause

MacPorts installs zsh at `/opt/local/bin/zsh`. OMX only allowlisted system, `/usr/local`, and Homebrew zsh paths, so MacPorts users fell back to `/bin/sh`. When `/bin/sh` then handled zsh-oriented startup behavior, tmux panes could exit immediately during `omx --tmux` / `omx --madmax` launches.

## Changes

- Preserve `/opt/local/bin/zsh` in the leader tmux pane launch path.
- Include `/opt/local/bin/zsh` in the team worker zsh candidate list.
- Add regression coverage for both leader and worker launch command builders.

## Validation

- `npm run build`
- `node --test dist/cli/__tests__/index.test.js dist/team/__tests__/tmux-session.test.js`
- `npm run lint`
