### PR TITLE
Fix flaky HUD watch coalescing test

### DIFF
--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -31,12 +31,24 @@ function flush(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-async function waitFor(predicate: () => boolean, attempts = 20): Promise<void> {
-  for (let index = 0; index < attempts; index += 1) {
-    if (predicate()) return;
-    await flush();
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function withTimeout(promise: Promise<void>, message: string, timeoutMs = 1000): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
-  assert.ok(predicate(), 'condition should become true before timeout');
 }
 
 afterEach(() => {
@@ -82,10 +94,9 @@ describe('runWatchMode', () => {
     let callCount = 0;
     let inFlight = 0;
     let maxInFlight = 0;
-    let releaseFirstRender: (() => void) | undefined;
-    const firstRenderGate = new Promise<void>((resolve) => {
-      releaseFirstRender = resolve;
-    });
+    const firstRenderGate = deferred();
+    const firstReadStarted = deferred();
+    const secondReadStarted = deferred();
 
     const promise = runWatchMode('/tmp', WATCH_FLAGS, {
       isTTY: true,
@@ -96,7 +107,10 @@ describe('runWatchMode', () => {
         maxInFlight = Math.max(maxInFlight, inFlight);
         try {
           if (callCount === 1) {
-            await firstRenderGate;
+            firstReadStarted.resolve();
+            await firstRenderGate.promise;
+          } else if (callCount === 2) {
+            secondReadStarted.resolve();
           }
           return emptyCtx();
         } finally {
@@ -117,13 +131,14 @@ describe('runWatchMode', () => {
 
     await flush();
     assert.ok(timerTick, 'interval tick should be registered');
+    await withTimeout(firstReadStarted.promise, 'first render should start before exercising queued ticks');
 
-    // Trigger multiple ticks while first render is still blocked.
+    // Trigger multiple ticks while first render is deterministically blocked.
     timerTick?.();
     timerTick?.();
 
-    releaseFirstRender?.();
-    await waitFor(() => callCount === 2);
+    firstRenderGate.resolve();
+    await withTimeout(secondReadStarted.promise, 'queued rerender should start after first render is released');
 
     sigintHandler?.();
     await promise;


### PR DESCRIPTION
## Summary\n- make the HUD watch coalescing test deterministic by waiting on explicit render-start gates instead of polling short timer flushes\n- keep the overlap assertion and collapsed queued-rerender assertion intact\n\n## Verification\n- npm run build\n- node --test dist/hud/__tests__/index.test.js --test-name-pattern 'coalesces ticks so slow renders do not overlap'\n- node --test dist/hud/__tests__/index.test.js (20 repeated runs)\n- npx c8 --all --src dist --exclude '**/__tests__/**' --exclude 'dist/bin/**' --exclude 'dist/**/*.d.ts' --reporter=text-summary --report-dir coverage/hud-flake node --test dist/hud/__tests__/index.test.js\n- npm run check:no-unused\n- npm run lint\n- node --test dist/hud/__tests__/index.test.js