### PR TITLE
Keep project-local Codex config free of transient NUX counters

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -34,6 +34,7 @@ import {
   readPersistedSetupScope,
   resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
+  resolveProjectLocalCodexHomeForLaunch,
   buildDetachedSessionBootstrapSteps,
   buildDetachedTmuxSessionName,
   buildDetachedSessionFinalizeSteps,
@@ -1188,6 +1189,39 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("marks only persisted project CODEX_HOME as project-local cleanup target", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      assert.equal(resolveProjectLocalCodexHomeForLaunch(wd, {}), join(wd, ".codex"));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not mark explicit CODEX_HOME as project-local cleanup target", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      assert.equal(
+        resolveProjectLocalCodexHomeForLaunch(wd, {
+          CODEX_HOME: "/tmp/user-global-codex-home",
+        }),
+        undefined,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps explicit CODEX_HOME override from env", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
     try {
@@ -1593,7 +1627,7 @@ describe("detached tmux new-session sequencing", () => {
     const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
     assert.match(
       source,
-      /buildTmuxPaneCommand\("env", \[`OMX_SESSION_ID=\$\{sessionId\}`, "node", omxBin, "hud", "--watch"\]\)/,
+      /buildTmuxPaneCommand\("env",\s*\[\s*`OMX_SESSION_ID=\$\{sessionId\}`,\s*"node",\s*omxBin,\s*"hud",\s*"--watch",?\s*\]\)/,
     );
   });
 

--- a/src/cli/codex-home.ts
+++ b/src/cli/codex-home.ts
@@ -8,16 +8,24 @@ import {
 export const readPersistedSetupPreferences = readPersistedSetupPreferencesSync;
 export const readPersistedSetupScope = readPersistedSetupScopeSync;
 
-export function resolveCodexHomeForLaunch(
+export function resolveProjectLocalCodexHomeForLaunch(
 	cwd: string,
 	env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
-	if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return env.CODEX_HOME;
+	if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return undefined;
 	const persistedScope = readPersistedSetupScope(cwd);
 	if (persistedScope === "project") {
 		return join(cwd, ".codex");
 	}
 	return undefined;
+}
+
+export function resolveCodexHomeForLaunch(
+	cwd: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+	if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return env.CODEX_HOME;
+	return resolveProjectLocalCodexHomeForLaunch(cwd, env);
 }
 
 export function resolveCodexConfigPathForLaunch(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,6 +54,7 @@ import {
 import {
   resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
+  resolveProjectLocalCodexHomeForLaunch,
 } from "./codex-home.js";
 
 export {
@@ -61,6 +62,7 @@ export {
   readPersistedSetupScope,
   resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
+  resolveProjectLocalCodexHomeForLaunch,
 } from "./codex-home.js";
 import { SKILL_ACTIVE_STATE_MODE, syncCanonicalSkillStateForMode } from "../state/skill-active.js";
 import { isTrackedWorkflowMode } from "../state/workflow-transition.js";
@@ -97,7 +99,7 @@ import {
 } from "../team/tmux-session.js";
 import { getPackageRoot } from "../utils/package.js";
 import { codexConfigPath, rememberOmxLaunchContext, resolveOmxEntryPath } from "../utils/paths.js";
-import { repairConfigIfNeeded } from "../config/generator.js";
+import { cleanCodexModelAvailabilityNuxIfNeeded, repairConfigIfNeeded } from "../config/generator.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
 import {
   createHudWatchPane as createSharedHudWatchPane,
@@ -1012,6 +1014,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
     notifyTempResult.passthroughArgs,
   );
   const codexHomeOverride = resolveCodexHomeForLaunch(launchCwd, process.env);
+  const projectLocalCodexHomeForCleanup = resolveProjectLocalCodexHomeForLaunch(launchCwd, process.env);
   const { launchPolicy, effectiveExplicitLaunchPolicy } =
     resolveTmuxAwareLaunchPolicy(explicitLaunchPolicy, isNativeWindows());
   const enableNotifyFallbackAuthority = launchPolicy === "direct";
@@ -1106,7 +1109,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
     );
   } finally {
     // ── Phase 3: postLaunch ─────────────────────────────────────────────
-    await postLaunch(cwd, sessionId, codexHomeOverride, enableNotifyFallbackAuthority);
+    await postLaunch(cwd, sessionId, codexHomeOverride, enableNotifyFallbackAuthority, projectLocalCodexHomeForCleanup);
   }
 }
 
@@ -1118,6 +1121,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
     process.env,
   );
   const codexHomeOverride = resolveCodexHomeForLaunch(launchCwd, process.env);
+  const projectLocalCodexHomeForCleanup = resolveProjectLocalCodexHomeForLaunch(launchCwd, process.env);
   const normalizedArgs = normalizeCodexLaunchArgs(
     notifyTempResult.passthroughArgs,
   );
@@ -1204,7 +1208,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
       : codexEnvBase;
     runCodexBlocking(cwd, codexArgs, codexEnv);
   } finally {
-    await postLaunch(cwd, sessionId, codexHomeOverride, true);
+    await postLaunch(cwd, sessionId, codexHomeOverride, true, projectLocalCodexHomeForCleanup);
   }
 }
 
@@ -2999,6 +3003,7 @@ async function postLaunch(
   sessionId: string,
   codexHomeOverride?: string,
   enableNotifyFallbackAuthority: boolean = false,
+  projectLocalCodexHomeForCleanup?: string,
 ): Promise<void> {
   // Capture session start time before cleanup (writeSessionEnd deletes session.json)
   let sessionStartedAt: string | undefined;
@@ -3043,6 +3048,19 @@ async function postLaunch(
   } catch (err) {
     logCliOperationFailure(err);
     // Non-fatal
+  }
+
+  // 0.5. Remove Codex transient TUI NUX counters from project-local config only.
+  try {
+    if (projectLocalCodexHomeForCleanup) {
+      await cleanCodexModelAvailabilityNuxIfNeeded(
+        join(projectLocalCodexHomeForCleanup, "config.toml"),
+      );
+    }
+  } catch (err) {
+    console.error(
+      `[omx] postLaunch: project config transient NUX cleanup failed: ${err instanceof Error ? err.message : err}`,
+    );
   }
 
   // 1. Remove session-scoped model instructions file

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -8,7 +8,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import TOML from "@iarna/toml";
-import { buildMergedConfig, mergeConfig, repairConfigIfNeeded } from "../generator.js";
+import { buildMergedConfig, cleanCodexModelAvailabilityNuxIfNeeded, mergeConfig, repairConfigIfNeeded } from "../generator.js";
 
 /** Count occurrences of a pattern in text */
 function count(text: string, pattern: RegExp): number {
@@ -95,6 +95,68 @@ function assertSingleOmxBlock(toml: string): void {
     "USE_OMX_EXPLORE_CMD should appear once",
   );
 }
+
+describe("Codex transient TUI NUX cleanup", () => {
+  it("removes only model availability NUX counters from project-local config", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-codex-nux-cleanup-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      await writeFile(configPath, [
+        'model = "gpt-5.5"',
+        'status_line = ["model-with-reasoning", "git-branch"]',
+        "",
+        "[tui]",
+        'theme = "dark"',
+        "notifications = true",
+        "",
+        "[tui.model_availability_nux]",
+        '"gpt-5.5" = 4',
+        '"gpt-5.4" = 1',
+        "",
+        "[mcp_servers.user]",
+        'command = "node"',
+        'args = ["server.js"]',
+        "",
+      ].join("\n"));
+
+      const cleaned = await cleanCodexModelAvailabilityNuxIfNeeded(configPath);
+      const toml = await readFile(configPath, "utf-8");
+
+      assert.equal(cleaned, true);
+      assert.doesNotMatch(toml, /^\[tui\.model_availability_nux\]$/m);
+      assert.doesNotMatch(toml, /gpt-5\.5" = 4/);
+      assert.match(toml, /^status_line = \["model-with-reasoning", "git-branch"\]$/m);
+      assert.match(toml, /^\[tui\]$/m);
+      assert.match(toml, /^theme = "dark"$/m);
+      assert.match(toml, /^notifications = true$/m);
+      assert.match(toml, /^\[mcp_servers\.user\]$/m);
+      assert.match(toml, /^command = "node"$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op when project config has no Codex NUX counters", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-codex-nux-noop-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      const original = [
+        'model = "gpt-5.5"',
+        "",
+        "[tui]",
+        'theme = "dark"',
+        "",
+      ].join("\n");
+      await writeFile(configPath, original);
+
+      const cleaned = await cleanCodexModelAvailabilityNuxIfNeeded(configPath);
+      assert.equal(cleaned, false);
+      assert.equal(await readFile(configPath, "utf-8"), original);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("config generator idempotency (#384)", () => {
   it("first run creates config with all current OMX sections", async () => {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -122,6 +122,44 @@ const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
 const OMX_CONFIG_MARKER = "oh-my-codex (OMX) Configuration";
 const OMX_CONFIG_END_MARKER = "# End oh-my-codex";
 
+const CODEX_MODEL_AVAILABILITY_NUX_TABLE_PATTERN = /^\s*\[tui\.model_availability_nux\]\s*(?:#.*)?$/;
+const TOML_TABLE_HEADER_PATTERN = /^\s*\[\[?[^\]]+\]?\]\s*(?:#.*)?$/;
+
+export function stripCodexModelAvailabilityNux(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const result: string[] = [];
+  let removed = false;
+
+  for (let i = 0; i < lines.length;) {
+    if (CODEX_MODEL_AVAILABILITY_NUX_TABLE_PATTERN.test(lines[i])) {
+      removed = true;
+      i += 1;
+      while (i < lines.length && !TOML_TABLE_HEADER_PATTERN.test(lines[i])) {
+        i += 1;
+      }
+      continue;
+    }
+
+    result.push(lines[i]);
+    i += 1;
+  }
+
+  return removed ? result.join("\n") : config;
+}
+
+export async function cleanCodexModelAvailabilityNuxIfNeeded(
+  configPath: string,
+): Promise<boolean> {
+  if (!existsSync(configPath)) return false;
+
+  const content = await readFile(configPath, "utf-8");
+  const cleaned = stripCodexModelAvailabilityNux(content);
+  if (cleaned === content) return false;
+
+  await writeFile(configPath, cleaned);
+  return true;
+}
+
 export function hasLegacyOmxTeamRunTable(config: string): boolean {
   return LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(config);
 }


### PR DESCRIPTION
## Summary
- track whether launch CODEX_HOME was derived from persisted project setup scope vs an explicit/user CODEX_HOME
- remove only Codex's transient `[tui.model_availability_nux]` table from project-local `.codex/config.toml` during post-launch cleanup
- preserve user-authored `[tui]`, `status_line`, MCP, and all unrelated config

Fixes #1993

## Verification
- `npm run build`
- `node --test dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/index.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- architect review approved

## Notes
- Live interactive Codex TUI NUX acknowledgement write was simulated via config regression tests rather than exercised against the real TUI.
