### PR TITLE
Enforce fallback slop detection at Stop

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -57,6 +57,14 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+async function initTempGitRepo(prefix: string): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), prefix));
+  execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd, stdio: "ignore" });
+  return cwd;
+}
+
 async function writeActiveAutopilotSession(cwd: string, sessionId: string): Promise<void> {
   await writeJson(join(cwd, ".omx", "state", "session.json"), {
     session_id: sessionId,
@@ -2532,6 +2540,263 @@ esac
       );
 
       assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("blocks Stop for untracked non-Bash-style sloppy fallback source edits", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-untracked-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-untracked" },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+      assert.match(JSON.stringify(result.outputJson), /src\/runtime\.ts/);
+      assert.match(JSON.stringify(result.outputJson), /grounded design/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("keeps blocking repeated Stop while sloppy fallback diff remains", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-repeat-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-repeat", turn_id: "turn-repeat" };
+
+      const first = await dispatchCodexNativeHook(payload, { cwd });
+      const repeated = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+
+      assert.equal((first.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((repeated.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((repeated.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("blocks Stop for unstaged tracked sloppy fallback source edits", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-unstaged-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(join(cwd, "src", "runtime.ts"), "export const runtime = 'base';\n");
+      execFileSync("git", ["add", "src/runtime.ts"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "initial"], { cwd, stdio: "ignore" });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // just bypass fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-unstaged" },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /unstaged/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks Stop from a subdirectory cwd for untracked sloppy source elsewhere", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-subdir-");
+    try {
+      await mkdir(join(cwd, "src", "nested"), { recursive: true });
+      await writeFile(join(cwd, "src", "nested", "anchor.ts"), "export const anchor = true;\n");
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+
+      const subdir = join(cwd, "src", "nested");
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd: subdir, session_id: "sess-stop-slop-subdir" },
+        { cwd: subdir },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /src\/runtime\.ts/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks Stop for staged sloppy fallback source edits", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-staged-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(join(cwd, "src", "runtime.ts"), "export const runtime = 'base';\n");
+      execFileSync("git", ["add", "src/runtime.ts"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "initial"], { cwd, stdio: "ignore" });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // temporary workaround fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      execFileSync("git", ["add", "src/runtime.ts"], { cwd, stdio: "ignore" });
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-staged" },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /staged/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block Stop for grounded compatibility fallback source edits", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-grounded-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "compat.ts"),
+        [
+          "export function resolveCompatMode() {",
+          "  // temporary fallback for legacy startup",
+          "  // compatibility fail-safe tested by regression coverage",
+          "  return 'legacy';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-grounded" },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("does not block Stop when existing nearby source context grounds a new fallback line", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-existing-ground-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "compat.ts"),
+        [
+          "export function resolveCompatMode() {",
+          "  // compatibility fail-safe tested by regression coverage",
+          "  return 'legacy';",
+          "}",
+        ].join("\n"),
+      );
+      execFileSync("git", ["add", "src/compat.ts"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "initial"], { cwd, stdio: "ignore" });
+      await writeFile(
+        join(cwd, "src", "compat.ts"),
+        [
+          "export function resolveCompatMode() {",
+          "  // compatibility fail-safe tested by regression coverage",
+          "  // temporary fallback if it fails",
+          "  return 'legacy';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-existing-ground" },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("does not block Stop for source-adjacent test file fallback wording", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-test-file-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.test.ts"),
+        "it('documents no quick hack fallback if it fails', () => {});\n",
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-test-file" },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block Stop for docs-only fallback wording", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-docs-");
+    try {
+      await mkdir(join(cwd, "docs"), { recursive: true });
+      await writeFile(
+        join(cwd, "docs", "notes.md"),
+        "Do not implement a quick hack fallback if it fails.\n",
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-docs" },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
       assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "child_process";
 import { closeSync, existsSync, openSync, readFileSync, readSync } from "fs";
 import { mkdir, readFile, readdir, writeFile } from "fs/promises";
-import { join, relative, resolve } from "path";
+import { extname, join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
 import { readModeState, readModeStateForSession, updateModeState } from "../modes/base.js";
 import {
@@ -45,9 +45,13 @@ import {
   resolveEffectiveAutoNudgeResponse,
 } from "./notify-hook/auto-nudge.js";
 import {
+  SLOPPY_FALLBACK_GROUNDING_PATTERNS,
+  SLOPPY_FALLBACK_IMPLEMENTATION_CONTEXT_PATTERNS,
+  SLOPPY_FALLBACK_PHRASE_PATTERNS,
   buildNativePostToolUseOutput,
   buildNativePreToolUseOutput,
   detectMcpTransportFailure,
+  hasAnyPattern,
 } from "./codex-native-pre-post.js";
 import { handleTeamWorkerPostToolUseSuccess } from "./notify-hook/team-worker-posttooluse.js";
 import {
@@ -708,6 +712,192 @@ function tryReadGitValue(cwd: string, args: string[]): string | null {
   }
 }
 
+interface SloppyFallbackDiffFinding {
+  path: string;
+  line: string;
+  source: "staged" | "unstaged" | "untracked";
+}
+
+const SOURCE_DIFF_EXTENSIONS = new Set([
+  ".c",
+  ".cc",
+  ".cjs",
+  ".cpp",
+  ".cs",
+  ".cts",
+  ".go",
+  ".h",
+  ".hpp",
+  ".java",
+  ".js",
+  ".jsx",
+  ".kt",
+  ".mjs",
+  ".mts",
+  ".php",
+  ".py",
+  ".rb",
+  ".rs",
+  ".sh",
+  ".swift",
+  ".ts",
+  ".tsx",
+]);
+
+function gitOutput(cwd: string, args: string[]): string {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+  } catch {
+    return "";
+  }
+}
+
+function normalizeGitPath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function isDiffAuditableSourcePath(path: string): boolean {
+  const normalized = normalizeGitPath(path).toLowerCase();
+  if (!normalized || normalized.startsWith(".git/") || normalized.startsWith(".omx/")) return false;
+  if (/(^|\/)(?:docs?|documentation|changelog|changeset|\.github)(?:\/|$)/i.test(normalized)) return false;
+  if (/(^|\/)(?:__tests__|__test__|test|tests|spec|specs|fixtures?|mocks?)(?:\/|$)/i.test(normalized)) return false;
+  if (/(?:^|\/)[^\/]+\.(?:test|spec)\.[^.\/]+$/i.test(normalized)) return false;
+  if (/(?:^|\/)(?:readme|changelog|changes|license|notice)(?:\.[^\/]*)?$/i.test(normalized)) return false;
+  if (/\.(?:md|mdx|markdown|txt|rst|adoc|ya?ml|json|lock)$/i.test(normalized)) return false;
+  return SOURCE_DIFF_EXTENSIONS.has(extname(normalized));
+}
+
+function isDiffHeaderLine(line: string): boolean {
+  return line.startsWith("+++") || line.startsWith("---") || line.startsWith("@@") || line.startsWith("diff --git ");
+}
+
+function isSuspiciousSloppyFallbackAddedLine(line: string, nearbyContext: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  if (!hasAnyPattern(trimmed, SLOPPY_FALLBACK_PHRASE_PATTERNS)) return false;
+  if (!hasAnyPattern(trimmed, SLOPPY_FALLBACK_IMPLEMENTATION_CONTEXT_PATTERNS)) return false;
+  if (hasAnyPattern(nearbyContext, SLOPPY_FALLBACK_GROUNDING_PATTERNS)) return false;
+  if (/compatib(?:le|ility)|fail-?safe|tested|regression|coverage|because|issue|PR\s*#?\d|#\d/i.test(nearbyContext)) return false;
+  return true;
+}
+
+interface SloppyFallbackCandidateLine {
+  text: string;
+  added: boolean;
+}
+
+function collectFindingsFromCandidateLines(
+  path: string,
+  lines: SloppyFallbackCandidateLine[],
+  source: SloppyFallbackDiffFinding["source"],
+): SloppyFallbackDiffFinding[] {
+  if (!path || !isDiffAuditableSourcePath(path)) return [];
+  const findings: SloppyFallbackDiffFinding[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const candidate = lines[index];
+    if (!candidate?.added) continue;
+    const nearbyContext = lines
+      .slice(Math.max(0, index - 2), Math.min(lines.length, index + 3))
+      .map((line) => line.text)
+      .join("\n");
+    if (isSuspiciousSloppyFallbackAddedLine(candidate.text, nearbyContext)) {
+      findings.push({ path, line: candidate.text.trim(), source });
+    }
+  }
+  return findings;
+}
+
+function collectSloppyFallbackFindingsFromPatch(
+  patch: string,
+  source: SloppyFallbackDiffFinding["source"],
+): SloppyFallbackDiffFinding[] {
+  const findings: SloppyFallbackDiffFinding[] = [];
+  let currentPath = "";
+  let hunkLines: SloppyFallbackCandidateLine[] = [];
+
+  const flushHunk = () => {
+    findings.push(...collectFindingsFromCandidateLines(currentPath, hunkLines, source));
+    hunkLines = [];
+  };
+
+  for (const rawLine of patch.split(/\r?\n/)) {
+    const fileMatch = rawLine.match(/^diff --git a\/(.*?) b\/(.*)$/);
+    if (fileMatch) {
+      flushHunk();
+      currentPath = normalizeGitPath(fileMatch[2] || fileMatch[1] || "");
+      continue;
+    }
+    const renameMatch = rawLine.match(/^\+\+\+ b\/(.*)$/);
+    if (renameMatch) {
+      currentPath = normalizeGitPath(renameMatch[1] || currentPath);
+      continue;
+    }
+    if (rawLine.startsWith("@@")) {
+      flushHunk();
+      continue;
+    }
+    if (!currentPath || !isDiffAuditableSourcePath(currentPath) || isDiffHeaderLine(rawLine)) continue;
+    if (rawLine.startsWith("+")) {
+      hunkLines.push({ text: rawLine.slice(1), added: true });
+    } else if (rawLine.startsWith(" ")) {
+      hunkLines.push({ text: rawLine.slice(1), added: false });
+    }
+  }
+  flushHunk();
+  return findings;
+}
+
+function collectSloppyFallbackFindingsFromUntracked(cwd: string): SloppyFallbackDiffFinding[] {
+  const output = gitOutput(cwd, ["ls-files", "--others", "--exclude-standard", "-z"]);
+  if (!output) return [];
+  const findings: SloppyFallbackDiffFinding[] = [];
+  for (const rawPath of output.split("\0")) {
+    const path = normalizeGitPath(rawPath.trim());
+    if (!path || !isDiffAuditableSourcePath(path)) continue;
+    let content = "";
+    try {
+      content = readFileSync(join(cwd, path), "utf-8");
+    } catch {
+      continue;
+    }
+    findings.push(...collectFindingsFromCandidateLines(path, content.split(/\r?\n/).map((text) => ({ text, added: true })), "untracked"));
+  }
+  return findings;
+}
+
+function findSloppyFallbackDiffFindings(cwd: string): SloppyFallbackDiffFinding[] {
+  const layout = findGitLayout(cwd);
+  if (!layout) return [];
+  const auditRoot = layout.worktreeRoot;
+  return [
+    ...collectSloppyFallbackFindingsFromPatch(gitOutput(auditRoot, ["diff", "--cached", "--no-ext-diff", "--unified=3"]), "staged"),
+    ...collectSloppyFallbackFindingsFromPatch(gitOutput(auditRoot, ["diff", "--no-ext-diff", "--unified=3"]), "unstaged"),
+    ...collectSloppyFallbackFindingsFromUntracked(auditRoot),
+  ];
+}
+
+function buildSloppyFallbackDiffStopOutput(findings: SloppyFallbackDiffFinding[]): Record<string, unknown> | null {
+  if (findings.length === 0) return null;
+  const preview = findings
+    .slice(0, 3)
+    .map((finding) => `${finding.path} (${finding.source}): ${finding.line}`)
+    .join("; ");
+  const systemMessage =
+    `Sloppy fallback/workaround diff audit detected ungrounded fallback code in added source lines: ${preview}. `
+    + "Continue by replacing the bypass/workaround with a grounded design, or add explicit compatibility/fail-safe/tested/issue rationale near the code if the fallback is intentional.";
+  return {
+    decision: "block",
+    reason: systemMessage,
+    stopReason: "sloppy_fallback_diff_audit",
+    systemMessage,
+  };
+}
 
 function localExcludeAlreadyIgnoresOmx(cwd: string): boolean {
   const layout = findGitLayout(cwd);
@@ -2140,6 +2330,20 @@ async function buildStopHookOutput(
             "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
         },
         canonicalSessionId,
+      );
+    }
+
+    const sloppyFallbackDiffFindings = findSloppyFallbackDiffFindings(cwd);
+    const sloppyFallbackDiffOutput = buildSloppyFallbackDiffStopOutput(sloppyFallbackDiffFindings);
+    if (sloppyFallbackDiffOutput) {
+      return await returnPersistentStopBlock(
+        payload,
+        stateDir,
+        "sloppy-fallback-diff-stop",
+        JSON.stringify(sloppyFallbackDiffFindings),
+        sloppyFallbackDiffOutput,
+        canonicalSessionId,
+        { allowRepeatDuringStopHook: true },
       );
     }
 

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -617,7 +617,7 @@ function buildDocumentRefreshPreToolUseOutput(
 }
 
 
-const SLOPPY_FALLBACK_PHRASE_PATTERNS = [
+export const SLOPPY_FALLBACK_PHRASE_PATTERNS = [
   /\bquick hack\b/i,
   /\bhacky\b/i,
   /\bworkaround for now\b/i,
@@ -631,7 +631,7 @@ const SLOPPY_FALLBACK_PHRASE_PATTERNS = [
   /\bbypass (?:the )?(?:failing )?(?:test|validation|checks?)\b/i,
 ] as const;
 
-const SLOPPY_FALLBACK_IMPLEMENTATION_CONTEXT_PATTERNS = [
+export const SLOPPY_FALLBACK_IMPLEMENTATION_CONTEXT_PATTERNS = [
   /\badd\b/i,
   /\bimplement\b/i,
   /\bpatch\b/i,
@@ -645,7 +645,7 @@ const SLOPPY_FALLBACK_IMPLEMENTATION_CONTEXT_PATTERNS = [
   /\bdisable\b/i,
 ] as const;
 
-const SLOPPY_FALLBACK_GROUNDING_PATTERNS = [
+export const SLOPPY_FALLBACK_GROUNDING_PATTERNS = [
   /\btested\b/i,
   /\btests? pass(?:ed)?\b/i,
   /\bnpm (?:run )?test\b/i,
@@ -709,7 +709,7 @@ function commandHasWriteLikeIntent(command: string): boolean {
     || /<<['"]?[A-Za-z0-9_ -]+['"]?[\s\S]*(?:^|\n)(?:\+\+\+\s|---\s|import\s|export\s|function\s|const\s|class\s|interface\s)/m.test(command);
 }
 
-function hasAnyPattern(text: string, patterns: readonly RegExp[]): boolean {
+export function hasAnyPattern(text: string, patterns: readonly RegExp[]): boolean {
   return patterns.some((pattern) => pattern.test(text));
 }
 


### PR DESCRIPTION
## Summary
- add a native Stop diff audit for staged, unstaged, and untracked source changes
- keep Bash PreToolUse as the fast early advisory while making Stop the universal final gate
- reuse fallback-slop phrase/grounding patterns and avoid docs/tests false positives
- add regressions for untracked, unstaged, staged, repeated Stop, subdirectory cwd, grounded context, docs-only, and test-file exclusions

## Review
- Final `$code-review` ran code-reviewer and architect lanes.
- Architect BLOCK fixed: audit now normalizes to the git worktree root for subdirectory cwd coverage.
- Code-reviewer REQUEST CHANGES fixed: test suffixes are excluded, unstaged tracked edits are covered, and findings are computed once for output/signature.

## Tests
- `npm run build && node --test dist/scripts/__tests__/codex-native-hook.test.js` (232 tests)
- `git diff --check`

## Not tested
- Full `npm test` suite
