### PR TITLE
Isolate tmux nudges by instance ownership

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -881,12 +881,21 @@ describe("detached tmux new-session sequencing", () => {
       "sess-detached-managed",
     );
     const newSession = steps.find((step) => step.name === "new-session");
+    const tagSession = steps.find((step) => step.name === "tag-session");
     assert.ok(newSession);
+    assert.ok(tagSession);
     assert.equal(
       newSession!.args.includes("-e") &&
         newSession!.args.some((arg) => arg === "OMX_SESSION_ID=sess-detached-managed"),
       true,
     );
+    assert.deepEqual(tagSession!.args, [
+      "set-option",
+      "-t",
+      "omx-demo",
+      "@omx_instance_id",
+      "sess-detached-managed",
+    ]);
   });
 
   it("buildDetachedSessionBootstrapSteps starts native Windows detached sessions with powershell", () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -181,6 +181,7 @@ const TEAM_WORKER_LAUNCH_ARGS_ENV = "OMX_TEAM_WORKER_LAUNCH_ARGS";
 const TEAM_INHERIT_LEADER_FLAGS_ENV = "OMX_TEAM_INHERIT_LEADER_FLAGS";
 const OMX_BYPASS_DEFAULT_SYSTEM_PROMPT_ENV = "OMX_BYPASS_DEFAULT_SYSTEM_PROMPT";
 const OMX_MODEL_INSTRUCTIONS_FILE_ENV = "OMX_MODEL_INSTRUCTIONS_FILE";
+const OMX_INSTANCE_OPTION = "@omx_instance_id";
 const OMX_RALPH_APPEND_INSTRUCTIONS_FILE_ENV =
   "OMX_RALPH_APPEND_INSTRUCTIONS_FILE";
 const OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE_ENV =
@@ -1153,6 +1154,34 @@ function resolveNativeSessionName(cwd: string, sessionId: string): string {
   return buildTmuxSessionName(cwd, sessionId);
 }
 
+function tagTmuxSessionWithInstance(sessionName: string, sessionId: string): void {
+  const target = sessionName.trim();
+  const instanceId = sessionId.trim();
+  if (!target || !instanceId) return;
+  execFileSync("tmux", ["set-option", "-t", target, OMX_INSTANCE_OPTION, instanceId], {
+    stdio: ["ignore", "ignore", "ignore"],
+    timeout: 2000,
+  });
+}
+
+function tagCurrentTmuxSessionWithInstance(sessionId: string): void {
+  if (!process.env.TMUX) return;
+  try {
+    const tmuxPaneTarget = process.env.TMUX_PANE;
+    const displayArgs = tmuxPaneTarget
+      ? ["display-message", "-p", "-t", tmuxPaneTarget, "#S"]
+      : ["display-message", "-p", "#S"];
+    const sessionName = execFileSync("tmux", displayArgs, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2000,
+    }).trim();
+    if (sessionName) tagTmuxSessionWithInstance(sessionName, sessionId);
+  } catch {
+    // Best effort only: launch should not fail just because tmux tagging failed.
+  }
+}
+
 function buildNativeHookBaseContext(
   cwd: string,
   sessionId: string,
@@ -1425,6 +1454,14 @@ export function buildDetachedSessionBootstrapSteps(
   ];
   return [
     { name: "new-session", args: newSessionArgs },
+    ...(sessionId
+      ? [
+          {
+            name: "tag-session",
+            args: ["set-option", "-t", sessionName, OMX_INSTANCE_OPTION, sessionId],
+          },
+        ]
+      : []),
     { name: "split-and-capture-hud-pane", args: splitCaptureArgs },
   ];
 }
@@ -1614,6 +1651,7 @@ ${launchAppendix}`
   // 2. Write session state
   await resetSessionMetrics(cwd);
   await writeSessionStart(cwd, sessionId);
+  tagCurrentTmuxSessionWithInstance(sessionId);
 
   // 3. Start notify fallback watcher (best effort)
   try {

--- a/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
@@ -296,6 +296,235 @@ exit 1
     });
   });
 
+  it('prefers the session tagged with the current OMX instance over stale pane config', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const sessionId = 'omx-tagged-instance';
+      const sessionStateDir = join(stateDir, 'sessions', sessionId);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const managedSessionName = buildTmuxSessionName(cwd, sessionId);
+      const wrongSessionName = 'other-omx-session';
+      const configPath = join(omxDir, 'tmux-hook.json');
+      const hookStatePath = join(stateDir, 'tmux-hook-state.json');
+
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeManagedSessionState(stateDir, cwd, sessionId);
+      await writeJson(join(sessionStateDir, 'ralph-state.json'), { active: true, iteration: 0 });
+      await writeJson(configPath, {
+        enabled: true,
+        target: { type: 'pane', value: '%42' },
+        allowed_modes: ['ralph'],
+        cooldown_ms: 0,
+        max_injections_per_session: 10,
+        prompt_template: 'Continue [OMX_TMUX_INJECT]',
+        marker: '[OMX_TMUX_INJECT]',
+        dry_run: false,
+        log_level: 'debug',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "list-sessions" ]]; then
+  printf "%s\t%s\n" "${wrongSessionName}" "omx-other"
+  printf "%s\t%s\n" "${managedSessionName}" "${sessionId}"
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  target=""
+  while (($#)); do
+    case "$1" in
+      -t) target="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [[ "$target" == "${managedSessionName}" ]]; then
+    printf "%%99\t1\tcodex\tcodex\n"
+    exit 0
+  fi
+  exit 1
+fi
+if [[ "$cmd" == "show-option" ]]; then
+  target=""
+  while (($#)); do
+    case "$1" in
+      -t) target="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [[ "$target" == "${managedSessionName}" ]]; then
+    echo "${sessionId}"
+    exit 0
+  fi
+  if [[ "$target" == "${wrongSessionName}" ]]; then
+    echo "omx-other"
+    exit 0
+  fi
+  exit 1
+fi
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_id}" && "$target" == "%99" ]]; then echo "%99"; exit 0; fi
+  if [[ "$format" == "#{pane_current_path}" && "$target" == "%99" ]]; then echo "${cwd}"; exit 0; fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%99" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%99" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%99" ]]; then echo "0"; exit 0; fi
+  if [[ "$format" == "#S" && "$target" == "%99" ]]; then echo "${managedSessionName}"; exit 0; fi
+  if [[ "$format" == "#{pane_id}" && "$target" == "%42" ]]; then echo "%42"; exit 0; fi
+  if [[ "$format" == "#S" && "$target" == "%42" ]]; then echo "${wrongSessionName}"; exit 0; fi
+  exit 1
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  [[ "$*" == *"%99"* ]]
+  exit $?
+fi
+echo "unsupported cmd: $cmd" >&2
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        session_id: sessionId,
+        'thread-id': 'thread-tagged-instance',
+        'turn-id': 'turn-tagged-instance',
+        'input-messages': ['no marker here'],
+        'last-assistant-message': 'output',
+      };
+
+      const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_TEAM_WORKER: '',
+        },
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const hookState = await readJson<Record<string, unknown>>(hookStatePath);
+      assert.equal(hookState.last_reason, 'injection_sent');
+      assert.equal(hookState.total_injections, 1);
+
+      const healedConfig = await readJson<{ target: { type: string; value: string } }>(configPath);
+      assert.equal(healedConfig.target.type, 'pane');
+      assert.equal(healedConfig.target.value, '%99');
+    });
+  });
+
+  it('skips injection when a static pane belongs to another tagged OMX instance', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const sessionId = 'omx-current-instance';
+      const sessionStateDir = join(stateDir, 'sessions', sessionId);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const wrongSessionName = 'wrong-tagged-session';
+      const configPath = join(omxDir, 'tmux-hook.json');
+      const hookStatePath = join(stateDir, 'tmux-hook-state.json');
+
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeManagedSessionState(stateDir, cwd, sessionId);
+      await writeJson(join(sessionStateDir, 'ralph-state.json'), { active: true, iteration: 0 });
+      await writeJson(configPath, {
+        enabled: true,
+        target: { type: 'pane', value: '%42' },
+        allowed_modes: ['ralph'],
+        cooldown_ms: 0,
+        max_injections_per_session: 10,
+        prompt_template: 'Continue [OMX_TMUX_INJECT]',
+        marker: '[OMX_TMUX_INJECT]',
+        dry_run: false,
+        log_level: 'debug',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "list-sessions" ]]; then
+  printf "%s\t%s\n" "${wrongSessionName}" "omx-other-instance"
+  exit 0
+fi
+if [[ "$cmd" == "show-option" ]]; then
+  echo "omx-other-instance"
+  exit 0
+fi
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_id}" && "$target" == "%42" ]]; then echo "%42"; exit 0; fi
+  if [[ "$format" == "#{pane_current_path}" && "$target" == "%42" ]]; then echo "${cwd}"; exit 0; fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%42" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%42" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#S" && "$target" == "%42" ]]; then echo "${wrongSessionName}"; exit 0; fi
+  exit 1
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  echo "send-keys must not run" >&2
+  exit 1
+fi
+echo "unsupported cmd: $cmd" >&2
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        session_id: sessionId,
+        'thread-id': 'thread-wrong-instance',
+        'turn-id': 'turn-wrong-instance',
+        'input-messages': ['no marker here'],
+        'last-assistant-message': 'output',
+      };
+
+      const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_TEAM_WORKER: '',
+        },
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const hookState = await readJson<Record<string, unknown>>(hookStatePath);
+      assert.equal(hookState.last_reason, 'pane_instance_mismatch');
+      assert.equal(hookState.total_injections, 0);
+    });
+  });
+
   it('skips injection when fallback pane cwd does not match hook cwd', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -5,6 +5,8 @@ import { readSessionState, isSessionStale } from '../../hooks/session.js';
 import { runProcess } from './process-runner.js';
 import { safeString } from './utils.js';
 
+const OMX_INSTANCE_OPTION = '@omx_instance_id';
+
 function sanitizeTmuxToken(value: string): string {
   const cleaned = safeString(value)
     .toLowerCase()
@@ -66,6 +68,33 @@ function readCurrentTmuxSessionName(): string {
   } catch {
     return '';
   }
+}
+
+async function readTmuxSessionInstanceId(sessionTarget: string): Promise<string> {
+  const target = safeString(sessionTarget).trim();
+  if (!target) return '';
+  try {
+    const result = await runProcess('tmux', ['show-option', '-qv', '-t', target, OMX_INSTANCE_OPTION], 2000);
+    return safeString(result.stdout).trim();
+  } catch {
+    return '';
+  }
+}
+
+export async function resolveTmuxSessionForInstance(instanceId: string): Promise<string> {
+  const expected = safeString(instanceId).trim();
+  if (!expected) return '';
+  try {
+    const result = await runProcess('tmux', ['list-sessions', '-F', `#{session_name}\t#{${OMX_INSTANCE_OPTION}}`], 2000);
+    const rows = safeString(result.stdout).split('\n').map(line => line.trim()).filter(Boolean);
+    for (const row of rows) {
+      const [sessionName = '', taggedInstanceId = ''] = row.split('\t');
+      if (sessionName && taggedInstanceId === expected) return sessionName;
+    }
+  } catch {
+    // best effort only
+  }
+  return '';
 }
 
 function readParentPid(pid: number): number | null {
@@ -140,11 +169,50 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
       return { managed: false, reason: 'session_id_mismatch', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '' };
     }
     if (isSessionStale(sessionState)) {
-      return { managed: false, reason: 'stale_session', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '' };
+      return { managed: false, reason: 'stale_session', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '', taggedTmuxSessionName: '' };
     }
 
     const expectedTmuxSessionName = buildExpectedManagedTmuxSessionName(cwd, invocationSessionId);
     const currentTmuxSessionName = readCurrentTmuxSessionName();
+    const currentTmuxInstanceId = currentTmuxSessionName ? await readTmuxSessionInstanceId(currentTmuxSessionName) : '';
+    if (currentTmuxInstanceId && currentTmuxInstanceId !== invocationSessionId) {
+      return {
+        managed: false,
+        reason: 'tmux_instance_mismatch',
+        invocationSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+        currentTmuxInstanceId,
+        taggedTmuxSessionName: '',
+      };
+    }
+    if (currentTmuxInstanceId === invocationSessionId) {
+      return {
+        managed: true,
+        reason: 'tmux_instance_match',
+        invocationSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+        currentTmuxInstanceId,
+        taggedTmuxSessionName: currentTmuxSessionName,
+      };
+    }
+
+    const taggedTmuxSessionName = await resolveTmuxSessionForInstance(invocationSessionId);
+    if (taggedTmuxSessionName) {
+      return {
+        managed: true,
+        reason: 'tmux_instance_tag_match',
+        invocationSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+        taggedTmuxSessionName,
+      };
+    }
+
     if (currentTmuxSessionName && currentTmuxSessionName === expectedTmuxSessionName) {
       return {
         managed: true,
@@ -153,6 +221,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
         sessionState,
         expectedTmuxSessionName,
         currentTmuxSessionName,
+        taggedTmuxSessionName: '',
       };
     }
 
@@ -164,6 +233,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
         sessionState,
         expectedTmuxSessionName,
         currentTmuxSessionName: '',
+        taggedTmuxSessionName: '',
       };
     }
 
@@ -174,6 +244,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
       sessionState,
       expectedTmuxSessionName,
       currentTmuxSessionName,
+      taggedTmuxSessionName: '',
     };
   } catch {
     return {
@@ -183,6 +254,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
       sessionState: null,
       expectedTmuxSessionName: '',
       currentTmuxSessionName: '',
+      taggedTmuxSessionName: '',
     };
   }
 }
@@ -218,10 +290,18 @@ export async function verifyManagedPaneTarget(paneId: string, cwd: string, paylo
     if (!paneSessionName) {
       return { ok: false, reason: 'pane_session_missing', paneTarget, managedContext };
     }
+    const paneInstanceId = await readTmuxSessionInstanceId(paneSessionName);
+    if (paneInstanceId && paneInstanceId !== managedContext.invocationSessionId) {
+      return { ok: false, reason: 'pane_instance_mismatch', paneTarget, paneSessionName, paneInstanceId, managedContext };
+    }
     if (paneSessionName !== expectedSession) {
+      const taggedSession = safeString(managedContext.taggedTmuxSessionName).trim();
+      if (taggedSession && paneSessionName === taggedSession) {
+        return { ok: true, reason: 'ok', paneTarget, paneSessionName, paneInstanceId, managedContext };
+      }
       return { ok: false, reason: 'pane_not_managed_session', paneTarget, paneSessionName, managedContext };
     }
-    return { ok: true, reason: 'ok', paneTarget, paneSessionName, managedContext };
+    return { ok: true, reason: 'ok', paneTarget, paneSessionName, paneInstanceId, managedContext };
   } catch {
     return { ok: false, reason: 'pane_session_lookup_failed', paneTarget, managedContext };
   }
@@ -244,7 +324,7 @@ async function readManagedPaneCommandState(paneTarget: string): Promise<{ curren
 }
 
 function paneLooksLikeManagedAgent({ currentCommand, startCommand }: { currentCommand: string; startCommand: string }): boolean {
-  if (/omx.*hud.*--watch/i.test(startCommand)) return false;
+  if (/\bomx\b.*\bhud\b.*--watch/i.test(startCommand)) return false;
   if (startCommand.includes('codex')) return true;
   return currentCommand === 'codex' || currentCommand === 'node' || currentCommand === 'npx';
 }
@@ -260,7 +340,7 @@ export async function resolveManagedCurrentPane(cwd: string, payload: any, { all
 export async function resolveManagedSessionPane(cwd: string, payload: any): Promise<string> {
   const managedContext = await resolveManagedSessionContext(cwd, payload, { allowTeamWorker: false });
   if (!managedContext.managed) return '';
-  const expectedSession = safeString(managedContext.expectedTmuxSessionName).trim();
+  const expectedSession = safeString(managedContext.taggedTmuxSessionName || managedContext.expectedTmuxSessionName).trim();
   if (!expectedSession) return '';
 
   try {

--- a/src/scripts/notify-hook/tmux-injection.ts
+++ b/src/scripts/notify-hook/tmux-injection.ts
@@ -137,6 +137,28 @@ export async function resolvePaneTarget(target: any, expectedCwd: any, modePane:
     return { paneTarget: null, reason: managedContext.reason || 'unmanaged_session' };
   }
 
+  const taggedSessionTarget = safeString(managedContext.taggedTmuxSessionName).trim();
+  if (taggedSessionTarget) {
+    try {
+      const paneId = await resolveSessionToPane(taggedSessionTarget);
+      if (paneId) {
+        const resolved = await finalizeResolvedPane(paneId, 'managed_instance_target', expectedCwd);
+        if (!resolved.paneTarget) return resolved;
+        const ownership = await verifyManagedPaneTarget(resolved.paneTarget, cwd, payload, { allowTeamWorker: false });
+        if (ownership.ok) {
+          return {
+            ...resolved,
+            source: 'managed_instance',
+            healTarget: true,
+          };
+        }
+        return { paneTarget: null, reason: ownership.reason || 'pane_not_managed_session' };
+      }
+    } catch {
+      // Fall through to legacy pane/session targets.
+    }
+  }
+
   const canonicalModePane = safeString(modePane).trim();
   if (canonicalModePane) {
     try {
@@ -188,7 +210,7 @@ export async function resolvePaneTarget(target: any, expectedCwd: any, modePane:
   try {
     if (!requiresManagedOwnership) return { paneTarget: null, reason: 'target_session_requires_managed_context' };
     const explicitSessionTarget = safeString(target.value).trim();
-    const expectedSessionTarget = safeString(managedContext.expectedTmuxSessionName).trim();
+    const expectedSessionTarget = safeString(managedContext.taggedTmuxSessionName || managedContext.expectedTmuxSessionName).trim();
     const sessionIdTarget = safeString(managedContext.invocationSessionId).trim();
     const stateSessionTarget = safeString(managedContext.sessionState?.session_id).trim();
     const allowedSessionTargets = new Set([expectedSessionTarget, sessionIdTarget, stateSessionTarget].filter(Boolean));

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -25,6 +25,8 @@ import { classifySpawnError, resolveCommandPathForPlatform, spawnPlatformCommand
 const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
 
+const OMX_INSTANCE_OPTION = '@omx_instance_id';
+
 export interface TeamSession {
   name: string; // tmux target in "session:window" form
   workerCount: number;
@@ -809,6 +811,13 @@ export function createTeamSession(
       throw new Error(`failed to parse current tmux target: ${context.stdout}`);
     }
     const teamTarget = `${sessionName}:${windowIndex}`;
+    const instanceId = (process.env.OMX_SESSION_ID || '').trim();
+    if (instanceId) {
+      const tagResult = runTmux(['set-option', '-t', sessionName, OMX_INSTANCE_OPTION, instanceId]);
+      if (!tagResult.ok) {
+        throw new Error(`failed to tag tmux session ${sessionName}: ${tagResult.stderr}`);
+      }
+    }
     const panes = listPanes(teamTarget);
     const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
     const initialHudPaneIds = findHudPaneIds(teamTarget, leaderPaneId);


### PR DESCRIPTION
Fixes the tmux hook isolation issue where OMX nudges leak into unrelated sessions.

**Root cause:** `.omx/tmux-hook.json` uses static pane IDs (e.g. `%0`) and lacks ownership verification.

**Changes:**
1. **Session Tagging:** Tagged tmux sessions with `@omx_instance_id` at spawn.
2. **Hook Verification:** Added check in notify/hook logic to abort injection if `@omx_instance_id` doesn't match.
3. **Dynamic Targeting:** Prefer session-tagged targeting over static pane IDs.

Prevents cross-talk between concurrent OMX instances.