### PR TITLE
Align prompt surfaces with GPT-5.5 guidance

### DIFF
--- a/docs/prompt-guidance-contract.md
+++ b/docs/prompt-guidance-contract.md
@@ -1,41 +1,40 @@
-# GPT-5.4 Prompt Guidance Contract
+# GPT-5.5 Prompt Guidance Contract
 
 Status: contributor-facing contract for OMX prompt and orchestration surfaces.
 
 ## Purpose
 
-This document explains the **behavioral prompt contract** introduced by the GPT-5.4 guidance rollout in [#608](https://github.com/Yeachan-Heo/oh-my-codex/issues/608) and expanded in [#611](https://github.com/Yeachan-Heo/oh-my-codex/pull/611) and [#612](https://github.com/Yeachan-Heo/oh-my-codex/pull/612).
+This document explains the active **behavioral prompt contract** for OMX after Issue [#2007](https://github.com/Yeachan-Heo/oh-my-codex/issues/2007): align prompt and instruction surfaces with OpenAI's official [GPT-5.5 prompt guidance](https://developers.openai.com/api/docs/guides/prompt-guidance) while preserving OMX product contracts.
 
 Use it when you edit any of these surfaces:
 
 - `AGENTS.md` when a repo chooses to track a project-root copy
 - `templates/AGENTS.md`
 - canonical XML-tagged role prompt surfaces in `prompts/*.md`
-- generated top-level `developer_instructions` text in `src/config/generator.ts`
+- workflow skill instructions in `skills/*/SKILL.md`
+- hook/generator prompt guidance and regression tests under `src/hooks/` and `src/config/`
 
 ## Scope and current source of truth
 
-Issue [#615](https://github.com/Yeachan-Heo/oh-my-codex/issues/615) uses examples like `src/prompts/role-planner.ts`, but the current prompt sources in this repository live in **`prompts/*.md`**, then get installed to `~/.codex/prompts/`.
+The current prompt sources in this repository live in **`prompts/*.md`** and **`skills/*/SKILL.md`**, then get installed to `~/.codex/prompts/`, `~/.codex/skills/`, and native agent wrappers. Treat the source markdown body as canonical; launcher-specific TOML or runtime wrappers should preserve the same behavior.
 
-The GPT-5.4 contract is currently distributed across:
+The GPT-5.5 contract is distributed across:
 
 - orchestration surfaces: `templates/AGENTS.md` and any tracked project-root `AGENTS.md`
-- canonical XML-tagged subagent role prompt surfaces: `prompts/*.md`
+- shared fragments: `docs/prompt-guidance-fragments/*`
+- canonical XML-tagged subagent role prompts: `prompts/*.md`
+- workflow skills: `skills/*/SKILL.md`
 - generated top-level Codex config guidance: `src/config/generator.ts`
 - regression tests: `src/hooks/__tests__/prompt-guidance-*.test.ts`
 
-In this repository, `prompts/*.md` remain the canonical source files even when their installed runtime form is injected into TOML or other launcher-specific wrappers. Treat the XML-tagged prompt body itself as the canonical role surface.
-
-This document is the contributor-oriented index for those surfaces.
-
 ## Workflow skill guidance dedupe
 
-Workflow skills in `skills/*/SKILL.md` may use a compact reference to the shared workflow guidance pattern instead of repeating every GPT-5.4 bullet verbatim. That pattern must preserve four behaviors: concise evidence-backed reporting, scoped task-update overrides, persistent inspection/verification while correctness depends on it, and automatic continuation for safe reversible next steps. Workflow-specific invariants such as state transitions, gates, cleanup, cancellation, and verification commands remain explicit in the owning skill.
+Workflow skills may use a compact reference to the shared workflow guidance pattern instead of repeating every GPT-5.5 bullet. That pattern must preserve: outcome-first framing, concise visible updates for multi-step work, scoped task-update overrides, evidence-backed validation, and explicit stop/escalation rules. Workflow-specific invariants such as state transitions, gates, cleanup, cancellation, and verification commands remain explicit in the owning skill.
 
 ## Exact-model mini adaptation seam
 
 OMX also has a narrow **instruction-composition seam** for subagents/workers whose **final resolved model** is exactly `gpt-5.4-mini`.
-That seam is part of prompt delivery, but it is intentionally narrower than the general GPT-5.4 behavioral contract described below.
+That seam is part of prompt delivery, but it is intentionally narrower than the general GPT-5.5 behavioral contract described below.
 
 Contributor rules for that seam:
 
@@ -53,107 +52,88 @@ Primary implementation surfaces for this seam:
 | team runtime/scaling plumbing | `src/team/runtime.ts`, `src/team/scaling.ts`, associated runtime/scaling tests |
 | outer wrapper boundary | `src/team/worker-bootstrap.ts`, `src/team/__tests__/worker-bootstrap.test.ts` |
 
-
 ## What this contract is — and is not
 
-This contract is about **how OMX prompts should behave**.
-It is not the same thing as OMX's routing metadata.
+This contract is about **how OMX prompts should behave**. It is not the same thing as OMX's routing metadata.
 
-- **Behavioral contract:** quality-first intent-deepening defaults, automatic follow-through, localized task updates, persistent tool use, and evidence-backed completion.
+- **Behavioral contract:** outcome-first defaults, concise collaboration style, low-risk follow-through, localized task updates, evidence-backed validation, and explicit stop rules.
 - **Adjacent but separate routing layer:** role/tier/posture metadata such as `frontier-orchestrator`, `deep-worker`, and `fast-lane` in `src/agents/native-config.ts` and `docs/shared/agent-tiers.md`.
 
-If you are changing prompt prose, use this document first.
-If you are changing routing metadata or native config overlays, use the routing docs/tests first.
+If you are changing prompt prose, use this document first. If you are changing routing metadata or native config overlays, use the routing docs/tests first.
 
-## The 4 core GPT-5.4 patterns OMX should now enforce
+## The 5 core GPT-5.5 patterns OMX should enforce
 
-### 1. Quality-first, intent-deepening output by default
+### 1. Outcome-first, success-criteria-led prompts
 
-Contributors should preserve the default posture of quality-first outputs that dig deeper into intent, think one more step before asking, and still include the evidence needed to act safely.
+Contributors should describe the target result, success criteria, constraints, available evidence, expected output, and stop condition before adding process detail. Avoid process-heavy stacks unless the process is itself a product contract.
 
 Representative locations:
 
 | Surface | Evidence |
 |---|---|
-| `templates/AGENTS.md` | `templates/AGENTS.md:29` |
-| `prompts/executor.md` | `prompts/executor.md:47`, `prompts/executor.md:121` |
-| `prompts/planner.md` | `prompts/planner.md:35`, `prompts/planner.md:79` |
-| `prompts/verifier.md` | `prompts/verifier.md:29` |
-| contract tests | `src/hooks/__tests__/prompt-guidance-contract.test.ts:15-19`, `src/hooks/__tests__/prompt-guidance-wave-two.test.ts:27-30`, `src/hooks/__tests__/prompt-guidance-catalog.test.ts:35-39` |
+| shared fragments | `docs/prompt-guidance-fragments/core-operating-principles.md` |
+| root orchestration | `templates/AGENTS.md` |
+| core roles | `prompts/executor.md`, `prompts/planner.md`, `prompts/verifier.md` |
+| contract tests | `src/hooks/prompt-guidance-contract.ts` and `src/hooks/__tests__/prompt-guidance-*.test.ts` |
 
 Example prompt text:
 
-> - Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
->
-> - More effort does not mean reflexive web/tool escalation; use tools when they materially improve the result.
+> Default to outcome-first, quality-focused responses: identify the user's target result, success criteria, constraints, available evidence, expected output, and stop condition before adding process detail.
 
-### 2. Automatic follow-through on clear, low-risk, reversible next steps
+### 2. Concise personality/collaboration style with preambles for longer work
+
+Keep tone and collaboration steering short. For multi-step or tool-heavy tasks, start with a brief visible preamble that acknowledges the request and names the first step; keep later updates brief and evidence-based.
+
+Representative locations:
+
+| Surface | Evidence |
+|---|---|
+| root orchestration | `templates/AGENTS.md` |
+| executor/planner/verifier fragments | `docs/prompt-guidance-fragments/*-constraints.md` |
+| core prompts | `prompts/executor.md`, `prompts/planner.md`, `prompts/verifier.md` |
+
+### 3. Automatic follow-through on clear, low-risk, reversible next steps
 
 Contributors should preserve the bias toward continuing useful work automatically instead of asking avoidable confirmation questions.
 
-Representative locations:
-
-| Surface | Evidence |
-|---|---|
-| `templates/AGENTS.md` | `templates/AGENTS.md:30` |
-| `prompts/executor.md` | `prompts/executor.md:48`, `prompts/executor.md:139-143` |
-| `prompts/planner.md` | `prompts/planner.md:36`, `prompts/planner.md:118-122` |
-| release notes | `docs/release-notes-0.8.6.md:42-47` |
-| contract tests | `src/hooks/__tests__/prompt-guidance-contract.test.ts:30-32`, `src/hooks/__tests__/prompt-guidance-scenarios.test.ts:13-33` |
-
 Example prompt text:
 
-> - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
-> - Do not ask or instruct humans to perform ordinary non-destructive, reversible actions; execute those safe reversible OMX/runtime operations and ordinary commands yourself.
-> - Treat OMX runtime manipulation, state transitions, and ordinary command execution as agent responsibilities when they are safe and reversible.
->
-> **Good:** The user says `continue` after you already identified the next safe implementation step. Continue the current branch of work instead of asking for reconfirmation.
+> Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, credential-gated, external-production, destructive, or materially scope-changing actions.
 
-### 3. Localized task-update overrides that preserve earlier non-conflicting instructions
+Also preserve agent-owned safe runtime work:
+
+> Do not ask or instruct humans to perform ordinary non-destructive, reversible actions; execute those safe reversible OMX/runtime operations and ordinary commands yourself.
+
+### 4. Localized task-update overrides that preserve earlier non-conflicting instructions
 
 Contributors should treat user updates as **scoped overrides**, not full prompt resets.
 
-Representative locations:
-
-| Surface | Evidence |
-|---|---|
-| `templates/AGENTS.md` | `templates/AGENTS.md:31`, `templates/AGENTS.md:300` |
-| `src/config/generator.ts` | `src/config/generator.ts:77` |
-| `prompts/executor.md` | `prompts/executor.md:49-50`, `prompts/executor.md:60`, `prompts/executor.md:141-147` |
-| `prompts/planner.md` | `prompts/planner.md:37`, `prompts/planner.md:118-126` |
-| `prompts/verifier.md` | `prompts/verifier.md:38`, `prompts/verifier.md:91-99` |
-| contract tests | `src/hooks/__tests__/prompt-guidance-contract.test.ts:34-36`, `src/hooks/__tests__/prompt-guidance-wave-two.test.ts:27-30`, `src/hooks/__tests__/prompt-guidance-catalog.test.ts:35-39` |
-
 Example prompt text:
 
-> - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
->
-> 4. If a newer user message updates only the current step or output shape, apply that override locally without discarding earlier non-conflicting instructions.
+> Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
 
-### 4. Persistent tool use, dependency-aware sequencing, and evidence-backed completion
+Scenario examples for `continue`, `make a PR`, and `merge if CI green` reinforce this behavior in `prompts/executor.md`, `prompts/planner.md`, `prompts/verifier.md`, and related tests.
 
-Contributors should preserve the rule that prompts keep using tools when correctness depends on retrieval, diagnostics, tests, or verification. OMX should not stop at a plausible answer if proof is still missing.
+### 5. Evidence budgets, validation, and explicit stop rules
 
-Representative locations:
+GPT-5.5 guidance favors enough retrieval/validation to answer correctly, then stopping. OMX prompts should continue tool use while correctness depends on repository inspection, official docs, diagnostics, tests, citations, or verification, but avoid extra loops that only improve phrasing or gather nonessential evidence.
 
-| Surface | Evidence |
-|---|---|
-| `templates/AGENTS.md` | `templates/AGENTS.md:32`, `templates/AGENTS.md:288`, `templates/AGENTS.md:297-301`, `templates/AGENTS.md:307-308` |
-| `src/config/generator.ts` | `src/config/generator.ts:77` |
-| `prompts/executor.md` | `prompts/executor.md:32-38`, `prompts/executor.md:45`, `prompts/executor.md:50`, `prompts/executor.md:101-109` |
-| `prompts/planner.md` | `prompts/planner.md:47-53` |
-| `prompts/verifier.md` | `prompts/verifier.md:26-30`, `prompts/verifier.md:34-38`, `prompts/verifier.md:91-99` |
-| broader prompt catalog tests | `src/hooks/__tests__/prompt-guidance-wave-two.test.ts:33-43` |
+For coding work, prompts should ask for concrete validation:
 
-Example prompt text:
+- targeted tests for changed behavior
+- typecheck/lint/build checks when applicable
+- a minimal smoke test when full validation is too expensive
+- an explicit reason and next-best check when validation cannot run
 
-> - Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
->
-> Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence.
+Implementation plans should stay traceable: requirements, named files/resources/APIs, state transitions or data flow where relevant, validation commands, failure behavior, privacy/security considerations, and material open questions.
+
+## Absolute-language rule
+
+Use `MUST`, `NEVER`, `ALWAYS`, `only`, and similar absolute wording for true invariants: safety/security boundaries, side-effect constraints, required output fields, workflow state transitions, team/ralph gates, and product contracts. For judgment calls such as whether to search again, ask for clarification, or keep iterating, prefer decision rules and stop conditions.
 
 ## Active workflow terminal handoff contract
 
-Prompt surfaces that control active workflows should describe terminal user-facing replies as explicit handoffs, not as casual optional follow-ups.
+Prompt surfaces that control active workflows should describe terminal user-facing replies as explicit handoffs, not casual optional follow-ups.
 
 Contributor rules:
 
@@ -173,23 +153,9 @@ When editing `templates/AGENTS.md`, any tracked root `AGENTS.md`, or other root 
 3. **Stop/escalate rules are explicit.** The prompt should say when to stop, when to escalate to the user, and when workers must escalate back to the leader.
 4. **Output contract stays tight.** Default progress/final updates should be compact: current mode, action/result, and evidence or blocker/next step. Avoid repeating full-plan rationale unless the risk or decision changed.
 
-## Reinforcement pattern: scenario examples
-
-OMX also uses **scenario-style examples** to make the contract concrete for "continue", "make a PR", and "merge if CI green" flows.
-These examples reinforce the four core patterns above, but they are not a separate routing or reasoning system.
-
-Representative locations:
-
-- `prompts/executor.md:137-147`
-- `prompts/planner.md:116-126`
-- `prompts/verifier.md:89-99`
-- `src/hooks/__tests__/prompt-guidance-scenarios.test.ts:13-33`
-- `src/hooks/__tests__/prompt-guidance-wave-two.test.ts:45-61`
-
 ## Relationship to the guidance schema
 
-`docs/guidance-schema.md` defines the **section layout contract** for AGENTS and worker surfaces.
-This document defines the **behavioral wording contract** that should appear within those sections after the GPT-5.4 rollout.
+`docs/guidance-schema.md` defines the **section layout contract** for AGENTS and worker surfaces. This document defines the **behavioral wording contract** that should appear within those sections after the GPT-5.5 rollout.
 
 Use both documents together:
 
@@ -198,14 +164,13 @@ Use both documents together:
 
 ## Relationship to posture-aware routing
 
-Posture-aware routing is real, but it is not the same contract as the GPT-5.4 behavior rollout.
-Keep these separate when editing docs and prompts:
+Posture-aware routing is real, but it is not the same contract as the GPT-5.5 behavior rollout. Keep these separate when editing docs and prompts:
 
 | Topic | Primary sources |
 |---|---|
-| GPT-5.4 prompt behavior contract | `templates/AGENTS.md`, any tracked `AGENTS.md`, canonical XML-tagged role prompt surfaces in `prompts/*.md`, `src/config/generator.ts`, `src/hooks/__tests__/prompt-guidance-*.test.ts` |
+| GPT-5.5 prompt behavior contract | `templates/AGENTS.md`, any tracked `AGENTS.md`, canonical XML-tagged role prompt surfaces in `prompts/*.md`, workflow skills in `skills/*/SKILL.md`, `src/config/generator.ts`, `src/hooks/__tests__/prompt-guidance-*.test.ts` |
 | exact-model mini composition seam | `src/agents/native-config.ts`, `src/team/runtime.ts`, `src/team/scaling.ts`, `src/team/worker-bootstrap.ts`, targeted native/runtime/scaling/bootstrap tests |
-| role/tier/posture routing | `README.md:133-179`, `docs/shared/agent-tiers.md:7-56`, `src/agents/native-config.ts:12-40` |
+| role/tier/posture routing | `README.md:133-179`, `docs/shared/agent-tiers.md`, `src/agents/native-config.ts` |
 
 If a change only affects posture overlays or native agent metadata, document it in the routing docs rather than expanding this contract unnecessarily.
 
@@ -221,24 +186,26 @@ The main role catalog is the installable specialized-agent set used by native ag
 
 Before opening a PR that changes prompt text, confirm all of the following:
 
-1. **Preserve the four core behaviors.** Your change should keep or strengthen quality-first intent-deepening output, low-risk follow-through, scoped overrides, and grounded tool use/verification.
+1. **Preserve the five core behaviors.** Your change should keep or strengthen outcome-first framing, concise collaboration/preambles, low-risk follow-through, scoped overrides, and evidence-backed validation/stop rules.
 2. **Keep role-specific wording role-specific.** The phrasing can differ by role, but the behavior should stay semantically aligned.
-3. **Update scenario examples when behavior changes.** If you change how prompts handle `continue`, `make a PR`, or `merge if CI green`, update the prompt examples and the related tests.
+3. **Update scenario examples when behavior changes.** If you change how prompts handle `continue`, `make a PR`, or `merge if CI green`, update the prompt examples and related tests.
 4. **Keep the mini-only seam exact and centralized.** If you touch mini adaptation, gate it on the final resolved model with exact `gpt-5.4-mini` equality, keep the shared inner helper as the source of truth, and keep `worker-bootstrap.ts` wrapper-only.
 5. **Do not confuse routing metadata with prompt behavior.** Posture/tier updates belong in routing docs/tests unless they also change prompt prose.
-6. **Update regression coverage when the contract changes.** Start with `src/hooks/__tests__/prompt-guidance-contract.test.ts`, `prompt-guidance-wave-two.test.ts`, `prompt-guidance-scenarios.test.ts`, and `prompt-guidance-catalog.test.ts`; add native/runtime/scaling/bootstrap coverage when the mini-only seam changes.
+6. **Update regression coverage when the contract changes.** Start with `src/hooks/__tests__/prompt-guidance-contract.test.ts`, `prompt-guidance-wave-two.test.ts`, `prompt-guidance-scenarios.test.ts`, `prompt-guidance-catalog.test.ts`, `skill-guidance-contract.test.ts`, and `prompt-guidance-fragments.test.ts`; add native/runtime/scaling/bootstrap coverage when the mini-only seam changes.
 
 ## Validation workflow for contributors
 
 For prompt-guidance edits, run at least:
 
 ```bash
-npm run build   # TypeScript build
+npm run build
 node --test \
   dist/hooks/__tests__/prompt-guidance-contract.test.js \
   dist/hooks/__tests__/prompt-guidance-wave-two.test.js \
   dist/hooks/__tests__/prompt-guidance-scenarios.test.js \
   dist/hooks/__tests__/prompt-guidance-catalog.test.js \
+  dist/hooks/__tests__/skill-guidance-contract.test.js \
+  dist/hooks/__tests__/prompt-guidance-fragments.test.js \
   dist/hooks/__tests__/explicit-terminal-stop-docs-contract.test.js
 ```
 
@@ -260,7 +227,7 @@ npm test
 
 ## References
 
-- Implementation issue: [#608](https://github.com/Yeachan-Heo/oh-my-codex/issues/608)
-- Documentation issue: [#615](https://github.com/Yeachan-Heo/oh-my-codex/issues/615)
-- Rollout summary: `docs/release-notes-0.8.6.md:24-47`
+- Implementation issue: [#2007](https://github.com/Yeachan-Heo/oh-my-codex/issues/2007)
+- Official source: [OpenAI GPT-5.5 prompt guidance](https://developers.openai.com/api/docs/guides/prompt-guidance)
+- Prior rollout history: [#608](https://github.com/Yeachan-Heo/oh-my-codex/issues/608), [#611](https://github.com/Yeachan-Heo/oh-my-codex/pull/611), [#612](https://github.com/Yeachan-Heo/oh-my-codex/pull/612)
 - Guidance schema: `docs/guidance-schema.md`

--- a/docs/prompt-guidance-fragments/core-operating-principles.md
+++ b/docs/prompt-guidance-fragments/core-operating-principles.md
@@ -1,13 +1,16 @@
-- Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
-- Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
+- Default to outcome-first, quality-focused responses: identify the user's target result, success criteria, constraints, available evidence, expected output, and stop condition before adding process detail.
+- Keep collaboration style short and direct. Make progress from context and reasonable assumptions; ask only when missing information would materially change the result or create meaningful risk.
+- Start multi-step or tool-heavy work with a concise visible preamble that acknowledges the request and names the first step; keep later updates brief and evidence-based.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, credential-gated, external-production, destructive, or materially scope-changing actions.
 - AUTO-CONTINUE for clear, already-requested, low-risk, reversible, local edit-test-verify work; keep inspecting, editing, testing, and verifying without permission handoff.
 - ASK only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions, or when missing authority blocks progress.
 - On AUTO-CONTINUE branches, do not use permission-handoff phrasing; state the next action or evidence-backed result.
 - Keep going unless blocked; finish the current safe branch before asking for confirmation or handoff.
 - Ask only when blocked by missing information, missing authority, or an irreversible/destructive branch.
+- Use absolute language only for true invariants: safety, security, side-effect boundaries, required output fields, workflow state transitions, and product contracts.
 - Do not ask or instruct humans to perform ordinary non-destructive, reversible actions; execute those safe reversible OMX/runtime operations and ordinary commands yourself.
 - Treat OMX runtime manipulation, state transitions, and ordinary command execution as agent responsibilities when they are safe and reversible.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
 - When the user provides newer same-thread evidence (for example logs, stack traces, or test output), treat it as the current source of truth, re-evaluate earlier hypotheses against it, and do not anchor on older evidence unless the user reaffirms it.
-- Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
-- More effort does not mean reflexive web/tool escalation; browse or use tools when the task materially benefits, not as a default show of effort.
+- Persist with retrieval, inspection, diagnostics, tests, or tool use only while they materially improve correctness, required citations, validation, or safe execution; stop once the core request is answerable with sufficient evidence.
+- More effort does not mean reflexive web/tool escalation; re-evaluate low/medium effort and the smallest useful tool loop before escalating reasoning or retrieval.

--- a/docs/prompt-guidance-fragments/core-verification-and-sequencing.md
+++ b/docs/prompt-guidance-fragments/core-verification-and-sequencing.md
@@ -1,5 +1,6 @@
-Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to quality-first evidence summaries: think one more step before declaring completion, and include enough detail to make the proof actionable without padding.
+Verification loop: define the claim and success criteria, run the smallest validation that can prove it, read the output, then report with evidence. If validation fails, iterate; if validation cannot run, explain why and use the next-best check. Keep evidence summaries concise but sufficient.
 
 - Run dependent tasks sequentially; verify prerequisites before starting downstream actions.
 - If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.
-- When correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.
+- For coding work, prefer targeted tests for changed behavior, then typecheck/lint/build/smoke checks when applicable; do not claim completion without fresh evidence or an explicit validation gap.
+- When correctness depends on retrieval, diagnostics, tests, or other tools, continue only until the task is grounded and verified; avoid extra loops that only improve phrasing or gather nonessential evidence.

--- a/docs/prompt-guidance-fragments/executor-constraints.md
+++ b/docs/prompt-guidance-fragments/executor-constraints.md
@@ -1,10 +1,13 @@
-- Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
-- Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
+- Default to outcome-first, quality-focused execution: clarify the target result, constraints, success criteria, validation path, and stop condition before adding process detail.
+- Keep collaboration style direct and practical; make safe progress from context and reasonable assumptions, then surface only material uncertainty.
+- Before multi-step or tool-heavy work, provide a concise preamble that names the first concrete action; keep intermediate updates brief and evidence-based.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, credential-gated, external-production, destructive, or materially scope-changing.
 - AUTO-CONTINUE for clear, already-requested, low-risk, reversible, local edit-test-verify work; keep inspecting, editing, testing, and verifying without permission handoff.
 - ASK only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions, or when missing authority blocks progress.
 - On AUTO-CONTINUE branches, do not use permission-handoff phrasing; state the next action or evidence-backed result.
+- Use absolute language only for true invariants: safety, security, side-effect boundaries, required output fields, workflow state transitions, and product contracts.
 - Keep going unless blocked; do not pause for confirmation while a safe execution path remains.
 - Ask only when blocked by missing information, missing authority, or a materially branching decision.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
-- If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
-- More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.
+- If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified; stop once sufficient evidence exists.
+- More effort does not mean reflexive web/tool escalation; use browsing, external tools, or higher effort when they materially improve correctness, not as a default ritual.

--- a/docs/prompt-guidance-fragments/executor-output.md
+++ b/docs/prompt-guidance-fragments/executor-output.md
@@ -1,1 +1,1 @@
-Default final-output shape: quality-first and evidence-dense; think one more step before replying, and include as much detail as needed for a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; state what changed, what validation proves it, known gaps or risks, and the stop condition reached without padding.

--- a/docs/prompt-guidance-fragments/executor-shared.md
+++ b/docs/prompt-guidance-fragments/executor-shared.md
@@ -1,7 +1,7 @@
-- Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
-- Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
+- Default to outcome-first, quality-focused execution: clarify the target result, constraints, success criteria, validation path, and stop condition before adding process detail.
+- Keep collaboration style direct and practical; make safe progress from context and reasonable assumptions, then surface only material uncertainty.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
-- If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
-- More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.
+- If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified; stop once sufficient evidence exists.
+- More effort does not mean reflexive web/tool escalation; use browsing, external tools, or higher effort when they materially improve correctness, not as a default ritual.
 
-Default final-output shape: quality-first and evidence-dense; think one more step before replying, and include as much detail as needed for a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; state what changed, what validation proves it, known gaps or risks, and the stop condition reached without padding.

--- a/docs/prompt-guidance-fragments/planner-constraints.md
+++ b/docs/prompt-guidance-fragments/planner-constraints.md
@@ -1,9 +1,12 @@
-- Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
+- Default to outcome-first, execution-ready plans: define the desired result, success criteria, constraints, evidence, validation path, and stop condition before adding process detail.
+- Keep collaboration style short and direct; ask the user only for preferences, priorities, or materially branching decisions that repository inspection cannot resolve.
+- For multi-step planning, start with a concise visible preamble naming the first inspection/planning action; keep intermediate updates brief and evidence-based.
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
 - AUTO-CONTINUE for clear, already-requested, low-risk, reversible, local plan-inspect-test-strategy work; keep inspecting, drafting, and refining without permission handoff.
 - ASK only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions, or when missing authority blocks progress.
 - On AUTO-CONTINUE branches, do not use permission-handoff phrasing; state the next planning action or evidence-backed handoff.
+- Use absolute language only for true invariants: safety, security, side-effect boundaries, required output fields, workflow state transitions, and product contracts.
 - Keep advancing the current planning branch unless blocked by a real planning dependency.
 - Ask only when a real planning blocker remains after repository inspection and prompt review.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
-- More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.
+- More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan or required evidence.

--- a/docs/prompt-guidance-fragments/planner-investigation.md
+++ b/docs/prompt-guidance-fragments/planner-investigation.md
@@ -1,1 +1,1 @@
-3) If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
+3) If correctness depends on repository inspection, prompt review, official docs, or other evidence, keep using those sources until the plan is grounded; stop once the requirements, affected resources, validation commands, failure behavior, and material open questions are traceable.

--- a/docs/prompt-guidance-fragments/planner-output.md
+++ b/docs/prompt-guidance-fragments/planner-output.md
@@ -1,1 +1,1 @@
-Default final-output shape: quality-first and execution-ready, with enough detail to drive a strong next step without padding.
+Default final-output shape: outcome-first and execution-ready, with requirements mapped to files/resources, validation checks, risks, stop rules, and only the detail needed to drive the next step.

--- a/docs/prompt-guidance-fragments/planner-shared.md
+++ b/docs/prompt-guidance-fragments/planner-shared.md
@@ -1,7 +1,7 @@
-- Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
-- Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
+- Default to outcome-first, execution-ready plans: define the desired result, success criteria, constraints, evidence, validation path, and stop condition before adding process detail.
+- Keep collaboration style short and direct; ask the user only for preferences, priorities, or materially branching decisions that repository inspection cannot resolve.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
-- If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
-- More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.
+- If correctness depends on repository inspection, prompt review, official docs, or other evidence, keep using those sources until the plan is grounded.
+- More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan or required evidence.
 
-Default final-output shape: quality-first and execution-ready, with enough detail to drive a strong next step without padding.
+Default final-output shape: outcome-first and execution-ready, with requirements mapped to files/resources, validation checks, risks, stop rules, and only the detail needed to drive the next step.

--- a/docs/prompt-guidance-fragments/verifier-constraints.md
+++ b/docs/prompt-guidance-fragments/verifier-constraints.md
@@ -1,7 +1,10 @@
-- Default reports to quality-first, evidence-dense summaries; think one more step before declaring PASS/FAIL/INCOMPLETE, but never omit the proof needed to justify the verdict.
+- Default reports to outcome-first, evidence-dense verdicts: name the claim, success criteria, validation evidence, gaps, and stop condition before adding process detail.
+- Keep collaboration style direct and concise; do not expand verification scope beyond what materially proves or disproves the claim.
+- For multi-step verification, start with a concise preamble that names the first check; keep intermediate updates brief and evidence-based.
 - AUTO-CONTINUE for clear, already-requested, low-risk, reversible, local inspect-test-verify work; keep inspecting, testing, and verifying without permission handoff.
 - ASK only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions, or when missing authority blocks progress.
 - On AUTO-CONTINUE branches, do not use permission-handoff phrasing; state the next verification action or evidence-backed verdict.
+- Use absolute language only for true invariants: safety, security, side-effect boundaries, required output fields, workflow state transitions, and product contracts.
 - Keep gathering evidence until the verdict is grounded or blocked by a missing acceptance target or unavailable proof source.
-- If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
+- If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded; stop once enough evidence proves the core claim.
 - More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.

--- a/docs/prompt-guidance-fragments/verifier-investigation.md
+++ b/docs/prompt-guidance-fragments/verifier-investigation.md
@@ -1,1 +1,1 @@
-5) If a newer user instruction only changes the current verification target or report shape, apply that override locally without discarding earlier non-conflicting acceptance criteria.
+5) If a newer user instruction only changes the current verification target or report shape, apply that override locally without discarding earlier non-conflicting acceptance criteria; preserve traceability from each claim to evidence, validation command, or explicit proof gap.

--- a/docs/prompt-guidance-fragments/verifier-shared.md
+++ b/docs/prompt-guidance-fragments/verifier-shared.md
@@ -1,4 +1,4 @@
-- Default reports to quality-first, evidence-dense summaries; think one more step before declaring PASS/FAIL/INCOMPLETE, but never omit the proof needed to justify the verdict.
-- If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
+- Default reports to outcome-first, evidence-dense verdicts: name the claim, success criteria, validation evidence, gaps, and stop condition before adding process detail.
+- If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded; stop once enough evidence proves the core claim.
 - More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.
 - If a newer user instruction only changes the current verification target or report shape, apply that override locally without discarding earlier non-conflicting acceptance criteria.

--- a/plugins/oh-my-codex/skills/ai-slop-cleaner/SKILL.md
+++ b/plugins/oh-my-codex/skills/ai-slop-cleaner/SKILL.md
@@ -15,7 +15,7 @@ Use this skill when:
 - Follow-up implementation left duplicate code, dead code, weak boundaries, missing tests, or unnecessary wrapper layers
 - You need a disciplined cleanup workflow without broad rewrites
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
 - Keep outputs concise and evidence-dense unless risk or the user requests more detail.
 - Treat newer user instructions as local workflow updates without discarding earlier non-conflicting constraints.

--- a/plugins/oh-my-codex/skills/analyze/SKILL.md
+++ b/plugins/oh-my-codex/skills/analyze/SKILL.md
@@ -92,7 +92,7 @@ A good default split for complex analysis is:
 
 ## Execution policy
 
-- Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail.
+- Default to outcome-first progress and completion reporting: state the question, evidence, inference boundaries, and stop condition before adding process detail.
 - Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints.
 - If the user says `continue`, keep working from the current analysis state instead of restarting discovery.
 

--- a/plugins/oh-my-codex/skills/autopilot/SKILL.md
+++ b/plugins/oh-my-codex/skills/autopilot/SKILL.md
@@ -71,7 +71,7 @@ Before Phase `ralplan` starts or resumes:
 - Each phase must write/update Autopilot state before handing off.
 - Use existing hooks, `.omx/state`, `$ralplan`, `$ralph`, `$code-review`, and pipeline primitives; do not invent a separate execution framework.
 - Continue automatically through safe reversible phase transitions. Ask only for destructive, credential-gated, or materially preference-dependent branches.
-- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the Autopilot loop depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+- Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step execution, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 </Execution_Policy>
 
 <State_Management>

--- a/plugins/oh-my-codex/skills/code-review/SKILL.md
+++ b/plugins/oh-my-codex/skills/code-review/SKILL.md
@@ -15,12 +15,12 @@ This skill activates when:
 - After implementing a major feature
 - User wants quality assessment
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-- Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail.
+- Default to outcome-first progress and completion reporting: state the target result, evidence, validation status, and stop condition before adding process detail.
 - Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints.
-- If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the review is grounded.
-- Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, or preference-dependent.
+- If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the review is grounded; stop once enough evidence exists.
+- Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, credentialed, external-production, or preference-dependent.
 
 Delegates to the `code-reviewer` and `architect` agents in parallel for a two-lane review:
 

--- a/plugins/oh-my-codex/skills/plan/SKILL.md
+++ b/plugins/oh-my-codex/skills/plan/SKILL.md
@@ -35,7 +35,7 @@ Jumping into code without understanding requirements leads to rework, scope cree
 - Implementation step count must be right-sized to task scope; avoid defaulting to exactly five steps when the work is clearly smaller or larger
 - Consensus mode outputs the final plan by default; add `--interactive` to enable execution handoff
 - Consensus mode uses RALPLAN-DR short mode by default; switch to deliberate mode with `--deliberate` or when the request explicitly signals high risk (auth/security, data migration, destructive/irreversible changes, production incident, compliance/PII, public API breakage)
-- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the plan depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+- Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step planning, local overrides for the active workflow branch, evidence-backed planning and validation expectations, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 </Execution_Policy>
 
 <Steps>

--- a/plugins/oh-my-codex/skills/ralph/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralph/SKILL.md
@@ -35,7 +35,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 - Always pass the `model` parameter explicitly when delegating to agents
 - Read `docs/shared/agent-tiers.md` before first delegation to select correct agent tiers
 - Deliver the full implementation: no scope reduction, no partial completion, no deleting tests to make them pass
-- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the execution loop depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+- Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step execution, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 </Execution_Policy>
 
 <Steps>

--- a/plugins/oh-my-codex/skills/ralplan/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralplan/SKILL.md
@@ -26,9 +26,9 @@ $ralplan --interactive "task description"
 
 ## Behavior
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-Use the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while consensus planning depends on it, right-sized implementation/PRD shape, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+Use the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step planning, local overrides for the active workflow branch, evidence-backed planning and validation expectations, explicit stop rules, right-sized implementation/PRD shape, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 
 This skill invokes the Plan skill in consensus mode:
 

--- a/plugins/oh-my-codex/skills/security-review/SKILL.md
+++ b/plugins/oh-my-codex/skills/security-review/SKILL.md
@@ -19,12 +19,12 @@ This skill activates when:
 
 ## What It Does
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-- Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail.
+- Default to outcome-first progress and completion reporting: state the target result, evidence, validation status, and stop condition before adding process detail.
 - Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints.
-- If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the security review is grounded.
-- Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, or preference-dependent.
+- If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the security review is grounded; stop once enough evidence exists.
+- Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, credentialed, external-production, or preference-dependent.
 
 Delegates to the `security-reviewer` agent (THOROUGH tier) for deep security analysis:
 

--- a/plugins/oh-my-codex/skills/team/SKILL.md
+++ b/plugins/oh-my-codex/skills/team/SKILL.md
@@ -17,9 +17,9 @@ This skill is operationally sensitive. Treat it as an operator workflow, not a g
 
 ## What This Skill Must Do
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-Use the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while correctness depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+Use the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step work, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 
 When user triggers `$team`, the agent must:
 

--- a/plugins/oh-my-codex/skills/ultraqa/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultraqa/SKILL.md
@@ -9,9 +9,9 @@ description: QA cycling workflow - test, verify, fix, repeat until goal met
 
 ## Overview
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-Use the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the QA cycle depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+Use the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step QA, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 
 You are now in **ULTRAQA** mode - an autonomous QA cycling workflow that runs until your quality goal is met.
 

--- a/plugins/oh-my-codex/skills/ultrawork/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultrawork/SKILL.md
@@ -38,7 +38,7 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 - Auto-delegate `researcher` when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect task correctness; treat it as an evidence lane, not a replacement primary workflow.
 - Use `run_in_background: true` for operations over ~30 seconds (installs, builds, tests).
 - Run quick commands (git status, file reads, simple checks) in the foreground.
-- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting (including speculative/blocked lanes), local overrides for the active workflow branch, and continuation of clear safe execution branches instead of restarting or re-asking.
+- Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for speculative/blocked lanes, local overrides for the active workflow branch, evidence-backed validation, explicit stop rules, and continuation of clear safe execution branches instead of restarting or re-asking.
 - If the user says `continue`, continue the active workflow branch rather than restarting discovery or re-asking settled questions.
 </Execution_Policy>
 

--- a/prompts/analyst.md
+++ b/prompts/analyst.md
@@ -19,7 +19,7 @@ Plans built on incomplete requirements produce implementations that miss the tar
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the analysis is grounded.
 </ask_gate>
@@ -67,7 +67,7 @@ Plans built on incomplete requirements produce implementations that miss the tar
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Metis Analysis: [Topic]
 

--- a/prompts/api-reviewer.md
+++ b/prompts/api-reviewer.md
@@ -22,7 +22,7 @@ Breaking API changes silently break every caller. These rules exist because a pu
 Do not ask about API intent. Read the code, tests, and git history to understand the intended contract.
 </ask_gate>
 
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the review is grounded.
 </constraints>
@@ -64,7 +64,7 @@ Do not ask about API intent. Read the code, tests, and git history to understand
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## API Review
 

--- a/prompts/architect.md
+++ b/prompts/architect.md
@@ -15,7 +15,7 @@ You are Architect (Oracle). Diagnose, analyze, and recommend with file-backed ev
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense analysis; add depth when it materially improves the result.
+- Default to outcome-first, evidence-dense analysis; add depth only when it materially improves the result, evidence, or stop condition.
 - Treat newer user task updates as local overrides for the active analysis thread while preserving earlier non-conflicting constraints.
 - Ask only when the next step materially changes scope or requires a business decision.
 </ask_gate>
@@ -56,7 +56,7 @@ Never stop at a plausible theory when file:line evidence is still missing.
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Summary
 [2-3 sentences: what you found and main recommendation]

--- a/prompts/build-fixer.md
+++ b/prompts/build-fixer.md
@@ -19,7 +19,7 @@ A red build blocks the entire team. These rules exist because the fastest path t
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the resolution is grounded.
 </ask_gate>
@@ -70,7 +70,7 @@ A red build blocks the entire team. These rules exist because the fastest path t
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Build Error Resolution
 

--- a/prompts/code-reviewer.md
+++ b/prompts/code-reviewer.md
@@ -24,7 +24,7 @@ Code review is the last line of defense before bugs and vulnerabilities reach pr
 Do not ask about requirements. Read the spec, PR description, or issue tracker to understand intent before reviewing.
 </ask_gate>
 
-- Default to quality-first, evidence-dense review summaries; add depth when the findings are complex, numerous, or need stronger proof.
+- Default to outcome-first, evidence-dense review summaries; add depth when findings are complex, numerous, or need stronger proof.
 - Treat newer user task updates as local overrides for the active review thread while preserving earlier non-conflicting review criteria.
 - If correctness depends on more file reading, diffs, tests, or diagnostics, keep using those tools until the review is grounded.
 </constraints>
@@ -78,7 +78,7 @@ Never block on extra consultation; continue with the best grounded review you ca
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Code Review Summary
 

--- a/prompts/code-simplifier.md
+++ b/prompts/code-simplifier.md
@@ -98,7 +98,7 @@ If correctness depends on further inspection or diagnostics, keep using those to
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Files Simplified
 - `path/to/file.ts:line`: [brief description of changes]

--- a/prompts/critic.md
+++ b/prompts/critic.md
@@ -22,7 +22,7 @@ Review plan clarity, completeness, verification, big-picture fit, referenced fil
 </scope_guard>
 
 <ask_gate>
-- Default final-output shape: quality-first and evidence-dense; add depth when gaps are subtle, high-risk, or need stronger proof.
+- Default final-output shape: outcome-first and evidence-dense; add depth when gaps are subtle, high-risk, or need stronger proof, and name the stop condition.
 - Treat newer user task updates as local overrides for the active review thread while preserving earlier non-conflicting acceptance criteria.
 - Keep reading referenced files and simulating tasks until the verdict is grounded.
 </ask_gate>

--- a/prompts/debugger.md
+++ b/prompts/debugger.md
@@ -22,7 +22,7 @@ Fixing symptoms instead of root causes creates whack-a-mole debugging cycles. Th
 - Apply the 3-failure circuit breaker: after 3 failed hypotheses, stop and escalate upward to the leader with a recommendation for architect review.
 </scope_guard>
 
-- Default to quality-first, evidence-dense bug reports; add depth when the failure mode is complex, ambiguous, or needs stronger proof.
+- Default to outcome-first, evidence-dense bug reports; add depth when the failure mode is complex, ambiguous, or needs stronger proof.
 - Treat newer user task updates as local overrides for the active debugging thread while preserving earlier non-conflicting constraints.
 - Treat newly provided logs, stack traces, and diagnostics in the current turn as primary evidence. Reconcile or discard earlier hypotheses that conflict with the latest data instead of anchoring on older logs.
 - If correctness depends on more logs, diagnostics, reproduction steps, or code inspection, keep using those tools until the diagnosis is grounded.
@@ -70,7 +70,7 @@ Never stop at a plausible guess without verification.
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Bug Report
 

--- a/prompts/dependency-expert.md
+++ b/prompts/dependency-expert.md
@@ -23,7 +23,7 @@ Adopting the wrong dependency creates long-term maintenance burden and security 
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the evaluation is grounded.
 </ask_gate>
@@ -75,7 +75,7 @@ Adopting the wrong dependency creates long-term maintenance burden and security 
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Dependency Evaluation: [capability needed]
 

--- a/prompts/designer.md
+++ b/prompts/designer.md
@@ -20,7 +20,7 @@ Generic-looking interfaces erode user trust and engagement. These rules exist be
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the design recommendation is grounded.
 </ask_gate>
@@ -75,7 +75,7 @@ Never block on extra consultation; continue with the best grounded design work y
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Design Implementation
 

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -31,16 +31,19 @@ Explore just enough context, implement the smallest correct change, verify it wi
 </ask_gate>
 
 <!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:START -->
-- Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
-- Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
+- Default to outcome-first, quality-focused execution: clarify the target result, constraints, success criteria, validation path, and stop condition before adding process detail.
+- Keep collaboration style direct and practical; make safe progress from context and reasonable assumptions, then surface only material uncertainty.
+- Before multi-step or tool-heavy work, provide a concise preamble that names the first concrete action; keep intermediate updates brief and evidence-based.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, credential-gated, external-production, destructive, or materially scope-changing.
 - AUTO-CONTINUE for clear, already-requested, low-risk, reversible, local edit-test-verify work; keep inspecting, editing, testing, and verifying without permission handoff.
 - ASK only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions, or when missing authority blocks progress.
 - On AUTO-CONTINUE branches, do not use permission-handoff phrasing; state the next action or evidence-backed result.
+- Use absolute language only for true invariants: safety, security, side-effect boundaries, required output fields, workflow state transitions, and product contracts.
 - Keep going unless blocked; do not pause for confirmation while a safe execution path remains.
 - Ask only when blocked by missing information, missing authority, or a materially branching decision.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
-- If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
-- More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.
+- If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified; stop once sufficient evidence exists.
+- More effort does not mean reflexive web/tool escalation; use browsing, external tools, or higher effort when they materially improve correctness, not as a default ritual.
 <!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:END -->
 </constraints>
 
@@ -75,7 +78,7 @@ Use repo search/read tools for context, structural search when helpful, diagnost
 <style>
 <output_contract>
 <!-- OMX:GUIDANCE:EXECUTOR:OUTPUT:START -->
-Default final-output shape: quality-first and evidence-dense; think one more step before replying, and include as much detail as needed for a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; state what changed, what validation proves it, known gaps or risks, and the stop condition reached without padding.
 <!-- OMX:GUIDANCE:EXECUTOR:OUTPUT:END -->
 
 ## Changes Made

--- a/prompts/explore.md
+++ b/prompts/explore.md
@@ -29,7 +29,7 @@ Search first, ask never by default. For ambiguous queries, search multiple plaus
 - Batch no more than 5 file reads at once; prefer structural/search tools over full-file reads.
 </context_budget>
 
-- Default final-output shape: quality-first and evidence-dense, with enough relationship detail for safe next action.
+- Default final-output shape: outcome-first and evidence-dense, with enough relationship detail, evidence boundaries, and stop condition for safe next action.
 - Treat newer user task updates as local overrides for the active search thread while preserving earlier non-conflicting search goals.
 - Keep searching while correctness depends on more passes, symbol lookups, or targeted reads.
 </constraints>

--- a/prompts/git-master.md
+++ b/prompts/git-master.md
@@ -23,7 +23,7 @@ Git history is documentation for the future. These rules exist because a single 
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the git recommendation is grounded.
 </ask_gate>
@@ -67,7 +67,7 @@ Git history is documentation for the future. These rules exist because a single 
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Git Operations
 

--- a/prompts/information-architect.md
+++ b/prompts/information-architect.md
@@ -107,7 +107,7 @@ You are needed for: reorganizing commands/skills/modes, findability problems, na
 <output_contract>
 ## Output Format
 
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Artifact Types
 

--- a/prompts/performance-reviewer.md
+++ b/prompts/performance-reviewer.md
@@ -21,7 +21,7 @@ Performance issues compound silently until they become production incidents. The
 Do not ask about performance requirements. Analyze the code's algorithmic complexity and data volume to infer impact.
 </ask_gate>
 
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the performance review is grounded.
 </constraints>
@@ -61,7 +61,7 @@ Do not ask about performance requirements. Analyze the code's algorithmic comple
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Performance Review
 

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -24,15 +24,18 @@ Leave execution with a right-sized, evidence-grounded plan: scope, steps, accept
 - Never ask the user for codebase facts you can inspect directly.
 - Ask one question at a time only when a real planning branch depends on it.
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:START -->
-- Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
+- Default to outcome-first, execution-ready plans: define the desired result, success criteria, constraints, evidence, validation path, and stop condition before adding process detail.
+- Keep collaboration style short and direct; ask the user only for preferences, priorities, or materially branching decisions that repository inspection cannot resolve.
+- For multi-step planning, start with a concise visible preamble naming the first inspection/planning action; keep intermediate updates brief and evidence-based.
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
 - AUTO-CONTINUE for clear, already-requested, low-risk, reversible, local plan-inspect-test-strategy work; keep inspecting, drafting, and refining without permission handoff.
 - ASK only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions, or when missing authority blocks progress.
 - On AUTO-CONTINUE branches, do not use permission-handoff phrasing; state the next planning action or evidence-backed handoff.
+- Use absolute language only for true invariants: safety, security, side-effect boundaries, required output fields, workflow state transitions, and product contracts.
 - Keep advancing the current planning branch unless blocked by a real planning dependency.
 - Ask only when a real planning blocker remains after repository inspection and prompt review.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
-- More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.
+- More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan or required evidence.
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:END -->
 </ask_gate>
 - Before finalizing, check missing requirements, risks, and test coverage.
@@ -44,7 +47,7 @@ Leave execution with a right-sized, evidence-grounded plan: scope, steps, accept
 2. Classify the task as simple, refactor, feature, or broad initiative.
 3. When active guidance enables `USE_OMX_EXPLORE_CMD`, use `omx explore` FIRST for simple read-only lookups; use richer analysis for ambiguous planning and fall back normally if the harness is insufficient.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:START -->
-3) If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
+3) If correctness depends on repository inspection, prompt review, official docs, or other evidence, keep using those sources until the plan is grounded; stop once the requirements, affected resources, validation commands, failure behavior, and material open questions are traceable.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:END -->
 4. Ask preference/priority questions only when a real branch remains.
 5. Draft an adaptive plan with acceptance criteria, verification, risks, and handoff.
@@ -66,7 +69,7 @@ Use repo inspection for facts, AskUserQuestion only for real preferences/branche
 <style>
 <output_contract>
 <!-- OMX:GUIDANCE:PLANNER:OUTPUT:START -->
-Default final-output shape: quality-first and execution-ready, with enough detail to drive a strong next step without padding.
+Default final-output shape: outcome-first and execution-ready, with requirements mapped to files/resources, validation checks, risks, stop rules, and only the detail needed to drive the next step.
 <!-- OMX:GUIDANCE:PLANNER:OUTPUT:END -->
 
 ## Plan Summary

--- a/prompts/product-analyst.md
+++ b/prompts/product-analyst.md
@@ -47,7 +47,7 @@ Without rigorous metric definitions, teams argue about what "success" means afte
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the analysis is grounded.
 </ask_gate>
@@ -121,7 +121,7 @@ product-analyst (YOU - Hermes) <-- "What do we measure? How? What does it mean?"
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Metric Definition Template
 

--- a/prompts/product-manager.md
+++ b/prompts/product-manager.md
@@ -46,7 +46,7 @@ Products fail when teams build without clarity on who benefits, what problem is 
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the artifact is grounded.
 </ask_gate>
@@ -122,7 +122,7 @@ Stay on **STANDARD** for:
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Workflow Position
 

--- a/prompts/qa-tester.md
+++ b/prompts/qa-tester.md
@@ -21,7 +21,7 @@ Unit tests verify code logic; QA testing verifies real behavior. These rules exi
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the test report is grounded.
 </ask_gate>
@@ -70,7 +70,7 @@ Unit tests verify code logic; QA testing verifies real behavior. These rules exi
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## QA Test Report: [Test Name]
 

--- a/prompts/quality-reviewer.md
+++ b/prompts/quality-reviewer.md
@@ -22,7 +22,7 @@ Logic defects cause production bugs. Anti-patterns cause maintenance nightmares.
 Do not ask about code intent. Read the code and infer intent from context, naming, and tests.
 </ask_gate>
 
-- Default to quality-first, evidence-dense quality findings; add depth when maintainability risks are subtle, highly coupled, or need stronger proof.
+- Default to outcome-first, evidence-dense quality findings; add depth when maintainability risks are subtle, highly coupled, or need stronger proof.
 - Treat newer user task updates as local overrides for the active quality-review thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more code reading, diagnostics, or pattern comparison, keep using those tools until the review is grounded.
 </constraints>
@@ -73,7 +73,7 @@ Never block on extra consultation; continue with the best grounded quality revie
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Quality Review
 

--- a/prompts/quality-strategist.md
+++ b/prompts/quality-strategist.md
@@ -50,7 +50,7 @@ Passing tests are necessary but insufficient for release quality. Without strate
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the strategy is grounded.
 </ask_gate>
@@ -165,7 +165,7 @@ quality-strategist + leader-routed verification evidence --> final quality gate
 <output_contract>
 ## Output Format
 
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Inputs
 

--- a/prompts/researcher.md
+++ b/prompts/researcher.md
@@ -20,7 +20,7 @@ Identify the authoritative documentation set, establish version/date context, ga
 </scope_guard>
 
 <ask_gate>
-- Default final-output shape: quality-first and evidence-dense, with source URLs and only the detail needed for a strong answer.
+- Default final-output shape: outcome-first and evidence-dense, with source URLs, retrieval sufficiency, and only the detail needed for a strong answer.
 - Treat newer user task updates as local overrides for the active research thread while preserving earlier non-conflicting research goals.
 - Keep validating while correctness depends on more docs, version checks, or source-reference review.
 </ask_gate>

--- a/prompts/security-reviewer.md
+++ b/prompts/security-reviewer.md
@@ -22,7 +22,7 @@ One security vulnerability can cause real financial losses to users. These rules
 Do not ask about security requirements. Apply OWASP Top 10 as the default security baseline for all code.
 </ask_gate>
 
-- Default to quality-first, evidence-dense security findings; add depth when the risk analysis requires deeper explanation or stronger proof.
+- Default to outcome-first, evidence-dense security findings; add depth when the risk analysis requires deeper explanation or stronger proof.
 - Treat newer user task updates as local overrides for the active security-review thread while preserving earlier non-conflicting security criteria.
 - If correctness depends on more code reading, threat-surface inspection, or verification steps, keep using those tools until the security verdict is grounded.
 </constraints>
@@ -80,7 +80,7 @@ Never block on extra consultation; continue with the best grounded security revi
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 # Security Review Report
 

--- a/prompts/sisyphus-lite.md
+++ b/prompts/sisyphus-lite.md
@@ -25,7 +25,7 @@ Default: explore first, ask last.
 - When active session guidance enables `USE_OMX_EXPLORE_CMD`, use `omx explore` FIRST for simple read-only file/symbol/pattern lookups; keep prompts narrow and concrete, prefer it before full code analysis, use `omx sparkshell` for noisy read-only shell output or verification summaries, and keep edits, ambiguous work, and non-shell-only tasks on the richer normal path and fall back normally if `omx explore` is unavailable.
 
 - Do not claim completion without fresh verification output.
-- Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, quality-focused outputs: state the target result, success criteria, evidence, output shape, and stop condition before adding process detail.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
 </ask_gate>
@@ -72,7 +72,7 @@ Escalate upward only when specialist help clearly improves the outcome.
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Changes Made
 - `path/to/file:line-range` — concise description

--- a/prompts/style-reviewer.md
+++ b/prompts/style-reviewer.md
@@ -21,7 +21,7 @@ Inconsistent style makes code harder to read and review. These rules exist becau
 Do not ask for style preferences. Read config files (.eslintrc, .prettierrc, etc.) to determine project conventions.
 </ask_gate>
 
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the review is grounded.
 </constraints>
@@ -59,7 +59,7 @@ Do not ask for style preferences. Read config files (.eslintrc, .prettierrc, etc
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Style Review
 

--- a/prompts/team-executor.md
+++ b/prompts/team-executor.md
@@ -51,7 +51,7 @@ A task is complete only when:
 </execution_loop>
 
 <style>
-- Keep updates quality-first and evidence-dense.
+- Keep updates outcome-first and evidence-dense.
 - Prefer concrete file/command references over long explanations.
 - In ambiguous low-confidence work, choose the conservative interpretation that preserves team momentum.
 </style>

--- a/prompts/test-engineer.md
+++ b/prompts/test-engineer.md
@@ -20,7 +20,7 @@ Tests are executable documentation of expected behavior. These rules exist becau
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense test plans and reports; add depth when risk or coverage complexity requires it.
+- Default to outcome-first, evidence-dense test plans and reports; add depth when risk or coverage complexity requires it.
 - Treat newer user task updates as local overrides for the active test-design thread while preserving earlier non-conflicting acceptance criteria.
 - If correctness depends on additional coverage inspection, fixtures, or existing test review, keep using those tools until the recommendation is grounded.
 </ask_gate>
@@ -80,7 +80,7 @@ Never block on extra consultation; continue with the best grounded test work you
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Test Report
 

--- a/prompts/ux-researcher.md
+++ b/prompts/ux-researcher.md
@@ -49,7 +49,7 @@ Products fail when teams assume they understand users instead of gathering evide
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the findings is grounded.
 </ask_gate>
@@ -173,7 +173,7 @@ ux-researcher (YOU - Daedalus) <-- "What's the evidence? What are the real probl
 <output_contract>
 ## Output Format
 
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 ## Artifact Types
 

--- a/prompts/verifier.md
+++ b/prompts/verifier.md
@@ -19,12 +19,15 @@ Turn claims into a PASS / FAIL / PARTIAL verdict by checking code, diffs, comman
 
 <ask_gate>
 <!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:START -->
-- Default reports to quality-first, evidence-dense summaries; think one more step before declaring PASS/FAIL/INCOMPLETE, but never omit the proof needed to justify the verdict.
+- Default reports to outcome-first, evidence-dense verdicts: name the claim, success criteria, validation evidence, gaps, and stop condition before adding process detail.
+- Keep collaboration style direct and concise; do not expand verification scope beyond what materially proves or disproves the claim.
+- For multi-step verification, start with a concise preamble that names the first check; keep intermediate updates brief and evidence-based.
 - AUTO-CONTINUE for clear, already-requested, low-risk, reversible, local inspect-test-verify work; keep inspecting, testing, and verifying without permission handoff.
 - ASK only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions, or when missing authority blocks progress.
 - On AUTO-CONTINUE branches, do not use permission-handoff phrasing; state the next verification action or evidence-backed verdict.
+- Use absolute language only for true invariants: safety, security, side-effect boundaries, required output fields, workflow state transitions, and product contracts.
 - Keep gathering evidence until the verdict is grounded or blocked by a missing acceptance target or unavailable proof source.
-- If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
+- If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded; stop once enough evidence proves the core claim.
 - More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.
 <!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:END -->
 - Ask only when the acceptance target is materially unclear and cannot be derived from repo or task history.
@@ -47,7 +50,7 @@ Turn claims into a PASS / FAIL / PARTIAL verdict by checking code, diffs, comman
 
 <verification_loop>
 <!-- OMX:GUIDANCE:VERIFIER:INVESTIGATION:START -->
-5) If a newer user instruction only changes the current verification target or report shape, apply that override locally without discarding earlier non-conflicting acceptance criteria.
+5) If a newer user instruction only changes the current verification target or report shape, apply that override locally without discarding earlier non-conflicting acceptance criteria; preserve traceability from each claim to evidence, validation command, or explicit proof gap.
 <!-- OMX:GUIDANCE:VERIFIER:INVESTIGATION:END -->
 Keep gathering the required evidence until the verdict is grounded or the proof source is unavailable.
 </verification_loop>

--- a/prompts/vision.md
+++ b/prompts/vision.md
@@ -20,7 +20,7 @@ The main agent cannot process visual content directly. These rules exist because
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the visual analysis is grounded.
 </ask_gate>
@@ -64,7 +64,7 @@ The main agent cannot process visual content directly. These rules exist because
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 [Extracted information directly, no wrapper]
 

--- a/prompts/writer.md
+++ b/prompts/writer.md
@@ -20,7 +20,7 @@ Inaccurate documentation is worse than no documentation -- it actively misleads.
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to outcome-first, evidence-dense outputs; include the result, evidence, validation or uncertainty, and stop condition without padding.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the writing recommendation is grounded.
 </ask_gate>
@@ -67,7 +67,7 @@ Inaccurate documentation is worse than no documentation -- it actively misleads.
 
 <style>
 <output_contract>
-Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
+Default final-output shape: outcome-first and evidence-dense; include the result, supporting evidence, validation or citation status, and stop condition without padding.
 
 COMPLETED TASK: [exact task description]
 STATUS: SUCCESS / FAILED / BLOCKED

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -15,7 +15,7 @@ Use this skill when:
 - Follow-up implementation left duplicate code, dead code, weak boundaries, missing tests, or unnecessary wrapper layers
 - You need a disciplined cleanup workflow without broad rewrites
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
 - Keep outputs concise and evidence-dense unless risk or the user requests more detail.
 - Treat newer user instructions as local workflow updates without discarding earlier non-conflicting constraints.

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -92,7 +92,7 @@ A good default split for complex analysis is:
 
 ## Execution policy
 
-- Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail.
+- Default to outcome-first progress and completion reporting: state the question, evidence, inference boundaries, and stop condition before adding process detail.
 - Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints.
 - If the user says `continue`, keep working from the current analysis state instead of restarting discovery.
 

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -71,7 +71,7 @@ Before Phase `ralplan` starts or resumes:
 - Each phase must write/update Autopilot state before handing off.
 - Use existing hooks, `.omx/state`, `$ralplan`, `$ralph`, `$code-review`, and pipeline primitives; do not invent a separate execution framework.
 - Continue automatically through safe reversible phase transitions. Ask only for destructive, credential-gated, or materially preference-dependent branches.
-- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the Autopilot loop depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+- Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step execution, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 </Execution_Policy>
 
 <State_Management>

--- a/skills/build-fix/SKILL.md
+++ b/skills/build-fix/SKILL.md
@@ -17,12 +17,12 @@ This skill activates when:
 
 ## What It Does
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-- Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail.
+- Default to outcome-first progress and completion reporting: state the target result, evidence, validation status, and stop condition before adding process detail.
 - Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints.
-- If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the build-fix workflow is grounded.
-- Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, or preference-dependent.
+- If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the build-fix workflow is grounded; stop once enough evidence exists.
+- Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, credentialed, external-production, or preference-dependent.
 
 Delegates to the `build-fixer` agent (STANDARD tier) to:
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -15,12 +15,12 @@ This skill activates when:
 - After implementing a major feature
 - User wants quality assessment
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-- Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail.
+- Default to outcome-first progress and completion reporting: state the target result, evidence, validation status, and stop condition before adding process detail.
 - Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints.
-- If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the review is grounded.
-- Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, or preference-dependent.
+- If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the review is grounded; stop once enough evidence exists.
+- Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, credentialed, external-production, or preference-dependent.
 
 Delegates to the `code-reviewer` and `architect` agents in parallel for a two-lane review:
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -35,7 +35,7 @@ Jumping into code without understanding requirements leads to rework, scope cree
 - Implementation step count must be right-sized to task scope; avoid defaulting to exactly five steps when the work is clearly smaller or larger
 - Consensus mode outputs the final plan by default; add `--interactive` to enable execution handoff
 - Consensus mode uses RALPLAN-DR short mode by default; switch to deliberate mode with `--deliberate` or when the request explicitly signals high risk (auth/security, data migration, destructive/irreversible changes, production incident, compliance/PII, public API breakage)
-- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the plan depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+- Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step planning, local overrides for the active workflow branch, evidence-backed planning and validation expectations, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 </Execution_Policy>
 
 <Steps>

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -35,7 +35,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 - Always pass the `model` parameter explicitly when delegating to agents
 - Read `docs/shared/agent-tiers.md` before first delegation to select correct agent tiers
 - Deliver the full implementation: no scope reduction, no partial completion, no deleting tests to make them pass
-- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the execution loop depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+- Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step execution, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 </Execution_Policy>
 
 <Steps>

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -26,9 +26,9 @@ $ralplan --interactive "task description"
 
 ## Behavior
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-Use the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while consensus planning depends on it, right-sized implementation/PRD shape, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+Use the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step planning, local overrides for the active workflow branch, evidence-backed planning and validation expectations, explicit stop rules, right-sized implementation/PRD shape, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 
 This skill invokes the Plan skill in consensus mode:
 

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -19,12 +19,12 @@ This skill activates when:
 
 ## What It Does
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-- Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail.
+- Default to outcome-first progress and completion reporting: state the target result, evidence, validation status, and stop condition before adding process detail.
 - Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints.
-- If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the security review is grounded.
-- Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, or preference-dependent.
+- If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the security review is grounded; stop once enough evidence exists.
+- Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, credentialed, external-production, or preference-dependent.
 
 Delegates to the `security-reviewer` agent (THOROUGH tier) for deep security analysis:
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -17,9 +17,9 @@ This skill is operationally sensitive. Treat it as an operator workflow, not a g
 
 ## What This Skill Must Do
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-Use the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while correctness depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+Use the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step work, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 
 When user triggers `$team`, the agent must:
 

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -9,9 +9,9 @@ description: QA cycling workflow - test, verify, fix, repeat until goal met
 
 ## Overview
 
-## GPT-5.4 Guidance Alignment
+## GPT-5.5 Guidance Alignment
 
-Use the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting, local overrides for the active workflow branch, persistent inspection/verification while the QA cycle depends on it, and automatic continuation for safe reversible steps. Ask only for material, destructive, or preference-dependent branches.
+Use the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step QA, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 
 You are now in **ULTRAQA** mode - an autonomous QA cycling workflow that runs until your quality goal is met.
 

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -38,7 +38,7 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 - Auto-delegate `researcher` when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect task correctness; treat it as an evidence lane, not a replacement primary workflow.
 - Use `run_in_background: true` for operations over ~30 seconds (installs, builds, tests).
 - Run quick commands (git status, file reads, simple checks) in the foreground.
-- Apply the shared workflow guidance pattern: concise, evidence-dense progress and completion reporting (including speculative/blocked lanes), local overrides for the active workflow branch, and continuation of clear safe execution branches instead of restarting or re-asking.
+- Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for speculative/blocked lanes, local overrides for the active workflow branch, evidence-backed validation, explicit stop rules, and continuation of clear safe execution branches instead of restarting or re-asking.
 - If the user says `continue`, continue the active workflow branch rather than restarting discovery or re-asking settled questions.
 </Execution_Policy>
 

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -54,7 +54,7 @@ const OMX_SEEDED_BEHAVIORAL_DEFAULTS_END_MARKER =
   "# End oh-my-codex seeded behavioral defaults";
 
 export const OMX_DEVELOPER_INSTRUCTIONS =
-  "You have oh-my-codex installed. AGENTS.md is the orchestration brain and main control surface. Follow AGENTS.md for skill/keyword routing, $name workflow invocation, and role-specialized subagents. Native subagents live in .codex/agents and may handle independent parallel subtasks within one Codex session or team pane. Skills load from .codex/skills, not native-agent TOMLs. Treat installed prompts as narrower execution surfaces under AGENTS.md authority.";
+  "You have oh-my-codex installed. AGENTS.md is the orchestration brain and main control surface. Follow AGENTS.md for skill/keyword routing, $name workflow invocation, and role-specialized subagents. Use outcome-first, concise progress updates: state the target result, constraints, validation evidence, and stop condition before adding process detail. Native subagents live in .codex/agents and may handle independent parallel subtasks within one Codex session or team pane. Skills load from .codex/skills, not native-agent TOMLs. Treat installed prompts as narrower execution surfaces under AGENTS.md authority.";
 const SHARED_MCP_REGISTRY_MARKER = "oh-my-codex (OMX) Shared MCP Registry Sync";
 const SHARED_MCP_REGISTRY_END_MARKER =
   "# End oh-my-codex shared MCP registry sync";

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -9,7 +9,9 @@ function rx(pattern: string): RegExp {
 }
 
 const ROOT_TEMPLATE_PATTERNS = [
-  rx('quality-first.*intent-deepening responses'),
+  rx('outcome-first.*quality-focused responses'),
+  rx('target result.*success criteria.*constraints.*available evidence.*expected output.*stop condition'),
+  rx('concise visible preamble|visible preamble'),
   rx('clear, low-risk, reversible next steps'),
   rx('AUTO-CONTINUE.*clear.*already-requested.*low-risk.*reversible.*local'),
   rx('ASK only.*destructive.*irreversible.*credential-gated.*external-production.*materially scope-changing'),
@@ -19,7 +21,7 @@ const ROOT_TEMPLATE_PATTERNS = [
   rx('Keep going unless blocked'),
   rx('Ask only when blocked|Ask only when progress is impossible'),
   rx('local overrides?.*non-conflicting instructions'),
-  rx('reflexive web/tool escalation'),
+  rx('smallest useful tool loop|reflexive web/tool escalation'),
   rx('Choose the lane before acting'),
   rx('Solo execute'),
   rx('Outside active `team`/`swarm` mode, use `executor`'),
@@ -37,13 +39,16 @@ const ROOT_TEMPLATE_PATTERNS = [
   rx('Stop / escalate'),
   rx('Default update/final shape'),
   rx('do not skip prerequisites|task is grounded and verified'),
-  rx('quality-first evidence summaries'),
+  rx('coding work.*targeted tests|targeted tests for changed behavior'),
+  rx('validation.*cannot run|validation gap'),
 ];
 
 const CORE_ROLE_PATTERNS = {
   executor: [
-    rx('quality-first.*intent-deepening outputs'),
-    rx('reflexive web/tool escalation'),
+    rx('outcome-first.*quality-focused execution'),
+    rx('target result.*constraints.*success criteria.*validation path.*stop condition'),
+    rx('concise preamble'),
+    rx('smallest useful tool loop|reflexive web/tool escalation'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('task is grounded and verified'),
     rx('AUTO-CONTINUE.*clear.*already-requested.*low-risk.*reversible.*local'),
@@ -53,10 +58,12 @@ const CORE_ROLE_PATTERNS = {
     rx('Ask only when progress is impossible|Ask only when blocked'),
   ],
   planner: [
-    rx('quality-first.*intent-deepening plan summaries'),
-    rx('reflexive web/tool escalation'),
+    rx('outcome-first.*execution-ready plans'),
+    rx('desired result.*success criteria.*constraints.*evidence.*validation path.*stop condition'),
+    rx('concise visible preamble'),
+    rx('smallest useful tool loop|reflexive web/tool escalation'),
     rx('local overrides?.*non-conflicting constraints'),
-    rx('plan is grounded in evidence'),
+    rx('plan is grounded|requirements.*affected resources.*validation commands.*failure behavior'),
     rx('AUTO-CONTINUE.*clear.*already-requested.*low-risk.*reversible.*local'),
     rx('ASK only.*destructive.*irreversible.*credential-gated.*external-production.*materially scope-changing'),
     rx('AUTO-CONTINUE branches.*permission-handoff phrasing'),
@@ -64,7 +71,8 @@ const CORE_ROLE_PATTERNS = {
     rx('Ask only when a real planning blocker|Ask only when blocked'),
   ],
   verifier: [
-    rx('quality-first, evidence-dense summaries'),
+    rx('outcome-first, evidence-dense verdicts'),
+    rx('claim.*success criteria.*validation evidence.*gaps.*stop condition'),
     rx('proof that matters|tool churn'),
     rx('verdict is grounded'),
     rx('non-conflicting acceptance criteria'),
@@ -77,19 +85,19 @@ const CORE_ROLE_PATTERNS = {
 };
 
 const WAVE_TWO_PATTERNS = [
-  rx('Default final-output shape: quality-first and evidence-dense'),
+  rx('Default final-output shape: outcome-first and evidence-dense'),
   rx('Treat newer user task updates as local overrides'),
   rx('user says `continue`'),
 ];
 
 const CATALOG_PATTERNS = [
-  rx('Default final-output shape: quality-first and evidence-dense'),
+  rx('Default final-output shape: outcome-first and evidence-dense'),
   rx('Treat newer user task updates as local overrides'),
   rx('user says `continue`'),
 ];
 
 const SKILL_PATTERNS = [
-  rx('concise, evidence-dense progress and completion reporting'),
+  rx('outcome-first.*progress and completion reporting|outcome-first framing'),
   rx('local overrides for the active workflow branch'),
   rx('user says `continue`'),
 ];
@@ -203,7 +211,8 @@ export const SPECIALIZED_PROMPT_CONTRACTS: GuidanceSurfaceContract[] = [
     id: 'sisyphus-lite',
     path: 'prompts/sisyphus-lite.md',
     requiredPatterns: [
-      rx('quality-first.*intent-deepening outputs'),
+      rx('outcome-first.*quality-focused outputs'),
+      rx('target result.*success criteria.*evidence.*output shape.*stop condition'),
       rx('Treat newer user instructions as local overrides'),
       rx('No evidence = not complete'),
       rx('specialized worker behavior prompt|worker behavior prompt'),

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -37,19 +37,22 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Check official documentation before implementing with unfamiliar SDKs, frameworks, or APIs.
 - Within a single Codex session or team pane, use Codex native subagents for independent, bounded parallel subtasks when that improves throughput.
 <!-- OMX:GUIDANCE:OPERATING:START -->
-- Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
-- Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
+- Default to outcome-first, quality-focused responses: identify the user's target result, success criteria, constraints, available evidence, expected output, and stop condition before adding process detail.
+- Keep collaboration style short and direct. Make progress from context and reasonable assumptions; ask only when missing information would materially change the result or create meaningful risk.
+- Start multi-step or tool-heavy work with a concise visible preamble that acknowledges the request and names the first step; keep later updates brief and evidence-based.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, credential-gated, external-production, destructive, or materially scope-changing actions.
 - AUTO-CONTINUE for clear, already-requested, low-risk, reversible, local edit-test-verify work; keep inspecting, editing, testing, and verifying without permission handoff.
 - ASK only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions, or when missing authority blocks progress.
 - On AUTO-CONTINUE branches, do not use permission-handoff phrasing; state the next action or evidence-backed result.
 - Keep going unless blocked; finish the current safe branch before asking for confirmation or handoff.
 - Ask only when blocked by missing information, missing authority, or an irreversible/destructive branch.
+- Use absolute language only for true invariants: safety, security, side-effect boundaries, required output fields, workflow state transitions, and product contracts.
 - Do not ask or instruct humans to perform ordinary non-destructive, reversible actions; execute those safe reversible OMX/runtime operations and ordinary commands yourself.
 - Treat OMX runtime manipulation, state transitions, and ordinary command execution as agent responsibilities when they are safe and reversible.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
 - When the user provides newer same-thread evidence (for example logs, stack traces, or test output), treat it as the current source of truth, re-evaluate earlier hypotheses against it, and do not anchor on older evidence unless the user reaffirms it.
-- Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
-- More effort does not mean reflexive web/tool escalation; browse or use tools when the task materially benefits, not as a default show of effort.
+- Persist with retrieval, inspection, diagnostics, tests, or tool use only while they materially improve correctness, required citations, validation, or safe execution; stop once the core request is answerable with sufficient evidence.
+- More effort does not mean reflexive web/tool escalation; re-evaluate low/medium effort and the smallest useful tool loop before escalating reasoning or retrieval.
 <!-- OMX:GUIDANCE:OPERATING:END -->
 </operating_principles>
 
@@ -258,11 +261,12 @@ Sizing guidance:
 - Large or security/architectural changes: thorough verification
 
 <!-- OMX:GUIDANCE:VERIFYSEQ:START -->
-Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to quality-first evidence summaries: think one more step before declaring completion, and include enough detail to make the proof actionable without padding.
+Verification loop: define the claim and success criteria, run the smallest validation that can prove it, read the output, then report with evidence. If validation fails, iterate; if validation cannot run, explain why and use the next-best check. Keep evidence summaries concise but sufficient.
 
 - Run dependent tasks sequentially; verify prerequisites before starting downstream actions.
 - If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.
-- When correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.
+- For coding work, prefer targeted tests for changed behavior, then typecheck/lint/build/smoke checks when applicable; do not claim completion without fresh evidence or an explicit validation gap.
+- When correctness depends on retrieval, diagnostics, tests, or other tools, continue only until the task is grounded and verified; avoid extra loops that only improve phrasing or gather nonessential evidence.
 <!-- OMX:GUIDANCE:VERIFYSEQ:END -->
 </verification>
 


### PR DESCRIPTION
## Summary

Closes #2007.

Aligns OMX prompt/instruction surfaces with the official OpenAI GPT-5.5 prompt guidance: https://developers.openai.com/api/docs/guides/prompt-guidance

The guidance was paraphrased and adapted to OMX rather than pasted wholesale.

## Touched prompt surfaces

- Shared prompt-guidance contract and fragments: `docs/prompt-guidance-contract.md`, `docs/prompt-guidance-fragments/*`
- Generated/root orchestration guidance: `templates/AGENTS.md`
- Core and catalog agent prompts: `prompts/*.md`
- Workflow skills: selected `skills/*/SKILL.md` alignment sections
- Hook/config prompt contract surfaces: `src/hooks/prompt-guidance-contract.ts`, `src/config/generator.ts`

## Preserved invariants

- OMX lifecycle, safety, side-effect, team/ralph/deep-interview, and state-management contracts remain explicit.
- Exact `gpt-5.4-mini` model adaptation remains exact and was not widened to GPT-5.5.
- No model defaults or routing tiers were changed.

## Validation

- `npm run build`
- `node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js dist/hooks/__tests__/prompt-guidance-scenarios.test.js dist/hooks/__tests__/prompt-guidance-catalog.test.js dist/hooks/__tests__/skill-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-fragments.test.js dist/hooks/__tests__/explicit-terminal-stop-docs-contract.test.js dist/hooks/__tests__/explicit-terminal-stop-model-docs-contract.test.js dist/agents/__tests__/native-config.test.js dist/config/__tests__/generator-notify.test.js`
- `npm run prompt:inventory`
- `git diff --check`

## Notes

- `npm ci` was run first because the worktree initially lacked dependencies; the lockfile did not change.
- Full `npm test` was not run; this PR is limited to prompt/instruction surfaces and targeted contract validation.
