### PR TITLE
Keep plugin-launched MCP servers alive

### DIFF
--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -101,6 +101,11 @@ describe('package bin contract', () => {
     const binSource = readFileSync(binPath, 'utf-8');
     const compiledCliSource = readFileSync(compiledCliPath, 'utf-8');
     assert.match(binSource, /^#!\/usr\/bin\/env node/);
+    assert.match(
+      binSource,
+      /process\.argv\[2\] !== ['"]mcp-serve['"]/,
+      'omx bin wrapper must not exit immediately after launching stdio MCP servers',
+    );
     assert.match(compiledCliSource, /omx update\s+Check npm now, update the global install immediately, then refresh setup/);
     assert.match(compiledCliSource, /case "update"/);
 

--- a/src/cli/omx.ts
+++ b/src/cli/omx.ts
@@ -20,7 +20,9 @@ const distEntry = join(root, 'dist', 'cli', 'index.js');
 if (existsSync(distEntry)) {
   const { main } = await import(pathToFileURL(distEntry).href);
   await main(process.argv.slice(2));
-  process.exit(process.exitCode ?? 0);
+  if (process.argv[2] !== 'mcp-serve') {
+    process.exit(process.exitCode ?? 0);
+  }
 } else {
   console.error('oh-my-codex: run "npm run build" first');
   process.exit(1);


### PR DESCRIPTION
## Summary

This fixes plugin-discovered OMX MCP servers launched through `omx mcp-serve`.

The Codex plugin metadata already exposes the MCP servers via `.mcp.json`, but the published `omx` bin wrapper exits immediately after dispatching the CLI command. That behavior is fine for one-shot commands, but it terminates stdio MCP servers before the client can complete initialization.

The wrapper now preserves normal explicit exit behavior for regular CLI commands while allowing `mcp-serve` to keep owning the stdio server lifecycle.

## Why this matters

With this change, OMX MCPs can be supplied by the Codex plugin auto-discovery path instead of requiring explicit `[mcp_servers.omx_*]` entries in `config.toml`.

That keeps the desired configuration shape:

- Codex config references the OMX plugin/marketplace
- OMX MCP entries are discovered from plugin metadata
- No hardwired OMX MCP server tables are required

## Validation

Automated:

- `npm run build`
- `node --test dist/cli/__tests__/package-bin-contract.test.js dist/cli/__tests__/mcp-serve.test.js dist/cli/__tests__/codex-plugin-layout.test.js`

Manual smoke testing:

- Verified plugin-discovered `omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`, and `omx_wiki` initialize successfully through `omx mcp-serve ...`
- Verified plugin metadata discovery works without explicit `[mcp_servers.omx_*]` config entries
- Verified memory write/read behavior through the plugin-discovered `omx_memory` MCP
- Reproduced and validated the fix on three independent systems

## Notes

The regression coverage now initializes the packaged `dist/cli/omx.js mcp-serve state` wrapper over stdio, which protects the plugin MCP discovery path from regressing.
