### PR TITLE
Reduce macOS startup polling pressure

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -79,6 +79,7 @@ describe('omx question CLI', () => {
     let stderr = '';
     child.stdout.on('data', (chunk) => { stdout += String(chunk); });
     child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+    const closePromise = new Promise<number | null>((resolve) => child.on('close', resolve));
 
     const questionsDir = join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions');
     let recordFile = '';
@@ -111,7 +112,7 @@ describe('omx question CLI', () => {
       other_text: 'free text answer',
     });
 
-    const exitCode = await new Promise<number | null>((resolve) => child.on('close', resolve));
+    const exitCode = await closePromise;
     assert.equal(exitCode, 0, stderr || stdout);
     const payload = JSON.parse(stdout);
     assert.equal(payload.ok, true);
@@ -480,6 +481,7 @@ esac
     let stderr = '';
     child.stdout.on('data', (chunk) => { stdout += String(chunk); });
     child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+    const closePromise = new Promise<number | null>((resolve) => child.on('close', resolve));
 
     const questionsDir = join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions');
     let recordFile = '';
@@ -510,7 +512,7 @@ esac
       selected_values: ['a'],
     });
 
-    const exitCode = await new Promise<number | null>((resolve) => child.on('close', resolve));
+    const exitCode = await closePromise;
     assert.equal(exitCode, 0, stderr || stdout);
     const payload = JSON.parse(stdout);
     assert.equal(payload.ok, true);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2737,6 +2737,10 @@ function runCodex(
       ? buildWindowsPromptCommand("codex", launchArgs)
       : null;
     const sessionName = buildDetachedTmuxSessionName(cwd, sessionId);
+    void writeSessionStart(cwd, sessionId, { tmuxSessionName: sessionName }).catch((err) => {
+      logCliOperationFailure(err);
+      // Non-fatal: managed tmux recovery can still use compatibility fallback.
+    });
     let createdDetachedSession = false;
     let registeredHookTarget: string | null = null;
     let registeredHookName: string | null = null;

--- a/src/hooks/__tests__/codebase-map.test.ts
+++ b/src/hooks/__tests__/codebase-map.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
+import { mkdtemp, rm, mkdir, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
@@ -130,6 +130,74 @@ describe('generateCodebaseMap', () => {
       assert.ok(!map.includes('secret-wip'), 'must not expose untracked filename');
     } finally {
       await rm(secDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses a durable cache for unchanged git index state', async () => {
+    const cacheDir = await mkdtemp(join(tmpdir(), 'omx-codebase-cache-'));
+    try {
+      execSync('git init', { cwd: cacheDir, stdio: 'ignore' });
+      execSync('git config user.email "test@test.com"', { cwd: cacheDir, stdio: 'ignore' });
+      execSync('git config user.name "Test"', { cwd: cacheDir, stdio: 'ignore' });
+      await mkdir(join(cacheDir, 'src'), { recursive: true });
+      await writeFile(join(cacheDir, 'src', 'tracked.ts'), 'export function tracked() {}');
+      execSync('git add src/tracked.ts', { cwd: cacheDir, stdio: 'ignore' });
+
+      const map = await generateCodebaseMap(cacheDir);
+      assert.ok(map.includes('tracked'));
+
+      const cachePath = join(cacheDir, '.omx', 'cache', 'codebase-map.json');
+      const cache = JSON.parse(await readFile(cachePath, 'utf-8'));
+      cache.map = '  src/: cached-only';
+      await writeFile(cachePath, JSON.stringify(cache, null, 2));
+
+      assert.equal(await generateCodebaseMap(cacheDir), '  src/: cached-only');
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidates stale and corrupt durable cache entries safely', async () => {
+    const cacheDir = await mkdtemp(join(tmpdir(), 'omx-codebase-cache-stale-'));
+    try {
+      execSync('git init', { cwd: cacheDir, stdio: 'ignore' });
+      execSync('git config user.email "test@test.com"', { cwd: cacheDir, stdio: 'ignore' });
+      execSync('git config user.name "Test"', { cwd: cacheDir, stdio: 'ignore' });
+      await mkdir(join(cacheDir, 'src'), { recursive: true });
+      await writeFile(join(cacheDir, 'src', 'first.ts'), 'export function first() {}');
+      execSync('git add src/first.ts', { cwd: cacheDir, stdio: 'ignore' });
+
+      assert.ok((await generateCodebaseMap(cacheDir)).includes('first'));
+      const cachePath = join(cacheDir, '.omx', 'cache', 'codebase-map.json');
+      await writeFile(cachePath, '{not-json');
+      assert.ok((await generateCodebaseMap(cacheDir)).includes('first'), 'corrupt cache should regenerate');
+
+      await writeFile(join(cacheDir, 'src', 'second.ts'), 'export function second() {}');
+      execSync('git add src/second.ts', { cwd: cacheDir, stdio: 'ignore' });
+      const updated = await generateCodebaseMap(cacheDir);
+      assert.ok(updated.includes('first'));
+      assert.ok(updated.includes('second'), 'index change should invalidate stale cache');
+      assert.ok(!updated.includes('secret-wip'), 'cache regeneration must not leak untracked names');
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  it('caches empty tracked-source results without exposing .omx paths', async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), 'omx-codebase-empty-cache-'));
+    try {
+      execSync('git init', { cwd: emptyDir, stdio: 'ignore' });
+      await writeFile(join(emptyDir, 'README.md'), '# empty source set\n');
+      execSync('git add README.md', { cwd: emptyDir, stdio: 'ignore' });
+      await mkdir(join(emptyDir, '.omx', 'cache'), { recursive: true });
+      await writeFile(join(emptyDir, '.omx', 'cache', 'secret.ts'), 'export const secret = true;');
+
+      assert.equal(await generateCodebaseMap(emptyDir), '');
+      const cache = JSON.parse(await readFile(join(emptyDir, '.omx', 'cache', 'codebase-map.json'), 'utf-8'));
+      assert.equal(cache.map, '');
+      assert.doesNotMatch(JSON.stringify(cache), /secret\.ts/);
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
     }
   });
 

--- a/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
+++ b/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
@@ -124,6 +124,63 @@ describe('notify-hook managed tmux windows fallback', () => {
     }
   });
 
+  it('uses authoritative tmux session metadata before recomputing branch-based names', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-authoritative-'));
+    try {
+      const sessionId = 'omx-authoritative-session';
+      const tmuxSessionName = 'omx-authoritative-without-git';
+      await writeSessionStart(cwd, sessionId, { tmuxSessionName });
+
+      await withFakeTmux(cwd, `#!/usr/bin/env bash
+if [[ "$1" == "display-message" ]]; then
+  echo "${tmuxSessionName}"
+  exit 0
+fi
+exit 1
+`, async () => {
+        process.env.TMUX = '1';
+        delete process.env.TMUX_PANE;
+        process.env.OMX_TEAM_WORKER = '';
+
+        const result = await resolveManagedSessionContext(cwd, { session_id: sessionId }, { allowTeamWorker: false });
+        assert.equal(result.managed, true);
+        assert.equal(result.reason, 'tmux_session_match');
+        assert.equal(result.expectedTmuxSessionName, tmuxSessionName);
+        assert.equal(result.currentTmuxSessionName, tmuxSessionName);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when authoritative tmux metadata disagrees with the active tmux session', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-authoritative-mismatch-'));
+    try {
+      const sessionId = 'omx-authoritative-session';
+      await writeSessionStart(cwd, sessionId, { tmuxSessionName: 'omx-expected-session' });
+
+      await withFakeTmux(cwd, `#!/usr/bin/env bash
+if [[ "$1" == "display-message" ]]; then
+  echo "omx-other-session"
+  exit 0
+fi
+exit 1
+`, async () => {
+        process.env.TMUX = '1';
+        delete process.env.TMUX_PANE;
+        process.env.OMX_TEAM_WORKER = '';
+
+        const result = await resolveManagedSessionContext(cwd, { session_id: sessionId }, { allowTeamWorker: false });
+        assert.equal(result.managed, false);
+        assert.equal(result.reason, 'tmux_session_mismatch');
+        assert.equal(result.expectedTmuxSessionName, 'omx-expected-session');
+        assert.equal(result.currentTmuxSessionName, 'omx-other-session');
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('accepts symlinked cwd aliases for the same managed session', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-cwd-alias-'));
     const aliasCwd = `${cwd}-alias`;

--- a/src/hooks/codebase-map.ts
+++ b/src/hooks/codebase-map.ts
@@ -13,8 +13,11 @@
  * - Safe: all errors return empty string (never blocks session start)
  */
 
-import { extname, basename } from 'path';
-import { execSync } from 'child_process';
+import { statSync } from 'node:fs';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { basename, extname, join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { findGitLayout } from '../utils/git-layout.js';
 
 /** Max chars for the whole map output. */
 const MAX_MAP_CHARS = 1000;
@@ -27,6 +30,74 @@ const MAX_DIRS = 14;
 
 /** Source extensions whose exports are worth scanning. */
 const SOURCE_EXTS = new Set(['.ts', '.tsx', '.js', '.mjs']);
+const CACHE_VERSION = 1;
+
+interface CodebaseMapCacheFile {
+  version: number;
+  worktreeRoot: string;
+  gitDir: string;
+  indexMtimeMs: number;
+  indexSize: number;
+  map: string;
+  createdAt: string;
+}
+
+function cachePathForWorktree(worktreeRoot: string): string {
+  return join(worktreeRoot, '.omx', 'cache', 'codebase-map.json');
+}
+
+function readGitIndexSignature(gitDir: string): { mtimeMs: number; size: number } | null {
+  try {
+    const stat = statSync(join(gitDir, 'index'));
+    return { mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch {
+    return null;
+  }
+}
+
+async function readCachedCodebaseMap(
+  worktreeRoot: string,
+  gitDir: string,
+  indexSignature: { mtimeMs: number; size: number },
+): Promise<string | null> {
+  try {
+    const parsed = JSON.parse(await readFile(cachePathForWorktree(worktreeRoot), 'utf-8')) as Partial<CodebaseMapCacheFile>;
+    if (parsed.version !== CACHE_VERSION) return null;
+    if (parsed.worktreeRoot !== worktreeRoot) return null;
+    if (parsed.gitDir !== gitDir) return null;
+    if (parsed.indexMtimeMs !== indexSignature.mtimeMs) return null;
+    if (parsed.indexSize !== indexSignature.size) return null;
+    return typeof parsed.map === 'string' ? parsed.map : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCachedCodebaseMap(
+  worktreeRoot: string,
+  gitDir: string,
+  indexSignature: { mtimeMs: number; size: number },
+  map: string,
+): Promise<void> {
+  const targetPath = cachePathForWorktree(worktreeRoot);
+  const tempPath = `${targetPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await mkdir(join(worktreeRoot, '.omx', 'cache'), { recursive: true });
+    const payload: CodebaseMapCacheFile = {
+      version: CACHE_VERSION,
+      worktreeRoot,
+      gitDir,
+      indexMtimeMs: indexSignature.mtimeMs,
+      indexSize: indexSignature.size,
+      map,
+      createdAt: new Date().toISOString(),
+    };
+    await writeFile(tempPath, JSON.stringify(payload, null, 2));
+    await rename(tempPath, targetPath);
+  } catch {
+    await rm(tempPath, { force: true }).catch(() => {});
+  }
+}
 
 /**
  * Return git-tracked source files relative to cwd.
@@ -44,7 +115,7 @@ function getTrackedSourceFiles(cwd: string): string[] {
     return out
       .trim()
       .split('\n')
-      .filter((f) => f && SOURCE_EXTS.has(extname(f)));
+      .filter((f) => f && !f.split('/').includes('.omx') && SOURCE_EXTS.has(extname(f)));
   } catch {
     return [];
   }
@@ -112,8 +183,20 @@ function buildDirLine(dir: string, files: string[]): string {
  */
 export async function generateCodebaseMap(cwd: string): Promise<string> {
   try {
+    const layout = findGitLayout(cwd);
+    const indexSignature = layout ? readGitIndexSignature(layout.gitDir) : null;
+    if (layout && indexSignature) {
+      const cached = await readCachedCodebaseMap(layout.worktreeRoot, layout.gitDir, indexSignature);
+      if (cached !== null) return cached;
+    }
+
     const files = getTrackedSourceFiles(cwd);
-    if (files.length === 0) return '';
+    if (files.length === 0) {
+      if (layout && indexSignature) {
+        await writeCachedCodebaseMap(layout.worktreeRoot, layout.gitDir, indexSignature, '');
+      }
+      return '';
+    }
 
     const grouped = groupByTopDir(files);
     const sortedDirs = sortDirs([...grouped.keys()]);
@@ -145,10 +228,21 @@ export async function generateCodebaseMap(cwd: string): Promise<string> {
       }
     }
 
-    if (lines.length === 0) return '';
+    if (lines.length === 0) {
+      if (layout && indexSignature) {
+        await writeCachedCodebaseMap(layout.worktreeRoot, layout.gitDir, indexSignature, '');
+      }
+      return '';
+    }
 
     const body = lines.join('\n');
-    return body.length > MAX_MAP_CHARS ? body.slice(0, MAX_MAP_CHARS - 3) + '...' : body;
+    const map = body.length <= MAX_MAP_CHARS
+      ? body
+      : body.slice(0, MAX_MAP_CHARS - 3) + '...';
+    if (layout && indexSignature) {
+      await writeCachedCodebaseMap(layout.worktreeRoot, layout.gitDir, indexSignature, map);
+    }
+    return map;
   } catch {
     return '';
   }

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -20,6 +20,7 @@ export interface SessionState {
   platform?: NodeJS.Platform;
   pid_start_ticks?: number;
   pid_cmdline?: string;
+  tmux_session_name?: string;
 }
 
 const SESSION_FILE = 'session.json';
@@ -158,6 +159,7 @@ interface SessionStartOptions {
   pid?: number;
   platform?: NodeJS.Platform;
   nativeSessionId?: string;
+  tmuxSessionName?: string;
 }
 
 function defaultIsPidAlive(pid: number): boolean {
@@ -221,11 +223,15 @@ function createSessionState(
     nowIso?: string;
     nativeSessionId?: string;
     startedAt?: string;
+    tmuxSessionName?: string;
   } = {},
 ): SessionState {
   const nowIso = options.nowIso ?? new Date().toISOString();
   const nativeSessionId = typeof options.nativeSessionId === 'string' && options.nativeSessionId.trim()
     ? options.nativeSessionId.trim()
+    : undefined;
+  const tmuxSessionName = typeof options.tmuxSessionName === 'string' && options.tmuxSessionName.trim()
+    ? options.tmuxSessionName.trim()
     : undefined;
 
   return {
@@ -237,6 +243,7 @@ function createSessionState(
     platform,
     pid_start_ticks: linuxIdentity?.startTicks,
     pid_cmdline: linuxIdentity?.cmdline ?? undefined,
+    ...(tmuxSessionName ? { tmux_session_name: tmuxSessionName } : {}),
   };
 }
 
@@ -293,6 +300,7 @@ export async function writeSessionStart(
     : null;
   const state = createSessionState(cwd, sessionId, pid, platform, linuxIdentity, {
     nativeSessionId: options.nativeSessionId,
+    tmuxSessionName: options.tmuxSessionName,
   });
 
   await writeFile(sessionPath(cwd), JSON.stringify(state, null, 2));
@@ -349,6 +357,7 @@ export async function reconcileNativeSessionStart(
     nowIso,
     nativeSessionId,
     startedAt: existing.started_at,
+    tmuxSessionName: existing.tmux_session_name,
   });
 
   await writeFile(sessionPath(cwd), JSON.stringify(state, null, 2));

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -9,6 +9,7 @@ import {
   isParentProcessAlive,
   parseProcessTable,
   resolveCurrentMcpEntrypointMarker,
+  resolveDuplicateSiblingWatchdogInitialDelayMs,
   shouldAutoStartMcpServer,
   shouldSelfExitForDuplicateSibling,
   type McpServerName,
@@ -89,6 +90,24 @@ describe('mcp parent watchdog liveness checks', () => {
 });
 
 describe('mcp shared stdio lifecycle contract', () => {
+  it('keeps server connection immediate and duplicate process-table scans delayed', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/bootstrap.ts'), 'utf8');
+    const connectIndex = src.indexOf('server.connect(transport)');
+    const duplicateDelayIndex = src.indexOf('duplicateSiblingInitialDelayTimer = setTimeout');
+
+    assert.ok(connectIndex > 0, 'bootstrap should still connect the MCP transport');
+    assert.ok(duplicateDelayIndex > 0, 'bootstrap should delay duplicate-sibling process scans');
+    assert.ok(
+      connectIndex > duplicateDelayIndex,
+      'duplicate-sibling scan delay must not wrap or delay server.connect',
+    );
+    assert.match(
+      src,
+      /const transport = new StdioServerTransport\(\);/,
+      'transport construction should remain eager',
+    );
+  });
+
   it('keeps shared stdio lifecycle wiring in bootstrap', async () => {
     const src = await readFile(join(process.cwd(), 'src/mcp/bootstrap.ts'), 'utf8');
 
@@ -128,6 +147,41 @@ describe('mcp shared stdio lifecycle contract', () => {
 });
 
 describe('mcp duplicate sibling detection', () => {
+  it('resolves deterministic bounded initial duplicate scan delays', () => {
+    const stateDelay = resolveDuplicateSiblingWatchdogInitialDelayMs(
+      'state',
+      'state-server.js',
+      { duplicateSiblingInitialDelayMs: null, duplicateSiblingInitialDelayMaxMs: 1000 },
+    );
+    const memoryDelay = resolveDuplicateSiblingWatchdogInitialDelayMs(
+      'memory',
+      'memory-server.js',
+      { duplicateSiblingInitialDelayMs: null, duplicateSiblingInitialDelayMaxMs: 1000 },
+    );
+
+    assert.equal(
+      stateDelay,
+      resolveDuplicateSiblingWatchdogInitialDelayMs(
+        'state',
+        'state-server.js',
+        { duplicateSiblingInitialDelayMs: null, duplicateSiblingInitialDelayMaxMs: 1000 },
+      ),
+      'delay should be stable for a server/entrypoint',
+    );
+    assert.ok(stateDelay >= 0 && stateDelay <= 1000);
+    assert.ok(memoryDelay >= 0 && memoryDelay <= 1000);
+    assert.notEqual(stateDelay, memoryDelay, 'first-party servers should be staggered by default');
+    assert.equal(
+      resolveDuplicateSiblingWatchdogInitialDelayMs(
+        'state',
+        'state-server.js',
+        { duplicateSiblingInitialDelayMs: 0, duplicateSiblingInitialDelayMaxMs: 1000 },
+      ),
+      0,
+      'explicit zero delay should remain available for tests/operators',
+    );
+  });
+
   it('extracts same-entrypoint markers from command lines', () => {
     assert.equal(
       extractMcpEntrypointMarker('node /tmp/oh-my-codex/dist/mcp/state-server.js'),

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -18,11 +18,14 @@ const PARENT_WATCHDOG_INTERVAL_ENV = 'OMX_MCP_PARENT_WATCHDOG_INTERVAL_MS';
 const DUPLICATE_SIBLING_WATCHDOG_INTERVAL_ENV = 'OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS';
 const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS';
 const DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS';
+const DUPLICATE_SIBLING_INITIAL_DELAY_ENV = 'OMX_MCP_DUPLICATE_SIBLING_INITIAL_DELAY_MS';
+const DUPLICATE_SIBLING_INITIAL_DELAY_MAX_ENV = 'OMX_MCP_DUPLICATE_SIBLING_INITIAL_DELAY_MAX_MS';
 export const MCP_ENTRYPOINT_MARKER_ENV = 'OMX_MCP_ENTRYPOINT_MARKER';
 const DEFAULT_PARENT_WATCHDOG_INTERVAL_MS = 1_000;
 const DEFAULT_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
 const DEFAULT_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
 const DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS = 60_000;
+const DEFAULT_DUPLICATE_SIBLING_INITIAL_DELAY_MAX_MS = 1_000;
 const MCP_ENTRYPOINT_PATTERN = /\b([a-z0-9-]+-server\.(?:[cm]?js|ts))\b/i;
 const MCP_SERVE_TARGET_PATTERN = /(?:^|\s)mcp-serve\s+([^\s]+)/i;
 
@@ -49,6 +52,8 @@ interface LifecycleTimingConfig {
   duplicateSiblingWatchdogIntervalMs: number;
   duplicateSiblingPreTrafficGraceMs: number;
   duplicateSiblingPostTrafficIdleMs: number;
+  duplicateSiblingInitialDelayMs: number | null;
+  duplicateSiblingInitialDelayMaxMs: number;
 }
 
 function normalizeCommand(command: string): string {
@@ -182,6 +187,17 @@ export function analyzeDuplicateSiblingState(
   };
 }
 
+function readNonNegativeIntegerEnv(
+  env: Record<string, string | undefined>,
+  name: string,
+  fallback: number | null,
+): number | null {
+  const raw = env[name];
+  if (typeof raw !== 'string' || raw.trim() === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
 function readPositiveIntegerEnv(
   env: Record<string, string | undefined>,
   name: string,
@@ -217,7 +233,39 @@ function resolveLifecycleTimingConfig(
       DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_ENV,
       DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
     ),
+    duplicateSiblingInitialDelayMs: readNonNegativeIntegerEnv(
+      env,
+      DUPLICATE_SIBLING_INITIAL_DELAY_ENV,
+      null,
+    ),
+    duplicateSiblingInitialDelayMaxMs: readPositiveIntegerEnv(
+      env,
+      DUPLICATE_SIBLING_INITIAL_DELAY_MAX_ENV,
+      DEFAULT_DUPLICATE_SIBLING_INITIAL_DELAY_MAX_MS,
+    ),
   };
+}
+
+function stableStringHash(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash * 31) + value.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+export function resolveDuplicateSiblingWatchdogInitialDelayMs(
+  serverName: McpServerName,
+  entrypoint: string | null,
+  config: Pick<LifecycleTimingConfig, 'duplicateSiblingInitialDelayMs' | 'duplicateSiblingInitialDelayMaxMs'>,
+): number {
+  if (typeof config.duplicateSiblingInitialDelayMs === 'number') {
+    return Math.max(0, config.duplicateSiblingInitialDelayMs);
+  }
+
+  const maxMs = Math.max(0, config.duplicateSiblingInitialDelayMaxMs);
+  if (maxMs <= 0) return 0;
+  return stableStringHash(`${serverName}:${entrypoint ?? 'unknown'}`) % (maxMs + 1);
 }
 
 export function shouldSelfExitForDuplicateSibling(
@@ -311,46 +359,64 @@ export function autoStartStdioMcpServer(
     }, lifecycleTiming.parentWatchdogIntervalMs)
     : null;
   parentWatchdog?.unref();
-  const duplicateSiblingWatchdog = trackedParentPid > 1 && trackedEntrypoint
-    ? setInterval(() => {
-      const processes = listProcessTable();
-      if (!processes) {
-        duplicateObservedAtMs = null;
-        return;
-      }
+  let duplicateSiblingWatchdog: ReturnType<typeof setInterval> | null = null;
+  let duplicateSiblingInitialDelayTimer: ReturnType<typeof setTimeout> | null = null;
 
-      const observation = analyzeDuplicateSiblingState(
-        processes,
-        process.pid,
-        trackedParentPid,
-        trackedEntrypoint,
+  const runDuplicateSiblingWatchdog = () => {
+    const processes = listProcessTable();
+    if (!processes) {
+      duplicateObservedAtMs = null;
+      return;
+    }
+
+    const observation = analyzeDuplicateSiblingState(
+      processes,
+      process.pid,
+      trackedParentPid,
+      trackedEntrypoint,
+    );
+
+    if (observation.status !== 'older_duplicate') {
+      duplicateObservedAtMs = null;
+      return;
+    }
+
+    duplicateObservedAtMs ??= Date.now();
+    if (!shouldSelfExitForDuplicateSibling(
+      observation,
+      Date.now(),
+      duplicateObservedAtMs,
+      lastTrafficAtMs,
+      lifecycleTiming.duplicateSiblingPreTrafficGraceMs,
+      lifecycleTiming.duplicateSiblingPostTrafficIdleMs,
+    )) {
+      return;
+    }
+
+    void shutdown(
+      lastTrafficAtMs !== null && lastTrafficAtMs > duplicateObservedAtMs
+        ? 'superseded_duplicate_after_idle'
+        : 'superseded_duplicate_before_traffic',
+    );
+  };
+
+  if (trackedParentPid > 1 && trackedEntrypoint) {
+    const initialDelayMs = resolveDuplicateSiblingWatchdogInitialDelayMs(
+      serverName,
+      trackedEntrypoint,
+      lifecycleTiming,
+    );
+    duplicateSiblingInitialDelayTimer = setTimeout(() => {
+      duplicateSiblingInitialDelayTimer = null;
+      runDuplicateSiblingWatchdog();
+      duplicateSiblingWatchdog = setInterval(
+        runDuplicateSiblingWatchdog,
+        lifecycleTiming.duplicateSiblingWatchdogIntervalMs,
       );
-
-      if (observation.status !== 'older_duplicate') {
-        duplicateObservedAtMs = null;
-        return;
-      }
-
-      duplicateObservedAtMs ??= Date.now();
-      if (!shouldSelfExitForDuplicateSibling(
-        observation,
-        Date.now(),
-        duplicateObservedAtMs,
-        lastTrafficAtMs,
-        lifecycleTiming.duplicateSiblingPreTrafficGraceMs,
-        lifecycleTiming.duplicateSiblingPostTrafficIdleMs,
-      )) {
-        return;
-      }
-
-      void shutdown(
-        lastTrafficAtMs !== null && lastTrafficAtMs > duplicateObservedAtMs
-          ? 'superseded_duplicate_after_idle'
-          : 'superseded_duplicate_before_traffic',
-      );
-    }, lifecycleTiming.duplicateSiblingWatchdogIntervalMs)
-    : null;
-  duplicateSiblingWatchdog?.unref();
+      duplicateSiblingWatchdog.unref();
+    }, initialDelayMs);
+    duplicateSiblingInitialDelayTimer.unref();
+  }
 
   const shutdown = async (reason: string) => {
     if (shuttingDown) {
@@ -360,6 +426,9 @@ export function autoStartStdioMcpServer(
     logLifecycle(`transport shutdown: ${reason}`);
     if (parentWatchdog) {
       clearInterval(parentWatchdog);
+    }
+    if (duplicateSiblingInitialDelayTimer) {
+      clearTimeout(duplicateSiblingInitialDelayTimer);
     }
     if (duplicateSiblingWatchdog) {
       clearInterval(duplicateSiblingWatchdog);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -30,6 +30,7 @@ import {
   writeTeamPhase,
 } from "../team/state.js";
 import { omxNotepadPath, omxProjectMemoryPath } from "../utils/paths.js";
+import { findGitLayout } from "../utils/git-layout.js";
 import { getStateFilePath, getStatePath } from "../mcp/state-paths.js";
 import {
   detectKeywords,
@@ -616,6 +617,22 @@ function tryReadGitValue(cwd: string, args: string[]): string | null {
   }
 }
 
+
+function localExcludeAlreadyIgnoresOmx(cwd: string): boolean {
+  const layout = findGitLayout(cwd);
+  if (!layout) return false;
+  const excludePath = join(layout.gitDir, "info", "exclude");
+  try {
+    const lines = readFileSync(excludePath, "utf-8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"));
+    return lines.includes(".omx/") || lines.includes(".omx");
+  } catch {
+    return false;
+  }
+}
+
 function isPathIgnoredByGit(cwd: string, path: string): boolean {
   try {
     execFileSync("git", ["check-ignore", "-q", path], {
@@ -632,7 +649,7 @@ function isPathIgnoredByGit(cwd: string, path: string): boolean {
 async function ensureOmxLocalIgnoreEntry(cwd: string): Promise<{ changed: boolean; excludePath?: string }> {
   const repoRoot = tryReadGitValue(cwd, ["rev-parse", "--show-toplevel"]);
   if (!repoRoot) return { changed: false };
-  if (isPathIgnoredByGit(repoRoot, ".omx/")) {
+  if (localExcludeAlreadyIgnoresOmx(repoRoot) || isPathIgnoredByGit(repoRoot, ".omx/")) {
     return { changed: false };
   }
 

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -61,6 +61,10 @@ function readNativeSessionId(sessionState: { native_session_id?: unknown; codex_
   return safeString(sessionState.native_session_id || sessionState.codex_session_id || '').trim();
 }
 
+function readAuthoritativeTmuxSessionName(sessionState: { tmux_session_name?: unknown; tmuxSessionName?: unknown }): string {
+  return safeString(sessionState.tmux_session_name || sessionState.tmuxSessionName || '').trim();
+}
+
 function readCurrentTmuxSessionName(): string {
   if (!process.env.TMUX) return '';
   try {
@@ -154,15 +158,29 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
     }
 
     const authoritativeSessionCwd = safeString(sessionState.cwd || cwd).trim() || cwd;
-    const expectedTmuxSessionName = buildExpectedManagedTmuxSessionName(
-      authoritativeSessionCwd,
-      canonicalSessionId || invocationSessionId,
-    );
+    const authoritativeTmuxSessionName = readAuthoritativeTmuxSessionName(sessionState);
+    const expectedTmuxSessionName = authoritativeTmuxSessionName
+      || buildExpectedManagedTmuxSessionName(
+        authoritativeSessionCwd,
+        canonicalSessionId || invocationSessionId,
+      );
     const currentTmuxSessionName = readCurrentTmuxSessionName();
     if (currentTmuxSessionName && currentTmuxSessionName === expectedTmuxSessionName) {
       return {
         managed: true,
         reason: 'tmux_session_match',
+        invocationSessionId,
+        canonicalSessionId,
+        nativeSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+      };
+    }
+    if (authoritativeTmuxSessionName && currentTmuxSessionName) {
+      return {
+        managed: false,
+        reason: 'tmux_session_mismatch',
         invocationSessionId,
         canonicalSessionId,
         nativeSessionId,


### PR DESCRIPTION
## Summary
- Stagger duplicate-sibling MCP watchdog process-table scans after startup while preserving eager `server.connect()` behavior.
- Add a git-index-keyed durable codebase-map cache so unchanged launches avoid repeated `git ls-files` shell-outs without exposing untracked `.omx` paths.
- Avoid a redundant `git check-ignore` call when `.git/info/exclude` already proves `.omx/` is ignored.
- Persist detached tmux session names and prefer that authoritative metadata in notify recovery, failing closed on mismatches while preserving PID ancestry fallback when metadata is absent.

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/bootstrap.test.js dist/hooks/__tests__/codebase-map.test.js dist/hooks/__tests__/notify-hook-managed-tmux.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `npm test`

## Notes
- Preserves launch/runtime/MCP/tmux contracts; default MCP startup remains eager.
- No Gatekeeper or OS security weakening.
- Not measured on real Intel macOS trustd/syspolicyd; mitigations reduce startup/polling process and git shell-out pressure by construction.

Closes #1986.
