### PR TITLE
Make Team startup consume experimental repo-aware DAG handoffs

### DIFF
--- a/docs/contracts/repo-aware-team-dag-decomposition.md
+++ b/docs/contracts/repo-aware-team-dag-decomposition.md
@@ -1,0 +1,98 @@
+# Repo-aware Team DAG decomposition contract
+
+This contract documents the repo-aware Team decomposition gate planned by `.omx/plans/prd-repo-aware-team-decomposition.md`. It is intentionally a pre-runtime contract: Team may import or derive richer planning metadata before launch, but worker execution must continue to use the existing claim-safe task lifecycle.
+
+## Contract boundary
+
+- `omx team` may preflight the latest approved PRD/test-spec pair and a matching DAG handoff artifact before `startTeam()` launches workers.
+- The preflight output may change the startup task list, worker count, owner assignment, inbox text, and observability metadata.
+- Runtime task mutation remains owned by the Team state APIs. Preflight must not bypass `assignTask()`, `claimTask()`, `transitionTaskStatus()`, or `update-task` lifecycle constraints.
+- Existing `omx team [N[:role]] "task"` behavior remains the fallback when no valid approved DAG handoff exists.
+
+## Artifact resolution
+
+1. Select the latest PRD using the same slug semantics as `selectLatestPlanningArtifacts()`.
+2. Prefer `.omx/plans/team-dag-<slug>.json` over embedded markdown handoff JSON.
+3. If multiple matching JSON candidates are possible, choose the lexicographically latest path and record a `multiple_matches` warning in preflight metadata.
+4. If the sidecar exists but is invalid, fall back to legacy text decomposition in v1 and persist the fallback reason. Do not silently ignore the invalid artifact.
+5. If no valid sidecar exists, parse an optional fenced `Team DAG Handoff` block from the selected PRD.
+6. If no valid handoff is found, set `decomposition_source=legacy_text` and use the existing `buildTeamExecutionPlan()` path.
+
+## DAG node requirements
+
+Each imported node should validate to a bounded data shape:
+
+- stable symbolic `id`
+- `subject` and `description`
+- optional `role`
+- `lane`
+- optional `filePaths` and `domains`
+- optional symbolic `depends_on`
+- optional `requires_code_change`
+- optional acceptance or verification notes
+
+Validation must reject duplicate node IDs and cyclic dependencies before worker launch. Input order is the tie-breaker for topological sorting so generated task IDs are stable across runs.
+
+## Runtime dependency remap
+
+DAG dependencies are symbolic at plan time, but Team runtime readiness is based on concrete task IDs. The startup sequence must therefore be:
+
+1. Validate and topologically sort DAG nodes.
+2. Create Team tasks in stable order without symbolic dependency fields.
+3. Build `node_id -> task_id` from created tasks.
+4. Patch dependency fields through the supported state helper/API path so `depends_on`/`blocked_by` contains concrete task IDs only.
+5. Persist the mapping in `decomposition-report.json` for inspection and debugging.
+6. Generate worker inboxes after remapping so dependency summaries show real task IDs.
+
+Do not persist symbolic IDs into runtime task dependencies; `claimTask()` cannot prove readiness from plan-only IDs.
+
+## Persistence and observability
+
+Preflight should keep rich planning data out of the claim lifecycle task payload unless the task schema explicitly supports the field.
+
+| Data | Expected storage |
+| --- | --- |
+| `decomposition_source`, `dag_artifact_path`, `fallback_reason`, `worker_count_requested`, `worker_count_effective`, `worker_count_source`, `ready_lane_count` | team manifest/config metadata, e.g. a `team_decomposition` policy block |
+| node-to-task mapping, allocation reasons, file/domain/lane hints, warnings | `.omx/state/team/<team>/decomposition-report.json` and optional markdown summary |
+| runtime dependencies | `TeamTask.depends_on` / `blocked_by` with concrete task IDs |
+| `requires_code_change` | thread into `TeamTask` only through supported schema/API fields; otherwise reject or drop with an explicit validation warning |
+| worker-facing ownership hints | initial inbox text for the assigned worker |
+
+## Worker count policy
+
+- CLI-explicit counts are user overrides and should be honored up to hard safety caps. If the count exceeds useful ready lanes, keep the count but record surplus support/idle capacity.
+- Plan-suggested counts may be reduced to useful lanes when the DAG shows less parallel work than requested.
+- Default-derived counts may be reduced to useful lanes.
+- Reserve a verification lane only when there is code-changing implementation work to verify and the verification lane is not fully dependency-blocked.
+- Never exceed `DEFAULT_MAX_WORKERS`.
+
+## Allocation and role coherence
+
+Allocation should prefer:
+
+1. dependency-ready root lanes first;
+2. same owner for implementation nodes touching the same file/domain;
+3. specialist roles (`test-engineer`, `writer`, `security-reviewer`) kept coherent when there is enough lane capacity;
+4. generic fallback only when mixed-role assignment is unavoidable, with `worker_runtime_role_reason=mixed_roles_fallback` recorded.
+
+Allocation reasons should be short and stable enough for tests, startup summaries, and worker inboxes.
+
+## Worker inbox UX
+
+The initial inbox should include preflight data that materially affects worker behavior:
+
+- assigned file paths and domains;
+- lane label;
+- dependency summary with concrete task IDs;
+- allocation reason;
+- exact assigned task IDs after symbolic remap.
+
+This makes ownership constraints visible where workers actually operate instead of hiding them only in manifest metadata.
+
+## Review risks to guard in implementation
+
+- Do not put a large opaque DAG heuristic block directly into `src/cli/team.ts`; keep a small preflight module seam.
+- Do not widen `TeamTask` with rich metadata unless state readers, API interop, and monitor snapshots are updated together.
+- Do not treat RALPLAN-suggested worker counts as CLI-explicit overrides.
+- Do not bypass claim-safety by directly writing in-progress/completed task state during preflight.
+- Do not launch workers before symbolic dependencies are remapped to concrete Team task IDs.

--- a/docs/contracts/repo-aware-team-dag-decomposition.md
+++ b/docs/contracts/repo-aware-team-dag-decomposition.md
@@ -25,7 +25,7 @@ Each imported node should validate to a bounded data shape:
 - stable symbolic `id`
 - `subject` and `description`
 - optional `role`
-- `lane`
+- optional `lane`
 - optional `filePaths` and `domains`
 - optional symbolic `depends_on`
 - optional `requires_code_change`
@@ -52,7 +52,7 @@ Preflight should keep rich planning data out of the claim lifecycle task payload
 
 | Data | Expected storage |
 | --- | --- |
-| `decomposition_source`, `dag_artifact_path`, `fallback_reason`, `worker_count_requested`, `worker_count_effective`, `worker_count_source`, `ready_lane_count` | team manifest/config metadata, e.g. a `team_decomposition` policy block |
+| `decomposition_source`, `dag_artifact_path`, `fallback_reason`, `worker_count_requested`, `worker_count_effective`, `worker_count_source`, `ready_lane_count` | team manifest/config metadata, via the top-level `team_decomposition` manifest block |
 | node-to-task mapping, allocation reasons, file/domain/lane hints, warnings | `.omx/state/team/<team>/decomposition-report.json` and optional markdown summary |
 | runtime dependencies | `TeamTask.depends_on` / `blocked_by` with concrete task IDs |
 | `requires_code_change` | thread into `TeamTask` only through supported schema/API fields; otherwise reject or drop with an explicit validation warning |

--- a/docs/contracts/repo-aware-team-dag-decomposition.md
+++ b/docs/contracts/repo-aware-team-dag-decomposition.md
@@ -4,15 +4,15 @@ This contract documents the repo-aware Team decomposition gate planned by `.omx/
 
 ## Contract boundary
 
-- `omx team` may preflight the latest approved PRD/test-spec pair and a matching DAG handoff artifact before `startTeam()` launches workers.
+- `omx team` may preflight the latest approved PRD/test-spec pair and a matching DAG handoff artifact before `startTeam()` launches workers only when the invocation is approved for that pair: either the CLI input matches the PRD's approved Team launch hint, or the user uses a short approved follow-up such as `omx team team` that resolves to that hint. Normal `omx team [N[:role]] "task"` startup must not consume ambient/stale `team-dag-*.json` files.
 - The preflight output may change the startup task list, worker count, owner assignment, inbox text, and observability metadata.
 - Runtime task mutation remains owned by the Team state APIs. Preflight must not bypass `assignTask()`, `claimTask()`, `transitionTaskStatus()`, or `update-task` lifecycle constraints.
 - Existing `omx team [N[:role]] "task"` behavior remains the fallback when no valid approved DAG handoff exists.
 
 ## Artifact resolution
 
-1. Select the latest PRD using the same slug semantics as `selectLatestPlanningArtifacts()`.
-2. Prefer `.omx/plans/team-dag-<slug>.json` over embedded markdown handoff JSON.
+1. Select the latest PRD using the same slug semantics as `selectLatestPlanningArtifacts()`, then require at least one matching `test-spec-<slug>.md`/`testspec-<slug>.md`; a PRD without its matching test spec is not an approved pair for DAG activation.
+2. Prefer `.omx/plans/team-dag-<slug>.json` over embedded markdown handoff JSON after the approved invocation gate passes.
 3. If multiple matching JSON candidates are possible, choose the lexicographically latest path and record a `multiple_matches` warning in preflight metadata.
 4. If the sidecar exists but is invalid, fall back to legacy text decomposition in v1 and persist the fallback reason. Do not silently ignore the invalid artifact.
 5. If no valid sidecar exists, parse an optional fenced `Team DAG Handoff` block from the selected PRD.

--- a/docs/reference/team-allocation-rebalance-policy.md
+++ b/docs/reference/team-allocation-rebalance-policy.md
@@ -45,6 +45,14 @@ To keep the upgrade incremental and reversible, separate **signal collection** f
 - Preserve `.omx/state/team/...` storage and `omx team api` contracts.
 - Make every allocation/rebalance decision explainable with a reason string suitable for logs, snapshots, and tests.
 
+## Repo-aware DAG handoff seam
+
+The repo-aware RALPLAN -> Team handoff should enter before `startTeam()` and before worker inbox generation. Keep the decomposition gate as a bounded preflight module that returns normalized startup tasks, an effective worker count, and an inspectable metadata/report payload. Runtime dispatch should remain unchanged: workers still receive tasks through inboxes and must claim through the existing lifecycle APIs.
+
+Preflight allocation may use DAG `filePaths`, `domains`, `lane`, and symbolic dependency metadata to improve owner assignment, but only concrete runtime task IDs should reach `blocked_by` / `depends_on`. Rich metadata belongs in a decomposition report or manifest policy block unless the Team task schema intentionally supports it.
+
+See `docs/contracts/repo-aware-team-dag-decomposition.md` for the detailed artifact precedence, worker-count provenance, dependency remap, and worker-inbox UX contract.
+
 ## Review notes
 - The code already has good low-level claim primitives; the main gap is decision logic, not transport.
 - The clearest review risk is letting new heuristics bypass `assignTask()`/claim safety. Any rebalance helper should return a decision, not perform ad-hoc mutation.

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -217,6 +217,7 @@ describe('parseTeamStartArgs', () => {
       assert.equal(result.parsed.workerCount, 3);
       assert.equal(result.parsed.agentType, 'executor');
       assert.equal(result.parsed.explicitWorkerCount, true);
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -238,6 +239,49 @@ describe('parseTeamStartArgs', () => {
       const result = parseTeamStartArgs(['team으로', '해줘']);
       assert.equal(result.parsed.task, 'Execute approved issue 831 plan');
       assert.equal(result.parsed.workerCount, 3);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('does not opt normal team startup into repo-aware DAG handoff even when a stale sidecar exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-dag-normal-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-831.md'),
+        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 831 plan"\n',
+      );
+      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-831.md'), '# Test spec\n');
+      await writeFile(join(wd, '.omx', 'plans', 'team-dag-issue-831.json'), '{"schema_version":1,"nodes":[{"id":"impl","subject":"Impl","description":"Impl"}]}\n');
+
+      const result = parseTeamStartArgs(['3:executor', 'fix', 'unrelated', 'bug']);
+      assert.equal(result.parsed.task, 'fix unrelated bug');
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, false);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('opts into repo-aware DAG handoff when the invocation matches the approved launch hint', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-dag-approved-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-831.md'),
+        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 831 plan"\n',
+      );
+      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-831.md'), '# Test spec\n');
+
+      const result = parseTeamStartArgs(['3:executor', 'Execute', 'approved', 'issue', '831', 'plan']);
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -39,6 +39,7 @@ interface ParsedTeamArgs {
   explicitWorkerCount: boolean;
   task: string;
   teamName: string;
+  allowRepoAwareDagHandoff: boolean;
 }
 
 
@@ -156,6 +157,7 @@ Notes:
   --worktree is deprecated for omx team and is now only a backward-compatible no-op override.
   omx team is a tmux-runtime surface by default; in Codex App or plain outside-tmux sessions, launch OMX CLI from shell first instead of treating team as directly available.
   use native Codex subagents for small in-session fanout; use omx team for durable tmux/state/worktree coordination.
+  repo-aware DAG handoff is opt-in: Team only imports a DAG when the invocation matches the latest approved PRD/test-spec launch hint (or a short approved follow-up like \`omx team team\`).
 
 Examples:
   omx team 3:executor "fix failing tests"
@@ -709,8 +711,14 @@ function parseTeamArgs(args: string[], cwd: string = process.cwd()): ParsedTeamA
     }
   }
 
+  const approvedHint = readApprovedExecutionLaunchHint(cwd, 'team');
+  const matchesApprovedLaunchHint = approvedHint?.task.trim() === effectiveTask.trim()
+    && (approvedHint.workerCount == null || approvedHint.workerCount === workerCount)
+    && (approvedHint.agentType == null || approvedHint.agentType === agentType);
+  const allowRepoAwareDagHandoff = followupContext != null || matchesApprovedLaunchHint;
+
   const teamName = sanitizeTeamName(slugifyTask(effectiveTask));
-  return { workerCount, agentType, explicitAgentType, explicitWorkerCount, task: effectiveTask, teamName };
+  return { workerCount, agentType, explicitAgentType, explicitWorkerCount, task: effectiveTask, teamName, allowRepoAwareDagHandoff };
 }
 
 export function parseTeamStartArgs(args: string[]): ParsedTeamStartArgs {
@@ -1100,6 +1108,7 @@ async function persistTeamShutdownModeState(
         explicitAgentType: false,
         explicitWorkerCount: false,
         teamName,
+        allowRepoAwareDagHandoff: false,
       });
     } else {
       await startMode('team', `shutdown team ${teamName}`, 50, cwd);
@@ -1389,6 +1398,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
       explicitAgentType: false,
       explicitWorkerCount: false,
       teamName: runtime.teamName,
+      allowRepoAwareDagHandoff: false,
     });
     const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
     const staffingPlan = buildFollowupStaffingPlan('team', runtime.config.task, availableAgentTypes, {
@@ -1439,6 +1449,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     explicitWorkerCount: parsed.explicitWorkerCount,
     cwd,
     buildLegacyPlan: buildTeamExecutionPlan,
+    allowDagHandoff: parsed.allowRepoAwareDagHandoff,
   });
   const tasks = executionPlan.tasks;
   const effectiveParsed = executionPlan.workerCount === parsed.workerCount

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { updateModeState, startMode, readModeState } from '../modes/base.js';
 import { getStatePath, validateSessionId } from '../mcp/state-paths.js';
 import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime, type TeamSnapshot } from '../team/runtime.js';
+import { buildRepoAwareTeamExecutionPlan } from '../team/repo-aware-decomposition.js';
 import { DEFAULT_MAX_WORKERS } from '../team/state.js';
 import { sanitizeTeamName } from '../team/tmux-session.js';
 import { readTeamEvents, waitForTeamEvent } from '../team/state/events.js';
@@ -1430,13 +1431,15 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
   }
 
   const parsed = parseTeamArgs(teamArgs, cwd);
-  const executionPlan = buildTeamExecutionPlan(
-    parsed.task,
-    parsed.workerCount,
-    parsed.agentType,
-    parsed.explicitAgentType,
-    parsed.explicitWorkerCount,
-  );
+  const executionPlan = buildRepoAwareTeamExecutionPlan({
+    task: parsed.task,
+    workerCount: parsed.workerCount,
+    agentType: parsed.agentType,
+    explicitAgentType: parsed.explicitAgentType,
+    explicitWorkerCount: parsed.explicitWorkerCount,
+    cwd,
+    buildLegacyPlan: buildTeamExecutionPlan,
+  });
   const tasks = executionPlan.tasks;
   const effectiveParsed = executionPlan.workerCount === parsed.workerCount
     ? parsed
@@ -1453,7 +1456,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     executionPlan.workerCount,
     tasks,
     cwd,
-    { worktreeMode },
+    { worktreeMode, decompositionMetadata: executionPlan.metadata },
   );
 
   await ensureTeamModeState(effectiveParsed, tasks);

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -276,6 +276,22 @@ describe('planning artifacts', () => {
     assert.equal(result.dag?.nodes[0]?.id, 'impl');
   });
 
+  it('does not overmatch sidecars for a different slug prefix', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-foo.md'), '# Foo\n');
+    await writeFile(join(plansDir, 'test-spec-foo.md'), '# Foo Test\n');
+    await writeFile(join(plansDir, 'team-dag-foobar.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'wrong', subject: 'Wrong slug', description: 'Must not match foo' }],
+    }));
+
+    const result = readTeamDagHandoffForLatestPlan(tempDir);
+    assert.equal(result.source, 'none');
+    assert.equal(result.planSlug, 'foo');
+    assert.equal(result.dag, null);
+  });
+
   it('prefers sidecar DAG over embedded PRD Team DAG Handoff block', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -4,7 +4,8 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { isPlanningComplete, readApprovedExecutionLaunchHint, readPlanningArtifacts } from '../artifacts.js';
+import { isPlanningComplete, readApprovedExecutionLaunchHint, readPlanningArtifacts, readTeamDagArtifactResolution } from '../artifacts.js';
+import { readTeamDagHandoffForLatestPlan } from '../../team/dag-schema.js';
 
 let tempDir: string;
 
@@ -33,6 +34,57 @@ describe('planning artifacts', () => {
     assert.equal(artifacts.testSpecPaths.length, 0);
   });
 
+
+
+
+  it('resolves matching Team DAG sidecar before markdown handoff', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-repo-aware.md'),
+      '# PRD\n\n## Team DAG Handoff\n```json\n{"source":"markdown"}\n```\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-repo-aware.md'), '# Test Spec\n');
+    await writeFile(join(plansDir, 'team-dag-repo-aware.json'), '{"source":"sidecar"}\n');
+
+    const resolution = readTeamDagArtifactResolution(tempDir);
+
+    assert.equal(resolution.source, 'json-sidecar');
+    assert.equal(resolution.planSlug, 'repo-aware');
+    assert.equal(resolution.artifactPath, join(plansDir, 'team-dag-repo-aware.json'));
+    assert.equal(resolution.content, '{"source":"sidecar"}\n');
+    assert.deepEqual(resolution.warnings, []);
+  });
+
+  it('falls back to embedded Team DAG handoff when sidecar is absent', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-repo-aware.md'),
+      '# PRD\n\n## Team DAG Handoff\n```json\n{"nodes":[]}\n```\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-repo-aware.md'), '# Test Spec\n');
+
+    const resolution = readTeamDagArtifactResolution(tempDir);
+
+    assert.equal(resolution.source, 'markdown-handoff');
+    assert.equal(resolution.planSlug, 'repo-aware');
+    assert.equal(resolution.content, '{"nodes":[]}');
+    assert.equal(resolution.artifactPath, undefined);
+  });
+
+  it('returns none for Team DAG resolution when planning is incomplete', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-repo-aware.md'), '# PRD\n');
+
+    const resolution = readTeamDagArtifactResolution(tempDir);
+
+    assert.equal(resolution.source, 'none');
+    assert.equal(resolution.prdPath, null);
+    assert.equal(resolution.planSlug, null);
+    assert.deepEqual(resolution.warnings, ['planning_incomplete']);
+  });
 
 
   it('parses $ralph aliases with single-quoted task text for approved launch hints', async () => {
@@ -183,4 +235,68 @@ describe('planning artifacts', () => {
       ['deep-interview-issue-827.md'],
     );
   });
+
+  it('loads a matching Team DAG sidecar for the latest PRD slug', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-alpha.md'), '# Alpha\n');
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha Test\n');
+    await writeFile(join(plansDir, 'team-dag-alpha.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'impl', subject: 'Implement alpha', description: 'Implement alpha DAG' }],
+    }));
+
+    const result = readTeamDagHandoffForLatestPlan(tempDir);
+    assert.equal(result.source, 'sidecar');
+    assert.equal(result.planSlug, 'alpha');
+    assert.equal(result.dag?.nodes[0]?.id, 'impl');
+  });
+
+  it('prefers sidecar DAG over embedded PRD Team DAG Handoff block', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-beta.md'), '# Beta\n\n## Team DAG Handoff\n```json\n{"schema_version":1,"nodes":[{"id":"markdown","subject":"Markdown"}]}\n```\n');
+    await writeFile(join(plansDir, 'test-spec-beta.md'), '# Beta Test\n');
+    await writeFile(join(plansDir, 'team-dag-beta.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'sidecar', subject: 'Sidecar wins', description: 'Sidecar DAG' }],
+    }));
+
+    const result = readTeamDagHandoffForLatestPlan(tempDir);
+    assert.equal(result.source, 'sidecar');
+    assert.equal(result.dag?.nodes[0]?.id, 'sidecar');
+  });
+
+  it('reports multiple matching sidecars and chooses the lexicographically latest', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-gamma.md'), '# Gamma\n');
+    await writeFile(join(plansDir, 'test-spec-gamma.md'), '# Gamma Test\n');
+    await writeFile(join(plansDir, 'team-dag-gamma-a.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'old', subject: 'Old', description: 'Old DAG' }],
+    }));
+    await writeFile(join(plansDir, 'team-dag-gamma-z.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'new', subject: 'New', description: 'New DAG' }],
+    }));
+
+    const result = readTeamDagHandoffForLatestPlan(tempDir);
+    assert.equal(result.warning, 'multiple_matches');
+    assert.equal(result.dag?.nodes[0]?.id, 'new');
+  });
+
+  it('fails open with explicit parse error metadata for malformed DAG sidecars', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-delta.md'), '# Delta\n');
+    await writeFile(join(plansDir, 'test-spec-delta.md'), '# Delta Test\n');
+    await writeFile(join(plansDir, 'team-dag-delta.json'), '{bad json');
+
+    const result = readTeamDagHandoffForLatestPlan(tempDir);
+    assert.equal(result.source, 'sidecar');
+    assert.equal(result.dag, null);
+    assert.match(result.error ?? '', /JSON|property/i);
+  });
+
 });

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -87,6 +87,30 @@ describe('planning artifacts', () => {
   });
 
 
+  it('does not approve latest PRD launch hints without a matching test spec slug', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-alpha.md'), '# Alpha\n\nLaunch via omx team 2:executor "Execute alpha"\n');
+    await writeFile(join(plansDir, 'test-spec-other.md'), '# Other Test Spec\n');
+
+    assert.equal(readApprovedExecutionLaunchHint(tempDir, 'team'), null);
+  });
+
+  it('does not resolve Team DAG artifacts without a matching test spec slug', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-repo-aware.md'), '# PRD\n');
+    await writeFile(join(plansDir, 'test-spec-other.md'), '# Other Test Spec\n');
+    await writeFile(join(plansDir, 'team-dag-repo-aware.json'), '{"source":"sidecar"}\n');
+
+    const resolution = readTeamDagArtifactResolution(tempDir);
+
+    assert.equal(resolution.source, 'none');
+    assert.equal(resolution.planSlug, 'repo-aware');
+    assert.deepEqual(resolution.warnings, ['missing_matching_test_spec']);
+  });
+
+
   it('parses $ralph aliases with single-quoted task text for approved launch hints', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     const specsDir = join(tempDir, '.omx', 'specs');
@@ -284,6 +308,40 @@ describe('planning artifacts', () => {
     const result = readTeamDagHandoffForLatestPlan(tempDir);
     assert.equal(result.warning, 'multiple_matches');
     assert.equal(result.dag?.nodes[0]?.id, 'new');
+  });
+
+
+  it('does not load a Team DAG handoff when the latest PRD lacks a matching test spec', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-epsilon.md'), '# Epsilon\n');
+    await writeFile(join(plansDir, 'test-spec-other.md'), '# Other Test\n');
+    await writeFile(join(plansDir, 'team-dag-epsilon.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'impl', subject: 'Implement epsilon', description: 'Implement epsilon DAG' }],
+    }));
+
+    const result = readTeamDagHandoffForLatestPlan(tempDir);
+    assert.equal(result.source, 'none');
+    assert.equal(result.dag, null);
+    assert.equal(result.error, 'missing_matching_test_spec');
+  });
+
+  it('rejects a Team DAG sidecar whose declared plan_slug does not match the latest PRD', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-zeta.md'), '# Zeta\n');
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta Test\n');
+    await writeFile(join(plansDir, 'team-dag-zeta.json'), JSON.stringify({
+      schema_version: 1,
+      plan_slug: 'other',
+      nodes: [{ id: 'impl', subject: 'Implement zeta', description: 'Implement zeta DAG' }],
+    }));
+
+    const result = readTeamDagHandoffForLatestPlan(tempDir);
+    assert.equal(result.source, 'sidecar');
+    assert.equal(result.dag, null);
+    assert.match(result.error ?? '', /does not match/);
   });
 
   it('fails open with explicit parse error metadata for malformed DAG sidecars', async () => {

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -35,6 +35,15 @@ export interface LatestPlanningArtifactSelection {
   deepInterviewSpecPaths: string[];
 }
 
+export interface TeamDagArtifactResolution {
+  source: 'json-sidecar' | 'markdown-handoff' | 'none';
+  prdPath: string | null;
+  planSlug: string | null;
+  artifactPath?: string;
+  content?: string;
+  warnings: string[];
+}
+
 function readMatchingPaths(dir: string, pattern: RegExp): string[] {
   if (!existsSync(dir)) {
     return [];
@@ -141,6 +150,66 @@ export function selectLatestPlanningArtifacts(
 
 export function readLatestPlanningArtifacts(cwd: string): LatestPlanningArtifactSelection {
   return selectLatestPlanningArtifacts(readPlanningArtifacts(cwd));
+}
+
+function extractTeamDagMarkdownHandoff(content: string): string | null {
+  const fencePattern = /```(?:json)?\s*\n(?<body>[\s\S]*?)```/gi;
+  let searchFrom = 0;
+  while (searchFrom < content.length) {
+    const headingIndex = content.toLowerCase().indexOf('team dag handoff', searchFrom);
+    if (headingIndex < 0) return null;
+    fencePattern.lastIndex = headingIndex;
+    const match = fencePattern.exec(content);
+    if (match?.groups?.body) {
+      return match.groups.body.trim();
+    }
+    searchFrom = headingIndex + 'team dag handoff'.length;
+  }
+  return null;
+}
+
+export function readTeamDagArtifactResolution(cwd: string): TeamDagArtifactResolution {
+  const artifacts = readPlanningArtifacts(cwd);
+  if (!isPlanningComplete(artifacts)) {
+    return { source: 'none', prdPath: null, planSlug: null, warnings: ['planning_incomplete'] };
+  }
+
+  const selection = selectLatestPlanningArtifacts(artifacts);
+  const prdPath = selection.prdPath;
+  const planSlug = prdPath ? artifactSlug(prdPath, /^prd-(?<slug>.*)\.md$/i) : null;
+  if (!prdPath || !planSlug) {
+    return { source: 'none', prdPath, planSlug, warnings: ['missing_prd_slug'] };
+  }
+
+  const sidecarName = `team-dag-${planSlug}.json`;
+  const sidecarPath = join(artifacts.plansDir, sidecarName);
+  if (existsSync(sidecarPath)) {
+    try {
+      return {
+        source: 'json-sidecar',
+        prdPath,
+        planSlug,
+        artifactPath: sidecarPath,
+        content: readFileSync(sidecarPath, 'utf-8'),
+        warnings: [],
+      };
+    } catch {
+      return { source: 'none', prdPath, planSlug, artifactPath: sidecarPath, warnings: ['sidecar_unreadable'] };
+    }
+  }
+
+
+  try {
+    const prdContent = readFileSync(prdPath, 'utf-8');
+    const markdownHandoff = extractTeamDagMarkdownHandoff(prdContent);
+    if (markdownHandoff) {
+      return { source: 'markdown-handoff', prdPath, planSlug, content: markdownHandoff, warnings: [] };
+    }
+  } catch {
+    return { source: 'none', prdPath, planSlug, warnings: ['prd_unreadable'] };
+  }
+
+  return { source: 'none', prdPath, planSlug, warnings: [] };
 }
 
 export function readApprovedExecutionLaunchHint(

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -109,7 +109,7 @@ function readApprovedPlanText(cwd: string): { content: string; context: Approved
 
   const selection = selectLatestPlanningArtifacts(artifacts);
   const latestPrdPath = selection.prdPath;
-  if (!latestPrdPath || !existsSync(latestPrdPath)) return null;
+  if (!latestPrdPath || selection.testSpecPaths.length === 0 || !existsSync(latestPrdPath)) return null;
 
   try {
     return {
@@ -179,6 +179,9 @@ export function readTeamDagArtifactResolution(cwd: string): TeamDagArtifactResol
   const planSlug = prdPath ? artifactSlug(prdPath, /^prd-(?<slug>.*)\.md$/i) : null;
   if (!prdPath || !planSlug) {
     return { source: 'none', prdPath, planSlug, warnings: ['missing_prd_slug'] };
+  }
+  if (selection.testSpecPaths.length === 0) {
+    return { source: 'none', prdPath, planSlug, warnings: ['missing_matching_test_spec'] };
   }
 
   const sidecarName = `team-dag-${planSlug}.json`;

--- a/src/team/__tests__/repo-aware-decomposition.test.ts
+++ b/src/team/__tests__/repo-aware-decomposition.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildRepoAwareTeamExecutionPlan } from '../repo-aware-decomposition.js';
+
+function repo(): string {
+  const cwd = mkdtempSync(join(tmpdir(), 'omx-dag-'));
+  mkdirSync(join(cwd, '.omx', 'plans'), { recursive: true });
+  mkdirSync(join(cwd, 'src', 'team'), { recursive: true });
+  writeFileSync(join(cwd, 'src', 'team', 'runtime.ts'), '');
+  writeFileSync(join(cwd, '.omx', 'plans', 'prd-demo.md'), '# Demo\n');
+  writeFileSync(join(cwd, '.omx', 'plans', 'test-spec-demo.md'), '# Tests\n');
+  return cwd;
+}
+
+const legacy = () => ({
+  workerCount: 3,
+  tasks: [{ subject: 'legacy', description: 'legacy', owner: 'worker-1', role: 'team-executor' }],
+});
+
+describe('buildRepoAwareTeamExecutionPlan', () => {
+  it('falls back to legacy text decomposition when no DAG exists', () => {
+    const cwd = repo();
+    const plan = buildRepoAwareTeamExecutionPlan({
+      task: 'fix tests', workerCount: 3, agentType: 'executor', explicitAgentType: false, explicitWorkerCount: false, cwd, buildLegacyPlan: legacy,
+    });
+    assert.equal(plan.metadata?.decomposition_source, 'legacy_text');
+    assert.equal(plan.tasks[0].subject, 'legacy');
+  });
+
+  it('imports DAG sidecar, reduces implicit worker count, and preserves dependencies', () => {
+    const cwd = repo();
+    writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [
+        { id: 'impl', lane: 'implementation', role: 'executor', subject: 'Implement runtime', description: 'Change runtime', filePaths: ['src/team/runtime.ts'], requires_code_change: true },
+        { id: 'tests', lane: 'verification', role: 'test-engineer', subject: 'Test runtime', description: 'Cover runtime', depends_on: ['impl'] },
+      ],
+      worker_policy: { requested_count: 3, count_source: 'plan-suggested' },
+    }));
+    const plan = buildRepoAwareTeamExecutionPlan({
+      task: 'team', workerCount: 3, agentType: 'executor', explicitAgentType: false, explicitWorkerCount: false, cwd, buildLegacyPlan: legacy,
+    });
+    assert.equal(plan.metadata?.decomposition_source, 'dag_sidecar');
+    assert.equal(plan.workerCount, 2);
+    assert.equal(plan.tasks.length, 2);
+    assert.deepEqual(plan.tasks[1].blocked_by, ['1']);
+    assert.equal(plan.metadata?.node_id_to_task_id?.impl, '1');
+    assert.match(plan.tasks[0].description, /File scope: src\/team\/runtime.ts/);
+  });
+
+  it('honors CLI-explicit worker count beyond ready lanes', () => {
+    const cwd = repo();
+    writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'impl', subject: 'Implement one lane', description: 'Do it' }],
+      worker_policy: { requested_count: 1, count_source: 'plan-suggested' },
+    }));
+    const plan = buildRepoAwareTeamExecutionPlan({
+      task: 'team', workerCount: 4, agentType: 'executor', explicitAgentType: true, explicitWorkerCount: true, cwd, buildLegacyPlan: legacy,
+    });
+    assert.equal(plan.workerCount, 4);
+    assert.equal(plan.metadata?.worker_count_source, 'cli-explicit');
+  });
+});

--- a/src/team/__tests__/repo-aware-decomposition.test.ts
+++ b/src/team/__tests__/repo-aware-decomposition.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { buildRepoAwareTeamExecutionPlan } from '../repo-aware-decomposition.js';
@@ -41,7 +41,7 @@ describe('buildRepoAwareTeamExecutionPlan', () => {
       worker_policy: { requested_count: 3, count_source: 'plan-suggested' },
     }));
     const plan = buildRepoAwareTeamExecutionPlan({
-      task: 'team', workerCount: 3, agentType: 'executor', explicitAgentType: false, explicitWorkerCount: false, cwd, buildLegacyPlan: legacy,
+      task: 'team', workerCount: 3, agentType: 'executor', explicitAgentType: false, explicitWorkerCount: false, cwd, buildLegacyPlan: legacy, allowDagHandoff: true,
     });
     assert.equal(plan.metadata?.decomposition_source, 'dag_sidecar');
     assert.equal(plan.workerCount, 2);
@@ -49,6 +49,39 @@ describe('buildRepoAwareTeamExecutionPlan', () => {
     assert.deepEqual(plan.tasks[1].blocked_by, ['1']);
     assert.equal(plan.metadata?.node_id_to_task_id?.impl, '1');
     assert.match(plan.tasks[0].description, /File scope: src\/team\/runtime.ts/);
+  });
+
+
+  it('does not import a stale DAG sidecar unless the approved launch gate opts in', () => {
+    const cwd = repo();
+    writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'stale', subject: 'Stale sidecar', description: 'Must not override normal startup' }],
+    }));
+    const plan = buildRepoAwareTeamExecutionPlan({
+      task: 'fix unrelated tests', workerCount: 3, agentType: 'executor', explicitAgentType: false, explicitWorkerCount: false, cwd, buildLegacyPlan: legacy,
+    });
+    assert.equal(plan.metadata?.decomposition_source, 'legacy_text');
+    assert.equal(plan.metadata?.fallback_reason, 'dag_handoff_not_approved_for_invocation');
+    assert.equal(plan.tasks[0].subject, 'legacy');
+  });
+
+  it('requires a matching approved test spec before importing an opted-in DAG sidecar', () => {
+    const cwd = repo();
+    writeFileSync(join(cwd, '.omx', 'plans', 'test-spec-demo.md'), '');
+    writeFileSync(join(cwd, '.omx', 'plans', 'test-spec-other.md'), '# Other tests\n');
+    writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'impl', subject: 'Implement', description: 'Implement from DAG' }],
+    }));
+    unlinkSync(join(cwd, '.omx', 'plans', 'test-spec-demo.md'));
+
+    const plan = buildRepoAwareTeamExecutionPlan({
+      task: 'team', workerCount: 3, agentType: 'executor', explicitAgentType: false, explicitWorkerCount: false, cwd, buildLegacyPlan: legacy, allowDagHandoff: true,
+    });
+    assert.equal(plan.metadata?.decomposition_source, 'legacy_text');
+    assert.equal(plan.metadata?.fallback_reason, 'missing_matching_test_spec');
+    assert.equal(plan.tasks[0].subject, 'legacy');
   });
 
   it('honors CLI-explicit worker count beyond ready lanes', () => {
@@ -59,7 +92,7 @@ describe('buildRepoAwareTeamExecutionPlan', () => {
       worker_policy: { requested_count: 1, count_source: 'plan-suggested' },
     }));
     const plan = buildRepoAwareTeamExecutionPlan({
-      task: 'team', workerCount: 4, agentType: 'executor', explicitAgentType: true, explicitWorkerCount: true, cwd, buildLegacyPlan: legacy,
+      task: 'team', workerCount: 4, agentType: 'executor', explicitAgentType: true, explicitWorkerCount: true, cwd, buildLegacyPlan: legacy, allowDagHandoff: true,
     });
     assert.equal(plan.workerCount, 4);
     assert.equal(plan.metadata?.worker_count_source, 'cli-explicit');

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -317,6 +317,7 @@ describe('team state', () => {
       policy.delegation_only = true;
       policy.nested_teams_allowed = true;
       policy.cleanup_requires_all_workers_inactive = false;
+      policy.team_decomposition = { decomposition_source: 'dag_sidecar' };
       manifest.policy = policy;
       delete manifest.governance;
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
@@ -330,6 +331,8 @@ describe('team state', () => {
       assert.equal('delegation_only' in (loaded?.policy ?? {}), false);
       assert.equal('nested_teams_allowed' in (loaded?.policy ?? {}), false);
       assert.equal('cleanup_requires_all_workers_inactive' in (loaded?.policy ?? {}), false);
+      assert.equal('team_decomposition' in (loaded?.policy ?? {}), false);
+      assert.deepEqual(loaded?.team_decomposition, { decomposition_source: 'dag_sidecar' });
 
       const freshCwd = await mkdtemp(join(tmpdir(), 'omx-team-manifest-policy-default-'));
       try {

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -278,6 +278,37 @@ describe("worker bootstrap", () => {
     assert.match(inbox, /Fix-Verify Loop/);
   });
 
+
+  it("generateInitialInbox includes repo-aware decomposition ownership hints", () => {
+    const inbox = generateInitialInbox(
+      "worker-1",
+      "team-dag",
+      "executor",
+      [
+        {
+          id: "1",
+          subject: "Implement DAG importer",
+          description: "Implement repo-aware decomposition",
+          status: "pending",
+          owner: "worker-1",
+          role: "executor",
+          created_at: "2026-04-27T00:00:00.000Z",
+          depends_on: ["0"],
+          filePaths: ["src/team/repo-aware-decomposition.ts"],
+          domains: ["team decomposition"],
+          lane: "implementation",
+          allocation_reason: "preserves low-overlap file/domain ownership",
+        } as TeamTask,
+      ],
+    );
+
+    assert.match(inbox, /Depends on: 0/);
+    assert.match(inbox, /File paths: src\/team\/repo-aware-decomposition\.ts/);
+    assert.match(inbox, /Domains: team decomposition/);
+    assert.match(inbox, /Lane: implementation/);
+    assert.match(inbox, /Allocation reason: preserves low-overlap file\/domain ownership/);
+  });
+
   it("generateInitialInbox shows blocked_by info for blocked tasks", () => {
     const tasks: TeamTask[] = [
       {

--- a/src/team/dag-schema.ts
+++ b/src/team/dag-schema.ts
@@ -1,0 +1,226 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { readLatestPlanningArtifacts } from '../planning/artifacts.js';
+
+export type TeamDagWorkerCountSource = 'cli-explicit' | 'plan-suggested' | 'default-derived';
+
+export interface TeamDagNode {
+  id: string;
+  subject: string;
+  description: string;
+  role?: string;
+  lane?: string;
+  filePaths?: string[];
+  domains?: string[];
+  depends_on?: string[];
+  requires_code_change?: boolean;
+  acceptance?: string[];
+}
+
+export interface TeamDagWorkerPolicy {
+  requested_count?: number;
+  count_source?: TeamDagWorkerCountSource;
+  max_count?: number;
+  reserve_verification_lane?: boolean;
+  strict_max_count?: boolean;
+}
+
+export interface TeamDagHandoff {
+  schema_version: 1;
+  plan_slug?: string;
+  source_prd?: string;
+  nodes: TeamDagNode[];
+  worker_policy?: TeamDagWorkerPolicy;
+}
+
+export interface TeamDagResolution {
+  dag: TeamDagHandoff | null;
+  source: 'sidecar' | 'markdown' | 'none';
+  path?: string;
+  planSlug?: string;
+  warning?: string;
+  error?: string;
+}
+
+function planningSlugFromPrdPath(prdPath: string | null): string | null {
+  if (!prdPath) return null;
+  const match = basename(prdPath).match(/^prd-(?<slug>.*)\.md$/i);
+  return match?.groups?.slug ?? null;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error('expected string array');
+  }
+  return value;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') throw new Error('expected string');
+  return value;
+}
+
+function asOptionalBoolean(value: unknown): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'boolean') throw new Error('expected boolean');
+  return value;
+}
+
+function asOptionalPositiveInteger(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+    throw new Error('expected positive integer');
+  }
+  return value;
+}
+
+function parseWorkerPolicy(value: unknown): TeamDagWorkerPolicy | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== 'object') throw new Error('worker_policy must be an object');
+  const raw = value as Record<string, unknown>;
+  const countSource = raw.count_source;
+  if (
+    countSource !== undefined
+    && countSource !== 'cli-explicit'
+    && countSource !== 'plan-suggested'
+    && countSource !== 'default-derived'
+  ) {
+    throw new Error('worker_policy.count_source is invalid');
+  }
+  return {
+    requested_count: asOptionalPositiveInteger(raw.requested_count),
+    count_source: countSource as TeamDagWorkerCountSource | undefined,
+    max_count: asOptionalPositiveInteger(raw.max_count),
+    reserve_verification_lane: asOptionalBoolean(raw.reserve_verification_lane),
+    strict_max_count: asOptionalBoolean(raw.strict_max_count),
+  };
+}
+
+export function parseTeamDagHandoff(value: unknown): TeamDagHandoff {
+  if (!value || typeof value !== 'object') throw new Error('Team DAG handoff must be an object');
+  const raw = value as Record<string, unknown>;
+  if (raw.schema_version !== 1) throw new Error('Team DAG handoff schema_version must be 1');
+  if (!Array.isArray(raw.nodes) || raw.nodes.length === 0) throw new Error('Team DAG handoff nodes must be a non-empty array');
+
+  const seen = new Set<string>();
+  const nodes = raw.nodes.map((nodeValue, index): TeamDagNode => {
+    if (!nodeValue || typeof nodeValue !== 'object') throw new Error(`node ${index + 1} must be an object`);
+    const node = nodeValue as Record<string, unknown>;
+    if (typeof node.id !== 'string' || node.id.trim() === '') throw new Error(`node ${index + 1} id is required`);
+    if (seen.has(node.id)) throw new Error(`duplicate node id: ${node.id}`);
+    seen.add(node.id);
+    if (typeof node.subject !== 'string' || node.subject.trim() === '') throw new Error(`node ${node.id} subject is required`);
+    if (typeof node.description !== 'string' || node.description.trim() === '') throw new Error(`node ${node.id} description is required`);
+    return {
+      id: node.id,
+      subject: node.subject,
+      description: node.description,
+      role: asOptionalString(node.role),
+      lane: asOptionalString(node.lane),
+      filePaths: asStringArray(node.filePaths),
+      domains: asStringArray(node.domains),
+      depends_on: asStringArray(node.depends_on),
+      requires_code_change: asOptionalBoolean(node.requires_code_change),
+      acceptance: asStringArray(node.acceptance),
+    };
+  });
+
+  for (const node of nodes) {
+    for (const dep of node.depends_on ?? []) {
+      if (!seen.has(dep)) throw new Error(`node ${node.id} depends on unknown node: ${dep}`);
+    }
+  }
+  assertAcyclic(nodes);
+
+  return {
+    schema_version: 1,
+    plan_slug: asOptionalString(raw.plan_slug),
+    source_prd: asOptionalString(raw.source_prd),
+    nodes,
+    worker_policy: parseWorkerPolicy(raw.worker_policy),
+  };
+}
+
+function assertAcyclic(nodes: TeamDagNode[]): void {
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (id: string): void => {
+    if (visited.has(id)) return;
+    if (visiting.has(id)) throw new Error(`cycle detected at node: ${id}`);
+    visiting.add(id);
+    for (const dep of byId.get(id)?.depends_on ?? []) visit(dep);
+    visiting.delete(id);
+    visited.add(id);
+  };
+  for (const node of nodes) visit(node.id);
+}
+
+function parseJsonText(text: string): TeamDagHandoff {
+  return parseTeamDagHandoff(JSON.parse(text) as unknown);
+}
+
+function readSidecar(plansDir: string, slug: string): Omit<TeamDagResolution, 'planSlug'> | null {
+  if (!existsSync(plansDir)) return null;
+  const candidates = readdirSync(plansDir)
+    .filter((file) => file.startsWith(`team-dag-${slug}`) && file.endsWith('.json'))
+    .sort((a, b) => a.localeCompare(b))
+    .map((file) => join(plansDir, file));
+  if (candidates.length === 0) return null;
+  const selected = candidates.at(-1)!;
+  try {
+    return {
+      dag: parseJsonText(readFileSync(selected, 'utf-8')),
+      source: 'sidecar',
+      path: selected,
+      warning: candidates.length > 1 ? 'multiple_matches' : undefined,
+    };
+  } catch (error) {
+    return {
+      dag: null,
+      source: 'sidecar',
+      path: selected,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function extractMarkdownHandoff(content: string): string | null {
+  const heading = content.search(/^#{1,6}\s+Team DAG Handoff\s*$/im);
+  const searchFrom = heading >= 0 ? heading : 0;
+  const fenced = content.slice(searchFrom).match(/```(?:json)?\s*\n([\s\S]*?)\n```/i);
+  return fenced?.[1]?.trim() || null;
+}
+
+export function readTeamDagHandoffForLatestPlan(cwd: string): TeamDagResolution {
+  const selection = readLatestPlanningArtifacts(cwd);
+  const prdPath = selection.prdPath;
+  const planSlug = planningSlugFromPrdPath(prdPath);
+  if (!prdPath || !planSlug) return { dag: null, source: 'none' };
+
+  const plansDir = join(cwd, '.omx', 'plans');
+  const sidecar = readSidecar(plansDir, planSlug);
+  if (sidecar?.dag) return { ...sidecar, planSlug };
+  if (sidecar?.error) return { ...sidecar, planSlug };
+
+  try {
+    const markdownJson = extractMarkdownHandoff(readFileSync(prdPath, 'utf-8'));
+    if (!markdownJson) return { dag: null, source: 'none', planSlug };
+    return {
+      dag: parseJsonText(markdownJson),
+      source: 'markdown',
+      path: prdPath,
+      planSlug,
+    };
+  } catch (error) {
+    return {
+      dag: null,
+      source: 'none',
+      path: prdPath,
+      planSlug,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/team/dag-schema.ts
+++ b/src/team/dag-schema.ts
@@ -171,10 +171,15 @@ function assertDagMatchesPlan(dag: TeamDagHandoff, slug: string, prdPath: string
   }
 }
 
+function matchesSidecarSlug(file: string, slug: string): boolean {
+  const prefix = `team-dag-${slug}`;
+  return (file === `${prefix}.json` || file.startsWith(`${prefix}-`)) && file.endsWith('.json');
+}
+
 function readSidecar(plansDir: string, slug: string, prdPath: string): Omit<TeamDagResolution, 'planSlug'> | null {
   if (!existsSync(plansDir)) return null;
   const candidates = readdirSync(plansDir)
-    .filter((file) => file.startsWith(`team-dag-${slug}`) && file.endsWith('.json'))
+    .filter((file) => matchesSidecarSlug(file, slug))
     .sort((a, b) => a.localeCompare(b))
     .map((file) => join(plansDir, file));
   if (candidates.length === 0) return null;

--- a/src/team/dag-schema.ts
+++ b/src/team/dag-schema.ts
@@ -162,7 +162,16 @@ function parseJsonText(text: string): TeamDagHandoff {
   return parseTeamDagHandoff(JSON.parse(text) as unknown);
 }
 
-function readSidecar(plansDir: string, slug: string): Omit<TeamDagResolution, 'planSlug'> | null {
+function assertDagMatchesPlan(dag: TeamDagHandoff, slug: string, prdPath: string): void {
+  if (dag.plan_slug !== undefined && dag.plan_slug !== slug) {
+    throw new Error(`Team DAG plan_slug ${dag.plan_slug} does not match latest approved plan slug ${slug}`);
+  }
+  if (dag.source_prd !== undefined && basename(dag.source_prd) !== basename(prdPath)) {
+    throw new Error(`Team DAG source_prd ${dag.source_prd} does not match latest approved PRD ${basename(prdPath)}`);
+  }
+}
+
+function readSidecar(plansDir: string, slug: string, prdPath: string): Omit<TeamDagResolution, 'planSlug'> | null {
   if (!existsSync(plansDir)) return null;
   const candidates = readdirSync(plansDir)
     .filter((file) => file.startsWith(`team-dag-${slug}`) && file.endsWith('.json'))
@@ -172,7 +181,11 @@ function readSidecar(plansDir: string, slug: string): Omit<TeamDagResolution, 'p
   const selected = candidates.at(-1)!;
   try {
     return {
-      dag: parseJsonText(readFileSync(selected, 'utf-8')),
+      dag: (() => {
+        const dag = parseJsonText(readFileSync(selected, 'utf-8'));
+        assertDagMatchesPlan(dag, slug, prdPath);
+        return dag;
+      })(),
       source: 'sidecar',
       path: selected,
       warning: candidates.length > 1 ? 'multiple_matches' : undefined,
@@ -201,7 +214,11 @@ export function readTeamDagHandoffForLatestPlan(cwd: string): TeamDagResolution 
   if (!prdPath || !planSlug) return { dag: null, source: 'none' };
 
   const plansDir = join(cwd, '.omx', 'plans');
-  const sidecar = readSidecar(plansDir, planSlug);
+  if (selection.testSpecPaths.length === 0) {
+    return { dag: null, source: 'none', planSlug, error: 'missing_matching_test_spec' };
+  }
+
+  const sidecar = readSidecar(plansDir, planSlug, prdPath);
   if (sidecar?.dag) return { ...sidecar, planSlug };
   if (sidecar?.error) return { ...sidecar, planSlug };
 
@@ -209,7 +226,11 @@ export function readTeamDagHandoffForLatestPlan(cwd: string): TeamDagResolution 
     const markdownJson = extractMarkdownHandoff(readFileSync(prdPath, 'utf-8'));
     if (!markdownJson) return { dag: null, source: 'none', planSlug };
     return {
-      dag: parseJsonText(markdownJson),
+      dag: (() => {
+        const dag = parseJsonText(markdownJson);
+        assertDagMatchesPlan(dag, planSlug, prdPath);
+        return dag;
+      })(),
       source: 'markdown',
       path: prdPath,
       planSlug,

--- a/src/team/repo-aware-decomposition.ts
+++ b/src/team/repo-aware-decomposition.ts
@@ -11,6 +11,7 @@ export interface LegacyTeamExecutionPlanInput {
   explicitWorkerCount: boolean;
   cwd: string;
   buildLegacyPlan: (task: string, workerCount: number, agentType: string, explicitAgentType: boolean, explicitWorkerCount: boolean) => RepoAwareTeamExecutionPlan;
+  allowDagHandoff?: boolean;
 }
 
 export interface RepoAwareTask {
@@ -247,7 +248,9 @@ function buildFromDag(input: LegacyTeamExecutionPlanInput, resolution: TeamDagRe
 }
 
 export function buildRepoAwareTeamExecutionPlan(input: LegacyTeamExecutionPlanInput): RepoAwareTeamExecutionPlan {
-  const resolution = readTeamDagHandoffForLatestPlan(input.cwd);
+  const resolution = input.allowDagHandoff === true
+    ? readTeamDagHandoffForLatestPlan(input.cwd)
+    : ({ dag: null, source: 'none', error: 'dag_handoff_not_approved_for_invocation' } satisfies TeamDagResolution);
   if (resolution.dag) return buildFromDag(input, resolution as TeamDagResolution & { dag: TeamDagHandoff });
 
   const legacy = input.buildLegacyPlan(input.task, input.workerCount, input.agentType, input.explicitAgentType, input.explicitWorkerCount);

--- a/src/team/repo-aware-decomposition.ts
+++ b/src/team/repo-aware-decomposition.ts
@@ -1,0 +1,268 @@
+import { existsSync } from 'node:fs';
+import { relative } from 'node:path';
+import { allocateTasksToWorkers } from './allocation-policy.js';
+import { readTeamDagHandoffForLatestPlan, type TeamDagHandoff, type TeamDagNode, type TeamDagResolution, type TeamDagWorkerCountSource } from './dag-schema.js';
+
+export interface LegacyTeamExecutionPlanInput {
+  task: string;
+  workerCount: number;
+  agentType: string;
+  explicitAgentType: boolean;
+  explicitWorkerCount: boolean;
+  cwd: string;
+  buildLegacyPlan: (task: string, workerCount: number, agentType: string, explicitAgentType: boolean, explicitWorkerCount: boolean) => RepoAwareTeamExecutionPlan;
+}
+
+export interface RepoAwareTask {
+  subject: string;
+  description: string;
+  owner: string;
+  role?: string;
+  blocked_by?: string[];
+  depends_on?: string[];
+  requires_code_change?: boolean;
+  filePaths?: string[];
+  domains?: string[];
+  lane?: string;
+  allocation_reason?: string;
+  symbolic_id?: string;
+}
+
+export interface TeamDecompositionMetadata {
+  decomposition_source: 'dag_sidecar' | 'dag_markdown' | 'legacy_text';
+  dag_artifact_path?: string;
+  dag_resolution_warning?: string;
+  fallback_reason?: string;
+  worker_count_requested: number;
+  worker_count_effective: number;
+  worker_count_source: TeamDagWorkerCountSource;
+  ready_lane_count: number;
+  useful_lane_count: number;
+  allocation_reasons: Record<string, string>;
+  node_id_to_task_id?: Record<string, string>;
+  task_hints?: Record<string, TaskHintSummary>;
+}
+
+export interface TaskHintSummary {
+  node_id?: string;
+  lane?: string;
+  filePaths?: string[];
+  domains?: string[];
+  allocation_reason?: string;
+}
+
+export interface RepoAwareTeamExecutionPlan {
+  workerCount: number;
+  tasks: RepoAwareTask[];
+  metadata?: TeamDecompositionMetadata;
+}
+
+const DEFAULT_MAX_WORKERS = 20;
+const IMPLEMENTATION_LANE_PATTERN = /\b(?:impl|implementation|code|build|feature|fix|refactor)\b/i;
+const VERIFICATION_LANE_PATTERN = /\b(?:verify|verification|test|qa|review)\b/i;
+
+function normalizePath(path: string): string {
+  return path.replace(/^\.\//, '');
+}
+
+function pathExists(cwd: string, path: string): boolean {
+  return existsSync(`${cwd}/${normalizePath(path)}`);
+}
+
+function inferDomains(node: TeamDagNode): string[] {
+  const domains = new Set(node.domains ?? []);
+  for (const path of node.filePaths ?? []) {
+    const normalized = normalizePath(path);
+    const first = normalized.split('/')[0];
+    if (first) domains.add(first);
+    const base = normalized.split('/').pop()?.replace(/\.[^.]+$/, '');
+    if (base) domains.add(base);
+  }
+  return [...domains];
+}
+
+function enrichNodeDescription(node: TeamDagNode, cwd: string): string {
+  const parts = [node.description];
+  const files = (node.filePaths ?? []).map(normalizePath);
+  if (files.length > 0) {
+    const existing = files.filter((file) => pathExists(cwd, file));
+    const missing = files.filter((file) => !pathExists(cwd, file));
+    parts.push(`File scope: ${files.join(', ')}`);
+    if (existing.length > 0) parts.push(`Existing paths: ${existing.map((file) => relative(cwd, `${cwd}/${file}`)).join(', ')}`);
+    if (missing.length > 0) parts.push(`Planned/new paths: ${missing.join(', ')}`);
+  }
+  const domains = inferDomains(node);
+  if (domains.length > 0) parts.push(`Domains: ${domains.join(', ')}`);
+  if (node.lane) parts.push(`Lane: ${node.lane}`);
+  if (node.acceptance?.length) parts.push(`Acceptance: ${node.acceptance.join('; ')}`);
+  return parts.join('\n');
+}
+
+function topologicalSort(nodes: TeamDagNode[]): TeamDagNode[] {
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const inputIndex = new Map(nodes.map((node, index) => [node.id, index]));
+  const indegree = new Map(nodes.map((node) => [node.id, 0]));
+  const outgoing = new Map<string, string[]>();
+  for (const node of nodes) {
+    for (const dep of node.depends_on ?? []) {
+      indegree.set(node.id, (indegree.get(node.id) ?? 0) + 1);
+      outgoing.set(dep, [...(outgoing.get(dep) ?? []), node.id]);
+    }
+  }
+  const ready = nodes.filter((node) => (indegree.get(node.id) ?? 0) === 0);
+  const sorted: TeamDagNode[] = [];
+  while (ready.length > 0) {
+    ready.sort((a, b) => (inputIndex.get(a.id) ?? 0) - (inputIndex.get(b.id) ?? 0));
+    const node = ready.shift()!;
+    sorted.push(node);
+    for (const next of outgoing.get(node.id) ?? []) {
+      indegree.set(next, (indegree.get(next) ?? 0) - 1);
+      if ((indegree.get(next) ?? 0) === 0) ready.push(byId.get(next)!);
+    }
+  }
+  if (sorted.length !== nodes.length) throw new Error('Team DAG contains a cycle');
+  return sorted;
+}
+
+function firstReadyLaneCount(nodes: TeamDagNode[]): number {
+  const ready = nodes.filter((node) => (node.depends_on?.length ?? 0) === 0);
+  if (ready.length === 0) return 1;
+  const conflictGroups = new Set<string>();
+  let noFileCount = 0;
+  for (const node of ready) {
+    const files = node.filePaths ?? [];
+    if (files.length === 0) {
+      noFileCount += 1;
+      continue;
+    }
+    conflictGroups.add(files.map(normalizePath).sort().join('|'));
+  }
+  return Math.max(1, conflictGroups.size + noFileCount);
+}
+
+function hasImplementationWork(nodes: TeamDagNode[]): boolean {
+  return nodes.some((node) => {
+    if (node.requires_code_change === true) return true;
+    const text = `${node.lane ?? ''} ${node.role ?? ''} ${node.subject} ${node.description}`;
+    return IMPLEMENTATION_LANE_PATTERN.test(text) && !VERIFICATION_LANE_PATTERN.test(text);
+  });
+}
+
+function usefulLaneCount(nodes: TeamDagNode[], readyLaneCount: number, reserveVerification: boolean): number {
+  const laneLabels = new Set(nodes.map((node) => node.lane?.trim()).filter(Boolean) as string[]);
+  const base = Math.max(readyLaneCount, laneLabels.size || readyLaneCount);
+  if (reserveVerification && hasImplementationWork(nodes)) return Math.max(base, Math.min(nodes.length, readyLaneCount + 1));
+  return base;
+}
+
+function resolveWorkerCount(params: {
+  requested: number;
+  explicitWorkerCount: boolean;
+  dag: TeamDagHandoff;
+  readyLaneCount: number;
+  usefulLaneCount: number;
+}): { count: number; source: TeamDagWorkerCountSource } {
+  const policy = params.dag.worker_policy;
+  const source: TeamDagWorkerCountSource = params.explicitWorkerCount
+    ? 'cli-explicit'
+    : policy?.count_source ?? (policy?.requested_count ? 'plan-suggested' : 'default-derived');
+  const requested = params.explicitWorkerCount
+    ? params.requested
+    : policy?.requested_count ?? params.requested;
+  const hardCap = Math.min(DEFAULT_MAX_WORKERS, policy?.max_count ?? DEFAULT_MAX_WORKERS);
+  if (source === 'cli-explicit') {
+    const cap = policy?.strict_max_count === true ? hardCap : DEFAULT_MAX_WORKERS;
+    return { count: Math.max(1, Math.min(requested, cap)), source };
+  }
+  return {
+    count: Math.max(1, Math.min(requested, hardCap, params.usefulLaneCount)),
+    source,
+  };
+}
+
+function buildFromDag(input: LegacyTeamExecutionPlanInput, resolution: TeamDagResolution & { dag: TeamDagHandoff }): RepoAwareTeamExecutionPlan {
+  const sorted = topologicalSort(resolution.dag.nodes);
+  const readyLaneCount = firstReadyLaneCount(sorted);
+  const useful = usefulLaneCount(sorted, readyLaneCount, resolution.dag.worker_policy?.reserve_verification_lane !== false);
+  const countPolicy = resolveWorkerCount({
+    requested: input.workerCount,
+    explicitWorkerCount: input.explicitWorkerCount,
+    dag: resolution.dag,
+    readyLaneCount,
+    usefulLaneCount: useful,
+  });
+  const workers = Array.from({ length: countPolicy.count }, (_, index) => ({
+    name: `worker-${index + 1}`,
+    role: input.explicitAgentType ? input.agentType : undefined,
+  }));
+
+  const nodeIdToIndex = new Map(sorted.map((node, index) => [node.id, String(index + 1)]));
+  const allocationInput = sorted.map((node) => ({
+    subject: node.subject,
+    description: enrichNodeDescription(node, input.cwd),
+    role: input.explicitAgentType ? input.agentType : node.role,
+    blocked_by: (node.depends_on ?? []).map((dep) => nodeIdToIndex.get(dep)!).filter(Boolean),
+    depends_on: (node.depends_on ?? []).map((dep) => nodeIdToIndex.get(dep)!).filter(Boolean),
+    requires_code_change: node.requires_code_change,
+    filePaths: node.filePaths,
+    domains: inferDomains(node),
+    lane: node.lane,
+    symbolic_id: node.id,
+  }));
+  const allocated = allocateTasksToWorkers(allocationInput, workers);
+  const allocationReasons: Record<string, string> = {};
+  const taskHints: Record<string, TaskHintSummary> = {};
+  const tasks = allocated.map((task, index): RepoAwareTask => {
+    const taskId = String(index + 1);
+    allocationReasons[task.symbolic_id] = task.allocation_reason;
+    taskHints[taskId] = {
+      node_id: task.symbolic_id,
+      lane: task.lane,
+      filePaths: task.filePaths,
+      domains: task.domains,
+      allocation_reason: task.allocation_reason,
+    };
+    return task;
+  });
+
+  return {
+    workerCount: countPolicy.count,
+    tasks,
+    metadata: {
+      decomposition_source: resolution.source === 'sidecar' ? 'dag_sidecar' : 'dag_markdown',
+      dag_artifact_path: resolution.path,
+      dag_resolution_warning: resolution.warning,
+      worker_count_requested: input.explicitWorkerCount
+        ? input.workerCount
+        : resolution.dag.worker_policy?.requested_count ?? input.workerCount,
+      worker_count_effective: countPolicy.count,
+      worker_count_source: countPolicy.source,
+      ready_lane_count: readyLaneCount,
+      useful_lane_count: useful,
+      allocation_reasons: allocationReasons,
+      node_id_to_task_id: Object.fromEntries(sorted.map((node, index) => [node.id, String(index + 1)])),
+      task_hints: taskHints,
+    },
+  };
+}
+
+export function buildRepoAwareTeamExecutionPlan(input: LegacyTeamExecutionPlanInput): RepoAwareTeamExecutionPlan {
+  const resolution = readTeamDagHandoffForLatestPlan(input.cwd);
+  if (resolution.dag) return buildFromDag(input, resolution as TeamDagResolution & { dag: TeamDagHandoff });
+
+  const legacy = input.buildLegacyPlan(input.task, input.workerCount, input.agentType, input.explicitAgentType, input.explicitWorkerCount);
+  return {
+    ...legacy,
+    metadata: {
+      decomposition_source: 'legacy_text',
+      dag_artifact_path: resolution.path,
+      fallback_reason: resolution.error ?? 'no_valid_dag',
+      worker_count_requested: input.workerCount,
+      worker_count_effective: legacy.workerCount,
+      worker_count_source: input.explicitWorkerCount ? 'cli-explicit' : 'default-derived',
+      ready_lane_count: legacy.workerCount,
+      useful_lane_count: legacy.workerCount,
+      allocation_reasons: {},
+    },
+  };
+}

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -89,6 +89,7 @@ import {
 } from './mcp-comm.js';
 import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
 import type { TeamReminderIntent } from './reminder-intents.js';
+import type { TeamDecompositionMetadata } from './repo-aware-decomposition.js';
 import {
   generateWorkerOverlay,
   writeTeamWorkerInstructionsFile,
@@ -1221,6 +1222,7 @@ export interface StaleTeamSummary {
 
 export interface TeamStartOptions {
   worktreeMode?: WorktreeMode;
+  decompositionMetadata?: TeamDecompositionMetadata;
   confirmStaleCleanup?: (summary: StaleTeamSummary) => Promise<boolean>;
   cleanupLaunchOrphanedMcpProcesses?: () => Promise<CleanupResult>;
   writeCleanupWarning?: (message: string) => void;
@@ -1987,6 +1989,26 @@ function resolveEffectiveWorkerCliForStartupLog(
   return resolveTeamWorkerCli(resolvedLaunchArgs, env);
 }
 
+
+async function writeDecompositionArtifacts(
+  teamName: string,
+  cwd: string,
+  metadata: TeamDecompositionMetadata,
+): Promise<void> {
+  const root = join(resolveCanonicalTeamStateRoot(cwd), 'team', teamName);
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, 'decomposition-report.json'), JSON.stringify(metadata, null, 2), 'utf8');
+
+  const manifest = await readTeamManifestV2(teamName, cwd);
+  if (manifest) {
+    await writeFile(
+      join(root, 'manifest.v2.json'),
+      JSON.stringify({ ...manifest, policy: { ...manifest.policy, team_decomposition: metadata } }, null, 2),
+      'utf8',
+    );
+  }
+}
+
 /**
  * Start a new team: init state, create tmux session, bootstrap workers.
  */
@@ -2020,7 +2042,7 @@ export async function startTeam(
   task: string,
   agentType: string,
   workerCount: number,
-  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[]; role?: string; delegation?: TeamTask['delegation'] }>,
+  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[]; depends_on?: string[]; role?: string; delegation?: TeamTask['delegation']; requires_code_change?: boolean; filePaths?: string[]; domains?: string[]; lane?: string; allocation_reason?: string; symbolic_id?: string }>,
   cwd: string,
   options: TeamStartOptions = {},
 ): Promise<TeamRuntime> {
@@ -2148,9 +2170,15 @@ export async function startTeam(
         description: t.description,
         status: 'pending',
         owner: t.owner,
-        blocked_by: t.blocked_by,
+        blocked_by: t.blocked_by ?? t.depends_on,
+        depends_on: t.depends_on ?? t.blocked_by,
         role: t.role,
         delegation: t.delegation ?? synthesizeDelegationPlan(t),
+        requires_code_change: t.requires_code_change,
+        filePaths: t.filePaths,
+        domains: t.domains,
+        lane: t.lane,
+        allocation_reason: t.allocation_reason,
       }, leaderCwd);
     }
 
@@ -2161,6 +2189,9 @@ export async function startTeam(
     }
 
     const allTasks = await listTasks(sanitized, leaderCwd);
+    if (options.decompositionMetadata) {
+      await writeDecompositionArtifacts(sanitized, leaderCwd, options.decompositionMetadata);
+    }
     const workerBootstrapPlans = [] as Array<{
       workerName: string;
       workerWorkspace: {
@@ -2228,6 +2259,7 @@ export async function startTeam(
         workerRole: runtimeRole,
         rolePromptContent: rawRolePromptContent ?? undefined,
         worktreeRootAgentsCanonical: Boolean(workerWorkspace.worktreePath),
+        taskHints: options.decompositionMetadata?.task_hints,
       });
       const triggerDirective = buildTriggerDirective(
         workerName,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2003,7 +2003,7 @@ async function writeDecompositionArtifacts(
   if (manifest) {
     await writeFile(
       join(root, 'manifest.v2.json'),
-      JSON.stringify({ ...manifest, policy: { ...manifest.policy, team_decomposition: metadata } }, null, 2),
+      JSON.stringify({ ...manifest, team_decomposition: metadata }, null, 2),
       'utf8',
     );
   }

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -258,6 +258,7 @@ export interface TeamManifestV2 {
   governance: TeamGovernance;
   lifecycle_profile: 'default';
   permissions_snapshot: PermissionsSnapshot;
+  team_decomposition?: Record<string, unknown>;
   tmux_session: string;
   worker_count: number;
   workers: WorkerInfo[];
@@ -988,6 +989,10 @@ export async function readTeamManifestV2(teamName: string, cwd: string): Promise
       policy?: Partial<TeamPolicy> & Partial<TeamGovernance>;
       governance?: Partial<TeamGovernance>;
     };
+    const legacyPolicy = parsedManifest.policy as (Partial<TeamPolicy> & Partial<TeamGovernance> & {
+      team_decomposition?: unknown;
+    }) | undefined;
+    const legacyTeamDecomposition = legacyPolicy?.team_decomposition;
     return {
       ...parsedManifest,
       policy: normalizeTeamPolicy(parsedManifest.policy, {
@@ -995,6 +1000,10 @@ export async function readTeamManifestV2(teamName: string, cwd: string): Promise
         worker_launch_mode: parsedManifest.policy?.worker_launch_mode === 'prompt' ? 'prompt' : 'interactive',
       }),
       governance: normalizeTeamGovernance(parsedManifest.governance, parsedManifest.policy),
+      team_decomposition: parsedManifest.team_decomposition
+        ?? (legacyTeamDecomposition && typeof legacyTeamDecomposition === 'object' && !Array.isArray(legacyTeamDecomposition)
+          ? legacyTeamDecomposition as Record<string, unknown>
+          : undefined),
       lifecycle_profile: 'default',
     };
   } catch {

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -156,6 +156,10 @@ export interface TeamTask {
   error?: string; // failure reason
   blocked_by?: string[]; // task IDs
   depends_on?: string[]; // task IDs
+  filePaths?: string[];
+  domains?: string[];
+  lane?: string;
+  allocation_reason?: string;
   version?: number;
   claim?: TeamTaskClaim;
   created_at: string;

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -182,6 +182,7 @@ export interface TeamManifestV2 {
   governance: TeamGovernance;
   lifecycle_profile: 'default';
   permissions_snapshot: PermissionsSnapshot;
+  team_decomposition?: Record<string, unknown>;
   tmux_session: string;
   worker_count: number;
   workers: WorkerInfo[];

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -10,6 +10,7 @@ import {
 import { codexHome, listInstalledSkillDirectories } from "../utils/paths.js";
 import { sleep } from "../utils/sleep.js";
 import type { TeamReminderDirective } from "./reminder-intents.js";
+import type { TaskHintSummary } from "./repo-aware-decomposition.js";
 
 const TEAM_OVERLAY_START = "<!-- OMX:TEAM:WORKER:START -->";
 const TEAM_OVERLAY_END = "<!-- OMX:TEAM:WORKER:END -->";
@@ -691,6 +692,7 @@ export function generateInitialInbox(
     workerRole?: string;
     rolePromptContent?: string;
     worktreeRootAgentsCanonical?: boolean;
+    taskHints?: Record<string, TaskHintSummary>;
   } = {},
 ): string {
   const taskList = tasks
@@ -699,8 +701,28 @@ export function generateInitialInbox(
       if (t.blocked_by && t.blocked_by.length > 0) {
         entry += `\n  Blocked by: ${t.blocked_by.join(", ")}`;
       }
+      if (t.depends_on && t.depends_on.length > 0 && !t.blocked_by?.length) {
+        entry += `\n  Depends on: ${t.depends_on.join(", ")}`;
+      }
       if (t.role) {
         entry += `\n  Role: ${t.role}`;
+      }
+      const hint = options.taskHints?.[t.id];
+      const filePaths = hint?.filePaths ?? t.filePaths;
+      const domains = hint?.domains ?? t.domains;
+      const lane = hint?.lane ?? t.lane;
+      const allocationReason = hint?.allocation_reason ?? t.allocation_reason;
+      if (filePaths?.length) {
+        entry += `\n  File paths: ${filePaths.join(", ")}`;
+      }
+      if (domains?.length) {
+        entry += `\n  Domains: ${domains.join(", ")}`;
+      }
+      if (lane) {
+        entry += `\n  Lane: ${lane}`;
+      }
+      if (allocationReason) {
+        entry += `\n  Allocation reason: ${allocationReason}`;
       }
       return entry;
     })


### PR DESCRIPTION
## Summary

This PR introduces an **experimental** repo-aware Team DAG handoff path for the RALPLAN -> Team workflow.

Instead of passing only prose from an approved plan into Team mode and letting Team re-split the prompt with shallow heuristics, Team startup can now read a structured `team-dag-<slug>.json` sidecar or embedded `## Team DAG Handoff` JSON block, normalize it into normal Team tasks, and preserve the planning metadata workers need: file ownership, domains, lanes, dependency ordering, allocation reasons, and worker-count provenance.

## Problem statement

The current RALPLAN -> Team flow preserves the high-level plan, but Team startup still largely acts on text. That makes worker allocation weaker than the planning phase because the runtime does not reliably know:

- which files or domains each worker should own
- which tasks are implementation, verification, or documentation lanes
- which tasks are dependency-blocked
- whether the requested worker count came from the CLI, the plan, or a default
- why a worker received a task

This is especially noticeable for complex Team runs where a good RALPLAN exists but Team still decomposes the launch prompt like a fresh standalone command.

## Root cause

Team mode had useful task-splitting, role-routing, and allocation seams, but there was no structured preflight contract between planning artifacts and Team runtime startup. Approved plans could suggest a team command, but the runtime did not consume a DAG artifact before creating Team tasks.

## What changed

- Added a Team DAG schema/parser in `src/team/dag-schema.ts`.
- Added `buildRepoAwareTeamExecutionPlan()` in `src/team/repo-aware-decomposition.ts`.
- Wired Team CLI startup through the repo-aware preflight before `startTeam()`.
- Added fallback behavior so legacy text decomposition remains unchanged when no valid DAG exists.
- Added worker-count provenance: `cli-explicit`, `plan-suggested`, or `default-derived`.
- Added symbolic DAG dependency remapping to concrete Team task IDs.
- Persisted repo-aware metadata into:
  - `.omx/state/team/<team>/decomposition-report.json`
  - manifest `policy.team_decomposition`
  - task fields used for worker inbox hints
- Extended worker inbox output with file paths, domains, lane, and allocation reason.
- Added a contract doc for the experimental handoff.
- Added regression coverage for sidecar/markdown precedence, malformed DAG fallback, worker-count behavior, dependency preservation, and inbox hint UX.

## Why this design

This keeps the feature as a bounded preflight layer instead of replacing the Team runtime.

Workers still use existing claim-safe Team lifecycle APIs. The DAG only compiles into normal Team tasks plus inspectable metadata. That makes the change easier to review, easier to disable through fallback, and less risky than introducing a second execution engine.

## Overlap assessment

Classification: **follow-up / adjacent but distinct**.

Related prior work:

- #443 added Team role routing and task decomposition.
- #761 added allocation/rebalance policy seams.
- #800 hardened worker decomposition and role-routing heuristics.
- #681 / #684 improved RALPLAN follow-up staffing guidance.
- #833 fixed post-RALPLAN Team follow-up context preservation.

Those PRs improved Team decomposition and handoff guidance, but this PR addresses the remaining gap: Team startup can now consume a structured repo-aware DAG artifact instead of only reinterpreting prose.

## Validation

Passed locally:

```bash
npm run build
node --test dist/planning/__tests__/artifacts.test.js dist/team/__tests__/repo-aware-decomposition.test.js dist/team/__tests__/worker-bootstrap.test.js
```

Focused test result: `63` tests passed, `0` failed.

## Risk / compatibility

- This is intentionally marked **experimental**.
- Legacy Team startup remains the fallback when no valid DAG handoff exists.
- Full `npm test` was not rerun for this PR; earlier Team-worker evidence reported unrelated `adapt.test` drift outside this change.
- The DAG handoff format is new and may need follow-up refinement after real Team runs.
- This PR does not make RALPLAN automatically emit complete DAG sidecars in every path; it makes Team capable of consuming them when present.

## Files changed

Key files:

- `src/team/dag-schema.ts`
- `src/team/repo-aware-decomposition.ts`
- `src/cli/team.ts`
- `src/team/runtime.ts`
- `src/team/worker-bootstrap.ts`
- `src/planning/artifacts.ts`
- `docs/contracts/repo-aware-team-dag-decomposition.md`
- `docs/reference/team-allocation-rebalance-policy.md`

Tests:

- `src/planning/__tests__/artifacts.test.ts`
- `src/team/__tests__/repo-aware-decomposition.test.ts`
- `src/team/__tests__/worker-bootstrap.test.ts`
