### PR TITLE
Fix detached tmux postLaunch tearing down live OMX sessions

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1905,15 +1905,26 @@ describe("detached tmux new-session sequencing", () => {
       "'codex' '--model' 'gpt-5'",
       "'node' '/tmp/omx.js' 'hud' '--watch'",
       null,
-      undefined,
+      "/tmp/codex-home",
       null,
       false,
       "omx-session-123",
+      "/tmp/project/.codex-project",
     );
     const leaderCmd = steps[0]?.args.at(-1);
     assert.equal(typeof leaderCmd, "string");
     assert.match(leaderCmd!, /runDetachedSessionPostLaunch/);
     assert.match(leaderCmd!, /omx-session-123/);
+    assert.match(leaderCmd!, /\/tmp\/codex-home/);
+    assert.match(leaderCmd!, /\/tmp\/project\/\.codex-project/);
+    const helperIndex = leaderCmd!.indexOf("runDetachedSessionPostLaunch");
+    const signalGateIndex = leaderCmd!.indexOf('if [ "$status" -lt 128 ]');
+    assert.ok(helperIndex >= 0);
+    assert.ok(signalGateIndex >= 0);
+    assert.ok(
+      helperIndex < signalGateIndex,
+      "detached postLaunch helper must run before the signal-derived tmux kill-session gate",
+    );
   });
 
   it("detached leader command keeps stdin open for the Codex child", async () => {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1898,6 +1898,24 @@ describe("detached tmux new-session sequencing", () => {
     assert.match(leaderCmd!, /exit \$status/);
   });
 
+  it("buildDetachedSessionBootstrapSteps finalizes postLaunch inside the detached leader when a session id is available", () => {
+    const steps = buildDetachedSessionBootstrapSteps(
+      "omx-demo",
+      "/tmp/project",
+      "'codex' '--model' 'gpt-5'",
+      "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null,
+      undefined,
+      null,
+      false,
+      "omx-session-123",
+    );
+    const leaderCmd = steps[0]?.args.at(-1);
+    assert.equal(typeof leaderCmd, "string");
+    assert.match(leaderCmd!, /runDetachedSessionPostLaunch/);
+    assert.match(leaderCmd!, /omx-session-123/);
+  });
+
   it("detached leader command keeps stdin open for the Codex child", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-stdin-"));
     const fakeBin = join(cwd, "bin");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1207,11 +1207,12 @@ export async function launchWithHud(args: string[]): Promise<void> {
   }
 
   // ── Phase 2: run ────────────────────────────────────────────────────────
+  let postLaunchHandledExternally = false;
   try {
     const notifyTempContractRaw = notifyTempResult.contract.active
       ? serializeNotifyTempContract(notifyTempResult.contract)
       : null;
-    runCodex(
+    const launchResult = runCodex(
       cwd,
       normalizedArgs,
       sessionId,
@@ -1220,9 +1221,12 @@ export async function launchWithHud(args: string[]): Promise<void> {
       notifyTempContractRaw,
       effectiveExplicitLaunchPolicy,
     );
+    postLaunchHandledExternally = launchResult.postLaunchHandledExternally;
   } finally {
     // ── Phase 3: postLaunch ─────────────────────────────────────────────
-    await postLaunch(cwd, sessionId, codexHomeOverride, enableNotifyFallbackAuthority, projectLocalCodexHomeForCleanup);
+    if (!postLaunchHandledExternally) {
+      await postLaunch(cwd, sessionId, codexHomeOverride, enableNotifyFallbackAuthority, projectLocalCodexHomeForCleanup);
+    }
   }
 }
 
@@ -1982,7 +1986,11 @@ function buildDetachedSessionLeaderCommand(
   cwd: string,
   sessionName: string,
   codexCmd: string,
+  sessionId?: string,
 ): string {
+  const detachedPostLaunchHelper = sessionId
+    ? `${buildDetachedSessionPostLaunchHelperCommand(cwd, sessionId)} >/dev/null 2>&1 || true;`
+    : "";
   const wrapped = [
     buildTmuxExtendedKeysAcquireShellSnippet(cwd),
     'exec 3<&0;',
@@ -1997,6 +2005,7 @@ function buildDetachedSessionLeaderCommand(
     'exec 3<&- 2>/dev/null || true;',
     buildTmuxExtendedKeysReleaseShellSnippet(cwd),
     'if [ "$status" -lt 128 ]; then',
+    detachedPostLaunchHelper,
     `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
     "fi;",
     "exit $status;",
@@ -2007,6 +2016,20 @@ function buildDetachedSessionLeaderCommand(
     'wait "$omx_codex_pid";',
   ].join(" ");
   return `/bin/sh -c ${quoteShellArg(wrapped)}`;
+}
+
+function buildDetachedSessionPostLaunchHelperCommand(
+  cwd: string,
+  sessionId: string,
+): string {
+  const cwdLiteral = JSON.stringify(cwd);
+  const sessionIdLiteral = JSON.stringify(sessionId);
+  const moduleUrlLiteral = JSON.stringify(import.meta.url);
+  const script = [
+    `const mod = await import(${moduleUrlLiteral});`,
+    `await mod.runDetachedSessionPostLaunch(${cwdLiteral}, ${sessionIdLiteral}, process.env.CODEX_HOME);`,
+  ].join(" ");
+  return `${quoteShellArg(process.execPath)} --input-type=module -e ${quoteShellArg(script)}`;
 }
 
 type TmuxExecSync = (file: string, args: readonly string[]) => string;
@@ -2175,7 +2198,7 @@ export function buildDetachedSessionBootstrapSteps(
 ): DetachedSessionTmuxStep[] {
   const detachedLeaderCmd = nativeWindows
     ? "powershell.exe"
-    : buildDetachedSessionLeaderCommand(cwd, sessionName, codexCmd);
+    : buildDetachedSessionLeaderCommand(cwd, sessionName, codexCmd, sessionId);
   const newSessionArgs: string[] = [
     "new-session",
     "-d",
@@ -2779,7 +2802,7 @@ function runCodex(
   codexHomeOverride?: string,
   notifyTempContractRaw?: string | null,
   explicitLaunchPolicy?: CodexLaunchPolicy,
-): void {
+): { postLaunchHandledExternally: boolean } {
   const launchArgs = injectModelInstructionsBypassArgs(
     cwd,
     args,
@@ -2819,7 +2842,7 @@ function runCodex(
 
   if (isCodexVersionRequest(launchArgs)) {
     runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
-    return;
+    return { postLaunchHandledExternally: false };
   }
 
   if (launchPolicy === "inside-tmux") {
@@ -2880,10 +2903,12 @@ function runCodex(
         killTmuxPane(paneId);
       }
     }
+    return { postLaunchHandledExternally: false };
   } else if (launchPolicy === "direct") {
     // Detached HUD sessions require tmux. Skip the bootstrap entirely when the
     // binary is unavailable so direct launches do not emit noisy ENOENT logs.
     runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+    return { postLaunchHandledExternally: false };
   } else {
     // Not in tmux: create a new tmux session with codex + HUD pane
     const codexCmd = buildTmuxPaneCommand("codex", launchArgs);
@@ -2996,6 +3021,7 @@ function runCodex(
           }
         }
       }
+      return { postLaunchHandledExternally: true };
     } catch (err) {
       logCliOperationFailure(err);
       if (createdDetachedSession) {
@@ -3016,6 +3042,7 @@ function runCodex(
       }
       // tmux not available or failed, just run codex directly
       runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+      return { postLaunchHandledExternally: false };
     }
   }
 }
@@ -3305,6 +3332,20 @@ async function postLaunch(
     logCliOperationFailure(err);
     // Non-fatal
   }
+}
+
+export async function runDetachedSessionPostLaunch(
+  cwd: string,
+  sessionId: string,
+  codexHomeOverride?: string,
+): Promise<void> {
+  await postLaunch(
+    cwd,
+    sessionId,
+    codexHomeOverride,
+    false,
+    resolveProjectLocalCodexHomeForLaunch(cwd, process.env),
+  );
 }
 
 async function emitNativeHookEvent(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1220,6 +1220,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
       codexHomeOverride,
       notifyTempContractRaw,
       effectiveExplicitLaunchPolicy,
+      projectLocalCodexHomeForCleanup,
     );
     postLaunchHandledExternally = launchResult.postLaunchHandledExternally;
   } finally {
@@ -1987,9 +1988,11 @@ function buildDetachedSessionLeaderCommand(
   sessionName: string,
   codexCmd: string,
   sessionId?: string,
+  codexHomeOverride?: string,
+  projectLocalCodexHomeForCleanup?: string,
 ): string {
   const detachedPostLaunchHelper = sessionId
-    ? `${buildDetachedSessionPostLaunchHelperCommand(cwd, sessionId)} >/dev/null 2>&1 || true;`
+    ? `${buildDetachedSessionPostLaunchHelperCommand(cwd, sessionId, codexHomeOverride, projectLocalCodexHomeForCleanup)} >/dev/null 2>&1 || true;`
     : "";
   const wrapped = [
     buildTmuxExtendedKeysAcquireShellSnippet(cwd),
@@ -2004,8 +2007,8 @@ function buildDetachedSessionLeaderCommand(
     "fi;",
     'exec 3<&- 2>/dev/null || true;',
     buildTmuxExtendedKeysReleaseShellSnippet(cwd),
-    'if [ "$status" -lt 128 ]; then',
     detachedPostLaunchHelper,
+    'if [ "$status" -lt 128 ]; then',
     `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
     "fi;",
     "exit $status;",
@@ -2021,13 +2024,24 @@ function buildDetachedSessionLeaderCommand(
 function buildDetachedSessionPostLaunchHelperCommand(
   cwd: string,
   sessionId: string,
+  codexHomeOverride?: string,
+  projectLocalCodexHomeForCleanup?: string,
 ): string {
   const cwdLiteral = JSON.stringify(cwd);
   const sessionIdLiteral = JSON.stringify(sessionId);
+  const codexHomeLiteral =
+    typeof codexHomeOverride === "string" && codexHomeOverride.length > 0
+      ? JSON.stringify(codexHomeOverride)
+      : "undefined";
+  const projectLocalCleanupLiteral =
+    typeof projectLocalCodexHomeForCleanup === "string" &&
+    projectLocalCodexHomeForCleanup.length > 0
+      ? JSON.stringify(projectLocalCodexHomeForCleanup)
+      : "undefined";
   const moduleUrlLiteral = JSON.stringify(import.meta.url);
   const script = [
     `const mod = await import(${moduleUrlLiteral});`,
-    `await mod.runDetachedSessionPostLaunch(${cwdLiteral}, ${sessionIdLiteral}, process.env.CODEX_HOME);`,
+    `await mod.runDetachedSessionPostLaunch(${cwdLiteral}, ${sessionIdLiteral}, ${codexHomeLiteral}, ${projectLocalCleanupLiteral});`,
   ].join(" ");
   return `${quoteShellArg(process.execPath)} --input-type=module -e ${quoteShellArg(script)}`;
 }
@@ -2195,10 +2209,18 @@ export function buildDetachedSessionBootstrapSteps(
   notifyTempContractRaw?: string | null,
   nativeWindows = false,
   sessionId?: string,
+  projectLocalCodexHomeForCleanup?: string,
 ): DetachedSessionTmuxStep[] {
   const detachedLeaderCmd = nativeWindows
     ? "powershell.exe"
-    : buildDetachedSessionLeaderCommand(cwd, sessionName, codexCmd, sessionId);
+    : buildDetachedSessionLeaderCommand(
+        cwd,
+        sessionName,
+        codexCmd,
+        sessionId,
+        codexHomeOverride,
+        projectLocalCodexHomeForCleanup,
+      );
   const newSessionArgs: string[] = [
     "new-session",
     "-d",
@@ -2802,6 +2824,7 @@ function runCodex(
   codexHomeOverride?: string,
   notifyTempContractRaw?: string | null,
   explicitLaunchPolicy?: CodexLaunchPolicy,
+  projectLocalCodexHomeForCleanup?: string,
 ): { postLaunchHandledExternally: boolean } {
   const launchArgs = injectModelInstructionsBypassArgs(
     cwd,
@@ -2935,6 +2958,7 @@ function runCodex(
         notifyTempContractRaw,
         nativeWindows,
         sessionId,
+        projectLocalCodexHomeForCleanup,
       );
       for (const step of bootstrapSteps) {
         const output = execTmuxFileSync(step.args, {
@@ -3021,7 +3045,7 @@ function runCodex(
           }
         }
       }
-      return { postLaunchHandledExternally: true };
+      return { postLaunchHandledExternally: !nativeWindows };
     } catch (err) {
       logCliOperationFailure(err);
       if (createdDetachedSession) {
@@ -3338,13 +3362,14 @@ export async function runDetachedSessionPostLaunch(
   cwd: string,
   sessionId: string,
   codexHomeOverride?: string,
+  projectLocalCodexHomeForCleanup?: string,
 ): Promise<void> {
   await postLaunch(
     cwd,
     sessionId,
     codexHomeOverride,
     false,
-    resolveProjectLocalCodexHomeForLaunch(cwd, process.env),
+    projectLocalCodexHomeForCleanup,
   );
 }
 


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Detached tmux launches currently run `postLaunch()` in the parent OMX wrapper as soon as `tmux attach-session` returns. Detaching from tmux returns control before the detached Codex leader exits, so OMX archives `session.json` / mode state while the live Codex + MCP tree keeps running in the background. Later launches then preserve those helper trees because they are still attached to a live Codex ancestor, which lets stale MCP stacks accumulate across detached sessions.

This PR moves detached-session `postLaunch()` ownership into the detached leader shell so cleanup only runs when the leader actually exits.

## Changes

- make `runCodex()` report when detached tmux hands postLaunch ownership to the detached leader shell
- skip parent-wrapper `postLaunch()` for successful detached launches and keep it for direct / inside-tmux / fallback paths
- inject a detached-session helper that calls `runDetachedSessionPostLaunch(cwd, sessionId, CODEX_HOME)` immediately before killing the detached tmux session on normal exit
- add regression coverage asserting the detached leader command now embeds the session-scoped postLaunch helper

## Validation

- [x] `npm run build`
- [ ] `npm test` *(fails locally on unrelated existing tests in `dist/agents/__tests__/native-config.test.js`, `dist/team/__tests__/runtime.test.js`, and `dist/team/__tests__/worker-runtime-identity.test.js`; targeted changed-area tests passed)*
- [ ] `omx doctor` (when setup/config behavior changes)

Additional focused verification:
- `npm run lint`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js`
- `node dist/scripts/run-test-files.js dist/mcp/__tests__/bootstrap.test.js dist/cli/__tests__/cleanup.test.js`
- live host validation against the installed `omx` binary: after detached tmux **detach**, `session.json` and the tmux session remained alive; after the fake Codex leader exited, `session.json` and the tmux session were cleaned up

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
Related: #1342, #1605, #1809
