### PR TITLE
Fix Ralph session state rebinding

### DIFF
--- a/src/modes/__tests__/base-session-scope.test.ts
+++ b/src/modes/__tests__/base-session-scope.test.ts
@@ -74,6 +74,37 @@ describe('modes/base session-scoped persistence', () => {
     }
   });
 
+  it('does not rebind root fallback Ralph task fields into a new session update', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-session-ralph-no-rebind-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-new-ralph';
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        mode: 'ralph',
+        iteration: 4,
+        max_iterations: 10,
+        current_phase: 'verifying',
+        task_slug: 'old-task',
+        owner_omx_session_id: 'old-session',
+      }));
+
+      await assert.rejects(
+        () => updateModeState('ralph', { current_phase: 'executing' }, wd),
+        /Mode ralph not found/,
+      );
+
+      assert.equal(existsSync(join(stateDir, 'sessions', sessionId, 'ralph-state.json')), false);
+      const root = JSON.parse(await readFile(join(stateDir, 'ralph-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(root.owner_omx_session_id, 'old-session');
+      assert.equal(root.task_slug, 'old-task');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('allows an explicit Ralph start to overwrite an inactive current-session Ralph file', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-session-ralph-restart-'));
     try {

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -208,6 +208,23 @@ export async function readModeStateForActiveDecision(
   return readModeStateFromPaths(paths);
 }
 
+function assertRalphUpdateMatchesSession(state: ModeState, sessionId?: string): void {
+  const normalizedSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+  if (!normalizedSessionId) return;
+
+  const ownerOmxSessionId = typeof state.owner_omx_session_id === 'string'
+    ? state.owner_omx_session_id.trim()
+    : '';
+  if (ownerOmxSessionId && ownerOmxSessionId !== normalizedSessionId) {
+    throw new Error(`Mode ralph state belongs to another session (${ownerOmxSessionId})`);
+  }
+
+  const stateSessionId = typeof state.session_id === 'string' ? state.session_id.trim() : '';
+  if (stateSessionId && stateSessionId !== normalizedSessionId) {
+    throw new Error(`Mode ralph state belongs to another session (${stateSessionId})`);
+  }
+}
+
 /**
  * Update mode state (merge fields)
  */
@@ -217,12 +234,18 @@ export async function updateModeState(
   projectRoot?: string,
   explicitSessionId?: string,
 ): Promise<ModeState> {
-  const current = explicitSessionId
-    ? await readModeStateForSession(mode, explicitSessionId, projectRoot)
-    : await readModeState(mode, projectRoot);
-  if (!current) throw new Error(`Mode ${mode} not found`);
   const scope = await resolveStateScope(projectRoot, explicitSessionId);
+  const current = mode === 'ralph' && scope.sessionId
+    ? await readModeStateForActiveDecision(mode, scope.sessionId, projectRoot)
+    : explicitSessionId
+      ? await readModeStateForSession(mode, explicitSessionId, projectRoot)
+      : await readModeState(mode, projectRoot);
+  if (!current) throw new Error(`Mode ${mode} not found`);
   await mkdir(scope.stateDir, { recursive: true });
+
+  if (mode === 'ralph') {
+    assertRalphUpdateMatchesSession(current, scope.sessionId);
+  }
 
   const updatedBase = { ...current, ...updates };
   if (!Object.prototype.hasOwnProperty.call(updates, 'run_outcome')) {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7004,6 +7004,51 @@ exit 0
     }
   });
 
+  it("does not block Stop when Ralph skill-active initialization points at another session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-stale-skill-active-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const currentSessionId = "sess-current-ralph";
+      await mkdir(join(stateDir, "sessions", currentSessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: currentSessionId,
+        native_session_id: currentSessionId,
+        cwd,
+      });
+      await writeJson(join(stateDir, "sessions", currentSessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "verifying",
+        session_id: currentSessionId,
+        owner_omx_session_id: currentSessionId,
+        task_slug: "stale-rebound-task",
+      });
+      await writeJson(join(stateDir, "sessions", currentSessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralph",
+        phase: "verifying",
+        session_id: currentSessionId,
+        initialized_mode: "ralph",
+        initialized_state_path: ".omx/state/sessions/sess-old-ralph/ralph-state.json",
+        active_skills: [{ skill: "ralph", phase: "verifying", active: true, session_id: currentSessionId }],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: currentSessionId,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks same-session Ralph Stop continuation when ownership identifiers match", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-owned-session-"));
     const previousTmuxPane = process.env.TMUX_PANE;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -5,6 +5,7 @@ import { extname, join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
 import { readModeState, readModeStateForActiveDecision, readModeStateForSession, updateModeState } from "../modes/base.js";
 import {
+  extractSessionIdFromInitializedStatePath,
   listActiveSkills,
   readVisibleSkillActiveState,
 } from "../state/skill-active.js";
@@ -553,6 +554,19 @@ async function isVisibleRalphActiveForSession(cwd: string, sessionId: string): P
   ));
 }
 
+async function hasConsistentRalphSkillActivation(cwd: string, sessionId: string): Promise<boolean> {
+  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+  if (!canonicalState) return true;
+
+  const initializedMode = safeString(canonicalState.initialized_mode).trim();
+  if (initializedMode && initializedMode !== "ralph") return true;
+
+  const initializedPathSessionId = extractSessionIdFromInitializedStatePath(canonicalState.initialized_state_path);
+  if (initializedPathSessionId && initializedPathSessionId !== sessionId) return false;
+
+  return true;
+}
+
 async function readActiveRalphState(
   stateDir: string,
   preferredSessionId?: string,
@@ -606,6 +620,7 @@ async function readActiveRalphState(
         currentNativeSessionId,
         tmuxPaneId: safeString(ownerContext?.tmuxPaneId).trim(),
       })
+      && await hasConsistentRalphSkillActivation(cwd, sessionId)
     ) {
       return { state: sessionScoped, path: sessionScopedPath };
     }

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -141,6 +141,48 @@ describe('skill-active state helpers', () => {
     });
   });
 
+  it('does not carry stale Ralph initialization fields from another session into current session state', async () => {
+    await withTempRepo('omx-skill-active-stale-init-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeSkillActiveStateCopies(cwd, {
+        active: true,
+        skill: 'ralph',
+        phase: 'verifying',
+        session_id: 'old-session',
+        initialized_mode: 'ralph',
+        initialized_state_path: '.omx/state/sessions/old-session/ralph-state.json',
+        task_slug: 'old-ralph-task',
+        context_snapshot_path: '.omx/context/old.md',
+        active_skills: [{ skill: 'ralph', phase: 'verifying', active: true, session_id: 'old-session' }],
+      });
+
+      await syncCanonicalSkillStateForMode({
+        cwd,
+        mode: 'ralph',
+        active: true,
+        currentPhase: 'executing',
+        sessionId: 'new-session',
+        nowIso: '2026-05-03T00:00:00.000Z',
+      });
+
+      const sessionState = await readVisibleSkillActiveState(cwd, 'new-session') as Record<string, unknown> | null;
+      assert.ok(sessionState);
+      assert.equal(sessionState.initialized_mode, undefined);
+      assert.equal(sessionState.initialized_state_path, undefined);
+      assert.equal(sessionState.task_slug, undefined);
+      assert.equal(sessionState.context_snapshot_path, undefined);
+      assert.equal(sessionState.session_id, 'new-session');
+      assert.deepEqual(
+        listActiveSkills(sessionState).map(({ skill, phase, session_id }) => ({ skill, phase, session_id })),
+        [{ skill: 'ralph', phase: 'executing', session_id: 'new-session' }],
+      );
+
+      const rootState = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(rootState.initialized_mode, undefined);
+      assert.equal(rootState.initialized_state_path, undefined);
+    });
+  });
+
   it('clears only the matching terminal session entry and preserves unrelated active skills', async () => {
     await withTempRepo('omx-skill-active-terminal-clear-', async (cwd) => {
       await mkdir(join(cwd, '.omx', 'state'), { recursive: true });

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -113,6 +113,56 @@ function normalizeSkillActiveEntry(raw: unknown): SkillActiveEntry | null {
   };
 }
 
+export function extractSessionIdFromInitializedStatePath(pathValue: unknown): string | undefined {
+  const pathText = safeString(pathValue).trim();
+  if (!pathText) return undefined;
+  const normalized = pathText.replace(/\\/g, '/');
+  const match = /(?:^|\/)sessions\/([^/]+)\/[^/]+-state\.json$/.exec(normalized);
+  return match?.[1];
+}
+
+function baseInitializationMatchesTargetSession(
+  base: SkillActiveStateLike | null,
+  targetSessionId?: string,
+): boolean {
+  const normalizedTargetSessionId = safeString(targetSessionId).trim();
+  if (!normalizedTargetSessionId) return true;
+
+  const initializedPathSessionId = extractSessionIdFromInitializedStatePath(base?.initialized_state_path);
+  if (initializedPathSessionId && initializedPathSessionId !== normalizedTargetSessionId) {
+    return false;
+  }
+
+  const baseSessionId = safeString(base?.session_id).trim();
+  if (baseSessionId && baseSessionId !== normalizedTargetSessionId) {
+    return false;
+  }
+
+  return true;
+}
+
+function sanitizeInheritedSkillActiveBase(
+  base: SkillActiveStateLike | null,
+  targetSessionId?: string,
+): SkillActiveStateLike {
+  const inherited = { ...(base ?? {}) };
+  if (!baseInitializationMatchesTargetSession(base, targetSessionId)) {
+    delete inherited.initialized_mode;
+    delete inherited.initialized_state_path;
+    delete inherited.input_lock;
+    delete inherited.context_snapshot_path;
+    delete inherited.prd_path;
+    delete inherited.test_spec_path;
+    delete inherited.task_slug;
+    delete inherited.task_description;
+    delete inherited.owner_omx_session_id;
+    delete inherited.owner_codex_session_id;
+    delete inherited.owner_codex_thread_id;
+    delete inherited.tmux_pane_id;
+  }
+  return inherited;
+}
+
 export function listActiveSkills(raw: unknown): SkillActiveEntry[] {
   if (!raw || typeof raw !== 'object') return [];
   const state = raw as SkillActiveStateLike;
@@ -278,23 +328,25 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
     base: SkillActiveStateLike | null,
     entries: SkillActiveEntry[],
     fallbackMode: string,
+    targetSessionId?: string,
   ): SkillActiveStateLike => {
-    const currentPrimary = safeString(base?.skill).trim();
+    const inheritedBase = sanitizeInheritedSkillActiveBase(base, targetSessionId);
+    const currentPrimary = safeString(inheritedBase.skill).trim();
     const primarySkill = pickPrimaryWorkflowMode(currentPrimary, entries.map((entry) => entry.skill), fallbackMode);
     const primaryEntry = entries.find((entry) => entry.skill === primarySkill) ?? entries[0];
     return {
-      ...(base ?? {}),
+      ...inheritedBase,
       version: 1,
       active: entries.length > 0,
       skill: primaryEntry?.skill || primarySkill || fallbackMode,
-      keyword: safeString(base?.keyword).trim(),
-      phase: primaryEntry?.phase || safeString(base?.phase).trim(),
-      activated_at: primaryEntry?.activated_at || safeString(base?.activated_at).trim() || nowIso,
+      keyword: safeString(inheritedBase.keyword).trim(),
+      phase: primaryEntry?.phase || safeString(inheritedBase.phase).trim(),
+      activated_at: primaryEntry?.activated_at || safeString(inheritedBase.activated_at).trim() || nowIso,
       updated_at: nowIso,
-      source: safeString(base?.source).trim() || source,
-      session_id: primaryEntry?.session_id || safeString(base?.session_id).trim() || undefined,
-      thread_id: primaryEntry?.thread_id || safeString(base?.thread_id).trim() || undefined,
-      turn_id: primaryEntry?.turn_id || safeString(base?.turn_id).trim() || undefined,
+      source: safeString(inheritedBase.source).trim() || source,
+      session_id: primaryEntry?.session_id || safeString(inheritedBase.session_id).trim() || undefined,
+      thread_id: primaryEntry?.thread_id || safeString(inheritedBase.thread_id).trim() || undefined,
+      turn_id: primaryEntry?.turn_id || safeString(inheritedBase.turn_id).trim() || undefined,
       active_skills: entries,
     };
   };
@@ -323,6 +375,7 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
       existingSession ?? existingRoot,
       [...nextRootEntries, ...nextSessionEntries],
       mode,
+      normalizedSessionId,
     );
     const nextRootState = nextRootEntries.length > 0
       ? applyEntriesToState(existingRoot, nextRootEntries, mode)
@@ -330,6 +383,7 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
         existingSession ?? existingRoot,
         active ? nextSessionEntries : [],
         mode,
+        normalizedSessionId,
       );
     await writeSkillActiveStateCopies(cwd, nextSessionState, sessionId, nextRootState);
     return;
@@ -377,6 +431,7 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
       existingSessionState ?? existingRoot,
       nextSessionEntries,
       nextSessionEntries[0]?.skill || mode,
+      sessionId,
     );
     await writeSkillActiveStateCopies(cwd, nextSessionState, sessionId, nextRootState);
   }


### PR DESCRIPTION
## Summary
- sanitize inherited skill-active state so cross-session Ralph initialized_state_path/task metadata is not copied into a new session
- make Ralph mode updates use authoritative current-session state instead of root fallback rebinding
- add Stop-hook defense for inconsistent Ralph skill-active initialization paths from another session

Closes #2080

## Verification
- `npm run build`
- `node --test dist/state/__tests__/skill-active.test.js dist/modes/__tests__/base-session-scope.test.js dist/scripts/__tests__/codex-native-hook.test.js` (260 tests passed)
- `npm run lint`
- `npm run check:no-unused`