### PR TITLE
Avoid model-backed team status inspect by default

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1320,6 +1320,16 @@ describe('teamCommand status', () => {
       assert.match(output, /inspect_hud: tmux capture-pane -p -t %11 -S -400/);
       assert.match(output, /inspect_worker-1: tmux capture-pane -p -t %21 -S -400/);
       assert.match(output, /inspect_worker-2: tmux capture-pane -p -t %22 -S -400/);
+      assert.match(output, /inspect_summary: .*command=tmux capture-pane -p -t %21 -S -400/);
+      assert.doesNotMatch(output
+        .split('\n')
+        .filter((line) => !line.includes('--model-inspect'))
+        .join('\n'), /omx sparkshell/);
+
+      logs.length = 0;
+      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-team', '--model-inspect']));
+      const modelInspectOutput = logs.join('\n');
+      assert.match(modelInspectOutput, /inspect_summary: .*command=omx sparkshell --tmux-pane %21 --tail-lines 400/);
     } finally {
       console.log = originalLog;
       process.chdir(previousCwd);

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1182,7 +1182,7 @@ describe('teamCommand api', () => {
 
 
 describe('teamCommand status', () => {
-  it('prints pane ids and sparkshell hint when tmux panes are recorded', async () => {
+  it('prints pane ids and raw inspect hints when tmux panes are recorded', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-panes-'));
     const previousCwd = process.cwd();
     const logs: string[] = [];
@@ -1315,11 +1315,11 @@ describe('teamCommand status', () => {
       const output = logs.join('\n');
       assert.match(output, /panes: leader=%10 hud=%11/);
       assert.match(output, /worker_panes: worker-1=%21 worker-2=%22/);
-      assert.match(output, /sparkshell_hint: omx sparkshell --tmux-pane <pane-id> --tail-lines 400/);
-      assert.match(output, /inspect_leader: omx sparkshell --tmux-pane %10 --tail-lines 400/);
-      assert.match(output, /inspect_hud: omx sparkshell --tmux-pane %11 --tail-lines 400/);
-      assert.match(output, /inspect_worker-1: omx sparkshell --tmux-pane %21 --tail-lines 400/);
-      assert.match(output, /inspect_worker-2: omx sparkshell --tmux-pane %22 --tail-lines 400/);
+      assert.match(output, /inspect_hint: raw tmux capture commands are quota-free/);
+      assert.match(output, /inspect_leader: tmux capture-pane -p -t %10 -S -400/);
+      assert.match(output, /inspect_hud: tmux capture-pane -p -t %11 -S -400/);
+      assert.match(output, /inspect_worker-1: tmux capture-pane -p -t %21 -S -400/);
+      assert.match(output, /inspect_worker-2: tmux capture-pane -p -t %22 -S -400/);
     } finally {
       console.log = originalLog;
       process.chdir(previousCwd);
@@ -1847,7 +1847,7 @@ describe('teamCommand status', () => {
     }
   });
 
-  it('supports custom tail lines for generated sparkshell commands', async () => {
+  it('supports custom tail lines for generated raw inspect commands', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-tail-lines-'));
     const previousCwd = process.cwd();
     const logs: string[] = [];
@@ -1875,6 +1875,10 @@ describe('teamCommand status', () => {
 
       console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
       await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-tail-team', '--tail-lines', '600']));
+      assert.match(logs.join('\n'), /inspect_worker-1: tmux capture-pane -p -t %51 -S -600/);
+
+      logs.length = 0;
+      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-tail-team', '--model-inspect', '--tail-lines', '600']));
       assert.match(logs.join('\n'), /inspect_worker-1: omx sparkshell --tmux-pane %51 --tail-lines 600/);
 
       logs.length = 0;

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -636,6 +636,14 @@ function formatInspectItemLine(index: number, item: TeamInspectItem, modelInspec
   return parts.filter(Boolean).join(' ');
 }
 
+function renderInspectSummary(summary: string, command: string | null): string {
+  if (!command) return summary;
+  if (/(^| )command=/.test(summary)) {
+    return summary.replace(/(^| )command=.*$/, `$1command=${command}`);
+  }
+  return `${summary} command=${command}`;
+}
+
 function renderTeamPaneStatus(
   paneStatus: TeamPaneStatus,
   modelInspect = false,
@@ -672,9 +680,7 @@ function renderTeamPaneStatus(
         ? paneStatus.recommended_inspect_command
         : rawTmuxCaptureCommand(paneStatus.recommended_inspect_items[0]?.pane_id ?? '', tailLines)
       : null;
-    const summary = summaryCommand
-      ? `${paneStatus.recommended_inspect_summary} command=${summaryCommand}`
-      : paneStatus.recommended_inspect_summary;
+    const summary = renderInspectSummary(paneStatus.recommended_inspect_summary, summaryCommand);
     console.log(`inspect_summary: ${summary}`);
   }
   for (const [index, item] of paneStatus.recommended_inspect_items.entries()) {

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -143,7 +143,7 @@ function isTerminalModePhase(phase: string): boolean {
 
 const TEAM_HELP = `
 Usage: omx team [N:agent-type] "<task description>"
-       omx team status <team-name> [--json] [--tail-lines <100-1000>]
+       omx team status <team-name> [--json] [--tail-lines <100-1000>] [--model-inspect]
        omx team await <team-name> [--timeout-ms <ms>] [--after-event-id <id>] [--json]
        omx team resume <team-name>
        omx team shutdown <team-name> [--force] [--confirm-issues]
@@ -160,7 +160,7 @@ Examples:
   omx team 3:executor "fix failing tests"
   omx team status my-team
   omx team status my-team --json
-  omx team status my-team --tail-lines 600
+  omx team status my-team --model-inspect --tail-lines 600
   omx team api send-message --input '{"team_name":"my-team","from_worker":"worker-1","to_worker":"leader-fixed","body":"ACK"}' --json
 `;
 
@@ -174,6 +174,10 @@ Supported operations:
 Examples:
   omx team api list-tasks --input '{"team_name":"my-team"}' --json
   omx team api claim-task --input '{"team_name":"my-team","task_id":"1","worker":"worker-1","expected_version":1}' --json
+
+Safety:
+  team status prints raw tmux capture commands by default so inspect hints do not spend Spark/model quota.
+  pass --model-inspect to print omx sparkshell summary commands intentionally.
 `;
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
@@ -354,6 +358,14 @@ function parseStatusTailLines(args: string[]): number {
     }
   }
   return DEFAULT_SPARKSHELL_TAIL_LINES;
+}
+
+function parseStatusModelInspect(args: string[]): boolean {
+  return args.includes('--model-inspect');
+}
+
+function rawTmuxCaptureCommand(paneId: string, tailLines: number): string {
+  return `tmux capture-pane -p -t ${paneId} -S -${tailLines}`;
 }
 
 export interface ParsedTeamStartArgs {
@@ -550,7 +562,8 @@ function inspectEntryDescriptors(paneStatus: TeamPaneStatus): InspectEntryDescri
   ];
 }
 
-function formatInspectItemLine(index: number, item: TeamInspectItem): string {
+function formatInspectItemLine(index: number, item: TeamInspectItem, modelInspect = false, tailLines = DEFAULT_SPARKSHELL_TAIL_LINES): string {
+  const command = modelInspect ? item.command : rawTmuxCaptureCommand(item.pane_id, tailLines);
   const parts = [
     `inspect_item_${index + 1}:`,
     `target=${item.target}`,
@@ -618,13 +631,15 @@ function formatInspectItemLine(index: number, item: TeamInspectItem): string {
     item.team_summary_snapshot_path ? `team_summary_snapshot_path=${item.team_summary_snapshot_path}` : '',
     `reason=${item.reason}`,
     item.state ? `state=${item.state}` : '',
-    `command=${item.command}`,
+    `command=${command}`,
   ];
   return parts.filter(Boolean).join(' ');
 }
 
 function renderTeamPaneStatus(
   paneStatus: TeamPaneStatus,
+  modelInspect = false,
+  tailLines = DEFAULT_SPARKSHELL_TAIL_LINES,
 ): void {
   if (paneStatus.leader_pane_id || paneStatus.hud_pane_id) {
     console.log(`panes: leader=${paneStatus.leader_pane_id || '-'} hud=${paneStatus.hud_pane_id || '-'}`);
@@ -636,7 +651,7 @@ function renderTeamPaneStatus(
   }
 
   if (paneStatus.sparkshell_hint) {
-    console.log('sparkshell_hint: omx sparkshell --tmux-pane <pane-id> --tail-lines 400');
+    console.log('inspect_hint: raw tmux capture commands are quota-free; rerun status with --model-inspect for omx sparkshell summaries');
   }
 
   if (paneStatus.recommended_inspect_targets.length > 0) {
@@ -646,19 +661,37 @@ function renderTeamPaneStatus(
   logInspectEntryDescriptors(inspectEntryDescriptors(paneStatus));
 
   if (paneStatus.recommended_inspect_command) {
-    console.log(`inspect_next: ${paneStatus.recommended_inspect_command}`);
+    const inspectCommand = modelInspect
+      ? paneStatus.recommended_inspect_command
+      : rawTmuxCaptureCommand(paneStatus.recommended_inspect_items[0]?.pane_id ?? '', tailLines);
+    if (inspectCommand.trim().length > 0) console.log(`inspect_next: ${inspectCommand}`);
   }
   if (paneStatus.recommended_inspect_summary) {
-    console.log(`inspect_summary: ${paneStatus.recommended_inspect_summary}`);
+    const summaryCommand = paneStatus.recommended_inspect_command
+      ? modelInspect
+        ? paneStatus.recommended_inspect_command
+        : rawTmuxCaptureCommand(paneStatus.recommended_inspect_items[0]?.pane_id ?? '', tailLines)
+      : null;
+    const summary = summaryCommand
+      ? `${paneStatus.recommended_inspect_summary} command=${summaryCommand}`
+      : paneStatus.recommended_inspect_summary;
+    console.log(`inspect_summary: ${summary}`);
   }
-  for (const [index, command] of paneStatus.recommended_inspect_commands.entries()) {
+  for (const [index, item] of paneStatus.recommended_inspect_items.entries()) {
+    const command = modelInspect ? item.command : rawTmuxCaptureCommand(item.pane_id, tailLines);
     console.log(`inspect_priority_${index + 1}: ${command}`);
   }
   for (const [index, item] of paneStatus.recommended_inspect_items.entries()) {
-    console.log(formatInspectItemLine(index, item));
+    console.log(formatInspectItemLine(index, item, modelInspect, tailLines));
   }
 
-  for (const [target, command] of Object.entries(paneStatus.sparkshell_commands)) {
+  for (const [target, paneId] of Object.entries({
+    ...(paneStatus.leader_pane_id ? { leader: paneStatus.leader_pane_id } : {}),
+    ...(paneStatus.hud_pane_id ? { hud: paneStatus.hud_pane_id } : {}),
+    ...paneStatus.worker_panes,
+  })) {
+    const modelCommand = paneStatus.sparkshell_commands[target];
+    const command = modelInspect && modelCommand ? modelCommand : rawTmuxCaptureCommand(paneId, tailLines);
     console.log(`inspect_${target}: ${command}`);
   }
 }
@@ -1240,6 +1273,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
       return;
     }
     const tailLines = parseStatusTailLines(teamArgs.slice(2));
+    const modelInspect = parseStatusModelInspect(teamArgs.slice(2));
     const config = await readTeamConfig(name, cwd);
     const paneStatus = await readTeamPaneStatus(config, cwd, snapshot, tailLines);
     if (wantsJson) {
@@ -1288,7 +1322,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
         `monitor_perf_ms: total=${snapshot.performance.total_ms} list=${snapshot.performance.list_tasks_ms} workers=${snapshot.performance.worker_scan_ms} mailbox=${snapshot.performance.mailbox_delivery_ms}`
       );
     }
-    renderTeamPaneStatus(paneStatus);
+    renderTeamPaneStatus(paneStatus, modelInspect, tailLines);
     return;
   }
 


### PR DESCRIPTION
## Summary

- Make `omx team status` text output print quota-free raw `tmux capture-pane` inspect commands by default.
- Add explicit `--model-inspect` opt-in for the previous model-backed `omx sparkshell` inspect commands.
- Update team status tests to lock the safe default and the explicit model-inspect escape hatch.

## Problem statement

`omx sparkshell` is useful, but it is not a purely local renderer for long pane output. Its native sidecar summarizes long output through `codex exec` with the Spark model by default. When a team run is stuck and status output keeps pointing operators at `omx sparkshell --tmux-pane ...`, repeated inspection can burn model quota while not advancing the team.

## Root cause

The runtime exposes pane inspection commands through `src/team/pane-status.ts`, and `src/cli/team.ts` rendered those commands directly as the default human-facing `inspect_*` hints. That made the expensive/model-backed path the normal recovery affordance instead of an intentional opt-in.

## What changed

- `omx team status <team>` now prints raw inspect commands like:
  - `tmux capture-pane -p -t %21 -S -400`
- `omx team status <team> --model-inspect` keeps the previous `omx sparkshell --tmux-pane ...` summary commands available intentionally.
- `--tail-lines` continues to control both raw capture and explicit model-inspect command generation.
- JSON status keeps the existing pane metadata shape, including `sparkshell_commands`, for compatibility.

## Why this design

Raw `tmux capture-pane` is the safe default because it is local and quota-free. `omx sparkshell` remains available when a user explicitly requests model-backed summarization with `--model-inspect`.

## Overlap assessment

**Follow-up.** Related prior work introduced/refined this area:

- #760 added `omx sparkshell` and team inspection metadata.
- #1774 refactored team status pane inspection rendering.

This PR does not duplicate either. It narrows the default human-facing inspect path after runtime evidence showed model-backed inspection can become a quota drain during stuck team supervision.

## Target-base semantic diff classification

**Bug fix with real implementation delta.** Against `origin/dev`, this changes the text-mode `omx team status` inspect behavior while preserving JSON metadata compatibility.

## Validation

- `npm run build`
- `node --test dist/cli/__tests__/team.test.js`
- `npx tsc --noEmit`
- `npm run check:no-unused`

## Risks / compatibility

- Operators used to seeing `omx sparkshell` directly in text status now need `--model-inspect` for that model-backed path.
- JSON consumers should remain compatible because pane metadata still includes `sparkshell_commands`.

## Changed files

- `src/cli/team.ts`
- `src/cli/__tests__/team.test.ts`
