### PR TITLE
Fix omx_state persistence after transport disconnects

### DIFF
--- a/plugins/oh-my-codex/skills/ralph/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralph/SKILL.md
@@ -95,6 +95,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 - If ToolSearch finds no MCP tools or Codex is unavailable, proceed with architect agent verification alone -- never block on external tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
 - Persist context snapshot path in Ralph mode state so later phases and agents share the same grounding context
+- If an `omx_state` MCP tool call reports that its stdio transport is unavailable/closed, do **not** retry the same MCP call. Retry once through the supported CLI parity surface with the same payload, preserving `workingDirectory` and `session_id`: `omx state write --input '<json>' --json`, `omx state read --input '<json>' --json`, or `omx state clear --input '<json>' --json`. If the CLI path also fails, continue with `.omx/context` / `.omx/plans` file-backed artifacts and report the state persistence blocker.
 </Tool_Usage>
 
 ## State Management

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -95,6 +95,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 - If ToolSearch finds no MCP tools or Codex is unavailable, proceed with architect agent verification alone -- never block on external tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
 - Persist context snapshot path in Ralph mode state so later phases and agents share the same grounding context
+- If an `omx_state` MCP tool call reports that its stdio transport is unavailable/closed, do **not** retry the same MCP call. Retry once through the supported CLI parity surface with the same payload, preserving `workingDirectory` and `session_id`: `omx state write --input '<json>' --json`, `omx state read --input '<json>' --json`, or `omx state clear --input '<json>' --json`. If the CLI path also fails, continue with `.omx/context` / `.omx/plans` file-backed artifacts and report the state persistence blocker.
 </Tool_Usage>
 
 ## State Management

--- a/src/cli/__tests__/mcp-parity.test.ts
+++ b/src/cli/__tests__/mcp-parity.test.ts
@@ -49,6 +49,106 @@ describe("mcpParityCommand", () => {
     }
   });
 
+  it("preserves session-scoped state when used as the state fallback path", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-mcp-parity-state-session-"));
+    const logs = captureLogs();
+    const previousDisable = process.env.OMX_STATE_SERVER_DISABLE_AUTO_START;
+
+    try {
+      process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = "1";
+      await mcpParityCommand("state", [
+        "write",
+        "--input",
+        JSON.stringify({
+          mode: "ralph",
+          active: true,
+          current_phase: "executing",
+          session_id: "session-fallback",
+          workingDirectory: cwd,
+        }),
+        "--json",
+      ]);
+      const writeResult = JSON.parse(logs.pop() || "{}") as { path?: string };
+      assert.equal(
+        writeResult.path,
+        join(cwd, ".omx", "state", "sessions", "session-fallback", "ralph-state.json"),
+      );
+
+      await mcpParityCommand("state", [
+        "read",
+        "--input",
+        JSON.stringify({
+          mode: "ralph",
+          session_id: "session-fallback",
+          workingDirectory: cwd,
+        }),
+        "--json",
+      ]);
+      const readResult = JSON.parse(logs.pop() || "{}") as {
+        active?: boolean;
+        current_phase?: string;
+        owner_omx_session_id?: string;
+      };
+      assert.equal(readResult.active, true);
+      assert.equal(readResult.current_phase, "executing");
+      assert.equal(readResult.owner_omx_session_id, "session-fallback");
+    } finally {
+      if (typeof previousDisable === "string") process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = previousDisable;
+      else delete process.env.OMX_STATE_SERVER_DISABLE_AUTO_START;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("matches state tool outcome-clearing semantics on fallback writes", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-mcp-parity-state-outcome-"));
+    const logs = captureLogs();
+
+    try {
+      await mcpParityCommand("state", [
+        "write",
+        "--input",
+        JSON.stringify({
+          mode: "deep-interview",
+          active: false,
+          lifecycle_outcome: "finished",
+          workingDirectory: cwd,
+        }),
+        "--json",
+      ]);
+      logs.pop();
+
+      await mcpParityCommand("state", [
+        "write",
+        "--input",
+        JSON.stringify({
+          mode: "deep-interview",
+          active: true,
+          current_phase: "intent",
+          workingDirectory: cwd,
+        }),
+        "--json",
+      ]);
+      logs.pop();
+
+      await mcpParityCommand("state", [
+        "read",
+        "--input",
+        JSON.stringify({ mode: "deep-interview", workingDirectory: cwd }),
+        "--json",
+      ]);
+      const readResult = JSON.parse(logs.pop() || "{}") as {
+        active?: boolean;
+        lifecycle_outcome?: string;
+        run_outcome?: string;
+      };
+      assert.equal(readResult.active, true);
+      assert.equal(readResult.lifecycle_outcome, undefined);
+      assert.equal(readResult.run_outcome, "continue");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("supports notepad and project-memory parity via CLI", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-mcp-parity-memory-"));
     const logs = captureLogs();

--- a/src/hooks/__tests__/pre-context-gate-skills.test.ts
+++ b/src/hooks/__tests__/pre-context-gate-skills.test.ts
@@ -49,4 +49,10 @@ describe('pre-context gate guidance in planning/execution-heavy skills', () => {
     assert.match(ralphSkill, /\.omx\/context\/\{task-slug\}-\{timestamp\}\.md/);
     assert.match(ralphSkill, /\$deep-interview\s+--quick/i);
   });
+
+  it('ralph documents state CLI retry guidance when the MCP channel is unavailable', () => {
+    assert.match(ralphSkill, /do \*\*not\*\* retry the same MCP call/i);
+    assert.match(ralphSkill, /omx state write --input '<json>' --json/i);
+    assert.match(ralphSkill, /preserving `workingDirectory` and `session_id`/i);
+  });
 });

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -9,48 +9,12 @@ import {
 	CallToolRequestSchema,
 	ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import {
-	readFile,
-	writeFile,
-	readdir,
-	mkdir,
-	unlink,
-	rename,
-} from "fs/promises";
-import { existsSync } from "fs";
-import { join } from "path";
-import {
-	getAllScopedStatePaths,
-	getReadScopedStateDirs,
-	getReadScopedStatePaths,
-	resolveStateScope,
-	getStateDir,
-	getStatePath,
-	resolveWorkingDirectoryForState,
-	validateSessionId,
-} from "./state-paths.js";
-import { withModeRuntimeContext } from "../state/mode-state-context.js";
-import {
-	SKILL_ACTIVE_STATE_MODE,
-	readSkillActiveState,
-	syncCanonicalSkillStateForMode,
-	writeSkillActiveStateCopies,
-} from "../state/skill-active.js";
-import {
-	isTrackedWorkflowMode,
-} from "../state/workflow-transition.js";
-import { reconcileWorkflowTransition } from "../state/workflow-transition-reconcile.js";
-import {
-	RALPH_PHASES,
-	validateAndNormalizeRalphState,
-} from "../ralph/contract.js";
-import { ensureCanonicalRalphArtifacts } from "../ralph/persistence.js";
-import { applyRunOutcomeContract } from "../runtime/run-outcome.js";
 import { autoStartStdioMcpServer } from "./bootstrap.js";
 import {
 	LEGACY_TEAM_MCP_TOOLS,
 	buildLegacyTeamDeprecationHint,
 } from "../team/api-interop.js";
+import { executeStateOperation } from "../state/operations.js";
 
 const SUPPORTED_MODES = [
 	"autopilot",
@@ -72,69 +36,6 @@ const STATE_TOOL_NAMES = new Set([
 	"state_get_status",
 ]);
 const TEAM_COMM_TOOL_NAMES: Set<string> = new Set([...LEGACY_TEAM_MCP_TOOLS]);
-
-const stateWriteQueues = new Map<string, Promise<void>>();
-
-async function listStateSessionIds(cwd: string): Promise<string[]> {
-	const sessionsDir = join(getStateDir(cwd), "sessions");
-	if (!existsSync(sessionsDir)) return [];
-	const entries = await readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
-	return entries
-		.filter((entry) => entry.isDirectory())
-		.map((entry) => entry.name)
-		.filter((entry) => entry.trim().length > 0);
-}
-
-async function withStateWriteLock<T>(
-	path: string,
-	fn: () => Promise<T>,
-): Promise<T> {
-	const tail = stateWriteQueues.get(path) ?? Promise.resolve();
-	let release!: () => void;
-	const gate = new Promise<void>((resolve) => {
-		release = resolve;
-	});
-	const queued = tail.finally(() => gate);
-	stateWriteQueues.set(path, queued);
-
-	await tail.catch(() => {});
-	try {
-		return await fn();
-	} finally {
-		release();
-		if (stateWriteQueues.get(path) === queued) {
-			stateWriteQueues.delete(path);
-		}
-	}
-}
-
-async function writeAtomicFile(path: string, data: string): Promise<void> {
-	const tmpPath = `${path}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
-	await writeFile(tmpPath, data, "utf-8");
-	try {
-		await rename(tmpPath, path);
-	} catch (error) {
-		await unlink(tmpPath).catch(() => {});
-		throw error;
-	}
-}
-
-async function writeClearedSessionScopedModeState(
-	path: string,
-	mode: string,
-	sessionId: string,
-): Promise<void> {
-	const nowIso = new Date().toISOString();
-	const clearedState = withModeRuntimeContext({}, {
-		mode,
-		active: false,
-		current_phase: "cleared",
-		updated_at: nowIso,
-		completed_at: nowIso,
-		session_id: sessionId,
-	});
-	await writeAtomicFile(path, JSON.stringify(clearedState, null, 2));
-}
 
 const server = new Server(
 	{ name: "omx-state", version: "0.1.0" },
@@ -265,428 +166,43 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 export async function handleStateToolCall(request: {
 	params: { name: string; arguments?: Record<string, unknown> };
 }) {
-	const { name, arguments: args } = request.params;
-	const wd = (args as Record<string, unknown>)?.workingDirectory as
-		| string
-		| undefined;
-	let normalizedWd: string;
-	try {
-		normalizedWd = resolveWorkingDirectoryForState(wd);
-	} catch (error) {
-		return {
-			content: [
-				{
-					type: "text",
-					text: JSON.stringify({ error: (error as Error).message }),
-				},
-			],
-			isError: true,
-		};
-	}
-	let cwd = normalizedWd;
-	let explicitSessionId: string | undefined;
-	try {
-		explicitSessionId = validateSessionId(
-			(args as Record<string, unknown>)?.session_id,
+	const { name, arguments: args = {} } = request.params;
+
+	if (TEAM_COMM_TOOL_NAMES.has(name)) {
+		const hint = buildLegacyTeamDeprecationHint(
+			name as (typeof LEGACY_TEAM_MCP_TOOLS)[number],
+			args,
 		);
-	} catch (error) {
 		return {
 			content: [
 				{
 					type: "text",
-					text: JSON.stringify({ error: (error as Error).message }),
+					text: JSON.stringify({
+						error: `MCP tool "${name}" is hard-deprecated. Team mutations now require CLI interop.`,
+						code: "deprecated_cli_only",
+						hint,
+					}),
 				},
 			],
 			isError: true,
 		};
 	}
 
-	try {
-		const stateScope = STATE_TOOL_NAMES.has(name)
-			? await resolveStateScope(cwd, explicitSessionId)
-			: undefined;
-		const effectiveSessionId = stateScope?.sessionId;
-
-		if (STATE_TOOL_NAMES.has(name)) {
-			await mkdir(getStateDir(cwd), { recursive: true });
-			if (effectiveSessionId) {
-				await mkdir(getStateDir(cwd, effectiveSessionId), { recursive: true });
-			}
-			const { ensureTmuxHookInitialized } = await import("../cli/tmux-hook.js");
-			await ensureTmuxHookInitialized(cwd);
-		}
-
-		if (TEAM_COMM_TOOL_NAMES.has(name)) {
-			const hint = buildLegacyTeamDeprecationHint(
-				name as (typeof LEGACY_TEAM_MCP_TOOLS)[number],
-				(args as Record<string, unknown>) ?? {},
-			);
-			return {
-				content: [
-					{
-						type: "text",
-						text: JSON.stringify({
-							error: `MCP tool "${name}" is hard-deprecated. Team mutations now require CLI interop.`,
-							code: "deprecated_cli_only",
-							hint,
-						}),
-					},
-				],
-				isError: true,
-			};
-		}
-
-		switch (name) {
-			case "state_read": {
-				const mode = (args as Record<string, unknown>).mode as string;
-				if (
-					!SUPPORTED_MODES.includes(mode as (typeof SUPPORTED_MODES)[number])
-				) {
-					return {
-						content: [
-							{
-								type: "text",
-								text: JSON.stringify({
-									error: `mode must be one of: ${SUPPORTED_MODES.join(", ")}`,
-								}),
-							},
-						],
-						isError: true,
-					};
-				}
-				const paths = await getReadScopedStatePaths(
-					mode,
-					cwd,
-					explicitSessionId,
-				);
-				const path = paths.find((candidate) => existsSync(candidate));
-				if (!path) {
-					return {
-						content: [
-							{ type: "text", text: JSON.stringify({ exists: false, mode }) },
-						],
-					};
-				}
-				const data = await readFile(path, "utf-8");
-				return { content: [{ type: "text", text: data }] };
-			}
-
-			case "state_write": {
-				const mode = (args as Record<string, unknown>).mode as string;
-				const path = getStatePath(mode, cwd, effectiveSessionId);
-				const {
-					mode: _m,
-					workingDirectory: _w,
-					session_id: _sid,
-					state: customState,
-					...fields
-					} = args as Record<string, unknown>;
-					let validationError: string | null = null;
-					let transitionMessage: string | undefined;
-					let ensureRalphArtifacts = false;
-					await withStateWriteLock(path, async () => {
-						let existing: Record<string, unknown> = {};
-						if (existsSync(path)) {
-						try {
-							existing = JSON.parse(await readFile(path, "utf-8"));
-						} catch (e) {
-							process.stderr.write(
-								"[state-server] Failed to parse state file: " + e + "\n",
-							);
-						}
-					}
-
-						const mergedRaw = {
-							...existing,
-							...fields,
-							...((customState as Record<string, unknown>) || {}),
-						} as Record<string, unknown>;
-						const explicitRunOutcome = Object.prototype.hasOwnProperty.call(fields, "run_outcome")
-							|| (
-								customState != null
-								&& Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, "run_outcome")
-							);
-						if (!explicitRunOutcome) {
-							delete mergedRaw.run_outcome;
-						}
-						const explicitLifecycleOutcome = Object.prototype.hasOwnProperty.call(fields, "lifecycle_outcome")
-							|| (
-								customState != null
-								&& Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, "lifecycle_outcome")
-							);
-						if (!explicitLifecycleOutcome) {
-							delete mergedRaw.lifecycle_outcome;
-						}
-						const explicitTerminalOutcome = Object.prototype.hasOwnProperty.call(fields, "terminal_outcome")
-							|| (
-								customState != null
-								&& Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, "terminal_outcome")
-							);
-						if (!explicitTerminalOutcome) {
-							delete mergedRaw.terminal_outcome;
-						}
-						if (
-							mode === "ralph" &&
-							effectiveSessionId &&
-						typeof mergedRaw.owner_omx_session_id !== "string"
-					) {
-						mergedRaw.owner_omx_session_id = effectiveSessionId;
-					}
-
-						if (mode === "ralph") {
-						const originalPhase = mergedRaw.current_phase;
-						const validation = validateAndNormalizeRalphState(mergedRaw);
-						if (!validation.ok || !validation.state) {
-							validationError =
-								validation.error ||
-								`ralph.current_phase must be one of: ${RALPH_PHASES.join(", ")}`;
-							return;
-						}
-						if (
-							typeof originalPhase === "string" &&
-							typeof validation.state.current_phase === "string" &&
-							validation.state.current_phase !== originalPhase
-							) {
-								validation.state.ralph_phase_normalized_from = originalPhase;
-							}
-							Object.assign(mergedRaw, validation.state);
-							ensureRalphArtifacts = true;
-						}
-						if (mode !== SKILL_ACTIVE_STATE_MODE) {
-							const runOutcomeValidation = applyRunOutcomeContract(mergedRaw);
-							if (!runOutcomeValidation.ok || !runOutcomeValidation.state) {
-								validationError =
-									runOutcomeValidation.error || "Invalid run outcome state";
-								return;
-							}
-							Object.assign(mergedRaw, runOutcomeValidation.state);
-						}
-						if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
-							try {
-								if (!effectiveSessionId) {
-									for (const sessionId of await listStateSessionIds(cwd)) {
-										const sessionTransition = await reconcileWorkflowTransition(cwd, mode, {
-											action: "write",
-											sessionId,
-											source: "state-server",
-										});
-										transitionMessage ??= sessionTransition.transitionMessage;
-									}
-								}
-								const transition = await reconcileWorkflowTransition(cwd, mode, {
-									action: "write",
-									sessionId: effectiveSessionId,
-									source: "state-server",
-								});
-								transitionMessage ??= transition.transitionMessage;
-							} catch (error) {
-								validationError = (error as Error).message;
-								return;
-							}
-						}
-
-						const merged = withModeRuntimeContext(existing, mergedRaw);
-						await writeAtomicFile(path, JSON.stringify(merged, null, 2));
-					});
-				if (validationError) {
-					return {
-						content: [
-							{
-								type: "text",
-								text: JSON.stringify({ error: validationError }),
-							},
-						],
-						isError: true,
-					};
-					}
-					if (mode === SKILL_ACTIVE_STATE_MODE) {
-						const state = await readSkillActiveState(path);
-						if (state) {
-							await writeSkillActiveStateCopies(cwd, state, effectiveSessionId);
-						}
-					} else {
-						if (mode === "ralph" && ensureRalphArtifacts) {
-							await ensureCanonicalRalphArtifacts(cwd, effectiveSessionId);
-						}
-						const data = JSON.parse(await readFile(path, "utf-8")) as Record<string, unknown>;
-						await syncCanonicalSkillStateForMode({
-							cwd,
-						mode,
-						active: data.active === true,
-						currentPhase: typeof data.current_phase === "string" ? data.current_phase : undefined,
-						sessionId: effectiveSessionId,
-					});
-				}
-				return {
-					content: [
-						{
-							type: "text",
-							text: JSON.stringify({
-								success: true,
-								mode,
-								path,
-								...(transitionMessage ? { transition: transitionMessage } : {}),
-							}),
-						},
-					],
-				};
-			}
-
-			case "state_clear": {
-				const mode = (args as Record<string, unknown>).mode as string;
-				const allSessions =
-					(args as Record<string, unknown>).all_sessions === true;
-
-				if (!allSessions) {
-					const path = getStatePath(mode, cwd, effectiveSessionId);
-					if (
-						mode !== SKILL_ACTIVE_STATE_MODE &&
-						effectiveSessionId &&
-						existsSync(getStatePath(mode, cwd))
-					) {
-						await writeClearedSessionScopedModeState(path, mode, effectiveSessionId);
-					} else if (existsSync(path)) {
-						await unlink(path);
-					}
-					if (mode !== SKILL_ACTIVE_STATE_MODE) {
-						await syncCanonicalSkillStateForMode({
-							cwd,
-							mode,
-							active: false,
-							sessionId: effectiveSessionId,
-						});
-					}
-					return {
-						content: [
-							{
-								type: "text",
-								text: JSON.stringify({ cleared: true, mode, path }),
-							},
-						],
-					};
-				}
-
-				const removedPaths: string[] = [];
-				const paths = await getAllScopedStatePaths(mode, cwd);
-				for (const path of paths) {
-					if (!existsSync(path)) continue;
-					await unlink(path);
-					removedPaths.push(path);
-				}
-				if (mode !== SKILL_ACTIVE_STATE_MODE) {
-					await syncCanonicalSkillStateForMode({
-						cwd,
-						mode,
-						active: false,
-					});
-				}
-
-				return {
-					content: [
-						{
-							type: "text",
-							text: JSON.stringify({
-								cleared: true,
-								mode,
-								all_sessions: true,
-								removed: removedPaths.length,
-								paths: removedPaths,
-								warning:
-									"all_sessions clears global and session-scoped state files",
-							}),
-						},
-					],
-				};
-			}
-
-			case "state_list_active": {
-				const stateDirs = await getReadScopedStateDirs(cwd, explicitSessionId);
-				const active: string[] = [];
-				const seenModes = new Set<string>();
-				for (const stateDir of stateDirs) {
-					if (!existsSync(stateDir)) continue;
-					const files = await readdir(stateDir);
-					for (const f of files) {
-						if (!f.endsWith("-state.json")) continue;
-						const mode = f.replace("-state.json", "");
-						if (mode === SKILL_ACTIVE_STATE_MODE) continue;
-						if (seenModes.has(mode)) continue;
-						seenModes.add(mode);
-						try {
-							const data = JSON.parse(
-								await readFile(join(stateDir, f), "utf-8"),
-							);
-							if (data.active) {
-								active.push(mode);
-							}
-						} catch (e) {
-							process.stderr.write(
-								"[state-server] Failed to parse state file: " + e + "\n",
-							);
-						}
-					}
-				}
-				return {
-					content: [
-						{ type: "text", text: JSON.stringify({ active_modes: active }) },
-					],
-				};
-			}
-
-			case "state_get_status": {
-				const mode = (args as Record<string, unknown>)?.mode as
-					| string
-					| undefined;
-				const stateDirs = await getReadScopedStateDirs(cwd, explicitSessionId);
-				const statuses: Record<string, unknown> = {};
-				const seenModes = new Set<string>();
-
-				for (const stateDir of stateDirs) {
-					if (!existsSync(stateDir)) continue;
-					const files = await readdir(stateDir);
-					for (const f of files) {
-						if (!f.endsWith("-state.json")) continue;
-						const m = f.replace("-state.json", "");
-						if (mode && m !== mode) continue;
-						if (seenModes.has(m)) continue;
-						seenModes.add(m);
-						try {
-							const data = JSON.parse(
-								await readFile(join(stateDir, f), "utf-8"),
-							);
-							statuses[m] = {
-								active: data.active,
-								phase: data.current_phase,
-								path: join(stateDir, f),
-								data,
-							};
-						} catch {
-							statuses[m] = { error: "malformed state file" };
-						}
-					}
-				}
-				return {
-					content: [{ type: "text", text: JSON.stringify({ statuses }) }],
-				};
-			}
-
-			default:
-				return {
-					content: [{ type: "text", text: `Unknown tool: ${name}` }],
-					isError: true,
-				};
-		}
-	} catch (error) {
+	if (!STATE_TOOL_NAMES.has(name)) {
 		return {
-			content: [
-				{
-					type: "text",
-					text: JSON.stringify({ error: (error as Error).message }),
-				},
-			],
+			content: [{ type: "text", text: `Unknown tool: ${name}` }],
 			isError: true,
 		};
 	}
+
+	const result = await executeStateOperation(
+		name as Parameters<typeof executeStateOperation>[0],
+		args,
+	);
+	return {
+		content: [{ type: "text", text: JSON.stringify(result.payload) }],
+		...(result.isError ? { isError: true } : {}),
+	};
 }
 server.setRequestHandler(CallToolRequestSchema, handleStateToolCall);
 

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -35,6 +35,7 @@ export const SUPPORTED_STATE_READ_MODES = [
   'ultraqa',
   'ralplan',
   'deep-interview',
+  'skill-active',
 ] as const;
 
 export type SupportedStateReadMode = (typeof SUPPORTED_STATE_READ_MODES)[number];
@@ -129,6 +130,18 @@ async function listStateSessionIds(cwd: string): Promise<string[]> {
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
     .filter((entry) => entry.trim().length > 0);
+}
+
+function hasExplicitStateField(
+  fields: Record<string, unknown>,
+  customState: unknown,
+  key: string,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(fields, key)
+    || (
+      customState != null
+      && Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, key)
+    );
 }
 
 export async function listStateStatuses(
@@ -243,13 +256,14 @@ export async function executeStateOperation(
             ...fields,
             ...((customState as Record<string, unknown>) || {}),
           } as Record<string, unknown>;
-          const explicitRunOutcome = Object.prototype.hasOwnProperty.call(fields, 'run_outcome')
-            || (
-              customState != null
-              && Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, 'run_outcome')
-            );
-          if (!explicitRunOutcome) {
+          if (!hasExplicitStateField(fields, customState, 'run_outcome')) {
             delete mergedRaw.run_outcome;
+          }
+          if (!hasExplicitStateField(fields, customState, 'lifecycle_outcome')) {
+            delete mergedRaw.lifecycle_outcome;
+          }
+          if (!hasExplicitStateField(fields, customState, 'terminal_outcome')) {
+            delete mergedRaw.terminal_outcome;
           }
 
           if (


### PR DESCRIPTION
## Summary
- route `omx_state` MCP state tools through the same shared state operation path used by `omx state`
- preserve session-scoped fallback writes and stale outcome cleanup semantics in CLI parity tests
- document Ralph guidance to stop retrying a closed MCP channel and retry once via `omx state ...` with the same payload/session

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/mcp-parity.test.js dist/cli/__tests__/state.test.js dist/mcp/__tests__/state-server.test.js dist/mcp/__tests__/state-server-ralph-phase.test.js dist/hooks/__tests__/pre-context-gate-skills.test.js dist/state/__tests__/operations.test.js`
- `npm run lint`
- `npm run check:no-unused`

Fixes #1988
