### PR TITLE
Guard sloppy fallback PreToolUse framing

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2420,6 +2420,115 @@ esac
     }
   });
 
+  it("warns on PreToolUse for vague sloppy fallback implementation framing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-slop-warn-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-slop-warn",
+          tool_input: {
+            command: [
+              "cat > src/runtime.ts <<'EOF'",
+              "export function loadRuntime() {",
+              "  // implement a quick hack fallback if it fails",
+              "  return process.env.RUNTIME || 'local';",
+              "}",
+              "EOF",
+            ].join("\n"),
+          },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, undefined);
+      assert.equal((result.outputJson as { hookSpecificOutput?: { hookEventName?: string } } | null)?.hookSpecificOutput?.hookEventName, "PreToolUse");
+      assert.match(JSON.stringify(result.outputJson), /don't make potential slop/);
+      assert.match(JSON.stringify(result.outputJson), /architect/);
+      assert.match(JSON.stringify(result.outputJson), /environment issue/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not warn on PreToolUse for read-only fallback text inspection", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-slop-readonly-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-slop-readonly",
+          tool_input: { command: "rg \"quick hack fallback if it fails\" src docs" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not warn on PreToolUse for grounded compatibility fallback code", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-slop-grounded-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-slop-grounded",
+          tool_input: {
+            command: [
+              "cat > src/compat.ts <<'EOF'",
+              "export function resolveCompatMode() {",
+              "  // temporary fallback because legacy compatibility needs fail-safe startup behavior",
+              "  return 'legacy';",
+              "}",
+              "// Tested: npm test",
+              "EOF",
+            ].join("\n"),
+          },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps git commit Lore enforcement ahead of sloppy fallback advisory", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-slop-git-priority-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-slop-git-priority",
+          tool_input: { command: 'git commit -m "quick hack fallback if it fails"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /Lore protocol/);
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /don't make potential slop/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks PreToolUse git commit with supported response shape when the inline message is not Lore-compliant", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-invalid-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2475,6 +2475,38 @@ esac
     }
   });
 
+  it("warns when a read-only command is chained before sloppy fallback writes", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-slop-chained-write-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-slop-chained-write",
+          tool_input: {
+            command: [
+              "rg foo src && cat > src/runtime.ts <<EOF",
+              "export function loadRuntime() {",
+              "  // implement quick hack fallback if it fails",
+              "  return 'local';",
+              "}",
+              "EOF",
+            ].join("\n"),
+          },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, undefined);
+      assert.equal((result.outputJson as { hookSpecificOutput?: { hookEventName?: string } } | null)?.hookSpecificOutput?.hookEventName, "PreToolUse");
+      assert.match(JSON.stringify(result.outputJson), /don't make potential slop/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not warn on PreToolUse for grounded compatibility fallback code", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-slop-grounded-"));
     try {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -616,6 +616,124 @@ function buildDocumentRefreshPreToolUseOutput(
   return buildDocumentRefreshAdvisoryOutput(warning, "PreToolUse");
 }
 
+
+const SLOPPY_FALLBACK_PHRASE_PATTERNS = [
+  /\bquick hack\b/i,
+  /\bhacky\b/i,
+  /\bworkaround for now\b/i,
+  /\btemporary workaround\b/i,
+  /\btemporary fallback\b/i,
+  /\bjust bypass\b/i,
+  /\bjust skip\b/i,
+  /\bskip (?:the )?(?:failing )?(?:test|validation|checks?)\b/i,
+  /\bfallback if (?:it|this|that) fails\b/i,
+  /\bfor now,? just\b/i,
+  /\bbypass (?:the )?(?:failing )?(?:test|validation|checks?)\b/i,
+] as const;
+
+const SLOPPY_FALLBACK_IMPLEMENTATION_CONTEXT_PATTERNS = [
+  /\badd\b/i,
+  /\bimplement\b/i,
+  /\bpatch\b/i,
+  /\bwrite\b/i,
+  /\bchange\b/i,
+  /\bfix\b/i,
+  /\bbypass\b/i,
+  /\bfallback\b/i,
+  /\bworkaround\b/i,
+  /\bskip\b/i,
+  /\bdisable\b/i,
+] as const;
+
+const SLOPPY_FALLBACK_GROUNDING_PATTERNS = [
+  /\btested\b/i,
+  /\btests? pass(?:ed)?\b/i,
+  /\bnpm (?:run )?test\b/i,
+  /\bnode --test\b/i,
+  /\bunit tests?\b/i,
+  /\bintegration tests?\b/i,
+  /\bregression tests?\b/i,
+  /\bcoverage\b/i,
+  /\bspec(?:ification)?\b/i,
+  /\bADR\b/,
+  /\barchitecture\b/i,
+  /\barchitect\b/i,
+  /\bdesign\b/i,
+  /\bbecause\b/i,
+  /\bcompatib(?:le|ility)\b/i,
+  /\bbackward-compatible\b/i,
+  /\bfail-safe\b/i,
+  /\bfailsafe\b/i,
+  /\benvironment issue\b/i,
+  /\benv(?:ironment)? problem\b/i,
+  /\buser approved\b/i,
+  /\bapproved by (?:the )?user\b/i,
+  /(?:^|\s)#\d+\b/,
+  /\bPR\s*#?\d+\b/i,
+] as const;
+
+const READ_ONLY_COMMAND_TOKENS = new Set([
+  "cat",
+  "find",
+  "grep",
+  "head",
+  "less",
+  "ls",
+  "rg",
+  "sed",
+  "tail",
+]);
+
+function commandStartsWithReadOnlyInspection(command: string): boolean {
+  const tokens = tokenizeShellCommand(command);
+  if (!tokens || tokens.length === 0) return false;
+  let commandToken = tokens[0] ?? "";
+  if (commandToken === "env") {
+    const nextCommand = tokens.find((token, index) => index > 0 && !token.startsWith("-") && !isInlineShellEnvAssignment(token));
+    commandToken = nextCommand ?? commandToken;
+  }
+  const basename = commandToken.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? commandToken.toLowerCase();
+  if (!READ_ONLY_COMMAND_TOKENS.has(basename)) return false;
+  if (basename === "sed" && tokens.some((token) => token === "-i" || token.startsWith("-i"))) return false;
+  if (basename === "cat" && /(?:^|[;&|]\s*)cat\b[\s\S]{0,200}>\s*[^\s&|;]+/.test(command)) return false;
+  return !/\|\s*(?:sh|bash|zsh|python3?|node|perl|ruby|apply_patch)\b/i.test(command);
+}
+
+function commandHasWriteLikeIntent(command: string): boolean {
+  return /\bapply_patch\b/.test(command)
+    || /(?:^|[;&|]\s*)(?:cat|printf|echo)\b[\s\S]{0,200}>\s*[^\s&|;]+/.test(command)
+    || /\btee\s+(?:-a\s+)?[^\s&|;]+/.test(command)
+    || /\bsed\s+(?:[^\n;&|]*\s)?-i(?:\b|['"])/.test(command)
+    || /\b(?:python3?|node|perl|ruby)\b[\s\S]{0,240}\b(?:writeFileSync|writeFile|write_text|open\([^)]*["']w|File\.write|Path\()/.test(command)
+    || /<<['"]?[A-Za-z0-9_ -]+['"]?[\s\S]*(?:^|\n)(?:\+\+\+\s|---\s|import\s|export\s|function\s|const\s|class\s|interface\s)/m.test(command);
+}
+
+function hasAnyPattern(text: string, patterns: readonly RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function detectSloppyFallbackFraming(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) return false;
+  if (commandStartsWithReadOnlyInspection(trimmed)) return false;
+  if (!commandHasWriteLikeIntent(trimmed)) return false;
+  if (!hasAnyPattern(trimmed, SLOPPY_FALLBACK_PHRASE_PATTERNS)) return false;
+  if (!hasAnyPattern(trimmed, SLOPPY_FALLBACK_IMPLEMENTATION_CONTEXT_PATTERNS)) return false;
+  if (hasAnyPattern(trimmed, SLOPPY_FALLBACK_GROUNDING_PATTERNS)) return false;
+  return true;
+}
+
+function buildSloppyFallbackPreToolUseOutput(commandText: string): Record<string, unknown> | null {
+  if (!detectSloppyFallbackFraming(commandText)) return null;
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+    },
+    systemMessage:
+      "Sloppy fallback/workaround framing detected: don't make potential slop. Consult an architect for a concrete architecture, or ask the user if this is an environment issue before adding bypass/fallback code.",
+  };
+}
+
 function commandInvokesOmxQuestion(command: string): boolean {
   const tokens = tokenizeShellCommand(command)?.map((token) => token.toLowerCase()) ?? [];
   for (let index = 0; index < tokens.length; index += 1) {
@@ -746,6 +864,8 @@ export function buildNativePreToolUseOutput(
     safeString(payload.cwd).trim() || process.cwd(),
   );
   if (documentRefreshWarning) return documentRefreshWarning;
+  const sloppyFallbackWarning = buildSloppyFallbackPreToolUseOutput(normalized.normalizedCommand);
+  if (sloppyFallbackWarning) return sloppyFallbackWarning;
   if (!matchesDestructiveFixture(normalized.normalizedCommand)) return null;
 
   return {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -685,6 +685,7 @@ const READ_ONLY_COMMAND_TOKENS = new Set([
 ]);
 
 function commandStartsWithReadOnlyInspection(command: string): boolean {
+  if (commandHasWriteLikeIntent(command)) return false;
   const tokens = tokenizeShellCommand(command);
   if (!tokens || tokens.length === 0) return false;
   let commandToken = tokens[0] ?? "";


### PR DESCRIPTION
## Summary
- Add a strict advisory-only native Bash PreToolUse guard for vague fallback/workaround/bypass/quick-hack implementation framing.
- Require write-like command context and missing grounding signals before warning with "don't make potential slop".\n- Preserve concrete compatibility/fail-safe fallback code when backed by tests, architecture/design rationale, issue context, or environment diagnosis.\n- Add detection, non-detection, and git-enforcement priority tests.\n\nRefs #2028\n\n## Verification\n- npm install\n- npm run build\n- npm run lint\n- node --test dist/scripts/__tests__/codex-native-hook.test.js