### PR TITLE
Warn for oversized gpt-5.5 context settings

### DIFF
--- a/src/cli/__tests__/doctor-context-window-warning.test.ts
+++ b/src/cli/__tests__/doctor-context-window-warning.test.ts
@@ -1,0 +1,151 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {},
+): { status: number | null; stdout: string; stderr: string; error?: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
+  const r = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
+  });
+  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error?.message };
+}
+
+function shouldSkipForSpawnPermissions(err?: string): boolean {
+  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+async function withConfig(
+  config: string,
+  fn: (args: { wd: string; home: string; codexDir: string; configPath: string }) => Promise<void>,
+): Promise<void> {
+  const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-context-window-'));
+  try {
+    const home = join(wd, 'home');
+    const codexDir = join(home, '.codex');
+    const configPath = join(codexDir, 'config.toml');
+    await mkdir(codexDir, { recursive: true });
+    await writeFile(configPath, config.trimStart());
+    await fn({ wd, home, codexDir, configPath });
+  } finally {
+    await rm(wd, { recursive: true, force: true });
+  }
+}
+
+function assertNoUnsupportedLimitClaim(stdout: string): void {
+  assert.doesNotMatch(stdout, /hard limit/i);
+  assert.doesNotMatch(stdout, /API[- ]?vs[- ]?Codex/i);
+  assert.doesNotMatch(stdout, /Codex context limit/i);
+}
+
+describe('omx doctor model context recommendation warning', () => {
+  it('warns when gpt-5.5 model_context_window exceeds the OMX setup recommendation', async () => {
+    await withConfig(
+      `
+model = "gpt-5.5"
+model_context_window = 1000000
+model_auto_compact_token_limit = 200000
+`,
+      async ({ wd, home, codexDir, configPath }) => {
+        const before = await readFile(configPath, 'utf-8');
+        const res = runOmx(wd, ['doctor'], { HOME: home, CODEX_HOME: codexDir });
+        if (shouldSkipForSpawnPermissions(res.error)) return;
+
+        assert.equal(res.status, 0, res.stderr || res.stdout);
+        assert.match(res.stdout, /\[!!\] Model context recommendation:/);
+        assert.match(res.stdout, /model_context_window=1000000/);
+        assert.match(res.stdout, /OMX setup recommendation/);
+        assert.match(res.stdout, /250000 \/ 200000/);
+        assertNoUnsupportedLimitClaim(res.stdout);
+        assert.equal(await readFile(configPath, 'utf-8'), before);
+      },
+    );
+  });
+
+  it('warns when gpt-5.5 model_auto_compact_token_limit exceeds the OMX setup recommendation', async () => {
+    await withConfig(
+      `
+model = "gpt-5.5"
+model_context_window = 250000
+model_auto_compact_token_limit = 900000
+`,
+      async ({ wd, home, codexDir, configPath }) => {
+        const before = await readFile(configPath, 'utf-8');
+        const res = runOmx(wd, ['doctor'], { HOME: home, CODEX_HOME: codexDir });
+        if (shouldSkipForSpawnPermissions(res.error)) return;
+
+        assert.equal(res.status, 0, res.stderr || res.stdout);
+        assert.match(res.stdout, /\[!!\] Model context recommendation:/);
+        assert.match(res.stdout, /model_auto_compact_token_limit=900000/);
+        assert.match(res.stdout, /OMX setup recommendation/);
+        assert.match(res.stdout, /250000 \/ 200000/);
+        assertNoUnsupportedLimitClaim(res.stdout);
+        assert.equal(await readFile(configPath, 'utf-8'), before);
+      },
+    );
+  });
+
+  it('warns with both oversized gpt-5.5 context settings in the same message', async () => {
+    await withConfig(
+      `
+model = "gpt-5.5"
+model_context_window = 1000000
+model_auto_compact_token_limit = 900000
+`,
+      async ({ wd, home, codexDir }) => {
+        const res = runOmx(wd, ['doctor'], { HOME: home, CODEX_HOME: codexDir });
+        if (shouldSkipForSpawnPermissions(res.error)) return;
+
+        assert.equal(res.status, 0, res.stderr || res.stdout);
+        assert.match(res.stdout, /model_context_window=1000000/);
+        assert.match(res.stdout, /model_auto_compact_token_limit=900000/);
+        assertNoUnsupportedLimitClaim(res.stdout);
+      },
+    );
+  });
+
+  it('does not warn when gpt-5.5 context settings match the OMX setup recommendation', async () => {
+    await withConfig(
+      `
+model = "gpt-5.5"
+model_context_window = 250000
+model_auto_compact_token_limit = 200000
+`,
+      async ({ wd, home, codexDir }) => {
+        const res = runOmx(wd, ['doctor'], { HOME: home, CODEX_HOME: codexDir });
+        if (shouldSkipForSpawnPermissions(res.error)) return;
+
+        assert.equal(res.status, 0, res.stderr || res.stdout);
+        assert.doesNotMatch(res.stdout, /Model context recommendation/);
+      },
+    );
+  });
+
+  it('does not apply the gpt-5.5 recommendation warning to other models', async () => {
+    await withConfig(
+      `
+model = "o3"
+model_context_window = 1000000
+model_auto_compact_token_limit = 900000
+`,
+      async ({ wd, home, codexDir }) => {
+        const res = runOmx(wd, ['doctor'], { HOME: home, CODEX_HOME: codexDir });
+        if (shouldSkipForSpawnPermissions(res.error)) return;
+
+        assert.equal(res.status, 0, res.stderr || res.stdout);
+        assert.doesNotMatch(res.stdout, /Model context recommendation/);
+      },
+    );
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -26,7 +26,10 @@ import {
 	EXPLORE_BIN_ENV,
 } from "./explore.js";
 import { getPackageRoot } from "../utils/package.js";
-import { hasLegacyOmxTeamRunTable } from "../config/generator.js";
+import {
+	hasLegacyOmxTeamRunTable,
+	getModelContextRecommendation,
+} from "../config/generator.js";
 import { getMissingManagedCodexHookEvents } from "../config/codex-hooks.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { getDefaultBridge, isBridgeEnabled } from "../runtime/bridge.js";
@@ -154,6 +157,12 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
 	// Check 4: Config file
 	checks.push(await checkConfig(paths.configPath));
+
+	// Check 4.1: Model context recommendation
+	const contextRecommendationCheck = await checkModelContextRecommendation(
+		paths.configPath,
+	);
+	if (contextRecommendationCheck) checks.push(contextRecommendationCheck);
 
 	// Check 4.25: Native hooks coverage
 	checks.push(await checkNativeHooks(paths.hooksPath, paths.configPath));
@@ -776,6 +785,65 @@ async function checkConfig(configPath: string): Promise<Check> {
 			status: "fail",
 			message: "cannot read config.toml",
 		};
+	}
+}
+
+function formatContextRecommendationWarning(
+	configuredValues: string[],
+	recommendedContextWindow: number,
+	recommendedAutoCompactLimit: number,
+): string {
+	return `${configuredValues.join(
+		", ",
+	)} exceeds the OMX setup recommendation for gpt-5.5 (${recommendedContextWindow} / ${recommendedAutoCompactLimit}); doctor does not rewrite user config, so lower these values or verify your active Codex runtime/provider behavior if this customization is intentional`;
+}
+
+async function checkModelContextRecommendation(
+	configPath: string,
+): Promise<Check | null> {
+	if (!existsSync(configPath)) return null;
+
+	try {
+		const content = await readFile(configPath, "utf-8");
+		const parsed = parseToml(content) as Record<string, unknown>;
+		const model = parsed.model;
+		if (typeof model !== "string") return null;
+
+		const recommendation = getModelContextRecommendation(model);
+		if (!recommendation) return null;
+
+		const configuredValues: string[] = [];
+		const contextWindow = parsed.model_context_window;
+		if (
+			typeof contextWindow === "number" &&
+			contextWindow > recommendation.modelContextWindow
+		) {
+			configuredValues.push(`model_context_window=${contextWindow}`);
+		}
+
+		const autoCompactLimit = parsed.model_auto_compact_token_limit;
+		if (
+			typeof autoCompactLimit === "number" &&
+			autoCompactLimit > recommendation.modelAutoCompactTokenLimit
+		) {
+			configuredValues.push(
+				`model_auto_compact_token_limit=${autoCompactLimit}`,
+			);
+		}
+
+		if (configuredValues.length === 0) return null;
+
+		return {
+			name: "Model context recommendation",
+			status: "warn",
+			message: formatContextRecommendationWarning(
+				configuredValues,
+				recommendation.modelContextWindow,
+				recommendation.modelAutoCompactTokenLimit,
+			),
+		};
+	} catch {
+		return null;
 	}
 }
 

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -45,9 +45,27 @@ const OMX_TOP_LEVEL_KEYS = [
   "developer_instructions",
 ] as const;
 
-const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
-const DEFAULT_SETUP_MODEL_CONTEXT_WINDOW = 250000;
-const DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT = 200000;
+export interface ModelContextRecommendation {
+  model: string;
+  modelContextWindow: number;
+  modelAutoCompactTokenLimit: number;
+}
+
+export const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
+export const DEFAULT_SETUP_MODEL_CONTEXT_WINDOW = 250000;
+export const DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT = 200000;
+
+export function getModelContextRecommendation(
+  model: string,
+): ModelContextRecommendation | null {
+  if (model !== DEFAULT_SETUP_MODEL) return null;
+
+  return {
+    model,
+    modelContextWindow: DEFAULT_SETUP_MODEL_CONTEXT_WINDOW,
+    modelAutoCompactTokenLimit: DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT,
+  };
+}
 const OMX_SEEDED_BEHAVIORAL_DEFAULTS_START_MARKER =
   "# oh-my-codex seeded behavioral defaults (uninstall removes unchanged defaults)";
 const OMX_SEEDED_BEHAVIORAL_DEFAULTS_END_MARKER =


### PR DESCRIPTION
## Summary
- Add a non-destructive `omx doctor` warning when `gpt-5.5` configs exceed OMX's setup recommendation for context settings (`250000 / 200000`).
- Preserve explicit user config values; doctor only reports and does not rewrite or clamp.
- Keep the warning framed as an OMX setup recommendation, not a Codex/API hard limit claim.

Refs #2018

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/doctor-context-window-warning.test.js dist/cli/__tests__/doctor-invalid-config.test.js dist/config/__tests__/generator-idempotent.test.js dist/config/__tests__/generator-notify.test.js`
- `npx biome lint src/cli/doctor.ts src/config/generator.ts src/cli/__tests__/doctor-context-window-warning.test.ts`
- `npx tsc -p tsconfig.json --noEmit`
- Manual doctor smoke confirmed the warning appears for `1000000 / 900000` and leaves config unchanged.
