### PR TITLE
Restore explicit setup path back to legacy mode

### DIFF
--- a/plugins/oh-my-codex/skills/omx-setup/SKILL.md
+++ b/plugins/oh-my-codex/skills/omx-setup/SKILL.md
@@ -10,7 +10,7 @@ Use this skill when users want to install or refresh oh-my-codex for the **curre
 ## Command
 
 ```bash
-omx setup [--force] [--merge-agents] [--dry-run] [--verbose] [--scope <user|project>] [--plugin]
+omx setup [--force] [--merge-agents] [--dry-run] [--verbose] [--scope <user|project>] [--plugin|--legacy|--install-mode <legacy|plugin>]
 ```
 
 If you only want lightweight `AGENTS.md` scaffolding for an existing repo or subtree, use `omx agents-init [path]` instead of full setup.
@@ -22,6 +22,8 @@ Supported setup flags (current implementation):
 - `--verbose`: print per-file/per-step details
 - `--scope`: choose install scope (`user`, `project`)
 - `--plugin`: use Codex plugin delivery for bundled skills while archiving/removing legacy OMX-managed prompts/native agents and keeping setup-owned runtime hooks
+- `--legacy`: use legacy setup delivery, overriding any persisted plugin install mode
+- `--install-mode`: explicitly choose setup delivery mode (`legacy` or `plugin`); canonical form for scripted setup
 
 ## What this setup actually does
 
@@ -34,7 +36,7 @@ Supported setup flags (current implementation):
    - else interactive prompt on TTY (default `user`)
    - else default `user` (safe for CI/tests)
 2. If scope is `user`, resolve user skill delivery mode:
-   - explicit `--plugin`, if present
+   - explicit `--plugin`, `--legacy`, or `--install-mode legacy|plugin`, if present
    - persisted install mode in `./.omx/setup-scope.json`, if present and the TTY review decision is `keep`
    - else discovered installed plugin cache under `${CODEX_HOME:-~/.codex}/plugins/cache/**/.codex-plugin/plugin.json` with `name: oh-my-codex` makes `plugin` the default
    - else interactive prompt on TTY (`legacy` by default, or `plugin` when a plugin cache is discovered)

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -10,7 +10,7 @@ Use this skill when users want to install or refresh oh-my-codex for the **curre
 ## Command
 
 ```bash
-omx setup [--force] [--merge-agents] [--dry-run] [--verbose] [--scope <user|project>] [--plugin]
+omx setup [--force] [--merge-agents] [--dry-run] [--verbose] [--scope <user|project>] [--plugin|--legacy|--install-mode <legacy|plugin>]
 ```
 
 If you only want lightweight `AGENTS.md` scaffolding for an existing repo or subtree, use `omx agents-init [path]` instead of full setup.
@@ -22,6 +22,8 @@ Supported setup flags (current implementation):
 - `--verbose`: print per-file/per-step details
 - `--scope`: choose install scope (`user`, `project`)
 - `--plugin`: use Codex plugin delivery for bundled skills while archiving/removing legacy OMX-managed prompts/native agents and keeping setup-owned runtime hooks
+- `--legacy`: use legacy setup delivery, overriding any persisted plugin install mode
+- `--install-mode`: explicitly choose setup delivery mode (`legacy` or `plugin`); canonical form for scripted setup
 
 ## What this setup actually does
 
@@ -34,7 +36,7 @@ Supported setup flags (current implementation):
    - else interactive prompt on TTY (default `user`)
    - else default `user` (safe for CI/tests)
 2. If scope is `user`, resolve user skill delivery mode:
-   - explicit `--plugin`, if present
+   - explicit `--plugin`, `--legacy`, or `--install-mode legacy|plugin`, if present
    - persisted install mode in `./.omx/setup-scope.json`, if present and the TTY review decision is `keep`
    - else discovered installed plugin cache under `${CODEX_HOME:-~/.codex}/plugins/cache/**/.codex-plugin/plugin.json` with `name: oh-my-codex` makes `plugin` the default
    - else interactive prompt on TTY (`legacy` by default, or `plugin` when a plugin cache is discovered)

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1054,12 +1054,44 @@ describe("resolveCliInvocation", () => {
 });
 
 describe("resolveSetupInstallModeArg", () => {
-  it("maps --plugin to plugin install mode", () => {
+  it("maps explicit setup install mode flags", () => {
     assert.equal(resolveSetupInstallModeArg(["--dry-run"]), undefined);
     assert.equal(resolveSetupInstallModeArg(["--plugin"]), "plugin");
+    assert.equal(resolveSetupInstallModeArg(["--legacy"]), "legacy");
+    assert.equal(
+      resolveSetupInstallModeArg(["--install-mode", "legacy"]),
+      "legacy",
+    );
+    assert.equal(
+      resolveSetupInstallModeArg(["--install-mode=plugin"]),
+      "plugin",
+    );
     assert.equal(
       resolveSetupInstallModeArg(["--scope", "project", "--plugin"]),
       "plugin",
+    );
+  });
+
+  it("rejects invalid setup install mode flags", () => {
+    assert.throws(
+      () => resolveSetupInstallModeArg(["--install-mode"]),
+      /Missing setup install mode value after --install-mode/,
+    );
+    assert.throws(
+      () => resolveSetupInstallModeArg(["--install-mode", "workspace"]),
+      /Invalid setup install mode: workspace/,
+    );
+    assert.throws(
+      () => resolveSetupInstallModeArg(["--plugin", "--legacy"]),
+      /Conflicting setup install mode flags/,
+    );
+    assert.throws(
+      () => resolveSetupInstallModeArg(["--plugin", "--install-mode", "legacy"]),
+      /Conflicting setup install mode flags/,
+    );
+    assert.throws(
+      () => resolveSetupInstallModeArg(["--legacy", "--install-mode=plugin"]),
+      /Conflicting setup install mode flags/,
     );
   });
 });

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -779,6 +779,76 @@ describe("omx setup install mode behavior", () => {
     }
   });
 
+  it("lets explicit project legacy setup clear persisted project plugin mode", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withTempCwd(wd, async () => {
+        await mkdir(join(wd, ".omx"), { recursive: true });
+        await writeFile(
+          join(wd, ".omx", "setup-scope.json"),
+          JSON.stringify({ scope: "project", installMode: "plugin" }),
+        );
+
+        await setup({ scope: "project", installMode: "legacy" });
+
+        const persisted = JSON.parse(
+          await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+        ) as { scope: string; installMode?: string };
+        assert.deepEqual(persisted, { scope: "project" });
+        assert.equal(
+          existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
+          true,
+        );
+        assert.equal(
+          existsSync(join(wd, ".codex", "agents", "planner.toml")),
+          true,
+        );
+        assert.equal(
+          existsSync(join(wd, ".codex", "prompts", "executor.md")),
+          true,
+        );
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("lets explicit user legacy setup override persisted user plugin mode", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        await withTempCwd(wd, async () => {
+          await mkdir(join(wd, ".omx"), { recursive: true });
+          await writeFile(
+            join(wd, ".omx", "setup-scope.json"),
+            JSON.stringify({ scope: "user", installMode: "plugin" }),
+          );
+
+          await setup({ installMode: "legacy" });
+
+          const persisted = JSON.parse(
+            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+          ) as { scope: string; installMode?: string };
+          assert.deepEqual(persisted, { scope: "user", installMode: "legacy" });
+          assert.equal(
+            existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
+            true,
+          );
+          assert.equal(
+            existsSync(join(codexHomeDir, "agents", "planner.toml")),
+            true,
+          );
+          assert.equal(
+            existsSync(join(codexHomeDir, "prompts", "executor.md")),
+            true,
+          );
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("installs project-scoped native hooks when plugin mode is explicitly requested", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -229,6 +229,9 @@ Options:
                 instead of overwriting user-authored content
   --dry-run     Show what would be done without doing it
   --plugin      Use Codex plugin delivery for omx setup and remove legacy OMX-managed user/project components
+  --legacy      Use legacy setup delivery for omx setup, overriding persisted plugin mode
+  --install-mode <legacy|plugin>
+                Explicit setup install mode (canonical form; --legacy/--plugin are aliases)
   --keep-config Skip config.toml cleanup during uninstall
   --purge       Remove .omx/ cache directory during uninstall
   --verbose     Show detailed output
@@ -341,8 +344,54 @@ export interface ResolvedCliInvocation {
 }
 
 export function resolveSetupInstallModeArg(args: string[]): SetupInstallMode | undefined {
-  if (args.includes("--plugin")) return "plugin";
-  return undefined;
+  let value: SetupInstallMode | undefined;
+  const setValue = (next: SetupInstallMode, source: string): void => {
+    if (value && value !== next) {
+      throw new Error(
+        `Conflicting setup install mode flags: ${source} selects ${next}, but another flag already selected ${value}`,
+      );
+    }
+    value = next;
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--plugin") {
+      setValue("plugin", arg);
+      continue;
+    }
+    if (arg === "--legacy") {
+      setValue("legacy", arg);
+      continue;
+    }
+    if (arg === "--install-mode") {
+      const next = args[index + 1];
+      if (!next || next.startsWith("-")) {
+        throw new Error(
+          `Missing setup install mode value after --install-mode. Expected one of: legacy, plugin`,
+        );
+      }
+      if (next !== "legacy" && next !== "plugin") {
+        throw new Error(
+          `Invalid setup install mode: ${next}. Expected one of: legacy, plugin`,
+        );
+      }
+      setValue(next, arg);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--install-mode=")) {
+      const next = arg.slice("--install-mode=".length);
+      if (next !== "legacy" && next !== "plugin") {
+        throw new Error(
+          `Invalid setup install mode: ${next}. Expected one of: legacy, plugin`,
+        );
+      }
+      setValue(next, "--install-mode");
+    }
+  }
+
+  return value;
 }
 
 export function resolveSetupScopeArg(args: string[]): SetupScope | undefined {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1555,21 +1555,20 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     }
     if (verbose) console.log(`  mkdir ${dir}`);
   }
-  await persistSetupPreferences(
-    projectRoot,
-    resolvedInstallMode
+  const setupPreferencesToPersist: PersistedSetupScope =
+    resolvedInstallMode &&
+    (resolvedScope.scope === "user" || resolvedInstallMode.installMode === "plugin")
       ? {
           scope: resolvedScope.scope,
           installMode: resolvedInstallMode.installMode,
         }
       : {
           scope: resolvedScope.scope,
-        },
-    {
-      dryRun,
-      verbose,
-    },
-  );
+        };
+  await persistSetupPreferences(projectRoot, setupPreferencesToPersist, {
+    dryRun,
+    verbose,
+  });
   console.log("  Done.\n");
 
   if (resolvedScope.scope === "project") {


### PR DESCRIPTION
## Summary
- Add explicit setup install mode overrides: `--legacy` and canonical `--install-mode legacy|plugin`, while preserving existing `--plugin`.
- Reject missing, invalid, or conflicting explicit setup install mode flags before setup runs.
- Let explicit project legacy setup clear stale persisted project plugin mode; user legacy setup persists `installMode: "legacy"`.
- Update setup skill docs in both source and plugin mirror.

Closes #1964.

## Verification
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/setup-scope.test.js`
- `node --test dist/config/__tests__/*.test.js`

— OpenAI Codex
