### PR TITLE
Fix stale team-worker Stop task blocks

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4087,7 +4087,7 @@ esac
         team_state_root: join(cwd, ".omx", "state"),
       });
       await writeJson(join(workerDir, "status.json"), {
-        state: "idle",
+        state: "working",
         current_task_id: "1",
         updated_at: new Date().toISOString(),
       });
@@ -4131,6 +4131,72 @@ esac
     }
   });
 
+  it("does not block Stop as a team-worker task failure when worker status is already terminal", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-terminal-stale-"));
+    const prevTeamWorker = process.env.OMX_TEAM_WORKER;
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const prevLeaderCwd = process.env.OMX_TEAM_LEADER_CWD;
+    try {
+      await initTeamState(
+        "worker-stale-team",
+        "worker stale stop fallback",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-team-worker-stale" },
+      );
+      const stateDir = join(cwd, ".omx", "state");
+      const workerCwd = join(cwd, ".omx", "team", "worker-stale-team", "worktrees", "worker-1");
+      const workerDir = join(stateDir, "team", "worker-stale-team", "workers", "worker-1");
+      await mkdir(workerCwd, { recursive: true });
+      await writeJson(join(workerDir, "identity.json"), {
+        name: "worker-1",
+        index: 1,
+        role: "executor",
+        assigned_tasks: ["1"],
+        worktree_path: workerCwd,
+        team_state_root: stateDir,
+      });
+      await writeJson(join(workerDir, "status.json"), {
+        state: "done",
+        current_task_id: "1",
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(stateDir, "team", "worker-stale-team", "tasks", "task-1.json"), {
+        id: "1",
+        subject: "stale hook task",
+        description: "stale task should not trap terminal worker Stop",
+        status: "in_progress",
+        owner: "worker-1",
+        created_at: new Date().toISOString(),
+      });
+
+      process.env.OMX_TEAM_WORKER = "worker-stale-team/worker-1";
+      process.env.OMX_TEAM_STATE_ROOT = stateDir;
+      process.env.OMX_TEAM_LEADER_CWD = cwd;
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd: workerCwd,
+          session_id: "sess-stop-team-worker-stale",
+        },
+        { cwd: workerCwd },
+      );
+
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "team_team-exec");
+    } finally {
+      if (typeof prevTeamWorker === "string") process.env.OMX_TEAM_WORKER = prevTeamWorker;
+      else delete process.env.OMX_TEAM_WORKER;
+      if (typeof prevTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof prevLeaderCwd === "string") process.env.OMX_TEAM_LEADER_CWD = prevLeaderCwd;
+      else delete process.env.OMX_TEAM_LEADER_CWD;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("suppresses identical team worker Stop replays but re-blocks fresh turns and task state changes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-repeat-"));
     try {
@@ -4157,7 +4223,7 @@ esac
         team_state_root: stateDir,
       });
       await writeJson(join(workerDir, "status.json"), {
-        state: "idle",
+        state: "working",
         current_task_id: "1",
         updated_at: new Date().toISOString(),
       });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -110,6 +110,7 @@ export interface NativeHookDispatchResult {
 const TERMINAL_MODE_PHASES = new Set(["complete", "completed", "failed", "cancelled"]);
 const SKILL_STOP_BLOCKERS = new Set(["ralplan"]);
 const TEAM_TERMINAL_TASK_STATUSES = new Set(["completed", "failed"]);
+const TEAM_WORKER_STOP_ACTIVE_STATES = new Set(["working", "blocked"]);
 const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
 const STABLE_FINAL_RECOMMENDATION_PATTERNS = [
   /^\s*(?:launch|release|ship)-?ready\s*:\s*(?:yes|no)\b[^\n\r]*/im,
@@ -1206,6 +1207,9 @@ async function buildTeamWorkerStopOutput(
     readJsonIfExists(join(workerRoot, "identity.json")),
     readJsonIfExists(join(workerRoot, "status.json")),
   ]);
+
+  const workerState = safeString(status?.state).trim().toLowerCase();
+  if (!TEAM_WORKER_STOP_ACTIVE_STATES.has(workerState)) return null;
 
   const candidateTaskIds = new Set<string>();
   const currentTaskId = safeString(status?.current_task_id).trim();


### PR DESCRIPTION
## Summary
- gates team-worker Stop blocking on active worker states (`working` / `blocked`) instead of stale task assignment alone
- preserves Stop protection for workers actively working on non-terminal tasks
- adds regression coverage for terminal worker status with stale `current_task_id` / `assigned_tasks`

## Problem
Recent Stop-hook evidence showed `decision: "block"` responses repeatedly surfacing as failed Stop hooks when team workers retained stale assigned task ids. A worker could already be `done` / inactive while the task file still said `in_progress`, so the Stop hook kept treating stale assignment metadata as active work.

## Root cause
`buildTeamWorkerStopOutput(...)` built candidate task ids from `status.current_task_id` and `identity.assigned_tasks`, then blocked on any referenced non-terminal task. It did not first check whether the worker status itself was still active. That let stale worker/task synchronization produce an indefinite team-worker Stop block.

## What changed
- Added an explicit team-worker Stop active-state allowlist: `working`, `blocked`.
- `buildTeamWorkerStopOutput(...)` now returns no worker-specific Stop block when the worker status is terminal/inactive (`done`, `failed`, `draining`, `idle`, unknown/missing), even if stale task references remain.
- Updated existing active-task tests from `idle` to `working` so they continue proving real active work is blocked.
- Added a regression test for `state: "done"` + stale non-terminal task reference.

## Why this design
The Stop hook should block when the worker is actively accountable for non-terminal work, not when persisted assignment metadata is stale. Team-level Stop gating still remains available after worker-specific gating, so the leader/team lifecycle is not silently bypassed.

## Overlap assessment
**Follow-up.** PR #2061 addresses state-level Stop replay signature loops, and PR #1884 addressed identical team-worker Stop replay suppression. This PR covers the adjacent remaining stale worker-state synchronization case: stale assigned task ids should not create a worker-specific non-terminal-task Stop block once the worker status is terminal/inactive.

## Validation
- `npm run build`
- `node --test --test-name-pattern='team worker' dist/scripts/__tests__/codex-native-hook.test.js`
- `node --test --test-name-pattern='already terminal' dist/scripts/__tests__/codex-native-hook.test.js`
- `npx tsc --noEmit`
- `npm run check:no-unused`

## Risks / compatibility
- Active workers in `working` or `blocked` state still block on non-terminal tasks.
- Inactive/terminal worker Stop no longer emits the misleading worker-specific non-terminal-task block; active team-level Stop gating can still block if the team phase remains non-terminal.

## Changed files
- `src/scripts/codex-native-hook.ts`
- `src/scripts/__tests__/codex-native-hook.test.ts`

## Target-base diff classification
Bug fix with real implementation delta.
