### PR TITLE
Fix Ralph Stop session ownership leak

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5654,6 +5654,101 @@ esac
     }
   });
 
+  it("does not block a question-only pane from Ralph state owned by another Codex session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-question-pane-"));
+    const previousTmuxPane = process.env.TMUX_PANE;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const questionSessionId = "sess-question-pane";
+      const questionNativeSessionId = "codex-question-pane";
+      await mkdir(join(stateDir, "sessions", questionSessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: questionSessionId,
+        native_session_id: questionNativeSessionId,
+        cwd,
+      });
+      await writeJson(join(stateDir, "sessions", questionSessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: questionSessionId,
+        owner_omx_session_id: "sess-ralph-owner",
+        owner_codex_session_id: "codex-ralph-owner",
+        thread_id: "thread-ralph-owner",
+        tmux_pane_id: "%41",
+      });
+
+      process.env.TMUX_PANE = "%99";
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: questionNativeSessionId,
+          thread_id: "thread-question-pane",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      if (typeof previousTmuxPane === "string") process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks same-session Ralph Stop continuation when ownership identifiers match", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-owned-session-"));
+    const previousTmuxPane = process.env.TMUX_PANE;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const omxSessionId = "sess-ralph-owned";
+      const nativeSessionId = "codex-ralph-owned";
+      await mkdir(join(stateDir, "sessions", omxSessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: omxSessionId,
+        native_session_id: nativeSessionId,
+        cwd,
+      });
+      await writeJson(join(stateDir, "sessions", omxSessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: omxSessionId,
+        owner_omx_session_id: omxSessionId,
+        owner_codex_session_id: nativeSessionId,
+        thread_id: "thread-ralph-owned",
+        tmux_pane_id: "%42",
+      });
+
+      process.env.TMUX_PANE = "%42";
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: nativeSessionId,
+          thread_id: "thread-ralph-owned",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX Ralph is still active (phase: executing; state: .omx/state/sessions/sess-ralph-owned/ralph-state.json); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ralph_executing",
+        systemMessage:
+          "OMX Ralph is still active (phase: executing; state: .omx/state/sessions/sess-ralph-owned/ralph-state.json); continue the task and gather fresh verification evidence before stopping.",
+      });
+    } finally {
+      if (typeof previousTmuxPane === "string") process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("prefers canonical run-state terminal lifecycle before stale session Ralph state during Stop", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-canonical-run-state-ralph-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -444,8 +444,57 @@ interface ActiveRalphStopState {
   path: string;
 }
 
+interface RalphStopOwnershipContext {
+  sessionId: string;
+  payloadSessionId: string;
+  threadId: string;
+  currentNativeSessionId: string;
+  tmuxPaneId: string;
+}
+
 function isRalphStartingPhase(state: Record<string, unknown>): boolean {
   return safeString(state.current_phase ?? state.currentPhase).trim().toLowerCase() === "starting";
+}
+
+function hasValue(values: string[], value: string): boolean {
+  return value !== "" && values.some((candidate) => candidate === value);
+}
+
+function activeRalphStateMatchesStopOwner(
+  state: Record<string, unknown>,
+  context: RalphStopOwnershipContext,
+): boolean {
+  const ownerOmxSessionId = safeString(state.owner_omx_session_id).trim();
+  if (ownerOmxSessionId && ownerOmxSessionId !== context.sessionId) {
+    return false;
+  }
+
+  const stateSessionId = safeString(state.session_id).trim();
+  if (!ownerOmxSessionId && stateSessionId && stateSessionId !== context.sessionId) {
+    return false;
+  }
+
+  const codexOwnerSessionId = safeString(state.owner_codex_session_id).trim();
+  if (codexOwnerSessionId) {
+    const stopCodexSessionIds = [
+      context.payloadSessionId,
+      context.currentNativeSessionId,
+      context.sessionId,
+    ].filter(Boolean);
+    if (!hasValue(stopCodexSessionIds, codexOwnerSessionId)) return false;
+  }
+
+  const stateThreadId = safeString(state.owner_codex_thread_id ?? state.thread_id).trim();
+  if (stateThreadId && context.threadId && stateThreadId !== context.threadId) {
+    return false;
+  }
+
+  const statePaneId = safeString(state.tmux_pane_id).trim();
+  if (statePaneId && context.tmuxPaneId && statePaneId !== context.tmuxPaneId) {
+    return false;
+  }
+
+  return true;
 }
 
 function shouldHonorCanonicalTerminalRunState(
@@ -481,6 +530,11 @@ async function isVisibleRalphActiveForSession(cwd: string, sessionId: string): P
 async function readActiveRalphState(
   stateDir: string,
   preferredSessionId?: string,
+  ownerContext?: {
+    payloadSessionId?: string;
+    threadId?: string;
+    tmuxPaneId?: string;
+  },
 ): Promise<ActiveRalphStopState | null> {
   const cwd = resolve(stateDir, "..", "..");
   const [rawSessionInfo, usableSessionInfo] = await Promise.all([
@@ -488,6 +542,7 @@ async function readActiveRalphState(
     readUsableSessionState(cwd),
   ]);
   const currentOmxSessionId = safeString(usableSessionInfo?.session_id).trim();
+  const currentNativeSessionId = safeString(usableSessionInfo?.native_session_id).trim();
   const staleCurrentSessionId = rawSessionInfo && !isSessionStateUsable(rawSessionInfo, cwd)
     ? safeString(rawSessionInfo.session_id).trim()
     : "";
@@ -515,7 +570,17 @@ async function readActiveRalphState(
     ) {
       continue;
     }
-    if (sessionScoped?.active === true && shouldContinueRun(sessionScoped)) {
+    if (
+      sessionScoped?.active === true
+      && shouldContinueRun(sessionScoped)
+      && activeRalphStateMatchesStopOwner(sessionScoped, {
+        sessionId,
+        payloadSessionId: safeString(ownerContext?.payloadSessionId).trim(),
+        threadId: safeString(ownerContext?.threadId).trim(),
+        currentNativeSessionId,
+        tmuxPaneId: safeString(ownerContext?.tmuxPaneId).trim(),
+      })
+    ) {
       return { state: sessionScoped, path: sessionScopedPath };
     }
   }
@@ -1865,7 +1930,11 @@ async function buildStopHookOutput(
   const threadId = readPayloadThreadId(payload);
   const execFollowupOutput = await buildExecFollowupStopOutput(cwd, canonicalSessionId);
   if (execFollowupOutput) return execFollowupOutput;
-  const ralphState = await readActiveRalphState(stateDir, canonicalSessionId);
+  const ralphState = await readActiveRalphState(stateDir, canonicalSessionId, {
+    payloadSessionId: sessionId,
+    threadId,
+    tmuxPaneId: safeString(process.env.TMUX_PANE).trim(),
+  });
   if (!ralphState) {
     const autoresearchState = await readActiveAutoresearchState(cwd, canonicalSessionId);
     if (autoresearchState) {


### PR DESCRIPTION
## Summary
- Scope Ralph native Stop continuation to matching OMX/native/thread/pane ownership when identifiers are present
- Fail closed on mismatched owner state so question-only panes in the same project do not inherit Ralph continuation
- Add regression coverage for cross-session leakage and same-session continuation

Fixes #2023.

## Verification
- npm install
- npm run build
- npm run lint
- node --test dist/scripts/__tests__/codex-native-hook.test.js

## Notes
- Did not commit `.clawhip/`.
- Live Zellij pane integration not tested locally.