### PR TITLE
Fix MCP duplicate sibling cleanup leak

### DIFF
--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -164,17 +164,10 @@ describe('findCleanupCandidates', () => {
         reason: 'duplicate-sibling',
       },
     ]);
-    assert.deepEqual(findLaunchSafeCleanupCandidates(reusedParentProcesses, 701), [
-      {
-        pid: 710,
-        ppid: 700,
-        command: 'node /repo/oh-my-codex/dist/mcp/state-server.js',
-        reason: 'duplicate-sibling',
-      },
-    ]);
+    assert.deepEqual(findLaunchSafeCleanupCandidates(reusedParentProcesses, 701), []);
   });
 
-  it('keeps non-duplicate live-session MCPs protected while allowing duplicate siblings', () => {
+  it('keeps live-session MCPs protected, including duplicate siblings', () => {
     const processes: ProcessEntry[] = [
       { pid: 700, ppid: 500, command: 'codex app-server' },
       { pid: 701, ppid: 700, command: 'node /repo/bin/omx.js cleanup --dry-run' },
@@ -185,14 +178,35 @@ describe('findCleanupCandidates', () => {
       { pid: 901, ppid: 900, command: 'node /repo/dist/mcp/trace-server.js' },
     ];
 
-    assert.deepEqual(findLaunchSafeCleanupCandidates(processes, 701), [
+    assert.deepEqual(findLaunchSafeCleanupCandidates(processes, 701), []);
+  });
+
+  it('preserves same-parent first-party MCP siblings under live Codex and OMX ancestors during launch-safe cleanup', () => {
+    const processes: ProcessEntry[] = [
+      { pid: 100, ppid: 1, command: 'codex app-server' },
+      { pid: 110, ppid: 100, command: 'node /repo/bin/omx.js launch' },
+      { pid: 111, ppid: 110, command: 'node /repo/bin/omx.js cleanup --launch-safe' },
+      { pid: 120, ppid: 100, command: 'node /repo/dist/mcp/state-server.js' },
+      { pid: 121, ppid: 100, command: 'node /repo/dist/mcp/state-server.js' },
+      { pid: 130, ppid: 110, command: 'node /repo/dist/mcp/memory-server.js' },
+      { pid: 131, ppid: 110, command: 'node /repo/dist/mcp/memory-server.js' },
+    ];
+
+    assert.deepEqual(findCleanupCandidates(processes, 111), [
       {
-        pid: 710,
-        ppid: 700,
+        pid: 120,
+        ppid: 100,
         command: 'node /repo/dist/mcp/state-server.js',
         reason: 'duplicate-sibling',
       },
+      {
+        pid: 130,
+        ppid: 110,
+        command: 'node /repo/dist/mcp/memory-server.js',
+        reason: 'duplicate-sibling',
+      },
     ]);
+    assert.deepEqual(findLaunchSafeCleanupCandidates(processes, 111), []);
   });
 
   it('keeps detached MCP candidates whose ancestor chain is live but unrelated to Codex or OMX launchers', () => {

--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -4,7 +4,9 @@ import {
   cleanupCommand,
   cleanupOmxMcpProcesses,
   cleanupStaleTmpDirectories,
+  extractOmxMcpEntrypoint,
   findCleanupCandidates,
+  findDuplicateSiblingCleanupCandidates,
   findLaunchSafeCleanupCandidates,
   isOmxMcpProcess,
   listOmxProcesses,
@@ -61,6 +63,18 @@ describe('findCleanupCandidates', () => {
     assert.equal(isOmxMcpProcess('node /tmp/worktree/dist/mcp/team-server.js'), false);
   });
 
+  it('extracts first-party MCP entrypoints for duplicate grouping', () => {
+    assert.equal(
+      extractOmxMcpEntrypoint('node /repo/oh-my-codex/dist/mcp/state-server.js'),
+      'state-server.js',
+    );
+    assert.equal(
+      extractOmxMcpEntrypoint('node C:\\repo\\oh-my-codex\\dist\\mcp\\code-intel-server.cjs'),
+      'code-intel-server.cjs',
+    );
+    assert.equal(extractOmxMcpEntrypoint('node /tmp/worktree/dist/mcp/team-server.js'), null);
+  });
+
   it('selects orphaned OMX MCP processes while preserving the current session tree', () => {
     assert.deepEqual(
       findCleanupCandidates(CURRENT_SESSION_PROCESSES, 701),
@@ -111,6 +125,74 @@ describe('findCleanupCandidates', () => {
         },
       ],
     );
+  });
+
+  it('selects older duplicate siblings under a reused current Codex parent', () => {
+    const reusedParentProcesses: ProcessEntry[] = [
+      { pid: 700, ppid: 500, command: 'codex app-server' },
+      { pid: 701, ppid: 700, command: 'node /repo/bin/omx.js cleanup --dry-run' },
+      {
+        pid: 710,
+        ppid: 700,
+        command: 'node /repo/oh-my-codex/dist/mcp/state-server.js',
+      },
+      {
+        pid: 730,
+        ppid: 700,
+        command: 'node /repo/oh-my-codex/dist/mcp/state-server.js',
+      },
+      {
+        pid: 740,
+        ppid: 700,
+        command: 'node /repo/oh-my-codex/dist/mcp/memory-server.js',
+      },
+    ];
+
+    assert.deepEqual(findDuplicateSiblingCleanupCandidates(reusedParentProcesses), [
+      {
+        pid: 710,
+        ppid: 700,
+        command: 'node /repo/oh-my-codex/dist/mcp/state-server.js',
+        reason: 'duplicate-sibling',
+      },
+    ]);
+    assert.deepEqual(findCleanupCandidates(reusedParentProcesses, 701), [
+      {
+        pid: 710,
+        ppid: 700,
+        command: 'node /repo/oh-my-codex/dist/mcp/state-server.js',
+        reason: 'duplicate-sibling',
+      },
+    ]);
+    assert.deepEqual(findLaunchSafeCleanupCandidates(reusedParentProcesses, 701), [
+      {
+        pid: 710,
+        ppid: 700,
+        command: 'node /repo/oh-my-codex/dist/mcp/state-server.js',
+        reason: 'duplicate-sibling',
+      },
+    ]);
+  });
+
+  it('keeps non-duplicate live-session MCPs protected while allowing duplicate siblings', () => {
+    const processes: ProcessEntry[] = [
+      { pid: 700, ppid: 500, command: 'codex app-server' },
+      { pid: 701, ppid: 700, command: 'node /repo/bin/omx.js cleanup --dry-run' },
+      { pid: 710, ppid: 700, command: 'node /repo/dist/mcp/state-server.js' },
+      { pid: 711, ppid: 700, command: 'node /repo/dist/mcp/state-server.js' },
+      { pid: 720, ppid: 700, command: 'node /repo/dist/mcp/wiki-server.js' },
+      { pid: 900, ppid: 800, command: 'codex --model gpt-5' },
+      { pid: 901, ppid: 900, command: 'node /repo/dist/mcp/trace-server.js' },
+    ];
+
+    assert.deepEqual(findLaunchSafeCleanupCandidates(processes, 701), [
+      {
+        pid: 710,
+        ppid: 700,
+        command: 'node /repo/dist/mcp/state-server.js',
+        reason: 'duplicate-sibling',
+      },
+    ]);
   });
 
   it('keeps detached MCP candidates whose ancestor chain is live but unrelated to Codex or OMX launchers', () => {

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -339,8 +339,13 @@ export function findLaunchSafeCleanupCandidates(
   );
 
   return findCleanupCandidates(processes, currentPid).filter((candidate) => {
-    if (candidate.reason === 'duplicate-sibling') return true;
     if (candidate.ppid <= 1) return true;
+
+    // Launch-safe cleanup runs automatically before starting Codex/OMX work.
+    // Preserve every MCP process still attached to a live Codex or OMX launch
+    // ancestor, including older same-parent duplicate siblings. Destructive
+    // duplicate-sibling reaping remains available through manual cleanup via
+    // findCleanupCandidates/default cleanupOmxMcpProcesses selection.
     return (
       !hasAncestorMatching(processByPid, candidate.pid, isCodexSessionProcess) &&
       !hasAncestorMatching(processByPid, candidate.pid, isOmxLaunchProcess)

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -17,6 +17,7 @@ const PROCESS_EXIT_POLL_MS = 100;
 const SIGTERM_GRACE_MS = 5_000;
 const STALE_TMP_MAX_AGE_MS = 60 * 60 * 1000;
 const OMX_MCP_SERVER_PATTERN = /(?:^|[\\/])dist[\\/]mcp[\\/](?:state|memory|code-intel|trace|wiki)-server\.(?:[cm]?js|ts)\b/i;
+const OMX_MCP_ENTRYPOINT_PATTERN = /(?:^|[\\/])dist[\\/]mcp[\\/]((?:state|memory|code-intel|trace|wiki)-server\.(?:[cm]?js|ts))\b/i;
 const CODEX_PROCESS_PATTERN = /(?:^|[\\/\s])codex(?:\.js)?(?:\s|$)|@openai[\\/]codex/i;
 const OMX_LAUNCH_PROCESS_PATTERN = /(?:^|[\\/\s])omx(?:\.js)?(?:\s|$)|(?:^|[\\/])(?:bin|dist[\\/]cli)[\\/]omx\.js(?:\s|$)|oh-my-codex[\\/]dist[\\/]cli[\\/]omx\.js/i;
 const OMX_TMP_DIRECTORY_PATTERN = /^(omc|omx|oh-my-codex)-/;
@@ -38,7 +39,7 @@ export interface ProcessEntry {
 }
 
 export interface CleanupCandidate extends ProcessEntry {
-  reason: 'ppid=1' | 'outside-current-session';
+  reason: 'ppid=1' | 'outside-current-session' | 'duplicate-sibling';
 }
 
 export interface CleanupResult {
@@ -102,6 +103,11 @@ function formatPlural(count: number, singular: string, plural = `${singular}s`):
 export function isOmxMcpProcess(command: string): boolean {
   const normalized = normalizeCommand(command);
   return OMX_MCP_SERVER_PATTERN.test(normalized);
+}
+
+export function extractOmxMcpEntrypoint(command: string): string | null {
+  const normalized = normalizeCommand(command);
+  return normalized.match(OMX_MCP_ENTRYPOINT_PATTERN)?.[1]?.toLowerCase() ?? null;
 }
 
 export function parsePsOutput(output: string): ProcessEntry[] {
@@ -272,21 +278,56 @@ export function buildProtectedPidSet(
   return protectedPids;
 }
 
+export function findDuplicateSiblingCleanupCandidates(
+  processes: readonly ProcessEntry[],
+): CleanupCandidate[] {
+  const groups = new Map<string, ProcessEntry[]>();
+
+  for (const processEntry of processes) {
+    const entrypoint = extractOmxMcpEntrypoint(processEntry.command);
+    if (!entrypoint) continue;
+    const key = `${processEntry.ppid}:${entrypoint}`;
+    const group = groups.get(key) ?? [];
+    group.push(processEntry);
+    groups.set(key, group);
+  }
+
+  const candidates: CleanupCandidate[] = [];
+  for (const group of groups.values()) {
+    if (group.length <= 1) continue;
+    const sorted = [...group].sort((left, right) => left.pid - right.pid);
+    for (const processEntry of sorted.slice(0, -1)) {
+      candidates.push({
+        ...processEntry,
+        reason: 'duplicate-sibling',
+      });
+    }
+  }
+
+  return candidates.sort((left, right) => left.pid - right.pid);
+}
+
 export function findCleanupCandidates(
   processes: readonly ProcessEntry[],
   currentPid: number,
 ): CleanupCandidate[] {
   const protectedPids = buildProtectedPidSet(processes, currentPid);
+  const duplicateCandidates = findDuplicateSiblingCleanupCandidates(processes)
+    .filter((processEntry) => processEntry.pid !== currentPid);
+  const duplicateCandidatePids = new Set(duplicateCandidates.map((candidate) => candidate.pid));
 
-  return processes
+  const orphanCandidates = processes
     .filter((processEntry) => processEntry.pid !== currentPid)
     .filter((processEntry) => isOmxMcpProcess(processEntry.command))
+    .filter((processEntry) => !duplicateCandidatePids.has(processEntry.pid))
     .filter((processEntry) => !protectedPids.has(processEntry.pid))
-    .sort((left, right) => left.pid - right.pid)
     .map((processEntry) => ({
       ...processEntry,
       reason: processEntry.ppid <= 1 ? 'ppid=1' : 'outside-current-session',
-    }));
+    }) satisfies CleanupCandidate);
+
+  return [...duplicateCandidates, ...orphanCandidates]
+    .sort((left, right) => left.pid - right.pid);
 }
 
 export function findLaunchSafeCleanupCandidates(
@@ -298,6 +339,7 @@ export function findLaunchSafeCleanupCandidates(
   );
 
   return findCleanupCandidates(processes, currentPid).filter((candidate) => {
+    if (candidate.reason === 'duplicate-sibling') return true;
     if (candidate.ppid <= 1) return true;
     return (
       !hasAncestorMatching(processByPid, candidate.pid, isCodexSessionProcess) &&

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -305,7 +305,7 @@ describe('mcp duplicate sibling detection', () => {
     );
   });
 
-  it('does not self-exit after any client traffic even when a newer sibling appears', () => {
+  it('lets post-traffic older duplicates self-exit only after the conservative idle window', () => {
     const observation = {
       status: 'older_duplicate' as const,
       entrypoint: 'state-server.js',
@@ -319,7 +319,7 @@ describe('mcp duplicate sibling detection', () => {
     );
     assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 311_000, 1_000, 10_000),
-      false,
+      true,
     );
   });
 
@@ -338,6 +338,36 @@ describe('mcp duplicate sibling detection', () => {
     assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 11_100, 9_000, 1_000),
       false,
+    );
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 70_000, 9_000, 1_000),
+      true,
+    );
+  });
+
+  it('uses the later of duplicate observation and last traffic for post-traffic idle', () => {
+    const observation = {
+      status: 'older_duplicate' as const,
+      entrypoint: 'state-server.js',
+      matchingPids: [101, 140],
+      newerSiblingPids: [140],
+    };
+
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 13_999, 10_000, 12_000, 1_000, 2_000),
+      false,
+    );
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 14_000, 10_000, 12_000, 1_000, 2_000),
+      true,
+    );
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 13_999, 12_000, 10_000, 1_000, 2_000),
+      false,
+    );
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 14_000, 12_000, 10_000, 1_000, 2_000),
+      true,
     );
   });
 

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -274,7 +274,7 @@ export function shouldSelfExitForDuplicateSibling(
   duplicateObservedAtMs: number | null,
   lastTrafficAtMs: number | null,
   preTrafficGraceMs = DEFAULT_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS,
-  _postTrafficIdleMs = DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
+  postTrafficIdleMs = DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
 ): boolean {
   if (observation.status !== 'older_duplicate') {
     return false;
@@ -288,12 +288,14 @@ export function shouldSelfExitForDuplicateSibling(
   }
 
   if (lastTrafficAtMs !== null) {
-    // Any stdin traffic means a client has already initialized or otherwise owns
-    // this stdio transport. In Codex App native subagent sessions, leader and
-    // subagent MCP servers can share a parent process and entrypoint while both
-    // transports remain active, so PID age alone is not safe proof that the
-    // older process is a stale duplicate.
-    return false;
+    // Stdio traffic means a client initialized or otherwise owned this transport.
+    // Keep that protection, but do not make it permanent: Codex.app can reuse a
+    // long-lived parent across sessions, leaving initialized older siblings alive
+    // after a newer server for the same first-party entrypoint has taken over.
+    // Require a conservative idle window after both the duplicate observation and
+    // the most recent traffic before self-exiting.
+    const idleSinceMs = Math.max(duplicateObservedAtMs, lastTrafficAtMs);
+    return nowMs - idleSinceMs >= postTrafficIdleMs;
   }
 
   return nowMs - duplicateObservedAtMs >= preTrafficGraceMs;


### PR DESCRIPTION
## Summary
- Allow older duplicate first-party MCP servers that have seen stdin traffic to self-exit after the conservative post-traffic idle window instead of staying alive forever.
- Teach `omx cleanup` to identify duplicate first-party MCP siblings by `(ppid, entrypoint)` and reap all but the newest, including under a reused Codex.app parent.
- Preserve live-session protections for non-duplicate MCP servers and add regression coverage for the reused-parent leak path.

Fixes #2077.

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/bootstrap.test.js dist/cli/__tests__/cleanup.test.js`
- `node --test dist/mcp/__tests__/server-lifecycle.test.js`
