### PR TITLE
[codex] Accept official Git marketplace in doctor

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -224,6 +224,53 @@ command = "node"
 		}
 	});
 
+	it("accepts official Git-backed plugin marketplace registration", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-git-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				JSON.stringify({ scope: "user", installMode: "plugin" }, null, 2) +
+					"\n",
+			);
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"codex_hooks = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "git"',
+					'source = "https://github.com/Yeachan-Heo/oh-my-codex.git"',
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(res.stdout, /Resolved setup install mode: plugin/);
+			assert.match(
+				res.stdout,
+				/Skills: plugin marketplace oh-my-codex-local registered from official Git source; OMX skills are supplied by/,
+			);
+			assert.doesNotMatch(
+				res.stdout,
+				/Codex marketplace oh-my-codex-local has source_type=git \(expected local\)/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("warns about retired omx_team_run config left behind after upgrade", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-copy-"));
 		try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -49,6 +49,8 @@ import {
 	resolvePackagedOmxMarketplace,
 } from "./plugin-marketplace.js";
 
+const OFFICIAL_OMX_GIT_SOURCE = "https://github.com/Yeachan-Heo/oh-my-codex";
+
 interface DoctorOptions {
 	verbose?: boolean;
 	force?: boolean;
@@ -1065,6 +1067,29 @@ function getParsedMarketplaceRegistration(
 	return parsed.marketplaces?.[OMX_LOCAL_MARKETPLACE_NAME] ?? null;
 }
 
+function normalizeMarketplaceGitSource(source: unknown): string | null {
+	if (typeof source !== "string") return null;
+	let normalized = source.trim();
+	if (normalized.startsWith("git+")) {
+		normalized = normalized.slice(4);
+	}
+	if (normalized.endsWith(".git")) {
+		normalized = normalized.slice(0, -4);
+	}
+	return normalized.replace(/\/+$/, "").toLowerCase();
+}
+
+function isOfficialGitMarketplaceRegistration(registration: {
+	source_type?: unknown;
+	source?: unknown;
+}): boolean {
+	return (
+		registration.source_type === "git" &&
+		normalizeMarketplaceGitSource(registration.source) ===
+			OFFICIAL_OMX_GIT_SOURCE.toLowerCase()
+	);
+}
+
 async function checkPluginMarketplaceRegistration(
 	configPath: string,
 ): Promise<Check> {
@@ -1097,11 +1122,18 @@ async function checkPluginMarketplaceRegistration(
 				message: `plugin mode selected, but Codex marketplace ${OMX_LOCAL_MARKETPLACE_NAME} is not registered; run "omx setup --plugin --force"`,
 			};
 		}
+		if (isOfficialGitMarketplaceRegistration(registration)) {
+			return {
+				name: "Skills",
+				status: "pass",
+				message: `plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} registered from official Git source; OMX skills are supplied by ${packagedMarketplace.pluginRoot}`,
+			};
+		}
 		if (registration.source_type !== "local") {
 			return {
 				name: "Skills",
 				status: "warn",
-				message: `Codex marketplace ${OMX_LOCAL_MARKETPLACE_NAME} has source_type=${String(registration.source_type)} (expected local); run "omx setup --plugin --force"`,
+				message: `Codex marketplace ${OMX_LOCAL_MARKETPLACE_NAME} has source_type=${String(registration.source_type)} (expected local or official Git source); run "omx setup --plugin --force"`,
 			};
 		}
 		if (registration.source !== getPackageRoot()) {


### PR DESCRIPTION
## Summary

- Accept the official Git-backed `oh-my-codex-local` marketplace as a valid plugin-mode registration in `omx doctor`.
- Keep the existing packaged local marketplace registration path valid.
- Add regression coverage so Git-backed managed plugin setups do not get told to run `omx setup --plugin --force`.

## Why

A managed Codex plugin install can intentionally register `oh-my-codex-local` with `source_type = "git"` and `source = "https://github.com/Yeachan-Heo/oh-my-codex.git"`. The old doctor check treated anything except `source_type = "local"` as drift and recommended `omx setup --plugin --force`, which would push users back toward local/package-owned registration and away from GitHub-managed plugin updates.

## Validation

- `npm run build && node --test dist/cli/__tests__/doctor-warning-copy.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- `node /Users/albert/.codex/.tmp/marketplaces/oh-my-codex-local/dist/cli/omx.js doctor` from a Git-backed plugin-mode setup: `14 passed, 0 warnings`
- Clean full compiled CI with isolated local config: `env XDG_CONFIG_HOME=<tmp> CODEX_HOME=<tmp> npm run test:ci:compiled` -> `4439 passed, 0 failed`

## Notes

This does not patch the installed global package. The installed `omx` command will stop warning only after this lands upstream and a normal package/update flow installs the released fix.