### PR TITLE
Avoid PostToolUse Bash diagnostic false positives

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3254,6 +3254,54 @@ esac
     }
   });
 
+  it("stays silent when successful Bash output quotes MCP transport warnings", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-bash-mcp-quote-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-bash-mcp-quote",
+          tool_input: { command: "cat diagnostic-log.txt" },
+          tool_response: JSON.stringify({
+            exit_code: 0,
+            stdout: "diagnostic log quoted: MCP transport closed; stdio pipe closed before response",
+            stderr: "",
+          }),
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("stays silent when Bash hard-failure text has no parsed exit code", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-bash-unparsed-failure-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-bash-unparsed-failure",
+          tool_input: { command: "cat captured-output.txt" },
+          tool_response: "captured transcript says: bash: foo: command not found",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns PostToolUse MCP transport fallback guidance for clear MCP transport death", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mcp-transport-"));
     try {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -152,6 +152,7 @@ export function detectMcpTransportFailure(
   payload: CodexHookPayload,
 ): McpTransportFailureSignal | null {
   const normalized = normalizePostToolUsePayload(payload);
+  if (normalized.isBash) return null;
   const combined = [
     normalized.stderrText,
     normalized.stdoutText,
@@ -789,7 +790,11 @@ export function buildNativePostToolUseOutput(
 
   const combined = `${normalized.stderrText}\n${normalized.stdoutText}`.trim();
   if (normalized.exitCode === 0) return null;
-  if (containsHardFailure(combined)) {
+  if (
+    normalized.exitCode !== null
+    && normalized.exitCode !== 0
+    && containsHardFailure(combined)
+  ) {
     return {
       decision: "block",
       reason: "The Bash output indicates a command/setup failure that should be fixed before retrying.",


### PR DESCRIPTION
## Summary
- Fixes #1938.
- Skip MCP transport-death detection for Bash PostToolUse output.
- Require a parsed non-zero Bash exit code before hard-failure phrase blocking.
- Add regressions for successful Bash diagnostics quoting blocker strings.

## Verification
- git diff --check
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js
- npm run lint
- npm run test:recent-bug-regressions:compiled

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
