### PR TITLE
Preserve provider context for spawned Codex agents

### DIFF
--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -139,6 +139,46 @@ describe("agents/native-config", () => {
     }
   });
 
+  it("preserves active provider on native agents so websocket-capable Responses providers are inherited", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-config-provider-"));
+    const codexHome = join(root, ".codex");
+    const promptsDir = join(root, "prompts");
+    const outDir = join(codexHome, "agents");
+    const previousCodexHome = process.env.CODEX_HOME;
+
+    try {
+      delete process.env.OMX_DEFAULT_STANDARD_MODEL;
+      process.env.CODEX_HOME = codexHome;
+      await mkdir(promptsDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, "config.toml"), [
+        'model = "gpt-5.5"',
+        'model_provider = "cheapRouter"',
+        '',
+        '[model_providers.cheapRouter]',
+        'name = "Cheap Router"',
+        'base_url = "https://cheaprouter.uk/v1"',
+        'wire_api = "responses"',
+        'supports_websockets = true',
+        '',
+      ].join('\n'));
+      await writeFile(join(promptsDir, "executor.md"), "executor prompt");
+
+      await installNativeAgentConfigs(root, {
+        agentsDir: outDir,
+        catalogManifest: manifestWithAgents(["executor"]),
+      });
+      const executorToml = await readFile(join(outDir, "executor.toml"), "utf8");
+      assert.match(executorToml, /model = "gpt-5\.5"/);
+      assert.match(executorToml, /model_provider = "cheapRouter"/);
+    } finally {
+      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      process.env.OMX_DEFAULT_STANDARD_MODEL = "gpt-5.4-mini";
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("inherits a custom root model for standard agents when no standard override exists", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-native-config-root-model-"));
     const codexHome = join(root, ".codex");

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -11,6 +11,7 @@ import { readCatalogManifest } from "../catalog/reader.js";
 import type { CatalogManifest } from "../catalog/schema.js";
 import { getInstallableNativeAgentNames } from "./policy.js";
 import {
+  getCodexConfigRootModelProvider,
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
   getSparkDefaultModel,
@@ -105,6 +106,7 @@ export interface GeneratedNativeAgentConfig {
   description: string;
   developerInstructions?: string;
   model?: string;
+  modelProvider?: string;
   reasoningEffort?: "low" | "medium" | "high" | "xhigh";
 }
 
@@ -274,6 +276,9 @@ export function generateStandaloneAgentToml(
   if (config.model) {
     lines.push(`model = "${escapeTomlBasicString(config.model)}"`);
   }
+  if (config.modelProvider) {
+    lines.push(`model_provider = "${escapeTomlBasicString(config.modelProvider)}"`);
+  }
   if (config.reasoningEffort) {
     lines.push(`model_reasoning_effort = "${config.reasoningEffort}"`);
   }
@@ -300,11 +305,13 @@ export function generateAgentToml(
   options: AgentModelResolutionOptions = {},
 ): string {
   const resolvedModel = resolveAgentModel(agent, options);
+  const resolvedModelProvider = getCodexConfigRootModelProvider(options.codexHomeOverride);
   return generateStandaloneAgentToml({
     name: agent.name,
     description: agent.description,
     developerInstructions: composeRoleInstructions(promptContent, agent, resolvedModel),
     model: resolvedModel,
+    modelProvider: resolvedModelProvider,
     reasoningEffort: agent.reasoningEffort,
   });
 }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2803,6 +2803,21 @@ describe("team worker launch arg inheritance helpers", () => {
     );
   });
 
+
+  it("collectInheritableTeamWorkerArgs preserves only safe model_provider config overrides", () => {
+    assert.deepEqual(
+      collectInheritableTeamWorkerArgs([
+        "-c",
+        'sandbox_mode="danger-full-access"',
+        "-c",
+        'model_provider="cheapRouter"',
+        "--model",
+        "gpt-5.5",
+      ]),
+      ["-c", 'model_provider="cheapRouter"', "--model", "gpt-5.5"],
+    );
+  });
+
   it("resolveTeamWorkerLaunchArgsEnv merges and normalizes with de-dupe + last reasoning/model wins", () => {
     assert.equal(
       resolveTeamWorkerLaunchArgsEnv(

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -130,11 +130,12 @@ export function readConfiguredEnvOverrides(codexHomeOverride?: string): NodeJS.P
 export function readActiveProviderEnvOverrides(
   env: NodeJS.ProcessEnv = process.env,
   codexHomeOverride?: string,
+  activeProviderOverride?: string,
 ): NodeJS.ProcessEnv {
   const config = readCodexConfigFile(codexHomeOverride);
   if (!config) return {};
 
-  const activeProvider = normalizeConfiguredValue(config.model_provider);
+  const activeProvider = normalizeConfiguredValue(activeProviderOverride) ?? normalizeConfiguredValue(config.model_provider);
   if (!activeProvider) return {};
 
   const providers = config.model_providers;

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -166,6 +166,10 @@ function getCodexConfigRootModel(codexHomeOverride?: string): string | undefined
   return normalizeConfiguredValue(readCodexConfigFile(codexHomeOverride)?.model);
 }
 
+export function getCodexConfigRootModelProvider(codexHomeOverride?: string): string | undefined {
+  return normalizeConfiguredValue(readCodexConfigFile(codexHomeOverride)?.model_provider);
+}
+
 export function getEnvConfiguredStandardDefaultModel(
   env: NodeJS.ProcessEnv = process.env,
   codexHomeOverride?: string,

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -33,6 +33,31 @@ describe('team model contract', () => {
     );
   });
 
+
+  it('collects only safe model_provider config overrides for worker inheritance', () => {
+    assert.deepEqual(
+      collectInheritableTeamWorkerArgs([
+        '-c',
+        'sandbox_mode="danger-full-access"',
+        '-c',
+        'model_provider="cheapRouter"',
+        '--model',
+        'gpt-5.5',
+      ]),
+      ['-c', 'model_provider="cheapRouter"', '--model', 'gpt-5.5'],
+    );
+  });
+
+  it('keeps exactly one model_provider override with precedence env > inherited', () => {
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({
+        existingRaw: '-c model_provider="envRouter" --no-alt-screen',
+        inheritedArgs: ['-c', 'model_provider="leaderRouter"', '--model', 'gpt-5.5'],
+      }),
+      ['--no-alt-screen', '-c', 'model_provider="envRouter"', '--model', 'gpt-5.5'],
+    );
+  });
+
   it('keeps exactly one canonical model flag with precedence env > inherited > fallback', () => {
     assert.deepEqual(
       resolveTeamWorkerLaunchArgs({

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -2055,6 +2055,52 @@ describe('team worker launch mode helpers', () => {
     }
   });
 
+  it('buildWorkerProcessLaunchSpec preserves ambient CODEX_HOME so Codex workers keep provider websocket metadata', async () => {
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevCodexHome = process.env.CODEX_HOME;
+    const prevProviderEnv = process.env.CUSTOM_PROVIDER_API_KEY;
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-team-provider-websocket-'));
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.CODEX_HOME = codexHome;
+    process.env.CUSTOM_PROVIDER_API_KEY = 'test-secret';
+
+    try {
+      await writeFile(join(codexHome, 'config.toml'), [
+        'model = "gpt-5.5"',
+        'model_provider = "custom_provider"',
+        '',
+        '[model_providers.custom_provider]',
+        'name = "custom_provider"',
+        'base_url = "http://localhost:3000/v1"',
+        'wire_api = "responses"',
+        'supports_websockets = true',
+        'requires_openai_auth = true',
+        'env_key = "CUSTOM_PROVIDER_API_KEY"',
+        '',
+      ].join('\n'));
+
+      const spec = buildWorkerProcessLaunchSpec(
+        'websocket-team',
+        1,
+        [],
+        '/tmp/workspace',
+        {},
+        'codex',
+      );
+
+      assert.equal(spec.env.CODEX_HOME, codexHome);
+      assert.equal(spec.env.CUSTOM_PROVIDER_API_KEY, 'test-secret');
+    } finally {
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevCodexHome === 'string') process.env.CODEX_HOME = prevCodexHome;
+      else delete process.env.CODEX_HOME;
+      if (typeof prevProviderEnv === 'string') process.env.CUSTOM_PROVIDER_API_KEY = prevProviderEnv;
+      else delete process.env.CUSTOM_PROVIDER_API_KEY;
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
   it('buildWorkerProcessLaunchSpec injects the active provider env_key from CODEX_HOME config.toml', async () => {
     const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
     const prevCodexHome = process.env.CODEX_HOME;
@@ -2130,6 +2176,7 @@ describe('team worker launch mode helpers', () => {
       );
 
       assert.equal(spec.workerCli, 'claude');
+      assert.equal(spec.env.CODEX_HOME, undefined);
       assert.equal(spec.env.CUSTOM_PROVIDER_API_KEY, undefined);
     } finally {
       if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -2144,6 +2144,62 @@ describe('team worker launch mode helpers', () => {
     }
   });
 
+  it('buildWorkerProcessLaunchSpec uses CLI model_provider override for Codex provider env injection', async () => {
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevCodexHome = process.env.CODEX_HOME;
+    const prevDefaultProviderEnv = process.env.DEFAULT_PROVIDER_API_KEY;
+    const prevCheapProviderEnv = process.env.CHEAP_PROVIDER_API_KEY;
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-team-provider-cli-override-'));
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.CODEX_HOME = codexHome;
+    process.env.DEFAULT_PROVIDER_API_KEY = 'default-secret';
+    process.env.CHEAP_PROVIDER_API_KEY = 'cheap-secret';
+
+    try {
+      await writeFile(join(codexHome, 'config.toml'), [
+        'model_provider = "default_provider"',
+        '',
+        '[model_providers.default_provider]',
+        'name = "default_provider"',
+        'base_url = "http://localhost:3000/v1"',
+        'wire_api = "responses"',
+        'requires_openai_auth = true',
+        'env_key = "DEFAULT_PROVIDER_API_KEY"',
+        '',
+        '[model_providers.cheapRouter]',
+        'name = "cheapRouter"',
+        'base_url = "http://localhost:4000/v1"',
+        'wire_api = "responses"',
+        'requires_openai_auth = true',
+        'env_key = "CHEAP_PROVIDER_API_KEY"',
+        '',
+      ].join('\n'));
+
+      const spec = buildWorkerProcessLaunchSpec(
+        'provider-override-team',
+        1,
+        ['-c', 'model_provider="cheapRouter"', '--model', 'gpt-5.5'],
+        '/tmp/workspace',
+        {},
+        'codex',
+      );
+
+      assert.equal(spec.env.CHEAP_PROVIDER_API_KEY, 'cheap-secret');
+      assert.equal(spec.env.DEFAULT_PROVIDER_API_KEY, undefined);
+      assert.deepEqual(spec.args.slice(0, 4), ['-c', 'model_provider="cheapRouter"', '--model', 'gpt-5.5']);
+    } finally {
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevCodexHome === 'string') process.env.CODEX_HOME = prevCodexHome;
+      else delete process.env.CODEX_HOME;
+      if (typeof prevDefaultProviderEnv === 'string') process.env.DEFAULT_PROVIDER_API_KEY = prevDefaultProviderEnv;
+      else delete process.env.DEFAULT_PROVIDER_API_KEY;
+      if (typeof prevCheapProviderEnv === 'string') process.env.CHEAP_PROVIDER_API_KEY = prevCheapProviderEnv;
+      else delete process.env.CHEAP_PROVIDER_API_KEY;
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
   it('buildWorkerProcessLaunchSpec does not inject the active provider env_key for non-codex workers', async () => {
     const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
     const prevCodexHome = process.env.CODEX_HOME;

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -11,6 +11,7 @@ const CODEX_BYPASS_FLAG = '--dangerously-bypass-approvals-and-sandbox';
 const MODEL_FLAG = '--model';
 const CONFIG_FLAG = '-c';
 const REASONING_KEY = 'model_reasoning_effort';
+const MODEL_PROVIDER_KEY = 'model_provider';
 
 const LOW_COMPLEXITY_AGENT_TYPES = new Set([
   'explore',
@@ -26,6 +27,7 @@ export interface ParsedTeamWorkerLaunchArgs {
   passthrough: string[];
   wantsBypass: boolean;
   reasoningOverride: string | null;
+  modelProviderOverride: string | null;
   modelOverride: string | null;
 }
 
@@ -37,8 +39,26 @@ export interface ResolveTeamWorkerLaunchArgsOptions {
 }
 
 
+function isConfigOverrideForKey(value: string, key: string): boolean {
+  return new RegExp(`^${key}\\s*=`).test(value.trim());
+}
+
 function isReasoningOverride(value: string): boolean {
-  return new RegExp(`^${REASONING_KEY}\\s*=`).test(value.trim());
+  return isConfigOverrideForKey(value, REASONING_KEY);
+}
+
+function isModelProviderOverride(value: string): boolean {
+  return isConfigOverrideForKey(value, MODEL_PROVIDER_KEY);
+}
+
+function extractConfigStringValue(value: string, key: string): string | null {
+  const trimmed = value.trim();
+  const match = new RegExp(`^${key}\\s*=\\s*(.+)$`).exec(trimmed);
+  if (!match) return null;
+  const raw = match[1]?.trim() ?? '';
+  if (raw === '') return null;
+  const quoted = /^(?:\"([^\"]*)\"|'([^']*)')$/.exec(raw);
+  return (quoted?.[1] ?? quoted?.[2] ?? raw).trim() || null;
 }
 
 function isValidModelValue(value: string): boolean {
@@ -72,6 +92,7 @@ export function parseTeamWorkerLaunchArgs(args: string[]): ParsedTeamWorkerLaunc
   const passthrough: string[] = [];
   let wantsBypass = false;
   let reasoningOverride: string | null = null;
+  let modelProviderOverride: string | null = null;
   let modelOverride: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
@@ -107,6 +128,11 @@ export function parseTeamWorkerLaunchArgs(args: string[]): ParsedTeamWorkerLaunc
         i += 1;
         continue;
       }
+      if (typeof maybeValue === 'string' && isModelProviderOverride(maybeValue)) {
+        modelProviderOverride = maybeValue;
+        i += 1;
+        continue;
+      }
     }
 
     passthrough.push(arg);
@@ -116,6 +142,7 @@ export function parseTeamWorkerLaunchArgs(args: string[]): ParsedTeamWorkerLaunc
     passthrough,
     wantsBypass,
     reasoningOverride,
+    modelProviderOverride,
     modelOverride,
   };
 }
@@ -125,15 +152,23 @@ export function collectInheritableTeamWorkerArgs(codexArgs: string[]): string[] 
 
   const inherited: string[] = [];
   if (parsed.wantsBypass) inherited.push(CODEX_BYPASS_FLAG);
+  if (parsed.modelProviderOverride) inherited.push(CONFIG_FLAG, parsed.modelProviderOverride);
   if (parsed.reasoningOverride) inherited.push(CONFIG_FLAG, parsed.reasoningOverride);
   if (parsed.modelOverride) inherited.push(MODEL_FLAG, parsed.modelOverride);
   return inherited;
+}
+
+export function extractModelProviderOverrideValue(args: string[]): string | undefined {
+  const override = parseTeamWorkerLaunchArgs(args).modelProviderOverride;
+  if (!override) return undefined;
+  return extractConfigStringValue(override, MODEL_PROVIDER_KEY) ?? undefined;
 }
 
 export function normalizeTeamWorkerLaunchArgs(
   args: string[],
   preferredModel?: string,
   preferredReasoning?: TeamReasoningEffort,
+  preferredModelProviderOverride?: string,
 ): string[] {
   const parsed = parseTeamWorkerLaunchArgs(args);
   const normalized = [...parsed.passthrough];
@@ -144,6 +179,8 @@ export function normalizeTeamWorkerLaunchArgs(
     ?? (normalizeOptionalReasoning(preferredReasoning)
       ? `${REASONING_KEY}="${normalizeOptionalReasoning(preferredReasoning)}"`
       : null);
+  const selectedModelProvider = preferredModelProviderOverride ?? parsed.modelProviderOverride;
+  if (selectedModelProvider) normalized.push(CONFIG_FLAG, selectedModelProvider);
   if (selectedReasoning) normalized.push(CONFIG_FLAG, selectedReasoning);
 
   const selectedModel = normalizeOptionalModel(preferredModel) ?? normalizeOptionalModel(parsed.modelOverride);
@@ -157,11 +194,14 @@ export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgs
   const inheritedArgs = options.inheritedArgs ?? [];
   const allArgs = [...envArgs, ...inheritedArgs];
 
-  const envModel = normalizeOptionalModel(parseTeamWorkerLaunchArgs(envArgs).modelOverride);
-  const inheritedModel = normalizeOptionalModel(parseTeamWorkerLaunchArgs(inheritedArgs).modelOverride);
+  const envParsed = parseTeamWorkerLaunchArgs(envArgs);
+  const inheritedParsed = parseTeamWorkerLaunchArgs(inheritedArgs);
+  const envModel = normalizeOptionalModel(envParsed.modelOverride);
+  const inheritedModel = normalizeOptionalModel(inheritedParsed.modelOverride);
   const fallbackModel = normalizeOptionalModel(options.fallbackModel);
   const selectedModel = envModel ?? inheritedModel ?? fallbackModel;
-  return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel, options.preferredReasoning);
+  const selectedModelProvider = envParsed.modelProviderOverride ?? inheritedParsed.modelProviderOverride ?? undefined;
+  return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel, options.preferredReasoning, selectedModelProvider);
 }
 
 export function resolveAgentReasoningEffort(agentType?: string): TeamReasoningEffort | undefined {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -925,16 +925,20 @@ export function buildWorkerProcessLaunchSpec(
     ? buildPlatformCommandSpec(workerCli, effectiveCliLaunchArgs, process.platform, effectiveEnv)
     : { command: resolvedCliPath, args: effectiveCliLaunchArgs };
   const resolvedLauncherPath = platformSpec.resolvedPath || resolvedCliPath;
+  const codexProviderEnv = workerCli === 'codex'
+    ? readActiveProviderEnvOverrides(
+        effectiveEnv,
+        providerLookupCodexHome,
+      )
+    : {};
   const workerEnv: Record<string, string> = {
     OMX_TEAM_WORKER: `${teamName}/worker-${workerIndex}`,
     [OMX_LEADER_NODE_PATH_ENV]: resolveLeaderNodePath(),
     [OMX_LEADER_CLI_PATH_ENV]: resolvedLauncherPath,
-    ...(workerCli === 'codex'
-      ? readActiveProviderEnvOverrides(
-          effectiveEnv,
-          providerLookupCodexHome,
-        )
+    ...(workerCli === 'codex' && workerCodexHomeOverride
+      ? { CODEX_HOME: workerCodexHomeOverride }
       : {}),
+    ...codexProviderEnv,
   };
   for (const [key, value] of Object.entries(extraEnv)) {
     if (typeof value !== 'string' || value.trim() === '') continue;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -21,6 +21,7 @@ import {
   paneLooksReady as sharedPaneLooksReady,
 } from '../scripts/tmux-hook-engine.js';
 import { readActiveProviderEnvOverrides } from '../config/models.js';
+import { extractModelProviderOverrideValue } from './model-contract.js';
 import { sleep, sleepSync } from '../utils/sleep.js';
 import {
   buildPlatformCommandSpec,
@@ -925,10 +926,14 @@ export function buildWorkerProcessLaunchSpec(
     ? buildPlatformCommandSpec(workerCli, effectiveCliLaunchArgs, process.platform, effectiveEnv)
     : { command: resolvedCliPath, args: effectiveCliLaunchArgs };
   const resolvedLauncherPath = platformSpec.resolvedPath || resolvedCliPath;
+  const modelProviderOverride = workerCli === 'codex'
+    ? extractModelProviderOverrideValue(effectiveCliLaunchArgs)
+    : undefined;
   const codexProviderEnv = workerCli === 'codex'
     ? readActiveProviderEnvOverrides(
         effectiveEnv,
         providerLookupCodexHome,
+        modelProviderOverride,
       )
     : {};
   const workerEnv: Record<string, string> = {


### PR DESCRIPTION
## Summary
- preserve effective `CODEX_HOME` for spawned Codex team workers so they can read the same provider config as the leader session
- emit the active `model_provider` into generated native agent TOMLs so native spawned agents inherit WebSocket-capable Responses providers instead of falling back to provider defaults
- add regressions for `wire_api = "responses"` with `supports_websockets = true` while keeping non-Codex workers isolated from Codex provider context

Fixes #1930.

## Verification
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/team/__tests__/tmux-session.test.js dist/agents/__tests__/native-config.test.js`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
