### PR TITLE
Add per-agent reasoning overrides

### DIFF
--- a/docs/reference/omx-config-schema-routing.md
+++ b/docs/reference/omx-config-schema-routing.md
@@ -25,6 +25,7 @@ Current code recognizes these top-level `.omx-config.json` keys:
 
 | Top-level key | Supported shape | Primary use |
 | --- | --- | --- |
+| `agentReasoning` | Object mapping agent names to `low`, `medium`, `high`, or `xhigh` | Optional per-agent reasoning overrides for generated native agent TOML and role-based worker/Ralph staffing guidance. |
 | `env` | Object of non-empty string values | Fallback environment values for model routing and helper launch paths. Model-related supported keys are listed below. |
 | `models` | Object of non-empty string values | Mode defaults and low-complexity model aliases. Supported model-routing keys are listed below. |
 | `notifications` | Object | Notification transports, profiles, templates, cooldowns, replies, and OpenClaw/custom aliases. See the notification summary below and the OpenClaw guide for full examples. |
@@ -49,10 +50,14 @@ Use [`docs/discord-integration.md`](../discord-integration.md) for Discord webho
 
 ## Supported model/env keys
 
-The model-routing reader supports two top-level objects: `env` and `models`.
+The model-routing reader supports `env`, `models`, and the role-reasoning override map `agentReasoning`.
 
 ```json
 {
+  "agentReasoning": {
+    "architect": "xhigh",
+    "critic": "xhigh"
+  },
   "env": {
     "OMX_DEFAULT_FRONTIER_MODEL": "gpt-5.5",
     "OMX_DEFAULT_STANDARD_MODEL": "gpt-5.4-mini",
@@ -97,6 +102,21 @@ Supported model-routing keys:
 | `teamLowComplexity` | Alias for `team_low_complexity`. |
 
 Do not invent per-role maps such as `models.executor`, `models.architect`, or `models.roles` unless your installed version documents that exact key. Current role routing is based on agent definitions and model class, not arbitrary per-role JSON maps.
+
+### `agentReasoning`
+
+`agentReasoning` is the supported per-agent reasoning override map. Keys are agent names and values must be one of `low`, `medium`, `high`, or `xhigh`.
+
+```json
+{
+  "agentReasoning": {
+    "architect": "xhigh",
+    "critic": "xhigh"
+  }
+}
+```
+
+These overrides do not change built-in defaults in source. They are user/project configuration that applies when OMX resolves role reasoning for generated native agent TOML and role-based team/Ralph staffing/worker guidance. Rerun `omx setup` after changing this map so setup-managed native agent TOML files are regenerated. Malformed agent names, empty values, and unsupported effort values are ignored.
 
 ## Effective model precedence
 
@@ -166,7 +186,7 @@ Use `omx team status <team-name> --model-inspect` when you need inspect hints fo
 
 ## Reasoning effort: supported places only
 
-`.omx-config.json` is **not** the general place to configure `model_reasoning_effort`. Do not add keys such as `reasoningEffort`, `modelReasoningEffort`, `reasoning`, or per-role reasoning maps to `.omx-config.json`.
+`.omx-config.json` is **not** the general place to configure root `model_reasoning_effort`. Do not add arbitrary keys such as `reasoningEffort`, `modelReasoningEffort`, `reasoning`, or undeclared per-role reasoning maps. The supported per-agent override map is exactly `agentReasoning`.
 
 Supported reasoning-effort surfaces are:
 
@@ -174,6 +194,7 @@ Supported reasoning-effort surfaces are:
 - `omx reasoning <low|medium|high|xhigh>`, which edits the active Codex `config.toml`.
 - `omx --high` and `omx --xhigh`, which pass `-c model_reasoning_effort="high|xhigh"` to Codex launch.
 - Generated native agent TOML files, where OMX writes each role's built-in `reasoningEffort` metadata.
+- `.omx-config.json` `agentReasoning`, which overrides selected role defaults for generated native agent TOML and role-based team/Ralph reasoning allocation without changing built-in defaults.
 - Team worker launch args, for example:
 
 ```bash
@@ -181,7 +202,7 @@ OMX_TEAM_WORKER_LAUNCH_ARGS='-c model_reasoning_effort="low" --model gpt-5.3-cod
   omx team 3:explore "map the config surfaces"
 ```
 
-Team runtime can also inject role-default reasoning for Codex workers when no explicit reasoning override is present. Explicit launch args win.
+Team runtime can also inject role-default or `agentReasoning`-overridden reasoning for Codex workers when no explicit reasoning override is present. Explicit launch args win.
 
 ## Starter configs
 
@@ -212,6 +233,10 @@ This keeps standard agents inheriting the frontier model by omitting `OMX_DEFAUL
 
 ```json
 {
+  "agentReasoning": {
+    "architect": "xhigh",
+    "critic": "xhigh"
+  },
   "env": {
     "OMX_DEFAULT_FRONTIER_MODEL": "gpt-5.5",
     "OMX_DEFAULT_SPARK_MODEL": "gpt-5.3-codex-spark"

--- a/plugins/oh-my-codex/skills/team/SKILL.md
+++ b/plugins/oh-my-codex/skills/team/SKILL.md
@@ -183,7 +183,7 @@ Default-model rule:
 Thinking-level rule (critical):
 - **No model-name heuristic mapping.**
 - Team runtime must **not** infer `model_reasoning_effort` from model-name substrings (e.g., `spark`, `high-capability`, `mini`).
-- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role (`low`, `medium`, `high`).
+- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role and `agentReasoning` overrides (`low`, `medium`, `high`, `xhigh`).
 - Explicit launch args still win: if `OMX_TEAM_WORKER_LAUNCH_ARGS` already includes `-c model_reasoning_effort=...`, that explicit value overrides dynamic allocation for every worker.
 
 Normalization requirements:
@@ -191,7 +191,7 @@ Normalization requirements:
 - Remove duplicate/conflicting model flags
 - Emit exactly one final canonical flag: `--model <value>`
 - Preserve unrelated args in worker launch config
-- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default reasoning level
+- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default or `agentReasoning`-overridden reasoning level
 
 ## Required Lifecycle (Operator Contract)
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -183,7 +183,7 @@ Default-model rule:
 Thinking-level rule (critical):
 - **No model-name heuristic mapping.**
 - Team runtime must **not** infer `model_reasoning_effort` from model-name substrings (e.g., `spark`, `high-capability`, `mini`).
-- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role (`low`, `medium`, `high`).
+- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role and `agentReasoning` overrides (`low`, `medium`, `high`, `xhigh`).
 - Explicit launch args still win: if `OMX_TEAM_WORKER_LAUNCH_ARGS` already includes `-c model_reasoning_effort=...`, that explicit value overrides dynamic allocation for every worker.
 
 Normalization requirements:
@@ -191,7 +191,7 @@ Normalization requirements:
 - Remove duplicate/conflicting model flags
 - Emit exactly one final canonical flag: `--model <value>`
 - Preserve unrelated args in worker launch config
-- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default reasoning level
+- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default or `agentReasoning`-overridden reasoning level
 
 ## Required Lifecycle (Operator Contract)
 

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -104,6 +104,33 @@ describe("agents/native-config", () => {
     );
   });
 
+  it("applies per-agent reasoning overrides when generating native TOML", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "omx-native-config-reasoning-"));
+    try {
+      await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({
+        agentReasoning: {
+          architect: "xhigh",
+        },
+      }));
+      const agent: AgentDefinition = {
+        name: "architect",
+        description: "System design",
+        reasoningEffort: "high",
+        posture: "frontier-orchestrator",
+        modelClass: "frontier",
+        routingRole: "leader",
+        tools: "read-only",
+        category: "build",
+      };
+
+      const toml = generateAgentToml(agent, "Architect prompt", { codexHomeOverride: codexHome });
+
+      assert.match(toml, /model_reasoning_effort = "xhigh"/);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
   it("applies exact-model mini guidance only for resolved gpt-5.4-mini standard roles", () => {
     const agent: AgentDefinition = {
       name: "debugger",
@@ -166,6 +193,34 @@ describe("agents/native-config", () => {
         catalogManifest: manifestWithAgents(["executor", "planner"]),
       });
       assert.equal(skipped, 0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("installs native agent TOML with configured per-agent reasoning overrides", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-config-install-reasoning-"));
+    const codexHome = join(root, ".codex");
+    const promptsDir = join(root, "prompts");
+    const outDir = join(codexHome, "agents");
+
+    try {
+      await mkdir(promptsDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({
+        agentReasoning: {
+          architect: "xhigh",
+        },
+      }));
+      await writeFile(join(promptsDir, "architect.md"), "architect prompt");
+
+      await installNativeAgentConfigs(root, {
+        agentsDir: outDir,
+        catalogManifest: manifestWithAgents(["architect"]),
+      });
+
+      const architectToml = await readFile(join(outDir, "architect.toml"), "utf8");
+      assert.match(architectToml, /model_reasoning_effort = "xhigh"/);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -13,6 +13,7 @@ import { getInstallableNativeAgentNames } from "./policy.js";
 import {
   getCodexConfigRootModelProvider,
   getEnvConfiguredStandardDefaultModel,
+  getAgentReasoningOverride,
   getMainDefaultModel,
   getSparkDefaultModel,
   getStandardDefaultModel,
@@ -312,7 +313,8 @@ export function generateAgentToml(
     developerInstructions: composeRoleInstructions(promptContent, agent, resolvedModel),
     model: resolvedModel,
     modelProvider: resolvedModelProvider,
-    reasoningEffort: agent.reasoningEffort,
+    reasoningEffort: getAgentReasoningOverride(agent.name, options.codexHomeOverride)
+      ?? agent.reasoningEffort,
   });
 }
 

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { startMode, updateModeState } from '../modes/base.js';
 import { readApprovedExecutionLaunchHint, type ApprovedExecutionLaunchHint } from '../planning/artifacts.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
+import { resolveCodexHomeForLaunch } from './codex-home.js';
 import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
@@ -296,7 +297,10 @@ export async function ralphCommand(args: string[]): Promise<void> {
   const task = explicitTask === 'ralph-cli-launch' ? approvedHint?.task ?? explicitTask : explicitTask;
   const noDeslop = normalizedArgs.some((arg) => arg.toLowerCase() === '--no-deslop');
   const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
-  const staffingPlan = buildFollowupStaffingPlan('ralph', task, availableAgentTypes);
+  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, process.env);
+  const staffingPlan = buildFollowupStaffingPlan('ralph', task, availableAgentTypes, {
+    codexHomeOverride,
+  });
   await startMode('ralph', task, 50);
   const sessionFiles = await writeRalphSessionFiles(cwd, task, { noDeslop, approvedHint });
   await updateModeState('ralph', {

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_FRONTIER_MODEL,
   DEFAULT_SPARK_MODEL,
   DEFAULT_TEAM_CHILD_MODEL,
+  getAgentReasoningOverride,
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
   getModelForMode,
@@ -14,6 +15,7 @@ import {
   getStandardDefaultModel,
   getTeamChildModel,
   getTeamLowComplexityModel,
+  readAgentReasoningOverrides,
   readConfiguredEnvOverrides,
 } from '../models.js';
 
@@ -243,6 +245,25 @@ describe('getModelForMode', () => {
       OMX_DEFAULT_STANDARD_MODEL: 'standard-local',
       OMX_DEFAULT_SPARK_MODEL: 'spark-local',
     });
+  });
+
+  it('reads normalized per-agent reasoning overrides from .omx-config.json', async () => {
+    await writeConfig({
+      agentReasoning: {
+        Architect: ' xhigh ',
+        critic: 'high',
+        executor: 'invalid',
+        'bad role': 'low',
+        empty: '   ',
+      },
+    });
+
+    assert.deepEqual(readAgentReasoningOverrides(), {
+      architect: 'xhigh',
+      critic: 'high',
+    });
+    assert.equal(getAgentReasoningOverride('ARCHITECT'), 'xhigh');
+    assert.equal(getAgentReasoningOverride('executor'), undefined);
   });
 
   it('keeps explicit low-complexity config ahead of OMX_DEFAULT_SPARK_MODEL', async () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -13,6 +13,9 @@
  *   "models": {
  *     "default": "o4-mini",
  *     "team": "gpt-4.1"
+ *   },
+ *   "agentReasoning": {
+ *     "architect": "xhigh"
  *   }
  * }
  *
@@ -32,7 +35,10 @@ export interface OmxConfigEnv {
   [key: string]: string | undefined;
 }
 
+export type ConfiguredAgentReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+
 interface OmxConfigFile {
+  agentReasoning?: Record<string, unknown>;
   env?: OmxConfigEnv;
   models?: ModelsConfig;
 }
@@ -95,6 +101,24 @@ function normalizeConfiguredValue(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function normalizeAgentReasoningEffort(value: unknown): ConfiguredAgentReasoningEffort | undefined {
+  const normalized = normalizeConfiguredValue(value)?.toLowerCase();
+  if (
+    normalized === 'low' ||
+    normalized === 'medium' ||
+    normalized === 'high' ||
+    normalized === 'xhigh'
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeAgentName(value: unknown): string | undefined {
+  const normalized = normalizeConfiguredValue(value)?.toLowerCase();
+  return normalized && /^[a-z0-9][a-z0-9_-]*$/.test(normalized) ? normalized : undefined;
+}
+
 function readConfigEnvValue(key: string, codexHomeOverride?: string): string | undefined {
   const config = readOmxConfigFile(codexHomeOverride);
   if (!config || !config.env || typeof config.env !== 'object' || Array.isArray(config.env)) {
@@ -125,6 +149,31 @@ export function readConfiguredEnvOverrides(codexHomeOverride?: string): NodeJS.P
     if (normalized) resolved[key] = normalized;
   }
   return resolved;
+}
+
+export function readAgentReasoningOverrides(
+  codexHomeOverride?: string,
+): Record<string, ConfiguredAgentReasoningEffort> {
+  const config = readOmxConfigFile(codexHomeOverride);
+  const raw = config?.agentReasoning;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+
+  const resolved: Record<string, ConfiguredAgentReasoningEffort> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const role = normalizeAgentName(key);
+    const effort = normalizeAgentReasoningEffort(value);
+    if (role && effort) resolved[role] = effort;
+  }
+  return resolved;
+}
+
+export function getAgentReasoningOverride(
+  agentName: string | undefined,
+  codexHomeOverride?: string,
+): ConfiguredAgentReasoningEffort | undefined {
+  const normalized = normalizeAgentName(agentName);
+  if (!normalized) return undefined;
+  return readAgentReasoningOverrides(codexHomeOverride)[normalized];
 }
 
 export function readActiveProviderEnvOverrides(

--- a/src/scripts/verify-native-agents.ts
+++ b/src/scripts/verify-native-agents.ts
@@ -188,7 +188,9 @@ export async function verifyNativeAgents(
     const promptContent = options.promptNames
       ? `${name} prompt fixture`
       : await readFile(promptPath, "utf-8");
-    const toml = generateAgentToml(agent, promptContent);
+    const toml = generateAgentToml(agent, promptContent, {
+      codexHomeOverride: join(root, ".omx", "verify-native-agents-codex-home"),
+    });
     assertTomlStructure(name, agent, toml);
   }
 

--- a/src/team/__tests__/followup-planner.test.ts
+++ b/src/team/__tests__/followup-planner.test.ts
@@ -78,6 +78,33 @@ describe('followup-planner', () => {
     assert.equal(plan.verificationPlan.checkpoints.length, 3);
   });
 
+  it('applies per-agent reasoning overrides to Ralph sign-off staffing guidance', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-followup-reasoning-'));
+    try {
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        agentReasoning: {
+          architect: 'xhigh',
+        },
+      }));
+
+      const plan = buildFollowupStaffingPlan(
+        'ralph',
+        'Investigate auth regression and verify the fix',
+        ['architect', 'debugger', 'executor', 'test-engineer'],
+        { codexHomeOverride: codexHome },
+      );
+
+      assert.ok(
+        plan.allocations.some(
+          (allocation) => allocation.role === 'architect' && allocation.reasoningEffort === 'xhigh',
+        ),
+      );
+      assert.match(plan.staffingSummary, /architect x1 .*xhigh reasoning/);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
   it('allocates explore plus researcher lanes for mixed local+official-doc follow-up', () => {
     const plan = buildFollowupStaffingPlan(
       'team',

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -163,6 +164,22 @@ describe('team model contract', () => {
     assert.equal(resolveAgentReasoningEffort('executor'), 'medium');
     assert.equal(resolveAgentReasoningEffort('architect'), 'high');
     assert.equal(resolveAgentReasoningEffort('does-not-exist'), undefined);
+  });
+
+  it('maps worker roles through configured per-agent reasoning overrides', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-model-contract-reasoning-'));
+    try {
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        agentReasoning: {
+          architect: 'xhigh',
+        },
+      }));
+
+      assert.equal(resolveAgentReasoningEffort('architect', codexHome), 'xhigh');
+      assert.equal(resolveAgentReasoningEffort('critic', codexHome), 'high');
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
   });
 
   it('maps worker roles to configured default model lanes', () => {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -96,6 +96,7 @@ function withIsolatedDefaultModelEnv<T>(run: () => T): T {
     'OMX_DEFAULT_STANDARD_MODEL',
     'OMX_DEFAULT_SPARK_MODEL',
     'OMX_SPARK_MODEL',
+    'OMX_TEAM_WORKER_LAUNCH_ARGS',
   ] as const) {
     savedEnv.set(key, process.env[key]);
     delete process.env[key];
@@ -125,6 +126,7 @@ async function withIsolatedDefaultModelEnvAsync<T>(
     'OMX_DEFAULT_STANDARD_MODEL',
     'OMX_DEFAULT_SPARK_MODEL',
     'OMX_SPARK_MODEL',
+    'OMX_TEAM_WORKER_LAUNCH_ARGS',
   ] as const) {
     savedEnv.set(key, process.env[key]);
     delete process.env[key];
@@ -3227,7 +3229,7 @@ process.exit(0);
   });
 
 
-  it('startTeam preserves routed task roles into team state and worker launch args', async () => {
+  it('startTeam preserves routed task roles into team state and override-aware worker launch args', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-role-routing-'));
     const binDir = join(cwd, 'bin');
     const fakeCodexPath = join(binDir, 'codex');
@@ -3269,8 +3271,16 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withIsolatedDefaultModelEnvAsync(async () =>
-        await withMockPromptModeCodexAllowed(() =>
+      runtime = await withIsolatedDefaultModelEnvAsync(async () => {
+        assert.ok(process.env.CODEX_HOME, 'isolated CODEX_HOME should be set');
+        await mkdir(process.env.CODEX_HOME, { recursive: true });
+        await writeFile(join(process.env.CODEX_HOME, '.omx-config.json'), JSON.stringify({
+          agentReasoning: {
+            writer: 'xhigh',
+          },
+        }));
+
+        return await withMockPromptModeCodexAllowed(() =>
           withoutTeamWorkerEnv(() =>
             startTeam(
               'team-role-routing',
@@ -3282,7 +3292,8 @@ process.on('SIGTERM', () => process.exit(0));
                 { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' },
               ],
               cwd,
-            ))));
+            )));
+      });
 
       assert.equal(runtime.config.worker_launch_mode, 'prompt');
       assert.equal(runtime.config.workers[0]?.role, 'test-engineer');
@@ -3327,7 +3338,7 @@ process.on('SIGTERM', () => process.exit(0));
       assert.match(worker1Joined, /model_reasoning_effort="medium"/);
       assert.match(worker1Joined, /model_instructions_file=.*worker-1\/AGENTS\.md/);
       assert.match(worker1Joined, /--model gpt-5\.5/);
-      assert.match(worker2Joined, /model_reasoning_effort="high"/);
+      assert.match(worker2Joined, /model_reasoning_effort="xhigh"/);
       assert.match(worker2Joined, /model_instructions_file=.*worker-2\/AGENTS\.md/);
       assert.match(worker2Joined, /--model gpt-5\.5/);
 

--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -106,12 +106,14 @@ process.on('SIGTERM', () => process.exit(0));
     const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const prevCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
+    const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
 
     process.env.PATH = `${binDir}:${prevPath ?? ''}`;
     delete process.env.TMUX;
     process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     process.env.OMX_TEAM_WORKER_CLI = 'codex';
     process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
+    delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
 
     let runtime: TeamRuntime | null = null;
     try {
@@ -180,6 +182,8 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevCaptureDir === 'string') process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
       else delete process.env.OMX_ARGV_CAPTURE_DIR;
+      if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/followup-planner.ts
+++ b/src/team/followup-planner.ts
@@ -39,6 +39,7 @@ export interface ResolveAvailableAgentTypesOptions {
 }
 
 export interface BuildFollowupStaffingPlanOptions {
+  codexHomeOverride?: string;
   workerCount?: number;
   fallbackRole?: string;
 }
@@ -140,9 +141,10 @@ function mergeAllocation(
   role: string,
   count: number,
   reason: string,
+  codexHomeOverride?: string,
 ): void {
   if (count <= 0) return;
-  const reasoningEffort = resolveAgentReasoningEffort(role);
+  const reasoningEffort = resolveAgentReasoningEffort(role, codexHomeOverride);
   const existing = allocations.find(
     (item) => item.role === role && item.reason === reason && item.reasoningEffort === reasoningEffort,
   );
@@ -290,31 +292,37 @@ export function buildFollowupStaffingPlan(
   );
   const allocations: FollowupAllocation[] = [];
 
-  mergeAllocation(allocations, primaryRole, 1, mode === 'team' ? 'primary delivery lane' : 'primary implementation lane');
+  mergeAllocation(
+    allocations,
+    primaryRole,
+    1,
+    mode === 'team' ? 'primary delivery lane' : 'primary implementation lane',
+    options.codexHomeOverride,
+  );
 
   if (mode === 'team') {
     if (workerCount >= 2) {
-      mergeAllocation(allocations, qualityRole, 1, 'verification + regression lane');
+      mergeAllocation(allocations, qualityRole, 1, 'verification + regression lane', options.codexHomeOverride);
     }
     if (workerCount >= 3) {
       const specialistRole = pickSpecialistRole(task, availableAgentTypes, primaryRole, primaryRole);
-      mergeAllocation(allocations, specialistRole, 1, 'specialist support lane');
+      mergeAllocation(allocations, specialistRole, 1, 'specialist support lane', options.codexHomeOverride);
     }
     if (workerCount >= 4) {
-      mergeAllocation(allocations, primaryRole, workerCount - 3, 'extra implementation capacity');
+      mergeAllocation(allocations, primaryRole, workerCount - 3, 'extra implementation capacity', options.codexHomeOverride);
     }
   } else {
-    mergeAllocation(allocations, qualityRole, 1, 'evidence + regression checks');
+    mergeAllocation(allocations, qualityRole, 1, 'evidence + regression checks', options.codexHomeOverride);
     const architectRole = chooseAvailableRole(
       availableAgentTypes,
       ['architect', 'critic', 'verifier'],
       qualityRole,
     );
-    mergeAllocation(allocations, architectRole, 1, 'final architecture / completion sign-off');
+    mergeAllocation(allocations, architectRole, 1, 'final architecture / completion sign-off', options.codexHomeOverride);
 
     if (workerCount >= 4) {
       const specialistRole = pickSpecialistRole(task, availableAgentTypes, primaryRole, primaryRole);
-      mergeAllocation(allocations, specialistRole, workerCount - 3, 'parallel specialist follow-up capacity');
+      mergeAllocation(allocations, specialistRole, workerCount - 3, 'parallel specialist follow-up capacity', options.codexHomeOverride);
     }
   }
 

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -1,6 +1,7 @@
 import { getAgent } from '../agents/definitions.js';
 import {
   DEFAULT_SPARK_MODEL,
+  getAgentReasoningOverride,
   getMainDefaultModel,
   getSparkDefaultModel,
   getStandardDefaultModel,
@@ -204,9 +205,13 @@ export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgs
   return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel, options.preferredReasoning, selectedModelProvider);
 }
 
-export function resolveAgentReasoningEffort(agentType?: string): TeamReasoningEffort | undefined {
+export function resolveAgentReasoningEffort(
+  agentType?: string,
+  codexHomeOverride?: string,
+): TeamReasoningEffort | undefined {
   if (typeof agentType !== 'string' || agentType.trim() === '') return undefined;
-  return normalizeOptionalReasoning(getAgent(agentType)?.reasoningEffort);
+  return normalizeOptionalReasoning(getAgentReasoningOverride(agentType, codexHomeOverride))
+    ?? normalizeOptionalReasoning(getAgent(agentType)?.reasoningEffort);
 }
 
 export function resolveAgentDefaultModel(

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2426,7 +2426,8 @@ export async function startTeam(
       const runtimeRole = workerRole;
       const rawRolePromptContent = await loadRolePrompt(runtimeRole, join(leaderCwd, '.codex', 'prompts'))
         ?? await loadRolePrompt(runtimeRole, codexPromptsDir());
-      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole) ?? resolveAgentReasoningEffort(agentType);
+      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, process.env.CODEX_HOME)
+        ?? resolveAgentReasoningEffort(agentType, process.env.CODEX_HOME);
       const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
         process.env,
         runtimeRole,

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -354,7 +354,8 @@ export async function scaleUp(
       // Build startup command and create tmux pane
       const rawRolePromptContent = await loadRolePrompt(runtimeRole, join(leaderCwd, '.codex', 'prompts'))
         ?? await loadRolePrompt(runtimeRole, codexPromptsDir());
-      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole) ?? resolveAgentReasoningEffort(agentType);
+      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, env.CODEX_HOME)
+        ?? resolveAgentReasoningEffort(agentType, env.CODEX_HOME);
       const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, runtimeRole, preferredReasoning);
       const resolvedWorkerModel = parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
       const rolePromptContent = rawRolePromptContent


### PR DESCRIPTION
## Summary

Addresses #2089.

- Add a documented `.omx-config.json` `agentReasoning` map for opt-in per-agent reasoning overrides (`low`, `medium`, `high`, `xhigh`) while preserving all built-in role defaults.
- Apply the override contract to generated native agent TOML, team worker/scaling launch reasoning allocation, and plain Ralph staffing/sign-off guidance.
- Document the supported config shape and update the team skill contract; keep native-agent verification isolated from a user's local override config.

## Tests

- `npm run build`
- `node --test dist/config/__tests__/models.test.js dist/agents/__tests__/native-config.test.js dist/team/__tests__/model-contract.test.js dist/team/__tests__/followup-planner.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/worker-runtime-identity.test.js dist/cli/__tests__/ralph.test.js`
- `npm run verify:native-agents && npm run sync:plugin:check`
- `npm test`
