### PR TITLE
Preserve detached tmux sessions across SSH attach disconnects

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ omx --madmax --high
 
 On macOS/Linux interactive terminals with `tmux` available, this starts the
 leader in OMX-managed detached tmux by default so the HUD/runtime panes can be
-created and recovered.
+created and recovered. If an SSH client or tmux attach command disconnects after
+startup while the managed session still exists, OMX leaves that detached session
+running; use `tmux ls` and `tmux attach-session -t <session>` to reattach.
 
 If you want a one-off launch with no OMX tmux/HUD management, use `--direct`:
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1965,7 +1965,9 @@ describe("detached tmux new-session sequencing", () => {
     assert.doesNotMatch(leaderCmd!, /^\/bin\/sh -lc '/);
     assert.match(leaderCmd!, /acquireTmuxExtendedKeysLease/);
     assert.match(leaderCmd!, /omx_detached_session_cleanup\(\)/);
-    assert.match(leaderCmd!, /trap omx_detached_session_cleanup 0 INT TERM HUP;/);
+    assert.match(leaderCmd!, /trap .* HUP;/);
+    assert.match(leaderCmd!, /trap omx_detached_session_cleanup 0 INT TERM;/);
+    assert.doesNotMatch(leaderCmd!, /trap omx_detached_session_cleanup 0 INT TERM HUP;/);
     assert.match(leaderCmd!, /exec 3<&0;/);
     assert.match(leaderCmd!, /omx_codex_pid=\$!;/);
     assert.match(leaderCmd!, /<\&3 &/);
@@ -2233,7 +2235,7 @@ exit 0
     }
   });
 
-  it("detached leader command terminates codex child on external SIGHUP", async () => {
+  it("detached leader command preserves codex child on external SIGHUP", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-hup-"));
     const fakeBin = join(cwd, "bin");
     const pidFile = join(cwd, "codex.pid");
@@ -2299,12 +2301,18 @@ exit 0
         assert.ok(codexPid > 0, "codex pid must be positive");
         assert.doesNotThrow(() => process.kill(codexPid, 0), "codex must be alive before signal");
 
-        const leaderExit = once(child, "exit");
         process.kill(child.pid!, "SIGHUP");
+
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        assert.doesNotThrow(() => process.kill(child.pid!, 0), "leader must ignore external SIGHUP");
+        assert.doesNotThrow(() => process.kill(codexPid, 0), "codex child must survive leader SIGHUP");
+
+        const leaderExit = once(child, "exit");
+        process.kill(child.pid!, "SIGTERM");
         await Promise.race([
           leaderExit,
           new Promise((_, reject) =>
-            setTimeout(() => reject(new Error("leader did not exit after SIGHUP")), 3000),
+            setTimeout(() => reject(new Error("leader did not exit after SIGTERM")), 3000),
           ),
         ]);
         assert.throws(
@@ -2314,7 +2322,7 @@ exit 0
             err !== null &&
             "code" in err &&
             (err as NodeJS.ErrnoException).code === "ESRCH",
-          "codex child must be terminated after leader SIGHUP",
+          "codex child must still be cleaned up after leader SIGTERM",
         );
       } finally {
         try {

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -521,7 +521,7 @@ exit 1
     }
   });
 
-  it('rolls back and falls back directly when attaching the detached tmux session fails', async () => {
+  it('preserves the detached tmux session when attach fails but the session still exists', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-attach-fail-'));
     try {
       const home = join(wd, 'home');
@@ -572,6 +572,9 @@ case "$1" in
     printf 'error connecting to /tmp/tmux-1000/default (Operation not permitted)\n' >&2
     exit 1
     ;;
+  has-session)
+    exit 0
+    ;;
   set-option|set-hook|kill-session|run-shell|resize-pane|select-pane)
     exit 0
     ;;
@@ -599,8 +602,78 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.doesNotMatch(result.stdout, /fake-codex:/);
+      assert.match(tmuxLog, /tmux:attach-session -t /);
+      assert.match(tmuxLog, /tmux:has-session -t /);
+      assert.doesNotMatch(tmuxLog, /tmux:kill-session -t /);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rolls back and falls back directly when attach fails and the detached session is gone', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-attach-gone-'));
+    try {
+      const { env, tmuxLogPath } = await createLaunchFixture(
+        wd,
+        (tmuxLogPath) => `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V|list-sessions)
+    exit 0
+    ;;
+  new-session)
+    printf 'leader-pane\n'
+    exit 0
+    ;;
+  split-window)
+    printf 'hud-pane\n'
+    exit 0
+    ;;
+  display-message)
+    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\n'
+    else
+      printf '0\n'
+    fi
+    exit 0
+    ;;
+  show-options)
+    printf 'off\n'
+    exit 0
+    ;;
+  attach-session)
+    printf 'lost detached session\n' >&2
+    exit 1
+    ;;
+  has-session)
+    exit 1
+    ;;
+  set-option|set-hook|kill-session|run-shell|resize-pane|select-pane)
+    exit 0
+    ;;
+esac
+exit 0
+`,
+      );
+
+      const result = runOmx(
+        wd,
+        ['--madmax', '--tmux'],
+        {
+          ...env,
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
       assert.match(tmuxLog, /tmux:attach-session -t /);
+      assert.match(tmuxLog, /tmux:has-session -t /);
       assert.match(tmuxLog, /tmux:kill-session -t /);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -804,6 +804,26 @@ function assertDetachedAttachDidNotNoop(
   );
 }
 
+function detachedTmuxSessionExists(sessionName: string): boolean {
+  try {
+    execTmuxFileSync(["has-session", "-t", sessionName], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function warnDetachedAttachPreserved(sessionName: string, error: unknown): void {
+  const detail = tmuxFailureMessage(error);
+  console.warn(
+    [
+      `[omx] tmux attach-session failed, but detached session "${sessionName}" is still running.`,
+      `Reattach with: tmux attach-session -t ${sessionName}`,
+      detail ? `Detail: ${detail}` : "",
+    ].filter(Boolean).join("\n"),
+  );
+}
+
 function resolveTmuxAwareLaunchPolicy(
   explicitLaunchPolicy: CodexLaunchPolicy | undefined,
   nativeWindows: boolean,
@@ -2150,10 +2170,11 @@ function buildDetachedSessionLeaderCommand(
   const wrapped = [
     buildTmuxExtendedKeysAcquireShellSnippet(cwd),
     'exec 3<&0;',
+    "trap '' HUP;",
     'omx_codex_pid="";',
     "omx_detached_session_cleanup() {",
     "status=$?;",
-    "trap - 0 INT TERM HUP;",
+    "trap - 0 INT TERM;",
     'if [ -n "$omx_codex_pid" ] && kill -0 "$omx_codex_pid" 2>/dev/null; then',
     'kill -TERM "$omx_codex_pid" 2>/dev/null || true;',
     'wait "$omx_codex_pid" 2>/dev/null || true;',
@@ -2166,7 +2187,7 @@ function buildDetachedSessionLeaderCommand(
     "fi;",
     "exit $status;",
     "};",
-    "trap omx_detached_session_cleanup 0 INT TERM HUP;",
+    "trap omx_detached_session_cleanup 0 INT TERM;",
     `${codexCmd} <&3 &`,
     "omx_codex_pid=$!;",
     'wait "$omx_codex_pid";',
@@ -3192,21 +3213,28 @@ function runCodex(
             }
             const stdio =
               finalizeStep.name === "attach-session" ? "inherit" : "ignore";
+            let attachStartedAtMs = 0;
             try {
-              const startedAtMs = Date.now();
+              attachStartedAtMs = Date.now();
               execTmuxFileSync(finalizeStep.args, { stdio });
-              if (finalizeStep.name === "attach-session") {
-                assertDetachedAttachDidNotNoop(
-                  sessionName,
-                  Date.now() - startedAtMs,
-                  process.env,
-                );
-              }
             } catch (err) {
-              logCliOperationFailure(err);
-              if (finalizeStep.name === "attach-session")
+              if (finalizeStep.name === "attach-session") {
+                if (detachedTmuxSessionExists(sessionName)) {
+                  warnDetachedAttachPreserved(sessionName, err);
+                  return { postLaunchHandledExternally: !nativeWindows };
+                }
+                logCliOperationFailure(err);
                 throw new Error("failed to attach detached tmux session");
+              }
+              logCliOperationFailure(err);
               continue;
+            }
+            if (finalizeStep.name === "attach-session") {
+              assertDetachedAttachDidNotNoop(
+                sessionName,
+                Date.now() - attachStartedAtMs,
+                process.env,
+              );
             }
             if (
               finalizeStep.name === "register-resize-hook" &&


### PR DESCRIPTION
Related: #2083 (closed; prior context, not an auto-close link)

## Summary
- preserve detached OMX tmux sessions when `attach-session` fails but `tmux has-session` confirms the session is still alive
- ignore external `SIGHUP` in the detached leader shell so SSH/client disconnects do not kill the Codex child
- keep rollback/direct fallback behavior when the detached session is actually gone, and keep the WSL attach-no-op fallback path distinct
- document the SSH/tmux reattach behavior in the README

## Validation
- [x] `npm run build`
- [x] `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js`
- [x] `npm run check:no-unused`
- [x] `npm run lint`
- [x] `git diff --check`

## Not-tested
- Full `npm test` completion in this attached OMX/tmux session. It was attempted, but local runtime environment interfered with unrelated tests: `question.test.js` opened a real tmux question UI, and inherited `OMX_TEAM_WORKER_LAUNCH_ARGS` changed expected team-worker reasoning defaults. The affected team assertions passed when that env override was removed.

## Notes
This is intentionally narrow launch lifecycle hardening: attach loss no longer implies session failure when tmux still reports the detached session exists.


