### PR TITLE
Render option descriptions in structured prompt UI

### DIFF
--- a/src/question/__tests__/ui.test.ts
+++ b/src/question/__tests__/ui.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import { describe, it } from 'node:test';
+import { PassThrough } from 'node:stream';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -141,6 +142,24 @@ describe('question ui arrow navigation', () => {
     assert.deepEqual(update.state.selectedIndices, [0, 1]);
   });
 
+  it('renders option descriptions beneath each option when present', () => {
+    const frame = renderInteractiveQuestionFrame(
+      makeRecord({
+        options: [
+          { label: 'Alpha', value: 'alpha', description: 'First choice explanation' },
+          { label: 'Beta', value: 'beta', description: 'Second choice explanation' },
+        ],
+      }),
+      {
+        cursorIndex: 0,
+        selectedIndices: [],
+      },
+    );
+
+    assert.match(frame, /› \[x\] 1\. Alpha\n\s+First choice explanation/);
+    assert.match(frame, /\[ \] 2\. Beta\n\s+Second choice explanation/);
+  });
+
   it('renders navigation instructions with checkbox markers', () => {
     const frame = renderInteractiveQuestionFrame(
       makeRecord({ multi_select: true, type: 'multi-answerable' }),
@@ -205,6 +224,48 @@ describe('question ui arrow navigation', () => {
       assert.equal(loaded?.answer?.kind, 'option');
       assert.equal(loaded?.answer?.value, 'b');
       assert.equal(loaded?.type, 'single-answerable');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('renders option descriptions in number-prompt mode', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-number-mode-'));
+    try {
+      const { recordPath } = await createQuestionRecord(
+        cwd,
+        {
+          question: 'Which lane?',
+          options: [
+            { label: 'Plan first', value: 'ralplan', description: 'Need architecture and test-shape review before execution' },
+            { label: 'Execute directly', value: 'autopilot', description: 'Requirements are already explicit enough for planning plus execution' },
+          ],
+          allow_other: false,
+          other_label: 'Other',
+          multi_select: false,
+          type: 'single-answerable',
+        },
+        'sess-ui-number-mode',
+      );
+
+      const input = new PassThrough() as PassThrough & { isTTY: boolean };
+      input.isTTY = false;
+      const output = new PassThrough() as PassThrough & { isTTY: boolean };
+      output.isTTY = false;
+      let rendered = '';
+      output.on('data', (chunk) => {
+        rendered += chunk.toString();
+      });
+
+      const runPromise = runQuestionUi(recordPath, { input, output });
+      input.write('1\n');
+      input.end();
+
+      await runPromise;
+      const loaded = await readQuestionRecord(recordPath);
+      assert.equal(loaded?.answer?.value, 'ralplan');
+      assert.match(rendered, /1\. Plan first\n\s+Need architecture and test-shape review before execution/);
+      assert.match(rendered, /2\. Execute directly\n\s+Requirements are already explicit enough for planning plus execution/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/question/ui.ts
+++ b/src/question/ui.ts
@@ -44,16 +44,39 @@ interface KeyLike {
   sequence?: string;
 }
 
-function getOptionLabels(record: QuestionRecord): string[] {
-  const labels = record.options.map((option, index) => `${index + 1}. ${option.label}`);
+interface QuestionOptionEntry {
+  label: string;
+  description?: string;
+}
+
+function getOptionEntries(record: QuestionRecord): QuestionOptionEntry[] {
+  const entries = record.options.map((option, index) => ({
+    label: `${index + 1}. ${option.label}`,
+    description: typeof option.description === 'string' && option.description.trim()
+      ? option.description.trim()
+      : undefined,
+  }));
   if (record.allow_other) {
-    labels.push(`${record.options.length + 1}. ${record.other_label}`);
+    entries.push({
+      label: `${record.options.length + 1}. ${record.other_label}`,
+      description: undefined,
+    });
   }
-  return labels;
+  return entries;
+}
+
+function getOptionLabels(record: QuestionRecord): string[] {
+  return getOptionEntries(record).map((entry) => entry.label);
 }
 
 function renderOptions(record: QuestionRecord): string[] {
-  return getOptionLabels(record).map((label) => `  [ ] ${label}`);
+  return getOptionEntries(record).flatMap((entry) => {
+    const lines = [`  [ ] ${entry.label}`];
+    if (entry.description) {
+      lines.push(`      ${entry.description}`);
+    }
+    return lines;
+  });
 }
 
 function parseSelection(raw: string, optionCount: number, multiSelect: boolean): number[] | null {
@@ -240,16 +263,19 @@ export function renderInteractiveQuestionFrame(
   record: QuestionRecord,
   state: InteractiveSelectionState,
 ): string {
-  const optionLabels = getOptionLabels(record);
+  const optionEntries = getOptionEntries(record);
   const lines: string[] = [];
 
   if (record.header) lines.push(record.header);
   lines.push(record.question, '');
 
-  optionLabels.forEach((label, index) => {
+  optionEntries.forEach((entry, index) => {
     const isActive = state.cursorIndex === index;
     const isChecked = isMultiAnswerableQuestion(record) ? state.selectedIndices.includes(index) : isActive;
-    lines.push(`${isActive ? '›' : ' '} [${isChecked ? 'x' : ' '}] ${label}`);
+    lines.push(`${isActive ? '›' : ' '} [${isChecked ? 'x' : ' '}] ${entry.label}`);
+    if (entry.description) {
+      lines.push(`      ${entry.description}`);
+    }
   });
 
   lines.push('');


### PR DESCRIPTION
## Summary
- render option descriptions below each option in the interactive omx prompt UI
- render the same descriptions in the numeric fallback prompt
- add focused coverage for both rendering paths

## Testing
- npm run build
- npm run lint -- src/question/ui.ts src/question/__tests__/ui.test.ts
- node --test dist/question/__tests__/ui.test.js
- node --test dist/cli/__tests__/question.test.js
