### PR TITLE
Let Ralph verifier children finish

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7100,6 +7100,98 @@ exit 0
     }
   });
 
+  it("allows native verifier subagent Stop to complete while leader Ralph remains active", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-subagent-verdict-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const omxSessionId = "sess-ralph-leader-verifier";
+      const leaderNativeSessionId = "codex-ralph-leader-verifier";
+      const childNativeSessionId = "codex-verifier-child";
+      await mkdir(join(stateDir, "sessions", omxSessionId), { recursive: true });
+      await writeSessionStart(cwd, omxSessionId, {
+        nativeSessionId: leaderNativeSessionId,
+      });
+      await writeJson(join(stateDir, "sessions", omxSessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "verifying",
+        session_id: omxSessionId,
+        owner_omx_session_id: omxSessionId,
+        owner_codex_session_id: leaderNativeSessionId,
+      });
+
+      const transcriptPath = join(cwd, "verifier-subagent-rollout.jsonl");
+      await writeFile(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: childNativeSessionId,
+            source: {
+              subagent: {
+                thread_spawn: {
+                  parent_thread_id: leaderNativeSessionId,
+                  depth: 1,
+                  agent_nickname: "Verifier",
+                  agent_role: "verifier",
+                },
+              },
+            },
+            agent_nickname: "Verifier",
+            agent_role: "verifier",
+          },
+        })}\n`,
+      );
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: childNativeSessionId,
+          transcript_path: transcriptPath,
+        },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+
+      const childStop = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: childNativeSessionId,
+          thread_id: childNativeSessionId,
+          last_assistant_message: "Verdict: APPROVED. Evidence is sufficient.",
+        },
+        { cwd },
+      );
+
+      assert.equal(childStop.omxEventName, "stop");
+      assert.equal(childStop.outputJson, null);
+
+      const leaderStop = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: leaderNativeSessionId,
+          thread_id: leaderNativeSessionId,
+          last_assistant_message: "Waiting on verification integration.",
+        },
+        { cwd },
+      );
+
+      assert.equal(leaderStop.omxEventName, "stop");
+      assert.deepEqual(leaderStop.outputJson, {
+        decision: "block",
+        reason:
+          "OMX Ralph is still active (phase: verifying; state: .omx/state/sessions/sess-ralph-leader-verifier/ralph-state.json); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ralph_verifying",
+        systemMessage:
+          "OMX Ralph is still active (phase: verifying; state: .omx/state/sessions/sess-ralph-leader-verifier/ralph-state.json); continue the task and gather fresh verification evidence before stopping.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("prefers canonical run-state terminal lifecycle before stale session Ralph state during Stop", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-canonical-run-state-ralph-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -266,7 +266,7 @@ async function nativeSubagentSessionStartBelongsToCanonicalSession(
   return summary.allThreadIds.includes(parentThreadId);
 }
 
-async function isNativeSubagentPromptSubmit(
+async function isNativeSubagentHook(
   cwd: string,
   canonicalSessionId: string,
   nativeSessionId: string,
@@ -2355,6 +2355,7 @@ async function buildStopHookOutput(
   payload: CodexHookPayload,
   cwd: string,
   stateDir: string,
+  options: { skipRalphStopBlock?: boolean } = {},
 ): Promise<Record<string, unknown> | null> {
   if (isStopExempt(payload)) {
     return null;
@@ -2365,11 +2366,13 @@ async function buildStopHookOutput(
   const threadId = readPayloadThreadId(payload);
   const execFollowupOutput = await buildExecFollowupStopOutput(cwd, canonicalSessionId);
   if (execFollowupOutput) return execFollowupOutput;
-  const ralphState = await readActiveRalphState(stateDir, canonicalSessionId, {
-    payloadSessionId: sessionId,
-    threadId,
-    tmuxPaneId: safeString(process.env.TMUX_PANE).trim(),
-  });
+  const ralphState = options.skipRalphStopBlock === true
+    ? null
+    : await readActiveRalphState(stateDir, canonicalSessionId, {
+      payloadSessionId: sessionId,
+      threadId,
+      tmuxPaneId: safeString(process.env.TMUX_PANE).trim(),
+    });
   if (!ralphState) {
     const autoresearchState = await readActiveAutoresearchState(cwd, canonicalSessionId);
     if (autoresearchState) {
@@ -2691,7 +2694,16 @@ export async function dispatchCodexNativeHook(
   const sessionIdForState = canonicalSessionId || nativeSessionId;
   let outputJson: Record<string, unknown> | null = null;
   const isSubagentPromptSubmit = hookEventName === "UserPromptSubmit"
-    ? await isNativeSubagentPromptSubmit(cwd, canonicalSessionId, nativeSessionId, threadId)
+    ? await isNativeSubagentHook(cwd, canonicalSessionId, nativeSessionId, threadId)
+    : false;
+  const isSubagentStop = hookEventName === "Stop"
+    ? (await Promise.all(
+      [...new Set([
+        canonicalSessionId,
+        safeString(currentSessionState?.session_id).trim(),
+      ].filter(Boolean))]
+        .map((candidateSessionId) => isNativeSubagentHook(cwd, candidateSessionId, nativeSessionId, threadId)),
+    )).some(Boolean)
     : false;
 
   if (hookEventName === "UserPromptSubmit") {
@@ -2840,7 +2852,9 @@ export async function dispatchCodexNativeHook(
     outputJson = buildNativePostToolUseOutput(payload);
     await handleTeamWorkerPostToolUseSuccess(payload, cwd);
   } else if (hookEventName === "Stop") {
-    outputJson = await buildStopHookOutput(payload, cwd, stateDir);
+    outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
+      skipRalphStopBlock: isSubagentStop,
+    });
   }
 
   return {


### PR DESCRIPTION
## Summary
- make native Stop handling child-agent aware for tracked subagent Stop payloads
- skip only Ralph leader Stop blocking for confirmed verifier/architect-style child threads so wait_agent can observe completion
- add regression coverage proving child verifier Stop returns null while leader Ralph Stop still blocks

Fixes #2093

## Verification
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js
- npm run check:no-unused
- npm run lint
- LSP diagnostics: 0 errors on changed source/test files
- Architect verification: APPROVED