### PR TITLE
Fix plugin-mode AGENTS guidance paths

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -737,6 +737,17 @@ describe("omx setup install mode behavior", () => {
 						"utf-8",
 					);
 					assert.match(config, /developer_instructions\s*=/);
+					assert.match(
+						config,
+						/Registered Codex plugin marketplace surfaces supply OMX workflows, prompts, and native-agent roles/,
+					);
+					assert.match(config, /User-installed skills may still live under ~\/.codex\/skills/);
+					assert.match(
+						config,
+						/Setup-owned prompt files and native-agent TOML defaults are intentionally omitted unless explicitly installed/,
+					);
+					assert.doesNotMatch(config, /Native subagents live in \.codex\/agents/);
+					assert.doesNotMatch(config, /Treat installed prompts as narrower execution surfaces/);
 					assert.match(config, /^codex_hooks = true$/m);
 					assert.doesNotMatch(config, /notify-hook|mcp_servers/);
 
@@ -759,8 +770,46 @@ describe("omx setup install mode behavior", () => {
 					);
 					assert.match(
 						agentsMd,
-						/Treat installed prompts as narrower execution surfaces under AGENTS\.md authority|Role prompts under `prompts\/\*\.md` are narrower execution surfaces/,
+						/Registered Codex plugin marketplace surfaces supply OMX workflows, prompts, and native-agent roles/,
 					);
+					assert.match(agentsMd, /User-installed skills may still live under `~\/.codex\/skills`/);
+					assert.match(
+						agentsMd,
+						/Setup-owned prompt files and native-agent TOML defaults are intentionally omitted in plugin mode unless explicitly installed/,
+					);
+					assert.doesNotMatch(agentsMd, /Role prompts under `prompts\/\*\.md`/);
+					assert.doesNotMatch(agentsMd, /load the installed prompt\/skill\/agent surfaces from/);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("uses project-scoped plugin AGENTS.md wording without legacy prompt or agent paths", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "project",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => true,
+						pluginDeveloperInstructionsPrompt: async () => false,
+					});
+
+					const agentsMd = await readFile(join(wd, "AGENTS.md"), "utf-8");
+					assert.match(
+						agentsMd,
+						/Registered Codex plugin marketplace surfaces supply OMX workflows, prompts, and native-agent roles/,
+					);
+					assert.match(
+						agentsMd,
+						/User-installed skills may still live under `\.\/.codex\/skills` for project scope, or `~\/.codex\/skills` for user-installed skills/,
+					);
+					assert.doesNotMatch(agentsMd, /`~\/.codex\/prompts`/);
+					assert.doesNotMatch(agentsMd, /`~\/.codex\/agents`/);
+					assert.doesNotMatch(agentsMd, /Role prompts under `prompts\/\*\.md`/);
 				});
 			});
 		} finally {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -40,7 +40,7 @@ import {
 	stripOmxFeatureFlags,
 	stripOmxSeededBehavioralDefaults,
 	upsertPluginModeRuntimeFeatureFlags,
-	OMX_DEVELOPER_INSTRUCTIONS,
+	OMX_PLUGIN_DEVELOPER_INSTRUCTIONS,
 } from "../config/generator.js";
 import { mergeManagedCodexHooksConfig } from "../config/codex-hooks.js";
 import {
@@ -229,6 +229,21 @@ function applyScopePathRewritesToAgentsTemplate(
 ): string {
 	if (scope !== "project") return content;
 	return content.replaceAll("~/.codex", "./.codex");
+}
+
+function applyPluginModeWordingToAgentsTemplate(
+	content: string,
+	scope: SetupScope,
+): string {
+	const scopedContent = applyScopePathRewritesToAgentsTemplate(content, scope);
+	const userSkillPath =
+		scope === "project"
+			? "`./.codex/skills` for project scope, or `~/.codex/skills` for user-installed skills"
+			: "`~/.codex/skills`";
+	return scopedContent.replace(
+		/Role prompts under `prompts\/\*\.md` are narrower execution surfaces\. They must follow this file, not override it\.\nWhen OMX is installed, load the installed prompt\/skill\/agent surfaces from [^\n]+active\)\./,
+		`Registered Codex plugin marketplace surfaces supply OMX workflows, prompts, and native-agent roles when the plugin is installed. They must follow this file, not override it.\nUser-installed skills may still live under ${userSkillPath}. Setup-owned prompt files and native-agent TOML defaults are intentionally omitted in plugin mode unless explicitly installed.`,
+	);
 }
 
 interface ResolvedSetupScope {
@@ -1336,7 +1351,7 @@ async function applyPluginDeveloperInstructionsDefault(
 	const existing = existsSync(configPath)
 		? await readFile(configPath, "utf-8")
 		: "";
-	const line = `developer_instructions = ${JSON.stringify(OMX_DEVELOPER_INSTRUCTIONS)}`;
+	const line = `developer_instructions = ${JSON.stringify(OMX_PLUGIN_DEVELOPER_INSTRUCTIONS)}`;
 	const hasExistingDeveloperInstructions = rootHasTomlKey(
 		existing,
 		"developer_instructions",
@@ -1929,7 +1944,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				);
 				const rewritten = upsertAgentsModelTable(
 					addGeneratedAgentsMarker(
-						applyScopePathRewritesToAgentsTemplate(
+						applyPluginModeWordingToAgentsTemplate(
 							content,
 							resolvedScope.scope,
 						),

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -73,6 +73,8 @@ const OMX_SEEDED_BEHAVIORAL_DEFAULTS_END_MARKER =
 
 export const OMX_DEVELOPER_INSTRUCTIONS =
   "You have oh-my-codex installed. AGENTS.md is the orchestration brain and main control surface. Follow AGENTS.md for skill/keyword routing, $name workflow invocation, and role-specialized subagents. Use outcome-first, concise progress updates: state the target result, constraints, validation evidence, and stop condition before adding process detail. Native subagents live in .codex/agents and may handle independent parallel subtasks within one Codex session or team pane. Skills load from .codex/skills, not native-agent TOMLs. Treat installed prompts as narrower execution surfaces under AGENTS.md authority.";
+export const OMX_PLUGIN_DEVELOPER_INSTRUCTIONS =
+  "You have oh-my-codex installed through Codex plugin mode. AGENTS.md is the orchestration brain and main control surface. Follow AGENTS.md for skill/keyword routing and $name workflow invocation. Registered Codex plugin marketplace surfaces supply OMX workflows, prompts, and native-agent roles when the plugin is installed. User-installed skills may still live under ~/.codex/skills. Setup-owned prompt files and native-agent TOML defaults are intentionally omitted unless explicitly installed. Use outcome-first, concise progress updates: state the target result, constraints, validation evidence, and stop condition before adding process detail.";
 const SHARED_MCP_REGISTRY_MARKER = "oh-my-codex (OMX) Shared MCP Registry Sync";
 const SHARED_MCP_REGISTRY_END_MARKER =
   "# End oh-my-codex shared MCP registry sync";


### PR DESCRIPTION
## Summary
- Add plugin-mode-specific developer_instructions wording that points to registered Codex plugin marketplace workflow surfaces.
- Rewrite optional plugin-mode AGENTS.md defaults at setup time so legacy prompt/native-agent paths are omitted while user-installed skills remain acknowledged.
- Add targeted setup tests for plugin-mode user/project generated AGENTS.md and developer_instructions wording.

Fixes #2090

## Verification
- npm run build
- npm run lint
- npm run check:no-unused
- node --test dist/cli/__tests__/setup-install-mode.test.js dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/setup-agents-overwrite.test.js
- npx tsc --noEmit (via lsp_diagnostics_directory)
- Architect verification: APPROVED

## Not run
- full npm test