### PR TITLE
Route explicit ulw through ralplan team handoff

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -57,6 +57,12 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.deepEqual(matches.map((m) => m.keyword), ['$oh-my-codex:ralplan', '$ralph']);
   });
 
+  it('keeps explicit $ulw detection compatible with ultrawork aliasing', () => {
+    const matches = detectKeywords('$ulw implement this');
+    assert.deepEqual(matches.map((m) => m.skill), ['ultrawork']);
+    assert.deepEqual(matches.map((m) => m.keyword), ['$ulw']);
+  });
+
   it('keeps recognized tokens on both sides of an unknown plugin-prefixed token in the same contiguous block', () => {
     const matches = detectKeywords('$oh-my-codex:ralplan $oh-my-codex:unknown $ralph');
     assert.deepEqual(matches.map((m) => m.skill), ['ralplan', 'ralph']);
@@ -625,6 +631,37 @@ describe('keyword detector skill-active-state lifecycle', () => {
         await readFile(join(stateDir, 'sessions', 'sess-visible', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
       ) as { active_skills?: Array<{ skill: string }> };
       assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team', 'ralph', 'ultrawork']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('routes explicit $ulw through ralplan first and defers team execution', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ulw-ralplan-team-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ulw implement the requested change',
+        sessionId: 'sess-ulw-rt',
+        threadId: 'thread-ulw-rt',
+        turnId: 'turn-ulw-rt',
+        nowIso: '2026-04-28T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'ralplan');
+      assert.equal(result.keyword, '$ralplan');
+      assert.equal(result.ulw_routing, 'ralplan->team');
+      assert.equal(result.requested_skills, undefined);
+      assert.deepEqual(result.deferred_skills, ['team']);
+      assert.deepEqual(result.active_skills?.map((entry) => entry.skill), ['ralplan']);
+      assert.equal(result.initialized_mode, 'ralplan');
+      assert.equal(result.initialized_state_path, '.omx/state/sessions/sess-ulw-rt/ralplan-state.json');
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-ulw-rt', 'ralplan-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'team-state.json')), false);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-ulw-rt', 'ultrawork-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -518,6 +518,10 @@ function normalizeExplicitSkillToken(token: string): string {
   return token === 'swarm' ? 'team' : token === 'ulw' ? 'ultrawork' : token;
 }
 
+function isExplicitUlwAliasKeyword(keyword: string): boolean {
+  return /^\$(?:oh-my-codex:)?ulw$/i.test(keyword.trim());
+}
+
 function parseExplicitSkillInvocations(text: string): ExplicitSkillParseResult {
   const results: KeywordMatch[] = [];
   const regex = /(?:^|[^\w])\$(?:(?:oh-my-codex:)?([a-z][a-z0-9-]*))\b/gi;
@@ -784,8 +788,12 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     const workflowMatches = parseExplicitSkillInvocations(normalizedInputText).matches
       .map((entry) => entry.skill)
       .filter(isTrackedWorkflowMode);
+    const explicitUlwAlias = isExplicitUlwAliasKeyword(match.keyword)
+      && /\$(?:oh-my-codex:)?ulw\b/i.test(input.text);
     const { requestedSkills: requestedWorkflowSkills, deferredSkills } = resolveRequestedWorkflowSkills(
-      workflowMatches.length > 0 ? workflowMatches : [match.skill],
+      explicitUlwAlias
+        ? ['ralplan', 'team']
+        : (workflowMatches.length > 0 ? workflowMatches : [match.skill]),
     );
 
     let nextWorkflowEntries = previousWorkflowEntries.map((entry) => ({ ...entry }));
@@ -888,6 +896,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       thread_id: input.threadId,
       turn_id: input.turnId,
       active_skills: nextWorkflowEntries,
+      ...(explicitUlwAlias ? { ulw_routing: 'ralplan->team' } : {}),
       ...(transitionMessages[0] ? { transition_message: transitionMessages[0] } : {}),
       ...(transitionMessages.length > 0 ? { transition_messages: [...new Set(transitionMessages)] } : {}),
       ...(requestedWorkflowSkills.length > 1 ? { requested_skills: requestedWorkflowSkills } : {}),

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -989,6 +989,9 @@ function buildAdditionalContextMessage(
   const deepInterviewPromptActivationNote = skillState?.initialized_mode === "deep-interview"
     ? buildDeepInterviewQuestionBridgeInstruction(cwd, payload)
     : null;
+  const explicitUlwRoutingNote = skillState?.ulw_routing === "ralplan->team"
+    ? "Explicit `ulw` alias routing: run ralplan-style consensus/planning first, then hand off execution through team mode. Keep the approved plan as the handoff contract; do not treat `ulw` as direct standalone ultrawork execution."
+    : null;
   const ultraworkPromptActivationNote = skillState?.initialized_mode === "ultrawork"
     ? "Ultrawork protocol: ground the task before editing, define pass/fail acceptance criteria, keep shared-file work local, and use direct-tool plus background evidence lanes only for truly independent work. Direct ultrawork provides lightweight verification only; Ralph owns persistence and the full verified-completion promise."
     : null;
@@ -1018,6 +1021,7 @@ function buildAdditionalContextMessage(
         ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
         : null,
       promptPriorityMessage,
+      explicitUlwRoutingNote,
       skillState.initialized_mode && skillState.initialized_state_path
         ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
         : null,
@@ -1042,6 +1046,7 @@ function buildAdditionalContextMessage(
       promptPriorityMessage,
       initializedStateMessage,
       deepInterviewPromptActivationNote,
+      explicitUlwRoutingNote,
       ultraworkPromptActivationNote,
       buildTeamRuntimeInstruction(cwd, payload),
       buildTeamHelpInstruction(cwd, payload),
@@ -1059,6 +1064,7 @@ function buildAdditionalContextMessage(
       promptPriorityMessage,
       `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
       deepInterviewPromptActivationNote,
+      explicitUlwRoutingNote,
       ultraworkPromptActivationNote,
       ralphPromptActivationNote,
       "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",


### PR DESCRIPTION
## Summary
- Routes explicit `$ulw` / `$oh-my-codex:ulw` prompt-submit activation through a ralplan-first handoff.
- Defers `team` as the execution follow-up so the approved plan remains the team contract.
- Preserves existing implicit `ulw` and Korean IME typo behavior as ultrawork-compatible shorthand.

## Problem
Operators want `ulw` to mean the same practical flow as “ralplan, then finish through team mode” for explicit workflow invocation. Before this change, `$ulw` normalized directly to the `ultrawork` workflow seed, so there was no deterministic planning-first handoff.

## Root cause
`parseExplicitSkillInvocations()` normalized the `ulw` token to the `ultrawork` skill and `recordSkillActivation()` used that normalized skill list directly. That made `$ulw` indistinguishable from direct ultrawork activation during state seeding.

## What changed
- Added an explicit `$ulw` alias check in `recordSkillActivation()`.
- When the original prompt actually contains explicit `$ulw` / `$oh-my-codex:ulw`, activation now requests `ralplan` first and defers `team`.
- Added a `ulw_routing: "ralplan->team"` marker so native hook additional context can tell the agent to plan first, then hand off through team.
- Added regression coverage for explicit `$ulw` detection and state seeding.

## Why this design
- Keeps the existing keyword parser compatibility: `$ulw` still detects as the ultrawork alias at the detection layer.
- Applies the new behavior only at workflow-state seeding time, where the ralplan/team handoff contract matters.
- Avoids broad remapping of implicit `ulw` prose or Korean IME typo normalization, preserving prior operator shortcuts.

## Overlap assessment
- Related issue: #715 is adjacent historical context about separating team mode and ultrawork orchestration assumptions.
- Matching PR search for `ulw ralplan team ultrawork`: no open/closed PR already delivers this explicit `$ulw` → ralplan/team routing.
- Classification: **Adjacent but distinct**.

## Target-base semantic diff classification
**Net-new behavior change** against `dev`: explicit `$ulw` / `$oh-my-codex:ulw` prompt-submit state seeding now starts `ralplan` and defers `team`, instead of directly seeding `ultrawork`.

## Validation
- `git diff --check`
- `npm install`
- `npm run build`
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `node --test dist/hooks/__tests__/keyword-detector.test.js`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js`

## Risks / compatibility
- Existing implicit `ulw` and Korean IME typo activation remain on the ultrawork-compatible path.
- The new ralplan/team behavior intentionally applies only when the original user prompt contains explicit `$ulw` or `$oh-my-codex:ulw`.

## Changed files
- `src/hooks/keyword-detector.ts`
- `src/scripts/codex-native-hook.ts`
- `src/hooks/__tests__/keyword-detector.test.ts`
