### PR TITLE
feat(config): preset-driven [tui] status_line (minimal | focused | full)

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -68,6 +68,26 @@ import {
   hasOmxManagedAgentsSections,
   isOmxGeneratedAgentsMd,
 } from "../utils/agents-md.js";
+import type { HudPreset } from "../hud/types.js";
+
+async function readStatusLinePresetFromHudConfig(
+  projectRoot: string,
+): Promise<HudPreset | undefined> {
+  const path = join(projectRoot, ".omx", "hud-config.json");
+  if (!existsSync(path)) return undefined;
+  try {
+    const raw = JSON.parse(await readFile(path, "utf-8")) as {
+      statusLine?: { preset?: unknown };
+    };
+    const preset = raw?.statusLine?.preset;
+    if (preset === "minimal" || preset === "focused" || preset === "full") {
+      return preset;
+    }
+  } catch {
+    // Malformed hud-config.json — fall through to default.
+  }
+  return undefined;
+}
 import {
   resolveAgentsModelTableContext,
   upsertAgentsModelTable,
@@ -1679,6 +1699,8 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     for (const warning of sharedMcpRegistry.warnings) {
       console.log(`  warning: ${warning}`);
     }
+    const statusLinePreset =
+      await readStatusLinePresetFromHudConfig(projectRoot);
     const managedConfig = await updateManagedConfig(
       scopeDirs.codexConfigFile,
       pkgRoot,
@@ -1689,6 +1711,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
         dryRun,
         modelUpgradePrompt,
         verbose,
+        statusLinePreset,
       },
     );
     resolvedConfig = managedConfig.finalConfig;
@@ -2725,7 +2748,7 @@ async function updateManagedConfig(
   options: Pick<
     SetupOptions,
     "dryRun" | "verbose" | "modelUpgradePrompt"
-  >,
+  > & { statusLinePreset?: HudPreset },
 ): Promise<ManagedConfigResult> {
   const existing = existsSync(configPath)
     ? await readFile(configPath, "utf-8")
@@ -2755,6 +2778,7 @@ async function updateManagedConfig(
     sharedMcpServers: sharedMcpRegistry.servers,
     sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
     verbose: options.verbose,
+    statusLinePreset: options.statusLinePreset,
   });
   const changed = existing !== finalConfig;
 

--- a/src/config/__tests__/generator-status-line-presets.test.ts
+++ b/src/config/__tests__/generator-status-line-presets.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the [tui].status_line preset feature.
+ *
+ * The OMX default for [tui].status_line is now derived from a HudPreset
+ * (minimal | focused | full). The default preset is "focused", which must
+ * remain byte-identical to the legacy hard-coded array so existing installs
+ * see no behavior change after this feature lands.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildMergedConfig,
+  mergeConfig,
+  statusLineForPreset,
+  STATUS_LINE_PRESETS,
+  DEFAULT_STATUS_LINE_PRESET,
+} from "../generator.js";
+
+const LEGACY_DEFAULT_STATUS_LINE =
+  'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"]';
+
+describe("status_line preset matrix", () => {
+  it("default preset is 'focused'", () => {
+    assert.equal(DEFAULT_STATUS_LINE_PRESET, "focused");
+  });
+
+  it("focused preset is byte-identical to the legacy hard-coded default", () => {
+    assert.equal(statusLineForPreset("focused"), LEGACY_DEFAULT_STATUS_LINE);
+  });
+
+  it("calling statusLineForPreset() with no argument returns the focused string", () => {
+    assert.equal(statusLineForPreset(), LEGACY_DEFAULT_STATUS_LINE);
+  });
+
+  it("minimal preset emits exactly model-with-reasoning and git-branch", () => {
+    assert.equal(
+      statusLineForPreset("minimal"),
+      'status_line = ["model-with-reasoning", "git-branch"]',
+    );
+  });
+
+  it("full preset is currently identical to focused (placeholder for expansion)", () => {
+    assert.equal(statusLineForPreset("full"), statusLineForPreset("focused"));
+  });
+
+  it("STATUS_LINE_PRESETS exposes every HudPreset key", () => {
+    assert.deepEqual(
+      Object.keys(STATUS_LINE_PRESETS).sort(),
+      ["focused", "full", "minimal"],
+    );
+  });
+
+  it("minimal preset only contains the two essential fields", () => {
+    assert.deepEqual(
+      [...STATUS_LINE_PRESETS.minimal],
+      ["model-with-reasoning", "git-branch"],
+    );
+  });
+});
+
+describe("buildMergedConfig with statusLinePreset", () => {
+  it("emits the focused (legacy default) status_line when no preset is passed", () => {
+    const wd = "/tmp/omx-preset-noop";
+    const toml = buildMergedConfig("", wd, {});
+    assert.match(
+      toml,
+      /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
+    );
+  });
+
+  it("emits the minimal status_line when statusLinePreset='minimal' on a fresh config", () => {
+    const wd = "/tmp/omx-preset-minimal";
+    const toml = buildMergedConfig("", wd, { statusLinePreset: "minimal" });
+    assert.match(toml, /^status_line = \["model-with-reasoning", "git-branch"\]$/m);
+    assert.doesNotMatch(toml, /context-remaining/);
+    assert.doesNotMatch(toml, /five-hour-limit/);
+  });
+
+  it("emits the focused status_line when statusLinePreset='focused' on a fresh config", () => {
+    const wd = "/tmp/omx-preset-focused";
+    const toml = buildMergedConfig("", wd, { statusLinePreset: "focused" });
+    assert.match(
+      toml,
+      /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
+    );
+  });
+
+  it("preserves a user-defined status_line even when a preset is requested", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-preset-pres-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      await writeFile(
+        configPath,
+        ['[tui]', 'status_line = ["git-branch"]', ""].join("\n"),
+      );
+
+      await mergeConfig(configPath, wd, { statusLinePreset: "minimal" });
+      const toml = await readFile(configPath, "utf-8");
+
+      assert.match(toml, /^status_line = \["git-branch"\]$/m);
+      assert.doesNotMatch(toml, /^status_line = \["model-with-reasoning"/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("upgrades a previously OMX-managed status_line to the new preset", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-preset-upgrade-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      // First populate with the focused (legacy) default via a no-preset merge.
+      await mergeConfig(configPath, wd, {});
+      let toml = await readFile(configPath, "utf-8");
+      assert.match(toml, /^status_line = \["model-with-reasoning", "git-branch", "context-remaining"/m);
+
+      // Now request minimal — the OMX-managed status_line should be replaced
+      // because it is detected as a known preset value, not a user override.
+      await mergeConfig(configPath, wd, { statusLinePreset: "minimal" });
+      toml = await readFile(configPath, "utf-8");
+
+      assert.match(toml, /^status_line = \["model-with-reasoning", "git-branch"\]$/m);
+      assert.doesNotMatch(toml, /context-remaining/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("mergeConfig with statusLinePreset (integration via .omx/hud-config.json)", () => {
+  it("renders the preset selected in MergeOptions when [tui] does not yet exist", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-preset-int-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "hud-config.json"),
+        JSON.stringify({
+          preset: "focused",
+          statusLine: { preset: "minimal" },
+        }),
+      );
+
+      const configPath = join(wd, "config.toml");
+      // Direct invocation mirrors what setup.ts does after reading hud-config.json.
+      await mergeConfig(configPath, wd, { statusLinePreset: "minimal" });
+
+      const toml = await readFile(configPath, "utf-8");
+      assert.match(toml, /^status_line = \["model-with-reasoning", "git-branch"\]$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -18,6 +18,7 @@ import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 import { getOmxFirstPartySetupMcpServers } from "./omx-first-party-mcp.js";
+import type { HudPreset } from "../hud/types.js";
 
 interface MergeOptions {
   includeTui?: boolean;
@@ -25,6 +26,7 @@ interface MergeOptions {
   sharedMcpServers?: UnifiedMcpRegistryServer[];
   sharedMcpRegistrySource?: string;
   verbose?: boolean;
+  statusLinePreset?: HudPreset;
 }
 
 function escapeTomlString(value: string): string {
@@ -60,8 +62,47 @@ const OMX_AGENTS_MAX_DEPTH = 2;
 const OMX_EXPLORE_ROUTING_DEFAULT = "1";
 const OMX_EXPLORE_CMD_ENV = "USE_OMX_EXPLORE_CMD";
 const DEFAULT_LAUNCHER_MCP_STARTUP_TIMEOUT_SEC = 15;
-const OMX_TUI_STATUS_LINE =
-  'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"]';
+const STATUS_LINE_FOCUSED_FIELDS: readonly string[] = [
+  "model-with-reasoning",
+  "git-branch",
+  "context-remaining",
+  "total-input-tokens",
+  "total-output-tokens",
+  "five-hour-limit",
+  "weekly-limit",
+];
+
+// `full` is currently identical to `focused`. It is reserved for future
+// expansion as Codex CLI adds support for additional status_line fields.
+export const STATUS_LINE_PRESETS: Record<HudPreset, readonly string[]> = {
+  minimal: ["model-with-reasoning", "git-branch"],
+  focused: STATUS_LINE_FOCUSED_FIELDS,
+  full: STATUS_LINE_FOCUSED_FIELDS,
+};
+
+export const DEFAULT_STATUS_LINE_PRESET: HudPreset = "focused";
+
+export function statusLineForPreset(
+  preset: HudPreset = DEFAULT_STATUS_LINE_PRESET,
+): string {
+  const fields =
+    STATUS_LINE_PRESETS[preset] ??
+    STATUS_LINE_PRESETS[DEFAULT_STATUS_LINE_PRESET];
+  return `status_line = [${fields.map((field) => `"${field}"`).join(", ")}]`;
+}
+
+const OMX_MANAGED_STATUS_LINES: ReadonlySet<string> = new Set(
+  (Object.keys(STATUS_LINE_PRESETS) as HudPreset[]).map((preset) =>
+    statusLineForPreset(preset),
+  ),
+);
+
+function isOmxManagedStatusLine(line: string): boolean {
+  return OMX_MANAGED_STATUS_LINES.has(line.trim());
+}
+
+// Backward-compatible alias: equivalent to statusLineForPreset("focused").
+const OMX_TUI_STATUS_LINE = statusLineForPreset(DEFAULT_STATUS_LINE_PRESET);
 const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
   /^\s*\[mcp_servers\.(?:"omx_team_run"|omx_team_run)\]\s*$/m;
 const OMX_CONFIG_MARKER = "oh-my-codex (OMX) Configuration";
@@ -705,7 +746,7 @@ function extractCustomizedTuiSectionsFromOmxBlocks(config: string): string[] {
         tuiLines.push(trimmed);
         if (
           /^status_line\s*=/.test(trimmed) &&
-          trimmed !== OMX_TUI_STATUS_LINE
+          !isOmxManagedStatusLine(trimmed)
         ) {
           hasCustomizedStatusLine = true;
         }
@@ -722,7 +763,10 @@ function extractCustomizedTuiSectionsFromOmxBlocks(config: string): string[] {
   return sections;
 }
 
-function upsertTuiStatusLine(config: string): {
+function upsertTuiStatusLine(
+  config: string,
+  preset: HudPreset = DEFAULT_STATUS_LINE_PRESET,
+): {
   cleaned: string;
   hadExistingTui: boolean;
 } {
@@ -774,7 +818,7 @@ function upsertTuiStatusLine(config: string): {
   const mergedSection = [
     "[tui]",
     ...preservedKeyLines,
-    preservedStatusLine ?? OMX_TUI_STATUS_LINE,
+    preservedStatusLine ?? statusLineForPreset(preset),
   ];
   const firstStart = sections[0].start;
   const rebuilt: string[] = [];
@@ -1066,7 +1110,11 @@ function getSharedMcpRegistryBlock(
  * OMX table-section block (MCP servers, TUI).
  * Contains ONLY [table] sections — no bare keys.
  */
-function getOmxTablesBlock(pkgRoot: string, includeTui = true): string {
+function getOmxTablesBlock(
+  pkgRoot: string,
+  includeTui = true,
+  statusLinePreset: HudPreset = DEFAULT_STATUS_LINE_PRESET,
+): string {
   const lines = [
     "",
     "# ============================================================",
@@ -1097,7 +1145,7 @@ function getOmxTablesBlock(pkgRoot: string, includeTui = true): string {
           "",
           "# OMX TUI StatusLine (Codex CLI v0.101.0+)",
           "[tui]",
-          OMX_TUI_STATUS_LINE,
+          statusLineForPreset(statusLinePreset),
           "",
         ]
       : [""]),
@@ -1130,6 +1178,8 @@ export function buildMergedConfig(
 ): string {
   let existing = existingConfig;
   const includeTui = options.includeTui !== false;
+  const statusLinePreset =
+    options.statusLinePreset ?? DEFAULT_STATUS_LINE_PRESET;
   const customizedManagedTuiSections =
     extractCustomizedTuiSectionsFromOmxBlocks(existing);
 
@@ -1155,7 +1205,7 @@ export function buildMergedConfig(
   existing = upsertEnvSettings(existing);
   existing = upsertAgentsSettings(existing);
   const tuiUpsert = includeTui
-    ? upsertTuiStatusLine(existing)
+    ? upsertTuiStatusLine(existing, statusLinePreset)
     : { cleaned: existing, hadExistingTui: false };
   existing = tuiUpsert.cleaned;
 
@@ -1167,6 +1217,7 @@ export function buildMergedConfig(
   const tablesBlock = getOmxTablesBlock(
     pkgRoot,
     includeTui && !tuiUpsert.hadExistingTui,
+    statusLinePreset,
   );
   const sharedRegistryBlock = getSharedMcpRegistryBlock(
     options.sharedMcpServers ?? [],

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -53,7 +53,7 @@ describe('runWatchMode', () => {
       isTTY: true,
       env: {},
       readAllStateFn: async (_cwd, config) => ({ ...emptyCtx(), gitBranch: config?.git.display ?? null }),
-      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' } }),
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
       renderHudFn: (ctx) => `frame:${ctx.gitBranch}`,
       writeStdout: (text) => { writes.push(text); },
       writeStderr: () => {},
@@ -103,7 +103,7 @@ describe('runWatchMode', () => {
           inFlight -= 1;
         }
       },
-      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' } }),
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
       renderHudFn: () => 'frame',
       writeStdout: (text) => { writes.push(text); },
       writeStderr: () => {},
@@ -142,7 +142,7 @@ describe('runWatchMode', () => {
       isTTY: true,
       env: {},
       readAllStateFn: async () => emptyCtx(),
-      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' } }),
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
       renderHudFn: () => 'frame',
       writeStdout: (text) => { writes.push(text); },
       writeStderr: () => {},
@@ -171,7 +171,7 @@ describe('runWatchMode', () => {
       readAllStateFn: async (_cwd, config) => {
         throw new Error('boom');
       },
-      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' } }),
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
       renderHudFn: () => 'frame',
       writeStdout: (text) => { writes.push(text); },
       writeStderr: (text) => { errors.push(text); },

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -138,6 +138,7 @@ describe('buildGitBranchLabel', () => {
     assert.equal(buildGitBranchLabel('/repo', {
       preset: 'focused',
       git: { display: 'repo-branch', remoteName: 'upstream' },
+      statusLine: { preset: 'focused' },
     }, gitRunner), 'upstream-repo/feature/test');
   });
 
@@ -181,6 +182,7 @@ describe('buildGitBranchLabel', () => {
     assert.equal(buildGitBranchLabel('/repo', {
       preset: 'focused',
       git: { display: 'branch' },
+      statusLine: { preset: 'focused' },
     }, gitRunner), 'feature/test');
   });
 
@@ -192,6 +194,7 @@ describe('buildGitBranchLabel', () => {
     assert.equal(buildGitBranchLabel('/repo', {
       preset: 'focused',
       git: { display: 'repo-branch', repoLabel: 'manual' },
+      statusLine: { preset: 'focused' },
     }, gitRunner), 'manual/feature/test');
   });
 
@@ -204,6 +207,7 @@ describe('buildGitBranchLabel', () => {
       const label = buildGitBranchLabel(cwd, {
         preset: 'focused',
         git: { display: 'repo-branch', remoteName: maliciousRemoteName },
+        statusLine: { preset: 'focused' },
       });
 
       assert.equal(label, 'origin-repo/safe-branch');

--- a/src/hud/__tests__/types.test.ts
+++ b/src/hud/__tests__/types.test.ts
@@ -11,6 +11,10 @@ describe('DEFAULT_HUD_CONFIG', () => {
   it('defaults git display to repo-branch', () => {
     assert.deepEqual(DEFAULT_HUD_CONFIG.git, { display: 'repo-branch' });
   });
+
+  it('defaults statusLine preset to "focused"', () => {
+    assert.equal(DEFAULT_HUD_CONFIG.statusLine.preset, 'focused');
+  });
 });
 
 describe('normalizeHudConfig', () => {
@@ -23,6 +27,7 @@ describe('normalizeHudConfig', () => {
     assert.deepEqual(normalizeHudConfig({ preset: 'minimal' }), {
       preset: 'minimal',
       git: { display: 'repo-branch' },
+      statusLine: { preset: 'focused' },
     });
   });
 
@@ -41,6 +46,7 @@ describe('normalizeHudConfig', () => {
         remoteName: 'upstream',
         repoLabel: 'manual-repo',
       },
+      statusLine: { preset: 'focused' },
     });
   });
 
@@ -53,5 +59,30 @@ describe('normalizeHudConfig', () => {
         repoLabel: 123 as never,
       },
     }), DEFAULT_HUD_CONFIG);
+  });
+
+  it('accepts a valid statusLine preset', () => {
+    const resolved = normalizeHudConfig({
+      preset: 'focused',
+      statusLine: { preset: 'minimal' },
+    });
+    assert.equal(resolved.statusLine.preset, 'minimal');
+  });
+
+  it('falls back to default for invalid statusLine preset', () => {
+    const resolved = normalizeHudConfig({
+      preset: 'focused',
+      statusLine: { preset: 'bogus' as never },
+    });
+    assert.equal(resolved.statusLine.preset, 'focused');
+  });
+
+  it('lets statusLine.preset diverge from top-level preset', () => {
+    const resolved = normalizeHudConfig({
+      preset: 'minimal',
+      statusLine: { preset: 'full' },
+    });
+    assert.equal(resolved.preset, 'minimal');
+    assert.equal(resolved.statusLine.preset, 'full');
   });
 });

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -82,6 +82,9 @@ export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedH
     git: {
       ...DEFAULT_HUD_CONFIG.git,
     },
+    statusLine: {
+      preset: DEFAULT_HUD_CONFIG.statusLine.preset,
+    },
   };
 
   if (!raw || typeof raw !== 'object') return normalized;
@@ -100,6 +103,12 @@ export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedH
 
     const repoLabel = sanitizeOptionalString(raw.git.repoLabel);
     if (repoLabel) normalized.git.repoLabel = repoLabel;
+  }
+
+  if (raw.statusLine && typeof raw.statusLine === 'object') {
+    if (isValidPreset(raw.statusLine.preset)) {
+      normalized.statusLine.preset = raw.statusLine.preset;
+    }
   }
 
   return normalized;

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -111,10 +111,16 @@ export interface HudGitConfig {
   repoLabel?: string;
 }
 
+/** Status line preset configuration (drives [tui].status_line in ~/.codex/config.toml) */
+export interface HudStatusLineConfig {
+  preset?: HudPreset;
+}
+
 /** HUD configuration stored in .omx/hud-config.json */
 export interface HudConfig {
   preset?: HudPreset;
   git?: HudGitConfig;
+  statusLine?: HudStatusLineConfig;
 }
 
 export interface ResolvedHudGitConfig {
@@ -123,9 +129,14 @@ export interface ResolvedHudGitConfig {
   repoLabel?: string;
 }
 
+export interface ResolvedHudStatusLineConfig {
+  preset: HudPreset;
+}
+
 export interface ResolvedHudConfig {
   preset: HudPreset;
   git: ResolvedHudGitConfig;
+  statusLine: ResolvedHudStatusLineConfig;
 }
 
 /** Default HUD configuration */
@@ -133,6 +144,9 @@ export const DEFAULT_HUD_CONFIG: ResolvedHudConfig = {
   preset: 'focused',
   git: {
     display: 'repo-branch',
+  },
+  statusLine: {
+    preset: 'focused',
   },
 };
 


### PR DESCRIPTION
## Summary

Reuse the existing `HudPreset` vocabulary (`minimal | focused | full`) to drive the OMX-managed `[tui].status_line` in `~/.codex/config.toml`. Today that array is hard-coded to one seven-field default — this PR makes it preset-driven, fully backward compatible, and configurable through the same `.omx/hud-config.json` users already know.

Companion to #1940 / #1942 (preservation of user-customized `status_line`). Layered on top of `dev`, not `main`.

## Why

OMX already ships preset infrastructure for the HUD (`omx hud --preset=...`, `DEFAULT_HUD_CONFIG.preset = 'focused'`, persisted in `.omx/hud-config.json`). The `status_line` array — the codex-native counterpart — has no equivalent knob, so users either accept the seven-field default or hand-edit the TOML each time. Symmetry is the obvious win: one preset vocabulary, two surfaces.

## Design

| Preset | Fields | When to use |
|---|---|---|
| `minimal` | `model-with-reasoning`, `git-branch` | Narrow terminals, distraction-free work |
| `focused` (default) | `model-with-reasoning`, `git-branch`, `context-remaining`, `total-input-tokens`, `total-output-tokens`, `five-hour-limit`, `weekly-limit` | **Byte-identical to today's hard-coded default** |
| `full` | same as `focused` today; reserved for future expansion | Power users; will diverge as Codex CLI adds more `status_line` keys |

Default is `focused`, so installs that do not specify a preset render exactly the same `status_line` as before this PR.

Independent from the HUD's own `preset` key — a user can have `preset: "minimal"` for the HUD and `statusLine.preset: "full"` for the codex statusline (or vice versa).

## Configuration

Extend `.omx/hud-config.json`:

```json
{
  "preset": "focused",
  "statusLine": { "preset": "minimal" }
}
```

Then `omx setup` (or the auto-refresh path from `omx update`) re-renders `[tui].status_line` per the chosen preset. No new files, no new commands. CLI flags (`omx setup --status-line-preset=...` / `omx hud --set-status-line-preset=...`) are intentionally deferred to a follow-up to keep this PR focused.

## Implementation

- **`src/config/generator.ts`** — Introduce `STATUS_LINE_PRESETS: Record<HudPreset, readonly string[]>` and `statusLineForPreset()`. Replace the `OMX_TUI_STATUS_LINE` constant with `statusLineForPreset(DEFAULT_STATUS_LINE_PRESET)`. Add `statusLinePreset?: HudPreset` to `MergeOptions` and thread it through `upsertTuiStatusLine` and `getOmxTablesBlock`. The customized-status_line detector at `extractCustomizedTuiSectionsFromOmxBlocks()` now treats every preset's serialized form as OMX-managed (via `OMX_MANAGED_STATUS_LINES`), so switching presets *upgrades* the line in place instead of being mistaken for a user override.
- **`src/hud/types.ts`** — Add `HudStatusLineConfig`, `ResolvedHudStatusLineConfig`, and a `statusLine` field on both `HudConfig` and `ResolvedHudConfig`. `DEFAULT_HUD_CONFIG.statusLine.preset = 'focused'`.
- **`src/hud/state.ts`** — Extend `normalizeHudConfig` to read `statusLine.preset`, fall back to default on missing/invalid input, and accept divergent top-level vs. statusLine presets.
- **`src/cli/setup.ts`** — New `readStatusLinePresetFromHudConfig(projectRoot)`. The setup flow reads it before calling `updateManagedConfig`, which forwards it through `MergeOptions.statusLinePreset` to `buildMergedConfig`.

## Backward compatibility

- Installs without `.omx/hud-config.json` or without `statusLine.preset` → `focused` → byte-identical to today's array.
- The user-customized `status_line` preserve path (PR #1942) is unchanged: an explicit user `status_line` still wins over any preset.
- Existing tests that asserted the legacy default array continue to pass unchanged. The new preset-matrix tests assert the byte-identical claim explicitly (see `generator-status-line-presets.test.ts`).

## Tests

New file: `src/config/__tests__/generator-status-line-presets.test.ts`
- Default preset is `focused`.
- `statusLineForPreset("focused")` is byte-identical to the legacy hard-coded default.
- `statusLineForPreset()` (no args) returns the focused string.
- `minimal` emits exactly `["model-with-reasoning", "git-branch"]`.
- `full === focused` today.
- `STATUS_LINE_PRESETS` exposes every `HudPreset` key.
- `buildMergedConfig({})` (no preset) emits the legacy default array.
- `buildMergedConfig({ statusLinePreset: "minimal" })` on a fresh config emits the minimal array.
- A user-defined `status_line` is preserved even when a preset is requested.
- An OMX-managed `status_line` is upgraded in place when a different preset is requested (the new detector treats all presets as managed).
- Integration: writing `{statusLine: {preset: "minimal"}}` into `.omx/hud-config.json` and running `mergeConfig` with that preset produces the minimal array.

Updates to `src/hud/__tests__/types.test.ts`:
- `DEFAULT_HUD_CONFIG.statusLine.preset === 'focused'`.
- Legacy preset-only configs normalize to `statusLine: { preset: 'focused' }`.
- Valid `statusLine.preset` is accepted; invalid falls back to the default; top-level and statusLine presets may diverge.

Existing fixtures in `src/hud/__tests__/index.test.ts` and `src/hud/__tests__/state.test.ts` updated to include the new required `statusLine` field on `ResolvedHudConfig`.

## Verification

- `npm run build` — clean.
- `node --test` over: `generator-status-line-presets`, `generator-idempotent`, `hud/types`, `hud/state`, `hud/index`, `setup-refresh`, `uninstall`, `doctor-invalid-config` → **141/141 pass**.
- Pre-existing failures on `dev` (`team/runtime.test.js`, `team/model-contract.test.js` matching `gpt-5.5`, and `cli/sparkshell-packaging.test.js` requiring `cargo`) reproduce on baseline `dev` without this PR — unrelated to status_line.

## Test plan

- [x] Build passes
- [x] Unit + integration tests for the preset matrix
- [x] Backward-compat assertion (no-preset default == legacy array)
- [x] HUD config normalization handles `statusLine` field
- [x] No regression in the `status_line` user-preservation path