### PR TITLE
Fix forced setup status line preset sync

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -404,6 +404,52 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("keeps forced HUD config overwrite and generated status_line preset in sync", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      await mkdir(join(wd, ".codex"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "hud-config.json"),
+        JSON.stringify({
+          preset: "focused",
+          statusLine: { preset: "minimal" },
+        }),
+      );
+      await writeFile(
+        join(wd, ".codex", "config.toml"),
+        [
+          "[tui]",
+          "# omx:managed-status-line",
+          'status_line = ["model-with-reasoning", "git-branch"]',
+          "",
+        ].join("\n"),
+      );
+
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        force: true,
+      });
+
+      const hudConfig = JSON.parse(
+        await readFile(join(wd, ".omx", "hud-config.json"), "utf-8"),
+      ) as { preset?: unknown };
+      assert.equal(hudConfig.preset, "focused");
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.match(
+        config,
+        /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
+      );
+      assert.doesNotMatch(
+        config,
+        /^status_line = \["model-with-reasoning", "git-branch"\]$/m,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps OMX-managed [tui] writes for older Codex CLI versions", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -450,6 +450,49 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("preserves user-owned status_line during forced setup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      await mkdir(join(wd, ".codex"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "hud-config.json"),
+        JSON.stringify({
+          preset: "focused",
+          statusLine: { preset: "minimal" },
+        }),
+      );
+      await writeFile(
+        join(wd, ".codex", "config.toml"),
+        [
+          'model = "gpt-5.5"',
+          "",
+          "[tui]",
+          'theme = "night"',
+          'status_line = ["git-branch"]',
+          "",
+        ].join("\n"),
+      );
+
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        force: true,
+        codexVersionProbe: () => "codex-cli 0.107.0",
+      });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.equal(config.match(/^\[tui\]$/gm)?.length ?? 0, 1);
+      assert.match(config, /^theme = "night"$/m);
+      assert.match(config, /^status_line = \["git-branch"\]$/m);
+      assert.doesNotMatch(
+        config,
+        /^status_line = \["model-with-reasoning", "git-branch", "context-remaining"/m,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps OMX-managed [tui] writes for older Codex CLI versions", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -69,11 +69,15 @@ import {
   isOmxGeneratedAgentsMd,
   upsertManagedAgentsBlock,
 } from "../utils/agents-md.js";
-import type { HudPreset } from "../hud/types.js";
+import { DEFAULT_HUD_CONFIG, type HudPreset } from "../hud/types.js";
 
-async function readStatusLinePresetFromHudConfig(
+async function resolveStatusLinePresetForSetup(
   projectRoot: string,
+  options: Pick<SetupOptions, "force">,
 ): Promise<HudPreset | undefined> {
+  if (options.force) {
+    return DEFAULT_HUD_CONFIG.statusLine.preset;
+  }
   const path = join(projectRoot, ".omx", "hud-config.json");
   if (!existsSync(path)) return undefined;
   try {
@@ -1811,8 +1815,9 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     for (const warning of sharedMcpRegistry.warnings) {
       console.log(`  warning: ${warning}`);
     }
-    const statusLinePreset =
-      await readStatusLinePresetFromHudConfig(projectRoot);
+    const statusLinePreset = await resolveStatusLinePresetForSetup(projectRoot, {
+      force,
+    });
     const managedConfig = await updateManagedConfig(
       scopeDirs.codexConfigFile,
       pkgRoot,
@@ -1824,6 +1829,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
         modelUpgradePrompt,
         verbose,
         statusLinePreset,
+        forceStatusLinePreset: force,
       },
     );
     resolvedConfig = managedConfig.finalConfig;
@@ -2888,7 +2894,7 @@ async function updateManagedConfig(
   options: Pick<
     SetupOptions,
     "dryRun" | "verbose" | "modelUpgradePrompt"
-  > & { statusLinePreset?: HudPreset },
+  > & { statusLinePreset?: HudPreset; forceStatusLinePreset?: boolean },
 ): Promise<ManagedConfigResult> {
   const existing = existsSync(configPath)
     ? await readFile(configPath, "utf-8")
@@ -2919,6 +2925,7 @@ async function updateManagedConfig(
     sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
     verbose: options.verbose,
     statusLinePreset: options.statusLinePreset,
+    forceStatusLinePreset: options.forceStatusLinePreset,
   });
   const changed = existing !== finalConfig;
 

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -827,13 +827,22 @@ function upsertTuiStatusLine(
   let preservedStatusLine: string | undefined;
 
   for (const section of sections) {
+    let lastNonBlankBeforeStatusLine: string | undefined;
+
     for (let i = section.start + 1; i < section.end; i++) {
       const line = lines[i];
       const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) continue;
+      if (!trimmed) continue;
+      if (trimmed.startsWith("#")) {
+        lastNonBlankBeforeStatusLine = trimmed;
+        continue;
+      }
 
       const keyMatch = trimmed.match(/^([A-Za-z0-9_-]+)\s*=/);
-      if (!keyMatch) continue;
+      if (!keyMatch) {
+        lastNonBlankBeforeStatusLine = trimmed;
+        continue;
+      }
 
       const key = keyMatch[1];
       if (key === "status_line") {
@@ -845,14 +854,29 @@ function upsertTuiStatusLine(
           i += 1;
           entryLines.push(lines[i].trim());
         }
-        if (!options.forceStatusLinePreset) {
-          preservedStatusLine ??= entryLines.join("\n");
+        const statusLineEntry = entryLines.join("\n");
+        const hasMarker =
+          lastNonBlankBeforeStatusLine === OMX_MANAGED_STATUS_LINE_MARKER;
+        const isManagedByMarker =
+          hasMarker && OMX_PRESET_STATUS_LINE_VALUES.has(statusLineEntry);
+        const isManagedByLegacyValue =
+          !hasMarker && statusLineEntry === LEGACY_OMX_STATUS_LINE;
+        const isOmxManagedStatusLine =
+          isManagedByMarker || isManagedByLegacyValue;
+
+        if (!options.forceStatusLinePreset || !isOmxManagedStatusLine) {
+          preservedStatusLine ??= statusLineEntry;
         }
+        lastNonBlankBeforeStatusLine = statusLineEntry;
         continue;
       }
-      if (seenKeys.has(key)) continue;
+      if (seenKeys.has(key)) {
+        lastNonBlankBeforeStatusLine = trimmed;
+        continue;
+      }
       seenKeys.add(key);
       preservedKeyLines.push(trimmed);
+      lastNonBlankBeforeStatusLine = trimmed;
     }
   }
 
@@ -1229,9 +1253,8 @@ export function buildMergedConfig(
   const includeTui = options.includeTui !== false;
   const statusLinePreset =
     options.statusLinePreset ?? DEFAULT_STATUS_LINE_PRESET;
-  const customizedManagedTuiSections = options.forceStatusLinePreset
-    ? []
-    : extractCustomizedTuiSectionsFromOmxBlocks(existing);
+  const customizedManagedTuiSections =
+    extractCustomizedTuiSectionsFromOmxBlocks(existing);
 
   if (existing.includes(OMX_CONFIG_MARKER)) {
     const stripped = stripExistingOmxBlocks(existing);

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -27,6 +27,7 @@ interface MergeOptions {
   sharedMcpRegistrySource?: string;
   verbose?: boolean;
   statusLinePreset?: HudPreset;
+  forceStatusLinePreset?: boolean;
 }
 
 function escapeTomlString(value: string): string {
@@ -795,6 +796,7 @@ function extractCustomizedTuiSectionsFromOmxBlocks(config: string): string[] {
 function upsertTuiStatusLine(
   config: string,
   preset: HudPreset = DEFAULT_STATUS_LINE_PRESET,
+  options: { forceStatusLinePreset?: boolean } = {},
 ): {
   cleaned: string;
   hadExistingTui: boolean;
@@ -843,7 +845,9 @@ function upsertTuiStatusLine(
           i += 1;
           entryLines.push(lines[i].trim());
         }
-        preservedStatusLine ??= entryLines.join("\n");
+        if (!options.forceStatusLinePreset) {
+          preservedStatusLine ??= entryLines.join("\n");
+        }
         continue;
       }
       if (seenKeys.has(key)) continue;
@@ -1225,8 +1229,9 @@ export function buildMergedConfig(
   const includeTui = options.includeTui !== false;
   const statusLinePreset =
     options.statusLinePreset ?? DEFAULT_STATUS_LINE_PRESET;
-  const customizedManagedTuiSections =
-    extractCustomizedTuiSectionsFromOmxBlocks(existing);
+  const customizedManagedTuiSections = options.forceStatusLinePreset
+    ? []
+    : extractCustomizedTuiSectionsFromOmxBlocks(existing);
 
   if (existing.includes(OMX_CONFIG_MARKER)) {
     const stripped = stripExistingOmxBlocks(existing);
@@ -1250,7 +1255,9 @@ export function buildMergedConfig(
   existing = upsertEnvSettings(existing);
   existing = upsertAgentsSettings(existing);
   const tuiUpsert = includeTui
-    ? upsertTuiStatusLine(existing, statusLinePreset)
+    ? upsertTuiStatusLine(existing, statusLinePreset, {
+        forceStatusLinePreset: options.forceStatusLinePreset,
+      })
     : { cleaned: existing, hadExistingTui: false };
   existing = tuiUpsert.cleaned;
 


### PR DESCRIPTION
## Summary
- Fixes the #1953 follow-up regression where `omx setup --scope project --force` could read a stale `.omx/hud-config.json` `statusLine.preset` before overwriting HUD config.
- Uses the forced HUD default preset when generating config during forced setup and regenerates `[tui].status_line` instead of preserving the stale value.
- Adds regression coverage for the minimal-to-focused force-sync repro.

## Verification
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/cli/__tests__/setup-refresh.test.js dist/config/__tests__/generator-status-line-presets.test.js`
- Manual repro with `node dist/cli/omx.js setup --scope project --force` confirmed HUD config and `status_line` both focused/default.

Fixes the #1953 follow-up regression.