### PR TITLE
Expose runtime bridge fallback evidence

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -475,6 +475,117 @@ exit 1
     }
   });
 
+
+  it('logs structured evidence when bridge dispatch compat cannot be parsed and legacy requests are used', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      process.env.OMX_RUNTIME_BRIDGE = '1';
+      await initTeamState('alpha', 'task', 'executor', 1, cwd);
+      const queued = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        trigger_message: 'ping',
+      }, cwd);
+      await writeFile(join(cwd, '.omx', 'state', 'dispatch.json'), '{ broken bridge json');
+
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const result = await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 5,
+        injector: async () => ({ ok: true, reason: 'injected_for_test' }),
+      });
+
+      assert.equal(result.processed, 1, 'legacy request fallback must still process the pending request');
+      const request = await readDispatchRequest('alpha', queued.request.request_id, cwd);
+      assert.equal(request?.status, 'notified');
+
+      const dispatchLogPath = join(cwd, '.omx', 'logs', `team-dispatch-${new Date().toISOString().slice(0, 10)}.jsonl`);
+      const dispatchLogs = (await readFile(dispatchLogPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const fallback = dispatchLogs.find((entry: { type?: string; fallback?: boolean; bridge_operation?: string }) =>
+        entry.type === 'bridge_fallback' && entry.bridge_operation === 'readBridgeDispatchRequests' && entry.fallback === true);
+      assert.ok(fallback, 'expected structured bridge fallback evidence in dispatch log');
+      assert.equal(fallback.team, 'alpha');
+      assert.equal(fallback.fallback_target, 'legacy_dispatch_requests');
+      assert.equal(fallback.counter, 'team_dispatch_bridge_fallback_total');
+      assert.match(fallback.reason, /parse_failed|invalid_dispatch_compat/);
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      assert.ok(deliveryLog.some((entry) =>
+        entry.event === 'bridge_fallback'
+        && entry.source === 'notify-hook.team-dispatch'
+        && entry.bridge_operation === 'readBridgeDispatchRequests'
+        && entry.fallback_target === 'legacy_dispatch_requests'
+        && entry.counter === 'team_dispatch_bridge_fallback_total'));
+    } finally {
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('logs structured evidence when runtimeExec fails and JS state remains authoritative', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        join(fakeBinDir, 'omx-runtime'),
+        `#!/usr/bin/env bash
+set -eu
+if [[ "\${1:-}" == "exec" ]]; then
+  echo "runtime schema drift" >&2
+  exit 43
+fi
+exit 0
+`,
+      );
+      await chmod(join(fakeBinDir, 'omx-runtime'), 0o755);
+      process.env.OMX_RUNTIME_BINARY = join(fakeBinDir, 'omx-runtime');
+      process.env.OMX_RUNTIME_BRIDGE = '1';
+
+      await initTeamState('alpha', 'task', 'executor', 1, cwd);
+      const queued = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        trigger_message: 'ping',
+      }, cwd);
+
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const result = await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 5,
+        injector: async () => ({ ok: true, reason: 'injected_for_test' }),
+      });
+
+      assert.equal(result.processed, 1, 'JS fallback path must still finish the dispatch');
+      const request = await readDispatchRequest('alpha', queued.request.request_id, cwd);
+      assert.equal(request?.status, 'notified');
+
+      const dispatchLogPath = join(cwd, '.omx', 'logs', `team-dispatch-${new Date().toISOString().slice(0, 10)}.jsonl`);
+      const dispatchLogs = (await readFile(dispatchLogPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const fallback = dispatchLogs.find((entry: { type?: string; bridge_operation?: string; request_id?: string }) =>
+        entry.type === 'bridge_fallback' && entry.bridge_operation === 'runtimeExec' && entry.request_id === queued.request.request_id);
+      assert.ok(fallback, 'expected structured runtimeExec fallback evidence in dispatch log');
+      assert.equal(fallback.command, 'MarkNotified');
+      assert.equal(fallback.fallback_target, 'js_state_mutation');
+      assert.equal(fallback.counter, 'team_dispatch_bridge_fallback_total');
+      assert.match(fallback.reason, /runtime schema drift|failed/);
+    } finally {
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('leader-fixed dispatch uses pane target only when leader_pane_id exists', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
     const fakeBinDir = join(cwd, 'fake-bin');

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -574,6 +574,7 @@ exit 0
         entry.type === 'bridge_fallback' && entry.bridge_operation === 'runtimeExec' && entry.request_id === queued.request.request_id);
       assert.ok(fallback, 'expected structured runtimeExec fallback evidence in dispatch log');
       assert.equal(fallback.command, 'MarkNotified');
+      assert.equal(fallback.team, 'alpha');
       assert.equal(fallback.fallback_target, 'js_state_mutation');
       assert.equal(fallback.counter, 'team_dispatch_bridge_fallback_total');
       assert.match(fallback.reason, /runtime schema drift|failed/);

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { appendFile, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'fs/promises';
-import { existsSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'node:url';
@@ -36,8 +36,78 @@ function runtimeExec(command, stateDir) {
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
     });
-  } catch {
+  } catch (error) {
+    recordBridgeFallback({
+      stateDir,
+      operation: 'runtimeExec',
+      fallbackTarget: 'js_state_mutation',
+      command: safeString(command?.command).trim() || 'unknown',
+      requestId: safeString(command?.request_id).trim() || undefined,
+      messageId: safeString(command?.message_id).trim() || undefined,
+      reason: bridgeErrorReason(error),
+    });
     // non-fatal: JS path is the fallback
+  }
+}
+
+function bridgeErrorReason(error) {
+  const err = error || {};
+  const stderr = safeString(err.stderr).trim();
+  if (stderr) return stderr.slice(0, 500);
+  const message = safeString(err.message).trim();
+  if (message) return message.slice(0, 500);
+  return 'unknown_bridge_error';
+}
+
+function bridgeFallbackLogPath(stateDir) {
+  return join(dirname(stateDir), 'logs', `team-dispatch-${new Date().toISOString().slice(0, 10)}.jsonl`);
+}
+
+function recordBridgeFallback({
+  stateDir,
+  team,
+  operation,
+  fallbackTarget,
+  command,
+  requestId,
+  messageId,
+  reason,
+}) {
+  const event = {
+    timestamp: new Date().toISOString(),
+    type: 'bridge_fallback',
+    source: 'notify-hook.team-dispatch',
+    fallback: true,
+    counter: 'team_dispatch_bridge_fallback_total',
+    bridge_operation: operation,
+    fallback_target: fallbackTarget,
+    team: safeString(team).trim() || null,
+    command: safeString(command).trim() || null,
+    request_id: safeString(requestId).trim() || null,
+    message_id: safeString(messageId).trim() || null,
+    reason: safeString(reason).trim() || 'unknown_bridge_fallback',
+  };
+  try {
+    const logPath = bridgeFallbackLogPath(stateDir);
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, `${JSON.stringify(event)}\n`);
+  } catch {
+    // best effort observability only
+  }
+  try {
+    appendTeamDeliveryLog(join(dirname(stateDir), 'logs'), {
+      event: 'bridge_fallback',
+      ...event,
+    }).catch(() => {});
+  } catch {
+    // best effort observability only
+  }
+  try {
+    process.emitWarning(`[omx] team-dispatch bridge fallback: ${event.bridge_operation} -> ${event.fallback_target}: ${event.reason}`, {
+      code: 'OMX_TEAM_DISPATCH_BRIDGE_FALLBACK',
+    });
+  } catch {
+    // best effort observability only
   }
 }
 
@@ -50,8 +120,29 @@ function readJson(path, fallback) {
 async function readBridgeDispatchRequests(stateDir, teamName) {
   const candidate = join(stateDir, 'dispatch.json');
   if (!existsSync(candidate)) return null;
-  const parsed = await readJson(candidate, null);
-  if (!parsed || !Array.isArray(parsed.records)) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFile(candidate, 'utf8'));
+  } catch (error) {
+    recordBridgeFallback({
+      stateDir,
+      team: teamName,
+      operation: 'readBridgeDispatchRequests',
+      fallbackTarget: 'legacy_dispatch_requests',
+      reason: `parse_failed:${bridgeErrorReason(error)}`,
+    });
+    return null;
+  }
+  if (!parsed || !Array.isArray(parsed.records)) {
+    recordBridgeFallback({
+      stateDir,
+      team: teamName,
+      operation: 'readBridgeDispatchRequests',
+      fallbackTarget: 'legacy_dispatch_requests',
+      reason: 'invalid_dispatch_compat_schema',
+    });
+    return null;
+  }
   return parsed.records
     .map((record) => {
       if (!record || typeof record !== 'object') return null;

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -27,7 +27,7 @@ import {
  * owned path.
  * Disable entirely with OMX_RUNTIME_BRIDGE=0.
  */
-function runtimeExec(command, stateDir) {
+function runtimeExec(command, stateDir, team) {
   if (process.env.OMX_RUNTIME_BRIDGE === '0') return;
   try {
     const binaryPath = resolveRuntimeBinaryPath();
@@ -39,6 +39,7 @@ function runtimeExec(command, stateDir) {
   } catch (error) {
     recordBridgeFallback({
       stateDir,
+      team,
       operation: 'runtimeExec',
       fallbackTarget: 'js_state_mutation',
       command: safeString(command?.command).trim() || 'unknown',
@@ -592,7 +593,7 @@ async function finalizeClaimedDispatchRequest({
         request.status = 'failed';
         request.failed_at = nowIso;
         request.last_reason = 'unconfirmed_after_max_retries';
-        runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: 'unconfirmed_after_max_retries' }, stateDir);
+        runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: 'unconfirmed_after_max_retries' }, stateDir, teamName);
         summary.processed += 1;
         summary.failed += 1;
         mutated = true;
@@ -629,9 +630,9 @@ async function finalizeClaimedDispatchRequest({
         request.status = 'notified';
         request.notified_at = nowIso;
         request.last_reason = result.reason;
-        runtimeExec({ command: 'MarkNotified', request_id: request.request_id, channel: 'tmux' }, stateDir);
+        runtimeExec({ command: 'MarkNotified', request_id: request.request_id, channel: 'tmux' }, stateDir, teamName);
         if (request.kind === 'mailbox' && request.message_id) {
-          runtimeExec({ command: 'MarkMailboxNotified', message_id: request.message_id }, stateDir);
+          runtimeExec({ command: 'MarkMailboxNotified', message_id: request.message_id }, stateDir, teamName);
           if (usingLegacyRequests) {
             await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(() => {});
           }
@@ -662,7 +663,7 @@ async function finalizeClaimedDispatchRequest({
       request.status = 'failed';
       request.failed_at = nowIso;
       request.last_reason = result.reason;
-      runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: result.reason }, stateDir);
+      runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: result.reason }, stateDir, teamName);
       summary.processed += 1;
       summary.failed += 1;
       mutated = true;
@@ -843,7 +844,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       const wideCap = await runProcess('tmux', verifyWideArgv, 2000);
       // Worker is actively processing (mirrors sync path tmux-session.ts:1292-1294)
       if (paneHasActiveTask(wideCap.stdout)) {
-        runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir);
+        runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir, request.team_name);
         return {
           ok: true,
           reason: 'tmux_send_keys_confirmed_active_task',
@@ -864,7 +865,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       const triggerInNarrow = capturedPaneContainsTrigger(narrowCap.stdout, request.trigger_message);
       const triggerNearTail = capturedPaneContainsTriggerNearTail(wideCap.stdout, request.trigger_message);
       if (!triggerInNarrow && !triggerNearTail) {
-        runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir);
+        runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir, request.team_name);
         return {
           ok: true,
           reason: 'tmux_send_keys_confirmed',


### PR DESCRIPTION
## Problem
`team-dispatch` kept delivery resilient by silently falling back to JS state when the Rust runtime bridge or `dispatch.json` compatibility reads failed. That made bridge/schema drift hard to detect because operators had no structured evidence that fallback happened.

## Root cause
Both fallback boundaries swallowed errors:
- `runtimeExec(...)` caught `omx-runtime exec` failures and continued without logging.
- `readBridgeDispatchRequests(...)` parsed bridge-authored `dispatch.json` through a generic fallback reader, so parse/schema failures looked the same as “no bridge data”.

## Changed files
- `src/scripts/notify-hook/team-dispatch.ts`
  - Adds `recordBridgeFallback(...)` evidence for bridge fallback events.
  - Emits structured `bridge_fallback` JSONL entries to the team dispatch log.
  - Mirrors fallback events into team delivery telemetry with `team_dispatch_bridge_fallback_total` counter metadata.
  - Emits a Node warning with code `OMX_TEAM_DISPATCH_BRIDGE_FALLBACK`.
  - Keeps JS fallback behavior non-fatal.
- `src/hooks/__tests__/notify-hook-team-dispatch.test.ts`
  - Adds regressions for malformed bridge dispatch compat fallback.
  - Adds regressions for failed `runtimeExec` fallback while JS state still completes dispatch.

## Validation
- `npm run build`
- `node --test dist/hooks/__tests__/notify-hook-team-dispatch.test.js`

## Risks
- Runtime bridge failures now produce warnings where they were previously silent. The warning is intentional observability, but noisy environments without `omx-runtime` may see more warning output.
- Evidence logging is best-effort and must not be treated as a delivery dependency.

## Overlap assessment
Checked open PRs targeting `dev` with search term `bridge fallback observability`; no existing PR covered this exact runtime bridge fallback observability gap.
