### PR TITLE
Fix worker startup readiness CI fixture

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1580,6 +1580,7 @@ case "$1" in
     case "$*" in
       *"pane_current_command"*) printf "%%1\tnode\t'codex'\n" ;;
       *"#{pane_dead} #{pane_pid}"*) echo "0 4242" ;;
+      *"#{pane_dead}"*) echo "0" ;;
       *"-t %2"*"#{pane_pid}"*) echo "4242" ;;
       *"-t %3"*"#{pane_pid}"*) echo "4343" ;;
       *"#{pane_pid}"*) echo "4141" ;;


### PR DESCRIPTION
## Summary
- Fix the concurrent worker readiness regression fixture so pane liveness probes receive a pane_dead-only response.
- Keep the change scoped to the failing Team Critical coverage gate test.

## Verification
- npm run build
- node --test --test-name-pattern 'startTeam starts worker-2 readiness before delayed worker-1 readiness settles' dist/team/__tests__/runtime.test.js\n- npm run coverage:team-critical:compiled\n- post-cleanup targeted regression rerun\n\n## Notes\n- Plato architect review timed out and was treated as non-blocking per user direction after all required gates passed.