### PR TITLE
fix(plugin): detect mirror CLI calls in spaced paths

### DIFF
--- a/src/catalog/__tests__/plugin-bundle-ssot.test.ts
+++ b/src/catalog/__tests__/plugin-bundle-ssot.test.ts
@@ -3,9 +3,13 @@ import assert from "node:assert/strict";
 import { cp, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { getSetupInstallableSkillNames } from "../installable.js";
 import { readCatalogManifest } from "../reader.js";
-import { syncPluginMirror } from "../../scripts/sync-plugin-mirror.js";
+import {
+	isDirectCliInvocation,
+	syncPluginMirror,
+} from "../../scripts/sync-plugin-mirror.js";
 
 const root = process.cwd();
 
@@ -25,6 +29,28 @@ async function copyBundleFixture(): Promise<string> {
 }
 
 describe("plugin bundle SSOT contract", () => {
+	it("detects direct CLI execution when repo paths contain spaces", () => {
+		const scriptPath = join(
+			tmpdir(),
+			"Manual Library",
+			"repo",
+			"dist",
+			"scripts",
+			"sync-plugin-mirror.js",
+		);
+		const importMetaUrl = pathToFileURL(scriptPath).href;
+
+		assert.equal(isDirectCliInvocation(importMetaUrl, scriptPath), true);
+		assert.equal(isDirectCliInvocation(importMetaUrl, undefined), false);
+		assert.equal(
+			isDirectCliInvocation(
+				importMetaUrl,
+				join(tmpdir(), "other", "sync-plugin-mirror.js"),
+			),
+			false,
+		);
+	});
+
 	it("verifies the checked-in plugin bundle mirrors canonical roots", async () => {
 		const result = await syncPluginMirror({ root, check: true });
 		const expectedSkillNames = [

--- a/src/scripts/sync-plugin-mirror.ts
+++ b/src/scripts/sync-plugin-mirror.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { existsSync } from "node:fs";
 import { cp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import {
 	getSetupInstallableSkillNames,
 	isCatalogInstallableStatus,
@@ -345,7 +346,15 @@ function parseArgs(argv: string[]): SyncPluginMirrorOptions {
 	};
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+export function isDirectCliInvocation(
+	importMetaUrl: string,
+	argvPath: string | undefined,
+): boolean {
+	if (!argvPath) return false;
+	return fileURLToPath(importMetaUrl) === resolve(argvPath);
+}
+
+if (isDirectCliInvocation(import.meta.url, process.argv[1])) {
 	syncPluginMirror(parseArgs(process.argv.slice(2)))
 		.then((result) => {
 			const action = result.checked ? "verified" : "synced";


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

`sync-plugin-mirror` currently skips its top-level CLI path when the repo path
contains spaces. `import.meta.url` percent-encodes the script path while
`process.argv[1]` remains unescaped, so the existing direct-invocation check
fails and the mirror CLI does not run from those checkouts.

## Changes

- normalize the direct-invocation check to compare filesystem paths instead of
  raw file URLs
- export the helper so the launch contract can be covered directly in tests
- add a regression test that exercises a space-containing script path

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/catalog/__tests__/plugin-bundle-ssot.test.js`
- [x] `node dist/scripts/sync-plugin-mirror.js --check`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
