### PR TITLE
Preserve user TUI status lines during setup refresh

### DIFF
--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -396,6 +396,53 @@ describe("config generator idempotency (#384)", () => {
     );
   });
 
+  it("seeds the default status_line into an existing [tui] section without one", () => {
+    const toml = buildMergedConfig(
+      ["[tui]", 'theme = "night"', ""].join("\n"),
+      "/tmp/omx",
+    );
+
+    assert.equal(count(toml, /^\[tui\]$/gm), 1, "[tui] should appear once");
+    assert.match(toml, /^theme = "night"$/m, "existing tui key preserved");
+    assert.match(
+      toml,
+      /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
+      "default status_line should be seeded when [tui] lacks one",
+    );
+  });
+
+  it("preserves a multiline user-owned status_line", () => {
+    const toml = buildMergedConfig(
+      [
+        "[tui]",
+        "status_line = [",
+        '  "git-branch",',
+        '  "context-remaining",',
+        "]",
+        "",
+      ].join("\n"),
+      "/tmp/omx",
+    );
+
+    assert.equal(count(toml, /^\[tui\]$/gm), 1, "[tui] should appear once");
+    assert.ok(
+      toml.includes(
+        [
+          "status_line = [",
+          '"git-branch",',
+          '"context-remaining",',
+          "]",
+        ].join("\n"),
+      ),
+      "multiline user status_line should be preserved",
+    );
+    assert.doesNotMatch(
+      toml,
+      /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
+      "default status_line should not overwrite multiline customization",
+    );
+  });
+
   it("preserves a customized managed-block status_line when refreshing setup", () => {
     const firstRun = buildMergedConfig("", "/tmp/omx");
     const customized = firstRun.replace(

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -762,7 +762,15 @@ function upsertTuiStatusLine(config: string): {
 
       const key = keyMatch[1];
       if (key === "status_line") {
-        preservedStatusLine ??= trimmed;
+        const entryLines = [trimmed];
+        while (
+          !parseStandaloneToml(entryLines.join("\n")) &&
+          i + 1 < section.end
+        ) {
+          i += 1;
+          entryLines.push(lines[i].trim());
+        }
+        preservedStatusLine ??= entryLines.join("\n");
         continue;
       }
       if (seenKeys.has(key)) continue;


### PR DESCRIPTION
## Summary
- Preserve user-owned `[tui].status_line` entries during `omx setup/update` config refresh, including multiline TOML arrays.
- Keep OMX default injection when `[tui]` exists without `status_line`.
- Add regression coverage for existing `[tui]` without `status_line` and multiline user-owned `status_line` preservation.

## Verification
- `npm run build`
- `node --test dist/config/__tests__/generator-idempotent.test.js`
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit --pretty false --project tsconfig.json` (0 diagnostics)

## Notes
- External PR #1941 targeted `main` and was closed; this PR is the `dev`-based fix.

Fixes #1940

🤖 Generated with OpenAI Codex