### PR TITLE
Fail fast when direct leader pane is missing

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6002,7 +6002,7 @@ esac
     }
   });
 
-  it('sendWorkerMessage transport_direct keeps leader-fixed request pending when leader_pane_id missing', async () => {
+  it('sendWorkerMessage transport_direct fails fast for leader-fixed when leader_pane_id missing', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-direct-'));
     try {
       await initTeamState('team-leader-direct', 'leader direct transport test', 'executor', 1, cwd);
@@ -6017,15 +6017,29 @@ esac
       manifest.policy = { ...(manifest.policy || {}), dispatch_mode: 'transport_direct' };
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
-      await sendWorkerMessage('team-leader-direct', 'worker-1', 'leader-fixed', 'hello leader direct', cwd);
+      await assert.rejects(
+        sendWorkerMessage('team-leader-direct', 'worker-1', 'leader-fixed', 'hello leader direct', cwd),
+        /mailbox_notify_failed:leader_pane_missing_transport_direct_failed/,
+      );
 
       const mailbox = await listMailboxMessages('team-leader-direct', 'leader-fixed', cwd);
       assert.ok(mailbox.length >= 1, `expected at least 1 mailbox message, got ${mailbox.length}`);
       const requests = await listDispatchRequests('team-leader-direct', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
       assert.ok(requests.length >= 1, `expected at least 1 leader-fixed dispatch request, got ${requests.length}`);
       const latest = requests[requests.length - 1];
-      assert.equal(latest?.status, 'pending');
-      assert.equal(latest?.last_reason, 'leader_pane_missing_deferred');
+      assert.equal(latest?.status, 'failed');
+      assert.equal(latest?.last_reason, 'leader_pane_missing_transport_direct_failed');
+      assert.ok(latest?.failed_at, 'missing leader pane should fail fast with failed_at evidence');
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      const runtimeEntries = deliveryLog.filter((entry) =>
+        entry.event === 'dispatch_result'
+        && entry.source === 'team.runtime'
+        && entry.to_worker === 'leader-fixed'
+        && entry.transport === 'mailbox'
+        && entry.result === 'failed'
+        && entry.reason === 'leader_pane_missing_transport_direct_failed');
+      assert.equal(runtimeEntries.length, 1, 'leader direct missing-pane failure should emit exactly one runtime dispatch_result entry');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -4418,11 +4418,15 @@ async function sendLeaderMailboxMessage(params: {
     cwd,
     transportPreference,
     fallbackAllowed: transportPreference === 'hook_preferred_with_fallback',
-    notify: async (_target, message) => (
-      transportPreference === 'hook_preferred_with_fallback'
-        ? { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' }
-        : await notifyLeaderAsync(config, message, cwd)
-    ),
+    notify: async (_target, message) => {
+      if (transportPreference === 'hook_preferred_with_fallback') {
+        return { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' };
+      }
+      if (!config.leader_pane_id) {
+        return { ok: false, transport: 'mailbox', reason: 'leader_pane_missing_transport_direct_failed' };
+      }
+      return await notifyLeaderAsync(config, message, cwd);
+    },
   });
 
   if (
@@ -4454,6 +4458,29 @@ async function sendLeaderMailboxMessage(params: {
       outcome: deferredOutcome,
     });
     return deferredOutcome;
+  }
+
+  if (
+    !isExistingMailboxNotificationOutcome(queuedOutcome)
+    && transportPreference === 'transport_direct'
+    && !config.leader_pane_id
+  ) {
+    const failedOutcome: DispatchOutcome = {
+      ...queuedOutcome,
+      ok: false,
+      transport: 'mailbox',
+      reason: 'leader_pane_missing_transport_direct_failed',
+    };
+    await logRuntimeDispatchOutcome({
+      cwd,
+      teamName,
+      workerName: 'leader-fixed',
+      requestId: failedOutcome.request_id,
+      messageId: failedOutcome.message_id,
+      intent: triggerDirective.intent,
+      outcome: failedOutcome,
+    });
+    return failedOutcome;
   }
 
   const canLeaderFallbackDirectly = Boolean(config.leader_pane_id) && isTmuxAvailable();


### PR DESCRIPTION
## Problem
`transport_direct` leader-directed mailbox sends could leave `leader-fixed` dispatch requests pending when `leader_pane_id` was missing, making worker→leader delivery look unresolved without an authoritative failure reason.

## Root cause
The leader mailbox path reused mailbox persistence semantics from hook-preferred fallback mode. In direct transport mode, a missing leader pane is not recoverable by the hook/HUD path, but the request could still be recorded as deferred/pending instead of failing fast.

## Changed files
- `src/team/runtime.ts`
  - Treats missing `leader_pane_id` under `transport_direct` as `leader_pane_missing_transport_direct_failed`.
  - Returns/logs a failed runtime dispatch outcome instead of proceeding as a deferred mailbox notification.
- `src/team/__tests__/runtime.test.ts`
  - Converts the existing regression case from “pending” expectation to fail-fast behavior.
  - Asserts failed request state, `failed_at` evidence, thrown send error, and runtime delivery-log evidence.

## Validation
- `npm run build`
- `node --test --test-name-pattern "leader-fixed when leader_pane_id missing" dist/team/__tests__/runtime.test.js`

## Risks
Low/narrow. This only changes the missing-leader-pane branch for leader-directed mailbox sends in `transport_direct`; hook-preferred missing-pane behavior remains mailbox-persisted/deferred.

## Overlap assessment
Checked open PRs targeting `dev` for this transport/direct leader-pane pending issue and found no existing overlapping PR before implementation.
