### PR TITLE
fix(config): preserve user [tui] status_line across merges

### DIFF
--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -358,7 +358,7 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
-  it("merges OMX status_line into an existing user [tui] section without duplicating the table", async () => {
+  it("preserves a user-defined status_line in [tui] across merges", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
       const configPath = join(wd, "config.toml");
@@ -377,8 +377,35 @@ describe("config generator idempotency (#384)", () => {
       assert.match(toml, /^theme = "night"$/m, "user tui key preserved");
       assert.match(
         toml,
+        /^status_line = \["git-branch"\]$/m,
+        "user-defined status_line is preserved unchanged",
+      );
+      assert.doesNotMatch(
+        toml,
+        /^status_line = \["model-with-reasoning",/m,
+        "OMX default status_line must not overwrite user value",
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("injects the OMX status_line when [tui] exists but has no status_line", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      const userTui = ["[tui]", 'theme = "night"', ""].join("\n");
+      await writeFile(configPath, userTui);
+
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, "utf-8");
+
+      assert.equal(count(toml, /^\[tui\]$/gm), 1, "[tui] should appear once");
+      assert.match(toml, /^theme = "night"$/m, "user tui key preserved");
+      assert.match(
+        toml,
         /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
-        "status_line updated in-place",
+        "OMX default status_line injected when user has none",
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -702,6 +702,7 @@ function upsertTuiStatusLine(config: string): {
 
   const preservedKeyLines: string[] = [];
   const seenKeys = new Set<string>();
+  let hasUserStatusLine = false;
 
   for (const section of sections) {
     for (let i = section.start + 1; i < section.end; i++) {
@@ -713,13 +714,16 @@ function upsertTuiStatusLine(config: string): {
       if (!keyMatch) continue;
 
       const key = keyMatch[1];
-      if (key === "status_line" || seenKeys.has(key)) continue;
+      if (seenKeys.has(key)) continue;
       seenKeys.add(key);
+      if (key === "status_line") hasUserStatusLine = true;
       preservedKeyLines.push(trimmed);
     }
   }
 
-  const mergedSection = ["[tui]", ...preservedKeyLines, OMX_TUI_STATUS_LINE];
+  const mergedSection = hasUserStatusLine
+    ? ["[tui]", ...preservedKeyLines]
+    : ["[tui]", ...preservedKeyLines, OMX_TUI_STATUS_LINE];
   const firstStart = sections[0].start;
   const rebuilt: string[] = [];
 


### PR DESCRIPTION
Fixes #1940.

## Summary

`omx update` (and even no-op stamp-bump refreshes) was silently overwriting the user's customized `status_line` in `~/.codex/config.toml` with the OMX hard-coded default. This PR makes the merge non-destructive: the user's `status_line` is preserved like every other `[tui]` key, and the OMX default is only injected when the user has none.

## Root cause

`upsertTuiStatusLine()` in `src/config/generator.ts` explicitly excluded `status_line` from the preserved `[tui]` keys and then unconditionally re-appended `OMX_TUI_STATUS_LINE`:

- `src/config/generator.ts:716` — `if (key === "status_line" || seenKeys.has(key)) continue;` — drops the user's `status_line`.
- `src/config/generator.ts:722` — `const mergedSection = ["[tui]", ...preservedKeyLines, OMX_TUI_STATUS_LINE];` — always re-injects the OMX default.

Update paths that triggered this on every release / refresh:

- `src/cli/update.ts:395` — `runSetupRefresh()` is called after every successful `npm install -g oh-my-codex@latest`.
- `src/cli/update.ts:354-359` — `runSetupRefresh()` is also called when the package is *already up to date* if `setup_completed_version` differs from the installed version.

Both reach `buildMergedConfig()` → `upsertTuiStatusLine()`, so users saw their customizations vanish on every update — including no-op ones.

## Changes

### `src/config/generator.ts`
- Stop excluding `status_line` from `preservedKeyLines`.
- Track whether the user already has a `status_line`.
- Append `OMX_TUI_STATUS_LINE` only when the user has none.

```diff
   const preservedKeyLines: string[] = [];
   const seenKeys = new Set<string>();
+  let hasUserStatusLine = false;

   for (const section of sections) {
     for (let i = section.start + 1; i < section.end; i++) {
       ...
       const key = keyMatch[1];
-      if (key === "status_line" || seenKeys.has(key)) continue;
+      if (seenKeys.has(key)) continue;
       seenKeys.add(key);
+      if (key === "status_line") hasUserStatusLine = true;
       preservedKeyLines.push(trimmed);
     }
   }

-  const mergedSection = ["[tui]", ...preservedKeyLines, OMX_TUI_STATUS_LINE];
+  const mergedSection = hasUserStatusLine
+    ? ["[tui]", ...preservedKeyLines]
+    : ["[tui]", ...preservedKeyLines, OMX_TUI_STATUS_LINE];
```

The "fresh install" path that creates a brand-new `[tui]` is unchanged: when the user has no `[tui]` at all, `getOmxTablesBlock()` (called via `buildMergedConfig` with `!tuiUpsert.hadExistingTui`) still emits the OMX default. The "user has `[tui]` but no `status_line`" path now also gets the default, courtesy of the new branch above.

### `src/config/__tests__/generator-idempotent.test.ts`
- Replace the test that documented the broken behavior (`"merges OMX status_line into an existing user [tui] section..."`) with `"preserves a user-defined status_line in [tui] across merges"`.
- Add `"injects the OMX status_line when [tui] exists but has no status_line"` to lock in the no-status_line-but-has-tui path.

## Test plan

- [x] `npm run build` — clean
- [x] `node --test dist/config/__tests__/generator-idempotent.test.js` — 34/34 pass (includes both new tests)
- [x] `node --test dist/cli/__tests__/setup-refresh.test.js` — 20/20 pass (the Codex CLI ≥ 0.107.0 "skip [tui]" path is unaffected)
- [x] `node --test dist/cli/__tests__/uninstall.test.js dist/cli/__tests__/doctor-invalid-config.test.js` — 25/25 pass

No existing test relied on the destructive behavior; the only one that did (`generator-idempotent.test.ts:361`) was a documentation-of-bug test and has been corrected.

## Backward compatibility

- Users with no `[tui]` section: unchanged — fresh OMX `[tui]` block with the default `status_line` is emitted.
- Users with `[tui]` but no `status_line`: unchanged — OMX default is injected.
- Users with `[tui]` and a custom `status_line`: **fixed** — their value is preserved across `omx update` and setup refreshes.