### PR TITLE
Simplify Autopilot into strict review loop

### DIFF
--- a/docs/STATE_MODEL.md
+++ b/docs/STATE_MODEL.md
@@ -146,6 +146,7 @@ Current allowlisted forward handoffs:
 - `ralplan -> team`
 - `ralplan -> ralph`
 - `ralplan -> autopilot`
+- `autopilot -> ralplan` when Autopilot's code-review phase is not clean
 
 ### D. Deny
 
@@ -159,11 +160,12 @@ The requested transition is not allowed and no state is changed.
 | `ralplan` | `team` | auto-complete `ralplan`, start `team` |
 | `ralplan` | `ralph` | auto-complete `ralplan`, start `ralph` |
 | `ralplan` | `autopilot` | auto-complete `ralplan`, start `autopilot` |
+| `autopilot` | `ralplan` | auto-complete `autopilot`, start `ralplan` for review-driven loopback |
 | `team` | `ralph` | allowed overlap |
 | `ralph` | `team` | allowed overlap |
 | `<any tracked mode>` | `ultrawork` | allowed overlap |
 | `ultrawork` | `<any tracked mode>` | allowed overlap |
-| execution-like mode | planning-like mode | denied rollback auto-complete |
+| execution-like mode | planning-like mode | denied rollback auto-complete, except the explicit `autopilot -> ralplan` review loopback |
 | anything else non-allowlisted | new conflicting mode | denied |
 
 ## Planning-like vs execution-like

--- a/docs/contracts/multi-state-transition-contract.md
+++ b/docs/contracts/multi-state-transition-contract.md
@@ -112,4 +112,4 @@ Implementation should be considered complete only when tests prove:
 4. unsupported overlaps deny without mutation
 5. denial messages mention both `omx state` and `omx_state.*`
 6. HUD / overlay / stop-hook consumers honor the combined set consistently
-7. `autopilot` and `autoresearch` still reject overlap attempts
+7. `autopilot` and `autoresearch` still reject unsupported overlap attempts; `autopilot -> ralplan` is the only review-driven planning loopback exception

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -33,7 +33,7 @@
       <ul>
         <li><code>$team</code> - coordinated multi-agent execution for the approved plan</li>
         <li><code>$ralph</code> - persistence loop until completion</li>
-        <li><code>$autopilot</code> - full autonomous execution when you intentionally skip the standard workflow</li>
+        <li><code>$autopilot</code> - strict autonomous loop over <code>$ralplan -> $ralph -> $code-review</code>, returning to planning when review is not clean</li>
         <li><code>$ultrawork</code> - max parallel execution</li>
         <li><code>$visual-verdict</code> - structured visual QA loop for screenshot/reference matching</li>
         <li><code>$ecomode</code> - token-efficient model routing</li>

--- a/plugins/oh-my-codex/skills/autopilot/SKILL.md
+++ b/plugins/oh-my-codex/skills/autopilot/SKILL.md
@@ -1,231 +1,163 @@
 ---
 name: autopilot
-description: Full autonomous execution from idea to working code
+description: "[OMX] Strict autonomous loop: $ralplan -> $ralph -> $code-review"
 ---
 
 <Purpose>
-Autopilot takes a brief product idea and autonomously handles the full lifecycle: requirements analysis, technical design, planning, parallel implementation, QA cycling, and multi-perspective validation. It produces working, verified code from a 2-3 line description.
+Autopilot is the strict autonomous delivery loop for non-trivial work. Its primary contract is exactly:
+
+```text
+$ralplan -> $ralph -> $code-review
+```
+
+If `$code-review` is not clean, Autopilot returns to `$ralplan` with the review findings as the next planning input, then continues again through `$ralph` and `$code-review` until the review is clean or a hard blocker is reported.
 </Purpose>
 
 <Use_When>
-- User wants end-to-end autonomous execution from an idea to working code
-- User says "autopilot", "auto pilot", "autonomous", "build me", "create me", "make me", "full auto", "handle it all", or "I want a/an..."
-- Task requires multiple phases: planning, coding, testing, and validation
-- User wants hands-off execution and is willing to let the system run to completion
+- User wants hands-off execution from a concrete idea, issue, PRD, or requirements artifact to reviewed code
+- User says `$autopilot`, "autopilot", "auto pilot", "autonomous", "build me", "create me", "make me", "full auto", "handle it all", or "I want a/an..."
+- Task needs planning, implementation, verification, and code review with automatic follow-up when review is not clean
 </Use_When>
 
 <Do_Not_Use_When>
-- User wants to explore options or brainstorm -- use `plan` skill instead
+- User wants to explore options or brainstorm -- use `$plan` / `$ralplan`
 - User says "just explain", "draft only", or "what would you suggest" -- respond conversationally
-- User wants a single focused code change -- use `ralph` or delegate to an executor agent
-- User wants to review or critique an existing plan -- use `plan --review`
-- Task is a quick fix or small bug -- use direct executor delegation
+- User wants a single focused code change -- use `$ralph` or direct executor work
+- User wants only review/critique of existing code -- use `$code-review`
 </Do_Not_Use_When>
 
-<Why_This_Exists>
-Most non-trivial software tasks require coordinated phases: understanding requirements, designing a solution, implementing in parallel, testing, and validating quality. Autopilot orchestrates all of these phases automatically so the user can describe what they want and receive working code without managing each step.
-</Why_This_Exists>
+<Strict_Loop_Contract>
+Autopilot must not run a separate broad expansion/planning/execution/QA/validation lifecycle as its primary behavior. It delegates those concerns to the three canonical workflow phases below:
+
+1. **Phase `ralplan`** — consensus planning gate
+   - Ground the task with pre-context intake.
+   - Run or resume `$ralplan` to produce/update PRD and test-spec artifacts.
+   - When returning from a non-clean review, include `return_to_ralplan_reason` and the review findings as first-class planning input.
+   - Required handoff artifact: an approved plan/test spec suitable for `$ralph`.
+
+2. **Phase `ralph`** — implementation + verification loop
+   - Run `$ralph` from the approved ralplan artifacts.
+   - Ralph owns implementation, tests, build/lint/typecheck evidence, deslop where applicable, and architect verification.
+   - Required handoff artifact: implementation evidence and changed-file summary suitable for `$code-review`.
+
+3. **Phase `code-review`** — merge-readiness gate
+   - Run `$code-review` on the diff/artifacts produced by `$ralph`.
+   - A clean review means final recommendation `APPROVE` with architectural status `CLEAR`.
+   - `COMMENT`, `REQUEST CHANGES`, any architectural `WATCH`/`BLOCK`, or any unresolved finding is not clean.
+   - If not clean, increment the review cycle, persist `review_verdict`, set `return_to_ralplan_reason`, and transition back to Phase `ralplan`.
+
+The only normal terminal state is `complete` after a clean code review. Cancellation, blocked credentials, unrecoverable repeated failures, or explicit user stop may terminate earlier with preserved state.
+</Strict_Loop_Contract>
+
+<Pre-context Intake>
+Before Phase `ralplan` starts or resumes:
+1. Derive a task slug from the request.
+2. Reuse the latest relevant `.omx/context/{slug}-*.md` snapshot when available.
+3. If none exists, create `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) with:
+   - task statement
+   - desired outcome
+   - known facts/evidence
+   - constraints
+   - unknowns/open questions
+   - likely codebase touchpoints
+4. If ambiguity remains high, run `explore` first for brownfield facts, then run the Socratic `$deep-interview --quick <task>` before `$ralplan`.
+5. Carry the snapshot path in Autopilot state and all handoff artifacts.
+</Pre-context Intake>
 
 <Execution_Policy>
-- Each phase must complete before the next begins
-- Parallel execution is used within phases where possible (Phase 2 and Phase 4)
-- QA cycles repeat up to 5 times; if the same error persists 3 times, stop and report the fundamental issue
-- Validation requires approval from all reviewers; rejected items get fixed and re-validated
-- Cancel with `/cancel` at any time; progress is preserved for resume
-- If a deep-interview spec exists, use it as high-clarity phase input instead of re-expanding from scratch
-- If input is too vague for reliable expansion, offer/trigger `$deep-interview` first
-- Do not enter expansion/planning/execution-heavy phases until pre-context grounding exists; if fast execution is forced, proceed only with explicit risk notes
-- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the workflow depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+- Always execute phases in order: `ralplan`, then `ralph`, then `code-review`.
+- Never skip directly from vague/freeform expansion to implementation; unclear input must be clarified or planned through `$ralplan`.
+- A non-clean `$code-review` always returns to `$ralplan`; do not patch findings ad hoc outside the loop.
+- Each phase must write/update Autopilot state before handing off.
+- Use existing hooks, `.omx/state`, `$ralplan`, `$ralph`, `$code-review`, and pipeline primitives; do not invent a separate execution framework.
+- Continue automatically through safe reversible phase transitions. Ask only for destructive, credential-gated, or materially preference-dependent branches.
+- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the Autopilot loop depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
 </Execution_Policy>
 
-<Steps>
-0. **Pre-context Intake (required before Phase 0 starts)**:
-   - Derive a task slug from the request.
-   - Load the latest relevant snapshot from `.omx/context/{slug}-*.md` when available.
-   - If no snapshot exists, create `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) with:
-     - Task statement
-     - Desired outcome
-     - Known facts/evidence
-     - Constraints
-     - Unknowns/open questions
-     - Likely codebase touchpoints
-   - If ambiguity remains high, run `explore` first for brownfield facts, then run `$deep-interview --quick <task>` before proceeding.
-   - Carry the snapshot path into autopilot artifacts/state so all phases share grounded context.
+<State_Management>
+Use `omx_state` MCP tools (or `omx state ... --json` fallback if MCP transport is unavailable) for Autopilot lifecycle state. State must be session-aware when a session id exists.
 
-1. **Phase 0 - Expansion**: Turn the user's idea into a detailed spec
-   - If `.omx/specs/deep-interview-*.md` exists for this task: reuse it and skip redundant expansion work
-   - If prompt is highly vague: route to `$deep-interview` for Socratic ambiguity-gated clarification
-   - Analyst (THOROUGH tier): Extract requirements
-   - Architect (THOROUGH tier): Create technical specification
-   - Output: `.omx/plans/autopilot-spec.md`
+Required fields:
 
-2. **Phase 1 - Planning**: Create an implementation plan from the spec
-   - Architect (THOROUGH tier): Create plan (direct mode, no interview)
-   - Critic (THOROUGH tier): Validate plan
-   - Output: `.omx/plans/autopilot-impl.md`
+```json
+{
+  "mode": "autopilot",
+  "active": true,
+  "current_phase": "ralplan",
+  "iteration": 1,
+  "review_cycle": 0,
+  "max_iterations": 10,
+  "phase_cycle": ["ralplan", "ralph", "code-review"],
+  "handoff_artifacts": {
+    "context_snapshot_path": ".omx/context/<slug>-<timestamp>.md",
+    "ralplan": null,
+    "ralph": null,
+    "code_review": null
+  },
+  "review_verdict": null,
+  "return_to_ralplan_reason": null
+}
+```
 
-3. **Phase 2 - Execution**: Implement the plan using Ralph + Ultrawork
-   - LOW-tier executor/search roles: Simple tasks
-   - STANDARD-tier executor roles: Standard tasks
-   - THOROUGH-tier executor/architect roles: Complex tasks
-   - Run independent tasks in parallel
+- **On start**: `state_write({mode:"autopilot", active:true, current_phase:"ralplan", iteration:1, review_cycle:0, state:{phase_cycle:["ralplan","ralph","code-review"], handoff_artifacts:{context_snapshot_path, ralplan:null, ralph:null, code_review:null}, review_verdict:null, return_to_ralplan_reason:null}})`
+- **On ralplan -> ralph**: set `current_phase:"ralph"`, persist the plan/test-spec paths under `handoff_artifacts.ralplan`.
+- **On ralph -> code-review**: set `current_phase:"code-review"`, persist implementation/test evidence under `handoff_artifacts.ralph`.
+- **On clean review**: set `active:false`, `current_phase:"complete"`, persist `review_verdict:{recommendation:"APPROVE", architectural_status:"CLEAR", clean:true}` and `completed_at`.
+- **On non-clean review**: increment `iteration` and `review_cycle`, set `current_phase:"ralplan"`, persist `review_verdict:{..., clean:false}`, persist `handoff_artifacts.code_review`, and set `return_to_ralplan_reason` to a concise review-driven reason.
+- **On cancellation**: run `$cancel`; preserve progress for resume rather than deleting handoff artifacts.
+</State_Management>
 
-4. **Phase 3 - QA**: Cycle until all tests pass (UltraQA mode)
-   - Build, lint, test, fix failures
-   - Repeat up to 5 cycles
-   - Stop early if the same error repeats 3 times (indicates a fundamental issue)
+<Continuation_And_Resume>
+When the user says `continue`, `resume`, or `keep going` while Autopilot is active, read `autopilot-state.json` and continue from `current_phase`:
+- `ralplan`: run/update consensus planning from current handoffs and any `return_to_ralplan_reason`.
+- `ralph`: execute the approved plan and record verification evidence.
+- `code-review`: review the current diff and decide clean vs return-to-ralplan.
+- `complete`: report completion evidence; do not restart.
 
-5. **Phase 4 - Validation**: Multi-perspective review in parallel
-   - Architect: Functional completeness
-   - Security-reviewer: Vulnerability check
-   - Code-reviewer: Quality review
-   - All must approve; fix and re-validate on rejection
+Do not restart discovery or discard handoff artifacts on continuation.
+</Continuation_And_Resume>
 
-6. **Phase 5 - Cleanup**: Clear all mode state via OMX MCP tools on successful completion
-   - `state_clear({mode: "autopilot"})`
-   - `state_clear({mode: "ralph"})`
-   - `state_clear({mode: "ultrawork"})`
-   - `state_clear({mode: "ultraqa"})`
-   - Or run `/cancel` for clean exit
-</Steps>
+<Pipeline_Orchestrator>
+Autopilot may be represented by the configurable pipeline orchestrator (`src/pipeline/`) when useful. The Autopilot pipeline contract is:
 
-<Tool_Usage>
-- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
-- Use `ask_codex` with `agent_role: "architect"` for Phase 4 architecture validation
-- Use `ask_codex` with `agent_role: "security-reviewer"` for Phase 4 security review
-- Use `ask_codex` with `agent_role: "code-reviewer"` for Phase 4 quality review
-- Agents form their own analysis first, then consult Codex for cross-validation
-- If ToolSearch finds no MCP tools or Codex is unavailable, proceed without it -- never block on external tools
-</Tool_Usage>
+```text
+ralplan -> ralph -> code-review
+```
 
-## State Management
-
-Use `omx_state` MCP tools for autopilot lifecycle state.
-
-- **On start**:
-  `state_write({mode: "autopilot", active: true, current_phase: "expansion", started_at: "<now>", state: {context_snapshot_path: "<snapshot-path>"}})`
-- **On phase transitions**:
-  `state_write({mode: "autopilot", current_phase: "planning"})`
-  `state_write({mode: "autopilot", current_phase: "execution"})`
-  `state_write({mode: "autopilot", current_phase: "qa"})`
-  `state_write({mode: "autopilot", current_phase: "validation"})`
-- **On completion**:
-  `state_write({mode: "autopilot", active: false, current_phase: "complete", completed_at: "<now>"})`
-- **On cancellation/cleanup**:
-  run `$cancel` (which should call `state_clear(mode="autopilot")`)
-
-
-## Scenario Examples
-
-**Good:** The user says `continue` after the workflow already has a clear next step. Continue the current branch of work instead of restarting or re-asking the same question.
-
-**Good:** The user changes only the output shape or downstream delivery step (for example `make a PR`). Preserve earlier non-conflicting workflow constraints and apply the update locally.
-
-**Bad:** The user says `continue`, and the workflow restarts discovery or stops before the missing verification/evidence is gathered.
-
-<Examples>
-<Good>
-User: "autopilot A REST API for a bookstore inventory with CRUD operations using TypeScript"
-Why good: Specific domain (bookstore), clear features (CRUD), technology constraint (TypeScript). Autopilot has enough context to expand into a full spec.
-</Good>
-
-<Good>
-User: "build me a CLI tool that tracks daily habits with streak counting"
-Why good: Clear product concept with a specific feature. The "build me" trigger activates autopilot.
-</Good>
-
-<Bad>
-User: "fix the bug in the login page"
-Why bad: This is a single focused fix, not a multi-phase project. Use direct executor delegation or ralph instead.
-</Bad>
-
-<Bad>
-User: "what are some good approaches for adding caching?"
-Why bad: This is an exploration/brainstorming request. Respond conversationally or use the plan skill.
-</Bad>
-</Examples>
+Pipeline state should use `current_phase` values that match the same phase names (`ralplan`, `ralph`, `code-review`, `complete`, `failed`) and should carry `iteration`, `review_cycle`, `handoff_artifacts`, `review_verdict`, and `return_to_ralplan_reason` alongside stage results.
+</Pipeline_Orchestrator>
 
 <Escalation_And_Stop_Conditions>
-- Stop and report when the same QA error persists across 3 cycles (fundamental issue requiring human input)
-- Stop and report when validation keeps failing after 3 re-validation rounds
-- Stop when the user says "stop", "cancel", or "abort"
-- If requirements were too vague and expansion produces an unclear spec, pause and redirect to `$deep-interview` before proceeding
+- Stop and report a blocker when required credentials/authority are missing.
+- Stop and report when the same review or verification failure recurs across 3 review cycles with no meaningful new plan.
+- Stop when the user says "stop", "cancel", or "abort" and run `$cancel`.
+- Otherwise, continue the loop until `$code-review` is clean.
 </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>
-- [ ] All 5 phases completed (Expansion, Planning, Execution, QA, Validation)
-- [ ] All validators approved in Phase 4
-- [ ] Tests pass (verified with fresh test run output)
-- [ ] Build succeeds (verified with fresh build output)
-- [ ] State files cleaned up
-- [ ] User informed of completion with summary of what was built
+- [ ] Phase `ralplan` produced/updated approved planning artifacts
+- [ ] Phase `ralph` implemented and verified the plan with fresh evidence
+- [ ] Phase `code-review` returned a clean verdict (`APPROVE` + `CLEAR`)
+- [ ] `review_verdict.clean` is true and `return_to_ralplan_reason` is null
+- [ ] Tests/build/lint/typecheck evidence from Ralph is available in handoff artifacts
+- [ ] Autopilot state is marked `complete` or cancellation state is preserved coherently
+- [ ] User receives a concise summary with plan, implementation, verification, and review evidence
 </Final_Checklist>
 
-<Advanced>
-## Configuration
+<Examples>
+<Good>
+User: `$autopilot implement GitHub issue #42`
+Flow: create/load context snapshot -> `$ralplan` issue plan -> `$ralph` implementation + tests -> `$code-review`; if review requests changes, return to `$ralplan` with findings.
+</Good>
 
-Optional settings in `~/.codex/config.toml`:
+<Good>
+User: `continue`
+Context: Autopilot state says `current_phase:"code-review"`.
+Flow: run `$code-review` on current diff, persist verdict, finish if clean or transition to `ralplan` with findings if not clean.
+</Good>
 
-```toml
-[omx.autopilot]
-maxIterations = 10
-maxQaCycles = 5
-maxValidationRounds = 3
-pauseAfterExpansion = false
-pauseAfterPlanning = false
-skipQa = false
-skipValidation = false
-```
-
-## Resume
-
-If autopilot was cancelled or failed, run `/autopilot` again to resume from where it stopped.
-
-## Recommended Clarity Pipeline
-
-For ambiguous requests, prefer:
-
-```
-deep-interview -> ralplan -> autopilot
-```
-
-- `deep-interview`: ambiguity-gated Socratic requirements
-- `ralplan`: consensus planning (planner/architect/critic)
-- `autopilot`: execution + QA + validation
-
-## Best Practices for Input
-
-1. Be specific about the domain -- "bookstore" not "store"
-2. Mention key features -- "with CRUD", "with authentication"
-3. Specify constraints -- "using TypeScript", "with PostgreSQL"
-4. Let it run -- avoid interrupting unless truly needed
-
-## Pipeline Orchestrator (v0.8+)
-
-Autopilot can be driven by the configurable pipeline orchestrator (`src/pipeline/`), which
-sequences stages through a uniform `PipelineStage` interface:
-
-```
-RALPLAN (consensus planning) -> team-exec (Codex CLI workers) -> ralph-verify (architect verification)
-```
-
-Pipeline configuration options:
-
-```toml
-[omx.autopilot.pipeline]
-maxRalphIterations = 10    # Ralph verification iteration ceiling
-workerCount = 2            # Number of Codex CLI team workers
-agentType = "executor"     # Agent type for team workers
-```
-
-The pipeline persists state via `pipeline-state.json` and supports resume from the last
-incomplete stage. See `src/pipeline/orchestrator.ts` for the full API.
-
-## Troubleshooting
-
-**Stuck in a phase?** Check TODO list for blocked tasks, run `state_read({mode: "autopilot"})`, or cancel and resume.
-
-**QA cycles exhausted?** The same error 3 times indicates a fundamental issue. Review the error pattern; manual intervention may be needed.
-
-**Validation keeps failing?** Review the specific issues. Requirements may have been too vague -- cancel and provide more detail.
-</Advanced>
+<Bad>
+Autopilot invents independent "Expansion", "QA", and "Validation" phases and treats them as the primary lifecycle.
+Why bad: this bypasses the strict `$ralplan -> $ralph -> $code-review` contract.
+</Bad>
+</Examples>

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -1,231 +1,163 @@
 ---
 name: autopilot
-description: Full autonomous execution from idea to working code
+description: "[OMX] Strict autonomous loop: $ralplan -> $ralph -> $code-review"
 ---
 
 <Purpose>
-Autopilot takes a brief product idea and autonomously handles the full lifecycle: requirements analysis, technical design, planning, parallel implementation, QA cycling, and multi-perspective validation. It produces working, verified code from a 2-3 line description.
+Autopilot is the strict autonomous delivery loop for non-trivial work. Its primary contract is exactly:
+
+```text
+$ralplan -> $ralph -> $code-review
+```
+
+If `$code-review` is not clean, Autopilot returns to `$ralplan` with the review findings as the next planning input, then continues again through `$ralph` and `$code-review` until the review is clean or a hard blocker is reported.
 </Purpose>
 
 <Use_When>
-- User wants end-to-end autonomous execution from an idea to working code
-- User says "autopilot", "auto pilot", "autonomous", "build me", "create me", "make me", "full auto", "handle it all", or "I want a/an..."
-- Task requires multiple phases: planning, coding, testing, and validation
-- User wants hands-off execution and is willing to let the system run to completion
+- User wants hands-off execution from a concrete idea, issue, PRD, or requirements artifact to reviewed code
+- User says `$autopilot`, "autopilot", "auto pilot", "autonomous", "build me", "create me", "make me", "full auto", "handle it all", or "I want a/an..."
+- Task needs planning, implementation, verification, and code review with automatic follow-up when review is not clean
 </Use_When>
 
 <Do_Not_Use_When>
-- User wants to explore options or brainstorm -- use `plan` skill instead
+- User wants to explore options or brainstorm -- use `$plan` / `$ralplan`
 - User says "just explain", "draft only", or "what would you suggest" -- respond conversationally
-- User wants a single focused code change -- use `ralph` or delegate to an executor agent
-- User wants to review or critique an existing plan -- use `plan --review`
-- Task is a quick fix or small bug -- use direct executor delegation
+- User wants a single focused code change -- use `$ralph` or direct executor work
+- User wants only review/critique of existing code -- use `$code-review`
 </Do_Not_Use_When>
 
-<Why_This_Exists>
-Most non-trivial software tasks require coordinated phases: understanding requirements, designing a solution, implementing in parallel, testing, and validating quality. Autopilot orchestrates all of these phases automatically so the user can describe what they want and receive working code without managing each step.
-</Why_This_Exists>
+<Strict_Loop_Contract>
+Autopilot must not run a separate broad expansion/planning/execution/QA/validation lifecycle as its primary behavior. It delegates those concerns to the three canonical workflow phases below:
+
+1. **Phase `ralplan`** — consensus planning gate
+   - Ground the task with pre-context intake.
+   - Run or resume `$ralplan` to produce/update PRD and test-spec artifacts.
+   - When returning from a non-clean review, include `return_to_ralplan_reason` and the review findings as first-class planning input.
+   - Required handoff artifact: an approved plan/test spec suitable for `$ralph`.
+
+2. **Phase `ralph`** — implementation + verification loop
+   - Run `$ralph` from the approved ralplan artifacts.
+   - Ralph owns implementation, tests, build/lint/typecheck evidence, deslop where applicable, and architect verification.
+   - Required handoff artifact: implementation evidence and changed-file summary suitable for `$code-review`.
+
+3. **Phase `code-review`** — merge-readiness gate
+   - Run `$code-review` on the diff/artifacts produced by `$ralph`.
+   - A clean review means final recommendation `APPROVE` with architectural status `CLEAR`.
+   - `COMMENT`, `REQUEST CHANGES`, any architectural `WATCH`/`BLOCK`, or any unresolved finding is not clean.
+   - If not clean, increment the review cycle, persist `review_verdict`, set `return_to_ralplan_reason`, and transition back to Phase `ralplan`.
+
+The only normal terminal state is `complete` after a clean code review. Cancellation, blocked credentials, unrecoverable repeated failures, or explicit user stop may terminate earlier with preserved state.
+</Strict_Loop_Contract>
+
+<Pre-context Intake>
+Before Phase `ralplan` starts or resumes:
+1. Derive a task slug from the request.
+2. Reuse the latest relevant `.omx/context/{slug}-*.md` snapshot when available.
+3. If none exists, create `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) with:
+   - task statement
+   - desired outcome
+   - known facts/evidence
+   - constraints
+   - unknowns/open questions
+   - likely codebase touchpoints
+4. If ambiguity remains high, run `explore` first for brownfield facts, then run the Socratic `$deep-interview --quick <task>` before `$ralplan`.
+5. Carry the snapshot path in Autopilot state and all handoff artifacts.
+</Pre-context Intake>
 
 <Execution_Policy>
-- Each phase must complete before the next begins
-- Parallel execution is used within phases where possible (Phase 2 and Phase 4)
-- QA cycles repeat up to 5 times; if the same error persists 3 times, stop and report the fundamental issue
-- Validation requires approval from all reviewers; rejected items get fixed and re-validated
-- Cancel with `/cancel` at any time; progress is preserved for resume
-- If a deep-interview spec exists, use it as high-clarity phase input instead of re-expanding from scratch
-- If input is too vague for reliable expansion, offer/trigger `$deep-interview` first
-- Do not enter expansion/planning/execution-heavy phases until pre-context grounding exists; if fast execution is forced, proceed only with explicit risk notes
-- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the workflow depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+- Always execute phases in order: `ralplan`, then `ralph`, then `code-review`.
+- Never skip directly from vague/freeform expansion to implementation; unclear input must be clarified or planned through `$ralplan`.
+- A non-clean `$code-review` always returns to `$ralplan`; do not patch findings ad hoc outside the loop.
+- Each phase must write/update Autopilot state before handing off.
+- Use existing hooks, `.omx/state`, `$ralplan`, `$ralph`, `$code-review`, and pipeline primitives; do not invent a separate execution framework.
+- Continue automatically through safe reversible phase transitions. Ask only for destructive, credential-gated, or materially preference-dependent branches.
+- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the Autopilot loop depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
 </Execution_Policy>
 
-<Steps>
-0. **Pre-context Intake (required before Phase 0 starts)**:
-   - Derive a task slug from the request.
-   - Load the latest relevant snapshot from `.omx/context/{slug}-*.md` when available.
-   - If no snapshot exists, create `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) with:
-     - Task statement
-     - Desired outcome
-     - Known facts/evidence
-     - Constraints
-     - Unknowns/open questions
-     - Likely codebase touchpoints
-   - If ambiguity remains high, run `explore` first for brownfield facts, then run `$deep-interview --quick <task>` before proceeding.
-   - Carry the snapshot path into autopilot artifacts/state so all phases share grounded context.
+<State_Management>
+Use `omx_state` MCP tools (or `omx state ... --json` fallback if MCP transport is unavailable) for Autopilot lifecycle state. State must be session-aware when a session id exists.
 
-1. **Phase 0 - Expansion**: Turn the user's idea into a detailed spec
-   - If `.omx/specs/deep-interview-*.md` exists for this task: reuse it and skip redundant expansion work
-   - If prompt is highly vague: route to `$deep-interview` for Socratic ambiguity-gated clarification
-   - Analyst (THOROUGH tier): Extract requirements
-   - Architect (THOROUGH tier): Create technical specification
-   - Output: `.omx/plans/autopilot-spec.md`
+Required fields:
 
-2. **Phase 1 - Planning**: Create an implementation plan from the spec
-   - Architect (THOROUGH tier): Create plan (direct mode, no interview)
-   - Critic (THOROUGH tier): Validate plan
-   - Output: `.omx/plans/autopilot-impl.md`
+```json
+{
+  "mode": "autopilot",
+  "active": true,
+  "current_phase": "ralplan",
+  "iteration": 1,
+  "review_cycle": 0,
+  "max_iterations": 10,
+  "phase_cycle": ["ralplan", "ralph", "code-review"],
+  "handoff_artifacts": {
+    "context_snapshot_path": ".omx/context/<slug>-<timestamp>.md",
+    "ralplan": null,
+    "ralph": null,
+    "code_review": null
+  },
+  "review_verdict": null,
+  "return_to_ralplan_reason": null
+}
+```
 
-3. **Phase 2 - Execution**: Implement the plan using Ralph + Ultrawork
-   - LOW-tier executor/search roles: Simple tasks
-   - STANDARD-tier executor roles: Standard tasks
-   - THOROUGH-tier executor/architect roles: Complex tasks
-   - Run independent tasks in parallel
+- **On start**: `state_write({mode:"autopilot", active:true, current_phase:"ralplan", iteration:1, review_cycle:0, state:{phase_cycle:["ralplan","ralph","code-review"], handoff_artifacts:{context_snapshot_path, ralplan:null, ralph:null, code_review:null}, review_verdict:null, return_to_ralplan_reason:null}})`
+- **On ralplan -> ralph**: set `current_phase:"ralph"`, persist the plan/test-spec paths under `handoff_artifacts.ralplan`.
+- **On ralph -> code-review**: set `current_phase:"code-review"`, persist implementation/test evidence under `handoff_artifacts.ralph`.
+- **On clean review**: set `active:false`, `current_phase:"complete"`, persist `review_verdict:{recommendation:"APPROVE", architectural_status:"CLEAR", clean:true}` and `completed_at`.
+- **On non-clean review**: increment `iteration` and `review_cycle`, set `current_phase:"ralplan"`, persist `review_verdict:{..., clean:false}`, persist `handoff_artifacts.code_review`, and set `return_to_ralplan_reason` to a concise review-driven reason.
+- **On cancellation**: run `$cancel`; preserve progress for resume rather than deleting handoff artifacts.
+</State_Management>
 
-4. **Phase 3 - QA**: Cycle until all tests pass (UltraQA mode)
-   - Build, lint, test, fix failures
-   - Repeat up to 5 cycles
-   - Stop early if the same error repeats 3 times (indicates a fundamental issue)
+<Continuation_And_Resume>
+When the user says `continue`, `resume`, or `keep going` while Autopilot is active, read `autopilot-state.json` and continue from `current_phase`:
+- `ralplan`: run/update consensus planning from current handoffs and any `return_to_ralplan_reason`.
+- `ralph`: execute the approved plan and record verification evidence.
+- `code-review`: review the current diff and decide clean vs return-to-ralplan.
+- `complete`: report completion evidence; do not restart.
 
-5. **Phase 4 - Validation**: Multi-perspective review in parallel
-   - Architect: Functional completeness
-   - Security-reviewer: Vulnerability check
-   - Code-reviewer: Quality review
-   - All must approve; fix and re-validate on rejection
+Do not restart discovery or discard handoff artifacts on continuation.
+</Continuation_And_Resume>
 
-6. **Phase 5 - Cleanup**: Clear all mode state via OMX MCP tools on successful completion
-   - `state_clear({mode: "autopilot"})`
-   - `state_clear({mode: "ralph"})`
-   - `state_clear({mode: "ultrawork"})`
-   - `state_clear({mode: "ultraqa"})`
-   - Or run `/cancel` for clean exit
-</Steps>
+<Pipeline_Orchestrator>
+Autopilot may be represented by the configurable pipeline orchestrator (`src/pipeline/`) when useful. The Autopilot pipeline contract is:
 
-<Tool_Usage>
-- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
-- Use `ask_codex` with `agent_role: "architect"` for Phase 4 architecture validation
-- Use `ask_codex` with `agent_role: "security-reviewer"` for Phase 4 security review
-- Use `ask_codex` with `agent_role: "code-reviewer"` for Phase 4 quality review
-- Agents form their own analysis first, then consult Codex for cross-validation
-- If ToolSearch finds no MCP tools or Codex is unavailable, proceed without it -- never block on external tools
-</Tool_Usage>
+```text
+ralplan -> ralph -> code-review
+```
 
-## State Management
-
-Use `omx_state` MCP tools for autopilot lifecycle state.
-
-- **On start**:
-  `state_write({mode: "autopilot", active: true, current_phase: "expansion", started_at: "<now>", state: {context_snapshot_path: "<snapshot-path>"}})`
-- **On phase transitions**:
-  `state_write({mode: "autopilot", current_phase: "planning"})`
-  `state_write({mode: "autopilot", current_phase: "execution"})`
-  `state_write({mode: "autopilot", current_phase: "qa"})`
-  `state_write({mode: "autopilot", current_phase: "validation"})`
-- **On completion**:
-  `state_write({mode: "autopilot", active: false, current_phase: "complete", completed_at: "<now>"})`
-- **On cancellation/cleanup**:
-  run `$cancel` (which should call `state_clear(mode="autopilot")`)
-
-
-## Scenario Examples
-
-**Good:** The user says `continue` after the workflow already has a clear next step. Continue the current branch of work instead of restarting or re-asking the same question.
-
-**Good:** The user changes only the output shape or downstream delivery step (for example `make a PR`). Preserve earlier non-conflicting workflow constraints and apply the update locally.
-
-**Bad:** The user says `continue`, and the workflow restarts discovery or stops before the missing verification/evidence is gathered.
-
-<Examples>
-<Good>
-User: "autopilot A REST API for a bookstore inventory with CRUD operations using TypeScript"
-Why good: Specific domain (bookstore), clear features (CRUD), technology constraint (TypeScript). Autopilot has enough context to expand into a full spec.
-</Good>
-
-<Good>
-User: "build me a CLI tool that tracks daily habits with streak counting"
-Why good: Clear product concept with a specific feature. The "build me" trigger activates autopilot.
-</Good>
-
-<Bad>
-User: "fix the bug in the login page"
-Why bad: This is a single focused fix, not a multi-phase project. Use direct executor delegation or ralph instead.
-</Bad>
-
-<Bad>
-User: "what are some good approaches for adding caching?"
-Why bad: This is an exploration/brainstorming request. Respond conversationally or use the plan skill.
-</Bad>
-</Examples>
+Pipeline state should use `current_phase` values that match the same phase names (`ralplan`, `ralph`, `code-review`, `complete`, `failed`) and should carry `iteration`, `review_cycle`, `handoff_artifacts`, `review_verdict`, and `return_to_ralplan_reason` alongside stage results.
+</Pipeline_Orchestrator>
 
 <Escalation_And_Stop_Conditions>
-- Stop and report when the same QA error persists across 3 cycles (fundamental issue requiring human input)
-- Stop and report when validation keeps failing after 3 re-validation rounds
-- Stop when the user says "stop", "cancel", or "abort"
-- If requirements were too vague and expansion produces an unclear spec, pause and redirect to `$deep-interview` before proceeding
+- Stop and report a blocker when required credentials/authority are missing.
+- Stop and report when the same review or verification failure recurs across 3 review cycles with no meaningful new plan.
+- Stop when the user says "stop", "cancel", or "abort" and run `$cancel`.
+- Otherwise, continue the loop until `$code-review` is clean.
 </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>
-- [ ] All 5 phases completed (Expansion, Planning, Execution, QA, Validation)
-- [ ] All validators approved in Phase 4
-- [ ] Tests pass (verified with fresh test run output)
-- [ ] Build succeeds (verified with fresh build output)
-- [ ] State files cleaned up
-- [ ] User informed of completion with summary of what was built
+- [ ] Phase `ralplan` produced/updated approved planning artifacts
+- [ ] Phase `ralph` implemented and verified the plan with fresh evidence
+- [ ] Phase `code-review` returned a clean verdict (`APPROVE` + `CLEAR`)
+- [ ] `review_verdict.clean` is true and `return_to_ralplan_reason` is null
+- [ ] Tests/build/lint/typecheck evidence from Ralph is available in handoff artifacts
+- [ ] Autopilot state is marked `complete` or cancellation state is preserved coherently
+- [ ] User receives a concise summary with plan, implementation, verification, and review evidence
 </Final_Checklist>
 
-<Advanced>
-## Configuration
+<Examples>
+<Good>
+User: `$autopilot implement GitHub issue #42`
+Flow: create/load context snapshot -> `$ralplan` issue plan -> `$ralph` implementation + tests -> `$code-review`; if review requests changes, return to `$ralplan` with findings.
+</Good>
 
-Optional settings in `~/.codex/config.toml`:
+<Good>
+User: `continue`
+Context: Autopilot state says `current_phase:"code-review"`.
+Flow: run `$code-review` on current diff, persist verdict, finish if clean or transition to `ralplan` with findings if not clean.
+</Good>
 
-```toml
-[omx.autopilot]
-maxIterations = 10
-maxQaCycles = 5
-maxValidationRounds = 3
-pauseAfterExpansion = false
-pauseAfterPlanning = false
-skipQa = false
-skipValidation = false
-```
-
-## Resume
-
-If autopilot was cancelled or failed, run `/autopilot` again to resume from where it stopped.
-
-## Recommended Clarity Pipeline
-
-For ambiguous requests, prefer:
-
-```
-deep-interview -> ralplan -> autopilot
-```
-
-- `deep-interview`: ambiguity-gated Socratic requirements
-- `ralplan`: consensus planning (planner/architect/critic)
-- `autopilot`: execution + QA + validation
-
-## Best Practices for Input
-
-1. Be specific about the domain -- "bookstore" not "store"
-2. Mention key features -- "with CRUD", "with authentication"
-3. Specify constraints -- "using TypeScript", "with PostgreSQL"
-4. Let it run -- avoid interrupting unless truly needed
-
-## Pipeline Orchestrator (v0.8+)
-
-Autopilot can be driven by the configurable pipeline orchestrator (`src/pipeline/`), which
-sequences stages through a uniform `PipelineStage` interface:
-
-```
-RALPLAN (consensus planning) -> team-exec (Codex CLI workers) -> ralph-verify (architect verification)
-```
-
-Pipeline configuration options:
-
-```toml
-[omx.autopilot.pipeline]
-maxRalphIterations = 10    # Ralph verification iteration ceiling
-workerCount = 2            # Number of Codex CLI team workers
-agentType = "executor"     # Agent type for team workers
-```
-
-The pipeline persists state via `pipeline-state.json` and supports resume from the last
-incomplete stage. See `src/pipeline/orchestrator.ts` for the full API.
-
-## Troubleshooting
-
-**Stuck in a phase?** Check TODO list for blocked tasks, run `state_read({mode: "autopilot"})`, or cancel and resume.
-
-**QA cycles exhausted?** The same error 3 times indicates a fundamental issue. Review the error pattern; manual intervention may be needed.
-
-**Validation keeps failing?** Review the specific issues. Requirements may have been too vague -- cancel and provide more detail.
-</Advanced>
+<Bad>
+Autopilot invents independent "Expansion", "QA", and "Validation" phases and treats them as the primary lifecycle.
+Why bad: this bypasses the strict `$ralplan -> $ralph -> $code-review` contract.
+</Bad>
+</Examples>

--- a/src/hooks/__tests__/autopilot-skill-contract.test.ts
+++ b/src/hooks/__tests__/autopilot-skill-contract.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const autopilotSkill = readFileSync(join(__dirname, '../../../skills/autopilot/SKILL.md'), 'utf-8');
+
+describe('autopilot skill strict 3-phase contract', () => {
+  it('makes ralplan -> ralph -> code-review the primary contract', () => {
+    assert.match(autopilotSkill, /\$ralplan\s*->\s*\$ralph\s*->\s*\$code-review/);
+    assert.match(autopilotSkill, /strict autonomous delivery loop/i);
+  });
+
+  it('returns non-clean code-review findings to ralplan', () => {
+    assert.match(autopilotSkill, /If `\$code-review` is not clean, Autopilot returns to `\$ralplan`/i);
+    assert.match(autopilotSkill, /COMMENT.*REQUEST CHANGES.*WATCH.*BLOCK/s);
+  });
+
+  it('requires tight phase, cycle, handoff, review state fields', () => {
+    for (const field of [
+      'current_phase',
+      'iteration',
+      'review_cycle',
+      'phase_cycle',
+      'handoff_artifacts',
+      'review_verdict',
+      'return_to_ralplan_reason',
+    ]) {
+      assert.match(autopilotSkill, new RegExp(field));
+    }
+  });
+
+  it('does not preserve the old broad phase lifecycle as primary behavior', () => {
+    assert.doesNotMatch(autopilotSkill, /All 5 phases completed/i);
+    assert.doesNotMatch(autopilotSkill, /Phase 0 - Expansion/i);
+    assert.doesNotMatch(autopilotSkill, /Phase 4 - Validation/i);
+    assert.match(autopilotSkill, /must not run a separate broad expansion\/planning\/execution\/QA\/validation lifecycle as its primary behavior/i);
+  });
+});

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -384,7 +384,7 @@ describe('keyword registry coverage', () => {
 });
 
 describe('keyword detector skill-active-state lifecycle', () => {
-  it('writes skill-active-state.json with planning phase when keyword activates', async () => {
+  it('writes skill-active-state.json with ralplan phase when autopilot keyword activates', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-'));
     const stateDir = join(cwd, '.omx', 'state');
     try {
@@ -400,11 +400,11 @@ describe('keyword detector skill-active-state lifecycle', () => {
 
       assert.ok(result);
       assert.equal(result.skill, 'autopilot');
-      assert.equal(result.phase, 'planning');
+      assert.equal(result.phase, 'ralplan');
       assert.equal(result.active, true);
       assert.deepEqual(result.active_skills, [{
         skill: 'autopilot',
-        phase: 'planning',
+        phase: 'ralplan',
         active: true,
         activated_at: '2026-02-25T00:00:00.000Z',
         updated_at: '2026-02-25T00:00:00.000Z',
@@ -423,11 +423,11 @@ describe('keyword detector skill-active-state lifecycle', () => {
         initialized_mode?: string;
       };
       assert.equal(persisted.skill, 'autopilot');
-      assert.equal(persisted.phase, 'planning');
+      assert.equal(persisted.phase, 'ralplan');
       assert.equal(persisted.active, true);
       assert.deepEqual(persisted.active_skills, [{
         skill: 'autopilot',
-        phase: 'planning',
+        phase: 'ralplan',
         active: true,
         activated_at: '2026-02-25T00:00:00.000Z',
         updated_at: '2026-02-25T00:00:00.000Z',
@@ -446,10 +446,26 @@ describe('keyword detector skill-active-state lifecycle', () => {
         mode: string;
         active: boolean;
         current_phase: string;
+        iteration: number;
+        review_cycle: number;
+        max_iterations: number;
+        state: {
+          phase_cycle: string[];
+          handoff_artifacts: Record<string, unknown>;
+          review_verdict: unknown;
+          return_to_ralplan_reason: string | null;
+        };
       };
       assert.equal(modeState.mode, 'autopilot');
       assert.equal(modeState.active, true);
-      assert.equal(modeState.current_phase, 'planning');
+      assert.equal(modeState.current_phase, 'ralplan');
+      assert.equal(modeState.iteration, 1);
+      assert.equal(modeState.review_cycle, 0);
+      assert.equal(modeState.max_iterations, 10);
+      assert.deepEqual(modeState.state.phase_cycle, ['ralplan', 'ralph', 'code-review']);
+      assert.deepEqual(modeState.state.handoff_artifacts, { ralplan: null, ralph: null, code_review: null });
+      assert.equal(modeState.state.review_verdict, null);
+      assert.equal(modeState.state.return_to_ralplan_reason, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1156,7 +1172,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
           active: true,
           skill: 'deep-interview',
           keyword: 'deep interview',
-          phase: 'planning',
+          phase: 'ralplan',
           activated_at: '2026-02-25T00:00:00.000Z',
           updated_at: '2026-02-25T00:00:00.000Z',
           source: 'keyword-detector',
@@ -1352,7 +1368,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
           active: true,
           skill: 'autopilot',
           keyword: '$autopilot',
-          phase: 'planning',
+          phase: 'ralplan',
           activated_at: '2026-02-25T00:00:00.000Z',
           updated_at: '2026-02-25T00:10:00.000Z',
           source: 'keyword-detector',
@@ -1389,7 +1405,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
           active: true,
           skill: 'autopilot',
           keyword: 'autopilot',
-          phase: 'planning',
+          phase: 'ralplan',
           activated_at: '2026-02-25T00:00:00.000Z',
           updated_at: '2026-02-25T00:10:00.000Z',
           source: 'keyword-detector',
@@ -1401,7 +1417,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
         JSON.stringify({
           active: true,
           mode: 'autopilot',
-          current_phase: 'execution',
+          current_phase: 'code-review',
           started_at: '2026-02-25T00:00:00.000Z',
           updated_at: '2026-02-25T00:10:00.000Z',
           session_id: 'sess-autopilot',
@@ -1418,12 +1434,12 @@ describe('keyword detector skill-active-state lifecycle', () => {
 
       assert.ok(result);
       assert.equal(result.skill, 'autopilot');
-      assert.equal(result.phase, 'planning');
+      assert.equal(result.phase, 'ralplan');
       assert.equal(result.transition_error, undefined);
       const modeState = JSON.parse(
         await readFile(join(stateDir, 'sessions', 'sess-autopilot', 'autopilot-state.json'), 'utf-8'),
       ) as { current_phase: string; started_at: string; state?: { context_snapshot_path?: string } };
-      assert.equal(modeState.current_phase, 'execution');
+      assert.equal(modeState.current_phase, 'code-review');
       assert.equal(modeState.started_at, '2026-02-25T00:00:00.000Z');
       assert.equal(modeState.state?.context_snapshot_path, '.omx/context/existing.md');
     } finally {
@@ -1601,7 +1617,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
           active: true,
           skill: 'autopilot',
           keyword: '$autopilot',
-          phase: 'planning',
+          phase: 'ralplan',
           activated_at: '2026-04-19T00:00:00.000Z',
           updated_at: '2026-04-19T00:10:00.000Z',
           source: 'keyword-detector',
@@ -1609,7 +1625,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
           active_skills: [
             {
               skill: 'autopilot',
-              phase: 'planning',
+              phase: 'ralplan',
               active: true,
               activated_at: '2026-04-19T00:00:00.000Z',
               updated_at: '2026-04-19T00:10:00.000Z',
@@ -1623,7 +1639,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
         JSON.stringify({
           active: true,
           mode: 'autopilot',
-          current_phase: 'execution',
+          current_phase: 'code-review',
           started_at: '2026-04-19T00:00:00.000Z',
           updated_at: '2026-04-19T00:10:00.000Z',
           session_id: 'sess-autopilot-bare',
@@ -1645,7 +1661,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
       const modeState = JSON.parse(
         await readFile(join(stateDir, 'sessions', 'sess-autopilot-bare', 'autopilot-state.json'), 'utf-8'),
       ) as { current_phase: string; state?: { context_snapshot_path?: string } };
-      assert.equal(modeState.current_phase, 'execution');
+      assert.equal(modeState.current_phase, 'code-review');
       assert.equal(modeState.state?.context_snapshot_path, '.omx/context/autopilot.md');
       assert.equal(existsSync(join(stateDir, 'sessions', 'sess-autopilot-bare', 'ralph-state.json')), false);
     } finally {
@@ -1775,7 +1791,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
           active: true,
           skill: 'autopilot',
           keyword: 'autopilot',
-          phase: 'planning',
+          phase: 'ralplan',
           activated_at: '2026-02-25T00:00:00.000Z',
           updated_at: '2026-02-25T00:10:00.000Z',
           source: 'keyword-detector',
@@ -1810,7 +1826,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
           active: true,
           skill: 'autopilot',
           keyword: 'autopilot',
-          phase: 'planning',
+          phase: 'ralplan',
           activated_at: '2026-02-25T00:00:00.000Z',
           updated_at: '2026-02-25T00:10:00.000Z',
           source: 'keyword-detector',

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -1893,7 +1893,7 @@ exit 0
         active: boolean;
       };
       assert.equal(skillState.skill, 'autopilot');
-      assert.equal(skillState.phase, 'planning');
+      assert.equal(skillState.phase, 'ralplan');
       assert.equal(skillState.active, true);
     });
   });

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -51,7 +51,7 @@ function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-export type SkillActivePhase = 'planning' | 'executing' | 'reviewing' | 'completing';
+export type SkillActivePhase = 'planning' | 'executing' | 'reviewing' | 'completing' | 'ralplan';
 
 export interface DeepInterviewInputLock {
   active: boolean;
@@ -131,7 +131,7 @@ const EXECUTION_LIKE_WORKFLOW_SKILLS = new Set<TrackedWorkflowMode>([
 
 const STATEFUL_SKILL_SEED_CONFIG: Record<StatefulSkillMode, StatefulSkillSeedConfig> = {
   'deep-interview': { mode: 'deep-interview', initialPhase: 'intent-first' },
-  autopilot: { mode: 'autopilot', initialPhase: 'planning' },
+  autopilot: { mode: 'autopilot', initialPhase: 'ralplan', includeIteration: true },
   autoresearch: { mode: 'autoresearch', initialPhase: 'executing' },
   ralph: { mode: 'ralph', initialPhase: 'starting', includeIteration: true },
   ralplan: { mode: 'ralplan', initialPhase: 'planning' },
@@ -378,8 +378,36 @@ async function persistStatefulSkillSeedState(
   );
 
   if (config.includeIteration) {
-    baseState.iteration = typeof existingModeState?.iteration === 'number' ? existingModeState.iteration : 0;
-    baseState.max_iterations = typeof existingModeState?.max_iterations === 'number' ? existingModeState.max_iterations : 50;
+    const defaultIteration = config.mode === 'autopilot' ? 1 : 0;
+    const defaultMaxIterations = config.mode === 'autopilot' ? 10 : 50;
+    baseState.iteration = typeof existingModeState?.iteration === 'number' ? existingModeState.iteration : defaultIteration;
+    baseState.max_iterations = typeof existingModeState?.max_iterations === 'number' ? existingModeState.max_iterations : defaultMaxIterations;
+  }
+
+  if (config.mode === 'autopilot') {
+    const existingState = (existingModeState?.state && typeof existingModeState.state === 'object')
+      ? existingModeState.state as Record<string, unknown>
+      : {};
+    const existingHandoffs = (existingState.handoff_artifacts && typeof existingState.handoff_artifacts === 'object')
+      ? existingState.handoff_artifacts as Record<string, unknown>
+      : {};
+    baseState.review_cycle = typeof existingModeState?.review_cycle === 'number' ? existingModeState.review_cycle : 0;
+    baseState.state = {
+      ...existingState,
+      phase_cycle: Array.isArray(existingState.phase_cycle) ? existingState.phase_cycle : ['ralplan', 'ralph', 'code-review'],
+      handoff_artifacts: {
+        ralplan: null,
+        ralph: null,
+        code_review: null,
+        ...existingHandoffs,
+      },
+      review_verdict: Object.prototype.hasOwnProperty.call(existingState, 'review_verdict')
+        ? existingState.review_verdict
+        : null,
+      return_to_ralplan_reason: Object.prototype.hasOwnProperty.call(existingState, 'return_to_ralplan_reason')
+        ? existingState.return_to_ralplan_reason
+        : null,
+    };
   }
 
   await mkdir(dirname(absolutePath), { recursive: true });
@@ -675,7 +703,9 @@ function resolveContinuationKeywordMatch(
 }
 
 function initialWorkflowPhaseForMode(mode: TrackedWorkflowMode): SkillActivePhase {
-  return mode === 'autoresearch' ? 'executing' : 'planning';
+  if (mode === 'autoresearch') return 'executing';
+  if (mode === 'autopilot') return 'ralplan';
+  return 'planning';
 }
 
 function resolveRequestedWorkflowSkills(requestedWorkflowSkills: TrackedWorkflowMode[]): {

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -310,9 +310,15 @@ export const PROMPT_REFACTOR_INVARIANT_CONTRACTS: GuidanceSurfaceContract[] = [
     requiredPatterns: [rx('test'), rx('verify'), rx('fix'), rx('repeat|loop')],
   },
   {
-    id: 'autopilot-completion-loop',
+    id: 'autopilot-strict-3phase-loop',
     path: 'skills/autopilot/SKILL.md',
-    requiredPatterns: [rx('requirements analysis'), rx('implementation'), rx('validation')],
+    requiredPatterns: [
+      rx('\\$ralplan\\s*->\\s*\\$ralph\\s*->\\s*\\$code-review'),
+      rx('return[s]? to `?\\$ralplan`?|current_phase.*ralplan'),
+      rx('review_cycle'),
+      rx('review_verdict'),
+      rx('return_to_ralplan_reason'),
+    ],
   },
   {
     id: 'explore-read-only-role-boundary',

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -679,7 +679,7 @@ describe('state-server directory initialization', () => {
             session_id: 'sess-deny',
             mode: 'autopilot',
             active: true,
-            current_phase: 'planning',
+            current_phase: 'ralplan',
           },
         },
       });
@@ -1036,9 +1036,9 @@ describe('state-server directory initialization', () => {
           arguments: {
             workingDirectory: wd,
             session_id: 'sess-rollback',
-            mode: 'autopilot',
+            mode: 'ralph',
             active: true,
-            current_phase: 'planning',
+            current_phase: 'executing',
           },
         },
       });

--- a/src/modes/__tests__/base-autoresearch-contract.test.ts
+++ b/src/modes/__tests__/base-autoresearch-contract.test.ts
@@ -84,7 +84,7 @@ describe('modes/base autoresearch contract integration', () => {
   it('startMode blocks execution-to-planning rollback auto-complete', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-rollback-deny-'));
     try {
-      await startMode('autopilot', 'demo', 5, wd);
+      await startMode('ralph', 'demo', 5, wd);
       await assert.rejects(
         () => startMode('ralplan', 'plan again', 5, wd),
         /Execution-to-planning rollback auto-complete is not allowed/i,

--- a/src/pipeline/__tests__/orchestrator.test.ts
+++ b/src/pipeline/__tests__/orchestrator.test.ts
@@ -187,6 +187,9 @@ describe('Pipeline Orchestrator', () => {
       assert.equal(ext?.review_cycle, 1);
       assert.equal((ext?.review_verdict as { clean?: boolean } | undefined)?.clean, true);
       assert.equal(ext?.return_to_ralplan_reason, null);
+      assert.ok(ext?.handoff_artifacts?.code_review);
+      assert.equal(Object.prototype.hasOwnProperty.call(ext?.handoff_artifacts ?? {}, 'code-review'), false);
+      assert.equal(Object.prototype.hasOwnProperty.call(ext?.handoff_artifacts ?? {}, 'review_verdict'), false);
     });
 
     it('fails after bounded non-clean code-review cycles', async () => {

--- a/src/pipeline/__tests__/orchestrator.test.ts
+++ b/src/pipeline/__tests__/orchestrator.test.ts
@@ -10,6 +10,7 @@ import {
   readPipelineState,
   cancelPipeline,
   createAutopilotPipelineConfig,
+  createStrictAutopilotStages,
 } from '../orchestrator.js';
 import type { PipelineConfig, PipelineStage, StageContext, StageResult } from '../types.js';
 
@@ -127,6 +128,94 @@ describe('Pipeline Orchestrator', () => {
       assert.equal(result.status, 'completed');
       assert.deepEqual(order, ['stage-a', 'stage-b', 'stage-c']);
       assert.equal(Object.keys(result.stageResults).length, 3);
+    });
+
+
+
+    it('returns to ralplan when code-review is not clean', async () => {
+      const order: string[] = [];
+      let reviewRuns = 0;
+      const stages: PipelineStage[] = [
+        {
+          name: 'ralplan',
+          async run(): Promise<StageResult> {
+            order.push('ralplan');
+            return { status: 'completed', artifacts: { plan: `cycle-${order.length}` }, duration_ms: 0 };
+          },
+        },
+        {
+          name: 'ralph',
+          async run(): Promise<StageResult> {
+            order.push('ralph');
+            return { status: 'completed', artifacts: { implemented: true }, duration_ms: 0 };
+          },
+        },
+        {
+          name: 'code-review',
+          async run(): Promise<StageResult> {
+            order.push('code-review');
+            reviewRuns += 1;
+            const clean = reviewRuns > 1;
+            return {
+              status: 'completed',
+              artifacts: {
+                review_verdict: {
+                  recommendation: clean ? 'APPROVE' : 'REQUEST CHANGES',
+                  architectural_status: 'CLEAR',
+                  clean,
+                },
+                return_to_ralplan_reason: clean ? null : 'Review requested a plan update.',
+              },
+              duration_ms: 0,
+            };
+          },
+        },
+      ];
+
+      const result = await runPipeline({
+        name: 'review-loop-test',
+        task: 'loop until review clean',
+        stages,
+        cwd: tempDir,
+        maxRalphIterations: 3,
+      });
+
+      assert.equal(result.status, 'completed');
+      assert.deepEqual(order, ['ralplan', 'ralph', 'code-review', 'ralplan', 'ralph', 'code-review']);
+
+      const ext = await readPipelineState(tempDir);
+      assert.equal(ext?.review_cycle, 1);
+      assert.equal((ext?.review_verdict as { clean?: boolean } | undefined)?.clean, true);
+      assert.equal(ext?.return_to_ralplan_reason, null);
+    });
+
+    it('fails after bounded non-clean code-review cycles', async () => {
+      const stages: PipelineStage[] = [
+        makeStage('ralplan'),
+        makeStage('ralph'),
+        makeStage('code-review', {
+          artifacts: {
+            review_verdict: {
+              recommendation: 'REQUEST CHANGES',
+              architectural_status: 'WATCH',
+              clean: false,
+            },
+            return_to_ralplan_reason: 'Review still has findings.',
+          },
+        }),
+      ];
+
+      const result = await runPipeline({
+        name: 'review-loop-fail-test',
+        task: 'loop until bounded failure',
+        stages,
+        cwd: tempDir,
+        maxRalphIterations: 2,
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.equal(result.failedStage, 'code-review');
+      assert.match(result.error ?? '', /Code review was not clean after 2 cycle/);
     });
 
     it('passes artifacts between stages', async () => {
@@ -441,7 +530,7 @@ describe('Pipeline Orchestrator', () => {
           mode: 'autopilot',
           iteration: 1,
           max_iterations: 3,
-          current_phase: 'stage:team-exec',
+          current_phase: 'ralph',
           pipeline_name: 'resume-test',
           started_at: new Date().toISOString(),
         }),
@@ -484,15 +573,20 @@ describe('Pipeline Orchestrator', () => {
 
   describe('createAutopilotPipelineConfig', () => {
     it('creates config with default values', () => {
-      const stages = [makeStage('a')];
-      const config = createAutopilotPipelineConfig('build feature X', { stages });
+      const config = createAutopilotPipelineConfig('build feature X', {});
 
       assert.equal(config.name, 'autopilot');
       assert.equal(config.task, 'build feature X');
       assert.equal(config.maxRalphIterations, 10);
       assert.equal(config.workerCount, 2);
       assert.equal(config.agentType, 'executor');
-      assert.equal(config.stages.length, 1);
+      assert.deepEqual(config.stages.map((stage) => stage.name), ['ralplan', 'ralph', 'code-review']);
+    });
+
+
+
+    it('exposes strict default autopilot stages', () => {
+      assert.deepEqual(createStrictAutopilotStages().map((stage) => stage.name), ['ralplan', 'ralph', 'code-review']);
     });
 
     it('accepts custom overrides', () => {

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -91,6 +91,38 @@ describe('RALPLAN Stage', () => {
     assert.equal(stage.canSkip!(makeCtx()), true);
   });
 
+  it('canSkip returns false after non-clean code-review loopback even when plans exist', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-my-feature.md'), '# Plan\n');
+    await writeFile(join(plansDir, 'test-spec-my-feature.md'), '# Test Spec\n');
+
+    const stage = createRalplanStage();
+    assert.equal(stage.canSkip!(makeCtx({
+      artifacts: {
+        return_to_ralplan_reason: 'Review requested a plan update.',
+        review_verdict: { recommendation: 'REQUEST CHANGES', architectural_status: 'CLEAR', clean: false },
+      },
+    })), false);
+  });
+
+  it('canSkip returns false when nested code-review artifacts are non-clean', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-my-feature.md'), '# Plan\n');
+    await writeFile(join(plansDir, 'test-spec-my-feature.md'), '# Test Spec\n');
+
+    const stage = createRalplanStage();
+    assert.equal(stage.canSkip!(makeCtx({
+      artifacts: {
+        'code-review': {
+          review_verdict: { recommendation: 'COMMENT', architectural_status: 'CLEAR', clean: true },
+          return_to_ralplan_reason: null,
+        },
+      },
+    })), false);
+  });
+
   it('surfaces deep-interview specs in ralplan artifacts for downstream traceability', async () => {
     const specsDir = join(tempDir, '.omx', 'specs');
     await mkdir(specsDir, { recursive: true });
@@ -289,6 +321,19 @@ describe('Ralph Verify Stage', () => {
     assert.equal(typeof (descriptor.staffingPlan as Record<string, unknown>).staffingSummary, 'string');
   });
 
+  it('preserves legacy verification context precedence over ralplan artifacts', async () => {
+    const stage = createRalphVerifyStage();
+    const result = await stage.run(makeCtx({
+      artifacts: {
+        ralplan: { plan: 'approved plan' },
+        'team-exec': { teamDescriptor: { task: 'completed work' } },
+      },
+    }));
+
+    const descriptor = (result.artifacts as Record<string, unknown>).verifyDescriptor as Record<string, unknown>;
+    assert.deepEqual(descriptor.executionArtifacts, { teamDescriptor: { task: 'completed work' } });
+  });
+
   describe('buildRalphInstruction', () => {
     it('includes max iterations in instruction', () => {
       const staffingPlan = buildFollowupStaffingPlan('ralph', 'verify feature', ['architect', 'executor', 'test-engineer']);
@@ -337,6 +382,18 @@ describe('Strict Autopilot Ralph Stage', () => {
 
   it('uses the strict phase name ralph', () => {
     assert.equal(createRalphStage().name, 'ralph');
+  });
+
+  it('uses ralplan artifacts as the primary strict ralph execution input', async () => {
+    const result = await createRalphStage().run(makeCtx({
+      artifacts: {
+        ralplan: { plan: 'approved plan' },
+        'team-exec': { teamDescriptor: { task: 'legacy work' } },
+      },
+    }));
+
+    const descriptor = (result.artifacts as Record<string, unknown>).verifyDescriptor as Record<string, unknown>;
+    assert.deepEqual(descriptor.executionArtifacts, { plan: 'approved plan' });
   });
 });
 

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -7,7 +7,8 @@ import { existsSync } from 'fs';
 import type { StageContext } from '../types.js';
 import { createRalplanStage } from '../stages/ralplan.js';
 import { createTeamExecStage, buildTeamInstruction } from '../stages/team-exec.js';
-import { createRalphVerifyStage, buildRalphInstruction } from '../stages/ralph-verify.js';
+import { createRalphVerifyStage, createRalphStage, buildRalphInstruction } from '../stages/ralph-verify.js';
+import { createCodeReviewStage, buildCodeReviewInstruction } from '../stages/code-review.js';
 import { buildFollowupStaffingPlan } from '../../team/followup-planner.js';
 
 // ---------------------------------------------------------------------------
@@ -322,5 +323,50 @@ describe('Ralph Verify Stage', () => {
       assert.match(instruction, /^omx ralph /);
       assert.match(instruction, /staffing=/);
     });
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Strict Autopilot stage tests
+// ---------------------------------------------------------------------------
+
+describe('Strict Autopilot Ralph Stage', () => {
+  beforeEach(async () => { await setup(); });
+  afterEach(async () => { await cleanup(); });
+
+  it('uses the strict phase name ralph', () => {
+    assert.equal(createRalphStage().name, 'ralph');
+  });
+});
+
+describe('Code Review Stage', () => {
+  beforeEach(async () => { await setup(); });
+  afterEach(async () => { await cleanup(); });
+
+  it('creates a strict code-review stage with a clean default verdict', async () => {
+    const stage = createCodeReviewStage();
+    assert.equal(stage.name, 'code-review');
+    const result = await stage.run(makeCtx({ artifacts: { ralph: { tests: 'passed' } } }));
+    const artifacts = result.artifacts as Record<string, unknown>;
+    const verdict = artifacts.review_verdict as Record<string, unknown>;
+    assert.equal(result.status, 'completed');
+    assert.equal(verdict.clean, true);
+    assert.equal(verdict.recommendation, 'APPROVE');
+    assert.equal(verdict.architectural_status, 'CLEAR');
+    assert.equal(artifacts.return_to_ralplan_reason, null);
+  });
+
+  it('marks non-clean review as return-to-ralplan input', async () => {
+    const stage = createCodeReviewStage({ recommendation: 'REQUEST CHANGES', architecturalStatus: 'BLOCK', summary: 'fix review findings' });
+    const result = await stage.run(makeCtx());
+    const artifacts = result.artifacts as Record<string, unknown>;
+    const verdict = artifacts.review_verdict as Record<string, unknown>;
+    assert.equal(verdict.clean, false);
+    assert.equal(artifacts.return_to_ralplan_reason, 'fix review findings');
+  });
+
+  it('builds a code-review instruction', () => {
+    assert.match(buildCodeReviewInstruction('review me'), /^\$code-review /);
   });
 });

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -1,8 +1,8 @@
 /**
  * Pipeline orchestrator for oh-my-codex
  *
- * Configurable pipeline that sequences: RALPLAN -> teams (codex workers) -> ralph verification.
- * Mirrors OMC #1130 pipeline design.
+ * Configurable pipeline that sequences: ralplan -> ralph -> code-review.
+ * This is the strict Autopilot loop; legacy team/ralph-verify adapters remain available.
  *
  * @module pipeline
  */
@@ -28,5 +28,7 @@ export { createRalplanStage } from './stages/ralplan.js';
 export type { CreateRalplanStageOptions } from './stages/ralplan.js';
 export { createTeamExecStage, buildTeamInstruction } from './stages/team-exec.js';
 export type { TeamExecStageOptions, TeamExecDescriptor } from './stages/team-exec.js';
-export { createRalphVerifyStage, buildRalphInstruction } from './stages/ralph-verify.js';
+export { createRalphVerifyStage, createRalphStage, buildRalphInstruction } from './stages/ralph-verify.js';
 export type { RalphVerifyStageOptions, RalphVerifyDescriptor } from './stages/ralph-verify.js';
+export { createCodeReviewStage, buildCodeReviewInstruction } from './stages/code-review.js';
+export type { CodeReviewStageOptions, CodeReviewDescriptor, CodeReviewVerdict } from './stages/code-review.js';

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -14,6 +14,7 @@ import { startMode, readModeState, updateModeState, cancelMode } from '../modes/
 import { createRalplanStage } from './stages/ralplan.js';
 import { createRalphStage } from './stages/ralph-verify.js';
 import { createCodeReviewStage } from './stages/code-review.js';
+import { isNonCleanReviewVerdict } from './review-verdict.js';
 import type {
   PipelineConfig,
   PipelineResult,
@@ -69,6 +70,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
   // Execute stages sequentially
   const stageResults: Record<string, StageResult> = {};
   const artifacts: Record<string, unknown> = {};
+  const handoffArtifactsByStage: Record<string, unknown> = {};
   let previousResult: StageResult | undefined;
   let lastStageName: string | undefined;
   let reviewCycle = 0;
@@ -136,6 +138,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     // Merge artifacts
     if (result.artifacts) {
       Object.assign(artifacts, { [stage.name]: result.artifacts });
+      Object.assign(handoffArtifactsByStage, { [stage.name]: result.artifacts });
     }
 
     const resultArtifacts = result.artifacts as Record<string, unknown>;
@@ -147,14 +150,21 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       && result.status === 'completed'
       && isNonCleanReviewVerdict(reviewVerdict);
 
+    if (stage.name === 'code-review') {
+      artifacts.review_verdict = reviewVerdict ?? null;
+      artifacts.return_to_ralplan_reason = returnToRalplanReason ?? null;
+    }
+
     if (reviewIsNotClean) {
       reviewCycle += 1;
     }
 
+    const handoffArtifacts = normalizeHandoffArtifactKeys(handoffArtifactsByStage);
+
     // Persist stage result
     await updateModeState(MODE_NAME, {
       current_phase: reviewIsNotClean ? 'ralplan' : (result.status === 'completed' ? stage.name : `${stage.name}:${result.status}`),
-      handoff_artifacts: { ...artifacts, [stage.name]: result.artifacts },
+      handoff_artifacts: handoffArtifacts,
       ...(stage.name === 'code-review' ? {
         review_verdict: reviewVerdict,
         return_to_ralplan_reason: returnToRalplanReason ?? null,
@@ -291,13 +301,16 @@ export async function cancelPipeline(cwd?: string): Promise<void> {
 // Validation
 // ---------------------------------------------------------------------------
 
-function isNonCleanReviewVerdict(verdict: unknown): boolean {
-  if (!verdict || typeof verdict !== 'object') return false;
-  const review = verdict as { clean?: unknown; recommendation?: unknown; architectural_status?: unknown };
-  if (review.clean === false) return true;
-  if (review.recommendation && review.recommendation !== 'APPROVE') return true;
-  if (review.architectural_status && review.architectural_status !== 'CLEAR') return true;
-  return false;
+function normalizeHandoffArtifactKeys(artifacts: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(artifacts)) {
+    normalized[toHandoffArtifactKey(key)] = value;
+  }
+  return normalized;
+}
+
+function toHandoffArtifactKey(stageName: string): string {
+  return stageName === 'code-review' ? 'code_review' : stageName;
 }
 
 function validateConfig(config: PipelineConfig): void {

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -1,16 +1,19 @@
 /**
  * Pipeline Orchestrator for oh-my-codex
  *
- * Sequences configurable stages (RALPLAN -> teams -> ralph verification)
+ * Sequences configurable stages (ralplan -> ralph -> code-review)
  * and persists state through the ModeState system.
  *
  * Mirrors OMC #1130 pipeline design with OMX-specific adaptations:
- * - Execution backend is always teams (Codex CLI workers)
  * - Ralph iteration count is configurable
- * - Integrates with existing team mode infrastructure
+ * - Code review is the merge-readiness gate
+ * - Non-clean review artifacts can drive a return to ralplan
  */
 
 import { startMode, readModeState, updateModeState, cancelMode } from '../modes/base.js';
+import { createRalplanStage } from './stages/ralplan.js';
+import { createRalphStage } from './stages/ralph-verify.js';
+import { createCodeReviewStage } from './stages/code-review.js';
 import type {
   PipelineConfig,
   PipelineResult,
@@ -51,12 +54,16 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     pipeline_max_ralph_iterations: maxRalphIterations,
     pipeline_worker_count: workerCount,
     pipeline_agent_type: agentType,
+    review_cycle: 0,
+    review_verdict: null,
+    return_to_ralplan_reason: null,
+    handoff_artifacts: {},
   };
 
   await updateModeState(MODE_NAME, {
     ...modeState,
     ...pipelineExtension,
-    current_phase: `stage:${config.stages[0].name}`,
+    current_phase: config.stages[0].name,
   }, cwd);
 
   // Execute stages sequentially
@@ -64,6 +71,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
   const artifacts: Record<string, unknown> = {};
   let previousResult: StageResult | undefined;
   let lastStageName: string | undefined;
+  let reviewCycle = 0;
 
   for (let i = 0; i < config.stages.length; i++) {
     const stage = config.stages[i];
@@ -92,7 +100,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       stageResults[stage.name] = skippedResult;
 
       await updateModeState(MODE_NAME, {
-        current_phase: `stage:${stage.name}:skipped`,
+        current_phase: `${stage.name}:skipped`,
         pipeline_stage_index: i,
         pipeline_stage_results: { ...stageResults },
       } as Partial<PipelineModeStateExtension>, cwd);
@@ -104,7 +112,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
 
     // Update state to running
     await updateModeState(MODE_NAME, {
-      current_phase: `stage:${stage.name}`,
+      current_phase: stage.name,
       pipeline_stage_index: i,
       iteration: i + 1,
     } as Partial<PipelineModeStateExtension>, cwd);
@@ -130,10 +138,29 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       Object.assign(artifacts, { [stage.name]: result.artifacts });
     }
 
+    const resultArtifacts = result.artifacts as Record<string, unknown>;
+    const reviewVerdict = stage.name === 'code-review' ? resultArtifacts.review_verdict : undefined;
+    const returnToRalplanReason = stage.name === 'code-review'
+      ? resultArtifacts.return_to_ralplan_reason as string | null | undefined
+      : undefined;
+    const reviewIsNotClean = stage.name === 'code-review'
+      && result.status === 'completed'
+      && isNonCleanReviewVerdict(reviewVerdict);
+
+    if (reviewIsNotClean) {
+      reviewCycle += 1;
+    }
+
     // Persist stage result
     await updateModeState(MODE_NAME, {
-      current_phase: `stage:${stage.name}:${result.status}`,
-      pipeline_stage_index: i,
+      current_phase: reviewIsNotClean ? 'ralplan' : (result.status === 'completed' ? stage.name : `${stage.name}:${result.status}`),
+      handoff_artifacts: { ...artifacts, [stage.name]: result.artifacts },
+      ...(stage.name === 'code-review' ? {
+        review_verdict: reviewVerdict,
+        return_to_ralplan_reason: returnToRalplanReason ?? null,
+        review_cycle: reviewCycle,
+      } : {}),
+      pipeline_stage_index: reviewIsNotClean ? 0 : i,
       pipeline_stage_results: { ...stageResults },
     } as Partial<PipelineModeStateExtension>, cwd);
 
@@ -156,6 +183,39 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
         error: result.error,
         failedStage: stage.name,
       };
+    }
+
+    if (reviewIsNotClean) {
+      if (reviewCycle >= maxRalphIterations) {
+        const error = returnToRalplanReason
+          ? `Code review was not clean after ${reviewCycle} cycle(s): ${returnToRalplanReason}`
+          : `Code review was not clean after ${reviewCycle} cycle(s).`;
+        const duration_ms = Date.now() - startTime;
+
+        await updateModeState(MODE_NAME, {
+          active: false,
+          current_phase: 'failed',
+          completed_at: new Date().toISOString(),
+          error,
+        }, cwd);
+
+        return {
+          status: 'failed',
+          stageResults,
+          duration_ms,
+          artifacts,
+          error,
+          failedStage: stage.name,
+        };
+      }
+
+      if (config.onStageTransition) {
+        config.onStageTransition(stage.name, 'ralplan');
+      }
+      lastStageName = undefined;
+      previousResult = result;
+      i = -1;
+      continue;
     }
 
     lastStageName = stage.name;
@@ -213,6 +273,10 @@ export async function readPipelineState(
     pipeline_max_ralph_iterations: state.pipeline_max_ralph_iterations as number,
     pipeline_worker_count: state.pipeline_worker_count as number,
     pipeline_agent_type: state.pipeline_agent_type as string,
+    review_cycle: state.review_cycle as number | undefined,
+    review_verdict: state.review_verdict,
+    return_to_ralplan_reason: state.return_to_ralplan_reason as string | null | undefined,
+    handoff_artifacts: state.handoff_artifacts as Record<string, unknown> | undefined,
   };
 }
 
@@ -226,6 +290,15 @@ export async function cancelPipeline(cwd?: string): Promise<void> {
 // ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
+
+function isNonCleanReviewVerdict(verdict: unknown): boolean {
+  if (!verdict || typeof verdict !== 'object') return false;
+  const review = verdict as { clean?: unknown; recommendation?: unknown; architectural_status?: unknown };
+  if (review.clean === false) return true;
+  if (review.recommendation && review.recommendation !== 'APPROVE') return true;
+  if (review.architectural_status && review.architectural_status !== 'CLEAR') return true;
+  return false;
+}
 
 function validateConfig(config: PipelineConfig): void {
   if (!config.name || config.name.trim() === '') {
@@ -270,8 +343,8 @@ function validateConfig(config: PipelineConfig): void {
 /**
  * Create the default autopilot pipeline configuration.
  *
- * Sequences: RALPLAN -> team-exec -> ralph-verify
- * This is the canonical OMX pipeline matching the OMC #1130 design.
+ * Sequences: ralplan -> ralph -> code-review.
+ * This is the strict Autopilot loop required by the skill contract.
  */
 export function createAutopilotPipelineConfig(
   task: string,
@@ -281,14 +354,14 @@ export function createAutopilotPipelineConfig(
     maxRalphIterations?: number;
     workerCount?: number;
     agentType?: string;
-    stages: PipelineConfig['stages'];
+    stages?: PipelineConfig['stages'];
     onStageTransition?: PipelineConfig['onStageTransition'];
   },
 ): PipelineConfig {
   return {
     name: 'autopilot',
     task,
-    stages: options.stages,
+    stages: options.stages ?? createStrictAutopilotStages(),
     cwd: options.cwd,
     sessionId: options.sessionId,
     maxRalphIterations: options.maxRalphIterations ?? 10,
@@ -296,4 +369,8 @@ export function createAutopilotPipelineConfig(
     agentType: options.agentType ?? 'executor',
     onStageTransition: options.onStageTransition,
   };
+}
+
+export function createStrictAutopilotStages(): PipelineConfig['stages'] {
+  return [createRalplanStage(), createRalphStage(), createCodeReviewStage()];
 }

--- a/src/pipeline/review-verdict.ts
+++ b/src/pipeline/review-verdict.ts
@@ -1,0 +1,10 @@
+/** Shared helpers for interpreting code-review stage verdicts. */
+
+export function isNonCleanReviewVerdict(verdict: unknown): boolean {
+  if (!verdict || typeof verdict !== 'object') return false;
+  const review = verdict as { clean?: unknown; recommendation?: unknown; architectural_status?: unknown };
+  if (review.clean === false) return true;
+  if (review.recommendation && review.recommendation !== 'APPROVE') return true;
+  if (review.architectural_status && review.architectural_status !== 'CLEAR') return true;
+  return false;
+}

--- a/src/pipeline/stages/code-review.ts
+++ b/src/pipeline/stages/code-review.ts
@@ -1,0 +1,79 @@
+/**
+ * Code-review stage adapter for the strict Autopilot loop.
+ *
+ * The stage produces a descriptor/instruction for the existing `$code-review`
+ * skill and reports whether the latest review is clean. A non-clean review is
+ * represented as `completed` with `clean: false` so Autopilot can return to
+ * ralplan instead of treating review findings as infrastructure failure.
+ */
+
+import type { PipelineStage, StageContext, StageResult } from '../types.js';
+
+export interface CodeReviewStageOptions {
+  /** Optional review recommendation injected by tests or runtime adapters. */
+  recommendation?: 'APPROVE' | 'COMMENT' | 'REQUEST CHANGES';
+
+  /** Optional architecture status injected by tests or runtime adapters. */
+  architecturalStatus?: 'CLEAR' | 'WATCH' | 'BLOCK';
+
+  /** Optional human-readable review summary. */
+  summary?: string;
+}
+
+export interface CodeReviewDescriptor {
+  task: string;
+  cwd: string;
+  sessionId?: string;
+  ralphArtifacts: Record<string, unknown>;
+  instruction: string;
+}
+
+export interface CodeReviewVerdict {
+  recommendation: 'APPROVE' | 'COMMENT' | 'REQUEST CHANGES';
+  architectural_status: 'CLEAR' | 'WATCH' | 'BLOCK';
+  clean: boolean;
+  summary: string;
+}
+
+export function createCodeReviewStage(options: CodeReviewStageOptions = {}): PipelineStage {
+  return {
+    name: 'code-review',
+
+    async run(ctx: StageContext): Promise<StageResult> {
+      const startTime = Date.now();
+      const ralphArtifacts = ctx.artifacts.ralph as Record<string, unknown> | undefined;
+      const descriptor: CodeReviewDescriptor = {
+        task: ctx.task,
+        cwd: ctx.cwd,
+        sessionId: ctx.sessionId,
+        ralphArtifacts: ralphArtifacts ?? {},
+        instruction: buildCodeReviewInstruction(ctx.task),
+      };
+      const recommendation = options.recommendation ?? 'APPROVE';
+      const architecturalStatus = options.architecturalStatus ?? 'CLEAR';
+      const clean = recommendation === 'APPROVE' && architecturalStatus === 'CLEAR';
+      const verdict: CodeReviewVerdict = {
+        recommendation,
+        architectural_status: architecturalStatus,
+        clean,
+        summary: options.summary ?? (clean ? 'Review clean.' : 'Review returned findings; return to ralplan.'),
+      };
+
+      return {
+        status: 'completed',
+        artifacts: {
+          stage: 'code-review',
+          codeReviewDescriptor: descriptor,
+          review_verdict: verdict,
+          return_to_ralplan_reason: clean ? null : verdict.summary,
+          instruction: descriptor.instruction,
+        },
+        duration_ms: Date.now() - startTime,
+      };
+    },
+  };
+}
+
+export function buildCodeReviewInstruction(task: string): string {
+  return `$code-review ${JSON.stringify(task)}`;
+}

--- a/src/pipeline/stages/ralph-verify.ts
+++ b/src/pipeline/stages/ralph-verify.ts
@@ -16,6 +16,13 @@ export interface RalphVerifyStageOptions {
   stageName?: string;
 
   /**
+   * Ordered artifact keys used as Ralph execution input.
+   * Legacy ralph-verify keeps reading prior ralph/team-exec output; strict Autopilot
+   * Ralph reads ralplan first so implementation starts from approved planning.
+   */
+  executionArtifactKeys?: readonly string[];
+
+  /**
    * Maximum number of ralph verification iterations.
    * Defaults to 10.
    */
@@ -42,8 +49,9 @@ export function createRalphVerifyStage(options: RalphVerifyStageOptions = {}): P
       const startTime = Date.now();
 
       try {
-        // Extract execution context from previous stage
-        const teamArtifacts = (ctx.artifacts.ralph ?? ctx.artifacts['team-exec']) as Record<string, unknown> | undefined;
+        // Extract execution context from previous stage.
+        const executionArtifactKeys = options.executionArtifactKeys ?? ['ralph', 'team-exec'];
+        const executionArtifacts = pickFirstArtifact(ctx.artifacts, executionArtifactKeys);
         const availableAgentTypes = await resolveAvailableAgentTypes(ctx.cwd);
         const staffingPlan = buildFollowupStaffingPlan('ralph', ctx.task, availableAgentTypes, {
           workerCount: Math.min(maxIterations, 3),
@@ -57,7 +65,7 @@ export function createRalphVerifyStage(options: RalphVerifyStageOptions = {}): P
           sessionId: ctx.sessionId,
           availableAgentTypes,
           staffingPlan,
-          executionArtifacts: teamArtifacts ?? {},
+          executionArtifacts: executionArtifacts ?? {},
         };
 
         return {
@@ -108,7 +116,24 @@ export function buildRalphInstruction(descriptor: RalphVerifyDescriptor): string
   return `${descriptor.staffingPlan.launchHints.shellCommand} # max_iterations=${descriptor.maxIterations} # staffing=${descriptor.staffingPlan.staffingSummary} # verify=${descriptor.staffingPlan.verificationPlan.summary}`;
 }
 
+function pickFirstArtifact(
+  artifacts: Record<string, unknown>,
+  keys: readonly string[],
+): Record<string, unknown> | undefined {
+  for (const key of keys) {
+    const artifact = artifacts[key];
+    if (artifact && typeof artifact === 'object') {
+      return artifact as Record<string, unknown>;
+    }
+  }
+  return undefined;
+}
+
 /** Create the strict Autopilot Ralph phase adapter. */
 export function createRalphStage(options: RalphVerifyStageOptions = {}): PipelineStage {
-  return createRalphVerifyStage({ ...options, stageName: 'ralph' });
+  return createRalphVerifyStage({
+    ...options,
+    stageName: 'ralph',
+    executionArtifactKeys: options.executionArtifactKeys ?? ['ralplan', 'team-exec'],
+  });
 }

--- a/src/pipeline/stages/ralph-verify.ts
+++ b/src/pipeline/stages/ralph-verify.ts
@@ -12,6 +12,9 @@ import {
 } from '../../team/followup-planner.js';
 
 export interface RalphVerifyStageOptions {
+  /** Stage name. Strict Autopilot uses 'ralph'; legacy pipeline adapters use 'ralph-verify'. */
+  stageName?: string;
+
   /**
    * Maximum number of ralph verification iterations.
    * Defaults to 10.
@@ -23,8 +26,8 @@ export interface RalphVerifyStageOptions {
  * Create a ralph-verify pipeline stage.
  *
  * This stage wraps the ralph persistence loop for the verification phase
- * of the pipeline. It takes the execution results from team-exec and
- * orchestrates architect-verified completion.
+ * of legacy pipelines. Strict Autopilot uses `createRalphStage()` for the
+ * implementation/verification phase before code-review.
  *
  * The iteration count is configurable, addressing issue #396 requirement
  * for configurable ralph iteration count.
@@ -33,14 +36,14 @@ export function createRalphVerifyStage(options: RalphVerifyStageOptions = {}): P
   const maxIterations = options.maxIterations ?? 10;
 
   return {
-    name: 'ralph-verify',
+    name: options.stageName ?? 'ralph-verify',
 
     async run(ctx: StageContext): Promise<StageResult> {
       const startTime = Date.now();
 
       try {
         // Extract execution context from previous stage
-        const teamArtifacts = ctx.artifacts['team-exec'] as Record<string, unknown> | undefined;
+        const teamArtifacts = (ctx.artifacts.ralph ?? ctx.artifacts['team-exec']) as Record<string, unknown> | undefined;
         const availableAgentTypes = await resolveAvailableAgentTypes(ctx.cwd);
         const staffingPlan = buildFollowupStaffingPlan('ralph', ctx.task, availableAgentTypes, {
           workerCount: Math.min(maxIterations, 3),
@@ -103,4 +106,9 @@ export interface RalphVerifyDescriptor {
  */
 export function buildRalphInstruction(descriptor: RalphVerifyDescriptor): string {
   return `${descriptor.staffingPlan.launchHints.shellCommand} # max_iterations=${descriptor.maxIterations} # staffing=${descriptor.staffingPlan.staffingSummary} # verify=${descriptor.staffingPlan.verificationPlan.summary}`;
+}
+
+/** Create the strict Autopilot Ralph phase adapter. */
+export function createRalphStage(options: RalphVerifyStageOptions = {}): PipelineStage {
+  return createRalphVerifyStage({ ...options, stageName: 'ralph' });
 }

--- a/src/pipeline/stages/ralplan.ts
+++ b/src/pipeline/stages/ralplan.ts
@@ -7,6 +7,7 @@
 
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
 import { isPlanningComplete, readPlanningArtifacts } from '../../planning/artifacts.js';
+import { isNonCleanReviewVerdict } from '../review-verdict.js';
 import {
   runRalplanConsensus,
   type RalplanConsensusExecutor,
@@ -33,6 +34,9 @@ export function createRalplanStage(options: CreateRalplanStageOptions = {}): Pip
     name: 'ralplan',
 
     canSkip(ctx: StageContext): boolean {
+      if (hasReviewLoopContext(ctx.artifacts)) {
+        return false;
+      }
       return isPlanningComplete(readPlanningArtifacts(ctx.cwd));
     },
 
@@ -98,4 +102,25 @@ export function createRalplanStage(options: CreateRalplanStageOptions = {}): Pip
       }
     },
   };
+}
+
+function hasReviewLoopContext(artifacts: Record<string, unknown>): boolean {
+  if (typeof artifacts.return_to_ralplan_reason === 'string' && artifacts.return_to_ralplan_reason.trim() !== '') {
+    return true;
+  }
+  if (isNonCleanReviewVerdict(artifacts.review_verdict)) {
+    return true;
+  }
+
+  const codeReviewArtifacts = artifacts['code-review'];
+  if (!codeReviewArtifacts || typeof codeReviewArtifacts !== 'object') {
+    return false;
+  }
+
+  const reviewArtifacts = codeReviewArtifacts as Record<string, unknown>;
+  return (
+    (typeof reviewArtifacts.return_to_ralplan_reason === 'string'
+      && reviewArtifacts.return_to_ralplan_reason.trim() !== '')
+    || isNonCleanReviewVerdict(reviewArtifacts.review_verdict)
+  );
 }

--- a/src/pipeline/stages/ralplan.ts
+++ b/src/pipeline/stages/ralplan.ts
@@ -22,7 +22,7 @@ export interface CreateRalplanStageOptions {
  *
  * The RALPLAN stage performs consensus planning by coordinating planner,
  * architect, and critic agents. It outputs a plan file that downstream
- * stages (team-exec) consume.
+ * stages consume.
  *
  * By default this remains a structural adapter — actual agent orchestration
  * happens at the skill layer. When an executor is provided, the stage can

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -165,7 +165,7 @@ export interface PipelineModeStateExtension {
   /** Reason Autopilot returned to ralplan after a non-clean review. */
   return_to_ralplan_reason?: string | null;
 
-  /** Phase handoff artifacts keyed by ralplan, ralph, and code-review. */
+  /** Phase handoff artifacts keyed by contract names: ralplan, ralph, and code_review. */
   handoff_artifacts?: Record<string, unknown>;
 
   /** Ralph iteration ceiling for the verification stage. */

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -1,8 +1,8 @@
 /**
  * Pipeline stage interfaces for oh-my-codex
  *
- * Shared stage contracts that align with OMC pipeline design (#1130).
- * The pipeline sequences: RALPLAN -> teams (codex workers) -> ralph verification.
+ * Shared stage contracts for the strict Autopilot loop.
+ * The pipeline sequences: ralplan -> ralph -> code-review.
  */
 
 // ---------------------------------------------------------------------------
@@ -52,10 +52,10 @@ export interface StageResult {
 
 /**
  * A single stage in the pipeline. Implementations wrap concrete execution
- * backends (ralplan, team, ralph) behind this uniform interface.
+ * backends (ralplan, ralph, code-review, and legacy team adapters) behind this uniform interface.
  */
 export interface PipelineStage {
-  /** Unique name for this stage (e.g. 'ralplan', 'team-exec', 'ralph-verify'). */
+  /** Unique name for this stage (e.g. 'ralplan', 'ralph', 'code-review'). */
   readonly name: string;
 
   /** Execute the stage. Must return a StageResult. */
@@ -93,13 +93,12 @@ export interface PipelineConfig {
 
   /**
    * Maximum ralph verification iterations.
-   * Passed through to the ralph-verify stage. Defaults to 10.
+   * Passed through to the ralph stage. Defaults to 10.
    */
   maxRalphIterations?: number;
 
   /**
-   * Number of team workers for the execution stage.
-   * Passed through to the team-exec stage. Defaults to 2.
+   * Legacy worker count for adapters that still launch team execution. Defaults to 2.
    */
   workerCount?: number;
 
@@ -156,6 +155,18 @@ export interface PipelineModeStateExtension {
 
   /** Per-stage results collected so far. */
   pipeline_stage_results: Record<string, StageResult>;
+
+  /** Current review cycle count; increments when code-review is not clean. */
+  review_cycle?: number;
+
+  /** Latest code-review verdict artifact. */
+  review_verdict?: unknown;
+
+  /** Reason Autopilot returned to ralplan after a non-clean review. */
+  return_to_ralplan_reason?: string | null;
+
+  /** Phase handoff artifacts keyed by ralplan, ralph, and code-review. */
+  handoff_artifacts?: Record<string, unknown>;
 
   /** Ralph iteration ceiling for the verification stage. */
   pipeline_max_ralph_iterations: number;

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -74,10 +74,20 @@ describe('workflow transition rules', () => {
   });
 
   it('builds rollback denial guidance for execution-to-planning transitions', () => {
-    const error = buildWorkflowTransitionError(['autopilot'], 'ralplan', 'start');
+    const error = buildWorkflowTransitionError(['ralph'], 'ralplan', 'start');
     assert.match(error, /Execution-to-planning rollback auto-complete is not allowed\./);
     assert.match(error, /First clear current state first and retry if this action is intended\./);
     assert.match(error, /Clear incompatible workflow state yourself via/);
+  });
+
+
+  it('allows autopilot to return to ralplan for non-clean code-review cycles', () => {
+    const decision = evaluateWorkflowTransition(['autopilot'], 'ralplan');
+    assert.equal(decision.allowed, true);
+    assert.equal(decision.kind, 'auto-complete');
+    assert.deepEqual(decision.autoCompleteModes, ['autopilot']);
+    assert.deepEqual(decision.resultingModes, ['ralplan']);
+    assert.equal(decision.transitionMessage, 'mode transiting: autopilot -> ralplan');
   });
 
   it('formats transition audit messages', () => {

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -28,6 +28,7 @@ const AUTO_COMPLETE_TRANSITIONS = new Set([
   'ralplan->ralph',
   'ralplan->autopilot',
   'ralplan->autoresearch',
+  'autopilot->ralplan',
 ]);
 
 const PLANNING_LIKE_MODES = new Set<TrackedWorkflowMode>([


### PR DESCRIPTION
## Summary

- Rewrites `$autopilot` skill (and plugin mirror) around the strict `$ralplan -> $ralph -> $code-review` loop.
- Seeds and preserves tight Autopilot hook/state fields: `current_phase: ralplan`, `iteration`, `review_cycle`, `phase_cycle`, `handoff_artifacts`, `review_verdict`, and `return_to_ralplan_reason`.
- Updates pipeline primitives so the default Autopilot pipeline is `ralplan -> ralph -> code-review`, and non-clean code-review verdicts loop back to `ralplan` until clean or bounded failure.
- Updates state transition/docs/contracts/tests so the old broad 5-phase lifecycle is no longer the primary contract.

## Verification

- `npm run build`
- `npm run sync:plugin:check`
- `node dist/scripts/generate-catalog-docs.js --check`
- `node --test dist/hooks/__tests__/autopilot-skill-contract.test.js dist/hooks/__tests__/keyword-detector.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/skill-guidance-contract.test.js dist/hooks/__tests__/deep-interview-contract.test.js dist/state/__tests__/workflow-transition.test.js dist/mcp/__tests__/state-server.test.js dist/modes/__tests__/base-autoresearch-contract.test.js dist/pipeline/__tests__/orchestrator.test.js dist/pipeline/__tests__/stages.test.js`
- `git diff --check`

## Notes

- `$code-review` pass: APPROVE / Architectural Status CLEAR.
- Did not touch autohft.
- A full `npm test` run was attempted before the final targeted fixes and surfaced stale expectations now covered by the targeted passing tests above; not rerun end-to-end after final fixes due runtime length.

Closes #2000
