### PR TITLE
Fix plugin-mode skills discovery

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -1,391 +1,571 @@
-import { describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { tmpdir } from 'node:os';
-import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import { withPackagedExploreHarnessHidden, withPackagedExploreHarnessLock } from './packaged-explore-harness-lock.js';
-import { checkExploreHarness } from '../doctor.js';
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+	withPackagedExploreHarnessHidden,
+	withPackagedExploreHarnessLock,
+} from "./packaged-explore-harness-lock.js";
+import { checkExploreHarness } from "../doctor.js";
 
 function runOmx(
-  cwd: string,
-  argv: string[],
-  envOverrides: Record<string, string> = {},
+	cwd: string,
+	argv: string[],
+	envOverrides: Record<string, string> = {},
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
-  const testDir = dirname(fileURLToPath(import.meta.url));
-  const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
-  const mergedEnv = { ...process.env, ...envOverrides };
-  if (typeof envOverrides.HOME === 'string' && typeof envOverrides.USERPROFILE !== 'string') {
-    mergedEnv.USERPROFILE = envOverrides.HOME;
-  }
-  const r = spawnSync(process.execPath, [omxBin, ...argv], {
-    cwd,
-    encoding: 'utf-8',
-    env: mergedEnv,
-  });
-  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error?.message };
+	const testDir = dirname(fileURLToPath(import.meta.url));
+	const repoRoot = join(testDir, "..", "..", "..");
+	const omxBin = join(repoRoot, "dist", "cli", "omx.js");
+	const mergedEnv = { ...process.env, ...envOverrides };
+	if (
+		typeof envOverrides.HOME === "string" &&
+		typeof envOverrides.USERPROFILE !== "string"
+	) {
+		mergedEnv.USERPROFILE = envOverrides.HOME;
+	}
+	const r = spawnSync(process.execPath, [omxBin, ...argv], {
+		cwd,
+		encoding: "utf-8",
+		env: mergedEnv,
+	});
+	return {
+		status: r.status,
+		stdout: r.stdout || "",
+		stderr: r.stderr || "",
+		error: r.error?.message,
+	};
 }
 
 function shouldSkipForSpawnPermissions(err?: string): boolean {
-  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+	return typeof err === "string" && /(EPERM|EACCES)/i.test(err);
 }
 
-describe('omx doctor onboarding warning copy', () => {
-  it('warns that the built-in explore harness is not ready on Windows', () => {
-    const check = checkExploreHarness('win32', {} as NodeJS.ProcessEnv);
+describe("omx doctor onboarding warning copy", () => {
+	it("warns that the built-in explore harness is not ready on Windows", () => {
+		const check = checkExploreHarness("win32", {} as NodeJS.ProcessEnv);
 
-    assert.equal(check.name, 'Explore Harness');
-    assert.equal(check.status, 'warn');
-    assert.match(check.message, /not ready on Windows/i);
-    assert.match(check.message, /OMX_EXPLORE_BIN/);
-  });
+		assert.equal(check.name, "Explore Harness");
+		assert.equal(check.status, "warn");
+		assert.match(check.message, /not ready on Windows/i);
+		assert.match(check.message, /OMX_EXPLORE_BIN/);
+	});
 
-  it('explains first-setup expectation for config and MCP onboarding warnings', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-copy-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      await mkdir(codexDir, { recursive: true });
-      await writeFile(
-        join(codexDir, 'config.toml'),
-        `
+	it("explains first-setup expectation for config and MCP onboarding warnings", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-copy-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				`
 [mcp_servers.non_omx]
 command = "node"
 `.trimStart(),
-      );
+			);
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: join(home, '.codex'),
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Config: config\.toml exists but no OMX entries yet \(expected before first setup; run "omx setup --force" once\)/,
-      );
-      assert.match(
-        res.stdout,
-        /MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: join(home, ".codex"),
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Config: config\.toml exists but no OMX entries yet \(expected before first setup; run "omx setup --force" once\)/,
+			);
+			assert.match(
+				res.stdout,
+				/MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('warns about retired omx_team_run config left behind after upgrade', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-copy-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      await mkdir(codexDir, { recursive: true });
-      await writeFile(
-        join(codexDir, 'config.toml'),
-        `
+	it("treats plugin-mode setup omissions as expected and verifies marketplace registration", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-mode-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+
+			const setupRes = runOmx(
+				wd,
+				["setup", "--scope", "user", "--plugin", "--force"],
+				{
+					HOME: home,
+					CODEX_HOME: codexDir,
+				},
+			);
+			if (shouldSkipForSpawnPermissions(setupRes.error)) return;
+			assert.equal(setupRes.status, 0, setupRes.stderr || setupRes.stdout);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(res.stdout, /Resolved setup install mode: plugin/);
+			assert.match(
+				res.stdout,
+				/Prompts: plugin mode intentionally omits setup-owned prompts; Codex plugin discovery supplies workflow surfaces/,
+			);
+			assert.match(
+				res.stdout,
+				/Skills: plugin marketplace oh-my-codex-local registered; OMX skills are supplied by/,
+			);
+			assert.match(
+				res.stdout,
+				/MCP Servers: plugin mode uses plugin-scoped MCP metadata; setup-owned OMX MCP tables are intentionally omitted/,
+			);
+			assert.doesNotMatch(res.stdout, /Prompts: prompts directory not found/);
+			assert.doesNotMatch(res.stdout, /Skills: skills directory not found/);
+			assert.doesNotMatch(res.stdout, /Skills: \d+ skills \(expected >=/);
+			assert.doesNotMatch(res.stdout, /MCP Servers: no MCP servers configured/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("uses project-scoped plugin marketplace registration without legacy omission warnings", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-project-plugin-mode-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+
+			const setupRes = runOmx(
+				wd,
+				["setup", "--scope", "project", "--plugin", "--force"],
+				{
+					HOME: home,
+					CODEX_HOME: codexDir,
+				},
+			);
+			if (shouldSkipForSpawnPermissions(setupRes.error)) return;
+			assert.equal(setupRes.status, 0, setupRes.stderr || setupRes.stdout);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Resolved setup scope: project \(from \.omx\/setup-scope\.json\)/,
+			);
+			assert.match(
+				res.stdout,
+				/Resolved setup install mode: plugin \(from \.omx\/setup-scope\.json\)/,
+			);
+			assert.match(
+				res.stdout,
+				/Skills: plugin marketplace oh-my-codex-local registered; OMX skills are supplied by/,
+			);
+			assert.match(
+				res.stdout,
+				/Prompts: plugin mode intentionally omits setup-owned prompts; Codex plugin discovery supplies workflow surfaces/,
+			);
+			assert.match(
+				res.stdout,
+				/MCP Servers: plugin mode uses plugin-scoped MCP metadata; setup-owned OMX MCP tables are intentionally omitted/,
+			);
+			assert.doesNotMatch(res.stdout, /Prompts: prompts directory not found/);
+			assert.doesNotMatch(res.stdout, /Skills: skills directory not found/);
+			assert.doesNotMatch(res.stdout, /MCP Servers: no MCP servers configured/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("warns specifically when plugin-mode marketplace registration is missing", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-mode-missing-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				JSON.stringify({ scope: "user", installMode: "plugin" }, null, 2) +
+					"\n",
+			);
+			await writeFile(join(codexDir, "config.toml"), "codex_hooks = true\n");
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(res.stdout, /Resolved setup install mode: plugin/);
+			assert.match(
+				res.stdout,
+				/Skills: plugin mode selected, but Codex marketplace oh-my-codex-local is not registered; run "omx setup --plugin --force"/,
+			);
+			assert.doesNotMatch(res.stdout, /Skills: skills directory not found/);
+			assert.doesNotMatch(res.stdout, /MCP Servers: no MCP servers configured/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("warns about retired omx_team_run config left behind after upgrade", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-copy-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				`
 [mcp_servers.omx_team_run]
 command = "node"
 args = ["/tmp/team-server.js"]
 enabled = true
 `.trimStart(),
-      );
+			);
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: join(home, '.codex'),
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Config: retired \[mcp_servers\.omx_team_run\] table still present; run "omx setup --force" to repair the config/,
-      );
-      assert.match(
-        res.stdout,
-        /MCP Servers: 1 servers configured, but retired \[mcp_servers\.omx_team_run\] is not supported; run "omx setup --force" to repair the config/,
-      );
-      assert.doesNotMatch(res.stdout, /Config: config\.toml has OMX entries/);
-      assert.doesNotMatch(
-        res.stdout,
-        /MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: join(home, ".codex"),
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Config: retired \[mcp_servers\.omx_team_run\] table still present; run "omx setup --force" to repair the config/,
+			);
+			assert.match(
+				res.stdout,
+				/MCP Servers: 1 servers configured, but retired \[mcp_servers\.omx_team_run\] is not supported; run "omx setup --force" to repair the config/,
+			);
+			assert.doesNotMatch(res.stdout, /Config: config\.toml has OMX entries/);
+			assert.doesNotMatch(
+				res.stdout,
+				/MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('warns when explore harness sources are packaged but cargo is unavailable', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-copy-'));
-    try {
-      await withPackagedExploreHarnessHidden(async () => {
-        const home = join(wd, 'home');
-        const codexDir = join(home, '.codex');
-        const fakeBin = join(wd, 'bin');
-        await mkdir(codexDir, { recursive: true });
-        await mkdir(fakeBin, { recursive: true });
-        await writeFile(join(fakeBin, 'codex'), '#!/bin/sh\necho "codex test"\n');
-        spawnSync('chmod', ['+x', join(fakeBin, 'codex')], { encoding: 'utf-8' });
+	it("warns when explore harness sources are packaged but cargo is unavailable", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-explore-copy-"));
+		try {
+			await withPackagedExploreHarnessHidden(async () => {
+				const home = join(wd, "home");
+				const codexDir = join(home, ".codex");
+				const fakeBin = join(wd, "bin");
+				await mkdir(codexDir, { recursive: true });
+				await mkdir(fakeBin, { recursive: true });
+				await writeFile(
+					join(fakeBin, "codex"),
+					'#!/bin/sh\necho "codex test"\n',
+				);
+				spawnSync("chmod", ["+x", join(fakeBin, "codex")], {
+					encoding: "utf-8",
+				});
 
-        const res = runOmx(wd, ['doctor'], {
-          HOME: home,
-          CODEX_HOME: join(home, '.codex'),
-          PATH: fakeBin,
-        });
-        if (shouldSkipForSpawnPermissions(res.error)) return;
-        assert.equal(res.status, 0, res.stderr || res.stdout);
-        assert.match(
-          res.stdout,
-          /Explore Harness: (Rust harness sources are packaged, but no compatible packaged prebuilt or cargo was found \(install Rust or set OMX_EXPLORE_BIN for omx explore\)|not ready \(no packaged binary, OMX_EXPLORE_BIN, or cargo toolchain\))/,
-        );
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+				const res = runOmx(wd, ["doctor"], {
+					HOME: home,
+					CODEX_HOME: join(home, ".codex"),
+					PATH: fakeBin,
+				});
+				if (shouldSkipForSpawnPermissions(res.error)) return;
+				assert.equal(res.status, 0, res.stderr || res.stdout);
+				assert.match(
+					res.stdout,
+					/Explore Harness: (Rust harness sources are packaged, but no compatible packaged prebuilt or cargo was found \(install Rust or set OMX_EXPLORE_BIN for omx explore\)|not ready \(no packaged binary, OMX_EXPLORE_BIN, or cargo toolchain\))/,
+				);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('passes explore harness check when a packaged native binary is present even without cargo', async () => {
-    await withPackagedExploreHarnessLock(async () => {
-      const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-binary-'));
-      try {
-        const home = join(wd, 'home');
-        const codexDir = join(home, '.codex');
-        const fakeBin = join(wd, 'bin');
-        const packageBinDir = join(process.cwd(), 'bin');
-        const packagedBinary = join(packageBinDir, process.platform === 'win32' ? 'omx-explore-harness.exe' : 'omx-explore-harness');
-        const packagedMeta = join(packageBinDir, 'omx-explore-harness.meta.json');
-        const hadExistingBinary = existsSync(packagedBinary);
-        const hadExistingMeta = existsSync(packagedMeta);
+	it("passes explore harness check when a packaged native binary is present even without cargo", async () => {
+		await withPackagedExploreHarnessLock(async () => {
+			const wd = await mkdtemp(join(tmpdir(), "omx-doctor-explore-binary-"));
+			try {
+				const home = join(wd, "home");
+				const codexDir = join(home, ".codex");
+				const fakeBin = join(wd, "bin");
+				const packageBinDir = join(process.cwd(), "bin");
+				const packagedBinary = join(
+					packageBinDir,
+					process.platform === "win32"
+						? "omx-explore-harness.exe"
+						: "omx-explore-harness",
+				);
+				const packagedMeta = join(
+					packageBinDir,
+					"omx-explore-harness.meta.json",
+				);
+				const hadExistingBinary = existsSync(packagedBinary);
+				const hadExistingMeta = existsSync(packagedMeta);
 
-        await mkdir(codexDir, { recursive: true });
-        await mkdir(fakeBin, { recursive: true });
-        await writeFile(join(fakeBin, 'codex'), '#!/bin/sh\necho "codex test"\n');
-        spawnSync('chmod', ['+x', join(fakeBin, 'codex')], { encoding: 'utf-8' });
-        const fsPromises = await import('node:fs/promises');
-        const originalBinary = hadExistingBinary ? await fsPromises.readFile(packagedBinary) : null;
-        const originalMeta = hadExistingMeta ? await fsPromises.readFile(packagedMeta, 'utf-8') : null;
-        await mkdir(packageBinDir, { recursive: true });
-        await writeFile(packagedBinary, '#!/bin/sh\necho "stub harness"\n');
-        await writeFile(packagedMeta, JSON.stringify({ binaryName: process.platform === 'win32' ? 'omx-explore-harness.exe' : 'omx-explore-harness', platform: process.platform, arch: process.arch }));
-        spawnSync('chmod', ['+x', packagedBinary], { encoding: 'utf-8' });
+				await mkdir(codexDir, { recursive: true });
+				await mkdir(fakeBin, { recursive: true });
+				await writeFile(
+					join(fakeBin, "codex"),
+					'#!/bin/sh\necho "codex test"\n',
+				);
+				spawnSync("chmod", ["+x", join(fakeBin, "codex")], {
+					encoding: "utf-8",
+				});
+				const fsPromises = await import("node:fs/promises");
+				const originalBinary = hadExistingBinary
+					? await fsPromises.readFile(packagedBinary)
+					: null;
+				const originalMeta = hadExistingMeta
+					? await fsPromises.readFile(packagedMeta, "utf-8")
+					: null;
+				await mkdir(packageBinDir, { recursive: true });
+				await writeFile(packagedBinary, '#!/bin/sh\necho "stub harness"\n');
+				await writeFile(
+					packagedMeta,
+					JSON.stringify({
+						binaryName:
+							process.platform === "win32"
+								? "omx-explore-harness.exe"
+								: "omx-explore-harness",
+						platform: process.platform,
+						arch: process.arch,
+					}),
+				);
+				spawnSync("chmod", ["+x", packagedBinary], { encoding: "utf-8" });
 
-        try {
-          const res = runOmx(wd, ['doctor'], {
-            HOME: home,
-            CODEX_HOME: join(home, '.codex'),
-            PATH: fakeBin,
-          });
-          if (shouldSkipForSpawnPermissions(res.error)) return;
-          assert.equal(res.status, 0, res.stderr || res.stdout);
-          assert.match(
-            res.stdout,
-            /Explore Harness: ready \(packaged native binary:/,
-          );
-        } finally {
-          if (originalBinary) {
-            await writeFile(packagedBinary, originalBinary);
-            spawnSync('chmod', ['+x', packagedBinary], { encoding: 'utf-8' });
-          } else {
-            await rm(packagedBinary, { force: true });
-          }
-          if (originalMeta !== null) {
-            await writeFile(packagedMeta, originalMeta);
-          } else {
-            await rm(packagedMeta, { force: true });
-          }
-        }
-      } finally {
-        await rm(wd, { recursive: true, force: true });
-      }
-    });
-  });
+				try {
+					const res = runOmx(wd, ["doctor"], {
+						HOME: home,
+						CODEX_HOME: join(home, ".codex"),
+						PATH: fakeBin,
+					});
+					if (shouldSkipForSpawnPermissions(res.error)) return;
+					assert.equal(res.status, 0, res.stderr || res.stdout);
+					assert.match(
+						res.stdout,
+						/Explore Harness: ready \(packaged native binary:/,
+					);
+				} finally {
+					if (originalBinary) {
+						await writeFile(packagedBinary, originalBinary);
+						spawnSync("chmod", ["+x", packagedBinary], { encoding: "utf-8" });
+					} else {
+						await rm(packagedBinary, { force: true });
+					}
+					if (originalMeta !== null) {
+						await writeFile(packagedMeta, originalMeta);
+					} else {
+						await rm(packagedMeta, { force: true });
+					}
+				}
+			} finally {
+				await rm(wd, { recursive: true, force: true });
+			}
+		});
+	});
 
-  it('warns when explore routing is explicitly disabled in config.toml', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-routing-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      await mkdir(codexDir, { recursive: true });
-      await writeFile(
-        join(codexDir, 'config.toml'),
-        `
+	it("warns when explore routing is explicitly disabled in config.toml", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-explore-routing-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				`
 [env]
 USE_OMX_EXPLORE_CMD = "off"
 `.trimStart(),
-      );
+			);
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: join(home, '.codex'),
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Explore routing: disabled in config\.toml \[env\]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing/,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: join(home, ".codex"),
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Explore routing: disabled in config\.toml \[env\]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('warns when canonical and legacy skill roots overlap', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-skill-overlap-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      const canonicalHelp = join(codexDir, 'skills', 'help');
-      const canonicalPlan = join(codexDir, 'skills', 'plan');
-      const legacyHelp = join(home, '.agents', 'skills', 'help');
-      await mkdir(canonicalHelp, { recursive: true });
-      await mkdir(canonicalPlan, { recursive: true });
-      await mkdir(legacyHelp, { recursive: true });
-      await writeFile(join(canonicalHelp, 'SKILL.md'), '# canonical help\n');
-      await writeFile(join(canonicalPlan, 'SKILL.md'), '# canonical plan\n');
-      await writeFile(join(legacyHelp, 'SKILL.md'), '# legacy help\n');
+	it("warns when canonical and legacy skill roots overlap", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-skill-overlap-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			const canonicalHelp = join(codexDir, "skills", "help");
+			const canonicalPlan = join(codexDir, "skills", "plan");
+			const legacyHelp = join(home, ".agents", "skills", "help");
+			await mkdir(canonicalHelp, { recursive: true });
+			await mkdir(canonicalPlan, { recursive: true });
+			await mkdir(legacyHelp, { recursive: true });
+			await writeFile(join(canonicalHelp, "SKILL.md"), "# canonical help\n");
+			await writeFile(join(canonicalPlan, "SKILL.md"), "# canonical plan\n");
+			await writeFile(join(legacyHelp, "SKILL.md"), "# legacy help\n");
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: codexDir,
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Legacy skill roots: 1 overlapping skill names between .*\.codex[\\/]+skills and .*\.agents[\\/]+skills; 1 differ in SKILL\.md content; Codex Enable\/Disable Skills may show duplicates until ~\/\.agents\/skills is cleaned up/,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Legacy skill roots: 1 overlapping skill names between .*\.codex[\\/]+skills and .*\.agents[\\/]+skills; 1 differ in SKILL\.md content; Codex Enable\/Disable Skills may show duplicates until ~\/\.agents\/skills is cleaned up/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('warns when hooks.json is missing OMX-managed native hook coverage', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-hooks-coverage-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      await mkdir(codexDir, { recursive: true });
-      await writeFile(
-        join(codexDir, 'hooks.json'),
-        JSON.stringify(
-          {
-            hooks: {
-              SessionStart: [
-                {
-                  hooks: [
-                    {
-                      type: 'command',
-                      command: 'node "/repo/dist/scripts/codex-native-hook.js"',
-                    },
-                  ],
-                },
-              ],
-            },
-          },
-          null,
-          2,
-        ) + '\n',
-      );
+	it("warns when hooks.json is missing OMX-managed native hook coverage", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-coverage-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "hooks.json"),
+				JSON.stringify(
+					{
+						hooks: {
+							SessionStart: [
+								{
+									hooks: [
+										{
+											type: "command",
+											command: 'node "/repo/dist/scripts/codex-native-hook.js"',
+										},
+									],
+								},
+							],
+						},
+					},
+					null,
+					2,
+				) + "\n",
+			);
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: codexDir,
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Native hooks: hooks\.json is missing OMX-managed coverage for PreToolUse, PostToolUse, UserPromptSubmit, Stop; run "omx setup --force" to restore native hooks/,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Native hooks: hooks\.json is missing OMX-managed coverage for PreToolUse, PostToolUse, UserPromptSubmit, Stop; run "omx setup --force" to restore native hooks/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('warns when hooks.json is missing after OMX config was already installed', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-hooks-missing-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      await mkdir(codexDir, { recursive: true });
-      await writeFile(
-        join(codexDir, 'config.toml'),
-        `
+	it("warns when hooks.json is missing after OMX config was already installed", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-missing-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				`
 omx_enabled = true
 [mcp_servers.omx_state]
 command = "node"
 `.trimStart(),
-      );
+			);
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: codexDir,
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Native hooks: hooks\.json not found even though config\.toml has OMX entries; run "omx setup --force" to restore native hook coverage/,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Native hooks: hooks\.json not found even though config\.toml has OMX entries; run "omx setup --force" to restore native hook coverage/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('fails when hooks.json is invalid and native hook coverage cannot be read', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-hooks-invalid-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      await mkdir(codexDir, { recursive: true });
-      await writeFile(join(codexDir, 'hooks.json'), '{invalid json\n');
+	it("fails when hooks.json is invalid and native hook coverage cannot be read", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-invalid-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(join(codexDir, "hooks.json"), "{invalid json\n");
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: codexDir,
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /\[XX\] Native hooks: invalid hooks\.json; Codex may skip OMX hook coverage until "omx setup --force" repairs it/,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/\[XX\] Native hooks: invalid hooks\.json; Codex may skip OMX hook coverage until "omx setup --force" repairs it/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('passes when legacy skill root is a link to the canonical skills directory', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-skill-link-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      const canonicalSkillsRoot = join(codexDir, 'skills');
-      const canonicalHelp = join(canonicalSkillsRoot, 'help');
-      const legacyRoot = join(home, '.agents', 'skills');
-      await mkdir(canonicalHelp, { recursive: true });
-      await mkdir(join(home, '.agents'), { recursive: true });
-      await writeFile(join(canonicalHelp, 'SKILL.md'), '# canonical help\n');
-      await symlink(
-        canonicalSkillsRoot,
-        legacyRoot,
-        process.platform === 'win32' ? 'junction' : 'dir',
-      );
+	it("passes when legacy skill root is a link to the canonical skills directory", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-skill-link-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			const canonicalSkillsRoot = join(codexDir, "skills");
+			const canonicalHelp = join(canonicalSkillsRoot, "help");
+			const legacyRoot = join(home, ".agents", "skills");
+			await mkdir(canonicalHelp, { recursive: true });
+			await mkdir(join(home, ".agents"), { recursive: true });
+			await writeFile(join(canonicalHelp, "SKILL.md"), "# canonical help\n");
+			await symlink(
+				canonicalSkillsRoot,
+				legacyRoot,
+				process.platform === "win32" ? "junction" : "dir",
+			);
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: codexDir,
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Legacy skill roots: ~\/\.agents\/skills links to canonical .*\.codex[\\/]+skills; treating both paths as one shared skill root/,
-      );
-      assert.doesNotMatch(res.stdout, /\[!!\] Legacy skill roots:/);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Legacy skill roots: ~\/\.agents\/skills links to canonical .*\.codex[\\/]+skills; treating both paths as one shared skill root/,
+			);
+			assert.doesNotMatch(res.stdout, /\[!!\] Legacy skill roots:/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1,1091 +1,1213 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import {
+	cp,
+	mkdir,
+	mkdtemp,
+	readFile,
+	readdir,
+	rm,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { parse as parseToml } from "@iarna/toml";
 import { setup } from "../setup.js";
 
 const packageRoot = process.cwd();
 
 async function withTempCwd(wd: string, fn: () => Promise<void>): Promise<void> {
-  const previousCwd = process.cwd();
-  process.chdir(wd);
-  try {
-    await fn();
-  } finally {
-    process.chdir(previousCwd);
-  }
+	const previousCwd = process.cwd();
+	process.chdir(wd);
+	try {
+		await fn();
+	} finally {
+		process.chdir(previousCwd);
+	}
 }
 
 async function runSetupWithCapturedLogs(
-  wd: string,
-  options: Parameters<typeof setup>[0],
+	wd: string,
+	options: Parameters<typeof setup>[0],
 ): Promise<string> {
-  const previousCwd = process.cwd();
-  const originalLog = console.log;
-  const logs: string[] = [];
-  process.chdir(wd);
-  console.log = (...args: unknown[]) => {
-    logs.push(args.map((arg) => String(arg)).join(" "));
-  };
-  try {
-    await setup(options);
-    return logs.join("\n");
-  } finally {
-    console.log = originalLog;
-    process.chdir(previousCwd);
-  }
+	const previousCwd = process.cwd();
+	const originalLog = console.log;
+	const logs: string[] = [];
+	process.chdir(wd);
+	console.log = (...args: unknown[]) => {
+		logs.push(args.map((arg) => String(arg)).join(" "));
+	};
+	try {
+		await setup(options);
+		return logs.join("\n");
+	} finally {
+		console.log = originalLog;
+		process.chdir(previousCwd);
+	}
 }
 
 async function withIsolatedUserHome<T>(
-  wd: string,
-  fn: (codexHomeDir: string) => Promise<T>,
+	wd: string,
+	fn: (codexHomeDir: string) => Promise<T>,
 ): Promise<T> {
-  const previousHome = process.env.HOME;
-  const previousCodexHome = process.env.CODEX_HOME;
-  const homeDir = join(wd, "home");
-  const codexHomeDir = join(homeDir, ".codex");
-  await mkdir(codexHomeDir, { recursive: true });
-  process.env.HOME = homeDir;
-  process.env.CODEX_HOME = codexHomeDir;
-  try {
-    return await fn(codexHomeDir);
-  } finally {
-    if (typeof previousHome === "string") process.env.HOME = previousHome;
-    else delete process.env.HOME;
-    if (typeof previousCodexHome === "string") {
-      process.env.CODEX_HOME = previousCodexHome;
-    } else {
-      delete process.env.CODEX_HOME;
-    }
-  }
+	const previousHome = process.env.HOME;
+	const previousCodexHome = process.env.CODEX_HOME;
+	const homeDir = join(wd, "home");
+	const codexHomeDir = join(homeDir, ".codex");
+	await mkdir(codexHomeDir, { recursive: true });
+	process.env.HOME = homeDir;
+	process.env.CODEX_HOME = codexHomeDir;
+	try {
+		return await fn(codexHomeDir);
+	} finally {
+		if (typeof previousHome === "string") process.env.HOME = previousHome;
+		else delete process.env.HOME;
+		if (typeof previousCodexHome === "string") {
+			process.env.CODEX_HOME = previousCodexHome;
+		} else {
+			delete process.env.CODEX_HOME;
+		}
+	}
 }
 
-
 async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {
-  const hooks = await readFile(join(wd, ".codex", "hooks.json"), "utf-8");
-  assert.match(hooks, /codex-native-hook\.js/);
-  const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-  assert.match(config, /^codex_hooks = true$/m);
-  assert.doesNotMatch(
-    config,
-    /developer_instructions|notify-hook|mcp_servers/,
-  );
-  assert.equal(
-    existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
-    false,
-  );
-  assert.equal(
-    existsSync(join(wd, ".codex", "agents", "planner.toml")),
-    false,
-  );
-  assert.equal(
-    existsSync(join(wd, ".codex", "prompts", "executor.md")),
-    false,
-  );
-  assert.equal(existsSync(join(wd, "AGENTS.md")), false);
+	const hooks = await readFile(join(wd, ".codex", "hooks.json"), "utf-8");
+	assert.match(hooks, /codex-native-hook\.js/);
+	const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+	assert.match(config, /^codex_hooks = true$/m);
+	assert.doesNotMatch(config, /developer_instructions|notify-hook|mcp_servers/);
+	assert.equal(
+		existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
+		false,
+	);
+	assert.equal(existsSync(join(wd, ".codex", "agents", "planner.toml")), false);
+	assert.equal(existsSync(join(wd, ".codex", "prompts", "executor.md")), false);
+	assert.equal(existsSync(join(wd, "AGENTS.md")), false);
 
-  const persisted = JSON.parse(
-    await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-  ) as { scope: string; installMode?: string };
-  assert.deepEqual(persisted, {
-    scope: "project",
-    installMode: "plugin",
-  });
+	const persisted = JSON.parse(
+		await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+	) as { scope: string; installMode?: string };
+	assert.deepEqual(persisted, {
+		scope: "project",
+		installMode: "plugin",
+	});
 }
 
 async function captureConsoleOutput(fn: () => Promise<void>): Promise<string> {
-  const originalLog = console.log;
-  const originalWarn = console.warn;
-  const lines: string[] = [];
-  console.log = (...args: unknown[]) => {
-    lines.push(args.map(String).join(" "));
-  };
-  console.warn = (...args: unknown[]) => {
-    lines.push(args.map(String).join(" "));
-  };
-  try {
-    await fn();
-  } finally {
-    console.log = originalLog;
-    console.warn = originalWarn;
-  }
-  return lines.join("\n");
+	const originalLog = console.log;
+	const originalWarn = console.warn;
+	const lines: string[] = [];
+	console.log = (...args: unknown[]) => {
+		lines.push(args.map(String).join(" "));
+	};
+	console.warn = (...args: unknown[]) => {
+		lines.push(args.map(String).join(" "));
+	};
+	try {
+		await fn();
+	} finally {
+		console.log = originalLog;
+		console.warn = originalWarn;
+	}
+	return lines.join("\n");
 }
 
 async function seedPluginCacheFromInstalledSkills(
-  codexHomeDir: string,
+	codexHomeDir: string,
 ): Promise<void> {
-  const artifactPath = join(
-    codexHomeDir,
-    "plugins",
-    "cache",
-    "local-marketplace",
-    "oh-my-codex",
-    "local",
-  );
-  await mkdir(join(artifactPath, ".codex-plugin"), { recursive: true });
-  await writeFile(
-    join(artifactPath, ".codex-plugin", "plugin.json"),
-    JSON.stringify({ name: "oh-my-codex", version: "local" }),
-  );
-  const manifest = JSON.parse(
-    await readFile(join(packageRoot, "src", "catalog", "manifest.json"), "utf-8"),
-  ) as { skills: Array<{ name: string; status?: string }> };
-  const installableSkillNames = new Set([
-    ...manifest.skills
-      .filter((skill) => skill.status === "active" || skill.status === "internal")
-      .map((skill) => skill.name),
-    "wiki",
-  ]);
-  await mkdir(join(artifactPath, "skills"), { recursive: true });
-  await Promise.all(
-    [...installableSkillNames].map((skillName) =>
-      cp(join(codexHomeDir, "skills", skillName), join(artifactPath, "skills", skillName), {
-        recursive: true,
-      }),
-    ),
-  );
+	const artifactPath = join(
+		codexHomeDir,
+		"plugins",
+		"cache",
+		"local-marketplace",
+		"oh-my-codex",
+		"local",
+	);
+	await mkdir(join(artifactPath, ".codex-plugin"), { recursive: true });
+	await writeFile(
+		join(artifactPath, ".codex-plugin", "plugin.json"),
+		JSON.stringify({ name: "oh-my-codex", version: "local" }),
+	);
+	const manifest = JSON.parse(
+		await readFile(
+			join(packageRoot, "src", "catalog", "manifest.json"),
+			"utf-8",
+		),
+	) as { skills: Array<{ name: string; status?: string }> };
+	const installableSkillNames = new Set([
+		...manifest.skills
+			.filter(
+				(skill) => skill.status === "active" || skill.status === "internal",
+			)
+			.map((skill) => skill.name),
+		"wiki",
+	]);
+	await mkdir(join(artifactPath, "skills"), { recursive: true });
+	await Promise.all(
+		[...installableSkillNames].map((skillName) =>
+			cp(
+				join(codexHomeDir, "skills", skillName),
+				join(artifactPath, "skills", skillName),
+				{
+					recursive: true,
+				},
+			),
+		),
+	);
 }
 
 describe("omx setup install mode behavior", () => {
-  it("summarizes and keeps persisted setup preferences when review chooses keep", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        await withTempCwd(wd, async () => {
-          await mkdir(join(wd, ".omx"), { recursive: true });
-          await writeFile(
-            join(wd, ".omx", "setup-scope.json"),
-            JSON.stringify({ scope: "user", installMode: "legacy" }),
-          );
-
-          const output = await captureConsoleOutput(async () => {
-            await setup({
-              persistedSetupReviewPrompt: async (preferences) => {
-                assert.deepEqual(preferences, {
-                  scope: "user",
-                  installMode: "legacy",
-                });
-                return "keep";
-              },
-            });
-          });
-
-          assert.match(
-            output,
-            /Setup preference review: keep \(scope=user, installMode=legacy\)/,
-          );
-          assert.match(
-            output,
-            /Using setup scope: user \(from \.omx\/setup-scope\.json\)/,
-          );
-          assert.match(
-            output,
-            /Using setup install mode: legacy \(from \.omx\/setup-scope\.json\)/,
-          );
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("uses persisted choices as defaults when review changes setup preferences", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        await withTempCwd(wd, async () => {
-          await mkdir(join(wd, ".omx"), { recursive: true });
-          await writeFile(
-            join(wd, ".omx", "setup-scope.json"),
-            JSON.stringify({ scope: "user", installMode: "legacy" }),
-          );
-
-          await setup({
-            persistedSetupReviewPrompt: async () => "review",
-            setupScopePrompt: async (defaultScope) => {
-              assert.equal(defaultScope, "user");
-              return "user";
-            },
-            installModePrompt: async (defaultMode) => {
-              assert.equal(defaultMode, "legacy");
-              return "plugin";
-            },
-          });
-
-          const persisted = JSON.parse(
-            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-          ) as { scope: string; installMode?: string };
-          assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("clears user-scope install mode when review switches setup to project scope", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        await withTempCwd(wd, async () => {
-          await mkdir(join(wd, ".omx"), { recursive: true });
-          await writeFile(
-            join(wd, ".omx", "setup-scope.json"),
-            JSON.stringify({ scope: "user", installMode: "plugin" }),
-          );
-
-          await setup({
-            persistedSetupReviewPrompt: async () => "review",
-            setupScopePrompt: async (defaultScope) => {
-              assert.equal(defaultScope, "user");
-              return "project";
-            },
-          });
-
-          const persisted = JSON.parse(
-            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-          ) as { scope: string; installMode?: string };
-          assert.deepEqual(persisted, { scope: "project" });
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("reviews persisted scope when only install mode is provided", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        await withTempCwd(wd, async () => {
-          await mkdir(join(wd, ".omx"), { recursive: true });
-          await writeFile(
-            join(wd, ".omx", "setup-scope.json"),
-            JSON.stringify({ scope: "project" }),
-          );
-
-          let reviewed = false;
-          await setup({
-            installMode: "plugin",
-            persistedSetupReviewPrompt: async () => {
-              reviewed = true;
-              return "reset";
-            },
-            setupScopePrompt: async (defaultScope) => {
-              assert.equal(defaultScope, "user");
-              return "user";
-            },
-          });
-
-          assert.equal(reviewed, true);
-          const persisted = JSON.parse(
-            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-          ) as { scope: string; installMode?: string };
-          assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("reviews persisted install mode when only user scope is provided", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        await withTempCwd(wd, async () => {
-          await mkdir(join(wd, ".omx"), { recursive: true });
-          await writeFile(
-            join(wd, ".omx", "setup-scope.json"),
-            JSON.stringify({ scope: "user", installMode: "legacy" }),
-          );
-
-          let reviewed = false;
-          await setup({
-            scope: "user",
-            persistedSetupReviewPrompt: async () => {
-              reviewed = true;
-              return "review";
-            },
-            installModePrompt: async (defaultMode) => {
-              assert.equal(defaultMode, "legacy");
-              return "plugin";
-            },
-          });
-
-          assert.equal(reviewed, true);
-          const persisted = JSON.parse(
-            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-          ) as { scope: string; installMode?: string };
-          assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("ignores persisted setup preferences when review chooses reset", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        await withTempCwd(wd, async () => {
-          await mkdir(join(wd, ".omx"), { recursive: true });
-          await writeFile(
-            join(wd, ".omx", "setup-scope.json"),
-            JSON.stringify({ scope: "project", installMode: "plugin" }),
-          );
-
-          await setup({
-            persistedSetupReviewPrompt: async () => "reset",
-            setupScopePrompt: async (defaultScope) => {
-              assert.equal(defaultScope, "user");
-              return "user";
-            },
-            installModePrompt: async (defaultMode) => {
-              assert.equal(defaultMode, "legacy");
-              return "legacy";
-            },
-          });
-
-          const persisted = JSON.parse(
-            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-          ) as { scope: string; installMode?: string };
-          assert.deepEqual(persisted, { scope: "user", installMode: "legacy" });
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("prints plugin-mode next steps without claiming native agent TOML files were written", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        const output = await runSetupWithCapturedLogs(wd, {
-          scope: "user",
-          installMode: "plugin",
-        });
-
-        assert.match(output, /Next steps:/);
-        assert.match(
-          output,
-          /Codex plugin discovery supplies OMX skills and workflow surfaces/,
-        );
-        assert.doesNotMatch(output, /TOML files written to \.codex\/agents\//);
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("keeps legacy-mode next steps describing native agent TOML output", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        const output = await runSetupWithCapturedLogs(wd, {
-          scope: "user",
-          installMode: "legacy",
-        });
-
-        assert.match(output, /Next steps:/);
-        assert.match(
-          output,
-          /Native agent defaults configured in config\.toml \[agents\] and TOML files written to \.codex\/agents\//,
-        );
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("persists user install mode choices alongside setup scope", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        await withTempCwd(wd, async () => {
-          await setup({ scope: "user", installMode: "plugin" });
-        });
-      });
-
-      const persisted = JSON.parse(
-        await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-      ) as { scope: string; installMode?: string };
-      assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("defaults to plugin mode when an installed oh-my-codex plugin cache is discovered", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          const pluginDir = join(
-            codexHomeDir,
-            "plugins",
-            "cache",
-            "oh-my-codex-local",
-            "oh-my-codex",
-          );
-          await mkdir(join(pluginDir, ".codex-plugin"), { recursive: true });
-          await writeFile(
-            join(pluginDir, ".codex-plugin", "plugin.json"),
-            JSON.stringify({ name: "oh-my-codex", version: "local" }),
-          );
-
-          await setup({ scope: "user" });
-
-          const persisted = JSON.parse(
-            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-          ) as { scope: string; installMode?: string };
-          assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
-          assert.equal(
-            existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
-            false,
-          );
-          const hooks = await readFile(
-            join(codexHomeDir, "hooks.json"),
-            "utf-8",
-          );
-          assert.match(hooks, /codex-native-hook\.js/);
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("does not prompt for install mode during project-scoped setup", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    let promptCalls = 0;
-    try {
-      await withTempCwd(wd, async () => {
-        await setup({
-          scope: "project",
-          installModePrompt: async () => {
-            promptCalls += 1;
-            return "plugin";
-          },
-        });
-      });
-
-      assert.equal(promptCalls, 0);
-      const persisted = JSON.parse(
-        await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-      ) as { scope: string; installMode?: string };
-      assert.deepEqual(persisted, { scope: "project" });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("does not reuse stale user install mode for project-scoped setup", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        await withTempCwd(wd, async () => {
-          await setup({ scope: "user", installMode: "plugin" });
-
-          await setup({ scope: "project" });
-
-          const persisted = JSON.parse(
-            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-          ) as { scope: string; installMode?: string };
-          assert.deepEqual(persisted, { scope: "project" });
-          assert.equal(
-            existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
-            true,
-          );
-
-          await setup({ scope: "project" });
-
-          const repeatedPersisted = JSON.parse(
-            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-          ) as { scope: string; installMode?: string };
-          assert.deepEqual(repeatedPersisted, { scope: "project" });
-          assert.equal(
-            existsSync(join(wd, ".codex", "agents", "planner.toml")),
-            true,
-          );
-          assert.equal(
-            existsSync(join(wd, ".codex", "prompts", "executor.md")),
-            true,
-          );
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("does not reuse stale project install mode for user-scoped setup", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          await setup({ scope: "project", installMode: "plugin" });
-
-          await setup({ scope: "user" });
-
-          const persisted = JSON.parse(
-            await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-          ) as { scope: string; installMode?: string };
-          assert.deepEqual(persisted, { scope: "user", installMode: "legacy" });
-          assert.equal(
-            existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
-            true,
-          );
-          assert.equal(
-            existsSync(join(codexHomeDir, "agents", "planner.toml")),
-            true,
-          );
-          assert.equal(
-            existsSync(join(codexHomeDir, "prompts", "executor.md")),
-            true,
-          );
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("installs user-scoped native hooks when plugin mode is selected", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          await setup({ scope: "user", installMode: "plugin" });
-
-          const hooks = await readFile(
-            join(codexHomeDir, "hooks.json"),
-            "utf-8",
-          );
-          assert.match(hooks, /codex-native-hook\.js/);
-          const config = await readFile(
-            join(codexHomeDir, "config.toml"),
-            "utf-8",
-          );
-          assert.match(config, /^codex_hooks = true$/m);
-          assert.doesNotMatch(
-            config,
-            /developer_instructions|notify-hook|mcp_servers/,
-          );
-          assert.equal(
-            existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
-            false,
-          );
-          assert.equal(
-            existsSync(join(codexHomeDir, "agents", "planner.toml")),
-            false,
-          );
-          assert.equal(
-            existsSync(join(codexHomeDir, "prompts", "executor.md")),
-            false,
-          );
-          assert.equal(existsSync(join(codexHomeDir, "AGENTS.md")), false);
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("can opt into plugin AGENTS.md and developer_instructions defaults", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          await setup({
-            scope: "user",
-            installMode: "plugin",
-            pluginAgentsMdPrompt: async () => true,
-            pluginDeveloperInstructionsPrompt: async () => true,
-          });
-
-          const hooks = await readFile(
-            join(codexHomeDir, "hooks.json"),
-            "utf-8",
-          );
-          assert.match(hooks, /codex-native-hook\.js/);
-          assert.equal(
-            existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
-            false,
-          );
-          assert.equal(
-            existsSync(join(codexHomeDir, "agents", "planner.toml")),
-            false,
-          );
-          assert.equal(
-            existsSync(join(codexHomeDir, "prompts", "executor.md")),
-            false,
-          );
-
-          const config = await readFile(
-            join(codexHomeDir, "config.toml"),
-            "utf-8",
-          );
-          assert.match(config, /developer_instructions\s*=/);
-          assert.match(config, /^codex_hooks = true$/m);
-          assert.doesNotMatch(config, /notify-hook|mcp_servers/);
-
-          const agentsMd = await readFile(
-            join(codexHomeDir, "AGENTS.md"),
-            "utf-8",
-          );
-          assert.match(
-            agentsMd,
-            /oh-my-codex - Intelligent Multi-Agent Orchestration/,
-          );
-          assert.match(agentsMd, /<!-- omx:generated:agents-md -->/);
-          assert.match(agentsMd, /<!-- OMX:MODELS:START -->/);
-          assert.match(agentsMd, /<!-- OMX:MODELS:END -->/);
-          assert.match(agentsMd, /<guidance_schema_contract>/);
-          assert.match(agentsMd, /<execution_protocols>/);
-          assert.match(agentsMd, /AGENTS\.md is the top-level operating contract/);
-          assert.match(agentsMd, /Treat installed prompts as narrower execution surfaces under AGENTS\.md authority|Role prompts under `prompts\/\*\.md` are narrower execution surfaces/);
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("preserves existing developer_instructions when plugin defaults are requested", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          const configPath = join(codexHomeDir, "config.toml");
-          const existingConfig = 'developer_instructions = "custom"\n';
-          await writeFile(configPath, existingConfig);
-
-          await setup({
-            scope: "user",
-            installMode: "plugin",
-            pluginDeveloperInstructionsPrompt: async () => true,
-          });
-
-          const config = await readFile(configPath, "utf-8");
-          assert.match(config, /^developer_instructions = "custom"$/m);
-          assert.match(config, /^codex_hooks = true$/m);
-          assert.equal(
-            (config.match(/^developer_instructions\s*=/gm) ?? []).length,
-            1,
-          );
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("can overwrite existing developer_instructions after explicit plugin prompt approval", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          const configPath = join(codexHomeDir, "config.toml");
-          await writeFile(configPath, 'developer_instructions = "custom"\n');
-
-          await setup({
-            scope: "user",
-            installMode: "plugin",
-            pluginDeveloperInstructionsPrompt: async () => true,
-            pluginDeveloperInstructionsOverwritePrompt: async () => true,
-          });
-
-          const config = await readFile(configPath, "utf-8");
-          assert.match(config, /You have oh-my-codex installed/);
-          assert.doesNotMatch(config, /^developer_instructions = "custom"$/m);
-          assert.equal(
-            (config.match(/^developer_instructions\s*=/gm) ?? []).length,
-            1,
-          );
-          assert.match(config, /^codex_hooks = true$/m);
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("preserves existing user hooks while installing plugin-mode native hooks", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          const hooksPath = join(codexHomeDir, "hooks.json");
-          const existingHooks =
-            JSON.stringify({ hooks: { UserPromptSubmit: [] } }, null, 2) + "\n";
-          await writeFile(hooksPath, existingHooks);
-
-          await setup({ scope: "user", installMode: "plugin" });
-
-          const hooks = await readFile(hooksPath, "utf-8");
-          assert.match(hooks, /"UserPromptSubmit"/);
-          assert.match(hooks, /codex-native-hook\.js/);
-          const config = await readFile(
-            join(codexHomeDir, "config.toml"),
-            "utf-8",
-          );
-          assert.match(config, /^codex_hooks = true$/m);
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("honors persisted project-scoped plugin mode on repeat setup", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withTempCwd(wd, async () => {
-        await setup({ scope: "project", installMode: "plugin" });
-
-        const persisted = JSON.parse(
-          await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-        ) as { scope: string; installMode?: string };
-        assert.deepEqual(persisted, {
-          scope: "project",
-          installMode: "plugin",
-        });
-
-        await setup({ scope: "project" });
-
-        assert.equal(
-          existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
-          false,
-        );
-        assert.equal(
-          existsSync(join(wd, ".codex", "agents", "planner.toml")),
-          false,
-        );
-        assert.equal(
-          existsSync(join(wd, ".codex", "prompts", "executor.md")),
-          false,
-        );
-        const hooks = await readFile(join(wd, ".codex", "hooks.json"), "utf-8");
-        assert.match(hooks, /codex-native-hook\.js/);
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("installs project-scoped native hooks when plugin mode is explicitly requested", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withTempCwd(wd, async () => {
-        await setup({ scope: "project", installMode: "plugin" });
-
-        await assertProjectPluginModeArtifacts(wd);
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("honors persisted project plugin mode on repeat setup", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withTempCwd(wd, async () => {
-        await setup({ scope: "project", installMode: "plugin" });
-        await setup();
-
-        await assertProjectPluginModeArtifacts(wd);
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("prints plugin-mode next steps without legacy-only claims", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async () => {
-        await withTempCwd(wd, async () => {
-          const pluginOutput = await captureConsoleOutput(async () => {
-            await setup({ scope: "project", installMode: "plugin" });
-          });
-          assert.match(pluginOutput, /Using setup install mode: plugin/);
-          assert.doesNotMatch(pluginOutput, /user-scope skill delivery mode/);
-          assert.doesNotMatch(
-            pluginOutput,
-            /Native agent defaults configured.*TOML files written to \.codex\/agents\//,
-          );
-          assert.doesNotMatch(
-            pluginOutput,
-            /Use role\/workflow keywords like \$architect, \$executor, and \$plan/,
-          );
-          assert.doesNotMatch(
-            pluginOutput,
-            /AGENTS keyword routing can also activate them implicitly/,
-          );
-          assert.doesNotMatch(
-            pluginOutput,
-            /The AGENTS\.md orchestration brain is loaded automatically/,
-          );
-          assert.match(
-            pluginOutput,
-            /Codex plugin discovery supplies OMX skills and workflow surfaces/,
-          );
-          assert.match(pluginOutput, /Browse plugin-provided skills with \/skills/);
-          assert.match(
-            pluginOutput,
-            /Optional AGENTS\.md and developer_instructions defaults are only installed when selected/,
-          );
-
-          const legacyWd = join(wd, "legacy");
-          await mkdir(legacyWd, { recursive: true });
-          await withTempCwd(legacyWd, async () => {
-            const legacyOutput = await captureConsoleOutput(async () => {
-              await setup({ scope: "user", installMode: "legacy" });
-            });
-            assert.match(
-              legacyOutput,
-              /Native agent defaults configured.*TOML files written to \.codex\/agents\//,
-            );
-            assert.match(
-              legacyOutput,
-              /Use role\/workflow keywords like \$architect, \$executor, and \$plan/,
-            );
-            assert.match(
-              legacyOutput,
-              /AGENTS keyword routing can also activate them implicitly/,
-            );
-            assert.match(
-              legacyOutput,
-              /The AGENTS\.md orchestration brain is loaded automatically/,
-            );
-          });
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("removes legacy user components when plugin mode is selected", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          await setup({ scope: "user", installMode: "legacy" });
-
-          const helpSkillPath = join(
-            codexHomeDir,
-            "skills",
-            "help",
-            "SKILL.md",
-          );
-          const promptPath = join(codexHomeDir, "prompts", "executor.md");
-          const agentPath = join(codexHomeDir, "agents", "planner.toml");
-          const hooksPath = join(codexHomeDir, "hooks.json");
-          const configPath = join(codexHomeDir, "config.toml");
-          const agentsMdPath = join(codexHomeDir, "AGENTS.md");
-          assert.equal(existsSync(helpSkillPath), true);
-          assert.equal(existsSync(promptPath), true);
-          assert.equal(existsSync(agentPath), true);
-          assert.equal(existsSync(hooksPath), true);
-          assert.equal(existsSync(configPath), true);
-          assert.equal(existsSync(agentsMdPath), true);
-
-          await setup({ scope: "user", installMode: "plugin" });
-
-          assert.equal(existsSync(helpSkillPath), false);
-          assert.equal(existsSync(promptPath), false);
-          assert.equal(existsSync(agentPath), false);
-          assert.equal(existsSync(hooksPath), true);
-          assert.equal(existsSync(agentsMdPath), false);
-          const hooks = await readFile(hooksPath, "utf-8");
-          assert.match(hooks, /codex-native-hook\.js/);
-          const config = await readFile(configPath, "utf-8");
-          assert.match(config, /^codex_hooks = true$/m);
-          assert.doesNotMatch(
-            config,
-            /oh-my-codex|mcp_servers|notify|developer_instructions/,
-          );
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("archives stale legacy prompts and generated native agents when plugin mode refreshes", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          await setup({ scope: "user", installMode: "legacy" });
-
-          const promptPath = join(codexHomeDir, "prompts", "executor.md");
-          const agentPath = join(codexHomeDir, "agents", "planner.toml");
-          await writeFile(
-            promptPath,
-            "---\ndescription: stale legacy executor prompt\n---\n\nold executor body\n",
-          );
-          await writeFile(
-            agentPath,
-            [
-              "# oh-my-codex agent: planner",
-              'name = "planner"',
-              'description = "stale legacy generated planner"',
-              'developer_instructions = """old planner body"""',
-              "",
-            ].join("\n"),
-          );
-
-          const output = await captureConsoleOutput(async () => {
-            await setup({ scope: "user", installMode: "plugin" });
-          });
-
-          assert.equal(existsSync(promptPath), false);
-          assert.equal(existsSync(agentPath), false);
-          assert.match(output, /Archived and removed .* legacy OMX-managed prompt file/);
-          assert.match(output, /Archived and removed .* legacy OMX-managed native agent config/);
-
-          const backupRoot = join(wd, "home", ".omx", "backups", "setup");
-          const backupRuns = await readdir(backupRoot);
-          assert.ok(backupRuns.length > 0);
-          assert.equal(
-            backupRuns.some((entry) =>
-              existsSync(join(backupRoot, entry, ".codex", "prompts", "executor.md")),
-            ),
-            true,
-          );
-          assert.equal(
-            backupRuns.some((entry) =>
-              existsSync(join(backupRoot, entry, ".codex", "agents", "planner.toml")),
-            ),
-            true,
-          );
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("counts plugin cleanup skill directory backups in the setup summary", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          await setup({ scope: "user", installMode: "legacy" });
-          await seedPluginCacheFromInstalledSkills(codexHomeDir);
-
-          const output = await captureConsoleOutput(async () => {
-            await setup({ scope: "user", installMode: "plugin" });
-          });
-
-          const skillsSummary = output.match(
-            /skills: updated=0, unchanged=0, backed_up=(\d+), skipped=0, removed=(\d+)/,
-          );
-          assert.notEqual(skillsSummary, null);
-          const backedUp = Number(skillsSummary?.[1]);
-          const removed = Number(skillsSummary?.[2]);
-          assert.ok(backedUp > 0);
-          assert.equal(backedUp, removed);
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("removes matching legacy user skills even when plugin readiness is proven", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          await setup({ scope: "user", installMode: "legacy" });
-          await seedPluginCacheFromInstalledSkills(codexHomeDir);
-
-          const helpSkillDir = join(codexHomeDir, "skills", "help");
-          const wikiSkillDir = join(codexHomeDir, "skills", "wiki");
-          assert.equal(existsSync(helpSkillDir), true);
-          assert.equal(existsSync(wikiSkillDir), true);
-
-          const outputLines: string[] = [];
-          const previousLog = console.log;
-          console.log = (...args: unknown[]) => {
-            outputLines.push(args.join(" "));
-          };
-          try {
-            await setup({ scope: "user", installMode: "plugin" });
-          } finally {
-            console.log = previousLog;
-          }
-
-          const setupOutput = outputLines.join("\n");
-          assert.equal(existsSync(helpSkillDir), false);
-          assert.equal(existsSync(wikiSkillDir), false);
-          assert.match(
-            setupOutput,
-            /skills: updated=0, unchanged=0, backed_up=\d+, skipped=0, removed=\d+/,
-          );
-
-          const backupSetupRoot = join(wd, "home", ".omx", "backups", "setup");
-          const backupTimestamps = await readdir(backupSetupRoot);
-          assert.equal(backupTimestamps.length, 1);
-          const backupSkillsDir = join(
-            backupSetupRoot,
-            backupTimestamps[0],
-            ".codex",
-            "skills",
-          );
-          const backedUpSkillNames = await readdir(backupSkillsDir);
-          assert.ok(backedUpSkillNames.includes("help"));
-          assert.ok(backedUpSkillNames.includes("wiki"));
-          assert.match(
-            setupOutput,
-            new RegExp(
-              `skills: updated=0, unchanged=0, backed_up=${backedUpSkillNames.length}, skipped=0, removed=${backedUpSkillNames.length}`,
-            ),
-          );
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it("preserves customized legacy user skills during plugin cleanup", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
-    try {
-      await withIsolatedUserHome(wd, async (codexHomeDir) => {
-        await withTempCwd(wd, async () => {
-          await setup({ scope: "user", installMode: "legacy" });
-          await seedPluginCacheFromInstalledSkills(codexHomeDir);
-
-          const helpSkillPath = join(
-            codexHomeDir,
-            "skills",
-            "help",
-            "SKILL.md",
-          );
-          const wikiSkillDir = join(codexHomeDir, "skills", "wiki");
-          await writeFile(helpSkillPath, "# customized help\n");
-
-          await setup({ scope: "user", installMode: "plugin" });
-
-          assert.equal(
-            await readFile(helpSkillPath, "utf-8"),
-            "# customized help\n",
-          );
-          assert.equal(existsSync(wikiSkillDir), false);
-        });
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+	it("summarizes and keeps persisted setup preferences when review chooses keep", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					await mkdir(join(wd, ".omx"), { recursive: true });
+					await writeFile(
+						join(wd, ".omx", "setup-scope.json"),
+						JSON.stringify({ scope: "user", installMode: "legacy" }),
+					);
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({
+							persistedSetupReviewPrompt: async (preferences) => {
+								assert.deepEqual(preferences, {
+									scope: "user",
+									installMode: "legacy",
+								});
+								return "keep";
+							},
+						});
+					});
+
+					assert.match(
+						output,
+						/Setup preference review: keep \(scope=user, installMode=legacy\)/,
+					);
+					assert.match(
+						output,
+						/Using setup scope: user \(from \.omx\/setup-scope\.json\)/,
+					);
+					assert.match(
+						output,
+						/Using setup install mode: legacy \(from \.omx\/setup-scope\.json\)/,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("uses persisted choices as defaults when review changes setup preferences", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					await mkdir(join(wd, ".omx"), { recursive: true });
+					await writeFile(
+						join(wd, ".omx", "setup-scope.json"),
+						JSON.stringify({ scope: "user", installMode: "legacy" }),
+					);
+
+					await setup({
+						persistedSetupReviewPrompt: async () => "review",
+						setupScopePrompt: async (defaultScope) => {
+							assert.equal(defaultScope, "user");
+							return "user";
+						},
+						installModePrompt: async (defaultMode) => {
+							assert.equal(defaultMode, "legacy");
+							return "plugin";
+						},
+					});
+
+					const persisted = JSON.parse(
+						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+					) as { scope: string; installMode?: string };
+					assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("clears user-scope install mode when review switches setup to project scope", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					await mkdir(join(wd, ".omx"), { recursive: true });
+					await writeFile(
+						join(wd, ".omx", "setup-scope.json"),
+						JSON.stringify({ scope: "user", installMode: "plugin" }),
+					);
+
+					await setup({
+						persistedSetupReviewPrompt: async () => "review",
+						setupScopePrompt: async (defaultScope) => {
+							assert.equal(defaultScope, "user");
+							return "project";
+						},
+					});
+
+					const persisted = JSON.parse(
+						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+					) as { scope: string; installMode?: string };
+					assert.deepEqual(persisted, { scope: "project" });
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reviews persisted scope when only install mode is provided", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					await mkdir(join(wd, ".omx"), { recursive: true });
+					await writeFile(
+						join(wd, ".omx", "setup-scope.json"),
+						JSON.stringify({ scope: "project" }),
+					);
+
+					let reviewed = false;
+					await setup({
+						installMode: "plugin",
+						persistedSetupReviewPrompt: async () => {
+							reviewed = true;
+							return "reset";
+						},
+						setupScopePrompt: async (defaultScope) => {
+							assert.equal(defaultScope, "user");
+							return "user";
+						},
+					});
+
+					assert.equal(reviewed, true);
+					const persisted = JSON.parse(
+						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+					) as { scope: string; installMode?: string };
+					assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reviews persisted install mode when only user scope is provided", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					await mkdir(join(wd, ".omx"), { recursive: true });
+					await writeFile(
+						join(wd, ".omx", "setup-scope.json"),
+						JSON.stringify({ scope: "user", installMode: "legacy" }),
+					);
+
+					let reviewed = false;
+					await setup({
+						scope: "user",
+						persistedSetupReviewPrompt: async () => {
+							reviewed = true;
+							return "review";
+						},
+						installModePrompt: async (defaultMode) => {
+							assert.equal(defaultMode, "legacy");
+							return "plugin";
+						},
+					});
+
+					assert.equal(reviewed, true);
+					const persisted = JSON.parse(
+						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+					) as { scope: string; installMode?: string };
+					assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("ignores persisted setup preferences when review chooses reset", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					await mkdir(join(wd, ".omx"), { recursive: true });
+					await writeFile(
+						join(wd, ".omx", "setup-scope.json"),
+						JSON.stringify({ scope: "project", installMode: "plugin" }),
+					);
+
+					await setup({
+						persistedSetupReviewPrompt: async () => "reset",
+						setupScopePrompt: async (defaultScope) => {
+							assert.equal(defaultScope, "user");
+							return "user";
+						},
+						installModePrompt: async (defaultMode) => {
+							assert.equal(defaultMode, "legacy");
+							return "legacy";
+						},
+					});
+
+					const persisted = JSON.parse(
+						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+					) as { scope: string; installMode?: string };
+					assert.deepEqual(persisted, { scope: "user", installMode: "legacy" });
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("prints plugin-mode next steps without claiming native agent TOML files were written", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				const output = await runSetupWithCapturedLogs(wd, {
+					scope: "user",
+					installMode: "plugin",
+				});
+
+				assert.match(output, /Next steps:/);
+				assert.match(
+					output,
+					/Registered Codex marketplace oh-my-codex-local supplies OMX skills and workflow surfaces/,
+				);
+				assert.doesNotMatch(output, /TOML files written to \.codex\/agents\//);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps legacy-mode next steps describing native agent TOML output", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				const output = await runSetupWithCapturedLogs(wd, {
+					scope: "user",
+					installMode: "legacy",
+				});
+
+				assert.match(output, /Next steps:/);
+				assert.match(
+					output,
+					/Native agent defaults configured in config\.toml \[agents\] and TOML files written to \.codex\/agents\//,
+				);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("persists user install mode choices alongside setup scope", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "plugin" });
+				});
+			});
+
+			const persisted = JSON.parse(
+				await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+			) as { scope: string; installMode?: string };
+			assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("defaults to plugin mode when an installed oh-my-codex plugin cache is discovered", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const pluginDir = join(
+						codexHomeDir,
+						"plugins",
+						"cache",
+						"oh-my-codex-local",
+						"oh-my-codex",
+					);
+					await mkdir(join(pluginDir, ".codex-plugin"), { recursive: true });
+					await writeFile(
+						join(pluginDir, ".codex-plugin", "plugin.json"),
+						JSON.stringify({ name: "oh-my-codex", version: "local" }),
+					);
+
+					await setup({ scope: "user" });
+
+					const persisted = JSON.parse(
+						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+					) as { scope: string; installMode?: string };
+					assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+					assert.equal(
+						existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
+						false,
+					);
+					const hooks = await readFile(
+						join(codexHomeDir, "hooks.json"),
+						"utf-8",
+					);
+					assert.match(hooks, /codex-native-hook\.js/);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not prompt for install mode during project-scoped setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		let promptCalls = 0;
+		try {
+			await withTempCwd(wd, async () => {
+				await setup({
+					scope: "project",
+					installModePrompt: async () => {
+						promptCalls += 1;
+						return "plugin";
+					},
+				});
+			});
+
+			assert.equal(promptCalls, 0);
+			const persisted = JSON.parse(
+				await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+			) as { scope: string; installMode?: string };
+			assert.deepEqual(persisted, { scope: "project" });
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not reuse stale user install mode for project-scoped setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "plugin" });
+
+					await setup({ scope: "project" });
+
+					const persisted = JSON.parse(
+						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+					) as { scope: string; installMode?: string };
+					assert.deepEqual(persisted, { scope: "project" });
+					assert.equal(
+						existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
+						true,
+					);
+
+					await setup({ scope: "project" });
+
+					const repeatedPersisted = JSON.parse(
+						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+					) as { scope: string; installMode?: string };
+					assert.deepEqual(repeatedPersisted, { scope: "project" });
+					assert.equal(
+						existsSync(join(wd, ".codex", "agents", "planner.toml")),
+						true,
+					);
+					assert.equal(
+						existsSync(join(wd, ".codex", "prompts", "executor.md")),
+						true,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not reuse stale project install mode for user-scoped setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "project", installMode: "plugin" });
+
+					await setup({ scope: "user" });
+
+					const persisted = JSON.parse(
+						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+					) as { scope: string; installMode?: string };
+					assert.deepEqual(persisted, { scope: "user", installMode: "legacy" });
+					assert.equal(
+						existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
+						true,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "agents", "planner.toml")),
+						true,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "prompts", "executor.md")),
+						true,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("registers the local Codex plugin marketplace without reintroducing legacy assets", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					await writeFile(
+						configPath,
+						[
+							'model = "gpt-5.5"',
+							"",
+							"[marketplaces.other]",
+							'source_type = "local"',
+							'source = "/tmp/other"',
+							"",
+							"[marketplaces.oh-my-codex-local]",
+							'source_type = "local"',
+							'source = "/tmp/stale-oh-my-codex"',
+							"",
+						].join("\n"),
+					);
+
+					await setup({ scope: "user", installMode: "plugin", force: true });
+					await setup({ scope: "user", installMode: "plugin", force: true });
+
+					const config = await readFile(configPath, "utf-8");
+					const parsed = parseToml(config) as {
+						marketplaces?: Record<
+							string,
+							{ source_type?: string; source?: string }
+						>;
+					};
+					assert.equal(
+						parsed.marketplaces?.["oh-my-codex-local"]?.source_type,
+						"local",
+					);
+					assert.equal(
+						parsed.marketplaces?.["oh-my-codex-local"]?.source,
+						packageRoot,
+					);
+					assert.equal(parsed.marketplaces?.other?.source_type, "local");
+					assert.equal(parsed.marketplaces?.other?.source, "/tmp/other");
+					assert.equal(
+						(config.match(/^\[marketplaces\.oh-my-codex-local\]$/gm) ?? [])
+							.length,
+						1,
+					);
+					assert.match(config, /^codex_hooks = true$/m);
+					assert.doesNotMatch(config, /\[mcp_servers\./);
+					assert.equal(
+						existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
+						false,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "agents", "planner.toml")),
+						false,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "prompts", "executor.md")),
+						false,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reports plugin marketplace registration during dry-run without mutating config", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					await writeFile(configPath, 'model = "gpt-5.5"\n');
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin", dryRun: true });
+					});
+
+					assert.match(
+						output,
+						/Would register local Codex plugin marketplace oh-my-codex-local/,
+					);
+					assert.equal(
+						await readFile(configPath, "utf-8"),
+						'model = "gpt-5.5"\n',
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("installs user-scoped native hooks when plugin mode is selected", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "plugin" });
+
+					const hooks = await readFile(
+						join(codexHomeDir, "hooks.json"),
+						"utf-8",
+					);
+					assert.match(hooks, /codex-native-hook\.js/);
+					const config = await readFile(
+						join(codexHomeDir, "config.toml"),
+						"utf-8",
+					);
+					assert.match(config, /^codex_hooks = true$/m);
+					assert.doesNotMatch(
+						config,
+						/developer_instructions|notify-hook|mcp_servers/,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
+						false,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "agents", "planner.toml")),
+						false,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "prompts", "executor.md")),
+						false,
+					);
+					assert.equal(existsSync(join(codexHomeDir, "AGENTS.md")), false);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("can opt into plugin AGENTS.md and developer_instructions defaults", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => true,
+						pluginDeveloperInstructionsPrompt: async () => true,
+					});
+
+					const hooks = await readFile(
+						join(codexHomeDir, "hooks.json"),
+						"utf-8",
+					);
+					assert.match(hooks, /codex-native-hook\.js/);
+					assert.equal(
+						existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
+						false,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "agents", "planner.toml")),
+						false,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "prompts", "executor.md")),
+						false,
+					);
+
+					const config = await readFile(
+						join(codexHomeDir, "config.toml"),
+						"utf-8",
+					);
+					assert.match(config, /developer_instructions\s*=/);
+					assert.match(config, /^codex_hooks = true$/m);
+					assert.doesNotMatch(config, /notify-hook|mcp_servers/);
+
+					const agentsMd = await readFile(
+						join(codexHomeDir, "AGENTS.md"),
+						"utf-8",
+					);
+					assert.match(
+						agentsMd,
+						/oh-my-codex - Intelligent Multi-Agent Orchestration/,
+					);
+					assert.match(agentsMd, /<!-- omx:generated:agents-md -->/);
+					assert.match(agentsMd, /<!-- OMX:MODELS:START -->/);
+					assert.match(agentsMd, /<!-- OMX:MODELS:END -->/);
+					assert.match(agentsMd, /<guidance_schema_contract>/);
+					assert.match(agentsMd, /<execution_protocols>/);
+					assert.match(
+						agentsMd,
+						/AGENTS\.md is the top-level operating contract/,
+					);
+					assert.match(
+						agentsMd,
+						/Treat installed prompts as narrower execution surfaces under AGENTS\.md authority|Role prompts under `prompts\/\*\.md` are narrower execution surfaces/,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves existing developer_instructions when plugin defaults are requested", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					const existingConfig = 'developer_instructions = "custom"\n';
+					await writeFile(configPath, existingConfig);
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginDeveloperInstructionsPrompt: async () => true,
+					});
+
+					const config = await readFile(configPath, "utf-8");
+					assert.match(config, /^developer_instructions = "custom"$/m);
+					assert.match(config, /^codex_hooks = true$/m);
+					assert.equal(
+						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
+						1,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("can overwrite existing developer_instructions after explicit plugin prompt approval", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					await writeFile(configPath, 'developer_instructions = "custom"\n');
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginDeveloperInstructionsPrompt: async () => true,
+						pluginDeveloperInstructionsOverwritePrompt: async () => true,
+					});
+
+					const config = await readFile(configPath, "utf-8");
+					assert.match(config, /You have oh-my-codex installed/);
+					assert.doesNotMatch(config, /^developer_instructions = "custom"$/m);
+					assert.equal(
+						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
+						1,
+					);
+					assert.match(config, /^codex_hooks = true$/m);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves existing user hooks while installing plugin-mode native hooks", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const existingHooks =
+						JSON.stringify({ hooks: { UserPromptSubmit: [] } }, null, 2) + "\n";
+					await writeFile(hooksPath, existingHooks);
+
+					await setup({ scope: "user", installMode: "plugin" });
+
+					const hooks = await readFile(hooksPath, "utf-8");
+					assert.match(hooks, /"UserPromptSubmit"/);
+					assert.match(hooks, /codex-native-hook\.js/);
+					const config = await readFile(
+						join(codexHomeDir, "config.toml"),
+						"utf-8",
+					);
+					assert.match(config, /^codex_hooks = true$/m);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("honors persisted project-scoped plugin mode on repeat setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withTempCwd(wd, async () => {
+				await setup({ scope: "project", installMode: "plugin" });
+
+				const persisted = JSON.parse(
+					await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+				) as { scope: string; installMode?: string };
+				assert.deepEqual(persisted, {
+					scope: "project",
+					installMode: "plugin",
+				});
+
+				await setup({ scope: "project" });
+
+				assert.equal(
+					existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
+					false,
+				);
+				assert.equal(
+					existsSync(join(wd, ".codex", "agents", "planner.toml")),
+					false,
+				);
+				assert.equal(
+					existsSync(join(wd, ".codex", "prompts", "executor.md")),
+					false,
+				);
+				const hooks = await readFile(join(wd, ".codex", "hooks.json"), "utf-8");
+				assert.match(hooks, /codex-native-hook\.js/);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("installs project-scoped native hooks when plugin mode is explicitly requested", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withTempCwd(wd, async () => {
+				await setup({ scope: "project", installMode: "plugin" });
+
+				await assertProjectPluginModeArtifacts(wd);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("honors persisted project plugin mode on repeat setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withTempCwd(wd, async () => {
+				await setup({ scope: "project", installMode: "plugin" });
+				await setup();
+
+				await assertProjectPluginModeArtifacts(wd);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("prints plugin-mode next steps without legacy-only claims", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					const pluginOutput = await captureConsoleOutput(async () => {
+						await setup({ scope: "project", installMode: "plugin" });
+					});
+					assert.match(pluginOutput, /Using setup install mode: plugin/);
+					assert.doesNotMatch(pluginOutput, /user-scope skill delivery mode/);
+					assert.doesNotMatch(
+						pluginOutput,
+						/Native agent defaults configured.*TOML files written to \.codex\/agents\//,
+					);
+					assert.doesNotMatch(
+						pluginOutput,
+						/Use role\/workflow keywords like \$architect, \$executor, and \$plan/,
+					);
+					assert.doesNotMatch(
+						pluginOutput,
+						/AGENTS keyword routing can also activate them implicitly/,
+					);
+					assert.doesNotMatch(
+						pluginOutput,
+						/The AGENTS\.md orchestration brain is loaded automatically/,
+					);
+					assert.match(
+						pluginOutput,
+						/Registered Codex marketplace oh-my-codex-local supplies OMX skills and workflow surfaces/,
+					);
+					assert.match(
+						pluginOutput,
+						/Browse plugin-provided skills with \/skills/,
+					);
+					assert.match(
+						pluginOutput,
+						/Optional AGENTS\.md and developer_instructions defaults are only installed when selected/,
+					);
+
+					const legacyWd = join(wd, "legacy");
+					await mkdir(legacyWd, { recursive: true });
+					await withTempCwd(legacyWd, async () => {
+						const legacyOutput = await captureConsoleOutput(async () => {
+							await setup({ scope: "user", installMode: "legacy" });
+						});
+						assert.match(
+							legacyOutput,
+							/Native agent defaults configured.*TOML files written to \.codex\/agents\//,
+						);
+						assert.match(
+							legacyOutput,
+							/Use role\/workflow keywords like \$architect, \$executor, and \$plan/,
+						);
+						assert.match(
+							legacyOutput,
+							/AGENTS keyword routing can also activate them implicitly/,
+						);
+						assert.match(
+							legacyOutput,
+							/The AGENTS\.md orchestration brain is loaded automatically/,
+						);
+					});
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("removes legacy user components when plugin mode is selected", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy" });
+
+					const helpSkillPath = join(
+						codexHomeDir,
+						"skills",
+						"help",
+						"SKILL.md",
+					);
+					const promptPath = join(codexHomeDir, "prompts", "executor.md");
+					const agentPath = join(codexHomeDir, "agents", "planner.toml");
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const agentsMdPath = join(codexHomeDir, "AGENTS.md");
+					assert.equal(existsSync(helpSkillPath), true);
+					assert.equal(existsSync(promptPath), true);
+					assert.equal(existsSync(agentPath), true);
+					assert.equal(existsSync(hooksPath), true);
+					assert.equal(existsSync(configPath), true);
+					assert.equal(existsSync(agentsMdPath), true);
+
+					await setup({ scope: "user", installMode: "plugin" });
+
+					assert.equal(existsSync(helpSkillPath), false);
+					assert.equal(existsSync(promptPath), false);
+					assert.equal(existsSync(agentPath), false);
+					assert.equal(existsSync(hooksPath), true);
+					assert.equal(existsSync(agentsMdPath), false);
+					const hooks = await readFile(hooksPath, "utf-8");
+					assert.match(hooks, /codex-native-hook\.js/);
+					const config = await readFile(configPath, "utf-8");
+					assert.match(config, /^codex_hooks = true$/m);
+					assert.doesNotMatch(
+						config,
+						/mcp_servers|notify|developer_instructions/,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("archives stale legacy prompts and generated native agents when plugin mode refreshes", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy" });
+
+					const promptPath = join(codexHomeDir, "prompts", "executor.md");
+					const agentPath = join(codexHomeDir, "agents", "planner.toml");
+					await writeFile(
+						promptPath,
+						"---\ndescription: stale legacy executor prompt\n---\n\nold executor body\n",
+					);
+					await writeFile(
+						agentPath,
+						[
+							"# oh-my-codex agent: planner",
+							'name = "planner"',
+							'description = "stale legacy generated planner"',
+							'developer_instructions = """old planner body"""',
+							"",
+						].join("\n"),
+					);
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					assert.equal(existsSync(promptPath), false);
+					assert.equal(existsSync(agentPath), false);
+					assert.match(
+						output,
+						/Archived and removed .* legacy OMX-managed prompt file/,
+					);
+					assert.match(
+						output,
+						/Archived and removed .* legacy OMX-managed native agent config/,
+					);
+
+					const backupRoot = join(wd, "home", ".omx", "backups", "setup");
+					const backupRuns = await readdir(backupRoot);
+					assert.ok(backupRuns.length > 0);
+					assert.equal(
+						backupRuns.some((entry) =>
+							existsSync(
+								join(backupRoot, entry, ".codex", "prompts", "executor.md"),
+							),
+						),
+						true,
+					);
+					assert.equal(
+						backupRuns.some((entry) =>
+							existsSync(
+								join(backupRoot, entry, ".codex", "agents", "planner.toml"),
+							),
+						),
+						true,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("counts plugin cleanup skill directory backups in the setup summary", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy" });
+					await seedPluginCacheFromInstalledSkills(codexHomeDir);
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					const skillsSummary = output.match(
+						/skills: updated=0, unchanged=0, backed_up=(\d+), skipped=0, removed=(\d+)/,
+					);
+					assert.notEqual(skillsSummary, null);
+					const backedUp = Number(skillsSummary?.[1]);
+					const removed = Number(skillsSummary?.[2]);
+					assert.ok(backedUp > 0);
+					assert.equal(backedUp, removed);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("removes matching legacy user skills even when plugin readiness is proven", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy" });
+					await seedPluginCacheFromInstalledSkills(codexHomeDir);
+
+					const helpSkillDir = join(codexHomeDir, "skills", "help");
+					const wikiSkillDir = join(codexHomeDir, "skills", "wiki");
+					assert.equal(existsSync(helpSkillDir), true);
+					assert.equal(existsSync(wikiSkillDir), true);
+
+					const outputLines: string[] = [];
+					const previousLog = console.log;
+					console.log = (...args: unknown[]) => {
+						outputLines.push(args.join(" "));
+					};
+					try {
+						await setup({ scope: "user", installMode: "plugin" });
+					} finally {
+						console.log = previousLog;
+					}
+
+					const setupOutput = outputLines.join("\n");
+					assert.equal(existsSync(helpSkillDir), false);
+					assert.equal(existsSync(wikiSkillDir), false);
+					assert.match(
+						setupOutput,
+						/skills: updated=0, unchanged=0, backed_up=\d+, skipped=0, removed=\d+/,
+					);
+
+					const backupSetupRoot = join(wd, "home", ".omx", "backups", "setup");
+					const backupTimestamps = await readdir(backupSetupRoot);
+					assert.equal(backupTimestamps.length, 1);
+					const backupSkillsDir = join(
+						backupSetupRoot,
+						backupTimestamps[0],
+						".codex",
+						"skills",
+					);
+					const backedUpSkillNames = await readdir(backupSkillsDir);
+					assert.ok(backedUpSkillNames.includes("help"));
+					assert.ok(backedUpSkillNames.includes("wiki"));
+					assert.match(
+						setupOutput,
+						new RegExp(
+							`skills: updated=0, unchanged=0, backed_up=${backedUpSkillNames.length}, skipped=0, removed=${backedUpSkillNames.length}`,
+						),
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves customized legacy user skills during plugin cleanup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy" });
+					await seedPluginCacheFromInstalledSkills(codexHomeDir);
+
+					const helpSkillPath = join(
+						codexHomeDir,
+						"skills",
+						"help",
+						"SKILL.md",
+					);
+					const wikiSkillDir = join(codexHomeDir, "skills", "wiki");
+					await writeFile(helpSkillPath, "# customized help\n");
+
+					await setup({ scope: "user", installMode: "plugin" });
+
+					assert.equal(
+						await readFile(helpSkillPath, "utf-8"),
+						"# customized help\n",
+					);
+					assert.equal(existsSync(wikiSkillDir), false);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });

--- a/src/cli/codex-home.ts
+++ b/src/cli/codex-home.ts
@@ -1,76 +1,31 @@
-import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { codexConfigPath } from "../utils/paths.js";
 import {
-  SETUP_INSTALL_MODES,
-  SETUP_SCOPES,
-  type SetupInstallMode,
-  type SetupScope,
-} from "./setup.js";
+	readPersistedSetupPreferencesSync,
+	readPersistedSetupScopeSync,
+} from "./setup-preferences.js";
 
-/**
- * Legacy scope values that may appear in persisted setup-scope.json files.
- * Both 'project-local' (renamed) and old 'project' (minimal, removed) are
- * migrated to the current 'project' scope on read.
- */
-const LEGACY_SCOPE_MIGRATION_SYNC: Record<string, SetupScope> = {
-  "project-local": "project",
-};
-
-export function readPersistedSetupScope(cwd: string): SetupScope | undefined {
-  return readPersistedSetupPreferences(cwd)?.scope;
-}
-
-export function readPersistedSetupPreferences(
-  cwd: string,
-): Partial<{ scope: SetupScope; installMode: SetupInstallMode }> | undefined {
-  const scopePath = join(cwd, ".omx", "setup-scope.json");
-  if (!existsSync(scopePath)) return undefined;
-  try {
-    const parsed = JSON.parse(readFileSync(scopePath, "utf-8")) as Partial<{
-      scope: string;
-      installMode: string;
-    }>;
-    const persisted: Partial<{ scope: SetupScope; installMode: SetupInstallMode }> = {};
-    if (typeof parsed.scope === "string") {
-      if (SETUP_SCOPES.includes(parsed.scope as SetupScope)) {
-        persisted.scope = parsed.scope as SetupScope;
-      }
-      const migrated = LEGACY_SCOPE_MIGRATION_SYNC[parsed.scope];
-      if (migrated) persisted.scope = migrated;
-    }
-    if (
-      typeof parsed.installMode === "string"
-      && SETUP_INSTALL_MODES.includes(parsed.installMode as SetupInstallMode)
-    ) {
-      persisted.installMode = parsed.installMode as SetupInstallMode;
-    }
-    return Object.keys(persisted).length > 0 ? persisted : undefined;
-  } catch (err) {
-    process.stderr.write(`[cli/codex-home] operation failed: ${err}\n`);
-    // Ignore malformed persisted scope and use defaults.
-  }
-  return undefined;
-}
+export const readPersistedSetupPreferences = readPersistedSetupPreferencesSync;
+export const readPersistedSetupScope = readPersistedSetupScopeSync;
 
 export function resolveCodexHomeForLaunch(
-  cwd: string,
-  env: NodeJS.ProcessEnv = process.env,
+	cwd: string,
+	env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
-  if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return env.CODEX_HOME;
-  const persistedScope = readPersistedSetupScope(cwd);
-  if (persistedScope === "project") {
-    return join(cwd, ".codex");
-  }
-  return undefined;
+	if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return env.CODEX_HOME;
+	const persistedScope = readPersistedSetupScope(cwd);
+	if (persistedScope === "project") {
+		return join(cwd, ".codex");
+	}
+	return undefined;
 }
 
 export function resolveCodexConfigPathForLaunch(
-  cwd: string,
-  env: NodeJS.ProcessEnv = process.env,
+	cwd: string,
+	env: NodeJS.ProcessEnv = process.env,
 ): string {
-  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, env);
-  return codexHomeOverride
-    ? join(codexHomeOverride, "config.toml")
-    : codexConfigPath();
+	const codexHomeOverride = resolveCodexHomeForLaunch(cwd, env);
+	return codexHomeOverride
+		? join(codexHomeOverride, "config.toml")
+		: codexConfigPath();
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,422 +2,493 @@
  * omx doctor - Validate oh-my-codex installation
  */
 
-import { existsSync } from 'fs';
-import { readdir, readFile } from 'fs/promises';
-import { join } from 'path';
+import { existsSync } from "fs";
+import { readdir, readFile } from "fs/promises";
+import { join } from "path";
 import {
-  codexHome, codexConfigPath, codexPromptsDir,
-  userSkillsDir, projectSkillsDir, omxStateDir, detectLegacySkillRootOverlap,
-} from '../utils/paths.js';
-import { classifySpawnError, spawnPlatformCommandSync } from '../utils/platform-command.js';
-import { getCatalogExpectations } from './catalog-contract.js';
-import { parse as parseToml } from '@iarna/toml';
+	codexHome,
+	codexConfigPath,
+	codexPromptsDir,
+	userSkillsDir,
+	projectSkillsDir,
+	omxStateDir,
+	detectLegacySkillRootOverlap,
+} from "../utils/paths.js";
 import {
-  getBuiltinExploreHarnessUnsupportedReason,
-  resolvePackagedExploreHarnessCommand,
-  EXPLORE_BIN_ENV,
-} from './explore.js';
-import { getPackageRoot } from '../utils/package.js';
-import { hasLegacyOmxTeamRunTable } from '../config/generator.js';
-import { getMissingManagedCodexHookEvents } from '../config/codex-hooks.js';
-import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from '../config/omx-first-party-mcp.js';
-import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
-import { OMX_EXPLORE_CMD_ENV, isExploreCommandRoutingEnabled } from '../hooks/explore-routing.js';
-import { isLeaderRuntimeStale } from '../team/leader-activity.js';
-import { triagePrompt } from '../hooks/triage-heuristic.js';
-import { readTriageConfig } from '../hooks/triage-config.js';
+	classifySpawnError,
+	spawnPlatformCommandSync,
+} from "../utils/platform-command.js";
+import { getCatalogExpectations } from "./catalog-contract.js";
+import { parse as parseToml } from "@iarna/toml";
+import {
+	getBuiltinExploreHarnessUnsupportedReason,
+	resolvePackagedExploreHarnessCommand,
+	EXPLORE_BIN_ENV,
+} from "./explore.js";
+import { getPackageRoot } from "../utils/package.js";
+import { hasLegacyOmxTeamRunTable } from "../config/generator.js";
+import { getMissingManagedCodexHookEvents } from "../config/codex-hooks.js";
+import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
+import { getDefaultBridge, isBridgeEnabled } from "../runtime/bridge.js";
+import {
+	OMX_EXPLORE_CMD_ENV,
+	isExploreCommandRoutingEnabled,
+} from "../hooks/explore-routing.js";
+import { isLeaderRuntimeStale } from "../team/leader-activity.js";
+import { triagePrompt } from "../hooks/triage-heuristic.js";
+import { readTriageConfig } from "../hooks/triage-config.js";
+import {
+	readPersistedSetupPreferences,
+	type SetupInstallMode,
+} from "./setup-preferences.js";
+import {
+	OMX_LOCAL_MARKETPLACE_NAME,
+	resolvePackagedOmxMarketplace,
+} from "./plugin-marketplace.js";
 
 interface DoctorOptions {
-  verbose?: boolean;
-  force?: boolean;
-  dryRun?: boolean;
-  team?: boolean;
+	verbose?: boolean;
+	force?: boolean;
+	dryRun?: boolean;
+	team?: boolean;
 }
 
 interface Check {
-  name: string;
-  status: 'pass' | 'warn' | 'fail';
-  message: string;
+	name: string;
+	status: "pass" | "warn" | "fail";
+	message: string;
 }
 
-type DoctorSetupScope = 'user' | 'project';
+type DoctorSetupScope = "user" | "project";
 
 interface DoctorScopeResolution {
-  scope: DoctorSetupScope;
-  source: 'persisted' | 'default';
+	scope: DoctorSetupScope;
+	source: "persisted" | "default";
+	installMode?: SetupInstallMode;
 }
 
 interface DoctorPaths {
-  codexHomeDir: string;
-  configPath: string;
-  hooksPath: string;
-  promptsDir: string;
-  skillsDir: string;
-  stateDir: string;
+	codexHomeDir: string;
+	configPath: string;
+	hooksPath: string;
+	promptsDir: string;
+	skillsDir: string;
+	stateDir: string;
 }
 
-const LEGACY_SCOPE_MIGRATION: Record<string, DoctorSetupScope> = {
-  'project-local': 'project',
-};
-
 async function resolveDoctorScope(cwd: string): Promise<DoctorScopeResolution> {
-  const scopePath = join(cwd, '.omx', 'setup-scope.json');
-  if (!existsSync(scopePath)) {
-    return { scope: 'user', source: 'default' };
-  }
+	const persisted = await readPersistedSetupPreferences(cwd);
+	if (persisted?.scope) {
+		return {
+			scope: persisted.scope,
+			source: "persisted",
+			installMode: persisted.installMode,
+		};
+	}
 
-  try {
-    const raw = await readFile(scopePath, 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<{ scope: string }>;
-    if (typeof parsed.scope === 'string') {
-      if (parsed.scope === 'user' || parsed.scope === 'project') {
-        return { scope: parsed.scope, source: 'persisted' };
-      }
-      const migrated = LEGACY_SCOPE_MIGRATION[parsed.scope];
-      if (migrated) {
-        return { scope: migrated, source: 'persisted' };
-      }
-    }
-  } catch {
-    // ignore invalid persisted scope and fall back to default
-  }
-
-  return { scope: 'user', source: 'default' };
+	return { scope: "user", source: "default" };
 }
 
 function resolveDoctorPaths(cwd: string, scope: DoctorSetupScope): DoctorPaths {
-  if (scope === 'project') {
-    const codexHomeDir = join(cwd, '.codex');
-    return {
-      codexHomeDir,
-      configPath: join(codexHomeDir, 'config.toml'),
-      hooksPath: join(codexHomeDir, 'hooks.json'),
-      promptsDir: join(codexHomeDir, 'prompts'),
-      skillsDir: projectSkillsDir(cwd),
-      stateDir: omxStateDir(cwd),
-    };
-  }
+	if (scope === "project") {
+		const codexHomeDir = join(cwd, ".codex");
+		return {
+			codexHomeDir,
+			configPath: join(codexHomeDir, "config.toml"),
+			hooksPath: join(codexHomeDir, "hooks.json"),
+			promptsDir: join(codexHomeDir, "prompts"),
+			skillsDir: projectSkillsDir(cwd),
+			stateDir: omxStateDir(cwd),
+		};
+	}
 
-  return {
-    codexHomeDir: codexHome(),
-    configPath: codexConfigPath(),
-    hooksPath: join(codexHome(), 'hooks.json'),
-    promptsDir: codexPromptsDir(),
-    skillsDir: userSkillsDir(),
-    stateDir: omxStateDir(cwd),
-  };
+	return {
+		codexHomeDir: codexHome(),
+		configPath: codexConfigPath(),
+		hooksPath: join(codexHome(), "hooks.json"),
+		promptsDir: codexPromptsDir(),
+		skillsDir: userSkillsDir(),
+		stateDir: omxStateDir(cwd),
+	};
 }
 
 export async function doctor(options: DoctorOptions = {}): Promise<void> {
-  if (options.team) {
-    await doctorTeam();
-    return;
-  }
+	if (options.team) {
+		await doctorTeam();
+		return;
+	}
 
-  const cwd = process.cwd();
-  const scopeResolution = await resolveDoctorScope(cwd);
-  const paths = resolveDoctorPaths(cwd, scopeResolution.scope);
-  const scopeSourceMessage = scopeResolution.source === 'persisted'
-    ? ' (from .omx/setup-scope.json)'
-    : '';
+	const cwd = process.cwd();
+	const scopeResolution = await resolveDoctorScope(cwd);
+	const paths = resolveDoctorPaths(cwd, scopeResolution.scope);
+	const scopeSourceMessage =
+		scopeResolution.source === "persisted"
+			? " (from .omx/setup-scope.json)"
+			: "";
 
-  console.log('oh-my-codex doctor');
-  console.log('==================\n');
-  console.log(`Resolved setup scope: ${scopeResolution.scope}${scopeSourceMessage}\n`);
+	console.log("oh-my-codex doctor");
+	console.log("==================\n");
+	console.log(
+		`Resolved setup scope: ${scopeResolution.scope}${scopeSourceMessage}`,
+	);
+	if (scopeResolution.installMode) {
+		console.log(
+			`Resolved setup install mode: ${scopeResolution.installMode}${scopeSourceMessage}`,
+		);
+	}
+	console.log();
 
-  const checks: Check[] = [];
+	const checks: Check[] = [];
 
-  // Check 1: Codex CLI installed
-  checks.push(checkCodexCli());
+	// Check 1: Codex CLI installed
+	checks.push(checkCodexCli());
 
-  // Check 2: Node.js version
-  checks.push(checkNodeVersion());
+	// Check 2: Node.js version
+	checks.push(checkNodeVersion());
 
-  // Check 2.5: Explore harness readiness
-  checks.push(checkExploreHarness());
+	// Check 2.5: Explore harness readiness
+	checks.push(checkExploreHarness());
 
-  // Check 3: Codex home directory
-  checks.push(checkDirectory('Codex home', paths.codexHomeDir));
+	// Check 3: Codex home directory
+	checks.push(checkDirectory("Codex home", paths.codexHomeDir));
 
-  // Check 4: Config file
-  checks.push(await checkConfig(paths.configPath));
+	// Check 4: Config file
+	checks.push(await checkConfig(paths.configPath));
 
-  // Check 4.25: Native hooks coverage
-  checks.push(await checkNativeHooks(paths.hooksPath, paths.configPath));
+	// Check 4.25: Native hooks coverage
+	checks.push(await checkNativeHooks(paths.hooksPath, paths.configPath));
 
-  // Check 4.5: Explore routing default
-  checks.push(await checkExploreRouting(paths.configPath));
+	// Check 4.5: Explore routing default
+	checks.push(await checkExploreRouting(paths.configPath));
 
-  // Check 5: Prompts installed
-  checks.push(await checkPrompts(paths.promptsDir));
+	// Check 5: Prompts installed
+	checks.push(
+		await checkPrompts(paths.promptsDir, scopeResolution.installMode),
+	);
 
-  // Check 6: Skills installed
-  checks.push(await checkSkills(paths.skillsDir));
+	// Check 6: Skills installed
+	checks.push(await checkSkills(paths, scopeResolution.installMode));
 
-  // Check 6.5: Legacy/current skill-root overlap
-  if (scopeResolution.scope === 'user') {
-    checks.push(await checkLegacySkillRootOverlap());
-  }
+	// Check 6.5: Legacy/current skill-root overlap
+	if (scopeResolution.scope === "user") {
+		checks.push(await checkLegacySkillRootOverlap());
+	}
 
-  // Check 7: AGENTS.md in project
-  checks.push(checkAgentsMd(scopeResolution.scope, paths.codexHomeDir));
+	// Check 7: AGENTS.md in project
+	checks.push(
+		checkAgentsMd(
+			scopeResolution.scope,
+			paths.codexHomeDir,
+			scopeResolution.installMode,
+		),
+	);
 
-  // Check 8: State directory
-  checks.push(checkDirectory('State dir', paths.stateDir));
+	// Check 8: State directory
+	checks.push(checkDirectory("State dir", paths.stateDir));
 
-  // Check 9: MCP servers configured
-  checks.push(await checkMcpServers(paths.configPath));
+	// Check 9: MCP servers configured
+	checks.push(
+		await checkMcpServers(paths.configPath, scopeResolution.installMode),
+	);
 
-  // Check 10: Prompt triage
-  checks.push(checkPromptTriage());
+	// Check 10: Prompt triage
+	checks.push(checkPromptTriage());
 
-  // Print results
-  let passCount = 0;
-  let warnCount = 0;
-  let failCount = 0;
+	// Print results
+	let passCount = 0;
+	let warnCount = 0;
+	let failCount = 0;
 
-  for (const check of checks) {
-    const icon = check.status === 'pass' ? '[OK]' : check.status === 'warn' ? '[!!]' : '[XX]';
-    console.log(`  ${icon} ${check.name}: ${check.message}`);
-    if (check.status === 'pass') passCount++;
-    else if (check.status === 'warn') warnCount++;
-    else failCount++;
-  }
+	for (const check of checks) {
+		const icon =
+			check.status === "pass"
+				? "[OK]"
+				: check.status === "warn"
+					? "[!!]"
+					: "[XX]";
+		console.log(`  ${icon} ${check.name}: ${check.message}`);
+		if (check.status === "pass") passCount++;
+		else if (check.status === "warn") warnCount++;
+		else failCount++;
+	}
 
-  console.log(`\nResults: ${passCount} passed, ${warnCount} warnings, ${failCount} failed`);
+	console.log(
+		`\nResults: ${passCount} passed, ${warnCount} warnings, ${failCount} failed`,
+	);
 
-  if (failCount > 0) {
-    console.log('\nRun "omx setup" to fix installation issues.');
-  } else if (warnCount > 0) {
-    console.log('\nRun "omx setup --force" to refresh all components.');
-  } else {
-    console.log('\nAll checks passed! oh-my-codex is ready.');
-  }
+	if (failCount > 0) {
+		console.log('\nRun "omx setup" to fix installation issues.');
+	} else if (warnCount > 0) {
+		console.log('\nRun "omx setup --force" to refresh all components.');
+	} else {
+		console.log("\nAll checks passed! oh-my-codex is ready.");
+	}
 }
 
 interface TeamDoctorIssue {
-  code: 'delayed_status_lag' | 'slow_shutdown' | 'orphan_tmux_session' | 'resume_blocker' | 'prompt_resume_unavailable' | 'stale_leader';
-  message: string;
-  severity: 'warn' | 'fail';
+	code:
+		| "delayed_status_lag"
+		| "slow_shutdown"
+		| "orphan_tmux_session"
+		| "resume_blocker"
+		| "prompt_resume_unavailable"
+		| "stale_leader";
+	message: string;
+	severity: "warn" | "fail";
 }
 
 async function doctorTeam(): Promise<void> {
-  console.log('oh-my-codex doctor --team');
-  console.log('=========================\n');
+	console.log("oh-my-codex doctor --team");
+	console.log("=========================\n");
 
-  const issues = await collectTeamDoctorIssues(process.cwd());
-  if (issues.length === 0) {
-    console.log('  [OK] team diagnostics: no issues');
-    console.log('\nAll team checks passed.');
-    return;
-  }
+	const issues = await collectTeamDoctorIssues(process.cwd());
+	if (issues.length === 0) {
+		console.log("  [OK] team diagnostics: no issues");
+		console.log("\nAll team checks passed.");
+		return;
+	}
 
-  const failureCount = issues.filter(issue => issue.severity === 'fail').length;
-  const warningCount = issues.length - failureCount;
+	const failureCount = issues.filter(
+		(issue) => issue.severity === "fail",
+	).length;
+	const warningCount = issues.length - failureCount;
 
-  for (const issue of issues) {
-    const icon = issue.severity === 'warn' ? '[!!]' : '[XX]';
-    console.log(`  ${icon} ${issue.code}: ${issue.message}`);
-  }
+	for (const issue of issues) {
+		const icon = issue.severity === "warn" ? "[!!]" : "[XX]";
+		console.log(`  ${icon} ${issue.code}: ${issue.message}`);
+	}
 
-  console.log(`\nResults: ${warningCount} warnings, ${failureCount} failed`);
-  // Ensure non-zero exit for `omx doctor --team` failures.
-  if (failureCount > 0) process.exitCode = 1;
+	console.log(`\nResults: ${warningCount} warnings, ${failureCount} failed`);
+	// Ensure non-zero exit for `omx doctor --team` failures.
+	if (failureCount > 0) process.exitCode = 1;
 }
 
-async function collectTeamDoctorIssues(cwd: string): Promise<TeamDoctorIssue[]> {
-  const issues: TeamDoctorIssue[] = [];
-  const stateDir = omxStateDir(cwd);
-  const teamsRoot = join(stateDir, 'team');
-  const nowMs = Date.now();
-  const lagThresholdMs = 60_000;
-  const shutdownThresholdMs = 30_000;
-  const leaderStaleThresholdMs = 180_000;
+async function collectTeamDoctorIssues(
+	cwd: string,
+): Promise<TeamDoctorIssue[]> {
+	const issues: TeamDoctorIssue[] = [];
+	const stateDir = omxStateDir(cwd);
+	const teamsRoot = join(stateDir, "team");
+	const nowMs = Date.now();
+	const lagThresholdMs = 60_000;
+	const shutdownThresholdMs = 30_000;
+	const leaderStaleThresholdMs = 180_000;
 
-  // Rust-first: if the runtime bridge is enabled, use Rust-authored readiness
-  // and authority as the semantic truth source for runtime health.
-  if (isBridgeEnabled()) {
-    const bridge = getDefaultBridge(stateDir);
-    const readiness = bridge.readReadiness();
-    const authority = bridge.readAuthority();
-    if (readiness && !readiness.ready) {
-      for (const reason of readiness.reasons) {
-        issues.push({
-          code: 'resume_blocker',
-          message: `runtime not ready: ${reason}`,
-          severity: 'fail',
-        });
-      }
-    }
-    if (authority?.stale) {
-      issues.push({
-        code: 'stale_leader',
-        message: `authority stale (owner: ${authority.owner ?? 'unknown'}): ${authority.stale_reason ?? 'unknown reason'}`,
-        severity: 'fail',
-      });
-    }
-  }
+	// Rust-first: if the runtime bridge is enabled, use Rust-authored readiness
+	// and authority as the semantic truth source for runtime health.
+	if (isBridgeEnabled()) {
+		const bridge = getDefaultBridge(stateDir);
+		const readiness = bridge.readReadiness();
+		const authority = bridge.readAuthority();
+		if (readiness && !readiness.ready) {
+			for (const reason of readiness.reasons) {
+				issues.push({
+					code: "resume_blocker",
+					message: `runtime not ready: ${reason}`,
+					severity: "fail",
+				});
+			}
+		}
+		if (authority?.stale) {
+			issues.push({
+				code: "stale_leader",
+				message: `authority stale (owner: ${authority.owner ?? "unknown"}): ${authority.stale_reason ?? "unknown reason"}`,
+				severity: "fail",
+			});
+		}
+	}
 
-  const teamDirs: string[] = [];
-  if (existsSync(teamsRoot)) {
-    const entries = await readdir(teamsRoot, { withFileTypes: true });
-    for (const e of entries) {
-      if (e.isDirectory()) teamDirs.push(e.name);
-    }
-  }
+	const teamDirs: string[] = [];
+	if (existsSync(teamsRoot)) {
+		const entries = await readdir(teamsRoot, { withFileTypes: true });
+		for (const e of entries) {
+			if (e.isDirectory()) teamDirs.push(e.name);
+		}
+	}
 
-  const tmuxSessions = listTeamTmuxSessions();
-  const tmuxUnavailable = tmuxSessions === null;
-  const knownTeamSessions = new Set<string>();
+	const tmuxSessions = listTeamTmuxSessions();
+	const tmuxUnavailable = tmuxSessions === null;
+	const knownTeamSessions = new Set<string>();
 
-  for (const teamName of teamDirs) {
-    const teamDir = join(teamsRoot, teamName);
-    const manifestPath = join(teamDir, 'manifest.v2.json');
-    const configPath = join(teamDir, 'config.json');
+	for (const teamName of teamDirs) {
+		const teamDir = join(teamsRoot, teamName);
+		const manifestPath = join(teamDir, "manifest.v2.json");
+		const configPath = join(teamDir, "config.json");
 
-    let tmuxSession = `omx-team-${teamName}`;
-    let workerLaunchMode: 'interactive' | 'prompt' = 'interactive';
-    let promptWorkers: Array<{ name?: string; pid?: number }> = [];
-    if (existsSync(manifestPath)) {
-      try {
-        const raw = await readFile(manifestPath, 'utf-8');
-        const parsed = JSON.parse(raw) as { tmux_session?: string; policy?: { worker_launch_mode?: string }; workers?: Array<{ name?: string; pid?: number }> };
-        if (typeof parsed.tmux_session === 'string' && parsed.tmux_session.trim() !== '') {
-          tmuxSession = parsed.tmux_session;
-        }
-        if (parsed.policy?.worker_launch_mode === 'prompt') workerLaunchMode = 'prompt';
-        if (Array.isArray(parsed.workers)) promptWorkers = parsed.workers;
-      } catch {
-        // ignore malformed manifest
-      }
-    } else if (existsSync(configPath)) {
-      try {
-        const raw = await readFile(configPath, 'utf-8');
-        const parsed = JSON.parse(raw) as { tmux_session?: string; worker_launch_mode?: string; workers?: Array<{ name?: string; pid?: number }> };
-        if (typeof parsed.tmux_session === 'string' && parsed.tmux_session.trim() !== '') {
-          tmuxSession = parsed.tmux_session;
-        }
-        if (parsed.worker_launch_mode === 'prompt') workerLaunchMode = 'prompt';
-        if (Array.isArray(parsed.workers)) promptWorkers = parsed.workers;
-      } catch {
-        // ignore malformed config
-      }
-    }
+		let tmuxSession = `omx-team-${teamName}`;
+		let workerLaunchMode: "interactive" | "prompt" = "interactive";
+		let promptWorkers: Array<{ name?: string; pid?: number }> = [];
+		if (existsSync(manifestPath)) {
+			try {
+				const raw = await readFile(manifestPath, "utf-8");
+				const parsed = JSON.parse(raw) as {
+					tmux_session?: string;
+					policy?: { worker_launch_mode?: string };
+					workers?: Array<{ name?: string; pid?: number }>;
+				};
+				if (
+					typeof parsed.tmux_session === "string" &&
+					parsed.tmux_session.trim() !== ""
+				) {
+					tmuxSession = parsed.tmux_session;
+				}
+				if (parsed.policy?.worker_launch_mode === "prompt") {
+					workerLaunchMode = "prompt";
+				}
+				if (Array.isArray(parsed.workers)) promptWorkers = parsed.workers;
+			} catch {
+				// ignore malformed manifest
+			}
+		} else if (existsSync(configPath)) {
+			try {
+				const raw = await readFile(configPath, "utf-8");
+				const parsed = JSON.parse(raw) as {
+					tmux_session?: string;
+					worker_launch_mode?: string;
+					workers?: Array<{ name?: string; pid?: number }>;
+				};
+				if (
+					typeof parsed.tmux_session === "string" &&
+					parsed.tmux_session.trim() !== ""
+				) {
+					tmuxSession = parsed.tmux_session;
+				}
+				if (parsed.worker_launch_mode === "prompt") {
+					workerLaunchMode = "prompt";
+				}
+				if (Array.isArray(parsed.workers)) promptWorkers = parsed.workers;
+			} catch {
+				// ignore malformed config
+			}
+		}
 
-    knownTeamSessions.add(tmuxSession);
+		knownTeamSessions.add(tmuxSession);
 
-    if (workerLaunchMode === 'prompt') {
-      for (const worker of promptWorkers) {
-        const pid = worker.pid ?? 0;
-        if (Number.isFinite(pid) && pid > 0 && isPidAlive(pid)) {
-          issues.push({
-            code: 'prompt_resume_unavailable',
-            message: `${teamName}/${worker.name ?? 'unknown'} pid ${pid} appears to be running, but doctor cannot verify that the PID still belongs to the original prompt-mode worker after CLI restart; if this is the original worker, shut it down or start a new team`,
-            severity: 'warn',
-          });
-        }
-      }
-    } else if (!tmuxUnavailable && !tmuxSessions.has(tmuxSession)) {
-      // resume_blocker: only meaningful if tmux is available to query for interactive teams.
-      issues.push({
-        code: 'resume_blocker',
-        message: `${teamName} references missing tmux session ${tmuxSession}`,
-        severity: 'fail',
-      });
-    }
+		if (workerLaunchMode === "prompt") {
+			for (const worker of promptWorkers) {
+				const pid = worker.pid ?? 0;
+				if (Number.isFinite(pid) && pid > 0 && isPidAlive(pid)) {
+					issues.push({
+						code: "prompt_resume_unavailable",
+						message: `${teamName}/${worker.name ?? "unknown"} pid ${pid} appears to be running, but doctor cannot verify that the PID still belongs to the original prompt-mode worker after CLI restart; if this is the original worker, shut it down or start a new team`,
+						severity: "warn",
+					});
+				}
+			}
+		} else if (!tmuxUnavailable && !tmuxSessions.has(tmuxSession)) {
+			// resume_blocker: only meaningful if tmux is available to query for interactive teams.
+			issues.push({
+				code: "resume_blocker",
+				message: `${teamName} references missing tmux session ${tmuxSession}`,
+				severity: "fail",
+			});
+		}
 
-    // delayed_status_lag + slow_shutdown checks
-    const workersRoot = join(teamDir, 'workers');
-    if (!existsSync(workersRoot)) continue;
-    const workers = await readdir(workersRoot, { withFileTypes: true });
-    for (const worker of workers) {
-      if (!worker.isDirectory()) continue;
-      const workerDir = join(workersRoot, worker.name);
-      const statusPath = join(workerDir, 'status.json');
-      const heartbeatPath = join(workerDir, 'heartbeat.json');
-      const shutdownReqPath = join(workerDir, 'shutdown-request.json');
-      const shutdownAckPath = join(workerDir, 'shutdown-ack.json');
+		// delayed_status_lag + slow_shutdown checks
+		const workersRoot = join(teamDir, "workers");
+		if (!existsSync(workersRoot)) continue;
+		const workers = await readdir(workersRoot, { withFileTypes: true });
+		for (const worker of workers) {
+			if (!worker.isDirectory()) continue;
+			const workerDir = join(workersRoot, worker.name);
+			const statusPath = join(workerDir, "status.json");
+			const heartbeatPath = join(workerDir, "heartbeat.json");
+			const shutdownReqPath = join(workerDir, "shutdown-request.json");
+			const shutdownAckPath = join(workerDir, "shutdown-ack.json");
 
-      if (existsSync(statusPath) && existsSync(heartbeatPath)) {
-        try {
-          const [statusRaw, hbRaw] = await Promise.all([
-            readFile(statusPath, 'utf-8'),
-            readFile(heartbeatPath, 'utf-8'),
-          ]);
-          const status = JSON.parse(statusRaw) as { state?: string };
-          const hb = JSON.parse(hbRaw) as { last_turn_at?: string };
-          const lastTurnMs = hb.last_turn_at ? Date.parse(hb.last_turn_at) : NaN;
-          if (status.state === 'working' && Number.isFinite(lastTurnMs) && nowMs - lastTurnMs > lagThresholdMs) {
-            issues.push({
-              code: 'delayed_status_lag',
-              message: `${teamName}/${worker.name} working with stale heartbeat`,
-              severity: 'fail',
-            });
-          }
-        } catch {
-          // ignore malformed files
-        }
-      }
+			if (existsSync(statusPath) && existsSync(heartbeatPath)) {
+				try {
+					const [statusRaw, hbRaw] = await Promise.all([
+						readFile(statusPath, "utf-8"),
+						readFile(heartbeatPath, "utf-8"),
+					]);
+					const status = JSON.parse(statusRaw) as { state?: string };
+					const hb = JSON.parse(hbRaw) as { last_turn_at?: string };
+					const lastTurnMs = hb.last_turn_at
+						? Date.parse(hb.last_turn_at)
+						: NaN;
+					if (
+						status.state === "working" &&
+						Number.isFinite(lastTurnMs) &&
+						nowMs - lastTurnMs > lagThresholdMs
+					) {
+						issues.push({
+							code: "delayed_status_lag",
+							message: `${teamName}/${worker.name} working with stale heartbeat`,
+							severity: "fail",
+						});
+					}
+				} catch {
+					// ignore malformed files
+				}
+			}
 
-      if (existsSync(shutdownReqPath) && !existsSync(shutdownAckPath)) {
-        try {
-          const reqRaw = await readFile(shutdownReqPath, 'utf-8');
-          const req = JSON.parse(reqRaw) as { requested_at?: string };
-          const reqMs = req.requested_at ? Date.parse(req.requested_at) : NaN;
-          if (Number.isFinite(reqMs) && nowMs - reqMs > shutdownThresholdMs) {
-            issues.push({
-              code: 'slow_shutdown',
-              message: `${teamName}/${worker.name} has stale shutdown request without ack`,
-              severity: 'fail',
-            });
-          }
-        } catch {
-          // ignore malformed files
-        }
-      }
-    }
-  }
+			if (existsSync(shutdownReqPath) && !existsSync(shutdownAckPath)) {
+				try {
+					const reqRaw = await readFile(shutdownReqPath, "utf-8");
+					const req = JSON.parse(reqRaw) as { requested_at?: string };
+					const reqMs = req.requested_at ? Date.parse(req.requested_at) : NaN;
+					if (Number.isFinite(reqMs) && nowMs - reqMs > shutdownThresholdMs) {
+						issues.push({
+							code: "slow_shutdown",
+							message: `${teamName}/${worker.name} has stale shutdown request without ack`,
+							severity: "fail",
+						});
+					}
+				} catch {
+					// ignore malformed files
+				}
+			}
+		}
+	}
 
-  // stale_leader: team has active workers but leader has no recent activity
-  const hudStatePath = join(stateDir, 'hud-state.json');
-  const leaderActivityPath = join(stateDir, 'leader-runtime-activity.json');
-  if ((existsSync(hudStatePath) || existsSync(leaderActivityPath)) && teamDirs.length > 0) {
-    try {
-      const leaderIsStale = await isLeaderRuntimeStale(stateDir, leaderStaleThresholdMs, nowMs);
+	// stale_leader: team has active workers but leader has no recent activity
+	const hudStatePath = join(stateDir, "hud-state.json");
+	const leaderActivityPath = join(stateDir, "leader-runtime-activity.json");
+	if (
+		(existsSync(hudStatePath) || existsSync(leaderActivityPath)) &&
+		teamDirs.length > 0
+	) {
+		try {
+			const leaderIsStale = await isLeaderRuntimeStale(
+				stateDir,
+				leaderStaleThresholdMs,
+				nowMs,
+			);
 
-      if (leaderIsStale && !tmuxUnavailable) {
-        // Check if any team tmux session has live worker panes
-        for (const teamName of teamDirs) {
-          const session = knownTeamSessions.has(`omx-team-${teamName}`)
-            ? `omx-team-${teamName}`
-            : [...knownTeamSessions].find(s => s.includes(teamName));
-          if (!session || !tmuxSessions.has(session)) continue;
-          issues.push({
-            code: 'stale_leader',
-            message: `${teamName} has active tmux session but leader has no recent activity`,
-            severity: 'fail',
-          });
-        }
-      }
-    } catch {
-      // ignore malformed HUD state
-    }
-  }
+			if (leaderIsStale && !tmuxUnavailable) {
+				// Check if any team tmux session has live worker panes
+				for (const teamName of teamDirs) {
+					const session = knownTeamSessions.has(`omx-team-${teamName}`)
+						? `omx-team-${teamName}`
+						: [...knownTeamSessions].find((s) => s.includes(teamName));
+					if (!session || !tmuxSessions.has(session)) continue;
+					issues.push({
+						code: "stale_leader",
+						message: `${teamName} has active tmux session but leader has no recent activity`,
+						severity: "fail",
+					});
+				}
+			}
+		} catch {
+			// ignore malformed HUD state
+		}
+	}
 
-  // orphan_tmux_session: session exists but no matching team state
-  if (!tmuxUnavailable) {
-    for (const session of tmuxSessions) {
-      if (!knownTeamSessions.has(session)) {
-        issues.push({
-          code: 'orphan_tmux_session',
-          message: `${session} exists without matching team state (possibly external project)`,
-          severity: 'warn',
-        });
-      }
-    }
-  }
+	// orphan_tmux_session: session exists but no matching team state
+	if (!tmuxUnavailable) {
+		for (const session of tmuxSessions) {
+			if (!knownTeamSessions.has(session)) {
+				issues.push({
+					code: "orphan_tmux_session",
+					message: `${session} exists without matching team state (possibly external project)`,
+					severity: "warn",
+				});
+			}
+		}
+	}
 
-  return dedupeIssues(issues);
+	return dedupeIssues(issues);
 }
 
 function isPidAlive(pid: number): boolean {
@@ -432,519 +503,764 @@ function isPidAlive(pid: number): boolean {
 }
 
 function dedupeIssues(issues: TeamDoctorIssue[]): TeamDoctorIssue[] {
-  const seen = new Set<string>();
-  const out: TeamDoctorIssue[] = [];
-  for (const issue of issues) {
-    const key = `${issue.code}:${issue.message}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    out.push(issue);
-  }
-  return out;
+	const seen = new Set<string>();
+	const out: TeamDoctorIssue[] = [];
+	for (const issue of issues) {
+		const key = `${issue.code}:${issue.message}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(issue);
+	}
+	return out;
 }
 
 function listTeamTmuxSessions(): Set<string> | null {
-  const { result: res } = spawnPlatformCommandSync('tmux', ['list-sessions', '-F', '#{session_name}'], { encoding: 'utf-8' });
-  if (res.error) {
-    // tmux binary unavailable or not executable.
-    return null;
-  }
+	const { result: res } = spawnPlatformCommandSync(
+		"tmux",
+		["list-sessions", "-F", "#{session_name}"],
+		{ encoding: "utf-8" },
+	);
+	if (res.error) {
+		// tmux binary unavailable or not executable.
+		return null;
+	}
 
-  if (res.status !== 0) {
-    const stderr = (res.stderr || '').toLowerCase();
-    // tmux installed but no server/session is running.
-    if (stderr.includes('no server running') || stderr.includes('failed to connect to server')) {
-      return new Set();
-    }
-    return null;
-  }
+	if (res.status !== 0) {
+		const stderr = (res.stderr || "").toLowerCase();
+		// tmux installed but no server/session is running.
+		if (
+			stderr.includes("no server running") ||
+			stderr.includes("failed to connect to server")
+		) {
+			return new Set();
+		}
+		return null;
+	}
 
-  const sessions = (res.stdout || '')
-    .split('\n')
-    .map((s) => s.trim())
-    .filter((s) => s.startsWith('omx-team-'));
-  return new Set(sessions);
+	const sessions = (res.stdout || "")
+		.split("\n")
+		.map((s) => s.trim())
+		.filter((s) => s.startsWith("omx-team-"));
+	return new Set(sessions);
 }
 
 function checkCodexCli(): Check {
-  const { result } = spawnPlatformCommandSync('codex', ['--version'], {
-    encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-  if (result.error) {
-    const code = (result.error as NodeJS.ErrnoException).code;
-    const kind = classifySpawnError(result.error as NodeJS.ErrnoException);
-    if (kind === 'missing') {
-      return { name: 'Codex CLI', status: 'fail', message: 'not found - install from https://github.com/openai/codex' };
-    }
-    if (kind === 'blocked') {
-      return {
-        name: 'Codex CLI',
-        status: 'fail',
-        message: `found but could not be executed in this environment (${code || 'blocked'})`,
-      };
-    }
-    return {
-      name: 'Codex CLI',
-      status: 'fail',
-      message: `probe failed - ${result.error.message}`,
-    };
-  }
-  if (result.status === 0) {
-    const version = (result.stdout || '').trim();
-    return { name: 'Codex CLI', status: 'pass', message: `installed (${version})` };
-  }
-  const stderr = (result.stderr || '').trim();
-  return {
-    name: 'Codex CLI',
-    status: 'fail',
-    message: stderr !== '' ? `probe failed - ${stderr}` : `probe failed with exit ${result.status}`,
-  };
+	const { result } = spawnPlatformCommandSync("codex", ["--version"], {
+		encoding: "utf-8",
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	if (result.error) {
+		const code = (result.error as NodeJS.ErrnoException).code;
+		const kind = classifySpawnError(result.error as NodeJS.ErrnoException);
+		if (kind === "missing") {
+			return {
+				name: "Codex CLI",
+				status: "fail",
+				message: "not found - install from https://github.com/openai/codex",
+			};
+		}
+		if (kind === "blocked") {
+			return {
+				name: "Codex CLI",
+				status: "fail",
+				message: `found but could not be executed in this environment (${code || "blocked"})`,
+			};
+		}
+		return {
+			name: "Codex CLI",
+			status: "fail",
+			message: `probe failed - ${result.error.message}`,
+		};
+	}
+	if (result.status === 0) {
+		const version = (result.stdout || "").trim();
+		return {
+			name: "Codex CLI",
+			status: "pass",
+			message: `installed (${version})`,
+		};
+	}
+	const stderr = (result.stderr || "").trim();
+	return {
+		name: "Codex CLI",
+		status: "fail",
+		message:
+			stderr !== ""
+				? `probe failed - ${stderr}`
+				: `probe failed with exit ${result.status}`,
+	};
 }
 
 function checkNodeVersion(): Check {
-  const major = parseInt(process.versions.node.split('.')[0] ?? '0', 10);
-  if (isNaN(major)) {
-    return { name: 'Node.js', status: 'fail', message: `v${process.versions.node} (unable to parse major version)` };
-  }
-  if (major >= 20) {
-    return { name: 'Node.js', status: 'pass', message: `v${process.versions.node}` };
-  }
-  return { name: 'Node.js', status: 'fail', message: `v${process.versions.node} (need >= 20)` };
+	const major = parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+	if (isNaN(major)) {
+		return {
+			name: "Node.js",
+			status: "fail",
+			message: `v${process.versions.node} (unable to parse major version)`,
+		};
+	}
+	if (major >= 20) {
+		return {
+			name: "Node.js",
+			status: "pass",
+			message: `v${process.versions.node}`,
+		};
+	}
+	return {
+		name: "Node.js",
+		status: "fail",
+		message: `v${process.versions.node} (need >= 20)`,
+	};
 }
 
 export function checkExploreHarness(
-  platform: NodeJS.Platform = process.platform,
-  env: NodeJS.ProcessEnv = process.env,
+	platform: NodeJS.Platform = process.platform,
+	env: NodeJS.ProcessEnv = process.env,
 ): Check {
-  const packageRoot = getPackageRoot();
-  const manifestPath = join(packageRoot, 'crates', 'omx-explore', 'Cargo.toml');
-  if (!existsSync(manifestPath)) {
-    return {
-      name: 'Explore Harness',
-      status: 'warn',
-      message: 'Rust harness sources not found in this install (omx explore unavailable until packaged or OMX_EXPLORE_BIN is set)',
-    };
-  }
+	const packageRoot = getPackageRoot();
+	const manifestPath = join(packageRoot, "crates", "omx-explore", "Cargo.toml");
+	if (!existsSync(manifestPath)) {
+		return {
+			name: "Explore Harness",
+			status: "warn",
+			message:
+				"Rust harness sources not found in this install (omx explore unavailable until packaged or OMX_EXPLORE_BIN is set)",
+		};
+	}
 
-  const override = env[EXPLORE_BIN_ENV]?.trim();
-  if (override) {
-    const resolved = join(packageRoot, override);
-    if (existsSync(override) || existsSync(resolved)) {
-      return {
-        name: 'Explore Harness',
-        status: 'pass',
-        message: `${EXPLORE_BIN_ENV} configured (${override})`,
-      };
-    }
-    return {
-      name: 'Explore Harness',
-      status: 'warn',
-      message: `OMX_EXPLORE_BIN is set but path was not found (${override})`,
-    };
-  }
+	const override = env[EXPLORE_BIN_ENV]?.trim();
+	if (override) {
+		const resolved = join(packageRoot, override);
+		if (existsSync(override) || existsSync(resolved)) {
+			return {
+				name: "Explore Harness",
+				status: "pass",
+				message: `${EXPLORE_BIN_ENV} configured (${override})`,
+			};
+		}
+		return {
+			name: "Explore Harness",
+			status: "warn",
+			message: `OMX_EXPLORE_BIN is set but path was not found (${override})`,
+		};
+	}
 
-  const unsupportedReason = getBuiltinExploreHarnessUnsupportedReason(platform, env);
-  if (unsupportedReason) {
-    return {
-      name: 'Explore Harness',
-      status: 'warn',
-      message: unsupportedReason,
-    };
-  }
+	const unsupportedReason = getBuiltinExploreHarnessUnsupportedReason(
+		platform,
+		env,
+	);
+	if (unsupportedReason) {
+		return {
+			name: "Explore Harness",
+			status: "warn",
+			message: unsupportedReason,
+		};
+	}
 
-  const packaged = resolvePackagedExploreHarnessCommand(packageRoot);
-  if (packaged) {
-    return {
-      name: 'Explore Harness',
-      status: 'pass',
-      message: `ready (packaged native binary: ${packaged.command})`,
-    };
-  }
+	const packaged = resolvePackagedExploreHarnessCommand(packageRoot);
+	if (packaged) {
+		return {
+			name: "Explore Harness",
+			status: "pass",
+			message: `ready (packaged native binary: ${packaged.command})`,
+		};
+	}
 
-  const { result } = spawnPlatformCommandSync('cargo', ['--version'], {
-    encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-  if (result.error) {
-    const kind = classifySpawnError(result.error as NodeJS.ErrnoException);
-    if (kind === 'missing') {
-      return {
-        name: 'Explore Harness',
-        status: 'warn',
-        message: `Rust harness sources are packaged, but no compatible packaged prebuilt or cargo was found (install Rust or set ${EXPLORE_BIN_ENV} for omx explore)`,
-      };
-    }
-    return {
-      name: 'Explore Harness',
-      status: 'warn',
-      message: `Rust harness sources are packaged, but cargo probe failed (${result.error.message})`,
-    };
-  }
+	const { result } = spawnPlatformCommandSync("cargo", ["--version"], {
+		encoding: "utf-8",
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	if (result.error) {
+		const kind = classifySpawnError(result.error as NodeJS.ErrnoException);
+		if (kind === "missing") {
+			return {
+				name: "Explore Harness",
+				status: "warn",
+				message: `Rust harness sources are packaged, but no compatible packaged prebuilt or cargo was found (install Rust or set ${EXPLORE_BIN_ENV} for omx explore)`,
+			};
+		}
+		return {
+			name: "Explore Harness",
+			status: "warn",
+			message: `Rust harness sources are packaged, but cargo probe failed (${result.error.message})`,
+		};
+	}
 
-  if (result.status === 0) {
-    const version = (result.stdout || '').trim();
-    return {
-      name: 'Explore Harness',
-      status: 'pass',
-      message: `ready (${version || 'cargo available'})`,
-    };
-  }
+	if (result.status === 0) {
+		const version = (result.stdout || "").trim();
+		return {
+			name: "Explore Harness",
+			status: "pass",
+			message: `ready (${version || "cargo available"})`,
+		};
+	}
 
-  return {
-    name: 'Explore Harness',
-    status: 'warn',
-    message: `Rust harness sources are packaged, but cargo probe failed with exit ${result.status} (install Rust or set ${EXPLORE_BIN_ENV})`,
-  };
+	return {
+		name: "Explore Harness",
+		status: "warn",
+		message: `Rust harness sources are packaged, but cargo probe failed with exit ${result.status} (install Rust or set ${EXPLORE_BIN_ENV})`,
+	};
 }
 
 function checkDirectory(name: string, path: string): Check {
-  if (existsSync(path)) {
-    return { name, status: 'pass', message: path };
-  }
-  return { name, status: 'warn', message: `${path} (not created yet)` };
+	if (existsSync(path)) {
+		return { name, status: "pass", message: path };
+	}
+	return { name, status: "warn", message: `${path} (not created yet)` };
 }
 
 function validateToml(content: string): string | null {
-  try {
-    parseToml(content);
-    return null;
-  } catch (error) {
-    if (error instanceof Error) {
-      return error.message;
-    }
-    return 'unknown TOML parse error';
-  }
+	try {
+		parseToml(content);
+		return null;
+	} catch (error) {
+		if (error instanceof Error) {
+			return error.message;
+		}
+		return "unknown TOML parse error";
+	}
 }
 
 async function checkConfig(configPath: string): Promise<Check> {
-  if (!existsSync(configPath)) {
-    return { name: 'Config', status: 'warn', message: 'config.toml not found' };
-  }
+	if (!existsSync(configPath)) {
+		return { name: "Config", status: "warn", message: "config.toml not found" };
+	}
 
-  try {
-    const content = await readFile(configPath, 'utf-8');
-    const tomlError = validateToml(content);
+	try {
+		const content = await readFile(configPath, "utf-8");
+		const tomlError = validateToml(content);
 
-    if (tomlError) {
-      const hint =
-        tomlError.includes("Can't redefine existing key") ||
-        tomlError.includes('duplicate') ||
-        tomlError.includes('[tui]')
-          ? 'possible duplicate TOML table such as [tui]'
-          : 'invalid TOML syntax';
+		if (tomlError) {
+			const hint =
+				tomlError.includes("Can't redefine existing key") ||
+				tomlError.includes("duplicate") ||
+				tomlError.includes("[tui]")
+					? "possible duplicate TOML table such as [tui]"
+					: "invalid TOML syntax";
 
-      return {
-        name: 'Config',
-        status: 'fail',
-        message: `invalid config.toml (${hint})`,
-      };
-    }
+			return {
+				name: "Config",
+				status: "fail",
+				message: `invalid config.toml (${hint})`,
+			};
+		}
 
-    if (hasLegacyOmxTeamRunTable(content)) {
-      return {
-        name: 'Config',
-        status: 'warn',
-        message:
-          'retired [mcp_servers.omx_team_run] table still present; run "omx setup --force" to repair the config',
-      };
-    }
+		if (hasLegacyOmxTeamRunTable(content)) {
+			return {
+				name: "Config",
+				status: "warn",
+				message:
+					'retired [mcp_servers.omx_team_run] table still present; run "omx setup --force" to repair the config',
+			};
+		}
 
-    const hasOmx = content.includes('omx_') || content.includes('oh-my-codex');
-    if (hasOmx) {
-      return { name: 'Config', status: 'pass', message: 'config.toml has OMX entries' };
-    }
+		const hasOmx = content.includes("omx_") || content.includes("oh-my-codex");
+		if (hasOmx) {
+			return {
+				name: "Config",
+				status: "pass",
+				message: "config.toml has OMX entries",
+			};
+		}
 
-    return {
-      name: 'Config',
-      status: 'warn',
-      message: 'config.toml exists but no OMX entries yet (expected before first setup; run "omx setup --force" once)',
-    };
-  } catch {
-    return { name: 'Config', status: 'fail', message: 'cannot read config.toml' };
-  }
+		return {
+			name: "Config",
+			status: "warn",
+			message:
+				'config.toml exists but no OMX entries yet (expected before first setup; run "omx setup --force" once)',
+		};
+	} catch {
+		return {
+			name: "Config",
+			status: "fail",
+			message: "cannot read config.toml",
+		};
+	}
 }
-
 
 async function checkExploreRouting(configPath: string): Promise<Check> {
-  const envValue = process.env[OMX_EXPLORE_CMD_ENV];
-  if (typeof envValue === 'string' && !isExploreCommandRoutingEnabled(process.env)) {
-    return {
-      name: 'Explore routing',
-      status: 'warn',
-      message:
-        'disabled by environment override; enable with USE_OMX_EXPLORE_CMD=1 (or remove the explicit opt-out)',
-    };
-  }
+	const envValue = process.env[OMX_EXPLORE_CMD_ENV];
+	if (
+		typeof envValue === "string" &&
+		!isExploreCommandRoutingEnabled(process.env)
+	) {
+		return {
+			name: "Explore routing",
+			status: "warn",
+			message:
+				"disabled by environment override; enable with USE_OMX_EXPLORE_CMD=1 (or remove the explicit opt-out)",
+		};
+	}
 
-  if (!existsSync(configPath)) {
-    return {
-      name: 'Explore routing',
-      status: 'pass',
-      message: 'enabled by default (config.toml not found yet)',
-    };
-  }
+	if (!existsSync(configPath)) {
+		return {
+			name: "Explore routing",
+			status: "pass",
+			message: "enabled by default (config.toml not found yet)",
+		};
+	}
 
-  try {
-    const content = await readFile(configPath, 'utf-8');
-    const parsed = parseToml(content) as { env?: Record<string, unknown> };
-    const configuredValue = parsed?.env?.USE_OMX_EXPLORE_CMD;
+	try {
+		const content = await readFile(configPath, "utf-8");
+		const parsed = parseToml(content) as { env?: Record<string, unknown> };
+		const configuredValue = parsed?.env?.USE_OMX_EXPLORE_CMD;
 
-    if (
-      typeof configuredValue === 'string' &&
-      !isExploreCommandRoutingEnabled({
-        USE_OMX_EXPLORE_CMD: configuredValue,
-      })
-    ) {
-      return {
-        name: 'Explore routing',
-        status: 'warn',
-        message:
-          'disabled in config.toml [env]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing',
-      };
-    }
+		if (
+			typeof configuredValue === "string" &&
+			!isExploreCommandRoutingEnabled({
+				USE_OMX_EXPLORE_CMD: configuredValue,
+			})
+		) {
+			return {
+				name: "Explore routing",
+				status: "warn",
+				message:
+					'disabled in config.toml [env]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing',
+			};
+		}
 
-    return {
-      name: 'Explore routing',
-      status: 'pass',
-      message: 'enabled by default',
-    };
-  } catch {
-    return {
-      name: 'Explore routing',
-      status: 'fail',
-      message: 'cannot read config.toml for explore routing check',
-    };
-  }
+		return {
+			name: "Explore routing",
+			status: "pass",
+			message: "enabled by default",
+		};
+	} catch {
+		return {
+			name: "Explore routing",
+			status: "fail",
+			message: "cannot read config.toml for explore routing check",
+		};
+	}
 }
 
-async function checkNativeHooks(hooksPath: string, configPath: string): Promise<Check> {
-  if (!existsSync(hooksPath)) {
-    if (existsSync(configPath)) {
-      try {
-        const configContent = await readFile(configPath, 'utf-8');
-        const hasOmx = configContent.includes('omx_') || configContent.includes('oh-my-codex');
-        if (hasOmx) {
-          return {
-            name: 'Native hooks',
-            status: 'warn',
-            message: 'hooks.json not found even though config.toml has OMX entries; run "omx setup --force" to restore native hook coverage',
-          };
-        }
-      } catch {
-        // fall through to the neutral first-setup path when config cannot be read here;
-        // the dedicated config check will report read failures separately.
-      }
-    }
+async function checkNativeHooks(
+	hooksPath: string,
+	configPath: string,
+): Promise<Check> {
+	if (!existsSync(hooksPath)) {
+		if (existsSync(configPath)) {
+			try {
+				const configContent = await readFile(configPath, "utf-8");
+				const hasOmx =
+					configContent.includes("omx_") ||
+					configContent.includes("oh-my-codex");
+				if (hasOmx) {
+					return {
+						name: "Native hooks",
+						status: "warn",
+						message:
+							'hooks.json not found even though config.toml has OMX entries; run "omx setup --force" to restore native hook coverage',
+					};
+				}
+			} catch {
+				// fall through to the neutral first-setup path when config cannot be read here;
+				// the dedicated config check will report read failures separately.
+			}
+		}
 
-    return {
-      name: 'Native hooks',
-      status: 'pass',
-      message: 'hooks.json not found yet (expected before first setup)',
-    };
-  }
+		return {
+			name: "Native hooks",
+			status: "pass",
+			message: "hooks.json not found yet (expected before first setup)",
+		};
+	}
 
-  try {
-    const content = await readFile(hooksPath, 'utf-8');
-    const missingEvents = getMissingManagedCodexHookEvents(content);
-    if (missingEvents === null) {
-      return {
-        name: 'Native hooks',
-        status: 'fail',
-        message: 'invalid hooks.json; Codex may skip OMX hook coverage until "omx setup --force" repairs it',
-      };
-    }
+	try {
+		const content = await readFile(hooksPath, "utf-8");
+		const missingEvents = getMissingManagedCodexHookEvents(content);
+		if (missingEvents === null) {
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message:
+					'invalid hooks.json; Codex may skip OMX hook coverage until "omx setup --force" repairs it',
+			};
+		}
 
-    if (missingEvents.length > 0) {
-      return {
-        name: 'Native hooks',
-        status: 'warn',
-        message:
-          `hooks.json is missing OMX-managed coverage for ${missingEvents.join(', ')}; run "omx setup --force" to restore native hooks`,
-      };
-    }
+		if (missingEvents.length > 0) {
+			return {
+				name: "Native hooks",
+				status: "warn",
+				message: `hooks.json is missing OMX-managed coverage for ${missingEvents.join(", ")}; run "omx setup --force" to restore native hooks`,
+			};
+		}
 
-    return {
-      name: 'Native hooks',
-      status: 'pass',
-      message: 'hooks.json includes OMX-managed coverage for all native hook events',
-    };
-  } catch {
-    return {
-      name: 'Native hooks',
-      status: 'fail',
-      message: 'cannot read hooks.json',
-    };
-  }
+		return {
+			name: "Native hooks",
+			status: "pass",
+			message:
+				"hooks.json includes OMX-managed coverage for all native hook events",
+		};
+	} catch {
+		return {
+			name: "Native hooks",
+			status: "fail",
+			message: "cannot read hooks.json",
+		};
+	}
 }
 
-async function checkPrompts(dir: string): Promise<Check> {
-  const expectations = getCatalogExpectations();
-  if (!existsSync(dir)) {
-    return { name: 'Prompts', status: 'warn', message: 'prompts directory not found' };
-  }
-  try {
-    const files = await readdir(dir);
-    const mdFiles = files.filter(f => f.endsWith('.md'));
-    if (mdFiles.length >= expectations.promptMin) {
-      return { name: 'Prompts', status: 'pass', message: `${mdFiles.length} agent prompts installed` };
-    }
-    return { name: 'Prompts', status: 'warn', message: `${mdFiles.length} prompts (expected >= ${expectations.promptMin})` };
-  } catch {
-    return { name: 'Prompts', status: 'fail', message: 'cannot read prompts directory' };
-  }
+async function checkPrompts(
+	dir: string,
+	installMode?: SetupInstallMode,
+): Promise<Check> {
+	if (installMode === "plugin") {
+		return {
+			name: "Prompts",
+			status: "pass",
+			message:
+				"plugin mode intentionally omits setup-owned prompts; Codex plugin discovery supplies workflow surfaces",
+		};
+	}
+
+	const expectations = getCatalogExpectations();
+	if (!existsSync(dir)) {
+		return {
+			name: "Prompts",
+			status: "warn",
+			message: "prompts directory not found",
+		};
+	}
+	try {
+		const files = await readdir(dir);
+		const mdFiles = files.filter((f) => f.endsWith(".md"));
+		if (mdFiles.length >= expectations.promptMin) {
+			return {
+				name: "Prompts",
+				status: "pass",
+				message: `${mdFiles.length} agent prompts installed`,
+			};
+		}
+		return {
+			name: "Prompts",
+			status: "warn",
+			message: `${mdFiles.length} prompts (expected >= ${expectations.promptMin})`,
+		};
+	} catch {
+		return {
+			name: "Prompts",
+			status: "fail",
+			message: "cannot read prompts directory",
+		};
+	}
 }
 
 async function checkLegacySkillRootOverlap(): Promise<Check> {
-  const overlap = await detectLegacySkillRootOverlap();
-  if (!overlap.legacyExists) {
-    return {
-      name: 'Legacy skill roots',
-      status: 'pass',
-      message: 'no ~/.agents/skills overlap detected',
-    };
-  }
+	const overlap = await detectLegacySkillRootOverlap();
+	if (!overlap.legacyExists) {
+		return {
+			name: "Legacy skill roots",
+			status: "pass",
+			message: "no ~/.agents/skills overlap detected",
+		};
+	}
 
-  if (overlap.sameResolvedTarget) {
-    return {
-      name: 'Legacy skill roots',
-      status: 'pass',
-      message:
-        `~/.agents/skills links to canonical ${overlap.canonicalDir}; treating both paths as one shared skill root`,
-    };
-  }
+	if (overlap.sameResolvedTarget) {
+		return {
+			name: "Legacy skill roots",
+			status: "pass",
+			message: `~/.agents/skills links to canonical ${overlap.canonicalDir}; treating both paths as one shared skill root`,
+		};
+	}
 
-  if (overlap.overlappingSkillNames.length === 0) {
-    return {
-      name: 'Legacy skill roots',
-      status: 'warn',
-      message:
-        `legacy ~/.agents/skills still exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}; remove or archive it if Codex shows duplicate entries`,
-    };
-  }
+	if (overlap.overlappingSkillNames.length === 0) {
+		return {
+			name: "Legacy skill roots",
+			status: "warn",
+			message: `legacy ~/.agents/skills still exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}; remove or archive it if Codex shows duplicate entries`,
+		};
+	}
 
-  const mismatchMessage = overlap.mismatchedSkillNames.length > 0
-    ? `; ${overlap.mismatchedSkillNames.length} differ in SKILL.md content`
-    : '';
-  return {
-    name: 'Legacy skill roots',
-    status: 'warn',
-    message:
-      `${overlap.overlappingSkillNames.length} overlapping skill names between ${overlap.canonicalDir} and ${overlap.legacyDir}${mismatchMessage}; Codex Enable/Disable Skills may show duplicates until ~/.agents/skills is cleaned up`,
-  };
+	const mismatchMessage =
+		overlap.mismatchedSkillNames.length > 0
+			? `; ${overlap.mismatchedSkillNames.length} differ in SKILL.md content`
+			: "";
+	return {
+		name: "Legacy skill roots",
+		status: "warn",
+		message: `${overlap.overlappingSkillNames.length} overlapping skill names between ${overlap.canonicalDir} and ${overlap.legacyDir}${mismatchMessage}; Codex Enable/Disable Skills may show duplicates until ~/.agents/skills is cleaned up`,
+	};
 }
 
-async function checkSkills(dir: string): Promise<Check> {
-  const expectations = getCatalogExpectations();
-  if (!existsSync(dir)) {
-    return { name: 'Skills', status: 'warn', message: 'skills directory not found' };
-  }
-  try {
-    const entries = await readdir(dir, { withFileTypes: true });
-    const skillDirs = entries.filter(e => e.isDirectory());
-    if (skillDirs.length >= expectations.skillMin) {
-      return { name: 'Skills', status: 'pass', message: `${skillDirs.length} skills installed` };
-    }
-    return { name: 'Skills', status: 'warn', message: `${skillDirs.length} skills (expected >= ${expectations.skillMin})` };
-  } catch {
-    return { name: 'Skills', status: 'fail', message: 'cannot read skills directory' };
-  }
+function getParsedMarketplaceRegistration(
+	content: string,
+): { source_type?: unknown; source?: unknown } | null {
+	const parsed = parseToml(content) as {
+		marketplaces?: Record<string, { source_type?: unknown; source?: unknown }>;
+	};
+	return parsed.marketplaces?.[OMX_LOCAL_MARKETPLACE_NAME] ?? null;
 }
 
-function checkAgentsMd(scope: DoctorSetupScope, codexHomeDir: string): Check {
-  if (scope === 'user') {
-    const userAgentsMd = join(codexHomeDir, 'AGENTS.md');
-    if (existsSync(userAgentsMd)) {
-      return { name: 'AGENTS.md', status: 'pass', message: `found in ${userAgentsMd}` };
-    }
-    return {
-      name: 'AGENTS.md',
-      status: 'warn',
-      message: `not found in ${userAgentsMd} (run omx setup --scope user)`,
-    };
-  }
+async function checkPluginMarketplaceRegistration(
+	configPath: string,
+): Promise<Check> {
+	const packagedMarketplace = await resolvePackagedOmxMarketplace(
+		getPackageRoot(),
+	);
+	if (!packagedMarketplace) {
+		return {
+			name: "Skills",
+			status: "warn",
+			message: `plugin mode selected, but packaged ${OMX_LOCAL_MARKETPLACE_NAME} metadata was not found; reinstall oh-my-codex or run from a package that includes plugins/`,
+		};
+	}
 
-  const projectAgentsMd = join(process.cwd(), 'AGENTS.md');
-  if (existsSync(projectAgentsMd)) {
-    return { name: 'AGENTS.md', status: 'pass', message: 'found in project root' };
-  }
-  return {
-    name: 'AGENTS.md',
-    status: 'warn',
-    message: 'not found in project root (run omx agents-init . or omx setup --scope project)',
-  };
+	if (!existsSync(configPath)) {
+		return {
+			name: "Skills",
+			status: "warn",
+			message: `plugin mode selected, but ${OMX_LOCAL_MARKETPLACE_NAME} is not registered because config.toml is missing; run "omx setup --plugin --force"`,
+		};
+	}
+
+	try {
+		const content = await readFile(configPath, "utf-8");
+		const registration = getParsedMarketplaceRegistration(content);
+		if (!registration) {
+			return {
+				name: "Skills",
+				status: "warn",
+				message: `plugin mode selected, but Codex marketplace ${OMX_LOCAL_MARKETPLACE_NAME} is not registered; run "omx setup --plugin --force"`,
+			};
+		}
+		if (registration.source_type !== "local") {
+			return {
+				name: "Skills",
+				status: "warn",
+				message: `Codex marketplace ${OMX_LOCAL_MARKETPLACE_NAME} has source_type=${String(registration.source_type)} (expected local); run "omx setup --plugin --force"`,
+			};
+		}
+		if (registration.source !== getPackageRoot()) {
+			return {
+				name: "Skills",
+				status: "warn",
+				message: `Codex marketplace ${OMX_LOCAL_MARKETPLACE_NAME} points to ${String(registration.source)} (expected ${getPackageRoot()}); run "omx setup --plugin --force"`,
+			};
+		}
+		return {
+			name: "Skills",
+			status: "pass",
+			message: `plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} registered; OMX skills are supplied by ${packagedMarketplace.pluginRoot}`,
+		};
+	} catch {
+		return {
+			name: "Skills",
+			status: "fail",
+			message:
+				"cannot read or parse config.toml for plugin marketplace registration",
+		};
+	}
+}
+
+async function checkSkills(
+	paths: DoctorPaths,
+	installMode?: SetupInstallMode,
+): Promise<Check> {
+	if (installMode === "plugin") {
+		return checkPluginMarketplaceRegistration(paths.configPath);
+	}
+
+	const expectations = getCatalogExpectations();
+	if (!existsSync(paths.skillsDir)) {
+		return {
+			name: "Skills",
+			status: "warn",
+			message: "skills directory not found",
+		};
+	}
+	try {
+		const entries = await readdir(paths.skillsDir, { withFileTypes: true });
+		const skillDirs = entries.filter((e) => e.isDirectory());
+		if (skillDirs.length >= expectations.skillMin) {
+			return {
+				name: "Skills",
+				status: "pass",
+				message: `${skillDirs.length} skills installed`,
+			};
+		}
+		return {
+			name: "Skills",
+			status: "warn",
+			message: `${skillDirs.length} skills (expected >= ${expectations.skillMin})`,
+		};
+	} catch {
+		return {
+			name: "Skills",
+			status: "fail",
+			message: "cannot read skills directory",
+		};
+	}
+}
+
+function checkAgentsMd(
+	scope: DoctorSetupScope,
+	codexHomeDir: string,
+	installMode?: SetupInstallMode,
+): Check {
+	if (scope === "user") {
+		const userAgentsMd = join(codexHomeDir, "AGENTS.md");
+		if (existsSync(userAgentsMd)) {
+			return {
+				name: "AGENTS.md",
+				status: "pass",
+				message: `found in ${userAgentsMd}`,
+			};
+		}
+		if (installMode === "plugin") {
+			return {
+				name: "AGENTS.md",
+				status: "pass",
+				message: `optional plugin-mode AGENTS.md defaults not installed in ${userAgentsMd}`,
+			};
+		}
+		return {
+			name: "AGENTS.md",
+			status: "warn",
+			message: `not found in ${userAgentsMd} (run omx setup --scope user)`,
+		};
+	}
+
+	const projectAgentsMd = join(process.cwd(), "AGENTS.md");
+	if (existsSync(projectAgentsMd)) {
+		return {
+			name: "AGENTS.md",
+			status: "pass",
+			message: "found in project root",
+		};
+	}
+	if (installMode === "plugin") {
+		return {
+			name: "AGENTS.md",
+			status: "pass",
+			message:
+				"optional plugin-mode AGENTS.md defaults not installed in project root",
+		};
+	}
+	return {
+		name: "AGENTS.md",
+		status: "warn",
+		message:
+			"not found in project root (run omx agents-init . or omx setup --scope project)",
+	};
 }
 
 function checkPromptTriage(): Check {
-  try {
-    const config = readTriageConfig();
+	try {
+		const config = readTriageConfig();
 
-    if (config.status === 'disabled') {
-      return {
-        name: 'Prompt triage',
-        status: 'warn',
-        message: `disabled via ${config.path}`,
-      };
-    }
+		if (config.status === "disabled") {
+			return {
+				name: "Prompt triage",
+				status: "warn",
+				message: `disabled via ${config.path}`,
+			};
+		}
 
-    if (config.status === 'invalid') {
-      return {
-        name: 'Prompt triage',
-        status: 'warn',
-        message: `config file malformed at ${config.path} — fails closed to disabled`,
-      };
-    }
+		if (config.status === "invalid") {
+			return {
+				name: "Prompt triage",
+				status: "warn",
+				message: `config file malformed at ${config.path} — fails closed to disabled`,
+			};
+		}
 
-    // Smoke test: verify the classifier is callable and returns the expected shape.
-    const decision = triagePrompt('hello');
-    const validLanes = new Set(['HEAVY', 'LIGHT', 'PASS']);
-    if (!decision || typeof decision !== 'object' || !validLanes.has(decision.lane)) {
-      return {
-        name: 'Prompt triage',
-        status: 'fail',
-        message: `classifier returned unexpected shape (lane: ${String(decision?.lane)})`,
-      };
-    }
+		// Smoke test: verify the classifier is callable and returns the expected shape.
+		const decision = triagePrompt("hello");
+		const validLanes = new Set(["HEAVY", "LIGHT", "PASS"]);
+		if (
+			!decision ||
+			typeof decision !== "object" ||
+			!validLanes.has(decision.lane)
+		) {
+			return {
+				name: "Prompt triage",
+				status: "fail",
+				message: `classifier returned unexpected shape (lane: ${String(decision?.lane)})`,
+			};
+		}
 
-    const sourceLabel = config.status === 'defaulted' ? 'enabled (default)' : 'enabled';
-    return {
-      name: 'Prompt triage',
-      status: 'pass',
-      message: `config: ${sourceLabel}`,
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { name: 'Prompt triage', status: 'fail', message: `module load error — ${msg}` };
-  }
+		const sourceLabel =
+			config.status === "defaulted" ? "enabled (default)" : "enabled";
+		return {
+			name: "Prompt triage",
+			status: "pass",
+			message: `config: ${sourceLabel}`,
+		};
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return {
+			name: "Prompt triage",
+			status: "fail",
+			message: `module load error — ${msg}`,
+		};
+	}
 }
 
-async function checkMcpServers(configPath: string): Promise<Check> {
-  if (!existsSync(configPath)) {
-    return { name: 'MCP Servers', status: 'warn', message: 'config.toml not found' };
-  }
-  try {
-    const content = await readFile(configPath, 'utf-8');
-    const mcpCount = (content.match(/\[mcp_servers\./g) || []).length;
-    if (mcpCount > 0) {
-      if (hasLegacyOmxTeamRunTable(content)) {
-        return {
-          name: 'MCP Servers',
-          status: 'warn',
-          message: `${mcpCount} servers configured, but retired [mcp_servers.omx_team_run] is not supported; run "omx setup --force" to repair the config`,
-        };
-      }
-      const hasOmx = OMX_FIRST_PARTY_MCP_SERVER_NAMES.some((name) => content.includes(name));
-      if (hasOmx) {
-        return { name: 'MCP Servers', status: 'pass', message: `${mcpCount} servers configured (OMX present)` };
-      }
-      return {
-        name: 'MCP Servers',
-        status: 'warn',
-        message: `${mcpCount} servers but no OMX servers yet (expected before first setup; run "omx setup --force" once)`,
-      };
-    }
-    return { name: 'MCP Servers', status: 'warn', message: 'no MCP servers configured' };
-  } catch {
-    return { name: 'MCP Servers', status: 'fail', message: 'cannot read config.toml' };
-  }
+async function checkMcpServers(
+	configPath: string,
+	installMode?: SetupInstallMode,
+): Promise<Check> {
+	if (!existsSync(configPath)) {
+		if (installMode === "plugin") {
+			return {
+				name: "MCP Servers",
+				status: "warn",
+				message:
+					'plugin mode selected, but config.toml is missing; run "omx setup --plugin --force" to register plugin discovery',
+			};
+		}
+		return {
+			name: "MCP Servers",
+			status: "warn",
+			message: "config.toml not found",
+		};
+	}
+	try {
+		const content = await readFile(configPath, "utf-8");
+		const mcpCount = (content.match(/\[mcp_servers\./g) || []).length;
+		if (hasLegacyOmxTeamRunTable(content)) {
+			return {
+				name: "MCP Servers",
+				status: "warn",
+				message: `${mcpCount} servers configured, but retired [mcp_servers.omx_team_run] is not supported; run "omx setup --force" to repair the config`,
+			};
+		}
+		if (installMode === "plugin") {
+			return {
+				name: "MCP Servers",
+				status: "pass",
+				message:
+					"plugin mode uses plugin-scoped MCP metadata; setup-owned OMX MCP tables are intentionally omitted",
+			};
+		}
+		if (mcpCount > 0) {
+			const hasOmx = OMX_FIRST_PARTY_MCP_SERVER_NAMES.some((name) =>
+				content.includes(name),
+			);
+			if (hasOmx) {
+				return {
+					name: "MCP Servers",
+					status: "pass",
+					message: `${mcpCount} servers configured (OMX present)`,
+				};
+			}
+			return {
+				name: "MCP Servers",
+				status: "warn",
+				message: `${mcpCount} servers but no OMX servers yet (expected before first setup; run "omx setup --force" once)`,
+			};
+		}
+		return {
+			name: "MCP Servers",
+			status: "warn",
+			message: "no MCP servers configured",
+		};
+	} catch {
+		return {
+			name: "MCP Servers",
+			status: "fail",
+			message: "cannot read config.toml",
+		};
+	}
 }

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,0 +1,126 @@
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import { join, resolve } from "path";
+
+export const OMX_LOCAL_MARKETPLACE_NAME = "oh-my-codex-local";
+export const OMX_PLUGIN_NAME = "oh-my-codex";
+
+export interface PackagedOmxMarketplace {
+	marketplacePath: string;
+	packageRoot: string;
+	pluginRoot: string;
+	pluginManifestPath: string;
+}
+
+interface MarketplaceManifest {
+	name?: unknown;
+	plugins?: Array<{
+		name?: unknown;
+		source?: { source?: unknown; path?: unknown };
+	}>;
+}
+
+interface PluginManifest {
+	name?: unknown;
+	skills?: unknown;
+}
+
+export async function resolvePackagedOmxMarketplace(
+	packageRoot: string,
+): Promise<PackagedOmxMarketplace | null> {
+	const marketplacePath = join(
+		packageRoot,
+		".agents",
+		"plugins",
+		"marketplace.json",
+	);
+	if (!existsSync(marketplacePath)) return null;
+
+	let marketplace: MarketplaceManifest;
+	try {
+		marketplace = JSON.parse(
+			await readFile(marketplacePath, "utf-8"),
+		) as MarketplaceManifest;
+	} catch {
+		return null;
+	}
+
+	if (marketplace.name !== OMX_LOCAL_MARKETPLACE_NAME) return null;
+	const pluginEntry = marketplace.plugins?.find(
+		(entry) =>
+			entry.name === OMX_PLUGIN_NAME &&
+			entry.source?.source === "local" &&
+			typeof entry.source.path === "string",
+	);
+	if (!pluginEntry || typeof pluginEntry.source?.path !== "string") return null;
+
+	const pluginRoot = resolve(packageRoot, pluginEntry.source.path);
+	const pluginManifestPath = join(pluginRoot, ".codex-plugin", "plugin.json");
+	if (!existsSync(pluginManifestPath)) return null;
+
+	try {
+		const pluginManifest = JSON.parse(
+			await readFile(pluginManifestPath, "utf-8"),
+		) as PluginManifest;
+		if (
+			pluginManifest.name !== OMX_PLUGIN_NAME ||
+			pluginManifest.skills !== "./skills/"
+		) {
+			return null;
+		}
+	} catch {
+		return null;
+	}
+
+	return { marketplacePath, packageRoot, pluginRoot, pluginManifestPath };
+}
+
+function marketplaceTableHeaderPattern(): RegExp {
+	return new RegExp(
+		`^\\s*\\[marketplaces\\.${OMX_LOCAL_MARKETPLACE_NAME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\]\\s*$`,
+	);
+}
+
+function isTomlTableHeader(line: string): boolean {
+	return /^\s*\[/.test(line);
+}
+
+export function stripLocalOmxMarketplaceRegistration(config: string): string {
+	const lines = config.split(/\r?\n/);
+	const headerPattern = marketplaceTableHeaderPattern();
+	const start = lines.findIndex((line) => headerPattern.test(line));
+	if (start < 0) return config;
+
+	let end = lines.length;
+	for (let index = start + 1; index < lines.length; index += 1) {
+		if (isTomlTableHeader(lines[index])) {
+			end = index;
+			break;
+		}
+	}
+
+	const nextLines = [...lines.slice(0, start), ...lines.slice(end)];
+	return nextLines
+		.join("\n")
+		.replace(/\n{3,}/g, "\n\n")
+		.trimEnd();
+}
+
+export function buildLocalOmxMarketplaceRegistration(
+	packageRoot: string,
+): string {
+	return [
+		`[marketplaces.${OMX_LOCAL_MARKETPLACE_NAME}]`,
+		`source_type = "local"`,
+		`source = ${JSON.stringify(packageRoot)}`,
+	].join("\n");
+}
+
+export function upsertLocalOmxMarketplaceRegistration(
+	config: string,
+	packageRoot: string,
+): string {
+	const stripped = stripLocalOmxMarketplaceRegistration(config).trimEnd();
+	const registration = buildLocalOmxMarketplaceRegistration(packageRoot);
+	return `${stripped ? `${stripped}\n\n` : ""}${registration}\n`;
+}

--- a/src/cli/setup-preferences.ts
+++ b/src/cli/setup-preferences.ts
@@ -1,0 +1,109 @@
+import { existsSync, readFileSync } from "fs";
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+export const SETUP_SCOPES = ["user", "project"] as const;
+export type SetupScope = (typeof SETUP_SCOPES)[number];
+
+export const SETUP_INSTALL_MODES = ["legacy", "plugin"] as const;
+export type SetupInstallMode = (typeof SETUP_INSTALL_MODES)[number];
+
+export interface PersistedSetupScope {
+	scope: SetupScope;
+	installMode?: SetupInstallMode;
+}
+
+export type PartialPersistedSetupScope = Partial<PersistedSetupScope>;
+
+const LEGACY_SCOPE_MIGRATION: Record<string, SetupScope> = {
+	"project-local": "project",
+};
+
+export function isSetupScope(value: string): value is SetupScope {
+	return SETUP_SCOPES.includes(value as SetupScope);
+}
+
+export function isSetupInstallMode(value: string): value is SetupInstallMode {
+	return SETUP_INSTALL_MODES.includes(value as SetupInstallMode);
+}
+
+export function getSetupScopeFilePath(projectRoot: string): string {
+	return join(projectRoot, ".omx", "setup-scope.json");
+}
+
+function parsePersistedSetupPreferences(
+	raw: string,
+	onLegacyScope?: (from: string, to: SetupScope) => void,
+): PartialPersistedSetupScope | undefined {
+	const parsed = JSON.parse(raw) as Partial<{
+		scope: unknown;
+		installMode: unknown;
+	}>;
+	const persisted: PartialPersistedSetupScope = {};
+
+	if (typeof parsed.scope === "string") {
+		if (isSetupScope(parsed.scope)) {
+			persisted.scope = parsed.scope;
+		}
+		const migrated = LEGACY_SCOPE_MIGRATION[parsed.scope];
+		if (migrated) {
+			onLegacyScope?.(parsed.scope, migrated);
+			persisted.scope = migrated;
+		}
+	}
+
+	if (
+		typeof parsed.installMode === "string" &&
+		isSetupInstallMode(parsed.installMode)
+	) {
+		persisted.installMode = parsed.installMode;
+	}
+
+	return Object.keys(persisted).length > 0 ? persisted : undefined;
+}
+
+export async function readPersistedSetupPreferences(
+	projectRoot: string,
+	options: { warnOnLegacyScope?: boolean } = {},
+): Promise<PartialPersistedSetupScope | undefined> {
+	const scopePath = getSetupScopeFilePath(projectRoot);
+	if (!existsSync(scopePath)) return undefined;
+	try {
+		const raw = await readFile(scopePath, "utf-8");
+		return parsePersistedSetupPreferences(
+			raw,
+			options.warnOnLegacyScope
+				? (from, to) => {
+						console.warn(
+							`[omx] Migrating persisted setup scope "${from}" → "${to}" ` +
+								`(see issue #243: simplified to user/project).`,
+						);
+					}
+				: undefined,
+		);
+	} catch {
+		return undefined;
+	}
+}
+
+export function readPersistedSetupPreferencesSync(
+	projectRoot: string,
+	options: { warnOnError?: boolean } = {},
+): PartialPersistedSetupScope | undefined {
+	const scopePath = getSetupScopeFilePath(projectRoot);
+	if (!existsSync(scopePath)) return undefined;
+	try {
+		return parsePersistedSetupPreferences(readFileSync(scopePath, "utf-8"));
+	} catch (err) {
+		if (options.warnOnError) {
+			process.stderr.write(`[cli/codex-home] operation failed: ${err}\n`);
+		}
+	}
+	return undefined;
+}
+
+export function readPersistedSetupScopeSync(
+	projectRoot: string,
+): SetupScope | undefined {
+	return readPersistedSetupPreferencesSync(projectRoot)?.scope;
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -4,15 +4,15 @@
  */
 
 import {
-  mkdir,
-  cp,
-  copyFile,
-  readdir,
-  readFile,
-  rename,
-  writeFile,
-  stat,
-  rm,
+	mkdir,
+	cp,
+	copyFile,
+	readdir,
+	readFile,
+	rename,
+	writeFile,
+	stat,
+	rm,
 } from "fs/promises";
 import { join, dirname, relative, basename } from "path";
 import { existsSync } from "fs";
@@ -20,43 +20,43 @@ import { spawnSync } from "child_process";
 import { createInterface } from "readline/promises";
 import { homedir } from "os";
 import {
-  codexHome,
-  codexConfigPath,
-  codexPromptsDir,
-  codexAgentsDir,
-  userSkillsDir,
-  omxStateDir,
-  detectLegacySkillRootOverlap,
-  omxPlansDir,
-  omxLogsDir,
+	codexHome,
+	codexConfigPath,
+	codexPromptsDir,
+	codexAgentsDir,
+	userSkillsDir,
+	omxStateDir,
+	detectLegacySkillRootOverlap,
+	omxPlansDir,
+	omxLogsDir,
 } from "../utils/paths.js";
 import {
-  buildMergedConfig,
-  getRootModelName,
-  hasLegacyOmxTeamRunTable,
-  stripExistingOmxBlocks,
-  stripExistingSharedMcpRegistryBlock,
-  stripOmxEnvSettings,
-  stripOmxFeatureFlags,
-  stripOmxSeededBehavioralDefaults,
-  upsertCodexHooksFeatureFlag,
-  OMX_DEVELOPER_INSTRUCTIONS,
+	buildMergedConfig,
+	getRootModelName,
+	hasLegacyOmxTeamRunTable,
+	stripExistingOmxBlocks,
+	stripExistingSharedMcpRegistryBlock,
+	stripOmxEnvSettings,
+	stripOmxFeatureFlags,
+	stripOmxSeededBehavioralDefaults,
+	upsertCodexHooksFeatureFlag,
+	OMX_DEVELOPER_INSTRUCTIONS,
 } from "../config/generator.js";
 import { mergeManagedCodexHooksConfig } from "../config/codex-hooks.js";
 import {
-  getLegacyUnifiedMcpRegistryCandidate,
-  getUnifiedMcpRegistryCandidates,
-  loadUnifiedMcpRegistry,
-  planClaudeCodeMcpSettingsSync,
-  type UnifiedMcpRegistryLoadResult,
+	getLegacyUnifiedMcpRegistryCandidate,
+	getUnifiedMcpRegistryCandidates,
+	loadUnifiedMcpRegistry,
+	planClaudeCodeMcpSettingsSync,
+	type UnifiedMcpRegistryLoadResult,
 } from "../config/mcp-registry.js";
 import { generateAgentToml } from "../agents/native-config.js";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import {
-  getCatalogAgentStatusByName,
-  getInstallableNativeAgentNames,
-  isNativeAgentInstallableStatus,
-  isSetupPromptAssetName,
+	getCatalogAgentStatusByName,
+	getInstallableNativeAgentNames,
+	isNativeAgentInstallableStatus,
+	isSetupPromptAssetName,
 } from "../agents/policy.js";
 import { getPackageRoot } from "../utils/package.js";
 import { readSessionState, isSessionStale } from "../hooks/session.js";
@@ -64,191 +64,189 @@ import { getCatalogHeadlineCounts } from "./catalog-contract.js";
 import { tryReadCatalogManifest } from "../catalog/reader.js";
 import { DEFAULT_FRONTIER_MODEL } from "../config/models.js";
 import {
-  addGeneratedAgentsMarker,
-  hasOmxManagedAgentsSections,
-  isOmxGeneratedAgentsMd,
-  upsertManagedAgentsBlock,
+	addGeneratedAgentsMarker,
+	hasOmxManagedAgentsSections,
+	isOmxGeneratedAgentsMd,
+	upsertManagedAgentsBlock,
 } from "../utils/agents-md.js";
 import { DEFAULT_HUD_CONFIG, type HudPreset } from "../hud/types.js";
+import {
+	SETUP_INSTALL_MODES,
+	SETUP_SCOPES,
+	getSetupScopeFilePath,
+	readPersistedSetupPreferences,
+	type PersistedSetupScope,
+	type SetupInstallMode,
+	type SetupScope,
+} from "./setup-preferences.js";
+import {
+	OMX_LOCAL_MARKETPLACE_NAME,
+	resolvePackagedOmxMarketplace,
+	upsertLocalOmxMarketplaceRegistration,
+} from "./plugin-marketplace.js";
 
 async function resolveStatusLinePresetForSetup(
-  projectRoot: string,
-  options: Pick<SetupOptions, "force">,
+	projectRoot: string,
+	options: Pick<SetupOptions, "force">,
 ): Promise<HudPreset | undefined> {
-  if (options.force) {
-    return DEFAULT_HUD_CONFIG.statusLine.preset;
-  }
-  const path = join(projectRoot, ".omx", "hud-config.json");
-  if (!existsSync(path)) return undefined;
-  try {
-    const raw = JSON.parse(await readFile(path, "utf-8")) as {
-      statusLine?: { preset?: unknown };
-    };
-    const preset = raw?.statusLine?.preset;
-    if (preset === "minimal" || preset === "focused" || preset === "full") {
-      return preset;
-    }
-  } catch {
-    // Malformed hud-config.json — fall through to default.
-  }
-  return undefined;
+	if (options.force) {
+		return DEFAULT_HUD_CONFIG.statusLine.preset;
+	}
+	const path = join(projectRoot, ".omx", "hud-config.json");
+	if (!existsSync(path)) return undefined;
+	try {
+		const raw = JSON.parse(await readFile(path, "utf-8")) as {
+			statusLine?: { preset?: unknown };
+		};
+		const preset = raw?.statusLine?.preset;
+		if (preset === "minimal" || preset === "focused" || preset === "full") {
+			return preset;
+		}
+	} catch {
+		// Malformed hud-config.json — fall through to default.
+	}
+	return undefined;
 }
 import {
-  resolveAgentsModelTableContext,
-  upsertAgentsModelTable,
+	resolveAgentsModelTableContext,
+	upsertAgentsModelTable,
 } from "../utils/agents-model-table.js";
 
 interface SetupOptions {
-  codexVersionProbe?: () => string | null;
-  force?: boolean;
-  mergeAgents?: boolean;
-  dryRun?: boolean;
-  installMode?: SetupInstallMode;
-  scope?: SetupScope;
-  verbose?: boolean;
-  agentsOverwritePrompt?: (destinationPath: string) => Promise<boolean>;
-  setupScopePrompt?: (defaultScope: SetupScope) => Promise<SetupScope>;
-  persistedSetupReviewPrompt?: (
-    preferences: Partial<PersistedSetupScope>,
-  ) => Promise<PersistedSetupReviewDecision>;
-  installModePrompt?: (
-    defaultMode: SetupInstallMode,
-  ) => Promise<SetupInstallMode>;
-  modelUpgradePrompt?: (
-    currentModel: string,
-    targetModel: string,
-  ) => Promise<boolean>;
-  pluginAgentsMdPrompt?: (destinationPath: string) => Promise<boolean>;
-  pluginDeveloperInstructionsPrompt?: (configPath: string) => Promise<boolean>;
-  pluginDeveloperInstructionsOverwritePrompt?: (
-    configPath: string,
-  ) => Promise<boolean>;
-  mcpRegistryCandidates?: string[];
+	codexVersionProbe?: () => string | null;
+	force?: boolean;
+	mergeAgents?: boolean;
+	dryRun?: boolean;
+	installMode?: SetupInstallMode;
+	scope?: SetupScope;
+	verbose?: boolean;
+	agentsOverwritePrompt?: (destinationPath: string) => Promise<boolean>;
+	setupScopePrompt?: (defaultScope: SetupScope) => Promise<SetupScope>;
+	persistedSetupReviewPrompt?: (
+		preferences: Partial<PersistedSetupScope>,
+	) => Promise<PersistedSetupReviewDecision>;
+	installModePrompt?: (
+		defaultMode: SetupInstallMode,
+	) => Promise<SetupInstallMode>;
+	modelUpgradePrompt?: (
+		currentModel: string,
+		targetModel: string,
+	) => Promise<boolean>;
+	pluginAgentsMdPrompt?: (destinationPath: string) => Promise<boolean>;
+	pluginDeveloperInstructionsPrompt?: (configPath: string) => Promise<boolean>;
+	pluginDeveloperInstructionsOverwritePrompt?: (
+		configPath: string,
+	) => Promise<boolean>;
+	mcpRegistryCandidates?: string[];
 }
 
-/**
- * Legacy scope values that may appear in persisted setup-scope.json files.
- * Both 'project-local' (renamed) and old 'project' (minimal, removed) are
- * migrated to the current 'project' scope on read.
- */
-const LEGACY_SCOPE_MIGRATION: Record<string, "project"> = {
-  "project-local": "project",
-};
-
-export const SETUP_SCOPES = ["user", "project"] as const;
-export type SetupScope = (typeof SETUP_SCOPES)[number];
-export const SETUP_INSTALL_MODES = ["legacy", "plugin"] as const;
-export type SetupInstallMode = (typeof SETUP_INSTALL_MODES)[number];
+export { SETUP_INSTALL_MODES, SETUP_SCOPES };
+export type { SetupInstallMode, SetupScope };
 
 export interface ScopeDirectories {
-  codexConfigFile: string;
-  codexHomeDir: string;
-  codexHooksFile: string;
-  nativeAgentsDir: string;
-  promptsDir: string;
-  skillsDir: string;
+	codexConfigFile: string;
+	codexHomeDir: string;
+	codexHooksFile: string;
+	nativeAgentsDir: string;
+	promptsDir: string;
+	skillsDir: string;
 }
 
 interface SetupCategorySummary {
-  updated: number;
-  unchanged: number;
-  backedUp: number;
-  skipped: number;
-  removed: number;
+	updated: number;
+	unchanged: number;
+	backedUp: number;
+	skipped: number;
+	removed: number;
 }
 
 interface SetupRunSummary {
-  prompts: SetupCategorySummary;
-  skills: SetupCategorySummary;
-  nativeAgents: SetupCategorySummary;
-  agentsMd: SetupCategorySummary;
-  config: SetupCategorySummary;
+	prompts: SetupCategorySummary;
+	skills: SetupCategorySummary;
+	nativeAgents: SetupCategorySummary;
+	agentsMd: SetupCategorySummary;
+	config: SetupCategorySummary;
 }
 
 interface SetupBackupContext {
-  backupRoot: string;
-  baseRoot: string;
+	backupRoot: string;
+	baseRoot: string;
 }
 
 interface ManagedConfigResult {
-  finalConfig: string;
-  omxManagesTui: boolean;
-  repairedLegacyTeamRunTable: boolean;
+	finalConfig: string;
+	omxManagesTui: boolean;
+	repairedLegacyTeamRunTable: boolean;
 }
 
 interface LegacySkillOverlapNotice {
-  shouldWarn: boolean;
-  message: string;
+	shouldWarn: boolean;
+	message: string;
 }
 
 export interface SkillFrontmatterMetadata {
-  name: string;
-  description: string;
+	name: string;
+	description: string;
 }
 
 const PROJECT_GITIGNORE_ENTRIES = [
-  ".omx/",
-  ".codex/*",
-  "!.codex/agents/",
-  "!.codex/agents/**",
-  "!.codex/skills/",
-  "!.codex/skills/**",
-  ".codex/skills/.system/**",
-  "!.codex/prompts/",
-  "!.codex/prompts/**",
+	".omx/",
+	".codex/*",
+	"!.codex/agents/",
+	"!.codex/agents/**",
+	"!.codex/skills/",
+	"!.codex/skills/**",
+	".codex/skills/.system/**",
+	"!.codex/prompts/",
+	"!.codex/prompts/**",
 ] as const;
 const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".codex/"] as const;
 const SETUP_ONLY_INSTALLABLE_SKILLS = new Set(["wiki"]);
 const HARD_DEPRECATED_SKILL_NAMES = new Set(["web-clone"]);
 
 function isCatalogInstallableStatus(status: string | undefined): boolean {
-  return status === "active" || status === "internal";
+	return status === "active" || status === "internal";
 }
 
 function getSetupInstallableSkillNames(
-  manifest = tryReadCatalogManifest(),
+	manifest = tryReadCatalogManifest(),
 ): Set<string> {
-  return new Set([
-    ...(manifest?.skills ?? [])
-      .filter(
-        (skill) =>
-          typeof skill.name === "string" &&
-          isCatalogInstallableStatus(skill.status),
-      )
-      .map((skill) => skill.name),
-    ...SETUP_ONLY_INSTALLABLE_SKILLS,
-  ]);
+	return new Set([
+		...(manifest?.skills ?? [])
+			.filter(
+				(skill) =>
+					typeof skill.name === "string" &&
+					isCatalogInstallableStatus(skill.status),
+			)
+			.map((skill) => skill.name),
+		...SETUP_ONLY_INSTALLABLE_SKILLS,
+	]);
 }
 
 function applyScopePathRewritesToAgentsTemplate(
-  content: string,
-  scope: SetupScope,
+	content: string,
+	scope: SetupScope,
 ): string {
-  if (scope !== "project") return content;
-  return content.replaceAll("~/.codex", "./.codex");
-}
-
-interface PersistedSetupScope {
-  scope: SetupScope;
-  installMode?: SetupInstallMode;
+	if (scope !== "project") return content;
+	return content.replaceAll("~/.codex", "./.codex");
 }
 
 interface ResolvedSetupScope {
-  scope: SetupScope;
-  source: "cli" | "persisted" | "prompt" | "default";
+	scope: SetupScope;
+	source: "cli" | "persisted" | "prompt" | "default";
 }
 
 interface ResolvedSetupInstallMode {
-  installMode: SetupInstallMode;
-  source: "cli" | "persisted" | "prompt" | "default";
+	installMode: SetupInstallMode;
+	source: "cli" | "persisted" | "prompt" | "default";
 }
 
 type PersistedSetupReviewDecision = "keep" | "review" | "reset";
 
 const REQUIRED_TEAM_CLI_API_MARKERS = [
-  "if (subcommand === 'api')",
-  "executeTeamApiOperation",
-  "TEAM_API_OPERATIONS",
+	"if (subcommand === 'api')",
+	"executeTeamApiOperation",
+	"TEAM_API_OPERATIONS",
 ] as const;
 
 const DEFAULT_SETUP_SCOPE: SetupScope = "user";
@@ -258,2809 +256,2839 @@ const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
 const OBSOLETE_NATIVE_AGENT_FIELD = ["skill", "ref"].join("_");
 
 function createEmptyCategorySummary(): SetupCategorySummary {
-  return {
-    updated: 0,
-    unchanged: 0,
-    backedUp: 0,
-    skipped: 0,
-    removed: 0,
-  };
+	return {
+		updated: 0,
+		unchanged: 0,
+		backedUp: 0,
+		skipped: 0,
+		removed: 0,
+	};
 }
 
 function createEmptyRunSummary(): SetupRunSummary {
-  return {
-    prompts: createEmptyCategorySummary(),
-    skills: createEmptyCategorySummary(),
-    nativeAgents: createEmptyCategorySummary(),
-    agentsMd: createEmptyCategorySummary(),
-    config: createEmptyCategorySummary(),
-  };
+	return {
+		prompts: createEmptyCategorySummary(),
+		skills: createEmptyCategorySummary(),
+		nativeAgents: createEmptyCategorySummary(),
+		agentsMd: createEmptyCategorySummary(),
+		config: createEmptyCategorySummary(),
+	};
 }
 
 function getBackupContext(
-  scope: SetupScope,
-  projectRoot: string,
+	scope: SetupScope,
+	projectRoot: string,
 ): SetupBackupContext {
-  const timestamp = new Date().toISOString().replace(/[:]/g, "-");
-  if (scope === "project") {
-    return {
-      backupRoot: join(projectRoot, ".omx", "backups", "setup", timestamp),
-      baseRoot: projectRoot,
-    };
-  }
-  return {
-    backupRoot: join(homedir(), ".omx", "backups", "setup", timestamp),
-    baseRoot: homedir(),
-  };
+	const timestamp = new Date().toISOString().replace(/[:]/g, "-");
+	if (scope === "project") {
+		return {
+			backupRoot: join(projectRoot, ".omx", "backups", "setup", timestamp),
+			baseRoot: projectRoot,
+		};
+	}
+	return {
+		backupRoot: join(homedir(), ".omx", "backups", "setup", timestamp),
+		baseRoot: homedir(),
+	};
 }
 
 async function ensureBackup(
-  destinationPath: string,
-  contentChanged: boolean,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	destinationPath: string,
+	contentChanged: boolean,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<boolean> {
-  if (!contentChanged || !existsSync(destinationPath)) return false;
+	if (!contentChanged || !existsSync(destinationPath)) return false;
 
-  const relativePath = relative(backupContext.baseRoot, destinationPath);
-  const safeRelativePath =
-    relativePath.startsWith("..") || relativePath === ""
-      ? destinationPath.replace(/^[/]+/, "")
-      : relativePath;
-  const backupPath = join(backupContext.backupRoot, safeRelativePath);
+	const relativePath = relative(backupContext.baseRoot, destinationPath);
+	const safeRelativePath =
+		relativePath.startsWith("..") || relativePath === ""
+			? destinationPath.replace(/^[/]+/, "")
+			: relativePath;
+	const backupPath = join(backupContext.backupRoot, safeRelativePath);
 
-  if (!options.dryRun) {
-    await mkdir(dirname(backupPath), { recursive: true });
-    await copyFile(destinationPath, backupPath);
-  }
-  if (options.verbose) {
-    console.log(`  backup ${destinationPath} -> ${backupPath}`);
-  }
-  return true;
+	if (!options.dryRun) {
+		await mkdir(dirname(backupPath), { recursive: true });
+		await copyFile(destinationPath, backupPath);
+	}
+	if (options.verbose) {
+		console.log(`  backup ${destinationPath} -> ${backupPath}`);
+	}
+	return true;
 }
 
 async function moveExistingAgentsToDeterministicBackup(
-  destinationPath: string,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	destinationPath: string,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<string | null> {
-  if (!existsSync(destinationPath)) return null;
+	if (!existsSync(destinationPath)) return null;
 
-  const backupBaseName = `.${basename(destinationPath)}.bkup`;
-  let backupPath = join(dirname(destinationPath), backupBaseName);
-  let suffix = 1;
+	const backupBaseName = `.${basename(destinationPath)}.bkup`;
+	let backupPath = join(dirname(destinationPath), backupBaseName);
+	let suffix = 1;
 
-  while (existsSync(backupPath)) {
-    backupPath = join(dirname(destinationPath), `${backupBaseName}${suffix}`);
-    suffix += 1;
-  }
+	while (existsSync(backupPath)) {
+		backupPath = join(dirname(destinationPath), `${backupBaseName}${suffix}`);
+		suffix += 1;
+	}
 
-  if (!options.dryRun) {
-    await rename(destinationPath, backupPath);
-  }
+	if (!options.dryRun) {
+		await rename(destinationPath, backupPath);
+	}
 
-  console.log(`  Backed up existing AGENTS.md to ${backupPath}.`);
-  return backupPath;
+	console.log(`  Backed up existing AGENTS.md to ${backupPath}.`);
+	return backupPath;
 }
 
 async function filesDiffer(src: string, dst: string): Promise<boolean> {
-  if (!existsSync(dst)) return true;
-  const [srcContent, dstContent] = await Promise.all([
-    readFile(src, "utf-8"),
-    readFile(dst, "utf-8"),
-  ]);
-  return srcContent !== dstContent;
+	if (!existsSync(dst)) return true;
+	const [srcContent, dstContent] = await Promise.all([
+		readFile(src, "utf-8"),
+		readFile(dst, "utf-8"),
+	]);
+	return srcContent !== dstContent;
 }
 
 function containsTomlKey(content: string, key: string): boolean {
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^\\s*${escapedKey}\\s*=`, "m").test(content);
+	const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return new RegExp(`^\\s*${escapedKey}\\s*=`, "m").test(content);
 }
 
 function parseSkillFrontmatterScalar(
-  value: string,
-  key: string,
-  filePath: string,
+	value: string,
+	key: string,
+	filePath: string,
 ): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
-  }
-  if (trimmed === "|" || trimmed === ">") {
-    throw new Error(
-      `${filePath} frontmatter "${key}" must be a single-line string`,
-    );
-  }
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
+	}
+	if (trimmed === "|" || trimmed === ">") {
+		throw new Error(
+			`${filePath} frontmatter "${key}" must be a single-line string`,
+		);
+	}
 
-  const quote = trimmed[0];
-  if (quote === '"' || quote === "'") {
-    if (trimmed.length < 2 || trimmed.at(-1) !== quote) {
-      throw new Error(
-        `${filePath} frontmatter "${key}" has an unterminated quoted string`,
-      );
-    }
-    const unquoted = trimmed.slice(1, -1).trim();
-    if (!unquoted) {
-      throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
-    }
-    return unquoted;
-  }
+	const quote = trimmed[0];
+	if (quote === '"' || quote === "'") {
+		if (trimmed.length < 2 || trimmed.at(-1) !== quote) {
+			throw new Error(
+				`${filePath} frontmatter "${key}" has an unterminated quoted string`,
+			);
+		}
+		const unquoted = trimmed.slice(1, -1).trim();
+		if (!unquoted) {
+			throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
+		}
+		return unquoted;
+	}
 
-  const unquoted = trimmed.replace(/\s+#.*$/, "").trim();
-  if (!unquoted) {
-    throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
-  }
-  return unquoted;
+	const unquoted = trimmed.replace(/\s+#.*$/, "").trim();
+	if (!unquoted) {
+		throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
+	}
+	return unquoted;
 }
 
 export function parseSkillFrontmatter(
-  content: string,
-  filePath = "SKILL.md",
+	content: string,
+	filePath = "SKILL.md",
 ): SkillFrontmatterMetadata {
-  const frontmatterMatch = content.match(
-    /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/,
-  );
-  if (!frontmatterMatch) {
-    throw new Error(
-      `${filePath} must start with YAML frontmatter containing non-empty name and description fields`,
-    );
-  }
+	const frontmatterMatch = content.match(
+		/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/,
+	);
+	if (!frontmatterMatch) {
+		throw new Error(
+			`${filePath} must start with YAML frontmatter containing non-empty name and description fields`,
+		);
+	}
 
-  let name: string | undefined;
-  let description: string | undefined;
-  const lines = frontmatterMatch[1].split(/\r?\n/);
+	let name: string | undefined;
+	let description: string | undefined;
+	const lines = frontmatterMatch[1].split(/\r?\n/);
 
-  for (const [index, rawLine] of lines.entries()) {
-    const line = rawLine.trimEnd();
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    if (/^\s/.test(rawLine)) continue;
+	for (const [index, rawLine] of lines.entries()) {
+		const line = rawLine.trimEnd();
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		if (/^\s/.test(rawLine)) continue;
 
-    const match = line.match(/^([A-Za-z0-9_-]+):(.*)$/);
-    if (!match) {
-      throw new Error(
-        `${filePath} has invalid YAML frontmatter on line ${index + 2}: ${trimmed}`,
-      );
-    }
+		const match = line.match(/^([A-Za-z0-9_-]+):(.*)$/);
+		if (!match) {
+			throw new Error(
+				`${filePath} has invalid YAML frontmatter on line ${index + 2}: ${trimmed}`,
+			);
+		}
 
-    const [, key, rawValue] = match;
-    if (!rawValue.trim()) continue;
+		const [, key, rawValue] = match;
+		if (!rawValue.trim()) continue;
 
-    const parsedValue = parseSkillFrontmatterScalar(rawValue, key, filePath);
-    if (key === "name") name = parsedValue;
-    if (key === "description") description = parsedValue;
-  }
+		const parsedValue = parseSkillFrontmatterScalar(rawValue, key, filePath);
+		if (key === "name") name = parsedValue;
+		if (key === "description") description = parsedValue;
+	}
 
-  if (!name) {
-    throw new Error(`${filePath} is missing a non-empty frontmatter "name"`);
-  }
-  if (!description) {
-    throw new Error(
-      `${filePath} is missing a non-empty frontmatter "description"`,
-    );
-  }
+	if (!name) {
+		throw new Error(`${filePath} is missing a non-empty frontmatter "name"`);
+	}
+	if (!description) {
+		throw new Error(
+			`${filePath} is missing a non-empty frontmatter "description"`,
+		);
+	}
 
-  return { name, description };
+	return { name, description };
 }
 
 export async function validateSkillFile(skillMdPath: string): Promise<void> {
-  const content = await readFile(skillMdPath, "utf-8");
-  parseSkillFrontmatter(content, skillMdPath);
+	const content = await readFile(skillMdPath, "utf-8");
+	parseSkillFrontmatter(content, skillMdPath);
 }
 
 function rewriteInstalledSkillDescriptionBadge(
-  content: string,
-  filePath = "SKILL.md",
+	content: string,
+	filePath = "SKILL.md",
 ): string {
-  const metadata = parseSkillFrontmatter(content, filePath);
-  const badgePrefix = "[OMX] ";
-  const displayDescription = metadata.description.startsWith(badgePrefix)
-    ? metadata.description
-    : `${badgePrefix}${metadata.description}`;
+	const metadata = parseSkillFrontmatter(content, filePath);
+	const badgePrefix = "[OMX] ";
+	const displayDescription = metadata.description.startsWith(badgePrefix)
+		? metadata.description
+		: `${badgePrefix}${metadata.description}`;
 
-  return content.replace(
-    /^---\r?\n([\s\S]*?)\r?\n---/,
-    (frontmatterBlock, body) => {
-      const rewrittenBody = body.replace(
-        /^([ \t]*)description:(.*)$/m,
-        (_line: string, indent: string) =>
-          `${indent}description: ${JSON.stringify(displayDescription)}`,
-      );
-      return frontmatterBlock.replace(body, rewrittenBody);
-    },
-  );
+	return content.replace(
+		/^---\r?\n([\s\S]*?)\r?\n---/,
+		(frontmatterBlock, body) => {
+			const rewrittenBody = body.replace(
+				/^([ \t]*)description:(.*)$/m,
+				(_line: string, indent: string) =>
+					`${indent}description: ${JSON.stringify(displayDescription)}`,
+			);
+			return frontmatterBlock.replace(body, rewrittenBody);
+		},
+	);
 }
 
 async function buildLegacySkillOverlapNotice(
-  scope: SetupScope,
+	scope: SetupScope,
 ): Promise<LegacySkillOverlapNotice> {
-  if (scope !== "user") {
-    return { shouldWarn: false, message: "" };
-  }
+	if (scope !== "user") {
+		return { shouldWarn: false, message: "" };
+	}
 
-  const overlap = await detectLegacySkillRootOverlap();
-  if (!overlap.legacyExists) {
-    return { shouldWarn: false, message: "" };
-  }
+	const overlap = await detectLegacySkillRootOverlap();
+	if (!overlap.legacyExists) {
+		return { shouldWarn: false, message: "" };
+	}
 
-  if (overlap.overlappingSkillNames.length === 0) {
-    return {
-      shouldWarn: true,
-      message: `Legacy ~/.agents/skills still exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}. Codex may still discover both roots; archive or remove ~/.agents/skills if Enable/Disable Skills shows duplicates.`,
-    };
-  }
+	if (overlap.overlappingSkillNames.length === 0) {
+		return {
+			shouldWarn: true,
+			message: `Legacy ~/.agents/skills still exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}. Codex may still discover both roots; archive or remove ~/.agents/skills if Enable/Disable Skills shows duplicates.`,
+		};
+	}
 
-  const mismatchSuffix =
-    overlap.mismatchedSkillNames.length > 0
-      ? ` ${overlap.mismatchedSkillNames.length} overlapping skills have different SKILL.md content.`
-      : "";
-  return {
-    shouldWarn: true,
-    message: `Detected ${overlap.overlappingSkillNames.length} overlapping skill names between canonical ${overlap.canonicalDir} and legacy ${overlap.legacyDir}.${mismatchSuffix} Remove or archive ~/.agents/skills after confirming ${overlap.canonicalDir} is the version you want Codex to load.`,
-  };
-}
-
-function logCategorySummary(name: string, summary: SetupCategorySummary): void {
-  console.log(
-    `  ${name}: updated=${summary.updated}, unchanged=${summary.unchanged}, ` +
-      `backed_up=${summary.backedUp}, skipped=${summary.skipped}, removed=${summary.removed}`,
-  );
-}
-
-function isSetupScope(value: string): value is SetupScope {
-  return SETUP_SCOPES.includes(value as SetupScope);
-}
-function getScopeFilePath(projectRoot: string): string {
-  return join(projectRoot, ".omx", "setup-scope.json");
-}
-
-function isSetupInstallMode(value: string): value is SetupInstallMode {
-  return SETUP_INSTALL_MODES.includes(value as SetupInstallMode);
+	const mismatchSuffix =
+		overlap.mismatchedSkillNames.length > 0
+			? ` ${overlap.mismatchedSkillNames.length} overlapping skills have different SKILL.md content.`
+			: "";
+	return {
+		shouldWarn: true,
+		message: `Detected ${overlap.overlappingSkillNames.length} overlapping skill names between canonical ${overlap.canonicalDir} and legacy ${overlap.legacyDir}.${mismatchSuffix} Remove or archive ~/.agents/skills after confirming ${overlap.canonicalDir} is the version you want Codex to load.`,
+	};
 }
 
 export function resolveScopeDirectories(
-  scope: SetupScope,
-  projectRoot: string,
+	scope: SetupScope,
+	projectRoot: string,
 ): ScopeDirectories {
-  if (scope === "project") {
-    const codexHomeDir = join(projectRoot, ".codex");
-    return {
-      codexConfigFile: join(codexHomeDir, "config.toml"),
-      codexHomeDir,
-      codexHooksFile: join(codexHomeDir, "hooks.json"),
-      nativeAgentsDir: join(codexHomeDir, "agents"),
-      promptsDir: join(codexHomeDir, "prompts"),
-      skillsDir: join(codexHomeDir, "skills"),
-    };
-  }
-  return {
-    codexConfigFile: codexConfigPath(),
-    codexHomeDir: codexHome(),
-    codexHooksFile: join(codexHome(), "hooks.json"),
-    nativeAgentsDir: codexAgentsDir(),
-    promptsDir: codexPromptsDir(),
-    skillsDir: userSkillsDir(),
-  };
+	if (scope === "project") {
+		const codexHomeDir = join(projectRoot, ".codex");
+		return {
+			codexConfigFile: join(codexHomeDir, "config.toml"),
+			codexHomeDir,
+			codexHooksFile: join(codexHomeDir, "hooks.json"),
+			nativeAgentsDir: join(codexHomeDir, "agents"),
+			promptsDir: join(codexHomeDir, "prompts"),
+			skillsDir: join(codexHomeDir, "skills"),
+		};
+	}
+	return {
+		codexConfigFile: codexConfigPath(),
+		codexHomeDir: codexHome(),
+		codexHooksFile: join(codexHome(), "hooks.json"),
+		nativeAgentsDir: codexAgentsDir(),
+		promptsDir: codexPromptsDir(),
+		skillsDir: userSkillsDir(),
+	};
 }
 
-async function readPersistedSetupPreferences(
-  projectRoot: string,
-): Promise<Partial<PersistedSetupScope> | undefined> {
-  const scopePath = getScopeFilePath(projectRoot);
-  if (!existsSync(scopePath)) return undefined;
-  try {
-    const raw = await readFile(scopePath, "utf-8");
-    const parsed = JSON.parse(raw) as Partial<PersistedSetupScope>;
-    const persisted: Partial<PersistedSetupScope> = {};
-    if (parsed && typeof parsed.scope === "string") {
-      // Direct match to current scopes
-      if (isSetupScope(parsed.scope)) {
-        persisted.scope = parsed.scope;
-      }
-      // Migrate legacy scope values (project-local → project)
-      const migrated = LEGACY_SCOPE_MIGRATION[parsed.scope];
-      if (migrated) {
-        console.warn(
-          `[omx] Migrating persisted setup scope "${parsed.scope}" → "${migrated}" ` +
-            `(see issue #243: simplified to user/project).`,
-        );
-        persisted.scope = migrated;
-      }
-    }
-    if (parsed && typeof parsed.installMode === "string") {
-      if (isSetupInstallMode(parsed.installMode)) {
-        persisted.installMode = parsed.installMode;
-      }
-    }
-    return Object.keys(persisted).length > 0 ? persisted : undefined;
-  } catch {
-    // ignore invalid persisted scope and fall back to prompt/default
-  }
-  return undefined;
+function logCategorySummary(name: string, summary: SetupCategorySummary): void {
+	console.log(
+		`  ${name}: updated=${summary.updated}, unchanged=${summary.unchanged}, ` +
+			`backed_up=${summary.backedUp}, skipped=${summary.skipped}, removed=${summary.removed}`,
+	);
 }
 
 async function promptForSetupScope(
-  defaultScope: SetupScope,
+	defaultScope: SetupScope,
 ): Promise<SetupScope> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return defaultScope;
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    const userDefaultMarker = defaultScope === "user" ? " (default)" : "";
-    const projectDefaultMarker = defaultScope === "project" ? " (default)" : "";
-    const defaultChoice = defaultScope === "project" ? "2" : "1";
-    console.log("Select setup scope:");
-    console.log(
-      `  1) user${userDefaultMarker} — installs to ${codexHome()} (skills default to ${userSkillsDir()})`,
-    );
-    console.log(
-      `  2) project${projectDefaultMarker} — installs to ./.codex (local to project)`,
-    );
-    const answer = (
-      await rl.question(`Scope [1-2] (default: ${defaultChoice}): `)
-    )
-      .trim()
-      .toLowerCase();
-    if (answer === "2" || answer === "project") return "project";
-    if (answer === "1" || answer === "user") return "user";
-    return defaultScope;
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return defaultScope;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		const userDefaultMarker = defaultScope === "user" ? " (default)" : "";
+		const projectDefaultMarker = defaultScope === "project" ? " (default)" : "";
+		const defaultChoice = defaultScope === "project" ? "2" : "1";
+		console.log("Select setup scope:");
+		console.log(
+			`  1) user${userDefaultMarker} — installs to ${codexHome()} (skills default to ${userSkillsDir()})`,
+		);
+		console.log(
+			`  2) project${projectDefaultMarker} — installs to ./.codex (local to project)`,
+		);
+		const answer = (
+			await rl.question(`Scope [1-2] (default: ${defaultChoice}): `)
+		)
+			.trim()
+			.toLowerCase();
+		if (answer === "2" || answer === "project") return "project";
+		if (answer === "1" || answer === "user") return "user";
+		return defaultScope;
+	} finally {
+		rl.close();
+	}
 }
 
 async function promptForSetupInstallMode(
-  defaultMode: SetupInstallMode,
+	defaultMode: SetupInstallMode,
 ): Promise<SetupInstallMode> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return defaultMode;
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    console.log("Select user-scope skill delivery mode:");
-    console.log(
-      `  1) legacy${defaultMode === "legacy" ? " (default)" : ""} — install/update OMX skills in the resolved user skill root`,
-    );
-    console.log(
-      `  2) plugin${defaultMode === "plugin" ? " (default)" : ""} — rely on Codex plugin discovery and clean up matching legacy OMX-managed setup artifacts`,
-    );
-    const defaultChoice = defaultMode === "plugin" ? "2" : "1";
-    const answer = (
-      await rl.question(`Install mode [1-2] (default: ${defaultChoice}): `)
-    )
-      .trim()
-      .toLowerCase();
-    if (answer === "2" || answer === "plugin") return "plugin";
-    if (answer === "1" || answer === "legacy") return "legacy";
-    return defaultMode;
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return defaultMode;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		console.log("Select user-scope skill delivery mode:");
+		console.log(
+			`  1) legacy${defaultMode === "legacy" ? " (default)" : ""} — install/update OMX skills in the resolved user skill root`,
+		);
+		console.log(
+			`  2) plugin${defaultMode === "plugin" ? " (default)" : ""} — rely on Codex plugin discovery and clean up matching legacy OMX-managed setup artifacts`,
+		);
+		const defaultChoice = defaultMode === "plugin" ? "2" : "1";
+		const answer = (
+			await rl.question(`Install mode [1-2] (default: ${defaultChoice}): `)
+		)
+			.trim()
+			.toLowerCase();
+		if (answer === "2" || answer === "plugin") return "plugin";
+		if (answer === "1" || answer === "legacy") return "legacy";
+		return defaultMode;
+	} finally {
+		rl.close();
+	}
 }
 
 function hasPersistedSetupPreferences(
-  preferences: Partial<PersistedSetupScope> | undefined,
+	preferences: Partial<PersistedSetupScope> | undefined,
 ): preferences is Partial<PersistedSetupScope> {
-  return Boolean(preferences?.scope || preferences?.installMode);
+	return Boolean(preferences?.scope || preferences?.installMode);
 }
 
 function formatPersistedSetupPreferenceSummary(
-  preferences: Partial<PersistedSetupScope>,
+	preferences: Partial<PersistedSetupScope>,
 ): string {
-  return [
-    `scope=${preferences.scope ?? "not recorded"}`,
-    `installMode=${preferences.installMode ?? "not recorded"}`,
-  ].join(", ");
+	return [
+		`scope=${preferences.scope ?? "not recorded"}`,
+		`installMode=${preferences.installMode ?? "not recorded"}`,
+	].join(", ");
 }
 
 async function promptForPersistedSetupReview(
-  preferences: Partial<PersistedSetupScope>,
+	preferences: Partial<PersistedSetupScope>,
 ): Promise<PersistedSetupReviewDecision> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return "keep";
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    console.log("Existing OMX setup preferences detected:");
-    console.log(`  ${formatPersistedSetupPreferenceSummary(preferences)}`);
-    console.log("  1) keep   — reuse these choices for this setup run");
-    console.log("  2) review — review/change choices, using these values as defaults");
-    console.log("  3) reset  — ignore saved choices and run setup as if fresh");
-    const answer = (
-      await rl.question("Setup preferences [1-3] (default: 1 keep): ")
-    )
-      .trim()
-      .toLowerCase();
-    if (answer === "2" || answer === "review" || answer === "change") {
-      return "review";
-    }
-    if (answer === "3" || answer === "reset" || answer === "fresh") {
-      return "reset";
-    }
-    return "keep";
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return "keep";
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		console.log("Existing OMX setup preferences detected:");
+		console.log(`  ${formatPersistedSetupPreferenceSummary(preferences)}`);
+		console.log("  1) keep   — reuse these choices for this setup run");
+		console.log(
+			"  2) review — review/change choices, using these values as defaults",
+		);
+		console.log("  3) reset  — ignore saved choices and run setup as if fresh");
+		const answer = (
+			await rl.question("Setup preferences [1-3] (default: 1 keep): ")
+		)
+			.trim()
+			.toLowerCase();
+		if (answer === "2" || answer === "review" || answer === "change") {
+			return "review";
+		}
+		if (answer === "3" || answer === "reset" || answer === "fresh") {
+			return "reset";
+		}
+		return "keep";
+	} finally {
+		rl.close();
+	}
 }
 
 async function promptForModelUpgrade(
-  currentModel: string,
-  targetModel: string,
+	currentModel: string,
+	targetModel: string,
 ): Promise<boolean> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return false;
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    const answer = (
-      await rl.question(
-        `Detected model "${currentModel}". Update to "${targetModel}"? [Y/n]: `,
-      )
-    )
-      .trim()
-      .toLowerCase();
-    return answer === "" || answer === "y" || answer === "yes";
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return false;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		const answer = (
+			await rl.question(
+				`Detected model "${currentModel}". Update to "${targetModel}"? [Y/n]: `,
+			)
+		)
+			.trim()
+			.toLowerCase();
+		return answer === "" || answer === "y" || answer === "yes";
+	} finally {
+		rl.close();
+	}
 }
 
 async function promptForAgentsOverwrite(
-  destinationPath: string,
+	destinationPath: string,
 ): Promise<boolean> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return false;
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    const answer = (
-      await rl.question(
-        `Overwrite existing AGENTS.md at "${destinationPath}"? [y/N]: `,
-      )
-    )
-      .trim()
-      .toLowerCase();
-    return answer === "y" || answer === "yes";
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return false;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		const answer = (
+			await rl.question(
+				`Overwrite existing AGENTS.md at "${destinationPath}"? [y/N]: `,
+			)
+		)
+			.trim()
+			.toLowerCase();
+		return answer === "y" || answer === "yes";
+	} finally {
+		rl.close();
+	}
 }
 
 async function promptForPluginAgentsMdDefault(
-  destinationPath: string,
+	destinationPath: string,
 ): Promise<boolean> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return false;
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    const answer = (
-      await rl.question(
-        `Plugin mode: install OMX AGENTS.md defaults at "${destinationPath}"? [y/N]: `,
-      )
-    )
-      .trim()
-      .toLowerCase();
-    return answer === "y" || answer === "yes";
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return false;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		const answer = (
+			await rl.question(
+				`Plugin mode: install OMX AGENTS.md defaults at "${destinationPath}"? [y/N]: `,
+			)
+		)
+			.trim()
+			.toLowerCase();
+		return answer === "y" || answer === "yes";
+	} finally {
+		rl.close();
+	}
 }
 
 async function promptForPluginDeveloperInstructionsDefault(
-  configPath: string,
+	configPath: string,
 ): Promise<boolean> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return false;
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    const answer = (
-      await rl.question(
-        `Plugin mode: add OMX developer_instructions defaults to "${configPath}"? [y/N]: `,
-      )
-    )
-      .trim()
-      .toLowerCase();
-    return answer === "y" || answer === "yes";
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return false;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		const answer = (
+			await rl.question(
+				`Plugin mode: add OMX developer_instructions defaults to "${configPath}"? [y/N]: `,
+			)
+		)
+			.trim()
+			.toLowerCase();
+		return answer === "y" || answer === "yes";
+	} finally {
+		rl.close();
+	}
 }
 
 async function promptForPluginDeveloperInstructionsOverwrite(
-  configPath: string,
+	configPath: string,
 ): Promise<boolean> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return false;
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    const answer = (
-      await rl.question(
-        `Plugin mode: overwrite existing developer_instructions in "${configPath}" with OMX defaults? [y/N]: `,
-      )
-    )
-      .trim()
-      .toLowerCase();
-    return answer === "y" || answer === "yes";
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return false;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		const answer = (
+			await rl.question(
+				`Plugin mode: overwrite existing developer_instructions in "${configPath}" with OMX defaults? [y/N]: `,
+			)
+		)
+			.trim()
+			.toLowerCase();
+		return answer === "y" || answer === "yes";
+	} finally {
+		rl.close();
+	}
 }
 
 async function resolveSetupScope(
-  projectRoot: string,
-  requestedScope?: SetupScope,
-  persistedReviewDecision: PersistedSetupReviewDecision = "keep",
-  persistedPreferences?: Partial<PersistedSetupScope>,
-  setupScopePrompt?: (defaultScope: SetupScope) => Promise<SetupScope>,
+	projectRoot: string,
+	requestedScope?: SetupScope,
+	persistedReviewDecision: PersistedSetupReviewDecision = "keep",
+	persistedPreferences?: Partial<PersistedSetupScope>,
+	setupScopePrompt?: (defaultScope: SetupScope) => Promise<SetupScope>,
 ): Promise<ResolvedSetupScope> {
-  if (requestedScope) {
-    return { scope: requestedScope, source: "cli" };
-  }
-  const persisted =
-    persistedPreferences ?? (await readPersistedSetupPreferences(projectRoot));
-  if (persisted?.scope && persistedReviewDecision === "keep") {
-    return { scope: persisted.scope, source: "persisted" };
-  }
-  if (
-    typeof setupScopePrompt === "function" ||
-    (process.stdin.isTTY && process.stdout.isTTY)
-  ) {
-    const defaultScope =
-      persistedReviewDecision === "review" && persisted?.scope
-        ? persisted.scope
-        : DEFAULT_SETUP_SCOPE;
-    const scope = setupScopePrompt
-      ? await setupScopePrompt(defaultScope)
-      : await promptForSetupScope(defaultScope);
-    return { scope, source: "prompt" };
-  }
-  return { scope: DEFAULT_SETUP_SCOPE, source: "default" };
+	if (requestedScope) {
+		return { scope: requestedScope, source: "cli" };
+	}
+	const persisted =
+		persistedPreferences ?? (await readPersistedSetupPreferences(projectRoot));
+	if (persisted?.scope && persistedReviewDecision === "keep") {
+		return { scope: persisted.scope, source: "persisted" };
+	}
+	if (
+		typeof setupScopePrompt === "function" ||
+		(process.stdin.isTTY && process.stdout.isTTY)
+	) {
+		const defaultScope =
+			persistedReviewDecision === "review" && persisted?.scope
+				? persisted.scope
+				: DEFAULT_SETUP_SCOPE;
+		const scope = setupScopePrompt
+			? await setupScopePrompt(defaultScope)
+			: await promptForSetupScope(defaultScope);
+		return { scope, source: "prompt" };
+	}
+	return { scope: DEFAULT_SETUP_SCOPE, source: "default" };
 }
 
 async function readPluginManifestName(
-  manifestPath: string,
+	manifestPath: string,
 ): Promise<string | null> {
-  try {
-    const parsed = JSON.parse(await readFile(manifestPath, "utf-8")) as unknown;
-    return typeof parsed === "object" &&
-      parsed !== null &&
-      "name" in parsed &&
-      typeof (parsed as { name?: unknown }).name === "string"
-      ? (parsed as { name: string }).name
-      : null;
-  } catch {
-    return null;
-  }
+	try {
+		const parsed = JSON.parse(await readFile(manifestPath, "utf-8")) as unknown;
+		return typeof parsed === "object" &&
+			parsed !== null &&
+			"name" in parsed &&
+			typeof (parsed as { name?: unknown }).name === "string"
+			? (parsed as { name: string }).name
+			: null;
+	} catch {
+		return null;
+	}
 }
 
 async function discoverOmxPluginCacheDir(
-  cacheRoot = join(codexHome(), "plugins", "cache"),
+	cacheRoot = join(codexHome(), "plugins", "cache"),
 ): Promise<string | null> {
-  if (!existsSync(cacheRoot)) return null;
+	if (!existsSync(cacheRoot)) return null;
 
-  const queue: Array<{ path: string; depth: number }> = [
-    { path: cacheRoot, depth: 0 },
-  ];
-  const maxDepth = 5;
+	const queue: Array<{ path: string; depth: number }> = [
+		{ path: cacheRoot, depth: 0 },
+	];
+	const maxDepth = 5;
 
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (!current) break;
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (!current) break;
 
-    const manifestPath = join(current.path, ".codex-plugin", "plugin.json");
-    if (existsSync(manifestPath)) {
-      const name = await readPluginManifestName(manifestPath);
-      if (name === "oh-my-codex") {
-        return current.path;
-      }
-    }
+		const manifestPath = join(current.path, ".codex-plugin", "plugin.json");
+		if (existsSync(manifestPath)) {
+			const name = await readPluginManifestName(manifestPath);
+			if (name === "oh-my-codex") {
+				return current.path;
+			}
+		}
 
-    if (current.depth >= maxDepth) continue;
+		if (current.depth >= maxDepth) continue;
 
-    let entries;
-    try {
-      entries = await readdir(current.path, { withFileTypes: true });
-    } catch {
-      continue;
-    }
+		let entries;
+		try {
+			entries = await readdir(current.path, { withFileTypes: true });
+		} catch {
+			continue;
+		}
 
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      if (entry.name === ".git" || entry.name === "node_modules") continue;
-      queue.push({
-        path: join(current.path, entry.name),
-        depth: current.depth + 1,
-      });
-    }
-  }
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			if (entry.name === ".git" || entry.name === "node_modules") continue;
+			queue.push({
+				path: join(current.path, entry.name),
+				depth: current.depth + 1,
+			});
+		}
+	}
 
-  return null;
+	return null;
 }
 
 async function resolveSetupInstallMode(
-  projectRoot: string,
-  scope: SetupScope,
-  requestedInstallMode?: SetupInstallMode,
-  installModePrompt?: (
-    defaultMode: SetupInstallMode,
-  ) => Promise<SetupInstallMode>,
-  persistedReviewDecision: PersistedSetupReviewDecision = "keep",
-  persistedPreferences?: Partial<PersistedSetupScope>,
+	projectRoot: string,
+	scope: SetupScope,
+	requestedInstallMode?: SetupInstallMode,
+	installModePrompt?: (
+		defaultMode: SetupInstallMode,
+	) => Promise<SetupInstallMode>,
+	persistedReviewDecision: PersistedSetupReviewDecision = "keep",
+	persistedPreferences?: Partial<PersistedSetupScope>,
 ): Promise<ResolvedSetupInstallMode | null> {
-  if (requestedInstallMode) {
-    return { installMode: requestedInstallMode, source: "cli" };
-  }
+	if (requestedInstallMode) {
+		return { installMode: requestedInstallMode, source: "cli" };
+	}
 
-  const persisted =
-    persistedPreferences ?? (await readPersistedSetupPreferences(projectRoot));
-  if (
-    persisted?.installMode &&
-    persistedReviewDecision === "keep" &&
-    persisted.scope === scope
-  ) {
-    return { installMode: persisted.installMode, source: "persisted" };
-  }
+	const persisted =
+		persistedPreferences ?? (await readPersistedSetupPreferences(projectRoot));
+	if (
+		persisted?.installMode &&
+		persistedReviewDecision === "keep" &&
+		persisted.scope === scope
+	) {
+		return { installMode: persisted.installMode, source: "persisted" };
+	}
 
-  if (scope !== "user") return null;
+	if (scope !== "user") return null;
 
-  const discoveredPluginCacheDir = await discoverOmxPluginCacheDir();
-  const defaultMode =
-    persistedReviewDecision === "review" && persisted?.installMode
-      ? persisted.installMode
-      : discoveredPluginCacheDir
-        ? "plugin"
-        : DEFAULT_SETUP_INSTALL_MODE;
+	const discoveredPluginCacheDir = await discoverOmxPluginCacheDir();
+	const defaultMode =
+		persistedReviewDecision === "review" && persisted?.installMode
+			? persisted.installMode
+			: discoveredPluginCacheDir
+				? "plugin"
+				: DEFAULT_SETUP_INSTALL_MODE;
 
-  if (
-    typeof installModePrompt === "function" ||
-    (process.stdin.isTTY && process.stdout.isTTY)
-  ) {
-    if (discoveredPluginCacheDir) {
-      console.log(
-        `Detected installed oh-my-codex Codex plugin cache at ${discoveredPluginCacheDir}.`,
-      );
-    }
-    const installMode = installModePrompt
-      ? await installModePrompt(defaultMode)
-      : await promptForSetupInstallMode(defaultMode);
-    return { installMode, source: "prompt" };
-  }
+	if (
+		typeof installModePrompt === "function" ||
+		(process.stdin.isTTY && process.stdout.isTTY)
+	) {
+		if (discoveredPluginCacheDir) {
+			console.log(
+				`Detected installed oh-my-codex Codex plugin cache at ${discoveredPluginCacheDir}.`,
+			);
+		}
+		const installMode = installModePrompt
+			? await installModePrompt(defaultMode)
+			: await promptForSetupInstallMode(defaultMode);
+		return { installMode, source: "prompt" };
+	}
 
-  return { installMode: defaultMode, source: "default" };
+	return { installMode: defaultMode, source: "default" };
 }
 
 function hasGitignoreEntry(content: string, entry: string): boolean {
-  return content
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .some((line) => line === entry);
+	return content
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.some((line) => line === entry);
 }
 
 function isProjectPathIgnoredByGit(projectRoot: string, path: string): boolean {
-  const result = spawnSync("git", ["check-ignore", "--no-index", "-q", path], {
-    cwd: projectRoot,
-    stdio: "ignore",
-    windowsHide: true,
-  });
-  return result.status === 0;
+	const result = spawnSync("git", ["check-ignore", "--no-index", "-q", path], {
+		cwd: projectRoot,
+		stdio: "ignore",
+		windowsHide: true,
+	});
+	return result.status === 0;
 }
 
 function shouldAddProjectGitignoreEntry(
-  projectRoot: string,
-  content: string,
-  entry: string,
+	projectRoot: string,
+	content: string,
+	entry: string,
 ): boolean {
-  if (hasGitignoreEntry(content, entry)) return false;
+	if (hasGitignoreEntry(content, entry)) return false;
 
-  if (entry === ".omx/" && isProjectPathIgnoredByGit(projectRoot, entry)) {
-    return false;
-  }
+	if (entry === ".omx/" && isProjectPathIgnoredByGit(projectRoot, entry)) {
+		return false;
+	}
 
-  return true;
+	return true;
 }
 
 function stripLegacyGitignoreEntries(
-  content: string,
-  legacyEntries: readonly string[],
+	content: string,
+	legacyEntries: readonly string[],
 ): { content: string; removed: boolean } {
-  const legacyEntrySet = new Set(legacyEntries);
-  const lines = content.split(/\r?\n/);
-  const filteredLines = lines.filter(
-    (line) => !legacyEntrySet.has(line.trim()),
-  );
-  const removed = filteredLines.length !== lines.length;
+	const legacyEntrySet = new Set(legacyEntries);
+	const lines = content.split(/\r?\n/);
+	const filteredLines = lines.filter(
+		(line) => !legacyEntrySet.has(line.trim()),
+	);
+	const removed = filteredLines.length !== lines.length;
 
-  return {
-    content: filteredLines.join("\n").replace(/\n+$/, "\n"),
-    removed,
-  };
+	return {
+		content: filteredLines.join("\n").replace(/\n+$/, "\n"),
+		removed,
+	};
 }
 
 async function ensureProjectGitignore(
-  projectRoot: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	projectRoot: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<"created" | "updated" | "unchanged"> {
-  const gitignorePath = join(projectRoot, ".gitignore");
-  const destinationExists = existsSync(gitignorePath);
-  const existing = destinationExists
-    ? await readFile(gitignorePath, "utf-8")
-    : "";
-  const normalized = stripLegacyGitignoreEntries(
-    existing,
-    LEGACY_PROJECT_GITIGNORE_ENTRIES,
-  );
+	const gitignorePath = join(projectRoot, ".gitignore");
+	const destinationExists = existsSync(gitignorePath);
+	const existing = destinationExists
+		? await readFile(gitignorePath, "utf-8")
+		: "";
+	const normalized = stripLegacyGitignoreEntries(
+		existing,
+		LEGACY_PROJECT_GITIGNORE_ENTRIES,
+	);
 
-  const missingEntries = PROJECT_GITIGNORE_ENTRIES.filter((entry) =>
-    shouldAddProjectGitignoreEntry(projectRoot, normalized.content, entry),
-  );
+	const missingEntries = PROJECT_GITIGNORE_ENTRIES.filter((entry) =>
+		shouldAddProjectGitignoreEntry(projectRoot, normalized.content, entry),
+	);
 
-  if (missingEntries.length === 0 && !normalized.removed) {
-    return "unchanged";
-  }
+	if (missingEntries.length === 0 && !normalized.removed) {
+		return "unchanged";
+	}
 
-  const nextContent = destinationExists
-    ? `${normalized.content}${normalized.content.endsWith("\n") || normalized.content.length === 0 ? "" : "\n"}${missingEntries.join("\n")}${missingEntries.length > 0 ? "\n" : ""}`
-    : `${missingEntries.join("\n")}\n`;
+	const nextContent = destinationExists
+		? `${normalized.content}${normalized.content.endsWith("\n") || normalized.content.length === 0 ? "" : "\n"}${missingEntries.join("\n")}${missingEntries.length > 0 ? "\n" : ""}`
+		: `${missingEntries.join("\n")}\n`;
 
-  if (
-    await ensureBackup(gitignorePath, destinationExists, backupContext, options)
-  ) {
-    // backup created when refreshing a pre-existing .gitignore
-  }
+	if (
+		await ensureBackup(gitignorePath, destinationExists, backupContext, options)
+	) {
+		// backup created when refreshing a pre-existing .gitignore
+	}
 
-  if (!options.dryRun) {
-    await writeFile(gitignorePath, nextContent);
-  }
+	if (!options.dryRun) {
+		await writeFile(gitignorePath, nextContent);
+	}
 
-  if (options.verbose) {
-    const changedDetails = [
-      normalized.removed ? "removed legacy .codex/" : "",
-      missingEntries.length > 0 ? missingEntries.join(", ") : "",
-    ]
-      .filter(Boolean)
-      .join("; ");
-    console.log(
-      `  ${options.dryRun ? "would update" : destinationExists ? "updated" : "created"} .gitignore${changedDetails ? ` (${changedDetails})` : ""}`,
-    );
-  }
+	if (options.verbose) {
+		const changedDetails = [
+			normalized.removed ? "removed legacy .codex/" : "",
+			missingEntries.length > 0 ? missingEntries.join(", ") : "",
+		]
+			.filter(Boolean)
+			.join("; ");
+		console.log(
+			`  ${options.dryRun ? "would update" : destinationExists ? "updated" : "created"} .gitignore${changedDetails ? ` (${changedDetails})` : ""}`,
+		);
+	}
 
-  return destinationExists ? "updated" : "created";
+	return destinationExists ? "updated" : "created";
 }
 
 async function persistSetupPreferences(
-  projectRoot: string,
-  preferences: PersistedSetupScope,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	projectRoot: string,
+	preferences: PersistedSetupScope,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
-  const scopePath = getScopeFilePath(projectRoot);
-  if (options.dryRun) {
-    if (options.verbose) console.log(`  dry-run: skip persisting ${scopePath}`);
-    return;
-  }
-  await mkdir(dirname(scopePath), { recursive: true });
-  await writeFile(scopePath, JSON.stringify(preferences, null, 2) + "\n");
-  if (options.verbose) console.log(`  Wrote ${scopePath}`);
+	const scopePath = getSetupScopeFilePath(projectRoot);
+	if (options.dryRun) {
+		if (options.verbose) console.log(`  dry-run: skip persisting ${scopePath}`);
+		return;
+	}
+	await mkdir(dirname(scopePath), { recursive: true });
+	await writeFile(scopePath, JSON.stringify(preferences, null, 2) + "\n");
+	if (options.verbose) console.log(`  Wrote ${scopePath}`);
 }
 
 async function removeEmptyDirectoryIfPresent(
-  dirPath: string,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	dirPath: string,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
-  if (options.dryRun || !existsSync(dirPath)) return;
-  try {
-    const remaining = await readdir(dirPath);
-    if (remaining.length === 0) {
-      await rm(dirPath, { recursive: true, force: true });
-      if (options.verbose) console.log(`  removed empty directory ${dirPath}`);
-    }
-  } catch {
-    // Best-effort cleanup only.
-  }
+	if (options.dryRun || !existsSync(dirPath)) return;
+	try {
+		const remaining = await readdir(dirPath);
+		if (remaining.length === 0) {
+			await rm(dirPath, { recursive: true, force: true });
+			if (options.verbose) console.log(`  removed empty directory ${dirPath}`);
+		}
+	} catch {
+		// Best-effort cleanup only.
+	}
 }
 
 async function cleanupPluginModeLegacyPrompts(
-  srcDir: string,
-  dstDir: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	srcDir: string,
+	dstDir: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<SetupCategorySummary> {
-  const summary = createEmptyCategorySummary();
-  if (!existsSync(srcDir) || !existsSync(dstDir)) return summary;
+	const summary = createEmptyCategorySummary();
+	if (!existsSync(srcDir) || !existsSync(dstDir)) return summary;
 
-  const manifest = tryReadCatalogManifest();
+	const manifest = tryReadCatalogManifest();
 
-  for (const file of await readdir(srcDir)) {
-    if (!file.endsWith(".md")) continue;
-    const promptName = file.slice(0, -3);
-    if (manifest && !isSetupPromptAssetName(promptName, manifest)) continue;
+	for (const file of await readdir(srcDir)) {
+		if (!file.endsWith(".md")) continue;
+		const promptName = file.slice(0, -3);
+		if (manifest && !isSetupPromptAssetName(promptName, manifest)) continue;
 
-    const dst = join(dstDir, file);
-    if (!existsSync(dst)) continue;
+		const dst = join(dstDir, file);
+		if (!existsSync(dst)) continue;
 
-    if (await ensureBackup(dst, true, backupContext, options)) {
-      summary.backedUp += 1;
-    }
-    if (!options.dryRun) {
-      await rm(dst, { force: true });
-    }
-    summary.removed += 1;
-    if (options.verbose) {
-      console.log(
-        `  ${options.dryRun ? "would archive and remove" : "archived and removed"} legacy prompt ${file}`,
-      );
-    }
-  }
+		if (await ensureBackup(dst, true, backupContext, options)) {
+			summary.backedUp += 1;
+		}
+		if (!options.dryRun) {
+			await rm(dst, { force: true });
+		}
+		summary.removed += 1;
+		if (options.verbose) {
+			console.log(
+				`  ${options.dryRun ? "would archive and remove" : "archived and removed"} legacy prompt ${file}`,
+			);
+		}
+	}
 
-  await removeEmptyDirectoryIfPresent(dstDir, options);
-  return summary;
+	await removeEmptyDirectoryIfPresent(dstDir, options);
+	return summary;
 }
 
 async function cleanupPluginModeLegacyNativeAgents(
-  pkgRoot: string,
-  agentsDir: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	pkgRoot: string,
+	agentsDir: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<SetupCategorySummary> {
-  const summary = createEmptyCategorySummary();
-  if (!existsSync(agentsDir)) return summary;
+	const summary = createEmptyCategorySummary();
+	if (!existsSync(agentsDir)) return summary;
 
-  const manifest = tryReadCatalogManifest();
-  const agentStatusByName = manifest
-    ? getCatalogAgentStatusByName(manifest)
-    : null;
+	const manifest = tryReadCatalogManifest();
+	const agentStatusByName = manifest
+		? getCatalogAgentStatusByName(manifest)
+		: null;
 
-  for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
-    const status = agentStatusByName?.get(name);
-    if (agentStatusByName && !isNativeAgentInstallableStatus(status)) continue;
+	for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
+		const status = agentStatusByName?.get(name);
+		if (agentStatusByName && !isNativeAgentInstallableStatus(status)) continue;
 
-    const dst = join(agentsDir, `${name}.toml`);
-    const promptPath = join(pkgRoot, "prompts", `${name}.md`);
-    if (!existsSync(dst) || !existsSync(promptPath)) continue;
+		const dst = join(agentsDir, `${name}.toml`);
+		const promptPath = join(pkgRoot, "prompts", `${name}.md`);
+		if (!existsSync(dst) || !existsSync(promptPath)) continue;
 
-    const promptContent = await readFile(promptPath, "utf-8");
-    const expectedToml = generateAgentToml(agent, promptContent, {
-      codexHomeOverride: join(agentsDir, ".."),
-    });
-    const installedToml = await readFile(dst, "utf-8");
-    if (
-      installedToml !== expectedToml &&
-      !isGeneratedOmxNativeAgentToml(installedToml, name)
-    ) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        console.log(
-          `  skipped legacy native agent cleanup for ${name}.toml: installed content is not an OMX-generated native agent`,
-        );
-      }
-      continue;
-    }
+		const promptContent = await readFile(promptPath, "utf-8");
+		const expectedToml = generateAgentToml(agent, promptContent, {
+			codexHomeOverride: join(agentsDir, ".."),
+		});
+		const installedToml = await readFile(dst, "utf-8");
+		if (
+			installedToml !== expectedToml &&
+			!isGeneratedOmxNativeAgentToml(installedToml, name)
+		) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				console.log(
+					`  skipped legacy native agent cleanup for ${name}.toml: installed content is not an OMX-generated native agent`,
+				);
+			}
+			continue;
+		}
 
-    if (await ensureBackup(dst, true, backupContext, options)) {
-      summary.backedUp += 1;
-    }
-    if (!options.dryRun) {
-      await rm(dst, { force: true });
-    }
-    summary.removed += 1;
-    if (options.verbose) {
-      console.log(
-        `  ${options.dryRun ? "would archive and remove" : "archived and removed"} legacy native agent ${name}.toml`,
-      );
-    }
-  }
+		if (await ensureBackup(dst, true, backupContext, options)) {
+			summary.backedUp += 1;
+		}
+		if (!options.dryRun) {
+			await rm(dst, { force: true });
+		}
+		summary.removed += 1;
+		if (options.verbose) {
+			console.log(
+				`  ${options.dryRun ? "would archive and remove" : "archived and removed"} legacy native agent ${name}.toml`,
+			);
+		}
+	}
 
-  if (manifest) {
-    const generatedCleanup = await cleanupGeneratedNonInstallableNativeAgents(
-      agentsDir,
-      manifest,
-      backupContext,
-      options,
-    );
-    summary.backedUp += generatedCleanup.backedUp;
-    summary.removed += generatedCleanup.removed;
-  }
+	if (manifest) {
+		const generatedCleanup = await cleanupGeneratedNonInstallableNativeAgents(
+			agentsDir,
+			manifest,
+			backupContext,
+			options,
+		);
+		summary.backedUp += generatedCleanup.backedUp;
+		summary.removed += generatedCleanup.removed;
+	}
 
-  await removeEmptyDirectoryIfPresent(agentsDir, options);
-  return summary;
+	await removeEmptyDirectoryIfPresent(agentsDir, options);
+	return summary;
 }
 
 function stripPluginModeLegacyRootDefaults(config: string): string {
-  const lines = config.split(/\r?\n/);
-  const firstTableIndex = lines.findIndex((line) => /^\s*\[/.test(line));
-  const boundary = firstTableIndex >= 0 ? firstTableIndex : lines.length;
-  const result: string[] = [];
+	const lines = config.split(/\r?\n/);
+	const firstTableIndex = lines.findIndex((line) => /^\s*\[/.test(line));
+	const boundary = firstTableIndex >= 0 ? firstTableIndex : lines.length;
+	const result: string[] = [];
 
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index];
-    if (
-      index < boundary &&
-      line.trim() ===
-        "# oh-my-codex top-level settings (must be before any [table])"
-    ) {
-      continue;
-    }
-    if (
-      index < boundary &&
-      /^\s*notify\s*=\s*\["node",\s*".*notify-hook\.js"\]\s*$/.test(line)
-    ) {
-      continue;
-    }
-    if (
-      index < boundary &&
-      /^\s*model_reasoning_effort\s*=\s*"medium"\s*$/.test(line)
-    ) {
-      continue;
-    }
-    if (
-      index < boundary &&
-      /^\s*developer_instructions\s*=/.test(line) &&
-      line.includes("You have oh-my-codex installed.")
-    ) {
-      continue;
-    }
-    result.push(line);
-  }
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index];
+		if (
+			index < boundary &&
+			line.trim() ===
+				"# oh-my-codex top-level settings (must be before any [table])"
+		) {
+			continue;
+		}
+		if (
+			index < boundary &&
+			/^\s*notify\s*=\s*\["node",\s*".*notify-hook\.js"\]\s*$/.test(line)
+		) {
+			continue;
+		}
+		if (
+			index < boundary &&
+			/^\s*model_reasoning_effort\s*=\s*"medium"\s*$/.test(line)
+		) {
+			continue;
+		}
+		if (
+			index < boundary &&
+			/^\s*developer_instructions\s*=/.test(line) &&
+			line.includes("You have oh-my-codex installed.")
+		) {
+			continue;
+		}
+		result.push(line);
+	}
 
-  return result.join("\n").replace(/\n{3,}/g, "\n\n");
+	return result.join("\n").replace(/\n{3,}/g, "\n\n");
 }
 
 function rootHasTomlKey(config: string, key: string): boolean {
-  const lines = config.split(/\r?\n/);
-  const firstTableIndex = lines.findIndex((line) => /^\s*\[/.test(line));
-  const boundary = firstTableIndex >= 0 ? firstTableIndex : lines.length;
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`^\\s*${escapedKey}\\s*=`);
-  return lines.slice(0, boundary).some((line) => pattern.test(line));
+	const lines = config.split(/\r?\n/);
+	const firstTableIndex = lines.findIndex((line) => /^\s*\[/.test(line));
+	const boundary = firstTableIndex >= 0 ? firstTableIndex : lines.length;
+	const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const pattern = new RegExp(`^\\s*${escapedKey}\\s*=`);
+	return lines.slice(0, boundary).some((line) => pattern.test(line));
 }
 
 function replaceRootTomlKey(config: string, key: string, line: string): string {
-  const lines = config.trimEnd().split(/\r?\n/);
-  const firstTableIndex = lines.findIndex((entry) => /^\s*\[/.test(entry));
-  const boundary = firstTableIndex < 0 ? lines.length : firstTableIndex;
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`^\\s*${escapedKey}\\s*=`);
+	const lines = config.trimEnd().split(/\r?\n/);
+	const firstTableIndex = lines.findIndex((entry) => /^\s*\[/.test(entry));
+	const boundary = firstTableIndex < 0 ? lines.length : firstTableIndex;
+	const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const pattern = new RegExp(`^\\s*${escapedKey}\\s*=`);
 
-  for (let i = 0; i < boundary; i++) {
-    if (pattern.test(lines[i])) {
-      lines[i] = line;
-      return lines.join("\n") + "\n";
-    }
-  }
+	for (let i = 0; i < boundary; i++) {
+		if (pattern.test(lines[i])) {
+			lines[i] = line;
+			return lines.join("\n") + "\n";
+		}
+	}
 
-  return insertRootTomlKey(config, line);
+	return insertRootTomlKey(config, line);
 }
 
 function insertRootTomlKey(config: string, line: string): string {
-  const lines = config.trimEnd().split(/\r?\n/);
-  if (lines.length === 1 && lines[0] === "") return `${line}\n`;
-  const firstTableIndex = lines.findIndex((entry) => /^\s*\[/.test(entry));
-  if (firstTableIndex < 0) return `${lines.join("\n")}\n${line}\n`;
-  const before = lines
-    .slice(0, firstTableIndex)
-    .filter((entry) => entry.trim() !== "");
-  const after = lines.slice(firstTableIndex);
-  return [...before, line, "", ...after].join("\n") + "\n";
+	const lines = config.trimEnd().split(/\r?\n/);
+	if (lines.length === 1 && lines[0] === "") return `${line}\n`;
+	const firstTableIndex = lines.findIndex((entry) => /^\s*\[/.test(entry));
+	if (firstTableIndex < 0) return `${lines.join("\n")}\n${line}\n`;
+	const before = lines
+		.slice(0, firstTableIndex)
+		.filter((entry) => entry.trim() !== "");
+	const after = lines.slice(firstTableIndex);
+	return [...before, line, "", ...after].join("\n") + "\n";
+}
+
+async function ensurePluginMarketplaceRegistration(
+	configPath: string,
+	pkgRoot: string,
+	backupContext: SetupBackupContext,
+	summary: SetupCategorySummary,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<"updated" | "unchanged" | "unavailable"> {
+	const packagedMarketplace = await resolvePackagedOmxMarketplace(pkgRoot);
+	if (!packagedMarketplace) {
+		summary.skipped += 1;
+		return "unavailable";
+	}
+
+	const existingConfig = existsSync(configPath)
+		? await readFile(configPath, "utf-8")
+		: "";
+	const nextConfig = upsertLocalOmxMarketplaceRegistration(
+		existingConfig,
+		pkgRoot,
+	);
+	const destinationExists = existsSync(configPath);
+
+	if (nextConfig === existingConfig) {
+		summary.unchanged += 1;
+		return "unchanged";
+	}
+
+	if (
+		await ensureBackup(configPath, destinationExists, backupContext, options)
+	) {
+		summary.backedUp += 1;
+	}
+	if (!options.dryRun) {
+		await mkdir(dirname(configPath), { recursive: true });
+		await writeFile(configPath, nextConfig);
+	}
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would register" : "registered"} local Codex plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} from ${pkgRoot}`,
+		);
+	}
+	return "updated";
 }
 
 async function applyPluginModeHooksConfig(
-  configPath: string,
-  hooksPath: string,
-  pkgRoot: string,
-  backupContext: SetupBackupContext,
-  summary: SetupCategorySummary,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	configPath: string,
+	hooksPath: string,
+	pkgRoot: string,
+	backupContext: SetupBackupContext,
+	summary: SetupCategorySummary,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
-  const existingConfig = existsSync(configPath)
-    ? await readFile(configPath, "utf-8")
-    : "";
-  const nextConfig =
-    upsertCodexHooksFeatureFlag(existingConfig).trimEnd() + "\n";
-  if (nextConfig !== existingConfig) {
-    if (
-      await ensureBackup(
-        configPath,
-        existsSync(configPath),
-        backupContext,
-        options,
-      )
-    ) {
-      summary.backedUp += 1;
-    }
-    if (!options.dryRun) {
-      await mkdir(dirname(configPath), { recursive: true });
-      await writeFile(configPath, nextConfig);
-    }
-    summary.updated += 1;
-  } else {
-    summary.unchanged += 1;
-  }
+	const existingConfig = existsSync(configPath)
+		? await readFile(configPath, "utf-8")
+		: "";
+	const nextConfig =
+		upsertCodexHooksFeatureFlag(existingConfig).trimEnd() + "\n";
+	if (nextConfig !== existingConfig) {
+		if (
+			await ensureBackup(
+				configPath,
+				existsSync(configPath),
+				backupContext,
+				options,
+			)
+		) {
+			summary.backedUp += 1;
+		}
+		if (!options.dryRun) {
+			await mkdir(dirname(configPath), { recursive: true });
+			await writeFile(configPath, nextConfig);
+		}
+		summary.updated += 1;
+	} else {
+		summary.unchanged += 1;
+	}
 
-  const existingHooksContent = existsSync(hooksPath)
-    ? await readFile(hooksPath, "utf-8")
-    : null;
-  const hooksConfig = mergeManagedCodexHooksConfig(
-    existingHooksContent,
-    pkgRoot,
-  );
-  await syncManagedContent(
-    hooksConfig,
-    hooksPath,
-    summary,
-    backupContext,
-    options,
-    `native hooks ${hooksPath}`,
-  );
+	const existingHooksContent = existsSync(hooksPath)
+		? await readFile(hooksPath, "utf-8")
+		: null;
+	const hooksConfig = mergeManagedCodexHooksConfig(
+		existingHooksContent,
+		pkgRoot,
+	);
+	await syncManagedContent(
+		hooksConfig,
+		hooksPath,
+		summary,
+		backupContext,
+		options,
+		`native hooks ${hooksPath}`,
+	);
 
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would configure" : "configured"} plugin-mode native hooks at ${hooksPath}`,
-    );
-  }
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would configure" : "configured"} plugin-mode native hooks at ${hooksPath}`,
+		);
+	}
 }
 
 async function applyPluginDeveloperInstructionsDefault(
-  configPath: string,
-  backupContext: SetupBackupContext,
-  summary: SetupCategorySummary,
-  options: Pick<
-    SetupOptions,
-    "dryRun" | "verbose" | "pluginDeveloperInstructionsOverwritePrompt"
-  >,
+	configPath: string,
+	backupContext: SetupBackupContext,
+	summary: SetupCategorySummary,
+	options: Pick<
+		SetupOptions,
+		"dryRun" | "verbose" | "pluginDeveloperInstructionsOverwritePrompt"
+	>,
 ): Promise<"updated" | "exists" | "skipped"> {
-  const existing = existsSync(configPath)
-    ? await readFile(configPath, "utf-8")
-    : "";
-  const line = `developer_instructions = ${JSON.stringify(OMX_DEVELOPER_INSTRUCTIONS)}`;
-  const hasExistingDeveloperInstructions = rootHasTomlKey(
-    existing,
-    "developer_instructions",
-  );
-  if (hasExistingDeveloperInstructions) {
-    const overwrite = options.pluginDeveloperInstructionsOverwritePrompt
-      ? await options.pluginDeveloperInstructionsOverwritePrompt(configPath)
-      : await promptForPluginDeveloperInstructionsOverwrite(configPath);
-    if (!overwrite) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        console.log(
-          "  skipped plugin developer_instructions default: root developer_instructions already exists",
-        );
-      }
-      return "exists";
-    }
-  }
+	const existing = existsSync(configPath)
+		? await readFile(configPath, "utf-8")
+		: "";
+	const line = `developer_instructions = ${JSON.stringify(OMX_DEVELOPER_INSTRUCTIONS)}`;
+	const hasExistingDeveloperInstructions = rootHasTomlKey(
+		existing,
+		"developer_instructions",
+	);
+	if (hasExistingDeveloperInstructions) {
+		const overwrite = options.pluginDeveloperInstructionsOverwritePrompt
+			? await options.pluginDeveloperInstructionsOverwritePrompt(configPath)
+			: await promptForPluginDeveloperInstructionsOverwrite(configPath);
+		if (!overwrite) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				console.log(
+					"  skipped plugin developer_instructions default: root developer_instructions already exists",
+				);
+			}
+			return "exists";
+		}
+	}
 
-  const nextConfig = hasExistingDeveloperInstructions
-    ? replaceRootTomlKey(existing, "developer_instructions", line)
-    : insertRootTomlKey(existing, line);
-  const destinationExists = existsSync(configPath);
-  if (
-    await ensureBackup(configPath, destinationExists, backupContext, options)
-  ) {
-    summary.backedUp += 1;
-  }
-  if (!options.dryRun) {
-    await mkdir(dirname(configPath), { recursive: true });
-    await writeFile(configPath, nextConfig);
-  }
-  summary.updated += 1;
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would add" : "added"} plugin developer_instructions default to ${configPath}`,
-    );
-  }
-  return "updated";
+	const nextConfig = hasExistingDeveloperInstructions
+		? replaceRootTomlKey(existing, "developer_instructions", line)
+		: insertRootTomlKey(existing, line);
+	const destinationExists = existsSync(configPath);
+	if (
+		await ensureBackup(configPath, destinationExists, backupContext, options)
+	) {
+		summary.backedUp += 1;
+	}
+	if (!options.dryRun) {
+		await mkdir(dirname(configPath), { recursive: true });
+		await writeFile(configPath, nextConfig);
+	}
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would add" : "added"} plugin developer_instructions default to ${configPath}`,
+		);
+	}
+	return "updated";
 }
 
 async function cleanupPluginModeLegacyConfig(
-  configPath: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	configPath: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<boolean> {
-  if (!existsSync(configPath)) return false;
+	if (!existsSync(configPath)) return false;
 
-  const original = await readFile(configPath, "utf-8");
-  let config = original;
-  config = stripExistingOmxBlocks(config).cleaned;
-  config = stripExistingSharedMcpRegistryBlock(config).cleaned;
-  config = stripPluginModeLegacyRootDefaults(config);
-  config = stripOmxSeededBehavioralDefaults(config);
-  config = stripOmxFeatureFlags(config);
-  config = stripOmxEnvSettings(config);
-  config = config.trim();
-  const nextConfig = config.length > 0 ? `${config}\n` : "";
+	const original = await readFile(configPath, "utf-8");
+	let config = original;
+	config = stripExistingOmxBlocks(config).cleaned;
+	config = stripExistingSharedMcpRegistryBlock(config).cleaned;
+	config = stripPluginModeLegacyRootDefaults(config);
+	config = stripOmxSeededBehavioralDefaults(config);
+	config = stripOmxFeatureFlags(config);
+	config = stripOmxEnvSettings(config);
+	config = config.trim();
+	const nextConfig = config.length > 0 ? `${config}\n` : "";
 
-  if (nextConfig === original) return false;
+	if (nextConfig === original) return false;
 
-  if (await ensureBackup(configPath, true, backupContext, options)) {
-    // backup created for pre-existing config
-  }
-  if (!options.dryRun) {
-    if (nextConfig.length === 0) {
-      await rm(configPath, { force: true });
-    } else {
-      await writeFile(configPath, nextConfig);
-    }
-  }
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would clean" : nextConfig.length === 0 ? "removed" : "cleaned"} legacy OMX config ${basename(configPath)}`,
-    );
-  }
-  return true;
+	if (await ensureBackup(configPath, true, backupContext, options)) {
+		// backup created for pre-existing config
+	}
+	if (!options.dryRun) {
+		if (nextConfig.length === 0) {
+			await rm(configPath, { force: true });
+		} else {
+			await writeFile(configPath, nextConfig);
+		}
+	}
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would clean" : nextConfig.length === 0 ? "removed" : "cleaned"} legacy OMX config ${basename(configPath)}`,
+		);
+	}
+	return true;
 }
 
 async function cleanupPluginModeLegacyAgentsMd(
-  agentsMdPath: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	agentsMdPath: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<boolean> {
-  if (!existsSync(agentsMdPath)) return false;
+	if (!existsSync(agentsMdPath)) return false;
 
-  const content = await readFile(agentsMdPath, "utf-8");
-  if (!isOmxGeneratedAgentsMd(content)) return false;
+	const content = await readFile(agentsMdPath, "utf-8");
+	if (!isOmxGeneratedAgentsMd(content)) return false;
 
-  if (await ensureBackup(agentsMdPath, true, backupContext, options)) {
-    // backup created for pre-existing AGENTS.md
-  }
-  if (!options.dryRun) {
-    await rm(agentsMdPath, { force: true });
-  }
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would remove" : "removed"} legacy OMX-generated AGENTS.md`,
-    );
-  }
-  return true;
+	if (await ensureBackup(agentsMdPath, true, backupContext, options)) {
+		// backup created for pre-existing AGENTS.md
+	}
+	if (!options.dryRun) {
+		await rm(agentsMdPath, { force: true });
+	}
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would remove" : "removed"} legacy OMX-generated AGENTS.md`,
+		);
+	}
+	return true;
 }
 
 export async function setup(options: SetupOptions = {}): Promise<void> {
-  const {
-    force = false,
-    dryRun = false,
-    installMode: requestedInstallMode,
-    scope: requestedScope,
-    verbose = false,
-    setupScopePrompt,
-    persistedSetupReviewPrompt,
-    installModePrompt,
-    modelUpgradePrompt,
-    pluginAgentsMdPrompt,
-    pluginDeveloperInstructionsPrompt,
-    pluginDeveloperInstructionsOverwritePrompt,
-  } = options;
-  const pkgRoot = getPackageRoot();
-  const projectRoot = process.cwd();
-  const persistedPreferences = await readPersistedSetupPreferences(projectRoot);
-  let persistedReviewDecision: PersistedSetupReviewDecision = "keep";
-  const effectiveScopeForInstallMode =
-    requestedScope ?? persistedPreferences?.scope ?? DEFAULT_SETUP_SCOPE;
-  const wouldUsePersistedScope =
-    !requestedScope && Boolean(persistedPreferences?.scope);
-  const wouldUsePersistedInstallMode =
-    !requestedInstallMode &&
-    Boolean(persistedPreferences?.installMode) &&
-    (!persistedPreferences?.scope ||
-      persistedPreferences.scope === effectiveScopeForInstallMode);
-  const shouldReviewPersistedSetup =
-    hasPersistedSetupPreferences(persistedPreferences) &&
-    (wouldUsePersistedScope || wouldUsePersistedInstallMode) &&
-    (typeof persistedSetupReviewPrompt === "function" ||
-      (process.stdin.isTTY && process.stdout.isTTY));
-  if (shouldReviewPersistedSetup) {
-    persistedReviewDecision = persistedSetupReviewPrompt
-      ? await persistedSetupReviewPrompt(persistedPreferences)
-      : await promptForPersistedSetupReview(persistedPreferences);
-    console.log(
-      `Setup preference review: ${persistedReviewDecision} (${formatPersistedSetupPreferenceSummary(persistedPreferences)})\n`,
-    );
-  }
-  const resolvedScope = await resolveSetupScope(
-    projectRoot,
-    requestedScope,
-    persistedReviewDecision,
-    persistedPreferences,
-    setupScopePrompt,
-  );
-  const resolvedInstallMode = await resolveSetupInstallMode(
-    projectRoot,
-    resolvedScope.scope,
-    requestedInstallMode,
-    installModePrompt,
-    persistedReviewDecision,
-    persistedPreferences,
-  );
-  const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
-  const scopeSourceMessage =
-    resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
-  const backupContext = getBackupContext(resolvedScope.scope, projectRoot);
-  const isPluginInstallMode = resolvedInstallMode?.installMode === "plugin";
-  const pluginAgentsMdDst =
-    resolvedScope.scope === "project"
-      ? join(projectRoot, "AGENTS.md")
-      : join(scopeDirs.codexHomeDir, "AGENTS.md");
-  const usePluginDeveloperInstructionsDefault = isPluginInstallMode
-    ? pluginDeveloperInstructionsPrompt
-      ? await pluginDeveloperInstructionsPrompt(scopeDirs.codexConfigFile)
-      : await promptForPluginDeveloperInstructionsDefault(
-          scopeDirs.codexConfigFile,
-        )
-    : false;
-  const usePluginAgentsMdDefault = isPluginInstallMode
-    ? pluginAgentsMdPrompt
-      ? await pluginAgentsMdPrompt(pluginAgentsMdDst)
-      : await promptForPluginAgentsMdDefault(pluginAgentsMdDst)
-    : false;
+	const {
+		force = false,
+		dryRun = false,
+		installMode: requestedInstallMode,
+		scope: requestedScope,
+		verbose = false,
+		setupScopePrompt,
+		persistedSetupReviewPrompt,
+		installModePrompt,
+		modelUpgradePrompt,
+		pluginAgentsMdPrompt,
+		pluginDeveloperInstructionsPrompt,
+		pluginDeveloperInstructionsOverwritePrompt,
+	} = options;
+	const pkgRoot = getPackageRoot();
+	const projectRoot = process.cwd();
+	const persistedPreferences = await readPersistedSetupPreferences(
+		projectRoot,
+		{ warnOnLegacyScope: true },
+	);
+	let persistedReviewDecision: PersistedSetupReviewDecision = "keep";
+	const effectiveScopeForInstallMode =
+		requestedScope ?? persistedPreferences?.scope ?? DEFAULT_SETUP_SCOPE;
+	const wouldUsePersistedScope =
+		!requestedScope && Boolean(persistedPreferences?.scope);
+	const wouldUsePersistedInstallMode =
+		!requestedInstallMode &&
+		Boolean(persistedPreferences?.installMode) &&
+		(!persistedPreferences?.scope ||
+			persistedPreferences.scope === effectiveScopeForInstallMode);
+	const shouldReviewPersistedSetup =
+		hasPersistedSetupPreferences(persistedPreferences) &&
+		(wouldUsePersistedScope || wouldUsePersistedInstallMode) &&
+		(typeof persistedSetupReviewPrompt === "function" ||
+			(process.stdin.isTTY && process.stdout.isTTY));
+	if (shouldReviewPersistedSetup) {
+		persistedReviewDecision = persistedSetupReviewPrompt
+			? await persistedSetupReviewPrompt(persistedPreferences)
+			: await promptForPersistedSetupReview(persistedPreferences);
+		console.log(
+			`Setup preference review: ${persistedReviewDecision} (${formatPersistedSetupPreferenceSummary(persistedPreferences)})\n`,
+		);
+	}
+	const resolvedScope = await resolveSetupScope(
+		projectRoot,
+		requestedScope,
+		persistedReviewDecision,
+		persistedPreferences,
+		setupScopePrompt,
+	);
+	const resolvedInstallMode = await resolveSetupInstallMode(
+		projectRoot,
+		resolvedScope.scope,
+		requestedInstallMode,
+		installModePrompt,
+		persistedReviewDecision,
+		persistedPreferences,
+	);
+	const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
+	const scopeSourceMessage =
+		resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
+	const backupContext = getBackupContext(resolvedScope.scope, projectRoot);
+	const isPluginInstallMode = resolvedInstallMode?.installMode === "plugin";
+	const pluginAgentsMdDst =
+		resolvedScope.scope === "project"
+			? join(projectRoot, "AGENTS.md")
+			: join(scopeDirs.codexHomeDir, "AGENTS.md");
+	const usePluginDeveloperInstructionsDefault = isPluginInstallMode
+		? pluginDeveloperInstructionsPrompt
+			? await pluginDeveloperInstructionsPrompt(scopeDirs.codexConfigFile)
+			: await promptForPluginDeveloperInstructionsDefault(
+					scopeDirs.codexConfigFile,
+				)
+		: false;
+	const usePluginAgentsMdDefault = isPluginInstallMode
+		? pluginAgentsMdPrompt
+			? await pluginAgentsMdPrompt(pluginAgentsMdDst)
+			: await promptForPluginAgentsMdDefault(pluginAgentsMdDst)
+		: false;
 
-  console.log("oh-my-codex setup");
-  console.log("=================\n");
-  console.log(
-    `Using setup scope: ${resolvedScope.scope}${scopeSourceMessage}\n`,
-  );
-  if (resolvedInstallMode) {
-    const installModeSourceMessage =
-      resolvedInstallMode.source === "persisted"
-        ? " (from .omx/setup-scope.json)"
-        : "";
-    console.log(
-      `Using setup install mode: ${resolvedInstallMode.installMode}${installModeSourceMessage}\n`,
-    );
-  }
+	console.log("oh-my-codex setup");
+	console.log("=================\n");
+	console.log(
+		`Using setup scope: ${resolvedScope.scope}${scopeSourceMessage}\n`,
+	);
+	if (resolvedInstallMode) {
+		const installModeSourceMessage =
+			resolvedInstallMode.source === "persisted"
+				? " (from .omx/setup-scope.json)"
+				: "";
+		console.log(
+			`Using setup install mode: ${resolvedInstallMode.installMode}${installModeSourceMessage}\n`,
+		);
+	}
 
-  // Step 1: Ensure directories exist
-  console.log("[1/8] Creating directories...");
-  const dirs = isPluginInstallMode
-    ? [
-        scopeDirs.codexHomeDir,
-        omxStateDir(projectRoot),
-        omxPlansDir(projectRoot),
-        omxLogsDir(projectRoot),
-      ]
-    : [
-        scopeDirs.codexHomeDir,
-        scopeDirs.promptsDir,
-        scopeDirs.skillsDir,
-        scopeDirs.nativeAgentsDir,
-        omxStateDir(projectRoot),
-        omxPlansDir(projectRoot),
-        omxLogsDir(projectRoot),
-      ];
-  for (const dir of dirs) {
-    if (!dryRun) {
-      await mkdir(dir, { recursive: true });
-    }
-    if (verbose) console.log(`  mkdir ${dir}`);
-  }
-  await persistSetupPreferences(
-    projectRoot,
-    resolvedInstallMode
-      ? {
-          scope: resolvedScope.scope,
-          installMode: resolvedInstallMode.installMode,
-        }
-      : {
-          scope: resolvedScope.scope,
-        },
-    {
-      dryRun,
-      verbose,
-    },
-  );
-  console.log("  Done.\n");
+	// Step 1: Ensure directories exist
+	console.log("[1/8] Creating directories...");
+	const dirs = isPluginInstallMode
+		? [
+				scopeDirs.codexHomeDir,
+				omxStateDir(projectRoot),
+				omxPlansDir(projectRoot),
+				omxLogsDir(projectRoot),
+			]
+		: [
+				scopeDirs.codexHomeDir,
+				scopeDirs.promptsDir,
+				scopeDirs.skillsDir,
+				scopeDirs.nativeAgentsDir,
+				omxStateDir(projectRoot),
+				omxPlansDir(projectRoot),
+				omxLogsDir(projectRoot),
+			];
+	for (const dir of dirs) {
+		if (!dryRun) {
+			await mkdir(dir, { recursive: true });
+		}
+		if (verbose) console.log(`  mkdir ${dir}`);
+	}
+	await persistSetupPreferences(
+		projectRoot,
+		resolvedInstallMode
+			? {
+					scope: resolvedScope.scope,
+					installMode: resolvedInstallMode.installMode,
+				}
+			: {
+					scope: resolvedScope.scope,
+				},
+		{
+			dryRun,
+			verbose,
+		},
+	);
+	console.log("  Done.\n");
 
-  if (resolvedScope.scope === "project") {
-    const gitignoreResult = await ensureProjectGitignore(
-      projectRoot,
-      backupContext,
-      { dryRun, verbose },
-    );
-    if (gitignoreResult === "created") {
-      console.log(
-        "  Created .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
-      );
-    } else if (gitignoreResult === "updated") {
-      console.log(
-        "  Updated .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
-      );
-    }
-  }
+	if (resolvedScope.scope === "project") {
+		const gitignoreResult = await ensureProjectGitignore(
+			projectRoot,
+			backupContext,
+			{ dryRun, verbose },
+		);
+		if (gitignoreResult === "created") {
+			console.log(
+				"  Created .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
+			);
+		} else if (gitignoreResult === "updated") {
+			console.log(
+				"  Updated .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
+			);
+		}
+	}
 
-  const catalogCounts = getCatalogHeadlineCounts();
-  const summary = createEmptyRunSummary();
+	const catalogCounts = getCatalogHeadlineCounts();
+	const summary = createEmptyRunSummary();
 
-  // Step 2: Install agent prompts
-  console.log("[2/8] Installing agent prompts...");
-  {
-    const promptsSrc = join(pkgRoot, "prompts");
-    const promptsDst = scopeDirs.promptsDir;
-    if (isPluginInstallMode) {
-      summary.prompts = await cleanupPluginModeLegacyPrompts(
-        promptsSrc,
-        promptsDst,
-        backupContext,
-        { dryRun, verbose },
-      );
-      console.log(
-        summary.prompts.removed > 0
-          ? `  ${dryRun ? "Would archive and remove" : "Archived and removed"} ${summary.prompts.removed} legacy OMX-managed prompt file(s).\n`
-          : "  Prompt refresh skipped; no legacy OMX-managed prompt files found.\n",
-      );
-    } else {
-      summary.prompts = await installPrompts(
-        promptsSrc,
-        promptsDst,
-        backupContext,
-        { force, dryRun, verbose },
-      );
-      const cleanedLegacyPromptShims = await cleanupLegacySkillPromptShims(
-        promptsSrc,
-        promptsDst,
-        {
-          dryRun,
-          verbose,
-        },
-      );
-      summary.prompts.removed += cleanedLegacyPromptShims;
-      if (cleanedLegacyPromptShims > 0) {
-        if (dryRun) {
-          console.log(
-            `  Would remove ${cleanedLegacyPromptShims} legacy skill prompt shim file(s).`,
-          );
-        } else {
-          console.log(
-            `  Removed ${cleanedLegacyPromptShims} legacy skill prompt shim file(s).`,
-          );
-        }
-      }
-      if (catalogCounts) {
-        console.log(
-          `  Prompt refresh complete (catalog baseline: ${catalogCounts.prompts}).\n`,
-        );
-      } else {
-        console.log("  Prompt refresh complete.\n");
-      }
-    }
-  }
+	// Step 2: Install agent prompts
+	console.log("[2/8] Installing agent prompts...");
+	{
+		const promptsSrc = join(pkgRoot, "prompts");
+		const promptsDst = scopeDirs.promptsDir;
+		if (isPluginInstallMode) {
+			summary.prompts = await cleanupPluginModeLegacyPrompts(
+				promptsSrc,
+				promptsDst,
+				backupContext,
+				{ dryRun, verbose },
+			);
+			console.log(
+				summary.prompts.removed > 0
+					? `  ${dryRun ? "Would archive and remove" : "Archived and removed"} ${summary.prompts.removed} legacy OMX-managed prompt file(s).\n`
+					: "  Prompt refresh skipped; no legacy OMX-managed prompt files found.\n",
+			);
+		} else {
+			summary.prompts = await installPrompts(
+				promptsSrc,
+				promptsDst,
+				backupContext,
+				{ force, dryRun, verbose },
+			);
+			const cleanedLegacyPromptShims = await cleanupLegacySkillPromptShims(
+				promptsSrc,
+				promptsDst,
+				{
+					dryRun,
+					verbose,
+				},
+			);
+			summary.prompts.removed += cleanedLegacyPromptShims;
+			if (cleanedLegacyPromptShims > 0) {
+				if (dryRun) {
+					console.log(
+						`  Would remove ${cleanedLegacyPromptShims} legacy skill prompt shim file(s).`,
+					);
+				} else {
+					console.log(
+						`  Removed ${cleanedLegacyPromptShims} legacy skill prompt shim file(s).`,
+					);
+				}
+			}
+			if (catalogCounts) {
+				console.log(
+					`  Prompt refresh complete (catalog baseline: ${catalogCounts.prompts}).\n`,
+				);
+			} else {
+				console.log("  Prompt refresh complete.\n");
+			}
+		}
+	}
 
-  // Step 3: Install skills
-  console.log("[3/8] Installing skills...");
-  {
-    const skillsSrc = join(pkgRoot, "skills");
-    const skillsDst = scopeDirs.skillsDir;
-    if (isPluginInstallMode) {
-      summary.skills = createEmptyCategorySummary();
-      const cleanup = await cleanupLegacyManagedSkills(
-        skillsSrc,
-        skillsDst,
-        backupContext,
-        { dryRun, verbose },
-      );
-      summary.skills.backedUp += cleanup.backedUp;
-      summary.skills.removed += cleanup.removedSkillNames.length;
-      summary.skills.skipped += cleanup.skippedSkillNames.length;
-      for (const warning of cleanup.warnings) {
-        console.log(`  warning: ${warning}`);
-      }
-      if (cleanup.removedSkillNames.length > 0) {
-        console.log(
-          `  ${dryRun ? "Would remove" : "Removed"} ${cleanup.removedSkillNames.length} legacy OMX-managed skill director${cleanup.removedSkillNames.length === 1 ? "y" : "ies"}.`,
-        );
-      } else {
-        console.log(
-          "  Skill refresh skipped; no removable legacy OMX-managed skill directories found.",
-        );
-      }
-    } else {
-      summary.skills = await installSkills(
-        skillsSrc,
-        skillsDst,
-        backupContext,
-        {
-          force,
-          dryRun,
-          verbose,
-        },
-      );
-    }
-    if (catalogCounts) {
-      console.log(
-        `  Skill refresh complete (catalog baseline: ${catalogCounts.skills}).\n`,
-      );
-    } else {
-      console.log("  Skill refresh complete.\n");
-    }
-  }
+	// Step 3: Install skills
+	console.log("[3/8] Installing skills...");
+	{
+		const skillsSrc = join(pkgRoot, "skills");
+		const skillsDst = scopeDirs.skillsDir;
+		if (isPluginInstallMode) {
+			summary.skills = createEmptyCategorySummary();
+			const cleanup = await cleanupLegacyManagedSkills(
+				skillsSrc,
+				skillsDst,
+				backupContext,
+				{ dryRun, verbose },
+			);
+			summary.skills.backedUp += cleanup.backedUp;
+			summary.skills.removed += cleanup.removedSkillNames.length;
+			summary.skills.skipped += cleanup.skippedSkillNames.length;
+			for (const warning of cleanup.warnings) {
+				console.log(`  warning: ${warning}`);
+			}
+			if (cleanup.removedSkillNames.length > 0) {
+				console.log(
+					`  ${dryRun ? "Would remove" : "Removed"} ${cleanup.removedSkillNames.length} legacy OMX-managed skill director${cleanup.removedSkillNames.length === 1 ? "y" : "ies"}.`,
+				);
+			} else {
+				console.log(
+					"  Skill refresh skipped; no removable legacy OMX-managed skill directories found.",
+				);
+			}
+		} else {
+			summary.skills = await installSkills(
+				skillsSrc,
+				skillsDst,
+				backupContext,
+				{
+					force,
+					dryRun,
+					verbose,
+				},
+			);
+		}
+		if (catalogCounts) {
+			console.log(
+				`  Skill refresh complete (catalog baseline: ${catalogCounts.skills}).\n`,
+			);
+		} else {
+			console.log("  Skill refresh complete.\n");
+		}
+	}
 
-  // Step 4: Install native agent configs
-  console.log("[4/8] Installing native agent configs...");
-  if (isPluginInstallMode) {
-    summary.nativeAgents = await cleanupPluginModeLegacyNativeAgents(
-      pkgRoot,
-      scopeDirs.nativeAgentsDir,
-      backupContext,
-      { dryRun, verbose },
-    );
-    console.log(
-      summary.nativeAgents.removed > 0
-        ? `  ${dryRun ? "Would archive and remove" : "Archived and removed"} ${summary.nativeAgents.removed} legacy OMX-managed native agent config(s).\n`
-        : "  Native agent refresh skipped; no legacy OMX-managed native agent configs found.\n",
-    );
-  } else {
-    summary.nativeAgents = await refreshNativeAgentConfigs(
-      pkgRoot,
-      scopeDirs.nativeAgentsDir,
-      backupContext,
-      {
-        force,
-        dryRun,
-        verbose,
-      },
-    );
-    console.log(
-      `  Native agent refresh complete (${scopeDirs.nativeAgentsDir}).\n`,
-    );
-  }
+	// Step 4: Install native agent configs
+	console.log("[4/8] Installing native agent configs...");
+	if (isPluginInstallMode) {
+		summary.nativeAgents = await cleanupPluginModeLegacyNativeAgents(
+			pkgRoot,
+			scopeDirs.nativeAgentsDir,
+			backupContext,
+			{ dryRun, verbose },
+		);
+		console.log(
+			summary.nativeAgents.removed > 0
+				? `  ${dryRun ? "Would archive and remove" : "Archived and removed"} ${summary.nativeAgents.removed} legacy OMX-managed native agent config(s).\n`
+				: "  Native agent refresh skipped; no legacy OMX-managed native agent configs found.\n",
+		);
+	} else {
+		summary.nativeAgents = await refreshNativeAgentConfigs(
+			pkgRoot,
+			scopeDirs.nativeAgentsDir,
+			backupContext,
+			{
+				force,
+				dryRun,
+				verbose,
+			},
+		);
+		console.log(
+			`  Native agent refresh complete (${scopeDirs.nativeAgentsDir}).\n`,
+		);
+	}
 
-  // Step 5: Update config.toml
-  console.log("[5/8] Updating config.toml...");
-  let resolvedConfig = "";
-  let omxManagesTui = false;
-  if (isPluginInstallMode) {
-    const configCleaned = await cleanupPluginModeLegacyConfig(
-      scopeDirs.codexConfigFile,
-      backupContext,
-      { dryRun, verbose },
-    );
-    if (configCleaned) summary.config.removed += 1;
-    console.log(
-      configCleaned
-        ? `  ${dryRun ? "Would clean" : "Cleaned"} legacy OMX config entries for plugin mode.\n`
-        : "  Config refresh skipped; no legacy OMX config entries found.\n",
-    );
+	// Step 5: Update config.toml
+	console.log("[5/8] Updating config.toml...");
+	let resolvedConfig = "";
+	let omxManagesTui = false;
+	if (isPluginInstallMode) {
+		const configCleaned = await cleanupPluginModeLegacyConfig(
+			scopeDirs.codexConfigFile,
+			backupContext,
+			{ dryRun, verbose },
+		);
+		if (configCleaned) summary.config.removed += 1;
+		console.log(
+			configCleaned
+				? `  ${dryRun ? "Would clean" : "Cleaned"} legacy OMX config entries for plugin mode.\n`
+				: "  Config refresh skipped; no legacy OMX config entries found.\n",
+		);
 
-    await applyPluginModeHooksConfig(
-      scopeDirs.codexConfigFile,
-      scopeDirs.codexHooksFile,
-      pkgRoot,
-      backupContext,
-      summary.config,
-      { dryRun, verbose },
-    );
-    resolvedConfig = existsSync(scopeDirs.codexConfigFile)
-      ? await readFile(scopeDirs.codexConfigFile, "utf-8")
-      : "";
-    console.log(
-      `  Native Codex hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
-    );
+		await applyPluginModeHooksConfig(
+			scopeDirs.codexConfigFile,
+			scopeDirs.codexHooksFile,
+			pkgRoot,
+			backupContext,
+			summary.config,
+			{ dryRun, verbose },
+		);
+		const pluginMarketplaceResult = await ensurePluginMarketplaceRegistration(
+			scopeDirs.codexConfigFile,
+			pkgRoot,
+			backupContext,
+			summary.config,
+			{ dryRun, verbose },
+		);
+		if (pluginMarketplaceResult === "unavailable") {
+			console.log(
+				`  warning: packaged ${OMX_LOCAL_MARKETPLACE_NAME} Codex plugin marketplace metadata not found; /skills plugin discovery was not registered.`,
+			);
+		} else if (pluginMarketplaceResult === "updated") {
+			console.log(
+				`  ${dryRun ? "Would register" : "Registered"} local Codex plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} (${pkgRoot}).`,
+			);
+		} else {
+			console.log(
+				`  Local Codex plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} already registered (${pkgRoot}).`,
+			);
+		}
+		resolvedConfig = existsSync(scopeDirs.codexConfigFile)
+			? await readFile(scopeDirs.codexConfigFile, "utf-8")
+			: "";
+		console.log(
+			`  Native Codex hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
+		);
 
-    if (usePluginDeveloperInstructionsDefault) {
-      const developerInstructionsResult =
-        await applyPluginDeveloperInstructionsDefault(
-          scopeDirs.codexConfigFile,
-          backupContext,
-          summary.config,
-          {
-            dryRun,
-            verbose,
-            pluginDeveloperInstructionsOverwritePrompt,
-          },
-        );
-      if (developerInstructionsResult === "updated") {
-        resolvedConfig = existsSync(scopeDirs.codexConfigFile)
-          ? await readFile(scopeDirs.codexConfigFile, "utf-8")
-          : "";
-        console.log(
-          `  ${dryRun ? "Would add" : "Added"} plugin-mode developer_instructions default (${scopeDirs.codexConfigFile}).\n`,
-        );
-      } else {
-        console.log(
-          `  Preserved existing developer_instructions in ${scopeDirs.codexConfigFile}.\n`,
-        );
-      }
-    } else {
-      console.log(
-        "  Plugin-mode developer_instructions default not selected.\n",
-      );
-    }
-  } else {
-    const registryCandidates = getUnifiedMcpRegistryCandidates();
-    const defaultRegistryCandidates = registryCandidates.slice(0, 1);
-    const legacyRegistryCandidate = getLegacyUnifiedMcpRegistryCandidate();
-    const sharedMcpRegistry = await loadUnifiedMcpRegistry({
-      candidates: options.mcpRegistryCandidates ?? defaultRegistryCandidates,
-    });
-    if (
-      !options.mcpRegistryCandidates &&
-      !sharedMcpRegistry.sourcePath &&
-      existsSync(legacyRegistryCandidate) &&
-      !existsSync(defaultRegistryCandidates[0])
-    ) {
-      console.log(
-        `  warning: legacy shared MCP registry detected at ${legacyRegistryCandidate} but ignored by default; move it to ${defaultRegistryCandidates[0]} if you still want setup to sync those servers`,
-      );
-    }
-    if (verbose && sharedMcpRegistry.sourcePath) {
-      console.log(
-        `  shared MCP registry: ${sharedMcpRegistry.sourcePath} (${sharedMcpRegistry.servers.length} servers)`,
-      );
-    }
-    for (const warning of sharedMcpRegistry.warnings) {
-      console.log(`  warning: ${warning}`);
-    }
-    const statusLinePreset = await resolveStatusLinePresetForSetup(projectRoot, {
-      force,
-    });
-    const managedConfig = await updateManagedConfig(
-      scopeDirs.codexConfigFile,
-      pkgRoot,
-      sharedMcpRegistry,
-      summary.config,
-      backupContext,
-      {
-        dryRun,
-        modelUpgradePrompt,
-        verbose,
-        statusLinePreset,
-        forceStatusLinePreset: force,
-      },
-    );
-    resolvedConfig = managedConfig.finalConfig;
-    omxManagesTui = managedConfig.omxManagesTui;
-    if (managedConfig.repairedLegacyTeamRunTable) {
-      console.log(
-        "  Removed retired [mcp_servers.omx_team_run] config during refresh.",
-      );
-    }
-    if (resolvedScope.scope === "user") {
-      await syncClaudeCodeMcpSettings(
-        sharedMcpRegistry,
-        summary.config,
-        backupContext,
-        { dryRun, verbose },
-      );
-    }
-    console.log(`  Config refresh complete (${scopeDirs.codexConfigFile}).\n`);
+		if (usePluginDeveloperInstructionsDefault) {
+			const developerInstructionsResult =
+				await applyPluginDeveloperInstructionsDefault(
+					scopeDirs.codexConfigFile,
+					backupContext,
+					summary.config,
+					{
+						dryRun,
+						verbose,
+						pluginDeveloperInstructionsOverwritePrompt,
+					},
+				);
+			if (developerInstructionsResult === "updated") {
+				resolvedConfig = existsSync(scopeDirs.codexConfigFile)
+					? await readFile(scopeDirs.codexConfigFile, "utf-8")
+					: "";
+				console.log(
+					`  ${dryRun ? "Would add" : "Added"} plugin-mode developer_instructions default (${scopeDirs.codexConfigFile}).\n`,
+				);
+			} else {
+				console.log(
+					`  Preserved existing developer_instructions in ${scopeDirs.codexConfigFile}.\n`,
+				);
+			}
+		} else {
+			console.log(
+				"  Plugin-mode developer_instructions default not selected.\n",
+			);
+		}
+	} else {
+		const registryCandidates = getUnifiedMcpRegistryCandidates();
+		const defaultRegistryCandidates = registryCandidates.slice(0, 1);
+		const legacyRegistryCandidate = getLegacyUnifiedMcpRegistryCandidate();
+		const sharedMcpRegistry = await loadUnifiedMcpRegistry({
+			candidates: options.mcpRegistryCandidates ?? defaultRegistryCandidates,
+		});
+		if (
+			!options.mcpRegistryCandidates &&
+			!sharedMcpRegistry.sourcePath &&
+			existsSync(legacyRegistryCandidate) &&
+			!existsSync(defaultRegistryCandidates[0])
+		) {
+			console.log(
+				`  warning: legacy shared MCP registry detected at ${legacyRegistryCandidate} but ignored by default; move it to ${defaultRegistryCandidates[0]} if you still want setup to sync those servers`,
+			);
+		}
+		if (verbose && sharedMcpRegistry.sourcePath) {
+			console.log(
+				`  shared MCP registry: ${sharedMcpRegistry.sourcePath} (${sharedMcpRegistry.servers.length} servers)`,
+			);
+		}
+		for (const warning of sharedMcpRegistry.warnings) {
+			console.log(`  warning: ${warning}`);
+		}
+		const statusLinePreset = await resolveStatusLinePresetForSetup(
+			projectRoot,
+			{ force },
+		);
+		const managedConfig = await updateManagedConfig(
+			scopeDirs.codexConfigFile,
+			pkgRoot,
+			sharedMcpRegistry,
+			summary.config,
+			backupContext,
+			{
+				dryRun,
+				modelUpgradePrompt,
+				verbose,
+				statusLinePreset,
+				forceStatusLinePreset: force,
+			},
+		);
+		resolvedConfig = managedConfig.finalConfig;
+		omxManagesTui = managedConfig.omxManagesTui;
+		if (managedConfig.repairedLegacyTeamRunTable) {
+			console.log(
+				"  Removed retired [mcp_servers.omx_team_run] config during refresh.",
+			);
+		}
+		if (resolvedScope.scope === "user") {
+			await syncClaudeCodeMcpSettings(
+				sharedMcpRegistry,
+				summary.config,
+				backupContext,
+				{ dryRun, verbose },
+			);
+		}
+		console.log(`  Config refresh complete (${scopeDirs.codexConfigFile}).\n`);
 
-    const existingHooksContent = existsSync(scopeDirs.codexHooksFile)
-      ? await readFile(scopeDirs.codexHooksFile, "utf-8")
-      : null;
-    const hooksConfig = mergeManagedCodexHooksConfig(
-      existingHooksContent,
-      pkgRoot,
-    );
-    await syncManagedContent(
-      hooksConfig,
-      scopeDirs.codexHooksFile,
-      summary.config,
-      backupContext,
-      { dryRun, verbose },
-      `native hooks ${scopeDirs.codexHooksFile}`,
-    );
-    console.log(
-      `  Native Codex hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
-    );
-  }
+		const existingHooksContent = existsSync(scopeDirs.codexHooksFile)
+			? await readFile(scopeDirs.codexHooksFile, "utf-8")
+			: null;
+		const hooksConfig = mergeManagedCodexHooksConfig(
+			existingHooksContent,
+			pkgRoot,
+		);
+		await syncManagedContent(
+			hooksConfig,
+			scopeDirs.codexHooksFile,
+			summary.config,
+			backupContext,
+			{ dryRun, verbose },
+			`native hooks ${scopeDirs.codexHooksFile}`,
+		);
+		console.log(
+			`  Native Codex hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
+		);
+	}
 
-  // Step 5.5: Verify team CLI interop surface is available.
-  console.log("[5.5/8] Verifying Team CLI API interop...");
-  const teamToolsCheck = await verifyTeamCliApiInterop(pkgRoot);
-  if (teamToolsCheck.ok) {
-    console.log("  omx team api command detected (CLI-first interop ready)");
-  } else {
-    console.log(`  WARNING: ${teamToolsCheck.message}`);
-    console.log("  Run `npm run build` and then re-run `omx setup`.");
-  }
-  console.log();
+	// Step 5.5: Verify team CLI interop surface is available.
+	console.log("[5.5/8] Verifying Team CLI API interop...");
+	const teamToolsCheck = await verifyTeamCliApiInterop(pkgRoot);
+	if (teamToolsCheck.ok) {
+		console.log("  omx team api command detected (CLI-first interop ready)");
+	} else {
+		console.log(`  WARNING: ${teamToolsCheck.message}`);
+		console.log("  Run `npm run build` and then re-run `omx setup`.");
+	}
+	console.log();
 
-  // Step 6: Generate AGENTS.md
-  console.log("[6/8] Generating AGENTS.md...");
-  if (isPluginInstallMode) {
-    const agentsMdRemoved = await cleanupPluginModeLegacyAgentsMd(
-      pluginAgentsMdDst,
-      backupContext,
-      { dryRun, verbose },
-    );
-    if (agentsMdRemoved) {
-      summary.agentsMd.removed += 1;
-      console.log(
-        `  ${dryRun ? "Would remove" : "Removed"} legacy OMX-generated AGENTS.md for plugin mode.\n`,
-      );
-    }
+	// Step 6: Generate AGENTS.md
+	console.log("[6/8] Generating AGENTS.md...");
+	if (isPluginInstallMode) {
+		const agentsMdRemoved = await cleanupPluginModeLegacyAgentsMd(
+			pluginAgentsMdDst,
+			backupContext,
+			{ dryRun, verbose },
+		);
+		if (agentsMdRemoved) {
+			summary.agentsMd.removed += 1;
+			console.log(
+				`  ${dryRun ? "Would remove" : "Removed"} legacy OMX-generated AGENTS.md for plugin mode.\n`,
+			);
+		}
 
-    if (usePluginAgentsMdDefault) {
-      const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
-      if (existsSync(agentsMdSrc)) {
-        const content = await readFile(agentsMdSrc, "utf-8");
-        const modelTableContext = resolveAgentsModelTableContext(
-          resolvedConfig,
-          {
-            codexHomeOverride: scopeDirs.codexHomeDir,
-          },
-        );
-        const rewritten = upsertAgentsModelTable(
-          addGeneratedAgentsMarker(
-            applyScopePathRewritesToAgentsTemplate(
-              content,
-              resolvedScope.scope,
-            ),
-          ),
-          modelTableContext,
-        );
-        const result = await syncManagedAgentsContent(
-          rewritten,
-          pluginAgentsMdDst,
-          summary.agentsMd,
-          backupContext,
-          {
-            agentsOverwritePrompt: options.agentsOverwritePrompt,
-            dryRun,
-            force,
-            verbose,
-          },
-        );
-        if (result === "updated") {
-          console.log(
-            resolvedScope.scope === "project"
-              ? "  Generated plugin-mode AGENTS.md defaults in project root."
-              : `  Generated plugin-mode AGENTS.md defaults in ${scopeDirs.codexHomeDir}.`,
-          );
-        } else if (result === "unchanged") {
-          console.log(
-            resolvedScope.scope === "project"
-              ? "  Plugin-mode AGENTS.md defaults already up to date in project root."
-              : `  Plugin-mode AGENTS.md defaults already up to date in ${scopeDirs.codexHomeDir}.`,
-          );
-        } else {
-          console.log(
-            `  Skipped plugin-mode AGENTS.md defaults for ${pluginAgentsMdDst}.`,
-          );
-        }
-      } else {
-        summary.agentsMd.skipped += 1;
-        console.log("  AGENTS.md template not found, skipping.");
-      }
-    } else {
-      summary.agentsMd.skipped += 1;
-      console.log(
-        agentsMdRemoved
-          ? "  Plugin-mode AGENTS.md defaults not selected.\n"
-          : "  AGENTS.md generation skipped; no legacy OMX-generated AGENTS.md found and defaults not selected.\n",
-      );
-    }
-  } else {
-    const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
-    const agentsMdDst =
-      resolvedScope.scope === "project"
-        ? join(projectRoot, "AGENTS.md")
-        : join(scopeDirs.codexHomeDir, "AGENTS.md");
-    const agentsMdExists = existsSync(agentsMdDst);
+		if (usePluginAgentsMdDefault) {
+			const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
+			if (existsSync(agentsMdSrc)) {
+				const content = await readFile(agentsMdSrc, "utf-8");
+				const modelTableContext = resolveAgentsModelTableContext(
+					resolvedConfig,
+					{
+						codexHomeOverride: scopeDirs.codexHomeDir,
+					},
+				);
+				const rewritten = upsertAgentsModelTable(
+					addGeneratedAgentsMarker(
+						applyScopePathRewritesToAgentsTemplate(
+							content,
+							resolvedScope.scope,
+						),
+					),
+					modelTableContext,
+				);
+				const result = await syncManagedAgentsContent(
+					rewritten,
+					pluginAgentsMdDst,
+					summary.agentsMd,
+					backupContext,
+					{
+						agentsOverwritePrompt: options.agentsOverwritePrompt,
+						dryRun,
+						force,
+						verbose,
+					},
+				);
+				if (result === "updated") {
+					console.log(
+						resolvedScope.scope === "project"
+							? "  Generated plugin-mode AGENTS.md defaults in project root."
+							: `  Generated plugin-mode AGENTS.md defaults in ${scopeDirs.codexHomeDir}.`,
+					);
+				} else if (result === "unchanged") {
+					console.log(
+						resolvedScope.scope === "project"
+							? "  Plugin-mode AGENTS.md defaults already up to date in project root."
+							: `  Plugin-mode AGENTS.md defaults already up to date in ${scopeDirs.codexHomeDir}.`,
+					);
+				} else {
+					console.log(
+						`  Skipped plugin-mode AGENTS.md defaults for ${pluginAgentsMdDst}.`,
+					);
+				}
+			} else {
+				summary.agentsMd.skipped += 1;
+				console.log("  AGENTS.md template not found, skipping.");
+			}
+		} else {
+			summary.agentsMd.skipped += 1;
+			console.log(
+				agentsMdRemoved
+					? "  Plugin-mode AGENTS.md defaults not selected.\n"
+					: "  AGENTS.md generation skipped; no legacy OMX-generated AGENTS.md found and defaults not selected.\n",
+			);
+		}
+	} else {
+		const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
+		const agentsMdDst =
+			resolvedScope.scope === "project"
+				? join(projectRoot, "AGENTS.md")
+				: join(scopeDirs.codexHomeDir, "AGENTS.md");
+		const agentsMdExists = existsSync(agentsMdDst);
 
-    // Guard: refuse to overwrite project-root AGENTS.md during active session
-    const activeSession =
-      resolvedScope.scope === "project"
-        ? await readSessionState(projectRoot)
-        : null;
-    const sessionIsActive = activeSession && !isSessionStale(activeSession);
+		// Guard: refuse to overwrite project-root AGENTS.md during active session
+		const activeSession =
+			resolvedScope.scope === "project"
+				? await readSessionState(projectRoot)
+				: null;
+		const sessionIsActive = activeSession && !isSessionStale(activeSession);
 
-    if (existsSync(agentsMdSrc)) {
-      const content = await readFile(agentsMdSrc, "utf-8");
-      const modelTableContext = resolveAgentsModelTableContext(resolvedConfig, {
-        codexHomeOverride: scopeDirs.codexHomeDir,
-      });
-      const rewritten = upsertAgentsModelTable(
-        addGeneratedAgentsMarker(
-          applyScopePathRewritesToAgentsTemplate(content, resolvedScope.scope),
-        ),
-        modelTableContext,
-      );
-      let changed = true;
-      let canApplyManagedModelRefresh = false;
-      let managedRefreshContent = "";
-      let canApplyManagedAgentsMerge = false;
-      let mergedAgentsContent = "";
-      if (agentsMdExists) {
-        const existing = await readFile(agentsMdDst, "utf-8");
-        changed = existing !== rewritten;
-        if (options.mergeAgents) {
-          mergedAgentsContent = upsertManagedAgentsBlock(existing, rewritten);
-          canApplyManagedAgentsMerge = mergedAgentsContent !== existing;
-        } else {
-          if (hasOmxManagedAgentsSections(existing)) {
-            managedRefreshContent = upsertAgentsModelTable(
-              existing,
-              modelTableContext,
-            );
-            canApplyManagedModelRefresh = managedRefreshContent !== existing;
-          }
-        }
-      }
+		if (existsSync(agentsMdSrc)) {
+			const content = await readFile(agentsMdSrc, "utf-8");
+			const modelTableContext = resolveAgentsModelTableContext(resolvedConfig, {
+				codexHomeOverride: scopeDirs.codexHomeDir,
+			});
+			const rewritten = upsertAgentsModelTable(
+				addGeneratedAgentsMarker(
+					applyScopePathRewritesToAgentsTemplate(content, resolvedScope.scope),
+				),
+				modelTableContext,
+			);
+			let changed = true;
+			let canApplyManagedModelRefresh = false;
+			let managedRefreshContent = "";
+			let canApplyManagedAgentsMerge = false;
+			let mergedAgentsContent = "";
+			if (agentsMdExists) {
+				const existing = await readFile(agentsMdDst, "utf-8");
+				changed = existing !== rewritten;
+				if (options.mergeAgents) {
+					mergedAgentsContent = upsertManagedAgentsBlock(existing, rewritten);
+					canApplyManagedAgentsMerge = mergedAgentsContent !== existing;
+				} else {
+					if (hasOmxManagedAgentsSections(existing)) {
+						managedRefreshContent = upsertAgentsModelTable(
+							existing,
+							modelTableContext,
+						);
+						canApplyManagedModelRefresh = managedRefreshContent !== existing;
+					}
+				}
+			}
 
-      if (
-        resolvedScope.scope === "project" &&
-        sessionIsActive &&
-        agentsMdExists &&
-        (changed || canApplyManagedAgentsMerge || canApplyManagedModelRefresh)
-      ) {
-        summary.agentsMd.skipped += 1;
-        console.log(
-          "  WARNING: Active omx session detected (pid " +
-            activeSession?.pid +
-            ").",
-        );
-        console.log(
-          "  Skipping AGENTS.md overwrite to avoid corrupting runtime overlay.",
-        );
-        console.log("  Stop the active session first, then re-run setup.");
-      } else if (options.mergeAgents && agentsMdExists && !canApplyManagedAgentsMerge) {
-        summary.agentsMd.unchanged += 1;
-        console.log(
-          resolvedScope.scope === "project"
-            ? "  AGENTS.md already up to date in project root."
-            : `  AGENTS.md already up to date in ${scopeDirs.codexHomeDir}.`,
-        );
-      } else if (canApplyManagedAgentsMerge) {
-        await syncManagedContent(
-          mergedAgentsContent,
-          agentsMdDst,
-          summary.agentsMd,
-          backupContext,
-          { dryRun, verbose },
-          `merged AGENTS ${agentsMdDst}`,
-        );
-        console.log(
-          resolvedScope.scope === "project"
-            ? "  Merged OMX-managed AGENTS.md sections into project root."
-            : `  Merged OMX-managed AGENTS.md sections into ${scopeDirs.codexHomeDir}.`,
-        );
-      } else if (canApplyManagedModelRefresh) {
-        await syncManagedContent(
-          managedRefreshContent,
-          agentsMdDst,
-          summary.agentsMd,
-          backupContext,
-          { dryRun, verbose },
-          `AGENTS model table ${agentsMdDst}`,
-        );
-        console.log(
-          resolvedScope.scope === "project"
-            ? "  Refreshed AGENTS.md model capability table in project root."
-            : `  Refreshed AGENTS.md model capability table in ${scopeDirs.codexHomeDir}.`,
-        );
-      } else {
-        const result = await syncManagedAgentsContent(
-          rewritten,
-          agentsMdDst,
-          summary.agentsMd,
-          backupContext,
-          {
-            agentsOverwritePrompt: options.agentsOverwritePrompt,
-            dryRun,
-            force,
-            verbose,
-          },
-        );
+			if (
+				resolvedScope.scope === "project" &&
+				sessionIsActive &&
+				agentsMdExists &&
+				(changed || canApplyManagedAgentsMerge || canApplyManagedModelRefresh)
+			) {
+				summary.agentsMd.skipped += 1;
+				console.log(
+					"  WARNING: Active omx session detected (pid " +
+						activeSession?.pid +
+						").",
+				);
+				console.log(
+					"  Skipping AGENTS.md overwrite to avoid corrupting runtime overlay.",
+				);
+				console.log("  Stop the active session first, then re-run setup.");
+			} else if (
+				options.mergeAgents &&
+				agentsMdExists &&
+				!canApplyManagedAgentsMerge
+			) {
+				summary.agentsMd.unchanged += 1;
+				console.log(
+					resolvedScope.scope === "project"
+						? "  AGENTS.md already up to date in project root."
+						: `  AGENTS.md already up to date in ${scopeDirs.codexHomeDir}.`,
+				);
+			} else if (canApplyManagedAgentsMerge) {
+				await syncManagedContent(
+					mergedAgentsContent,
+					agentsMdDst,
+					summary.agentsMd,
+					backupContext,
+					{ dryRun, verbose },
+					`merged AGENTS ${agentsMdDst}`,
+				);
+				console.log(
+					resolvedScope.scope === "project"
+						? "  Merged OMX-managed AGENTS.md sections into project root."
+						: `  Merged OMX-managed AGENTS.md sections into ${scopeDirs.codexHomeDir}.`,
+				);
+			} else if (canApplyManagedModelRefresh) {
+				await syncManagedContent(
+					managedRefreshContent,
+					agentsMdDst,
+					summary.agentsMd,
+					backupContext,
+					{ dryRun, verbose },
+					`AGENTS model table ${agentsMdDst}`,
+				);
+				console.log(
+					resolvedScope.scope === "project"
+						? "  Refreshed AGENTS.md model capability table in project root."
+						: `  Refreshed AGENTS.md model capability table in ${scopeDirs.codexHomeDir}.`,
+				);
+			} else {
+				const result = await syncManagedAgentsContent(
+					rewritten,
+					agentsMdDst,
+					summary.agentsMd,
+					backupContext,
+					{
+						agentsOverwritePrompt: options.agentsOverwritePrompt,
+						dryRun,
+						force,
+						verbose,
+					},
+				);
 
-        if (result === "updated") {
-          console.log(
-            resolvedScope.scope === "project"
-              ? "  Generated AGENTS.md in project root."
-              : `  Generated AGENTS.md in ${scopeDirs.codexHomeDir}.`,
-          );
-        } else if (result === "unchanged") {
-          console.log(
-            resolvedScope.scope === "project"
-              ? "  AGENTS.md already up to date in project root."
-              : `  AGENTS.md already up to date in ${scopeDirs.codexHomeDir}.`,
-          );
-        } else if (agentsMdExists) {
-          console.log(
-            `  Skipped AGENTS.md overwrite for ${agentsMdDst}. Re-run interactively to confirm or use --force.`,
-          );
-        }
-      }
-      if (resolvedScope.scope === "user") {
-        console.log("  User scope leaves project AGENTS.md unchanged.");
-      }
-    } else {
-      summary.agentsMd.skipped += 1;
-      console.log("  AGENTS.md template not found, skipping.");
-    }
-    console.log();
-  }
+				if (result === "updated") {
+					console.log(
+						resolvedScope.scope === "project"
+							? "  Generated AGENTS.md in project root."
+							: `  Generated AGENTS.md in ${scopeDirs.codexHomeDir}.`,
+					);
+				} else if (result === "unchanged") {
+					console.log(
+						resolvedScope.scope === "project"
+							? "  AGENTS.md already up to date in project root."
+							: `  AGENTS.md already up to date in ${scopeDirs.codexHomeDir}.`,
+					);
+				} else if (agentsMdExists) {
+					console.log(
+						`  Skipped AGENTS.md overwrite for ${agentsMdDst}. Re-run interactively to confirm or use --force.`,
+					);
+				}
+			}
+			if (resolvedScope.scope === "user") {
+				console.log("  User scope leaves project AGENTS.md unchanged.");
+			}
+		} else {
+			summary.agentsMd.skipped += 1;
+			console.log("  AGENTS.md template not found, skipping.");
+		}
+		console.log();
+	}
 
-  // Step 7: Set up notify hook
-  console.log("[7/8] Configuring notification hook...");
-  if (isPluginInstallMode) {
-    console.log("  Skipped for plugin skill delivery mode.\n");
-  } else {
-    await setupNotifyHook(pkgRoot, { dryRun, verbose });
-    console.log("  Done.\n");
-  }
+	// Step 7: Set up notify hook
+	console.log("[7/8] Configuring notification hook...");
+	if (isPluginInstallMode) {
+		console.log("  Skipped for plugin skill delivery mode.\n");
+	} else {
+		await setupNotifyHook(pkgRoot, { dryRun, verbose });
+		console.log("  Done.\n");
+	}
 
-  // Step 8: Configure HUD
-  console.log("[8/8] Configuring HUD...");
-  const hudConfigPath = join(projectRoot, ".omx", "hud-config.json");
-  if (force || !existsSync(hudConfigPath)) {
-    if (!dryRun) {
-      const defaultHudConfig = { preset: "focused" };
-      await writeFile(hudConfigPath, JSON.stringify(defaultHudConfig, null, 2));
-    }
-    if (verbose) console.log("  Wrote .omx/hud-config.json");
-    console.log("  HUD config created (preset: focused).");
-  } else {
-    console.log("  HUD config already exists (use --force to overwrite).");
-  }
-  if (omxManagesTui) {
-    console.log("  StatusLine configured in config.toml via [tui] section.");
-  }
-  console.log();
+	// Step 8: Configure HUD
+	console.log("[8/8] Configuring HUD...");
+	const hudConfigPath = join(projectRoot, ".omx", "hud-config.json");
+	if (force || !existsSync(hudConfigPath)) {
+		if (!dryRun) {
+			const defaultHudConfig = { preset: "focused" };
+			await writeFile(hudConfigPath, JSON.stringify(defaultHudConfig, null, 2));
+		}
+		if (verbose) console.log("  Wrote .omx/hud-config.json");
+		console.log("  HUD config created (preset: focused).");
+	} else {
+		console.log("  HUD config already exists (use --force to overwrite).");
+	}
+	if (omxManagesTui) {
+		console.log("  StatusLine configured in config.toml via [tui] section.");
+	}
+	console.log();
 
-  console.log("Setup refresh summary:");
-  logCategorySummary("prompts", summary.prompts);
-  logCategorySummary("skills", summary.skills);
-  logCategorySummary("native_agents", summary.nativeAgents);
-  logCategorySummary("agents_md", summary.agentsMd);
-  logCategorySummary("config", summary.config);
-  console.log();
+	console.log("Setup refresh summary:");
+	logCategorySummary("prompts", summary.prompts);
+	logCategorySummary("skills", summary.skills);
+	logCategorySummary("native_agents", summary.nativeAgents);
+	logCategorySummary("agents_md", summary.agentsMd);
+	logCategorySummary("config", summary.config);
+	console.log();
 
-  const legacySkillOverlapNotice = await buildLegacySkillOverlapNotice(
-    resolvedScope.scope,
-  );
-  if (legacySkillOverlapNotice.shouldWarn) {
-    console.log(`Migration hint: ${legacySkillOverlapNotice.message}`);
-    console.log();
-  }
+	const legacySkillOverlapNotice = await buildLegacySkillOverlapNotice(
+		resolvedScope.scope,
+	);
+	if (legacySkillOverlapNotice.shouldWarn) {
+		console.log(`Migration hint: ${legacySkillOverlapNotice.message}`);
+		console.log();
+	}
 
-  if (force) {
-    console.log(
-      "Force mode: enabled additional destructive maintenance (for example stale deprecated skill cleanup).",
-    );
-    console.log();
-  }
+	if (force) {
+		console.log(
+			"Force mode: enabled additional destructive maintenance (for example stale deprecated skill cleanup).",
+		);
+		console.log();
+	}
 
-  console.log('Setup complete! Run "omx doctor" to verify installation.');
-  console.log("\nNext steps:");
-  console.log("  1. Start Codex CLI in your project directory");
-  if (isPluginInstallMode) {
-    console.log(
-      "  2. Codex plugin discovery supplies OMX skills and workflow surfaces",
-    );
-    console.log("  3. Browse plugin-provided skills with /skills");
-    console.log(
-      "  4. Optional AGENTS.md and developer_instructions defaults are only installed when selected during plugin-mode setup",
-    );
-    console.log(
-      "  5. Legacy native-agent TOML defaults remain uninstalled in plugin mode",
-    );
-  } else {
-    console.log(
-      "  2. Use role/workflow keywords like $architect, $executor, and $plan in Codex",
-    );
-    console.log(
-      "  3. Browse skills with /skills; AGENTS keyword routing can also activate them implicitly",
-    );
-    console.log("  4. The AGENTS.md orchestration brain is loaded automatically");
-    console.log(
-      "  5. Native agent defaults configured in config.toml [agents] and TOML files written to .codex/agents/",
-    );
-  }
-  console.log(
-    '  6. "omx explore" and "omx sparkshell" can hydrate native release binaries on first use; source installs still allow repo-local fallbacks and OMX_EXPLORE_BIN / OMX_SPARKSHELL_BIN overrides',
-  );
-  if (isGitHubCliConfigured()) {
-    console.log("\nSupport the project: gh repo star Yeachan-Heo/oh-my-codex");
-  }
+	console.log('Setup complete! Run "omx doctor" to verify installation.');
+	console.log("\nNext steps:");
+	console.log("  1. Start Codex CLI in your project directory");
+	if (isPluginInstallMode) {
+		console.log(
+			`  2. Registered Codex marketplace ${OMX_LOCAL_MARKETPLACE_NAME} supplies OMX skills and workflow surfaces`,
+		);
+		console.log("  3. Browse plugin-provided skills with /skills");
+		console.log(
+			"  4. Optional AGENTS.md and developer_instructions defaults are only installed when selected during plugin-mode setup",
+		);
+		console.log(
+			"  5. Legacy native-agent TOML defaults remain uninstalled in plugin mode",
+		);
+	} else {
+		console.log(
+			"  2. Use role/workflow keywords like $architect, $executor, and $plan in Codex",
+		);
+		console.log(
+			"  3. Browse skills with /skills; AGENTS keyword routing can also activate them implicitly",
+		);
+		console.log(
+			"  4. The AGENTS.md orchestration brain is loaded automatically",
+		);
+		console.log(
+			"  5. Native agent defaults configured in config.toml [agents] and TOML files written to .codex/agents/",
+		);
+	}
+	console.log(
+		'  6. "omx explore" and "omx sparkshell" can hydrate native release binaries on first use; source installs still allow repo-local fallbacks and OMX_EXPLORE_BIN / OMX_SPARKSHELL_BIN overrides',
+	);
+	if (isGitHubCliConfigured()) {
+		console.log("\nSupport the project: gh repo star Yeachan-Heo/oh-my-codex");
+	}
 }
 
 function isLegacySkillPromptShim(content: string): boolean {
-  const marker =
-    /Read and follow the full skill instructions at\s+.*\/skills\/[^/\s]+\/SKILL\.md/i;
-  return marker.test(content);
+	const marker =
+		/Read and follow the full skill instructions at\s+.*\/skills\/[^/\s]+\/SKILL\.md/i;
+	return marker.test(content);
 }
 
 async function cleanupLegacySkillPromptShims(
-  promptsSrcDir: string,
-  promptsDstDir: string,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	promptsSrcDir: string,
+	promptsDstDir: string,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<number> {
-  if (!existsSync(promptsSrcDir) || !existsSync(promptsDstDir)) return 0;
+	if (!existsSync(promptsSrcDir) || !existsSync(promptsDstDir)) return 0;
 
-  const sourceFiles = new Set(
-    (await readdir(promptsSrcDir)).filter((name) => name.endsWith(".md")),
-  );
+	const sourceFiles = new Set(
+		(await readdir(promptsSrcDir)).filter((name) => name.endsWith(".md")),
+	);
 
-  const installedFiles = await readdir(promptsDstDir);
-  let removed = 0;
+	const installedFiles = await readdir(promptsDstDir);
+	let removed = 0;
 
-  for (const file of installedFiles) {
-    if (!file.endsWith(".md")) continue;
-    if (sourceFiles.has(file)) continue;
+	for (const file of installedFiles) {
+		if (!file.endsWith(".md")) continue;
+		if (sourceFiles.has(file)) continue;
 
-    const fullPath = join(promptsDstDir, file);
-    let content = "";
-    try {
-      content = await readFile(fullPath, "utf-8");
-    } catch {
-      continue;
-    }
+		const fullPath = join(promptsDstDir, file);
+		let content = "";
+		try {
+			content = await readFile(fullPath, "utf-8");
+		} catch {
+			continue;
+		}
 
-    if (!isLegacySkillPromptShim(content)) continue;
+		if (!isLegacySkillPromptShim(content)) continue;
 
-    if (!options.dryRun) {
-      await rm(fullPath, { force: true });
-    }
-    if (options.verbose) console.log(`  removed legacy prompt shim ${file}`);
-    removed++;
-  }
+		if (!options.dryRun) {
+			await rm(fullPath, { force: true });
+		}
+		if (options.verbose) console.log(`  removed legacy prompt shim ${file}`);
+		removed++;
+	}
 
-  return removed;
+	return removed;
 }
 
 function isGitHubCliConfigured(): boolean {
-  const result = spawnSync("gh", ["auth", "status"], {
-    stdio: "ignore",
-    windowsHide: true,
-  });
-  return result.status === 0;
+	const result = spawnSync("gh", ["auth", "status"], {
+		stdio: "ignore",
+		windowsHide: true,
+	});
+	return result.status === 0;
 }
 
 async function syncManagedFileFromDisk(
-  srcPath: string,
-  dstPath: string,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
-  verboseLabel: string,
+	srcPath: string,
+	dstPath: string,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+	verboseLabel: string,
 ): Promise<void> {
-  const destinationExists = existsSync(dstPath);
-  const changed = !destinationExists || (await filesDiffer(srcPath, dstPath));
+	const destinationExists = existsSync(dstPath);
+	const changed = !destinationExists || (await filesDiffer(srcPath, dstPath));
 
-  if (!changed) {
-    summary.unchanged += 1;
-    return;
-  }
+	if (!changed) {
+		summary.unchanged += 1;
+		return;
+	}
 
-  if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
-    summary.backedUp += 1;
-  }
+	if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
+		summary.backedUp += 1;
+	}
 
-  if (!options.dryRun) {
-    await mkdir(dirname(dstPath), { recursive: true });
-    await copyFile(srcPath, dstPath);
-  }
+	if (!options.dryRun) {
+		await mkdir(dirname(dstPath), { recursive: true });
+		await copyFile(srcPath, dstPath);
+	}
 
-  summary.updated += 1;
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
-    );
-  }
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
+		);
+	}
 }
 
 async function syncManagedContent(
-  content: string,
-  dstPath: string,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
-  verboseLabel: string,
+	content: string,
+	dstPath: string,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+	verboseLabel: string,
 ): Promise<void> {
-  const destinationExists = existsSync(dstPath);
-  let changed = true;
-  if (destinationExists) {
-    const existing = await readFile(dstPath, "utf-8");
-    changed = existing !== content;
-  }
+	const destinationExists = existsSync(dstPath);
+	let changed = true;
+	if (destinationExists) {
+		const existing = await readFile(dstPath, "utf-8");
+		changed = existing !== content;
+	}
 
-  if (!changed) {
-    summary.unchanged += 1;
-    return;
-  }
+	if (!changed) {
+		summary.unchanged += 1;
+		return;
+	}
 
-  if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
-    summary.backedUp += 1;
-  }
+	if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
+		summary.backedUp += 1;
+	}
 
-  if (!options.dryRun) {
-    await mkdir(dirname(dstPath), { recursive: true });
-    await writeFile(dstPath, content);
-  }
+	if (!options.dryRun) {
+		await mkdir(dirname(dstPath), { recursive: true });
+		await writeFile(dstPath, content);
+	}
 
-  summary.updated += 1;
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
-    );
-  }
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
+		);
+	}
 }
 
 async function syncManagedAgentsContent(
-  content: string,
-  dstPath: string,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: Pick<
-    SetupOptions,
-    "agentsOverwritePrompt" | "dryRun" | "force" | "verbose"
-  >,
+	content: string,
+	dstPath: string,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<
+		SetupOptions,
+		"agentsOverwritePrompt" | "dryRun" | "force" | "verbose"
+	>,
 ): Promise<"updated" | "unchanged" | "skipped"> {
-  const destinationExists = existsSync(dstPath);
-  let existing = "";
-  let changed = true;
-  let acceptedInteractiveOverwrite = false;
+	const destinationExists = existsSync(dstPath);
+	let existing = "";
+	let changed = true;
+	let acceptedInteractiveOverwrite = false;
 
-  if (destinationExists) {
-    existing = await readFile(dstPath, "utf-8");
-    changed = existing !== content;
-  }
+	if (destinationExists) {
+		existing = await readFile(dstPath, "utf-8");
+		changed = existing !== content;
+	}
 
-  if (!changed) {
-    summary.unchanged += 1;
-    return "unchanged";
-  }
+	if (!changed) {
+		summary.unchanged += 1;
+		return "unchanged";
+	}
 
-  if (destinationExists && !options.force) {
-    if (options.dryRun) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        console.log(`  would prompt before overwriting ${dstPath}`);
-      }
-      return "skipped";
-    }
+	if (destinationExists && !options.force) {
+		if (options.dryRun) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				console.log(`  would prompt before overwriting ${dstPath}`);
+			}
+			return "skipped";
+		}
 
-    const shouldOverwrite = options.agentsOverwritePrompt
-      ? await options.agentsOverwritePrompt(dstPath)
-      : await promptForAgentsOverwrite(dstPath);
+		const shouldOverwrite = options.agentsOverwritePrompt
+			? await options.agentsOverwritePrompt(dstPath)
+			: await promptForAgentsOverwrite(dstPath);
 
-    if (!shouldOverwrite) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        const managedLabel = isOmxGeneratedAgentsMd(existing)
-          ? "managed"
-          : "unmanaged";
-        console.log(`  skipped ${managedLabel} AGENTS.md at ${dstPath}`);
-      }
-      return "skipped";
-    }
+		if (!shouldOverwrite) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				const managedLabel = isOmxGeneratedAgentsMd(existing)
+					? "managed"
+					: "unmanaged";
+				console.log(`  skipped ${managedLabel} AGENTS.md at ${dstPath}`);
+			}
+			return "skipped";
+		}
 
-    acceptedInteractiveOverwrite = true;
-  }
+		acceptedInteractiveOverwrite = true;
+	}
 
-  if (
-    acceptedInteractiveOverwrite &&
-    (await moveExistingAgentsToDeterministicBackup(dstPath, options))
-  ) {
-    summary.backedUp += 1;
-  } else if (
-    await ensureBackup(dstPath, destinationExists, backupContext, options)
-  ) {
-    summary.backedUp += 1;
-  }
+	if (
+		acceptedInteractiveOverwrite &&
+		(await moveExistingAgentsToDeterministicBackup(dstPath, options))
+	) {
+		summary.backedUp += 1;
+	} else if (
+		await ensureBackup(dstPath, destinationExists, backupContext, options)
+	) {
+		summary.backedUp += 1;
+	}
 
-  if (!options.dryRun) {
-    await mkdir(dirname(dstPath), { recursive: true });
-    await writeFile(dstPath, content);
-  }
+	if (!options.dryRun) {
+		await mkdir(dirname(dstPath), { recursive: true });
+		await writeFile(dstPath, content);
+	}
 
-  summary.updated += 1;
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would update" : "updated"} AGENTS ${dstPath}`,
-    );
-  }
-  return "updated";
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} AGENTS ${dstPath}`,
+		);
+	}
+	return "updated";
 }
 
 async function installPrompts(
-  srcDir: string,
-  dstDir: string,
-  backupContext: SetupBackupContext,
-  options: SetupOptions,
+	srcDir: string,
+	dstDir: string,
+	backupContext: SetupBackupContext,
+	options: SetupOptions,
 ): Promise<SetupCategorySummary> {
-  const summary = createEmptyCategorySummary();
-  if (!existsSync(srcDir)) return summary;
+	const summary = createEmptyCategorySummary();
+	if (!existsSync(srcDir)) return summary;
 
-  const manifest = tryReadCatalogManifest();
-  const agentStatusByName = manifest
-    ? getCatalogAgentStatusByName(manifest)
-    : null;
+	const manifest = tryReadCatalogManifest();
+	const agentStatusByName = manifest
+		? getCatalogAgentStatusByName(manifest)
+		: null;
 
-  const files = await readdir(srcDir);
+	const files = await readdir(srcDir);
 
-  for (const file of files) {
-    if (!file.endsWith(".md")) continue;
-    const promptName = file.slice(0, -3);
+	for (const file of files) {
+		if (!file.endsWith(".md")) continue;
+		const promptName = file.slice(0, -3);
 
-    const status = agentStatusByName?.get(promptName);
-    if (manifest && !isSetupPromptAssetName(promptName, manifest)) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        const label = status ?? "unclassified";
-        console.log(`  skipped ${file} (status: ${label})`);
-      }
-      continue;
-    }
+		const status = agentStatusByName?.get(promptName);
+		if (manifest && !isSetupPromptAssetName(promptName, manifest)) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				const label = status ?? "unclassified";
+				console.log(`  skipped ${file} (status: ${label})`);
+			}
+			continue;
+		}
 
-    const src = join(srcDir, file);
-    const dst = join(dstDir, file);
-    const srcStat = await stat(src);
-    if (!srcStat.isFile()) continue;
-    await syncManagedFileFromDisk(
-      src,
-      dst,
-      summary,
-      backupContext,
-      options,
-      `prompt ${file}`,
-    );
-  }
+		const src = join(srcDir, file);
+		const dst = join(dstDir, file);
+		const srcStat = await stat(src);
+		if (!srcStat.isFile()) continue;
+		await syncManagedFileFromDisk(
+			src,
+			dst,
+			summary,
+			backupContext,
+			options,
+			`prompt ${file}`,
+		);
+	}
 
-  if (options.force && manifest && existsSync(dstDir)) {
-    const installedFiles = await readdir(dstDir);
-    for (const file of installedFiles) {
-      if (!file.endsWith(".md")) continue;
-      const promptName = file.slice(0, -3);
-      const status = agentStatusByName?.get(promptName);
-      if (isSetupPromptAssetName(promptName, manifest)) continue;
+	if (options.force && manifest && existsSync(dstDir)) {
+		const installedFiles = await readdir(dstDir);
+		for (const file of installedFiles) {
+			if (!file.endsWith(".md")) continue;
+			const promptName = file.slice(0, -3);
+			const status = agentStatusByName?.get(promptName);
+			if (isSetupPromptAssetName(promptName, manifest)) continue;
 
-      const stalePromptPath = join(dstDir, file);
-      if (!existsSync(stalePromptPath)) continue;
+			const stalePromptPath = join(dstDir, file);
+			if (!existsSync(stalePromptPath)) continue;
 
-      if (await ensureBackup(stalePromptPath, true, backupContext, options)) {
-        summary.backedUp += 1;
-      }
-      if (!options.dryRun) {
-        await rm(stalePromptPath, { force: true });
-      }
-      summary.removed += 1;
-      if (options.verbose) {
-        const prefix = options.dryRun
-          ? "would remove stale prompt"
-          : "removed stale prompt";
-        const label = status ?? "unlisted";
-        console.log(`  ${prefix} ${file} (status: ${label})`);
-      }
-    }
-  }
+			if (await ensureBackup(stalePromptPath, true, backupContext, options)) {
+				summary.backedUp += 1;
+			}
+			if (!options.dryRun) {
+				await rm(stalePromptPath, { force: true });
+			}
+			summary.removed += 1;
+			if (options.verbose) {
+				const prefix = options.dryRun
+					? "would remove stale prompt"
+					: "removed stale prompt";
+				const label = status ?? "unlisted";
+				console.log(`  ${prefix} ${file} (status: ${label})`);
+			}
+		}
+	}
 
-  return summary;
+	return summary;
 }
 
 function isGeneratedOmxNativeAgentToml(
-  content: string,
-  agentName: string,
+	content: string,
+	agentName: string,
 ): boolean {
-  const firstLine = content.split(/\r?\n/, 1)[0]?.trim();
-  return firstLine === `# oh-my-codex agent: ${agentName}`;
+	const firstLine = content.split(/\r?\n/, 1)[0]?.trim();
+	return firstLine === `# oh-my-codex agent: ${agentName}`;
 }
 
 async function cleanupGeneratedNonInstallableNativeAgents(
-  agentsDir: string,
-  manifest: NonNullable<ReturnType<typeof tryReadCatalogManifest>>,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	agentsDir: string,
+	manifest: NonNullable<ReturnType<typeof tryReadCatalogManifest>>,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<SetupCategorySummary> {
-  const summary = createEmptyCategorySummary();
-  if (!existsSync(agentsDir)) return summary;
+	const summary = createEmptyCategorySummary();
+	if (!existsSync(agentsDir)) return summary;
 
-  const agentStatusByName = getCatalogAgentStatusByName(manifest);
-  const installedFiles = await readdir(agentsDir);
+	const agentStatusByName = getCatalogAgentStatusByName(manifest);
+	const installedFiles = await readdir(agentsDir);
 
-  for (const file of installedFiles) {
-    if (!file.endsWith(".toml")) continue;
-    const agentName = file.slice(0, -5);
-    const agentStatus = agentStatusByName.get(agentName);
-    if (
-      agentStatus === undefined ||
-      isNativeAgentInstallableStatus(agentStatus)
-    ) {
-      continue;
-    }
+	for (const file of installedFiles) {
+		if (!file.endsWith(".toml")) continue;
+		const agentName = file.slice(0, -5);
+		const agentStatus = agentStatusByName.get(agentName);
+		if (
+			agentStatus === undefined ||
+			isNativeAgentInstallableStatus(agentStatus)
+		) {
+			continue;
+		}
 
-    const staleAgentPath = join(agentsDir, file);
-    let content = "";
-    try {
-      content = await readFile(staleAgentPath, "utf-8");
-    } catch {
-      continue;
-    }
+		const staleAgentPath = join(agentsDir, file);
+		let content = "";
+		try {
+			content = await readFile(staleAgentPath, "utf-8");
+		} catch {
+			continue;
+		}
 
-    if (!isGeneratedOmxNativeAgentToml(content, agentName)) {
-      if (options.verbose) {
-        console.log(
-          `  skipped stale native agent ${file}: not an OMX-generated native agent`,
-        );
-      }
-      continue;
-    }
+		if (!isGeneratedOmxNativeAgentToml(content, agentName)) {
+			if (options.verbose) {
+				console.log(
+					`  skipped stale native agent ${file}: not an OMX-generated native agent`,
+				);
+			}
+			continue;
+		}
 
-    if (await ensureBackup(staleAgentPath, true, backupContext, options)) {
-      summary.backedUp += 1;
-    }
-    if (!options.dryRun) {
-      await rm(staleAgentPath, { force: true });
-    }
-    summary.removed += 1;
-    if (options.verbose) {
-      const prefix = options.dryRun
-        ? "would remove stale generated native agent"
-        : "removed stale generated native agent";
-      console.log(`  ${prefix} ${file} (status: ${agentStatus})`);
-    }
-  }
+		if (await ensureBackup(staleAgentPath, true, backupContext, options)) {
+			summary.backedUp += 1;
+		}
+		if (!options.dryRun) {
+			await rm(staleAgentPath, { force: true });
+		}
+		summary.removed += 1;
+		if (options.verbose) {
+			const prefix = options.dryRun
+				? "would remove stale generated native agent"
+				: "removed stale generated native agent";
+			console.log(`  ${prefix} ${file} (status: ${agentStatus})`);
+		}
+	}
 
-  return summary;
+	return summary;
 }
 
 async function refreshNativeAgentConfigs(
-  pkgRoot: string,
-  agentsDir: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose" | "force">,
+	pkgRoot: string,
+	agentsDir: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose" | "force">,
 ): Promise<SetupCategorySummary> {
-  const summary = createEmptyCategorySummary();
+	const summary = createEmptyCategorySummary();
 
-  if (!options.dryRun) {
-    await mkdir(agentsDir, { recursive: true });
-  }
+	if (!options.dryRun) {
+		await mkdir(agentsDir, { recursive: true });
+	}
 
-  const manifest = tryReadCatalogManifest();
-  const agentStatusByName = manifest
-    ? getCatalogAgentStatusByName(manifest)
-    : null;
-  const staleCandidateNativeAgentNames = new Set(
-    manifest?.agents.map((agent) => agent.name) ?? [],
-  );
+	const manifest = tryReadCatalogManifest();
+	const agentStatusByName = manifest
+		? getCatalogAgentStatusByName(manifest)
+		: null;
+	const staleCandidateNativeAgentNames = new Set(
+		manifest?.agents.map((agent) => agent.name) ?? [],
+	);
 
-  const nativeAgentNames = manifest
-    ? [...getInstallableNativeAgentNames(manifest)].sort()
-    : Object.keys(AGENT_DEFINITIONS).sort();
+	const nativeAgentNames = manifest
+		? [...getInstallableNativeAgentNames(manifest)].sort()
+		: Object.keys(AGENT_DEFINITIONS).sort();
 
-  for (const name of nativeAgentNames) {
-    staleCandidateNativeAgentNames.add(name);
-    const agent = AGENT_DEFINITIONS[name];
-    if (!agent) {
-      if (options.verbose) {
-        console.log(`  skipped native agent ${name}.toml (missing definition)`);
-      }
-      summary.skipped += 1;
-      continue;
-    }
+	for (const name of nativeAgentNames) {
+		staleCandidateNativeAgentNames.add(name);
+		const agent = AGENT_DEFINITIONS[name];
+		if (!agent) {
+			if (options.verbose) {
+				console.log(`  skipped native agent ${name}.toml (missing definition)`);
+			}
+			summary.skipped += 1;
+			continue;
+		}
 
-    const promptPath = join(pkgRoot, "prompts", `${name}.md`);
-    if (!existsSync(promptPath)) {
-      continue;
-    }
+		const promptPath = join(pkgRoot, "prompts", `${name}.md`);
+		if (!existsSync(promptPath)) {
+			continue;
+		}
 
-    const promptContent = await readFile(promptPath, "utf-8");
-    const toml = generateAgentToml(agent, promptContent, {
-      codexHomeOverride: join(agentsDir, ".."),
-    });
-    const dst = join(agentsDir, `${name}.toml`);
-    await syncManagedContent(
-      toml,
-      dst,
-      summary,
-      backupContext,
-      options,
-      `native agent ${name}.toml`,
-    );
-  }
+		const promptContent = await readFile(promptPath, "utf-8");
+		const toml = generateAgentToml(agent, promptContent, {
+			codexHomeOverride: join(agentsDir, ".."),
+		});
+		const dst = join(agentsDir, `${name}.toml`);
+		await syncManagedContent(
+			toml,
+			dst,
+			summary,
+			backupContext,
+			options,
+			`native agent ${name}.toml`,
+		);
+	}
 
-  summary.removed += await cleanupObsoleteNativeAgents(
-    agentsDir,
-    backupContext,
-    options,
-  );
+	summary.removed += await cleanupObsoleteNativeAgents(
+		agentsDir,
+		backupContext,
+		options,
+	);
 
-  if (manifest) {
-    const generatedCleanup = await cleanupGeneratedNonInstallableNativeAgents(
-      agentsDir,
-      manifest,
-      backupContext,
-      options,
-    );
-    summary.backedUp += generatedCleanup.backedUp;
-    summary.removed += generatedCleanup.removed;
-  }
+	if (manifest) {
+		const generatedCleanup = await cleanupGeneratedNonInstallableNativeAgents(
+			agentsDir,
+			manifest,
+			backupContext,
+			options,
+		);
+		summary.backedUp += generatedCleanup.backedUp;
+		summary.removed += generatedCleanup.removed;
+	}
 
-  if (options.force && manifest && existsSync(agentsDir)) {
-    const installedFiles = await readdir(agentsDir);
-    for (const file of installedFiles) {
-      if (!file.endsWith(".toml")) continue;
-      const agentName = file.slice(0, -5);
-      const agentStatus = agentStatusByName?.get(agentName);
-      if (isNativeAgentInstallableStatus(agentStatus)) continue;
-      if (
-        !staleCandidateNativeAgentNames.has(agentName) &&
-        agentStatus === undefined
-      )
-        continue;
+	if (options.force && manifest && existsSync(agentsDir)) {
+		const installedFiles = await readdir(agentsDir);
+		for (const file of installedFiles) {
+			if (!file.endsWith(".toml")) continue;
+			const agentName = file.slice(0, -5);
+			const agentStatus = agentStatusByName?.get(agentName);
+			if (isNativeAgentInstallableStatus(agentStatus)) continue;
+			if (
+				!staleCandidateNativeAgentNames.has(agentName) &&
+				agentStatus === undefined
+			)
+				continue;
 
-      const staleAgentPath = join(agentsDir, file);
-      if (!existsSync(staleAgentPath)) continue;
+			const staleAgentPath = join(agentsDir, file);
+			if (!existsSync(staleAgentPath)) continue;
 
-      if (await ensureBackup(staleAgentPath, true, backupContext, options)) {
-        summary.backedUp += 1;
-      }
-      if (!options.dryRun) {
-        await rm(staleAgentPath, { force: true });
-      }
-      summary.removed += 1;
-      if (options.verbose) {
-        const prefix = options.dryRun
-          ? "would remove stale native agent"
-          : "removed stale native agent";
-        const label = agentStatus ?? "unlisted";
-        console.log(`  ${prefix} ${file} (status: ${label})`);
-      }
-    }
-  }
+			if (await ensureBackup(staleAgentPath, true, backupContext, options)) {
+				summary.backedUp += 1;
+			}
+			if (!options.dryRun) {
+				await rm(staleAgentPath, { force: true });
+			}
+			summary.removed += 1;
+			if (options.verbose) {
+				const prefix = options.dryRun
+					? "would remove stale native agent"
+					: "removed stale native agent";
+				const label = agentStatus ?? "unlisted";
+				console.log(`  ${prefix} ${file} (status: ${label})`);
+			}
+		}
+	}
 
-  return summary;
+	return summary;
 }
 
 async function cleanupObsoleteNativeAgents(
-  agentsDir: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	agentsDir: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<number> {
-  if (!existsSync(agentsDir)) return 0;
+	if (!existsSync(agentsDir)) return 0;
 
-  const installedFiles = await readdir(agentsDir);
-  let removed = 0;
+	const installedFiles = await readdir(agentsDir);
+	let removed = 0;
 
-  for (const file of installedFiles) {
-    if (!file.endsWith(".toml")) continue;
+	for (const file of installedFiles) {
+		if (!file.endsWith(".toml")) continue;
 
-    const fullPath = join(agentsDir, file);
-    let content = "";
-    try {
-      content = await readFile(fullPath, "utf-8");
-    } catch {
-      continue;
-    }
+		const fullPath = join(agentsDir, file);
+		let content = "";
+		try {
+			content = await readFile(fullPath, "utf-8");
+		} catch {
+			continue;
+		}
 
-    if (!containsTomlKey(content, OBSOLETE_NATIVE_AGENT_FIELD)) continue;
+		if (!containsTomlKey(content, OBSOLETE_NATIVE_AGENT_FIELD)) continue;
 
-    if (await ensureBackup(fullPath, true, backupContext, options)) {
-      // backup created for pre-existing obsolete native agent config
-    }
-    if (!options.dryRun) {
-      await rm(fullPath, { force: true });
-    }
-    if (options.verbose) {
-      const prefix = options.dryRun
-        ? "would remove stale obsolete native agent"
-        : "removed stale obsolete native agent";
-      console.log(`  ${prefix} ${file}`);
-    }
-    removed += 1;
-  }
+		if (await ensureBackup(fullPath, true, backupContext, options)) {
+			// backup created for pre-existing obsolete native agent config
+		}
+		if (!options.dryRun) {
+			await rm(fullPath, { force: true });
+		}
+		if (options.verbose) {
+			const prefix = options.dryRun
+				? "would remove stale obsolete native agent"
+				: "removed stale obsolete native agent";
+			console.log(`  ${prefix} ${file}`);
+		}
+		removed += 1;
+	}
 
-  return removed;
+	return removed;
 }
 
 export async function installSkills(
-  srcDir: string,
-  dstDir: string,
-  backupContext: SetupBackupContext,
-  options: SetupOptions,
+	srcDir: string,
+	dstDir: string,
+	backupContext: SetupBackupContext,
+	options: SetupOptions,
 ): Promise<SetupCategorySummary> {
-  const summary = createEmptyCategorySummary();
-  if (!existsSync(srcDir)) return summary;
-  const installableSkillNames = getSetupInstallableSkillNames();
-  const installableSkills: Array<{
-    name: string;
-    sourceDir: string;
-    destinationDir: string;
-  }> = [];
-  const manifest = tryReadCatalogManifest();
-  const skillStatusByName = manifest
-    ? new Map(manifest.skills.map((skill) => [skill.name, skill.status]))
-    : null;
-  const isSetupInstallableSkill = (
-    skillName: string,
-    status: string | undefined,
-  ): boolean =>
-    isCatalogInstallableStatus(status) || installableSkillNames.has(skillName);
-  const entries = await readdir(srcDir, { withFileTypes: true });
-  const staleCandidateSkillNames = new Set(
-    manifest?.skills.map((skill) => skill.name) ?? [],
-  );
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    staleCandidateSkillNames.add(entry.name);
-    const status = skillStatusByName?.get(entry.name);
-    if (skillStatusByName && !isSetupInstallableSkill(entry.name, status)) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        const label = status ?? "unlisted";
-        console.log(`  skipped ${entry.name}/ (status: ${label})`);
-      }
-      continue;
-    }
+	const summary = createEmptyCategorySummary();
+	if (!existsSync(srcDir)) return summary;
+	const installableSkillNames = getSetupInstallableSkillNames();
+	const installableSkills: Array<{
+		name: string;
+		sourceDir: string;
+		destinationDir: string;
+	}> = [];
+	const manifest = tryReadCatalogManifest();
+	const skillStatusByName = manifest
+		? new Map(manifest.skills.map((skill) => [skill.name, skill.status]))
+		: null;
+	const isSetupInstallableSkill = (
+		skillName: string,
+		status: string | undefined,
+	): boolean =>
+		isCatalogInstallableStatus(status) || installableSkillNames.has(skillName);
+	const entries = await readdir(srcDir, { withFileTypes: true });
+	const staleCandidateSkillNames = new Set(
+		manifest?.skills.map((skill) => skill.name) ?? [],
+	);
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		staleCandidateSkillNames.add(entry.name);
+		const status = skillStatusByName?.get(entry.name);
+		if (skillStatusByName && !isSetupInstallableSkill(entry.name, status)) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				const label = status ?? "unlisted";
+				console.log(`  skipped ${entry.name}/ (status: ${label})`);
+			}
+			continue;
+		}
 
-    const skillSrc = join(srcDir, entry.name);
-    const skillDst = join(dstDir, entry.name);
-    const skillMd = join(skillSrc, "SKILL.md");
-    if (!existsSync(skillMd)) continue;
+		const skillSrc = join(srcDir, entry.name);
+		const skillDst = join(dstDir, entry.name);
+		const skillMd = join(skillSrc, "SKILL.md");
+		if (!existsSync(skillMd)) continue;
 
-    installableSkills.push({
-      name: entry.name,
-      sourceDir: skillSrc,
-      destinationDir: skillDst,
-    });
-  }
+		installableSkills.push({
+			name: entry.name,
+			sourceDir: skillSrc,
+			destinationDir: skillDst,
+		});
+	}
 
-  for (const skill of installableSkills) {
-    await validateSkillFile(join(skill.sourceDir, "SKILL.md"));
-  }
+	for (const skill of installableSkills) {
+		await validateSkillFile(join(skill.sourceDir, "SKILL.md"));
+	}
 
-  for (const skill of installableSkills) {
-    const skillName = skill.name;
-    const skillSrc = skill.sourceDir;
-    const skillDst = skill.destinationDir;
+	for (const skill of installableSkills) {
+		const skillName = skill.name;
+		const skillSrc = skill.sourceDir;
+		const skillDst = skill.destinationDir;
 
-    if (!options.dryRun) {
-      await mkdir(skillDst, { recursive: true });
-    }
+		if (!options.dryRun) {
+			await mkdir(skillDst, { recursive: true });
+		}
 
-    const skillFiles = await readdir(skillSrc);
-    for (const sf of skillFiles) {
-      const sfPath = join(skillSrc, sf);
-      const sfStat = await stat(sfPath);
-      if (!sfStat.isFile()) continue;
-      const dstPath = join(skillDst, sf);
-      if (sf === "SKILL.md") {
-        await syncManagedContent(
-          rewriteInstalledSkillDescriptionBadge(
-            await readFile(sfPath, "utf-8"),
-            sfPath,
-          ),
-          dstPath,
-          summary,
-          backupContext,
-          options,
-          `skill ${skillName}/${sf}`,
-        );
-        continue;
-      }
-      await syncManagedFileFromDisk(
-        sfPath,
-        dstPath,
-        summary,
-        backupContext,
-        options,
-        `skill ${skillName}/${sf}`,
-      );
-    }
-  }
+		const skillFiles = await readdir(skillSrc);
+		for (const sf of skillFiles) {
+			const sfPath = join(skillSrc, sf);
+			const sfStat = await stat(sfPath);
+			if (!sfStat.isFile()) continue;
+			const dstPath = join(skillDst, sf);
+			if (sf === "SKILL.md") {
+				await syncManagedContent(
+					rewriteInstalledSkillDescriptionBadge(
+						await readFile(sfPath, "utf-8"),
+						sfPath,
+					),
+					dstPath,
+					summary,
+					backupContext,
+					options,
+					`skill ${skillName}/${sf}`,
+				);
+				continue;
+			}
+			await syncManagedFileFromDisk(
+				sfPath,
+				dstPath,
+				summary,
+				backupContext,
+				options,
+				`skill ${skillName}/${sf}`,
+			);
+		}
+	}
 
-  if (manifest && existsSync(dstDir)) {
-    for (const staleSkill of staleCandidateSkillNames) {
-      const status = skillStatusByName?.get(staleSkill);
-      if (isSetupInstallableSkill(staleSkill, status)) continue;
-      const hardDeprecated = HARD_DEPRECATED_SKILL_NAMES.has(staleSkill);
-      if (!options.force && !hardDeprecated) continue;
+	if (manifest && existsSync(dstDir)) {
+		for (const staleSkill of staleCandidateSkillNames) {
+			const status = skillStatusByName?.get(staleSkill);
+			if (isSetupInstallableSkill(staleSkill, status)) continue;
+			const hardDeprecated = HARD_DEPRECATED_SKILL_NAMES.has(staleSkill);
+			if (!options.force && !hardDeprecated) continue;
 
-      const staleSkillDir = join(dstDir, staleSkill);
-      if (!existsSync(staleSkillDir)) continue;
+			const staleSkillDir = join(dstDir, staleSkill);
+			if (!existsSync(staleSkillDir)) continue;
 
-      if (!options.dryRun) {
-        await rm(staleSkillDir, { recursive: true, force: true });
-      }
-      summary.removed += 1;
-      if (options.verbose) {
-        const prefix = options.dryRun
-          ? "would remove stale skill"
-          : "removed stale skill";
-        const label = status ?? "unlisted";
-        const reason = hardDeprecated ? ", hard-deprecated" : "";
-        console.log(`  ${prefix} ${staleSkill}/ (status: ${label}${reason})`);
-      }
-    }
-  }
+			if (!options.dryRun) {
+				await rm(staleSkillDir, { recursive: true, force: true });
+			}
+			summary.removed += 1;
+			if (options.verbose) {
+				const prefix = options.dryRun
+					? "would remove stale skill"
+					: "removed stale skill";
+				const label = status ?? "unlisted";
+				const reason = hardDeprecated ? ", hard-deprecated" : "";
+				console.log(`  ${prefix} ${staleSkill}/ (status: ${label}${reason})`);
+			}
+		}
+	}
 
-  return summary;
+	return summary;
 }
 
 async function removeDirectoryCopyAware(
-  sourceDir: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	sourceDir: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<boolean> {
-  const destinationExists = existsSync(sourceDir);
-  if (!destinationExists) return false;
+	const destinationExists = existsSync(sourceDir);
+	if (!destinationExists) return false;
 
-  const relativePath = relative(backupContext.baseRoot, sourceDir);
-  const safeRelativePath =
-    relativePath.startsWith("..") || relativePath === ""
-      ? sourceDir.replace(/^[/]+/, "")
-      : relativePath;
-  const backupPath = join(backupContext.backupRoot, safeRelativePath);
+	const relativePath = relative(backupContext.baseRoot, sourceDir);
+	const safeRelativePath =
+		relativePath.startsWith("..") || relativePath === ""
+			? sourceDir.replace(/^[/]+/, "")
+			: relativePath;
+	const backupPath = join(backupContext.backupRoot, safeRelativePath);
 
-  if (!options.dryRun) {
-    await mkdir(dirname(backupPath), { recursive: true });
-    await cp(sourceDir, backupPath, { recursive: true });
-  }
-  if (options.verbose) {
-    console.log(`  backup ${sourceDir} -> ${backupPath}`);
-  }
+	if (!options.dryRun) {
+		await mkdir(dirname(backupPath), { recursive: true });
+		await cp(sourceDir, backupPath, { recursive: true });
+	}
+	if (options.verbose) {
+		console.log(`  backup ${sourceDir} -> ${backupPath}`);
+	}
 
-  if (!options.dryRun) {
-    await rm(sourceDir, { recursive: true, force: true });
-  }
-  return true;
+	if (!options.dryRun) {
+		await rm(sourceDir, { recursive: true, force: true });
+	}
+	return true;
 }
 
 interface LegacySkillCleanupResult {
-  backedUp: number;
-  removedSkillNames: string[];
-  skippedSkillNames: string[];
-  warnings: string[];
+	backedUp: number;
+	removedSkillNames: string[];
+	skippedSkillNames: string[];
+	warnings: string[];
 }
 
 async function cleanupLegacyManagedSkills(
-  srcDir: string,
-  dstDir: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	srcDir: string,
+	dstDir: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<LegacySkillCleanupResult> {
-  const result: LegacySkillCleanupResult = {
-    backedUp: 0,
-    removedSkillNames: [],
-    skippedSkillNames: [],
-    warnings: [],
-  };
-  if (!existsSync(dstDir) || !existsSync(srcDir)) {
-    return result;
-  }
+	const result: LegacySkillCleanupResult = {
+		backedUp: 0,
+		removedSkillNames: [],
+		skippedSkillNames: [],
+		warnings: [],
+	};
+	if (!existsSync(dstDir) || !existsSync(srcDir)) {
+		return result;
+	}
 
-  const manifest = tryReadCatalogManifest();
-  const installableSkillNames = getSetupInstallableSkillNames(manifest);
+	const manifest = tryReadCatalogManifest();
+	const installableSkillNames = getSetupInstallableSkillNames(manifest);
 
-  for (const skillName of installableSkillNames) {
-    const shippedSkillDir = join(srcDir, skillName);
-    const installedSkillDir = join(dstDir, skillName);
-    const shippedSkillMd = join(shippedSkillDir, "SKILL.md");
-    const installedSkillMd = join(installedSkillDir, "SKILL.md");
-    if (!existsSync(shippedSkillMd) || !existsSync(installedSkillMd)) continue;
+	for (const skillName of installableSkillNames) {
+		const shippedSkillDir = join(srcDir, skillName);
+		const installedSkillDir = join(dstDir, skillName);
+		const shippedSkillMd = join(shippedSkillDir, "SKILL.md");
+		const installedSkillMd = join(installedSkillDir, "SKILL.md");
+		if (!existsSync(shippedSkillMd) || !existsSync(installedSkillMd)) continue;
 
-    const [shippedSkillContent, installedSkillContent] = await Promise.all([
-      readFile(shippedSkillMd, "utf-8"),
-      readFile(installedSkillMd, "utf-8"),
-    ]);
-    const expectedInstalledContent = rewriteInstalledSkillDescriptionBadge(
-      shippedSkillContent,
-      shippedSkillMd,
-    );
+		const [shippedSkillContent, installedSkillContent] = await Promise.all([
+			readFile(shippedSkillMd, "utf-8"),
+			readFile(installedSkillMd, "utf-8"),
+		]);
+		const expectedInstalledContent = rewriteInstalledSkillDescriptionBadge(
+			shippedSkillContent,
+			shippedSkillMd,
+		);
 
-    if (installedSkillContent !== expectedInstalledContent) {
-      const warning = `Skipping legacy skill cleanup for ${skillName}: installed SKILL.md differs from OMX-managed content.`;
-      result.skippedSkillNames.push(skillName);
-      result.warnings.push(warning);
-      continue;
-    }
+		if (installedSkillContent !== expectedInstalledContent) {
+			const warning = `Skipping legacy skill cleanup for ${skillName}: installed SKILL.md differs from OMX-managed content.`;
+			result.skippedSkillNames.push(skillName);
+			result.warnings.push(warning);
+			continue;
+		}
 
-    const removed = await removeDirectoryCopyAware(
-      installedSkillDir,
-      backupContext,
-      options,
-    );
-    if (removed) {
-      result.backedUp += 1;
-      result.removedSkillNames.push(skillName);
-    }
-  }
+		const removed = await removeDirectoryCopyAware(
+			installedSkillDir,
+			backupContext,
+			options,
+		);
+		if (removed) {
+			result.backedUp += 1;
+			result.removedSkillNames.push(skillName);
+		}
+	}
 
-  return result;
+	return result;
 }
 
 async function updateManagedConfig(
-  configPath: string,
-  pkgRoot: string,
-  sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: Pick<
-    SetupOptions,
-    "dryRun" | "verbose" | "modelUpgradePrompt"
-  > & { statusLinePreset?: HudPreset; forceStatusLinePreset?: boolean },
+	configPath: string,
+	pkgRoot: string,
+	sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose" | "modelUpgradePrompt"> & {
+		statusLinePreset?: HudPreset;
+		forceStatusLinePreset?: boolean;
+	},
 ): Promise<ManagedConfigResult> {
-  const existing = existsSync(configPath)
-    ? await readFile(configPath, "utf-8")
-    : "";
-  const hadLegacyTeamRunTable = hasLegacyOmxTeamRunTable(existing);
-  const currentModel = getRootModelName(existing);
-  let modelOverride: string | undefined;
-  const omxManagesTui = true;
+	const existing = existsSync(configPath)
+		? await readFile(configPath, "utf-8")
+		: "";
+	const hadLegacyTeamRunTable = hasLegacyOmxTeamRunTable(existing);
+	const currentModel = getRootModelName(existing);
+	let modelOverride: string | undefined;
+	const omxManagesTui = true;
 
-  if (currentModel === LEGACY_SETUP_MODEL) {
-    const shouldPrompt =
-      typeof options.modelUpgradePrompt === "function" ||
-      (process.stdin.isTTY && process.stdout.isTTY);
-    if (shouldPrompt) {
-      const shouldUpgrade = options.modelUpgradePrompt
-        ? await options.modelUpgradePrompt(currentModel, DEFAULT_SETUP_MODEL)
-        : await promptForModelUpgrade(currentModel, DEFAULT_SETUP_MODEL);
-      if (shouldUpgrade) {
-        modelOverride = DEFAULT_SETUP_MODEL;
-      }
-    }
-  }
+	if (currentModel === LEGACY_SETUP_MODEL) {
+		const shouldPrompt =
+			typeof options.modelUpgradePrompt === "function" ||
+			(process.stdin.isTTY && process.stdout.isTTY);
+		if (shouldPrompt) {
+			const shouldUpgrade = options.modelUpgradePrompt
+				? await options.modelUpgradePrompt(currentModel, DEFAULT_SETUP_MODEL)
+				: await promptForModelUpgrade(currentModel, DEFAULT_SETUP_MODEL);
+			if (shouldUpgrade) {
+				modelOverride = DEFAULT_SETUP_MODEL;
+			}
+		}
+	}
 
-  const finalConfig = buildMergedConfig(existing, pkgRoot, {
-    includeTui: omxManagesTui,
-    modelOverride,
-    sharedMcpServers: sharedMcpRegistry.servers,
-    sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
-    verbose: options.verbose,
-    statusLinePreset: options.statusLinePreset,
-    forceStatusLinePreset: options.forceStatusLinePreset,
-  });
-  const changed = existing !== finalConfig;
+	const finalConfig = buildMergedConfig(existing, pkgRoot, {
+		includeTui: omxManagesTui,
+		modelOverride,
+		sharedMcpServers: sharedMcpRegistry.servers,
+		sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
+		verbose: options.verbose,
+		statusLinePreset: options.statusLinePreset,
+		forceStatusLinePreset: options.forceStatusLinePreset,
+	});
+	const changed = existing !== finalConfig;
 
-  if (!changed) {
-    summary.unchanged += 1;
-    return {
-      finalConfig,
-      omxManagesTui,
-      repairedLegacyTeamRunTable: false,
-    };
-  }
+	if (!changed) {
+		summary.unchanged += 1;
+		return {
+			finalConfig,
+			omxManagesTui,
+			repairedLegacyTeamRunTable: false,
+		};
+	}
 
-  if (
-    await ensureBackup(
-      configPath,
-      existsSync(configPath),
-      backupContext,
-      options,
-    )
-  ) {
-    summary.backedUp += 1;
-  }
+	if (
+		await ensureBackup(
+			configPath,
+			existsSync(configPath),
+			backupContext,
+			options,
+		)
+	) {
+		summary.backedUp += 1;
+	}
 
-  if (!options.dryRun) {
-    await writeFile(configPath, finalConfig);
-  }
+	if (!options.dryRun) {
+		await writeFile(configPath, finalConfig);
+	}
 
-  if (
-    options.verbose &&
-    modelOverride &&
-    currentModel &&
-    currentModel !== modelOverride
-  ) {
-    console.log(
-      `  ${options.dryRun ? "would update" : "updated"} root model from ${currentModel} to ${modelOverride}`,
-    );
-  }
+	if (
+		options.verbose &&
+		modelOverride &&
+		currentModel &&
+		currentModel !== modelOverride
+	) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} root model from ${currentModel} to ${modelOverride}`,
+		);
+	}
 
-  summary.updated += 1;
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would update" : "updated"} config ${configPath}`,
-    );
-  }
-  return {
-    finalConfig,
-    omxManagesTui,
-    repairedLegacyTeamRunTable:
-      hadLegacyTeamRunTable && !hasLegacyOmxTeamRunTable(finalConfig),
-  };
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} config ${configPath}`,
+		);
+	}
+	return {
+		finalConfig,
+		omxManagesTui,
+		repairedLegacyTeamRunTable:
+			hadLegacyTeamRunTable && !hasLegacyOmxTeamRunTable(finalConfig),
+	};
 }
 
 function getClaudeCodeSettingsPath(homeDir = homedir()): string {
-  return join(homeDir, ".claude", "settings.json");
+	return join(homeDir, ".claude", "settings.json");
 }
 
 async function syncClaudeCodeMcpSettings(
-  sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
-  if (sharedMcpRegistry.servers.length === 0) return;
+	if (sharedMcpRegistry.servers.length === 0) return;
 
-  const settingsPath = getClaudeCodeSettingsPath();
-  const existing = existsSync(settingsPath)
-    ? await readFile(settingsPath, "utf-8")
-    : "";
-  const syncPlan = planClaudeCodeMcpSettingsSync(
-    existing,
-    sharedMcpRegistry.servers,
-  );
+	const settingsPath = getClaudeCodeSettingsPath();
+	const existing = existsSync(settingsPath)
+		? await readFile(settingsPath, "utf-8")
+		: "";
+	const syncPlan = planClaudeCodeMcpSettingsSync(
+		existing,
+		sharedMcpRegistry.servers,
+	);
 
-  for (const warning of syncPlan.warnings) {
-    console.log(`  warning: ${warning}`);
-  }
-  if (syncPlan.warnings.length > 0) {
-    summary.skipped += 1;
-    return;
-  }
-  if (!syncPlan.content) {
-    summary.unchanged += 1;
-    if (options.verbose && syncPlan.unchanged.length > 0) {
-      console.log(
-        `  shared MCP servers already present in Claude Code settings (${settingsPath})`,
-      );
-    }
-    return;
-  }
+	for (const warning of syncPlan.warnings) {
+		console.log(`  warning: ${warning}`);
+	}
+	if (syncPlan.warnings.length > 0) {
+		summary.skipped += 1;
+		return;
+	}
+	if (!syncPlan.content) {
+		summary.unchanged += 1;
+		if (options.verbose && syncPlan.unchanged.length > 0) {
+			console.log(
+				`  shared MCP servers already present in Claude Code settings (${settingsPath})`,
+			);
+		}
+		return;
+	}
 
-  await syncManagedContent(
-    syncPlan.content,
-    settingsPath,
-    summary,
-    backupContext,
-    options,
-    `Claude Code MCP settings ${settingsPath} (+${syncPlan.added.join(", ")})`,
-  );
+	await syncManagedContent(
+		syncPlan.content,
+		settingsPath,
+		summary,
+		backupContext,
+		options,
+		`Claude Code MCP settings ${settingsPath} (+${syncPlan.added.join(", ")})`,
+	);
 }
 
 async function setupNotifyHook(
-  pkgRoot: string,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	pkgRoot: string,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
-  const hookScript = join(pkgRoot, "dist", "scripts", "notify-hook.js");
-  if (!existsSync(hookScript)) {
-    if (options.verbose)
-      console.log("  Notify hook script not found, skipping.");
-    return;
-  }
-  // The notify hook is configured in config.toml via mergeConfig
-  if (options.verbose) console.log(`  Notify hook: ${hookScript}`);
+	const hookScript = join(pkgRoot, "dist", "scripts", "notify-hook.js");
+	if (!existsSync(hookScript)) {
+		if (options.verbose)
+			console.log("  Notify hook script not found, skipping.");
+		return;
+	}
+	// The notify hook is configured in config.toml via mergeConfig
+	if (options.verbose) console.log(`  Notify hook: ${hookScript}`);
 }
 
 async function verifyTeamCliApiInterop(
-  pkgRoot: string,
+	pkgRoot: string,
 ): Promise<{ ok: true } | { ok: false; message: string }> {
-  const teamCliPath = join(pkgRoot, "dist", "cli", "team.js");
-  if (!existsSync(teamCliPath)) {
-    return { ok: false, message: `missing ${teamCliPath}` };
-  }
+	const teamCliPath = join(pkgRoot, "dist", "cli", "team.js");
+	if (!existsSync(teamCliPath)) {
+		return { ok: false, message: `missing ${teamCliPath}` };
+	}
 
-  try {
-    const content = await readFile(teamCliPath, "utf-8");
-    const missing = REQUIRED_TEAM_CLI_API_MARKERS.filter(
-      (marker) => !content.includes(marker),
-    );
-    if (missing.length > 0) {
-      return {
-        ok: false,
-        message: `team CLI interop markers missing: ${missing.join(", ")}`,
-      };
-    }
-    return { ok: true };
-  } catch {
-    return { ok: false, message: `cannot read ${teamCliPath}` };
-  }
+	try {
+		const content = await readFile(teamCliPath, "utf-8");
+		const missing = REQUIRED_TEAM_CLI_API_MARKERS.filter(
+			(marker) => !content.includes(marker),
+		);
+		if (missing.length > 0) {
+			return {
+				ok: false,
+				message: `team CLI interop markers missing: ${missing.join(", ")}`,
+			};
+		}
+		return { ok: true };
+	} catch {
+		return { ok: false, message: `cannot read ${teamCliPath}` };
+	}
 }


### PR DESCRIPTION
## Summary
- Register the packaged local Codex plugin marketplace during `omx setup --plugin` via `[marketplaces.oh-my-codex-local]` with `source_type = "local"` and `source = <packageRoot>`.
- Keep plugin mode on the plugin-discovery path instead of reinstalling legacy prompts, skills, native agents, or setup-owned MCP tables.
- Centralize persisted setup preference parsing for setup/doctor and make `omx doctor` plugin-mode aware, including a specific warning when marketplace registration is missing or stale.
- Add semantic TOML-backed setup/doctor regressions for plugin marketplace registration, dry-run behavior, expected plugin omissions, and missing registration warnings.

Closes #1968.

## Verification
- `codex plugin marketplace add --help` confirms local marketplace root directories are supported.
- `npm run build`
- `npm run check:no-unused`
- `npm run lint`
- `node --test dist/cli/__tests__/doctor-warning-copy.test.js dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/codex-plugin-layout.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js`
- Architect verifier: APPROVE, no concrete issues.

Signed-off-by: Yeachan-Heo <54757707+Yeachan-Heo@users.noreply.github.com>
