### PR TITLE
test(codex-home): isolate ambient defaults in env-sensitive suites

### DIFF
--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -26,17 +26,49 @@ function manifestWithAgents(names: string[]): CatalogManifest {
   };
 }
 
+const originalCodexHome = process.env.CODEX_HOME;
+const originalFrontierModel = process.env.OMX_DEFAULT_FRONTIER_MODEL;
 const originalStandardModel = process.env.OMX_DEFAULT_STANDARD_MODEL;
+const originalSparkModel = process.env.OMX_DEFAULT_SPARK_MODEL;
+const originalLegacySparkModel = process.env.OMX_SPARK_MODEL;
+const isolatedCodexHome = join(
+  tmpdir(),
+  `omx-native-config-empty-codex-home-${process.pid}`,
+);
 
 beforeEach(() => {
+  process.env.CODEX_HOME = isolatedCodexHome;
+  delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
   process.env.OMX_DEFAULT_STANDARD_MODEL = "gpt-5.4-mini";
+  delete process.env.OMX_DEFAULT_SPARK_MODEL;
+  delete process.env.OMX_SPARK_MODEL;
 });
 
 afterEach(() => {
+  if (typeof originalCodexHome === "string") {
+    process.env.CODEX_HOME = originalCodexHome;
+  } else {
+    delete process.env.CODEX_HOME;
+  }
+  if (typeof originalFrontierModel === "string") {
+    process.env.OMX_DEFAULT_FRONTIER_MODEL = originalFrontierModel;
+  } else {
+    delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
+  }
   if (typeof originalStandardModel === "string") {
     process.env.OMX_DEFAULT_STANDARD_MODEL = originalStandardModel;
   } else {
     delete process.env.OMX_DEFAULT_STANDARD_MODEL;
+  }
+  if (typeof originalSparkModel === "string") {
+    process.env.OMX_DEFAULT_SPARK_MODEL = originalSparkModel;
+  } else {
+    delete process.env.OMX_DEFAULT_SPARK_MODEL;
+  }
+  if (typeof originalLegacySparkModel === "string") {
+    process.env.OMX_SPARK_MODEL = originalLegacySparkModel;
+  } else {
+    delete process.env.OMX_SPARK_MODEL;
   }
 });
 

--- a/src/cli/__tests__/exec.test.ts
+++ b/src/cli/__tests__/exec.test.ts
@@ -26,6 +26,7 @@ function runOmx(
     encoding: 'utf-8',
     env: {
       ...process.env,
+      CODEX_HOME: '',
       OMX_MODEL_INSTRUCTIONS_FILE: '',
       OMX_TEAM_WORKER: '',
       OMX_TEAM_STATE_ROOT: '',

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -42,7 +42,7 @@ function runOmx(
   const r = spawnSync(nodeWrapper, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',
-    env: { ...process.env, ...envOverrides },
+    env: { ...process.env, CODEX_HOME: '', ...envOverrides },
   });
   return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error?.message };
 }
@@ -642,22 +642,46 @@ describe('resolveExploreHarnessCommand', () => {
 describe('buildExploreHarnessArgs', () => {
   it('includes cwd, prompt, prompt contract, and constrained model settings', () => {
     const wd = join(tmpdir(), 'omx-explore-arg-test');
-    const args = buildExploreHarnessArgs('find auth', wd, {
-      OMX_EXPLORE_SPARK_MODEL: 'spark-model',
-    } as NodeJS.ProcessEnv, '/pkg');
-    assert.deepEqual(args.slice(0, 3), ['--cwd', wd, '--prompt']);
-    assert.match(args[3] || '', /Original Explore Prompt/);
-    assert.match(args[3] || '', /find auth/);
-    assert.deepEqual(args.slice(4), [
-      '--prompt-file',
-      '/pkg/prompts/explore-harness.md',
-      '--instructions-file',
-      '/pkg/templates/model-instructions/explore-lightweight-AGENTS.md',
-      '--model-spark',
-      'spark-model',
-      '--model-fallback',
-      'gpt-5.5',
-    ]);
+    const isolatedCodexHome = join(
+      tmpdir(),
+      `omx-explore-defaults-${process.pid}-${Date.now()}`,
+    );
+    const savedEnv = new Map<string, string | undefined>();
+    for (const key of [
+      'CODEX_HOME',
+      'OMX_DEFAULT_FRONTIER_MODEL',
+      'OMX_DEFAULT_STANDARD_MODEL',
+      'OMX_DEFAULT_SPARK_MODEL',
+      'OMX_SPARK_MODEL',
+    ] as const) {
+      savedEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+
+    try {
+      const args = buildExploreHarnessArgs('find auth', wd, {
+        CODEX_HOME: isolatedCodexHome,
+        OMX_EXPLORE_SPARK_MODEL: 'spark-model',
+      } as NodeJS.ProcessEnv, '/pkg');
+      assert.deepEqual(args.slice(0, 3), ['--cwd', wd, '--prompt']);
+      assert.match(args[3] || '', /Original Explore Prompt/);
+      assert.match(args[3] || '', /find auth/);
+      assert.deepEqual(args.slice(4), [
+        '--prompt-file',
+        '/pkg/prompts/explore-harness.md',
+        '--instructions-file',
+        '/pkg/templates/model-instructions/explore-lightweight-AGENTS.md',
+        '--model-spark',
+        'spark-model',
+        '--model-fallback',
+        'gpt-5.5',
+      ]);
+    } finally {
+      for (const [key, value] of savedEnv.entries()) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 
   it('honors configured env overrides for fallback model and instructions file', async () => {

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   collectInheritableTeamWorkerArgs,
   isLowComplexityAgentType,
@@ -12,6 +14,33 @@ import {
 
 function expectedLowComplexityModel(): string {
   return resolveTeamLowComplexityDefaultModel();
+}
+
+function withIsolatedDefaultModelEnv<T>(run: () => T): T {
+  const savedEnv = new Map<string, string | undefined>();
+  for (const key of [
+    'CODEX_HOME',
+    'OMX_DEFAULT_FRONTIER_MODEL',
+    'OMX_DEFAULT_STANDARD_MODEL',
+    'OMX_DEFAULT_SPARK_MODEL',
+    'OMX_SPARK_MODEL',
+  ] as const) {
+    savedEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  process.env.CODEX_HOME = join(
+    tmpdir(),
+    `omx-model-contract-defaults-${process.pid}-${Date.now()}`,
+  );
+
+  try {
+    return run();
+  } finally {
+    for (const [key, value] of savedEnv.entries()) {
+      if (typeof value === 'string') process.env[key] = value;
+      else delete process.env[key];
+    }
+  }
 }
 
 describe('team model contract', () => {
@@ -137,18 +166,22 @@ describe('team model contract', () => {
   });
 
   it('maps worker roles to configured default model lanes', () => {
-    assert.equal(resolveAgentDefaultModel('explore'), expectedLowComplexityModel());
-    assert.equal(resolveAgentDefaultModel('writer'), 'gpt-5.5');
-    assert.equal(resolveAgentDefaultModel('executor'), 'gpt-5.5');
-    assert.equal(resolveAgentDefaultModel('architect'), 'gpt-5.5');
-    assert.equal(resolveAgentDefaultModel('does-not-exist'), undefined);
+    withIsolatedDefaultModelEnv(() => {
+      assert.equal(resolveAgentDefaultModel('explore'), expectedLowComplexityModel());
+      assert.equal(resolveAgentDefaultModel('writer'), 'gpt-5.5');
+      assert.equal(resolveAgentDefaultModel('executor'), 'gpt-5.5');
+      assert.equal(resolveAgentDefaultModel('architect'), 'gpt-5.5');
+      assert.equal(resolveAgentDefaultModel('does-not-exist'), undefined);
+    });
   });
 
   it('keeps assigned worker roles as their own runtime identity', () => {
-    assert.equal(resolveAgentDefaultModel('explore'), expectedLowComplexityModel());
-    assert.equal(resolveAgentReasoningEffort('explore'), 'low');
-    assert.equal(resolveAgentDefaultModel('style-reviewer'), expectedLowComplexityModel());
-    assert.equal(resolveAgentReasoningEffort('style-reviewer'), 'low');
+    withIsolatedDefaultModelEnv(() => {
+      assert.equal(resolveAgentDefaultModel('explore'), expectedLowComplexityModel());
+      assert.equal(resolveAgentReasoningEffort('explore'), 'low');
+      assert.equal(resolveAgentDefaultModel('style-reviewer'), expectedLowComplexityModel());
+      assert.equal(resolveAgentReasoningEffort('style-reviewer'), 'low');
+    });
   });
 });
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -87,6 +87,62 @@ function expectedLowComplexityModel(codexHomeOverride?: string): string {
   return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
 }
 
+function withIsolatedDefaultModelEnv<T>(run: () => T): T {
+  const savedEnv = new Map<string, string | undefined>();
+  for (const key of [
+    'CODEX_HOME',
+    'OMX_DEFAULT_FRONTIER_MODEL',
+    'OMX_DEFAULT_STANDARD_MODEL',
+    'OMX_DEFAULT_SPARK_MODEL',
+    'OMX_SPARK_MODEL',
+  ] as const) {
+    savedEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  process.env.CODEX_HOME = join(
+    tmpdir(),
+    `omx-runtime-defaults-${process.pid}-${Date.now()}`,
+  );
+
+  try {
+    return run();
+  } finally {
+    for (const [key, value] of savedEnv.entries()) {
+      if (typeof value === 'string') process.env[key] = value;
+      else delete process.env[key];
+    }
+  }
+}
+
+async function withIsolatedDefaultModelEnvAsync<T>(
+  run: () => Promise<T>,
+): Promise<T> {
+  const savedEnv = new Map<string, string | undefined>();
+  for (const key of [
+    'CODEX_HOME',
+    'OMX_DEFAULT_FRONTIER_MODEL',
+    'OMX_DEFAULT_STANDARD_MODEL',
+    'OMX_DEFAULT_SPARK_MODEL',
+    'OMX_SPARK_MODEL',
+  ] as const) {
+    savedEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  process.env.CODEX_HOME = join(
+    tmpdir(),
+    `omx-runtime-defaults-${process.pid}-${Date.now()}`,
+  );
+
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of savedEnv.entries()) {
+      if (typeof value === 'string') process.env[key] = value;
+      else delete process.env[key];
+    }
+  }
+}
+
 async function readTeamDeliveryLog(cwd: string): Promise<Array<Record<string, unknown>>> {
   const path = join(cwd, '.omx', 'logs', `team-delivery-${new Date().toISOString().slice(0, 10)}.jsonl`);
   const raw = await readFile(path, 'utf-8').catch(() => '');
@@ -410,43 +466,49 @@ describe('runtime', () => {
   });
 
   it('resolveWorkerLaunchArgsFromEnv reads low-complexity model from config when present', async () => {
-    const previousCodexHome = process.env.CODEX_HOME;
-    const tempCodexHome = await mkdtemp(join(tmpdir(), 'omx-codex-home-'));
-    await writeFile(
-      join(tempCodexHome, '.omx-config.json'),
-      JSON.stringify({ models: { team_low_complexity: 'gpt-4.1-mini' } }),
-    );
-    process.env.CODEX_HOME = tempCodexHome;
-    try {
-      const args = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-        'explore',
+    await withIsolatedDefaultModelEnvAsync(async () => {
+      const previousCodexHome = process.env.CODEX_HOME;
+      const tempCodexHome = await mkdtemp(join(tmpdir(), 'omx-codex-home-'));
+      await writeFile(
+        join(tempCodexHome, '.omx-config.json'),
+        JSON.stringify({ models: { team_low_complexity: 'gpt-4.1-mini' } }),
       );
-      assert.deepEqual(args, ['--no-alt-screen', '--model', 'gpt-4.1-mini']);
-    } finally {
-      if (typeof previousCodexHome === 'string') process.env.CODEX_HOME = previousCodexHome;
-      else delete process.env.CODEX_HOME;
-      await rm(tempCodexHome, { recursive: true, force: true });
-    }
+      process.env.CODEX_HOME = tempCodexHome;
+      try {
+        const args = resolveWorkerLaunchArgsFromEnv(
+          { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+          'explore',
+        );
+        assert.deepEqual(args, ['--no-alt-screen', '--model', 'gpt-4.1-mini']);
+      } finally {
+        if (typeof previousCodexHome === 'string') process.env.CODEX_HOME = previousCodexHome;
+        else delete process.env.CODEX_HOME;
+        await rm(tempCodexHome, { recursive: true, force: true });
+      }
+    });
   });
 
   it('resolveWorkerLaunchArgsFromEnv injects the frontier default model for executor workers', () => {
-    const args = resolveWorkerLaunchArgsFromEnv(
-      { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-      'executor',
-    );
-    assert.deepEqual(args, ['--no-alt-screen', '--model', 'gpt-5.5']);
+    withIsolatedDefaultModelEnv(() => {
+      const args = resolveWorkerLaunchArgsFromEnv(
+        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+        'executor',
+      );
+      assert.deepEqual(args, ['--no-alt-screen', '--model', 'gpt-5.5']);
+    });
   });
 
   it('resolveWorkerLaunchArgsFromEnv uses medium reasoning for executor launch defaults', () => {
-    const args = resolveWorkerLaunchArgsFromEnv(
-      { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-      'executor',
-      undefined,
-      resolveAgentReasoningEffort('executor'),
-      'codex',
-    );
-    assert.deepEqual(args, ['--no-alt-screen', '-c', 'model_reasoning_effort="medium"', '--model', 'gpt-5.5']);
+    withIsolatedDefaultModelEnv(() => {
+      const args = resolveWorkerLaunchArgsFromEnv(
+        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+        'executor',
+        undefined,
+        resolveAgentReasoningEffort('executor'),
+        'codex',
+      );
+      assert.deepEqual(args, ['--no-alt-screen', '-c', 'model_reasoning_effort="medium"', '--model', 'gpt-5.5']);
+    });
   });
 
   it('resolveWorkerLaunchArgsFromEnv treats *-low aliases as low complexity', () => {
@@ -498,22 +560,24 @@ describe('runtime', () => {
     const originalLog = console.log;
     console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
     try {
-      const lowArgs = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-        'executor',
-        undefined,
-        'low',
-        'codex',
-      );
-      const highArgs = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-        'executor',
-        undefined,
-        'high',
-        'codex',
-      );
-      assert.deepEqual(lowArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="low"', '--model', 'gpt-5.5']);
-      assert.deepEqual(highArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', 'gpt-5.5']);
+      withIsolatedDefaultModelEnv(() => {
+        const lowArgs = resolveWorkerLaunchArgsFromEnv(
+          { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+          'executor',
+          undefined,
+          'low',
+          'codex',
+        );
+        const highArgs = resolveWorkerLaunchArgsFromEnv(
+          { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+          'executor',
+          undefined,
+          'high',
+          'codex',
+        );
+        assert.deepEqual(lowArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="low"', '--model', 'gpt-5.5']);
+        assert.deepEqual(highArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', 'gpt-5.5']);
+      });
     } finally {
       console.log = originalLog;
     }
@@ -613,13 +677,16 @@ describe('runtime', () => {
     const originalLog = console.log;
     console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
     try {
-      const codexArgs = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-        'executor',
-        undefined,
-        'high',
-        'codex',
-      );
+      let codexArgs: string[] = [];
+      withIsolatedDefaultModelEnv(() => {
+        codexArgs = resolveWorkerLaunchArgsFromEnv(
+          { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+          'executor',
+          undefined,
+          'high',
+          'codex',
+        );
+      });
       const claudeArgs = resolveWorkerLaunchArgsFromEnv(
         { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen --model claude-3-7-sonnet' },
         'executor',
@@ -2959,19 +3026,20 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withMockPromptModeCodexAllowed(() =>
-        withoutTeamWorkerEnv(() =>
-          startTeam(
-            'team-role-routing',
-            'heuristic routing handoff',
-            'executor',
-            2,
-            [
-              { subject: 'test routing report only', description: 'test routing report only', owner: 'worker-1', role: 'test-engineer' },
-              { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' },
-            ],
-            cwd,
-          )));
+      runtime = await withIsolatedDefaultModelEnvAsync(async () =>
+        await withMockPromptModeCodexAllowed(() =>
+          withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-role-routing',
+              'heuristic routing handoff',
+              'executor',
+              2,
+              [
+                { subject: 'test routing report only', description: 'test routing report only', owner: 'worker-1', role: 'test-engineer' },
+                { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' },
+              ],
+              cwd,
+            ))));
 
       assert.equal(runtime.config.worker_launch_mode, 'prompt');
       assert.equal(runtime.config.workers[0]?.role, 'test-engineer');


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Several env-sensitive suites still inherit the operator's ambient `CODEX_HOME`
and default-model env. With a poisoned `CODEX_HOME` plus default-model env,
unchanged upstream tests pick up ambient frontier, standard, or spark defaults
and fail without any source change.

## Changes

- isolate `native-config`, `model-contract`, and `runtime` default-model
  assertions by clearing ambient `CODEX_HOME` plus frontier, standard, and
  spark env at the test boundary
- make CLI helper tests blank ambient `CODEX_HOME` unless the case explicitly
  sets one
- keep the patch test-only; production model resolution and runtime behavior
  are unchanged

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/agents/__tests__/native-config.test.js dist/cli/__tests__/explore.test.js dist/team/__tests__/model-contract.test.js dist/team/__tests__/runtime.test.js dist/cli/__tests__/exec.test.js`
- [x] hostile-env spot check with poisoned `CODEX_HOME` plus default-model env
  for the previously failing `native-config`, `explore`, `model-contract`, and
  focused `runtime` cases

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
