### PR TITLE
[codex] Fix Codex config env schema warning

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -390,7 +390,7 @@ enabled = true
 			await writeFile(
 				join(codexDir, "config.toml"),
 				`
-[env]
+[shell_environment_policy.set]
 USE_OMX_EXPLORE_CMD = "off"
 `.trimStart(),
 			);
@@ -403,7 +403,7 @@ USE_OMX_EXPLORE_CMD = "off"
 			assert.equal(res.status, 0, res.stderr || res.stdout);
 			assert.match(
 				res.stdout,
-				/Explore routing: disabled in config\.toml \[env\]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing/,
+				/Explore routing: disabled in config\.toml; set USE_OMX_EXPLORE_CMD = "1" under \[shell_environment_policy\.set\] to restore default explore-first routing/,
 			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -213,7 +213,8 @@ describe("omx setup scope behavior", () => {
       assert.match(configToml, /^\[agents\]$/m);
       assert.match(configToml, /^max_threads = 6$/m);
       assert.match(configToml, /^max_depth = 2$/m);
-      assert.match(configToml, /^\[env\]$/m);
+      assert.doesNotMatch(configToml, /^\[env\]$/m);
+      assert.match(configToml, /^\[shell_environment_policy\.set\]$/m);
       assert.match(configToml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
       assert.match(configToml, /^codex_hooks = true$/m);
       const hooksJson = JSON.parse(await readFile(localHooks, "utf-8")) as {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -803,8 +803,13 @@ async function checkExploreRouting(configPath: string): Promise<Check> {
 
 	try {
 		const content = await readFile(configPath, "utf-8");
-		const parsed = parseToml(content) as { env?: Record<string, unknown> };
-		const configuredValue = parsed?.env?.USE_OMX_EXPLORE_CMD;
+		const parsed = parseToml(content) as {
+			env?: Record<string, unknown>;
+			shell_environment_policy?: { set?: Record<string, unknown> };
+		};
+		const configuredValue =
+			parsed?.shell_environment_policy?.set?.USE_OMX_EXPLORE_CMD ??
+			parsed?.env?.USE_OMX_EXPLORE_CMD;
 
 		if (
 			typeof configuredValue === "string" &&
@@ -816,7 +821,7 @@ async function checkExploreRouting(configPath: string): Promise<Check> {
 				name: "Explore routing",
 				status: "warn",
 				message:
-					'disabled in config.toml [env]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing',
+					'disabled in config.toml; set USE_OMX_EXPLORE_CMD = "1" under [shell_environment_policy.set] to restore default explore-first routing',
 			};
 		}
 

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -88,7 +88,12 @@ function assertSingleOmxBlock(toml: string): void {
     1,
     "developer_instructions should appear once",
   );
-  assert.equal(count(toml, /^\[env\]$/gm), 1, "[env] should appear once");
+  assert.equal(count(toml, /^\[env\]$/gm), 0, "[env] should not be emitted");
+  assert.equal(
+    count(toml, /^\[shell_environment_policy\.set\]$/gm),
+    1,
+    "[shell_environment_policy.set] should appear once",
+  );
   assert.equal(
     count(toml, /^USE_OMX_EXPLORE_CMD = "1"$/gm),
     1,
@@ -534,24 +539,26 @@ describe("config generator idempotency (#384)", () => {
 
     assert.doesNotMatch(toml, /^\[tui\]$/m);
     assert.match(toml, /^\[mcp_servers\.omx_state\]$/m);
-    assert.match(toml, /^\[env\]$/m);
+    assert.match(toml, /^\[shell_environment_policy\.set\]$/m);
     assert.match(toml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
   });
 
   it('seeds USE_OMX_EXPLORE_CMD=1 into generated config by default', () => {
     const toml = buildMergedConfig('', '/tmp/omx');
 
-    assert.match(toml, /^\[env\]$/m);
+    assert.doesNotMatch(toml, /^\[env\]$/m);
+    assert.match(toml, /^\[shell_environment_policy\.set\]$/m);
     assert.match(toml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
   });
 
-  it('preserves existing [env] keys and explicit explore routing opt-outs', () => {
+  it('migrates existing [env] keys and explicit explore routing opt-outs', () => {
     const toml = buildMergedConfig(
       ['[env]', 'FOO = "bar"', 'USE_OMX_EXPLORE_CMD = "0"', ''].join('\n'),
       '/tmp/omx',
     );
 
-    assert.match(toml, /^\[env\]$/m);
+    assert.doesNotMatch(toml, /^\[env\]$/m);
+    assert.match(toml, /^\[shell_environment_policy\.set\]$/m);
     assert.match(toml, /^FOO = "bar"$/m);
     assert.match(toml, /^USE_OMX_EXPLORE_CMD = "0"$/m);
   });

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -563,6 +563,33 @@ describe("config generator idempotency (#384)", () => {
     assert.match(toml, /^USE_OMX_EXPLORE_CMD = "0"$/m);
   });
 
+  it("migrates multiline [env] values without truncating TOML entries", () => {
+    const toml = buildMergedConfig(
+      [
+        "[env]",
+        'FOO = """first line',
+        "  second line",
+        'third line"""',
+        "BAR = [",
+        '  "one",',
+        '  "two",',
+        "]",
+        "",
+      ].join("\n"),
+      "/tmp/omx",
+    );
+
+    assert.doesNotMatch(toml, /^\[env\]$/m);
+    assert.match(toml, /^\[shell_environment_policy\.set\]$/m);
+    assert.match(
+      toml,
+      /FOO = """first line\n  second line\nthird line"""/,
+    );
+    assert.match(toml, /BAR = \[\n  "one",\n  "two",\n\]/);
+    assert.match(toml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
+    assert.doesNotThrow(() => TOML.parse(toml));
+  });
+
   it("replaces an existing OMX notify entry without leaving orphan fragments behind", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -7,7 +7,7 @@
  * [table] header.  This generator therefore splits its output into:
  *   1. Top-level keys  (notify, model_reasoning_effort, developer_instructions)
  *   2. [features] flags
- *   3. [table] sections (env, mcp_servers, tui)
+ *   3. [table] sections (shell_environment_policy.set, mcp_servers, tui)
  */
 
 import { readFile, writeFile } from "fs/promises";
@@ -516,43 +516,125 @@ export function upsertCodexHooksFeatureFlag(config: string): string {
   return lines.join("\n");
 }
 
+interface TomlTableRange {
+  start: number;
+  end: number;
+}
+
+function findTomlTableRange(
+  lines: string[],
+  headerPattern: RegExp,
+): TomlTableRange | undefined {
+  const start = lines.findIndex((line) => headerPattern.test(line));
+  if (start < 0) return undefined;
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+
+  return { start, end };
+}
+
+function tomlAssignmentKey(line: string): string | undefined {
+  return line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/)?.[1];
+}
+
+function stripTomlTableKey(
+  lines: string[],
+  headerPattern: RegExp,
+  keyName: string,
+): string[] {
+  const range = findTomlTableRange(lines, headerPattern);
+  if (!range) return lines;
+
+  const filtered = [...lines];
+  for (let i = range.end - 1; i > range.start; i--) {
+    if (tomlAssignmentKey(filtered[i]) === keyName) {
+      filtered.splice(i, 1);
+    }
+  }
+
+  const newRange = findTomlTableRange(filtered, headerPattern);
+  if (!newRange) return filtered;
+
+  const sectionContent = filtered.slice(newRange.start + 1, newRange.end);
+  if (sectionContent.every((line) => line.trim() === "")) {
+    filtered.splice(newRange.start, newRange.end - newRange.start);
+  }
+
+  return filtered;
+}
+
 function upsertEnvSettings(config: string): string {
   const lines = config.split(/\r?\n/);
-  const envStart = lines.findIndex((line) => /^\s*\[env\]\s*$/.test(line));
+  const legacyEnvRange = findTomlTableRange(lines, /^\s*\[env\]\s*$/);
+  const legacyEnvEntries =
+    legacyEnvRange === undefined
+      ? []
+      : lines
+          .slice(legacyEnvRange.start + 1, legacyEnvRange.end)
+          .filter((line) => tomlAssignmentKey(line) !== undefined)
+          .map((line) => line.trim());
 
-  if (envStart < 0) {
-    const base = config.trimEnd();
+  if (legacyEnvRange !== undefined) {
+    lines.splice(
+      legacyEnvRange.start,
+      legacyEnvRange.end - legacyEnvRange.start,
+    );
+  }
+
+  const shellEnvSetRange = findTomlTableRange(
+    lines,
+    /^\s*\[shell_environment_policy\.set\]\s*$/,
+  );
+  if (shellEnvSetRange === undefined) {
+    const base = lines.join("\n").trimEnd();
+    const envLines = [...legacyEnvEntries];
+    if (
+      envLines.every(
+        (line) => tomlAssignmentKey(line) !== OMX_EXPLORE_CMD_ENV,
+      )
+    ) {
+      envLines.push(
+        `${OMX_EXPLORE_CMD_ENV} = "${OMX_EXPLORE_ROUTING_DEFAULT}"`,
+      );
+    }
     const envBlock = [
-      "[env]",
-      `${OMX_EXPLORE_CMD_ENV} = "${OMX_EXPLORE_ROUTING_DEFAULT}"`,
+      "[shell_environment_policy.set]",
+      ...envLines,
       "",
     ].join("\n");
     if (base.length === 0) return envBlock;
     return `${base}\n\n${envBlock}`;
   }
 
-  let sectionEnd = lines.length;
-  for (let i = envStart + 1; i < lines.length; i++) {
-    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
-      sectionEnd = i;
-      break;
+  const shellEnvKeys = new Set<string>();
+  for (let i = shellEnvSetRange.start + 1; i < shellEnvSetRange.end; i++) {
+    const key = tomlAssignmentKey(lines[i]);
+    if (key !== undefined) shellEnvKeys.add(key);
+  }
+
+  const linesToInsert: string[] = [];
+  for (const line of legacyEnvEntries) {
+    const key = tomlAssignmentKey(line);
+    if (key !== undefined && !shellEnvKeys.has(key)) {
+      linesToInsert.push(line);
+      shellEnvKeys.add(key);
     }
   }
 
-  let exploreRoutingIdx = -1;
-  for (let i = envStart + 1; i < sectionEnd; i++) {
-    if (new RegExp(`^\\s*${OMX_EXPLORE_CMD_ENV}\\s*=`).test(lines[i])) {
-      exploreRoutingIdx = i;
-      break;
-    }
-  }
-
-  if (exploreRoutingIdx < 0) {
-    lines.splice(
-      sectionEnd,
-      0,
+  if (!shellEnvKeys.has(OMX_EXPLORE_CMD_ENV)) {
+    linesToInsert.push(
       `${OMX_EXPLORE_CMD_ENV} = "${OMX_EXPLORE_ROUTING_DEFAULT}"`,
     );
+  }
+
+  if (linesToInsert.length > 0) {
+    lines.splice(shellEnvSetRange.end, 0, ...linesToInsert);
   }
 
   return lines.join("\n");
@@ -659,48 +741,14 @@ export function stripOmxFeatureFlags(config: string): string {
 }
 
 export function stripOmxEnvSettings(config: string): string {
-  const lines = config.split(/\r?\n/);
-  const envStart = lines.findIndex((line) => /^\s*\[env\]\s*$/.test(line));
-
-  if (envStart < 0) return config;
-
-  let sectionEnd = lines.length;
-  for (let i = envStart + 1; i < lines.length; i++) {
-    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
-      sectionEnd = i;
-      break;
-    }
-  }
-
-  const filtered: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    if (i > envStart && i < sectionEnd) {
-      const isOmxEnvKey = new RegExp(`^\\s*${OMX_EXPLORE_CMD_ENV}\\s*=`).test(
-        lines[i],
-      );
-      if (isOmxEnvKey) continue;
-    }
-    filtered.push(lines[i]);
-  }
-
-  const newEnvStart = filtered.findIndex((line) =>
-    /^\s*\[env\]\s*$/.test(line),
+  let lines = config.split(/\r?\n/);
+  lines = stripTomlTableKey(lines, /^\s*\[env\]\s*$/, OMX_EXPLORE_CMD_ENV);
+  lines = stripTomlTableKey(
+    lines,
+    /^\s*\[shell_environment_policy\.set\]\s*$/,
+    OMX_EXPLORE_CMD_ENV,
   );
-  if (newEnvStart >= 0) {
-    let newSectionEnd = filtered.length;
-    for (let i = newEnvStart + 1; i < filtered.length; i++) {
-      if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(filtered[i])) {
-        newSectionEnd = i;
-        break;
-      }
-    }
-    const envContent = filtered.slice(newEnvStart + 1, newSectionEnd);
-    if (envContent.every((line) => line.trim() === "")) {
-      filtered.splice(newEnvStart, newSectionEnd - newEnvStart);
-    }
-  }
-
-  return filtered.join("\n");
+  return lines.join("\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -1278,7 +1326,7 @@ function getOmxTablesBlock(
  * Layout:
  *   1. OMX top-level keys (notify, model_reasoning_effort, developer_instructions)
  *   2. [features] with multi_agent + child_agents_md
- *   3. [env] with defaulted explore-routing opt-in
+ *   3. [shell_environment_policy.set] with defaulted explore-routing opt-in
  *   4. … user sections …
  *   5. OMX [table] sections (mcp_servers, tui)
  */

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -543,6 +543,60 @@ function tomlAssignmentKey(line: string): string | undefined {
   return line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/)?.[1];
 }
 
+interface TomlTableEntryRange {
+  key?: string;
+  start: number;
+  end: number;
+}
+
+function findTomlTableEntryRanges(
+  lines: string[],
+  start: number,
+  end: number,
+): TomlTableEntryRange[] {
+  const ranges: TomlTableEntryRange[] = [];
+  let index = start;
+
+  while (index < end) {
+    const key = tomlAssignmentKey(lines[index]);
+    if (key === undefined) {
+      ranges.push({ start: index, end: index + 1 });
+      index += 1;
+      continue;
+    }
+
+    let entryEnd = index + 1;
+    while (
+      !parseStandaloneToml(lines.slice(index, entryEnd).join("\n")) &&
+      entryEnd < end
+    ) {
+      entryEnd += 1;
+    }
+
+    ranges.push({ key, start: index, end: entryEnd });
+    index = entryEnd;
+  }
+
+  return ranges;
+}
+
+function collectTomlTableKeyEntries(
+  lines: string[],
+  range: TomlTableRange,
+): { key: string; lines: string[] }[] {
+  return findTomlTableEntryRanges(lines, range.start + 1, range.end)
+    .filter(
+      (
+        entry,
+      ): entry is TomlTableEntryRange & { key: string } =>
+        entry.key !== undefined,
+    )
+    .map((entry) => ({
+      key: entry.key,
+      lines: lines.slice(entry.start, entry.end),
+    }));
+}
+
 function stripTomlTableKey(
   lines: string[],
   headerPattern: RegExp,
@@ -552,9 +606,15 @@ function stripTomlTableKey(
   if (!range) return lines;
 
   const filtered = [...lines];
-  for (let i = range.end - 1; i > range.start; i--) {
-    if (tomlAssignmentKey(filtered[i]) === keyName) {
-      filtered.splice(i, 1);
+  const entries = findTomlTableEntryRanges(
+    filtered,
+    range.start + 1,
+    range.end,
+  );
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.key === keyName) {
+      filtered.splice(entry.start, entry.end - entry.start);
     }
   }
 
@@ -575,10 +635,7 @@ function upsertEnvSettings(config: string): string {
   const legacyEnvEntries =
     legacyEnvRange === undefined
       ? []
-      : lines
-          .slice(legacyEnvRange.start + 1, legacyEnvRange.end)
-          .filter((line) => tomlAssignmentKey(line) !== undefined)
-          .map((line) => line.trim());
+      : collectTomlTableKeyEntries(lines, legacyEnvRange);
 
   if (legacyEnvRange !== undefined) {
     lines.splice(
@@ -593,10 +650,10 @@ function upsertEnvSettings(config: string): string {
   );
   if (shellEnvSetRange === undefined) {
     const base = lines.join("\n").trimEnd();
-    const envLines = [...legacyEnvEntries];
+    const envLines = legacyEnvEntries.flatMap((entry) => entry.lines);
     if (
-      envLines.every(
-        (line) => tomlAssignmentKey(line) !== OMX_EXPLORE_CMD_ENV,
+      legacyEnvEntries.every(
+        (entry) => entry.key !== OMX_EXPLORE_CMD_ENV,
       )
     ) {
       envLines.push(
@@ -619,11 +676,10 @@ function upsertEnvSettings(config: string): string {
   }
 
   const linesToInsert: string[] = [];
-  for (const line of legacyEnvEntries) {
-    const key = tomlAssignmentKey(line);
-    if (key !== undefined && !shellEnvKeys.has(key)) {
-      linesToInsert.push(line);
-      shellEnvKeys.add(key);
+  for (const entry of legacyEnvEntries) {
+    if (!shellEnvKeys.has(entry.key)) {
+      linesToInsert.push(...entry.lines);
+      shellEnvKeys.add(entry.key);
     }
   }
 


### PR DESCRIPTION
## Summary

- Retargets the closed #2003 fix onto `dev`, per maintainer feedback.
- Seeds OMX explore-routing environment config under Codex-supported `[shell_environment_policy.set]` instead of root `[env]`.
- Migrates legacy `[env]` entries into `[shell_environment_policy.set]` during setup refresh so existing OMX-generated configs stop tripping schema diagnostics.
- Updates doctor to read both canonical `shell_environment_policy.set` and legacy `env` locations while pointing users at the canonical table.

## Root cause

Codex CLI 0.125.0 rejects unknown root config properties, so the OMX-generated `[env]` table surfaces as `Additional properties are not allowed (env was unexpected)`. Codex already supports environment injection through `shell_environment_policy.set`.

## Validation

- `npm run build`
- `node --test dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/doctor-warning-copy.test.js dist/cli/__tests__/setup-scope.test.js`
- `npm run lint`
- `npm run test:ci:compiled`
- `git diff --check`
- Manual generator smoke: fresh `buildMergedConfig` output has no `[env]`, has `[shell_environment_policy.set]`, and has `USE_OMX_EXPLORE_CMD = "1"`

Replaces closed PR #2003, which targeted `main` as a draft.