### PR TITLE
fix(planning): exact-match approved launch hint selection

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -12,6 +12,8 @@ import {
   filterRalphCodexArgs,
   isRalphPrdMode,
   normalizeRalphCliArgs,
+  readMatchedApprovedRalphExecutionHint,
+  resolveApprovedRalphExecutionHint,
 } from '../ralph.js';
 import type { ApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
 
@@ -30,6 +32,68 @@ describe('extractRalphTaskDescription', () => {
   });
   it('supports -- separator', () => {
     assert.equal(extractRalphTaskDescription(['--model', 'gpt-5', '--', 'fix', '--weird-name']), 'fix --weird-name');
+  });
+});
+
+describe('resolveApprovedRalphExecutionHint', () => {
+  it('reuses the approved hint for follow-up launches without explicit task text', () => {
+    assert.equal(resolveApprovedRalphExecutionHint(approvedHint, 'ralph-cli-launch'), approvedHint);
+  });
+
+  it('reuses the approved hint when the explicit task matches the approved handoff', () => {
+    assert.equal(resolveApprovedRalphExecutionHint(approvedHint, 'Execute approved issue 1072 plan'), approvedHint);
+  });
+
+  it('drops the approved hint for unrelated explicit Ralph tasks', () => {
+    assert.equal(resolveApprovedRalphExecutionHint(approvedHint, 'Refactor unrelated queue handling'), null);
+  });
+});
+
+describe('readMatchedApprovedRalphExecutionHint', () => {
+  it('selects the matching approved Ralph hint when a PRD lists multiple launch hints', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-approved-context-'));
+    try {
+      await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'plans', 'prd-issue-909.md'),
+        [
+          '# PRD',
+          '',
+          'Launch via omx ralph "Execute alpha"',
+          'Launch via omx ralph "Execute beta"',
+        ].join('\n'),
+      );
+      await writeFile(join(cwd, '.omx', 'plans', 'test-spec-issue-909.md'), '# Test Spec\n');
+
+      const hint = readMatchedApprovedRalphExecutionHint(cwd, 'Execute alpha');
+      assert.ok(hint);
+      assert.equal(hint?.task, 'Execute alpha');
+      assert.equal(hint?.command, 'omx ralph "Execute alpha"');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for bare Ralph follow-up reuse when a PRD lists multiple Ralph launch hints', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-approved-context-'));
+    try {
+      await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'plans', 'prd-issue-909-bare.md'),
+        [
+          '# PRD',
+          '',
+          'Launch via omx ralph "Execute alpha"',
+          'Launch via omx ralph "Execute beta"',
+        ].join('\n'),
+      );
+      await writeFile(join(cwd, '.omx', 'plans', 'test-spec-issue-909-bare.md'), '# Test Spec\n');
+
+      const hint = readMatchedApprovedRalphExecutionHint(cwd, 'ralph-cli-launch');
+      assert.equal(hint, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -245,6 +245,33 @@ describe('parseTeamStartArgs', () => {
     }
   });
 
+  it('fails closed for a short team follow-up when the selected PRD lists multiple team launch hints', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-ambiguous-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-831-ambiguous.md'),
+        [
+          '# Approved plan',
+          '',
+          'Launch via omx team 3:executor "Execute approved issue 831 plan"',
+          'Launch via omx team 5:debugger "Execute alternate issue 831 plan"',
+        ].join('\n'),
+      );
+      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-831-ambiguous.md'), '# Test spec\n');
+
+      assert.throws(
+        () => parseTeamStartArgs(['team']),
+        /approved_execution_hint_ambiguous:team/,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 
   it('does not opt normal team startup into repo-aware DAG handoff even when a stale sidecar exists', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-dag-normal-'));

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -136,6 +136,31 @@ export function extractRalphTaskDescription(args: readonly string[], fallbackTas
   return words.join(' ') || fallbackTask || 'ralph-cli-launch';
 }
 
+export function resolveApprovedRalphExecutionHint(
+  candidate: ApprovedExecutionLaunchHint | null,
+  explicitTask: string,
+): ApprovedExecutionLaunchHint | null {
+  if (!candidate) return null;
+  if (explicitTask === 'ralph-cli-launch') {
+    return candidate;
+  }
+  return candidate.task.trim() === explicitTask.trim() ? candidate : null;
+}
+
+export function readMatchedApprovedRalphExecutionHint(
+  cwd: string,
+  explicitTask: string,
+): ApprovedExecutionLaunchHint | null {
+  return resolveApprovedRalphExecutionHint(
+    readApprovedExecutionLaunchHint(
+      cwd,
+      'ralph',
+      explicitTask === 'ralph-cli-launch' ? {} : { task: explicitTask },
+    ),
+    explicitTask,
+  );
+}
+
 function buildRalphApprovedContextLines(approvedHint: ApprovedExecutionLaunchHint | null): string[] {
   if (!approvedHint) return [];
   const lines = [
@@ -260,12 +285,9 @@ export async function ralphCommand(args: string[]): Promise<void> {
   }
   assertRequiredRalphPrdJson(cwd, args);
   const artifacts = await ensureCanonicalRalphArtifacts(cwd);
-  const rawApprovedHint = readApprovedExecutionLaunchHint(cwd, 'ralph');
   const explicitTask = extractRalphTaskDescription(normalizedArgs);
-  const task = explicitTask === 'ralph-cli-launch' ? rawApprovedHint?.task ?? explicitTask : explicitTask;
-  const approvedHint = rawApprovedHint && (explicitTask === 'ralph-cli-launch' || rawApprovedHint.task.trim() === task.trim())
-    ? rawApprovedHint
-    : null;
+  const approvedHint = readMatchedApprovedRalphExecutionHint(cwd, explicitTask);
+  const task = explicitTask === 'ralph-cli-launch' ? approvedHint?.task ?? explicitTask : explicitTask;
   const noDeslop = normalizedArgs.some((arg) => arg.toLowerCase() === '--no-deslop');
   const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
   const staffingPlan = buildFollowupStaffingPlan('ralph', task, availableAgentTypes);

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -10,7 +10,11 @@ import { readTeamEvents, waitForTeamEvent } from '../team/state/events.js';
 import type { TeamEvent } from '../team/state.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
 import { classifyTaskSize } from '../hooks/task-size-detector.js';
-import { readApprovedExecutionLaunchHint, type ApprovedRepositoryContextSummary } from '../planning/artifacts.js';
+import {
+  readApprovedExecutionLaunchHint,
+  readApprovedExecutionLaunchHintOutcome,
+  type ApprovedRepositoryContextSummary,
+} from '../planning/artifacts.js';
 import { routeTaskToRole } from '../team/role-router.js';
 import { allocateTasksToWorkers } from '../team/allocation-policy.js';
 import {
@@ -103,8 +107,12 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
   const shortFollowup = ['team', 'team으로 해줘', 'team으로 해주세요'].includes(normalizedTask);
   if (!shortFollowup) return null;
 
-  const approvedHint = readApprovedExecutionLaunchHint(cwd, 'team');
-  if (!approvedHint) return null;
+  const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team');
+  if (approvedHintOutcome.status === 'ambiguous') {
+    throw new Error('approved_execution_hint_ambiguous:team');
+  }
+  if (approvedHintOutcome.status !== 'resolved') return null;
+  const approvedHint = approvedHintOutcome.hint;
 
   const persistedTask = typeof existingTeamState?.task_description === 'string'
     ? existingTeamState.task_description
@@ -751,7 +759,7 @@ function parseTeamArgs(args: string[], cwd: string = process.cwd()): ParsedTeamA
     }
   }
 
-  const approvedHint = readApprovedExecutionLaunchHint(cwd, 'team');
+  const approvedHint = readApprovedExecutionLaunchHint(cwd, 'team', { task: effectiveTask });
   const matchesApprovedLaunchHint = approvedHint?.task.trim() === effectiveTask.trim()
     && (approvedHint.workerCount == null || approvedHint.workerCount === workerCount)
     && (approvedHint.agentType == null || approvedHint.agentType === agentType);

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -239,6 +239,152 @@ describe('planning artifacts', () => {
     assert.deepEqual(hint?.deepInterviewSpecPaths, [join(specsDir, 'deep-interview-zeta.md')]);
   });
 
+  it('binds approved launch hints to the requested prd path', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const alphaPrdPath = join(plansDir, 'prd-alpha.md');
+    await writeFile(alphaPrdPath, '# Alpha\n\nLaunch via omx ralph "Execute alpha"\n');
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha Test Spec\n');
+    await writeFile(join(plansDir, 'prd-zeta.md'), '# Zeta\n\nLaunch via omx ralph "Execute zeta"\n');
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph', { prdPath: alphaPrdPath });
+    assert.ok(hint);
+    assert.equal(hint?.task, 'Execute alpha');
+    assert.equal(hint?.sourcePath, alphaPrdPath);
+    assert.deepEqual(hint?.testSpecPaths, [join(plansDir, 'test-spec-alpha.md')]);
+  });
+
+  it('honors the requested Ralph task when a single plan lists multiple Ralph launch hints', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-909.md'),
+      [
+        '# PRD',
+        '',
+        'Launch via omx ralph "Execute alpha"',
+        'Launch via omx ralph "Execute beta"',
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-909.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph', { task: 'Execute alpha' });
+    assert.ok(hint);
+    assert.equal(hint?.task, 'Execute alpha');
+    assert.equal(hint?.command, 'omx ralph "Execute alpha"');
+  });
+
+  it('fails closed for bare Ralph lookups when a single plan lists multiple Ralph launch hints', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-909-bare.md'),
+      [
+        '# PRD',
+        '',
+        'Launch via omx ralph "Execute alpha"',
+        'Launch via omx ralph "Execute beta"',
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-909-bare.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.equal(hint, null);
+  });
+
+  it('honors the requested team task when a single plan lists multiple team launch hints', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-910.md'),
+      [
+        '# PRD',
+        '',
+        'Launch via omx team 2:executor "Execute alpha"',
+        'Launch via omx team 5:debugger "Execute beta"',
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-910.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team', { task: 'Execute alpha' });
+    assert.ok(hint);
+    assert.equal(hint?.task, 'Execute alpha');
+    assert.equal(hint?.workerCount, 2);
+    assert.equal(hint?.agentType, 'executor');
+    assert.equal(hint?.command, 'omx team 2:executor "Execute alpha"');
+  });
+
+  it('fails closed when a single plan repeats the same team task in multiple launch hints', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const prdPath = join(plansDir, 'prd-issue-910-duplicate.md');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      prdPath,
+      [
+        '# PRD',
+        '',
+        'Launch via omx team 2:executor "Execute alpha"',
+        'Launch via $team 5:debugger "Execute alpha"',
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-910-duplicate.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team', {
+      prdPath,
+      task: 'Execute alpha',
+    });
+    assert.equal(hint, null);
+  });
+
+  it('rehydrates the exact team launch hint by command when one PRD repeats the same task', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const sharedTask = 'Ship feature';
+    const primaryCommand = `omx team 2:executor ${JSON.stringify(sharedTask)}`;
+    const secondaryCommand = `$team ralph 5:debugger ${JSON.stringify(sharedTask)}`;
+    const prdPath = join(plansDir, 'prd-issue-910-command.md');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      prdPath,
+      [
+        '# Approved plan',
+        '',
+        `Launch via ${primaryCommand}`,
+        `Launch via ${secondaryCommand}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-910-command.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team', {
+      prdPath,
+      task: sharedTask,
+      command: primaryCommand,
+    });
+    assert.ok(hint);
+    assert.equal(hint?.command, primaryCommand);
+    assert.equal(hint?.workerCount, 2);
+    assert.equal(hint?.agentType, 'executor');
+    assert.equal(hint?.linkedRalph, false);
+  });
+
+  it('fails closed for bare team lookups when a single plan lists multiple team launch hints', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-910-bare.md'),
+      [
+        '# PRD',
+        '',
+        'Launch via omx team 2:executor "Execute alpha"',
+        'Launch via omx team 5:debugger "Execute beta"',
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-910-bare.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team');
+    assert.equal(hint, null);
+  });
+
 
   it('attaches bounded approved repository context from a matching latest-plan sidecar', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -44,6 +44,17 @@ export interface LatestPlanningArtifactSelection {
   deepInterviewSpecPaths: string[];
 }
 
+interface ApprovedExecutionLaunchHintReadOptions {
+  prdPath?: string;
+  task?: string;
+  command?: string;
+}
+
+export type ApprovedExecutionLaunchHintOutcome =
+  | { status: 'absent' }
+  | { status: 'ambiguous' }
+  | { status: 'resolved'; hint: ApprovedExecutionLaunchHint };
+
 export interface TeamDagArtifactResolution {
   source: 'json-sidecar' | 'markdown-handoff' | 'none';
   prdPath: string | null;
@@ -112,6 +123,33 @@ function filterArtifactsForSlug(paths: readonly string[], prefixPattern: RegExp,
   return paths.filter((path) => artifactSlug(path, prefixPattern) === slug);
 }
 
+function selectPlanningArtifacts(
+  artifacts: PlanningArtifacts,
+  prdPath?: string,
+): LatestPlanningArtifactSelection {
+  const selectedPrdPath = prdPath == null
+    ? artifacts.prdPaths.at(-1) ?? null
+    : artifacts.prdPaths.includes(prdPath)
+      ? prdPath
+      : null;
+  const slug = selectedPrdPath
+    ? artifactSlug(selectedPrdPath, /^prd-(?<slug>.*)\.md$/i)
+    : null;
+
+  return {
+    prdPath: selectedPrdPath,
+    testSpecPaths: filterArtifactsForSlug(
+      artifacts.testSpecPaths,
+      /^test-?spec-(?<slug>.*)\.md$/i,
+      slug,
+    ),
+    deepInterviewSpecPaths: filterArtifactsForSlug(
+      artifacts.deepInterviewSpecPaths,
+      /^deep-interview-(?<slug>.*)\.md$/i,
+      slug,
+    ),
+  };
+}
 
 function boundedRepositoryContextSummary(sourcePath: string, content: string): ApprovedRepositoryContextSummary | null {
   const normalizedLines = content
@@ -165,11 +203,14 @@ function readApprovedRepositoryContextSummary(
   return extractApprovedRepositoryContextSection(prdPath, prdContent);
 }
 
-function readApprovedPlanText(cwd: string): { content: string; context: ApprovedPlanContext } | null {
+function readApprovedPlanText(
+  cwd: string,
+  options: ApprovedExecutionLaunchHintReadOptions = {},
+): { content: string; context: ApprovedPlanContext } | null {
   const artifacts = readPlanningArtifacts(cwd);
   if (!isPlanningComplete(artifacts)) return null;
 
-  const selection = selectLatestPlanningArtifacts(artifacts);
+  const selection = selectPlanningArtifacts(artifacts, options.prdPath);
   const latestPrdPath = selection.prdPath;
   if (!latestPrdPath || selection.testSpecPaths.length === 0 || !existsSync(latestPrdPath)) return null;
 
@@ -194,24 +235,7 @@ function readApprovedPlanText(cwd: string): { content: string; context: Approved
 export function selectLatestPlanningArtifacts(
   artifacts: PlanningArtifacts,
 ): LatestPlanningArtifactSelection {
-  const latestPrdPath = artifacts.prdPaths.at(-1) ?? null;
-  const slug = latestPrdPath
-    ? artifactSlug(latestPrdPath, /^prd-(?<slug>.*)\.md$/i)
-    : null;
-
-  return {
-    prdPath: latestPrdPath,
-    testSpecPaths: filterArtifactsForSlug(
-      artifacts.testSpecPaths,
-      /^test-?spec-(?<slug>.*)\.md$/i,
-      slug,
-    ),
-    deepInterviewSpecPaths: filterArtifactsForSlug(
-      artifacts.deepInterviewSpecPaths,
-      /^deep-interview-(?<slug>.*)\.md$/i,
-      slug,
-    ),
-  };
+  return selectPlanningArtifacts(artifacts);
 }
 
 export function readLatestPlanningArtifacts(cwd: string): LatestPlanningArtifactSelection {
@@ -281,41 +305,113 @@ export function readTeamDagArtifactResolution(cwd: string): TeamDagArtifactResol
   return { source: 'none', prdPath, planSlug, warnings: [] };
 }
 
-export function readApprovedExecutionLaunchHint(
+type LaunchHintSelection =
+  | { status: 'no-match' }
+  | { status: 'ambiguous' }
+  | { status: 'unique'; match: RegExpMatchArray; task: string };
+
+function launchHintPattern(mode: 'team' | 'ralph'): RegExp {
+  return mode === 'team'
+    ? /(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi
+    : /(?<command>(?:omx\s+ralph|\$ralph)\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
+}
+
+function collectLaunchHintMatches(
+  content: string,
+  mode: 'team' | 'ralph',
+): RegExpMatchArray[] {
+  return [...content.matchAll(launchHintPattern(mode))];
+}
+
+function selectLaunchHintMatch(
+  matches: RegExpMatchArray[],
+  normalizedTask?: string,
+  normalizedCommand?: string,
+): LaunchHintSelection {
+  if (normalizedCommand) {
+    const exactMatches = matches.flatMap((match) => {
+      const command = match.groups?.command?.trim();
+      if (!command || command !== normalizedCommand) {
+        return [];
+      }
+      const task = match.groups?.task ? decodeQuotedValue(match.groups.task) : null;
+      return task ? [{ match, task }] : [];
+    });
+    if (exactMatches.length === 0) return { status: 'no-match' };
+    if (exactMatches.length > 1) return { status: 'ambiguous' };
+    return { status: 'unique', ...exactMatches[0]! };
+  }
+
+  if (!normalizedTask) {
+    const decodedMatches = matches.flatMap((match) => {
+      const task = match.groups?.task ? decodeQuotedValue(match.groups.task) : null;
+      return task ? [{ match, task }] : [];
+    });
+    if (decodedMatches.length === 0) return { status: 'no-match' };
+    if (decodedMatches.length > 1) return { status: 'ambiguous' };
+    return { status: 'unique', ...decodedMatches[0]! };
+  }
+
+  const exactMatches = matches.flatMap((match) => {
+    const task = match.groups?.task ? decodeQuotedValue(match.groups.task) : null;
+    return task && task.trim() === normalizedTask ? [{ match, task }] : [];
+  });
+  if (exactMatches.length === 0) return { status: 'no-match' };
+  if (exactMatches.length > 1) return { status: 'ambiguous' };
+  return { status: 'unique', ...exactMatches[0]! };
+}
+
+export function readApprovedExecutionLaunchHintOutcome(
   cwd: string,
   mode: 'team' | 'ralph',
-): ApprovedExecutionLaunchHint | null {
-  const approvedPlan = readApprovedPlanText(cwd);
-  if (!approvedPlan) return null;
+  options: ApprovedExecutionLaunchHintReadOptions = {},
+): ApprovedExecutionLaunchHintOutcome {
+  const approvedPlan = readApprovedPlanText(cwd, options);
+  if (!approvedPlan) return { status: 'absent' };
+
+  const selected = selectLaunchHintMatch(
+    collectLaunchHintMatches(approvedPlan.content, mode),
+    options.task?.trim(),
+    options.command?.trim(),
+  );
+  if (selected.status === 'ambiguous') return { status: 'ambiguous' };
+  if (selected.status !== 'unique' || !selected.match.groups) return { status: 'absent' };
 
   if (mode === 'team') {
-    const teamPattern = /(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
-    const matches = [...approvedPlan.content.matchAll(teamPattern)];
-    const last = matches.at(-1);
-    if (!last?.groups) return null;
-    const task = decodeQuotedValue(last.groups.task);
-    if (!task) return null;
+    const workerCount = Number.parseInt(selected.match.groups.count, 10);
+    if (!Number.isFinite(workerCount)) {
+      return { status: 'absent' };
+    }
     return {
-      mode,
-      command: last.groups.command,
-      task,
-      workerCount: Number.parseInt(last.groups.count, 10),
-      agentType: last.groups.role || undefined,
-      linkedRalph: Boolean(last.groups.ralph?.trim()),
-      ...approvedPlan.context,
+      status: 'resolved',
+      hint: {
+        mode,
+        command: selected.match.groups.command,
+        task: selected.task,
+        workerCount,
+        agentType: selected.match.groups.role || undefined,
+        linkedRalph: Boolean(selected.match.groups.ralph?.trim()),
+        ...approvedPlan.context,
+      },
     };
   }
 
-  const ralphPattern = /(?<command>(?:omx\s+ralph|\$ralph)\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
-  const matches = [...approvedPlan.content.matchAll(ralphPattern)];
-  const last = matches.at(-1);
-  if (!last?.groups) return null;
-  const task = decodeQuotedValue(last.groups.task);
-  if (!task) return null;
   return {
-    mode,
-    command: last.groups.command,
-    task,
-    ...approvedPlan.context,
+    status: 'resolved',
+    hint: {
+      mode,
+      command: selected.match.groups.command,
+      task: selected.task,
+      ...approvedPlan.context,
+    },
   };
+}
+
+export function readApprovedExecutionLaunchHint(
+  cwd: string,
+  mode: 'team' | 'ralph',
+  options: ApprovedExecutionLaunchHintReadOptions = {},
+): ApprovedExecutionLaunchHint | null {
+  const outcome = readApprovedExecutionLaunchHintOutcome(cwd, mode, options);
+  return outcome.status === 'resolved' ? outcome.hint : null;
 }


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Current `upstream/dev` still resolves approved launch hints by taking the last visible matching line from the latest approved PRD. That is unsafe once a single PRD contains multiple visible `omx team` or `omx ralph` launch hints, because short follow-ups and explicit Ralph invocations can silently bind to the wrong approved handoff.

## Changes

- extend `readApprovedExecutionLaunchHint` so callers can bind by exact `prdPath`, `task`, or `command`
- add an ambiguity-aware outcome helper so Team follow-up parsing can fail closed instead of silently selecting an arbitrary latest hint
- route explicit Ralph task reuse through exact approved-hint matching so multi-hint PRDs do not fall back to an unrelated launch line
- add focused regression coverage for multi-hint PRDs, exact command rehydration, explicit PRD selection, ambiguous short Team follow-ups, and explicit Ralph task matching

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Focused validation run for this PR:
- `node --test dist/planning/__tests__/artifacts.test.js dist/cli/__tests__/team.test.js dist/cli/__tests__/ralph.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- none
