### PR TITLE
[codex] Treat absent tmux server socket as launchable

### DIFF
--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -174,6 +174,158 @@ exit 0
     }
   });
 
+  it('treats a missing tmux server socket as launchable detached tmux', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-missing-server-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const fakeTmuxPath = join(fakeBin, 'tmux');
+      const tmuxLogPath = join(wd, 'tmux.log');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        fakeCodexPath,
+        '#!/bin/sh\nprintf \'fake-codex:%s\\n\' "$*"\n',
+      );
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+      await writeFile(
+        fakeTmuxPath,
+        `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    printf 'tmux 3.4\n'
+    exit 0
+    ;;
+  list-sessions)
+    printf 'error connecting to /tmp/tmux-1000/default (No such file or directory)\n' >&2
+    exit 1
+    ;;
+  new-session)
+    printf 'leader-pane\n'
+    exit 0
+    ;;
+  split-window)
+    printf 'hud-pane\n'
+    exit 0
+    ;;
+  display-message)
+    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\n'
+    else
+      printf '0\n'
+    fi
+    exit 0
+    ;;
+  show-options)
+    printf 'off\n'
+    exit 0
+    ;;
+  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane)
+    exit 0
+    ;;
+esac
+exit 0
+`,
+      );
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runOmx(
+        wd,
+        ['--madmax', '--tmux'],
+        {
+          HOME: home,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(tmuxLog, /tmux:new-session .* -s /);
+      assert.doesNotMatch(result.stderr, /server\/socket is unusable/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back directly for mixed tmux missing-socket and unusable-socket stderr', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-mixed-socket-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const fakeTmuxPath = join(fakeBin, 'tmux');
+      const tmuxLogPath = join(wd, 'tmux.log');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        fakeCodexPath,
+        '#!/bin/sh\nprintf \'fake-codex:%s\\n\' "$*"\n',
+      );
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+      await writeFile(
+        fakeTmuxPath,
+        `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    printf 'tmux 3.6a\n'
+    exit 0
+    ;;
+  list-sessions)
+    printf 'error connecting to /tmp/tmux-1000/default (No such file or directory)\n' >&2
+    printf 'error connecting to /tmp/tmux-1000/default (Operation not permitted)\n' >&2
+    exit 1
+    ;;
+esac
+printf 'unexpected tmux command: %s\n' "$*" >&2
+exit 1
+`,
+      );
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runOmx(
+        wd,
+        ['--madmax', '--tmux'],
+        {
+          HOME: home,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
+      assert.match(result.stderr, /server\/socket is unusable/);
+      assert.doesNotMatch(tmuxLog, /new-session|attach-session/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('falls back directly when tmux is installed but the server socket is unusable', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-stale-socket-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -518,7 +518,14 @@ function tmuxFailureMessage(error: unknown): string {
 }
 
 function isBenignMissingTmuxServerMessage(message: string): boolean {
-  return /no server running/i.test(message);
+  const trimmed = message.trim();
+  return (
+    /^no server running(?: on \S+)?$/i.test(trimmed) ||
+    /^failed to connect to server$/i.test(trimmed) ||
+    /^error connecting to \S+\/tmux-\d+\/default \(No such file or directory\)$/i.test(
+      trimmed,
+    )
+  );
 }
 
 export interface TmuxLaunchHealth {


### PR DESCRIPTION
## Summary

- Treat tmux `list-sessions` output for a missing default server socket as a benign no-server state.
- Keep direct-launch fallback behavior for genuinely unusable tmux sockets, including permission-denied socket errors.
- Add a regression test that confirms `omx --tmux` still creates a detached tmux session when `list-sessions` reports a missing socket.

## Root cause

tmux can report an `error connecting ... (No such file or directory)` message when no tmux server is currently running. The launcher previously classified that as an unusable tmux socket, so `omx --tmux` fell back to direct Codex launch instead of letting tmux create the server.

## Impact

This prevents a false fallback warning and preserves detached tmux/HUD bootstrap behavior on fresh systems or shells with no active tmux server.

## Validation

- `npm run build`
- `npm run lint`
- `node --test dist/cli/__tests__/launch-fallback.test.js`
- `node -e` import of `checkDetachedTmuxLaunchHealth()` in the local missing-socket environment returned `{ "usable": true }`
