### PR TITLE
Add read-only OMX team sidecar

### DIFF
--- a/src/cli/__tests__/sidecar.test.ts
+++ b/src/cli/__tests__/sidecar.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { main, resolveCliInvocation } from '../index.js';
+
+afterEach(() => {
+  process.exitCode = undefined;
+});
+
+describe('omx sidecar CLI', () => {
+  it('resolves sidecar as a first-class CLI command', () => {
+    assert.deepEqual(resolveCliInvocation(['sidecar', 'demo']), { command: 'sidecar', launchArgs: [] });
+  });
+
+  it('routes local sidecar help to the sidecar command', async () => {
+    const originalLog = console.log;
+    const logs: string[] = [];
+    console.log = (message?: unknown) => { logs.push(String(message)); };
+    try {
+      await main(['sidecar', '--help']);
+    } finally {
+      console.log = originalLog;
+    }
+    assert.ok(logs.some((line) => line.includes('omx sidecar <team-name> --tmux')));
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { version } from "./version.js";
 import { tmuxHookCommand } from "./tmux-hook.js";
 import { hooksCommand } from "./hooks.js";
 import { hudCommand } from "../hud/index.js";
+import { sidecarCommand } from "../sidecar/index.js";
 import { teamCommand } from "./team.js";
 import { ralphCommand } from "./ralph.js";
 import { askCommand } from "./ask.js";
@@ -178,6 +179,7 @@ Usage:
   omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
   omx hooks     Manage hook plugins (init|status|validate|test)
   omx hud       Show HUD statusline (--watch, --json, --preset=NAME)
+  omx sidecar   Show read-only team/multi-agent visualization (--watch, --json, --tmux)
   omx state     Read/write/list OMX mode state via CLI parity surface
   omx notepad   CLI parity for OMX notepad MCP tools
   omx project-memory
@@ -290,6 +292,7 @@ type CliCommand =
   | "tmux-hook"
   | "hooks"
   | "hud"
+  | "sidecar"
   | "state"
   | "wiki"
   | "status"
@@ -310,6 +313,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "exec",
   "hooks",
   "hud",
+  "sidecar",
   "state",
   "wiki",
   "ralph",
@@ -617,6 +621,7 @@ export async function main(args: string[]): Promise<void> {
     "tmux-hook",
     "hooks",
     "hud",
+    "sidecar",
     "state",
     "status",
     "cancel",
@@ -719,6 +724,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "hud":
         await hudCommand(args.slice(1));
+        break;
+      case "sidecar":
+        await sidecarCommand(args.slice(1));
         break;
       case "state":
         await stateCommand(args.slice(1));

--- a/src/sidecar/__tests__/boundary.test.ts
+++ b/src/sidecar/__tests__/boundary.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const FORBIDDEN_PRODUCTION_TOKENS = [
+  'monitorTeam',
+  'getTeamSummary',
+  'teamReadConfig',
+  'runHudAuthorityTick',
+  'runAuthorityTick',
+  'authority',
+  'notify-fallback-authority',
+  'acquireTeamTaskClaim',
+  'writeTeamTask',
+  'writeTeamPhase',
+  'appendTeamEvent',
+  'writeWorkerStatus',
+  'writeWorkerHeartbeat',
+  'dispatchTeamWorkerRequest',
+];
+
+async function productionFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.name === '__tests__') continue;
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...await productionFiles(path));
+    else if (entry.isFile() && (/\.(ts|js)$/.test(path))) files.push(path);
+  }
+  return files;
+}
+
+describe('sidecar mutation boundary', () => {
+  it('does not import known mutating team/HUD authority APIs', async () => {
+    const root = dirname(dirname(fileURLToPath(import.meta.url)));
+    const files = await productionFiles(root);
+    assert.ok(files.length > 0, 'expected sidecar production files to scan');
+    for (const file of files) {
+      const text = await readFile(file, 'utf-8');
+      for (const token of FORBIDDEN_PRODUCTION_TOKENS) {
+        assert.ok(!text.includes(token), `${file} must not reference ${token}`);
+      }
+    }
+  });
+});

--- a/src/sidecar/__tests__/collector.test.ts
+++ b/src/sidecar/__tests__/collector.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readdir, readFile, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+import { describe, it } from 'node:test';
+import { collectSidecarSnapshot, readTailText } from '../collector.js';
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function snapshotFiles(root: string): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  async function visit(dir: string): Promise<void> {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await visit(path);
+      } else if (entry.isFile()) {
+        result.set(relative(root, path), await readFile(path, 'utf-8'));
+      }
+    }
+  }
+  await visit(root);
+  return result;
+}
+
+async function withFixture(test: (cwd: string, teamRoot: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-sidecar-'));
+  try {
+    const teamRoot = join(cwd, '.omx', 'state', 'team', 'demo');
+    await mkdir(teamRoot, { recursive: true });
+    await test(cwd, teamRoot);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('collectSidecarSnapshot', () => {
+  it('normalizes existing team state without migrating legacy config or mutating files', async () => {
+    await withFixture(async (cwd, teamRoot) => {
+      await writeJson(join(teamRoot, 'config.json'), {
+        name: 'demo',
+        task: 'ship sidecar',
+        worker_count: 2,
+        tmux_session: 'omx-demo',
+        leader_pane_id: '%1',
+        hud_pane_id: '%2',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: ['1'], pane_id: '%3' },
+          { name: 'worker-2', index: 2, role: 'verifier', assigned_tasks: ['2'], pane_id: '%4' },
+        ],
+      });
+      await writeJson(join(teamRoot, 'tasks', 'task-1.json'), {
+        id: '1', subject: 'Implement collector', status: 'in_progress', owner: 'worker-1', version: 3,
+        claim: { owner: 'worker-1', token: 'secret-claim-token', leased_until: '2026-04-27T02:10:00.000Z' },
+      });
+      await writeJson(join(teamRoot, 'tasks', 'task-2.json'), {
+        id: '2', subject: 'Blocked verification', status: 'blocked', owner: 'worker-2', blocked_by: ['1'], version: 1,
+      });
+      await writeJson(join(teamRoot, 'tasks', 'task-3.json'), {
+        id: '3', subject: 'Failed smoke', status: 'failed', owner: 'worker-2', error: 'smoke failed', version: 1,
+      });
+      await writeJson(join(teamRoot, 'workers', 'worker-1', 'status.json'), {
+        state: 'working', current_task_id: '1', updated_at: '2026-04-27T02:00:00.000Z',
+      });
+      await writeJson(join(teamRoot, 'workers', 'worker-1', 'heartbeat.json'), {
+        pid: 123, alive: true, turn_count: 8, last_turn_at: '2026-04-27T02:00:01.000Z',
+      });
+      await writeJson(join(teamRoot, 'workers', 'worker-2', 'status.json'), {
+        state: 'blocked', reason: 'needs plan approval', current_task_id: '2', updated_at: '2026-04-27T02:00:02.000Z',
+      });
+      await writeJson(join(teamRoot, 'workers', 'worker-2', 'heartbeat.json'), {
+        pid: 456, alive: false, turn_count: 2, last_turn_at: '2026-04-27T01:59:00.000Z',
+      });
+      await writeJson(join(teamRoot, 'phase.json'), { current_phase: 'team-exec' });
+      await writeJson(join(teamRoot, 'monitor-snapshot.json'), {
+        workerTurnCountByName: { 'worker-1': 1 },
+        workerTaskIdByName: { 'worker-1': '1' },
+      });
+      await mkdir(join(teamRoot, 'events'), { recursive: true });
+      await writeFile(join(teamRoot, 'events', 'events.ndjson'), [
+        JSON.stringify({ event_id: 'e1', team: 'demo', type: 'worker_idle', worker: 'worker-2', reason: 'waiting', created_at: '2026-04-27T02:00:03.000Z' }),
+        JSON.stringify({ event_id: 'e2', team: 'demo', type: 'task_failed', worker: 'worker-2', task_id: '3', reason: 'smoke failed', created_at: '2026-04-27T02:00:04.000Z' }),
+      ].join('\n'));
+      await writeJson(join(teamRoot, 'mailbox', 'worker-1.json'), { messages: ['must remain unchanged'] });
+
+      const before = await snapshotFiles(teamRoot);
+      const snapshot = await collectSidecarSnapshot('demo', { cwd, now: new Date('2026-04-27T02:01:00.000Z') });
+      const after = await snapshotFiles(teamRoot);
+
+      assert.deepEqual(after, before, 'sidecar collector must be read-only over team state');
+      assert.ok(!after.has('manifest.v2.json'), 'legacy config must not be migrated into a v2 manifest');
+      assert.ok(snapshot);
+      assert.equal(snapshot.schema_version, 'omx.sidecar/v1');
+      assert.ok(!JSON.stringify(snapshot).includes('secret-claim-token'), 'claim tokens must never be exposed in sidecar snapshots');
+      assert.deepEqual(snapshot.tasks.find((task) => task.id === '1')?.claim, { owner: 'worker-1', leased_until: '2026-04-27T02:10:00.000Z' });
+      assert.equal(snapshot.phase, 'team-exec');
+      assert.equal(snapshot.workers.length, 2);
+      assert.equal(snapshot.events[0]?.type, 'worker_state_changed');
+      assert.equal(snapshot.events[0]?.source_type, 'worker_idle');
+      assert.deepEqual(snapshot.panes.map((pane) => pane.pane_id), ['%1', '%2', '%3', '%4']);
+      assert.ok(snapshot.highlights.some((highlight) => highlight.kind === 'blocked-worker' && highlight.target === 'worker-2'));
+      assert.ok(snapshot.highlights.some((highlight) => highlight.kind === 'dead-worker' && highlight.target === 'worker-2'));
+      assert.ok(snapshot.highlights.some((highlight) => highlight.kind === 'non-reporting-worker' && highlight.target === 'worker-1'));
+      assert.ok(snapshot.highlights.some((highlight) => highlight.kind === 'blocked-task' && highlight.target === 'task-2'));
+      assert.ok(snapshot.highlights.some((highlight) => highlight.kind === 'failed-task' && highlight.target === 'task-3'));
+      assert.match(snapshot.topology.summary, /2 workers/);
+    });
+  });
+
+  it('rejects unsafe team names before reading state', async () => {
+    await assert.rejects(() => collectSidecarSnapshot('../demo', { cwd: '/tmp' }), /Invalid team name/);
+  });
+
+  it('skips unsafe worker names before resolving worker state paths', async () => {
+    await withFixture(async (cwd, teamRoot) => {
+      await writeJson(join(teamRoot, 'config.json'), {
+        name: 'demo',
+        task: 'ship sidecar',
+        tmux_session: 'omx-demo',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor' },
+          { name: '../escape', index: 2, role: 'executor' },
+        ],
+      });
+      await writeJson(join(teamRoot, 'workers', 'worker-1', 'status.json'), { state: 'idle' });
+      await writeJson(join(teamRoot, 'escape', 'status.json'), { state: 'working', current_task_id: 'escaped-status' });
+
+      const snapshot = await collectSidecarSnapshot('demo', { cwd, now: new Date('2026-04-27T02:01:00.000Z') });
+
+      assert.ok(snapshot);
+      assert.deepEqual(snapshot.workers.map((worker) => worker.name), ['worker-1']);
+      assert.ok(snapshot.source_warnings.some((warning) => warning.includes('skipped unsafe worker name: ../escape')));
+      assert.ok(!JSON.stringify(snapshot).includes('escaped-status'));
+    });
+  });
+
+  it('returns recent events from a bounded tail window', async () => {
+    await withFixture(async (cwd, teamRoot) => {
+      await writeJson(join(teamRoot, 'config.json'), {
+        name: 'demo',
+        task: 'ship sidecar',
+        tmux_session: 'omx-demo',
+        workers: [{ name: 'worker-1', index: 1, role: 'executor' }],
+      });
+      await mkdir(join(teamRoot, 'events'), { recursive: true });
+      const eventPath = join(teamRoot, 'events', 'events.ndjson');
+      const lines = [
+        '{invalid-json',
+        ...Array.from({ length: 30 }, (_, index) => JSON.stringify({
+          event_id: `e${index + 1}`,
+          team: 'demo',
+          type: 'worker_state_changed',
+          worker: 'worker-1',
+          state: 'idle',
+          created_at: `2026-04-27T02:${String(index).padStart(2, '0')}:00.000Z`,
+        })),
+      ];
+      await writeFile(eventPath, `${lines.join('\n')}\n`);
+
+      const tail = await readTailText(eventPath, 80);
+      assert.ok(tail);
+      assert.ok(Buffer.byteLength(tail) <= 80);
+
+      const snapshot = await collectSidecarSnapshot('demo', { cwd, eventLimit: 3, now: new Date('2026-04-27T02:31:00.000Z') });
+
+      assert.ok(snapshot);
+      assert.deepEqual(snapshot.events.map((event) => event.event_id), ['e28', 'e29', 'e30']);
+    });
+  });
+});

--- a/src/sidecar/__tests__/render.test.ts
+++ b/src/sidecar/__tests__/render.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { renderSidecar } from '../render.js';
+import type { SidecarSnapshot } from '../types.js';
+
+const SNAPSHOT: SidecarSnapshot = {
+  schema_version: 'omx.sidecar/v1',
+  generated_at: '2026-04-27T02:01:00.000Z',
+  team_name: 'demo',
+  team_task: 'ship sidecar',
+  phase: 'team-exec',
+  topology: {
+    summary: '2 workers · 1 working · 1 blocked · 1 in progress · 0 pending',
+    nodes: ['leader', 'worker-1', 'worker-2'],
+    edges: [{ from: 'leader', to: 'worker-1', label: 'task-1' }],
+  },
+  workers: [
+    {
+      name: 'worker-1', index: 1, role: 'executor', assigned_tasks: ['1'], pane_id: '%3',
+      status: { state: 'working', current_task_id: '1' }, heartbeat: { alive: true, turn_count: 8 }, alive: true,
+      current_task: { id: '1', subject: 'Implement collector', description: '', status: 'in_progress', owner: 'worker-1' },
+      turns_without_progress: 7,
+    },
+  ],
+  tasks: [{ id: '1', subject: 'Implement collector', description: '', status: 'in_progress', owner: 'worker-1' }],
+  events: [{ event_id: 'e1', team: 'demo', type: 'worker_state_changed', worker: 'worker-1', state: 'working', created_at: '2026-04-27T02:00:00.000Z' }],
+  panes: [{ target: 'worker-1', pane_id: '%3', role: 'worker' }],
+  highlights: [{ severity: 'warning', target: 'worker-1', kind: 'non-reporting-worker', message: 'worker-1 has 7 turns without task progress' }],
+  source_warnings: [],
+};
+
+describe('renderSidecar', () => {
+  it('renders stacked text panels with core visualization vocabulary', () => {
+    const output = renderSidecar(SNAPSHOT, { width: 88, color: false });
+    for (const label of ['OMX Sidecar · demo', 'Topology', 'Agents', 'Tasks', 'Highlights', 'Panes', 'Events']) {
+      assert.match(output, new RegExp(label));
+    }
+    assert.match(output, /worker-1 \[working\/alive\] executor task-1 %3 Δturns=7/);
+    assert.match(output, /task-1 \[in_progress\] @worker-1 Implement collector/);
+    assert.match(output, /worker-1 has 7 turns without task progress/);
+  });
+
+
+  it('does not leak raw ANSI fragments in default colored panel content', () => {
+    const output = renderSidecar({ ...SNAPSHOT, highlights: [], source_warnings: ['watch warning'] }, { width: 88 });
+    assert.match(output, /no blockers detected/);
+    assert.match(output, /watch warning/);
+    assert.doesNotMatch(output, /(?:^|[^\x1b])\[(?:32|33|0)m/);
+  });
+
+  it('sanitizes dynamic header and panel values before terminal rendering', () => {
+    const output = renderSidecar({
+      ...SNAPSHOT,
+      team_name: 'demo\u001b]0;owned\u0007\u001b[31m',
+      phase: 'team-exec\u001b[2J\u0001',
+      topology: { ...SNAPSHOT.topology, summary: 'safe\u001b[31m summary' },
+      tasks: [{ ...SNAPSHOT.tasks[0]!, subject: 'task\u001b]2;owned\u0007 subject' }],
+      events: [{ ...SNAPSHOT.events[0]!, reason: 'reason\u001b[2J' }],
+      highlights: [{ ...SNAPSHOT.highlights[0]!, message: 'highlight\u001b[31m message' }],
+    }, { width: 88, color: false });
+
+    assert.match(output, /OMX Sidecar · demo/);
+    assert.match(output, /phase=team-exec/);
+    assert.doesNotMatch(output, /\x1b\]/);
+    assert.doesNotMatch(output, /\x1b\[[0-?]*[ -/]*[@-~]/);
+    assert.doesNotMatch(output, /owned/);
+  });
+
+  it('honors height truncation for narrow right-side panes', () => {
+    const output = renderSidecar(SNAPSHOT, { width: 44, height: 5, color: false });
+    assert.ok(output.split('\n').length <= 5);
+    assert.match(output, /more lines/);
+  });
+});

--- a/src/sidecar/__tests__/tmux.test.ts
+++ b/src/sidecar/__tests__/tmux.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildSidecarTmuxSplitArgs, buildSidecarWatchCommand, launchSidecarTmuxPane } from '../tmux.js';
+
+describe('sidecar tmux launcher', () => {
+  it('builds a detached horizontal right-side split running watch mode', () => {
+    const args = buildSidecarTmuxSplitArgs({ cwd: '/repo', teamName: 'demo-team', width: 52, sessionId: 'sess 1', omxBin: '/repo/dist/cli/omx.js' });
+    assert.deepEqual(args.slice(0, 6), ['split-window', '-h', '-d', '-l', '52', '-c']);
+    assert.equal(args[6], '/repo');
+    assert.equal(args[8], '-F');
+    assert.equal(args[9], '#{pane_id}');
+    assert.match(args[10], /OMX_SESSION_ID='sess 1'/);
+    assert.match(args[10], /node '\/repo\/dist\/cli\/omx\.js' sidecar 'demo-team' --watch --width 52/);
+  });
+
+  it('uses a safe minimum sidecar width and parses the new pane id', () => {
+    const command = buildSidecarWatchCommand({ cwd: '/repo', teamName: 'demo', width: 10, omxBin: '/repo/omx.js' });
+    assert.match(command, /--width 48$/);
+
+    const paneId = launchSidecarTmuxPane(
+      { cwd: '/repo', teamName: 'demo', width: 48, omxBin: '/repo/omx.js' },
+      (args) => {
+        assert.equal(args[0], 'split-window');
+        return '%42\n';
+      },
+    );
+    assert.equal(paneId, '%42');
+  });
+
+  it('returns null when tmux launch throws', () => {
+    const paneId = launchSidecarTmuxPane(
+      { cwd: '/repo', teamName: 'demo', width: 48, omxBin: '/repo/omx.js' },
+      () => {
+        throw new Error('tmux unavailable');
+      },
+    );
+    assert.equal(paneId, null);
+  });
+});

--- a/src/sidecar/__tests__/watch.test.ts
+++ b/src/sidecar/__tests__/watch.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { runSidecarWatch } from '../index.js';
+import type { SidecarSnapshot } from '../types.js';
+
+function snapshot(): SidecarSnapshot {
+  return {
+    schema_version: 'omx.sidecar/v1',
+    generated_at: '2026-04-27T02:01:00.000Z',
+    team_name: 'demo',
+    team_task: 'ship sidecar',
+    phase: null,
+    topology: { summary: '0 workers', nodes: ['leader'], edges: [] },
+    workers: [],
+    tasks: [],
+    events: [],
+    panes: [],
+    highlights: [],
+    source_warnings: [],
+  };
+}
+
+describe('runSidecarWatch', () => {
+  it('renders read-only frames and restores cursor when stopped', async () => {
+    const writes: string[] = [];
+    let sigintHandler: (() => void) | undefined;
+    let collectCalls = 0;
+
+    await runSidecarWatch('demo', { json: false, watch: true, tmux: false, intervalMs: 100 }, {}, {
+      collect: async () => { collectCalls += 1; return snapshot(); },
+      render: (frame, options) => `frame:${frame.team_name}:${options.width}:${options.height}`,
+      writeStdout: (text) => { writes.push(text); },
+      writeStderr: () => {},
+      registerSigint: (handler) => { sigintHandler = handler; },
+      stdoutColumns: () => 51,
+      stdoutRows: () => 22,
+      sleep: async () => { sigintHandler?.(); },
+    });
+
+    assert.equal(collectCalls, 1);
+    assert.ok(writes.some((chunk) => chunk.includes('\x1b[?25l')), 'watch hides cursor');
+    assert.ok(writes.some((chunk) => chunk.includes('\x1b[2J\x1b[H')), 'first render clears screen');
+    assert.ok(writes.some((chunk) => chunk.includes('frame:demo:51:22')), 'watch writes rendered sidecar frame');
+    assert.ok(writes.some((chunk) => chunk.includes('\x1b[?25h')), 'watch restores cursor');
+  });
+});

--- a/src/sidecar/collector.ts
+++ b/src/sidecar/collector.ts
@@ -118,7 +118,7 @@ function normalizeConfig(raw: unknown): NormalizedConfig | null {
   };
 }
 
-async function readSidecarConfig(teamName: string, root: string): Promise<{ config: SidecarTeamConfig | null; source: string | null; warnings: string[] }> {
+async function readSidecarConfig(root: string): Promise<{ config: SidecarTeamConfig | null; source: string | null; warnings: string[] }> {
   const manifestPath = join(root, 'manifest.v2.json');
   const manifest = await readJson<unknown>(manifestPath);
   const manifestConfig = normalizeConfig(manifest);
@@ -349,7 +349,7 @@ function buildHighlights(workers: SidecarWorkerSnapshot[], tasks: SidecarTask[])
   return highlights;
 }
 
-function buildTopology(config: SidecarTeamConfig, workers: SidecarWorkerSnapshot[], tasks: SidecarTask[]): SidecarTopology {
+function buildTopology(workers: SidecarWorkerSnapshot[], tasks: SidecarTask[]): SidecarTopology {
   const activeWorkers = workers.filter((worker) => worker.status.state === 'working').length;
   const blockedWorkers = workers.filter((worker) => worker.status.state === 'blocked').length;
   const pendingTasks = tasks.filter((task) => task.status === 'pending').length;
@@ -373,7 +373,7 @@ export async function collectSidecarSnapshot(
   const env = options.env ?? process.env;
   const root = teamRoot(sanitized, cwd, env);
   const warnings: string[] = [];
-  const { config, source, warnings: configWarnings } = await readSidecarConfig(sanitized, root);
+  const { config, source, warnings: configWarnings } = await readSidecarConfig(root);
   if (!config) return null;
   warnings.push(...configWarnings);
   if (!source) warnings.push('team config source missing');
@@ -387,7 +387,7 @@ export async function collectSidecarSnapshot(
   const workers = await buildWorkers(config, tasks, root, monitorSnapshot);
   const panes = buildPanes(config);
   const highlights = buildHighlights(workers, tasks);
-  const topology = buildTopology(config, workers, tasks);
+  const topology = buildTopology(workers, tasks);
   return {
     schema_version: 'omx.sidecar/v1',
     generated_at: (options.now ?? new Date()).toISOString(),

--- a/src/sidecar/collector.ts
+++ b/src/sidecar/collector.ts
@@ -1,0 +1,405 @@
+import { open, readFile, readdir } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { TEAM_NAME_SAFE_PATTERN, TEAM_TASK_STATUSES, WORKER_NAME_SAFE_PATTERN } from '../team/contracts.js';
+import type {
+  CollectSidecarSnapshotOptions,
+  SidecarEvent,
+  SidecarHighlight,
+  SidecarPaneMapping,
+  SidecarSnapshot,
+  SidecarTask,
+  SidecarTeamConfig,
+  SidecarTopology,
+  SidecarWorkerHeartbeat,
+  SidecarWorkerInfo,
+  SidecarWorkerSnapshot,
+  SidecarWorkerState,
+  SidecarWorkerStatus,
+} from './types.js';
+
+const WORKER_STATES = ['idle', 'working', 'blocked', 'done', 'failed', 'draining', 'unknown'] as const;
+const DEFAULT_EVENT_LIMIT = 12;
+const DEFAULT_EVENT_TAIL_BYTES = 64 * 1024;
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function optionalString(value: unknown): string | undefined {
+  const safe = safeString(value);
+  return safe || undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
+}
+
+function asWorkerState(value: unknown): SidecarWorkerState {
+  return typeof value === 'string' && (WORKER_STATES as readonly string[]).includes(value) ? value as SidecarWorkerState : 'unknown';
+}
+
+function asTaskStatus(value: unknown): SidecarTask['status'] {
+  return typeof value === 'string' && (TEAM_TASK_STATUSES as readonly string[]).includes(value) ? value as SidecarTask['status'] : 'pending';
+}
+
+function stateRoot(cwd: string, env: NodeJS.ProcessEnv): string {
+  const explicit = safeString(env.OMX_TEAM_STATE_ROOT);
+  return explicit ? resolve(cwd, explicit) : join(cwd, '.omx', 'state');
+}
+
+function teamRoot(teamName: string, cwd: string, env: NodeJS.ProcessEnv): string {
+  return join(stateRoot(cwd, env), 'team', teamName);
+}
+
+async function readJson<T>(path: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+interface NormalizedConfig {
+  config: SidecarTeamConfig;
+  warnings: string[];
+}
+
+function normalizeWorker(raw: unknown, indexFallback: number): { worker: SidecarWorkerInfo | null; warning?: string } | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const value = raw as Record<string, unknown>;
+  const name = safeString(value.name);
+  if (!name) return { worker: null };
+  if (!WORKER_NAME_SAFE_PATTERN.test(name)) {
+    return { worker: null, warning: `skipped unsafe worker name: ${name}` };
+  }
+  return {
+    worker: {
+      name,
+      index: optionalNumber(value.index) ?? indexFallback,
+      role: safeString(value.role) || 'executor',
+      assigned_tasks: asStringArray(value.assigned_tasks),
+      pane_id: optionalString(value.pane_id),
+      worker_cli: optionalString(value.worker_cli),
+      working_dir: optionalString(value.working_dir),
+      worktree_path: optionalString(value.worktree_path),
+      worktree_branch: optionalString(value.worktree_branch),
+    },
+  };
+}
+
+function normalizeConfig(raw: unknown): NormalizedConfig | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const value = raw as Record<string, unknown>;
+  const name = safeString(value.name);
+  if (!name) return null;
+  const warnings: string[] = [];
+  const workers = Array.isArray(value.workers)
+    ? value.workers.map((worker, index) => normalizeWorker(worker, index + 1)).flatMap((normalized): SidecarWorkerInfo[] => {
+      if (!normalized) return [];
+      if (normalized.warning) warnings.push(normalized.warning);
+      return normalized.worker ? [normalized.worker] : [];
+    })
+    : [];
+  return {
+    config: {
+      name,
+      task: safeString(value.task),
+      worker_count: optionalNumber(value.worker_count) ?? workers.length,
+      tmux_session: safeString(value.tmux_session),
+      leader_pane_id: optionalString(value.leader_pane_id) ?? null,
+      hud_pane_id: optionalString(value.hud_pane_id) ?? null,
+      workers,
+    },
+    warnings,
+  };
+}
+
+async function readSidecarConfig(teamName: string, root: string): Promise<{ config: SidecarTeamConfig | null; source: string | null; warnings: string[] }> {
+  const manifestPath = join(root, 'manifest.v2.json');
+  const manifest = await readJson<unknown>(manifestPath);
+  const manifestConfig = normalizeConfig(manifest);
+  if (manifestConfig) return { config: manifestConfig.config, source: manifestPath, warnings: manifestConfig.warnings };
+
+  const configPath = join(root, 'config.json');
+  const legacy = await readJson<unknown>(configPath);
+  const legacyConfig = normalizeConfig(legacy);
+  if (legacyConfig) return { config: legacyConfig.config, source: configPath, warnings: legacyConfig.warnings };
+
+  return { config: null, source: null, warnings: [] };
+}
+
+function normalizeTask(raw: unknown): SidecarTask | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const value = raw as Record<string, unknown>;
+  const id = safeString(value.id);
+  if (!id) return null;
+  const claim = value.claim && typeof value.claim === 'object'
+    ? value.claim as Record<string, unknown>
+    : null;
+  return {
+    id,
+    subject: safeString(value.subject) || `task-${id}`,
+    description: safeString(value.description),
+    status: asTaskStatus(value.status),
+    owner: optionalString(value.owner),
+    role: optionalString(value.role),
+    result: optionalString(value.result),
+    error: optionalString(value.error),
+    blocked_by: asStringArray(value.blocked_by),
+    depends_on: asStringArray(value.depends_on),
+    version: optionalNumber(value.version),
+    claim: claim && safeString(claim.owner) && safeString(claim.leased_until)
+      ? { owner: safeString(claim.owner), leased_until: safeString(claim.leased_until) }
+      : undefined,
+    created_at: optionalString(value.created_at),
+    completed_at: optionalString(value.completed_at),
+  };
+}
+
+async function readTasks(root: string): Promise<SidecarTask[]> {
+  const tasksRoot = join(root, 'tasks');
+  let files: string[] = [];
+  try {
+    files = await readdir(tasksRoot);
+  } catch {
+    return [];
+  }
+  const tasks = await Promise.all(
+    files
+      .filter((file) => /^task-\d+\.json$/.test(file))
+      .sort((a, b) => Number(a.match(/\d+/)?.[0] ?? 0) - Number(b.match(/\d+/)?.[0] ?? 0))
+      .map((file) => readJson<unknown>(join(tasksRoot, file)).then(normalizeTask)),
+  );
+  return tasks.filter((task): task is SidecarTask => task !== null);
+}
+
+async function readWorkerStatus(root: string, workerName: string): Promise<SidecarWorkerStatus> {
+  const raw = await readJson<Record<string, unknown>>(join(root, 'workers', workerName, 'status.json'));
+  return {
+    state: asWorkerState(raw?.state),
+    current_task_id: optionalString(raw?.current_task_id),
+    reason: optionalString(raw?.reason),
+    updated_at: optionalString(raw?.updated_at),
+  };
+}
+
+async function readWorkerHeartbeat(root: string, workerName: string): Promise<SidecarWorkerHeartbeat | null> {
+  const raw = await readJson<Record<string, unknown>>(join(root, 'workers', workerName, 'heartbeat.json'));
+  if (!raw) return null;
+  return {
+    pid: optionalNumber(raw.pid),
+    last_turn_at: optionalString(raw.last_turn_at),
+    turn_count: optionalNumber(raw.turn_count),
+    alive: typeof raw.alive === 'boolean' ? raw.alive : undefined,
+  };
+}
+
+async function readPhase(root: string): Promise<string | null> {
+  const raw = await readJson<Record<string, unknown>>(join(root, 'phase.json'));
+  return optionalString(raw?.current_phase) ?? null;
+}
+
+async function readMonitorSnapshot(root: string): Promise<Record<string, unknown> | null> {
+  return readJson<Record<string, unknown>>(join(root, 'monitor-snapshot.json'));
+}
+
+function normalizeEvent(raw: unknown): SidecarEvent | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const value = raw as Record<string, unknown>;
+  const eventId = safeString(value.event_id);
+  const team = safeString(value.team);
+  const type = safeString(value.type);
+  const worker = safeString(value.worker);
+  const createdAt = safeString(value.created_at);
+  if (!eventId || !team || !type || !worker || !createdAt) return null;
+  if (type === 'worker_idle') {
+    return {
+      event_id: eventId,
+      team,
+      type: 'worker_state_changed',
+      source_type: 'worker_idle',
+      worker,
+      task_id: optionalString(value.task_id),
+      state: 'idle',
+      prev_state: value.prev_state ? asWorkerState(value.prev_state) : undefined,
+      reason: optionalString(value.reason),
+      created_at: createdAt,
+    };
+  }
+  return {
+    event_id: eventId,
+    team,
+    type,
+    worker,
+    task_id: optionalString(value.task_id),
+    state: value.state ? asWorkerState(value.state) : undefined,
+    prev_state: value.prev_state ? asWorkerState(value.prev_state) : undefined,
+    reason: optionalString(value.reason),
+    source_type: optionalString(value.source_type),
+    created_at: createdAt,
+  };
+}
+
+export async function readTailText(path: string, maxBytes: number = DEFAULT_EVENT_TAIL_BYTES): Promise<string | null> {
+  let file: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    file = await open(path, 'r');
+    const stats = await file.stat();
+    if (!stats.isFile()) return null;
+    const bytesToRead = Math.min(stats.size, Math.max(1, Math.floor(maxBytes)));
+    const buffer = Buffer.alloc(bytesToRead);
+    await file.read(buffer, 0, bytesToRead, stats.size - bytesToRead);
+    return buffer.toString('utf-8');
+  } catch {
+    return null;
+  } finally {
+    await file?.close().catch(() => undefined);
+  }
+}
+
+async function readEvents(root: string, limit: number): Promise<SidecarEvent[]> {
+  const path = join(root, 'events', 'events.ndjson');
+  const raw = await readTailText(path, DEFAULT_EVENT_TAIL_BYTES);
+  if (!raw) return [];
+  const lines = raw
+    .split('\n')
+    .filter((line) => line.trim().length > 0);
+  if (lines.length > 0 && !raw.startsWith('{')) lines.shift();
+  return lines
+    .map((line) => {
+      try { return normalizeEvent(JSON.parse(line) as unknown); } catch { return null; }
+    })
+    .filter((event): event is SidecarEvent => event !== null)
+    .slice(-Math.max(1, limit));
+}
+
+function readRecordNumber(record: unknown, key: string): number | null {
+  if (!record || typeof record !== 'object') return null;
+  const value = (record as Record<string, unknown>)[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function readRecordString(record: unknown, key: string): string {
+  if (!record || typeof record !== 'object') return '';
+  return safeString((record as Record<string, unknown>)[key]);
+}
+
+function buildWorkers(config: SidecarTeamConfig, tasks: SidecarTask[], root: string, monitorSnapshot: Record<string, unknown> | null): Promise<SidecarWorkerSnapshot[]> {
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const previousTurns = monitorSnapshot?.workerTurnCountByName;
+  const previousTaskIds = monitorSnapshot?.workerTaskIdByName;
+  return Promise.all(config.workers.map(async (worker) => {
+    const [status, heartbeat] = await Promise.all([
+      readWorkerStatus(root, worker.name),
+      readWorkerHeartbeat(root, worker.name),
+    ]);
+    const currentTaskId = status.current_task_id ?? '';
+    const currentTask = currentTaskId ? taskById.get(currentTaskId) ?? null : null;
+    const prevTaskId = readRecordString(previousTaskIds, worker.name);
+    const prevTurnCount = readRecordNumber(previousTurns, worker.name);
+    const currentTurnCount = heartbeat?.turn_count;
+    const turnsWithoutProgress =
+      status.state === 'working' && currentTask && prevTaskId === currentTaskId && prevTurnCount !== null && typeof currentTurnCount === 'number'
+        ? Math.max(0, currentTurnCount - prevTurnCount)
+        : null;
+    return {
+      ...worker,
+      status,
+      heartbeat,
+      alive: typeof heartbeat?.alive === 'boolean' ? heartbeat.alive : null,
+      current_task: currentTask,
+      turns_without_progress: turnsWithoutProgress,
+    };
+  }));
+}
+
+function buildPanes(config: SidecarTeamConfig): SidecarPaneMapping[] {
+  return [
+    config.leader_pane_id ? { target: 'leader', pane_id: config.leader_pane_id, role: 'leader' as const } : null,
+    config.hud_pane_id ? { target: 'hud', pane_id: config.hud_pane_id, role: 'hud' as const } : null,
+    ...config.workers.map((worker) => worker.pane_id ? { target: worker.name, pane_id: worker.pane_id, role: 'worker' as const } : null),
+  ].filter((pane): pane is NonNullable<typeof pane> => pane !== null);
+}
+
+function buildHighlights(workers: SidecarWorkerSnapshot[], tasks: SidecarTask[]): SidecarHighlight[] {
+  const highlights: SidecarHighlight[] = [];
+  for (const worker of workers) {
+    if (worker.status.state === 'blocked') {
+      highlights.push({ severity: 'warning', target: worker.name, kind: 'blocked-worker', message: worker.status.reason || `${worker.name} is blocked` });
+    }
+    if (worker.alive === false) {
+      highlights.push({ severity: 'critical', target: worker.name, kind: 'dead-worker', message: `${worker.name} heartbeat reports not alive` });
+    }
+    if (typeof worker.turns_without_progress === 'number' && worker.turns_without_progress > 5) {
+      highlights.push({ severity: 'warning', target: worker.name, kind: 'non-reporting-worker', message: `${worker.name} has ${worker.turns_without_progress} turns without task progress` });
+    }
+  }
+  for (const task of tasks) {
+    if (task.status === 'blocked') {
+      highlights.push({ severity: 'warning', target: `task-${task.id}`, kind: 'blocked-task', message: task.subject || `task-${task.id} is blocked` });
+    }
+    if (task.status === 'failed') {
+      highlights.push({ severity: 'critical', target: `task-${task.id}`, kind: 'failed-task', message: task.error || task.subject || `task-${task.id} failed` });
+    }
+  }
+  return highlights;
+}
+
+function buildTopology(config: SidecarTeamConfig, workers: SidecarWorkerSnapshot[], tasks: SidecarTask[]): SidecarTopology {
+  const activeWorkers = workers.filter((worker) => worker.status.state === 'working').length;
+  const blockedWorkers = workers.filter((worker) => worker.status.state === 'blocked').length;
+  const pendingTasks = tasks.filter((task) => task.status === 'pending').length;
+  const inProgressTasks = tasks.filter((task) => task.status === 'in_progress').length;
+  return {
+    summary: `${workers.length} workers · ${activeWorkers} working · ${blockedWorkers} blocked · ${inProgressTasks} in progress · ${pendingTasks} pending`,
+    nodes: ['leader', ...workers.map((worker) => worker.name)],
+    edges: workers.map((worker) => ({ from: 'leader', to: worker.name, label: worker.current_task ? `task-${worker.current_task.id}` : worker.status.state })),
+  };
+}
+
+export async function collectSidecarSnapshot(
+  teamName: string,
+  options: CollectSidecarSnapshotOptions = {},
+): Promise<SidecarSnapshot | null> {
+  const sanitized = safeString(teamName);
+  if (!TEAM_NAME_SAFE_PATTERN.test(sanitized)) {
+    throw new Error(`Invalid team name: "${teamName}". Team name must match ${TEAM_NAME_SAFE_PATTERN}.`);
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const root = teamRoot(sanitized, cwd, env);
+  const warnings: string[] = [];
+  const { config, source, warnings: configWarnings } = await readSidecarConfig(sanitized, root);
+  if (!config) return null;
+  warnings.push(...configWarnings);
+  if (!source) warnings.push('team config source missing');
+
+  const [tasks, events, phase, monitorSnapshot] = await Promise.all([
+    readTasks(root),
+    readEvents(root, options.eventLimit ?? DEFAULT_EVENT_LIMIT),
+    readPhase(root),
+    readMonitorSnapshot(root),
+  ]);
+  const workers = await buildWorkers(config, tasks, root, monitorSnapshot);
+  const panes = buildPanes(config);
+  const highlights = buildHighlights(workers, tasks);
+  const topology = buildTopology(config, workers, tasks);
+  return {
+    schema_version: 'omx.sidecar/v1',
+    generated_at: (options.now ?? new Date()).toISOString(),
+    team_name: config.name,
+    team_task: config.task,
+    phase,
+    topology,
+    workers,
+    tasks,
+    events,
+    panes,
+    highlights,
+    source_warnings: warnings,
+  };
+}

--- a/src/sidecar/index.ts
+++ b/src/sidecar/index.ts
@@ -1,0 +1,187 @@
+import { collectSidecarSnapshot } from './collector.js';
+import { renderSidecar } from './render.js';
+import { launchSidecarTmuxPane } from './tmux.js';
+import type { CollectSidecarSnapshotOptions, SidecarFlags, SidecarSnapshot } from './types.js';
+
+export const SIDECAR_USAGE = [
+  'Usage:',
+  '  omx sidecar <team-name>              Render sidecar once',
+  '  omx sidecar <team-name> --json       Output normalized sidecar snapshot',
+  '  omx sidecar <team-name> --watch      Refresh sidecar in the current terminal',
+  '  omx sidecar <team-name> --tmux       Open a right-side tmux pane running watch mode',
+  'Options:',
+  '  --width <cols> / --width=<cols>      Sidecar width (default 48, minimum 30)',
+  '  --interval-ms <ms>                   Watch refresh interval (default 1000)',
+].join('\n');
+
+interface ParsedSidecarArgs {
+  teamName: string;
+  flags: SidecarFlags;
+}
+
+type SleepFn = (ms: number, signal?: AbortSignal) => Promise<void>;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function parseSidecarArgs(args: string[]): ParsedSidecarArgs {
+  const flags: SidecarFlags = { json: false, watch: false, tmux: false };
+  const rest: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') flags.json = true;
+    else if (arg === '--watch' || arg === '-w') flags.watch = true;
+    else if (arg === '--tmux') flags.tmux = true;
+    else if (arg === '--width') {
+      flags.width = parsePositiveInt(args[index + 1], 48);
+      index += 1;
+    } else if (arg.startsWith('--width=')) {
+      flags.width = parsePositiveInt(arg.slice('--width='.length), 48);
+    } else if (arg === '--interval-ms') {
+      flags.intervalMs = parsePositiveInt(args[index + 1], 1000);
+      index += 1;
+    } else if (arg.startsWith('--interval-ms=')) {
+      flags.intervalMs = parsePositiveInt(arg.slice('--interval-ms='.length), 1000);
+    } else {
+      rest.push(arg);
+    }
+  }
+  return { teamName: rest[0] || '', flags };
+}
+
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+}
+
+export interface RunSidecarWatchDeps {
+  collect: (teamName: string, options: CollectSidecarSnapshotOptions) => Promise<SidecarSnapshot | null>;
+  render: (snapshot: SidecarSnapshot, options: { width?: number; height?: number }) => string;
+  writeStdout: (text: string) => void;
+  writeStderr: (text: string) => void;
+  sleep: SleepFn;
+  registerSigint: (handler: () => void) => void;
+  stdoutColumns?: () => number | undefined;
+  stdoutRows?: () => number | undefined;
+}
+
+export async function runSidecarWatch(
+  teamName: string,
+  flags: SidecarFlags,
+  options: CollectSidecarSnapshotOptions = {},
+  deps: Partial<RunSidecarWatchDeps> = {},
+): Promise<void> {
+  const dependencies: RunSidecarWatchDeps = {
+    collect: deps.collect ?? collectSidecarSnapshot,
+    render: deps.render ?? renderSidecar,
+    writeStdout: deps.writeStdout ?? ((text) => process.stdout.write(text)),
+    writeStderr: deps.writeStderr ?? ((text) => process.stderr.write(text)),
+    sleep: deps.sleep ?? defaultSleep,
+    registerSigint: deps.registerSigint ?? ((handler) => process.on('SIGINT', handler)),
+    stdoutColumns: deps.stdoutColumns ?? (() => process.stdout.columns),
+    stdoutRows: deps.stdoutRows ?? (() => process.stdout.rows),
+  };
+  const intervalMs = Math.max(100, flags.intervalMs ?? 1000);
+  const abortController = new AbortController();
+  let firstRender = true;
+  let inFlight = false;
+  let queued = false;
+  let stopped = false;
+
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    abortController.abort();
+    dependencies.writeStdout('\x1b[?25h');
+  };
+  dependencies.registerSigint(stop);
+  dependencies.writeStdout('\x1b[?25l');
+
+  const renderTick = async (): Promise<void> => {
+    if (stopped) return;
+    if (inFlight) {
+      queued = true;
+      return;
+    }
+    inFlight = true;
+    try {
+      const snapshot = await dependencies.collect(teamName, options);
+      const output = snapshot
+        ? dependencies.render(snapshot, { width: flags.width ?? dependencies.stdoutColumns?.(), height: dependencies.stdoutRows?.() })
+        : `No team state found for ${teamName}`;
+      dependencies.writeStdout(firstRender ? '\x1b[2J\x1b[H' : '\x1b[H');
+      firstRender = false;
+      dependencies.writeStdout(`${output}\x1b[J`);
+    } catch (error) {
+      dependencies.writeStderr(`Sidecar watch render failed: ${error instanceof Error ? error.message : String(error)}\n`);
+      stop();
+    } finally {
+      inFlight = false;
+    }
+    if (queued) {
+      queued = false;
+      await renderTick();
+    }
+  };
+
+  while (!stopped && !abortController.signal.aborted) {
+    const started = Date.now();
+    await renderTick();
+    if (stopped || abortController.signal.aborted) break;
+    await dependencies.sleep(Math.max(0, intervalMs - (Date.now() - started)), abortController.signal);
+  }
+  dependencies.writeStdout('\x1b[?25h');
+}
+
+export async function sidecarCommand(args: string[]): Promise<void> {
+  if (args[0] === '--help' || args[0] === '-h' || args.length === 0) {
+    console.log(SIDECAR_USAGE);
+    return;
+  }
+  const { teamName, flags } = parseSidecarArgs(args);
+  if (!teamName) throw new Error(SIDECAR_USAGE);
+  const cwd = process.cwd();
+
+  if (flags.tmux) {
+    if (!process.env.TMUX) {
+      console.error('Not inside a tmux session. Start tmux first, then run: omx sidecar <team-name> --tmux');
+      process.exitCode = 1;
+      return;
+    }
+    const paneId = launchSidecarTmuxPane({ cwd, teamName, width: flags.width, sessionId: process.env.OMX_SESSION_ID });
+    if (!paneId) {
+      console.error('Failed to create sidecar tmux pane. Ensure tmux is available.');
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`Sidecar launched in right tmux pane ${paneId}.`);
+    return;
+  }
+
+  if (flags.watch) {
+    await runSidecarWatch(teamName, flags, { cwd });
+    return;
+  }
+
+  const snapshot = await collectSidecarSnapshot(teamName, { cwd });
+  if (flags.json) {
+    console.log(JSON.stringify(snapshot ?? { status: 'missing', team_name: teamName }, null, 2));
+    return;
+  }
+  if (!snapshot) {
+    console.log(`No team state found for ${teamName}`);
+    return;
+  }
+  console.log(renderSidecar(snapshot, { width: flags.width ?? process.stdout.columns }));
+}

--- a/src/sidecar/render.ts
+++ b/src/sidecar/render.ts
@@ -1,0 +1,80 @@
+import { bold, cyan, dim, green, isColorEnabled, setColorEnabled, yellow } from '../hud/colors.js';
+import type { RenderSidecarOptions, SidecarHighlight, SidecarSnapshot, SidecarTask, SidecarWorkerSnapshot } from './types.js';
+
+const CONTROL_CHARS_RE = /[\u0000-\u001f\u007f-\u009f]/g;
+const OSC_RE = /\x1b\][\s\S]*?(?:\u0007|\x1b\\)/g;
+const ANSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+
+function clean(value: string | undefined | null): string {
+  return (value ?? '').replace(OSC_RE, '').replace(ANSI_RE, '').replace(CONTROL_CHARS_RE, '').trim();
+}
+
+function visibleLength(value: string): number {
+  return clean(value).length;
+}
+
+function truncate(value: string, width: number): string {
+  const sanitized = clean(value);
+  if (width <= 0) return '';
+  if (sanitized.length <= width) return sanitized;
+  if (width <= 1) return '…';
+  return `${sanitized.slice(0, Math.max(0, width - 1))}…`;
+}
+
+function panel(title: string, lines: string[], width: number): string[] {
+  const safeWidth = Math.max(24, width);
+  const rule = '─'.repeat(Math.max(1, safeWidth - visibleLength(title) - 4));
+  return [bold(`╭ ${title} ${rule}`), ...lines.map((line) => `│ ${truncate(line, safeWidth - 2)}`)];
+}
+
+function taskLabel(task: SidecarTask): string {
+  const owner = task.owner ? ` @${task.owner}` : '';
+  return `task-${task.id} [${task.status}]${owner} ${task.subject}`;
+}
+
+function workerLabel(worker: SidecarWorkerSnapshot): string {
+  const alive = worker.alive === false ? 'dead' : worker.alive === true ? 'alive' : 'unknown';
+  const task = worker.current_task ? ` task-${worker.current_task.id}` : '';
+  const pane = worker.pane_id ? ` ${worker.pane_id}` : '';
+  const turns = typeof worker.turns_without_progress === 'number' ? ` Δturns=${worker.turns_without_progress}` : '';
+  return `${worker.name} [${worker.status.state}/${alive}] ${worker.role}${task}${pane}${turns}`;
+}
+
+function highlightLabel(highlight: SidecarHighlight): string {
+  const prefix = highlight.severity === 'critical' ? '!!' : highlight.severity === 'warning' ? '!' : '·';
+  return `${prefix} ${highlight.target}: ${highlight.message}`;
+}
+
+function withColorSetting<T>(enabled: boolean, fn: () => T): T {
+  const previous = isColorEnabled();
+  setColorEnabled(enabled);
+  try {
+    return fn();
+  } finally {
+    setColorEnabled(previous);
+  }
+}
+
+export function renderSidecar(snapshot: SidecarSnapshot, options: RenderSidecarOptions = {}): string {
+  const width = Math.max(32, Math.floor(options.width ?? 72));
+  const maxLines = Math.max(0, Math.floor(options.height ?? 0));
+  return withColorSetting(options.color !== false, () => {
+    const lines: string[] = [];
+    lines.push(cyan(bold(`OMX Sidecar · ${clean(snapshot.team_name)}`)));
+    lines.push(dim(`phase=${clean(snapshot.phase ?? 'unknown')} generated=${clean(snapshot.generated_at)}`));
+    lines.push('');
+
+    lines.push(...panel('Topology', [snapshot.topology.summary, ...snapshot.topology.edges.map((edge) => `${edge.from} ──${edge.label ? ` ${edge.label} ` : ' '}→ ${edge.to}`)], width));
+    lines.push(...panel('Agents', snapshot.workers.length > 0 ? snapshot.workers.map(workerLabel) : ['no workers found'], width));
+    lines.push(...panel('Tasks', snapshot.tasks.length > 0 ? snapshot.tasks.map(taskLabel) : ['no tasks found'], width));
+    lines.push(...panel('Highlights', snapshot.highlights.length > 0 ? snapshot.highlights.map(highlightLabel) : [green('no blockers detected')], width));
+    lines.push(...panel('Panes', snapshot.panes.length > 0 ? snapshot.panes.map((pane) => `${pane.target} [${pane.role}] ${pane.pane_id}`) : ['no pane mapping available'], width));
+    lines.push(...panel('Events', snapshot.events.length > 0 ? snapshot.events.map((event) => `${event.created_at} ${event.type} ${event.worker}${event.task_id ? ` task-${event.task_id}` : ''}${event.reason ? ` · ${event.reason}` : ''}`) : ['no recent events'], width));
+    if (snapshot.source_warnings.length > 0) {
+      lines.push(...panel('Warnings', snapshot.source_warnings.map((warning) => yellow(warning)), width));
+    }
+
+    const rendered = maxLines > 0 && lines.length > maxLines ? [...lines.slice(0, Math.max(0, maxLines - 1)), dim(`… ${lines.length - maxLines + 1} more lines`)] : lines;
+    return rendered.join('\n');
+  });
+}

--- a/src/sidecar/tmux.ts
+++ b/src/sidecar/tmux.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from 'node:child_process';
+import { parsePaneIdFromTmuxOutput, shellEscapeSingle } from '../hud/tmux.js';
+import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
+import { resolveOmxCliEntryPath } from '../utils/paths.js';
+
+export interface SidecarTmuxOptions {
+  cwd: string;
+  teamName: string;
+  width?: number;
+  sessionId?: string;
+  omxBin?: string;
+}
+
+type TmuxExecSync = (args: string[]) => string;
+
+function sidecarWidth(width: number | undefined): number {
+  return Number.isFinite(width) && (width ?? 0) >= 30 ? Math.floor(width ?? 48) : 48;
+}
+
+export function buildSidecarWatchCommand(options: SidecarTmuxOptions): string {
+  const omxBin = options.omxBin ?? resolveOmxCliEntryPath();
+  if (!omxBin) throw new Error('Failed to resolve OMX launcher path for sidecar startup.');
+  const prefix = options.sessionId ? `OMX_SESSION_ID=${shellEscapeSingle(options.sessionId)} ` : '';
+  return `${prefix}node ${shellEscapeSingle(omxBin)} sidecar ${shellEscapeSingle(options.teamName)} --watch --width ${sidecarWidth(options.width)}`;
+}
+
+export function buildSidecarTmuxSplitArgs(options: SidecarTmuxOptions): string[] {
+  return [
+    'split-window',
+    '-h',
+    '-d',
+    '-l',
+    String(sidecarWidth(options.width)),
+    '-c',
+    options.cwd,
+    '-P',
+    '-F',
+    '#{pane_id}',
+    buildSidecarWatchCommand(options),
+  ];
+}
+
+function defaultExecTmuxSync(args: string[]): string {
+  return execFileSync(resolveTmuxBinaryForPlatform() || 'tmux', args, {
+    encoding: 'utf-8',
+    ...(process.platform === 'win32' ? { windowsHide: true } : {}),
+  });
+}
+
+export function launchSidecarTmuxPane(
+  options: SidecarTmuxOptions,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): string | null {
+  try {
+    return parsePaneIdFromTmuxOutput(execTmuxSync(buildSidecarTmuxSplitArgs(options)));
+  } catch {
+    return null;
+  }
+}

--- a/src/sidecar/types.ts
+++ b/src/sidecar/types.ts
@@ -1,0 +1,135 @@
+import type { TeamEventType, TeamTaskStatus } from '../team/contracts.js';
+
+export type SidecarWorkerState = 'idle' | 'working' | 'blocked' | 'done' | 'failed' | 'draining' | 'unknown';
+
+export interface SidecarTeamConfig {
+  name: string;
+  task: string;
+  worker_count: number;
+  tmux_session: string;
+  leader_pane_id: string | null;
+  hud_pane_id: string | null;
+  workers: SidecarWorkerInfo[];
+}
+
+export interface SidecarWorkerInfo {
+  name: string;
+  index: number;
+  role: string;
+  assigned_tasks: string[];
+  pane_id?: string;
+  worker_cli?: string;
+  working_dir?: string;
+  worktree_path?: string;
+  worktree_branch?: string;
+}
+
+export interface SidecarWorkerStatus {
+  state: SidecarWorkerState;
+  current_task_id?: string;
+  reason?: string;
+  updated_at?: string;
+}
+
+export interface SidecarWorkerHeartbeat {
+  pid?: number;
+  last_turn_at?: string;
+  turn_count?: number;
+  alive?: boolean;
+}
+
+export interface SidecarTask {
+  id: string;
+  subject: string;
+  description: string;
+  status: TeamTaskStatus;
+  owner?: string;
+  role?: string;
+  result?: string;
+  error?: string;
+  blocked_by?: string[];
+  depends_on?: string[];
+  version?: number;
+  claim?: {
+    owner: string;
+    leased_until: string;
+  };
+  created_at?: string;
+  completed_at?: string;
+}
+
+export interface SidecarWorkerSnapshot extends SidecarWorkerInfo {
+  status: SidecarWorkerStatus;
+  heartbeat: SidecarWorkerHeartbeat | null;
+  alive: boolean | null;
+  current_task: SidecarTask | null;
+  turns_without_progress: number | null;
+}
+
+export interface SidecarEvent {
+  event_id: string;
+  team: string;
+  type: TeamEventType | string;
+  worker: string;
+  task_id?: string;
+  state?: SidecarWorkerState;
+  prev_state?: SidecarWorkerState;
+  reason?: string;
+  source_type?: string;
+  created_at: string;
+}
+
+export interface SidecarPaneMapping {
+  target: string;
+  pane_id: string;
+  role: 'leader' | 'hud' | 'worker';
+}
+
+export interface SidecarHighlight {
+  severity: 'info' | 'warning' | 'critical';
+  target: string;
+  kind: 'blocked-worker' | 'blocked-task' | 'failed-task' | 'dead-worker' | 'non-reporting-worker';
+  message: string;
+}
+
+export interface SidecarTopology {
+  summary: string;
+  nodes: string[];
+  edges: Array<{ from: string; to: string; label?: string }>;
+}
+
+export interface SidecarSnapshot {
+  schema_version: 'omx.sidecar/v1';
+  generated_at: string;
+  team_name: string;
+  team_task: string;
+  phase: string | null;
+  topology: SidecarTopology;
+  workers: SidecarWorkerSnapshot[];
+  tasks: SidecarTask[];
+  events: SidecarEvent[];
+  panes: SidecarPaneMapping[];
+  highlights: SidecarHighlight[];
+  source_warnings: string[];
+}
+
+export interface CollectSidecarSnapshotOptions {
+  cwd?: string;
+  now?: Date;
+  eventLimit?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface RenderSidecarOptions {
+  width?: number;
+  height?: number;
+  color?: boolean;
+}
+
+export interface SidecarFlags {
+  json: boolean;
+  watch: boolean;
+  tmux: boolean;
+  width?: number;
+  intervalMs?: number;
+}


### PR DESCRIPTION
## Summary
- add `omx sidecar <team>` as a read-only terminal visualization for OMX teams/multi-agent runs
- render stacked text panels for topology, agents, tasks, blockers, pane mapping, and recent events
- support `--json`, `--watch`, and right-side `--tmux` launch without changing worker behavior or team state
- harden terminal/path boundaries: sanitize dynamic output, validate worker names, redact claim tokens, tail event logs with a bounded read, and catch tmux launch failures

## Verification
- [x] `npm run build`
- [x] `node --test dist/sidecar/__tests__/*.test.js dist/cli/__tests__/sidecar.test.js`
- [x] `npm run lint`
- [x] `npm test` (4004 pass, catalog check ok)
- [x] `$code-review`: code-reviewer COMMENT with 0 issues; architect WATCH only for tracked read-model/JSON diagnostic tradeoffs

## Architecture watchlist
- Sidecar intentionally reads private team-state files directly to preserve a non-mutating boundary; consider a canonical read-only visualization projection later.
- JSON output is diagnostic/internal for now and includes operational paths/worker metadata, while claim tokens are redacted.
- Source parse/read failures stay quiet for watch-mode polish; future work can add richer `source_warnings`.
