### PR TITLE
Guide ai-slop-cleaner through fallback cleanup

### DIFF
--- a/plugins/oh-my-codex/skills/ai-slop-cleaner/SKILL.md
+++ b/plugins/oh-my-codex/skills/ai-slop-cleaner/SKILL.md
@@ -12,7 +12,7 @@ Reduce AI-generated slop with a regression-tests-first, smell-by-smell cleanup w
 Use this skill when:
 - A code path works but feels bloated, noisy, repetitive, or over-abstracted
 - A user asks to “cleanup”, “refactor”, or “deslop” AI-generated output
-- Follow-up implementation left duplicate code, dead code, weak boundaries, missing tests, or unnecessary wrapper layers
+- Follow-up implementation left duplicate code, dead code, weak boundaries, missing tests, fallback-like code, or unnecessary wrapper layers
 - You need a disciplined cleanup workflow without broad rewrites
 
 ## GPT-5.5 Guidance Alignment
@@ -34,22 +34,35 @@ Use this skill when:
    - Identify the behavior that must not change
    - Add or run targeted regression tests before editing cleanup candidates
    - If behavior is currently untested, create the narrowest test coverage needed first
+   - For fallback-like code, cover the primary path and any preserved compatibility/fail-safe fallback before cleanup
 
 2. **Create a cleanup plan before code**
    - List the specific smells to remove
    - Bound the pass to the requested files/scope
    - If a file list scope is provided, keep the pass restricted to that changed-files list
+   - Include fallback findings, classifications, and escalation status in the plan
    - Order fixes from safest/highest-signal to riskiest
    - Do not start coding until the cleanup plan is explicit
 
-3. **Categorize issues before editing**
+3. **Inventory fallback-like code before editing**
+   - Search the requested scope for fallback-like detection signals: quick hacks, temporary workaround, temporary fallback, just bypass, just skip, fallback if it fails, swallowed errors, silent defaults, broad compatibility shims, and duplicate alternate execution paths
+   - Classify each finding before changing it:
+     - **Masking fallback slop** — hides errors or evidence, bypasses the primary contract, suppresses tests or validation, swallows failures, silently defaults, or adds untested alternate paths
+     - **Grounded compatibility/fail-safe fallback** — is scoped to an external/version/fail-safe boundary, documents the rationale, preserves failure evidence, and has regression tests for both the primary and fallback behavior
+   - Prefer root-cause repair, deletion, boundary repair, or explicit failure behavior before preserving fallback paths
+   - For broad, ambiguous, cross-layer, or architectural fallback-like code, invoke `$ralplan` for consensus resolution before edits
+   - Recursion guard: when already inside ralplan, ralph, team, or another OMX workflow, do not spawn a nested `$ralplan`; record the finding and attach it to the active ralplan, leader, or plan handoff instead
+
+4. **Categorize issues before editing**
+   - **Fallback-like code** — masking fallbacks, workaround branches, bypasses, swallowed errors, silent defaults, broad shims, alternate execution paths
    - **Duplication** — repeated logic, copy-paste branches, redundant helpers
    - **Dead code** — unused code, unreachable branches, stale flags, debug leftovers
    - **Needless abstraction** — pass-through wrappers, speculative indirection, single-use helper layers
    - **Boundary violations** — hidden coupling, leaky responsibilities, wrong-layer imports or side effects
    - **Missing tests** — behavior not locked, weak regression coverage, gaps around edge cases
 
-4. **Execute passes one smell at a time**
+5. **Execute passes one smell at a time**
+   - **Fallback-like code resolution gate** — remove masking fallback slop, repair root causes, or escalate ambiguous cases before continuing
    - **Pass 1: Dead code deletion**
    - **Pass 2: Duplicate removal**
    - **Pass 3: Naming/error handling cleanup**
@@ -57,7 +70,7 @@ Use this skill when:
    - Re-run targeted verification after each pass
    - Avoid bundling unrelated refactors into the same edit set
 
-5. **Run quality gates**
+6. **Run quality gates**
    - Regression tests stay green
    - Lint passes
    - Typecheck passes
@@ -66,9 +79,10 @@ Use this skill when:
    - Diff stays minimal and scoped
    - No new abstractions or dependencies unless explicitly required
 
-6. **Finish with an evidence-dense report**
+7. **Finish with an evidence-dense report**
    - Changed files
    - Simplifications made
+   - Fallback findings, classifications, and escalation status
    - Tests/diagnostics/build checks run
    - Remaining risks
    - Residual follow-ups or consciously deferred cleanup
@@ -82,8 +96,10 @@ AI SLOP CLEANUP REPORT
 Scope: [files or feature area]
 Behavior Lock: [targeted regression tests added/run]
 Cleanup Plan: [bounded smells and order]
+Fallback Findings: [none, or finding -> masking fallback slop / grounded compatibility/fail-safe fallback -> escalation status]
 
 Passes Completed:
+- Fallback-like code resolution gate - [root-cause repair, explicit failure behavior, preserved grounded fallback, or ralplan handoff]
 1. Pass 1: Dead code deletion - [concise fix]
 2. Pass 2: Duplicate removal - [concise fix]
 3. Pass 3: Naming/error handling cleanup - [concise fix]
@@ -99,6 +115,11 @@ Quality Gates:
 Changed Files:
 - [path] - [simplification]
 
+Fallback Review:
+- Findings: [fallback-like findings detected]
+- Classification: [masking fallback slop | grounded fallback]
+- Escalation Status: [none | raised to leader/ralplan | no escalation]
+
 Remaining Risks:
 - [none or short deferred item]
 ```
@@ -112,3 +133,7 @@ Remaining Risks:
 **Bad:** Start rewriting architecture before protecting behavior with tests.
 
 **Bad:** Collapse multiple smell categories into one large refactor with no intermediate verification.
+
+**Bad:** Keep a `fallback if it fails` branch that silently defaults after a swallowed error instead of fixing the root cause or making failure explicit.
+
+**Good:** A version-specific compatibility shim is narrow, documented, preserves error evidence, has primary and fallback regression tests, and is reported as a grounded compatibility/fail-safe fallback.

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -12,7 +12,7 @@ Reduce AI-generated slop with a regression-tests-first, smell-by-smell cleanup w
 Use this skill when:
 - A code path works but feels bloated, noisy, repetitive, or over-abstracted
 - A user asks to “cleanup”, “refactor”, or “deslop” AI-generated output
-- Follow-up implementation left duplicate code, dead code, weak boundaries, missing tests, or unnecessary wrapper layers
+- Follow-up implementation left duplicate code, dead code, weak boundaries, missing tests, fallback-like code, or unnecessary wrapper layers
 - You need a disciplined cleanup workflow without broad rewrites
 
 ## GPT-5.5 Guidance Alignment
@@ -34,22 +34,35 @@ Use this skill when:
    - Identify the behavior that must not change
    - Add or run targeted regression tests before editing cleanup candidates
    - If behavior is currently untested, create the narrowest test coverage needed first
+   - For fallback-like code, cover the primary path and any preserved compatibility/fail-safe fallback before cleanup
 
 2. **Create a cleanup plan before code**
    - List the specific smells to remove
    - Bound the pass to the requested files/scope
    - If a file list scope is provided, keep the pass restricted to that changed-files list
+   - Include fallback findings, classifications, and escalation status in the plan
    - Order fixes from safest/highest-signal to riskiest
    - Do not start coding until the cleanup plan is explicit
 
-3. **Categorize issues before editing**
+3. **Inventory fallback-like code before editing**
+   - Search the requested scope for fallback-like detection signals: quick hacks, temporary workaround, temporary fallback, just bypass, just skip, fallback if it fails, swallowed errors, silent defaults, broad compatibility shims, and duplicate alternate execution paths
+   - Classify each finding before changing it:
+     - **Masking fallback slop** — hides errors or evidence, bypasses the primary contract, suppresses tests or validation, swallows failures, silently defaults, or adds untested alternate paths
+     - **Grounded compatibility/fail-safe fallback** — is scoped to an external/version/fail-safe boundary, documents the rationale, preserves failure evidence, and has regression tests for both the primary and fallback behavior
+   - Prefer root-cause repair, deletion, boundary repair, or explicit failure behavior before preserving fallback paths
+   - For broad, ambiguous, cross-layer, or architectural fallback-like code, invoke `$ralplan` for consensus resolution before edits
+   - Recursion guard: when already inside ralplan, ralph, team, or another OMX workflow, do not spawn a nested `$ralplan`; record the finding and attach it to the active ralplan, leader, or plan handoff instead
+
+4. **Categorize issues before editing**
+   - **Fallback-like code** — masking fallbacks, workaround branches, bypasses, swallowed errors, silent defaults, broad shims, alternate execution paths
    - **Duplication** — repeated logic, copy-paste branches, redundant helpers
    - **Dead code** — unused code, unreachable branches, stale flags, debug leftovers
    - **Needless abstraction** — pass-through wrappers, speculative indirection, single-use helper layers
    - **Boundary violations** — hidden coupling, leaky responsibilities, wrong-layer imports or side effects
    - **Missing tests** — behavior not locked, weak regression coverage, gaps around edge cases
 
-4. **Execute passes one smell at a time**
+5. **Execute passes one smell at a time**
+   - **Fallback-like code resolution gate** — remove masking fallback slop, repair root causes, or escalate ambiguous cases before continuing
    - **Pass 1: Dead code deletion**
    - **Pass 2: Duplicate removal**
    - **Pass 3: Naming/error handling cleanup**
@@ -57,7 +70,7 @@ Use this skill when:
    - Re-run targeted verification after each pass
    - Avoid bundling unrelated refactors into the same edit set
 
-5. **Run quality gates**
+6. **Run quality gates**
    - Regression tests stay green
    - Lint passes
    - Typecheck passes
@@ -66,9 +79,10 @@ Use this skill when:
    - Diff stays minimal and scoped
    - No new abstractions or dependencies unless explicitly required
 
-6. **Finish with an evidence-dense report**
+7. **Finish with an evidence-dense report**
    - Changed files
    - Simplifications made
+   - Fallback findings, classifications, and escalation status
    - Tests/diagnostics/build checks run
    - Remaining risks
    - Residual follow-ups or consciously deferred cleanup
@@ -82,8 +96,10 @@ AI SLOP CLEANUP REPORT
 Scope: [files or feature area]
 Behavior Lock: [targeted regression tests added/run]
 Cleanup Plan: [bounded smells and order]
+Fallback Findings: [none, or finding -> masking fallback slop / grounded compatibility/fail-safe fallback -> escalation status]
 
 Passes Completed:
+- Fallback-like code resolution gate - [root-cause repair, explicit failure behavior, preserved grounded fallback, or ralplan handoff]
 1. Pass 1: Dead code deletion - [concise fix]
 2. Pass 2: Duplicate removal - [concise fix]
 3. Pass 3: Naming/error handling cleanup - [concise fix]
@@ -99,6 +115,11 @@ Quality Gates:
 Changed Files:
 - [path] - [simplification]
 
+Fallback Review:
+- Findings: [fallback-like findings detected]
+- Classification: [masking fallback slop | grounded fallback]
+- Escalation Status: [none | raised to leader/ralplan | no escalation]
+
 Remaining Risks:
 - [none or short deferred item]
 ```
@@ -112,3 +133,7 @@ Remaining Risks:
 **Bad:** Start rewriting architecture before protecting behavior with tests.
 
 **Bad:** Collapse multiple smell categories into one large refactor with no intermediate verification.
+
+**Bad:** Keep a `fallback if it fails` branch that silently defaults after a swallowed error instead of fixing the root cause or making failure explicit.
+
+**Good:** A version-specific compatibility shim is narrow, documented, preserves error evidence, has primary and fallback regression tests, and is reported as a grounded compatibility/fail-safe fallback.

--- a/src/hooks/__tests__/anti-slop-workflow.test.ts
+++ b/src/hooks/__tests__/anti-slop-workflow.test.ts
@@ -11,37 +11,113 @@ function read(path: string): string {
   return readFileSync(join(repoRoot, path), 'utf-8');
 }
 
+function assertMatchesAll(content: string, patterns: RegExp[]): void {
+  for (const pattern of patterns) {
+    assert.match(content, pattern);
+  }
+}
+
+function assertCanonicalPluginParity(path: string): void {
+  const pluginPath = `plugins/oh-my-codex/${path}`;
+  assert.ok(existsSync(join(repoRoot, pluginPath)), `${pluginPath} must exist in the plugin mirror`);
+  assert.equal(read(pluginPath), read(path), `${path} must match the plugin mirror exactly`);
+}
+
+const antiSlopWorkingAgreementPatterns = [
+  /^## Working agreements$/m,
+  /^- For cleanup\/refactor\/deslop work, write a cleanup plan and lock behavior with regression tests before editing when coverage is missing\.$/m,
+  /^- Prefer deletion, existing utilities, and existing patterns before new abstractions; add dependencies only when explicitly requested\.$/m,
+  /^- Keep diffs small, reviewable, and reversible\.$/m,
+  /^- Verify with lint, typecheck, tests, and static analysis after changes; final reports include changed files, simplifications, and remaining risks\.$/m,
+];
+
+const antiSlopWorkflowPatterns = [
+  /^Anti-slop workflow:$/m,
+  /^- Cleanup\/refactor\/deslop work still follows the same `\$deep-interview` -> `\$ralplan` -> `\$team`\/`\$ralph` path; use `\$ai-slop-cleaner` as a bounded helper inside the chosen execution lane, not as a competing top-level workflow\.$/m,
+  /^- Write a cleanup plan before modifying code; lock existing behavior with regression tests first, then make one smell-focused pass at a time\.$/m,
+  /^- Prefer deletion over addition, and prefer reuse plus boundary repair over new layers\.$/m,
+  /^- No new dependencies without explicit request\.$/m,
+  /^- Run lint, typecheck, tests, and static analysis before claiming completion\.$/m,
+  /^- Keep writer\/reviewer pass separation for cleanup plans and approvals; preserve writer\/reviewer pass separation explicitly\.$/m,
+];
+
+const aiSlopCleanerWorkflowPatterns = [
+  /^Reduce AI-generated slop with a regression-tests-first, smell-by-smell cleanup workflow that preserves behavior and raises signal quality\.$/m,
+  /^## Scoped File Lists and Ralph Workflow$/m,
+  /^- This skill can accept a \*\*file list scope\*\* instead of a whole feature area\.$/m,
+  /^- In the \*\*Ralph workflow\*\*, the mandatory deslop pass should run this skill on Ralph's changed files only, in standard mode unless the caller explicitly requests otherwise\.$/m,
+  /^1\. \*\*Lock behavior with regression tests first\*\*$/m,
+  /^   - For fallback-like code, cover the primary path and any preserved compatibility\/fail-safe fallback before cleanup$/m,
+  /^2\. \*\*Create a cleanup plan before code\*\*$/m,
+  /^   - Include fallback findings, classifications, and escalation status in the plan$/m,
+  /^3\. \*\*Inventory fallback-like code before editing\*\*$/m,
+  /^   - Search the requested scope for fallback-like detection signals: quick hacks?, temporary workaround, temporary fallback, just bypass, just skip, fallback if it fails, swallowed errors, silent defaults, broad compatibility shims, and duplicate alternate execution paths$/m,
+  /^   - Classify each finding before changing it:$/m,
+  /^     - \*\*Masking fallback slop\*\* — hides errors or evidence, bypasses the primary contract, suppresses tests or validation, swallows failures, silently defaults, or adds untested alternate paths$/m,
+  /^     - \*\*Grounded compatibility\/fail-safe fallback\*\* — is scoped to an external\/version\/fail-safe boundary, documents the rationale, preserves failure evidence, and has regression tests for both the primary and fallback behavior$/m,
+  /^   - Prefer root-cause repair, deletion, boundary repair, or explicit failure behavior before preserving fallback paths$/m,
+  /^   - For broad, ambiguous, cross-layer, or architectural fallback-like code, invoke `\$ralplan` for consensus resolution before edits$/m,
+  /^   - Recursion guard: when already inside ralplan, ralph, team, or another OMX workflow, do not spawn a nested `\$ralplan`; record the finding and attach it to the active ralplan, leader, or plan handoff instead$/m,
+  /^4\. \*\*Categorize issues before editing\*\*$/m,
+  /^   - \*\*Fallback-like code\*\* — masking fallbacks, workaround branches, bypasses, swallowed errors, silent defaults, broad shims, alternate execution paths$/m,
+  /^   - \*\*Duplication\*\* — repeated logic, copy-paste branches, redundant helpers$/m,
+  /^   - \*\*Dead code\*\* — unused code, unreachable branches, stale flags, debug leftovers$/m,
+  /^   - \*\*Needless abstraction\*\* — pass-through wrappers, speculative indirection, single-use helper layers$/m,
+  /^   - \*\*Boundary violations\*\* — hidden coupling, leaky responsibilities, wrong-layer imports or side effects$/m,
+  /^5\. \*\*Execute passes one smell at a time\*\*$/m,
+  /^   - \*\*Fallback-like code resolution gate\*\* — remove masking fallback slop, repair root causes, or escalate ambiguous cases before continuing$/m,
+  /^   - \*\*Pass 1: Dead code deletion\*\*$/m,
+  /^   - \*\*Pass 2: Duplicate removal\*\*$/m,
+  /^   - \*\*Pass 3: Naming\/error handling cleanup\*\*$/m,
+  /^   - \*\*Pass 4: Test reinforcement\*\*$/m,
+  /^6\. \*\*Run quality gates\*\*$/m,
+  /^   - Regression tests stay green$/m,
+  /^   - Static\/security scan passes when available$/m,
+  /^7\. \*\*Finish with an evidence-dense report\*\*$/m,
+  /^   - Changed files$/m,
+  /^   - Fallback findings, classifications, and escalation status$/m,
+  /^   - Remaining risks$/m,
+];
+
 describe('anti-slop workflow surfaces', () => {
-  it('adds anti-slop working agreements to tracked AGENTS surfaces', () => {
-    for (const file of ['AGENTS.md', 'templates/AGENTS.md'].filter((path) => existsSync(join(repoRoot, path)))) {
-      const content = read(file);
-      assert.match(content, /## Working agreements/);
-      assert.match(content, /Write a cleanup plan before modifying code/i);
-      assert.match(content, /Lock existing behavior with regression tests/i);
-      assert.match(content, /Prefer deletion over addition/i);
-      assert.match(content, /No new dependencies without explicit request/i);
-      assert.match(content, /Run lint, typecheck, tests, and static analysis/i);
-      assert.match(content, /\$ai-slop-cleaner/);
-      assert.match(content, /writer\/reviewer pass separation/i);
+  it('adds durable anti-slop guidance to AGENTS surfaces', () => {
+    const templateContent = read('templates/AGENTS.md');
+    assertMatchesAll(templateContent, antiSlopWorkingAgreementPatterns);
+    assertMatchesAll(templateContent, antiSlopWorkflowPatterns);
+
+    if (existsSync(join(repoRoot, 'AGENTS.md'))) {
+      const content = read('AGENTS.md');
+      if (/^## Working agreements$/m.test(content)) {
+        assertMatchesAll(content, antiSlopWorkingAgreementPatterns);
+      }
     }
   });
 
   it('documents reviewer-only separation in review and plan review mode', () => {
+    assertCanonicalPluginParity('skills/plan/SKILL.md');
+
     const reviewSkill = read('skills/review/SKILL.md');
     const planSkill = read('skills/plan/SKILL.md');
 
-    assert.match(reviewSkill, /reviewer-only pass/i);
-    assert.match(reviewSkill, /Never write and approve in the same context/i);
-    assert.match(reviewSkill, /cleanup\/refactor\/anti-slop/i);
+    assertMatchesAll(reviewSkill, [
+      /reviewer-only\s+pass/i,
+      /never\s+write\s+and\s+approve\s+in\s+the\s+same\s+context/i,
+      /cleanup\/refactor\/anti-slop/i,
+    ]);
 
-    assert.match(planSkill, /### Review Mode \(`--review`\)/);
-    assert.match(planSkill, /reviewer-only pass/i);
-    assert.match(planSkill, /MUST NOT be the context that approves it/i);
-    assert.match(planSkill, /cleanup plan, regression tests/i);
+    assertMatchesAll(planSkill, [
+      /### Review Mode \(`--review`\)/,
+      /reviewer-only\s+pass/i,
+      /MUST\s+NOT\s+be\s+the\s+context\s+that\s+approves\s+it/i,
+      /cleanup\s+plan,\s*regression\s+tests/i,
+    ]);
   });
 
   it('defines the built-in ai-slop-cleaner workflow', () => {
     const skill = read('skills/ai-slop-cleaner/SKILL.md');
+    const pluginSkill = read('plugins/oh-my-codex/skills/ai-slop-cleaner/SKILL.md');
+    assert.equal(pluginSkill, skill);
+    assertMatchesAll(skill, aiSlopCleanerWorkflowPatterns);
     assert.match(skill, /regression tests first/i);
     assert.match(skill, /cleanup plan/i);
     assert.match(skill, /duplication/i);
@@ -57,5 +133,27 @@ describe('anti-slop workflow surfaces', () => {
     assert.match(skill, /file list scope/i);
     assert.match(skill, /changed files/i);
     assert.match(skill, /Ralph workflow/i);
+    assert.match(skill, /fallback-like (?:inventory|detection|code)/i);
+    assert.match(skill, /quick hack/i);
+    assert.match(skill, /temporary workaround/i);
+    assert.match(skill, /temporary fallback/i);
+    assert.match(skill, /just bypass/i);
+    assert.match(skill, /fallback if it fails/i);
+    assert.match(skill, /swallowed errors/i);
+    assert.match(skill, /silent defaults/i);
+    assert.match(skill, /broad compatibility shims/i);
+    assert.match(skill, /alternate execution paths/i);
+    assert.match(skill, /Masking fallback slop/i);
+    assert.match(skill, /Grounded compatibility\/fail-safe fallback/i);
+    assert.match(skill, /root-cause repair/i);
+    assert.match(skill, /explicit failure behavior/i);
+    assert.match(skill, /\$ralplan/);
+    assert.match(skill, /consensus resolution/i);
+    assert.match(skill, /Recursion guard/i);
+    assert.match(skill, /do not spawn a nested `?\$ralplan`?/i);
+    assert.match(skill, /active ralplan/i);
+    assert.match(skill, /Fallback Findings/i);
+    assert.match(skill, /classifications/i);
+    assert.match(skill, /escalation status/i);
   });
 });


### PR DESCRIPTION
## Summary
- teach `ai-slop-cleaner` to inventory fallback-like code before cleanup
- classify masking fallback slop vs grounded compatibility/fail-safe fallbacks
- add ralplan escalation and no-nested-ralplan guardrails for ambiguous fallback cleanup
- lock canonical/plugin skill parity and fallback-aware workflow structure in regression tests

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/anti-slop-workflow.test.js`
- `npm run sync:plugin:check`
- `npm run verify:plugin-bundle`
- `git diff --check`

## Review
- Code-reviewer: APPROVE, 0 remaining issues
- Architect: CLEAR, no blockers
