### PR TITLE
Integrate Ralph with Codex goal mode

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -8,7 +8,7 @@ This page is the canonical answer to:
 
 `omx setup` now owns both of these native Codex artifacts:
 
-- `.codex/config.toml` → enables `[features].codex_hooks = true`
+- `.codex/config.toml` → enables setup-owned runtime feature flags including `[features].codex_hooks = true` and `[features].goal = true`
 - `.codex/hooks.json` → registers the OMX-managed native hook command while preserving non-OMX hook entries already in the file
 
 For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of source control.

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -8,7 +8,7 @@ This page is the canonical answer to:
 
 `omx setup` now owns both of these native Codex artifacts:
 
-- `.codex/config.toml` → enables setup-owned runtime feature flags including `[features].codex_hooks = true` and `[features].goal = true`
+- `.codex/config.toml` → enables setup-owned runtime feature flags including `[features].codex_hooks = true` and `[features].goals = true`
 - `.codex/hooks.json` → registers the OMX-managed native hook command while preserving non-OMX hook entries already in the file
 
 For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of source control.

--- a/plugins/oh-my-codex/skills/omx-setup/SKILL.md
+++ b/plugins/oh-my-codex/skills/omx-setup/SKILL.md
@@ -60,7 +60,7 @@ Supported setup flags (current implementation):
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
 - User-scope skill delivery targets:
   - `legacy`: keep installing/updating OMX skills in the resolved user skill root
-  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and setup-owned runtime feature flags (`codex_hooks = true`, `goal = true`) because plugins do not carry hooks or enable Codex goal mode by themselves.
+  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and setup-owned runtime feature flags (`codex_hooks = true`, `goals = true`) because plugins do not carry hooks or enable Codex goal mode by themselves.
 - Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
@@ -74,7 +74,7 @@ Use this map when reconciling setup behavior or debugging a confusing install:
 | Surface | Owner | Notes |
 | --- | --- | --- |
 | `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
-| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, `codex_hooks`, and `goal`. |
+| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, `codex_hooks`, and `goals`. |
 | `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
 | prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompt/native-agent copies. |
 | `AGENTS.md` | `omx setup` with overwrite safety | Generated defaults or managed refreshes are guarded by force/session checks. |

--- a/plugins/oh-my-codex/skills/omx-setup/SKILL.md
+++ b/plugins/oh-my-codex/skills/omx-setup/SKILL.md
@@ -60,7 +60,7 @@ Supported setup flags (current implementation):
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
 - User-scope skill delivery targets:
   - `legacy`: keep installing/updating OMX skills in the resolved user skill root
-  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and `codex_hooks = true` because plugins do not carry hooks.
+  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and setup-owned runtime feature flags (`codex_hooks = true`, `goal = true`) because plugins do not carry hooks or enable Codex goal mode by themselves.
 - Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
@@ -74,7 +74,7 @@ Use this map when reconciling setup behavior or debugging a confusing install:
 | Surface | Owner | Notes |
 | --- | --- | --- |
 | `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
-| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content. |
+| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, `codex_hooks`, and `goal`. |
 | `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
 | prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompt/native-agent copies. |
 | `AGENTS.md` | `omx setup` with overwrite safety | Generated defaults or managed refreshes are guarded by force/session checks. |

--- a/plugins/oh-my-codex/skills/ralph/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralph/SKILL.md
@@ -36,6 +36,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 - Read `docs/shared/agent-tiers.md` before first delegation to select correct agent tiers
 - Deliver the full implementation: no scope reduction, no partial completion, no deleting tests to make them pass
 - Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step execution, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
+- Integrate with Codex goal mode when goal tools are available: inspect the active thread goal with `get_goal`, preserve it as the top-level stop condition, and only call `update_goal({status: "complete"})` after a Ralph completion audit proves the objective is actually achieved.
 </Execution_Policy>
 
 <Steps>
@@ -66,6 +67,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
    - Default pass threshold: `score >= 90`.
    - **URL-based visual cloning tasks**: When the task description contains a target URL (e.g., "clone https://example.com"), route the work through `$visual-ralph`. `$web-clone` is hard-deprecated; Visual Ralph owns the migrated live-URL visual implementation use case and uses `$visual-verdict` for measured visual scoring.
 6. **Verify completion with fresh evidence**:
+   - If Codex goal mode is available, call `get_goal` before final verification to restate the active objective and include it in the evidence checklist.
    a. Identify what command proves the task is complete
    b. Run verification (test, build, lint)
    c. Read the output -- confirm it actually passed
@@ -84,7 +86,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
    - After the deslop pass, re-run all tests/build/lint and read the output to confirm they still pass.
    - If post-deslop regression fails, roll back cleaner changes or fix and retry. Then rerun Step 7.5 and Step 7.6 until the regression is green.
    - Do not proceed to completion until post-deslop regression is green (unless `--no-deslop` explicitly skipped the deslop pass).
-8. **On approval**: Run `/cancel` to cleanly exit and clean up all state files
+8. **On approval**: If Codex goal mode is active, call `update_goal({status: "complete"})` before `/cancel`; report final elapsed time and token-budget usage when the tool returns it. Then run `/cancel` to cleanly exit and clean up all state files.
 9. **On rejection**: Fix the issues raised, then re-verify at the same tier
 </Steps>
 
@@ -94,9 +96,25 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 - Skip Codex consultation for simple feature additions, well-tested changes, or time-critical verification
 - If ToolSearch finds no MCP tools or Codex is unavailable, proceed with architect agent verification alone -- never block on external tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
+- Use Codex goal tools when present: `get_goal` to discover or re-check the active objective, `create_goal` only when the user/system explicitly requested a new goal and no active goal exists, and `update_goal` only after the audited objective is fully achieved.
 - Persist context snapshot path in Ralph mode state so later phases and agents share the same grounding context
 - If an `omx_state` MCP tool call reports that its stdio transport is unavailable/closed, do **not** retry the same MCP call. Retry once through the supported CLI parity surface with the same payload, preserving `workingDirectory` and `session_id`: `omx state write --input '<json>' --json`, `omx state read --input '<json>' --json`, or `omx state clear --input '<json>' --json`. If the CLI path also fails, continue with `.omx/context` / `.omx/plans` file-backed artifacts and report the state persistence blocker.
 </Tool_Usage>
+
+## Goal Mode Integration
+
+Codex goal mode is the thread-level completion contract for long-running Ralph work. Ralph state tracks workflow mechanics; goal mode tracks whether the user objective is truly done. When the goal tools are available:
+
+1. Call `get_goal` during intake or before the first execution loop when the prompt/hook says an active thread goal exists.
+2. If no goal exists, call `create_goal` only when the user or system explicitly asked for goal tracking; otherwise continue with Ralph state alone.
+3. Treat `goal.objective` as binding acceptance scope. Newer user updates can refine the current branch, but do not silently narrow the goal.
+4. Before completion, perform a prompt-to-artifact checklist and completion audit against real evidence:
+   - restate the objective as deliverables/success criteria
+   - map every prompt requirement, named workflow (`$ralplan`, `$ralph`), file, command, test, gate, and deliverable to evidence
+   - inspect the actual files, command output, state, and tests behind each checklist item
+   - identify missing, weakly verified, or uncovered requirements and continue if any remain
+5. Call `update_goal({status: "complete"})` only when the audit shows no required work remains. Do not use passing tests, Ralph state, or architect approval as proxy proof unless they cover the whole goal.
+6. If goal tools are unavailable, keep working through Ralph state and mention the missing goal-mode evidence in the final report.
 
 ## State Management
 
@@ -177,6 +195,7 @@ Why bad: These are independent tasks that should run in parallel, not sequential
 - [ ] Fresh build output shows success
 - [ ] lsp_diagnostics shows 0 errors on affected files
 - [ ] Architect verification passed (STANDARD tier minimum)
+- [ ] Codex goal-mode completion audit passed, and `update_goal({status: "complete"})` was called when an active goal exists
 - [ ] ai-slop-cleaner pass completed on changed files (or --no-deslop specified)
 - [ ] Post-deslop regression tests pass
 - [ ] `/cancel` run for clean state cleanup

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -60,7 +60,7 @@ Supported setup flags (current implementation):
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
 - User-scope skill delivery targets:
   - `legacy`: keep installing/updating OMX skills in the resolved user skill root
-  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and setup-owned runtime feature flags (`codex_hooks = true`, `goal = true`) because plugins do not carry hooks or enable Codex goal mode by themselves.
+  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and setup-owned runtime feature flags (`codex_hooks = true`, `goals = true`) because plugins do not carry hooks or enable Codex goal mode by themselves.
 - Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
@@ -74,7 +74,7 @@ Use this map when reconciling setup behavior or debugging a confusing install:
 | Surface | Owner | Notes |
 | --- | --- | --- |
 | `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
-| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, `codex_hooks`, and `goal`. |
+| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, `codex_hooks`, and `goals`. |
 | `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
 | prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompt/native-agent copies. |
 | `AGENTS.md` | `omx setup` with overwrite safety | Generated defaults or managed refreshes are guarded by force/session checks. |

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -60,7 +60,7 @@ Supported setup flags (current implementation):
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
 - User-scope skill delivery targets:
   - `legacy`: keep installing/updating OMX skills in the resolved user skill root
-  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and `codex_hooks = true` because plugins do not carry hooks.
+  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and setup-owned runtime feature flags (`codex_hooks = true`, `goal = true`) because plugins do not carry hooks or enable Codex goal mode by themselves.
 - Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
@@ -74,7 +74,7 @@ Use this map when reconciling setup behavior or debugging a confusing install:
 | Surface | Owner | Notes |
 | --- | --- | --- |
 | `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
-| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content. |
+| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, `codex_hooks`, and `goal`. |
 | `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
 | prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompt/native-agent copies. |
 | `AGENTS.md` | `omx setup` with overwrite safety | Generated defaults or managed refreshes are guarded by force/session checks. |

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -36,6 +36,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 - Read `docs/shared/agent-tiers.md` before first delegation to select correct agent tiers
 - Deliver the full implementation: no scope reduction, no partial completion, no deleting tests to make them pass
 - Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step execution, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
+- Integrate with Codex goal mode when goal tools are available: inspect the active thread goal with `get_goal`, preserve it as the top-level stop condition, and only call `update_goal({status: "complete"})` after a Ralph completion audit proves the objective is actually achieved.
 </Execution_Policy>
 
 <Steps>
@@ -66,6 +67,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
    - Default pass threshold: `score >= 90`.
    - **URL-based visual cloning tasks**: When the task description contains a target URL (e.g., "clone https://example.com"), route the work through `$visual-ralph`. `$web-clone` is hard-deprecated; Visual Ralph owns the migrated live-URL visual implementation use case and uses `$visual-verdict` for measured visual scoring.
 6. **Verify completion with fresh evidence**:
+   - If Codex goal mode is available, call `get_goal` before final verification to restate the active objective and include it in the evidence checklist.
    a. Identify what command proves the task is complete
    b. Run verification (test, build, lint)
    c. Read the output -- confirm it actually passed
@@ -84,7 +86,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
    - After the deslop pass, re-run all tests/build/lint and read the output to confirm they still pass.
    - If post-deslop regression fails, roll back cleaner changes or fix and retry. Then rerun Step 7.5 and Step 7.6 until the regression is green.
    - Do not proceed to completion until post-deslop regression is green (unless `--no-deslop` explicitly skipped the deslop pass).
-8. **On approval**: Run `/cancel` to cleanly exit and clean up all state files
+8. **On approval**: If Codex goal mode is active, call `update_goal({status: "complete"})` before `/cancel`; report final elapsed time and token-budget usage when the tool returns it. Then run `/cancel` to cleanly exit and clean up all state files.
 9. **On rejection**: Fix the issues raised, then re-verify at the same tier
 </Steps>
 
@@ -94,9 +96,25 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 - Skip Codex consultation for simple feature additions, well-tested changes, or time-critical verification
 - If ToolSearch finds no MCP tools or Codex is unavailable, proceed with architect agent verification alone -- never block on external tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
+- Use Codex goal tools when present: `get_goal` to discover or re-check the active objective, `create_goal` only when the user/system explicitly requested a new goal and no active goal exists, and `update_goal` only after the audited objective is fully achieved.
 - Persist context snapshot path in Ralph mode state so later phases and agents share the same grounding context
 - If an `omx_state` MCP tool call reports that its stdio transport is unavailable/closed, do **not** retry the same MCP call. Retry once through the supported CLI parity surface with the same payload, preserving `workingDirectory` and `session_id`: `omx state write --input '<json>' --json`, `omx state read --input '<json>' --json`, or `omx state clear --input '<json>' --json`. If the CLI path also fails, continue with `.omx/context` / `.omx/plans` file-backed artifacts and report the state persistence blocker.
 </Tool_Usage>
+
+## Goal Mode Integration
+
+Codex goal mode is the thread-level completion contract for long-running Ralph work. Ralph state tracks workflow mechanics; goal mode tracks whether the user objective is truly done. When the goal tools are available:
+
+1. Call `get_goal` during intake or before the first execution loop when the prompt/hook says an active thread goal exists.
+2. If no goal exists, call `create_goal` only when the user or system explicitly asked for goal tracking; otherwise continue with Ralph state alone.
+3. Treat `goal.objective` as binding acceptance scope. Newer user updates can refine the current branch, but do not silently narrow the goal.
+4. Before completion, perform a prompt-to-artifact checklist and completion audit against real evidence:
+   - restate the objective as deliverables/success criteria
+   - map every prompt requirement, named workflow (`$ralplan`, `$ralph`), file, command, test, gate, and deliverable to evidence
+   - inspect the actual files, command output, state, and tests behind each checklist item
+   - identify missing, weakly verified, or uncovered requirements and continue if any remain
+5. Call `update_goal({status: "complete"})` only when the audit shows no required work remains. Do not use passing tests, Ralph state, or architect approval as proxy proof unless they cover the whole goal.
+6. If goal tools are unavailable, keep working through Ralph state and mention the missing goal-mode evidence in the final report.
 
 ## State Management
 
@@ -177,6 +195,7 @@ Why bad: These are independent tasks that should run in parallel, not sequential
 - [ ] Fresh build output shows success
 - [ ] lsp_diagnostics shows 0 errors on affected files
 - [ ] Architect verification passed (STANDARD tier minimum)
+- [ ] Codex goal-mode completion audit passed, and `update_goal({status: "complete"})` was called when an active goal exists
 - [ ] ai-slop-cleaner pass completed on changed files (or --no-deslop specified)
 - [ ] Post-deslop regression tests pass
 - [ ] `/cancel` run for clean state cleanup

--- a/src/cli/__tests__/ralph-goal-mode-contract.test.ts
+++ b/src/cli/__tests__/ralph-goal-mode-contract.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildRalphAppendInstructions } from '../ralph.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ralphSkill = readFileSync(join(__dirname, '../../../skills/ralph/SKILL.md'), 'utf-8');
+
+describe('ralph goal mode integration contract', () => {
+  it('documents Codex goal-mode audit and completion semantics in the Ralph skill', () => {
+    assert.match(ralphSkill, /Goal Mode Integration/i);
+    assert.match(ralphSkill, /get_goal/i);
+    assert.match(ralphSkill, /create_goal/i);
+    assert.match(ralphSkill, /update_goal\(\{status: "complete"\}\)/i);
+    assert.match(ralphSkill, /prompt-to-artifact checklist/i);
+    assert.match(ralphSkill, /Do not use passing tests, Ralph state, or architect approval as proxy proof/i);
+  });
+
+  it('injects goal-mode guidance into launched Ralph sessions', () => {
+    const instructions = buildRalphAppendInstructions('ship the integration', {
+      changedFilesPath: '.omx/ralph/changed-files.txt',
+      noDeslop: false,
+    });
+
+    assert.match(instructions, /Goal mode guidance/i);
+    assert.match(instructions, /get_goal/i);
+    assert.match(instructions, /create_goal/i);
+    assert.match(instructions, /update_goal\(\{status: "complete"\}\)/i);
+    assert.match(instructions, /top-level completion contract/i);
+    assert.match(instructions, /prompt-to-artifact checklist/i);
+  });
+});

--- a/src/cli/__tests__/ralph-prd-smoke.test.ts
+++ b/src/cli/__tests__/ralph-prd-smoke.test.ts
@@ -181,6 +181,15 @@ describe('omx ralph --prd smoke gate', () => {
         .filter((line) => line.length > 0);
       assert.equal(launches.length, 1, `expected exactly one Codex launch, got ${launches.length}`);
       assert.match(launches[0], /ship release checklist/);
+
+      const ralphState = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'ralph-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(ralphState.goal_mode_integration, 'codex-goal-tools');
+      assert.match(String(ralphState.goal_mode_policy ?? ''), /get_goal/);
+      assert.match(String(ralphState.goal_mode_policy ?? ''), /update_goal/);
+
+      const instructions = await readFile(join(cwd, '.omx', 'ralph', 'session-instructions.md'), 'utf-8');
+      assert.match(instructions, /Goal mode guidance/);
+      assert.match(instructions, /prompt-to-artifact checklist/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -76,7 +76,7 @@ async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {
 	assert.match(hooks, /codex-native-hook\.js/);
 	const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
 	assert.match(config, /^codex_hooks = true$/m);
-	assert.match(config, /^goal = true$/m);
+	assert.match(config, /^goals = true$/m);
 	assert.doesNotMatch(config, /developer_instructions|notify-hook|mcp_servers/);
 	assert.equal(
 		existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
@@ -677,7 +677,7 @@ describe("omx setup install mode behavior", () => {
 						"utf-8",
 						);
 						assert.match(config, /^codex_hooks = true$/m);
-						assert.match(config, /^goal = true$/m);
+						assert.match(config, /^goals = true$/m);
 						assert.doesNotMatch(
 							config,
 							/developer_instructions|notify-hook|mcp_servers/,
@@ -1001,7 +1001,7 @@ describe("omx setup install mode behavior", () => {
 					assert.match(pluginOutput, /Using setup install mode: plugin/);
 					assert.match(
 						pluginOutput,
-						/Native Codex hooks and runtime feature flags refresh complete .*codex_hooks, goal/,
+						/Native Codex hooks and runtime feature flags refresh complete .*codex_hooks, goals/,
 					);
 					assert.doesNotMatch(pluginOutput, /user-scope skill delivery mode/);
 					assert.doesNotMatch(

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -76,6 +76,7 @@ async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {
 	assert.match(hooks, /codex-native-hook\.js/);
 	const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
 	assert.match(config, /^codex_hooks = true$/m);
+	assert.match(config, /^goal = true$/m);
 	assert.doesNotMatch(config, /developer_instructions|notify-hook|mcp_servers/);
 	assert.equal(
 		existsSync(join(wd, ".codex", "skills", "help", "SKILL.md")),
@@ -674,11 +675,12 @@ describe("omx setup install mode behavior", () => {
 					const config = await readFile(
 						join(codexHomeDir, "config.toml"),
 						"utf-8",
-					);
-					assert.match(config, /^codex_hooks = true$/m);
-					assert.doesNotMatch(
-						config,
-						/developer_instructions|notify-hook|mcp_servers/,
+						);
+						assert.match(config, /^codex_hooks = true$/m);
+						assert.match(config, /^goal = true$/m);
+						assert.doesNotMatch(
+							config,
+							/developer_instructions|notify-hook|mcp_servers/,
 					);
 					assert.equal(
 						existsSync(join(codexHomeDir, "skills", "help", "SKILL.md")),
@@ -997,6 +999,10 @@ describe("omx setup install mode behavior", () => {
 						await setup({ scope: "project", installMode: "plugin" });
 					});
 					assert.match(pluginOutput, /Using setup install mode: plugin/);
+					assert.match(
+						pluginOutput,
+						/Native Codex hooks and runtime feature flags refresh complete .*codex_hooks, goal/,
+					);
 					assert.doesNotMatch(pluginOutput, /user-scope skill delivery mode/);
 					assert.doesNotMatch(
 						pluginOutput,

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -217,6 +217,7 @@ describe("omx setup scope behavior", () => {
       assert.match(configToml, /^\[shell_environment_policy\.set\]$/m);
       assert.match(configToml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
       assert.match(configToml, /^codex_hooks = true$/m);
+      assert.match(configToml, /^goal = true$/m);
       const hooksJson = JSON.parse(await readFile(localHooks, "utf-8")) as {
         hooks?: Record<string, unknown>;
       };

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -217,7 +217,7 @@ describe("omx setup scope behavior", () => {
       assert.match(configToml, /^\[shell_environment_policy\.set\]$/m);
       assert.match(configToml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
       assert.match(configToml, /^codex_hooks = true$/m);
-      assert.match(configToml, /^goal = true$/m);
+      assert.match(configToml, /^goals = true$/m);
       const hooksJson = JSON.parse(await readFile(localHooks, "utf-8")) as {
         hooks?: Record<string, unknown>;
       };

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -50,7 +50,7 @@ function buildOmxConfig(): string {
     'multi_agent = true',
     'child_agents_md = true',
     'codex_hooks = true',
-    'goal = true',
+    'goals = true',
     '',
     '# ============================================================',
     '# oh-my-codex (OMX) Configuration',
@@ -124,7 +124,7 @@ function buildConfigWithSeededModelContext(): string {
     'multi_agent = true',
     'child_agents_md = true',
     'codex_hooks = true',
-    'goal = true',
+    'goals = true',
     '',
     '# ============================================================',
     '# oh-my-codex (OMX) Configuration',
@@ -158,7 +158,7 @@ function buildConfigWithEditedSeededModelContext(): string {
     'multi_agent = true',
     'child_agents_md = true',
     'codex_hooks = true',
-    'goal = true',
+    'goals = true',
     '',
     '# ============================================================',
     '# oh-my-codex (OMX) Configuration',
@@ -190,7 +190,7 @@ function buildMixedConfig(): string {
     'multi_agent = true',
     'child_agents_md = true',
     'codex_hooks = true',
-    'goal = true',
+    'goals = true',
     'web_search = true',
     '',
     '[mcp_servers.user_custom]',
@@ -793,6 +793,7 @@ describe('stripOmxFeatureFlags', () => {
       '[features]',
       'multi_agent = true',
       'child_agents_md = true',
+      'goals = true',
       'goal = true',
       'web_search = true',
       '',
@@ -801,6 +802,7 @@ describe('stripOmxFeatureFlags', () => {
     const result = stripOmxFeatureFlags(config);
     assert.doesNotMatch(result, /multi_agent/);
     assert.doesNotMatch(result, /child_agents_md/);
+    assert.doesNotMatch(result, /^goals\s*=/m);
     assert.doesNotMatch(result, /^goal\s*=/m);
     assert.match(result, /web_search = true/);
     assert.match(result, /\[features\]/);
@@ -813,14 +815,14 @@ describe('stripOmxFeatureFlags', () => {
       '[features]',
       'multi_agent = true',
       'child_agents_md = true',
-      'goal = true',
+      'goals = true',
       '',
     ].join('\n');
 
     const result = stripOmxFeatureFlags(config);
     assert.doesNotMatch(result, /\[features\]/);
     assert.doesNotMatch(result, /multi_agent/);
-    assert.doesNotMatch(result, /^goal\s*=/m);
+    assert.doesNotMatch(result, /^goals\s*=/m);
   });
 
   it('handles config without [features] section', async () => {

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -50,6 +50,7 @@ function buildOmxConfig(): string {
     'multi_agent = true',
     'child_agents_md = true',
     'codex_hooks = true',
+    'goal = true',
     '',
     '# ============================================================',
     '# oh-my-codex (OMX) Configuration',
@@ -123,6 +124,7 @@ function buildConfigWithSeededModelContext(): string {
     'multi_agent = true',
     'child_agents_md = true',
     'codex_hooks = true',
+    'goal = true',
     '',
     '# ============================================================',
     '# oh-my-codex (OMX) Configuration',
@@ -156,6 +158,7 @@ function buildConfigWithEditedSeededModelContext(): string {
     'multi_agent = true',
     'child_agents_md = true',
     'codex_hooks = true',
+    'goal = true',
     '',
     '# ============================================================',
     '# oh-my-codex (OMX) Configuration',
@@ -187,6 +190,7 @@ function buildMixedConfig(): string {
     'multi_agent = true',
     'child_agents_md = true',
     'codex_hooks = true',
+    'goal = true',
     'web_search = true',
     '',
     '[mcp_servers.user_custom]',
@@ -534,6 +538,7 @@ describe('omx uninstall', () => {
       assert.match(res.stdout, /TUI status line section/);
       assert.match(res.stdout, /Top-level keys/);
       assert.match(res.stdout, /Feature flags/);
+      assert.match(res.stdout, /goal/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -788,6 +793,7 @@ describe('stripOmxFeatureFlags', () => {
       '[features]',
       'multi_agent = true',
       'child_agents_md = true',
+      'goal = true',
       'web_search = true',
       '',
     ].join('\n');
@@ -795,6 +801,7 @@ describe('stripOmxFeatureFlags', () => {
     const result = stripOmxFeatureFlags(config);
     assert.doesNotMatch(result, /multi_agent/);
     assert.doesNotMatch(result, /child_agents_md/);
+    assert.doesNotMatch(result, /^goal\s*=/m);
     assert.match(result, /web_search = true/);
     assert.match(result, /\[features\]/);
   });
@@ -806,12 +813,14 @@ describe('stripOmxFeatureFlags', () => {
       '[features]',
       'multi_agent = true',
       'child_agents_md = true',
+      'goal = true',
       '',
     ].join('\n');
 
     const result = stripOmxFeatureFlags(config);
     assert.doesNotMatch(result, /\[features\]/);
     assert.doesNotMatch(result, /multi_agent/);
+    assert.doesNotMatch(result, /^goal\s*=/m);
   });
 
   it('handles config without [features] section', async () => {

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -245,6 +245,12 @@ export function buildRalphAppendInstructions(
     '- Do not declare the task complete, and do not transition into final verification/completion, while active native subagent threads are still running.',
     '- Before closing a verification wave, confirm that active native subagent threads have drained.',
     ...buildRalphApprovedContextLines(options.approvedHint ?? null),
+    'Goal mode guidance:',
+    '- If Codex goal tools are available, call `get_goal` during Ralph intake or before final verification to discover the active thread goal.',
+    '- Treat any active goal objective as the top-level completion contract for this Ralph run; Ralph mode state is not proof of goal completion by itself.',
+    '- Call `create_goal` only when the user/system explicitly requested a new goal and `get_goal` reports no active goal; otherwise do not invent a goal.',
+    '- Before completion, build a prompt-to-artifact checklist, inspect real evidence for every requirement, and continue working if any item is missing, incomplete, weakly verified, or uncovered.',
+    '- Call `update_goal({status: "complete"})` only after that audit proves the active objective is fully achieved; then report final elapsed time and token-budget usage when provided.',
     'Final deslop guidance:',
     options.noDeslop
       ? '- `--no-deslop` is active for this Ralph run, so skip the mandatory ai-slop-cleaner final pass and use the latest successful pre-deslop verification evidence.'
@@ -302,6 +308,8 @@ export async function ralphCommand(args: string[]): Promise<void> {
     native_subagents_enabled: true,
     native_subagent_tracking_path: '.omx/state/subagent-tracking.json',
     native_subagent_policy: 'Parallel Codex subagents are allowed for independent work, but phase completion must wait for active native subagent threads to finish.',
+    goal_mode_integration: 'codex-goal-tools',
+    goal_mode_policy: 'Use get_goal for active objective discovery and update_goal only after a prompt-to-artifact completion audit proves the objective is achieved.',
     deslop_enabled: !noDeslop,
     deslop_opt_out: noDeslop,
     deslop_changed_files_path: sessionFiles.changedFilesPath,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -39,7 +39,7 @@ import {
 	stripOmxEnvSettings,
 	stripOmxFeatureFlags,
 	stripOmxSeededBehavioralDefaults,
-	upsertCodexHooksFeatureFlag,
+	upsertPluginModeRuntimeFeatureFlags,
 	OMX_DEVELOPER_INSTRUCTIONS,
 } from "../config/generator.js";
 import { mergeManagedCodexHooksConfig } from "../config/codex-hooks.js";
@@ -1280,7 +1280,7 @@ async function applyPluginModeHooksConfig(
 		? await readFile(configPath, "utf-8")
 		: "";
 	const nextConfig =
-		upsertCodexHooksFeatureFlag(existingConfig).trimEnd() + "\n";
+		upsertPluginModeRuntimeFeatureFlags(existingConfig).trimEnd() + "\n";
 	if (nextConfig !== existingConfig) {
 		if (
 			await ensureBackup(
@@ -1317,11 +1317,11 @@ async function applyPluginModeHooksConfig(
 		`native hooks ${hooksPath}`,
 	);
 
-	if (options.verbose) {
-		console.log(
-			`  ${options.dryRun ? "would configure" : "configured"} plugin-mode native hooks at ${hooksPath}`,
-		);
-	}
+		if (options.verbose) {
+			console.log(
+				`  ${options.dryRun ? "would configure" : "configured"} plugin-mode native hooks and runtime feature flags at ${hooksPath}`,
+			);
+		}
 }
 
 async function applyPluginDeveloperInstructionsDefault(
@@ -1775,12 +1775,12 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				`  Local Codex plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} already registered (${pkgRoot}).`,
 			);
 		}
-		resolvedConfig = existsSync(scopeDirs.codexConfigFile)
-			? await readFile(scopeDirs.codexConfigFile, "utf-8")
-			: "";
-		console.log(
-			`  Native Codex hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
-		);
+			resolvedConfig = existsSync(scopeDirs.codexConfigFile)
+				? await readFile(scopeDirs.codexConfigFile, "utf-8")
+				: "";
+			console.log(
+				`  Native Codex hooks and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; codex_hooks, goal).\n`,
+			);
 
 		if (usePluginDeveloperInstructionsDefault) {
 			const developerInstructionsResult =

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1779,7 +1779,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				? await readFile(scopeDirs.codexConfigFile, "utf-8")
 				: "";
 			console.log(
-				`  Native Codex hooks and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; codex_hooks, goal).\n`,
+				`  Native Codex hooks and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; codex_hooks, goals).\n`,
 			);
 
 		if (usePluginDeveloperInstructionsDefault) {

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -82,6 +82,7 @@ function detectOmxConfigArtifacts(config: string): {
     /^\s*multi_agent\s*=\s*true/m.test(config) ||
     /^\s*child_agents_md\s*=\s*true/m.test(config) ||
     /^\s*codex_hooks\s*=\s*true/m.test(config) ||
+    /^\s*goals\s*=\s*true/m.test(config) ||
     /^\s*goal\s*=\s*true/m.test(config);
   const hasExploreRoutingEnv = /^\s*USE_OMX_EXPLORE_CMD\s*=/m.test(config);
 
@@ -389,7 +390,7 @@ function printSummary(summary: UninstallSummary, dryRun: boolean): void {
       );
     }
     if (summary.featureFlagsRemoved) {
-      console.log("    Feature flags (multi_agent, child_agents_md, codex_hooks, goal)");
+      console.log("    Feature flags (multi_agent, child_agents_md, codex_hooks, goals)");
     }
   } else if (!summary.configCleaned && summary.mcpServersRemoved.length === 0) {
     console.log("  config.toml: no OMX entries found (or --keep-config used)");

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -81,7 +81,8 @@ function detectOmxConfigArtifacts(config: string): {
   const hasFeatureFlags =
     /^\s*multi_agent\s*=\s*true/m.test(config) ||
     /^\s*child_agents_md\s*=\s*true/m.test(config) ||
-    /^\s*codex_hooks\s*=\s*true/m.test(config);
+    /^\s*codex_hooks\s*=\s*true/m.test(config) ||
+    /^\s*goal\s*=\s*true/m.test(config);
   const hasExploreRoutingEnv = /^\s*USE_OMX_EXPLORE_CMD\s*=/m.test(config);
 
   return {
@@ -388,7 +389,7 @@ function printSummary(summary: UninstallSummary, dryRun: boolean): void {
       );
     }
     if (summary.featureFlagsRemoved) {
-      console.log("    Feature flags (multi_agent, child_agents_md, codex_hooks)");
+      console.log("    Feature flags (multi_agent, child_agents_md, codex_hooks, goal)");
     }
   } else if (!summary.configCleaned && summary.mcpServersRemoved.length === 0) {
     console.log("  config.toml: no OMX entries found (or --keep-config used)");

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -175,7 +175,7 @@ describe("config generator idempotency (#384)", () => {
       assert.match(toml, /^multi_agent = true$/m);
       assert.match(toml, /^child_agents_md = true$/m);
       assert.match(toml, /^codex_hooks = true$/m);
-      assert.match(toml, /^goal = true$/m);
+      assert.match(toml, /^goals = true$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -232,7 +232,7 @@ describe("config generator idempotency (#384)", () => {
         "",
         "[features]",
         "multi_agent = true",
-        "goal = false",
+        "goals = false",
         "",
         "[mcp_servers.omx_state]",
         'command = "node"',
@@ -349,7 +349,7 @@ describe("config generator idempotency (#384)", () => {
       const orphanedAgents = [
         "[features]",
         "multi_agent = true",
-        "goal = false",
+        "goals = false",
         "",
         "# OMX Native Agent Roles (Codex multi-agent)",
         "",

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -175,6 +175,7 @@ describe("config generator idempotency (#384)", () => {
       assert.match(toml, /^multi_agent = true$/m);
       assert.match(toml, /^child_agents_md = true$/m);
       assert.match(toml, /^codex_hooks = true$/m);
+      assert.match(toml, /^goal = true$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -231,6 +232,7 @@ describe("config generator idempotency (#384)", () => {
         "",
         "[features]",
         "multi_agent = true",
+        "goal = false",
         "",
         "[mcp_servers.omx_state]",
         'command = "node"',
@@ -347,6 +349,7 @@ describe("config generator idempotency (#384)", () => {
       const orphanedAgents = [
         "[features]",
         "multi_agent = true",
+        "goal = false",
         "",
         "# OMX Native Agent Roles (Codex multi-agent)",
         "",

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -260,6 +260,7 @@ describe('config generator', () => {
 
       // OMX feature flags added
       assert.match(toml, /^multi_agent = true$/m);
+      assert.match(toml, /^goal = true$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -359,6 +360,7 @@ describe('config generator', () => {
         '[features]',
         'custom_user_flag = false',
         'child_agents_md = false',
+        'goal = false',
         '',
         '[user.settings]',
         'name = "kept"',
@@ -373,6 +375,7 @@ describe('config generator', () => {
       assert.match(merged, /^custom_user_flag = false$/m);
       assert.match(merged, /^multi_agent = true$/m);
       assert.match(merged, /^child_agents_md = true$/m);
+      assert.match(merged, /^goal = true$/m);
       assert.match(merged, /^\[user.settings\]$/m);
       assert.match(merged, /^name = "kept"$/m);
     } finally {

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -260,7 +260,7 @@ describe('config generator', () => {
 
       // OMX feature flags added
       assert.match(toml, /^multi_agent = true$/m);
-      assert.match(toml, /^goal = true$/m);
+      assert.match(toml, /^goals = true$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -360,7 +360,8 @@ describe('config generator', () => {
         '[features]',
         'custom_user_flag = false',
         'child_agents_md = false',
-        'goal = false',
+        'goal = true',
+        'goals = false',
         '',
         '[user.settings]',
         'name = "kept"',
@@ -375,7 +376,8 @@ describe('config generator', () => {
       assert.match(merged, /^custom_user_flag = false$/m);
       assert.match(merged, /^multi_agent = true$/m);
       assert.match(merged, /^child_agents_md = true$/m);
-      assert.match(merged, /^goal = true$/m);
+      assert.match(merged, /^goals = true$/m);
+      assert.doesNotMatch(merged, /^goal\s*=/m);
       assert.match(merged, /^\[user.settings\]$/m);
       assert.match(merged, /^name = "kept"$/m);
     } finally {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -434,7 +434,7 @@ function upsertFeatureFlags(config: string): string {
       "multi_agent = true",
       "child_agents_md = true",
       "codex_hooks = true",
-      "goal = true",
+      "goals = true",
       "",
     ].join("\n");
     if (base.length === 0) {
@@ -451,9 +451,10 @@ function upsertFeatureFlags(config: string): string {
     }
   }
 
-  // Remove deprecated 'collab' key (superseded by multi_agent)
+  // Remove deprecated 'collab' key (superseded by multi_agent) and
+  // the misspelled singular 'goal' flag written by unreleased PR builds.
   for (let i = sectionEnd - 1; i > featuresStart; i--) {
-    if (/^\s*collab\s*=/.test(lines[i])) {
+    if (/^\s*(?:collab|goal)\s*=/.test(lines[i])) {
       lines.splice(i, 1);
       sectionEnd -= 1;
     }
@@ -462,7 +463,7 @@ function upsertFeatureFlags(config: string): string {
   let multiAgentIdx = -1;
   let childAgentsIdx = -1;
   let codexHooksIdx = -1;
-  let goalIdx = -1;
+  let goalsIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {
     if (/^\s*multi_agent\s*=/.test(lines[i])) {
       multiAgentIdx = i;
@@ -470,8 +471,8 @@ function upsertFeatureFlags(config: string): string {
       childAgentsIdx = i;
     } else if (/^\s*codex_hooks\s*=/.test(lines[i])) {
       codexHooksIdx = i;
-    } else if (/^\s*goal\s*=/.test(lines[i])) {
-      goalIdx = i;
+    } else if (/^\s*goals\s*=/.test(lines[i])) {
+      goalsIdx = i;
     }
   }
 
@@ -496,10 +497,10 @@ function upsertFeatureFlags(config: string): string {
     sectionEnd += 1;
   }
 
-  if (goalIdx >= 0) {
-    lines[goalIdx] = "goal = true";
+  if (goalsIdx >= 0) {
+    lines[goalsIdx] = "goals = true";
   } else {
-    lines.splice(sectionEnd, 0, "goal = true");
+    lines.splice(sectionEnd, 0, "goals = true");
   }
 
   return lines.join("\n");
@@ -516,7 +517,7 @@ export function upsertPluginModeRuntimeFeatureFlags(config: string): string {
     const featureBlock = [
       "[features]",
       "codex_hooks = true",
-      "goal = true",
+      "goals = true",
       "",
     ].join("\n");
     if (base.length === 0) {
@@ -533,13 +534,22 @@ export function upsertPluginModeRuntimeFeatureFlags(config: string): string {
     }
   }
 
+  // Remove the misspelled singular flag from unreleased PR builds before
+  // upserting the supported plural Codex feature flag.
+  for (let i = sectionEnd - 1; i > featuresStart; i--) {
+    if (/^\s*goal\s*=/.test(lines[i])) {
+      lines.splice(i, 1);
+      sectionEnd -= 1;
+    }
+  }
+
   let codexHooksIdx = -1;
-  let goalIdx = -1;
+  let goalsIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {
     if (/^\s*codex_hooks\s*=/.test(lines[i])) {
       codexHooksIdx = i;
-    } else if (/^\s*goal\s*=/.test(lines[i])) {
-      goalIdx = i;
+    } else if (/^\s*goals\s*=/.test(lines[i])) {
+      goalsIdx = i;
     }
   }
 
@@ -550,10 +560,10 @@ export function upsertPluginModeRuntimeFeatureFlags(config: string): string {
     sectionEnd++;
   }
 
-  if (goalIdx >= 0) {
-    lines[goalIdx] = "goal = true";
+  if (goalsIdx >= 0) {
+    lines[goalsIdx] = "goals = true";
   } else {
-    lines.splice(sectionEnd, 0, "goal = true");
+    lines.splice(sectionEnd, 0, "goals = true");
   }
 
   return lines.join("\n");
@@ -809,6 +819,7 @@ export function stripOmxFeatureFlags(config: string): string {
     "multi_agent",
     "child_agents_md",
     "codex_hooks",
+    "goals",
     "goal",
     "collab",
   ];
@@ -1429,7 +1440,7 @@ function getOmxTablesBlock(
  *
  * Layout:
  *   1. OMX top-level keys (notify, model_reasoning_effort, developer_instructions)
- *   2. [features] with multi_agent + child_agents_md + codex_hooks + goal
+ *   2. [features] with multi_agent + child_agents_md + codex_hooks + goals
  *   3. [shell_environment_policy.set] with defaulted explore-routing opt-in
  *   4. … user sections …
  *   5. OMX [table] sections (mcp_servers, tui)

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -434,6 +434,7 @@ function upsertFeatureFlags(config: string): string {
       "multi_agent = true",
       "child_agents_md = true",
       "codex_hooks = true",
+      "goal = true",
       "",
     ].join("\n");
     if (base.length === 0) {
@@ -461,6 +462,7 @@ function upsertFeatureFlags(config: string): string {
   let multiAgentIdx = -1;
   let childAgentsIdx = -1;
   let codexHooksIdx = -1;
+  let goalIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {
     if (/^\s*multi_agent\s*=/.test(lines[i])) {
       multiAgentIdx = i;
@@ -468,6 +470,8 @@ function upsertFeatureFlags(config: string): string {
       childAgentsIdx = i;
     } else if (/^\s*codex_hooks\s*=/.test(lines[i])) {
       codexHooksIdx = i;
+    } else if (/^\s*goal\s*=/.test(lines[i])) {
+      goalIdx = i;
     }
   }
 
@@ -489,12 +493,19 @@ function upsertFeatureFlags(config: string): string {
     lines[codexHooksIdx] = "codex_hooks = true";
   } else {
     lines.splice(sectionEnd, 0, "codex_hooks = true");
+    sectionEnd += 1;
+  }
+
+  if (goalIdx >= 0) {
+    lines[goalIdx] = "goal = true";
+  } else {
+    lines.splice(sectionEnd, 0, "goal = true");
   }
 
   return lines.join("\n");
 }
 
-export function upsertCodexHooksFeatureFlag(config: string): string {
+export function upsertPluginModeRuntimeFeatureFlags(config: string): string {
   const lines = config.split(/\r?\n/);
   const featuresStart = lines.findIndex((line) =>
     /^\s*\[features\]\s*$/.test(line),
@@ -502,7 +513,12 @@ export function upsertCodexHooksFeatureFlag(config: string): string {
 
   if (featuresStart < 0) {
     const base = config.trimEnd();
-    const featureBlock = ["[features]", "codex_hooks = true", ""].join("\n");
+    const featureBlock = [
+      "[features]",
+      "codex_hooks = true",
+      "goal = true",
+      "",
+    ].join("\n");
     if (base.length === 0) {
       return featureBlock;
     }
@@ -518,10 +534,12 @@ export function upsertCodexHooksFeatureFlag(config: string): string {
   }
 
   let codexHooksIdx = -1;
+  let goalIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {
     if (/^\s*codex_hooks\s*=/.test(lines[i])) {
       codexHooksIdx = i;
-      break;
+    } else if (/^\s*goal\s*=/.test(lines[i])) {
+      goalIdx = i;
     }
   }
 
@@ -529,11 +547,17 @@ export function upsertCodexHooksFeatureFlag(config: string): string {
     lines[codexHooksIdx] = "codex_hooks = true";
   } else {
     lines.splice(sectionEnd, 0, "codex_hooks = true");
+    sectionEnd++;
+  }
+
+  if (goalIdx >= 0) {
+    lines[goalIdx] = "goal = true";
+  } else {
+    lines.splice(sectionEnd, 0, "goal = true");
   }
 
   return lines.join("\n");
 }
-
 interface TomlTableRange {
   start: number;
   end: number;
@@ -781,7 +805,13 @@ export function stripOmxFeatureFlags(config: string): string {
     }
   }
 
-  const omxFlags = ["multi_agent", "child_agents_md", "codex_hooks", "collab"];
+  const omxFlags = [
+    "multi_agent",
+    "child_agents_md",
+    "codex_hooks",
+    "goal",
+    "collab",
+  ];
   const filtered: string[] = [];
   for (let i = 0; i < lines.length; i++) {
     if (i > featuresStart && i < sectionEnd) {
@@ -1399,7 +1429,7 @@ function getOmxTablesBlock(
  *
  * Layout:
  *   1. OMX top-level keys (notify, model_reasoning_effort, developer_instructions)
- *   2. [features] with multi_agent + child_agents_md
+ *   2. [features] with multi_agent + child_agents_md + codex_hooks + goal
  *   3. [shell_environment_policy.set] with defaulted explore-routing opt-in
  *   4. … user sections …
  *   5. OMX [table] sections (mcp_servers, tui)


### PR DESCRIPTION
## Summary
- integrate Ralph guidance with Codex goal-mode tools and completion-audit expectations
- enable setup-owned `[features].goal = true` alongside existing OMX runtime feature flags
- make plugin-mode setup, uninstall reporting, docs, and plugin skill mirrors consistent for `codex_hooks` + `goal`

## Verification
- `npm run build && node --test dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/uninstall.test.js dist/cli/__tests__/setup-scope.test.js dist/config/__tests__/generator-notify.test.js dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/ralph-goal-mode-contract.test.js dist/cli/__tests__/ralph-prd-smoke.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `npm run verify:plugin-bundle`
- `npm run verify:native-agents`
- `git diff --check`

## Review evidence
- Code-review lane: APPROVE, 0 issues
- Architecture re-review: CLEAR
