### PR TITLE
Preserve approved execution handoff context

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -86,6 +86,11 @@ const approvedHint: ApprovedExecutionLaunchHint = {
   sourcePath: '.omx/plans/prd-issue-1072.md',
   testSpecPaths: ['.omx/plans/test-spec-issue-1072.md'],
   deepInterviewSpecPaths: ['.omx/specs/deep-interview-issue-1072.md'],
+  repositoryContextSummary: {
+    sourcePath: '.omx/plans/repo-context-issue-1072.md',
+    content: 'Key files: src/cli/ralph.ts and src/planning/artifacts.ts',
+    truncated: false,
+  },
 };
 
 describe('assertRequiredRalphPrdJson', () => {
@@ -225,6 +230,8 @@ describe('ralph deslop launch wiring', () => {
     assert.match(instructions, /test specs: \.omx\/plans\/test-spec-issue-1072\.md/i);
     assert.match(instructions, /deep-interview specs: \.omx\/specs\/deep-interview-issue-1072\.md/i);
     assert.match(instructions, /Carry forward the approved deep-interview requirements/i);
+    assert.match(instructions, /approved repository context summary: \.omx\/plans\/repo-context-issue-1072\.md/i);
+    assert.match(instructions, /Key files: src\/cli\/ralph\.ts and src\/planning\/artifacts\.ts/i);
   });
 
   it('seeds the changed-files artifact with bounded-scope guidance', () => {

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -288,6 +288,30 @@ describe('parseTeamStartArgs', () => {
     }
   });
 
+  it('attaches approved repository context summary only for matching team launches', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-context-approved-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-2039.md'),
+        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 2039 plan"\n',
+      );
+      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-2039.md'), '# Test spec\n');
+      await writeFile(join(wd, '.omx', 'plans', 'repo-context-issue-2039.md'), 'Key boundary: latest approved handoff only.\n');
+
+      const approved = parseTeamStartArgs(['3:executor', 'Execute', 'approved', 'issue', '2039', 'plan']);
+      assert.equal(approved.parsed.approvedRepositoryContextSummary?.content, 'Key boundary: latest approved handoff only.');
+
+      const unrelated = parseTeamStartArgs(['3:executor', 'fix', 'unrelated', 'bug']);
+      assert.equal(unrelated.parsed.approvedRepositoryContextSummary, undefined);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves explicit team staffing overrides while reusing the approved plan task', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-override-'));
     const previousCwd = process.cwd();

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -149,6 +149,11 @@ function buildRalphApprovedContextLines(approvedHint: ApprovedExecutionLaunchHin
     lines.push(`- deep-interview specs: ${approvedHint.deepInterviewSpecPaths.join(', ')}`);
     lines.push('- Carry forward the approved deep-interview requirements and constraints during Ralph execution and final verification.');
   }
+  if (approvedHint.repositoryContextSummary) {
+    lines.push(`- approved repository context summary: ${approvedHint.repositoryContextSummary.sourcePath}${approvedHint.repositoryContextSummary.truncated ? ' (bounded/truncated)' : ''}`);
+    lines.push('Approved repository context summary (bounded, inspectable):');
+    lines.push(approvedHint.repositoryContextSummary.content);
+  }
   return lines;
 }
 
@@ -255,9 +260,12 @@ export async function ralphCommand(args: string[]): Promise<void> {
   }
   assertRequiredRalphPrdJson(cwd, args);
   const artifacts = await ensureCanonicalRalphArtifacts(cwd);
-  const approvedHint = readApprovedExecutionLaunchHint(cwd, 'ralph');
+  const rawApprovedHint = readApprovedExecutionLaunchHint(cwd, 'ralph');
   const explicitTask = extractRalphTaskDescription(normalizedArgs);
-  const task = explicitTask === 'ralph-cli-launch' ? approvedHint?.task ?? explicitTask : explicitTask;
+  const task = explicitTask === 'ralph-cli-launch' ? rawApprovedHint?.task ?? explicitTask : explicitTask;
+  const approvedHint = rawApprovedHint && (explicitTask === 'ralph-cli-launch' || rawApprovedHint.task.trim() === task.trim())
+    ? rawApprovedHint
+    : null;
   const noDeslop = normalizedArgs.some((arg) => arg.toLowerCase() === '--no-deslop');
   const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
   const staffingPlan = buildFollowupStaffingPlan('ralph', task, availableAgentTypes);

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -10,7 +10,7 @@ import { readTeamEvents, waitForTeamEvent } from '../team/state/events.js';
 import type { TeamEvent } from '../team/state.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
 import { classifyTaskSize } from '../hooks/task-size-detector.js';
-import { readApprovedExecutionLaunchHint } from '../planning/artifacts.js';
+import { readApprovedExecutionLaunchHint, type ApprovedRepositoryContextSummary } from '../planning/artifacts.js';
 import { routeTaskToRole } from '../team/role-router.js';
 import { allocateTasksToWorkers } from '../team/allocation-policy.js';
 import {
@@ -40,6 +40,7 @@ interface ParsedTeamArgs {
   task: string;
   teamName: string;
   allowRepoAwareDagHandoff: boolean;
+  approvedRepositoryContextSummary?: ApprovedRepositoryContextSummary;
 }
 
 
@@ -755,10 +756,23 @@ function parseTeamArgs(args: string[], cwd: string = process.cwd()): ParsedTeamA
     && (approvedHint.workerCount == null || approvedHint.workerCount === workerCount)
     && (approvedHint.agentType == null || approvedHint.agentType === agentType);
   const allowRepoAwareDagHandoff = followupContext != null || matchesApprovedLaunchHint;
+  const approvedRepositoryContextSummary = allowRepoAwareDagHandoff
+    ? approvedHint?.repositoryContextSummary
+    : undefined;
 
   const teamName = sanitizeTeamName(slugifyTask(effectiveTask));
-  return { workerCount, agentType, explicitAgentType, explicitWorkerCount, task: effectiveTask, teamName, allowRepoAwareDagHandoff };
+  return {
+    workerCount,
+    agentType,
+    explicitAgentType,
+    explicitWorkerCount,
+    task: effectiveTask,
+    teamName,
+    allowRepoAwareDagHandoff,
+    ...(approvedRepositoryContextSummary ? { approvedRepositoryContextSummary } : {}),
+  };
 }
+
 
 export function parseTeamStartArgs(args: string[]): ParsedTeamStartArgs {
   const parsedWorktree = parseWorktreeMode(args);
@@ -1490,6 +1504,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     cwd,
     buildLegacyPlan: buildTeamExecutionPlan,
     allowDagHandoff: parsed.allowRepoAwareDagHandoff,
+    approvedRepositoryContextSummary: parsed.approvedRepositoryContextSummary,
   });
   const tasks = executionPlan.tasks;
   const effectiveParsed = executionPlan.workerCount === parsed.workerCount

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -35,8 +35,6 @@ describe('planning artifacts', () => {
   });
 
 
-
-
   it('resolves matching Team DAG sidecar before markdown handoff', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });
@@ -221,8 +219,6 @@ describe('planning artifacts', () => {
     assert.deepEqual(hint?.deepInterviewSpecPaths, [join(specsDir, 'deep-interview-zeta.md')]);
   });
 
-
-
   it('binds approved handoff context to the selected PRD slug in multi-plan repos', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     const specsDir = join(tempDir, '.omx', 'specs');
@@ -241,6 +237,58 @@ describe('planning artifacts', () => {
     assert.equal(hint?.sourcePath, join(plansDir, 'prd-zeta.md'));
     assert.deepEqual(hint?.testSpecPaths, [join(plansDir, 'test-spec-zeta.md')]);
     assert.deepEqual(hint?.deepInterviewSpecPaths, [join(specsDir, 'deep-interview-zeta.md')]);
+  });
+
+
+  it('attaches bounded approved repository context from a matching latest-plan sidecar', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-2039.md'),
+      '# PRD\n\nLaunch via omx team 3:executor "Execute approved issue 2039 plan"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-2039.md'), '# Test Spec\n');
+    await writeFile(join(plansDir, 'repo-context-issue-2039.md'), 'Key files: src/planning/artifacts.ts\n'.repeat(120));
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team');
+
+    assert.ok(hint?.repositoryContextSummary);
+    assert.equal(hint.repositoryContextSummary.sourcePath, join(plansDir, 'repo-context-issue-2039.md'));
+    assert.match(hint.repositoryContextSummary.content, /Key files: src\/planning\/artifacts\.ts/);
+    assert.equal(hint.repositoryContextSummary.truncated, true);
+    assert.ok(hint.repositoryContextSummary.content.split('\n').length <= 80);
+  });
+
+  it('does not attach stale repository context from a different PRD slug', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-alpha.md'), '# Alpha\n\nLaunch via omx team 2:executor "Execute alpha"\n');
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha Test Spec\n');
+    await writeFile(join(plansDir, 'repo-context-alpha.md'), 'stale alpha context\n');
+    await writeFile(join(plansDir, 'prd-zeta.md'), '# Zeta\n\nLaunch via omx team 3:executor "Execute zeta"\n');
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team');
+
+    assert.ok(hint);
+    assert.equal(hint.task, 'Execute zeta');
+    assert.equal(hint.repositoryContextSummary, undefined);
+  });
+
+  it('falls back to an inline approved repository context section when no sidecar exists', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-inline.md'),
+      '# PRD\n\nLaunch via omx ralph "Execute inline"\n\n## Approved Repository Context Summary\n\n- Reuse src/cli/ralph.ts.\n\n## Verification\nRun tests.\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-inline.md'), '# Inline Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+
+    assert.ok(hint?.repositoryContextSummary);
+    assert.equal(hint.repositoryContextSummary.sourcePath, join(plansDir, 'prd-inline.md'));
+    assert.equal(hint.repositoryContextSummary.content, '- Reuse src/cli/ralph.ts.');
   });
 
   it('surfaces deep-interview specs for downstream traceability', async () => {

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -5,6 +5,8 @@ import { omxPlansDir } from '../utils/paths.js';
 const PRD_PATTERN = /^prd-.*\.md$/i;
 const TEST_SPEC_PATTERN = /^test-?spec-.*\.md$/i;
 const DEEP_INTERVIEW_SPEC_PATTERN = /^deep-interview-.*\.md$/i;
+const APPROVED_REPOSITORY_CONTEXT_MAX_CHARS = 4_000;
+const APPROVED_REPOSITORY_CONTEXT_MAX_LINES = 80;
 
 export interface PlanningArtifacts {
   plansDir: string;
@@ -14,10 +16,17 @@ export interface PlanningArtifacts {
   deepInterviewSpecPaths: string[];
 }
 
+export interface ApprovedRepositoryContextSummary {
+  sourcePath: string;
+  content: string;
+  truncated: boolean;
+}
+
 export interface ApprovedPlanContext {
   sourcePath: string;
   testSpecPaths: string[];
   deepInterviewSpecPaths: string[];
+  repositoryContextSummary?: ApprovedRepositoryContextSummary;
 }
 
 export interface ApprovedExecutionLaunchHint extends ApprovedPlanContext {
@@ -103,6 +112,59 @@ function filterArtifactsForSlug(paths: readonly string[], prefixPattern: RegExp,
   return paths.filter((path) => artifactSlug(path, prefixPattern) === slug);
 }
 
+
+function boundedRepositoryContextSummary(sourcePath: string, content: string): ApprovedRepositoryContextSummary | null {
+  const normalizedLines = content
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((line) => line.trimEnd());
+  const trimmed = normalizedLines.join('\n').trim();
+  if (!trimmed) return null;
+
+  const limitedLines = normalizedLines.slice(0, APPROVED_REPOSITORY_CONTEXT_MAX_LINES);
+  const lineTruncated = normalizedLines.length > limitedLines.length;
+  let limited = limitedLines.join('\n').trim();
+  let charTruncated = false;
+  if (limited.length > APPROVED_REPOSITORY_CONTEXT_MAX_CHARS) {
+    limited = limited.slice(0, APPROVED_REPOSITORY_CONTEXT_MAX_CHARS).trimEnd();
+    charTruncated = true;
+  }
+  return { sourcePath, content: limited, truncated: lineTruncated || charTruncated };
+}
+
+function extractApprovedRepositoryContextSection(sourcePath: string, content: string): ApprovedRepositoryContextSummary | null {
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+  const headingIndex = lines.findIndex((line) => /^#{1,6}\s+Approved Repository Context Summary\s*$/i.test(line.trim()));
+  if (headingIndex < 0) return null;
+  const headingLevel = lines[headingIndex].match(/^(#+)/)?.[1].length ?? 1;
+  const body: string[] = [];
+  for (let index = headingIndex + 1; index < lines.length; index += 1) {
+    const heading = lines[index].match(/^(#{1,6})\s+/);
+    if (heading && heading[1].length <= headingLevel) break;
+    body.push(lines[index]);
+  }
+  return boundedRepositoryContextSummary(sourcePath, body.join('\n'));
+}
+
+function readApprovedRepositoryContextSummary(
+  artifacts: PlanningArtifacts,
+  prdPath: string,
+  planSlug: string | null,
+  prdContent: string,
+): ApprovedRepositoryContextSummary | null {
+  if (!planSlug) return extractApprovedRepositoryContextSection(prdPath, prdContent);
+  const sidecarPath = join(artifacts.plansDir, `repo-context-${planSlug}.md`);
+  if (existsSync(sidecarPath)) {
+    try {
+      const sidecar = boundedRepositoryContextSummary(sidecarPath, readFileSync(sidecarPath, 'utf-8'));
+      if (sidecar) return sidecar;
+    } catch {
+      // Fall through to an inline approved PRD section when the inspectable sidecar is unreadable.
+    }
+  }
+  return extractApprovedRepositoryContextSection(prdPath, prdContent);
+}
+
 function readApprovedPlanText(cwd: string): { content: string; context: ApprovedPlanContext } | null {
   const artifacts = readPlanningArtifacts(cwd);
   if (!isPlanningComplete(artifacts)) return null;
@@ -112,12 +174,16 @@ function readApprovedPlanText(cwd: string): { content: string; context: Approved
   if (!latestPrdPath || selection.testSpecPaths.length === 0 || !existsSync(latestPrdPath)) return null;
 
   try {
+    const content = readFileSync(latestPrdPath, 'utf-8');
+    const planSlug = artifactSlug(latestPrdPath, /^prd-(?<slug>.*)\.md$/i);
+    const repositoryContextSummary = readApprovedRepositoryContextSummary(artifacts, latestPrdPath, planSlug, content);
     return {
-      content: readFileSync(latestPrdPath, 'utf-8'),
+      content,
       context: {
         sourcePath: latestPrdPath,
         testSpecPaths: selection.testSpecPaths,
         deepInterviewSpecPaths: selection.deepInterviewSpecPaths,
+        ...(repositoryContextSummary ? { repositoryContextSummary } : {}),
       },
     };
   } catch {

--- a/src/team/__tests__/repo-aware-decomposition.test.ts
+++ b/src/team/__tests__/repo-aware-decomposition.test.ts
@@ -87,6 +87,53 @@ describe('buildRepoAwareTeamExecutionPlan', () => {
     assert.equal(plan.tasks[0].subject, 'legacy');
   });
 
+
+
+  it('carries approved repository context summary only when the launch gate supplies it', () => {
+    const cwd = repo();
+    writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'impl', subject: 'Implement', description: 'Implement from DAG' }],
+    }));
+    const plan = buildRepoAwareTeamExecutionPlan({
+      task: 'team',
+      workerCount: 3,
+      agentType: 'executor',
+      explicitAgentType: false,
+      explicitWorkerCount: false,
+      cwd,
+      buildLegacyPlan: legacy,
+      allowDagHandoff: true,
+      approvedRepositoryContextSummary: {
+        sourcePath: join(cwd, '.omx', 'plans', 'repo-context-demo.md'),
+        content: 'Approved context: runtime lives in src/team/runtime.ts',
+        truncated: false,
+      },
+    });
+
+    assert.equal(plan.metadata?.approved_context_summary?.content, 'Approved context: runtime lives in src/team/runtime.ts');
+  });
+
+  it('does not consume ambient repository context summary without an approved launch match', () => {
+    const cwd = repo();
+    writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'stale', subject: 'Stale', description: 'Stale DAG' }],
+    }));
+    const plan = buildRepoAwareTeamExecutionPlan({
+      task: 'fix unrelated tests',
+      workerCount: 3,
+      agentType: 'executor',
+      explicitAgentType: false,
+      explicitWorkerCount: false,
+      cwd,
+      buildLegacyPlan: legacy,
+    });
+
+    assert.equal(plan.metadata?.approved_context_summary, undefined);
+    assert.equal(plan.metadata?.fallback_reason, 'dag_handoff_not_approved_for_invocation');
+  });
+
   it('honors CLI-explicit worker count beyond ready lanes', () => {
     const cwd = repo();
     writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -979,4 +979,26 @@ describe("worker bootstrap", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("generateInitialInbox includes approved repository context summary when provided", () => {
+    const inbox = generateInitialInbox(
+      "worker-1",
+      "context-team",
+      "executor",
+      [{ id: "1", subject: "Implement", description: "Do task", status: "pending", owner: "worker-1", created_at: "2026-04-30T00:00:00.000Z" }],
+      {
+        approvedContextSummary: {
+          sourcePath: ".omx/plans/repo-context-issue-2039.md",
+          content: "Key boundary: preserve approved context only for matching launches.",
+          truncated: false,
+        },
+      },
+    );
+
+    assert.match(inbox, /## Approved Repository Context Summary/);
+    assert.match(inbox, /Source: \.omx\/plans\/repo-context-issue-2039\.md/);
+    assert.match(inbox, /preserve approved context only for matching launches/);
+  });
+
 });
+

--- a/src/team/repo-aware-decomposition.ts
+++ b/src/team/repo-aware-decomposition.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { relative } from 'node:path';
 import { allocateTasksToWorkers } from './allocation-policy.js';
+import type { ApprovedRepositoryContextSummary } from '../planning/artifacts.js';
 import { readTeamDagHandoffForLatestPlan, type TeamDagHandoff, type TeamDagNode, type TeamDagResolution, type TeamDagWorkerCountSource } from './dag-schema.js';
 
 export interface LegacyTeamExecutionPlanInput {
@@ -12,6 +13,7 @@ export interface LegacyTeamExecutionPlanInput {
   cwd: string;
   buildLegacyPlan: (task: string, workerCount: number, agentType: string, explicitAgentType: boolean, explicitWorkerCount: boolean) => RepoAwareTeamExecutionPlan;
   allowDagHandoff?: boolean;
+  approvedRepositoryContextSummary?: ApprovedRepositoryContextSummary;
 }
 
 export interface RepoAwareTask {
@@ -44,6 +46,7 @@ export interface TeamDecompositionMetadata {
   node_dependencies?: Record<string, string[]>;
   node_id_to_task_id?: Record<string, string>;
   task_hints?: Record<string, TaskHintSummary>;
+  approved_context_summary?: ApprovedRepositoryContextSummary;
 }
 
 export interface TaskHintSummary {
@@ -238,6 +241,7 @@ function buildFromDag(input: LegacyTeamExecutionPlanInput, resolution: TeamDagRe
       useful_lane_count: useful,
       allocation_reasons: allocationReasons,
       node_dependencies: nodeDependencies,
+      ...(input.approvedRepositoryContextSummary ? { approved_context_summary: input.approvedRepositoryContextSummary } : {}),
     },
   };
 }
@@ -296,6 +300,7 @@ export function buildRepoAwareTeamExecutionPlan(input: LegacyTeamExecutionPlanIn
       ready_lane_count: legacy.workerCount,
       useful_lane_count: legacy.workerCount,
       allocation_reasons: {},
+      ...(input.approvedRepositoryContextSummary ? { approved_context_summary: input.approvedRepositoryContextSummary } : {}),
     },
   };
 }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2383,6 +2383,7 @@ export async function startTeam(
         rolePromptContent: rawRolePromptContent ?? undefined,
         worktreeRootAgentsCanonical: Boolean(workerWorkspace.worktreePath),
         taskHints: effectiveDecompositionMetadata?.task_hints,
+        approvedContextSummary: effectiveDecompositionMetadata?.approved_context_summary,
       });
       const triggerDirective = buildTriggerDirective(
         workerName,

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -9,6 +9,7 @@ import {
 } from "../verification/verifier.js";
 import { codexHome, listInstalledSkillDirectories } from "../utils/paths.js";
 import { sleep } from "../utils/sleep.js";
+import type { ApprovedRepositoryContextSummary } from "../planning/artifacts.js";
 import type { TeamReminderDirective } from "./reminder-intents.js";
 import type { TaskHintSummary } from "./repo-aware-decomposition.js";
 
@@ -699,6 +700,7 @@ export function generateInitialInbox(
     rolePromptContent?: string;
     worktreeRootAgentsCanonical?: boolean;
     taskHints?: Record<string, TaskHintSummary>;
+    approvedContextSummary?: ApprovedRepositoryContextSummary;
   } = {},
 ): string {
   const taskList = tasks
@@ -739,6 +741,16 @@ export function generateInitialInbox(
   const displayRole = options.workerRole ?? agentType;
   const delegationSection = renderDelegationContracts(tasks);
 
+  const approvedContextSection = options.approvedContextSummary
+    ? `
+## Approved Repository Context Summary
+
+Source: ${options.approvedContextSummary.sourcePath}${options.approvedContextSummary.truncated ? ' (bounded/truncated)' : ''}
+
+${options.approvedContextSummary.content}
+`
+    : "";
+
   const specializationSection = options.worktreeRootAgentsCanonical === true
     ? ""
     : options.rolePromptContent
@@ -754,7 +766,7 @@ export function generateInitialInbox(
 ## Your Assigned Tasks
 
 ${taskList}
-
+${approvedContextSection}
 ## Instructions
 
 1. Load and follow the worker skill from the first existing path:


### PR DESCRIPTION
## Summary\n- Adds a bounded, inspectable approved repository context summary tied to the latest PRD/test-spec slug and launch hint.\n- Gates Team/Ralph context consumption to matching approved execution handoffs, preserving fallback behavior when absent or unrelated.\n- Threads approved context into Ralph append instructions and Team worker inboxes without a generic context dump or .omx/context rollout.\n\nCloses #2039\n\n## Verification\n- npm run build\n- npm run lint\n- npm run check:no-unused\n- node --test dist/planning/__tests__/artifacts.test.js dist/cli/__tests__/team.test.js dist/cli/__tests__/ralph.test.js dist/team/__tests__/repo-aware-decomposition.test.js dist/team/__tests__/worker-bootstrap.test.js