### PR TITLE
Resolve prerelease state, DAG, and launch-note issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 
 ### Added
-- **Direct leader launch controls** — `omx --direct` and `OMX_LAUNCH_POLICY=direct|tmux|detached-tmux|auto` now let operators opt out of OMX tmux/HUD management without changing the default detached-tmux startup behavior.
+- **Default detached-tmux launch is explicit, with opt-outs** — `omx --direct` and `OMX_LAUNCH_POLICY=direct|tmux|detached-tmux|auto` are now documented and supported as operator escape hatches, while preserving the default detached-tmux startup behavior.
 
 ## [0.15.0] - 2026-04-25
 

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -37,6 +37,7 @@ Release readiness evidence is recorded in `docs/qa/release-readiness-0.15.0.md`.
 - No tag, npm publish, or GitHub release has been created by this release-prep change.
 - Existing CLI users can continue with legacy skill delivery; setup now makes plugin-vs-legacy mode explicit and preserves persisted choices.
 - Codex App users should prefer the shipped first-party plugin bundle once the release owner publishes `v0.15.0`.
+- Launching remains detached-tmux by default; operators can bypass that with `omx --direct` or `OMX_LAUNCH_POLICY=direct`, and can also force `tmux`/`detached-tmux` via `OMX_LAUNCH_POLICY`.
 - Existing model overrides remain respected; default generated guidance continues to use `gpt-5.5` for frontier lanes, `gpt-5.4-mini` for standard lanes, and `gpt-5.3-codex-spark` for fast exploration.
 
 ## Contributors

--- a/docs/release-notes-0.15.0.md
+++ b/docs/release-notes-0.15.0.md
@@ -12,6 +12,7 @@ Range note: `v0.14.4` exists off the current `dev` ancestry and is not a valid r
 - Codex App compatibility paths avoid tmux-only runtime assumptions and preserve plugin-prefixed skill routing.
 - Visual Ralph is available as a first-class workflow skill with routing, generated docs, and regression coverage.
 - Setup can preserve plugin-vs-legacy install mode, report cleanup/backups clearly, and keep hooks/runtime assets aligned without overwriting local choices.
+- **Launch behavior is explicit by default and operator-controllable:** the default launch path remains detached-tmux; use `omx --direct` or `OMX_LAUNCH_POLICY=direct` (or `=tmux`/`=detached-tmux`) to force the desired launch mode.
 - Native agent and model-routing contracts are enforced across definitions, generated model tables, setup refresh paths, and runtime guidance.
 - Hook/runtime hardening covers Stop-hook parseability, notification fallback watchers, derived watchers, stale tmux sockets, team worker identity, and CI silence protection.
 - Windows/tmux question handling and Rust 1.73-compatible explore harness behavior are covered by targeted tests.

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -78,7 +78,7 @@ exit 1
 }
 
 describe('state-server directory initialization', () => {
-  it('creates .omx/state for state tools without setup', async () => {
+  it('keeps read-only state tools side-effect-free without setup', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
 
@@ -96,8 +96,8 @@ describe('state-server directory initialization', () => {
         },
       });
 
-      assert.equal(existsSync(stateDir), true);
-      assert.equal(existsSync(tmuxHookConfig), true);
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
       assert.deepEqual(
         JSON.parse(response.content[0]?.text || '{}'),
         { active_modes: [] },
@@ -107,7 +107,65 @@ describe('state-server directory initialization', () => {
     }
   });
 
-  it('bootstraps state-tool tmux-hook from the current tmux pane when available', async () => {
+  it('keeps missing state_read side-effect-free without setup', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-read-test-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const tmuxHookConfig = join(wd, '.omx', 'tmux-hook.json');
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
+
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_read',
+          arguments: { workingDirectory: wd, mode: 'deep-interview' },
+        },
+      });
+
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
+      assert.deepEqual(
+        JSON.parse(response.content[0]?.text || '{}'),
+        { exists: false, mode: 'deep-interview' },
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps state_get_status side-effect-free without setup', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-status-test-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const tmuxHookConfig = join(wd, '.omx', 'tmux-hook.json');
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
+
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_get_status',
+          arguments: { workingDirectory: wd },
+        },
+      });
+
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
+      assert.deepEqual(
+        JSON.parse(response.content[0]?.text || '{}'),
+        { statuses: {} },
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('bootstraps state-tool tmux-hook from the current tmux pane for mutating tools', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
 
@@ -125,11 +183,17 @@ describe('state-server directory initialization', () => {
         async () => {
           const response = await handleStateToolCall({
             params: {
-              name: 'state_list_active',
-              arguments: { workingDirectory: wd },
+              name: 'state_write',
+              arguments: {
+                workingDirectory: wd,
+                mode: 'deep-interview',
+                active: true,
+                current_phase: 'deep-interview',
+              },
             },
           });
-          assert.deepEqual(JSON.parse(response.content[0]?.text || '{}'), { active_modes: [] });
+          const payload = JSON.parse(response.content[0]?.text || '{}');
+          assert.equal(payload.success, true);
         },
       );
 
@@ -272,14 +336,18 @@ describe('state-server directory initialization', () => {
     }
   });
 
-  it('creates session-scoped state directory when session_id is provided', async () => {
+  it('keeps session-scoped state_get_status side-effect-free when session_id is provided', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
 
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-test-'));
     try {
+      const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(wd, '.omx', 'state', 'sessions', 'sess1');
+      const tmuxHookConfig = join(wd, '.omx', 'tmux-hook.json');
+      assert.equal(existsSync(stateDir), false);
       assert.equal(existsSync(sessionDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
 
       const response = await handleStateToolCall({
         params: {
@@ -288,7 +356,9 @@ describe('state-server directory initialization', () => {
         },
       });
 
-      assert.equal(existsSync(sessionDir), true);
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(sessionDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
       assert.deepEqual(
         JSON.parse(response.content[0]?.text || '{}'),
         { statuses: {} },

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -80,7 +80,7 @@ exit 1
 }
 
 describe('state operations directory initialization', () => {
-  it('creates .omx/state for state operations without setup', async () => {
+  it('keeps state_list_active side-effect-free without setup', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-test-'));
     try {
       const stateDir = join(wd, '.omx', 'state');
@@ -92,15 +92,59 @@ describe('state operations directory initialization', () => {
         workingDirectory: wd,
       });
 
-      assert.equal(existsSync(stateDir), true);
-      assert.equal(existsSync(tmuxHookConfig), true);
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
       assert.deepEqual(response.payload, { active_modes: [] });
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it('bootstraps tmux-hook from the current tmux pane when available', async () => {
+  it('keeps state_get_status side-effect-free when session_id is provided', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-status-readonly-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', 'sess1');
+      const tmuxHookConfig = join(wd, '.omx', 'tmux-hook.json');
+      assert.equal(existsSync(sessionDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
+
+      const response = await executeStateOperation('state_get_status', {
+        workingDirectory: wd,
+        session_id: 'sess1',
+      });
+
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(sessionDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
+      assert.deepEqual(response.payload, { statuses: {} });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps missing state_read side-effect-free without setup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-readonly-missing-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const tmuxHookConfig = join(wd, '.omx', 'tmux-hook.json');
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
+
+      const response = await executeStateOperation('state_read', {
+        workingDirectory: wd,
+        mode: 'deep-interview',
+      });
+
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
+      assert.deepEqual(response.payload, { exists: false, mode: 'deep-interview' });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('bootstraps tmux-hook from the current tmux pane for mutating state operations', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-live-'));
     try {
       const tmuxHookConfig = join(wd, '.omx', 'tmux-hook.json');
@@ -113,10 +157,14 @@ describe('state operations directory initialization', () => {
           PATH: `${fakeBin}:${process.env.PATH || ''}`,
         },
         async () => {
-          const response = await executeStateOperation('state_list_active', {
+          const response = await executeStateOperation('state_write', {
             workingDirectory: wd,
+            mode: 'deep-interview',
+            active: true,
+            current_phase: 'deep-interview',
           });
-          assert.deepEqual(response.payload, { active_modes: [] });
+          assert.equal(response.isError, undefined);
+          assert.equal((response.payload as { success?: boolean }).success, true);
         },
       );
 
@@ -215,24 +263,6 @@ describe('state operations directory initialization', () => {
       });
 
       assert.deepEqual(response.payload, { active_modes: [] });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-
-  it('creates session-scoped state directory when session_id is provided', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-session-'));
-    try {
-      const sessionDir = join(wd, '.omx', 'state', 'sessions', 'sess1');
-      assert.equal(existsSync(sessionDir), false);
-
-      const response = await executeStateOperation('state_get_status', {
-        workingDirectory: wd,
-        session_id: 'sess1',
-      });
-
-      assert.equal(existsSync(sessionDir), true);
-      assert.deepEqual(response.payload, { statuses: {} });
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -211,10 +211,6 @@ export async function executeStateOperation(
   }
 
   try {
-    const stateScope = await resolveStateScope(cwd, explicitSessionId);
-    const effectiveSessionId = stateScope.sessionId;
-    await initializeStateEnvironment(cwd, effectiveSessionId);
-
     switch (name) {
       case 'state_read': {
         const mode = validateStrictReadableMode(rawArgs.mode);
@@ -228,6 +224,10 @@ export async function executeStateOperation(
       }
 
       case 'state_write': {
+        const stateScope = await resolveStateScope(cwd, explicitSessionId);
+        const effectiveSessionId = stateScope.sessionId;
+        await initializeStateEnvironment(cwd, effectiveSessionId);
+
         const mode = validateStateModeSegment(rawArgs.mode);
         const path = getStatePath(mode, cwd, effectiveSessionId);
         const {
@@ -368,6 +368,10 @@ export async function executeStateOperation(
       }
 
       case 'state_clear': {
+        const stateScope = await resolveStateScope(cwd, explicitSessionId);
+        const effectiveSessionId = stateScope.sessionId;
+        await initializeStateEnvironment(cwd, effectiveSessionId);
+
         const mode = validateStateModeSegment(rawArgs.mode);
         const allSessions = rawArgs.all_sessions === true;
 

--- a/src/team/__tests__/repo-aware-decomposition.test.ts
+++ b/src/team/__tests__/repo-aware-decomposition.test.ts
@@ -30,7 +30,7 @@ describe('buildRepoAwareTeamExecutionPlan', () => {
     assert.equal(plan.tasks[0].subject, 'legacy');
   });
 
-  it('imports DAG sidecar, reduces implicit worker count, and preserves dependencies', () => {
+  it('imports DAG sidecar, reduces implicit worker count, and preserves symbolic dependencies for runtime remap', () => {
     const cwd = repo();
     writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({
       schema_version: 1,
@@ -46,8 +46,11 @@ describe('buildRepoAwareTeamExecutionPlan', () => {
     assert.equal(plan.metadata?.decomposition_source, 'dag_sidecar');
     assert.equal(plan.workerCount, 2);
     assert.equal(plan.tasks.length, 2);
-    assert.deepEqual(plan.tasks[1].blocked_by, ['1']);
-    assert.equal(plan.metadata?.node_id_to_task_id?.impl, '1');
+    assert.deepEqual(plan.tasks[1].blocked_by, undefined);
+    assert.deepEqual(plan.tasks[1].depends_on, undefined);
+    assert.deepEqual(plan.tasks[1].symbolic_depends_on, ['impl']);
+    assert.equal(plan.metadata?.node_id_to_task_id, undefined);
+    assert.deepEqual(plan.metadata?.node_dependencies?.tests, ['impl']);
     assert.match(plan.tasks[0].description, /File scope: src\/team\/runtime.ts/);
   });
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -5572,6 +5572,100 @@ esac
     }
   });
 
+  it('startTeam remaps repo-aware DAG dependencies after concrete task IDs are created', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    await mkdir(binDir, { recursive: true });
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withPromptModeCodexEnv(binDir, {}, () =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-dag-remap',
+            'repo-aware DAG remap test',
+            'executor',
+            2,
+            [
+              {
+                subject: 'Implement runtime',
+                description: 'Change runtime',
+                owner: 'worker-1',
+                role: 'executor',
+                symbolic_id: 'impl',
+                symbolic_depends_on: [],
+                lane: 'implementation',
+                filePaths: ['src/team/runtime.ts'],
+                allocation_reason: 'balances current load',
+              },
+              {
+                subject: 'Verify runtime',
+                description: 'Test runtime',
+                owner: 'worker-2',
+                role: 'test-engineer',
+                symbolic_id: 'verify',
+                symbolic_depends_on: ['impl'],
+                lane: 'verification',
+                allocation_reason: 'keeps blocked work on a lighter lane',
+              },
+            ],
+            cwd,
+            {
+              decompositionMetadata: {
+                decomposition_source: 'dag_sidecar',
+                worker_count_requested: 2,
+                worker_count_effective: 2,
+                worker_count_source: 'plan-suggested',
+                ready_lane_count: 1,
+                useful_lane_count: 2,
+                allocation_reasons: {
+                  impl: 'balances current load',
+                  verify: 'keeps blocked work on a lighter lane',
+                },
+                node_dependencies: {
+                  impl: [],
+                  verify: ['impl'],
+                },
+              },
+            },
+          ),
+        ),
+      );
+
+      const first = await readTask('team-dag-remap', '1', cwd);
+      const second = await readTask('team-dag-remap', '2', cwd);
+      assert.deepEqual(first?.depends_on, []);
+      assert.deepEqual(first?.blocked_by, undefined);
+      assert.deepEqual(second?.depends_on, ['1']);
+      assert.deepEqual(second?.blocked_by, ['1']);
+
+      const report = JSON.parse(
+        await readFile(join(cwd, '.omx', 'state', 'team', 'team-dag-remap', 'decomposition-report.json'), 'utf-8'),
+      ) as {
+        node_id_to_task_id?: Record<string, string>;
+        task_hints?: Record<string, { node_id?: string; depends_on?: string[]; symbolic_depends_on?: string[] }>;
+      };
+      assert.deepEqual(report.node_id_to_task_id, { impl: '1', verify: '2' });
+      assert.deepEqual(report.task_hints?.['2']?.depends_on, ['1']);
+      assert.deepEqual(report.task_hints?.['2']?.symbolic_depends_on, ['impl']);
+
+      const inbox = await readFile(join(cwd, '.omx', 'state', 'team', 'team-dag-remap', 'workers', 'worker-2', 'inbox.md'), 'utf-8');
+      assert.match(inbox, /Blocked by: 1/);
+      assert.doesNotMatch(inbox, /Blocked by: impl/);
+      assert.doesNotMatch(inbox, /Depends on: impl/);
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('assignTask synthesizes delegation before follow-up dispatch rollback', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
     try {

--- a/src/team/repo-aware-decomposition.ts
+++ b/src/team/repo-aware-decomposition.ts
@@ -21,6 +21,7 @@ export interface RepoAwareTask {
   role?: string;
   blocked_by?: string[];
   depends_on?: string[];
+  symbolic_depends_on?: string[];
   requires_code_change?: boolean;
   filePaths?: string[];
   domains?: string[];
@@ -40,6 +41,7 @@ export interface TeamDecompositionMetadata {
   ready_lane_count: number;
   useful_lane_count: number;
   allocation_reasons: Record<string, string>;
+  node_dependencies?: Record<string, string[]>;
   node_id_to_task_id?: Record<string, string>;
   task_hints?: Record<string, TaskHintSummary>;
 }
@@ -49,6 +51,8 @@ export interface TaskHintSummary {
   lane?: string;
   filePaths?: string[];
   domains?: string[];
+  depends_on?: string[];
+  symbolic_depends_on?: string[];
   allocation_reason?: string;
 }
 
@@ -197,13 +201,12 @@ function buildFromDag(input: LegacyTeamExecutionPlanInput, resolution: TeamDagRe
     role: input.explicitAgentType ? input.agentType : undefined,
   }));
 
-  const nodeIdToIndex = new Map(sorted.map((node, index) => [node.id, String(index + 1)]));
   const allocationInput = sorted.map((node) => ({
     subject: node.subject,
     description: enrichNodeDescription(node, input.cwd),
     role: input.explicitAgentType ? input.agentType : node.role,
-    blocked_by: (node.depends_on ?? []).map((dep) => nodeIdToIndex.get(dep)!).filter(Boolean),
-    depends_on: (node.depends_on ?? []).map((dep) => nodeIdToIndex.get(dep)!).filter(Boolean),
+    blocked_by: node.depends_on ?? [],
+    symbolic_depends_on: node.depends_on ?? [],
     requires_code_change: node.requires_code_change,
     filePaths: node.filePaths,
     domains: inferDomains(node),
@@ -212,19 +215,12 @@ function buildFromDag(input: LegacyTeamExecutionPlanInput, resolution: TeamDagRe
   }));
   const allocated = allocateTasksToWorkers(allocationInput, workers);
   const allocationReasons: Record<string, string> = {};
-  const taskHints: Record<string, TaskHintSummary> = {};
-  const tasks = allocated.map((task, index): RepoAwareTask => {
-    const taskId = String(index + 1);
+  const tasks = allocated.map((task): RepoAwareTask => {
     allocationReasons[task.symbolic_id] = task.allocation_reason;
-    taskHints[taskId] = {
-      node_id: task.symbolic_id,
-      lane: task.lane,
-      filePaths: task.filePaths,
-      domains: task.domains,
-      allocation_reason: task.allocation_reason,
-    };
-    return task;
+    const { blocked_by: _symbolicBlockedBy, ...runtimeTask } = task;
+    return runtimeTask;
   });
+  const nodeDependencies = Object.fromEntries(sorted.map((node) => [node.id, node.depends_on ?? []]));
 
   return {
     workerCount: countPolicy.count,
@@ -241,9 +237,43 @@ function buildFromDag(input: LegacyTeamExecutionPlanInput, resolution: TeamDagRe
       ready_lane_count: readyLaneCount,
       useful_lane_count: useful,
       allocation_reasons: allocationReasons,
-      node_id_to_task_id: Object.fromEntries(sorted.map((node, index) => [node.id, String(index + 1)])),
-      task_hints: taskHints,
+      node_dependencies: nodeDependencies,
     },
+  };
+}
+
+export function remapRepoAwareDecompositionMetadataToCreatedTasks(
+  metadata: TeamDecompositionMetadata,
+  plannedTasks: Array<Pick<RepoAwareTask, 'symbolic_id' | 'symbolic_depends_on' | 'lane' | 'filePaths' | 'domains' | 'allocation_reason'>>,
+  createdTasks: Array<{ id: string }>,
+): TeamDecompositionMetadata {
+  const nodeIdToTaskId: Record<string, string> = {};
+  plannedTasks.forEach((task, index) => {
+    if (task.symbolic_id && createdTasks[index]?.id) {
+      nodeIdToTaskId[task.symbolic_id] = createdTasks[index].id;
+    }
+  });
+
+  const taskHints: Record<string, TaskHintSummary> = {};
+  plannedTasks.forEach((task, index) => {
+    const taskId = createdTasks[index]?.id;
+    if (!taskId || !task.symbolic_id) return;
+    const symbolicDeps = task.symbolic_depends_on ?? metadata.node_dependencies?.[task.symbolic_id] ?? [];
+    taskHints[taskId] = {
+      node_id: task.symbolic_id,
+      lane: task.lane,
+      filePaths: task.filePaths,
+      domains: task.domains,
+      depends_on: symbolicDeps.map((dep) => nodeIdToTaskId[dep]).filter(Boolean),
+      symbolic_depends_on: symbolicDeps,
+      allocation_reason: task.allocation_reason ?? metadata.allocation_reasons[task.symbolic_id],
+    };
+  });
+
+  return {
+    ...metadata,
+    node_id_to_task_id: nodeIdToTaskId,
+    task_hints: taskHints,
   };
 }
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -89,7 +89,10 @@ import {
 } from './mcp-comm.js';
 import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
 import type { TeamReminderIntent } from './reminder-intents.js';
-import type { TeamDecompositionMetadata } from './repo-aware-decomposition.js';
+import {
+  remapRepoAwareDecompositionMetadataToCreatedTasks,
+  type TeamDecompositionMetadata,
+} from './repo-aware-decomposition.js';
 import {
   generateWorkerOverlay,
   writeTeamWorkerInstructionsFile,
@@ -2042,7 +2045,7 @@ export async function startTeam(
   task: string,
   agentType: string,
   workerCount: number,
-  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[]; depends_on?: string[]; role?: string; delegation?: TeamTask['delegation']; requires_code_change?: boolean; filePaths?: string[]; domains?: string[]; lane?: string; allocation_reason?: string; symbolic_id?: string }>,
+  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[]; depends_on?: string[]; symbolic_depends_on?: string[]; role?: string; delegation?: TeamTask['delegation']; requires_code_change?: boolean; filePaths?: string[]; domains?: string[]; lane?: string; allocation_reason?: string; symbolic_id?: string }>,
   cwd: string,
   options: TeamStartOptions = {},
 ): Promise<TeamRuntime> {
@@ -2163,15 +2166,19 @@ export async function startTeam(
     config.workspace_mode = workspaceMode;
     config.worktree_mode = effectiveWorktreeMode;
 
-    // 4. Create tasks
+    // 4. Create tasks. Repo-aware DAG dependencies are symbolic until the
+    // state layer returns concrete task IDs, so create those tasks dependency
+    // free and patch runtime dependency fields after ID assignment.
+    const createdTasks: TeamTask[] = [];
     for (const t of tasks) {
-      await createStateTask(sanitized, {
+      const hasSymbolicDagIdentity = Boolean(t.symbolic_id);
+      const created = await createStateTask(sanitized, {
         subject: t.subject,
         description: t.description,
         status: 'pending',
         owner: t.owner,
-        blocked_by: t.blocked_by ?? t.depends_on,
-        depends_on: t.depends_on ?? t.blocked_by,
+        blocked_by: hasSymbolicDagIdentity ? undefined : t.blocked_by ?? t.depends_on,
+        depends_on: hasSymbolicDagIdentity ? undefined : t.depends_on ?? t.blocked_by,
         role: t.role,
         delegation: t.delegation ?? synthesizeDelegationPlan(t),
         requires_code_change: t.requires_code_change,
@@ -2179,6 +2186,27 @@ export async function startTeam(
         domains: t.domains,
         lane: t.lane,
         allocation_reason: t.allocation_reason,
+      }, leaderCwd);
+      createdTasks.push(created);
+    }
+
+    const effectiveDecompositionMetadata = options.decompositionMetadata
+      ? remapRepoAwareDecompositionMetadataToCreatedTasks(options.decompositionMetadata, tasks, createdTasks)
+      : undefined;
+    const nodeIdToTaskId = effectiveDecompositionMetadata?.node_id_to_task_id ?? {};
+    for (let index = 0; index < tasks.length; index += 1) {
+      const planned = tasks[index];
+      if (!planned?.symbolic_id) continue;
+      const created = createdTasks[index];
+      if (!created) continue;
+      const symbolicDeps = planned.symbolic_depends_on
+        ?? effectiveDecompositionMetadata?.node_dependencies?.[planned.symbolic_id]
+        ?? [];
+      const concreteDeps = symbolicDeps.map((dep) => nodeIdToTaskId[dep]).filter(Boolean);
+      if (concreteDeps.length === 0) continue;
+      await updateTask(sanitized, created.id, {
+        blocked_by: concreteDeps,
+        depends_on: concreteDeps,
       }, leaderCwd);
     }
 
@@ -2189,8 +2217,8 @@ export async function startTeam(
     }
 
     const allTasks = await listTasks(sanitized, leaderCwd);
-    if (options.decompositionMetadata) {
-      await writeDecompositionArtifacts(sanitized, leaderCwd, options.decompositionMetadata);
+    if (effectiveDecompositionMetadata) {
+      await writeDecompositionArtifacts(sanitized, leaderCwd, effectiveDecompositionMetadata);
     }
     const workerBootstrapPlans = [] as Array<{
       workerName: string;
@@ -2259,7 +2287,7 @@ export async function startTeam(
         workerRole: runtimeRole,
         rolePromptContent: rawRolePromptContent ?? undefined,
         worktreeRootAgentsCanonical: Boolean(workerWorkspace.worktreePath),
-        taskHints: options.decompositionMetadata?.task_hints,
+        taskHints: effectiveDecompositionMetadata?.task_hints,
       });
       const triggerDirective = buildTriggerDirective(
         workerName,


### PR DESCRIPTION
## Summary
- keep state read/list/status operations passive so they do not initialize runtime state or tmux-hook setup
- create repo-aware DAG tasks before patching concrete depends_on/blocked_by IDs, while preserving symbolic dependency metadata for reporting
- document detached-tmux default plus `omx --direct` and `OMX_LAUNCH_POLICY=direct` in release collateral

## Verification
- `npm run build`
- `node --test dist/state/__tests__/operations.test.js dist/mcp/__tests__/state-server.test.js dist/team/__tests__/repo-aware-decomposition.test.js dist/team/__tests__/runtime.test.js`
- `npm run check:no-unused`
- `npm run lint`

## Notes
- Full `npm test` was attempted in the team verification lane and hit broader existing failures unrelated to this prerelease sweep; targeted regression coverage passed.
