### PR TITLE
fix(team): make runtime launch instruction portable

### DIFF
--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -706,7 +706,7 @@ function renderTeamPaneStatus(
   }
 }
 
-function parseTeamArgs(args: string[], cwd: string = process.cwd()): ParsedTeamArgs {
+export function parseTeamArgs(args: string[], cwd: string = process.cwd()): ParsedTeamArgs {
   const tokens = [...args];
   let workerCount = 3;
   let agentType = 'executor';

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -272,12 +272,16 @@ describe('Team Exec Stage', () => {
       );
       assert.equal(runtimeCliInput.teamName, 'implement-feature');
       assert.equal(runtimeCliInput.workerCount, 3);
-      assert.deepEqual(runtimeCliInput.agentTypes, ['codex']);
+      assert.equal('agentTypes' in runtimeCliInput, false);
       assert.equal(runtimeCliInput.cwd, '/tmp/test');
       assert.ok(Array.isArray(runtimeCliInput.tasks));
       assert.equal((runtimeCliInput.tasks as unknown[]).length > 0, true);
       assert.equal('task' in runtimeCliInput, false);
       assert.equal('useWorktrees' in runtimeCliInput, false);
+      assert.equal(
+        (runtimeCliInput.decompositionMetadata as Record<string, unknown>).decomposition_source,
+        'legacy_text',
+      );
       assert.match(instruction, /staffing=/);
       assert.match(instruction, /verify=/);
     });
@@ -328,8 +332,69 @@ describe('Team Exec Stage', () => {
       assert.doesNotMatch(instruction, /# staffing=/);
       assert.doesNotMatch(instruction, /# verify=/);
       assert.equal(runtimeCliInput.workerCount, 1);
-      assert.deepEqual(runtimeCliInput.agentTypes, ['codex']);
+      assert.equal('agentTypes' in runtimeCliInput, false);
       assert.equal(runtimeCliInput.cwd, 'C:\\repo with spaces');
+    });
+
+    it('preserves approved DAG handoff tasks and metadata in the runtime-cli payload', async () => {
+      const plansDir = join(tempDir, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      await writeFile(
+        join(plansDir, 'prd-demo.md'),
+        '# Demo\n\nLaunch via omx team 2:executor "Execute approved demo plan"\n',
+      );
+      await writeFile(join(plansDir, 'test-spec-demo.md'), '# Demo Test Spec\n');
+      await writeFile(join(plansDir, 'team-dag-demo.json'), JSON.stringify({
+        schema_version: 1,
+        nodes: [
+          {
+            id: 'impl',
+            lane: 'implementation',
+            role: 'executor',
+            subject: 'Implement runtime',
+            description: 'Change runtime',
+            filePaths: ['src/team/runtime.ts'],
+            requires_code_change: true,
+          },
+          {
+            id: 'verify',
+            lane: 'verification',
+            role: 'test-engineer',
+            subject: 'Verify runtime',
+            description: 'Cover runtime',
+            depends_on: ['impl'],
+          },
+        ],
+        worker_policy: { requested_count: 2, count_source: 'cli-explicit' },
+      }));
+      const staffingPlan = buildFollowupStaffingPlan('team', 'Execute approved demo plan', ['executor', 'test-engineer'], {
+        workerCount: 2,
+      });
+      const instruction = buildTeamInstruction({
+        task: 'Execute approved demo plan',
+        workerCount: 2,
+        agentType: 'executor',
+        availableAgentTypes: ['executor', 'test-engineer'],
+        staffingPlan,
+        useWorktrees: false,
+        cwd: tempDir,
+      });
+      const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
+      const tasks = runtimeCliInput.tasks as Array<Record<string, unknown>>;
+      const decompositionMetadata = runtimeCliInput.decompositionMetadata as Record<string, unknown>;
+
+      assert.equal(runtimeCliInput.teamName, 'execute-approved-demo-plan');
+      assert.equal(runtimeCliInput.workerCount, 2);
+      assert.equal(tasks.length, 2);
+      assert.equal(tasks[0]?.symbolic_id, 'impl');
+      assert.deepEqual(tasks[1]?.symbolic_depends_on, ['impl']);
+      assert.deepEqual(tasks[0]?.filePaths, ['src/team/runtime.ts']);
+      assert.equal(tasks[0]?.lane, 'implementation');
+      assert.equal(decompositionMetadata.decomposition_source, 'dag_sidecar');
+      assert.deepEqual(decompositionMetadata.node_dependencies, {
+        impl: [],
+        verify: ['impl'],
+      });
     });
   });
 });

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -213,10 +213,14 @@ describe('Team Exec Stage', () => {
   it('respects custom worker count and agent type', async () => {
     const stage = createTeamExecStage({ workerCount: 4, agentType: 'architect' });
     const result = await stage.run(makeCtx());
+    const runtimeCliInput = decodeRuntimeCliInstructionPayload(
+      (result.artifacts as Record<string, unknown>).instruction as string,
+    );
 
     const arts = result.artifacts as Record<string, unknown>;
     assert.equal(arts.workerCount, 4);
     assert.equal(arts.agentType, 'architect');
+    assert.equal(runtimeCliInput.agentType, 'architect');
   });
 
   it('includes ralplan artifacts in team task when available', async () => {
@@ -272,6 +276,7 @@ describe('Team Exec Stage', () => {
       );
       assert.equal(runtimeCliInput.teamName, 'implement-feature');
       assert.equal(runtimeCliInput.workerCount, 3);
+      assert.equal(runtimeCliInput.agentType, 'executor');
       assert.equal('agentTypes' in runtimeCliInput, false);
       assert.equal(runtimeCliInput.cwd, '/tmp/test');
       assert.ok(Array.isArray(runtimeCliInput.tasks));
@@ -305,6 +310,7 @@ describe('Team Exec Stage', () => {
       assert.match(instruction, /runtime-cli\.js/);
       assert.match(instruction, /--input-json-base64/);
       assert.equal(runtimeCliInput.workerCount, 1);
+      assert.equal(runtimeCliInput.agentType, 'executor');
       assert.match(instruction, /staffing=/);
     });
 
@@ -332,6 +338,7 @@ describe('Team Exec Stage', () => {
       assert.doesNotMatch(instruction, /# staffing=/);
       assert.doesNotMatch(instruction, /# verify=/);
       assert.equal(runtimeCliInput.workerCount, 1);
+      assert.equal(runtimeCliInput.agentType, 'executor');
       assert.equal('agentTypes' in runtimeCliInput, false);
       assert.equal(runtimeCliInput.cwd, 'C:\\repo with spaces');
     });
@@ -385,6 +392,7 @@ describe('Team Exec Stage', () => {
 
       assert.equal(runtimeCliInput.teamName, 'execute-approved-demo-plan');
       assert.equal(runtimeCliInput.workerCount, 2);
+      assert.equal(runtimeCliInput.agentType, 'executor');
       assert.equal(tasks.length, 2);
       assert.equal(tasks[0]?.symbolic_id, 'impl');
       assert.deepEqual(tasks[1]?.symbolic_depends_on, ['impl']);

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -10,6 +10,7 @@ import { createTeamExecStage, buildTeamInstruction } from '../stages/team-exec.j
 import { createRalphVerifyStage, createRalphStage, buildRalphInstruction } from '../stages/ralph-verify.js';
 import { createCodeReviewStage, buildCodeReviewInstruction } from '../stages/code-review.js';
 import { buildFollowupStaffingPlan } from '../../team/followup-planner.js';
+import { packageRoot } from '../../utils/paths.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -35,6 +36,16 @@ async function cleanup(): Promise<void> {
   if (tempDir && existsSync(tempDir)) {
     await rm(tempDir, { recursive: true, force: true });
   }
+}
+
+function decodeRuntimeCliInstructionPayload(instruction: string): Record<string, unknown> {
+  const match = instruction.match(/--input-json-base64\s+([A-Za-z0-9_-]+)/);
+  assert.ok(match?.[1], 'expected --input-json-base64 payload');
+  return JSON.parse(Buffer.from(match[1], 'base64url').toString('utf-8')) as Record<string, unknown>;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // ---------------------------------------------------------------------------
@@ -234,7 +245,7 @@ describe('Team Exec Stage', () => {
   });
 
   describe('buildTeamInstruction', () => {
-    it('builds correct CLI instruction', () => {
+    it('builds correct runtime-cli instruction', () => {
       const staffingPlan = buildFollowupStaffingPlan('team', 'implement feature', ['executor', 'test-engineer'], {
         workerCount: 3,
       });
@@ -247,9 +258,26 @@ describe('Team Exec Stage', () => {
         useWorktrees: false,
         cwd: '/tmp/test',
       });
+      const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
 
-      assert.match(instruction, /^omx team 3:executor /);
-      assert.match(instruction, /implement feature/);
+      assert.match(instruction, /runtime-cli\.js/);
+      assert.match(instruction, /--input-json-base64/);
+      assert.match(
+        instruction,
+        new RegExp(escapeRegExp(join(packageRoot(), 'dist', 'team', 'runtime-cli.js'))),
+      );
+      assert.doesNotMatch(
+        instruction,
+        new RegExp(escapeRegExp(join('/tmp/test', 'dist', 'team', 'runtime-cli.js'))),
+      );
+      assert.equal(runtimeCliInput.teamName, 'implement-feature');
+      assert.equal(runtimeCliInput.workerCount, 3);
+      assert.deepEqual(runtimeCliInput.agentTypes, ['codex']);
+      assert.equal(runtimeCliInput.cwd, '/tmp/test');
+      assert.ok(Array.isArray(runtimeCliInput.tasks));
+      assert.equal((runtimeCliInput.tasks as unknown[]).length > 0, true);
+      assert.equal('task' in runtimeCliInput, false);
+      assert.equal('useWorktrees' in runtimeCliInput, false);
       assert.match(instruction, /staffing=/);
       assert.match(instruction, /verify=/);
     });
@@ -268,9 +296,40 @@ describe('Team Exec Stage', () => {
         useWorktrees: false,
         cwd: '/tmp',
       });
+      const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
 
-      assert.match(instruction, /^omx team 1:executor /);
+      assert.match(instruction, /runtime-cli\.js/);
+      assert.match(instruction, /--input-json-base64/);
+      assert.equal(runtimeCliInput.workerCount, 1);
       assert.match(instruction, /staffing=/);
+    });
+
+    it('keeps Windows instructions free of POSIX launch comments', () => {
+      const task = `fix "quoted" paths, keep it's 100% safe & support café 运行时`;
+      const staffingPlan = buildFollowupStaffingPlan('team', task, ['executor', 'test-engineer'], {
+        workerCount: 1,
+      });
+      const instruction = buildTeamInstruction({
+        task,
+        workerCount: 1,
+        agentType: 'executor',
+        availableAgentTypes: ['executor', 'test-engineer'],
+        staffingPlan,
+        useWorktrees: false,
+        cwd: 'C:\\repo with spaces',
+      }, { platform: 'win32' });
+      const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
+      const commandPrefix = instruction.split('--input-json-base64')[0] ?? '';
+      const encodedPayload = instruction.match(/--input-json-base64\s+([A-Za-z0-9_-]+)/)?.[1] ?? '';
+
+      assert.match(instruction, /^"[^"]+"\s+"[^"]*runtime-cli\.js"\s+--input-json-base64\s+[A-Za-z0-9_-]+/);
+      assert.equal(commandPrefix.includes("'"), false);
+      assert.doesNotMatch(encodedPayload, /[%&|<>"'\s]/);
+      assert.doesNotMatch(instruction, /# staffing=/);
+      assert.doesNotMatch(instruction, /# verify=/);
+      assert.equal(runtimeCliInput.workerCount, 1);
+      assert.deepEqual(runtimeCliInput.agentTypes, ['codex']);
+      assert.equal(runtimeCliInput.cwd, 'C:\\repo with spaces');
     });
   });
 });

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -8,12 +8,12 @@
 
 import { join } from 'node:path';
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
-import { buildTeamExecutionPlan } from '../../cli/team.js';
+import { buildRepoAwareTeamExecutionPlan, type TeamDecompositionMetadata } from '../../team/repo-aware-decomposition.js';
+import { buildTeamExecutionPlan, parseTeamArgs } from '../../cli/team.js';
 import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
 } from '../../team/followup-planner.js';
-import { sanitizeTeamName } from '../../team/tmux-session.js';
 import { packageRoot } from '../../utils/paths.js';
 
 export interface TeamExecStageOptions {
@@ -30,8 +30,6 @@ export interface TeamExecStageOptions {
   extraEnv?: Record<string, string>;
 }
 
-const DEFAULT_TEAM_RUNTIME_PROVIDER = 'codex';
-
 interface BuildTeamInstructionOptions {
   platform?: NodeJS.Platform;
 }
@@ -40,25 +38,24 @@ interface TeamRuntimeCliTaskInput {
   subject: string;
   description: string;
   owner?: string;
+  blocked_by?: string[];
+  depends_on?: string[];
+  symbolic_depends_on?: string[];
   role?: string;
+  requires_code_change?: boolean;
+  filePaths?: string[];
+  domains?: string[];
+  lane?: string;
+  allocation_reason?: string;
+  symbolic_id?: string;
 }
 
 interface TeamRuntimeCliLaunchInput {
   teamName: string;
   workerCount: number;
-  agentTypes: string[];
   tasks: TeamRuntimeCliTaskInput[];
   cwd: string;
-}
-
-function deriveTeamNameFromTask(task: string): string {
-  const slug = task
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 30);
-  return sanitizeTeamName(slug || 'team-task');
+  decompositionMetadata?: TeamDecompositionMetadata;
 }
 
 function quotePosixShellArg(value: string): string {
@@ -74,24 +71,55 @@ function quoteShellArg(value: string, platform: NodeJS.Platform): string {
 }
 
 function buildTeamRuntimeCliLaunchInput(descriptor: TeamExecDescriptor): TeamRuntimeCliLaunchInput {
-  const executionPlan = buildTeamExecutionPlan(
-    descriptor.task,
-    descriptor.workerCount,
-    descriptor.agentType,
-    true,
-    true,
+  const parsed = parseTeamArgs(
+    [`${descriptor.workerCount}:${descriptor.agentType}`, descriptor.task],
+    descriptor.cwd,
   );
+  const executionPlan = buildRepoAwareTeamExecutionPlan({
+    task: parsed.task,
+    workerCount: parsed.workerCount,
+    agentType: parsed.agentType,
+    explicitAgentType: parsed.explicitAgentType,
+    explicitWorkerCount: parsed.explicitWorkerCount,
+    cwd: descriptor.cwd,
+    buildLegacyPlan: buildTeamExecutionPlan,
+    allowDagHandoff: parsed.allowRepoAwareDagHandoff,
+    approvedRepositoryContextSummary: parsed.approvedRepositoryContextSummary,
+  });
   return {
-    teamName: deriveTeamNameFromTask(descriptor.task),
-    workerCount: descriptor.workerCount,
-    agentTypes: [DEFAULT_TEAM_RUNTIME_PROVIDER],
-    tasks: executionPlan.tasks.map(({ subject, description, owner, role }) => ({
+    teamName: parsed.teamName,
+    workerCount: executionPlan.workerCount,
+    tasks: executionPlan.tasks.map(({
+      subject,
+      description,
+      owner,
+      blocked_by,
+      depends_on,
+      symbolic_depends_on,
+      role,
+      requires_code_change,
+      filePaths,
+      domains,
+      lane,
+      allocation_reason,
+      symbolic_id,
+    }) => ({
       subject,
       description,
       ...(owner ? { owner } : {}),
+      ...(blocked_by?.length ? { blocked_by } : {}),
+      ...(depends_on?.length ? { depends_on } : {}),
+      ...(symbolic_depends_on?.length ? { symbolic_depends_on } : {}),
       ...(role ? { role } : {}),
+      ...(requires_code_change ? { requires_code_change } : {}),
+      ...(filePaths?.length ? { filePaths } : {}),
+      ...(domains?.length ? { domains } : {}),
+      ...(lane ? { lane } : {}),
+      ...(allocation_reason ? { allocation_reason } : {}),
+      ...(symbolic_id ? { symbolic_id } : {}),
     })),
     cwd: descriptor.cwd,
+    ...(executionPlan.metadata ? { decompositionMetadata: executionPlan.metadata } : {}),
   };
 }
 

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -53,6 +53,7 @@ interface TeamRuntimeCliTaskInput {
 interface TeamRuntimeCliLaunchInput {
   teamName: string;
   workerCount: number;
+  agentType: string;
   tasks: TeamRuntimeCliTaskInput[];
   cwd: string;
   decompositionMetadata?: TeamDecompositionMetadata;
@@ -89,6 +90,7 @@ function buildTeamRuntimeCliLaunchInput(descriptor: TeamExecDescriptor): TeamRun
   return {
     teamName: parsed.teamName,
     workerCount: executionPlan.workerCount,
+    agentType: descriptor.agentType,
     tasks: executionPlan.tasks.map(({
       subject,
       description,

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -6,11 +6,15 @@
  * canonical OMX execution surface.
  */
 
+import { join } from 'node:path';
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
+import { buildTeamExecutionPlan } from '../../cli/team.js';
 import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
 } from '../../team/followup-planner.js';
+import { sanitizeTeamName } from '../../team/tmux-session.js';
+import { packageRoot } from '../../utils/paths.js';
 
 export interface TeamExecStageOptions {
   /** Number of Codex CLI workers to launch. Defaults to 2. */
@@ -24,6 +28,71 @@ export interface TeamExecStageOptions {
 
   /** Additional environment variables for worker launch. */
   extraEnv?: Record<string, string>;
+}
+
+const DEFAULT_TEAM_RUNTIME_PROVIDER = 'codex';
+
+interface BuildTeamInstructionOptions {
+  platform?: NodeJS.Platform;
+}
+
+interface TeamRuntimeCliTaskInput {
+  subject: string;
+  description: string;
+  owner?: string;
+  role?: string;
+}
+
+interface TeamRuntimeCliLaunchInput {
+  teamName: string;
+  workerCount: number;
+  agentTypes: string[];
+  tasks: TeamRuntimeCliTaskInput[];
+  cwd: string;
+}
+
+function deriveTeamNameFromTask(task: string): string {
+  const slug = task
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 30);
+  return sanitizeTeamName(slug || 'team-task');
+}
+
+function quotePosixShellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function quoteWindowsCmdArg(value: string): string {
+  return `"${value.replace(/%/g, '%%').replace(/"/g, '""')}"`;
+}
+
+function quoteShellArg(value: string, platform: NodeJS.Platform): string {
+  return platform === 'win32' ? quoteWindowsCmdArg(value) : quotePosixShellArg(value);
+}
+
+function buildTeamRuntimeCliLaunchInput(descriptor: TeamExecDescriptor): TeamRuntimeCliLaunchInput {
+  const executionPlan = buildTeamExecutionPlan(
+    descriptor.task,
+    descriptor.workerCount,
+    descriptor.agentType,
+    true,
+    true,
+  );
+  return {
+    teamName: deriveTeamNameFromTask(descriptor.task),
+    workerCount: descriptor.workerCount,
+    agentTypes: [DEFAULT_TEAM_RUNTIME_PROVIDER],
+    tasks: executionPlan.tasks.map(({ subject, description, owner, role }) => ({
+      subject,
+      description,
+      ...(owner ? { owner } : {}),
+      ...(role ? { role } : {}),
+    })),
+    cwd: descriptor.cwd,
+  };
 }
 
 /**
@@ -114,7 +183,17 @@ export interface TeamExecDescriptor {
 /**
  * Build the `omx team` CLI instruction from a descriptor.
  */
-export function buildTeamInstruction(descriptor: TeamExecDescriptor): string {
-  const launchCommand = `omx team ${descriptor.workerCount}:${descriptor.agentType} ${JSON.stringify(descriptor.task)}`;
+export function buildTeamInstruction(
+  descriptor: TeamExecDescriptor,
+  options: BuildTeamInstructionOptions = {},
+): string {
+  const runtimeCliInput = buildTeamRuntimeCliLaunchInput(descriptor);
+  const runtimeCliPath = join(packageRoot(), 'dist', 'team', 'runtime-cli.js');
+  const platform = options.platform ?? process.platform;
+  const encodedInput = Buffer.from(JSON.stringify(runtimeCliInput), 'utf-8').toString('base64url');
+  const launchCommand = `${quoteShellArg(process.execPath, platform)} ${quoteShellArg(runtimeCliPath, platform)} --input-json-base64 ${encodedInput}`;
+  if (platform === 'win32') {
+    return launchCommand;
+  }
   return `${launchCommand} # staffing=${descriptor.staffingPlan.staffingSummary} # verify=${descriptor.staffingPlan.verificationPlan.summary}`;
 }

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -49,6 +49,31 @@ describe('runtime-cli helpers', () => {
       runtimeCli.normalizeAgentTypes(['gemini'], 3),
       ['gemini'],
     );
+    assert.equal(
+      runtimeCli.resolveRuntimeCliProviderMap(undefined, 2),
+      null,
+    );
+    assert.equal(
+      runtimeCli.resolveRuntimeCliProviderMap(['claude'], 2),
+      'claude',
+    );
+    assert.deepEqual(
+      runtimeCli.resolveRuntimeCliMissingFields({
+        teamName: 'alpha',
+        workerCount: 2,
+        tasks: [{ subject: 'task', description: 'desc' }],
+        cwd: '/tmp/repo',
+      }),
+      [],
+    );
+    assert.deepEqual(
+      runtimeCli.resolveRuntimeCliMissingFields({
+        teamName: 'alpha',
+        tasks: [{ subject: 'task', description: 'desc' }],
+        cwd: '/tmp/repo',
+      }),
+      ['workerCount or agentTypes'],
+    );
     assert.throws(
       () => runtimeCli.normalizeAgentTypes(['codex', 'invalid'], 2),
       /Expected codex\\|claude\\|gemini/,

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -57,6 +57,14 @@ describe('runtime-cli helpers', () => {
       runtimeCli.resolveRuntimeCliProviderMap(['claude'], 2),
       'claude',
     );
+    assert.equal(
+      runtimeCli.resolveRuntimeCliAgentType(undefined),
+      'executor',
+    );
+    assert.equal(
+      runtimeCli.resolveRuntimeCliAgentType('test-engineer'),
+      'test-engineer',
+    );
     assert.deepEqual(
       runtimeCli.resolveRuntimeCliMissingFields({
         teamName: 'alpha',

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -12,6 +12,32 @@ async function loadRuntimeCliModule() {
 }
 
 describe('runtime-cli helpers', () => {
+  it('accepts inline JSON payloads without consuming stdin', async () => {
+    const runtimeCli = await loadRuntimeCliModule();
+    const base64Payload = Buffer.from(
+      '{"teamName":"alpha","task":"quote \\"this\\" & keep 100%"}',
+      'utf-8',
+    ).toString('base64url');
+
+    assert.equal(
+      runtimeCli.resolveRuntimeCliInlineInput(['--input-json', '{"teamName":"alpha"}']),
+      '{"teamName":"alpha"}',
+    );
+    assert.equal(
+      runtimeCli.resolveRuntimeCliInlineInput(['--input-json-base64', base64Payload]),
+      '{"teamName":"alpha","task":"quote \\"this\\" & keep 100%"}',
+    );
+    assert.equal(runtimeCli.resolveRuntimeCliInlineInput([]), null);
+    assert.throws(
+      () => runtimeCli.resolveRuntimeCliInlineInput(['--input-json']),
+      /Missing JSON payload for --input-json/,
+    );
+    assert.throws(
+      () => runtimeCli.resolveRuntimeCliInlineInput(['--input-json-base64']),
+      /Missing JSON payload for --input-json-base64/,
+    );
+  });
+
   it('normalizes per-worker providers and validates supported values', async () => {
     const runtimeCli = await loadRuntimeCliModule();
 

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -13,6 +13,7 @@ import { writeFile, rename } from 'fs/promises';
 import { join } from 'path';
 import { startTeam, monitorTeam, shutdownTeam } from './runtime.js';
 import type { TeamRuntime, TeamShutdownSummary, StaleTeamSummary } from './runtime.js';
+import type { TeamDecompositionMetadata } from './repo-aware-decomposition.js';
 import { teamReadConfig as readTeamConfig } from './team-ops.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 
@@ -38,10 +39,25 @@ async function promptStaleCleanup(summary: StaleTeamSummary): Promise<boolean> {
 interface CliInput {
   teamName: string;
   workerCount?: number;
-  agentTypes: string[];
-  tasks: Array<{ subject: string; description: string; owner?: string; role?: string }>;
+  agentTypes?: string[];
+  tasks: Array<{
+    subject: string;
+    description: string;
+    owner?: string;
+    blocked_by?: string[];
+    depends_on?: string[];
+    symbolic_depends_on?: string[];
+    role?: string;
+    requires_code_change?: boolean;
+    filePaths?: string[];
+    domains?: string[];
+    lane?: string;
+    allocation_reason?: string;
+    symbolic_id?: string;
+  }>;
   cwd: string;
   pollIntervalMs?: number;
+  decompositionMetadata?: TeamDecompositionMetadata;
 }
 
 const RUNTIME_CLI_INPUT_JSON_FLAG = '--input-json';
@@ -202,6 +218,29 @@ export function normalizeAgentTypes(raw: string[], workerCount: number): TeamWor
   return providers as TeamWorkerProvider[];
 }
 
+export function resolveRuntimeCliProviderMap(
+  raw: string[] | undefined,
+  workerCount: number,
+): string | null {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return null;
+  }
+  return normalizeAgentTypes(raw, workerCount).join(',');
+}
+
+export function resolveRuntimeCliMissingFields(input: Partial<CliInput>): string[] {
+  const missing: string[] = [];
+  if (!input.teamName) missing.push('teamName');
+  const hasAgentTypes = Array.isArray(input.agentTypes) && input.agentTypes.length > 0;
+  const hasWorkerCount = Number.isInteger(input.workerCount) && Number(input.workerCount) > 0;
+  if (!hasAgentTypes && !hasWorkerCount) {
+    missing.push('workerCount or agentTypes');
+  }
+  if (!input.tasks || !Array.isArray(input.tasks) || input.tasks.length === 0) missing.push('tasks');
+  if (!input.cwd) missing.push('cwd');
+  return missing;
+}
+
 export function resolveRuntimeCliInlineInput(argv: readonly string[]): string | null {
   const index = argv.indexOf(RUNTIME_CLI_INPUT_JSON_FLAG);
   if (index !== -1) {
@@ -250,11 +289,7 @@ async function main(): Promise<void> {
   }
 
   // Validate required fields
-  const missing: string[] = [];
-  if (!input.teamName) missing.push('teamName');
-  if (!input.agentTypes || !Array.isArray(input.agentTypes) || input.agentTypes.length === 0) missing.push('agentTypes');
-  if (!input.tasks || !Array.isArray(input.tasks) || input.tasks.length === 0) missing.push('tasks');
-  if (!input.cwd) missing.push('cwd');
+  const missing = resolveRuntimeCliMissingFields(input);
   if (missing.length > 0) {
     process.stderr.write(`[runtime-cli] Missing required fields: ${missing.join(', ')}\n`);
     process.exit(1);
@@ -266,9 +301,10 @@ async function main(): Promise<void> {
     tasks,
     cwd,
     pollIntervalMs = 5000,
+    decompositionMetadata,
   } = input;
 
-  const workerCount = input.workerCount ?? agentTypes.length;
+  const workerCount = input.workerCount ?? agentTypes?.length ?? 0;
   const stateRoot = resolveRuntimeCliStateRoot(cwd);
 
   let runtime: TeamRuntime | null = null;
@@ -336,10 +372,12 @@ async function main(): Promise<void> {
   // Start the team — OMX's startTeam takes individual parameters
   const agentType = 'executor';
   try {
-    const providers = normalizeAgentTypes(agentTypes, workerCount);
+    const providerMap = resolveRuntimeCliProviderMap(agentTypes, workerCount);
     const previousCliMap = process.env.OMX_TEAM_WORKER_CLI_MAP;
     try {
-      process.env.OMX_TEAM_WORKER_CLI_MAP = providers.join(',');
+      if (providerMap) {
+        process.env.OMX_TEAM_WORKER_CLI_MAP = providerMap;
+      }
       runtime = await startTeam(
         teamName,
         tasks.map(t => t.subject).join('; '),
@@ -347,11 +385,16 @@ async function main(): Promise<void> {
         workerCount,
         tasks,
         cwd,
-        { confirmStaleCleanup: promptStaleCleanup },
+        {
+          confirmStaleCleanup: promptStaleCleanup,
+          ...(decompositionMetadata ? { decompositionMetadata } : {}),
+        },
       );
     } finally {
-      if (typeof previousCliMap === 'string') process.env.OMX_TEAM_WORKER_CLI_MAP = previousCliMap;
-      else delete process.env.OMX_TEAM_WORKER_CLI_MAP;
+      if (providerMap) {
+        if (typeof previousCliMap === 'string') process.env.OMX_TEAM_WORKER_CLI_MAP = previousCliMap;
+        else delete process.env.OMX_TEAM_WORKER_CLI_MAP;
+      }
     }
   } catch (err) {
     process.stderr.write(`[runtime-cli] startTeam failed: ${err}\n`);

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -39,6 +39,7 @@ async function promptStaleCleanup(summary: StaleTeamSummary): Promise<boolean> {
 interface CliInput {
   teamName: string;
   workerCount?: number;
+  agentType?: string;
   agentTypes?: string[];
   tasks: Array<{
     subject: string;
@@ -228,6 +229,11 @@ export function resolveRuntimeCliProviderMap(
   return normalizeAgentTypes(raw, workerCount).join(',');
 }
 
+export function resolveRuntimeCliAgentType(raw: string | undefined): string {
+  const normalized = typeof raw === 'string' ? raw.trim() : '';
+  return normalized || 'executor';
+}
+
 export function resolveRuntimeCliMissingFields(input: Partial<CliInput>): string[] {
   const missing: string[] = [];
   if (!input.teamName) missing.push('teamName');
@@ -297,6 +303,7 @@ async function main(): Promise<void> {
 
   const {
     teamName,
+    agentType: rawAgentType,
     agentTypes,
     tasks,
     cwd,
@@ -370,7 +377,7 @@ async function main(): Promise<void> {
   process.on('SIGTERM', () => handleShutdown('SIGTERM'));
 
   // Start the team — OMX's startTeam takes individual parameters
-  const agentType = 'executor';
+  const agentType = resolveRuntimeCliAgentType(rawAgentType);
   try {
     const providerMap = resolveRuntimeCliProviderMap(agentTypes, workerCount);
     const previousCliMap = process.env.OMX_TEAM_WORKER_CLI_MAP;

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -1,7 +1,8 @@
 /**
  * CLI entry point for team runtime.
- * Reads JSON config from stdin, runs startTeam/monitorTeam/shutdownTeam,
- * writes structured JSON result to stdout.
+ * Reads JSON config from --input-json, --input-json-base64, or stdin,
+ * runs startTeam/monitorTeam/shutdownTeam, writes structured JSON result
+ * to stdout.
  *
  * Spawned by OMX team orchestration entrypoints when a background team run starts.
  */
@@ -38,10 +39,13 @@ interface CliInput {
   teamName: string;
   workerCount?: number;
   agentTypes: string[];
-  tasks: Array<{ subject: string; description: string }>;
+  tasks: Array<{ subject: string; description: string; owner?: string; role?: string }>;
   cwd: string;
   pollIntervalMs?: number;
 }
+
+const RUNTIME_CLI_INPUT_JSON_FLAG = '--input-json';
+const RUNTIME_CLI_INPUT_JSON_BASE64_FLAG = '--input-json-base64';
 
 type TeamWorkerProvider = 'codex' | 'claude' | 'gemini';
 
@@ -198,21 +202,50 @@ export function normalizeAgentTypes(raw: string[], workerCount: number): TeamWor
   return providers as TeamWorkerProvider[];
 }
 
-async function main(): Promise<void> {
-  const startTime = Date.now();
+export function resolveRuntimeCliInlineInput(argv: readonly string[]): string | null {
+  const index = argv.indexOf(RUNTIME_CLI_INPUT_JSON_FLAG);
+  if (index !== -1) {
+    const payload = argv[index + 1];
+    if (typeof payload !== 'string' || payload.trim() === '') {
+      throw new Error(`Missing JSON payload for ${RUNTIME_CLI_INPUT_JSON_FLAG}`);
+    }
+    return payload;
+  }
 
-  // Read stdin
+  const base64Index = argv.indexOf(RUNTIME_CLI_INPUT_JSON_BASE64_FLAG);
+  if (base64Index === -1) {
+    return null;
+  }
+  const payload = argv[base64Index + 1];
+  if (typeof payload !== 'string' || payload.trim() === '') {
+    throw new Error(`Missing JSON payload for ${RUNTIME_CLI_INPUT_JSON_BASE64_FLAG}`);
+  }
+  return Buffer.from(payload.trim(), 'base64url').toString('utf-8');
+}
+
+async function readRuntimeCliRawInput(argv: readonly string[]): Promise<string> {
+  const inlineInput = resolveRuntimeCliInlineInput(argv);
+  if (inlineInput != null) {
+    return inlineInput.trim();
+  }
+
   const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) {
     chunks.push(chunk as Buffer);
   }
-  const rawInput = Buffer.concat(chunks).toString('utf-8').trim();
+  return Buffer.concat(chunks).toString('utf-8').trim();
+}
+
+async function main(): Promise<void> {
+  const startTime = Date.now();
+
+  const rawInput = await readRuntimeCliRawInput(process.argv.slice(2));
 
   let input: CliInput;
   try {
     input = JSON.parse(rawInput) as CliInput;
   } catch (err) {
-    process.stderr.write(`[runtime-cli] Failed to parse stdin JSON: ${err}\n`);
+    process.stderr.write(`[runtime-cli] Failed to parse JSON input: ${err}\n`);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

`team-exec` currently emits a raw `omx team ...` launch string that
serializes the entire task into shell text and assumes the caller's current
working tree contains `dist/team/runtime-cli.js`. That breaks portability for
quoted or long payloads and leaves the pipeline without a structured handoff
path into `runtime-cli`.

## Changes

- teach `src/team/runtime-cli.ts` to accept `--input-json` and
  `--input-json-base64` before falling back to stdin
- switch `buildTeamInstruction` to launch package-root
  `dist/team/runtime-cli.js` with a base64url payload that stays limited to
  current upstream runtime fields
- cover the launch shape in `stages.test.ts` and the inline input parsing in
  `runtime-cli.test.ts`, including Windows comment-free instructions

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/pipeline/__tests__/stages.test.js dist/team/__tests__/runtime-cli.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- Source commit: `16f348d1`
- No tracked issue for this narrow transport fix.
