### PR TITLE
Avoid duplicate generated AGENTS instructions

### DIFF
--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -21,6 +21,11 @@ import {
   removeSessionModelInstructionsFile,
   sessionModelInstructionsPath,
 } from "../agents-overlay.js";
+import {
+  OMX_GENERATED_AGENTS_MARKER,
+  OMX_MANAGED_AGENTS_END_MARKER,
+  OMX_MANAGED_AGENTS_START_MARKER,
+} from "../../utils/agents-md.js";
 
 const RUNTIME_START = "<!-- OMX:RUNTIME:START -->";
 const RUNTIME_END = "<!-- OMX:RUNTIME:END -->";
@@ -791,6 +796,94 @@ describe("session-scoped model instructions file", () => {
 
     assert.ok(sessionContent.includes("<!-- OMX:RUNTIME:START -->"));
     assert.ok(sessionContent.includes("<!-- OMX:RUNTIME:END -->"));
+    assert.doesNotMatch(sessionContent, /omx:generated:agents-md/);
+  });
+
+  it("omits pure generated OMX project AGENTS from the session model instructions file", async () => {
+    await mkdir(join(tempDir, "home", ".codex"), { recursive: true });
+    await rm(join(tempDir, "home", ".codex", "AGENTS.md"), { force: true });
+    await writeFile(
+      join(tempDir, "AGENTS.md"),
+      [
+        "<!-- AUTONOMY DIRECTIVE — DO NOT REMOVE -->",
+        "YOU ARE AN AUTONOMOUS CODING AGENT.",
+        "<!-- END AUTONOMY DIRECTIVE -->",
+        OMX_GENERATED_AGENTS_MARKER,
+        "",
+        "# oh-my-codex - Intelligent Multi-Agent Orchestration",
+        "",
+        "Generated orchestration brain.",
+      ].join("\n"),
+    );
+
+    const overlay = await generateOverlay(tempDir, "session-generated");
+    const writtenPath = await writeSessionModelInstructionsFile(
+      tempDir,
+      "session-generated",
+      overlay,
+    );
+    const sessionContent = await readFile(writtenPath, "utf-8");
+
+    assert.doesNotMatch(sessionContent, /Generated orchestration brain/);
+    assert.doesNotMatch(sessionContent, /omx:generated:agents-md/);
+    assert.match(sessionContent, /<!-- OMX:RUNTIME:START -->/);
+  });
+
+  it("preserves real unmarked project AGENTS guidance distinct from generated session AGENTS", async () => {
+    await mkdir(join(tempDir, "home", ".codex"), { recursive: true });
+    await rm(join(tempDir, "home", ".codex", "AGENTS.md"), { force: true });
+    await writeFile(
+      join(tempDir, "AGENTS.md"),
+      "# Real project AGENTS\n\nPreserve this project guidance.\n",
+    );
+
+    const overlay = await generateOverlay(tempDir, "session-real-project");
+    const writtenPath = await writeSessionModelInstructionsFile(
+      tempDir,
+      "session-real-project",
+      overlay,
+    );
+    const sessionContent = await readFile(writtenPath, "utf-8");
+
+    assert.match(sessionContent, /# Real project AGENTS/);
+    assert.match(sessionContent, /Preserve this project guidance\./);
+    assert.match(sessionContent, /<!-- OMX:RUNTIME:START -->/);
+  });
+
+  it("strips only generated OMX managed blocks from merged AGENTS files", async () => {
+    await mkdir(join(tempDir, "home", ".codex"), { recursive: true });
+    await rm(join(tempDir, "home", ".codex", "AGENTS.md"), { force: true });
+    await writeFile(
+      join(tempDir, "AGENTS.md"),
+      [
+        "# Team AGENTS",
+        "",
+        "Preserve header guidance.",
+        "",
+        OMX_MANAGED_AGENTS_START_MARKER,
+        OMX_GENERATED_AGENTS_MARKER,
+        "# oh-my-codex - Intelligent Multi-Agent Orchestration",
+        "Generated managed block.",
+        OMX_MANAGED_AGENTS_END_MARKER,
+        "",
+        "Preserve footer guidance.",
+      ].join("\n"),
+    );
+
+    const overlay = await generateOverlay(tempDir, "session-merged-project");
+    const writtenPath = await writeSessionModelInstructionsFile(
+      tempDir,
+      "session-merged-project",
+      overlay,
+    );
+    const sessionContent = await readFile(writtenPath, "utf-8");
+
+    assert.match(sessionContent, /# Team AGENTS/);
+    assert.match(sessionContent, /Preserve header guidance\./);
+    assert.match(sessionContent, /Preserve footer guidance\./);
+    assert.doesNotMatch(sessionContent, /Generated managed block/);
+    assert.doesNotMatch(sessionContent, /omx:generated:agents-md/);
+    assert.match(sessionContent, /<!-- OMX:RUNTIME:START -->/);
   });
 
   it("removes session-scoped file without touching project AGENTS.md", async () => {

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -40,6 +40,11 @@ import {
   listActiveSkills,
   readVisibleSkillActiveState,
 } from "../state/skill-active.js";
+import {
+  OMX_GENERATED_AGENTS_MARKER,
+  OMX_MANAGED_AGENTS_END_MARKER,
+  OMX_MANAGED_AGENTS_START_MARKER,
+} from "../utils/agents-md.js";
 
 const START_MARKER = "<!-- OMX:RUNTIME:START -->";
 const END_MARKER = "<!-- OMX:RUNTIME:END -->";
@@ -627,6 +632,30 @@ function dropShadowedSkillReferenceLines(
   return keptLines.join("\n");
 }
 
+function stripOmxManagedAgentsBlocks(content: string): string {
+  let next = content;
+
+  while (true) {
+    const startIndex = next.indexOf(OMX_MANAGED_AGENTS_START_MARKER);
+    if (startIndex < 0) return next;
+
+    const endIndex = next.indexOf(
+      OMX_MANAGED_AGENTS_END_MARKER,
+      startIndex + OMX_MANAGED_AGENTS_START_MARKER.length,
+    );
+    if (endIndex < 0) return next;
+
+    const replaceEnd = endIndex + OMX_MANAGED_AGENTS_END_MARKER.length;
+    next = `${next.slice(0, startIndex)}${next.slice(replaceEnd)}`;
+  }
+}
+
+function stripGeneratedOmxAgentsForSession(content: string): string {
+  const withoutManagedBlocks = stripOmxManagedAgentsBlocks(content).trim();
+  if (withoutManagedBlocks.includes(OMX_GENERATED_AGENTS_MARKER)) return "";
+  return withoutManagedBlocks;
+}
+
 /**
  * Build a session-scoped AGENTS.md that combines user-level CODEX_HOME
  * instructions, project instructions (if any), and the runtime overlay,
@@ -656,6 +685,7 @@ export async function writeSessionModelInstructionsFile(
 
     let content = await readFile(sourcePath, "utf-8");
     content = stripOverlayContent(content).trim();
+    content = stripGeneratedOmxAgentsForSession(content);
     if (sourcePath === join(codexHome(), "AGENTS.md")) {
       content = dropShadowedSkillReferenceLines(
         content,


### PR DESCRIPTION
## Summary\n- Strip OMX-generated/managed AGENTS content when composing the session-scoped model instructions file\n- Preserve real unmarked project/user AGENTS guidance and user text around managed blocks\n- Add regression coverage for empty/minimal sessions, pure generated AGENTS suppression, real project AGENTS preservation, and merged managed-block stripping\n\nFixes #2025.\n\n## Verification\n- npm install\n- npm run build\n- npm run lint\n- node --test dist/hooks/__tests__/agents-overlay.test.js\n- node --test dist/hooks/__tests__/agents-overlay.test.js dist/cli/__tests__/index.test.js