### PR TITLE
Prevent stale legacy setup surfaces in plugin mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ omx --madmax --high
 
 On a real `oh-my-codex` version bump, the global npm install now prints an explicit reminder instead of launching `omx setup` automatically. When you're ready, run `omx setup` manually or use `omx update` to check npm and then run the same setup refresh path.
 
-**Codex plugin install note:** this repo also ships an official Codex plugin layout at `plugins/oh-my-codex` with marketplace metadata in `.agents/plugins/marketplace.json`. That plugin now bundles the mirrored skill surface plus plugin-scoped companion metadata for MCP servers and apps. Native/runtime hooks still stay on the setup/runtime side rather than the installable plugin manifest. It is still **not** a replacement for `npm install -g oh-my-codex` plus `omx setup`: `omx setup` remains responsible for native agents, prompts/config/hooks/AGENTS.md/HUD/runtime wiring, including native `.codex/hooks.json` coverage.
+**Codex plugin install note:** this repo also ships an official Codex plugin layout at `plugins/oh-my-codex` with marketplace metadata in `.agents/plugins/marketplace.json`. That plugin bundles the mirrored skill surface plus plugin-scoped companion metadata for MCP servers and apps. Native/runtime hooks still stay on the setup/runtime side rather than the installable plugin manifest. It is still **not** a replacement for `npm install -g oh-my-codex` plus `omx setup`: legacy setup mode installs native agents and prompts, while plugin setup mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompts/native-agent TOMLs so stale role files cannot shadow plugin behavior.
 
 Then work normally inside Codex:
 

--- a/docs/plugin-bundle-ssot.md
+++ b/docs/plugin-bundle-ssot.md
@@ -8,7 +8,7 @@ The repository keeps one canonical authoring surface for each plugin/setup asset
 - **Plugin skill membership:** `templates/catalog-manifest.json` controls which catalog skills are installable. Active/internal skills, plus setup-only policy additions, must have canonical root skill directories and plugin mirrors.
 - **Plugin MCP metadata:** `src/config/omx-first-party-mcp.ts` is canonical. `plugins/oh-my-codex/.mcp.json` must match `buildOmxPluginMcpManifest()`.
 - **Plugin manifest version and paths:** `package.json` is canonical for the plugin version. The plugin manifest must point to `./skills/`, `./.mcp.json`, and `./.app.json`.
-- **Native agents and prompts:** root `prompts/` plus `src/agents/definitions.ts` are setup-owned canonical sources. The official plugin intentionally does not ship plugin-scoped `agents`, `prompts`, or hooks.
+- **Native agents and prompts:** root `prompts/` plus `src/agents/definitions.ts` are setup-owned canonical sources for legacy setup mode. The official plugin intentionally does not ship plugin-scoped `agents`, `prompts`, or hooks; plugin setup archives/removes legacy OMX-managed prompt and native-agent files so users do not keep stale mixed surfaces.
 
 ## Commands
 
@@ -49,4 +49,4 @@ The verifier fails when installable catalog agents are missing definitions or pr
 
 `omx setup` converges generated native-agent TOMLs safely: normal setup removes stale non-installable TOMLs only when they carry the exact `# oh-my-codex agent: <name>` generated marker for the same cataloged agent name. User-authored or ambiguous TOMLs are preserved during normal setup; `--force` remains the explicit destructive cleanup path for stale non-installable native-agent files. Prompt cleanup uses the prompt asset policy, so cataloged prompt files and explicit setup prompt assets are preserved even when they are not installable native-agent TOMLs.
 
-The official plugin manifest must continue to omit `agents`, `prompts`, and `hooks`; those remain installed by `omx setup`, not by the plugin bundle.
+The official plugin manifest must continue to omit `agents`, `prompts`, and `hooks`; legacy setup mode installs prompts/native agents, while plugin setup mode removes archived legacy copies instead of refreshing plugin-scoped prompt or agent assets.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@ omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"
 Treat the boundary this way:
 
 - Codex plugin install/discovery may cache `oh-my-codex` under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (with `local` possible as a version identifier for local installs). That confirms a marketplace/plugin artifact; the packaged plugin includes plugin-scoped companion metadata for MCP servers and apps, while native/runtime hooks remain setup-owned, so it is still not the full OMX runtime setup.
-- Plugin install/discovery is not a replacement for `npm install -g oh-my-codex` plus `omx setup`; `omx setup` remains responsible for native agents, prompts/config/hooks/AGENTS.md/HUD/runtime wiring, including native `.codex/hooks.json` coverage.
+- Plugin install/discovery is not a replacement for `npm install -g oh-my-codex` plus `omx setup`; legacy setup mode installs native agents and prompts, while plugin setup mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompts/native-agent TOMLs so stale role files cannot shadow plugin behavior.
 - `omx doctor` green: install and local runtime wiring look sane.
 - `codex login status` green: the active Codex profile can see login state.
 - `omx exec ...` returns `OMX-EXEC-OK`: real execution, auth, provider routing, and current working-directory assumptions are working together.

--- a/plugins/oh-my-codex/.codex-plugin/plugin.json
+++ b/plugins/oh-my-codex/.codex-plugin/plugin.json
@@ -23,7 +23,7 @@
   "interface": {
     "displayName": "oh-my-codex",
     "shortDescription": "Workflow layer and skill bundle for OpenAI Codex CLI.",
-    "longDescription": "Plugin = OMX skill/workflow discovery plus plugin-scoped companion metadata for MCP servers and apps. Setup = runtime wiring; keep npm install plus omx setup for native agents, prompts, config, native .codex/hooks.json coverage, AGENTS.md, HUD, and runtime state.",
+    "longDescription": "Plugin = OMX skill/workflow discovery plus plugin-scoped companion metadata for MCP servers and apps. Setup = runtime wiring; legacy setup installs native agents/prompts, while plugin setup archives stale legacy native agents/prompts and keeps config, native .codex/hooks.json coverage, optional AGENTS.md, HUD, and runtime state current.",
     "developerName": "Yeachan Heo",
     "category": "Developer Tools"
   }

--- a/plugins/oh-my-codex/skills/doctor/SKILL.md
+++ b/plugins/oh-my-codex/skills/doctor/SKILL.md
@@ -123,7 +123,7 @@ ls -la ~/.agents/skills/ 2>/dev/null
 ```
 
 **Diagnosis**:
-- If `~/.codex/agents/` exists with oh-my-codex-related files: WARN - legacy generated agents or hand-installed role files. The Codex plugin can package reusable workflows plus plugin-scoped companion metadata for MCP/apps, but `omx setup` remains responsible for native agents/config/hooks.
+- If `~/.codex/agents/` exists with oh-my-codex-related files: WARN - legacy generated agents or hand-installed role files. The Codex plugin can package reusable workflows plus plugin-scoped companion metadata for MCP/apps; legacy setup installs native agents, while plugin setup archives stale legacy native-agent files and keeps config/hooks current.
 - If `~/.codex/commands/` exists with oh-my-codex-related files: WARN - legacy command files from older installs. Current OMX uses skills/workflows plus setup-managed native surfaces.
 - If `${CODEX_HOME:-~/.codex}/skills/` exists with OMX skills: OK - canonical current user skill root
 - If `~/.agents/skills/` exists: WARN - historical legacy skill root that can overlap with `${CODEX_HOME:-~/.codex}/skills/` and cause duplicate Enable/Disable Skills entries

--- a/plugins/oh-my-codex/skills/help/SKILL.md
+++ b/plugins/oh-my-codex/skills/help/SKILL.md
@@ -49,7 +49,7 @@ If you haven't configured OMX yet:
 /omx-setup
 ```
 
-This is the primary setup command for full OMX runtime wiring. Codex plugin install/discovery can expose packaged skills/workflows plus plugin-scoped companion metadata for MCP servers and apps, while native/runtime hooks remain setup-owned; it is not a replacement for `npm install -g oh-my-codex` plus `omx setup`. `omx setup` remains responsible for native agents, prompts/config/hooks/AGENTS.md/HUD/runtime wiring, including native `.codex/hooks.json` coverage. Plugin caches may appear under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (or `local` for local installs).
+This is the primary setup command for full OMX runtime wiring. Codex plugin install/discovery can expose packaged skills/workflows plus plugin-scoped companion metadata for MCP servers and apps, while native/runtime hooks remain setup-owned; it is not a replacement for `npm install -g oh-my-codex` plus `omx setup`. Legacy setup mode installs native agents/prompts; plugin setup mode archives stale legacy prompt/native-agent files and keeps config/hooks/optional AGENTS.md/HUD/runtime wiring current, including native `.codex/hooks.json` coverage. Plugin caches may appear under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (or `local` for local installs).
 
 If you only need lightweight directory guidance scaffolding for `AGENTS.md` files, use:
 

--- a/plugins/oh-my-codex/skills/omx-setup/SKILL.md
+++ b/plugins/oh-my-codex/skills/omx-setup/SKILL.md
@@ -21,7 +21,7 @@ Supported setup flags (current implementation):
 - `--dry-run`: print actions without mutating files
 - `--verbose`: print per-file/per-step details
 - `--scope`: choose install scope (`user`, `project`)
-- `--plugin`: use Codex plugin delivery for skills/prompts/agents while keeping setup-owned runtime hooks
+- `--plugin`: use Codex plugin delivery for bundled skills while archiving/removing legacy OMX-managed prompts/native agents and keeping setup-owned runtime hooks
 
 ## What this setup actually does
 
@@ -40,7 +40,7 @@ Supported setup flags (current implementation):
    - else interactive prompt on TTY (`legacy` by default, or `plugin` when a plugin cache is discovered)
    - else default `legacy` unless a plugin cache is discovered
 3. Create directories and persist effective scope/install mode
-4. In legacy mode, install prompts/native agents/skills and merge full config.toml. In plugin mode, remove matching legacy OMX-managed prompts/native agents/skills but keep native Codex hooks installed.
+4. In legacy mode, install prompts/native agents/skills and merge full config.toml. In plugin mode, archive/remove legacy OMX-managed prompts/native agents/skills but keep native Codex hooks installed.
 5. Verify Team CLI API interop markers exist in built `dist/cli/team.js`
 6. Generate AGENTS.md defaults only when selected/allowed (or legacy behavior outside plugin mode)
 7. Configure notify hook references outside plugin mode and write `./.omx/hud-config.json`
@@ -58,7 +58,7 @@ Supported setup flags (current implementation):
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
 - User-scope skill delivery targets:
   - `legacy`: keep installing/updating OMX skills in the resolved user skill root
-  - `plugin`: rely on Codex plugin discovery for bundled skills and remove only matching OMX-managed legacy prompts/skills/native agents; setup still installs native Codex hooks and `codex_hooks = true` because plugins do not carry hooks.
+  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and `codex_hooks = true` because plugins do not carry hooks.
 - Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
@@ -74,7 +74,7 @@ Use this map when reconciling setup behavior or debugging a confusing install:
 | `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
 | `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content. |
 | `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
-| prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery and cleans matching legacy OMX-managed copies. |
+| prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompt/native-agent copies. |
 | `AGENTS.md` | `omx setup` with overwrite safety | Generated defaults or managed refreshes are guarded by force/session checks. |
 | `./.omx/hud-config.json` | `omx setup` / `$hud` | Setup creates the focused default; `$hud` can adjust it later. |
 | notification hooks | `omx setup` / `$configure-notifications` | Setup wires defaults outside plugin skill delivery; notification skill owns deeper provider configuration. |

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -123,7 +123,7 @@ ls -la ~/.agents/skills/ 2>/dev/null
 ```
 
 **Diagnosis**:
-- If `~/.codex/agents/` exists with oh-my-codex-related files: WARN - legacy generated agents or hand-installed role files. The Codex plugin can package reusable workflows plus plugin-scoped companion metadata for MCP/apps, but `omx setup` remains responsible for native agents/config/hooks.
+- If `~/.codex/agents/` exists with oh-my-codex-related files: WARN - legacy generated agents or hand-installed role files. The Codex plugin can package reusable workflows plus plugin-scoped companion metadata for MCP/apps; legacy setup installs native agents, while plugin setup archives stale legacy native-agent files and keeps config/hooks current.
 - If `~/.codex/commands/` exists with oh-my-codex-related files: WARN - legacy command files from older installs. Current OMX uses skills/workflows plus setup-managed native surfaces.
 - If `${CODEX_HOME:-~/.codex}/skills/` exists with OMX skills: OK - canonical current user skill root
 - If `~/.agents/skills/` exists: WARN - historical legacy skill root that can overlap with `${CODEX_HOME:-~/.codex}/skills/` and cause duplicate Enable/Disable Skills entries

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -49,7 +49,7 @@ If you haven't configured OMX yet:
 /omx-setup
 ```
 
-This is the primary setup command for full OMX runtime wiring. Codex plugin install/discovery can expose packaged skills/workflows plus plugin-scoped companion metadata for MCP servers and apps, while native/runtime hooks remain setup-owned; it is not a replacement for `npm install -g oh-my-codex` plus `omx setup`. `omx setup` remains responsible for native agents, prompts/config/hooks/AGENTS.md/HUD/runtime wiring, including native `.codex/hooks.json` coverage. Plugin caches may appear under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (or `local` for local installs).
+This is the primary setup command for full OMX runtime wiring. Codex plugin install/discovery can expose packaged skills/workflows plus plugin-scoped companion metadata for MCP servers and apps, while native/runtime hooks remain setup-owned; it is not a replacement for `npm install -g oh-my-codex` plus `omx setup`. Legacy setup mode installs native agents/prompts; plugin setup mode archives stale legacy prompt/native-agent files and keeps config/hooks/optional AGENTS.md/HUD/runtime wiring current, including native `.codex/hooks.json` coverage. Plugin caches may appear under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (or `local` for local installs).
 
 If you only need lightweight directory guidance scaffolding for `AGENTS.md` files, use:
 

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -21,7 +21,7 @@ Supported setup flags (current implementation):
 - `--dry-run`: print actions without mutating files
 - `--verbose`: print per-file/per-step details
 - `--scope`: choose install scope (`user`, `project`)
-- `--plugin`: use Codex plugin delivery for skills/prompts/agents while keeping setup-owned runtime hooks
+- `--plugin`: use Codex plugin delivery for bundled skills while archiving/removing legacy OMX-managed prompts/native agents and keeping setup-owned runtime hooks
 
 ## What this setup actually does
 
@@ -40,7 +40,7 @@ Supported setup flags (current implementation):
    - else interactive prompt on TTY (`legacy` by default, or `plugin` when a plugin cache is discovered)
    - else default `legacy` unless a plugin cache is discovered
 3. Create directories and persist effective scope/install mode
-4. In legacy mode, install prompts/native agents/skills and merge full config.toml. In plugin mode, remove matching legacy OMX-managed prompts/native agents/skills but keep native Codex hooks installed.
+4. In legacy mode, install prompts/native agents/skills and merge full config.toml. In plugin mode, archive/remove legacy OMX-managed prompts/native agents/skills but keep native Codex hooks installed.
 5. Verify Team CLI API interop markers exist in built `dist/cli/team.js`
 6. Generate AGENTS.md defaults only when selected/allowed (or legacy behavior outside plugin mode)
 7. Configure notify hook references outside plugin mode and write `./.omx/hud-config.json`
@@ -58,7 +58,7 @@ Supported setup flags (current implementation):
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
 - User-scope skill delivery targets:
   - `legacy`: keep installing/updating OMX skills in the resolved user skill root
-  - `plugin`: rely on Codex plugin discovery for bundled skills and remove only matching OMX-managed legacy prompts/skills/native agents; setup still installs native Codex hooks and `codex_hooks = true` because plugins do not carry hooks.
+  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and `codex_hooks = true` because plugins do not carry hooks.
 - Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
@@ -74,7 +74,7 @@ Use this map when reconciling setup behavior or debugging a confusing install:
 | `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
 | `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content. |
 | `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
-| prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery and cleans matching legacy OMX-managed copies. |
+| prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompt/native-agent copies. |
 | `AGENTS.md` | `omx setup` with overwrite safety | Generated defaults or managed refreshes are guarded by force/session checks. |
 | `./.omx/hud-config.json` | `omx setup` / `$hud` | Setup creates the focused default; `$hud` can adjust it later. |
 | notification hooks | `omx setup` / `$configure-notifications` | Setup wires defaults outside plugin skill delivery; notification skill owns deeper provider configuration. |

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -304,7 +304,7 @@ describe('official Codex plugin layout', () => {
     const combined = combinedDocs.join('\n');
     assert.match(combined, /plugins\/cache\/\$MARKETPLACE_NAME\/oh-my-codex\/\$VERSION\//);
     assert.match(combined, /not a replacement for `npm install -g oh-my-codex` plus `omx setup`/);
-    assert.match(combined, /omx setup` remains responsible for native agents, prompts\/config\/hooks\/AGENTS\.md\/HUD\/runtime wiring/);
+    assert.match(combined, /legacy setup mode installs native agents\/prompts|plugin setup mode archives stale legacy prompt\/native-agent files/);
     assert.match(combined, /plugin-scoped companion metadata for MCP servers and apps/i);
     assert.match(combined, /hooks stay setup-owned|hooks remain setup-owned|native \.codex\/hooks\.json coverage/i);
   });

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -919,6 +919,61 @@ describe("omx setup install mode behavior", () => {
     }
   });
 
+  it("archives stale legacy prompts and generated native agents when plugin mode refreshes", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        await withTempCwd(wd, async () => {
+          await setup({ scope: "user", installMode: "legacy" });
+
+          const promptPath = join(codexHomeDir, "prompts", "executor.md");
+          const agentPath = join(codexHomeDir, "agents", "planner.toml");
+          await writeFile(
+            promptPath,
+            "---\ndescription: stale legacy executor prompt\n---\n\nold executor body\n",
+          );
+          await writeFile(
+            agentPath,
+            [
+              "# oh-my-codex agent: planner",
+              'name = "planner"',
+              'description = "stale legacy generated planner"',
+              'developer_instructions = """old planner body"""',
+              "",
+            ].join("\n"),
+          );
+
+          const output = await captureConsoleOutput(async () => {
+            await setup({ scope: "user", installMode: "plugin" });
+          });
+
+          assert.equal(existsSync(promptPath), false);
+          assert.equal(existsSync(agentPath), false);
+          assert.match(output, /Archived and removed .* legacy OMX-managed prompt file/);
+          assert.match(output, /Archived and removed .* legacy OMX-managed native agent config/);
+
+          const backupRoot = join(wd, "home", ".omx", "backups", "setup");
+          const backupRuns = await readdir(backupRoot);
+          assert.ok(backupRuns.length > 0);
+          assert.equal(
+            backupRuns.some((entry) =>
+              existsSync(join(backupRoot, entry, ".codex", "prompts", "executor.md")),
+            ),
+            true,
+          );
+          assert.equal(
+            backupRuns.some((entry) =>
+              existsSync(join(backupRoot, entry, ".codex", "agents", "planner.toml")),
+            ),
+            true,
+          );
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("counts plugin cleanup skill directory backups in the setup summary", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
     try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1078,23 +1078,8 @@ async function cleanupPluginModeLegacyPrompts(
     const promptName = file.slice(0, -3);
     if (manifest && !isSetupPromptAssetName(promptName, manifest)) continue;
 
-    const src = join(srcDir, file);
     const dst = join(dstDir, file);
     if (!existsSync(dst)) continue;
-
-    const [srcContent, dstContent] = await Promise.all([
-      readFile(src, "utf-8"),
-      readFile(dst, "utf-8"),
-    ]);
-    if (srcContent !== dstContent) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        console.log(
-          `  skipped legacy prompt cleanup for ${file}: installed content differs from OMX-managed content`,
-        );
-      }
-      continue;
-    }
 
     if (await ensureBackup(dst, true, backupContext, options)) {
       summary.backedUp += 1;
@@ -1105,7 +1090,7 @@ async function cleanupPluginModeLegacyPrompts(
     summary.removed += 1;
     if (options.verbose) {
       console.log(
-        `  ${options.dryRun ? "would remove" : "removed"} legacy prompt ${file}`,
+        `  ${options.dryRun ? "would archive and remove" : "archived and removed"} legacy prompt ${file}`,
       );
     }
   }
@@ -1141,11 +1126,14 @@ async function cleanupPluginModeLegacyNativeAgents(
       codexHomeOverride: join(agentsDir, ".."),
     });
     const installedToml = await readFile(dst, "utf-8");
-    if (installedToml !== expectedToml) {
+    if (
+      installedToml !== expectedToml &&
+      !isGeneratedOmxNativeAgentToml(installedToml, name)
+    ) {
       summary.skipped += 1;
       if (options.verbose) {
         console.log(
-          `  skipped legacy native agent cleanup for ${name}.toml: installed content differs from OMX-managed content`,
+          `  skipped legacy native agent cleanup for ${name}.toml: installed content is not an OMX-generated native agent`,
         );
       }
       continue;
@@ -1160,7 +1148,7 @@ async function cleanupPluginModeLegacyNativeAgents(
     summary.removed += 1;
     if (options.verbose) {
       console.log(
-        `  ${options.dryRun ? "would remove" : "removed"} legacy native agent ${name}.toml`,
+        `  ${options.dryRun ? "would archive and remove" : "archived and removed"} legacy native agent ${name}.toml`,
       );
     }
   }
@@ -1598,7 +1586,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
       );
       console.log(
         summary.prompts.removed > 0
-          ? `  ${dryRun ? "Would remove" : "Removed"} ${summary.prompts.removed} legacy OMX-managed prompt file(s).\n`
+          ? `  ${dryRun ? "Would archive and remove" : "Archived and removed"} ${summary.prompts.removed} legacy OMX-managed prompt file(s).\n`
           : "  Prompt refresh skipped; no legacy OMX-managed prompt files found.\n",
       );
     } else {
@@ -1698,7 +1686,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     );
     console.log(
       summary.nativeAgents.removed > 0
-        ? `  ${dryRun ? "Would remove" : "Removed"} ${summary.nativeAgents.removed} legacy OMX-managed native agent config(s).\n`
+        ? `  ${dryRun ? "Would archive and remove" : "Archived and removed"} ${summary.nativeAgents.removed} legacy OMX-managed native agent config(s).\n`
         : "  Native agent refresh skipped; no legacy OMX-managed native agent configs found.\n",
     );
   } else {


### PR DESCRIPTION
## Summary
- Clarifies plugin setup mode as plugin-discovered skills plus setup-owned runtime wiring, without plugin-scoped native agents/prompts.
- Makes plugin-mode setup archive and remove stale OMX-managed prompt files and generated native-agent TOMLs, even when their content differs from the current release.
- Adds regression coverage for a legacy setup followed by a plugin-mode refresh with stale prompt/native-agent content.
- Updates docs/plugin metadata and mirrored skills to document the no-silent-mixed-state behavior.

## Tests
- `npm run build && npm run verify:plugin-bundle && node --test dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/codex-plugin-layout.test.js`
- `npm run verify:native-agents && npm run lint && npm run check:no-unused`

Closes #1947
