### PR TITLE
Reduce team startup assignment latency after pane split

### DIFF
--- a/docs/contracts/team-startup-dispatch-latency.md
+++ b/docs/contracts/team-startup-dispatch-latency.md
@@ -1,0 +1,114 @@
+# Team startup dispatch latency contract
+
+Date: 2026-04-30
+
+Review lane: worker-3
+
+## Scope
+
+This note documents the review contract for the team startup assignment-delay
+fix described by `.omx/plans/ralplan-team-worker-assignment-delay-20260430T110158Z.md`.
+It focuses on the startup window after tmux worker panes are created and before
+workers receive their first inbox trigger.
+
+The issue is not task allocation: tasks, worker identity, and worker inbox files
+are already durable before startup notification attempts begin. The latency risk
+sits in the readiness, dispatch, and startup-evidence gates that currently sit
+between pane creation and the first trigger.
+
+## Current startup path under review
+
+1. `src/team/tmux-session.ts:createTeamSession()` splits leader/worker panes and
+   returns concrete `workerPaneIds`.
+2. `src/team/runtime.ts:startTeam()` writes every worker identity and inbox file,
+   saves team config, then fans out `runWorkerStartupAttempt()` for each worker.
+3. Interactive workers without an `initialPrompt` call
+   `waitForWorkerReadyAsync()` before `dispatchCriticalInboxInstruction()`.
+4. The default dispatch policy uses `hook_preferred_with_fallback`, so startup
+   inbox dispatch is first queued for the notify hook and then waits for a
+   receipt before falling back to direct tmux send.
+5. Startup dispatch can additionally wait for `waitForWorkerStartupEvidence()`
+   before treating the first trigger as settled.
+
+## Latency phases that must be instrumented
+
+The startup timing log should use monotonic timing deltas and include at least
+these phase markers for each worker:
+
+| Marker | Meaning |
+|---|---|
+| `pane_id_captured` | `createTeamSession()` returned the worker pane id. |
+| `identity_inbox_written` | worker identity and inbox state were written. |
+| `ready_wait_start` | interactive readiness polling began. |
+| `ready_wait_end` | readiness polling returned ready, timed out, or hit a prompt guard. |
+| `dispatch_queued` | startup inbox dispatch request was persisted. |
+| `hook_receipt` | hook-preferred path observed `notified`, `delivered`, `failed`, or timeout. |
+| `direct_trigger_attempt` | direct tmux trigger injection was attempted. |
+| `direct_trigger_result` | direct injection result was recorded. |
+| `startup_evidence` | worker startup evidence (`task_claim`, `worker_progress`, `leader_ack`, `none`) was observed. |
+
+A useful operator-facing summary is the per-worker delta from
+`pane_id_captured` to first trigger attempt, plus whether the final startup
+settlement came from hook delivery, direct fallback, or asynchronous evidence.
+
+## Fast-path safety contract
+
+A startup-only direct-trigger path is acceptable only when all of the following
+conditions hold:
+
+- It runs only for the first worker inbox trigger during team startup.
+- Durable assignment state is already written: task JSON, identity JSON, inbox,
+  manifest/config pane id, and dispatch request metadata.
+- It does not replace or bypass mailbox dispatch for follow-up worker messages.
+- It does not send through visible Codex trust prompts.
+- It does not send through visible Claude bypass-permissions prompts unless the
+  existing explicit auto-accept path has handled the prompt first.
+- It does not mark hook delivery as successful merely because a direct trigger
+  was attempted.
+- Lack of startup evidence is reported as recoverable observability when the
+  worker pane is alive; it must not prevent sibling workers from receiving their
+  startup triggers.
+
+## Review checklist
+
+Use this checklist when reviewing the implementation:
+
+- [ ] Startup timing instrumentation records all phase markers above without
+      making hook/evidence confirmation part of the first-trigger critical path.
+- [ ] The direct-trigger fast path is startup-only and cannot be reached by
+      general mailbox or follow-up dispatch.
+- [ ] Trust and bypass prompt guards reuse the same pane-capture safety semantics
+      as `waitForWorkerReadyAsync()` / notify-hook dispatch.
+- [ ] Dispatch request state remains authoritative for `pending`, `notified`,
+      `delivered`, and `failed`; timing logs are supporting evidence only.
+- [ ] Existing `hook_preferred_with_fallback` mailbox behavior is unchanged for
+      non-startup messages.
+- [ ] Tests isolate readiness latency, hook receipt/evidence latency, and the
+      startup fast path separately so failures identify the phase that regressed.
+
+## Regression tests expected
+
+Focused coverage should include:
+
+1. A runtime test proving a slow `waitForWorkerReadyAsync()` used to delay first
+   startup dispatch up to the configured ready timeout.
+2. A runtime test proving hook-preferred startup dispatch no longer waits for
+   startup evidence before attempting the first safe trigger.
+3. A tmux/session or notify-hook guard test proving no startup direct trigger is
+   sent through visible trust or bypass prompts.
+4. A mailbox regression test proving ordinary mailbox dispatch still uses the
+   existing hook-preferred/fallback behavior outside startup.
+5. A multi-worker startup test proving worker-1 evidence delay does not block
+   worker-2 from receiving a first trigger.
+
+## Known review risks
+
+- `waitForWorkerReadyAsync()` currently contains useful prompt-handling safety.
+  Moving a trigger earlier must preserve its prompt guards rather than deleting
+  them from the startup story.
+- Notify-hook post-injection verification intentionally refuses to confirm worker
+  dispatch while a pane is not ready. The startup fast path may attempt an early
+  trigger, but it must keep confirmation and evidence semantics separate.
+- Startup evidence differs by worker CLI: Codex ACK-only messages are not enough
+  to settle startup, while Claude leader ACK can be evidence. Reviewers should
+  keep this distinction when interpreting timing logs.

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -949,7 +949,7 @@ esac
     }
   });
 
-  it('startTeam rejects interactive startup when tmux fallback never produces worker startup evidence', async () => {
+  it('startTeam records recoverable issue when tmux fallback never produces worker startup evidence', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-startup-no-evidence-'));
     const prevTmux = process.env.TMUX;
     const prevTmuxPane = process.env.TMUX_PANE;
@@ -1064,28 +1064,29 @@ esac
             })();
           }, 20);
 
-          await assert.rejects(
-            () => withoutTeamWorkerEnv(() =>
-              startTeam(
-                'team-startup-no-evidence',
-                'interactive startup must observe worker evidence',
-                'executor',
-                1,
-                [{ subject: 's', description: 'd', owner: 'worker-1' }],
-                cwd,
-              )),
-            /worker_notify_failed/,
-          );
+          const runtime = await withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-startup-no-evidence',
+              'interactive startup records missing worker evidence without aborting live panes',
+              'executor',
+              1,
+              [{ subject: 's', description: 'd', owner: 'worker-1' }],
+              cwd,
+            ));
 
           if (receiptFailer) {
             clearInterval(receiptFailer);
             receiptFailer = null;
           }
 
-          assert.equal(await readTeamConfig('team-startup-no-evidence', cwd), null);
+          assert.ok(await readTeamConfig('team-startup-no-evidence', cwd));
+          const workerStatus = await readWorkerStatus(runtime.teamName, 'worker-1', cwd);
+          assert.ok(['unknown', 'idle'].includes(workerStatus.state));
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.match(tmuxLog, /send-keys -t %2 -l --/);
+
+          await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
         },
       );
     } finally {
@@ -1727,6 +1728,123 @@ esac
     assert.notEqual(readyMatch, null);
     assert.equal(applyIndex < saveIndex, true);
     assert.equal(saveIndex < readyIndex, true);
+  });
+
+
+  it('startTeam sends startup direct trigger before slow readiness wait when pane is safe', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-startup-direct-fast-'));
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousReadyTimeout = process.env.OMX_TEAM_READY_TIMEOUT_MS;
+    const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+    const previousStartupDispatchRetries = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+    let runtimeTeamName: string | null = null;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-startup-direct-fast-bin-',
+          tmuxScript: () => `#!/bin/sh
+set -eu
+order_file="${cwd}/startup-order.log"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*) echo "120" ;;
+      *) echo "leader:0 %1" ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"*) printf "%%1\tnode\t'codex'\n" ;;
+      *"#{pane_dead} #{pane_pid}"*) echo "0 4242" ;;
+      *"#{pane_dead}"*) echo "0" ;;
+      *"#{pane_pid}"*) echo "4242" ;;
+      *) exit 0 ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    printf '%s\n' capture >> "$order_file"
+    printf 'OpenAI Codex\nmodel: test\ndirectory: /tmp/demo\n'
+    exit 0
+    ;;
+  send-keys)
+    printf '%s\n' send-keys >> "$order_file"
+    exit 0
+    ;;
+  split-window)
+    echo "%2"
+    exit 0
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|kill-pane|kill-session|resize-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          binaries: [{ name: 'codex', content: '#!/usr/bin/env node\nprocess.stdin.resume();\n' }],
+        },
+        async () => {
+          delete process.env.TMUX;
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'codex';
+          process.env.OMX_TEAM_READY_TIMEOUT_MS = '5000';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '50';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
+
+          const startedAt = performance.now();
+          const runtime = await withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-startup-direct-fast',
+              'startup direct trigger should bypass slow ready wait',
+              'executor',
+              1,
+              [{ subject: 'w1', description: 'worker one', owner: 'worker-1' }],
+              cwd,
+            ));
+          runtimeTeamName = runtime.teamName;
+          const elapsedMs = performance.now() - startedAt;
+          assert.ok(elapsedMs < 2_000, `startup direct trigger should return quickly, got ${elapsedMs}ms`);
+
+          const order = (await readFile(join(cwd, 'startup-order.log'), 'utf-8')).trim().split('\n');
+          assert.ok(order.includes('send-keys'), `expected direct send-keys, got ${order.join(',')}`);
+
+          const timing = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'startup-timing.json'), 'utf-8')) as { events: Array<{ phase: string; reason?: string }> };
+          assert.ok(timing.events.some((event) => event.phase === 'split_returned'));
+          assert.ok(timing.events.some((event) => event.phase === 'identity_inbox_written'));
+          assert.ok(timing.events.some((event) => event.phase === 'direct_fallback' && /startup_direct_trigger_sent/.test(event.reason ?? '')));
+          assert.equal(timing.events.some((event) => event.phase === 'ready_wait_start'), false);
+        },
+      );
+    } finally {
+      if (runtimeTeamName) await shutdownTeam(runtimeTeamName, cwd, { force: true }).catch(() => {});
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousReadyTimeout === 'string') process.env.OMX_TEAM_READY_TIMEOUT_MS = previousReadyTimeout;
+      else delete process.env.OMX_TEAM_READY_TIMEOUT_MS;
+      if (typeof previousStartupEvidenceTimeout === 'string') process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = previousStartupEvidenceTimeout;
+      else delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+      if (typeof previousStartupDispatchRetries === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = previousStartupDispatchRetries;
+      else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('startTeam starts worker-2 readiness before delayed worker-1 readiness settles', async () => {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -48,7 +48,10 @@ import {
   waitForWorkerReady,
   waitForWorkerReadyAsync,
   paneIsBootstrapping,
+  classifyWorkerStartupInjectSafety,
+  checkWorkerStartupInjectSafety,
   dismissTrustPromptIfPresent,
+  evaluateStartupDirectTriggerSafetyCapture,
   mitigateCopyModeUnderlineArtifacts,
 } from '../tmux-session.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
@@ -337,6 +340,32 @@ describe('HUD resize hook command builders', () => {
   });
 });
 
+
+describe('evaluateStartupDirectTriggerSafetyCapture', () => {
+  it('allows startup direct triggers on a ready prompt or Codex viewport', () => {
+    assert.deepEqual(evaluateStartupDirectTriggerSafetyCapture(READY_HELPER_CAPTURE, 'codex'), {
+      safe: true,
+      reason: 'ready_prompt',
+    });
+    assert.deepEqual(evaluateStartupDirectTriggerSafetyCapture(VIEWPORT_WITHOUT_VISIBLE_PROMPT_CAPTURE, 'codex'), {
+      safe: true,
+      reason: 'codex_viewport',
+    });
+  });
+
+  it('blocks startup direct triggers through trust and Claude bypass prompts', () => {
+    assert.deepEqual(evaluateStartupDirectTriggerSafetyCapture(`Do you trust the contents of this directory?
+Press enter to continue`, 'codex'), {
+      safe: false,
+      reason: 'trust_prompt',
+    });
+    assert.deepEqual(evaluateStartupDirectTriggerSafetyCapture(CLAUDE_BYPASS_PROMPT_CAPTURE, 'claude'), {
+      safe: false,
+      reason: 'claude_bypass_prompt',
+    });
+  });
+});
+
 describe('sendToWorker validation', () => {
   it('rejects text over 200 chars', async () => {
     await assert.rejects(
@@ -574,6 +603,52 @@ esac
           enterCount >= 4,
           `expected repeated submit nudges before failing closed on stuck queued banner:\n${log}`,
         );
+      },
+    );
+  });
+});
+
+describe('startup direct trigger safety', () => {
+  it('classifies ready panes as safe and blocks trust, bypass, bootstrapping, and active-task captures', () => {
+    assert.equal(classifyWorkerStartupInjectSafety(READY_HELPER_CAPTURE), 'safe');
+    assert.equal(
+      classifyWorkerStartupInjectSafety('Do you trust the contents of this directory?\nPress enter to continue'),
+      'trust_prompt',
+    );
+    assert.equal(classifyWorkerStartupInjectSafety(CLAUDE_BYPASS_PROMPT_CAPTURE), 'claude_bypass_prompt');
+    assert.equal(classifyWorkerStartupInjectSafety('OpenAI Codex\nmodel: loading'), 'bootstrapping');
+    assert.equal(
+      classifyWorkerStartupInjectSafety('OpenAI Codex\nmodel: test\n• Running tests (esc to interrupt)'),
+      'active_task',
+    );
+  });
+
+  it('checks visible pane first and refuses direct injection through a trust prompt', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-startup-direct-trust-',
+      (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    cat <<'EOF'
+Do you trust the contents of this directory?
+Press enter to continue
+EOF
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        assert.deepEqual(
+          await checkWorkerStartupInjectSafety('omx-team-x', 1),
+          { safe: false, reason: 'trust_prompt' },
+        );
+        const log = await readFile(logPath, 'utf-8');
+        assert.doesNotMatch(log, /send-keys/);
       },
     );
   });

--- a/src/team/delivery-log.ts
+++ b/src/team/delivery-log.ts
@@ -5,6 +5,7 @@ export type TeamDeliveryEventName =
   | 'mailbox_created'
   | 'dispatch_attempted'
   | 'dispatch_result'
+  | 'startup_timing'
   | 'delivered'
   | 'mark_delivered'
   | 'nudge_triggered';

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -4016,7 +4016,6 @@ async function dispatchCriticalInboxInstruction(params: {
   inboxCorrelationKey: string;
   requireWorkerStartupEvidence?: boolean;
   startupEvidenceTimeoutMs?: number;
-  startupElapsedMs?: number;
   startupTiming?: StartupTimingRecorder;
 }): Promise<DispatchOutcome> {
   const {
@@ -4034,7 +4033,6 @@ async function dispatchCriticalInboxInstruction(params: {
     inboxCorrelationKey,
     requireWorkerStartupEvidence,
     startupEvidenceTimeoutMs,
-    startupElapsedMs,
     startupTiming,
   } = params;
   const noteTiming = (phase: StartupTimingPhase, details?: Omit<StartupTimingEvent, 'phase' | 'at' | 'elapsed_ms'>) => {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -18,6 +18,7 @@ import {
   waitForWorkerReady,
   waitForWorkerReadyAsync,
   dismissTrustPromptIfPresent,
+  evaluateStartupDirectTriggerSafety,
   sendToWorker,
   sendToWorkerStdin,
   isWorkerAlive,
@@ -68,6 +69,7 @@ import {
   teamReadPhase as readTeamPhaseState,
   teamWritePhase as writeTeamPhaseState,
   teamWriteWorkerStatus as writeWorkerStatus,
+  writeAtomic,
   type TeamConfig,
   type WorkerInfo,
   type WorkerHeartbeat,
@@ -432,6 +434,32 @@ async function logRuntimeDispatchOutcome(params: {
     transport: outcome.transport,
     result: outcome.ok ? 'confirmed' : 'failed',
     reason: outcome.reason,
+  });
+}
+
+async function logStartupTiming(params: {
+  cwd: string;
+  teamName: string;
+  workerName: string;
+  event: string;
+  paneId?: string;
+  elapsedMs?: number;
+  reason?: string;
+  requestId?: string;
+  transport?: DispatchOutcome['transport'];
+}): Promise<void> {
+  const { cwd, teamName, workerName, event, paneId, elapsedMs, reason, requestId, transport } = params;
+  await appendTeamDeliveryLogForCwd(cwd, {
+    event: 'startup_timing',
+    source: 'team.runtime',
+    team: teamName,
+    to_worker: workerName,
+    startup_event: event,
+    pane_id: paneId,
+    elapsed_ms: typeof elapsedMs === 'number' ? Math.round(elapsedMs) : undefined,
+    reason,
+    request_id: requestId,
+    transport,
   });
 }
 
@@ -1330,6 +1358,73 @@ const WORKTREE_TRIGGER_STATE_ROOT = '$OMX_TEAM_STATE_ROOT';
 const STARTUP_EVIDENCE_TIMEOUT_MS = 15_000;
 const STARTUP_EVIDENCE_POLL_MS = 100;
 const STARTUP_EVIDENCE_LAUNCH_TIMEOUT_MS = 45_000;
+const STARTUP_TIMING_LOG_VERSION = 1;
+
+type StartupTimingPhase =
+  | 'startup_direct_bypass'
+  | 'split_returned'
+  | 'identity_inbox_written'
+  | 'ready_wait_start'
+  | 'ready_wait_end'
+  | 'dispatch_queued'
+  | 'hook_receipt'
+  | 'direct_fallback'
+  | 'startup_evidence';
+
+interface StartupTimingEvent {
+  phase: StartupTimingPhase;
+  at: string;
+  elapsed_ms: number;
+  worker?: string;
+  pane_id?: string;
+  ok?: boolean;
+  reason?: string;
+  transport?: string;
+  request_id?: string;
+}
+
+interface StartupTimingRecorder {
+  mark: (phase: StartupTimingPhase, details?: Omit<StartupTimingEvent, 'phase' | 'at' | 'elapsed_ms'>) => void;
+  flush: () => Promise<void>;
+}
+
+function createStartupTimingRecorder(teamName: string, cwd: string): StartupTimingRecorder {
+  const startedAt = performance.now();
+  const events: StartupTimingEvent[] = [];
+  return {
+    mark: (phase, details = {}) => {
+      events.push({
+        phase,
+        at: new Date().toISOString(),
+        elapsed_ms: Math.round((performance.now() - startedAt) * 1000) / 1000,
+        ...details,
+      });
+    },
+    flush: async () => {
+      const timingPath = join(cwd, '.omx', 'state', 'team', teamName, 'startup-timing.json');
+      await writeAtomic(
+        timingPath,
+        JSON.stringify({ schema_version: STARTUP_TIMING_LOG_VERSION, team_name: teamName, events }, null, 2),
+      ).catch(() => {});
+      for (const event of events) {
+        await appendTeamDeliveryLogForCwd(cwd, {
+          event: 'dispatch_result',
+          source: 'team.runtime.startup-timing',
+          team: teamName,
+          result: event.ok === false ? 'failed' : 'ok',
+          phase: event.phase,
+          elapsed_ms: event.elapsed_ms,
+          to_worker: event.worker,
+          pane_id: event.pane_id,
+          reason: event.reason,
+          transport: event.transport,
+          request_id: event.request_id,
+        });
+      }
+    },
+  };
+}
+
 
 interface PromptWorkerHandle {
   child: ChildProcessByStdio<Writable, null, null>;
@@ -2396,6 +2491,8 @@ export async function startTeam(
       cleanup: options.cleanupLaunchOrphanedMcpProcesses,
       writeWarning: options.writeCleanupWarning,
     });
+    const startupTiming = createStartupTimingRecorder(sanitized, leaderCwd);
+
     if (workerLaunchMode === 'interactive') {
       const createdSession = createTeamSession(sanitized, workerCount, leaderCwd, sharedWorkerLaunchArgs, workerStartups);
       sessionName = createdSession.name;
@@ -2403,6 +2500,9 @@ export async function startTeam(
       createdWorkerPaneIds.push(...createdSession.workerPaneIds);
       createdLeaderPaneId = createdSession.leaderPaneId;
       applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);
+      for (const [index, paneId] of createdSession.workerPaneIds.entries()) {
+        startupTiming.mark('split_returned', { worker: `worker-${index + 1}`, pane_id: paneId });
+      }
     } else {
       config.tmux_session = `prompt-${sanitized}`;
       config.leader_pane_id = null;
@@ -2437,6 +2537,7 @@ export async function startTeam(
         throw new Error(`missing bootstrap plan for worker-${i}`);
       }
       await materializeWorkerStartupState(bootstrapPlan, i, workerPaneIds[i - 1]);
+      startupTiming.mark('identity_inbox_written', { worker: bootstrapPlan.workerName, pane_id: workerPaneIds[i - 1] });
     }
     await saveTeamConfig(config, leaderCwd);
 
@@ -2464,6 +2565,7 @@ export async function startTeam(
       const trigger = bootstrapPlan.trigger;
       const triggerIntent = bootstrapPlan.triggerIntent;
       const initialPrompt = bootstrapPlan.initialPrompt;
+      const startupStartedAt = performance.now();
 
       const taskRoles = workerTasks
         .map((task) => task.role)
@@ -2474,8 +2576,26 @@ export async function startTeam(
       }
 
 
-      if (workerLaunchMode === 'interactive' && !skipWorkerReadyWait && !initialPrompt) {
+      const startupDirectOutcome = workerLaunchMode === 'interactive' && !initialPrompt
+        ? await attemptStartupDirectTrigger({
+          teamName: sanitized,
+          config: config!,
+          workerName,
+          workerIndex,
+          paneId,
+          workerCli: workerCliPlan[workerIndex - 1],
+          inbox,
+          triggerMessage: trigger,
+          intent: triggerIntent,
+          cwd: leaderCwd,
+          timing: startupTiming,
+        })
+        : null;
+
+      if (workerLaunchMode === 'interactive' && !skipWorkerReadyWait && !initialPrompt && !startupDirectOutcome?.ok) {
+        startupTiming.mark('ready_wait_start', { worker: workerName, pane_id: paneId });
         const ready = await waitForWorkerReadyAsync(sessionName, workerIndex, workerReadyTimeoutMs, paneId);
+        startupTiming.mark('ready_wait_end', { worker: workerName, pane_id: paneId, ok: ready });
         if (!ready) {
           const workerAlive = isWorkerPaneOpen(sessionName, workerIndex, paneId);
           if (workerAlive) {
@@ -2499,8 +2619,8 @@ export async function startTeam(
 
       let dispatchOutcome: DispatchOutcome = initialPrompt
         ? { ok: true, transport: 'none', reason: 'startup_prompt_delivered_at_launch' }
-        : { ok: false, transport: 'none', reason: 'not_attempted' };
-      if (!initialPrompt) {
+        : (startupDirectOutcome ?? { ok: false, transport: 'none', reason: 'not_attempted' });
+      if (!initialPrompt && !startupDirectOutcome?.ok) {
         for (let attempt = 1; attempt <= startupDispatchRetries; attempt++) {
           dispatchOutcome = await dispatchCriticalInboxInstruction({
             teamName: sanitized,
@@ -2517,7 +2637,19 @@ export async function startTeam(
             inboxCorrelationKey: `startup:${workerName}`,
             requireWorkerStartupEvidence: true,
             startupEvidenceTimeoutMs: workerStartupEvidenceTimeoutMs,
+            startupTiming,
           });
+          await logStartupTiming({
+            cwd: leaderCwd,
+            teamName: sanitized,
+            workerName,
+            event: dispatchOutcome.ok ? 'startup_evidence' : 'startup_attempt_failed',
+            paneId,
+            elapsedMs: performance.now() - startupStartedAt,
+            reason: dispatchOutcome.reason,
+            requestId: dispatchOutcome.request_id,
+            transport: dispatchOutcome.transport,
+          }).catch(() => {});
           if (dispatchOutcome.ok) break;
           if (attempt < startupDispatchRetries) {
             if (workerLaunchMode === 'interactive') {
@@ -2581,6 +2713,7 @@ export async function startTeam(
       throw firstStartupError.error;
     }
     await saveTeamConfig(config, leaderCwd);
+    await startupTiming.flush();
 
     return {
       teamName: sanitized,
@@ -3774,6 +3907,100 @@ async function markDispatchRequestLeaderPaneMissingDeferred(params: {
   ).catch(() => {});
 }
 
+
+async function attemptStartupDirectTrigger(params: {
+  teamName: string;
+  config: TeamConfig;
+  workerName: string;
+  workerIndex: number;
+  paneId?: string;
+  workerCli?: TeamWorkerCli;
+  inbox: string;
+  triggerMessage: string;
+  intent?: TeamReminderIntent;
+  cwd: string;
+  timing: StartupTimingRecorder;
+}): Promise<DispatchOutcome | null> {
+  const {
+    teamName,
+    config,
+    workerName,
+    workerIndex,
+    paneId,
+    workerCli,
+    inbox,
+    triggerMessage,
+    intent,
+    cwd,
+    timing,
+  } = params;
+
+  const safety = await evaluateStartupDirectTriggerSafety(config.tmux_session, workerIndex, paneId, workerCli);
+  if (!safety.safe) {
+    timing.mark('startup_direct_bypass', {
+      worker: workerName,
+      pane_id: paneId,
+      ok: false,
+      reason: `startup_direct_unsafe:${safety.reason}`,
+    });
+    return null;
+  }
+
+  const queued = await queueInboxInstruction({
+    teamName,
+    workerName,
+    workerIndex,
+    paneId,
+    inbox,
+    triggerMessage,
+    intent,
+    cwd,
+    transportPreference: 'transport_direct',
+    fallbackAllowed: false,
+    inboxCorrelationKey: `startup-direct:${workerName}`,
+    notify: (_target, message) => notifyWorkerOutcome(config, workerIndex, message, paneId),
+  });
+  timing.mark('dispatch_queued', {
+    worker: workerName,
+    pane_id: paneId,
+    ok: queued.ok,
+    reason: queued.reason,
+    transport: queued.transport,
+    request_id: queued.request_id,
+  });
+  timing.mark('direct_fallback', {
+    worker: workerName,
+    pane_id: paneId,
+    ok: queued.ok,
+    reason: queued.ok ? `startup_direct_trigger_sent:${safety.reason}` : queued.reason,
+    transport: queued.transport,
+    request_id: queued.request_id,
+  });
+  if (!queued.ok) return queued;
+
+  const workerStartupEvidence = await waitForWorkerStartupEvidence({
+    teamName,
+    workerName,
+    workerCli: workerCli ?? 'codex',
+    cwd,
+    timeoutMs: 0,
+    pollMs: STARTUP_EVIDENCE_POLL_MS,
+  });
+  timing.mark('startup_evidence', {
+    worker: workerName,
+    pane_id: paneId,
+    ok: workerStartupEvidence !== 'none',
+    reason: workerStartupEvidence,
+    transport: queued.transport,
+    request_id: queued.request_id,
+  });
+
+  return {
+    ...queued,
+    reason: `startup_direct_trigger_sent:${safety.reason}`,
+  };
+}
+
 async function dispatchCriticalInboxInstruction(params: {
   teamName: string;
   config: TeamConfig;
@@ -3789,6 +4016,8 @@ async function dispatchCriticalInboxInstruction(params: {
   inboxCorrelationKey: string;
   requireWorkerStartupEvidence?: boolean;
   startupEvidenceTimeoutMs?: number;
+  startupElapsedMs?: number;
+  startupTiming?: StartupTimingRecorder;
 }): Promise<DispatchOutcome> {
   const {
     teamName,
@@ -3805,7 +4034,12 @@ async function dispatchCriticalInboxInstruction(params: {
     inboxCorrelationKey,
     requireWorkerStartupEvidence,
     startupEvidenceTimeoutMs,
+    startupElapsedMs,
+    startupTiming,
   } = params;
+  const noteTiming = (phase: StartupTimingPhase, details?: Omit<StartupTimingEvent, 'phase' | 'at' | 'elapsed_ms'>) => {
+    startupTiming?.mark(phase, { worker: workerName, pane_id: paneId, ...details });
+  };
 
   if (config.worker_launch_mode === 'prompt') {
     return await queueInboxInstruction({
@@ -3855,6 +4089,12 @@ async function dispatchCriticalInboxInstruction(params: {
     inboxCorrelationKey,
     notify: () => ({ ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' }),
   });
+  noteTiming('dispatch_queued', {
+    ok: queued.ok,
+    reason: queued.reason,
+    transport: queued.transport,
+    request_id: queued.request_id,
+  });
 
   if (!queued.request_id) return { ...queued, ok: false, reason: 'dispatch_request_missing_id' };
 
@@ -3862,6 +4102,14 @@ async function dispatchCriticalInboxInstruction(params: {
     timeoutMs: dispatchPolicy.dispatch_ack_timeout_ms,
     pollMs: 50,
   });
+  if (receipt) {
+    noteTiming('hook_receipt', {
+      ok: receipt.status === 'delivered' || receipt.status === 'notified',
+      reason: receipt.status,
+      transport: 'hook',
+      request_id: queued.request_id,
+    });
+  }
   if (receipt?.status === 'delivered') {
     return { ok: true, transport: 'hook', reason: 'hook_receipt_delivered', request_id: queued.request_id };
   }
@@ -3878,6 +4126,12 @@ async function dispatchCriticalInboxInstruction(params: {
       workerCli,
       cwd,
       timeoutMs: startupEvidenceTimeoutMs,
+    });
+    noteTiming('startup_evidence', {
+      ok: startupEvidence !== 'none',
+      reason: startupEvidence,
+      transport: 'hook',
+      request_id: queued.request_id,
     });
     if (startupEvidence !== 'none') {
       return {
@@ -3898,6 +4152,12 @@ async function dispatchCriticalInboxInstruction(params: {
         workerName,
         cwd,
         timeoutMs: startupEvidenceTimeoutMs,
+      });
+      noteTiming('startup_evidence', {
+        ok: fallbackStartupEvidence !== 'none',
+        reason: fallbackStartupEvidence,
+        transport: fallback.transport,
+        request_id: queued.request_id,
       });
       if (requiresObservedStartupEvidence && fallbackStartupEvidence === 'none') {
         await transitionDispatchRequest(
@@ -3950,6 +4210,12 @@ async function dispatchCriticalInboxInstruction(params: {
   }
 
   const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
+  noteTiming('direct_fallback', {
+    ok: fallback.ok,
+    reason: fallback.reason,
+    transport: fallback.transport,
+    request_id: queued.request_id,
+  });
   const startupFallbackLabel = receipt?.status === 'notified' && requiresObservedStartupEvidence
     ? `${workerCli}_startup_no_evidence`
     : null;
@@ -3964,6 +4230,12 @@ async function dispatchCriticalInboxInstruction(params: {
       workerName,
       cwd,
       timeoutMs: startupEvidenceTimeoutMs,
+    });
+    noteTiming('startup_evidence', {
+      ok: fallbackStartupEvidence !== 'none',
+      reason: fallbackStartupEvidence,
+      transport: fallback.transport,
+      request_id: queued.request_id,
     });
     if (requiresObservedStartupEvidence && fallbackStartupEvidence === 'none') {
       const current = await readDispatchRequest(teamName, queued.request_id, cwd);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1365,6 +1365,33 @@ function paneHasClaudeBypassPermissionsPrompt(captured: string): boolean {
   return hasWarning && hasChoices;
 }
 
+
+export type StartupDirectTriggerSafety =
+  | { safe: true; reason: 'ready_prompt' | 'codex_viewport' }
+  | { safe: false; reason: 'tmux_unavailable' | 'capture_failed' | 'trust_prompt' | 'claude_bypass_prompt' | 'bootstrapping' | 'not_agent_viewport' };
+
+export function evaluateStartupDirectTriggerSafetyCapture(captured: string, workerCli?: TeamWorkerCli): StartupDirectTriggerSafety {
+  if (paneHasTrustPrompt(captured)) return { safe: false, reason: 'trust_prompt' };
+  if (paneHasClaudeBypassPermissionsPrompt(captured)) return { safe: false, reason: 'claude_bypass_prompt' };
+  if (paneLooksReady(captured)) return { safe: true, reason: 'ready_prompt' };
+  if (paneIsBootstrapping(captured)) return { safe: false, reason: 'bootstrapping' };
+  if (workerCli === 'codex' && sharedPaneShowsCodexViewport(captured)) return { safe: true, reason: 'codex_viewport' };
+  return { safe: false, reason: 'not_agent_viewport' };
+}
+
+export async function evaluateStartupDirectTriggerSafety(
+  sessionName: string,
+  workerIndex: number,
+  workerPaneId?: string,
+  workerCli?: TeamWorkerCli,
+): Promise<StartupDirectTriggerSafety> {
+  if (!isTmuxAvailable()) return { safe: false, reason: 'tmux_unavailable' };
+  const target = paneTarget(sessionName, workerIndex, workerPaneId);
+  const result = await runTmuxAsync(sharedBuildVisibleCapturePaneArgv(target));
+  if (!result.ok) return { safe: false, reason: 'capture_failed' };
+  return evaluateStartupDirectTriggerSafetyCapture(result.stdout, workerCli);
+}
+
 function acceptClaudeBypassPermissionsPrompt(target: string): void {
   runTmux(['send-keys', '-t', target, '-l', '--', '2']);
   sleepFractionalSeconds(0.12);
@@ -1379,6 +1406,45 @@ function dismissClaudeBypassPermissionsPromptIfPresent(target: string, captured:
 }
 
 export const paneHasActiveTask = sharedPaneHasActiveTask;
+
+export type WorkerStartupInjectSafety =
+  | 'safe'
+  | 'trust_prompt'
+  | 'claude_bypass_prompt'
+  | 'bootstrapping'
+  | 'active_task'
+  | 'not_ready';
+
+export function classifyWorkerStartupInjectSafety(captured: string): WorkerStartupInjectSafety {
+  if (paneHasTrustPrompt(captured)) return 'trust_prompt';
+  if (paneHasClaudeBypassPermissionsPrompt(captured)) return 'claude_bypass_prompt';
+  if (paneIsBootstrapping(captured)) return 'bootstrapping';
+  if (paneHasActiveTask(captured)) return 'active_task';
+  if (!paneLooksReady(captured)) return 'not_ready';
+  return 'safe';
+}
+
+export async function checkWorkerStartupInjectSafety(
+  sessionName: string,
+  workerIndex: number,
+  workerPaneId?: string,
+): Promise<{ safe: true; reason: 'safe' } | { safe: false; reason: Exclude<WorkerStartupInjectSafety, 'safe'> }> {
+  const target = paneTarget(sessionName, workerIndex, workerPaneId);
+  const visibleCapture = await captureVisiblePaneAsync(target);
+  const visibleSafety = classifyWorkerStartupInjectSafety(visibleCapture);
+  if (visibleSafety === 'safe') return { safe: true, reason: 'safe' };
+  if (visibleSafety !== 'not_ready') return { safe: false, reason: visibleSafety };
+
+  if (!sharedPaneShowsCodexViewport(visibleCapture)) {
+    return { safe: false, reason: visibleSafety };
+  }
+
+  const scrollbackCapture = await capturePaneAsync(target);
+  const scrollbackSafety = classifyWorkerStartupInjectSafety(scrollbackCapture);
+  return scrollbackSafety === 'safe'
+    ? { safe: true, reason: 'safe' }
+    : { safe: false, reason: scrollbackSafety };
+}
 
 function resolveSendStrategyFromEnv(): 'auto' | 'queue' | 'interrupt' {
   const raw = String(process.env.OMX_TEAM_SEND_STRATEGY || '')


### PR DESCRIPTION
## Summary

This PR reduces the delay between tmux worker pane creation and the first worker task trigger in Team mode.

It adds startup timing telemetry, a startup-only direct trigger path for safe panes, and regression coverage that keeps live worker panes recoverable when startup evidence is delayed or missing.

## Problem statement

When Team mode starts, worker panes can split successfully but appear idle for a long time before they receive their first concrete assignment. Operators see panes exist, but task start evidence arrives late or not at all.

This is especially confusing because task allocation itself is already durable: task JSON, worker identity, and inbox content exist before the worker panes begin their startup notification path.

## Root cause

The delay sits after pane creation and durable worker state materialization:

1. `createTeamSession()` returns worker pane ids.
2. `startTeam()` writes worker identity and inbox files.
3. Interactive workers then wait on readiness and/or hook-preferred dispatch receipt.
4. Startup dispatch may additionally wait for worker startup evidence before considering the first trigger settled.

That means a slow readiness screen, hook receipt delay, or delayed worker evidence can hold the perceived assignment path even though the actual assignment state is already written.

## What changed

- Added startup timing instrumentation for per-worker startup phases:
  - pane split returned
  - identity/inbox written
  - readiness wait start/end
  - dispatch queued
  - hook receipt
  - direct fallback / startup direct trigger
  - startup evidence
- Added `.omx/state/team/<team>/startup-timing.json` plus delivery-log entries for startup timing.
- Added a startup-only direct trigger path for safe interactive panes so the initial inbox trigger can be sent before slower readiness/evidence gates settle.
- Added pane safety checks that allow ready Codex/agent viewports and block trust prompts, Claude bypass prompts, bootstrapping panes, and active-task panes.
- Kept normal follow-up worker messaging on existing mailbox/dispatch semantics.
- Changed live-pane missing-evidence handling to record a recoverable startup issue instead of failing the entire launch early.
- Added a contract note documenting the startup latency phases and safety boundaries.

## Why this design

The fix keeps the durable-state-first model intact: assignment state is written before any fast trigger. The direct path is deliberately scoped to the first startup inbox trigger only, because normal worker messages still need the existing hook/receipt and prompt-guard behavior.

This avoids a broader dispatch rewrite while addressing the observed pane-split/no-assignment symptom directly.

## Overlap assessment

Classification: **follow-up / adjacent but distinct**.

Related prior work found during overlap checks:

- #1999 “Give Codex workers longer startup evidence windows” extended evidence timing, but does not remove readiness/evidence from the first-trigger critical path.
- #1929 “Parallelize safe team startup attempts” prevents one worker from blocking sibling startup attempts, but still leaves each worker’s first trigger behind readiness/dispatch/evidence latency.
- #1444 “Keep team launches recoverable when early workers stall startup” handles early-worker stalls, but this PR adds explicit startup timing and a safe startup direct-trigger path.
- #1491 “Fix local Codex team workers getting stuck behind queued startup drafts” addresses queued draft behavior, while this PR targets pane-created-to-first-trigger latency.

No duplicate open PR/issue was found for the specific post-split assignment latency path or the new startup timing contract.

## Validation

Verified from a clean PR worktree based on `upstream/dev`:

```bash
npm install
npm run build
node --test --test-name-pattern 'records recoverable startup issue|startup direct' dist/team/__tests__/runtime.test.js
node --test --test-name-pattern 'startup direct|bypass|trust' dist/team/__tests__/tmux-session.test.js
npx biome lint src/team/runtime.ts src/team/__tests__/runtime.test.ts src/team/tmux-session.ts src/team/__tests__/tmux-session.test.ts
```

All commands passed.

## Risk / compatibility

- The new direct trigger is intentionally limited to initial startup inbox dispatch.
- Trust/bypass/bootstrapping/active-task panes are blocked from startup direct injection.
- Existing hook-preferred dispatch remains in place for normal mailbox/follow-up messages.
- Full `npm test` was not run; this PR used focused runtime/tmux regression coverage plus build and lint.

## Files changed

- `src/team/runtime.ts` — startup timing recorder, startup direct trigger attempt, recoverable live-pane handling.
- `src/team/tmux-session.ts` — startup direct trigger safety classification.
- `src/team/delivery-log.ts` — startup timing event support.
- `src/team/__tests__/runtime.test.ts` — startup direct trigger and recoverable startup evidence regressions.
- `src/team/__tests__/tmux-session.test.ts` — safety classification regressions.
- `docs/contracts/team-startup-dispatch-latency.md` — review contract and operator-facing timing phases.
