### PR TITLE
fix(pipeline): validate approved team handoff path

### DIFF
--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -208,20 +208,123 @@ describe('Team Exec Stage', () => {
     assert.equal(arts.agentType, 'architect');
   });
 
-  it('includes ralplan artifacts in team task when available', async () => {
-    const stage = createTeamExecStage();
-    const ctx = makeCtx({
-      artifacts: {
-        ralplan: { data: 'plan-content', stage: 'ralplan' },
-      },
-    });
-    const result = await stage.run(ctx);
+  it('derives the team-exec task from the latest approved PRD handoff', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const approvedPrdPath = join(plansDir, 'prd-alpha.md');
+    await writeFile(
+      approvedPrdPath,
+      '# Alpha plan\n\nLaunch via omx team 2:executor "Execute alpha handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha test spec\n');
+    await writeFile(
+      join(plansDir, 'prd-zeta.md'),
+      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
 
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'original request task',
+      artifacts: {
+        ralplan: {
+          task: 'original request task',
+          data: 'plan-content',
+          stage: 'ralplan',
+          latestPlanPath: approvedPrdPath,
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'completed');
     const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
-    assert.ok((descriptor.task as string).includes('plan-content'));
+    const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+    assert.equal(descriptor.task, 'Execute alpha handoff');
+    assert.match(instruction, /Execute alpha handoff/);
+    assert.doesNotMatch(instruction, /Execute zeta handoff/);
+    assert.doesNotMatch(instruction, /plan-content/);
     assert.ok(Array.isArray(descriptor.availableAgentTypes));
     assert.ok((descriptor.availableAgentTypes as unknown[]).length > 0);
     assert.equal(typeof (descriptor.staffingPlan as Record<string, unknown>).staffingSummary, 'string');
+  });
+
+  it('keeps structural ralplan handoffs on the generic task path', async () => {
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'structural pipeline task',
+      artifacts: {
+        ralplan: {
+          task: 'structural pipeline task',
+          data: 'plan-content',
+          stage: 'ralplan',
+          plansDir: join(tempDir, '.omx', 'plans'),
+          specsDir: join(tempDir, '.omx', 'specs'),
+          prdPaths: [],
+          testSpecPaths: [],
+          deepInterviewSpecPaths: [],
+          planningComplete: false,
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'completed');
+    const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+    const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+    assert.equal(descriptor.task, 'structural pipeline task');
+    assert.match(instruction, /structural pipeline task/);
+    assert.doesNotMatch(instruction, /plan-content/);
+  });
+
+  it('fails closed when latestPlanPath has no team launch hint', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-no-team-hint.md');
+    await writeFile(prdPath, '# PRD\n\nNo team launch hint here.\n');
+
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'original request task',
+      artifacts: {
+        ralplan: {
+          task: 'original request task',
+          stage: 'ralplan',
+          latestPlanPath: prdPath,
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'failed');
+    assert.match(result.error ?? '', /team_exec_approved_handoff_missing:/);
+  });
+
+  it('fails closed when latestPlanPath has ambiguous team launch hints', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-ambiguous-team-hint.md');
+    await writeFile(
+      prdPath,
+      [
+        '# PRD',
+        '',
+        'Launch via omx team 2:executor "Execute first handoff"',
+        'Launch via omx team 2:executor "Execute second handoff"',
+      ].join('\n'),
+    );
+
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'original request task',
+      artifacts: {
+        ralplan: {
+          task: 'original request task',
+          stage: 'ralplan',
+          latestPlanPath: prdPath,
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'failed');
+    assert.match(result.error ?? '', /team_exec_approved_handoff_ambiguous:/);
   });
 
   it('falls back to raw task when no ralplan artifacts exist', async () => {

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -282,6 +282,40 @@ describe('Team Exec Stage', () => {
     }
   });
 
+  it('derives the team-exec task when latestPlanPath resolves through equivalent relative segments', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-zeta.md'),
+      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+
+    const relativeCwd = basename(tempDir);
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(dirname(tempDir));
+      const stage = createTeamExecStage();
+      const result = await stage.run(makeCtx({
+        cwd: relativeCwd,
+        task: 'original request task',
+        artifacts: {
+          ralplan: {
+            task: 'original request task',
+            stage: 'ralplan',
+            latestPlanPath: join('..', relativeCwd, '.omx', 'plans', 'prd-zeta.md'),
+          },
+        },
+      }));
+
+      assert.equal(result.status, 'completed');
+      const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+      assert.equal(descriptor.task, 'Execute zeta handoff');
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
   it('derives the team-exec task from single-quoted approved handoff text with escapes', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -377,6 +377,41 @@ Launch via $team 2:executor 'Fix C:\\tmp and keep \n literal'
     assert.ok(instruction.includes(JSON.stringify(expectedTask)));
   });
 
+  it('derives the team-exec task from the latest ralplan draft when numeric PRD slugs sort lexically out of order', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-9.md'),
+      '# Issue 9 plan\n\nLaunch via omx team 2:executor "Execute issue 9 handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-9.md'), '# Issue 9 test spec\n');
+    await writeFile(
+      join(plansDir, 'prd-issue-10.md'),
+      '# Issue 10 plan\n\nLaunch via omx team 3:debugger "Execute issue 10 handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-10.md'), '# Issue 10 test spec\n');
+
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'original request task',
+      artifacts: {
+        ralplan: {
+          task: 'original request task',
+          stage: 'ralplan',
+          latestPlanPath: join('.omx', 'plans', 'prd-issue-10.md'),
+          drafts: [
+            { planPath: join('.omx', 'plans', 'prd-issue-9.md') },
+            { planPath: join('.omx', 'plans', 'prd-issue-10.md') },
+          ],
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'completed');
+    const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+    assert.equal(descriptor.task, 'Execute issue 10 handoff');
+  });
+
   it('fails closed when latestPlanPath is not the selected latest approved PRD', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -208,12 +208,52 @@ describe('Team Exec Stage', () => {
     assert.equal(arts.agentType, 'architect');
   });
 
-  it('derives the team-exec task from the latest approved PRD handoff', async () => {
+  it('derives the team-exec task from a relative latest approved PRD handoff path', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });
-    const approvedPrdPath = join(plansDir, 'prd-alpha.md');
+    const approvedPrdPath = join(plansDir, 'prd-zeta.md');
     await writeFile(
       approvedPrdPath,
+      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(tmpdir());
+      const stage = createTeamExecStage();
+      const result = await stage.run(makeCtx({
+        task: 'original request task',
+        artifacts: {
+          ralplan: {
+            task: 'original request task',
+            data: 'plan-content',
+            stage: 'ralplan',
+            latestPlanPath: join('.omx', 'plans', 'prd-zeta.md'),
+          },
+        },
+      }));
+
+      assert.equal(result.status, 'completed');
+      const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+      const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+      assert.equal(descriptor.task, 'Execute zeta handoff');
+      assert.match(instruction, /Execute zeta handoff/);
+      assert.doesNotMatch(instruction, /plan-content/);
+      assert.ok(Array.isArray(descriptor.availableAgentTypes));
+      assert.ok((descriptor.availableAgentTypes as unknown[]).length > 0);
+      assert.equal(typeof (descriptor.staffingPlan as Record<string, unknown>).staffingSummary, 'string');
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it('fails closed when latestPlanPath is not the selected latest approved PRD', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const stalePrdPath = join(plansDir, 'prd-alpha.md');
+    await writeFile(
+      stalePrdPath,
       '# Alpha plan\n\nLaunch via omx team 2:executor "Execute alpha handoff"\n',
     );
     await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha test spec\n');
@@ -231,21 +271,14 @@ describe('Team Exec Stage', () => {
           task: 'original request task',
           data: 'plan-content',
           stage: 'ralplan',
-          latestPlanPath: approvedPrdPath,
+          latestPlanPath: stalePrdPath,
         },
       },
     }));
 
-    assert.equal(result.status, 'completed');
-    const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
-    const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
-    assert.equal(descriptor.task, 'Execute alpha handoff');
-    assert.match(instruction, /Execute alpha handoff/);
-    assert.doesNotMatch(instruction, /Execute zeta handoff/);
-    assert.doesNotMatch(instruction, /plan-content/);
-    assert.ok(Array.isArray(descriptor.availableAgentTypes));
-    assert.ok((descriptor.availableAgentTypes as unknown[]).length > 0);
-    assert.equal(typeof (descriptor.staffingPlan as Record<string, unknown>).staffingSummary, 'string');
+    assert.equal(result.status, 'failed');
+    assert.match(result.error ?? '', /team_exec_approved_handoff_stale:/);
+    assert.deepEqual(result.artifacts, {});
   });
 
   it('keeps structural ralplan handoffs on the generic task path', async () => {
@@ -273,6 +306,37 @@ describe('Team Exec Stage', () => {
     assert.equal(descriptor.task, 'structural pipeline task');
     assert.match(instruction, /structural pipeline task/);
     assert.doesNotMatch(instruction, /plan-content/);
+  });
+
+  it('does not adopt a pre-existing approved plan when latestPlanPath is absent', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-zeta.md'),
+      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'generic pipeline task',
+      artifacts: {
+        ralplan: {
+          task: 'generic pipeline task',
+          stage: 'ralplan',
+          prdPaths: [join(plansDir, 'prd-zeta.md')],
+          testSpecPaths: [join(plansDir, 'test-spec-zeta.md')],
+          planningComplete: true,
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'completed');
+    const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+    const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+    assert.equal(descriptor.task, 'generic pipeline task');
+    assert.match(instruction, /generic pipeline task/);
+    assert.doesNotMatch(instruction, /Execute zeta handoff/);
   });
 
   it('fails closed when latestPlanPath has no team launch hint', async () => {
@@ -310,6 +374,7 @@ describe('Team Exec Stage', () => {
         'Launch via omx team 2:executor "Execute second handoff"',
       ].join('\n'),
     );
+    await writeFile(join(plansDir, 'test-spec-ambiguous-team-hint.md'), '# Test spec\n');
 
     const stage = createTeamExecStage();
     const result = await stage.run(makeCtx({

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { basename, dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
 import type { StageContext } from '../types.js';
@@ -243,6 +243,40 @@ describe('Team Exec Stage', () => {
       assert.ok(Array.isArray(descriptor.availableAgentTypes));
       assert.ok((descriptor.availableAgentTypes as unknown[]).length > 0);
       assert.equal(typeof (descriptor.staffingPlan as Record<string, unknown>).staffingSummary, 'string');
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it('derives the team-exec task when latestPlanPath is already cwd-prefixed', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-zeta.md'),
+      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+
+    const relativeCwd = basename(tempDir);
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(dirname(tempDir));
+      const stage = createTeamExecStage();
+      const result = await stage.run(makeCtx({
+        cwd: relativeCwd,
+        task: 'original request task',
+        artifacts: {
+          ralplan: {
+            task: 'original request task',
+            stage: 'ralplan',
+            latestPlanPath: join(relativeCwd, '.omx', 'plans', 'prd-zeta.md'),
+          },
+        },
+      }));
+
+      assert.equal(result.status, 'completed');
+      const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+      assert.equal(descriptor.task, 'Execute zeta handoff');
     } finally {
       process.chdir(previousCwd);
     }

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -311,6 +311,38 @@ describe('Team Exec Stage', () => {
     assert.doesNotMatch(instruction, /Fix Bob\\'s regression/);
   });
 
+  it('preserves literal backslashes in single-quoted approved handoff text', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-zeta.md'),
+      String.raw`# Zeta plan
+
+Launch via $team 2:executor 'Fix C:\\tmp and keep \n literal'
+`,
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'original request task',
+      artifacts: {
+        ralplan: {
+          task: 'original request task',
+          stage: 'ralplan',
+          latestPlanPath: join('.omx', 'plans', 'prd-zeta.md'),
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'completed');
+    const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+    const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+    const expectedTask = String.raw`Fix C:\\tmp and keep \n literal`;
+    assert.equal(descriptor.task, expectedTask);
+    assert.ok(instruction.includes(JSON.stringify(expectedTask)));
+  });
+
   it('fails closed when latestPlanPath is not the selected latest approved PRD', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -282,6 +282,35 @@ describe('Team Exec Stage', () => {
     }
   });
 
+  it('derives the team-exec task from single-quoted approved handoff text with escapes', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-zeta.md'),
+      "# Zeta plan\n\nLaunch via $team 2:executor 'Fix Bob\\'s regression'\n",
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'original request task',
+      artifacts: {
+        ralplan: {
+          task: 'original request task',
+          stage: 'ralplan',
+          latestPlanPath: join('.omx', 'plans', 'prd-zeta.md'),
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'completed');
+    const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+    const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+    assert.equal(descriptor.task, "Fix Bob's regression");
+    assert.match(instruction, /Fix Bob's regression/);
+    assert.doesNotMatch(instruction, /Fix Bob\\'s regression/);
+  });
+
   it('fails closed when latestPlanPath is not the selected latest approved PRD', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -75,9 +75,12 @@ function resolvePlanningPrdPath(
   const repoRoot = dirname(dirname(artifacts.plansDir));
   const normalizedPath = normalizePlanningRelativePath(normalizedRawPath);
   const matchedPath = artifacts.prdPaths.find((candidatePath) => {
+    const artifactPath = normalizePlanningRelativePath(candidatePath);
     const repoRelativePath = normalizePlanningRelativePath(relative(repoRoot, candidatePath));
     const plansRelativePath = normalizePlanningRelativePath(relative(artifacts.plansDir, candidatePath));
-    return normalizedPath === repoRelativePath || normalizedPath === plansRelativePath;
+    return normalizedPath === artifactPath
+      || normalizedPath === repoRelativePath
+      || normalizedPath === plansRelativePath;
   }) ?? null;
   return {
     matchedPath,

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -43,7 +43,7 @@ function decodeQuotedValue(raw: string): string | null {
       return normalized.slice(1, -1);
     }
     if (normalized.startsWith("'") && normalized.endsWith("'")) {
-      return normalized.slice(1, -1).replace(/\\(.)/g, '$1');
+      return normalized.slice(1, -1).replace(/\\'/g, "'");
     }
     return null;
   }

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -74,6 +74,7 @@ function resolvePlanningPrdPath(
 
   const repoRoot = dirname(dirname(artifacts.plansDir));
   const normalizedPath = normalizePlanningRelativePath(normalizedRawPath);
+  const resolvedPath = resolve(cwd, normalizedPath);
   const matchedPath = artifacts.prdPaths.find((candidatePath) => {
     const artifactPath = normalizePlanningRelativePath(candidatePath);
     const repoRelativePath = normalizePlanningRelativePath(relative(repoRoot, candidatePath));
@@ -81,10 +82,10 @@ function resolvePlanningPrdPath(
     return normalizedPath === artifactPath
       || normalizedPath === repoRelativePath
       || normalizedPath === plansRelativePath;
-  }) ?? null;
+  }) ?? artifacts.prdPaths.find((candidatePath) => sameFilePath(candidatePath, resolvedPath)) ?? null;
   return {
     matchedPath,
-    fallbackPath: resolve(cwd, normalizedPath),
+    fallbackPath: resolvedPath,
   };
 }
 

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -7,11 +7,13 @@
  */
 
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
 import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
 } from '../../team/followup-planner.js';
+import { readLatestPlanningArtifacts } from '../../planning/artifacts.js';
 
 export interface TeamExecStageOptions {
   /** Number of Codex CLI workers to launch. Defaults to 2. */
@@ -51,25 +53,41 @@ function resolveRequestedTask(ctx: StageContext, ralplanArtifacts?: Record<strin
   return ralplanTask || ctx.task;
 }
 
-function resolveApprovedTeamTaskFromPlanPath(latestPlanPath: string): string {
+function resolveApprovedTeamPlanPath(cwd: string, latestPlanPath: string): string {
+  const resolvedLatestPlanPath = resolve(cwd, latestPlanPath);
+  const selection = readLatestPlanningArtifacts(cwd);
+  const selectedPrdPath = selection.prdPath ? resolve(selection.prdPath) : null;
+
+  if (!selectedPrdPath || selection.testSpecPaths.length === 0) {
+    throw new Error(`team_exec_approved_handoff_missing:${resolvedLatestPlanPath}`);
+  }
+  if (selectedPrdPath !== resolvedLatestPlanPath) {
+    throw new Error(`team_exec_approved_handoff_stale:${resolvedLatestPlanPath}:${selectedPrdPath}`);
+  }
+
+  return selectedPrdPath;
+}
+
+function resolveApprovedTeamTaskFromPlanPath(cwd: string, latestPlanPath: string): string {
+  const approvedPlanPath = resolveApprovedTeamPlanPath(cwd, latestPlanPath);
   let content = '';
   try {
-    content = readFileSync(latestPlanPath, 'utf-8');
+    content = readFileSync(approvedPlanPath, 'utf-8');
   } catch {
-    throw new Error(`team_exec_approved_handoff_missing:${latestPlanPath}`);
+    throw new Error(`team_exec_approved_handoff_missing:${approvedPlanPath}`);
   }
 
   const matches = [...content.matchAll(APPROVED_TEAM_LAUNCH_PATTERN)];
   if (matches.length === 0) {
-    throw new Error(`team_exec_approved_handoff_missing:${latestPlanPath}`);
+    throw new Error(`team_exec_approved_handoff_missing:${approvedPlanPath}`);
   }
   if (matches.length > 1) {
-    throw new Error(`team_exec_approved_handoff_ambiguous:${latestPlanPath}`);
+    throw new Error(`team_exec_approved_handoff_ambiguous:${approvedPlanPath}`);
   }
 
   const task = matches[0]?.groups?.task ? decodeQuotedValue(matches[0].groups.task) : null;
   if (!task) {
-    throw new Error(`team_exec_approved_handoff_missing:${latestPlanPath}`);
+    throw new Error(`team_exec_approved_handoff_missing:${approvedPlanPath}`);
   }
   return task;
 }
@@ -82,7 +100,7 @@ function resolveTeamExecTask(ctx: StageContext, ralplanArtifacts?: Record<string
   if (!latestPlanPath) {
     return requestedTask;
   }
-  return resolveApprovedTeamTaskFromPlanPath(latestPlanPath);
+  return resolveApprovedTeamTaskFromPlanPath(ctx.cwd, latestPlanPath);
 }
 
 /**

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -7,13 +7,14 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, isAbsolute, normalize, relative, resolve } from 'node:path';
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
 import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
 } from '../../team/followup-planner.js';
-import { readLatestPlanningArtifacts } from '../../planning/artifacts.js';
+import { readLatestPlanningArtifacts, readPlanningArtifacts, type PlanningArtifacts } from '../../planning/artifacts.js';
+import { sameFilePath } from '../../utils/paths.js';
 
 export interface TeamExecStageOptions {
   /** Number of Codex CLI workers to launch. Defaults to 2. */
@@ -53,16 +54,50 @@ function resolveRequestedTask(ctx: StageContext, ralplanArtifacts?: Record<strin
   return ralplanTask || ctx.task;
 }
 
-function resolveApprovedTeamPlanPath(cwd: string, latestPlanPath: string): string {
-  const resolvedLatestPlanPath = resolve(cwd, latestPlanPath);
-  const selection = readLatestPlanningArtifacts(cwd);
-  const selectedPrdPath = selection.prdPath ? resolve(selection.prdPath) : null;
+function normalizePlanningRelativePath(rawPath: string): string {
+  const trimmed = rawPath.trim().replace(/^`|`$/g, '').replace(/\\/g, '/');
+  const withoutDotPrefix = trimmed.startsWith('./') ? trimmed.slice(2) : trimmed;
+  return normalize(withoutDotPrefix).replace(/\\/g, '/');
+}
 
-  if (!selectedPrdPath || selection.testSpecPaths.length === 0) {
-    throw new Error(`team_exec_approved_handoff_missing:${resolvedLatestPlanPath}`);
+function resolvePlanningPrdPath(
+  artifacts: PlanningArtifacts,
+  cwd: string,
+  rawPath: string,
+): { matchedPath: string | null; fallbackPath: string } {
+  const normalizedRawPath = rawPath.trim();
+  if (isAbsolute(normalizedRawPath)) {
+    const resolvedPath = resolve(normalizedRawPath);
+    const matchedPath = artifacts.prdPaths.find((candidatePath) => sameFilePath(candidatePath, resolvedPath)) ?? null;
+    return { matchedPath, fallbackPath: resolvedPath };
   }
-  if (selectedPrdPath !== resolvedLatestPlanPath) {
-    throw new Error(`team_exec_approved_handoff_stale:${resolvedLatestPlanPath}:${selectedPrdPath}`);
+
+  const repoRoot = dirname(dirname(artifacts.plansDir));
+  const normalizedPath = normalizePlanningRelativePath(normalizedRawPath);
+  const matchedPath = artifacts.prdPaths.find((candidatePath) => {
+    const repoRelativePath = normalizePlanningRelativePath(relative(repoRoot, candidatePath));
+    const plansRelativePath = normalizePlanningRelativePath(relative(artifacts.plansDir, candidatePath));
+    return normalizedPath === repoRelativePath || normalizedPath === plansRelativePath;
+  }) ?? null;
+  return {
+    matchedPath,
+    fallbackPath: resolve(cwd, normalizedPath),
+  };
+}
+
+function resolveApprovedTeamPlanPath(cwd: string, latestPlanPath: string): string {
+  const artifacts = readPlanningArtifacts(cwd);
+  const resolvedLatestPlanPath = resolvePlanningPrdPath(artifacts, cwd, latestPlanPath);
+  const selection = readLatestPlanningArtifacts(cwd);
+  const selectedPrdPath = selection.prdPath
+    ? resolvePlanningPrdPath(artifacts, cwd, selection.prdPath).matchedPath
+    : null;
+
+  if (!selectedPrdPath || selection.testSpecPaths.length === 0 || !resolvedLatestPlanPath.matchedPath) {
+    throw new Error(`team_exec_approved_handoff_missing:${resolvedLatestPlanPath.fallbackPath}`);
+  }
+  if (selectedPrdPath !== resolvedLatestPlanPath.matchedPath) {
+    throw new Error(`team_exec_approved_handoff_stale:${resolvedLatestPlanPath.matchedPath}:${selectedPrdPath}`);
   }
 
   return selectedPrdPath;

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -39,11 +39,11 @@ function decodeQuotedValue(raw: string): string | null {
   try {
     return JSON.parse(normalized) as string;
   } catch {
-    if (
-      (normalized.startsWith('"') && normalized.endsWith('"'))
-      || (normalized.startsWith("'") && normalized.endsWith("'"))
-    ) {
+    if (normalized.startsWith('"') && normalized.endsWith('"')) {
       return normalized.slice(1, -1);
+    }
+    if (normalized.startsWith("'") && normalized.endsWith("'")) {
+      return normalized.slice(1, -1).replace(/\\(.)/g, '$1');
     }
     return null;
   }

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -7,7 +7,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { dirname, isAbsolute, normalize, relative, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, normalize, relative, resolve } from 'node:path';
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
 import {
   buildFollowupStaffingPlan,
@@ -60,6 +60,20 @@ function normalizePlanningRelativePath(rawPath: string): string {
   return normalize(withoutDotPrefix).replace(/\\/g, '/');
 }
 
+function planningArtifactSlug(path: string, prefixPattern: RegExp): string | null {
+  const file = basename(path);
+  const match = file.match(prefixPattern);
+  return match?.groups?.slug ?? null;
+}
+
+function matchingTestSpecPathsForPrd(artifacts: PlanningArtifacts, prdPath: string): string[] {
+  const prdSlug = planningArtifactSlug(prdPath, /^prd-(?<slug>.*)\.md$/i);
+  if (!prdSlug) return [];
+  return artifacts.testSpecPaths.filter(
+    (testSpecPath) => planningArtifactSlug(testSpecPath, /^test-?spec-(?<slug>.*)\.md$/i) === prdSlug,
+  );
+}
+
 function resolvePlanningPrdPath(
   artifacts: PlanningArtifacts,
   cwd: string,
@@ -89,10 +103,37 @@ function resolvePlanningPrdPath(
   };
 }
 
-function resolveApprovedTeamPlanPath(cwd: string, latestPlanPath: string): string {
+function readRuntimeLatestPlanningSelection(
+  artifacts: PlanningArtifacts,
+  cwd: string,
+  ralplanArtifacts?: Record<string, unknown>,
+): { prdPath: string | null; testSpecPaths: string[] } | null {
+  const drafts = Array.isArray(ralplanArtifacts?.drafts) ? ralplanArtifacts.drafts : [];
+  for (let index = drafts.length - 1; index >= 0; index -= 1) {
+    const draft = drafts[index];
+    if (!draft || typeof draft !== 'object') continue;
+    const draftRecord = draft as { planPath?: unknown };
+    const draftPlanPath = typeof draftRecord.planPath === 'string'
+      ? draftRecord.planPath.trim()
+      : '';
+    if (!draftPlanPath) continue;
+    const resolvedDraftPlanPath = resolvePlanningPrdPath(artifacts, cwd, draftPlanPath).matchedPath;
+    return {
+      prdPath: resolvedDraftPlanPath,
+      testSpecPaths: resolvedDraftPlanPath ? matchingTestSpecPathsForPrd(artifacts, resolvedDraftPlanPath) : [],
+    };
+  }
+  return null;
+}
+
+function resolveApprovedTeamPlanPath(
+  cwd: string,
+  latestPlanPath: string,
+  ralplanArtifacts?: Record<string, unknown>,
+): string {
   const artifacts = readPlanningArtifacts(cwd);
   const resolvedLatestPlanPath = resolvePlanningPrdPath(artifacts, cwd, latestPlanPath);
-  const selection = readLatestPlanningArtifacts(cwd);
+  const selection = readRuntimeLatestPlanningSelection(artifacts, cwd, ralplanArtifacts) ?? readLatestPlanningArtifacts(cwd);
   const selectedPrdPath = selection.prdPath
     ? resolvePlanningPrdPath(artifacts, cwd, selection.prdPath).matchedPath
     : null;
@@ -107,8 +148,12 @@ function resolveApprovedTeamPlanPath(cwd: string, latestPlanPath: string): strin
   return selectedPrdPath;
 }
 
-function resolveApprovedTeamTaskFromPlanPath(cwd: string, latestPlanPath: string): string {
-  const approvedPlanPath = resolveApprovedTeamPlanPath(cwd, latestPlanPath);
+function resolveApprovedTeamTaskFromPlanPath(
+  cwd: string,
+  latestPlanPath: string,
+  ralplanArtifacts?: Record<string, unknown>,
+): string {
+  const approvedPlanPath = resolveApprovedTeamPlanPath(cwd, latestPlanPath, ralplanArtifacts);
   let content = '';
   try {
     content = readFileSync(approvedPlanPath, 'utf-8');
@@ -139,7 +184,7 @@ function resolveTeamExecTask(ctx: StageContext, ralplanArtifacts?: Record<string
   if (!latestPlanPath) {
     return requestedTask;
   }
-  return resolveApprovedTeamTaskFromPlanPath(ctx.cwd, latestPlanPath);
+  return resolveApprovedTeamTaskFromPlanPath(ctx.cwd, latestPlanPath, ralplanArtifacts);
 }
 
 /**

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -6,6 +6,7 @@
  * canonical OMX execution surface.
  */
 
+import { readFileSync } from 'node:fs';
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
 import {
   buildFollowupStaffingPlan,
@@ -26,13 +27,71 @@ export interface TeamExecStageOptions {
   extraEnv?: Record<string, string>;
 }
 
+const APPROVED_TEAM_LAUNCH_PATTERN = /(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
+
+function decodeQuotedValue(raw: string): string | null {
+  const normalized = raw.trim();
+  if (!normalized) return null;
+
+  try {
+    return JSON.parse(normalized) as string;
+  } catch {
+    if (
+      (normalized.startsWith('"') && normalized.endsWith('"'))
+      || (normalized.startsWith("'") && normalized.endsWith("'"))
+    ) {
+      return normalized.slice(1, -1);
+    }
+    return null;
+  }
+}
+
+function resolveRequestedTask(ctx: StageContext, ralplanArtifacts?: Record<string, unknown>): string {
+  const ralplanTask = typeof ralplanArtifacts?.task === 'string' ? ralplanArtifacts.task.trim() : '';
+  return ralplanTask || ctx.task;
+}
+
+function resolveApprovedTeamTaskFromPlanPath(latestPlanPath: string): string {
+  let content = '';
+  try {
+    content = readFileSync(latestPlanPath, 'utf-8');
+  } catch {
+    throw new Error(`team_exec_approved_handoff_missing:${latestPlanPath}`);
+  }
+
+  const matches = [...content.matchAll(APPROVED_TEAM_LAUNCH_PATTERN)];
+  if (matches.length === 0) {
+    throw new Error(`team_exec_approved_handoff_missing:${latestPlanPath}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`team_exec_approved_handoff_ambiguous:${latestPlanPath}`);
+  }
+
+  const task = matches[0]?.groups?.task ? decodeQuotedValue(matches[0].groups.task) : null;
+  if (!task) {
+    throw new Error(`team_exec_approved_handoff_missing:${latestPlanPath}`);
+  }
+  return task;
+}
+
+function resolveTeamExecTask(ctx: StageContext, ralplanArtifacts?: Record<string, unknown>): string {
+  const requestedTask = resolveRequestedTask(ctx, ralplanArtifacts);
+  const latestPlanPath = typeof ralplanArtifacts?.latestPlanPath === 'string'
+    ? ralplanArtifacts.latestPlanPath.trim()
+    : '';
+  if (!latestPlanPath) {
+    return requestedTask;
+  }
+  return resolveApprovedTeamTaskFromPlanPath(latestPlanPath);
+}
+
 /**
  * Create a team-exec pipeline stage.
  *
  * This stage delegates to the existing `omx team` infrastructure, which
- * starts real Codex CLI workers in tmux panes. The stage collects the
- * plan artifacts from the previous RALPLAN stage and passes them as
- * the team task description.
+ * starts real Codex CLI workers in tmux panes. When RALPLAN names a
+ * concrete approved PRD handoff, team-exec reuses that exact task text;
+ * otherwise it stays on the generic request-task path.
  */
 export function createTeamExecStage(options: TeamExecStageOptions = {}): PipelineStage {
   const workerCount = options.workerCount ?? 2;
@@ -45,20 +104,19 @@ export function createTeamExecStage(options: TeamExecStageOptions = {}): Pipelin
       const startTime = Date.now();
 
       try {
-        // Extract plan context from previous stage artifacts
-        const ralplanArtifacts = ctx.artifacts['ralplan'] as Record<string, unknown> | undefined;
-        const planContext = ralplanArtifacts
-          ? `Plan from RALPLAN stage:\n${JSON.stringify(ralplanArtifacts, null, 2)}\n\nTask: ${ctx.task}`
-          : ctx.task;
+        const ralplanArtifacts = typeof ctx.artifacts['ralplan'] === 'object' && ctx.artifacts['ralplan'] !== null
+          ? ctx.artifacts['ralplan'] as Record<string, unknown>
+          : undefined;
+        const task = resolveTeamExecTask(ctx, ralplanArtifacts);
         const availableAgentTypes = await resolveAvailableAgentTypes(ctx.cwd);
-        const staffingPlan = buildFollowupStaffingPlan('team', ctx.task, availableAgentTypes, {
+        const staffingPlan = buildFollowupStaffingPlan('team', task, availableAgentTypes, {
           workerCount,
           fallbackRole: agentType,
         });
 
         // Build team execution descriptor
         const teamDescriptor: TeamExecDescriptor = {
-          task: planContext,
+          task,
           workerCount,
           agentType,
           availableAgentTypes,

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -383,5 +383,5 @@ export function buildTeamInstruction(
   if (platform === 'win32') {
     return launchCommand;
   }
-  return `${launchCommand} # staffing=${descriptor.staffingPlan.staffingSummary} # verify=${descriptor.staffingPlan.verificationPlan.summary}`;
+  return `${launchCommand} # task=${JSON.stringify(descriptor.task)} # staffing=${descriptor.staffingPlan.staffingSummary} # verify=${descriptor.staffingPlan.verificationPlan.summary}`;
 }


### PR DESCRIPTION
## Summary

`team-exec` should not embed raw `ralplan` artifacts into the runnable
`omx team` task, but the first row-4 patch still trusted
`ralplan.latestPlanPath` by itself. That let stale handoff paths
override the canonical approved planning selection, and it also broke
when `latestPlanPath` was relative to `ctx.cwd` instead of the process
working directory.

## Changes

- resolve `ralplan.latestPlanPath` against `ctx.cwd` before reading the
  approved PRD
- validate that path against the canonical latest approved PRD/test-spec
  selection for the current workspace before deriving the team task
- fail closed on stale or mismatched handoff paths, missing team launch
  hints, and ambiguous team launch hints
- keep the generic request-task path when `latestPlanPath` is absent,
  even if pre-existing approved plans already exist in `.omx/plans`
- add regressions for relative handoff paths, stale latest-plan
  pointers, pre-existing approved plans without `latestPlanPath`, and
  ambiguous launch-hint parsing

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/planning/__tests__/artifacts.test.js dist/pipeline/__tests__/stages.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- Follow-up to closed PR #2048.
