### PR TITLE
Require delegation evidence for broad team tasks

### DIFF
--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -911,6 +911,102 @@ exit 1
     }
   });
 
+  it('transitionTaskStatus rejects broad delegated completion without spawn evidence or skip reason', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-delegation-evidence-'));
+    try {
+      await initTeamState('team-delegation-evidence', 't', 'executor', 1, cwd);
+      const t = await createTask('team-delegation-evidence', {
+        subject: 'Investigate flaky runtime behavior',
+        description: 'Search runtime and debug flaky assignment behavior',
+        status: 'pending',
+        delegation: {
+          mode: 'auto',
+          required_parallel_probe: true,
+          skip_allowed_reason_required: true,
+        },
+      }, cwd);
+      const claim = await claimTask('team-delegation-evidence', t.id, 'worker-1', t.version ?? 1, cwd);
+      assert.equal(claim.ok, true);
+      if (!claim.ok) return;
+
+      const missing = await transitionTaskStatus(
+        'team-delegation-evidence',
+        t.id,
+        'in_progress',
+        'completed',
+        claim.claimToken,
+        cwd,
+        { result: 'Verification:\nPASS - focused regression' },
+      );
+
+      assert.equal(missing.ok, false);
+      assert.equal(missing.ok ? 'x' : missing.error, 'missing_delegation_compliance_evidence');
+      const reread = await readTask('team-delegation-evidence', t.id, cwd);
+      assert.equal(reread?.status, 'in_progress');
+
+      const completedWithSpawnEvidence = await transitionTaskStatus(
+        'team-delegation-evidence',
+        t.id,
+        'in_progress',
+        'completed',
+        claim.claimToken,
+        cwd,
+        {
+          result: [
+            'Verification:',
+            'PASS - focused regression',
+            'Subagent spawn evidence: spawned 2 native subagents for runtime map and test probe',
+          ].join('\n'),
+        },
+      );
+      assert.equal(completedWithSpawnEvidence.ok, true);
+      assert.equal(completedWithSpawnEvidence.task.delegation_compliance?.status, 'spawned');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('transitionTaskStatus accepts documented skip reason for broad delegated completion', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-delegation-skip-'));
+    try {
+      await initTeamState('team-delegation-skip', 't', 'executor', 1, cwd);
+      const t = await createTask('team-delegation-skip', {
+        subject: 'Review focused regression',
+        description: 'Audit one already-isolated failing test',
+        status: 'pending',
+        delegation: {
+          mode: 'auto',
+          required_parallel_probe: true,
+          skip_allowed_reason_required: true,
+        },
+      }, cwd);
+      const claim = await claimTask('team-delegation-skip', t.id, 'worker-1', t.version ?? 1, cwd);
+      assert.equal(claim.ok, true);
+      if (!claim.ok) return;
+
+      const completed = await transitionTaskStatus(
+        'team-delegation-skip',
+        t.id,
+        'in_progress',
+        'completed',
+        claim.claimToken,
+        cwd,
+        {
+          result: [
+            'Verification:',
+            'PASS - focused regression',
+            'Subagent skip reason: task scope collapsed to one isolated assertion; spawning would duplicate serial verification',
+          ].join('\n'),
+        },
+      );
+
+      assert.equal(completed.ok, true);
+      assert.equal(completed.task.delegation_compliance?.status, 'skipped');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('transitionTaskStatus persists terminal result and error payloads', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-transition-payload-'));
     try {

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -966,6 +966,63 @@ exit 1
     }
   });
 
+  it('transitionTaskStatus requires evidence when optional delegation carries required parallel probe', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-optional-required-probe-'));
+    try {
+      await initTeamState('team-optional-required-probe', 't', 'executor', 1, cwd);
+      const t = await createTask('team-optional-required-probe', {
+        subject: 'Investigate optional delegated runtime behavior',
+        description: 'Optional mode was elevated by a required parallel probe from review enforcement',
+        status: 'pending',
+        delegation: {
+          mode: 'optional',
+          required_parallel_probe: true,
+          skip_allowed_reason_required: true,
+        },
+      }, cwd);
+      const claim = await claimTask('team-optional-required-probe', t.id, 'worker-1', t.version ?? 1, cwd);
+      assert.equal(claim.ok, true);
+      if (!claim.ok) return;
+
+      const missing = await transitionTaskStatus(
+        'team-optional-required-probe',
+        t.id,
+        'in_progress',
+        'completed',
+        claim.claimToken,
+        cwd,
+        { result: 'Verification:\nPASS - focused regression' },
+      );
+
+      assert.equal(missing.ok, false);
+      assert.equal(missing.ok ? 'x' : missing.error, 'missing_delegation_compliance_evidence');
+      const reread = await readTask('team-optional-required-probe', t.id, cwd);
+      assert.equal(reread?.status, 'in_progress');
+
+      const completed = await transitionTaskStatus(
+        'team-optional-required-probe',
+        t.id,
+        'in_progress',
+        'completed',
+        claim.claimToken,
+        cwd,
+        {
+          result: [
+            'Verification:',
+            'PASS - focused regression',
+            'Subagent spawn evidence: spawned 1 native subagent for delegation evidence regression mapping',
+          ].join('\n'),
+        },
+      );
+
+      assert.equal(completed.ok, true);
+      assert.equal(completed.task.delegation_compliance?.status, 'spawned');
+      assert.equal(completed.task.delegation_compliance?.source, 'terminal_result');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('transitionTaskStatus accepts documented skip reason for broad delegated completion', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-delegation-skip-'));
     try {

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -421,7 +421,10 @@ describe("worker bootstrap", () => {
     assert.match(inbox, /gpt-5\.4-mini/);
     assert.match(inbox, /Map runtime assignment flow/);
     assert.match(inbox, /Subagent evidence reporting fields/);
+    assert.match(inbox, /Delegation compliance evidence \(required for completion\)/);
+    assert.match(inbox, /Subagent spawn evidence:/);
     assert.match(inbox, /Subagent skip reason:/);
+    assert.match(inbox, /missing_delegation_compliance_evidence/);
   });
 
   it("generateInitialInbox keeps mode none tasks quiet about delegation contract", () => {
@@ -493,6 +496,7 @@ describe("worker bootstrap", () => {
     assert.match(inbox, /spawn up to 3 Codex native subagents/i);
     assert.match(inbox, /gpt-5\.4-mini/);
     assert.match(inbox, /Search parser references/);
+    assert.match(inbox, /Subagent spawn evidence:/);
     assert.match(inbox, /Subagent skip reason:/);
   });
 

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -132,6 +132,13 @@ export interface WorkerStatus {
 export type TeamTaskDelegationMode = 'none' | 'optional' | 'auto' | 'required';
 export type TeamTaskChildModelPolicy = 'standard' | 'fast' | 'inherit' | 'frontier';
 
+export interface TeamTaskDelegationComplianceEvidence {
+  status: 'spawned' | 'skipped';
+  source: 'terminal_result';
+  detail: string;
+  recorded_at: string;
+}
+
 export interface TeamTaskDelegationPlan {
   mode: TeamTaskDelegationMode;
   max_parallel_subtasks?: number;
@@ -161,6 +168,7 @@ export interface TeamTask {
   created_at: string;
   completed_at?: string;
   delegation?: TeamTaskDelegationPlan;
+  delegation_compliance?: TeamTaskDelegationComplianceEvidence;
 }
 
 export interface TeamTaskClaim {
@@ -340,7 +348,7 @@ export type ClaimTaskResult =
 
 export type TransitionTaskResult =
   | { ok: true; task: TeamTaskV2 }
-  | { ok: false; error: 'claim_conflict' | 'invalid_transition' | 'task_not_found' | 'already_terminal' | 'lease_expired' };
+  | { ok: false; error: 'claim_conflict' | 'invalid_transition' | 'task_not_found' | 'already_terminal' | 'lease_expired' | 'missing_delegation_compliance_evidence' };
 
 export type ReleaseTaskClaimResult =
   | { ok: true; task: TeamTaskV2 }

--- a/src/team/state/tasks.ts
+++ b/src/team/state/tasks.ts
@@ -5,6 +5,7 @@ import { readFile, readdir } from 'fs/promises';
 import type { TeamTaskStatus } from '../contracts.js';
 import type {
   TeamTask,
+  TeamTaskDelegationComplianceEvidence,
   TeamTaskV2,
   TaskReadiness,
   ClaimTaskResult,
@@ -112,6 +113,37 @@ export async function claimTask(
   return lock.value;
 }
 
+function extractDelegationComplianceEvidence(
+  task: TeamTaskV2,
+  terminalData: { result?: string; error?: string } | undefined,
+): TeamTaskDelegationComplianceEvidence | null {
+  const plan = task.delegation;
+  if (!plan || plan.mode === 'none' || plan.mode === 'optional') return null;
+
+  const result = typeof terminalData?.result === 'string' ? terminalData.result : '';
+  const spawnMatch = result.match(/^\s*Subagent spawn evidence:\s*(.+)$/im);
+  if (spawnMatch?.[1]?.trim()) {
+    const detail = spawnMatch[1].trim();
+    if (!/^none\b|^0\b/i.test(detail)) {
+      return { status: 'spawned', source: 'terminal_result', detail, recorded_at: new Date().toISOString() };
+    }
+  }
+
+  if (plan.skip_allowed_reason_required === true) {
+    const skipMatch = result.match(/^\s*Subagent skip reason:\s*(.+)$/im);
+    if (skipMatch?.[1]?.trim()) {
+      return { status: 'skipped', source: 'terminal_result', detail: skipMatch[1].trim(), recorded_at: new Date().toISOString() };
+    }
+  }
+
+  return null;
+}
+
+function requiresDelegationComplianceEvidence(task: TeamTaskV2): boolean {
+  const plan = task.delegation;
+  return !!plan && (plan.mode === 'auto' || plan.mode === 'required' || plan.required_parallel_probe === true);
+}
+
 interface TransitionDeps extends ClaimTaskDeps {
   canTransitionTaskStatus: (from: TeamTaskStatus, to: TeamTaskStatus) => boolean;
   appendTeamEvent: (
@@ -155,12 +187,20 @@ export async function transitionTaskStatus(
 
     const normalizedResult = typeof terminalData?.result === 'string' ? terminalData.result : undefined;
     const normalizedError = typeof terminalData?.error === 'string' ? terminalData.error : undefined;
+    const delegationCompliance = to === 'completed'
+      ? extractDelegationComplianceEvidence(v, terminalData)
+      : null;
+    if (to === 'completed' && requiresDelegationComplianceEvidence(v) && !delegationCompliance) {
+      return { ok: false as const, error: 'missing_delegation_compliance_evidence' as const };
+    }
+
     const updated: TeamTaskV2 = {
       ...v,
       status: to,
       completed_at: new Date().toISOString(),
       result: to === 'completed' ? normalizedResult : undefined,
       error: to === 'failed' ? normalizedError : undefined,
+      delegation_compliance: to === 'completed' ? delegationCompliance ?? v.delegation_compliance : v.delegation_compliance,
       claim: undefined,
       version: v.version + 1,
     };

--- a/src/team/state/tasks.ts
+++ b/src/team/state/tasks.ts
@@ -118,7 +118,8 @@ function extractDelegationComplianceEvidence(
   terminalData: { result?: string; error?: string } | undefined,
 ): TeamTaskDelegationComplianceEvidence | null {
   const plan = task.delegation;
-  if (!plan || plan.mode === 'none' || plan.mode === 'optional') return null;
+  if (!plan || plan.mode === 'none') return null;
+  if (plan.mode === 'optional' && plan.required_parallel_probe !== true) return null;
 
   const result = typeof terminalData?.result === 'string' ? terminalData.result : '';
   const spawnMatch = result.match(/^\s*Subagent spawn evidence:\s*(.+)$/im);

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -60,6 +60,13 @@ export interface WorkerStatus {
 export type TeamTaskDelegationMode = 'none' | 'optional' | 'auto' | 'required';
 export type TeamTaskChildModelPolicy = 'standard' | 'fast' | 'inherit' | 'frontier';
 
+export interface TeamTaskDelegationComplianceEvidence {
+  status: 'spawned' | 'skipped';
+  source: 'terminal_result';
+  detail: string;
+  recorded_at: string;
+}
+
 export interface TeamTaskDelegationPlan {
   mode: TeamTaskDelegationMode;
   max_parallel_subtasks?: number;
@@ -89,6 +96,7 @@ export interface TeamTask {
   created_at: string;
   completed_at?: string;
   delegation?: TeamTaskDelegationPlan;
+  delegation_compliance?: TeamTaskDelegationComplianceEvidence;
 }
 
 export interface TeamTaskClaim {
@@ -258,7 +266,7 @@ export type ClaimTaskResult =
 
 export type TransitionTaskResult =
   | { ok: true; task: TeamTaskV2 }
-  | { ok: false; error: 'claim_conflict' | 'invalid_transition' | 'task_not_found' | 'already_terminal' | 'lease_expired' };
+  | { ok: false; error: 'claim_conflict' | 'invalid_transition' | 'task_not_found' | 'already_terminal' | 'lease_expired' | 'missing_delegation_compliance_evidence' };
 
 export type ReleaseTaskClaimResult =
   | { ok: true; task: TeamTaskV2 }

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -664,6 +664,12 @@ Subagent evidence reporting fields:
 - Subagent model: ${childModel}
 - Findings integrated: <brief bullets>
 - Serial searches before spawn: <number>
+
+Delegation compliance evidence (required for completion):
+- Include exactly one of these lines in the task completion \`result\` passed to \`omx team api transition-task-status\`:
+  - \`Subagent spawn evidence: <count, child task names/thread ids, and what findings were integrated>\`
+  - \`Subagent skip reason: <why serial execution was safer/sufficient>\`
+- Completion is rejected with \`missing_delegation_compliance_evidence\` when this broad-task evidence is absent.
 `;
 }
 


### PR DESCRIPTION
## Problem
Broad Team worker tasks had a delegation/subagent contract in prompts and inbox text, but runtime evidence was weak: a worker could complete a broad auto-delegated task without reporting whether it spawned native subagents or why it skipped them.

## Root cause
`TeamTask.delegation` synthesized expectations such as `required_parallel_probe` and `skip_allowed_reason_required`, but `transitionTaskStatus()` only persisted generic result/error payloads. The completion path did not validate or persist delegation compliance evidence.

## Changed files
- `src/team/state/types.ts` / `src/team/state.ts` — add persisted `delegation_compliance` evidence and transition error typing.
- `src/team/state/tasks.ts` — reject broad delegated completions unless terminal result includes `Subagent spawn evidence:` or an allowed `Subagent skip reason:`, and persist normalized evidence.
- `src/team/worker-bootstrap.ts` — make the required completion evidence explicit in worker inbox delegation contracts.
- `src/team/__tests__/state.test.ts` — regression coverage for missing evidence rejection plus spawn/skip acceptance.
- `src/team/__tests__/worker-bootstrap.test.ts` — assert worker instructions expose the enforced evidence fields and rejection code.

## Validation
- `npm run build`
- `node --test dist/team/__tests__/delegation-policy.test.js dist/team/__tests__/worker-bootstrap.test.js dist/team/__tests__/state.test.js`
- `git diff --check`

## Risks
- This is a completion-time enforcement seam, not live native subagent telemetry. It requires workers to report evidence in the terminal result; future work can bind this to native spawn event tracking when that signal is complete.
- Existing broad delegated tasks that omit the new evidence line will fail completion and need to resubmit with either spawn evidence or an explicit skip reason.

## Overlap assessment
No open PR targeting `dev` directly covers delegation compliance evidence. Existing open PRs are adjacent Team/context/setup work, but none enforce broad task completion on subagent spawn/skip evidence.
