### PR TITLE
docs: add GitHub package pipeline templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ If this happens, try:
 - [Agent catalog](./docs/agents.html)
 - [Skills reference](./docs/skills.html)
 - [Codex native hook mapping](./docs/codex-native-hooks.md)
+- [GitHub / PR / package identity pipeline](./docs/pipeline/github-pr-package-identity.md)
 - [Integrations](./docs/integrations.html)
 - [Troubleshooting execution readiness](./docs/troubleshooting.md)
 - [OpenClaw / notification gateway guide](./docs/openclaw-integration.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,6 +77,7 @@
       <h2>Reference Guides</h2>
       <ul>
         <li><a href="./reference/omx-config-schema-routing.md">.omx-config.json model/env routing reference</a></li>
+        <li><a href="./pipeline/github-pr-package-identity.md">GitHub / PR / package identity pipeline</a></li>
       </ul>
 
       <h2>Integration Guides</h2>

--- a/docs/pipeline/github-pr-package-identity.md
+++ b/docs/pipeline/github-pr-package-identity.md
@@ -1,0 +1,233 @@
+# GitHub / PR / package identity pipeline
+
+This guide documents the public contract for turning GitHub or community reports into traceable OMX work packages, worktrees, pull requests, reviews, and merge decisions. It is intentionally infrastructure-neutral: repositories may implement the glue with GitHub Actions, bots, scheduled scripts, or manual maintainer commands, but the artifacts and gates below are the source of truth.
+
+## Public scope and source of truth
+
+- **Repo-available contract:** the Markdown templates in [`docs/pipeline/templates/`](./templates/) and this workflow contract are safe to copy, review, and version in the repository.
+- **External orchestration glue:** webhook listeners, Discord bots, queue workers, credential stores, deployment targets, and scheduler internals live outside this contract. Do not document secrets, hostnames, queue names, tokens, private channels, or operational topology here.
+- **Truth model:** chat messages are coordination hints, not truth. The truth lives in GitHub issues, pull requests, and package artifacts committed to branches or attached to issues/PRs.
+- **Mutation safety:** any state-changing action must pass an explicit gate. Only one active mutating runtime may own a worktree at a time; observers and reviewers may read concurrently.
+
+## Pipeline overview
+
+1. **GitHub/Discord intake**
+   - Accept reports from GitHub issues and optional Discord/community threads.
+   - Mirror external context into the GitHub issue when it is needed for future maintainers.
+   - Record the canonical identity with [`issue-package-identity.md`](./templates/issue-package-identity.md).
+2. **Classify, dedupe, reproduce, and risk-gate**
+   - Classify as bug, feature/contract proposal, duplicate, support question, or invalid/spam.
+   - Search for existing issues and PRs before creating a package.
+   - Ask for a minimal reproduction when a bug report is not actionable.
+   - Apply a risk gate before any mutating runtime starts: branch target, affected surfaces, expected tests, and whether credentials or destructive commands are involved.
+3. **Package identity**
+   - Create a stable `package_id` for actionable work, usually `issue-<number>-<short-slug>`.
+   - Bind the package to one repo, one issue, one branch, one worktree, and optional external thread reference.
+   - Store package state transitions in the issue/PR/package artifacts, not only in chat.
+4. **Worktree/session/branch mapping**
+   - Branch: `<kind>/issue-<number>-<short-slug>` such as `fix/issue-1234-repro-timeout` or `docs/issue-2087-pipeline-templates`.
+   - Worktree: a deterministic path containing the `package_id`, for example `../oh-my-codex-worktrees/<package_id>`.
+   - OMX session: a runtime label containing or linking to the `package_id`; it may be implementation-specific, but the package artifact must say which runtime owned mutation.
+5. **Execution artifacts**
+   - `package.md` records identity, scope, gates, and state.
+   - `plan.md` records planned changes and validation.
+   - `execution-result.md` records what changed and evidence.
+   - `review.md` records review findings and approval/rejection.
+   - `merge-decision.md` records final gate outcome.
+6. **PR, review, and merge gates**
+   - PRs target the agreed base branch, usually `dev`.
+   - The PR links the issue and package artifacts.
+   - Review checks traceability, validation, risk, and single-owner worktree mutation.
+   - Merge only after validation evidence and review approval are recorded.
+
+## States
+
+Recommended package states:
+
+- `intake`: report received; no package created yet.
+- `needs_repro`: bug-like report needs exact reproduction details.
+- `duplicate`: closed or redirected to canonical issue.
+- `proposal`: feature/contract idea needs maintainer scope gate.
+- `ready`: package identity exists and mutation has not started.
+- `executing`: one mutating runtime owns the worktree.
+- `review`: implementation submitted; mutation paused except requested fixes.
+- `merge_ready`: review and validation gates passed.
+- `merged`: PR merged and issue closure recorded.
+- `closed`: no further work planned.
+
+## Issue/package identity
+
+Use [`templates/issue-package-identity.md`](./templates/issue-package-identity.md) in the issue body, a package artifact, or both. Required fields are:
+
+- `source`
+- `repo`
+- `issue`
+- `package_id`
+- `branch`
+- `worktree`
+- `discord_thread`
+- `state`
+
+## Triage policy templates
+
+Use the templates in [`templates/triage/`](./templates/triage/) for common issue outcomes:
+
+- [`needs-repro-question.md`](./templates/triage/needs-repro-question.md)
+- [`timeout-close.md`](./templates/triage/timeout-close.md)
+- [`duplicate-close.md`](./templates/triage/duplicate-close.md)
+- [`reproducible-bug-package.md`](./templates/triage/reproducible-bug-package.md)
+- [`feature-contract-proposal-gate.md`](./templates/triage/feature-contract-proposal-gate.md)
+
+## Execution artifact templates
+
+Use the templates in [`templates/execution/`](./templates/execution/) for package lifecycle records:
+
+- [`package.md`](./templates/execution/package.md)
+- [`plan.md`](./templates/execution/plan.md)
+- [`execution-result.md`](./templates/execution/execution-result.md)
+- [`review.md`](./templates/execution/review.md)
+- [`merge-decision.md`](./templates/execution/merge-decision.md)
+
+## Coordinator skeleton
+
+The coordinator is orchestration glue. Keep implementation-specific endpoints, credentials, process managers, queue names, and private channel identifiers outside public docs.
+
+```ts
+type IntakeEvent = {
+  source: "github" | "discord";
+  repo: string;
+  issue?: number;
+  externalThread?: string;
+  title: string;
+  body: string;
+  author: string;
+  receivedAt: string;
+};
+
+type Classification = {
+  kind: "bug" | "feature" | "contract" | "duplicate" | "support" | "invalid";
+  confidence: number;
+  canonicalIssue?: number;
+  needsRepro: boolean;
+  risk: "low" | "medium" | "high";
+  rationale: string;
+  suggestedPackageId?: string;
+};
+
+async function intakeLoop() {
+  for await (const event of pollOrReceiveWebhookEvents()) {
+    const issue = await ensureCanonicalGitHubIssue(event);
+    const classification = await classify(issue);
+
+    if (classification.kind === "duplicate") {
+      await commentFromTemplate(issue, "triage/duplicate-close.md", classification);
+      await closeIssue(issue, "not planned");
+      continue;
+    }
+
+    if (classification.needsRepro) {
+      await commentFromTemplate(issue, "triage/needs-repro-question.md", classification);
+      await label(issue, ["needs-repro"]);
+      continue;
+    }
+
+    if (classification.kind === "feature" || classification.kind === "contract") {
+      await commentFromTemplate(issue, "triage/feature-contract-proposal-gate.md", classification);
+      await label(issue, ["proposal", "needs-maintainer-gate"]);
+      continue;
+    }
+
+    if (classification.kind === "bug") {
+      await createPackageIdempotently(issue, classification);
+    }
+  }
+}
+
+async function createPackageIdempotently(issue: Issue, classification: Classification) {
+  const packageId = classification.suggestedPackageId ?? `issue-${issue.number}-${slug(issue.title)}`;
+  const existing = await findPackageByIssue(issue.repo, issue.number);
+  if (existing) return existing;
+
+  const branch = `fix/${packageId}`;
+  const worktree = `../oh-my-codex-worktrees/${packageId}`;
+  const session = `tmux-or-omx-${packageId}`;
+
+  await requireGate("risk", {
+    issue: issue.number,
+    packageId,
+    risk: classification.risk,
+    mutationOwner: session,
+  });
+
+  await run(`git fetch origin dev`);
+  await run(`git worktree add ${shellQuote(worktree)} -b ${shellQuote(branch)} origin/dev`);
+  await writeTemplate(`${worktree}/package.md`, "execution/package.md", {
+    source: "github",
+    repo: issue.repo,
+    issue: issue.number,
+    package_id: packageId,
+    branch,
+    worktree,
+    discord_thread: "n/a",
+    state: "ready",
+  });
+
+  await commentFromTemplate(issue, "triage/reproducible-bug-package.md", {
+    packageId,
+    branch,
+    worktree,
+    session,
+  });
+
+  // Dispatch is explicit: the coordinator records the command it asked a runtime to run.
+  const prompt = `Implement ${packageId}; keep package.md and execution-result.md current.`;
+  const command = `OMX_PACKAGE_ID=${packageId} omx team 1:executor ${shellQuote(prompt)}`;
+  await runInWorktree(worktree, command);
+  await recordDispatch(issue, {
+    command,
+    worktree,
+    branch,
+    packageId,
+  });
+}
+```
+
+## Explicit dispatch command examples
+
+These examples are placeholders; adapt them to the public CLI commands available in your environment and record the actual command in `package.md` or `execution-result.md`.
+
+```sh
+# Create a deterministic worktree for the package.
+git fetch origin dev
+git worktree add ../oh-my-codex-worktrees/issue-2087-pipeline-templates \
+  -b docs/issue-2087-pipeline-templates origin/dev
+
+# Start exactly one mutating runtime for that worktree and record the command.
+cd ../oh-my-codex-worktrees/issue-2087-pipeline-templates
+OMX_PACKAGE_ID=issue-2087-pipeline-templates \
+  omx team 1:executor "Implement issue-2087; keep package artifacts current."
+
+# Open a pull request after validation evidence exists.
+gh pr create --base dev --head docs/issue-2087-pipeline-templates \
+  --title "docs: add issue package pipeline templates" \
+  --body-file .github/pr-body.md
+```
+
+## Public safety checklist
+
+Before dispatch:
+
+- [ ] A canonical GitHub issue exists.
+- [ ] Duplicate search completed.
+- [ ] Reproduction or proposal scope is sufficient.
+- [ ] Risk gate is recorded.
+- [ ] `package_id`, branch, worktree, and optional external thread are recorded.
+- [ ] No secret, credential, private URL, queue name, or host-specific topology is present in public artifacts.
+- [ ] Exactly one mutating runtime owns the worktree.
+
+Before merge:
+
+- [ ] PR links the issue and package artifacts.
+- [ ] Validation evidence is current.
+- [ ] Review decision is recorded.
+- [ ] Merge decision states whether the PR closes the issue.

--- a/docs/pipeline/templates/README.md
+++ b/docs/pipeline/templates/README.md
@@ -1,0 +1,9 @@
+# Pipeline templates
+
+These public templates support the GitHub / PR / package identity pipeline documented in [`../github-pr-package-identity.md`](../github-pr-package-identity.md).
+
+- [`issue-package-identity.md`](./issue-package-identity.md): canonical identity block.
+- [`triage/`](./triage/): issue comments for common triage outcomes.
+- [`execution/`](./execution/): package, plan, result, review, and merge artifacts.
+
+Keep secrets and internal orchestration details out of these files. Chat can summarize status, but GitHub issues, PRs, and package artifacts remain the source of truth.

--- a/docs/pipeline/templates/execution/execution-result.md
+++ b/docs/pipeline/templates/execution/execution-result.md
@@ -1,0 +1,30 @@
+# Execution result
+
+## Package
+
+- package_id:
+- issue:
+- branch:
+- PR:
+
+## Changes made
+
+-
+
+## Validation evidence
+
+- Command:
+  - Result:
+- Command:
+  - Result:
+
+## Artifact updates
+
+- [ ] package.md updated.
+- [ ] plan.md updated.
+- [ ] review.md linked or pending.
+- [ ] merge-decision.md linked or pending.
+
+## Notes
+
+Do not rely on chat-only status. Copy durable evidence into the issue, PR, or package artifacts.

--- a/docs/pipeline/templates/execution/merge-decision.md
+++ b/docs/pipeline/templates/execution/merge-decision.md
@@ -1,0 +1,30 @@
+# Merge decision
+
+## Package
+
+- package_id:
+- issue:
+- PR:
+- base branch:
+- head branch:
+
+## Preconditions
+
+- [ ] PR review approved.
+- [ ] Required checks passed.
+- [ ] Latest validation evidence reviewed.
+- [ ] Merge closes or updates the issue intentionally.
+- [ ] Runtime ownership released or no longer mutating.
+
+## Decision
+
+- [ ] Merge
+- [ ] Do not merge yet
+- [ ] Close without merge
+
+## Closure text
+
+Closes #0000
+
+## Notes
+

--- a/docs/pipeline/templates/execution/merge-decision.md
+++ b/docs/pipeline/templates/execution/merge-decision.md
@@ -27,4 +27,3 @@
 Closes #0000
 
 ## Notes
-

--- a/docs/pipeline/templates/execution/package.md
+++ b/docs/pipeline/templates/execution/package.md
@@ -1,0 +1,34 @@
+# Package
+
+## Identity
+
+```yaml
+source: github
+repo: Yeachan-Heo/oh-my-codex
+issue: 0000
+package_id: issue-0000-short-slug
+branch: kind/issue-0000-short-slug
+worktree: ../oh-my-codex-worktrees/issue-0000-short-slug
+discord_thread: n/a
+state: ready
+```
+
+## Scope
+
+- Problem:
+- In scope:
+- Out of scope:
+
+## Gates
+
+- [ ] Duplicate search complete.
+- [ ] Repro or proposal contract recorded.
+- [ ] Risk gate recorded.
+- [ ] One active mutating runtime assigned to this worktree.
+- [ ] No secrets or internal infrastructure details in public artifacts.
+
+## Runtime ownership
+
+- Mutating runtime/session:
+- Started at:
+- Released at:

--- a/docs/pipeline/templates/execution/plan.md
+++ b/docs/pipeline/templates/execution/plan.md
@@ -1,0 +1,26 @@
+# Plan
+
+## Package
+
+- package_id:
+- issue:
+- branch:
+- worktree:
+
+## Intended changes
+
+1.
+2.
+3.
+
+## Validation plan
+
+- [ ] Build/typecheck:
+- [ ] Tests:
+- [ ] Docs-safe checks:
+- [ ] Manual review:
+
+## Risks and mitigations
+
+- Risk:
+  - Mitigation:

--- a/docs/pipeline/templates/execution/review.md
+++ b/docs/pipeline/templates/execution/review.md
@@ -1,0 +1,29 @@
+# Review
+
+## Package
+
+- package_id:
+- issue:
+- PR:
+- reviewer:
+
+## Checks
+
+- [ ] Scope matches issue/package.
+- [ ] Validation evidence is current.
+- [ ] Risk gate satisfied.
+- [ ] No secrets or internal infrastructure details added.
+- [ ] Worktree mutation ownership was singular.
+- [ ] Docs/code quality acceptable.
+
+## Findings
+
+-
+
+## Decision
+
+- [ ] Approved
+- [ ] Changes requested
+- [ ] Rejected
+
+Rationale:

--- a/docs/pipeline/templates/issue-package-identity.md
+++ b/docs/pipeline/templates/issue-package-identity.md
@@ -1,0 +1,18 @@
+# Issue/package identity
+
+```yaml
+source: github # github | discord | other
+repo: Yeachan-Heo/oh-my-codex
+issue: 0000
+package_id: issue-0000-short-slug
+branch: kind/issue-0000-short-slug
+worktree: ../oh-my-codex-worktrees/issue-0000-short-slug
+discord_thread: n/a
+state: intake # intake | needs_repro | duplicate | proposal | ready | executing | review | merge_ready | merged | closed
+```
+
+Notes:
+
+- The GitHub issue is canonical even when intake starts elsewhere.
+- `discord_thread` may be `n/a` or a public-safe reference; do not include private channel IDs or tokens.
+- Update `state` only when the matching gate or artifact has been recorded.

--- a/docs/pipeline/templates/triage/duplicate-close.md
+++ b/docs/pipeline/templates/triage/duplicate-close.md
@@ -1,0 +1,3 @@
+Closing as a duplicate of #CANONICAL_ISSUE.
+
+Please continue discussion and validation on the canonical issue so the package identity, branch, worktree, PR, and review history stay in one place.

--- a/docs/pipeline/templates/triage/feature-contract-proposal-gate.md
+++ b/docs/pipeline/templates/triage/feature-contract-proposal-gate.md
@@ -1,0 +1,9 @@
+Thanks for the proposal. Before implementation, a maintainer should confirm the contract:
+
+- User problem and expected behavior.
+- Public CLI/API/docs surface affected.
+- Compatibility impact and migration path.
+- Validation plan.
+- Whether this should be solved in repo docs/code or by external orchestration glue.
+
+Until this gate is approved, do not create a mutating worktree. Discussion can continue here, but the accepted contract must be captured in the issue or PR artifacts.

--- a/docs/pipeline/templates/triage/needs-repro-question.md
+++ b/docs/pipeline/templates/triage/needs-repro-question.md
@@ -1,0 +1,5 @@
+Thanks for the report. I need one focused reproduction detail before this can become an executable package:
+
+**What is the smallest exact command or prompt that reproduces the problem, and what output do you get?**
+
+Please include only the environment facts needed to run that command (`oh-my-codex` version, OS/shell, Node.js version) and redact secrets from logs. We will keep this labeled `needs-repro` until the issue can be reproduced or narrowed to a specific contract. If there is no follow-up after the timeout window, maintainers may close it as not actionable.

--- a/docs/pipeline/templates/triage/reproducible-bug-package.md
+++ b/docs/pipeline/templates/triage/reproducible-bug-package.md
@@ -1,0 +1,17 @@
+This looks reproducible and is ready for a package/worktree/OMX session.
+
+```yaml
+package_id: issue-0000-short-slug
+branch: fix/issue-0000-short-slug
+worktree: ../oh-my-codex-worktrees/issue-0000-short-slug
+omx_session: issue-0000-short-slug
+state: ready
+```
+
+Mutation gate:
+
+- [ ] Duplicate search completed.
+- [ ] Reproduction steps are present in the issue.
+- [ ] Risk level recorded.
+- [ ] Exactly one mutating runtime is assigned to the worktree.
+- [ ] Package artifact exists or will be committed with the implementation.

--- a/docs/pipeline/templates/triage/timeout-close.md
+++ b/docs/pipeline/templates/triage/timeout-close.md
@@ -1,0 +1,10 @@
+Closing because the requested reproduction details were not provided within the timeout window.
+
+If you can still reproduce this, please open a new issue or ask to reopen with:
+
+- the exact command or prompt,
+- environment details,
+- expected vs actual behavior,
+- redacted logs/screenshots.
+
+Chat context alone is not enough to reopen; the GitHub issue must contain the actionable evidence.


### PR DESCRIPTION
## Summary

Adds public documentation and copyable templates for the GitHub / PR / package identity pipeline requested in #2087.

## Changes

- Documents the repo-available pipeline contract vs external orchestration glue.
- Adds issue/package identity, triage policy, execution artifact, review, and merge-decision templates.
- Includes coordinator pseudo-code for intake, classification, idempotent package creation, worktree/session naming, and explicit dispatch commands.
- Links the new guide from README and the docs index.

## Validation

- [x] docs contract check for required templates/fields/policy statements
- [x] `git diff --check`
- [x] `npm run build`

## Related

Closes #2087
