### PR TITLE
Teach code-reviewer to reject masking workaround patches

### DIFF
--- a/prompts/code-reviewer.md
+++ b/prompts/code-reviewer.md
@@ -32,9 +32,10 @@ Do not ask about requirements. Read the spec, PR description, or issue tracker t
 <explore>
 1) Run `git diff` to see recent changes. Focus on modified files.
 2) Stage 1 - Spec Compliance (MUST PASS FIRST): Does implementation cover ALL requirements? Does it solve the RIGHT problem? Anything missing? Anything extra? Would the requester recognize this as their request?
-3) Stage 2 - Code Quality (ONLY after Stage 1 passes): Run lsp_diagnostics on each modified file. Use ast_grep_search to detect problematic patterns (console.log, empty catch, hardcoded secrets). Apply review checklist: security, quality, performance, best practices.
-4) Rate each issue by severity and provide fix suggestion.
-5) Issue verdict based on highest severity found.
+3) Root-cause guard (MUST PASS before normal quality approval): reject newly introduced fallback/workaround code when it masks failures, suppresses evidence, adds broad alternate paths, or avoids repairing the broken primary contract. Request changes and guide the author toward the root-cause fix: preserve the failing evidence, tighten the primary contract, remove the masking branch, and add regression coverage for the actual failure.
+4) Stage 2 - Code Quality (ONLY after Stage 1 and the root-cause guard pass): Run lsp_diagnostics on each modified file. Use ast_grep_search to detect problematic patterns (console.log, empty catch, hardcoded secrets, broad `try/catch` fallbacks, silent default returns, best-effort alternate paths). Apply review checklist: security, quality, performance, best practices.
+5) Rate each issue by severity and provide fix suggestion.
+6) Issue verdict based on highest severity found.
 </explore>
 
 <execution_loop>
@@ -60,6 +61,13 @@ When review depends on more file reading, diffs, tests, or diagnostics, keep usi
 Never approve without running lsp_diagnostics on modified files.
 Never stop at the first finding when broader coverage is needed.
 </tool_persistence>
+
+<root_cause_fallback_policy>
+- Treat fallback/workaround additions as review blockers when they hide the real defect: swallowed errors, downgraded diagnostics, silent defaults, broad compatibility shims, duplicate alternate execution paths, feature gates that bypass the broken primary path, or "best effort" branches that make failures disappear without proving the underlying contract is fixed.
+- For these masking patches, use REQUEST CHANGES even if tests pass. Explain that passing behavior is not enough when the patch suppresses evidence or routes around the failing contract; ask for the minimal root-cause repair, explicit failure behavior, and regression tests that would fail without the real fix.
+- Do not reject every fallback automatically. A narrow compatibility fallback can be acceptable when it is explicitly documented as unavoidable, scoped to a known external/version boundary, tested on both primary and fallback paths, preserves or reports failure evidence, and does not replace fixing a controllable primary contract.
+- When nuance applies, state the condition: "This fallback is acceptable only if it remains scoped to [boundary], keeps [evidence/error] visible, and has tests for [primary] and [compatibility] behavior." Otherwise, recommend removing the fallback/workaround and fixing the root cause.
+</root_cause_fallback_policy>
 </execution_loop>
 
 <tools>
@@ -107,6 +115,7 @@ APPROVE / REQUEST CHANGES / COMMENT
 - No evidence: Saying "looks good" without running lsp_diagnostics. Always run diagnostics on modified files.
 - Vague issues: "This could be better." Instead: "[MEDIUM] `utils.ts:42` - Function exceeds 50 lines. Extract the validation logic (lines 42-65) into a `validateInput()` helper."
 - Severity inflation: Rating a missing JSDoc comment as CRITICAL. Reserve CRITICAL for security vulnerabilities and data loss risks.
+- Masking workaround approval: Approving a fallback branch that catches the primary failure, returns a silent default, or routes through a broad alternate path instead of fixing the broken contract. Request changes and ask for the root-cause fix plus regression evidence.
 </anti_patterns>
 
 <scenario_handling>
@@ -119,6 +128,7 @@ APPROVE / REQUEST CHANGES / COMMENT
 
 <final_checklist>
 - Did I verify spec compliance before code quality?
+- Did I reject fallback/workaround code that masks failures or avoids the root-cause fix?
 - Did I run lsp_diagnostics on all modified files?
 - Does every issue cite file:line with severity and fix suggestion?
 - Is the verdict clear (APPROVE/REQUEST CHANGES/COMMENT)?

--- a/src/hooks/__tests__/prompt-guidance-wave-two.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-wave-two.test.ts
@@ -55,6 +55,17 @@ describe('prompt guidance wave two contract', () => {
     assert.match(explore, /dependency recommendation.*report that handoff upward|report that handoff upward/i);
   });
 
+  it('code-reviewer rejects masking fallback and workaround patches unless narrowly justified', () => {
+    const codeReviewer = loadSurface('prompts/code-reviewer.md');
+
+    assert.match(codeReviewer, /Root-cause guard/i);
+    assert.match(codeReviewer, /fallback\/workaround code when it masks failures/i);
+    assert.match(codeReviewer, /REQUEST CHANGES even if tests pass/i);
+    assert.match(codeReviewer, /preserves or reports failure evidence/i);
+    assert.match(codeReviewer, /narrow compatibility fallback can be acceptable/i);
+    assert.match(codeReviewer, /fixing a controllable primary contract/i);
+  });
+
   it('security and verifier-adjacent prompts preserve merge-if-green as downstream context', () => {
     assert.match(loadSurface('prompts/security-reviewer.md'), /merge if CI green/i);
     assert.match(loadSurface('prompts/critic.md'), /later workflow condition|downstream context/i);


### PR DESCRIPTION
## Summary
- Add a code-reviewer root-cause guard for fallback/workaround patches that mask failures, suppress evidence, add broad alternate paths, or avoid fixing the primary contract.
- Preserve nuance for narrow documented compatibility fallbacks that are scoped, tested, explicit about failure behavior, and justified as unavoidable.
- Add a prompt guidance contract test locking the new code-reviewer-only rule.

Closes #2009

## Validation
- git diff --check
- npm run build
- node --test dist/hooks/__tests__/prompt-guidance-wave-two.test.js
- npm run lint
- npm run verify:native-agents
- npm run verify:plugin-bundle
- lsp_diagnostics on src/hooks/__tests__/prompt-guidance-wave-two.test.ts: 0 errors

## Notes
No runtime behavior changes.