### PR TITLE
Allow audited follow-ups for running exec jobs

### DIFF
--- a/src/cli/__tests__/exec.test.ts
+++ b/src/cli/__tests__/exec.test.ts
@@ -73,6 +73,36 @@ describe('omx exec', () => {
     }
   });
 
+  it('preserves all follow-up prompts from concurrent injections', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-exec-followup-concurrent-'));
+    try {
+      const session = await writeSessionStart(wd, 'omx-test-concurrent-followup');
+      const count = 25;
+      const results = await Promise.all(Array.from({ length: count }, async (_, index) => (
+        injectExecFollowup({
+          cwd: wd,
+          sessionId: session.session_id,
+          actor: `operator-${index}`,
+          prompt: `Concurrent follow-up ${index}`,
+          nowIso: '2026-04-27T10:01:00.000Z',
+        })
+      )));
+
+      const pending = await readPendingExecFollowups(wd, session.session_id);
+      assert.equal(pending.pending.length, count);
+      assert.deepEqual(
+        [...new Set(pending.pending.map((record) => record.id))].sort(),
+        results.map((result) => result.queued.id).sort(),
+      );
+      assert.deepEqual(
+        pending.pending.map((record) => record.prompt).sort(),
+        Array.from({ length: count }, (_, index) => `Concurrent follow-up ${index}`).sort(),
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('delivers queued follow-ups through Stop hook output and marks them delivered', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-exec-followup-stop-'));
     try {
@@ -98,6 +128,34 @@ describe('omx exec', () => {
       };
       assert.equal(persisted.records[0]?.delivery_event, 'stop-hook');
       assert.ok(persisted.records[0]?.delivered_at);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('quarantines malformed follow-up queue JSON instead of crashing Stop delivery', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-exec-followup-corrupt-'));
+    try {
+      const session = await writeSessionStart(wd, 'omx-test-corrupt-followup');
+      const queuePath = join(wd, '.omx', 'state', 'sessions', session.session_id, 'exec-followups.json');
+      await mkdir(dirname(queuePath), { recursive: true });
+      await writeFile(queuePath, '{"version":1,"records":[', 'utf-8');
+
+      const output = await buildExecFollowupStopOutput(wd, session.session_id);
+      assert.equal(output, null);
+
+      const recovered = JSON.parse(await readFile(queuePath, 'utf-8')) as {
+        records: Array<Record<string, unknown>>;
+      };
+      assert.deepEqual(recovered.records, []);
+
+      const queueDirEntries = await readdir(dirname(queuePath));
+      assert.ok(
+        queueDirEntries.some((entry) => entry.startsWith('exec-followups.json.corrupt-')),
+        'malformed queue should be quarantined beside the recovered queue',
+      );
+      const auditPath = join(wd, '.omx', 'logs', `exec-followups-${new Date().toISOString().slice(0, 10)}.jsonl`);
+      assert.match(await readFile(auditPath, 'utf-8'), /exec_followup_queue_corrupt_recovered/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/exec.test.ts
+++ b/src/cli/__tests__/exec.test.ts
@@ -1,11 +1,17 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  buildExecFollowupStopOutput,
+  injectExecFollowup,
+  readPendingExecFollowups,
+} from '../../exec/followup.js';
+import { writeSessionStart } from '../../hooks/session.js';
 
 function runOmx(
   cwd: string,
@@ -36,6 +42,67 @@ function runOmx(
 }
 
 describe('omx exec', () => {
+  it('persists audited follow-up prompts for the active exec session without pane input', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-exec-followup-'));
+    try {
+      const session = await writeSessionStart(wd, 'omx-test-followup');
+      const result = await injectExecFollowup({
+        cwd: wd,
+        sessionId: session.session_id,
+        actor: 'test-operator',
+        prompt: 'Please include the new migration note before finishing.',
+        nowIso: '2026-04-27T10:00:00.000Z',
+      });
+
+      assert.equal(result.queued.session_id, 'omx-test-followup');
+      assert.equal(result.queued.actor, 'test-operator');
+      assert.equal(result.queued.prompt, 'Please include the new migration note before finishing.');
+      assert.match(result.queuePath, /exec-followups\.json$/);
+
+      const persisted = JSON.parse(await readFile(result.queuePath, 'utf-8')) as {
+        records: Array<Record<string, unknown>>;
+      };
+      assert.equal(persisted.records.length, 1);
+      assert.equal(persisted.records[0]?.delivered_at, undefined);
+
+      const auditPath = join(wd, '.omx', 'logs', 'exec-followups-2026-04-27.jsonl');
+      assert.match(await readFile(auditPath, 'utf-8'), /exec_followup_queued/);
+      assert.match(await readFile(auditPath, 'utf-8'), /Please include the new migration note/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('delivers queued follow-ups through Stop hook output and marks them delivered', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-exec-followup-stop-'));
+    try {
+      const session = await writeSessionStart(wd, 'omx-test-stop-followup');
+      const queued = await injectExecFollowup({
+        cwd: wd,
+        sessionId: session.session_id,
+        actor: 'qa',
+        prompt: 'Before stopping, verify the targeted exec tests.',
+        nowIso: '2026-04-27T10:05:00.000Z',
+      });
+
+      const output = await buildExecFollowupStopOutput(wd, session.session_id);
+      assert.equal(output?.decision, 'block');
+      assert.match(String(output?.reason), new RegExp(queued.queued.id));
+      assert.match(String(output?.systemMessage), /queued follow-up instruction/);
+      assert.match(String(output?.systemMessage), /Before stopping, verify the targeted exec tests/);
+
+      const after = await readPendingExecFollowups(wd, session.session_id);
+      assert.equal(after.pending.length, 0);
+      const persisted = JSON.parse(await readFile(queued.queuePath, 'utf-8')) as {
+        records: Array<{ delivered_at?: string; delivery_event?: string }>;
+      };
+      assert.equal(persisted.records[0]?.delivery_event, 'stop-hook');
+      assert.ok(persisted.records[0]?.delivered_at);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('runs codex exec with session-scoped instructions that preserve AGENTS and overlay content', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-exec-cli-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -134,6 +134,7 @@ import {
   type NotifyTempContract,
   type ParseNotifyTempContractResult,
 } from "../notifications/temp-contract.js";
+import { execInjectCommand } from "../exec/followup.js";
 
 export function resolveNotifyFallbackWatcherScript(pkgRoot = getPackageRoot()): string {
   return resolveDistScript(pkgRoot, "notify-fallback-watcher.js");
@@ -157,6 +158,8 @@ oh-my-codex (omx) - Multi-agent orchestration for Codex CLI
 Usage:
   omx           Launch Codex CLI (HUD auto-attaches only when already inside tmux)
   omx exec      Run codex exec non-interactively with OMX AGENTS/overlay injection
+  omx exec inject <session-id> --prompt <text>
+                Queue audited follow-up instructions for a running non-interactive exec job
   omx setup     Install skills, prompts, MCP servers, and scope-specific AGENTS.md
                 (user scope prompts for legacy vs plugin skill delivery when needed)
   omx update    Check npm now, update the global install immediately, then refresh setup
@@ -816,7 +819,11 @@ export async function main(args: string[]): Promise<void> {
         await exploreCommand(args.slice(1));
         break;
       case "exec":
-        await execWithOverlay(launchArgs);
+        if (launchArgs[0] === "inject") {
+          await execInjectCommand(launchArgs);
+        } else {
+          await execWithOverlay(launchArgs);
+        }
         break;
       case "sparkshell":
         await sparkshellCommand(args.slice(1));

--- a/src/exec/followup.ts
+++ b/src/exec/followup.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import { existsSync, readFileSync } from "fs";
-import { appendFile, mkdir, readFile, writeFile } from "fs/promises";
+import { appendFile, mkdir, readFile, rename, rm, stat, writeFile } from "fs/promises";
 import { dirname, join } from "path";
 import { isSessionStateUsable, readUsableSessionState } from "../hooks/session.js";
 
@@ -35,6 +35,9 @@ export interface InjectExecFollowupResult {
 
 const QUEUE_FILE = "exec-followups.json";
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const QUEUE_LOCK_STALE_MS = 30_000;
+const QUEUE_LOCK_RETRY_MS = 10;
+const QUEUE_LOCK_MAX_WAIT_MS = 5_000;
 
 function stateDir(cwd: string): string {
   return join(cwd, ".omx", "state");
@@ -44,8 +47,24 @@ function sessionQueuePath(cwd: string, sessionId: string): string {
   return join(stateDir(cwd), "sessions", sessionId, QUEUE_FILE);
 }
 
+function sessionQueueLockPath(queuePath: string): string {
+  return `${queuePath}.lock`;
+}
+
 function auditLogPath(cwd: string, nowIso: string): string {
   return join(cwd, ".omx", "logs", `exec-followups-${nowIso.slice(0, 10)}.jsonl`);
+}
+
+function safeTimestampForPath(nowIso: string): string {
+  return nowIso.replace(/[^0-9A-Za-z_-]/g, "-");
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function normalizeSessionId(sessionId: string): string {
@@ -67,11 +86,69 @@ function normalizeActor(actor?: string): string {
   return normalized || "unknown";
 }
 
-async function readQueue(path: string, sessionId: string): Promise<ExecFollowupQueue> {
+async function appendAudit(cwd: string, event: Record<string, unknown>, nowIso: string): Promise<void> {
+  const path = auditLogPath(cwd, nowIso);
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, JSON.stringify({ ...event, timestamp: nowIso }) + "\n");
+}
+
+async function quarantineCorruptQueue(
+  path: string,
+  sessionId: string,
+  options: { cwd: string; nowIso: string; error: unknown },
+): Promise<ExecFollowupQueue> {
+  const quarantinePath = `${path}.corrupt-${safeTimestampForPath(options.nowIso)}`;
+  let quarantined = false;
+  try {
+    await rename(path, quarantinePath);
+    quarantined = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      await appendAudit(options.cwd, {
+        event: "exec_followup_queue_corrupt_quarantine_failed",
+        session_id: sessionId,
+        queue_path: path,
+        quarantine_path: quarantinePath,
+        error: errorMessage(error),
+        parse_error: errorMessage(options.error),
+      }, options.nowIso);
+    }
+  }
+
+  await appendAudit(options.cwd, {
+    event: "exec_followup_queue_corrupt_recovered",
+    session_id: sessionId,
+    queue_path: path,
+    ...(quarantined ? { quarantine_path: quarantinePath } : {}),
+    error: errorMessage(options.error),
+  }, options.nowIso);
+
+  const recovered: ExecFollowupQueue = { version: 1, session_id: sessionId, records: [] };
+  await writeQueue(path, recovered);
+  return recovered;
+}
+
+async function readQueue(
+  path: string,
+  sessionId: string,
+  options?: { cwd: string; nowIso: string; recoverCorrupt?: boolean },
+): Promise<ExecFollowupQueue> {
   if (!existsSync(path)) {
     return { version: 1, session_id: sessionId, records: [] };
   }
-  const parsed = JSON.parse(await readFile(path, "utf-8")) as Partial<ExecFollowupQueue>;
+  let parsed: Partial<ExecFollowupQueue>;
+  try {
+    parsed = JSON.parse(await readFile(path, "utf-8")) as Partial<ExecFollowupQueue>;
+  } catch (error) {
+    if (options?.recoverCorrupt) {
+      return await quarantineCorruptQueue(path, sessionId, {
+        cwd: options.cwd,
+        nowIso: options.nowIso,
+        error,
+      });
+    }
+    throw error;
+  }
   const records = Array.isArray(parsed.records) ? parsed.records : [];
   return {
     version: 1,
@@ -92,13 +169,47 @@ async function readQueue(path: string, sessionId: string): Promise<ExecFollowupQ
 
 async function writeQueue(path: string, queue: ExecFollowupQueue): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(queue, null, 2) + "\n");
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(tempPath, JSON.stringify(queue, null, 2) + "\n");
+  await rename(tempPath, path);
 }
 
-async function appendAudit(cwd: string, event: Record<string, unknown>, nowIso: string): Promise<void> {
-  const path = auditLogPath(cwd, nowIso);
-  await mkdir(dirname(path), { recursive: true });
-  await appendFile(path, JSON.stringify({ ...event, timestamp: nowIso }) + "\n");
+async function withQueueLock<T>(queuePath: string, operation: () => Promise<T>): Promise<T> {
+  await mkdir(dirname(queuePath), { recursive: true });
+  const lockPath = sessionQueueLockPath(queuePath);
+  const start = Date.now();
+  while (true) {
+    try {
+      await mkdir(lockPath);
+      await writeFile(join(lockPath, "owner.json"), JSON.stringify({
+        pid: process.pid,
+        acquired_at: new Date().toISOString(),
+      }, null, 2));
+      try {
+        return await operation();
+      } finally {
+        await rm(lockPath, { recursive: true, force: true });
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+
+      try {
+        const lockStat = await stat(lockPath);
+        if (Date.now() - lockStat.mtimeMs > QUEUE_LOCK_STALE_MS) {
+          await rm(lockPath, { recursive: true, force: true });
+          continue;
+        }
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw statError;
+      }
+
+      if (Date.now() - start > QUEUE_LOCK_MAX_WAIT_MS) {
+        throw new Error("exec_followup_queue_lock_timeout");
+      }
+      await sleep(QUEUE_LOCK_RETRY_MS);
+    }
+  }
 }
 
 export async function injectExecFollowup(
@@ -119,7 +230,6 @@ export async function injectExecFollowup(
 
   const canonicalSessionId = active.session_id;
   const queuePath = sessionQueuePath(options.cwd, canonicalSessionId);
-  const queue = await readQueue(queuePath, canonicalSessionId);
   const queued: ExecFollowupRecord = {
     id: randomUUID(),
     session_id: canonicalSessionId,
@@ -127,9 +237,16 @@ export async function injectExecFollowup(
     prompt,
     created_at: nowIso,
   };
-  queue.session_id = canonicalSessionId;
-  queue.records.push(queued);
-  await writeQueue(queuePath, queue);
+  await withQueueLock(queuePath, async () => {
+    const queue = await readQueue(queuePath, canonicalSessionId, {
+      cwd: options.cwd,
+      nowIso,
+      recoverCorrupt: true,
+    });
+    queue.session_id = canonicalSessionId;
+    queue.records.push(queued);
+    await writeQueue(queuePath, queue);
+  });
   await appendAudit(options.cwd, {
     event: "exec_followup_queued",
     followup_id: queued.id,
@@ -146,7 +263,11 @@ export async function readPendingExecFollowups(
 ): Promise<{ queuePath: string; pending: ExecFollowupRecord[] }> {
   const canonicalSessionId = normalizeSessionId(sessionId);
   const queuePath = sessionQueuePath(cwd, canonicalSessionId);
-  const queue = await readQueue(queuePath, canonicalSessionId);
+  const queue = await readQueue(queuePath, canonicalSessionId, {
+    cwd,
+    nowIso: new Date().toISOString(),
+    recoverCorrupt: true,
+  });
   return {
     queuePath,
     pending: queue.records.filter((record) => !record.delivered_at),
@@ -162,23 +283,29 @@ export async function markExecFollowupsDelivered(
   const canonicalSessionId = normalizeSessionId(sessionId);
   const nowIso = options.nowIso ?? new Date().toISOString();
   const queuePath = sessionQueuePath(cwd, canonicalSessionId);
-  const queue = await readQueue(queuePath, canonicalSessionId);
-  const ids = new Set(followupIds);
-  let changed = false;
-  for (const record of queue.records) {
-    if (!ids.has(record.id) || record.delivered_at) continue;
-    record.delivered_at = nowIso;
-    record.delivery_event = options.deliveryEvent ?? "stop-hook";
-    changed = true;
-    await appendAudit(cwd, {
-      event: "exec_followup_delivered",
-      followup_id: record.id,
-      session_id: canonicalSessionId,
-      actor: record.actor,
-      delivery_event: record.delivery_event,
-    }, nowIso);
-  }
-  if (changed) await writeQueue(queuePath, queue);
+  await withQueueLock(queuePath, async () => {
+    const queue = await readQueue(queuePath, canonicalSessionId, {
+      cwd,
+      nowIso,
+      recoverCorrupt: true,
+    });
+    const ids = new Set(followupIds);
+    let changed = false;
+    for (const record of queue.records) {
+      if (!ids.has(record.id) || record.delivered_at) continue;
+      record.delivered_at = nowIso;
+      record.delivery_event = options.deliveryEvent ?? "stop-hook";
+      changed = true;
+      await appendAudit(cwd, {
+        event: "exec_followup_delivered",
+        followup_id: record.id,
+        session_id: canonicalSessionId,
+        actor: record.actor,
+        delivery_event: record.delivery_event,
+      }, nowIso);
+    }
+    if (changed) await writeQueue(queuePath, queue);
+  });
 }
 
 export async function buildExecFollowupStopOutput(

--- a/src/exec/followup.ts
+++ b/src/exec/followup.ts
@@ -1,0 +1,290 @@
+import { randomUUID } from "crypto";
+import { existsSync, readFileSync } from "fs";
+import { appendFile, mkdir, readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+import { isSessionStateUsable, readUsableSessionState } from "../hooks/session.js";
+
+export interface ExecFollowupRecord {
+  id: string;
+  session_id: string;
+  actor: string;
+  prompt: string;
+  created_at: string;
+  delivered_at?: string;
+  delivery_event?: "stop-hook";
+}
+
+export interface ExecFollowupQueue {
+  version: 1;
+  session_id: string;
+  records: ExecFollowupRecord[];
+}
+
+export interface InjectExecFollowupOptions {
+  cwd: string;
+  sessionId: string;
+  prompt: string;
+  actor?: string;
+  nowIso?: string;
+}
+
+export interface InjectExecFollowupResult {
+  queued: ExecFollowupRecord;
+  queuePath: string;
+}
+
+const QUEUE_FILE = "exec-followups.json";
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+function stateDir(cwd: string): string {
+  return join(cwd, ".omx", "state");
+}
+
+function sessionQueuePath(cwd: string, sessionId: string): string {
+  return join(stateDir(cwd), "sessions", sessionId, QUEUE_FILE);
+}
+
+function auditLogPath(cwd: string, nowIso: string): string {
+  return join(cwd, ".omx", "logs", `exec-followups-${nowIso.slice(0, 10)}.jsonl`);
+}
+
+function normalizeSessionId(sessionId: string): string {
+  const normalized = sessionId.trim();
+  if (!SESSION_ID_PATTERN.test(normalized)) {
+    throw new Error("invalid_session_id");
+  }
+  return normalized;
+}
+
+function normalizePrompt(prompt: string): string {
+  const normalized = prompt.trim();
+  if (!normalized) throw new Error("missing_prompt");
+  return normalized;
+}
+
+function normalizeActor(actor?: string): string {
+  const normalized = (actor || process.env.USER || process.env.USERNAME || "unknown").trim();
+  return normalized || "unknown";
+}
+
+async function readQueue(path: string, sessionId: string): Promise<ExecFollowupQueue> {
+  if (!existsSync(path)) {
+    return { version: 1, session_id: sessionId, records: [] };
+  }
+  const parsed = JSON.parse(await readFile(path, "utf-8")) as Partial<ExecFollowupQueue>;
+  const records = Array.isArray(parsed.records) ? parsed.records : [];
+  return {
+    version: 1,
+    session_id: typeof parsed.session_id === "string" && parsed.session_id.trim()
+      ? parsed.session_id.trim()
+      : sessionId,
+    records: records.filter((record): record is ExecFollowupRecord => (
+      typeof record === "object"
+      && record !== null
+      && typeof record.id === "string"
+      && typeof record.session_id === "string"
+      && typeof record.actor === "string"
+      && typeof record.prompt === "string"
+      && typeof record.created_at === "string"
+    )),
+  };
+}
+
+async function writeQueue(path: string, queue: ExecFollowupQueue): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(queue, null, 2) + "\n");
+}
+
+async function appendAudit(cwd: string, event: Record<string, unknown>, nowIso: string): Promise<void> {
+  const path = auditLogPath(cwd, nowIso);
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, JSON.stringify({ ...event, timestamp: nowIso }) + "\n");
+}
+
+export async function injectExecFollowup(
+  options: InjectExecFollowupOptions,
+): Promise<InjectExecFollowupResult> {
+  const sessionId = normalizeSessionId(options.sessionId);
+  const prompt = normalizePrompt(options.prompt);
+  const actor = normalizeActor(options.actor);
+  const nowIso = options.nowIso ?? new Date().toISOString();
+
+  const active = await readUsableSessionState(options.cwd);
+  if (!active || !isSessionStateUsable(active, options.cwd)) {
+    throw new Error("job_not_input_accepting:no_active_exec_session");
+  }
+  if (active.session_id !== sessionId && active.native_session_id !== sessionId) {
+    throw new Error(`job_not_input_accepting:session_mismatch:${active.session_id}`);
+  }
+
+  const canonicalSessionId = active.session_id;
+  const queuePath = sessionQueuePath(options.cwd, canonicalSessionId);
+  const queue = await readQueue(queuePath, canonicalSessionId);
+  const queued: ExecFollowupRecord = {
+    id: randomUUID(),
+    session_id: canonicalSessionId,
+    actor,
+    prompt,
+    created_at: nowIso,
+  };
+  queue.session_id = canonicalSessionId;
+  queue.records.push(queued);
+  await writeQueue(queuePath, queue);
+  await appendAudit(options.cwd, {
+    event: "exec_followup_queued",
+    followup_id: queued.id,
+    session_id: canonicalSessionId,
+    actor,
+    prompt,
+  }, nowIso);
+  return { queued, queuePath };
+}
+
+export async function readPendingExecFollowups(
+  cwd: string,
+  sessionId: string,
+): Promise<{ queuePath: string; pending: ExecFollowupRecord[] }> {
+  const canonicalSessionId = normalizeSessionId(sessionId);
+  const queuePath = sessionQueuePath(cwd, canonicalSessionId);
+  const queue = await readQueue(queuePath, canonicalSessionId);
+  return {
+    queuePath,
+    pending: queue.records.filter((record) => !record.delivered_at),
+  };
+}
+
+export async function markExecFollowupsDelivered(
+  cwd: string,
+  sessionId: string,
+  followupIds: string[],
+  options: { nowIso?: string; deliveryEvent?: "stop-hook" } = {},
+): Promise<void> {
+  const canonicalSessionId = normalizeSessionId(sessionId);
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const queuePath = sessionQueuePath(cwd, canonicalSessionId);
+  const queue = await readQueue(queuePath, canonicalSessionId);
+  const ids = new Set(followupIds);
+  let changed = false;
+  for (const record of queue.records) {
+    if (!ids.has(record.id) || record.delivered_at) continue;
+    record.delivered_at = nowIso;
+    record.delivery_event = options.deliveryEvent ?? "stop-hook";
+    changed = true;
+    await appendAudit(cwd, {
+      event: "exec_followup_delivered",
+      followup_id: record.id,
+      session_id: canonicalSessionId,
+      actor: record.actor,
+      delivery_event: record.delivery_event,
+    }, nowIso);
+  }
+  if (changed) await writeQueue(queuePath, queue);
+}
+
+export async function buildExecFollowupStopOutput(
+  cwd: string,
+  sessionId: string | undefined | null,
+): Promise<Record<string, unknown> | null> {
+  const normalizedSessionId = typeof sessionId === "string" ? sessionId.trim() : "";
+  if (!normalizedSessionId) return null;
+  const { pending } = await readPendingExecFollowups(cwd, normalizedSessionId);
+  if (pending.length === 0) return null;
+
+  const ids = pending.map((record) => record.id);
+  await markExecFollowupsDelivered(cwd, normalizedSessionId, ids, {
+    deliveryEvent: "stop-hook",
+  });
+
+  const rendered = pending.map((record, index) => (
+    `Follow-up ${index + 1} (${record.id}) from ${record.actor} at ${record.created_at}:\n${record.prompt}`
+  )).join("\n\n");
+  const systemMessage =
+    `OMX exec has ${pending.length} queued follow-up instruction${pending.length === 1 ? "" : "s"} for this non-interactive job. ` +
+    "Treat them as the newest user instructions, continue the same run, and include the follow-up id(s) in your final audit summary.\n\n" +
+    rendered;
+
+  return {
+    decision: "block",
+    reason: `exec_followup_pending:${ids.join(",")}`,
+    systemMessage,
+  };
+}
+
+export function formatInjectExecFollowupSuccess(result: InjectExecFollowupResult): string {
+  return [
+    `Queued exec follow-up ${result.queued.id} for session ${result.queued.session_id}.`,
+    `Queue: ${result.queuePath}`,
+    "Delivery: next Stop hook checkpoint; no tmux pane input was sent.",
+  ].join("\n");
+}
+
+export function parseExecInjectArgs(args: string[]): {
+  sessionId: string;
+  prompt: string;
+  actor?: string;
+  json: boolean;
+} {
+  const [, sessionIdRaw, ...rest] = args;
+  const sessionId = sessionIdRaw?.trim();
+  if (!sessionId) throw new Error("Usage: omx exec inject <session-id> --prompt <text> [--actor <name>] [--json]");
+
+  let prompt = "";
+  let actor: string | undefined;
+  let json = false;
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i]!;
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--prompt") {
+      const value = rest[i + 1];
+      if (!value) throw new Error("Missing value after --prompt");
+      prompt = value;
+      i += 1;
+    } else if (arg.startsWith("--prompt=")) {
+      prompt = arg.slice("--prompt=".length);
+    } else if (arg === "--prompt-file") {
+      const value = rest[i + 1];
+      if (!value) throw new Error("Missing path after --prompt-file");
+      prompt = readFileSyncForCli(value);
+      i += 1;
+    } else if (arg.startsWith("--prompt-file=")) {
+      prompt = readFileSyncForCli(arg.slice("--prompt-file=".length));
+    } else if (arg === "--actor") {
+      const value = rest[i + 1];
+      if (!value) throw new Error("Missing value after --actor");
+      actor = value;
+      i += 1;
+    } else if (arg.startsWith("--actor=")) {
+      actor = arg.slice("--actor=".length);
+    } else if (!arg.startsWith("-") && !prompt) {
+      prompt = [arg, ...rest.slice(i + 1)].join(" ");
+      break;
+    } else {
+      throw new Error(`Unknown exec inject argument: ${arg}`);
+    }
+  }
+  return { sessionId, prompt, actor, json };
+}
+
+function readFileSyncForCli(path: string): string {
+  return readFileSync(path, "utf-8");
+}
+
+export async function execInjectCommand(args: string[], cwd = process.cwd()): Promise<void> {
+  const parsed = parseExecInjectArgs(args);
+  const result = await injectExecFollowup({
+    cwd,
+    sessionId: parsed.sessionId,
+    prompt: parsed.prompt,
+    actor: parsed.actor,
+  });
+  if (parsed.json) {
+    console.log(JSON.stringify({
+      ok: true,
+      queued: result.queued,
+      queue_path: result.queuePath,
+    }, null, 2));
+  } else {
+    console.log(formatInjectExecFollowupSuccess(result));
+  }
+}

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -278,6 +278,31 @@ describe("codex native hook dispatch", () => {
       const output = parseSingleJsonStdout(stdout);
 
       assert.deepEqual(output, {});
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not crash Stop hook dispatch when the exec follow-up queue is malformed", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-stop-exec-followup-corrupt-"));
+    try {
+      const session = await writeSessionStart(cwd, "sess-exec-followup-corrupt");
+      const queuePath = join(cwd, ".omx", "state", "sessions", session.session_id, "exec-followups.json");
+      await mkdir(dirname(queuePath), { recursive: true });
+      await writeFile(queuePath, '{"version":1,"records":[', "utf-8");
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: session.session_id,
+      });
+
+      assert.equal(result.hookEventName, "Stop");
+      assert.equal(result.outputJson, null);
+      const queueDirEntries = await readdir(dirname(queuePath));
+      assert.ok(queueDirEntries.some((entry) => entry.startsWith("exec-followups.json.corrupt-")));
+      const auditPath = join(cwd, ".omx", "logs", `exec-followups-${new Date().toISOString().slice(0, 10)}.jsonl`);
+      assert.match(await readFile(auditPath, "utf-8"), /exec_followup_queue_corrupt_recovered/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -81,6 +81,7 @@ import {
   evaluateFinalHandoffDocumentRefresh,
   isFinalHandoffDocumentRefreshCandidate,
 } from "../document-refresh/enforcer.js";
+import { buildExecFollowupStopOutput } from "../exec/followup.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -1817,6 +1818,8 @@ async function buildStopHookOutput(
   const sessionId = readPayloadSessionId(payload);
   const canonicalSessionId = await resolveInternalSessionIdForPayload(cwd, sessionId);
   const threadId = readPayloadThreadId(payload);
+  const execFollowupOutput = await buildExecFollowupStopOutput(cwd, canonicalSessionId);
+  if (execFollowupOutput) return execFollowupOutput;
   const ralphState = await readActiveRalphState(stateDir, canonicalSessionId);
   if (!ralphState) {
     const autoresearchState = await readActiveAutoresearchState(cwd, canonicalSessionId);


### PR DESCRIPTION
Closes #1961.

## Summary
- Add `omx exec inject <session-id> --prompt ...` to queue audited follow-up instructions for the active non-interactive exec session.
- Persist follow-ups under `.omx/state/sessions/<session>/exec-followups.json` plus JSONL audit logs for queue and delivery events.
- Deliver pending follow-ups through the native Stop hook as a continuation block, avoiding tmux pane typing or ambiguous stdin writes.

## Behavior
- Injection validates the authoritative active session before writing; stale, ended, or mismatched jobs fail as not input-accepting.
- Running jobs pick up queued instructions at the next Stop checkpoint and mark them delivered.

## Verification
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/cli/__tests__/exec.test.js`