### PR TITLE
Keep OMX MCP serve process alive

### DIFF
--- a/src/cli/__tests__/mcp-serve.test.ts
+++ b/src/cli/__tests__/mcp-serve.test.ts
@@ -10,6 +10,7 @@ describe("mcp-serve command", () => {
 
 		await mcpServeCommand(["trace"], {
 			env,
+			keepProcessAlive: false,
 			loaders: {
 				"state-server.js": async () => {
 					loaded.push("state-server.js");
@@ -37,10 +38,42 @@ describe("mcp-serve command", () => {
 		const env: Record<string, string | undefined> = {};
 
 		await assert.rejects(
-			mcpServeCommand(["unknown-entrypoint"], { env }),
+			mcpServeCommand(["unknown-entrypoint"], { env, keepProcessAlive: false }),
 			/Unknown MCP target: unknown-entrypoint/,
 		);
 
 		assert.equal(env[MCP_ENTRYPOINT_MARKER_ENV], undefined);
+	});
+
+	it("keeps the stdio server process alive after loading the target module", async () => {
+		const env: Record<string, string | undefined> = {};
+		let loaded = false;
+		let settled = false;
+
+		const commandPromise = mcpServeCommand(["state"], {
+			env,
+			loaders: {
+				"state-server.js": async () => {
+					loaded = true;
+				},
+				"memory-server.js": async () => {},
+				"code-intel-server.js": async () => {},
+				"trace-server.js": async () => {},
+				"wiki-server.js": async () => {},
+			},
+		});
+		void commandPromise.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		assert.equal(loaded, true);
+		assert.equal(settled, false);
 	});
 });

--- a/src/cli/mcp-serve.ts
+++ b/src/cli/mcp-serve.ts
@@ -13,6 +13,7 @@ type McpServeLoaderMap = Record<McpServeEntrypoint, McpServeLoader>;
 interface McpServeCommandOptions {
   env?: Record<string, string | undefined>;
   loaders?: McpServeLoaderMap;
+  keepProcessAlive?: boolean;
 }
 
 const MCP_SERVE_USAGE = [
@@ -84,4 +85,12 @@ export async function mcpServeCommand(
   const loaders = options.loaders ?? MCP_SERVE_LOADERS;
   env[MCP_ENTRYPOINT_MARKER_ENV] = target;
   await loaders[target]();
+  if (options.keepProcessAlive === false) return;
+
+  // MCP server modules start their stdio lifecycle as a top-level import side
+  // effect. Keep the CLI command from returning after that import so the MCP
+  // client can complete initialize and continue using the inherited stdio
+  // transport. The server bootstrap owns shutdown when stdin closes, the parent
+  // exits, or the transport disconnects.
+  await new Promise<never>(() => undefined);
 }


### PR DESCRIPTION
## Summary
- keep `omx mcp-serve <target>` pending after the selected MCP server module loads so stdio MCP clients do not lose the server during startup
- add focused regression coverage for the old immediate-settle path
- add a test-only `keepProcessAlive: false` opt-out so dispatch/validation unit tests can still await the command

## Problem

`mcpServeCommand()` returned as soon as the target loader finished. In the bin-wrapper path that can let the CLI command complete and close the stdio MCP process before the client finishes initialization.

## Root cause

The MCP server modules start their stdio lifecycle as a top-level import side effect, but the CLI command did not keep ownership of the process after `await loaders[target]()`.

## Changes

- after loading the target, keep `mcpServeCommand()` pending unless tests explicitly disable keepalive
- update existing tests to use the opt-out for dispatch/validation paths
- add a red-green regression asserting the loader ran while the command promise remains unsettled after one event-loop tick

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/mcp-serve.test.js`
- `node --test dist/cli/__tests__/package-bin-contract.test.js`

## Risk / compatibility
- runtime behavior changes only for `omx mcp-serve <target>`: the command now stays alive for the stdio MCP lifecycle
- validation errors and help output still return normally before keepalive is entered
- the opt-out is only exposed for tests
