### PR TITLE
Make omx question a batch popup wizard

### DIFF
--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -64,9 +64,26 @@ function makeFakeStructuredQuestionAsker(
 		const next = queue.shift() ?? "";
 		const matchingOption = input.options.find((option) => option.value === next);
 		if (matchingOption) {
+			const answer = {
+				kind: "option" as const,
+				value: matchingOption.value,
+				selected_labels: [matchingOption.label],
+				selected_values: [matchingOption.value],
+			};
 			return {
 				ok: true,
 				question_id: `q-${questions.length}`,
+				questions: [{
+					id: "q-1",
+					header: input.header,
+					question: input.question,
+					options: input.options,
+					allow_other: input.allow_other,
+					other_label: input.other_label ?? "Other",
+					multi_select: input.multi_select ?? false,
+					type: input.type ?? (input.multi_select ? "multi-answerable" : "single-answerable"),
+				}],
+				answers: [{ question_id: "q-1", index: 0, answer }],
 				prompt: {
 					header: input.header,
 					question: input.question,
@@ -76,18 +93,31 @@ function makeFakeStructuredQuestionAsker(
 					multi_select: input.multi_select ?? false,
 					source: input.source,
 				},
-				answer: {
-					kind: "option",
-					value: matchingOption.value,
-					selected_labels: [matchingOption.label],
-					selected_values: [matchingOption.value],
-				},
+				answer,
 			};
 		}
 
+		const answer = {
+			kind: "other" as const,
+			value: next,
+			selected_labels: [input.other_label ?? "Other"],
+			selected_values: [next],
+			other_text: next,
+		};
 		return {
 			ok: true,
 			question_id: `q-${questions.length}`,
+			questions: [{
+				id: "q-1",
+				header: input.header,
+				question: input.question,
+				options: input.options,
+				allow_other: input.allow_other,
+				other_label: input.other_label ?? "Other",
+				multi_select: input.multi_select ?? false,
+				type: input.type ?? (input.multi_select ? "multi-answerable" : "single-answerable"),
+			}],
+			answers: [{ question_id: "q-1", index: 0, answer }],
 			prompt: {
 				header: input.header,
 				question: input.question,
@@ -97,13 +127,7 @@ function makeFakeStructuredQuestionAsker(
 				multi_select: input.multi_select ?? false,
 				source: input.source,
 			},
-			answer: {
-				kind: "other",
-				value: next,
-				selected_labels: [input.other_label ?? "Other"],
-				selected_values: [next],
-				other_text: next,
-			},
+			answer,
 		};
 	};
 }

--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -117,6 +117,8 @@ describe('omx question CLI', () => {
     const payload = JSON.parse(stdout);
     assert.equal(payload.ok, true);
     assert.equal(payload.answer.value, 'free text answer');
+    assert.equal(payload.answers[0].answer.value, 'free text answer');
+    assert.equal(payload.questions[0].question, 'Pick one');
     assert.equal(payload.prompt.source, 'deep-interview');
     assert.equal(payload.prompt.type, 'multi-answerable');
   });
@@ -163,6 +165,8 @@ esac
           PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
           TMUX: '/tmp/fake',
           TMUX_PANE: '%0',
+          OMX_QUESTION_RETURN_PANE: '',
+          OMX_LEADER_PANE_ID: '',
           OMX_AUTO_UPDATE: '0',
           OMX_NOTIFY_FALLBACK: '0',
           OMX_HOOK_DERIVED_SIGNALS: '0',
@@ -236,6 +240,8 @@ esac
           PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
           TMUX: '/tmp/fake',
           TMUX_PANE: '%0',
+          OMX_QUESTION_RETURN_PANE: '',
+          OMX_LEADER_PANE_ID: '',
           OMX_AUTO_UPDATE: '0',
           OMX_NOTIFY_FALLBACK: '0',
           OMX_HOOK_DERIVED_SIGNALS: '0',
@@ -327,6 +333,8 @@ exit 0
     };
     delete childEnv.TMUX;
     delete childEnv.TMUX_PANE;
+    delete childEnv.OMX_QUESTION_RETURN_PANE;
+    delete childEnv.OMX_LEADER_PANE_ID;
     delete childEnv.OMX_QUESTION_TEST_RENDERER;
 
     const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
@@ -401,6 +409,8 @@ exit 0
           PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
           TMUX: '/tmp/fake',
           TMUX_PANE: '%0',
+          OMX_QUESTION_RETURN_PANE: '',
+          OMX_LEADER_PANE_ID: '',
           OMX_AUTO_UPDATE: '0',
           OMX_NOTIFY_FALLBACK: '0',
           OMX_HOOK_DERIVED_SIGNALS: '0',
@@ -444,11 +454,14 @@ exit 0
     await writeFile(join(fakeBinDir, 'tmux'), `#!/bin/sh
 printf '%s\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
+  display-message)
+    printf '40\n'
+    ;;
   split-window)
     printf '%%45\n'
     ;;
   list-panes)
-    printf '0\t%%45\n'
+    printf '0	%%45\n'
     ;;
 esac
 `, { mode: 0o755 });
@@ -470,6 +483,7 @@ esac
     };
     delete childEnv.TMUX;
     delete childEnv.TMUX_PANE;
+    delete childEnv.OMX_LEADER_PANE_ID;
     delete childEnv.OMX_QUESTION_TEST_RENDERER;
 
     const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
@@ -494,13 +508,11 @@ esac
     assert.notEqual(recordFile, '', `expected question record file, stderr=${stderr}`);
     const recordPath = join(questionsDir, recordFile);
 
-    let record = null;
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      record = await readQuestionRecord(recordPath);
-      if (record?.status === 'prompting') break;
+    let record = await readQuestionRecord(recordPath);
+    for (let attempt = 0; attempt < 100 && !record?.renderer; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 20));
+      record = await readQuestionRecord(recordPath);
     }
-    assert.equal(record?.status, 'prompting', `expected prompting question record, stderr=${stderr}`);
     assert.equal(record?.renderer?.renderer, 'tmux-pane');
     assert.equal(record?.renderer?.target, '%45');
     assert.equal(record?.renderer?.return_target, '%44');
@@ -519,7 +531,7 @@ esac
     assert.equal(payload.answer.value, 'a');
 
     const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-    assert.match(tmuxLog, /split-window -v -l 12 -t %44 -P -F #\{pane_id\}/);
+    assert.match(tmuxLog, /split-window -v -l 24 -t %44 -P -F #\{pane_id\}/);
     assert.doesNotMatch(tmuxLog, /new-session/);
   });
 

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -54,6 +54,12 @@ export type AutoresearchStructuredQuestionAsker = (
 	input: AutoresearchStructuredQuestionInput,
 ) => Promise<OmxQuestionSuccessPayload>;
 
+function primaryStructuredAnswer(response: OmxQuestionSuccessPayload): OmxQuestionSuccessPayload["answers"][number]["answer"] {
+	const answer = response.answers[0]?.answer ?? response.answer;
+	if (!answer) throw new Error("Structured question returned no answer.");
+	return answer;
+}
+
 function createQuestionIO(): AutoresearchQuestionIO {
 	const rl = createInterface({ input: process.stdin, output: process.stdout });
 	return {
@@ -92,8 +98,9 @@ async function promptWithDefault(
 				: "Enter your response",
 			source: "deep-interview",
 		});
-		const answerValue = response.answer.other_text?.trim()
-			|| (typeof response.answer.value === "string" ? response.answer.value.trim() : "");
+		const answer = primaryStructuredAnswer(response);
+		const answerValue = answer.other_text?.trim()
+			|| (typeof answer.value === "string" ? answer.value.trim() : "");
 		return answerValue || trimmedCurrentValue || "";
 	}
 
@@ -126,8 +133,9 @@ async function promptAction(
 			allow_other: false,
 			source: "deep-interview",
 		});
-		const answerValue = typeof response.answer.value === "string"
-			? response.answer.value.trim().toLowerCase()
+		const answer = primaryStructuredAnswer(response);
+		const answerValue = typeof answer.value === "string"
+			? answer.value.trim().toLowerCase()
 			: "";
 		if (answerValue === "launch") return "launch";
 		if (answerValue === "refine") return "refine";

--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -36,6 +36,9 @@ Input schema:
   {
     "header": "Optional short heading",
     "question": "What should OMX do next?",
+    "questions": [
+      {"id":"next-step","question":"What should OMX do next?","options":[{"label":"Proceed","value":"proceed"}],"allow_other":false}
+    ],
     "options": [
       {"label": "Proceed", "value": "proceed", "description": "Continue"},
       {"label": "Revise", "value": "revise"}
@@ -52,7 +55,9 @@ Notes:
   - 'type' accepts 'single-answerable' or 'multi-answerable'; legacy 'multi_select' is still accepted.
   - options may be [] only when allow_other is true, for a free-text-only prompt.
   - machine callers should use --json and read stdout; the command does not return
-    until the user selected a predefined option or submitted Other text.
+    until the user submitted all answers. Success payloads include primary
+    batch fields 'questions' and 'answers'; one-question calls may also include
+    transitional 'prompt' and 'answer' projections.
 `;
 
 interface ParsedQuestionArgs {
@@ -223,16 +228,24 @@ export async function questionCommand(args: string[]): Promise<void> {
     ok: true,
     question_id: finalRecord.question_id,
     session_id: finalRecord.session_id,
-    prompt: {
-      header: finalRecord.header,
-      question: finalRecord.question,
-      options: finalRecord.options,
-      allow_other: finalRecord.allow_other,
-      other_label: finalRecord.other_label,
-      type: finalRecord.type,
-      multi_select: finalRecord.multi_select,
-      source: finalRecord.source,
-    },
-    answer: finalRecord.answer,
+    questions: finalRecord.questions,
+    answers: finalRecord.answers ?? (finalRecord.answer ? [{
+      question_id: finalRecord.questions?.[0]?.id ?? 'q-1',
+      index: 0,
+      answer: finalRecord.answer,
+    }] : []),
+    ...(finalRecord.answer ? {
+      prompt: {
+        header: finalRecord.header,
+        question: finalRecord.question,
+        options: finalRecord.options,
+        allow_other: finalRecord.allow_other,
+        other_label: finalRecord.other_label,
+        type: finalRecord.type,
+        multi_select: finalRecord.multi_select,
+        source: finalRecord.source,
+      },
+      answer: finalRecord.answer,
+    } : {}),
   }, parsed.json);
 }

--- a/src/question/__tests__/client.test.ts
+++ b/src/question/__tests__/client.test.ts
@@ -30,6 +30,25 @@ describe('runOmxQuestion', () => {
           ok: true,
           question_id: 'q-1',
           session_id: 'sess-1',
+          questions: [{
+            id: 'q-1',
+            question: 'What next?',
+            options: [{ label: 'Launch', value: 'launch' }],
+            allow_other: true,
+            other_label: 'Other',
+            type: 'single-answerable',
+            multi_select: false,
+          }],
+          answers: [{
+            question_id: 'q-1',
+            index: 0,
+            answer: {
+              kind: 'option',
+              value: 'launch',
+              selected_labels: ['Launch'],
+              selected_values: ['launch'],
+            },
+          }],
           prompt: {
             question: 'What next?',
             options: [{ label: 'Launch', value: 'launch' }],
@@ -50,9 +69,10 @@ describe('runOmxQuestion', () => {
     );
 
     assert.equal(result.ok, true);
-    assert.equal(result.answer.value, 'launch');
-    assert.equal(result.prompt.source, 'deep-interview');
-    assert.equal(result.prompt.type, 'single-answerable');
+    assert.equal(result.answers[0]?.answer.value, 'launch');
+    assert.equal(result.answer?.value, 'launch');
+    assert.equal(result.prompt?.source, 'deep-interview');
+    assert.equal(result.prompt?.type, 'single-answerable');
   });
 
   it('throws explicit question errors from stdout payloads', async () => {

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -4,8 +4,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import {
+  computeAdaptiveQuestionPaneHeight,
   formatQuestionAnswerForInjection,
+  formatQuestionAnswersForInjection,
   injectQuestionAnswerToPane,
+  injectQuestionAnswersToPane,
   launchQuestionRenderer,
   resolveQuestionRendererStrategy,
 } from '../renderer.js';
@@ -111,6 +114,16 @@ describe('resolveQuestionRendererStrategy', () => {
 });
 
 
+describe('adaptive question pane sizing', () => {
+  it('computes large adaptive heights with caps and fallback-sized terminals', () => {
+    assert.equal(computeAdaptiveQuestionPaneHeight(50, 10), 30);
+    assert.equal(computeAdaptiveQuestionPaneHeight(50, 42), 42);
+    assert.equal(computeAdaptiveQuestionPaneHeight(20, 50), 18);
+    assert.equal(computeAdaptiveQuestionPaneHeight(Number.NaN, 10), 24);
+    assert.equal(computeAdaptiveQuestionPaneHeight(9, 20), 7);
+  });
+});
+
 describe('launchQuestionRenderer', () => {
   it('fails before building UI argv or invoking tmux when no visible renderer is available', () => {
     const calls: string[][] = [];
@@ -176,23 +189,60 @@ describe('launchQuestionRenderer', () => {
     assert.equal(result.target, '%42');
     assert.equal(result.return_target, '%11');
     assert.equal(result.return_transport, 'tmux-send-keys');
-    assert.equal(calls.length, 3);
     assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%11', '#{session_attached}']);
-    assert.equal(calls[1]?.[0], 'split-window');
-    assert.ok(!calls[1]?.includes('-d'));
-    assert.equal(calls[1]?.[calls[1]!.length - 6], process.execPath);
-    assert.equal(calls[1]?.[calls[1]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
-    assert.deepEqual(calls[1]?.slice(-4), [
+    const splitCall = calls.find((call) => call[0] === 'split-window');
+    assert.ok(splitCall);
+    assert.ok(!splitCall.includes('-d'));
+    assert.ok(splitCall.includes('-t'));
+    assert.ok(splitCall.includes('%11'));
+    assert.notEqual(splitCall[3], '12');
+    assert.equal(splitCall[splitCall.length - 6], process.execPath);
+    assert.equal(splitCall[splitCall.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(splitCall.slice(-4), [
       'question',
       '--ui',
       '--state-path',
       '/repo/.omx/state/sessions/s1/questions/question-1.json',
     ]);
-    assert.ok(calls[1]?.includes('-e'));
-    assert.ok(calls[1]?.includes('OMX_SESSION_ID=s1'));
-    assert.ok(calls[1]?.includes('OMX_QUESTION_RETURN_TARGET=%11'));
-    assert.ok(calls[1]?.includes('OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys'));
-    assert.deepEqual(calls[2], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
+    assert.ok(splitCall.includes('-e'));
+    assert.ok(splitCall.includes('OMX_SESSION_ID=s1'));
+    assert.ok(splitCall.includes('OMX_QUESTION_RETURN_TARGET=%11'));
+    assert.ok(splitCall.includes('OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys'));
+    assert.ok(calls.some((call) => call.join(' ') === 'list-panes -t %42 -F #{pane_dead}\t#{pane_id}'));
+  });
+
+  it('targets the explicit leader pane even when the caller is already inside tmux', () => {
+    const calls: string[][] = [];
+    const result = launchQuestionRenderer(
+      {
+        cwd: '/repo',
+        recordPath: '/repo/.omx/state/sessions/s1/questions/question-leader.json',
+        sessionId: 's1',
+        env: {
+          TMUX: '/tmp/tmux-demo',
+          TMUX_PANE: '%22',
+          OMX_QUESTION_RETURN_PANE: '%44',
+        } as NodeJS.ProcessEnv,
+      },
+      {
+        strategy: 'inside-tmux',
+        execTmux: (args) => {
+          calls.push(args);
+          if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
+          if (args[0] === 'display-message') return '1\n';
+          if (args[0] === 'split-window') return '%45\n';
+          if (args[0] === 'list-panes') return '0\t%45\n';
+          return '';
+        },
+        sleepSync: () => {},
+      },
+    );
+
+    assert.equal(result.target, '%45');
+    assert.equal(result.return_target, '%44');
+    const splitCall = calls.find((call) => call[0] === 'split-window');
+    assert.ok(splitCall);
+    assert.deepEqual(splitCall.slice(0, 6), ['split-window', '-v', '-l', '24', '-t', '%44']);
   });
 
   it('fails closed before splitting when inside a detached tmux session', () => {
@@ -253,10 +303,14 @@ describe('launchQuestionRenderer', () => {
     assert.equal(result.target, '%78');
     assert.equal(result.return_target, '%77');
     assert.equal(result.return_transport, 'tmux-send-keys');
-    assert.equal(calls[0]?.[0], 'split-window');
-    assert.ok(!calls[0]?.includes('-d'));
-    assert.deepEqual(calls[0]?.slice(0, 7), ['split-window', '-v', '-l', '12', '-t', '%77', '-P']);
-    assert.deepEqual(calls[1], ['list-panes', '-t', '%78', '-F', '#{pane_dead}\t#{pane_id}']);
+    const splitCall = calls.find((call) => call[0] === 'split-window');
+    assert.ok(splitCall);
+    assert.ok(!splitCall.includes('-d'));
+    assert.deepEqual(splitCall.slice(0, 3), ['split-window', '-v', '-l']);
+    assert.equal(splitCall[3], '24');
+    assert.ok(splitCall.includes('-t'));
+    assert.ok(splitCall.includes('%77'));
+    assert.ok(calls.some((call) => call.join(' ') === 'list-panes -t %78 -F #{pane_dead}\t#{pane_id}'));
   });
 
   it('opens a detached Windows console instead of a psmux split pane when a return bridge is present', () => {
@@ -340,7 +394,11 @@ describe('launchQuestionRenderer', () => {
       assert.equal(result.target, '%92');
       assert.equal(result.return_target, '%91');
       assert.equal(result.return_transport, 'tmux-send-keys');
-      assert.deepEqual(calls[0]?.slice(0, 7), ['split-window', '-v', '-l', '12', '-t', '%91', '-P']);
+      const splitCall = calls.find((call) => call[0] === 'split-window');
+      assert.ok(splitCall);
+      assert.deepEqual(splitCall.slice(0, 3), ['split-window', '-v', '-l']);
+      assert.equal(splitCall[3], '24');
+      assert.ok(splitCall.includes('%91'));
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
@@ -371,18 +429,18 @@ describe('launchQuestionRenderer', () => {
       /Question UI pane %42 disappeared immediately after launch/,
     );
 
-    assert.equal(calls.length, 3);
     assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%11', '#{session_attached}']);
-    assert.equal(calls[1]?.[0], 'split-window');
-    assert.equal(calls[1]?.[calls[1]!.length - 6], process.execPath);
-    assert.equal(calls[1]?.[calls[1]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
-    assert.deepEqual(calls[1]?.slice(-4), [
+    const splitCall = calls.find((call) => call[0] === 'split-window');
+    assert.ok(splitCall);
+    assert.equal(splitCall[splitCall.length - 6], process.execPath);
+    assert.equal(splitCall[splitCall.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(splitCall.slice(-4), [
       'question',
       '--ui',
       '--state-path',
       '/repo/.omx/state/sessions/s1/questions/question-1.json',
     ]);
-    assert.deepEqual(calls[2], ['list-panes', '-t', '%42', '-F', '#{pane_dead}\t#{pane_id}']);
+    assert.ok(calls.some((call) => call.join(' ') === 'list-panes -t %42 -F #{pane_dead}\t#{pane_id}'));
   });
 
   it('uses inline-tty on Windows without invoking tmux when no attached tmux pane is available', () => {
@@ -447,8 +505,8 @@ describe('launchQuestionRenderer', () => {
 
       assert.equal(result.return_target, '%91');
       assert.equal(result.return_transport, 'tmux-send-keys');
-      assert.deepEqual(calls[0], ['display-message', '-p', '#{session_attached}']);
-      assert.equal(calls[1]?.[0], 'split-window');
+      assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%91', '#{session_attached}']);
+      assert.ok(calls.some((call) => call[0] === 'split-window'));
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
@@ -505,7 +563,7 @@ describe('launchQuestionRenderer', () => {
         cwd: '/repo',
         recordPath: '/repo/question with spaces.json',
         sessionId: 'sess-123',
-        env: { TMUX: '/tmp/tmux-demo' } as NodeJS.ProcessEnv,
+        env: { TMUX: '/tmp/tmux-demo', TMUX_PANE: '%428' } as NodeJS.ProcessEnv,
       },
       {
         strategy: 'inside-tmux',
@@ -520,13 +578,14 @@ describe('launchQuestionRenderer', () => {
       },
     );
 
-    assert.equal(calls.length, 3);
-    assert.deepEqual(calls[0], ['display-message', '-p', '#{session_attached}']);
-    assert.equal(calls[1]?.some((part) => /question --ui --state-path/.test(part)), false);
-    assert.equal(calls[1]?.some((part) => /^'.*'$/.test(part)), false);
-    assert.equal(calls[1]?.[calls[1]!.length - 6], process.execPath);
-    assert.equal(calls[1]?.[calls[1]!.length - 5]?.endsWith('/dist/cli/omx.js'), true);
-    assert.deepEqual(calls[1]?.slice(-4), [
+    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%428', '#{session_attached}']);
+    const splitCall = calls.find((call) => call[0] === 'split-window');
+    assert.ok(splitCall);
+    assert.equal(splitCall.some((part) => /question --ui --state-path/.test(part)), false);
+    assert.equal(splitCall.some((part) => /^'.*'$/.test(part)), false);
+    assert.equal(splitCall[splitCall.length - 6], process.execPath);
+    assert.equal(splitCall[splitCall.length - 5]?.endsWith('/dist/cli/omx.js'), true);
+    assert.deepEqual(splitCall.slice(-4), [
       'question',
       '--ui',
       '--state-path',
@@ -546,7 +605,7 @@ describe('launchQuestionRenderer', () => {
           cwd: '/repo',
           recordPath: '/repo/question-4.json',
           sessionId: 'sess-123',
-          env: { TMUX: '/tmp/tmux-demo' } as NodeJS.ProcessEnv,
+        env: { TMUX: '/tmp/tmux-demo', TMUX_PANE: '%200' } as NodeJS.ProcessEnv,
         },
         {
           strategy: 'inside-tmux',
@@ -565,7 +624,7 @@ describe('launchQuestionRenderer', () => {
       );
 
       assert.equal(result.return_target, '%200');
-      assert.deepEqual(calls[0], ['display-message', '-p', '#{session_attached}']);
+      assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%200', '#{session_attached}']);
     } finally {
       if (typeof originalTmuxPane === 'string') process.env.TMUX_PANE = originalTmuxPane;
       else delete process.env.TMUX_PANE;
@@ -669,8 +728,10 @@ describe('launchQuestionRenderer', () => {
 
       assert.equal(result.target, '%42');
       assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%11', '#{session_attached}']);
-      assert.equal(calls[1]?.includes('/repo/dist/cli/omx.js'), true);
-      assert.equal(calls[1]?.includes('/stale/global/dist/cli/omx.js'), false);
+      const splitCall = calls.find((call) => call[0] === 'split-window');
+      assert.ok(splitCall);
+      assert.equal(splitCall.includes('/repo/dist/cli/omx.js'), true);
+      assert.equal(splitCall.includes('/stale/global/dist/cli/omx.js'), false);
     } finally {
       process.argv[1] = originalArgv1;
     }
@@ -688,6 +749,33 @@ describe('question answer injection', () => {
         other_text: 'hello\nworld',
       }),
       '[omx question answered] hello world',
+    );
+  });
+
+  it('formats batch answers into one continuation-safe prompt', () => {
+    assert.equal(
+      formatQuestionAnswersForInjection([
+        {
+          question_id: 'first',
+          answer: {
+            kind: 'option',
+            value: 'a',
+            selected_labels: ['A'],
+            selected_values: ['a'],
+          },
+        },
+        {
+          question_id: 'second',
+          answer: {
+            kind: 'multi',
+            value: ['b', 'custom\nvalue'],
+            selected_labels: ['B', 'Other'],
+            selected_values: ['b', 'custom\nvalue'],
+            other_text: 'custom\nvalue',
+          },
+        },
+      ]),
+      '[omx question answered] first: a; second: b, custom value',
     );
   });
 
@@ -715,5 +803,44 @@ describe('question answer injection', () => {
     assert.deepEqual(calls, buildSendPaneArgvs('%11', '[omx question answered] proceed', true));
     assert.deepEqual(sleeps, [120, 100]);
     assert.equal(calls.some((argv) => argv.includes('Enter')), false);
+  });
+
+  it('injects all batch answers back into the requester pane', () => {
+    const calls: string[][] = [];
+    const sleeps: number[] = [];
+    const ok = injectQuestionAnswersToPane(
+      '%11',
+      [
+        {
+          question_id: 'first',
+          answer: {
+            kind: 'option',
+            value: 'a',
+            selected_labels: ['A'],
+            selected_values: ['a'],
+          },
+        },
+        {
+          question_id: 'second',
+          answer: {
+            kind: 'option',
+            value: 'd',
+            selected_labels: ['D'],
+            selected_values: ['d'],
+          },
+        },
+      ],
+      (args) => {
+        calls.push(args);
+        return '';
+      },
+      (ms) => {
+        sleeps.push(ms);
+      },
+    );
+
+    assert.equal(ok, true);
+    assert.deepEqual(calls, buildSendPaneArgvs('%11', '[omx question answered] first: a; second: d', true));
+    assert.deepEqual(sleeps, [120, 100]);
   });
 });

--- a/src/question/__tests__/types.test.ts
+++ b/src/question/__tests__/types.test.ts
@@ -48,6 +48,35 @@ describe('normalizeQuestionInput', () => {
     );
   });
 
+
+
+  it('normalizes batch questions with stable unique ids', () => {
+    const result = normalizeQuestionInput({
+      header: 'Batch',
+      questions: [
+        { id: 'first', question: 'Pick first', options: ['A'], allow_other: false },
+        { id: 'second', question: 'Pick second', options: ['B'], allow_other: false, type: 'multi-answerable' },
+      ],
+    });
+
+    assert.equal(result.question, 'Pick first');
+    assert.equal(result.questions?.length, 2);
+    assert.equal(result.questions?.[0]?.id, 'first');
+    assert.equal(result.questions?.[1]?.multi_select, true);
+  });
+
+  it('rejects duplicate batch question ids', () => {
+    assert.throws(
+      () => normalizeQuestionInput({
+        questions: [
+          { id: 'same', question: 'One', options: ['A'], allow_other: false },
+          { id: 'same', question: 'Two', options: ['B'], allow_other: false },
+        ],
+      }),
+      /questions id must be unique: same/,
+    );
+  });
+
   it('rejects empty options when allow_other is false', () => {
     assert.throws(
       () => normalizeQuestionInput({ question: 'Pick one', options: [], allow_other: false }),

--- a/src/question/__tests__/ui.test.ts
+++ b/src/question/__tests__/ui.test.ts
@@ -6,12 +6,16 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createQuestionRecord, markQuestionPrompting, readQuestionRecord } from '../state.js';
+import { normalizeQuestionInput } from '../types.js';
 import { formatQuestionAnswerForInjection } from '../renderer.js';
 import {
   applyInteractiveSelectionKey,
+  applyQuestionWizardKey,
   createInitialInteractiveSelectionState,
+  createInitialQuestionWizardState,
   promptForSelectionsWithArrows,
   renderInteractiveQuestionFrame,
+  renderQuestionWizardFrame,
   runQuestionUi,
 } from '../ui.js';
 import type { QuestionRecord } from '../types.js';
@@ -296,8 +300,8 @@ describe('question ui arrow navigation', () => {
       const runPromise = runQuestionUi(recordPath, {
         input,
         output,
-        injectAnswerToPane: (paneId, answer) => {
-          injected.push({ paneId, value: answer.value });
+        injectAnswersToPane: (paneId, answers) => {
+          injected.push({ paneId, value: answers[0]!.answer.value });
           return true;
         },
       });
@@ -352,8 +356,8 @@ describe('question ui arrow navigation', () => {
           OMX_QUESTION_RETURN_TARGET: '%11',
           OMX_QUESTION_RETURN_TRANSPORT: 'tmux-send-keys',
         } as NodeJS.ProcessEnv,
-        injectAnswerToPane: (paneId, answer) => {
-          injected.push({ paneId, value: answer.value });
+        injectAnswersToPane: (paneId, answers) => {
+          injected.push({ paneId, value: answers[0]!.answer.value });
           return true;
         },
       });
@@ -398,8 +402,8 @@ describe('question ui arrow navigation', () => {
           OMX_QUESTION_RETURN_TARGET: '%11',
           OMX_QUESTION_RETURN_TRANSPORT: 'tmux-send-keys',
         } as NodeJS.ProcessEnv,
-        injectAnswerToPane: (paneId, answer) => {
-          injected.push({ paneId, value: answer.value });
+        injectAnswersToPane: (paneId, answers) => {
+          injected.push({ paneId, value: answers[0]!.answer.value });
           return true;
         },
       });
@@ -416,6 +420,121 @@ describe('question ui arrow navigation', () => {
       const loaded = await readQuestionRecord(recordPath);
       assert.equal(loaded?.status, 'answered');
       assert.deepEqual(loaded?.answer?.selected_values, ['a', 'b']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+
+describe('question ui batch wizard', () => {
+  it('renders a review frame for Other selections before free-text collection', () => {
+    const record = makeRecord({
+      questions: [
+        {
+          id: 'first',
+          question: 'First?',
+          options: [{ label: 'A', value: 'a' }],
+          allow_other: true,
+          other_label: 'Custom',
+          multi_select: false,
+          type: 'single-answerable',
+        },
+      ],
+    });
+    let state = createInitialQuestionWizardState(record);
+    state = applyQuestionWizardKey(record, state, { name: 'down' }).state;
+    state = applyQuestionWizardKey(record, state, { name: 'enter' }).state;
+
+    assert.equal(state.mode, 'review');
+    assert.match(renderQuestionWizardFrame(record, state), /Custom/);
+  });
+
+  it('submits a batch after navigating back and editing an earlier answer', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-batch-'));
+    try {
+      const { recordPath } = await createQuestionRecord(
+        cwd,
+        normalizeQuestionInput({
+          header: 'Batch prompt',
+          questions: [
+            { id: 'first', question: 'First?', options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }], allow_other: false },
+            { id: 'second', question: 'Second?', options: [{ label: 'C', value: 'c' }, { label: 'D', value: 'd' }], allow_other: false },
+          ],
+        }),
+        'sess-ui-batch',
+      );
+
+      const input = new FakeTtyInput();
+      const output = new FakeTtyOutput();
+      const runPromise = runQuestionUi(recordPath, { input, output });
+
+      setTimeout(() => {
+        input.emit('keypress', '', { name: 'enter' });
+        input.emit('keypress', '', { name: 'down' });
+        input.emit('keypress', '', { name: 'enter' });
+        input.emit('keypress', '', { name: 'left' });
+        input.emit('keypress', '', { name: 'left' });
+        input.emit('keypress', '', { name: 'down' });
+        input.emit('keypress', '', { name: 'enter' });
+        input.emit('keypress', '', { name: 'enter' });
+        input.emit('keypress', '', { name: 'enter' });
+      }, 25);
+
+      await runPromise;
+      const loaded = await readQuestionRecord(recordPath);
+      assert.equal(loaded?.status, 'answered');
+      assert.deepEqual(loaded?.answers?.map((entry) => entry.answer.value), ['b', 'd']);
+      assert.match(output.toString(), /Question 2 of 2/);
+      assert.match(output.toString(), /Press Enter to submit/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('injects every batch answer into the return pane', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-batch-inject-'));
+    try {
+      const { recordPath } = await createQuestionRecord(
+        cwd,
+        normalizeQuestionInput({
+          header: 'Batch prompt',
+          questions: [
+            { id: 'first', question: 'First?', options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }], allow_other: false },
+            { id: 'second', question: 'Second?', options: [{ label: 'C', value: 'c' }, { label: 'D', value: 'd' }], allow_other: false },
+          ],
+        }),
+        'sess-ui-batch-inject',
+      );
+      await markQuestionPrompting(recordPath, {
+        renderer: 'tmux-pane',
+        target: '%42',
+        launched_at: '2026-04-19T00:00:00.000Z',
+        return_target: '%11',
+        return_transport: 'tmux-send-keys',
+      });
+
+      const injected: Array<{ paneId: string; values: Array<string | string[]> }> = [];
+      const input = new FakeTtyInput();
+      const output = new FakeTtyOutput();
+      const runPromise = runQuestionUi(recordPath, {
+        input,
+        output,
+        injectAnswersToPane: (paneId, answers) => {
+          injected.push({ paneId, values: answers.map((entry) => entry.answer.value) });
+          return true;
+        },
+      });
+
+      setTimeout(() => {
+        input.emit('keypress', '', { name: 'enter' });
+        input.emit('keypress', '', { name: 'down' });
+        input.emit('keypress', '', { name: 'enter' });
+        input.emit('keypress', '', { name: 'enter' });
+      }, 25);
+
+      await runPromise;
+      assert.deepEqual(injected, [{ paneId: '%11', values: ['a', 'd'] }]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/question/client.ts
+++ b/src/question/client.ts
@@ -1,13 +1,16 @@
 import { spawn } from 'node:child_process';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
-import type { QuestionAnswer, QuestionInput } from './types.js';
+import type { QuestionAnswer, QuestionAnswerEntry, QuestionInput, NormalizedQuestionItem } from './types.js';
 
 export interface OmxQuestionSuccessPayload {
   ok: true;
   question_id: string;
   session_id?: string;
-  prompt: QuestionInput;
-  answer: QuestionAnswer;
+  questions: NormalizedQuestionItem[];
+  answers: QuestionAnswerEntry[];
+  prompt?: QuestionInput | NormalizedQuestionItem;
+  question?: QuestionInput | NormalizedQuestionItem;
+  answer?: QuestionAnswer;
 }
 
 export interface OmxQuestionErrorPayload {
@@ -115,7 +118,7 @@ function parseQuestionStdout(stdout: string, stderr: string, exitCode: number | 
 }
 
 export async function runOmxQuestion(
-  input: Partial<QuestionInput> & { question: string },
+  input: (Partial<QuestionInput> & { question: string }) | { questions: Array<Partial<QuestionInput> & { question: string }>; header?: string; source?: string; session_id?: string },
   options: OmxQuestionClientOptions = {},
 ): Promise<OmxQuestionSuccessPayload> {
   const cwd = options.cwd ?? process.cwd();

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -11,7 +11,7 @@ import { getStatePath } from '../mcp/state-paths.js';
 import { TRACKED_WORKFLOW_MODES } from '../state/workflow-transition.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
-import type { QuestionAnswer, QuestionRendererState } from './types.js';
+import type { QuestionAnswer, QuestionRecord, QuestionRendererState } from './types.js';
 
 export type QuestionRendererStrategy = 'inside-tmux' | 'detached-tmux' | 'inline-tty' | 'windows-console' | 'test-noop' | 'unsupported';
 
@@ -90,6 +90,70 @@ export function resolveQuestionRendererStrategy(
     return 'inline-tty';
   }
   return 'unsupported';
+}
+
+
+function lineCount(value: string | undefined): number {
+  if (!value) return 0;
+  return Math.max(1, value.split('\n').length);
+}
+
+export function estimateQuestionContentLines(record: QuestionRecord | null | undefined): number {
+  if (!record) return 24;
+  const questions = record.questions?.length
+    ? record.questions
+    : [{
+      header: record.header,
+      question: record.question,
+      options: record.options,
+      allow_other: record.allow_other,
+      other_label: record.other_label,
+      multi_select: record.multi_select,
+      type: record.type,
+      id: 'q-1',
+    }];
+  let lines = 2;
+  if (record.header) lines += lineCount(record.header);
+  for (const question of questions) {
+    lines += 2 + lineCount(question.question);
+    if (question.header && question.header !== record.header) lines += lineCount(question.header);
+    for (const option of question.options) {
+      lines += 1 + lineCount(option.description);
+    }
+    if (question.allow_other) lines += 1;
+    lines += 2;
+  }
+  if (questions.length > 1) lines += 3;
+  return lines;
+}
+
+export function computeAdaptiveQuestionPaneHeight(availableHeight: number, estimatedContentLines: number): number {
+  const safeAvailable = Number.isFinite(availableHeight) && availableHeight > 0 ? Math.floor(availableHeight) : 40;
+  const maxHeight = Math.max(1, safeAvailable - 2);
+  const minLarge = Math.min(Math.max(18, Math.floor(safeAvailable * 0.60)), maxHeight);
+  const requested = Number.isFinite(estimatedContentLines) && estimatedContentLines > 0 ? Math.ceil(estimatedContentLines) : 24;
+  return Math.min(Math.max(Math.max(requested, minLarge), Math.min(8, maxHeight)), maxHeight);
+}
+
+function readQuestionRecordForSizing(recordPath: string): QuestionRecord | null {
+  return readJsonFileIfExists(recordPath) as QuestionRecord | null;
+}
+
+function resolveAvailablePaneHeight(
+  execTmux: ExecTmuxSync,
+  target: string | undefined,
+): number {
+  const format = '#{pane_height}';
+  const attempts = target ? [['display-message', '-p', '-t', target, format], ['display-message', '-p', format]] : [['display-message', '-p', format]];
+  for (const args of attempts) {
+    try {
+      const parsed = Number.parseInt(execTmux(args).trim(), 10);
+      if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    } catch {
+      // Try the next source, then fall back.
+    }
+  }
+  return 40;
 }
 
 function resolveQuestionUiProcessArgs(
@@ -243,8 +307,9 @@ function resolveReturnTarget(options: {
 function isCurrentTmuxSessionAttached(
   execTmux: ExecTmuxSync = defaultExecTmux,
   env: NodeJS.ProcessEnv = process.env,
+  targetPane?: string,
 ): boolean {
-  const paneTarget = safeString(env.TMUX_PANE).trim();
+  const paneTarget = targetPane ?? safeString(env.TMUX_PANE).trim();
   const targetArgs = isPaneId(paneTarget) ? ['-t', paneTarget] : [];
   try {
     const attached = execTmux(['display-message', '-p', ...targetArgs, '#{session_attached}']).trim();
@@ -323,6 +388,17 @@ export function formatQuestionAnswerForInjection(answer: QuestionAnswer): string
   return sanitizeReplyInput(`${prefix} ${String(answer.value)}`);
 }
 
+export function formatQuestionAnswersForInjection(answers: Array<{ question_id: string; answer: QuestionAnswer }>): string {
+  const prefix = '[omx question answered]';
+  const body = answers
+    .map((entry) => {
+      const value = Array.isArray(entry.answer.value) ? entry.answer.value.join(', ') : String(entry.answer.value);
+      return `${entry.question_id}: ${value}`;
+    })
+    .join('; ');
+  return sanitizeReplyInput(`${prefix} ${body}`);
+}
+
 export function injectQuestionAnswerToPane(
   paneId: string,
   answer: QuestionAnswer,
@@ -331,6 +407,27 @@ export function injectQuestionAnswerToPane(
 ): boolean {
   if (!isPaneId(paneId)) return false;
   const text = formatQuestionAnswerForInjection(answer);
+  if (!text) return false;
+
+  const argvs = buildSendPaneArgvs(paneId, text, true);
+  for (const [index, argv] of argvs.entries()) {
+    execTmux(argv);
+    const hasNextArgv = index < argvs.length - 1;
+    if (!hasNextArgv) continue;
+    sleepImpl(index === 0 ? QUESTION_TEXT_SETTLE_MS : QUESTION_SUBMIT_REPEAT_DELAY_MS);
+  }
+  return true;
+}
+
+export function injectQuestionAnswersToPane(
+  paneId: string,
+  answers: Array<{ question_id: string; answer: QuestionAnswer }>,
+  execTmux: ExecTmuxSync = defaultExecTmux,
+  sleepImpl: SleepSync = sleepSync,
+): boolean {
+  if (!isPaneId(paneId) || answers.length === 0) return false;
+  if (answers.length === 1) return injectQuestionAnswerToPane(paneId, answers[0]!.answer, execTmux, sleepImpl);
+  const text = formatQuestionAnswersForInjection(answers);
   if (!text) return false;
 
   const argvs = buildSendPaneArgvs(paneId, text, true);
@@ -384,20 +481,27 @@ export function launchQuestionRenderer(
   });
 
   if (strategy === 'inside-tmux') {
-    const splitTarget = returnTarget && !safeString(env.TMUX).trim()
-      ? ['-t', returnTarget]
-      : [];
-    if (splitTarget.length === 0 && !isCurrentTmuxSessionAttached(execTmux, env)) {
+    const splitTarget = returnTarget ? ['-t', returnTarget] : [];
+    const attachedCheckTarget = safeString(env.TMUX).trim()
+      ? returnTarget || safeString(env.TMUX_PANE).trim() || undefined
+      : undefined;
+    if (safeString(env.TMUX).trim() && !isCurrentTmuxSessionAttached(execTmux, env, attachedCheckTarget)) {
       throw new Error(
         'omx question cannot open a visible renderer because this tmux session has no attached client. Run omx question from an attached tmux pane.',
       );
     }
 
+    const sizingTarget = returnTarget || safeString(env.TMUX_PANE).trim() || undefined;
+    const availableHeight = resolveAvailablePaneHeight(execTmux, sizingTarget);
+    const requestedHeight = computeAdaptiveQuestionPaneHeight(
+      availableHeight,
+      estimateQuestionContentLines(readQuestionRecordForSizing(options.recordPath)),
+    );
     const rawPane = execTmux([
       'split-window',
       '-v',
       '-l',
-      '12',
+      String(requestedHeight),
       ...splitTarget,
       '-P',
       '-F',

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -4,9 +4,10 @@ import { dirname, join } from 'node:path';
 import { getStateDir } from '../mcp/state-paths.js';
 import { writeAtomic } from '../team/state.js';
 import { sleep } from '../utils/sleep.js';
-import { getNormalizedQuestionType } from './types.js';
+import { getNormalizedQuestionType, normalizeQuestionInput } from './types.js';
 import type {
   QuestionAnswer,
+  QuestionAnswerEntry,
   QuestionInput,
   QuestionRecord,
   QuestionRendererState,
@@ -45,6 +46,7 @@ export async function createQuestionRecord(
   sessionId?: string,
   now = new Date(),
 ): Promise<{ recordPath: string; record: QuestionRecord }> {
+  const normalizedInput = normalizeQuestionInput(input);
   const questionId = buildQuestionId(now);
   const nowIso = now.toISOString();
   const record: QuestionRecord = {
@@ -54,14 +56,15 @@ export async function createQuestionRecord(
     created_at: nowIso,
     updated_at: nowIso,
     status: 'pending',
-    ...(input.header ? { header: input.header } : {}),
-    question: input.question,
-    options: input.options,
-    allow_other: input.allow_other,
-    other_label: input.other_label,
-    multi_select: input.multi_select,
-    type: getNormalizedQuestionType(input),
-    ...(input.source ? { source: input.source } : {}),
+    ...(normalizedInput.header ? { header: normalizedInput.header } : {}),
+    question: normalizedInput.question,
+    options: normalizedInput.options,
+    allow_other: normalizedInput.allow_other,
+    other_label: normalizedInput.other_label,
+    multi_select: normalizedInput.multi_select,
+    type: getNormalizedQuestionType(normalizedInput),
+    questions: normalizedInput.questions,
+    ...(normalizedInput.source ? { source: normalizedInput.source } : {}),
   };
   const recordPath = getQuestionRecordPath(cwd, questionId, sessionId);
   await writeQuestionRecord(recordPath, record);
@@ -93,15 +96,22 @@ export async function markQuestionPrompting(
 
 export async function markQuestionAnswered(
   recordPath: string,
-  answer: QuestionAnswer,
+  answerOrAnswers: QuestionAnswer | QuestionAnswerEntry[],
 ): Promise<QuestionRecord> {
-  return updateQuestionRecord(recordPath, (record) => ({
-    ...record,
-    status: 'answered',
-    updated_at: new Date().toISOString(),
-    answer,
-    error: undefined,
-  }));
+  return updateQuestionRecord(recordPath, (record) => {
+    const answers = Array.isArray(answerOrAnswers)
+      ? answerOrAnswers
+      : [{ question_id: record.questions?.[0]?.id ?? 'q-1', index: 0, answer: answerOrAnswers }];
+    const firstAnswer = answers[0]?.answer;
+    return {
+      ...record,
+      status: 'answered',
+      updated_at: new Date().toISOString(),
+      ...(firstAnswer ? { answer: firstAnswer } : {}),
+      answers,
+      error: undefined,
+    };
+  });
 }
 
 export async function markQuestionTerminalError(

--- a/src/question/types.ts
+++ b/src/question/types.ts
@@ -6,6 +6,24 @@ export interface QuestionOption {
 
 export type QuestionType = 'single-answerable' | 'multi-answerable';
 
+export interface QuestionItem {
+  id?: string;
+  header?: string;
+  question: string;
+  options: QuestionOption[];
+  allow_other: boolean;
+  other_label: string;
+  multi_select: boolean;
+  type?: QuestionType;
+}
+
+export interface NormalizedQuestionItem extends QuestionItem {
+  id: string;
+  source?: string;
+  type: QuestionType;
+  multi_select: boolean;
+}
+
 export interface QuestionInput {
   header?: string;
   question: string;
@@ -16,9 +34,8 @@ export interface QuestionInput {
   type?: QuestionType;
   source?: string;
   session_id?: string;
+  questions?: NormalizedQuestionItem[];
 }
-
-export type QuestionRendererKind = 'tmux-pane' | 'tmux-session' | 'inline-tty' | 'windows-console';
 
 export interface QuestionAnswer {
   kind: 'option' | 'other' | 'multi';
@@ -27,6 +44,14 @@ export interface QuestionAnswer {
   selected_values: string[];
   other_text?: string;
 }
+
+export interface QuestionAnswerEntry {
+  question_id: string;
+  index: number;
+  answer: QuestionAnswer;
+}
+
+export type QuestionRendererKind = 'tmux-pane' | 'tmux-session' | 'inline-tty' | 'windows-console';
 
 export type QuestionStatus = 'pending' | 'prompting' | 'answered' | 'aborted' | 'error';
 
@@ -53,9 +78,11 @@ export interface QuestionRecord {
   other_label: string;
   multi_select: boolean;
   type?: QuestionType;
+  questions?: NormalizedQuestionItem[];
   source?: string;
   renderer?: QuestionRendererState;
   answer?: QuestionAnswer;
+  answers?: QuestionAnswerEntry[];
   error?: {
     code: string;
     message: string;
@@ -106,49 +133,84 @@ export function isMultiAnswerableQuestion(input: {
   return getNormalizedQuestionType(input) === 'multi-answerable';
 }
 
+function normalizeQuestionItem(raw: unknown, index: number, inheritedHeader?: string): NormalizedQuestionItem {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`questions[${index}] must be a JSON object`);
+  }
+  const input = raw as Record<string, unknown>;
+  const question = safeString(input.question).trim();
+  const header = safeString(input.header).trim() || (index === 0 ? inheritedHeader : undefined);
+  const other_label = safeString(input.other_label).trim() || 'Other';
+  const allow_other = input.allow_other !== false;
+  const rawMultiSelect = input.multi_select;
+  const parsedType = parseQuestionType(input.type);
+  const rawOptions = Array.isArray(input.options) ? input.options : [];
+  const id = safeString(input.id).trim() || `q-${index + 1}`;
+
+  if (!question) throw new Error(`questions[${index}].question must be a non-empty string`);
+  if (!id) throw new Error(`questions[${index}].id must be a non-empty string`);
+  if (rawOptions.length === 0 && !allow_other) {
+    throw new Error(`questions[${index}].options must be a non-empty array unless allow_other is true`);
+  }
+  if (parsedType === 'single-answerable' && rawMultiSelect === true) {
+    throw new Error(`questions[${index}] type=single-answerable conflicts with multi_select=true`);
+  }
+  if (parsedType === 'multi-answerable' && rawMultiSelect === false) {
+    throw new Error(`questions[${index}] type=multi-answerable conflicts with multi_select=false`);
+  }
+
+  const type = getNormalizedQuestionType({
+    type: parsedType,
+    multi_select: rawMultiSelect === true,
+  });
+  return {
+    id,
+    ...(header ? { header } : {}),
+    question,
+    options: rawOptions.map((option, optionIndex) => normalizeOption(option, optionIndex)),
+    allow_other,
+    other_label,
+    multi_select: type === 'multi-answerable',
+    type,
+  };
+}
+
+function normalizeLegacyQuestion(raw: Record<string, unknown>, header?: string): NormalizedQuestionItem {
+  return normalizeQuestionItem({ ...raw, id: safeString(raw.id).trim() || 'q-1', header }, 0, header);
+}
+
 export function normalizeQuestionInput(raw: unknown): QuestionInput {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new Error('question input must be a JSON object');
   }
 
   const input = raw as Record<string, unknown>;
-  const question = safeString(input.question).trim();
   const header = safeString(input.header).trim() || undefined;
   const source = safeString(input.source).trim() || undefined;
   const session_id = safeString(input.session_id).trim() || undefined;
-  const other_label = safeString(input.other_label).trim() || 'Other';
-  const allow_other = input.allow_other !== false;
-  const rawMultiSelect = input.multi_select;
-  const parsedType = parseQuestionType(input.type);
-  const rawOptions = Array.isArray(input.options) ? input.options : [];
+  const rawQuestions = Array.isArray(input.questions) ? input.questions : undefined;
 
-  if (!question) throw new Error('question must be a non-empty string');
-  if (rawOptions.length === 0 && !allow_other) {
-    throw new Error('options must be a non-empty array unless allow_other is true');
+  const questions = rawQuestions
+    ? rawQuestions.map((item, index) => normalizeQuestionItem(item, index, header))
+    : [normalizeLegacyQuestion(input, header)];
+
+  if (questions.length === 0) throw new Error('questions must be a non-empty array');
+  const seenIds = new Set<string>();
+  for (const question of questions) {
+    if (seenIds.has(question.id)) throw new Error(`questions id must be unique: ${question.id}`);
+    seenIds.add(question.id);
   }
 
-  if (parsedType === 'single-answerable' && rawMultiSelect === true) {
-    throw new Error('type=single-answerable conflicts with multi_select=true');
-  }
-  if (parsedType === 'multi-answerable' && rawMultiSelect === false) {
-    throw new Error('type=multi-answerable conflicts with multi_select=false');
-  }
-
-  const options = rawOptions.map(normalizeOption);
-  const type = getNormalizedQuestionType({
-    type: parsedType,
-    multi_select: rawMultiSelect === true,
-  });
-  const multi_select = type === 'multi-answerable';
-
+  const first = questions[0]!;
   return {
     ...(header ? { header } : {}),
-    question,
-    options,
-    allow_other,
-    other_label,
-    multi_select,
-    type,
+    question: first.question,
+    options: first.options,
+    allow_other: first.allow_other,
+    other_label: first.other_label,
+    multi_select: first.multi_select,
+    type: first.type,
+    questions,
     ...(source ? { source } : {}),
     ...(session_id ? { session_id } : {}),
   };

--- a/src/question/ui.ts
+++ b/src/question/ui.ts
@@ -1,10 +1,10 @@
 import { emitKeypressEvents } from 'node:readline';
 import { createInterface as createPromptInterface } from 'node:readline/promises';
 import { stdin as defaultInput, stdout as defaultOutput } from 'node:process';
-import { injectQuestionAnswerToPane } from './renderer.js';
+import { injectQuestionAnswersToPane } from './renderer.js';
 import { markQuestionAnswered, markQuestionTerminalError, readQuestionRecord } from './state.js';
 import { isMultiAnswerableQuestion } from './types.js';
-import type { QuestionAnswer, QuestionRecord } from './types.js';
+import type { NormalizedQuestionItem, QuestionAnswer, QuestionAnswerEntry, QuestionRecord } from './types.js';
 
 interface QuestionUiInput {
   isTTY?: boolean;
@@ -24,7 +24,7 @@ interface QuestionUiDeps {
   input?: QuestionUiInput;
   output?: QuestionUiOutput;
   env?: NodeJS.ProcessEnv;
-  injectAnswerToPane?: (paneId: string, answer: QuestionAnswer) => boolean;
+  injectAnswersToPane?: (paneId: string, answers: QuestionAnswerEntry[]) => boolean;
 }
 
 interface InteractiveSelectionState {
@@ -49,32 +49,56 @@ interface QuestionOptionEntry {
   description?: string;
 }
 
-function getOptionEntries(record: QuestionRecord): QuestionOptionEntry[] {
-  const entries = record.options.map((option, index) => ({
+interface WizardState {
+  currentQuestionIndex: number;
+  selections: InteractiveSelectionState[];
+  mode: 'answering' | 'review';
+  error?: string;
+}
+
+interface WizardUpdate {
+  state: WizardState;
+  submit: boolean;
+}
+
+function recordQuestions(record: QuestionRecord): NormalizedQuestionItem[] {
+  if (record.questions?.length) return record.questions;
+  return [{
+    id: 'q-1',
+    ...(record.header ? { header: record.header } : {}),
+    question: record.question,
+    options: record.options,
+    allow_other: record.allow_other,
+    other_label: record.other_label,
+    multi_select: record.multi_select,
+    type: record.type ?? (record.multi_select ? 'multi-answerable' : 'single-answerable'),
+  }];
+}
+
+function getOptionEntries(question: Pick<NormalizedQuestionItem, 'options' | 'allow_other' | 'other_label'>): QuestionOptionEntry[] {
+  const entries = question.options.map((option, index) => ({
     label: `${index + 1}. ${option.label}`,
     description: typeof option.description === 'string' && option.description.trim()
       ? option.description.trim()
       : undefined,
   }));
-  if (record.allow_other) {
+  if (question.allow_other) {
     entries.push({
-      label: `${record.options.length + 1}. ${record.other_label}`,
+      label: `${question.options.length + 1}. ${question.other_label}`,
       description: undefined,
     });
   }
   return entries;
 }
 
-function getOptionLabels(record: QuestionRecord): string[] {
-  return getOptionEntries(record).map((entry) => entry.label);
+function getOptionLabels(question: Pick<NormalizedQuestionItem, 'options' | 'allow_other' | 'other_label'>): string[] {
+  return getOptionEntries(question).map((entry) => entry.label);
 }
 
-function renderOptions(record: QuestionRecord): string[] {
-  return getOptionEntries(record).flatMap((entry) => {
+function renderOptions(question: Pick<NormalizedQuestionItem, 'options' | 'allow_other' | 'other_label'>): string[] {
+  return getOptionEntries(question).flatMap((entry) => {
     const lines = [`  [ ] ${entry.label}`];
-    if (entry.description) {
-      lines.push(`      ${entry.description}`);
-    }
+    if (entry.description) lines.push(`      ${entry.description}`);
     return lines;
   });
 }
@@ -92,68 +116,47 @@ function parseSelection(raw: string, optionCount: number, multiSelect: boolean):
   return [...new Set(values)];
 }
 
-function buildAnswer(record: QuestionRecord, selections: number[], otherText?: string): QuestionAnswer {
-  const optionCount = record.options.length;
+function buildAnswer(question: NormalizedQuestionItem, selections: number[], otherText?: string): QuestionAnswer {
+  const optionCount = question.options.length;
   const otherIndex = optionCount + 1;
   const selectedOptions = selections
     .filter((value) => value <= optionCount)
-    .map((value) => record.options[value - 1]);
+    .map((value) => question.options[value - 1]);
   const selected_labels = selectedOptions.map((option) => option.label);
   const selected_values = selectedOptions.map((option) => option.value);
-  const includesOther = record.allow_other && selections.includes(otherIndex);
+  const includesOther = question.allow_other && selections.includes(otherIndex);
 
-  if (isMultiAnswerableQuestion(record)) {
-    const values = includesOther && otherText ? [...selected_values, otherText] : selected_values;
-    const labels = includesOther && otherText ? [...selected_labels, record.other_label] : selected_labels;
-    return {
-      kind: 'multi',
-      value: values,
-      selected_labels: labels,
-      selected_values: values,
-      ...(includesOther && otherText ? { other_text: otherText } : {}),
-    };
+  if (includesOther && !otherText) throw new Error('Other response text is required.');
+  const resolvedOtherText = includesOther ? otherText as string : undefined;
+
+  if (isMultiAnswerableQuestion(question)) {
+    const values = resolvedOtherText ? [...selected_values, resolvedOtherText] : selected_values;
+    const labels = includesOther ? [...selected_labels, question.other_label] : selected_labels;
+    return { kind: 'multi', value: values, selected_labels: labels, selected_values: values, ...(resolvedOtherText ? { other_text: resolvedOtherText } : {}) };
   }
 
   if (includesOther) {
-    if (!otherText) throw new Error('Other response text is required.');
-    return {
-      kind: 'other',
-      value: otherText,
-      selected_labels: [record.other_label],
-      selected_values: [otherText],
-      other_text: otherText,
-    };
+    return { kind: 'other', value: resolvedOtherText!, selected_labels: [question.other_label], selected_values: [resolvedOtherText!], other_text: resolvedOtherText! };
   }
 
   const selected = selectedOptions[0];
   if (!selected) throw new Error('No option selected.');
-  return {
-    kind: 'option',
-    value: selected.value,
-    selected_labels: [selected.label],
-    selected_values: [selected.value],
-  };
+  return { kind: 'option', value: selected.value, selected_labels: [selected.label], selected_values: [selected.value] };
 }
 
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-function maybeInjectAnswer(
-  record: QuestionRecord,
-  answer: QuestionAnswer,
-  deps: Pick<QuestionUiDeps, 'env' | 'injectAnswerToPane'> = {},
-): void {
+function maybeInjectAnswers(record: QuestionRecord, answers: QuestionAnswerEntry[], deps: Pick<QuestionUiDeps, 'env' | 'injectAnswersToPane'> = {}): void {
   const env = deps.env ?? process.env;
   const envTransport = safeString(env.OMX_QUESTION_RETURN_TRANSPORT).trim();
   const target = record.renderer?.return_target ?? safeString(env.OMX_QUESTION_RETURN_TARGET).trim();
   const transport = record.renderer?.return_transport ?? (envTransport === 'tmux-send-keys' ? envTransport : undefined);
   if (!target || transport !== 'tmux-send-keys') return;
   try {
-    (deps.injectAnswerToPane ?? injectQuestionAnswerToPane)(target, answer);
-  } catch {
-    // Best-effort continuation nudge only; stdout return path remains canonical.
-  }
+    (deps.injectAnswersToPane ?? injectQuestionAnswersToPane)(target, answers);
+  } catch {}
 }
 
 function supportsInteractiveArrowUi(input: QuestionUiInput, output: QuestionUiOutput): boolean {
@@ -167,27 +170,17 @@ function toggleSelection(selectedIndices: number[], index: number): number[] {
 }
 
 export function createInitialInteractiveSelectionState(): InteractiveSelectionState {
-  return {
-    cursorIndex: 0,
-    selectedIndices: [],
-  };
+  return { cursorIndex: 0, selectedIndices: [] };
 }
 
-export function applyInteractiveSelectionKey(
-  record: QuestionRecord,
-  state: InteractiveSelectionState,
-  key: KeyLike,
-): SelectionUpdate {
-  const optionCount = getOptionLabels(record).length;
+export function applyInteractiveSelectionKey(record: QuestionRecord, state: InteractiveSelectionState, key: KeyLike): SelectionUpdate {
+  const question = recordQuestions(record)[0]!;
+  const optionCount = getOptionLabels(question).length;
   if (optionCount === 0) throw new Error('Interactive question UI requires at least one selectable option.');
 
   const moveCursor = (delta: number): SelectionUpdate => ({
     submit: false,
-    state: {
-      ...state,
-      cursorIndex: (state.cursorIndex + delta + optionCount) % optionCount,
-      error: undefined,
-    },
+    state: { ...state, cursorIndex: (state.cursorIndex + delta + optionCount) % optionCount, error: undefined },
   });
 
   if (key.name === 'up') return moveCursor(-1);
@@ -197,159 +190,161 @@ export function applyInteractiveSelectionKey(
     const explicitIndex = Number.parseInt(key.sequence, 10) - 1;
     if (explicitIndex < optionCount) {
       return {
-        submit: !isMultiAnswerableQuestion(record),
-        state: {
-          ...state,
-          cursorIndex: explicitIndex,
-          selectedIndices: isMultiAnswerableQuestion(record) ? toggleSelection(state.selectedIndices, explicitIndex) : state.selectedIndices,
-          error: undefined,
-        },
+        submit: !isMultiAnswerableQuestion(question),
+        state: { ...state, cursorIndex: explicitIndex, selectedIndices: isMultiAnswerableQuestion(question) ? toggleSelection(state.selectedIndices, explicitIndex) : state.selectedIndices, error: undefined },
       };
     }
   }
 
   if (key.name === 'space') {
-    if (!isMultiAnswerableQuestion(record)) {
-      return {
-        submit: true,
-        state: {
-          ...state,
-          error: undefined,
-        },
-      };
-    }
-    return {
-      submit: false,
-      state: {
-        ...state,
-        selectedIndices: toggleSelection(state.selectedIndices, state.cursorIndex),
-        error: undefined,
-      },
-    };
+    if (!isMultiAnswerableQuestion(question)) return { submit: true, state: { ...state, error: undefined } };
+    return { submit: false, state: { ...state, selectedIndices: toggleSelection(state.selectedIndices, state.cursorIndex), error: undefined } };
   }
 
   if (key.name === 'return' || key.name === 'enter') {
-    if (!isMultiAnswerableQuestion(record)) {
-      return {
-        submit: true,
-        state: {
-          ...state,
-          error: undefined,
-        },
-      };
-    }
-    if (state.selectedIndices.length > 0) {
-      return {
-        submit: true,
-        state: {
-          ...state,
-          error: undefined,
-        },
-      };
-    }
-    return {
-      submit: false,
-      state: {
-        ...state,
-        error: 'Select one or more options with Space before pressing Enter.',
-      },
-    };
+    if (!isMultiAnswerableQuestion(question)) return { submit: true, state: { ...state, error: undefined } };
+    if (state.selectedIndices.length > 0) return { submit: true, state: { ...state, error: undefined } };
+    return { submit: false, state: { ...state, error: 'Select one or more options with Space before pressing Enter.' } };
   }
 
   return { submit: false, state };
 }
 
-export function renderInteractiveQuestionFrame(
-  record: QuestionRecord,
-  state: InteractiveSelectionState,
-): string {
-  const optionEntries = getOptionEntries(record);
+export function renderInteractiveQuestionFrame(record: QuestionRecord, state: InteractiveSelectionState): string {
+  const question = recordQuestions(record)[0]!;
+  const optionEntries = getOptionEntries(question);
   const lines: string[] = [];
 
-  if (record.header) lines.push(record.header);
-  lines.push(record.question, '');
+  if (record.header || question.header) lines.push(record.header ?? question.header ?? '');
+  lines.push(question.question, '');
 
   optionEntries.forEach((entry, index) => {
     const isActive = state.cursorIndex === index;
-    const isChecked = isMultiAnswerableQuestion(record) ? state.selectedIndices.includes(index) : isActive;
+    const isChecked = isMultiAnswerableQuestion(question) ? state.selectedIndices.includes(index) : isActive;
     lines.push(`${isActive ? '›' : ' '} [${isChecked ? 'x' : ' '}] ${entry.label}`);
-    if (entry.description) {
-      lines.push(`      ${entry.description}`);
-    }
+    if (entry.description) lines.push(`      ${entry.description}`);
   });
 
   lines.push('');
-  lines.push(
-    isMultiAnswerableQuestion(record)
-      ? 'Use ↑/↓ to move, Space to toggle, Enter to submit.'
-      : 'Use ↑/↓ to move, Enter to select.',
-  );
-
+  lines.push(isMultiAnswerableQuestion(question) ? 'Use ↑/↓ to move, Space to toggle, Enter to submit.' : 'Use ↑/↓ to move, Enter to select.');
   if (state.error) lines.push(state.error);
   return `${lines.join('\n')}\n`;
 }
 
-export async function promptForSelectionsWithArrows(
-  record: QuestionRecord,
-  deps: QuestionUiDeps = {},
-): Promise<number[]> {
+export function createInitialQuestionWizardState(record: QuestionRecord): WizardState {
+  return { currentQuestionIndex: 0, selections: recordQuestions(record).map(() => createInitialInteractiveSelectionState()), mode: 'answering' };
+}
+
+function isQuestionSelectionValid(question: NormalizedQuestionItem, state: InteractiveSelectionState): boolean {
+  return !isMultiAnswerableQuestion(question) || state.selectedIndices.length > 0;
+}
+
+function advanceWizard(record: QuestionRecord, state: WizardState): WizardState {
+  const questions = recordQuestions(record);
+  const current = questions[state.currentQuestionIndex]!;
+  if (!isQuestionSelectionValid(current, state.selections[state.currentQuestionIndex]!)) {
+    const selections = state.selections.map((item, index) => index === state.currentQuestionIndex ? { ...item, error: 'Select one or more options with Space before continuing.' } : item);
+    return { ...state, selections };
+  }
+  if (state.currentQuestionIndex >= questions.length - 1) return { ...state, mode: 'review', error: undefined };
+  return { ...state, currentQuestionIndex: state.currentQuestionIndex + 1, error: undefined };
+}
+
+export function applyQuestionWizardKey(record: QuestionRecord, state: WizardState, key: KeyLike): WizardUpdate {
+  if (state.mode === 'review') {
+    if (key.name === 'left' || key.name === 'backspace') return { submit: false, state: { ...state, mode: 'answering', currentQuestionIndex: recordQuestions(record).length - 1 } };
+    if (key.name === 'return' || key.name === 'enter') return { submit: true, state };
+    return { submit: false, state };
+  }
+
+  if (key.name === 'left' || key.name === 'backspace') {
+    return { submit: false, state: { ...state, currentQuestionIndex: Math.max(0, state.currentQuestionIndex - 1), error: undefined } };
+  }
+
+  const questions = recordQuestions(record);
+  const current = questions[state.currentQuestionIndex]!;
+  const currentSelection = state.selections[state.currentQuestionIndex]!;
+  if (key.name === 'right') return { submit: false, state: advanceWizard(record, state) };
+
+  const update = applyInteractiveSelectionKey({ ...record, ...current, questions: [current] }, currentSelection, key);
+  const nextSelections = state.selections.map((item, index) => index === state.currentQuestionIndex ? update.state : item);
+  const nextState = { ...state, selections: nextSelections };
+  if (!update.submit) return { submit: false, state: nextState };
+  return { submit: false, state: advanceWizard(record, nextState) };
+}
+
+function selectedNumbersForQuestion(question: NormalizedQuestionItem, state: InteractiveSelectionState): number[] {
+  if (isMultiAnswerableQuestion(question)) return state.selectedIndices.map((index) => index + 1);
+  return [state.cursorIndex + 1];
+}
+
+function buildAnswerEntries(record: QuestionRecord, state: WizardState, otherTexts: Array<string | undefined> = []): QuestionAnswerEntry[] {
+  return recordQuestions(record).map((question, index) => ({
+    question_id: question.id,
+    index,
+    answer: buildAnswer(question, selectedNumbersForQuestion(question, state.selections[index]!), otherTexts[index]),
+  }));
+}
+
+function formatSelectedLabels(question: NormalizedQuestionItem, state: InteractiveSelectionState): string {
+  const selections = selectedNumbersForQuestion(question, state);
+  return selections
+    .map((selection) => question.options[selection - 1]?.label ?? question.other_label)
+    .join(', ');
+}
+
+export function renderQuestionWizardFrame(record: QuestionRecord, state: WizardState): string {
+  const questions = recordQuestions(record);
+  if (state.mode === 'review') {
+    const lines = [record.header ?? 'Review answers', ''];
+    questions.forEach((question, index) => {
+      lines.push(`${index + 1}. ${questions[index]!.question}`);
+      lines.push(`   ${formatSelectedLabels(question, state.selections[index]!)}`);
+    });
+    lines.push('', 'Press Enter to submit, ←/Backspace to edit.');
+    return `${lines.join('\n')}\n`;
+  }
+
+  const question = questions[state.currentQuestionIndex]!;
+  const selection = state.selections[state.currentQuestionIndex]!;
+  const optionEntries = getOptionEntries(question);
+  const lines: string[] = [];
+  if (record.header) lines.push(record.header);
+  if (question.header && question.header !== record.header) lines.push(question.header);
+  lines.push(`Question ${state.currentQuestionIndex + 1} of ${questions.length}`);
+  lines.push(question.question, '');
+  optionEntries.forEach((entry, index) => {
+    const isActive = selection.cursorIndex === index;
+    const isChecked = isMultiAnswerableQuestion(question) ? selection.selectedIndices.includes(index) : isActive;
+    lines.push(`${isActive ? '›' : ' '} [${isChecked ? 'x' : ' '}] ${entry.label}`);
+    if (entry.description) lines.push(`      ${entry.description}`);
+  });
+  lines.push('', isMultiAnswerableQuestion(question) ? 'Use ↑/↓ to move, Space to toggle, Enter/→ to continue, ← to go back.' : 'Use ↑/↓ to move, Enter/→ to continue, ← to go back.');
+  if (selection.error || state.error) lines.push(selection.error ?? state.error ?? '');
+  return `${lines.join('\n')}\n`;
+}
+
+export async function promptForSelectionsWithArrows(record: QuestionRecord, deps: QuestionUiDeps = {}): Promise<number[]> {
   const input = deps.input ?? defaultInput;
   const output = deps.output ?? defaultOutput;
-  if (!supportsInteractiveArrowUi(input, output)) {
-    throw new Error('Interactive arrow UI requires TTY stdin/stdout with raw-mode support.');
-  }
+  if (!supportsInteractiveArrowUi(input, output)) throw new Error('Interactive arrow UI requires TTY stdin/stdout with raw-mode support.');
 
   return new Promise<number[]>((resolve, reject) => {
     let state = createInitialInteractiveSelectionState();
     let finished = false;
-
-    const cleanup = () => {
-      input.off('keypress', onKeypress);
-      input.setRawMode?.(false);
-      input.pause?.();
-      output.write('\u001b[?25h');
-    };
-
-    const finish = (selections: number[]) => {
-      if (finished) return;
-      finished = true;
-      cleanup();
-      output.write('\n');
-      resolve(selections);
-    };
-
-    const fail = (error: Error) => {
-      if (finished) return;
-      finished = true;
-      cleanup();
-      output.write('\n');
-      reject(error);
-    };
-
-    const render = () => {
-      output.write('\u001b[H\u001b[J');
-      output.write('\u001b[?25l');
-      output.write(renderInteractiveQuestionFrame(record, state));
-    };
-
+    const cleanup = () => { input.off('keypress', onKeypress); input.setRawMode?.(false); input.pause?.(); output.write('\u001b[?25h'); };
+    const finish = (selections: number[]) => { if (finished) return; finished = true; cleanup(); output.write('\n'); resolve(selections); };
+    const fail = (error: Error) => { if (finished) return; finished = true; cleanup(); output.write('\n'); reject(error); };
+    const render = () => { output.write('\u001b[H\u001b[J'); output.write('\u001b[?25l'); output.write(renderInteractiveQuestionFrame(record, state)); };
     const onKeypress = (_: string, key: KeyLike) => {
-      if (key.ctrl && key.name === 'c') {
-        fail(new Error('Question UI cancelled by user.'));
-        return;
-      }
-
+      if (key.ctrl && key.name === 'c') { fail(new Error('Question UI cancelled by user.')); return; }
       const update = applyInteractiveSelectionKey(record, state, key);
       state = update.state;
       render();
       if (!update.submit) return;
-
-      if (isMultiAnswerableQuestion(record)) {
-        finish(state.selectedIndices.map((index) => index + 1));
-        return;
-      }
-      finish([state.cursorIndex + 1]);
+      const question = recordQuestions(record)[0]!;
+      finish(isMultiAnswerableQuestion(question) ? state.selectedIndices.map((index) => index + 1) : [state.cursorIndex + 1]);
     };
-
     emitKeypressEvents(input as NodeJS.ReadableStream);
     input.setRawMode?.(true);
     input.resume?.();
@@ -358,27 +353,69 @@ export async function promptForSelectionsWithArrows(
   });
 }
 
-async function promptForSelectionsWithNumbers(
-  record: QuestionRecord,
-  deps: QuestionUiDeps = {},
-): Promise<number[]> {
+async function promptForAnswersWithArrows(record: QuestionRecord, deps: QuestionUiDeps = {}): Promise<QuestionAnswerEntry[]> {
+  const input = deps.input ?? defaultInput;
+  const output = deps.output ?? defaultOutput;
+  if (!supportsInteractiveArrowUi(input, output)) throw new Error('Interactive arrow UI requires TTY stdin/stdout with raw-mode support.');
+  return new Promise<QuestionAnswerEntry[]>((resolve, reject) => {
+    let state = createInitialQuestionWizardState(record);
+    let finished = false;
+    const cleanup = () => { input.off('keypress', onKeypress); input.setRawMode?.(false); input.pause?.(); output.write('\u001b[?25h'); };
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      output.write('\n');
+      void (async () => {
+        try {
+          const otherTexts = await promptForWizardOtherTexts(record, state, { input, output });
+          resolve(buildAnswerEntries(record, state, otherTexts));
+        } catch (error) {
+          reject(error);
+        }
+      })();
+    };
+    const fail = (error: Error) => { if (finished) return; finished = true; cleanup(); output.write('\n'); reject(error); };
+    const render = () => { output.write('\u001b[H\u001b[J'); output.write('\u001b[?25l'); output.write(renderQuestionWizardFrame(record, state)); };
+    const onKeypress = (_: string, key: KeyLike) => {
+      if (key.ctrl && key.name === 'c') { fail(new Error('Question UI cancelled by user.')); return; }
+      const update = applyQuestionWizardKey(record, state, key);
+      state = update.state;
+      render();
+      if (update.submit) finish();
+    };
+    emitKeypressEvents(input as NodeJS.ReadableStream);
+    input.setRawMode?.(true);
+    input.resume?.();
+    input.on('keypress', onKeypress);
+    render();
+  });
+}
+
+async function promptForWizardOtherTexts(record: QuestionRecord, state: WizardState, deps: QuestionUiDeps = {}): Promise<Array<string | undefined>> {
+  const otherTexts: Array<string | undefined> = [];
+  for (const [index, question] of recordQuestions(record).entries()) {
+    const selectedNumbers = selectedNumbersForQuestion(question, state.selections[index]!);
+    if (!question.allow_other || !selectedNumbers.includes(question.options.length + 1)) continue;
+    otherTexts[index] = await promptForOtherText(question.other_label, deps);
+  }
+  return otherTexts;
+}
+
+async function promptForQuestionWithNumbers(question: NormalizedQuestionItem, deps: QuestionUiDeps = {}): Promise<number[]> {
   const input = deps.input ?? defaultInput;
   const output = deps.output ?? defaultOutput;
   const rl = createPromptInterface({ input: input as NodeJS.ReadableStream, output: output as NodeJS.WritableStream });
   try {
     output.write('\n');
-    if (record.header) output.write(`${record.header}\n`);
-    output.write(`${record.question}\n\n`);
-    output.write(`${renderOptions(record).join('\n')}\n\n`);
-
-    const optionCount = record.options.length + (record.allow_other ? 1 : 0);
-    const prompt = isMultiAnswerableQuestion(record)
-      ? 'Choose one or more options by number (comma-separated): '
-      : 'Choose an option by number: ';
-
+    if (question.header) output.write(`${question.header}\n`);
+    output.write(`${question.question}\n\n`);
+    output.write(`${renderOptions(question).join('\n')}\n\n`);
+    const optionCount = question.options.length + (question.allow_other ? 1 : 0);
+    const prompt = isMultiAnswerableQuestion(question) ? 'Choose one or more options by number (comma-separated): ' : 'Choose an option by number: ';
     let selections: number[] | null = null;
     while (!selections) {
-      selections = parseSelection(await rl.question(prompt), optionCount, isMultiAnswerableQuestion(record));
+      selections = parseSelection(await rl.question(prompt), optionCount, isMultiAnswerableQuestion(question));
       if (!selections) output.write('Invalid selection. Please try again.\n');
     }
     return selections;
@@ -387,10 +424,7 @@ async function promptForSelectionsWithNumbers(
   }
 }
 
-async function promptForOtherText(
-  label: string,
-  deps: QuestionUiDeps = {},
-): Promise<string> {
+async function promptForOtherText(label: string, deps: QuestionUiDeps = {}): Promise<string> {
   const input = deps.input ?? defaultInput;
   const output = deps.output ?? defaultOutput;
   const rl = createPromptInterface({ input: input as NodeJS.ReadableStream, output: output as NodeJS.WritableStream });
@@ -405,36 +439,45 @@ async function promptForOtherText(
   }
 }
 
+async function promptForAnswersWithNumbers(record: QuestionRecord, deps: QuestionUiDeps = {}): Promise<QuestionAnswerEntry[]> {
+  const entries: QuestionAnswerEntry[] = [];
+  for (const [index, question] of recordQuestions(record).entries()) {
+    const selections = await promptForQuestionWithNumbers(question, deps);
+    let otherText: string | undefined;
+    if (question.allow_other && selections.includes(question.options.length + 1)) otherText = await promptForOtherText(question.other_label, deps);
+    entries.push({ question_id: question.id, index, answer: buildAnswer(question, selections, otherText) });
+  }
+  return entries;
+}
+
 export async function runQuestionUi(recordPath: string, deps: QuestionUiDeps = {}): Promise<void> {
   const record = await readQuestionRecord(recordPath);
   if (!record) throw new Error(`Question record not found: ${recordPath}`);
-
   const input = deps.input ?? defaultInput;
   const output = deps.output ?? defaultOutput;
 
   try {
-    const selections = supportsInteractiveArrowUi(input, output)
-      ? await promptForSelectionsWithArrows(record, { input, output })
-      : await promptForSelectionsWithNumbers(record, { input, output });
-
-    let otherText: string | undefined;
-    if (record.allow_other && selections.includes(record.options.length + 1)) {
-      otherText = await promptForOtherText(record.other_label, { input, output });
+    const questions = recordQuestions(record);
+    let answers: QuestionAnswerEntry[];
+    if (questions.length === 1) {
+      const question = questions[0]!;
+      const selections = supportsInteractiveArrowUi(input, output)
+        ? await promptForSelectionsWithArrows(record, { input, output })
+        : await promptForQuestionWithNumbers(question, { input, output });
+      let otherText: string | undefined;
+      if (question.allow_other && selections.includes(question.options.length + 1)) {
+        otherText = await promptForOtherText(question.other_label, { input, output });
+      }
+      answers = [{ question_id: question.id, index: 0, answer: buildAnswer(question, selections, otherText) }];
+    } else {
+      answers = supportsInteractiveArrowUi(input, output)
+        ? await promptForAnswersWithArrows(record, { input, output })
+        : await promptForAnswersWithNumbers(record, { input, output });
     }
-
-    const answer = buildAnswer(record, selections, otherText);
-    const answeredRecord = await markQuestionAnswered(recordPath, answer);
-    maybeInjectAnswer(answeredRecord, answer, {
-      env: deps.env,
-      injectAnswerToPane: deps.injectAnswerToPane,
-    });
+    const answeredRecord = await markQuestionAnswered(recordPath, answers);
+    maybeInjectAnswers(answeredRecord, answers, { env: deps.env, injectAnswersToPane: deps.injectAnswersToPane });
   } catch (error) {
-    await markQuestionTerminalError(
-      recordPath,
-      'error',
-      'question_ui_failed',
-      error instanceof Error ? error.message : String(error),
-    );
+    await markQuestionTerminalError(recordPath, 'error', 'question_ui_failed', error instanceof Error ? error.message : String(error));
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
- add batch-native omx question normalization, records, and success payloads with legacy single-question projections
- render questions in a large adaptive leader-targeted tmux split with arrow navigation, back-edit, review, and auto-disappearing flow
- return all batch answers through state/stdout and tmux answer injection

## Review / QA
- code-reviewer: APPROVE
- architect: CLEAR
- UltraQA complete after 2 cycles

## Tested
- npm run build
- targeted compiled tests: 85/85 passed
- npx tsc --noEmit --pretty false
- git diff --check
- npm run lint
- npm run check:no-unused
- live omx question batch panel demo

## Notes
- Full test:ci:compiled was not rerun after final fixes; an earlier full run had an unrelated notify-fallback watcher flake that passed in focused rerun.
