### PR TITLE
Fix boxed team state path routing

### DIFF
--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { omxStateDir } from '../utils/paths.js';
 import { updateModeState, startMode, readModeState } from '../modes/base.js';
 import { getStatePath, validateSessionId } from '../mcp/state-paths.js';
 import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime, type TeamSnapshot } from '../team/runtime.js';
@@ -83,7 +84,7 @@ function readPersistedTeamFollowupState(cwd: string): {
   agent_types?: string;
   linkedRalph?: boolean;
 } | null {
-  const path = join(cwd, '.omx', 'state', 'team-state.json');
+  const path = join(omxStateDir(cwd), 'team-state.json');
   if (!existsSync(path)) return null;
   try {
     return JSON.parse(readFileSync(path, 'utf-8')) as {

--- a/src/cli/tmux-hook.ts
+++ b/src/cli/tmux-hook.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
+import { omxRoot } from '../utils/paths.js';
 import { getPackageRoot } from '../utils/package.js';
 import { resolveCodexPane } from '../scripts/tmux-hook-engine.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
@@ -90,7 +91,7 @@ export async function tmuxHookCommand(args: string[]): Promise<void> {
 }
 
 function omxDir(cwd = process.cwd()): string {
-  return join(cwd, '.omx');
+  return omxRoot(cwd);
 }
 
 function tmuxHookConfigPath(cwd = process.cwd()): string {

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -61,6 +61,27 @@ describe('validateStateFileName', () => {
 });
 
 describe('state paths', () => {
+  it('uses OMX_ROOT as boxed workspace root before workingDirectory', () => {
+    const prevRoot = process.env.OMX_ROOT;
+    const prevStateRoot = process.env.OMX_STATE_ROOT;
+    const prevTeamRoot = process.env.OMX_TEAM_STATE_ROOT;
+    process.env.OMX_ROOT = '/tmp/omx-box';
+    process.env.OMX_STATE_ROOT = '/tmp/ignored-state-root';
+    process.env.OMX_TEAM_STATE_ROOT = '/tmp/ignored-team-state-root';
+    try {
+      assert.equal(getBaseStateDir('/tmp/source'), '/tmp/omx-box/.omx/state');
+      assert.equal(getStateDir('/tmp/source', 'sess1'), '/tmp/omx-box/.omx/state/sessions/sess1');
+      assert.equal(getStatePath('ralph', '/tmp/source', 'sess1'), '/tmp/omx-box/.omx/state/sessions/sess1/ralph-state.json');
+    } finally {
+      if (typeof prevRoot === 'string') process.env.OMX_ROOT = prevRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof prevStateRoot === 'string') process.env.OMX_STATE_ROOT = prevStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof prevTeamRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+    }
+  });
+
   it('resolveWorkingDirectoryForState defaults to process.cwd()', () => {
     assert.equal(resolveWorkingDirectoryForState(undefined), process.cwd());
     assert.equal(resolveWorkingDirectoryForState(''), process.cwd());

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -61,13 +61,34 @@ describe('validateStateFileName', () => {
 });
 
 describe('state paths', () => {
-  it('uses OMX_ROOT as boxed workspace root before workingDirectory', () => {
+  it('uses explicit OMX_TEAM_STATE_ROOT before boxed roots and workingDirectory', () => {
     const prevRoot = process.env.OMX_ROOT;
     const prevStateRoot = process.env.OMX_STATE_ROOT;
     const prevTeamRoot = process.env.OMX_TEAM_STATE_ROOT;
     process.env.OMX_ROOT = '/tmp/omx-box';
     process.env.OMX_STATE_ROOT = '/tmp/ignored-state-root';
-    process.env.OMX_TEAM_STATE_ROOT = '/tmp/ignored-team-state-root';
+    process.env.OMX_TEAM_STATE_ROOT = '/tmp/explicit-team-state';
+    try {
+      assert.equal(getBaseStateDir('/tmp/source'), '/tmp/explicit-team-state');
+      assert.equal(getStateDir('/tmp/source', 'sess1'), '/tmp/explicit-team-state/sessions/sess1');
+      assert.equal(getStatePath('ralph', '/tmp/source', 'sess1'), '/tmp/explicit-team-state/sessions/sess1/ralph-state.json');
+    } finally {
+      if (typeof prevRoot === 'string') process.env.OMX_ROOT = prevRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof prevStateRoot === 'string') process.env.OMX_STATE_ROOT = prevStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof prevTeamRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+    }
+  });
+
+  it('uses OMX_ROOT as boxed workspace root before workingDirectory when no team root is explicit', () => {
+    const prevRoot = process.env.OMX_ROOT;
+    const prevStateRoot = process.env.OMX_STATE_ROOT;
+    const prevTeamRoot = process.env.OMX_TEAM_STATE_ROOT;
+    process.env.OMX_ROOT = '/tmp/omx-box';
+    process.env.OMX_STATE_ROOT = '/tmp/ignored-state-root';
+    delete process.env.OMX_TEAM_STATE_ROOT;
     try {
       assert.equal(getBaseStateDir('/tmp/source'), '/tmp/omx-box/.omx/state');
       assert.equal(getStateDir('/tmp/source', 'sess1'), '/tmp/omx-box/.omx/state/sessions/sess1');

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -107,6 +107,43 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('creates boxed runtime state under OMX_ROOT for mutating tools', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const root = await mkdtemp(join(tmpdir(), 'omx-state-server-boxed-'));
+    const box = join(root, 'box');
+    const wd = join(root, 'source');
+    try {
+      await mkdir(wd, { recursive: true });
+      process.env.OMX_ROOT = box;
+
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'ralph',
+            active: true,
+            iteration: 1,
+            current_phase: 'executing',
+          },
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      assert.equal(existsSync(join(box, '.omx', 'state', 'ralph-state.json')), true);
+      assert.equal(existsSync(join(box, '.omx', 'tmux-hook.json')), true);
+      assert.equal(existsSync(join(wd, '.omx', 'state')), false);
+      assert.equal(existsSync(join(wd, '.omx', 'tmux-hook.json')), false);
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps missing state_read side-effect-free without setup', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -8,6 +8,8 @@ export const STATE_MODE_SEGMENT_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const STATE_FILE_SUFFIX = '-state.json';
 const STATE_FILE_NAME_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const WORKDIR_ALLOWLIST_ENV = 'OMX_MCP_WORKDIR_ROOTS';
+const OMX_ROOT_ENV = 'OMX_ROOT';
+const OMX_STATE_ROOT_ENV = 'OMX_STATE_ROOT';
 
 export type StateFileScope = 'root' | 'session';
 
@@ -160,6 +162,12 @@ function enforceWorkingDirectoryPolicy(resolvedWorkingDirectory: string): void {
 }
 
 export function getBaseStateDir(workingDirectory?: string): string {
+  const omxRootOverride = process.env[OMX_ROOT_ENV]?.trim() || process.env[OMX_STATE_ROOT_ENV]?.trim();
+  if (typeof omxRootOverride === 'string' && omxRootOverride !== '') {
+    try {
+      return join(resolveWorkingDirectoryForState(omxRootOverride), '.omx', 'state');
+    } catch {}
+  }
   if ((workingDirectory == null || workingDirectory === '') && typeof process.env.OMX_TEAM_STATE_ROOT === 'string' && process.env.OMX_TEAM_STATE_ROOT.trim() !== '') {
     try {
       return resolveWorkingDirectoryForState(process.env.OMX_TEAM_STATE_ROOT.trim());

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -162,17 +162,20 @@ function enforceWorkingDirectoryPolicy(resolvedWorkingDirectory: string): void {
 }
 
 export function getBaseStateDir(workingDirectory?: string): string {
+  const teamStateRootOverride = process.env.OMX_TEAM_STATE_ROOT?.trim();
+  if (typeof teamStateRootOverride === 'string' && teamStateRootOverride !== '') {
+    try {
+      return resolveWorkingDirectoryForState(teamStateRootOverride);
+    } catch {}
+  }
+
   const omxRootOverride = process.env[OMX_ROOT_ENV]?.trim() || process.env[OMX_STATE_ROOT_ENV]?.trim();
   if (typeof omxRootOverride === 'string' && omxRootOverride !== '') {
     try {
       return join(resolveWorkingDirectoryForState(omxRootOverride), '.omx', 'state');
     } catch {}
   }
-  if ((workingDirectory == null || workingDirectory === '') && typeof process.env.OMX_TEAM_STATE_ROOT === 'string' && process.env.OMX_TEAM_STATE_ROOT.trim() !== '') {
-    try {
-      return resolveWorkingDirectoryForState(process.env.OMX_TEAM_STATE_ROOT.trim());
-    } catch {}
-  }
+
   return join(resolveWorkingDirectoryForState(workingDirectory), '.omx', 'state');
 }
 

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -1838,6 +1838,61 @@ describe('executeTeamApiOperation: read-stall-state', () => {
     }
   });
 
+  it('reads leader runtime activity from boxed OMX_ROOT state consistently with writer path', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-interop-boxed-cwd-'));
+    const box = await mkdtemp(join(tmpdir(), 'omx-interop-boxed-root-'));
+    const previousRoot = process.env.OMX_ROOT;
+    const previousStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_ROOT = box;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      await initTeamState('stall-state-boxed-activity', 'boxed activity test', 'executor', 1, cwd);
+      await writeTeamLeaderAttention('stall-state-boxed-activity', {
+        team_name: 'stall-state-boxed-activity',
+        updated_at: '2026-03-10T10:05:00.000Z',
+        source: 'native_stop',
+        leader_decision_state: 'still_actionable',
+        leader_attention_pending: true,
+        leader_attention_reason: 'leader_session_stopped',
+        attention_reasons: ['leader_session_stopped'],
+        leader_stale: false,
+        leader_session_active: false,
+        leader_session_id: 'leader-session-1',
+        leader_session_stopped_at: '2026-03-10T10:05:00.000Z',
+        unread_leader_message_count: 0,
+        work_remaining: false,
+        stalled_for_ms: null,
+      }, cwd);
+      await mkdir(join(box, '.omx', 'state'), { recursive: true });
+      await writeFile(join(box, '.omx', 'state', 'leader-runtime-activity.json'), JSON.stringify({
+        last_activity_at: '2026-03-10T10:06:00.000Z',
+        last_source: 'team_status',
+        last_team_name: 'stall-state-boxed-activity',
+      }, null, 2));
+
+      const result = await executeTeamApiOperation('read-stall-state', {
+        team_name: 'stall-state-boxed-activity',
+      }, cwd);
+
+      assert.equal(result.ok, true);
+      if (result.ok) {
+        assert.equal(result.data.leader_attention_pending, false);
+        assert.equal(result.data.leader_stale, false);
+      }
+    } finally {
+      if (typeof previousRoot === 'string') process.env.OMX_ROOT = previousRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousStateRoot === 'string') process.env.OMX_STATE_ROOT = previousStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(box, { recursive: true, force: true });
+    }
+  });
+
   it('suppresses stale native-stop attention after newer leader activity', async () => {
     const { cwd, cleanup } = await setupTeam('stall-state-resume');
     try {

--- a/src/team/__tests__/delivery-log.test.ts
+++ b/src/team/__tests__/delivery-log.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { appendTeamDeliveryLogForCwd } from '../delivery-log.js';
+
+describe('appendTeamDeliveryLogForCwd', () => {
+  it('writes runtime delivery logs under boxed OMX_ROOT instead of source cwd', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-delivery-cwd-'));
+    const box = await mkdtemp(join(tmpdir(), 'omx-delivery-box-'));
+    const previousRoot = process.env.OMX_ROOT;
+    const previousStateRoot = process.env.OMX_STATE_ROOT;
+    try {
+      process.env.OMX_ROOT = box;
+      delete process.env.OMX_STATE_ROOT;
+
+      await appendTeamDeliveryLogForCwd(cwd, {
+        event: 'dispatch_result',
+        source: 'test',
+        team: 'boxed-log-team',
+        result: 'ok',
+      });
+
+      const date = new Date().toISOString().slice(0, 10);
+      const boxedLog = join(box, '.omx', 'logs', `team-delivery-${date}.jsonl`);
+      const cwdLog = join(cwd, '.omx', 'logs', `team-delivery-${date}.jsonl`);
+      assert.equal(existsSync(cwdLog), false);
+      const raw = await readFile(boxedLog, 'utf-8');
+      assert.match(raw, /"team":"boxed-log-team"/);
+    } finally {
+      if (typeof previousRoot === 'string') process.env.OMX_ROOT = previousRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousStateRoot === 'string') process.env.OMX_STATE_ROOT = previousStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(box, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/team/__tests__/runtime-boxed-state.test.ts
+++ b/src/team/__tests__/runtime-boxed-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { join } from 'path';
+import {
+  teamRuntimeSessionPath,
+  teamRuntimeTeamRoot,
+  teamRuntimeTeamsRoot,
+  teamStartupTimingPath,
+} from '../runtime.js';
+
+describe('team runtime boxed state path helpers', () => {
+  it('routes runtime-owned team state paths through OMX_ROOT without changing source cwd semantics', () => {
+    const previousRoot = process.env.OMX_ROOT;
+    const previousStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_ROOT = '/tmp/box';
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+
+      assert.equal(teamRuntimeTeamsRoot('/tmp/source'), '/tmp/box/.omx/state/team');
+      assert.equal(teamRuntimeTeamRoot('team-a', '/tmp/source'), '/tmp/box/.omx/state/team/team-a');
+      assert.equal(
+        teamStartupTimingPath('team-a', '/tmp/source'),
+        '/tmp/box/.omx/state/team/team-a/startup-timing.json',
+      );
+      assert.equal(teamRuntimeSessionPath('/tmp/source'), '/tmp/box/.omx/state/session.json');
+      assert.equal(join('/tmp/source', 'README.md'), '/tmp/source/README.md');
+
+      process.env.OMX_TEAM_STATE_ROOT = '/tmp/explicit-team-state';
+      assert.equal(teamRuntimeTeamsRoot('/tmp/source'), '/tmp/explicit-team-state/team');
+      assert.equal(
+        teamStartupTimingPath('team-a', '/tmp/source'),
+        '/tmp/explicit-team-state/team/team-a/startup-timing.json',
+      );
+    } finally {
+      if (typeof previousRoot === 'string') process.env.OMX_ROOT = previousRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousStateRoot === 'string') process.env.OMX_STATE_ROOT = previousStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+    }
+  });
+});

--- a/src/team/__tests__/state-root.test.ts
+++ b/src/team/__tests__/state-root.test.ts
@@ -40,6 +40,20 @@ describe('state-root', () => {
 
 
 
+  it('honors OMX_ROOT as boxed workspace root when no explicit team state root is set', () => {
+    const previousOmxRoot = process.env.OMX_ROOT;
+    try {
+      process.env.OMX_ROOT = '/tmp/omx-box';
+      assert.equal(
+        resolveCanonicalTeamStateRoot('/tmp/demo/project', {}),
+        '/tmp/omx-box/.omx/state',
+      );
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+    }
+  });
+
   async function writeTeamMetadata(
     stateRoot: string,
     teamName: string,

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve as resolvePath } from 'node:path';
+import { omxStateDir } from '../utils/paths.js';
 import { sendWorkerMessage, shutdownTeam } from './runtime.js';
 import {
   TEAM_NAME_SAFE_PATTERN,
@@ -300,7 +301,7 @@ function buildIdleState(
 }
 
 function readLatestLeaderRuntimeActivityMs(cwd: string): number {
-  const path = join(cwd, '.omx', 'state', 'leader-runtime-activity.json');
+  const path = join(omxStateDir(cwd), 'leader-runtime-activity.json');
   if (!existsSync(path)) return Number.NaN;
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf8')) as { last_activity_at?: string };
@@ -446,7 +447,7 @@ function parseValidatedTaskIdArray(value: unknown, fieldName: string): string[] 
 
 function teamStateExists(teamName: string, candidateCwd: string): boolean {
   if (!TEAM_NAME_SAFE_PATTERN.test(teamName)) return false;
-  const teamRoot = join(candidateCwd, '.omx', 'state', 'team', teamName);
+  const teamRoot = join(resolveCanonicalTeamStateRoot(candidateCwd), 'team', teamName);
   return existsSync(join(teamRoot, 'config.json')) || existsSync(join(teamRoot, 'tasks')) || existsSync(teamRoot);
 }
 
@@ -468,7 +469,7 @@ function stateRootToWorkingDirectory(stateRoot: string): string {
 }
 
 function resolveTeamWorkingDirectoryFromMetadata(teamName: string, candidateCwd: string): string | null {
-  const teamRoot = join(candidateCwd, '.omx', 'state', 'team', teamName);
+  const teamRoot = join(resolveCanonicalTeamStateRoot(candidateCwd), 'team', teamName);
   if (!existsSync(teamRoot)) return null;
 
   const fromManifest = readTeamStateRootFromManifest(join(teamRoot, 'manifest.v2.json'));

--- a/src/team/delivery-log.ts
+++ b/src/team/delivery-log.ts
@@ -1,5 +1,6 @@
 import { appendFile, mkdir } from 'fs/promises';
 import { join } from 'path';
+import { omxLogsDir } from '../utils/paths.js';
 
 export type TeamDeliveryEventName =
   | 'mailbox_created'
@@ -69,5 +70,5 @@ export async function appendTeamDeliveryLog(logsDir: string, event: TeamDelivery
 }
 
 export async function appendTeamDeliveryLogForCwd(cwd: string, event: TeamDeliveryLogEvent): Promise<void> {
-  await appendTeamDeliveryLog(join(cwd, '.omx', 'logs'), event);
+  await appendTeamDeliveryLog(omxLogsDir(cwd), event);
 }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -112,7 +112,7 @@ import {
 import { synthesizeDelegationPlan } from './delegation-policy.js';
 import { loadRolePrompt } from './role-router.js';
 import { composeRoleInstructionsForRole } from '../agents/native-config.js';
-import { codexPromptsDir } from '../utils/paths.js';
+import { codexPromptsDir, omxStateDir } from '../utils/paths.js';
 import { isTerminalPhase, type TeamPhase, type TerminalPhase } from './orchestrator.js';
 import {
   resolveTeamWorkerLaunchArgs,
@@ -1389,6 +1389,22 @@ interface StartupTimingRecorder {
   flush: () => Promise<void>;
 }
 
+export function teamStartupTimingPath(teamName: string, cwd: string): string {
+  return join(resolveCanonicalTeamStateRoot(cwd), 'team', teamName, 'startup-timing.json');
+}
+
+export function teamRuntimeTeamsRoot(cwd: string): string {
+  return join(resolveCanonicalTeamStateRoot(cwd), 'team');
+}
+
+export function teamRuntimeTeamRoot(teamName: string, cwd: string): string {
+  return join(teamRuntimeTeamsRoot(cwd), teamName);
+}
+
+export function teamRuntimeSessionPath(cwd: string): string {
+  return join(omxStateDir(cwd), 'session.json');
+}
+
 function createStartupTimingRecorder(teamName: string, cwd: string): StartupTimingRecorder {
   const startedAt = performance.now();
   const events: StartupTimingEvent[] = [];
@@ -1402,7 +1418,7 @@ function createStartupTimingRecorder(teamName: string, cwd: string): StartupTimi
       });
     },
     flush: async () => {
-      const timingPath = join(cwd, '.omx', 'state', 'team', teamName, 'startup-timing.json');
+      const timingPath = teamStartupTimingPath(teamName, cwd);
       await writeAtomic(
         timingPath,
         JSON.stringify({ schema_version: STARTUP_TIMING_LOG_VERSION, team_name: teamName, events }, null, 2),
@@ -3725,7 +3741,7 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
 }
 
 async function findActiveTeams(cwd: string, leaderSessionId: string): Promise<string[]> {
-  const root = join(cwd, '.omx', 'state', 'team');
+  const root = teamRuntimeTeamsRoot(cwd);
   if (!existsSync(root)) return [];
   const sessions = new Set(listTeamSessions());
   const entries = await readdir(root, { withFileTypes: true });
@@ -3762,7 +3778,7 @@ async function detectAndCleanStaleTeam(
   workerCount: number,
   confirmFn?: (summary: StaleTeamSummary) => Promise<boolean>,
 ): Promise<void> {
-  const stateDir = join(leaderCwd, '.omx', 'state', 'team', teamName);
+  const stateDir = teamRuntimeTeamRoot(teamName, leaderCwd);
   if (!existsSync(stateDir)) return;
 
   const sessions = new Set(listTeamSessions());
@@ -3816,7 +3832,7 @@ async function resolveLeaderSessionId(cwd: string): Promise<string> {
   const fromEnv = process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID || process.env.SESSION_ID;
   if (fromEnv && fromEnv.trim() !== '') return fromEnv.trim();
 
-  const p = join(cwd, '.omx', 'state', 'session.json');
+  const p = teamRuntimeSessionPath(cwd);
   if (!existsSync(p)) return '';
   try {
     const raw = await readFile(p, 'utf-8');

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -14,6 +14,7 @@ import {
   listInstalledSkillDirectories,
   detectLegacySkillRootOverlap,
   omxStateDir,
+  omxRoot,
   omxProjectMemoryPath,
   omxNotepadPath,
   omxPlansDir,
@@ -346,12 +347,43 @@ describe("listInstalledSkillDirectories", () => {
 });
 
 describe("omxStateDir", () => {
+  let originalOmxRoot: string | undefined;
+  let originalOmxStateRoot: string | undefined;
+
+  beforeEach(() => {
+    originalOmxRoot = process.env.OMX_ROOT;
+    originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+  });
+
+  afterEach(() => {
+    if (typeof originalOmxRoot === "string") process.env.OMX_ROOT = originalOmxRoot;
+    else delete process.env.OMX_ROOT;
+    if (typeof originalOmxStateRoot === "string") process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+    else delete process.env.OMX_STATE_ROOT;
+  });
+
   it("uses provided projectRoot", () => {
     assert.equal(omxStateDir("/my/project"), join("/my/project", ".omx", "state"));
   });
 
   it("defaults to cwd when no projectRoot given", () => {
     assert.equal(omxStateDir(), join(process.cwd(), ".omx", "state"));
+  });
+
+  it("uses OMX_ROOT override when set", () => {
+    process.env.OMX_ROOT = "/tmp/omx-root";
+    assert.equal(omxRoot("/ignored/project"), "/tmp/omx-root/.omx");
+    assert.equal(omxStateDir("/ignored/project"), "/tmp/omx-root/.omx/state");
+  });
+
+  it("uses OMX_ROOT as boxed workspace root for all runtime paths", () => {
+    process.env.OMX_ROOT = "/tmp/omx-box";
+    assert.equal(omxRoot("/ignored/project"), "/tmp/omx-box/.omx");
+    assert.equal(omxStateDir("/ignored/project"), "/tmp/omx-box/.omx/state");
+    assert.equal(omxProjectMemoryPath("/ignored/project"), "/tmp/omx-box/.omx/project-memory.json");
+    assert.equal(omxNotepadPath("/ignored/project"), "/tmp/omx-box/.omx/notepad.md");
+    assert.equal(omxPlansDir("/ignored/project"), "/tmp/omx-box/.omx/plans");
+    assert.equal(omxLogsDir("/ignored/project"), "/tmp/omx-box/.omx/logs");
   });
 });
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -18,6 +18,23 @@ export function codexHome(): string {
 export const OMX_ENTRY_PATH_ENV = "OMX_ENTRY_PATH";
 export const OMX_STARTUP_CWD_ENV = "OMX_STARTUP_CWD";
 
+function resolveOmxRootCandidate(raw?: string): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return isAbsolute(trimmed) ? trimmed : resolve(trimmed);
+}
+
+/** Optional override root for OMX runtime files. */
+export function omxRoot(projectRoot?: string): string {
+  const override =
+    resolveOmxRootCandidate(process.env.OMX_ROOT)
+    ?? resolveOmxRootCandidate(process.env.OMX_STATE_ROOT);
+  if (override) return join(override, ".omx");
+  return join(projectRoot || process.cwd(), ".omx");
+}
+
+
 function resolveLauncherPath(rawPath: string, baseCwd: string): string {
   const absolutePath = isAbsolute(rawPath) ? rawPath : resolve(baseCwd, rawPath);
   if (!existsSync(absolutePath)) return absolutePath;
@@ -285,37 +302,37 @@ async function hashSkillDirectory(
 
 /** oh-my-codex state directory (.omx/state/) */
 export function omxStateDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "state");
+  return join(omxRoot(projectRoot), "state");
 }
 
 /** oh-my-codex project memory file (.omx/project-memory.json) */
 export function omxProjectMemoryPath(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "project-memory.json");
+  return join(omxRoot(projectRoot), "project-memory.json");
 }
 
 /** oh-my-codex notepad file (.omx/notepad.md) */
 export function omxNotepadPath(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "notepad.md");
+  return join(omxRoot(projectRoot), "notepad.md");
 }
 
 /** oh-my-codex wiki directory (.omx/wiki/) */
 export function omxWikiDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "wiki");
+  return join(omxRoot(projectRoot), "wiki");
 }
 
 /** oh-my-codex plans directory (.omx/plans/) */
 export function omxPlansDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "plans");
+  return join(omxRoot(projectRoot), "plans");
 }
 
 /** oh-my-codex adapters directory (.omx/adapters/) */
 export function omxAdaptersDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "adapters");
+  return join(omxRoot(projectRoot), "adapters");
 }
 
 /** oh-my-codex logs directory (.omx/logs/) */
 export function omxLogsDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".omx", "logs");
+  return join(omxRoot(projectRoot), "logs");
 }
 
 /** User-scope install/update stamp path ($CODEX_HOME/.omx/install-state.json) */


### PR DESCRIPTION
## Summary
- preserve explicit `OMX_TEAM_STATE_ROOT` precedence over boxed/root state for MCP state paths
- route remaining team runtime, delivery-log, and leader activity readers through boxed-aware state/log roots
- add regression coverage for boxed writer/reader consistency and explicit team-state-root precedence

Supersedes the blocked follow-up path on #2085, whose fork head could not be updated from this environment.

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/state-paths.test.js dist/team/__tests__/delivery-log.test.js dist/team/__tests__/api-interop.test.js dist/team/__tests__/runtime-boxed-state.test.js`
- `npm run check:no-unused`
- `npm run lint`