### PR TITLE
Fix native hook CLI detection for symlinked installs

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { existsSync, realpathSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -232,6 +232,27 @@ describe("codex native hook dispatch", () => {
       isCodexNativeHookMainModule(pathToFileURL(entryPath).href, entryPath),
       true,
     );
+  });
+
+  it("treats symlinked argv entry paths as the main module", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-main-symlink-"));
+    try {
+      const realDir = join(cwd, "real");
+      const linkDir = join(cwd, "link");
+      await mkdir(realDir, { recursive: true });
+      await mkdir(linkDir, { recursive: true });
+      const realEntryPath = join(realDir, "codex-native-hook.js");
+      const symlinkEntryPath = join(linkDir, "codex-native-hook.js");
+      await writeFile(realEntryPath, "", "utf-8");
+      await symlink(realEntryPath, symlinkEntryPath);
+
+      assert.equal(
+        isCodexNativeHookMainModule(pathToFileURL(realpathSync(realEntryPath)).href, symlinkEntryPath),
+        true,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it("does not treat a different module url as the main module", () => {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { closeSync, existsSync, openSync, readFileSync, readSync } from "fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, realpathSync } from "fs";
 import { mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
@@ -2428,7 +2428,11 @@ export function isCodexNativeHookMainModule(
   argv1: string | undefined,
 ): boolean {
   if (!argv1) return false;
-  return moduleUrl === pathToFileURL(argv1).href;
+  try {
+    return moduleUrl === pathToFileURL(realpathSync(argv1)).href;
+  } catch {
+    return moduleUrl === pathToFileURL(argv1).href;
+  }
 }
 
 async function readStdinJson(): Promise<NativeHookCliReadResult> {


### PR DESCRIPTION
## Summary

Fixes native hook CLI main-module detection when `oh-my-codex` is invoked through an npm-global package symlink.

Node resolves `import.meta.url` to the real file path, while `process.argv[1]` can remain the symlinked package path. Before this change, that mismatch made `codex-native-hook.js` skip its CLI entrypoint, so inactive Stop hook payloads could exit successfully with empty stdout instead of the expected `{}` JSON response.

## Changes

- Normalize `argv[1]` with `realpathSync()` before comparing it with `import.meta.url`.
- Keep the previous path comparison as a fallback when realpath resolution fails.
- Add a regression test for symlinked native hook argv entry paths.

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [ ] `npm test` — not run; targeted native-hook regression was run instead.
- [ ] `omx doctor` (when setup/config behavior changes) — not applicable; this does not change setup/config behavior.

Additional validation:

- [x] `node --test --test-name-pattern 'main module|Stop CLI runs' dist/scripts/__tests__/codex-native-hook.test.js`
- [x] Stop payload smoke through npm-global symlink path:
  - `OMX_HOOK_PLUGINS=0 node /home/yun/.npm-global/lib/node_modules/oh-my-codex/dist/scripts/codex-native-hook.js`
  - output: `{}`
- [x] Stop payload smoke through realpath:
  - `OMX_HOOK_PLUGINS=0 node /home/yun/.omx/dev-oh-my-codex/dist/scripts/codex-native-hook.js`
  - output: `{}`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — not needed; internal CLI entrypoint detection fix with regression coverage
- [x] Backward-compatibility impact considered

## Related

Closes #
