### PR TITLE
fix(ralplan): clarify handoff continuation status

### DIFF
--- a/src/ralplan/__tests__/runtime.test.ts
+++ b/src/ralplan/__tests__/runtime.test.ts
@@ -67,6 +67,7 @@ describe('ralplan runtime', () => {
       assert.equal(finalState?.current_phase, 'complete');
       assert.equal(finalState?.iteration, 1);
       assert.equal(finalState?.planning_complete, true);
+      assert.match(String(finalState?.status_message || ''), /Status: complete/);
       assert.equal(finalState?.latest_architect_verdict, 'approve');
       assert.equal(finalState?.latest_critic_verdict, 'approve');
       assert.equal(Array.isArray(finalState?.review_history), true);
@@ -153,6 +154,7 @@ describe('ralplan runtime', () => {
       const finalState = await readModeState('ralplan', cwd);
       assert.equal(finalState?.active, false);
       assert.equal(finalState?.current_phase, 'failed');
+      assert.match(String(finalState?.status_message || ''), /Status: failed/);
       assert.match(String(finalState?.error || ''), /architect blew up/);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/ralplan/runtime.ts
+++ b/src/ralplan/runtime.ts
@@ -78,6 +78,7 @@ interface RalplanModeUpdates {
   latest_architect_summary?: string;
   latest_critic_verdict?: RalplanReviewVerdict;
   latest_critic_summary?: string;
+  status_message?: string;
   review_history?: Array<Record<string, unknown>>;
   [key: string]: unknown;
 }
@@ -197,6 +198,9 @@ export async function runRalplanConsensus(
           completed_at: new Date().toISOString(),
           planning_complete: planningComplete,
           latest_plan_path: latestPlanPath,
+          status_message: planningComplete
+            ? 'Status: complete — ralplan consensus approved and planning artifacts are ready for handoff.'
+            : 'Status: paused_for_review — ralplan consensus approved, but expected planning artifacts are missing; continue from the current artifact and emit the final handoff once artifacts are written.',
           review_history: reviewHistory,
         });
         return {
@@ -224,6 +228,7 @@ export async function runRalplanConsensus(
           latest_critic_verdict: criticReview.verdict,
           latest_critic_summary: criticReview.summary,
           review_history: reviewHistory,
+          status_message: `Status: paused_for_review — ralplan reached the ${maxIterations}-iteration review limit without approval; continue from the best current artifact or ask the user how to proceed.`,
           error,
         });
         return {
@@ -252,6 +257,7 @@ export async function runRalplanConsensus(
       planning_complete: false,
       latest_plan_path: latestPlanPath,
       review_history: buildReviewHistory(drafts, architectReviews, criticReviews),
+      status_message: 'Status: failed — ralplan encountered an error and cannot continue without inspecting the failure.',
       error: message,
     });
     return {
@@ -275,6 +281,7 @@ export async function runRalplanConsensus(
     current_phase: 'failed',
     completed_at: new Date().toISOString(),
     planning_complete: false,
+    status_message: 'Status: failed — ralplan reached an unexpected runtime state.',
     error: unreachableError,
   });
   return {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5264,13 +5264,12 @@ exit 0
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.deepEqual(result.outputJson, {
-        decision: "block",
-        reason:
-          "OMX skill ralplan is still active (phase: planning); continue until the current ralplan workflow reaches a terminal state.",
-        stopReason: "skill_ralplan_planning",
-        systemMessage: "OMX skill ralplan is still active (phase: planning).",
-      });
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Status: continue_from_artifact/);
+      assert.match(String(result.outputJson?.reason ?? ""), /ralplan is still active \(phase: planning\)/);
+      assert.match(String(result.outputJson?.reason ?? ""), /continue from the current ralplan artifact/i);
+      assert.equal(result.outputJson?.stopReason, "skill_ralplan_planning_continue_artifact");
+      assert.match(String(result.outputJson?.systemMessage ?? ""), /complete, paused for review, waiting for input, or still continuing/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -5405,7 +5404,7 @@ exit 0
     }
   });
 
-  it("does not block on active ralplan skill when subagents are still active", async () => {
+  it("returns an explicit ralplan waiting status while subagents are still active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-skill-subagent-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -5457,7 +5456,11 @@ exit 0
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.equal(result.outputJson, null);
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Status: waiting/);
+      assert.match(String(result.outputJson?.reason ?? ""), /waiting for 1 active native subagent thread/);
+      assert.match(String(result.outputJson?.reason ?? ""), /then continue from the current ralplan artifact/i);
+      assert.equal(result.outputJson?.stopReason, "skill_ralplan_planning_waiting_subagent");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -7674,13 +7677,10 @@ exit 0
       );
 
       assert.equal(repeated.omxEventName, "stop");
-      assert.deepEqual(repeated.outputJson, {
-        decision: "block",
-        reason:
-          "OMX skill ralplan is still active (phase: planning); continue until the current ralplan workflow reaches a terminal state.",
-        stopReason: "skill_ralplan_planning",
-        systemMessage: "OMX skill ralplan is still active (phase: planning).",
-      });
+      assert.equal(repeated.outputJson?.decision, "block");
+      assert.match(String(repeated.outputJson?.reason ?? ""), /Status: continue_from_artifact/);
+      assert.match(String(repeated.outputJson?.reason ?? ""), /continue from the current ralplan artifact/i);
+      assert.equal(repeated.outputJson?.stopReason, "skill_ralplan_planning_continue_artifact");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1678,7 +1678,7 @@ async function readBlockingSkillForStop(
   sessionId: string,
   threadId: string,
   requiredSkill?: string,
-): Promise<{ skill: string; phase: string } | null> {
+): Promise<{ skill: string; phase: string; latestPlanPath?: string; planningComplete?: boolean; runOutcome?: string } | null> {
   const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
   const visibleEntries = canonicalState ? listActiveSkills(canonicalState) : [];
   const candidateSkills = requiredSkill
@@ -1708,7 +1708,13 @@ async function readBlockingSkillForStop(
     }
 
     if (!canonicalState) {
-      return { skill, phase };
+      return {
+        skill,
+        phase,
+        latestPlanPath: safeString(modeState.latest_plan_path ?? modeState.latestPlanPath).trim() || undefined,
+        planningComplete: modeState.planning_complete === true || modeState.planningComplete === true,
+        runOutcome: safeString(modeState.run_outcome ?? modeState.outcome).trim() || undefined,
+      };
     }
 
     const blocker = visibleEntries.find((entry) => (
@@ -1720,10 +1726,63 @@ async function readBlockingSkillForStop(
     return {
       skill,
       phase: formatPhase(modeState.current_phase ?? blocker.phase ?? canonicalState.phase, "planning"),
+      latestPlanPath: safeString(modeState.latest_plan_path ?? modeState.latestPlanPath).trim() || undefined,
+      planningComplete: modeState.planning_complete === true || modeState.planningComplete === true,
+      runOutcome: safeString(modeState.run_outcome ?? modeState.outcome).trim() || undefined,
     };
   }
 
   return null;
+}
+
+function buildRalplanContinuationStatus(
+  blocker: { phase: string; latestPlanPath?: string; planningComplete?: boolean; runOutcome?: string },
+  activeSubagentCount: number,
+): { reason: string; systemMessage: string; stopReasonSuffix: string } {
+  const phase = blocker.phase || "planning";
+  const artifact = blocker.latestPlanPath
+    ? ` Artifact: ${blocker.latestPlanPath}.`
+    : " Artifact: use the latest `.omx/plans/` ralplan artifact if present.";
+
+  if (activeSubagentCount > 0) {
+    return {
+      reason:
+        `Status: waiting — ralplan is waiting for ${activeSubagentCount} active native subagent thread(s) to finish (phase: ${phase}). Do not stop silently; wait for the subagent result, then continue from the current ralplan artifact and proceed to the next planning/review step.${artifact}`,
+      stopReasonSuffix: "waiting_subagent",
+      systemMessage:
+        `OMX ralplan status: waiting for ${activeSubagentCount} active native subagent thread(s) at phase ${phase}; after they finish, continue from the current ralplan artifact and state the next status explicitly.`,
+    };
+  }
+
+  const normalizedPhase = phase.toLowerCase();
+  const normalizedOutcome = (blocker.runOutcome ?? "").toLowerCase();
+  const waitingForInput =
+    normalizedOutcome === "blocked_on_user"
+    || normalizedPhase.includes("blocked")
+    || normalizedPhase.includes("input")
+    || normalizedPhase.includes("question");
+
+  if (waitingForInput) {
+    return {
+      reason:
+        `Status: waiting_for_input — ralplan is paused for required user/operator input (phase: ${phase}). Ask the missing question or present the review choice explicitly before stopping.${artifact}`,
+      stopReasonSuffix: "waiting_input",
+      systemMessage:
+        `OMX ralplan status: waiting for input at phase ${phase}; ask the required question or present the explicit review choice before stopping.`,
+    };
+  }
+
+  const completeHint = blocker.planningComplete
+    ? " The planning artifacts are present; if consensus is approved, emit the final complete/approved handoff instead of stopping here."
+    : "";
+
+  return {
+    reason:
+      `Status: continue_from_artifact — ralplan is still active (phase: ${phase}) and has not emitted a terminal complete/paused/waiting status. Continue from the current ralplan artifact, resolve any review ambiguity conservatively or ask the user if needed, and proceed to the next planning/review step before stopping.${artifact}${completeHint}`,
+    stopReasonSuffix: "continue_artifact",
+    systemMessage:
+      `OMX ralplan status: continue_from_artifact at phase ${phase}; continue from the current ralplan artifact and finish by stating whether ralplan is complete, paused for review, waiting for input, or still continuing.`,
+  };
 }
 
 async function readStopAutoNudgePhase(
@@ -2048,7 +2107,19 @@ async function buildSkillStopOutput(
   if (!blocker) return null;
 
   const subagentSummary = await readSubagentSessionSummary(cwd, sessionId).catch(() => null);
-  if (subagentSummary && subagentSummary.activeSubagentThreadIds.length > 0) {
+  const activeSubagentCount = subagentSummary?.activeSubagentThreadIds.length ?? 0;
+
+  if (blocker.skill === "ralplan") {
+    const status = buildRalplanContinuationStatus(blocker, activeSubagentCount);
+    return {
+      decision: "block",
+      reason: status.reason,
+      stopReason: `skill_${blocker.skill}_${blocker.phase}_${status.stopReasonSuffix}`,
+      systemMessage: status.systemMessage,
+    };
+  }
+
+  if (activeSubagentCount > 0) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- add explicit ralplan Stop-hook statuses for waiting subagent handoffs, waiting for input, and continue-from-artifact states
- persist terminal ralplan runtime status messages for complete, paused-for-review, and failed outcomes
- update regression coverage for ralplan handoff/status behavior

Closes #2075

## Verification
- npm run build
- node --test dist/ralplan/__tests__/runtime.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npm run lint -- src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts src/ralplan/runtime.ts src/ralplan/__tests__/runtime.test.ts
- npm run check:no-unused