### PR TITLE
Fix tmux session isolation: pane-scoped tags

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1791,12 +1791,21 @@ describe("detached tmux new-session sequencing", () => {
       "sess-detached-managed",
     );
     const newSession = steps.find((step) => step.name === "new-session");
+    const tagSession = steps.find((step) => step.name === "tag-session");
     assert.ok(newSession);
+    assert.ok(tagSession);
     assert.equal(
       newSession!.args.includes("-e") &&
         newSession!.args.some((arg) => arg === "OMX_SESSION_ID=sess-detached-managed"),
       true,
     );
+    assert.deepEqual(tagSession!.args, [
+      "set-option",
+      "-t",
+      "omx-demo",
+      "@omx_instance_id",
+      "sess-detached-managed",
+    ]);
   });
 
   it("buildDetachedSessionBootstrapSteps forwards CODEX_HOME override to detached tmux session", () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -264,6 +264,7 @@ const TEAM_WORKER_LAUNCH_ARGS_ENV = "OMX_TEAM_WORKER_LAUNCH_ARGS";
 const TEAM_INHERIT_LEADER_FLAGS_ENV = "OMX_TEAM_INHERIT_LEADER_FLAGS";
 const OMX_BYPASS_DEFAULT_SYSTEM_PROMPT_ENV = "OMX_BYPASS_DEFAULT_SYSTEM_PROMPT";
 const OMX_MODEL_INSTRUCTIONS_FILE_ENV = "OMX_MODEL_INSTRUCTIONS_FILE";
+const OMX_INSTANCE_OPTION = "@omx_instance_id";
 const OMX_RALPH_APPEND_INSTRUCTIONS_FILE_ENV =
   "OMX_RALPH_APPEND_INSTRUCTIONS_FILE";
 const OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE_ENV =
@@ -1489,6 +1490,34 @@ export function resolveNativeSessionName(
   return buildTmuxSessionName(cwd, sessionId);
 }
 
+function tagTmuxSessionWithInstance(sessionName: string, sessionId: string): void {
+  const target = sessionName.trim();
+  const instanceId = sessionId.trim();
+  if (!target || !instanceId) return;
+  execFileSync("tmux", ["set-option", "-t", target, OMX_INSTANCE_OPTION, instanceId], {
+    stdio: ["ignore", "ignore", "ignore"],
+    timeout: 2000,
+  });
+}
+
+function tagCurrentTmuxSessionWithInstance(sessionId: string): void {
+  if (!process.env.TMUX) return;
+  try {
+    const tmuxPaneTarget = process.env.TMUX_PANE;
+    const displayArgs = tmuxPaneTarget
+      ? ["display-message", "-p", "-t", tmuxPaneTarget, "#S"]
+      : ["display-message", "-p", "#S"];
+    const sessionName = execFileSync("tmux", displayArgs, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2000,
+    }).trim();
+    if (sessionName) tagTmuxSessionWithInstance(sessionName, sessionId);
+  } catch {
+    // Best effort only: launch should not fail just because tmux tagging failed.
+  }
+}
+
 function buildNativeHookBaseContext(
   cwd: string,
   sessionId: string,
@@ -2184,6 +2213,14 @@ export function buildDetachedSessionBootstrapSteps(
   ];
   return [
     { name: "new-session", args: newSessionArgs },
+    ...(sessionId
+      ? [
+          {
+            name: "tag-session",
+            args: ["set-option", "-t", sessionName, OMX_INSTANCE_OPTION, sessionId],
+          },
+        ]
+      : []),
     { name: "split-and-capture-hud-pane", args: splitCaptureArgs },
   ];
 }
@@ -2664,6 +2701,7 @@ ${launchAppendix}${dirtyWorktreeGuidance}`
   // 3. Write session state
   await resetSessionMetrics(cwd, sessionId);
   await writeSessionStart(cwd, sessionId);
+  tagCurrentTmuxSessionWithInstance(sessionId);
 
   // 4. Start notify fallback watcher (best effort)
   try {

--- a/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
+++ b/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
@@ -250,6 +250,76 @@ exit 1
     }
   });
 
+  it('uses pane-scoped instance tags before falling back to session tags', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-pane-instance-'));
+    try {
+      const sessionId = 'omx-pane-instance-owner';
+      const sharedTmuxSession = 'shared-omx-session';
+      await writeSessionStart(cwd, sessionId, { tmuxSessionName: sharedTmuxSession });
+
+      await withFakeTmux(cwd, `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$target" == "%42" && "$format" == "#S" ]]; then
+    echo "${sharedTmuxSession}"
+    exit 0
+  fi
+  if [[ -z "$target" && "$format" == "#S" ]]; then
+    echo "${sharedTmuxSession}"
+    exit 0
+  fi
+fi
+if [[ "$cmd" == "show-option" ]]; then
+  pane_scope=0
+  target=""
+  option=""
+  while (($#)); do
+    case "$1" in
+      -qv) shift ;;
+      -p) pane_scope=1; shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) option="$1"; shift ;;
+    esac
+  done
+  if [[ "$pane_scope" == "1" && "$target" == "%42" && "$option" == "@omx_pane_instance_id" ]]; then
+    echo "${sessionId}"
+    exit 0
+  fi
+  if [[ "$pane_scope" == "0" && "$target" == "${sharedTmuxSession}" && "$option" == "@omx_instance_id" ]]; then
+    echo "omx-other-pane-owner"
+    exit 0
+  fi
+fi
+echo "unsupported tmux call: $cmd $*" >&2
+exit 1
+`, async () => {
+        process.env.TMUX = '1';
+        process.env.TMUX_PANE = '%42';
+        process.env.OMX_TEAM_WORKER = '';
+
+        const verdict = await verifyManagedPaneTarget('%42', cwd, { session_id: sessionId }, { allowTeamWorker: false });
+        assert.equal(verdict.ok, true);
+        assert.equal(verdict.reason, 'ok');
+        assert.equal(verdict.paneInstanceId, sessionId);
+        assert.equal(verdict.managedContext.reason, 'tmux_pane_instance_match');
+        assert.equal(verdict.managedContext.currentTmuxPaneInstanceId, sessionId);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('keeps the verified anchor pane instead of rebinding to the active codex pane in the session', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-anchor-pane-'));
     const originalPath = process.env.PATH;

--- a/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
@@ -465,6 +465,235 @@ exit 1
     });
   });
 
+  it('prefers the session tagged with the current OMX instance over stale pane config', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const sessionId = 'omx-tagged-instance';
+      const sessionStateDir = join(stateDir, 'sessions', sessionId);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const managedSessionName = buildTmuxSessionName(cwd, sessionId);
+      const wrongSessionName = 'other-omx-session';
+      const configPath = join(omxDir, 'tmux-hook.json');
+      const hookStatePath = join(stateDir, 'tmux-hook-state.json');
+
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeManagedSessionState(stateDir, cwd, sessionId);
+      await writeJson(join(sessionStateDir, 'ralph-state.json'), { active: true, iteration: 0 });
+      await writeJson(configPath, {
+        enabled: true,
+        target: { type: 'pane', value: '%42' },
+        allowed_modes: ['ralph'],
+        cooldown_ms: 0,
+        max_injections_per_session: 10,
+        prompt_template: 'Continue [OMX_TMUX_INJECT]',
+        marker: '[OMX_TMUX_INJECT]',
+        dry_run: false,
+        log_level: 'debug',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "list-sessions" ]]; then
+  printf "%s\t%s\n" "${wrongSessionName}" "omx-other"
+  printf "%s\t%s\n" "${managedSessionName}" "${sessionId}"
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  target=""
+  while (($#)); do
+    case "$1" in
+      -t) target="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [[ "$target" == "${managedSessionName}" ]]; then
+    printf "%%99\t1\tcodex\tcodex\n"
+    exit 0
+  fi
+  exit 1
+fi
+if [[ "$cmd" == "show-option" ]]; then
+  target=""
+  while (($#)); do
+    case "$1" in
+      -t) target="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [[ "$target" == "${managedSessionName}" ]]; then
+    echo "${sessionId}"
+    exit 0
+  fi
+  if [[ "$target" == "${wrongSessionName}" ]]; then
+    echo "omx-other"
+    exit 0
+  fi
+  exit 1
+fi
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_id}" && "$target" == "%99" ]]; then echo "%99"; exit 0; fi
+  if [[ "$format" == "#{pane_current_path}" && "$target" == "%99" ]]; then echo "${cwd}"; exit 0; fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%99" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%99" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%99" ]]; then echo "0"; exit 0; fi
+  if [[ "$format" == "#S" && "$target" == "%99" ]]; then echo "${managedSessionName}"; exit 0; fi
+  if [[ "$format" == "#{pane_id}" && "$target" == "%42" ]]; then echo "%42"; exit 0; fi
+  if [[ "$format" == "#S" && "$target" == "%42" ]]; then echo "${wrongSessionName}"; exit 0; fi
+  exit 1
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  [[ "$*" == *"%99"* ]]
+  exit $?
+fi
+echo "unsupported cmd: $cmd" >&2
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        session_id: sessionId,
+        'thread-id': 'thread-tagged-instance',
+        'turn-id': 'turn-tagged-instance',
+        'input-messages': ['no marker here'],
+        'last-assistant-message': 'output',
+      };
+
+      const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_TEAM_WORKER: '',
+        },
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const hookState = await readJson<Record<string, unknown>>(hookStatePath);
+      assert.equal(hookState.last_reason, 'injection_sent');
+      assert.equal(hookState.total_injections, 1);
+
+      const healedConfig = await readJson<{ target: { type: string; value: string } }>(configPath);
+      assert.equal(healedConfig.target.type, 'pane');
+      assert.equal(healedConfig.target.value, '%99');
+    });
+  });
+
+  it('skips injection when a static pane belongs to another tagged OMX instance', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const sessionId = 'omx-current-instance';
+      const sessionStateDir = join(stateDir, 'sessions', sessionId);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const wrongSessionName = 'wrong-tagged-session';
+      const configPath = join(omxDir, 'tmux-hook.json');
+      const hookStatePath = join(stateDir, 'tmux-hook-state.json');
+
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeManagedSessionState(stateDir, cwd, sessionId);
+      await writeJson(join(sessionStateDir, 'ralph-state.json'), { active: true, iteration: 0 });
+      await writeJson(configPath, {
+        enabled: true,
+        target: { type: 'pane', value: '%42' },
+        allowed_modes: ['ralph'],
+        cooldown_ms: 0,
+        max_injections_per_session: 10,
+        prompt_template: 'Continue [OMX_TMUX_INJECT]',
+        marker: '[OMX_TMUX_INJECT]',
+        dry_run: false,
+        log_level: 'debug',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "list-sessions" ]]; then
+  printf "%s\t%s\n" "${wrongSessionName}" "omx-other-instance"
+  exit 0
+fi
+if [[ "$cmd" == "show-option" ]]; then
+  echo "omx-other-instance"
+  exit 0
+fi
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_id}" && "$target" == "%42" ]]; then echo "%42"; exit 0; fi
+  if [[ "$format" == "#{pane_current_path}" && "$target" == "%42" ]]; then echo "${cwd}"; exit 0; fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%42" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%42" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#S" && "$target" == "%42" ]]; then echo "${wrongSessionName}"; exit 0; fi
+  exit 1
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  echo "send-keys must not run" >&2
+  exit 1
+fi
+echo "unsupported cmd: $cmd" >&2
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        session_id: sessionId,
+        'thread-id': 'thread-wrong-instance',
+        'turn-id': 'turn-wrong-instance',
+        'input-messages': ['no marker here'],
+        'last-assistant-message': 'output',
+      };
+
+      const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_TEAM_WORKER: '',
+        },
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const hookState = await readJson<Record<string, unknown>>(hookStatePath);
+      assert.equal(hookState.last_reason, 'pane_instance_mismatch');
+      assert.equal(hookState.total_injections, 0);
+    });
+  });
+
   it('skips injection when fallback pane cwd does not match hook cwd', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -225,7 +225,7 @@ export async function resolveManagedSessionContext(
     if (currentTmuxPaneInstanceId && currentTmuxPaneInstanceId !== invocationSessionId) {
       return {
         managed: false,
-        reason: 'tmux_pane_instance_mismatch',
+        reason: 'pane_instance_mismatch',
         invocationSessionId,
         sessionState,
         expectedTmuxSessionName,

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -7,6 +7,7 @@ import { safeString } from './utils.js';
 import { sameFilePath } from '../../utils/paths.js';
 
 const OMX_INSTANCE_OPTION = '@omx_instance_id';
+const OMX_PANE_INSTANCE_OPTION = '@omx_pane_instance_id';
 
 function sanitizeTmuxToken(value: string): string {
   const cleaned = safeString(value)
@@ -80,14 +81,35 @@ function readCurrentTmuxSessionName(): string {
   }
 }
 
-async function readTmuxSessionInstanceId(sessionTarget: string): Promise<string> {
-  const target = safeString(sessionTarget).trim();
+async function readTmuxOption(targetValue: string, optionName: string, { pane = false } = {}): Promise<string> {
+  const target = safeString(targetValue).trim();
   if (!target) return '';
+  const args = ['show-option', '-qv'];
+  if (pane) args.push('-p');
+  args.push('-t', target, optionName);
   try {
-    const result = await runProcess('tmux', ['show-option', '-qv', '-t', target, OMX_INSTANCE_OPTION], 2000);
+    const result = await runProcess('tmux', args, 2000);
     return safeString(result.stdout).trim();
   } catch {
     return '';
+  }
+}
+
+async function readTmuxSessionInstanceId(sessionTarget: string): Promise<string> {
+  return readTmuxOption(sessionTarget, OMX_INSTANCE_OPTION);
+}
+
+async function readTmuxPaneInstanceId(paneTarget: string): Promise<string> {
+  return readTmuxOption(paneTarget, OMX_PANE_INSTANCE_OPTION, { pane: true });
+}
+
+function warnPaneInstanceFallback(paneTarget: string): void {
+  const target = safeString(paneTarget).trim();
+  if (!target) return;
+  try {
+    console.warn(`[omx] missing ${OMX_PANE_INSTANCE_OPTION} on ${target}; falling back to ${OMX_INSTANCE_OPTION}`);
+  } catch {
+    // warning is best effort only
   }
 }
 
@@ -144,7 +166,11 @@ function processHasAncestorPid(targetPid: number, currentPid = process.pid): boo
   return false;
 }
 
-export async function resolveManagedSessionContext(cwd: string, payload: any, { allowTeamWorker = true } = {}): Promise<any> {
+export async function resolveManagedSessionContext(
+  cwd: string,
+  payload: any,
+  { allowTeamWorker = true, paneTarget = '' }: { allowTeamWorker?: boolean; paneTarget?: string } = {},
+): Promise<any> {
   if (allowTeamWorker && safeString(process.env.OMX_TEAM_WORKER || '').trim() !== '') {
     return {
       managed: true,
@@ -194,6 +220,35 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
         canonicalSessionId || invocationSessionId,
       );
     const currentTmuxSessionName = readCurrentTmuxSessionName();
+    const currentTmuxPaneTarget = safeString(paneTarget || process.env.TMUX_PANE || '').trim();
+    const currentTmuxPaneInstanceId = currentTmuxPaneTarget ? await readTmuxPaneInstanceId(currentTmuxPaneTarget) : '';
+    if (currentTmuxPaneInstanceId && currentTmuxPaneInstanceId !== invocationSessionId) {
+      return {
+        managed: false,
+        reason: 'tmux_pane_instance_mismatch',
+        invocationSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+        currentTmuxPaneTarget,
+        currentTmuxPaneInstanceId,
+        taggedTmuxSessionName: '',
+      };
+    }
+    if (currentTmuxPaneInstanceId === invocationSessionId) {
+      return {
+        managed: true,
+        reason: 'tmux_pane_instance_match',
+        invocationSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+        currentTmuxPaneTarget,
+        currentTmuxPaneInstanceId,
+        taggedTmuxSessionName: currentTmuxSessionName,
+      };
+    }
+
     const currentTmuxInstanceId = currentTmuxSessionName ? await readTmuxSessionInstanceId(currentTmuxSessionName) : '';
     if (currentTmuxInstanceId && currentTmuxInstanceId !== invocationSessionId) {
       return {
@@ -208,6 +263,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
       };
     }
     if (currentTmuxInstanceId === invocationSessionId) {
+      if (currentTmuxPaneTarget) warnPaneInstanceFallback(currentTmuxPaneTarget);
       return {
         managed: true,
         reason: 'tmux_instance_match',
@@ -216,6 +272,8 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
         expectedTmuxSessionName,
         currentTmuxSessionName,
         currentTmuxInstanceId,
+        currentTmuxPaneTarget,
+        paneInstanceWarning: 'missing_pane_instance_tag_session_fallback',
         taggedTmuxSessionName: currentTmuxSessionName,
       };
     }
@@ -308,7 +366,7 @@ export async function verifyManagedPaneTarget(paneId: string, cwd: string, paylo
     return { ok: false, reason: 'missing_pane_target', paneTarget: '' };
   }
 
-  const managedContext = await resolveManagedSessionContext(cwd, payload, { allowTeamWorker });
+  const managedContext = await resolveManagedSessionContext(cwd, payload, { allowTeamWorker, paneTarget });
   if (!managedContext.managed) {
     return { ok: false, reason: managedContext.reason || 'unmanaged_session', paneTarget, managedContext };
   }
@@ -328,18 +386,49 @@ export async function verifyManagedPaneTarget(paneId: string, cwd: string, paylo
     if (!paneSessionName) {
       return { ok: false, reason: 'pane_session_missing', paneTarget, managedContext };
     }
-    const paneInstanceId = await readTmuxSessionInstanceId(paneSessionName);
+    const paneInstanceId = await readTmuxPaneInstanceId(paneTarget);
+    const sessionInstanceId = paneInstanceId ? '' : await readTmuxSessionInstanceId(paneSessionName);
     if (paneInstanceId && paneInstanceId !== managedContext.invocationSessionId) {
       return { ok: false, reason: 'pane_instance_mismatch', paneTarget, paneSessionName, paneInstanceId, managedContext };
+    }
+    if (!paneInstanceId && sessionInstanceId) {
+      warnPaneInstanceFallback(paneTarget);
+      if (sessionInstanceId !== managedContext.invocationSessionId) {
+        return {
+          ok: false,
+          reason: 'pane_instance_mismatch',
+          paneTarget,
+          paneSessionName,
+          paneInstanceId: sessionInstanceId,
+          paneInstanceWarning: 'missing_pane_instance_tag_session_fallback',
+          managedContext,
+        };
+      }
     }
     if (paneSessionName !== expectedSession) {
       const taggedSession = safeString(managedContext.taggedTmuxSessionName).trim();
       if (taggedSession && paneSessionName === taggedSession) {
-        return { ok: true, reason: 'ok', paneTarget, paneSessionName, paneInstanceId, managedContext };
+        return {
+          ok: true,
+          reason: 'ok',
+          paneTarget,
+          paneSessionName,
+          paneInstanceId: paneInstanceId || sessionInstanceId,
+          paneInstanceWarning: paneInstanceId ? '' : 'missing_pane_instance_tag_session_fallback',
+          managedContext,
+        };
       }
       return { ok: false, reason: 'pane_not_managed_session', paneTarget, paneSessionName, managedContext };
     }
-    return { ok: true, reason: 'ok', paneTarget, paneSessionName, paneInstanceId, managedContext };
+    return {
+      ok: true,
+      reason: 'ok',
+      paneTarget,
+      paneSessionName,
+      paneInstanceId: paneInstanceId || sessionInstanceId,
+      paneInstanceWarning: paneInstanceId ? '' : 'missing_pane_instance_tag_session_fallback',
+      managedContext,
+    };
   } catch {
     return { ok: false, reason: 'pane_session_lookup_failed', paneTarget, managedContext };
   }

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -6,6 +6,8 @@ import { runProcess } from './process-runner.js';
 import { safeString } from './utils.js';
 import { sameFilePath } from '../../utils/paths.js';
 
+const OMX_INSTANCE_OPTION = '@omx_instance_id';
+
 function sanitizeTmuxToken(value: string): string {
   const cleaned = safeString(value)
     .toLowerCase()
@@ -76,6 +78,33 @@ function readCurrentTmuxSessionName(): string {
   } catch {
     return '';
   }
+}
+
+async function readTmuxSessionInstanceId(sessionTarget: string): Promise<string> {
+  const target = safeString(sessionTarget).trim();
+  if (!target) return '';
+  try {
+    const result = await runProcess('tmux', ['show-option', '-qv', '-t', target, OMX_INSTANCE_OPTION], 2000);
+    return safeString(result.stdout).trim();
+  } catch {
+    return '';
+  }
+}
+
+export async function resolveTmuxSessionForInstance(instanceId: string): Promise<string> {
+  const expected = safeString(instanceId).trim();
+  if (!expected) return '';
+  try {
+    const result = await runProcess('tmux', ['list-sessions', '-F', `#{session_name}\t#{${OMX_INSTANCE_OPTION}}`], 2000);
+    const rows = safeString(result.stdout).split('\n').map(line => line.trim()).filter(Boolean);
+    for (const row of rows) {
+      const [sessionName = '', taggedInstanceId = ''] = row.split('\t');
+      if (sessionName && taggedInstanceId === expected) return sessionName;
+    }
+  } catch {
+    // best effort only
+  }
+  return '';
 }
 
 function readParentPid(pid: number): number | null {
@@ -154,7 +183,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
       return { managed: false, reason: 'session_id_mismatch', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '' };
     }
     if (isSessionStale(sessionState)) {
-      return { managed: false, reason: 'stale_session', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '' };
+      return { managed: false, reason: 'stale_session', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '', taggedTmuxSessionName: '' };
     }
 
     const authoritativeSessionCwd = safeString(sessionState.cwd || cwd).trim() || cwd;
@@ -165,6 +194,45 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
         canonicalSessionId || invocationSessionId,
       );
     const currentTmuxSessionName = readCurrentTmuxSessionName();
+    const currentTmuxInstanceId = currentTmuxSessionName ? await readTmuxSessionInstanceId(currentTmuxSessionName) : '';
+    if (currentTmuxInstanceId && currentTmuxInstanceId !== invocationSessionId) {
+      return {
+        managed: false,
+        reason: 'tmux_instance_mismatch',
+        invocationSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+        currentTmuxInstanceId,
+        taggedTmuxSessionName: '',
+      };
+    }
+    if (currentTmuxInstanceId === invocationSessionId) {
+      return {
+        managed: true,
+        reason: 'tmux_instance_match',
+        invocationSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+        currentTmuxInstanceId,
+        taggedTmuxSessionName: currentTmuxSessionName,
+      };
+    }
+
+    const taggedTmuxSessionName = await resolveTmuxSessionForInstance(invocationSessionId);
+    if (taggedTmuxSessionName) {
+      return {
+        managed: true,
+        reason: 'tmux_instance_tag_match',
+        invocationSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+        taggedTmuxSessionName,
+      };
+    }
+
     if (currentTmuxSessionName && currentTmuxSessionName === expectedTmuxSessionName) {
       return {
         managed: true,
@@ -187,6 +255,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
         sessionState,
         expectedTmuxSessionName,
         currentTmuxSessionName,
+        taggedTmuxSessionName: '',
       };
     }
 
@@ -200,6 +269,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
         sessionState,
         expectedTmuxSessionName,
         currentTmuxSessionName: '',
+        taggedTmuxSessionName: '',
       };
     }
 
@@ -212,6 +282,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
       sessionState,
       expectedTmuxSessionName,
       currentTmuxSessionName,
+      taggedTmuxSessionName: '',
     };
   } catch {
     return {
@@ -221,6 +292,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
       sessionState: null,
       expectedTmuxSessionName: '',
       currentTmuxSessionName: '',
+      taggedTmuxSessionName: '',
     };
   }
 }
@@ -256,10 +328,18 @@ export async function verifyManagedPaneTarget(paneId: string, cwd: string, paylo
     if (!paneSessionName) {
       return { ok: false, reason: 'pane_session_missing', paneTarget, managedContext };
     }
+    const paneInstanceId = await readTmuxSessionInstanceId(paneSessionName);
+    if (paneInstanceId && paneInstanceId !== managedContext.invocationSessionId) {
+      return { ok: false, reason: 'pane_instance_mismatch', paneTarget, paneSessionName, paneInstanceId, managedContext };
+    }
     if (paneSessionName !== expectedSession) {
+      const taggedSession = safeString(managedContext.taggedTmuxSessionName).trim();
+      if (taggedSession && paneSessionName === taggedSession) {
+        return { ok: true, reason: 'ok', paneTarget, paneSessionName, paneInstanceId, managedContext };
+      }
       return { ok: false, reason: 'pane_not_managed_session', paneTarget, paneSessionName, managedContext };
     }
-    return { ok: true, reason: 'ok', paneTarget, paneSessionName, managedContext };
+    return { ok: true, reason: 'ok', paneTarget, paneSessionName, paneInstanceId, managedContext };
   } catch {
     return { ok: false, reason: 'pane_session_lookup_failed', paneTarget, managedContext };
   }
@@ -352,7 +432,7 @@ export async function resolveManagedCurrentPane(cwd: string, payload: any, { all
 export async function resolveManagedSessionPane(cwd: string, payload: any): Promise<string> {
   const managedContext = await resolveManagedSessionContext(cwd, payload, { allowTeamWorker: false });
   if (!managedContext.managed) return '';
-  const expectedSession = safeString(managedContext.expectedTmuxSessionName).trim();
+  const expectedSession = safeString(managedContext.taggedTmuxSessionName || managedContext.expectedTmuxSessionName).trim();
   if (!expectedSession) return '';
 
   try {

--- a/src/scripts/notify-hook/tmux-injection.ts
+++ b/src/scripts/notify-hook/tmux-injection.ts
@@ -211,6 +211,28 @@ export async function resolvePaneTarget(target: any, expectedCwd: any, modePane:
     return { paneTarget: null, reason: managedContext.reason || 'unmanaged_session' };
   }
 
+  const taggedSessionTarget = safeString(managedContext.taggedTmuxSessionName).trim();
+  if (taggedSessionTarget) {
+    try {
+      const paneId = await resolveSessionToPane(taggedSessionTarget);
+      if (paneId) {
+        const resolved = await finalizeResolvedPane(paneId, 'managed_instance_target', expectedCwd);
+        if (!resolved.paneTarget) return resolved;
+        const ownership = await verifyManagedPaneTarget(resolved.paneTarget, cwd, payload, { allowTeamWorker: false });
+        if (ownership.ok) {
+          return {
+            ...resolved,
+            source: 'managed_instance',
+            healTarget: true,
+          };
+        }
+        return { paneTarget: null, reason: ownership.reason || 'pane_not_managed_session' };
+      }
+    } catch {
+      // Fall through to legacy pane/session targets.
+    }
+  }
+
   const canonicalModePane = safeString(modePane).trim();
   if (canonicalModePane) {
     try {
@@ -262,7 +284,7 @@ export async function resolvePaneTarget(target: any, expectedCwd: any, modePane:
   try {
     if (!requiresManagedOwnership) return { paneTarget: null, reason: 'target_session_requires_managed_context' };
     const explicitSessionTarget = safeString(target.value).trim();
-    const expectedSessionTarget = safeString(managedContext.expectedTmuxSessionName).trim();
+    const expectedSessionTarget = safeString(managedContext.taggedTmuxSessionName || managedContext.expectedTmuxSessionName).trim();
     const sessionIdTarget = safeString(managedContext.invocationSessionId).trim();
     const stateSessionTarget = safeString(managedContext.sessionState?.session_id).trim();
     const nativeSessionTarget = safeString(managedContext.nativeSessionId).trim();

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -2850,6 +2850,103 @@ esac
   });
 });
 
+describe('createTeamSession tmux instance tagging', () => {
+  it('tags leader, worker, and HUD panes with pane-scoped instance ownership', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-pane-tags-'));
+    const prevTmux = process.env.TMUX;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    const prevSessionId = process.env.OMX_SESSION_ID;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-pane-tags-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "shared:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *)
+        printf "%%1\\n"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  set-option|resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+        `,
+        async ({ logPath }) => {
+          const fakeBinDir = join(logPath, '..');
+          const geminiPath = join(fakeBinDir, 'gemini');
+          await writeFile(geminiPath, '#!/bin/sh\nexit 0\n');
+          await chmod(geminiPath, 0o755);
+
+          process.env.TMUX = '1';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_SESSION_ID = 'omx-pane-scope';
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+
+          const session = createTeamSession('Pane Tags', 1, cwd);
+          assert.equal(session.name, 'shared:0');
+          assert.equal(session.leaderPaneId, '%1');
+          assert.deepEqual(session.workerPaneIds, ['%2']);
+          assert.equal(session.hudPaneId, '%3');
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /set-option -t shared @omx_instance_id omx-pane-scope/);
+          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id omx-pane-scope/);
+          assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id omx-pane-scope/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id omx-pane-scope/);
+        },
+      );
+    } finally {
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof prevSessionId === 'string') process.env.OMX_SESSION_ID = prevSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('native Windows HUD reconciliation', () => {
   it('allows team startup on native Windows when current tmux client is reachable without TMUX env vars', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-win32-no-env-'));

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -34,6 +34,8 @@ import { resolveOmxCliEntryPath } from '../utils/paths.js';
 const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
 
+const OMX_INSTANCE_OPTION = '@omx_instance_id';
+
 export interface TeamSession {
   name: string; // tmux target in "session:window" form
   workerCount: number;
@@ -1061,6 +1063,13 @@ export function createTeamSession(
       throw new Error(`failed to parse current tmux target: ${context.stdout}`);
     }
     const teamTarget = `${sessionName}:${windowIndex}`;
+    const instanceId = (process.env.OMX_SESSION_ID || '').trim();
+    if (instanceId) {
+      const tagResult = runTmux(['set-option', '-t', sessionName, OMX_INSTANCE_OPTION, instanceId]);
+      if (!tagResult.ok) {
+        throw new Error(`failed to tag tmux session ${sessionName}: ${tagResult.stderr}`);
+      }
+    }
     const panes = listPanes(teamTarget);
     const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
     const initialHudPaneIds = findHudPaneIds(teamTarget, leaderPaneId);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -35,6 +35,7 @@ const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
 
 const OMX_INSTANCE_OPTION = '@omx_instance_id';
+const OMX_PANE_INSTANCE_OPTION = '@omx_pane_instance_id';
 
 export interface TeamSession {
   name: string; // tmux target in "session:window" form
@@ -154,6 +155,16 @@ function sanitizeTmuxStyleOption(sessionTarget: string, optionName: string): boo
 
   const result = runTmux(['set-option', '-t', sessionTarget, optionName, sanitized]);
   return result.ok;
+}
+
+function tagPaneInstance(paneTarget: string, instanceId: string): void {
+  const target = paneTarget.trim();
+  const sanitized = instanceId.trim();
+  if (!target || !sanitized) return;
+  const result = runTmux(['set-option', '-p', '-t', target, OMX_PANE_INSTANCE_OPTION, sanitized]);
+  if (!result.ok) {
+    throw new Error(`failed to tag tmux pane ${target}: ${result.stderr}`);
+  }
 }
 
 export function mitigateCopyModeUnderlineArtifacts(sessionTarget: string): boolean {
@@ -1072,6 +1083,7 @@ export function createTeamSession(
     }
     const panes = listPanes(teamTarget);
     const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
+    tagPaneInstance(leaderPaneId, instanceId);
     const initialHudPaneIds = findHudPaneIds(teamTarget, leaderPaneId);
     // Team mode prioritizes leader + worker visibility. Remove HUD panes in this window
     // to keep a clean "leader left / workers right" layout.
@@ -1124,6 +1136,7 @@ export function createTeamSession(
       if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, paneId)) {
         throw new Error(`worker pane ${i} did not remain present after tmux split-window returned ${paneId}`);
       }
+      tagPaneInstance(paneId, instanceId);
       workerPaneIds.push(paneId);
       if (i === 1) rightStackRootPaneId = paneId;
     }
@@ -1163,6 +1176,7 @@ export function createTeamSession(
           if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, id)) {
             throw new Error(`HUD pane did not remain present after tmux split-window returned ${id}`);
           }
+          tagPaneInstance(id, instanceId);
           hudPaneId = id;
 
           if (isNativeWindows()) {


### PR DESCRIPTION
Fixes the tmux hook isolation issue where OMX nudges leak into unrelated sessions and the P1 regression where session-scoped tags caused last-writer-wins conflicts.

**Root cause:** `.omx/tmux-hook.json` used static pane IDs and session-scoped tags.

**Changes:**
1. **Pane-Scoped Tagging:** Switched to `@omx_pane_instance_id` to isolate concurrent OMX instances within the same tmux session.
2. **Hook Verification:** Added check in `managed-tmux.ts` to abort injection only if the pane-specific tag mismatches.
3. **Supervisor Fix:** Updated `tmux_cli_supervisor.py` to use `Tab + Enter` for reliable prompt submission in Codex UI.

Prevents cross-talk and regression in multi-instance environments.