### PR TITLE
Add approved context pack handoffs

### DIFF
--- a/docs/context-packs.md
+++ b/docs/context-packs.md
@@ -1,0 +1,43 @@
+# OMX context packs
+
+Context packs are compact execution handoff artifacts for approved plans.
+They live under `.omx/context/` and use JSON schema `omx-context-pack-v1`.
+
+They are intentionally narrow: Ralph and Team only read a pack after the
+existing approved PRD/test-spec handoff path has been selected. Normal Ralph or
+Team launches do not implicitly consume `.omx/context` files.
+
+## Shape
+
+```json
+{
+  "schema": "omx-context-pack-v1",
+  "slug": "issue-1970",
+  "basis": {
+    "prd": { "path": ".omx/plans/prd-issue-1970.md", "sha1": "<sha1>" },
+    "testSpecs": [
+      { "path": ".omx/plans/test-spec-issue-1970.md", "sha1": "<sha1>" }
+    ]
+  },
+  "entries": [
+    { "path": "docs/context-packs.md", "roles": ["scope"] },
+    {
+      "path": "src/planning/artifacts.ts",
+      "roles": ["build"],
+      "selector": { "type": "lines", "start": 1, "end": 120 }
+    },
+    { "path": "src/planning/__tests__/artifacts.test.ts", "roles": ["verify"] }
+  ]
+}
+```
+
+## Validation contract
+
+- `basis.prd` and every `basis.testSpecs[]` entry must match the selected
+  approved PRD/test-spec file path and SHA-1 digest.
+- `entries` must be non-empty.
+- Entry `roles` are limited to `scope`, `build`, and `verify`.
+- Optional selectors currently support only line ranges with
+  `1 <= start <= end`.
+- A stale or malformed relevant pack blocks approved Ralph/Team handoff with an
+  actionable error; a missing pack preserves existing behavior.

--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -13,7 +13,7 @@ import {
   isRalphPrdMode,
   normalizeRalphCliArgs,
 } from '../ralph.js';
-import type { ApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
+import { CONTEXT_PACK_SCHEMA, type ApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
 
 describe('extractRalphTaskDescription', () => {
   it('returns plain task text from positional args', () => {
@@ -78,7 +78,6 @@ describe('filterRalphCodexArgs', () => {
   });
 });
 
-
 const approvedHint: ApprovedExecutionLaunchHint = {
   mode: 'ralph',
   command: 'omx ralph "Execute approved issue 1072 plan"',
@@ -87,6 +86,38 @@ const approvedHint: ApprovedExecutionLaunchHint = {
   testSpecPaths: ['.omx/plans/test-spec-issue-1072.md'],
   deepInterviewSpecPaths: ['.omx/specs/deep-interview-issue-1072.md'],
 };
+
+describe('buildRalphAppendInstructions approved context pack', () => {
+  it('renders approved context pack entries as narrow first context', () => {
+    const instructions = buildRalphAppendInstructions('Execute approved issue 1072 plan', {
+      changedFilesPath: '.omx/ralph/changed-files.txt',
+      noDeslop: false,
+      approvedHint: {
+        ...approvedHint,
+        contextPack: {
+          path: '.omx/context/context-issue-1072.json',
+          pack: {
+            schema: CONTEXT_PACK_SCHEMA,
+            slug: 'issue-1072',
+            basis: {
+              prd: { path: '.omx/plans/prd-issue-1072.md', sha1: 'a'.repeat(40) },
+              testSpecs: [{ path: '.omx/plans/test-spec-issue-1072.md', sha1: 'b'.repeat(40) }],
+            },
+            entries: [
+              { path: 'src/planning/artifacts.ts', roles: ['build'], selector: { type: 'lines', start: 1, end: 120 } },
+              { path: 'src/planning/__tests__/artifacts.test.ts', roles: ['verify'] },
+            ],
+          },
+        },
+      },
+    });
+
+    assert.match(instructions, /context pack: \.omx\/context\/context-issue-1072\.json/);
+    assert.match(instructions, /first narrow execution context/);
+    assert.match(instructions, /\[build\] src\/planning\/artifacts\.ts:1-120/);
+    assert.match(instructions, /\[verify\] src\/planning\/__tests__\/artifacts\.test\.ts/);
+  });
+});
 
 describe('assertRequiredRalphPrdJson', () => {
   it('throws when --prd mode starts without .omx/prd.json', async () => {
@@ -211,8 +242,6 @@ describe('ralph deslop launch wiring', () => {
     assert.match(instructions, /skip the mandatory ai-slop-cleaner final pass/i);
     assert.match(instructions, /latest successful pre-deslop verification evidence/i);
   });
-
-
 
   it('includes approved plan and deep-interview handoff context when available', () => {
     const instructions = buildRalphAppendInstructions('Execute approved issue 1072 plan', {

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../team.js';
+import { createContextPackDraft } from '../../planning/artifacts.js';
 import { readModeState } from '../../modes/base.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
 import {
@@ -238,6 +239,69 @@ describe('parseTeamStartArgs', () => {
       const result = parseTeamStartArgs(['team으로', '해줘']);
       assert.equal(result.parsed.task, 'Execute approved issue 831 plan');
       assert.equal(result.parsed.workerCount, 3);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('attaches a valid context pack only for approved short follow-up handoffs', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-context-pack-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'context'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-1970.md'),
+        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 1970 plan"\n',
+      );
+      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-1970.md'), '# Test spec\n');
+      const draft = createContextPackDraft(wd, [
+        { path: 'src/planning/artifacts.ts', roles: ['build'] },
+      ], { slug: 'issue-1970' });
+      assert.ok(draft);
+      await writeFile(join(wd, '.omx', 'context', 'context-issue-1970.json'), JSON.stringify(draft, null, 2));
+
+      const approvedFollowup = parseTeamStartArgs(['team']);
+      assert.equal(approvedFollowup.parsed.task, 'Execute approved issue 1970 plan');
+      assert.equal(approvedFollowup.parsed.contextPack?.pack.slug, 'issue-1970');
+
+      const normalTask = parseTeamStartArgs(['3:executor', 'implement', 'something', 'else']);
+      assert.equal(normalTask.parsed.contextPack, undefined);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stale context packs for approved short follow-up handoffs', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-stale-context-pack-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'context'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-1970.md'),
+        '# Approved plan v1\n\nLaunch via omx team 3:executor "Execute approved issue 1970 plan"\n',
+      );
+      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-1970.md'), '# Test spec\n');
+      const draft = createContextPackDraft(wd, [
+        { path: 'src/planning/artifacts.ts', roles: ['build'] },
+      ], { slug: 'issue-1970' });
+      assert.ok(draft);
+      await writeFile(join(wd, '.omx', 'context', 'context-issue-1970.json'), JSON.stringify(draft, null, 2));
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-1970.md'),
+        '# Approved plan v2\n\nLaunch via omx team 3:executor "Execute approved issue 1970 plan"\n',
+      );
+
+      assert.throws(
+        () => parseTeamStartArgs(['team']),
+        /Invalid approved context pack.*basis\.prd/,
+      );
+      assert.doesNotThrow(() => parseTeamStartArgs(['3:executor', 'implement', 'something', 'else']));
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -1137,7 +1201,6 @@ describe('teamCommand api', () => {
     }
   });
 
-
   it('accepts new canonical event types via CLI api append-event', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-event-'));
     const previousCwd = process.cwd();
@@ -1179,7 +1242,6 @@ describe('teamCommand api', () => {
     }
   });
 });
-
 
 describe('teamCommand status', () => {
   it('prints pane ids and sparkshell hint when tmux panes are recorded', async () => {
@@ -1727,7 +1789,6 @@ describe('teamCommand status', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
-
 
   it('prints workspace_mode in text status output when present', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-workspace-mode-'));

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -2,7 +2,12 @@ import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { startMode, updateModeState } from '../modes/base.js';
-import { readApprovedExecutionLaunchHint, type ApprovedExecutionLaunchHint } from '../planning/artifacts.js';
+import {
+  readApprovedContextPack,
+  readApprovedExecutionLaunchHint,
+  type ApprovedExecutionLaunchHint,
+  type ValidatedContextPack,
+} from '../planning/artifacts.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import {
   buildFollowupStaffingPlan,
@@ -136,6 +141,18 @@ export function extractRalphTaskDescription(args: readonly string[], fallbackTas
   return words.join(' ') || fallbackTask || 'ralph-cli-launch';
 }
 
+function buildRalphContextPackLines(contextPack: ValidatedContextPack | null | undefined): string[] {
+  if (!contextPack) return [];
+  return [
+    `- context pack: ${contextPack.path}`,
+    '- Use the context pack entries below as the first narrow execution context; widen only when necessary.',
+    ...contextPack.pack.entries.map((entry) => {
+      const selector = entry.selector ? `:${entry.selector.start}-${entry.selector.end}` : '';
+      return `  - [${entry.roles.join(',')}] ${entry.path}${selector}`;
+    }),
+  ];
+}
+
 function buildRalphApprovedContextLines(approvedHint: ApprovedExecutionLaunchHint | null): string[] {
   if (!approvedHint) return [];
   const lines = [
@@ -149,6 +166,7 @@ function buildRalphApprovedContextLines(approvedHint: ApprovedExecutionLaunchHin
     lines.push(`- deep-interview specs: ${approvedHint.deepInterviewSpecPaths.join(', ')}`);
     lines.push('- Carry forward the approved deep-interview requirements and constraints during Ralph execution and final verification.');
   }
+  lines.push(...buildRalphContextPackLines(approvedHint.contextPack));
   return lines;
 }
 
@@ -257,6 +275,16 @@ export async function ralphCommand(args: string[]): Promise<void> {
   const artifacts = await ensureCanonicalRalphArtifacts(cwd);
   const approvedHint = readApprovedExecutionLaunchHint(cwd, 'ralph');
   const explicitTask = extractRalphTaskDescription(normalizedArgs);
+  const usesApprovedHandoffTask = approvedHint != null
+    && (explicitTask === 'ralph-cli-launch' || explicitTask.trim() === approvedHint.task.trim());
+  if (usesApprovedHandoffTask) {
+    const contextPackResult = readApprovedContextPack(cwd, approvedHint);
+    if (contextPackResult.status === 'valid') {
+      approvedHint.contextPack = contextPackResult.contextPack;
+    } else if (contextPackResult.status === 'stale' || contextPackResult.status === 'malformed') {
+      throw new Error(`[ralph] Invalid approved context pack at ${contextPackResult.path}: ${contextPackResult.errors.join('; ')}`);
+    }
+  }
   const task = explicitTask === 'ralph-cli-launch' ? approvedHint?.task ?? explicitTask : explicitTask;
   const noDeslop = normalizedArgs.some((arg) => arg.toLowerCase() === '--no-deslop');
   const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
@@ -279,6 +307,8 @@ export async function ralphCommand(args: string[]): Promise<void> {
     approved_plan_path: approvedHint?.sourcePath,
     approved_test_spec_paths: approvedHint?.testSpecPaths ?? [],
     approved_deep_interview_spec_paths: approvedHint?.deepInterviewSpecPaths ?? [],
+    approved_context_pack_path: approvedHint?.contextPack?.path,
+    approved_context_pack_entries: approvedHint?.contextPack?.pack.entries ?? [],
     ...(artifacts.canonicalPrdPath ? { canonical_prd_path: artifacts.canonicalPrdPath } : {}),
   });
   if (artifacts.migratedPrd) {

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -9,7 +9,7 @@ import { readTeamEvents, waitForTeamEvent } from '../team/state/events.js';
 import type { TeamEvent } from '../team/state.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
 import { classifyTaskSize } from '../hooks/task-size-detector.js';
-import { readApprovedExecutionLaunchHint } from '../planning/artifacts.js';
+import { readApprovedContextPack, readApprovedExecutionLaunchHint, type ValidatedContextPack } from '../planning/artifacts.js';
 import { routeTaskToRole } from '../team/role-router.js';
 import { allocateTasksToWorkers } from '../team/allocation-policy.js';
 import {
@@ -38,6 +38,7 @@ interface ParsedTeamArgs {
   explicitWorkerCount: boolean;
   task: string;
   teamName: string;
+  contextPack?: ValidatedContextPack;
 }
 
 
@@ -47,6 +48,7 @@ interface TeamFollowupContext {
   explicitWorkerCount: boolean;
   agentType?: string;
   explicitAgentType?: boolean;
+  contextPack?: ValidatedContextPack;
 }
 
 function persistExactTeamModeState(
@@ -74,6 +76,7 @@ function readPersistedTeamFollowupState(cwd: string): {
   agentType?: string;
   agent_types?: string;
   linkedRalph?: boolean;
+  contextPack?: ValidatedContextPack;
 } | null {
   const path = join(cwd, '.omx', 'state', 'team-state.json');
   if (!existsSync(path)) return null;
@@ -102,6 +105,13 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
 
   const approvedHint = readApprovedExecutionLaunchHint(cwd, 'team');
   if (!approvedHint) return null;
+  const contextPackResult = readApprovedContextPack(cwd, approvedHint);
+  let contextPack: ValidatedContextPack | undefined;
+  if (contextPackResult.status === 'valid') {
+    contextPack = contextPackResult.contextPack;
+  } else if (contextPackResult.status === 'stale' || contextPackResult.status === 'malformed') {
+    throw new Error(`[team] Invalid approved context pack at ${contextPackResult.path}: ${contextPackResult.errors.join('; ')}`);
+  }
 
   const persistedTask = typeof existingTeamState?.task_description === 'string'
     ? existingTeamState.task_description
@@ -120,6 +130,7 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
       explicitWorkerCount: true,
       agentType: approvedHint.agentType,
       explicitAgentType: approvedHint.agentType != null,
+      contextPack,
     };
   }
 
@@ -129,6 +140,7 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
     explicitWorkerCount: approvedHint.workerCount != null,
     agentType: approvedHint.agentType,
     explicitAgentType: approvedHint.agentType != null,
+    contextPack,
   };
 }
 
@@ -709,7 +721,15 @@ function parseTeamArgs(args: string[], cwd: string = process.cwd()): ParsedTeamA
   }
 
   const teamName = sanitizeTeamName(slugifyTask(effectiveTask));
-  return { workerCount, agentType, explicitAgentType, explicitWorkerCount, task: effectiveTask, teamName };
+  return {
+    workerCount,
+    agentType,
+    explicitAgentType,
+    explicitWorkerCount,
+    task: effectiveTask,
+    teamName,
+    ...(followupContext?.contextPack ? { contextPack: followupContext.contextPack } : {}),
+  };
 }
 
 export function parseTeamStartArgs(args: string[]): ParsedTeamStartArgs {
@@ -1020,6 +1040,8 @@ async function ensureTeamModeState(
       staffing_summary: staffingPlan.staffingSummary,
       staffing_allocations: staffingPlan.allocations,
       completed_at: completionStamp,
+      approved_context_pack_path: parsed.contextPack?.path,
+      approved_context_pack_entries: parsed.contextPack?.pack.entries ?? [],
     });
     return;
   }
@@ -1035,6 +1057,8 @@ async function ensureTeamModeState(
     staffing_summary: staffingPlan.staffingSummary,
     staffing_allocations: staffingPlan.allocations,
     completed_at: completionStamp,
+    approved_context_pack_path: parsed.contextPack?.path,
+    approved_context_pack_entries: parsed.contextPack?.pack.entries ?? [],
   });
 
 }

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -4,7 +4,14 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { isPlanningComplete, readApprovedExecutionLaunchHint, readPlanningArtifacts } from '../artifacts.js';
+import {
+  CONTEXT_PACK_SCHEMA,
+  createContextPackDraft,
+  isPlanningComplete,
+  readApprovedContextPack,
+  readApprovedExecutionLaunchHint,
+  readPlanningArtifacts,
+} from '../artifacts.js';
 
 let tempDir: string;
 
@@ -32,8 +39,6 @@ describe('planning artifacts', () => {
     assert.equal(artifacts.prdPaths.length, 1);
     assert.equal(artifacts.testSpecPaths.length, 0);
   });
-
-
 
   it('parses $ralph aliases with single-quoted task text for approved launch hints', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
@@ -145,8 +150,6 @@ describe('planning artifacts', () => {
     assert.deepEqual(hint?.deepInterviewSpecPaths, [join(specsDir, 'deep-interview-zeta.md')]);
   });
 
-
-
   it('binds approved handoff context to the selected PRD slug in multi-plan repos', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     const specsDir = join(tempDir, '.omx', 'specs');
@@ -165,6 +168,103 @@ describe('planning artifacts', () => {
     assert.equal(hint?.sourcePath, join(plansDir, 'prd-zeta.md'));
     assert.deepEqual(hint?.testSpecPaths, [join(plansDir, 'test-spec-zeta.md')]);
     assert.deepEqual(hint?.deepInterviewSpecPaths, [join(specsDir, 'deep-interview-zeta.md')]);
+  });
+
+  it('validates a context pack with matching approved PRD/test-spec basis', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const contextDir = join(tempDir, '.omx', 'context');
+    await mkdir(plansDir, { recursive: true });
+    await mkdir(contextDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-issue-1970.md');
+    const testSpecPath = join(plansDir, 'test-spec-issue-1970.md');
+    await writeFile(prdPath, '# PRD\n\nLaunch via omx ralph "Execute issue 1970"\n');
+    await writeFile(testSpecPath, '# Test Spec\n');
+
+    const draft = createContextPackDraft(tempDir, [
+      { path: 'docs/context-packs.md', roles: ['scope'] },
+      { path: 'src/planning/artifacts.ts', roles: ['build'], selector: { type: 'lines', start: 1, end: 80 } },
+      { path: 'src/planning/__tests__/artifacts.test.ts', roles: ['verify'] },
+    ], { slug: 'issue-1970' });
+    assert.ok(draft);
+    await writeFile(join(contextDir, 'context-issue-1970.json'), JSON.stringify(draft, null, 2));
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    const result = readApprovedContextPack(tempDir, hint);
+    assert.equal(result.status, 'valid');
+    assert.equal(result.status === 'valid' ? result.contextPack.pack.schema : null, CONTEXT_PACK_SCHEMA);
+    assert.deepEqual(
+      result.status === 'valid' ? result.contextPack.pack.entries.map((entry) => entry.roles.join(',')) : [],
+      ['scope', 'build', 'verify'],
+    );
+  });
+
+  it('rejects context packs with stale approved PRD basis hashes', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const contextDir = join(tempDir, '.omx', 'context');
+    await mkdir(plansDir, { recursive: true });
+    await mkdir(contextDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-issue-1970.md'), '# PRD v1\n\nLaunch via omx ralph "Execute issue 1970"\n');
+    await writeFile(join(plansDir, 'test-spec-issue-1970.md'), '# Test Spec\n');
+    const draft = createContextPackDraft(tempDir, [
+      { path: 'src/planning/artifacts.ts', roles: ['build'] },
+    ], { slug: 'issue-1970' });
+    assert.ok(draft);
+    await writeFile(join(contextDir, 'context-issue-1970.json'), JSON.stringify(draft, null, 2));
+    await writeFile(join(plansDir, 'prd-issue-1970.md'), '# PRD v2\n\nLaunch via omx ralph "Execute issue 1970"\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    const result = readApprovedContextPack(tempDir, hint);
+    assert.equal(result.status, 'stale');
+    assert.match(result.status === 'stale' ? result.errors.join('\n') : '', /basis\.prd/);
+  });
+
+  it('rejects malformed context pack entries and line selectors', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const contextDir = join(tempDir, '.omx', 'context');
+    await mkdir(plansDir, { recursive: true });
+    await mkdir(contextDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-issue-1970.md'), '# PRD\n\nLaunch via omx ralph "Execute issue 1970"\n');
+    await writeFile(join(plansDir, 'test-spec-issue-1970.md'), '# Test Spec\n');
+    const draft = createContextPackDraft(tempDir, [
+      { path: 'src/planning/artifacts.ts', roles: ['build'] },
+    ], { slug: 'issue-1970' });
+    assert.ok(draft);
+    await writeFile(join(contextDir, 'context-issue-1970.json'), JSON.stringify({
+      ...draft,
+      entries: [
+        { path: '', roles: ['scope'] },
+        { path: 'src/planning/artifacts.ts', roles: ['magic'] },
+        { path: 'src/cli/ralph.ts', roles: ['build'], selector: { type: 'lines', start: 10, end: 2 } },
+      ],
+    }, null, 2));
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    const result = readApprovedContextPack(tempDir, hint);
+    assert.equal(result.status, 'malformed');
+    const errors = result.status === 'malformed' ? result.errors.join('\n') : '';
+    assert.match(errors, /path must be a non-empty string/);
+    assert.match(errors, /invalid role/);
+    assert.match(errors, /start\/end/);
+  });
+
+  it('does not discover context packs without an approved handoff context', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const contextDir = join(tempDir, '.omx', 'context');
+    await mkdir(plansDir, { recursive: true });
+    await mkdir(contextDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-issue-1970.md'), '# PRD without launch hint\n');
+    await writeFile(join(plansDir, 'test-spec-issue-1970.md'), '# Test Spec\n');
+    const draft = createContextPackDraft(tempDir, [
+      { path: 'src/planning/artifacts.ts', roles: ['build'] },
+    ], { slug: 'issue-1970' });
+    assert.ok(draft);
+    await writeFile(join(contextDir, 'context-issue-1970.json'), JSON.stringify(draft, null, 2));
+
+    assert.equal(readApprovedExecutionLaunchHint(tempDir, 'ralph'), null);
+    assert.equal(readApprovedExecutionLaunchHint(tempDir, 'team'), null);
   });
 
   it('surfaces deep-interview specs for downstream traceability', async () => {

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -199,6 +199,49 @@ describe('planning artifacts', () => {
     );
   });
 
+  it('ignores malformed unrelated context drafts when a valid approved pack exists', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const contextDir = join(tempDir, '.omx', 'context');
+    await mkdir(plansDir, { recursive: true });
+    await mkdir(contextDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-issue-1970.md');
+    const testSpecPath = join(plansDir, 'test-spec-issue-1970.md');
+    await writeFile(prdPath, '# PRD\n\nLaunch via omx ralph "Execute issue 1970"\n');
+    await writeFile(testSpecPath, '# Test Spec\n');
+
+    const draft = createContextPackDraft(tempDir, [
+      { path: 'src/planning/artifacts.ts', roles: ['build'] },
+    ], { slug: 'issue-1970' });
+    assert.ok(draft);
+    await writeFile(join(contextDir, 'context-issue-1970.json'), JSON.stringify(draft, null, 2));
+    await writeFile(join(contextDir, 'zz-unrelated-draft.json'), '{ not valid json');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    const result = readApprovedContextPack(tempDir, hint);
+    assert.equal(result.status, 'valid');
+    assert.equal(result.status === 'valid' ? result.contextPack.pack.slug : null, 'issue-1970');
+  });
+
+  it('ignores malformed unrelated context drafts when no pack matches the approved basis', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const contextDir = join(tempDir, '.omx', 'context');
+    await mkdir(plansDir, { recursive: true });
+    await mkdir(contextDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-1970.md'),
+      '# PRD\n\nLaunch via omx ralph "Execute issue 1970"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-1970.md'), '# Test Spec\n');
+    await writeFile(join(contextDir, 'zz-unrelated-draft.json'), '{ not valid json');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    const result = readApprovedContextPack(tempDir, hint);
+    assert.equal(result.status, 'missing');
+    assert.match(result.status === 'missing' ? result.reason : '', /no context pack matches/);
+  });
+
   it('rejects context packs with stale approved PRD basis hashes', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     const contextDir = join(tempDir, '.omx', 'context');

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -1,5 +1,6 @@
+import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, isAbsolute, join, relative, resolve } from 'node:path';
 import { omxPlansDir } from '../utils/paths.js';
 
 const PRD_PATTERN = /^prd-.*\.md$/i;
@@ -27,6 +28,7 @@ export interface ApprovedExecutionLaunchHint extends ApprovedPlanContext {
   workerCount?: number;
   agentType?: string;
   linkedRalph?: boolean;
+  contextPack?: ValidatedContextPack;
 }
 
 export interface LatestPlanningArtifactSelection {
@@ -34,6 +36,51 @@ export interface LatestPlanningArtifactSelection {
   testSpecPaths: string[];
   deepInterviewSpecPaths: string[];
 }
+
+export const CONTEXT_PACK_SCHEMA = 'omx-context-pack-v1';
+export const CONTEXT_PACK_ROLES = ['scope', 'build', 'verify'] as const;
+
+export type ContextPackRole = (typeof CONTEXT_PACK_ROLES)[number];
+
+export interface ContextPackBasisFile {
+  path: string;
+  sha1: string;
+}
+
+export interface ContextPackBasis {
+  prd: ContextPackBasisFile;
+  testSpecs: ContextPackBasisFile[];
+}
+
+export interface ContextPackLineSelector {
+  type: 'lines';
+  start: number;
+  end: number;
+}
+
+export interface ContextPackEntry {
+  path: string;
+  roles: ContextPackRole[];
+  selector?: ContextPackLineSelector;
+}
+
+export interface ContextPackArtifact {
+  schema: typeof CONTEXT_PACK_SCHEMA;
+  slug?: string;
+  basis: ContextPackBasis;
+  entries: ContextPackEntry[];
+}
+
+export interface ValidatedContextPack {
+  path: string;
+  pack: ContextPackArtifact;
+}
+
+export type ContextPackReadResult =
+  | { status: 'missing'; reason: string }
+  | { status: 'valid'; contextPack: ValidatedContextPack }
+  | { status: 'stale'; path: string; errors: string[]; expectedBasis: ContextPackBasis }
+  | { status: 'malformed'; path: string; errors: string[] };
 
 function readMatchingPaths(dir: string, pattern: RegExp): string[] {
   if (!existsSync(dir)) {
@@ -92,6 +139,254 @@ function artifactSlug(path: string, prefixPattern: RegExp): string | null {
 function filterArtifactsForSlug(paths: readonly string[], prefixPattern: RegExp, slug: string | null): string[] {
   if (!slug) return [];
   return paths.filter((path) => artifactSlug(path, prefixPattern) === slug);
+}
+
+function contextDir(cwd: string): string {
+  return join(cwd, '.omx', 'context');
+}
+
+function toRepoRelativePath(cwd: string, path: string): string {
+  const absolutePath = isAbsolute(path) ? path : resolve(cwd, path);
+  return relative(cwd, absolutePath).replace(/\\/g, '/');
+}
+
+function resolveRepoPath(cwd: string, path: string): string {
+  return isAbsolute(path) ? path : resolve(cwd, path);
+}
+
+function sha1File(path: string): string {
+  return createHash('sha1').update(readFileSync(path)).digest('hex');
+}
+
+export function createContextPackBasis(
+  cwd: string,
+  selection: LatestPlanningArtifactSelection = readLatestPlanningArtifacts(cwd),
+): ContextPackBasis | null {
+  if (!selection.prdPath) return null;
+  if (!existsSync(selection.prdPath)) return null;
+
+  return {
+    prd: {
+      path: toRepoRelativePath(cwd, selection.prdPath),
+      sha1: sha1File(selection.prdPath),
+    },
+    testSpecs: selection.testSpecPaths
+      .filter((path) => existsSync(path))
+      .map((path) => ({
+        path: toRepoRelativePath(cwd, path),
+        sha1: sha1File(path),
+      })),
+  };
+}
+
+export function createContextPackDraft(
+  cwd: string,
+  entries: ContextPackEntry[],
+  options: { slug?: string; selection?: LatestPlanningArtifactSelection } = {},
+): ContextPackArtifact | null {
+  const basis = createContextPackBasis(cwd, options.selection ?? readLatestPlanningArtifacts(cwd));
+  if (!basis) return null;
+  return {
+    schema: CONTEXT_PACK_SCHEMA,
+    ...(options.slug ? { slug: options.slug } : {}),
+    basis,
+    entries,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validateSha1(value: unknown, field: string, errors: string[]): value is string {
+  if (typeof value !== 'string' || !/^[a-f0-9]{40}$/i.test(value)) {
+    errors.push(`${field} must be a SHA-1 hex digest`);
+    return false;
+  }
+  return true;
+}
+
+function validateBasisFile(value: unknown, field: string, errors: string[]): ContextPackBasisFile | null {
+  if (!isRecord(value)) {
+    errors.push(`${field} must be an object`);
+    return null;
+  }
+  const path = value.path;
+  const sha1 = value.sha1;
+  if (typeof path !== 'string' || path.trim() === '') {
+    errors.push(`${field}.path must be a non-empty string`);
+  }
+  validateSha1(sha1, `${field}.sha1`, errors);
+  if (typeof path !== 'string' || path.trim() === '' || typeof sha1 !== 'string') return null;
+  return { path, sha1 };
+}
+
+function validateContextPackShape(value: unknown): { pack: ContextPackArtifact | null; errors: string[] } {
+  const errors: string[] = [];
+  if (!isRecord(value)) return { pack: null, errors: ['context pack must be a JSON object'] };
+
+  if (value.schema !== CONTEXT_PACK_SCHEMA) {
+    errors.push(`schema must be ${CONTEXT_PACK_SCHEMA}`);
+  }
+  if (value.slug != null && (typeof value.slug !== 'string' || value.slug.trim() === '')) {
+    errors.push('slug must be a non-empty string when present');
+  }
+
+  const basisValue = value.basis;
+  let basis: ContextPackBasis | null = null;
+  if (!isRecord(basisValue)) {
+    errors.push('basis must be an object');
+  } else {
+    const prd = validateBasisFile(basisValue.prd, 'basis.prd', errors);
+    const testSpecsValue = basisValue.testSpecs;
+    const testSpecs: ContextPackBasisFile[] = [];
+    if (!Array.isArray(testSpecsValue)) {
+      errors.push('basis.testSpecs must be an array');
+    } else {
+      for (const [index, spec] of testSpecsValue.entries()) {
+        const parsed = validateBasisFile(spec, `basis.testSpecs[${index}]`, errors);
+        if (parsed) testSpecs.push(parsed);
+      }
+    }
+    if (prd && Array.isArray(testSpecsValue)) basis = { prd, testSpecs };
+  }
+
+  const entriesValue = value.entries;
+  const entries: ContextPackEntry[] = [];
+  if (!Array.isArray(entriesValue) || entriesValue.length === 0) {
+    errors.push('entries must be a non-empty array');
+  } else {
+    const allowedRoles = new Set<string>(CONTEXT_PACK_ROLES);
+    for (const [index, entryValue] of entriesValue.entries()) {
+      if (!isRecord(entryValue)) {
+        errors.push(`entries[${index}] must be an object`);
+        continue;
+      }
+      const path = entryValue.path;
+      if (typeof path !== 'string' || path.trim() === '') {
+        errors.push(`entries[${index}].path must be a non-empty string`);
+      }
+      const rolesValue = entryValue.roles;
+      const roles: ContextPackRole[] = [];
+      if (!Array.isArray(rolesValue) || rolesValue.length === 0) {
+        errors.push(`entries[${index}].roles must be a non-empty array`);
+      } else {
+        for (const role of rolesValue) {
+          if (typeof role !== 'string' || !allowedRoles.has(role)) {
+            errors.push(`entries[${index}].roles contains invalid role ${JSON.stringify(role)}`);
+          } else if (!roles.includes(role as ContextPackRole)) {
+            roles.push(role as ContextPackRole);
+          }
+        }
+      }
+
+      let selector: ContextPackLineSelector | undefined;
+      if (entryValue.selector != null) {
+        if (!isRecord(entryValue.selector)) {
+          errors.push(`entries[${index}].selector must be an object`);
+        } else if (entryValue.selector.type !== 'lines') {
+          errors.push(`entries[${index}].selector.type must be lines`);
+        } else {
+          const start = entryValue.selector.start;
+          const end = entryValue.selector.end;
+          if (typeof start !== 'number' || typeof end !== 'number' || !Number.isInteger(start) || !Number.isInteger(end) || start < 1 || end < start) {
+            errors.push(`entries[${index}].selector lines must use integer start/end with 1 <= start <= end`);
+          } else {
+            selector = { type: 'lines', start, end };
+          }
+        }
+      }
+
+      if (typeof path === 'string' && path.trim() !== '' && roles.length > 0) {
+        entries.push({ path, roles, ...(selector ? { selector } : {}) });
+      }
+    }
+  }
+
+  if (errors.length > 0 || !basis || value.schema !== CONTEXT_PACK_SCHEMA) {
+    return { pack: null, errors };
+  }
+
+  return {
+    pack: {
+      schema: CONTEXT_PACK_SCHEMA,
+      ...(typeof value.slug === 'string' ? { slug: value.slug } : {}),
+      basis,
+      entries,
+    },
+    errors,
+  };
+}
+
+function basisFileMatches(cwd: string, actual: ContextPackBasisFile, expected: ContextPackBasisFile): boolean {
+  return resolveRepoPath(cwd, actual.path) === resolveRepoPath(cwd, expected.path)
+    && actual.sha1.toLowerCase() === expected.sha1.toLowerCase();
+}
+
+function basisPathsMatch(cwd: string, actual: ContextPackBasis, expected: ContextPackBasis): boolean {
+  if (resolveRepoPath(cwd, actual.prd.path) !== resolveRepoPath(cwd, expected.prd.path)) return false;
+  if (actual.testSpecs.length !== expected.testSpecs.length) return false;
+  return actual.testSpecs.every((actualSpec, index) => (
+    resolveRepoPath(cwd, actualSpec.path) === resolveRepoPath(cwd, expected.testSpecs[index]?.path ?? '')
+  ));
+}
+
+function validateBasisFreshness(cwd: string, actual: ContextPackBasis, expected: ContextPackBasis): string[] {
+  const errors: string[] = [];
+  if (!basisFileMatches(cwd, actual.prd, expected.prd)) {
+    errors.push(`basis.prd is stale or does not match ${expected.prd.path}`);
+  }
+  if (actual.testSpecs.length !== expected.testSpecs.length) {
+    errors.push(`basis.testSpecs length ${actual.testSpecs.length} does not match expected ${expected.testSpecs.length}`);
+  }
+  for (const [index, expectedSpec] of expected.testSpecs.entries()) {
+    const actualSpec = actual.testSpecs[index];
+    if (!actualSpec || !basisFileMatches(cwd, actualSpec, expectedSpec)) {
+      errors.push(`basis.testSpecs[${index}] is stale or does not match ${expectedSpec.path}`);
+    }
+  }
+  return errors;
+}
+
+function readContextPackJson(path: string): { pack: ContextPackArtifact | null; errors: string[] } {
+  try {
+    return validateContextPackShape(JSON.parse(readFileSync(path, 'utf-8')) as unknown);
+  } catch (error) {
+    return { pack: null, errors: [`invalid JSON: ${error instanceof Error ? error.message : String(error)}`] };
+  }
+}
+
+export function readApprovedContextPack(cwd: string, approvedContext: ApprovedPlanContext): ContextPackReadResult {
+  const expectedBasis = createContextPackBasis(cwd, {
+    prdPath: approvedContext.sourcePath,
+    testSpecPaths: approvedContext.testSpecPaths,
+    deepInterviewSpecPaths: approvedContext.deepInterviewSpecPaths,
+  });
+  if (!expectedBasis) return { status: 'missing', reason: 'approved planning basis is incomplete' };
+
+  const dir = contextDir(cwd);
+  if (!existsSync(dir)) return { status: 'missing', reason: '.omx/context does not exist' };
+
+  let files: string[];
+  try {
+    files = readdirSync(dir)
+      .filter((file) => file.endsWith('.json'))
+      .sort((a, b) => b.localeCompare(a))
+      .map((file) => join(dir, file));
+  } catch {
+    return { status: 'missing', reason: '.omx/context is not readable' };
+  }
+
+  for (const path of files) {
+    const { pack, errors } = readContextPackJson(path);
+    if (!pack) return { status: 'malformed', path, errors };
+    if (!basisPathsMatch(cwd, pack.basis, expectedBasis)) continue;
+    const staleErrors = validateBasisFreshness(cwd, pack.basis, expectedBasis);
+    if (staleErrors.length > 0) return { status: 'stale', path, errors: staleErrors, expectedBasis };
+    return { status: 'valid', contextPack: { path, pack } };
+  }
+
+  return { status: 'missing', reason: 'no context pack matches the approved planning basis' };
 }
 
 function readApprovedPlanText(cwd: string): { content: string; context: ApprovedPlanContext } | null {

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -348,12 +348,33 @@ function validateBasisFreshness(cwd: string, actual: ContextPackBasis, expected:
   return errors;
 }
 
-function readContextPackJson(path: string): { pack: ContextPackArtifact | null; errors: string[] } {
+function readContextPackJson(path: string): { pack: ContextPackArtifact | null; errors: string[]; value?: unknown } {
   try {
-    return validateContextPackShape(JSON.parse(readFileSync(path, 'utf-8')) as unknown);
+    const value = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+    return { ...validateContextPackShape(value), value };
   } catch (error) {
     return { pack: null, errors: [`invalid JSON: ${error instanceof Error ? error.message : String(error)}`] };
   }
+}
+
+function contextPackFileCouldMatchApprovedSlug(path: string, approvedSlug: string | null): boolean {
+  if (!approvedSlug) return true;
+  return basename(path, '.json').toLowerCase().includes(approvedSlug.toLowerCase());
+}
+
+function rawBasisPathsMatch(cwd: string, value: unknown, expected: ContextPackBasis): boolean {
+  if (!isRecord(value) || !isRecord(value.basis)) return false;
+  const prd = value.basis.prd;
+  if (!isRecord(prd) || typeof prd.path !== 'string') return false;
+  if (resolveRepoPath(cwd, prd.path) !== resolveRepoPath(cwd, expected.prd.path)) return false;
+
+  const testSpecs = value.basis.testSpecs;
+  if (!Array.isArray(testSpecs) || testSpecs.length !== expected.testSpecs.length) return false;
+  return testSpecs.every((spec, index) => (
+    isRecord(spec)
+    && typeof spec.path === 'string'
+    && resolveRepoPath(cwd, spec.path) === resolveRepoPath(cwd, expected.testSpecs[index]?.path ?? '')
+  ));
 }
 
 export function readApprovedContextPack(cwd: string, approvedContext: ApprovedPlanContext): ContextPackReadResult {
@@ -377,9 +398,18 @@ export function readApprovedContextPack(cwd: string, approvedContext: ApprovedPl
     return { status: 'missing', reason: '.omx/context is not readable' };
   }
 
+  const approvedSlug = artifactSlug(approvedContext.sourcePath, /^prd-(?<slug>.*)\.md$/i);
   for (const path of files) {
-    const { pack, errors } = readContextPackJson(path);
-    if (!pack) return { status: 'malformed', path, errors };
+    const { pack, errors, value } = readContextPackJson(path);
+    if (!pack) {
+      if (
+        rawBasisPathsMatch(cwd, value, expectedBasis)
+        || contextPackFileCouldMatchApprovedSlug(path, approvedSlug)
+      ) {
+        return { status: 'malformed', path, errors };
+      }
+      continue;
+    }
     if (!basisPathsMatch(cwd, pack.basis, expectedBasis)) continue;
     const staleErrors = validateBasisFreshness(cwd, pack.basis, expectedBasis);
     if (staleErrors.length > 0) return { status: 'stale', path, errors: staleErrors, expectedBasis };


### PR DESCRIPTION
## Summary
- Add canonical `.omx/context` JSON context packs with `omx-context-pack-v1` schema, PRD/test-spec SHA-1 basis binding, scoped entries, and optional line selectors.
- Wire Ralph and Team to consume valid packs only through explicit approved handoff paths, with stale/malformed pack rejection and missing-pack fallback to existing behavior.
- Document the v1 contract in `docs/context-packs.md`.

Closes #1970

## Verification
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `node --test dist/planning/__tests__/artifacts.test.js dist/cli/__tests__/ralph.test.js dist/cli/__tests__/team.test.js`
- [x] `git diff --check`

## Notes
This is an explicit approved-handoff-only v1 contract: normal Ralph/Team launches do not implicitly consume `.omx/context` packs.
