### PR TITLE
fix(pipeline): derive team-exec task from approved handoff

### DIFF
--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -208,20 +208,123 @@ describe('Team Exec Stage', () => {
     assert.equal(arts.agentType, 'architect');
   });
 
-  it('includes ralplan artifacts in team task when available', async () => {
-    const stage = createTeamExecStage();
-    const ctx = makeCtx({
-      artifacts: {
-        ralplan: { data: 'plan-content', stage: 'ralplan' },
-      },
-    });
-    const result = await stage.run(ctx);
+  it('derives the team-exec task from the latest approved PRD handoff', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const approvedPrdPath = join(plansDir, 'prd-alpha.md');
+    await writeFile(
+      approvedPrdPath,
+      '# Alpha plan\n\nLaunch via omx team 2:executor "Execute alpha handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha test spec\n');
+    await writeFile(
+      join(plansDir, 'prd-zeta.md'),
+      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
 
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'original request task',
+      artifacts: {
+        ralplan: {
+          task: 'original request task',
+          data: 'plan-content',
+          stage: 'ralplan',
+          latestPlanPath: approvedPrdPath,
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'completed');
     const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
-    assert.ok((descriptor.task as string).includes('plan-content'));
+    const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+    assert.equal(descriptor.task, 'Execute alpha handoff');
+    assert.match(instruction, /Execute alpha handoff/);
+    assert.doesNotMatch(instruction, /Execute zeta handoff/);
+    assert.doesNotMatch(instruction, /plan-content/);
     assert.ok(Array.isArray(descriptor.availableAgentTypes));
     assert.ok((descriptor.availableAgentTypes as unknown[]).length > 0);
     assert.equal(typeof (descriptor.staffingPlan as Record<string, unknown>).staffingSummary, 'string');
+  });
+
+  it('keeps structural ralplan handoffs on the generic task path', async () => {
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'structural pipeline task',
+      artifacts: {
+        ralplan: {
+          task: 'structural pipeline task',
+          data: 'plan-content',
+          stage: 'ralplan',
+          plansDir: join(tempDir, '.omx', 'plans'),
+          specsDir: join(tempDir, '.omx', 'specs'),
+          prdPaths: [],
+          testSpecPaths: [],
+          deepInterviewSpecPaths: [],
+          planningComplete: false,
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'completed');
+    const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+    const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+    assert.equal(descriptor.task, 'structural pipeline task');
+    assert.match(instruction, /structural pipeline task/);
+    assert.doesNotMatch(instruction, /plan-content/);
+  });
+
+  it('fails closed when latestPlanPath has no team launch hint', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-no-team-hint.md');
+    await writeFile(prdPath, '# PRD\n\nNo team launch hint here.\n');
+
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'original request task',
+      artifacts: {
+        ralplan: {
+          task: 'original request task',
+          stage: 'ralplan',
+          latestPlanPath: prdPath,
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'failed');
+    assert.match(result.error ?? '', /team_exec_approved_handoff_missing:/);
+  });
+
+  it('fails closed when latestPlanPath has ambiguous team launch hints', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-ambiguous-team-hint.md');
+    await writeFile(
+      prdPath,
+      [
+        '# PRD',
+        '',
+        'Launch via omx team 2:executor "Execute first handoff"',
+        'Launch via omx team 2:executor "Execute second handoff"',
+      ].join('\n'),
+    );
+
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'original request task',
+      artifacts: {
+        ralplan: {
+          task: 'original request task',
+          stage: 'ralplan',
+          latestPlanPath: prdPath,
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'failed');
+    assert.match(result.error ?? '', /team_exec_approved_handoff_ambiguous:/);
   });
 
   it('falls back to raw task when no ralplan artifacts exist', async () => {

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -6,6 +6,7 @@
  * canonical OMX execution surface.
  */
 
+import { readFileSync } from 'node:fs';
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
 import {
   buildFollowupStaffingPlan,
@@ -26,13 +27,71 @@ export interface TeamExecStageOptions {
   extraEnv?: Record<string, string>;
 }
 
+const APPROVED_TEAM_LAUNCH_PATTERN = /(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
+
+function decodeQuotedValue(raw: string): string | null {
+  const normalized = raw.trim();
+  if (!normalized) return null;
+
+  try {
+    return JSON.parse(normalized) as string;
+  } catch {
+    if (
+      (normalized.startsWith('"') && normalized.endsWith('"'))
+      || (normalized.startsWith("'") && normalized.endsWith("'"))
+    ) {
+      return normalized.slice(1, -1);
+    }
+    return null;
+  }
+}
+
+function resolveRequestedTask(ctx: StageContext, ralplanArtifacts?: Record<string, unknown>): string {
+  const ralplanTask = typeof ralplanArtifacts?.task === 'string' ? ralplanArtifacts.task.trim() : '';
+  return ralplanTask || ctx.task;
+}
+
+function resolveApprovedTeamTaskFromPlanPath(latestPlanPath: string): string {
+  let content = '';
+  try {
+    content = readFileSync(latestPlanPath, 'utf-8');
+  } catch {
+    throw new Error(`team_exec_approved_handoff_missing:${latestPlanPath}`);
+  }
+
+  const matches = [...content.matchAll(APPROVED_TEAM_LAUNCH_PATTERN)];
+  if (matches.length === 0) {
+    throw new Error(`team_exec_approved_handoff_missing:${latestPlanPath}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`team_exec_approved_handoff_ambiguous:${latestPlanPath}`);
+  }
+
+  const task = matches[0]?.groups?.task ? decodeQuotedValue(matches[0].groups.task) : null;
+  if (!task) {
+    throw new Error(`team_exec_approved_handoff_missing:${latestPlanPath}`);
+  }
+  return task;
+}
+
+function resolveTeamExecTask(ctx: StageContext, ralplanArtifacts?: Record<string, unknown>): string {
+  const requestedTask = resolveRequestedTask(ctx, ralplanArtifacts);
+  const latestPlanPath = typeof ralplanArtifacts?.latestPlanPath === 'string'
+    ? ralplanArtifacts.latestPlanPath.trim()
+    : '';
+  if (!latestPlanPath) {
+    return requestedTask;
+  }
+  return resolveApprovedTeamTaskFromPlanPath(latestPlanPath);
+}
+
 /**
  * Create a team-exec pipeline stage.
  *
  * This stage delegates to the existing `omx team` infrastructure, which
- * starts real Codex CLI workers in tmux panes. The stage collects the
- * plan artifacts from the previous RALPLAN stage and passes them as
- * the team task description.
+ * starts real Codex CLI workers in tmux panes. When RALPLAN names a
+ * concrete approved PRD handoff, team-exec reuses that exact task text;
+ * otherwise it stays on the generic request-task path.
  */
 export function createTeamExecStage(options: TeamExecStageOptions = {}): PipelineStage {
   const workerCount = options.workerCount ?? 2;
@@ -45,20 +104,19 @@ export function createTeamExecStage(options: TeamExecStageOptions = {}): Pipelin
       const startTime = Date.now();
 
       try {
-        // Extract plan context from previous stage artifacts
-        const ralplanArtifacts = ctx.artifacts['ralplan'] as Record<string, unknown> | undefined;
-        const planContext = ralplanArtifacts
-          ? `Plan from RALPLAN stage:\n${JSON.stringify(ralplanArtifacts, null, 2)}\n\nTask: ${ctx.task}`
-          : ctx.task;
+        const ralplanArtifacts = typeof ctx.artifacts['ralplan'] === 'object' && ctx.artifacts['ralplan'] !== null
+          ? ctx.artifacts['ralplan'] as Record<string, unknown>
+          : undefined;
+        const task = resolveTeamExecTask(ctx, ralplanArtifacts);
         const availableAgentTypes = await resolveAvailableAgentTypes(ctx.cwd);
-        const staffingPlan = buildFollowupStaffingPlan('team', ctx.task, availableAgentTypes, {
+        const staffingPlan = buildFollowupStaffingPlan('team', task, availableAgentTypes, {
           workerCount,
           fallbackRole: agentType,
         });
 
         // Build team execution descriptor
         const teamDescriptor: TeamExecDescriptor = {
-          task: planContext,
+          task,
           workerCount,
           agentType,
           availableAgentTypes,


### PR DESCRIPTION
## Summary

`team-exec` currently serializes the full `ralplan` artifact object into
the runnable `omx team` task. That ignores `ralplan.latestPlanPath`,
can launch against the wrong approved handoff, and leaks raw planner
JSON into the team command.

## Changes

- derive the runnable team task from the exact PRD named by
  `ralplan.latestPlanPath` when that PRD contains a single `omx team`
  launch hint
- fail closed when the named PRD has no team launch hint or more than
  one team launch hint
- keep structural plan-only handoffs on the generic request-task path
  and stop embedding serialized `ralplan` artifacts in the team
  command

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/planning/__tests__/artifacts.test.js dist/pipeline/__tests__/stages.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
