### PR TITLE
Keep plugin MCP servers alive through omx mcp-serve

### DIFF
--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -101,6 +101,35 @@ describe('package bin contract', () => {
     const binSource = readFileSync(binPath, 'utf-8');
     const compiledCliSource = readFileSync(compiledCliPath, 'utf-8');
     assert.match(binSource, /^#!\/usr\/bin\/env node/);
+    const mcpInitialize = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'package-bin-contract', version: '0' },
+      },
+    }) + '\n';
+    const mcpServe = spawnSync(
+      process.execPath,
+      [binPath, 'mcp-serve', 'state'],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf-8',
+        input: mcpInitialize,
+        timeout: 5_000,
+      },
+    );
+    assert.equal(mcpServe.status, 0, mcpServe.stderr || mcpServe.stdout);
+    const mcpResponse = JSON.parse(mcpServe.stdout) as {
+      result?: { serverInfo?: { name?: string; version?: string } };
+    };
+    assert.deepEqual(
+      mcpResponse.result?.serverInfo,
+      { name: 'omx-state', version: '0.1.0' },
+      'omx bin wrapper must keep mcp-serve alive long enough to complete stdio initialization',
+    );
     assert.match(compiledCliSource, /omx update\s+Check npm now, update the global install immediately, then refresh setup/);
     assert.match(compiledCliSource, /case "update"/);
 

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -7,6 +7,7 @@ import { spawnSync } from 'node:child_process';
 import { getInstallableNativeAgentNames } from '../../agents/policy.js';
 import { getSetupInstallableSkillNames } from '../../catalog/installable.js';
 import { readCatalogManifest } from '../../catalog/reader.js';
+import { OMX_FIRST_PARTY_MCP_PLUGIN_TARGETS } from '../../config/omx-first-party-mcp.js';
 
 type PackageJson = {
   files?: string[];
@@ -111,25 +112,36 @@ describe('package bin contract', () => {
         clientInfo: { name: 'package-bin-contract', version: '0' },
       },
     }) + '\n';
-    const mcpServe = spawnSync(
-      process.execPath,
-      [binPath, 'mcp-serve', 'state'],
-      {
-        cwd: process.cwd(),
-        encoding: 'utf-8',
-        input: mcpInitialize,
-        timeout: 5_000,
-      },
-    );
-    assert.equal(mcpServe.status, 0, mcpServe.stderr || mcpServe.stdout);
-    const mcpResponse = JSON.parse(mcpServe.stdout) as {
-      result?: { serverInfo?: { name?: string; version?: string } };
-    };
-    assert.deepEqual(
-      mcpResponse.result?.serverInfo,
-      { name: 'omx-state', version: '0.1.0' },
-      'omx bin wrapper must keep mcp-serve alive long enough to complete stdio initialization',
-    );
+    for (const target of OMX_FIRST_PARTY_MCP_PLUGIN_TARGETS) {
+      const mcpServe = spawnSync(
+        process.execPath,
+        [binPath, 'mcp-serve', target],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf-8',
+          input: mcpInitialize,
+          timeout: 5_000,
+        },
+      );
+      assert.equal(
+        mcpServe.status,
+        0,
+        `${target} stderr=${mcpServe.stderr} stdout=${mcpServe.stdout}`,
+      );
+      assert.notEqual(
+        mcpServe.stdout.trim(),
+        '',
+        `omx bin wrapper must keep mcp-serve ${target} alive long enough to complete stdio initialization`,
+      );
+      const mcpResponse = JSON.parse(mcpServe.stdout) as {
+        result?: { serverInfo?: { name?: string; version?: string } };
+      };
+      assert.match(
+        mcpResponse.result?.serverInfo?.name ?? '',
+        /^omx-/,
+        `${target} initialize response should include serverInfo`,
+      );
+    }
     assert.match(compiledCliSource, /omx update\s+Check npm now, update the global install immediately, then refresh setup/);
     assert.match(compiledCliSource, /case "update"/);
 

--- a/src/cli/omx.ts
+++ b/src/cli/omx.ts
@@ -20,7 +20,9 @@ const distEntry = join(root, 'dist', 'cli', 'index.js');
 if (existsSync(distEntry)) {
   const { main } = await import(pathToFileURL(distEntry).href);
   await main(process.argv.slice(2));
-  process.exit(process.exitCode ?? 0);
+  if (process.argv[2] !== 'mcp-serve') {
+    process.exit(process.exitCode ?? 0);
+  }
 } else {
   console.error('oh-my-codex: run "npm run build" first');
   process.exit(1);


### PR DESCRIPTION
## Summary

Supersedes draft PR #1959 while preserving its contributor-authored lifecycle fix.

Fixes #2011 by allowing `omx mcp-serve <target>` to keep the stdio MCP server lifecycle alive after `main()` returns, instead of the published/bin-equivalent wrapper forcing `process.exit()` before the MCP initialize response can be written.

## What changed

- Keeps PR #1959's narrow `src/cli/omx.ts` fix: normal CLI commands still exit explicitly, but `mcp-serve` does not force-exit after dispatch.
- Widens the regression coverage in `src/cli/__tests__/package-bin-contract.test.ts` from `state` only to every first-party plugin MCP target in `.mcp.json`: `state`, `memory`, `code-intel`, `trace`, and `wiki`.

## Validation

- Reproduced current `dev` failure: all five targets returned `wrapper_bytes=0` through `node dist/cli/omx.js mcp-serve <target>`.
- Bounded post-fix probes using `timeout 3s` + `head -n 1` returned initialize responses:
  - `state wrapper_bytes=146 server=omx-state`
  - `memory wrapper_bytes=147 server=omx-memory`
  - `code-intel wrapper_bytes=151 server=omx-code-intel`
  - `trace wrapper_bytes=146 server=omx-trace`
  - `wiki wrapper_bytes=145 server=omx-wiki`
- `npm run build`
- `node --test dist/cli/__tests__/package-bin-contract.test.js`
- `node --test dist/cli/__tests__/package-bin-contract.test.js dist/cli/__tests__/mcp-serve.test.js dist/cli/__tests__/codex-plugin-layout.test.js`
- `npx biome lint src/cli/omx.ts src/cli/__tests__/package-bin-contract.test.ts`
- `npm run verify:native-agents`
- `npm run verify:plugin-bundle`
- `npm run test:plugin-boundaries:compiled`

## Notes

A full `npm run test:ci:compiled` was started and showed substantial progress, but was intentionally interrupted because the broad team runtime lane is long-running in this attached tmux session and not necessary for this narrow CLI/plugin MCP contract change.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*