### PR TITLE
Make prompt team restart resume diagnostics explicit

### DIFF
--- a/src/cli/__tests__/doctor-team.test.ts
+++ b/src/cli/__tests__/doctor-team.test.ts
@@ -61,7 +61,7 @@ describe('omx doctor --team', () => {
     }
   });
 
-  it('prints prompt_resume_unavailable when live prompt workers cannot be reattached after restart', async () => {
+  it('warns without failing when a prompt worker pid is live but identity cannot be verified', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-team-prompt-'));
     const sleeper = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
       stdio: 'ignore',
@@ -78,14 +78,22 @@ describe('omx doctor --team', () => {
         tmux_session: 'prompt-team-alpha',
         workers: [{ name: 'worker-1', pid: sleeperPid }],
       }));
+      await writeFile(join(teamRoot, 'manifest.v2.json'), JSON.stringify({
+        name: 'prompt-alpha',
+        policy: { worker_launch_mode: 'prompt' },
+        tmux_session: 'prompt-team-alpha',
+        workers: [{ name: 'worker-1', pid: sleeperPid }],
+      }));
 
       const fakeBin = await createFakeTmuxBin(wd, '#!/bin/sh\n# prompt-mode teams do not require tmux session checks\nexit 0\n');
       const res = runOmx(wd, ['doctor', '--team'], { PATH: `${fakeBin}:${process.env.PATH || ''}` });
       if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 1, res.stderr || res.stdout);
+      assert.equal(res.status, 0, res.stderr || res.stdout);
       assert.match(res.stdout, /prompt_resume_unavailable/);
       assert.match(res.stdout, /prompt-alpha\/worker-1/);
       assert.match(res.stdout, new RegExp(String(sleeperPid)));
+      assert.match(res.stdout, /cannot verify that the PID still belongs/);
+      assert.match(res.stdout, /Results: 1 warnings, 0 failed/);
     } finally {
       if (sleeperPid > 0) {
         try {

--- a/src/cli/__tests__/doctor-team.test.ts
+++ b/src/cli/__tests__/doctor-team.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
 function runOmx(
@@ -57,6 +57,43 @@ describe('omx doctor --team', () => {
       assert.equal(res.status, 1, res.stderr || res.stdout);
       assert.match(res.stdout, /resume_blocker/);
     } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('prints prompt_resume_unavailable when live prompt workers cannot be reattached after restart', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-team-prompt-'));
+    const sleeper = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore',
+      detached: false,
+    });
+    const sleeperPid = sleeper.pid ?? 0;
+
+    try {
+      const teamRoot = join(wd, '.omx', 'state', 'team', 'prompt-alpha');
+      await mkdir(join(teamRoot, 'workers', 'worker-1'), { recursive: true });
+      await writeFile(join(teamRoot, 'config.json'), JSON.stringify({
+        name: 'prompt-alpha',
+        worker_launch_mode: 'prompt',
+        tmux_session: 'prompt-team-alpha',
+        workers: [{ name: 'worker-1', pid: sleeperPid }],
+      }));
+
+      const fakeBin = await createFakeTmuxBin(wd, '#!/bin/sh\n# prompt-mode teams do not require tmux session checks\nexit 0\n');
+      const res = runOmx(wd, ['doctor', '--team'], { PATH: `${fakeBin}:${process.env.PATH || ''}` });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 1, res.stderr || res.stdout);
+      assert.match(res.stdout, /prompt_resume_unavailable/);
+      assert.match(res.stdout, /prompt-alpha\/worker-1/);
+      assert.match(res.stdout, new RegExp(String(sleeperPid)));
+    } finally {
+      if (sleeperPid > 0) {
+        try {
+          process.kill(sleeperPid, 'SIGKILL');
+        } catch {
+          // already exited
+        }
+      }
       await rm(wd, { recursive: true, force: true });
     }
   });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -312,8 +312,8 @@ async function collectTeamDoctorIssues(cwd: string): Promise<TeamDoctorIssue[]> 
         if (Number.isFinite(pid) && pid > 0 && isPidAlive(pid)) {
           issues.push({
             code: 'prompt_resume_unavailable',
-            message: `${teamName}/${worker.name ?? 'unknown'} pid ${pid} is still running, but prompt-mode worker handles are process-local and cannot be reattached after CLI restart; shut down the prompt worker or start a new team`,
-            severity: 'fail',
+            message: `${teamName}/${worker.name ?? 'unknown'} pid ${pid} appears to be running, but doctor cannot verify that the PID still belongs to the original prompt-mode worker after CLI restart; if this is the original worker, shut it down or start a new team`,
+            severity: 'warn',
           });
         }
       }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -196,7 +196,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 }
 
 interface TeamDoctorIssue {
-  code: 'delayed_status_lag' | 'slow_shutdown' | 'orphan_tmux_session' | 'resume_blocker' | 'stale_leader';
+  code: 'delayed_status_lag' | 'slow_shutdown' | 'orphan_tmux_session' | 'resume_blocker' | 'prompt_resume_unavailable' | 'stale_leader';
   message: string;
   severity: 'warn' | 'fail';
 }
@@ -276,23 +276,29 @@ async function collectTeamDoctorIssues(cwd: string): Promise<TeamDoctorIssue[]> 
     const configPath = join(teamDir, 'config.json');
 
     let tmuxSession = `omx-team-${teamName}`;
+    let workerLaunchMode: 'interactive' | 'prompt' = 'interactive';
+    let promptWorkers: Array<{ name?: string; pid?: number }> = [];
     if (existsSync(manifestPath)) {
       try {
         const raw = await readFile(manifestPath, 'utf-8');
-        const parsed = JSON.parse(raw) as { tmux_session?: string };
+        const parsed = JSON.parse(raw) as { tmux_session?: string; policy?: { worker_launch_mode?: string }; workers?: Array<{ name?: string; pid?: number }> };
         if (typeof parsed.tmux_session === 'string' && parsed.tmux_session.trim() !== '') {
           tmuxSession = parsed.tmux_session;
         }
+        if (parsed.policy?.worker_launch_mode === 'prompt') workerLaunchMode = 'prompt';
+        if (Array.isArray(parsed.workers)) promptWorkers = parsed.workers;
       } catch {
         // ignore malformed manifest
       }
     } else if (existsSync(configPath)) {
       try {
         const raw = await readFile(configPath, 'utf-8');
-        const parsed = JSON.parse(raw) as { tmux_session?: string };
+        const parsed = JSON.parse(raw) as { tmux_session?: string; worker_launch_mode?: string; workers?: Array<{ name?: string; pid?: number }> };
         if (typeof parsed.tmux_session === 'string' && parsed.tmux_session.trim() !== '') {
           tmuxSession = parsed.tmux_session;
         }
+        if (parsed.worker_launch_mode === 'prompt') workerLaunchMode = 'prompt';
+        if (Array.isArray(parsed.workers)) promptWorkers = parsed.workers;
       } catch {
         // ignore malformed config
       }
@@ -300,8 +306,19 @@ async function collectTeamDoctorIssues(cwd: string): Promise<TeamDoctorIssue[]> 
 
     knownTeamSessions.add(tmuxSession);
 
-    // resume_blocker: only meaningful if tmux is available to query
-    if (!tmuxUnavailable && !tmuxSessions.has(tmuxSession)) {
+    if (workerLaunchMode === 'prompt') {
+      for (const worker of promptWorkers) {
+        const pid = worker.pid ?? 0;
+        if (Number.isFinite(pid) && pid > 0 && isPidAlive(pid)) {
+          issues.push({
+            code: 'prompt_resume_unavailable',
+            message: `${teamName}/${worker.name ?? 'unknown'} pid ${pid} is still running, but prompt-mode worker handles are process-local and cannot be reattached after CLI restart; shut down the prompt worker or start a new team`,
+            severity: 'fail',
+          });
+        }
+      }
+    } else if (!tmuxUnavailable && !tmuxSessions.has(tmuxSession)) {
+      // resume_blocker: only meaningful if tmux is available to query for interactive teams.
       issues.push({
         code: 'resume_blocker',
         message: `${teamName} references missing tmux session ${tmuxSession}`,
@@ -401,6 +418,17 @@ async function collectTeamDoctorIssues(cwd: string): Promise<TeamDoctorIssue[]> 
   }
 
   return dedupeIssues(issues);
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    return false;
+  }
 }
 
 function dedupeIssues(issues: TeamDoctorIssue[]): TeamDoctorIssue[] {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -5375,9 +5375,24 @@ esac
       config.workers[0].pid = sleeperPid;
       config.workers[0].pane_id = null;
       await writeFile(configPath, JSON.stringify(config, null, 2));
+      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-prompt-resume', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
+      manifest.policy.worker_launch_mode = 'prompt';
+      manifest.tmux_session = 'prompt-team-prompt-resume';
+      manifest.leader_pane_id = null;
+      manifest.hud_pane_id = null;
+      manifest.workers[0].pid = sleeperPid;
+      manifest.workers[0].pane_id = null;
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
       const runtime = await resumeTeam('team-prompt-resume', cwd);
       assert.equal(runtime, null);
+
+      const events = await readTeamEvents('team-prompt-resume', cwd);
+      assert.ok(
+        events.some((event) => event.reason === `prompt_resume_unavailable:missing_handle:worker-1:${sleeperPid}`),
+        'resumeTeam should persist an explicit missing-handle diagnostic event',
+      );
     } finally {
       if (sleeperPid > 0) {
         try {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3390,7 +3390,8 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
   config.lifecycle_profile = 'default';
 
   if (config.worker_launch_mode === 'prompt') {
-    const hasLivePromptWorker = config.workers.some((worker) => isPromptWorkerAlive(config, worker));
+    const handleTeamConfig = { ...config, name: sanitized };
+    const hasLivePromptWorker = config.workers.some((worker) => isPromptWorkerAlive(handleTeamConfig, worker));
     if (!hasLivePromptWorker) return null;
 
     const missingHandles = config.workers


### PR DESCRIPTION
## Problem
Prompt-mode team resume after a CLI restart was ambiguous: prompt worker PIDs can survive, but `promptWorkerRegistry` is process-local, so `resumeTeam()` cannot recover the `ChildProcess` handles needed to safely dispatch to those workers.

## Root cause
`resumeTeam()` relies on in-memory prompt worker handles for live prompt workers. After restart, persisted worker PIDs may still be alive while the registry is empty, causing a null resume with only an event-level `missing_handle` diagnostic. `doctor --team` also treated prompt teams like tmux-backed interactive teams, producing misleading missing tmux-session diagnostics.

## Changed files
- `src/team/runtime.ts`: keeps prompt teams non-resumable after missing process-local handles and normalizes prompt-handle lookup to the requested sanitized team name.
- `src/team/__tests__/runtime.test.ts`: expands the restart regression to assert the explicit `prompt_resume_unavailable:missing_handle` event.
- `src/cli/doctor.ts`: adds `prompt_resume_unavailable` diagnostics for live prompt worker PIDs and skips tmux resume-blocker checks for prompt teams.
- `src/cli/__tests__/doctor-team.test.ts`: covers doctor output for live prompt workers that cannot be reattached after restart.

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/doctor-team.test.js`
- `node --test --test-name-pattern='resumeTeam returns null for prompt teams' dist/team/__tests__/runtime.test.js`

## Risks
- Prompt teams remain intentionally non-resumable across CLI restarts when handles are missing; this PR improves explicit diagnostics rather than attempting unsafe PID-only reattach.
- Doctor PID liveness uses `process.kill(pid, 0)`, matching existing runtime behavior but still subject to OS permission semantics.

## Overlap assessment
Checked open PRs targeting `dev` for `prompt resume`, `promptWorkerRegistry`, `resumeTeam`, and `missing_handle`; no existing PR covered this fix at the time of creation.
