### PR TITLE
Fix prompt worker startup death handling

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -2038,7 +2038,7 @@ describe('teamCommand await', () => {
     await writeFile(
       fakeCodexPath,
       `#!/usr/bin/env node
-setTimeout(() => process.exit(0), 150);
+setTimeout(() => process.exit(0), 0);
 process.stdin.resume();
 process.on('SIGTERM', () => process.exit(0));
 `,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1637,6 +1637,38 @@ async function recordRecoverableStartupIssue(params: {
   ).catch(() => {});
 }
 
+async function recordPromptStartupWorkerStopped(params: {
+  teamName: string;
+  workerName: string;
+  taskIds: string[];
+  reason: string;
+  cwd: string;
+}): Promise<void> {
+  const { teamName, workerName, taskIds, reason, cwd } = params;
+  const updatedAt = new Date().toISOString();
+  await writeWorkerStatus(
+    teamName,
+    workerName,
+    {
+      state: 'failed',
+      current_task_id: taskIds[0],
+      reason,
+      updated_at: updatedAt,
+    },
+    cwd,
+  ).catch(() => {});
+  await appendTeamEvent(
+    teamName,
+    {
+      type: 'worker_stopped',
+      worker: workerName,
+      task_id: taskIds[0],
+      reason,
+    },
+    cwd,
+  ).catch(() => {});
+}
+
 function setTeamModelInstructionsFile(teamName: string, filePath: string): void {
   if (!previousModelInstructionsFileByTeam.has(teamName)) {
     previousModelInstructionsFileByTeam.set(teamName, process.env[MODEL_INSTRUCTIONS_FILE_ENV]);
@@ -2676,6 +2708,16 @@ export async function startTeam(
           && isRecoverableInteractiveStartupReason(dispatchOutcome.reason)
         ) {
           await recordRecoverableStartupIssue({
+            teamName: sanitized,
+            workerName,
+            taskIds: workerTasks.map((task) => task.id),
+            reason: dispatchOutcome.reason,
+            cwd: leaderCwd,
+          });
+          return { ok: true, workerIndex, workerName };
+        }
+        if (workerLaunchMode === 'prompt' && !workerAlive) {
+          await recordPromptStartupWorkerStopped({
             teamName: sanitized,
             workerName,
             taskIds: workerTasks.map((task) => task.id),


### PR DESCRIPTION
## Summary\n- Treat prompt-launched workers that die before startup dispatch as dead workers instead of startup notify failures\n- Record failed worker status and a worker_stopped event so team await/status can surface the dead-worker path\n- Tighten the prompt dead-worker smoke test to exercise immediate worker exit\n\n## Verification\n- npm run build\n- node --test --test-name-pattern "returns a dead-worker event for the prompt-launch smoke path instead of timing out" dist/cli/__tests__/team.test.js\n- node --test dist/cli/__tests__/team.test.js\n- npm run check:no-unused\n- npm run lint\n- npx c8 --all --src dist --exclude '**/__tests__/**' --exclude 'dist/bin/**' --exclude 'dist/**/*.d.ts' --reporter=text-summary --report-dir coverage/ts-full-target node --test --test-name-pattern "returns a dead-worker event for the prompt-launch smoke path instead of timing out" dist/cli/__tests__/team.test.js