### PR TITLE
Fix explore native hydration for installed packages

### DIFF
--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -513,10 +513,13 @@ describe('resolveExploreHarnessCommand', () => {
       await writeFile(join(wd, 'package.json'), '{}\n');
       await writeFile(join(crateDir, 'Cargo.toml'), '[package]\nname = "omx-explore-harness"\nversion = "0.0.0"\n');
 
-      const resolved = resolveExploreHarnessCommand(wd, {} as NodeJS.ProcessEnv);
+      const cacheDir = join(wd, 'native-cache');
+      const resolved = resolveExploreHarnessCommand(wd, { OMX_NATIVE_CACHE_DIR: cacheDir } as NodeJS.ProcessEnv);
       assert.equal(resolved.command, 'cargo');
       assert.ok(resolved.args.includes('--manifest-path'));
       assert.ok(resolved.args.includes(join(wd, 'crates', 'omx-explore', 'Cargo.toml')));
+      assert.ok(resolved.args.includes('--target-dir'));
+      assert.ok(resolved.args.includes(join(cacheDir, 'cargo-target', 'omx-explore-harness')));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -534,6 +537,10 @@ describe('resolveExploreHarnessCommand', () => {
         version: '0.8.15',
         repository: { url: 'git+https://github.com/Yeachan-Heo/oh-my-codex.git' },
       }));
+      // Published packages intentionally ship src/scripts for postinstall, but
+      // that must not make them look like writable source checkouts.
+      await mkdir(join(wd, 'src', 'scripts'), { recursive: true });
+      await writeFile(join(wd, 'src', 'scripts', 'postinstall-bootstrap.js'), '');
       await mkdir(join(wd, 'crates', 'omx-explore'), { recursive: true });
       await writeFile(join(wd, 'crates', 'omx-explore', 'Cargo.toml'), '[package]\nname=\"omx-explore-harness\"\nversion=\"0.8.15\"\n');
       const binaryPath = join(stagingDir, packagedExploreHarnessBinaryName());

--- a/src/cli/__tests__/native-assets.test.ts
+++ b/src/cli/__tests__/native-assets.test.ts
@@ -9,6 +9,7 @@ import { spawnSync } from 'node:child_process';
 import {
   hydrateNativeBinary,
   inferNativeAssetLibc,
+  isRepositoryCheckout,
   resolveCachedNativeBinaryCandidatePaths,
   resolveCachedNativeBinaryPath,
   type NativeReleaseManifest,
@@ -41,6 +42,33 @@ async function startStaticServer(root: string): Promise<{ baseUrl: string; close
 function sha256(buffer: Buffer): string {
   return createHash('sha256').update(buffer).digest('hex');
 }
+
+describe('repository checkout detection', () => {
+  it('does not treat an installed npm package that ships src/scripts as a source checkout', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-native-installed-'));
+    try {
+      const packageRoot = join(wd, 'node_modules', 'oh-my-codex');
+      await mkdir(join(packageRoot, 'src', 'scripts'), { recursive: true });
+      await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ name: 'oh-my-codex' }));
+
+      assert.equal(isRepositoryCheckout(packageRoot), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('recognizes a git working tree as a source checkout', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-native-checkout-'));
+    try {
+      await mkdir(join(wd, '.git'), { recursive: true });
+      await mkdir(join(wd, 'src'), { recursive: true });
+
+      assert.equal(isRepositoryCheckout(wd), true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('native asset helpers', () => {
   it('infers Linux libc variants from manifest metadata', () => {

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -23,6 +23,7 @@ import {
   isRepositoryCheckout,
   resolveCachedNativeBinaryCandidatePaths,
   getPackageVersion,
+  resolveNativeCacheRoot,
 } from './native-assets.js';
 import { getWikiDir, queryWiki } from '../wiki/index.js';
 import { resolveCodexHomeForLaunch } from './codex-home.js';
@@ -368,7 +369,15 @@ export function resolveExploreHarnessCommand(
 
   return {
     command: 'cargo',
-    args: ['run', '--quiet', '--manifest-path', manifestPath, '--'],
+    args: [
+      'run',
+      '--quiet',
+      '--target-dir',
+      join(resolveNativeCacheRoot(env), 'cargo-target', 'omx-explore-harness'),
+      '--manifest-path',
+      manifestPath,
+      '--',
+    ],
   };
 }
 

--- a/src/cli/native-assets.ts
+++ b/src/cli/native-assets.ts
@@ -226,7 +226,7 @@ export function resolveNativeReleaseAssetCandidates(
 }
 
 export function isRepositoryCheckout(packageRoot = getPackageRoot()): boolean {
-  return existsSync(join(packageRoot, '.git')) || existsSync(join(packageRoot, 'src'));
+  return existsSync(join(packageRoot, '.git'));
 }
 
 export async function loadNativeReleaseManifest(


### PR DESCRIPTION
## Summary
- tighten `isRepositoryCheckout` so packaged `src/scripts` no longer marks npm installs as source checkouts
- keep explore hydration active for installed packages that ship `src/scripts`
- send cargo fallback build output to the writable OMX native cache target dir

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/native-assets.test.js dist/cli/__tests__/explore.test.js`
- `npm run test:explore`

Fixes #2066

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
