### PR TITLE
Detect detached tmux attach no-ops on WSL

### DIFF
--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -607,6 +607,73 @@ exit 0
     }
   });
 
+  it('rolls back with guidance when WSL Windows Terminal attach exits without attaching', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-attach-noop-'));
+    try {
+      const { env, tmuxLogPath } = await createLaunchFixture(
+        wd,
+        (tmuxLogPath) => `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V|list-sessions)
+    exit 0
+    ;;
+  new-session)
+    printf 'leader-pane\n'
+    exit 0
+    ;;
+  split-window)
+    printf 'hud-pane\n'
+    exit 0
+    ;;
+  display-message)
+    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\n'
+    else
+      printf '0\n'
+    fi
+    exit 0
+    ;;
+  show-options)
+    printf 'off\n'
+    exit 0
+    ;;
+  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane|select-pane)
+    exit 0
+    ;;
+esac
+exit 0
+`,
+      );
+
+      const result = runOmx(
+        wd,
+        ['--madmax', '--tmux'],
+        {
+          ...env,
+          TMUX: '',
+          TMUX_PANE: '',
+          WSL_DISTRO_NAME: 'Ubuntu',
+          WSL_INTEROP: '/run/WSL/1_interop',
+          WT_SESSION: 'windows-terminal-session',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
+      assert.match(result.stderr, /attach-session returned immediately without attaching a client/i);
+      assert.match(result.stderr, /Falling back to direct Codex launch/i);
+      assert.match(tmuxLog, /tmux:attach-session -t /);
+      assert.match(tmuxLog, /tmux:display-message -p -t .* #\{session_attached\}/);
+      assert.match(tmuxLog, /tmux:kill-session -t /);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves the requested cwd through detached tmux launch when an unsupported SHELL value falls back away from rc-driven cwd drift', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-cwd-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -754,6 +754,55 @@ function warnDetachedTmuxFallback(reason?: string): void {
   );
 }
 
+const QUICK_ATTACH_NOOP_THRESHOLD_MS = 2_000;
+
+function isWslWindowsTerminalEnvironment(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    env.WT_SESSION?.trim() &&
+      (env.WSL_INTEROP?.trim() ||
+        env.WSL_DISTRO_NAME?.trim() ||
+        env.WSLENV?.trim()),
+  );
+}
+
+function readDetachedSessionAttachedClientCount(sessionName: string): number | null {
+  try {
+    const output = execTmuxFileSync(
+      ["display-message", "-p", "-t", sessionName, "#{session_attached}"],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf-8",
+      },
+    ).trim();
+    const parsed = Number.parseInt(output, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch (err) {
+    logCliOperationFailure(err);
+    return null;
+  }
+}
+
+function assertDetachedAttachDidNotNoop(
+  sessionName: string,
+  elapsedMs: number,
+  env: NodeJS.ProcessEnv,
+): void {
+  if (!isWslWindowsTerminalEnvironment(env)) return;
+  if (elapsedMs >= QUICK_ATTACH_NOOP_THRESHOLD_MS) return;
+
+  const attachedClients = readDetachedSessionAttachedClientCount(sessionName);
+  if (attachedClients === null || attachedClients > 0) return;
+
+  throw new Error(
+    [
+      "tmux attach-session returned immediately without attaching a client",
+      `(session=${sessionName}).`,
+      "This can happen on WSL2 under Windows Terminal.",
+      "Falling back to direct Codex launch.",
+    ].join(" "),
+  );
+}
+
 function resolveTmuxAwareLaunchPolicy(
   explicitLaunchPolicy: CodexLaunchPolicy | undefined,
   nativeWindows: boolean,
@@ -3138,7 +3187,15 @@ function runCodex(
             const stdio =
               finalizeStep.name === "attach-session" ? "inherit" : "ignore";
             try {
+              const startedAtMs = Date.now();
               execTmuxFileSync(finalizeStep.args, { stdio });
+              if (finalizeStep.name === "attach-session") {
+                assertDetachedAttachDidNotNoop(
+                  sessionName,
+                  Date.now() - startedAtMs,
+                  process.env,
+                );
+              }
             } catch (err) {
               logCliOperationFailure(err);
               if (finalizeStep.name === "attach-session")


### PR DESCRIPTION
## Summary
- detect WSL2 + Windows Terminal detached `tmux attach-session` calls that return quickly without attaching any clients
- report the no-op instead of silently returning to the shell
- roll back the failed detached bootstrap and fall back to direct Codex launch

Fixes #2067.

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js`
- `npm run check:no-unused`
- `npm run lint`
