### PR TITLE
feat(planning): timestamp canonical handoff artifacts

### DIFF
--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -4,7 +4,13 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { isPlanningComplete, readApprovedExecutionLaunchHint, readPlanningArtifacts, readTeamDagArtifactResolution } from '../artifacts.js';
+import {
+  isPlanningComplete,
+  readApprovedExecutionLaunchHint,
+  readLatestPlanningArtifacts,
+  readPlanningArtifacts,
+  readTeamDagArtifactResolution,
+} from '../artifacts.js';
 import { readTeamDagHandoffForLatestPlan } from '../../team/dag-schema.js';
 
 let tempDir: string;
@@ -105,6 +111,102 @@ describe('planning artifacts', () => {
 
     assert.equal(resolution.source, 'none');
     assert.equal(resolution.planSlug, 'repo-aware');
+    assert.deepEqual(resolution.warnings, ['missing_matching_test_spec']);
+  });
+
+  it('prefers timestamped PRD/test-spec pairs while keeping legacy artifacts compatible', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const specsDir = join(tempDir, '.omx', 'specs');
+    await mkdir(plansDir, { recursive: true });
+    await mkdir(specsDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-legacy.md'),
+      '# Legacy\n\nLaunch via omx ralph "Execute legacy plan"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-legacy.md'), '# Legacy Test Spec\n');
+    await writeFile(
+      join(plansDir, 'prd-20260427T153000Z-alpha.md'),
+      '# Old Alpha\n\nLaunch via omx ralph "Execute old alpha plan"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha Legacy Test Spec\n');
+    await writeFile(
+      join(plansDir, 'prd-20260427T153100Z-alpha.md'),
+      '# New Alpha\n\nLaunch via omx ralph "Execute new alpha plan"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-20260427T153100Z-alpha.md'), '# Alpha Timestamped Test Spec\n');
+    await writeFile(join(specsDir, 'deep-interview-alpha.md'), '# Alpha Legacy Deep Interview\n');
+    await writeFile(join(specsDir, 'deep-interview-20260427T153100Z-alpha.md'), '# Alpha Timestamped Deep Interview\n');
+    await writeFile(join(specsDir, 'deep-interview-autoresearch-20260427T153100Z-alpha.md'), '# Autoresearch Draft\n');
+
+    const selection = readLatestPlanningArtifacts(tempDir);
+    assert.equal(selection.prdPath, join(plansDir, 'prd-20260427T153100Z-alpha.md'));
+    assert.deepEqual(selection.testSpecPaths, [join(plansDir, 'test-spec-20260427T153100Z-alpha.md')]);
+    assert.deepEqual(selection.deepInterviewSpecPaths, [
+      join(specsDir, 'deep-interview-alpha.md'),
+      join(specsDir, 'deep-interview-20260427T153100Z-alpha.md'),
+    ]);
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    assert.equal(hint?.task, 'Execute new alpha plan');
+    assert.deepEqual(hint?.testSpecPaths, [join(plansDir, 'test-spec-20260427T153100Z-alpha.md')]);
+    assert.deepEqual(hint?.deepInterviewSpecPaths, [
+      join(specsDir, 'deep-interview-alpha.md'),
+      join(specsDir, 'deep-interview-20260427T153100Z-alpha.md'),
+    ]);
+
+    const artifacts = readPlanningArtifacts(tempDir);
+    assert.equal(isPlanningComplete(artifacts), true);
+  });
+
+  it('keeps legacy test-spec compatibility aliases for non-timestamped PRDs', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-alpha.md'),
+      '# Alpha\n\nLaunch via omx ralph "Execute alpha"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha Test Spec\n');
+    await writeFile(join(plansDir, 'testspec-alpha.md'), '# Alpha Compatibility Test Spec\n');
+    await writeFile(join(plansDir, 'test-spec-20260427T153100Z-alpha.md'), '# Alpha Timestamped Test Spec\n');
+
+    const selection = readLatestPlanningArtifacts(tempDir);
+    assert.equal(selection.prdPath, join(plansDir, 'prd-alpha.md'));
+    assert.deepEqual(selection.testSpecPaths, [
+      join(plansDir, 'test-spec-alpha.md'),
+      join(plansDir, 'testspec-alpha.md'),
+    ]);
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    assert.deepEqual(hint?.testSpecPaths, [
+      join(plansDir, 'test-spec-alpha.md'),
+      join(plansDir, 'testspec-alpha.md'),
+    ]);
+  });
+
+  it('fails closed for timestamped PRDs when only legacy slug test specs exist', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-20260427T153100Z-alpha.md'),
+      '# Alpha\n\nLaunch via omx ralph "Execute alpha"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha Legacy Test Spec\n');
+
+    const artifacts = readPlanningArtifacts(tempDir);
+    assert.equal(isPlanningComplete(artifacts), false);
+
+    const selection = readLatestPlanningArtifacts(tempDir);
+    assert.equal(selection.prdPath, join(plansDir, 'prd-20260427T153100Z-alpha.md'));
+    assert.deepEqual(selection.testSpecPaths, []);
+
+    assert.equal(readApprovedExecutionLaunchHint(tempDir, 'ralph'), null);
+
+    const resolution = readTeamDagArtifactResolution(tempDir);
+    assert.equal(resolution.source, 'none');
+    assert.equal(resolution.prdPath, join(plansDir, 'prd-20260427T153100Z-alpha.md'));
+    assert.equal(resolution.planSlug, '20260427T153100Z-alpha');
     assert.deepEqual(resolution.warnings, ['missing_matching_test_spec']);
   });
 
@@ -259,6 +361,30 @@ describe('planning artifacts', () => {
     assert.ok(hint.repositoryContextSummary.content.split('\n').length <= 80);
   });
 
+  it('prefers exact timestamped repository context sidecars for timestamped PRDs', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-20260427T153100Z-alpha.md'),
+      '# Alpha\n\nLaunch via omx team 2:executor "Execute alpha"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-20260427T153100Z-alpha.md'), '# Alpha Test Spec\n');
+    await writeFile(join(plansDir, 'repo-context-alpha.md'), 'stale alpha context\n');
+    await writeFile(
+      join(plansDir, 'repo-context-20260427T153100Z-alpha.md'),
+      'fresh alpha context\n',
+    );
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team');
+
+    assert.ok(hint?.repositoryContextSummary);
+    assert.equal(
+      hint.repositoryContextSummary.sourcePath,
+      join(plansDir, 'repo-context-20260427T153100Z-alpha.md'),
+    );
+    assert.equal(hint.repositoryContextSummary.content, 'fresh alpha context');
+  });
+
   it('does not attach stale repository context from a different PRD slug', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });
@@ -322,6 +448,29 @@ describe('planning artifacts', () => {
     assert.equal(result.source, 'sidecar');
     assert.equal(result.planSlug, 'alpha');
     assert.equal(result.dag?.nodes[0]?.id, 'impl');
+  });
+
+  it('prefers exact timestamped Team DAG sidecars for timestamped PRDs', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-20260427T153100Z-alpha.md'), '# Alpha\n');
+    await writeFile(join(plansDir, 'test-spec-20260427T153100Z-alpha.md'), '# Alpha Test\n');
+    await writeFile(join(plansDir, 'team-dag-alpha.json'), '{"source":"stale"}\n');
+    await writeFile(
+      join(plansDir, 'team-dag-20260427T153100Z-alpha.json'),
+      '{"source":"fresh"}\n',
+    );
+
+    const resolution = readTeamDagArtifactResolution(tempDir);
+
+    assert.equal(resolution.source, 'json-sidecar');
+    assert.equal(resolution.planSlug, '20260427T153100Z-alpha');
+    assert.equal(
+      resolution.artifactPath,
+      join(plansDir, 'team-dag-20260427T153100Z-alpha.json'),
+    );
+    assert.equal(resolution.content, '{"source":"fresh"}\n');
+    assert.deepEqual(resolution.warnings, []);
   });
 
   it('does not overmatch sidecars for a different slug prefix', async () => {

--- a/src/planning/artifact-names.ts
+++ b/src/planning/artifact-names.ts
@@ -1,0 +1,130 @@
+import { basename } from 'node:path';
+
+const PLANNING_ARTIFACT_TIMESTAMP_PATTERN = /^\d{8}T\d{6}Z$/;
+
+export type PlanningArtifactKind = 'prd' | 'test-spec' | 'deep-interview' | 'deep-interview-autoresearch';
+
+export interface PlanningArtifactNameInfo {
+  kind: PlanningArtifactKind;
+  slug: string;
+  timestamp?: string;
+}
+
+export function planningArtifactTimestamp(date: Date = new Date()): string {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function legacyTestSpecSlug(fileNameOrPath: string): string | null {
+  const match = basename(fileNameOrPath).match(/^test-?spec-(?<slug>.+)\.md$/i);
+  return match?.groups?.slug ?? null;
+}
+
+function requiredTimestampedTestSpecFileName(prdArtifact: PlanningArtifactNameInfo): string | null {
+  return prdArtifact.kind === 'prd' && prdArtifact.timestamp
+    ? `test-spec-${prdArtifact.timestamp}-${prdArtifact.slug}.md`
+    : null;
+}
+
+function splitTimestampPrefix(rawSlug: string): { slug: string; timestamp?: string } {
+  const separatorIndex = rawSlug.indexOf('-');
+  if (separatorIndex === -1) {
+    return { slug: rawSlug };
+  }
+  const prefix = rawSlug.slice(0, separatorIndex);
+  if (!PLANNING_ARTIFACT_TIMESTAMP_PATTERN.test(prefix)) {
+    return { slug: rawSlug };
+  }
+  return {
+    timestamp: prefix,
+    slug: rawSlug.slice(separatorIndex + 1),
+  };
+}
+
+export function parsePlanningArtifactFileName(fileNameOrPath: string): PlanningArtifactNameInfo | null {
+  const fileName = basename(fileNameOrPath);
+  const autoresearchDeepInterviewMatch = fileName.match(/^deep-interview-autoresearch-(?<slug>.+)\.md$/i);
+  if (autoresearchDeepInterviewMatch?.groups?.slug) {
+    const parsedSlug = splitTimestampPrefix(autoresearchDeepInterviewMatch.groups.slug);
+    if (!parsedSlug.slug) return null;
+    return {
+      kind: 'deep-interview-autoresearch',
+      ...parsedSlug,
+    };
+  }
+
+  const deepInterviewMatch = fileName.match(/^deep-interview-(?<slug>.+)\.md$/i);
+  if (deepInterviewMatch?.groups?.slug) {
+    const parsedSlug = splitTimestampPrefix(deepInterviewMatch.groups.slug);
+    if (!parsedSlug.slug) return null;
+    return {
+      kind: 'deep-interview',
+      ...parsedSlug,
+    };
+  }
+
+  const prdMatch = fileName.match(/^prd-(?<slug>.+)\.md$/i);
+  if (prdMatch?.groups?.slug) {
+    const parsedSlug = splitTimestampPrefix(prdMatch.groups.slug);
+    if (!parsedSlug.slug) return null;
+    return {
+      kind: 'prd',
+      ...parsedSlug,
+    };
+  }
+
+  const testSpecMatch = fileName.match(/^test-?spec-(?<slug>.+)\.md$/i);
+  if (testSpecMatch?.groups?.slug) {
+    const parsedSlug = splitTimestampPrefix(testSpecMatch.groups.slug);
+    if (!parsedSlug.slug) return null;
+    return {
+      kind: 'test-spec',
+      ...parsedSlug,
+    };
+  }
+
+  return null;
+}
+
+export function planningArtifactSlug(fileNameOrPath: string, kind: PlanningArtifactKind): string | null {
+  const parsed = parsePlanningArtifactFileName(fileNameOrPath);
+  return parsed?.kind === kind ? parsed.slug : null;
+}
+
+export function comparePlanningArtifactPaths(left: string, right: string): number {
+  const leftParsed = parsePlanningArtifactFileName(left);
+  const rightParsed = parsePlanningArtifactFileName(right);
+  if (leftParsed?.timestamp && rightParsed?.timestamp && leftParsed.timestamp !== rightParsed.timestamp) {
+    return leftParsed.timestamp.localeCompare(rightParsed.timestamp);
+  }
+  if (leftParsed?.timestamp && !rightParsed?.timestamp) {
+    return 1;
+  }
+  if (!leftParsed?.timestamp && rightParsed?.timestamp) {
+    return -1;
+  }
+  return left.localeCompare(right);
+}
+
+export function selectMatchingTestSpecsForPrd(
+  prdPath: string | null,
+  testSpecPaths: readonly string[],
+): string[] {
+  if (!prdPath) {
+    return [];
+  }
+
+  const prdArtifact = parsePlanningArtifactFileName(prdPath);
+  if (prdArtifact?.kind !== 'prd') {
+    return [];
+  }
+
+  const requiredTimestampedFileName = requiredTimestampedTestSpecFileName(prdArtifact);
+  return (requiredTimestampedFileName
+    ? testSpecPaths.filter((path) => basename(path) === requiredTimestampedFileName)
+    : testSpecPaths.filter((path) => legacyTestSpecSlug(path) === prdArtifact.slug))
+    .sort(comparePlanningArtifactPaths);
+}
+
+export function selectLatestPlanningArtifactPath(paths: readonly string[]): string | null {
+  return [...paths].sort(comparePlanningArtifactPaths).at(-1) ?? null;
+}

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -1,5 +1,12 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, join } from 'node:path';
+import {
+  comparePlanningArtifactPaths,
+  parsePlanningArtifactFileName,
+  planningArtifactSlug,
+  selectLatestPlanningArtifactPath,
+  selectMatchingTestSpecsForPrd,
+} from './artifact-names.js';
 import { omxPlansDir } from '../utils/paths.js';
 
 const PRD_PATTERN = /^prd-.*\.md$/i;
@@ -61,7 +68,7 @@ function readMatchingPaths(dir: string, pattern: RegExp): string[] {
   try {
     return readdirSync(dir)
       .filter((file) => pattern.test(file))
-      .sort((a, b) => a.localeCompare(b))
+      .sort(comparePlanningArtifactPaths)
       .map((file) => join(dir, file));
   } catch {
     return [];
@@ -77,12 +84,14 @@ export function readPlanningArtifacts(cwd: string): PlanningArtifacts {
     specsDir,
     prdPaths: readMatchingPaths(plansDir, PRD_PATTERN),
     testSpecPaths: readMatchingPaths(plansDir, TEST_SPEC_PATTERN),
-    deepInterviewSpecPaths: readMatchingPaths(specsDir, DEEP_INTERVIEW_SPEC_PATTERN),
+    deepInterviewSpecPaths: readMatchingPaths(specsDir, DEEP_INTERVIEW_SPEC_PATTERN)
+      .filter((path) => parsePlanningArtifactFileName(path)?.kind === 'deep-interview'),
   };
 }
 
 export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
-  return artifacts.prdPaths.length > 0 && artifacts.testSpecPaths.length > 0;
+  const selection = selectLatestPlanningArtifacts(artifacts);
+  return Boolean(selection.prdPath) && selection.testSpecPaths.length > 0;
 }
 
 function decodeQuotedValue(raw: string): string | null {
@@ -101,15 +110,17 @@ function decodeQuotedValue(raw: string): string | null {
   }
 }
 
-function artifactSlug(path: string, prefixPattern: RegExp): string | null {
+function artifactPathSuffix(path: string, prefixPattern: RegExp): string | null {
   const file = basename(path);
   const match = file.match(prefixPattern);
   return match?.groups?.slug ?? null;
 }
 
-function filterArtifactsForSlug(paths: readonly string[], prefixPattern: RegExp, slug: string | null): string[] {
+function selectDeepInterviewSpecPathsForSlug(paths: readonly string[], slug: string | null): string[] {
   if (!slug) return [];
-  return paths.filter((path) => artifactSlug(path, prefixPattern) === slug);
+  return paths
+    .filter((path) => planningArtifactSlug(path, 'deep-interview') === slug)
+    .sort(comparePlanningArtifactPaths);
 }
 
 
@@ -175,7 +186,7 @@ function readApprovedPlanText(cwd: string): { content: string; context: Approved
 
   try {
     const content = readFileSync(latestPrdPath, 'utf-8');
-    const planSlug = artifactSlug(latestPrdPath, /^prd-(?<slug>.*)\.md$/i);
+    const planSlug = artifactPathSuffix(latestPrdPath, /^prd-(?<slug>.*)\.md$/i);
     const repositoryContextSummary = readApprovedRepositoryContextSummary(artifacts, latestPrdPath, planSlug, content);
     return {
       content,
@@ -194,23 +205,15 @@ function readApprovedPlanText(cwd: string): { content: string; context: Approved
 export function selectLatestPlanningArtifacts(
   artifacts: PlanningArtifacts,
 ): LatestPlanningArtifactSelection {
-  const latestPrdPath = artifacts.prdPaths.at(-1) ?? null;
+  const latestPrdPath = selectLatestPlanningArtifactPath(artifacts.prdPaths);
   const slug = latestPrdPath
-    ? artifactSlug(latestPrdPath, /^prd-(?<slug>.*)\.md$/i)
+    ? planningArtifactSlug(latestPrdPath, 'prd')
     : null;
 
   return {
     prdPath: latestPrdPath,
-    testSpecPaths: filterArtifactsForSlug(
-      artifacts.testSpecPaths,
-      /^test-?spec-(?<slug>.*)\.md$/i,
-      slug,
-    ),
-    deepInterviewSpecPaths: filterArtifactsForSlug(
-      artifacts.deepInterviewSpecPaths,
-      /^deep-interview-(?<slug>.*)\.md$/i,
-      slug,
-    ),
+    testSpecPaths: selectMatchingTestSpecsForPrd(latestPrdPath, artifacts.testSpecPaths),
+    deepInterviewSpecPaths: selectDeepInterviewSpecPathsForSlug(artifacts.deepInterviewSpecPaths, slug),
   };
 }
 
@@ -236,13 +239,13 @@ function extractTeamDagMarkdownHandoff(content: string): string | null {
 
 export function readTeamDagArtifactResolution(cwd: string): TeamDagArtifactResolution {
   const artifacts = readPlanningArtifacts(cwd);
-  if (!isPlanningComplete(artifacts)) {
+  if (artifacts.prdPaths.length === 0 || artifacts.testSpecPaths.length === 0) {
     return { source: 'none', prdPath: null, planSlug: null, warnings: ['planning_incomplete'] };
   }
 
   const selection = selectLatestPlanningArtifacts(artifacts);
   const prdPath = selection.prdPath;
-  const planSlug = prdPath ? artifactSlug(prdPath, /^prd-(?<slug>.*)\.md$/i) : null;
+  const planSlug = prdPath ? artifactPathSuffix(prdPath, /^prd-(?<slug>.*)\.md$/i) : null;
   if (!prdPath || !planSlug) {
     return { source: 'none', prdPath, planSlug, warnings: ['missing_prd_slug'] };
   }

--- a/src/ralph/__tests__/persistence.test.ts
+++ b/src/ralph/__tests__/persistence.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { ensureCanonicalRalphArtifacts, recordRalphVisualFeedback } from '../persistence.js';
 import { VISUAL_NEXT_ACTIONS_LIMIT } from '../../visual/constants.js';
 
@@ -57,6 +57,10 @@ describe('ensureCanonicalRalphArtifacts', () => {
       assert.ok(result.canonicalPrdPath);
       assert.equal(existsSync(result.canonicalPrdPath!), true);
       assert.equal(existsSync(result.canonicalProgressPath), true);
+      assert.match(
+        basename(result.canonicalPrdPath!),
+        /^prd-\d{8}T\d{6}Z-legacy-ralph-project(?:-\d+)?\.md$/,
+      );
 
       const canonicalPrd = await readFile(result.canonicalPrdPath!, 'utf-8');
       const canonicalProgress = JSON.parse(await readFile(result.canonicalProgressPath, 'utf-8'));
@@ -69,6 +73,26 @@ describe('ensureCanonicalRalphArtifacts', () => {
       // Legacy artifacts remain untouched for compatibility window.
       assert.equal(await readFile(legacyPrdPath, 'utf-8'), legacyPrdBefore);
       assert.equal(await readFile(legacyProgressPath, 'utf-8'), legacyProgressBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers the newest timestamped canonical PRD when multiple canonical files exist', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-canonical-order-'));
+    try {
+      const plansDir = join(cwd, '.omx', 'plans');
+      const canonicalProgress = join(cwd, '.omx', 'state', 'ralph-progress.json');
+      await mkdir(plansDir, { recursive: true });
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(plansDir, 'prd-legacy.md'), '# Legacy canonical PRD\n');
+      await writeFile(join(plansDir, 'prd-20260427T153000Z-alpha.md'), '# Older timestamped PRD\n');
+      await writeFile(join(plansDir, 'prd-20260427T153100Z-alpha.md'), '# Newer timestamped PRD\n');
+      await writeFile(canonicalProgress, JSON.stringify({ canonical: true }, null, 2));
+
+      const result = await ensureCanonicalRalphArtifacts(cwd);
+      assert.equal(result.migratedPrd, false);
+      assert.equal(result.canonicalPrdPath, join(plansDir, 'prd-20260427T153100Z-alpha.md'));
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/ralph/persistence.ts
+++ b/src/ralph/persistence.ts
@@ -2,6 +2,7 @@ import { createHash } from 'crypto';
 import { existsSync } from 'fs';
 import { mkdir, readFile, readdir, writeFile } from 'fs/promises';
 import { join } from 'path';
+import { comparePlanningArtifactPaths, planningArtifactTimestamp } from '../planning/artifact-names.js';
 import { getStateDir } from '../state/paths.js';
 import { VISUAL_NEXT_ACTIONS_LIMIT, type VisualVerdictStatus } from '../visual/constants.js';
 
@@ -90,7 +91,7 @@ async function listCanonicalPrdFiles(cwd: string): Promise<string[]> {
   const files = await readdir(plansDir).catch(() => [] as string[]);
   return files
     .filter((file) => file.startsWith(PRD_PREFIX) && file.endsWith(PRD_SUFFIX))
-    .sort()
+    .sort(comparePlanningArtifactPaths)
     .map((file) => join(plansDir, file));
 }
 
@@ -191,10 +192,11 @@ async function migrateLegacyPrdIfNeeded(
 
   const title = resolveLegacyPrdTitle(legacyParsed);
   const baseSlug = slugify(title);
-  let canonicalPrdPath = join(plansDir, `prd-${baseSlug}.md`);
+  const timestamp = planningArtifactTimestamp();
+  let canonicalPrdPath = join(plansDir, `prd-${timestamp}-${baseSlug}.md`);
   let counter = 1;
   while (existsSync(canonicalPrdPath)) {
-    canonicalPrdPath = join(plansDir, `prd-${baseSlug}-${counter}.md`);
+    canonicalPrdPath = join(plansDir, `prd-${timestamp}-${baseSlug}-${counter}.md`);
     counter += 1;
   }
 
@@ -315,7 +317,7 @@ export async function ensureCanonicalRalphArtifacts(
   await mkdir(getStateDir(cwd, sessionId), { recursive: true });
 
   const canonicalPrdFiles = await listCanonicalPrdFiles(cwd);
-  const migratedPrdResult = await migrateLegacyPrdIfNeeded(cwd, canonicalPrdFiles[0]);
+  const migratedPrdResult = await migrateLegacyPrdIfNeeded(cwd, canonicalPrdFiles.at(-1));
   const migratedProgress = await migrateLegacyProgressIfNeeded(cwd, canonicalProgressPath);
   await ensureCanonicalProgressLedgerFile(canonicalProgressPath);
 


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only
> when a maintainer explicitly asks for it.

`upstream/dev` still orders planning artifacts lexically and still
selects migrated Ralph PRDs without a timestamp-aware tie-break, so a
newer canonical handoff can lose latest-plan selection and a timestamped
PRD can reuse an older slug-only test spec. This change makes PRD and
test-spec selection timestamp-aware while preserving the current exact
latest-plan suffix rule for repository-context and Team DAG sidecars.

## Changes

- add `src/planning/artifact-names.ts` for timestamp parsing, canonical
  slug extraction, and timestamp-aware planning artifact ordering
- require exact `test-spec-<timestamp>-<slug>.md` matches for
  timestamped PRDs while keeping legacy non-timestamped
  `test-spec-*`/`testspec-*` compatibility
- migrate legacy Ralph PRDs to `prd-<timestamp>-<slug>.md` and prefer
  the newest canonical PRD when multiple canonical files exist
- keep deep-interview selection limited to canonical non-autoresearch
  artifacts and preserve exact latest-plan suffix matching for
  `repo-context-*` and `team-dag-*` sidecars

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Focused validation run for this PR:
- `node --test dist/planning/__tests__/artifacts.test.js dist/ralph/__tests__/persistence.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- No tracked issue for this narrow planning artifact selection change.
