### PR TITLE
Preserve AGENTS.md guidance during setup refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ These are operator/support surfaces:
 - Codex plugin marketplace install/discovery can cache the plugin under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (local installs may use `local` as the version identifier); that packaged plugin now includes plugin-scoped companion metadata for MCP servers and apps, while native/runtime hooks remain setup-owned, so it is still not the full OMX runtime setup
 - `omx setup` installs prompts, skills, AGENTS scaffolding, `.codex/config.toml`, and OMX-managed native Codex hooks in `.codex/hooks.json`
   - setup refresh preserves non-OMX hook entries in `.codex/hooks.json` and only rewrites OMX-managed wrappers
+  - `omx setup --merge-agents` preserves existing `AGENTS.md` guidance while inserting or refreshing generated OMX sections between `<!-- OMX:AGENTS:START -->` / `<!-- OMX:AGENTS:END -->`; without `--merge-agents` or `--force`, non-interactive setup keeps skipping existing `AGENTS.md` files
   - `omx uninstall` removes OMX-managed wrappers from `.codex/hooks.json` but keeps the file when user hooks remain
 - `omx update` checks npm immediately, installs the newest global OMX build, then reruns the same interactive setup refresh path
 - fresh OMX-managed `gpt-5.5` config seeding now recommends `model_context_window = 250000` and `model_auto_compact_token_limit = 200000`, but only when those keys are missing

--- a/plugins/oh-my-codex/skills/omx-setup/SKILL.md
+++ b/plugins/oh-my-codex/skills/omx-setup/SKILL.md
@@ -10,13 +10,14 @@ Use this skill when users want to install or refresh oh-my-codex for the **curre
 ## Command
 
 ```bash
-omx setup [--force] [--dry-run] [--verbose] [--scope <user|project>] [--plugin]
+omx setup [--force] [--merge-agents] [--dry-run] [--verbose] [--scope <user|project>] [--plugin]
 ```
 
 If you only want lightweight `AGENTS.md` scaffolding for an existing repo or subtree, use `omx agents-init [path]` instead of full setup.
 
 Supported setup flags (current implementation):
 - `--force`: overwrite/reinstall managed artifacts where applicable
+- `--merge-agents`: when `AGENTS.md` already exists, preserve user-authored content and insert/refresh OMX-managed generated sections between explicit `<!-- OMX:AGENTS:START -->` / `<!-- OMX:AGENTS:END -->` markers
 - `--dry-run`: print actions without mutating files
 - `--verbose`: print per-file/per-step details
 - `--scope`: choose install scope (`user`, `project`)
@@ -48,7 +49,8 @@ Supported setup flags (current implementation):
 - `omx setup` only prompts for scope when no scope is provided/persisted and stdin/stdout are TTY.
 - In `user` scope, `omx setup` also prompts for skill delivery mode when no prior install mode is persisted; installed plugin cache discovery makes plugin mode the default prompt/non-interactive choice.
 - Local project orchestration file is `./AGENTS.md` (project root).
-- If `AGENTS.md` exists and `--force` is not used, interactive TTY runs ask whether to overwrite. Non-interactive runs preserve the file.
+- If `AGENTS.md` exists and neither `--force` nor `--merge-agents` is used, interactive TTY runs ask whether to overwrite. Non-interactive runs preserve the file.
+- Use `--merge-agents` to keep existing project guidance while allowing setup to refresh OMX-managed AGENTS sections and the generated model capability table idempotently.
 - Scope targets:
   - `user`: user directories (`~/.codex`, `~/.codex/skills`, `~/.omx/agents`)
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
@@ -58,7 +60,7 @@ Supported setup flags (current implementation):
 - Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
-- With `--force`, AGENTS overwrite may still be skipped if an active OMX session is detected (safety guard).
+- With `--force` or `--merge-agents`, AGENTS updates may still be skipped if an active OMX session is detected (safety guard).
 - Legacy persisted scope values (`project-local`) are automatically migrated to `project` with a one-time warning.
 
 ## Recommended workflow
@@ -102,3 +104,4 @@ node bin/omx.js doctor
 ```
 
 - If AGENTS.md was not overwritten during `--force`, stop active OMX session and rerun setup.
+- If AGENTS.md was not merged during `--merge-agents`, stop active OMX session and rerun setup.

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -10,13 +10,14 @@ Use this skill when users want to install or refresh oh-my-codex for the **curre
 ## Command
 
 ```bash
-omx setup [--force] [--dry-run] [--verbose] [--scope <user|project>] [--plugin]
+omx setup [--force] [--merge-agents] [--dry-run] [--verbose] [--scope <user|project>] [--plugin]
 ```
 
 If you only want lightweight `AGENTS.md` scaffolding for an existing repo or subtree, use `omx agents-init [path]` instead of full setup.
 
 Supported setup flags (current implementation):
 - `--force`: overwrite/reinstall managed artifacts where applicable
+- `--merge-agents`: when `AGENTS.md` already exists, preserve user-authored content and insert/refresh OMX-managed generated sections between explicit `<!-- OMX:AGENTS:START -->` / `<!-- OMX:AGENTS:END -->` markers
 - `--dry-run`: print actions without mutating files
 - `--verbose`: print per-file/per-step details
 - `--scope`: choose install scope (`user`, `project`)
@@ -48,7 +49,8 @@ Supported setup flags (current implementation):
 - `omx setup` only prompts for scope when no scope is provided/persisted and stdin/stdout are TTY.
 - In `user` scope, `omx setup` also prompts for skill delivery mode when no prior install mode is persisted; installed plugin cache discovery makes plugin mode the default prompt/non-interactive choice.
 - Local project orchestration file is `./AGENTS.md` (project root).
-- If `AGENTS.md` exists and `--force` is not used, interactive TTY runs ask whether to overwrite. Non-interactive runs preserve the file.
+- If `AGENTS.md` exists and neither `--force` nor `--merge-agents` is used, interactive TTY runs ask whether to overwrite. Non-interactive runs preserve the file.
+- Use `--merge-agents` to keep existing project guidance while allowing setup to refresh OMX-managed AGENTS sections and the generated model capability table idempotently.
 - Scope targets:
   - `user`: user directories (`~/.codex`, `~/.codex/skills`, `~/.omx/agents`)
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
@@ -58,7 +60,7 @@ Supported setup flags (current implementation):
 - Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
-- With `--force`, AGENTS overwrite may still be skipped if an active OMX session is detected (safety guard).
+- With `--force` or `--merge-agents`, AGENTS updates may still be skipped if an active OMX session is detected (safety guard).
 - Legacy persisted scope values (`project-local`) are automatically migrated to `project` with a one-time warning.
 
 ## Recommended workflow
@@ -102,3 +104,4 @@ node bin/omx.js doctor
 ```
 
 - If AGENTS.md was not overwritten during `--force`, stop active OMX session and rerun setup.
+- If AGENTS.md was not merged during `--merge-agents`, stop active OMX session and rerun setup.

--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promis
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import { questionCommand } from '../question.js';
 import { markQuestionAnswered, readQuestionRecord } from '../../question/state.js';
 
@@ -12,6 +12,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..', '..', '..');
 const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
 const tempDirs: string[] = [];
+let originalProcessExitCode: string | number | null | undefined;
 
 async function makeRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-question-cli-'));
@@ -22,10 +23,16 @@ async function makeRepo(): Promise<string> {
 }
 
 afterEach(async () => {
+  process.exitCode = originalProcessExitCode;
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
 describe('omx question CLI', () => {
+  beforeEach(() => {
+    originalProcessExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
   it('hard-fails worker contexts before UI launch', async () => {
     const cwd = await makeRepo();
     const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {

--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -5,7 +5,11 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { setup } from '../setup.js';
-import { addGeneratedAgentsMarker } from '../../utils/agents-md.js';
+import {
+  addGeneratedAgentsMarker,
+  OMX_MANAGED_AGENTS_END_MARKER,
+  OMX_MANAGED_AGENTS_START_MARKER,
+} from '../../utils/agents-md.js';
 import { resolveAgentsModelTableContext, upsertAgentsModelTable } from '../../utils/agents-model-table.js';
 
 function setMockTty(value: boolean): () => void {
@@ -38,6 +42,10 @@ function setMockHome(home: string): () => void {
 
 function normalizeDarwinTmpPath(value: string): string {
   return process.platform === 'darwin' ? value.replaceAll('/private/var/', '/var/') : value;
+}
+
+function countOccurrences(value: string, needle: string): number {
+  return value.split(needle).length - 1;
 }
 
 async function runSetupWithCapturedLogs(
@@ -284,6 +292,163 @@ describe('omx setup AGENTS refresh behavior', () => {
 
       assert.match(output, /Skipped AGENTS\.md overwrite/);
       assert.doesNotMatch(output, /Refreshed AGENTS\.md model capability table/);
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
+      assert.equal(existsSync(join(wd, '.omx', 'backups', 'setup')), false);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('merges OMX-managed sections into an unmarked user-authored AGENTS.md when explicitly requested', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const existing = '# Team Instructions\n\nKeep this custom guidance.\n';
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        mergeAgents: true,
+      });
+
+      const agentsContent = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+
+      assert.match(output, /Merged OMX-managed AGENTS\.md sections into project root\./);
+      assert.match(output, /agents_md: updated=1, unchanged=0, backed_up=1, skipped=0, removed=0/);
+      assert.match(agentsContent, /^# Team Instructions/);
+      assert.match(agentsContent, /Keep this custom guidance\./);
+      assert.match(agentsContent, new RegExp(OMX_MANAGED_AGENTS_START_MARKER));
+      assert.match(agentsContent, new RegExp(OMX_MANAGED_AGENTS_END_MARKER));
+      assert.match(agentsContent, /# oh-my-codex - Intelligent Multi-Agent Orchestration/);
+      assert.equal(existsSync(join(wd, '.omx', 'backups', 'setup')), true);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps explicit AGENTS.md merge idempotent on repeated runs', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), '# Team Instructions\n\nKeep this custom guidance.\n');
+
+      await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        mergeAgents: true,
+      });
+      const firstContent = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        mergeAgents: true,
+      });
+      const secondContent = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+
+      assert.equal(secondContent, firstContent);
+      assert.match(output, /AGENTS\.md already up to date in project root\./);
+      assert.match(output, /agents_md: updated=0, unchanged=1, backed_up=0, skipped=0, removed=0/);
+      assert.equal(countOccurrences(secondContent, OMX_MANAGED_AGENTS_START_MARKER), 1);
+      assert.equal(countOccurrences(secondContent, OMX_MANAGED_AGENTS_END_MARKER), 1);
+      assert.equal(countOccurrences(secondContent, '# oh-my-codex - Intelligent Multi-Agent Orchestration'), 1);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshes the managed model table inside an explicit merged AGENTS.md block', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const template = readFileSync(join(process.cwd(), 'templates', 'AGENTS.md'), 'utf-8');
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      const staleManaged = upsertAgentsModelTable(
+        addGeneratedAgentsMarker(template),
+        {
+          frontierModel: 'legacy-frontier',
+          sparkModel: 'legacy-spark',
+          subagentDefaultModel: 'legacy-frontier',
+        },
+      );
+      const existing = [
+        '# Team Instructions',
+        '',
+        'Keep this custom guidance.',
+        '',
+        OMX_MANAGED_AGENTS_START_MARKER,
+        staleManaged.trimEnd(),
+        OMX_MANAGED_AGENTS_END_MARKER,
+        '',
+      ].join('\n');
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        mergeAgents: true,
+      });
+      const agentsContent = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+      const expectedContext = resolveAgentsModelTableContext(
+        await readFile(join(wd, '.codex', 'config.toml'), 'utf-8'),
+        { codexHomeOverride: join(wd, '.codex') },
+      );
+
+      assert.match(output, /Merged OMX-managed AGENTS\.md sections into project root\./);
+      assert.match(agentsContent, /Keep this custom guidance\./);
+      assert.match(
+        agentsContent,
+        new RegExp(`\\| Frontier \\(leader\\) \\| \`${expectedContext.frontierModel}\` \\| high \\|`),
+      );
+      assert.doesNotMatch(agentsContent, /legacy-frontier/);
+      assert.doesNotMatch(agentsContent, /legacy-spark/);
+      assert.equal(countOccurrences(agentsContent, OMX_MANAGED_AGENTS_START_MARKER), 1);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips explicit AGENTS.md merge during an active project session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(true);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const existing = '# active session file\n';
+    try {
+      const pidStartTicks = await readCurrentLinuxStartTicks();
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+      await writeFile(
+        join(wd, '.omx', 'state', 'session.json'),
+        JSON.stringify({
+          session_id: 'sess-test',
+          started_at: new Date().toISOString(),
+          cwd: wd,
+          pid: process.pid,
+          pid_start_ticks: pidStartTicks,
+        }, null, 2)
+      );
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        mergeAgents: true,
+      });
+
+      assert.match(output, /WARNING: Active omx session detected/);
+      assert.match(output, /Skipping AGENTS\.md overwrite to avoid corrupting runtime overlay\./);
+      assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
       assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
       assert.equal(existsSync(join(wd, '.omx', 'backups', 'setup')), false);
     } finally {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -222,6 +222,9 @@ Options:
   -w, --worktree[=<name>]
                 Launch Codex in a git worktree (detached when no name is given)
   --force       Force reinstall (overwrite existing files)
+  --merge-agents
+                Merge OMX-managed AGENTS.md sections into an existing AGENTS.md
+                instead of overwriting user-authored content
   --dry-run     Show what would be done without doing it
   --plugin      Use Codex plugin delivery for omx setup and remove legacy OMX-managed user/project components
   --keep-config Skip config.toml cleanup during uninstall
@@ -731,6 +734,7 @@ export async function main(args: string[]): Promise<void> {
   const flags = new Set(args.filter((a) => a.startsWith("--")));
   const options = {
     force: flags.has("--force"),
+    mergeAgents: flags.has("--merge-agents"),
     dryRun: flags.has("--dry-run"),
     verbose: flags.has("--verbose"),
     team: flags.has("--team"),
@@ -752,6 +756,7 @@ export async function main(args: string[]): Promise<void> {
       case "setup":
         await setup({
           force: options.force,
+          mergeAgents: options.mergeAgents,
           dryRun: options.dryRun,
           verbose: options.verbose,
           scope: resolveSetupScopeArg(args.slice(1)),

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -67,6 +67,7 @@ import {
   addGeneratedAgentsMarker,
   hasOmxManagedAgentsSections,
   isOmxGeneratedAgentsMd,
+  upsertManagedAgentsBlock,
 } from "../utils/agents-md.js";
 import {
   resolveAgentsModelTableContext,
@@ -76,6 +77,7 @@ import {
 interface SetupOptions {
   codexVersionProbe?: () => string | null;
   force?: boolean;
+  mergeAgents?: boolean;
   dryRun?: boolean;
   installMode?: SetupInstallMode;
   scope?: SetupScope;
@@ -1843,15 +1845,22 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
       let changed = true;
       let canApplyManagedModelRefresh = false;
       let managedRefreshContent = "";
+      let canApplyManagedAgentsMerge = false;
+      let mergedAgentsContent = "";
       if (agentsMdExists) {
         const existing = await readFile(agentsMdDst, "utf-8");
         changed = existing !== rewritten;
-        if (hasOmxManagedAgentsSections(existing)) {
-          managedRefreshContent = upsertAgentsModelTable(
-            existing,
-            modelTableContext,
-          );
-          canApplyManagedModelRefresh = managedRefreshContent !== existing;
+        if (options.mergeAgents) {
+          mergedAgentsContent = upsertManagedAgentsBlock(existing, rewritten);
+          canApplyManagedAgentsMerge = mergedAgentsContent !== existing;
+        } else {
+          if (hasOmxManagedAgentsSections(existing)) {
+            managedRefreshContent = upsertAgentsModelTable(
+              existing,
+              modelTableContext,
+            );
+            canApplyManagedModelRefresh = managedRefreshContent !== existing;
+          }
         }
       }
 
@@ -1859,7 +1868,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
         resolvedScope.scope === "project" &&
         sessionIsActive &&
         agentsMdExists &&
-        changed
+        (changed || canApplyManagedAgentsMerge || canApplyManagedModelRefresh)
       ) {
         summary.agentsMd.skipped += 1;
         console.log(
@@ -1871,6 +1880,27 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
           "  Skipping AGENTS.md overwrite to avoid corrupting runtime overlay.",
         );
         console.log("  Stop the active session first, then re-run setup.");
+      } else if (options.mergeAgents && agentsMdExists && !canApplyManagedAgentsMerge) {
+        summary.agentsMd.unchanged += 1;
+        console.log(
+          resolvedScope.scope === "project"
+            ? "  AGENTS.md already up to date in project root."
+            : `  AGENTS.md already up to date in ${scopeDirs.codexHomeDir}.`,
+        );
+      } else if (canApplyManagedAgentsMerge) {
+        await syncManagedContent(
+          mergedAgentsContent,
+          agentsMdDst,
+          summary.agentsMd,
+          backupContext,
+          { dryRun, verbose },
+          `merged AGENTS ${agentsMdDst}`,
+        );
+        console.log(
+          resolvedScope.scope === "project"
+            ? "  Merged OMX-managed AGENTS.md sections into project root."
+            : `  Merged OMX-managed AGENTS.md sections into ${scopeDirs.codexHomeDir}.`,
+        );
       } else if (canApplyManagedModelRefresh) {
         await syncManagedContent(
           managedRefreshContent,

--- a/src/utils/agents-md.ts
+++ b/src/utils/agents-md.ts
@@ -4,6 +4,8 @@ import {
 } from './agents-model-table.js'
 
 export const OMX_GENERATED_AGENTS_MARKER = '<!-- omx:generated:agents-md -->'
+export const OMX_MANAGED_AGENTS_START_MARKER = '<!-- OMX:AGENTS:START -->'
+export const OMX_MANAGED_AGENTS_END_MARKER = '<!-- OMX:AGENTS:END -->'
 const AUTONOMY_DIRECTIVE_END_MARKER = '<!-- END AUTONOMY DIRECTIVE -->'
 
 export function isOmxGeneratedAgentsMd(content: string): boolean {
@@ -13,9 +15,39 @@ export function isOmxGeneratedAgentsMd(content: string): boolean {
 export function hasOmxManagedAgentsSections(content: string): boolean {
   return (
     isOmxGeneratedAgentsMd(content) ||
+    (content.includes(OMX_MANAGED_AGENTS_START_MARKER) &&
+      content.includes(OMX_MANAGED_AGENTS_END_MARKER)) ||
     (content.includes(OMX_MODELS_START_MARKER) &&
       content.includes(OMX_MODELS_END_MARKER))
   )
+}
+
+export function upsertManagedAgentsBlock(
+  existingContent: string,
+  managedContent: string,
+): string {
+  const normalizedExisting = existingContent.endsWith('\n')
+    ? existingContent
+    : `${existingContent}\n`
+  const normalizedManaged = managedContent.endsWith('\n')
+    ? managedContent
+    : `${managedContent}\n`
+  const block = [
+    OMX_MANAGED_AGENTS_START_MARKER,
+    normalizedManaged.trimEnd(),
+    OMX_MANAGED_AGENTS_END_MARKER,
+  ].join('\n')
+
+  const startIndex = normalizedExisting.indexOf(OMX_MANAGED_AGENTS_START_MARKER)
+  const endIndex = normalizedExisting.indexOf(OMX_MANAGED_AGENTS_END_MARKER)
+
+  if (startIndex >= 0 && endIndex > startIndex) {
+    const replaceEnd = endIndex + OMX_MANAGED_AGENTS_END_MARKER.length
+    const next = `${normalizedExisting.slice(0, startIndex)}${block}${normalizedExisting.slice(replaceEnd)}`
+    return next.endsWith('\n') ? next : `${next}\n`
+  }
+
+  return `${normalizedExisting.trimEnd()}\n\n${block}\n`
 }
 
 export function addGeneratedAgentsMarker(content: string): string {


### PR DESCRIPTION
## Summary
- Add explicit `omx setup --merge-agents` support to preserve existing AGENTS.md guidance while inserting/refreshing OMX-managed generated sections between `<!-- OMX:AGENTS:START -->` / `<!-- OMX:AGENTS:END -->` markers.
- Keep existing default safety: unmanaged AGENTS.md files are skipped in non-interactive setup unless `--merge-agents` or `--force` is explicit, and active project sessions still block project-root AGENTS rewrites.
- Document the new flag in CLI help, README setup notes, and the setup skill/plugin mirror.
- Add regression coverage for unmarked user AGENTS merge, user content preservation, idempotent repeated merge, managed model table refresh, active-session protection, and default non-interactive safety.

Fixes #1898

## Verification
- `npm install` (restored missing dependencies in the local workspace)
- `npm run build`
- `node --test dist/cli/__tests__/setup-agents-overwrite.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `npm run verify:plugin-bundle`
- `git diff --check -- README.md skills/omx-setup/SKILL.md plugins/oh-my-codex/skills/omx-setup/SKILL.md src/cli/__tests__/setup-agents-overwrite.test.ts src/cli/index.ts src/cli/setup.ts src/utils/agents-md.ts`

Note: full `npm test` was started and progressed through many suites, but the user directed not to wait on the stalling background run after the targeted gates above had passed.

## Signature
Implemented by Codex / OMX Ralph workflow.
