### PR TITLE
Protect active MCP transports from sibling cleanup

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -251,7 +251,7 @@ describe('mcp duplicate sibling detection', () => {
     );
   });
 
-  it('does not self-exit after post-duplicate traffic until the duplicate has remained safely idle long enough', () => {
+  it('does not self-exit after any client traffic even when a newer sibling appears', () => {
     const observation = {
       status: 'older_duplicate' as const,
       entrypoint: 'state-server.js',
@@ -265,11 +265,11 @@ describe('mcp duplicate sibling detection', () => {
     );
     assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 311_000, 1_000, 10_000),
-      true,
+      false,
     );
   });
 
-  it('uses the duplicate grace window when last traffic predates duplicate observation', () => {
+  it('keeps an already-initialized older sibling alive when last traffic predates duplicate observation', () => {
     const observation = {
       status: 'older_duplicate' as const,
       entrypoint: 'state-server.js',
@@ -283,7 +283,7 @@ describe('mcp duplicate sibling detection', () => {
     );
     assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 11_100, 9_000, 1_000),
-      true,
+      false,
     );
   });
 

--- a/src/mcp/__tests__/server-lifecycle.test.ts
+++ b/src/mcp/__tests__/server-lifecycle.test.ts
@@ -213,7 +213,7 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
     });
   }
 
-  it('older duplicate entrypoints self-exit after post-duplicate idle while the newest sibling survives', async () => {
+  it('uninitialized older duplicate entrypoints self-exit while the newest sibling survives', async () => {
     const entrypoint = IDLE_ENTRYPOINTS[0];
     const sharedEnv = {
       ...process.env,
@@ -242,7 +242,62 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
       await waitForSpawn(older, entrypoint, stderr, stdout);
       await assertChildAliveBeforeTeardown(older, entrypoint, stderr, stdout);
 
-      older.stdin?.write('pre-duplicate-traffic');
+      newer = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
+        cwd: process.cwd(),
+        env: sharedEnv,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      attachLogs(newer);
+      await waitForSpawn(newer, entrypoint, stderr, stdout);
+      await assertChildAliveBeforeTeardown(newer, entrypoint, stderr, stdout);
+
+      await waitForCondition(
+        () => !isChildAlive(older),
+        2_500,
+        `older duplicate failed to self-exit: ${formatFailureContext(entrypoint, stderr, stdout)}`,
+      );
+
+      assert.equal(isChildAlive(newer), true, `newest duplicate should survive: ${formatFailureContext(entrypoint, stderr, stdout)}`);
+      const olderExit = await waitForExit(older, entrypoint, stderr, stdout);
+      assert.notEqual(olderExit.signal, 'SIGKILL');
+    } finally {
+      await forceCleanup(older);
+      if (newer) {
+        await forceCleanup(newer);
+      }
+    }
+  });
+
+  it('initialized older duplicate entrypoints remain alive when a native subagent sibling starts', async () => {
+    const entrypoint = IDLE_ENTRYPOINTS[0];
+    const sharedEnv = {
+      ...process.env,
+      OMX_MCP_PARENT_WATCHDOG_INTERVAL_MS: '250',
+      OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS: '250',
+      OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS: '750',
+    };
+    const older = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
+      cwd: process.cwd(),
+      env: sharedEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let newer: ChildProcess | null = null;
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const attachLogs = (child: ChildProcess) => {
+      child.stdout?.setEncoding('utf8');
+      child.stderr?.setEncoding('utf8');
+      child.stdout?.on('data', (chunk: string) => stdout.push(chunk));
+      child.stderr?.on('data', (chunk: string) => stderr.push(chunk));
+    };
+    attachLogs(older);
+
+    try {
+      await waitForSpawn(older, entrypoint, stderr, stdout);
+      await assertChildAliveBeforeTeardown(older, entrypoint, stderr, stdout);
+
+      older.stdin?.write('leader-initialize-traffic');
       await delay(100);
 
       newer = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
@@ -254,17 +309,18 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
       await waitForSpawn(newer, entrypoint, stderr, stdout);
       await assertChildAliveBeforeTeardown(newer, entrypoint, stderr, stdout);
 
-      await delay(400);
-      older.stdin?.write('post-duplicate-traffic');
-      await waitForCondition(
-        () => !isChildAlive(older),
-        2_500,
-        `older duplicate failed to self-exit: ${formatFailureContext(entrypoint, stderr, stdout)}`,
-      );
+      await delay(1_500);
 
-      assert.equal(isChildAlive(newer), true, `newest duplicate should survive: ${formatFailureContext(entrypoint, stderr, stdout)}`);
-      const olderExit = await waitForExit(older, entrypoint, stderr, stdout);
-      assert.notEqual(olderExit.signal, 'SIGKILL');
+      assert.equal(
+        isChildAlive(older),
+        true,
+        `initialized older sibling should keep active transport alive: ${formatFailureContext(entrypoint, stderr, stdout)}`,
+      );
+      assert.equal(
+        isChildAlive(newer),
+        true,
+        `newer sibling should also survive: ${formatFailureContext(entrypoint, stderr, stdout)}`,
+      );
     } finally {
       await forceCleanup(older);
       if (newer) {

--- a/src/mcp/__tests__/server-lifecycle.test.ts
+++ b/src/mcp/__tests__/server-lifecycle.test.ts
@@ -219,7 +219,7 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
       ...process.env,
       OMX_MCP_PARENT_WATCHDOG_INTERVAL_MS: '250',
       OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS: '250',
-      OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS: '750',
+      OMX_MCP_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS: '500',
     };
     const older = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
       cwd: process.cwd(),
@@ -253,7 +253,7 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
 
       await waitForCondition(
         () => !isChildAlive(older),
-        2_500,
+        4_000,
         `older duplicate failed to self-exit: ${formatFailureContext(entrypoint, stderr, stdout)}`,
       );
 
@@ -274,7 +274,7 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
       ...process.env,
       OMX_MCP_PARENT_WATCHDOG_INTERVAL_MS: '250',
       OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS: '250',
-      OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS: '750',
+      OMX_MCP_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS: '500',
     };
     const older = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
       cwd: process.cwd(),

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -226,7 +226,7 @@ export function shouldSelfExitForDuplicateSibling(
   duplicateObservedAtMs: number | null,
   lastTrafficAtMs: number | null,
   preTrafficGraceMs = DEFAULT_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS,
-  postTrafficIdleMs = DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
+  _postTrafficIdleMs = DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
 ): boolean {
   if (observation.status !== 'older_duplicate') {
     return false;
@@ -239,10 +239,16 @@ export function shouldSelfExitForDuplicateSibling(
     return false;
   }
 
-  if (lastTrafficAtMs === null || lastTrafficAtMs <= duplicateObservedAtMs) {
-    return nowMs - duplicateObservedAtMs >= preTrafficGraceMs;
+  if (lastTrafficAtMs !== null) {
+    // Any stdin traffic means a client has already initialized or otherwise owns
+    // this stdio transport. In Codex App native subagent sessions, leader and
+    // subagent MCP servers can share a parent process and entrypoint while both
+    // transports remain active, so PID age alone is not safe proof that the
+    // older process is a stale duplicate.
+    return false;
   }
-  return nowMs - lastTrafficAtMs >= postTrafficIdleMs;
+
+  return nowMs - duplicateObservedAtMs >= preTrafficGraceMs;
 }
 
 export function isParentProcessAlive(


### PR DESCRIPTION
## Summary

Fixes #1960 by making the stdio MCP duplicate-sibling watchdog preserve any server process that has observed client stdin traffic.

Codex App native subagents can start another same-entrypoint MCP server under the same app-server parent as the leader. The old PID-order cleanup path could then classify the leader's older process as superseded and close its active transport after the post-traffic idle window. With this change, PID age is only allowed to clean up uninitialized/pre-traffic duplicate siblings; once a client has touched the transport, duplicate cleanup fails safe and leaves it alive.

## Relationship to #1959

I inspected #1959 first. That PR keeps plugin-launched `omx mcp-serve` wrapper processes alive long enough for stdio MCP initialization. This PR addresses the separate duplicate sibling watchdog path in `src/mcp/bootstrap.ts`; it does not duplicate the #1959 wrapper-lifetime fix.

## Validation

- `npm run build`
- `npm run check:no-unused`
- `node --test dist/mcp/__tests__/bootstrap.test.js dist/mcp/__tests__/server-lifecycle.test.js`
- `node --test dist/cli/__tests__/mcp-serve.test.js dist/cli/__tests__/package-bin-contract.test.js dist/cli/__tests__/codex-plugin-layout.test.js dist/agents/__tests__/native-config.test.js`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js`

## Notes

Not live-tested in a real Codex App/native subagent session. Regression coverage models the key lifecycle distinction: uninitialized older duplicates still self-exit, while initialized older siblings remain alive when a newer same-entrypoint sibling starts.
