### PR TITLE
Keep boxed OMX state out of source workspaces

### DIFF
--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { omxStateDir } from '../utils/paths.js';
 import { updateModeState, startMode, readModeState } from '../modes/base.js';
 import { getStatePath, validateSessionId } from '../mcp/state-paths.js';
 import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime, type TeamSnapshot } from '../team/runtime.js';
@@ -83,7 +84,7 @@ function readPersistedTeamFollowupState(cwd: string): {
   agent_types?: string;
   linkedRalph?: boolean;
 } | null {
-  const path = join(cwd, '.omx', 'state', 'team-state.json');
+  const path = join(omxStateDir(cwd), 'team-state.json');
   if (!existsSync(path)) return null;
   try {
     return JSON.parse(readFileSync(path, 'utf-8')) as {

--- a/src/cli/tmux-hook.ts
+++ b/src/cli/tmux-hook.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
+import { omxRoot } from '../utils/paths.js';
 import { getPackageRoot } from '../utils/package.js';
 import { resolveCodexPane } from '../scripts/tmux-hook-engine.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
@@ -90,7 +91,7 @@ export async function tmuxHookCommand(args: string[]): Promise<void> {
 }
 
 function omxDir(cwd = process.cwd()): string {
-  return join(cwd, '.omx');
+  return omxRoot(cwd);
 }
 
 function tmuxHookConfigPath(cwd = process.cwd()): string {

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -61,6 +61,27 @@ describe('validateStateFileName', () => {
 });
 
 describe('state paths', () => {
+  it('uses OMX_ROOT as boxed workspace root before workingDirectory', () => {
+    const prevRoot = process.env.OMX_ROOT;
+    const prevStateRoot = process.env.OMX_STATE_ROOT;
+    const prevTeamRoot = process.env.OMX_TEAM_STATE_ROOT;
+    process.env.OMX_ROOT = '/tmp/omx-box';
+    process.env.OMX_STATE_ROOT = '/tmp/ignored-state-root';
+    process.env.OMX_TEAM_STATE_ROOT = '/tmp/ignored-team-state-root';
+    try {
+      assert.equal(getBaseStateDir('/tmp/source'), '/tmp/omx-box/.omx/state');
+      assert.equal(getStateDir('/tmp/source', 'sess1'), '/tmp/omx-box/.omx/state/sessions/sess1');
+      assert.equal(getStatePath('ralph', '/tmp/source', 'sess1'), '/tmp/omx-box/.omx/state/sessions/sess1/ralph-state.json');
+    } finally {
+      if (typeof prevRoot === 'string') process.env.OMX_ROOT = prevRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof prevStateRoot === 'string') process.env.OMX_STATE_ROOT = prevStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof prevTeamRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+    }
+  });
+
   it('resolveWorkingDirectoryForState defaults to process.cwd()', () => {
     assert.equal(resolveWorkingDirectoryForState(undefined), process.cwd());
     assert.equal(resolveWorkingDirectoryForState(''), process.cwd());

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -107,6 +107,43 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('creates boxed runtime state under OMX_ROOT for mutating tools', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const root = await mkdtemp(join(tmpdir(), 'omx-state-server-boxed-'));
+    const box = join(root, 'box');
+    const wd = join(root, 'source');
+    try {
+      await mkdir(wd, { recursive: true });
+      process.env.OMX_ROOT = box;
+
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'ralph',
+            active: true,
+            iteration: 1,
+            current_phase: 'executing',
+          },
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      assert.equal(existsSync(join(box, '.omx', 'state', 'ralph-state.json')), true);
+      assert.equal(existsSync(join(box, '.omx', 'tmux-hook.json')), true);
+      assert.equal(existsSync(join(wd, '.omx', 'state')), false);
+      assert.equal(existsSync(join(wd, '.omx', 'tmux-hook.json')), false);
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps missing state_read side-effect-free without setup', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -8,6 +8,8 @@ export const STATE_MODE_SEGMENT_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const STATE_FILE_SUFFIX = '-state.json';
 const STATE_FILE_NAME_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const WORKDIR_ALLOWLIST_ENV = 'OMX_MCP_WORKDIR_ROOTS';
+const OMX_ROOT_ENV = 'OMX_ROOT';
+const OMX_STATE_ROOT_ENV = 'OMX_STATE_ROOT';
 
 export type StateFileScope = 'root' | 'session';
 
@@ -160,6 +162,12 @@ function enforceWorkingDirectoryPolicy(resolvedWorkingDirectory: string): void {
 }
 
 export function getBaseStateDir(workingDirectory?: string): string {
+  const omxRootOverride = process.env[OMX_ROOT_ENV]?.trim() || process.env[OMX_STATE_ROOT_ENV]?.trim();
+  if (typeof omxRootOverride === 'string' && omxRootOverride !== '') {
+    try {
+      return join(resolveWorkingDirectoryForState(omxRootOverride), '.omx', 'state');
+    } catch {}
+  }
   if ((workingDirectory == null || workingDirectory === '') && typeof process.env.OMX_TEAM_STATE_ROOT === 'string' && process.env.OMX_TEAM_STATE_ROOT.trim() !== '') {
     try {
       return resolveWorkingDirectoryForState(process.env.OMX_TEAM_STATE_ROOT.trim());

--- a/src/team/__tests__/state-root.test.ts
+++ b/src/team/__tests__/state-root.test.ts
@@ -40,6 +40,20 @@ describe('state-root', () => {
 
 
 
+  it('honors OMX_ROOT as boxed workspace root when no explicit team state root is set', () => {
+    const previousOmxRoot = process.env.OMX_ROOT;
+    try {
+      process.env.OMX_ROOT = '/tmp/omx-box';
+      assert.equal(
+        resolveCanonicalTeamStateRoot('/tmp/demo/project', {}),
+        '/tmp/omx-box/.omx/state',
+      );
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+    }
+  });
+
   async function writeTeamMetadata(
     stateRoot: string,
     teamName: string,

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -14,6 +14,7 @@ import {
   listInstalledSkillDirectories,
   detectLegacySkillRootOverlap,
   omxStateDir,
+  omxRoot,
   omxProjectMemoryPath,
   omxNotepadPath,
   omxPlansDir,
@@ -346,12 +347,43 @@ describe("listInstalledSkillDirectories", () => {
 });
 
 describe("omxStateDir", () => {
+  let originalOmxRoot: string | undefined;
+  let originalOmxStateRoot: string | undefined;
+
+  beforeEach(() => {
+    originalOmxRoot = process.env.OMX_ROOT;
+    originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+  });
+
+  afterEach(() => {
+    if (typeof originalOmxRoot === "string") process.env.OMX_ROOT = originalOmxRoot;
+    else delete process.env.OMX_ROOT;
+    if (typeof originalOmxStateRoot === "string") process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+    else delete process.env.OMX_STATE_ROOT;
+  });
+
   it("uses provided projectRoot", () => {
     assert.equal(omxStateDir("/my/project"), join("/my/project", ".omx", "state"));
   });
 
   it("defaults to cwd when no projectRoot given", () => {
     assert.equal(omxStateDir(), join(process.cwd(), ".omx", "state"));
+  });
+
+  it("uses OMX_ROOT override when set", () => {
+    process.env.OMX_ROOT = "/tmp/omx-root";
+    assert.equal(omxRoot("/ignored/project"), "/tmp/omx-root/.omx");
+    assert.equal(omxStateDir("/ignored/project"), "/tmp/omx-root/.omx/state");
+  });
+
+  it("uses OMX_ROOT as boxed workspace root for all runtime paths", () => {
+    process.env.OMX_ROOT = "/tmp/omx-box";
+    assert.equal(omxRoot("/ignored/project"), "/tmp/omx-box/.omx");
+    assert.equal(omxStateDir("/ignored/project"), "/tmp/omx-box/.omx/state");
+    assert.equal(omxProjectMemoryPath("/ignored/project"), "/tmp/omx-box/.omx/project-memory.json");
+    assert.equal(omxNotepadPath("/ignored/project"), "/tmp/omx-box/.omx/notepad.md");
+    assert.equal(omxPlansDir("/ignored/project"), "/tmp/omx-box/.omx/plans");
+    assert.equal(omxLogsDir("/ignored/project"), "/tmp/omx-box/.omx/logs");
   });
 });
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -18,6 +18,23 @@ export function codexHome(): string {
 export const OMX_ENTRY_PATH_ENV = "OMX_ENTRY_PATH";
 export const OMX_STARTUP_CWD_ENV = "OMX_STARTUP_CWD";
 
+function resolveOmxRootCandidate(raw?: string): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return isAbsolute(trimmed) ? trimmed : resolve(trimmed);
+}
+
+/** Optional override root for OMX runtime files. */
+export function omxRoot(projectRoot?: string): string {
+  const override =
+    resolveOmxRootCandidate(process.env.OMX_ROOT)
+    ?? resolveOmxRootCandidate(process.env.OMX_STATE_ROOT);
+  if (override) return join(override, ".omx");
+  return join(projectRoot || process.cwd(), ".omx");
+}
+
+
 function resolveLauncherPath(rawPath: string, baseCwd: string): string {
   const absolutePath = isAbsolute(rawPath) ? rawPath : resolve(baseCwd, rawPath);
   if (!existsSync(absolutePath)) return absolutePath;
@@ -285,37 +302,37 @@ async function hashSkillDirectory(
 
 /** oh-my-codex state directory (.omx/state/) */
 export function omxStateDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "state");
+  return join(omxRoot(projectRoot), "state");
 }
 
 /** oh-my-codex project memory file (.omx/project-memory.json) */
 export function omxProjectMemoryPath(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "project-memory.json");
+  return join(omxRoot(projectRoot), "project-memory.json");
 }
 
 /** oh-my-codex notepad file (.omx/notepad.md) */
 export function omxNotepadPath(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "notepad.md");
+  return join(omxRoot(projectRoot), "notepad.md");
 }
 
 /** oh-my-codex wiki directory (.omx/wiki/) */
 export function omxWikiDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "wiki");
+  return join(omxRoot(projectRoot), "wiki");
 }
 
 /** oh-my-codex plans directory (.omx/plans/) */
 export function omxPlansDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "plans");
+  return join(omxRoot(projectRoot), "plans");
 }
 
 /** oh-my-codex adapters directory (.omx/adapters/) */
 export function omxAdaptersDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "adapters");
+  return join(omxRoot(projectRoot), "adapters");
 }
 
 /** oh-my-codex logs directory (.omx/logs/) */
 export function omxLogsDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "logs");
+  return join(omxRoot(projectRoot), "logs");
 }
 
 /** User-scope install/update stamp path ($CODEX_HOME/.omx/install-state.json) */


### PR DESCRIPTION
## Summary
- Route runtime-owned `.omx` helpers through an `OMX_ROOT` / `OMX_STATE_ROOT` aware root.
- Keep source cwd semantics intact while boxed launches store mode, MCP, tmux-hook, plans, logs, memory, wiki, and team state under the boxed workspace.
- Preserve explicit `OMX_TEAM_STATE_ROOT` precedence for team sessions.

## Problem
`omxbox` already isolates a launch by exporting `OMX_ROOT`, then running `omx` from the user's original project cwd. Several runtime path helpers still derived `.omx` paths directly from `workingDirectory` / cwd, so a boxed `omx --madmax` launch could still write runtime state into the source project.

## Root cause
The wrapper created the box, but the runtime path contract did not consistently treat `OMX_ROOT` as the owner for runtime `.omx` state.

## Changes
- `src/utils/paths.ts`: adds `omxRoot()` and routes runtime-owned `.omx` helpers through it.
- `src/mcp/state-paths.ts`: prefers `OMX_ROOT` / `OMX_STATE_ROOT` before `workingDirectory` for MCP state roots.
- `src/cli/tmux-hook.ts`: writes tmux-hook config under the boxed root.
- `src/team/state-root.ts` and `src/cli/team.ts`: resolve canonical team state through the boxed-aware state helper unless `OMX_TEAM_STATE_ROOT` is explicitly set.
- Adds regression coverage for path helpers, MCP state writes, and canonical team state root resolution.

## Overlap assessment
- Related prior PR: #2050 (`Fix same-cwd team session isolation`) is adjacent but distinct.
- #2050 addressed same-cwd team session identity/state isolation.
- This PR fixes the lower-level boxed runtime root contract for `OMX_ROOT` so `omxbox` / `omx --madmax` can isolate runtime state while keeping project cwd stable.

## Validation
- `npm run build`
- `node --test dist/utils/__tests__/paths.test.js dist/mcp/__tests__/state-paths.test.js dist/mcp/__tests__/state-server.test.js dist/team/__tests__/state-root.test.js` — 93 passing tests
- Runtime smoke with `OMX_ROOT=<box>` and `state_write`: confirmed writes under `<box>/.omx/state` and `<box>/.omx/tmux-hook.json`, with no source cwd `.omx` state writes.

## Risk
Moderate: this changes shared runtime path helpers. Tests cover the boxed path and preserve explicit team state root precedence.

## Not tested
Full `npm test` was not used as the final signal because this checkout has unrelated baseline failures around current model expectation / team integration behavior. Targeted affected suites and build are green.
