### PR TITLE
Implement ultragoal multi-goal workflow

### DIFF
--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -1,0 +1,65 @@
+# Ultragoal
+
+`ultragoal` is a durable, repo-native multi-goal workflow layered over Codex goal mode. It keeps the long-range plan in files while letting Codex treat exactly one item at a time as the active thread goal.
+
+## Why this shape
+
+Codex CLI 0.128.0 exposes `goals` as an enabled feature, but `codex --help` has no `goal` shell subcommand. In this runtime, goal mode is exposed to the agent as model tools:
+
+- `get_goal` reads the active thread goal.
+- `create_goal` creates one active objective for a thread and fails if the thread already has a goal.
+- `update_goal` can only mark the existing goal `complete`.
+
+Upstream Codex goal source also constrains objectives to 4,000 characters, tracks token/time usage, emits `ThreadGoalUpdated` events, and uses continuation/budget-limit prompts to keep work focused. OMX therefore must not pretend a shell command can mutate hidden Codex thread state. Instead, `omx ultragoal complete-goals` checkpoints repo state and prints an explicit handoff for the active Codex agent to call goal tools safely.
+
+## Artifacts
+
+All artifacts live under `.omx/ultragoal/`:
+
+- `brief.md` — original project/conversation brief.
+- `goals.json` — ordered durable plan with status, attempts, evidence, and the active goal id.
+- `ledger.jsonl` — append-only checkpoint events (`plan_created`, `goal_started`, `goal_resumed`, `goal_completed`, `goal_failed`, `goal_retried`).
+
+## Commands
+
+Create a plan:
+
+```sh
+omx ultragoal create-goals --brief "Ship the feature in three safe milestones"
+omx ultragoal create-goals --brief-file docs/my-brief.md
+cat docs/my-brief.md | omx ultragoal create-goals --from-stdin
+```
+
+Start or resume the next goal:
+
+```sh
+omx ultragoal complete-goals
+```
+
+The command marks the next pending goal `in_progress`, appends a ledger entry, and prints a goal-tool handoff. The agent should call `get_goal`, then `create_goal` only if no active Codex goal exists. After the goal is complete, the agent calls `update_goal({status: "complete"})` and checkpoints:
+
+```sh
+omx ultragoal checkpoint --goal-id G001-example --status complete --evidence "npm test passed; docs updated"
+```
+
+Failure handling:
+
+```sh
+omx ultragoal checkpoint --goal-id G001-example --status failed --evidence "blocked on missing credential"
+omx ultragoal complete-goals --retry-failed
+```
+
+Status:
+
+```sh
+omx ultragoal status
+omx ultragoal status --json
+```
+
+## Integration constraints
+
+- One Codex thread can have at most one active goal.
+- `create_goal` starts the active objective; it is not a general plan store.
+- `update_goal` is completion-only; pause/resume/budget state is controlled by Codex/user/system, not OMX.
+- Ultragoal owns durable plan and ledger state; Codex goal mode owns active-thread focus and accounting.
+- A goal is not complete merely because tests pass or a ledger entry exists. The agent must audit the objective against files, commands, tests, PR state, or other concrete evidence.

--- a/plugins/oh-my-codex/skills/ultragoal/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultragoal/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: ultragoal
+description: Create and execute durable repo-native multi-goal plans over Codex goal mode artifacts.
+---
+
+# Ultragoal Workflow
+
+Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durable multi-goal planning, or sequential execution over Codex `/goal`.
+
+## Purpose
+
+`ultragoal` turns a brief into repo-native artifacts and then drives one goal at a time through Codex goal tools:
+
+- `.omx/ultragoal/brief.md`
+- `.omx/ultragoal/goals.json`
+- `.omx/ultragoal/ledger.jsonl`
+
+## Create goals
+
+1. Run one of:
+   - `omx ultragoal create-goals --brief "<brief>"`
+   - `omx ultragoal create-goals --brief-file <path>`
+   - `cat <brief> | omx ultragoal create-goals --from-stdin`
+2. Inspect `.omx/ultragoal/goals.json` and refine if needed.
+
+## Complete goals
+
+Loop until `omx ultragoal status` reports all goals complete:
+
+1. Run `omx ultragoal complete-goals`.
+2. Read the printed handoff.
+3. Call `get_goal`.
+4. If no active Codex goal exists, call `create_goal` with the printed payload.
+5. Complete that single goal only.
+6. Run a completion audit against the objective and real artifacts/tests.
+7. When complete, call `update_goal({status: "complete"})`.
+8. Checkpoint the durable ledger:
+   `omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>"`
+9. If blocked or failed, checkpoint failure:
+   `omx ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
+10. Resume failed goals with `omx ultragoal complete-goals --retry-failed`.
+
+## Constraints
+
+- The shell command cannot directly invoke Codex interactive `/goal`; it emits a model-facing handoff for the active Codex agent.
+- Never call `create_goal` when `get_goal` reports a different active goal.
+- Never call `update_goal` unless the current goal is actually complete.
+- Treat `ledger.jsonl` as the durable audit trail; checkpoint after every success or failure.

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: ultragoal
+description: Create and execute durable repo-native multi-goal plans over Codex goal mode artifacts.
+---
+
+# Ultragoal Workflow
+
+Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durable multi-goal planning, or sequential execution over Codex `/goal`.
+
+## Purpose
+
+`ultragoal` turns a brief into repo-native artifacts and then drives one goal at a time through Codex goal tools:
+
+- `.omx/ultragoal/brief.md`
+- `.omx/ultragoal/goals.json`
+- `.omx/ultragoal/ledger.jsonl`
+
+## Create goals
+
+1. Run one of:
+   - `omx ultragoal create-goals --brief "<brief>"`
+   - `omx ultragoal create-goals --brief-file <path>`
+   - `cat <brief> | omx ultragoal create-goals --from-stdin`
+2. Inspect `.omx/ultragoal/goals.json` and refine if needed.
+
+## Complete goals
+
+Loop until `omx ultragoal status` reports all goals complete:
+
+1. Run `omx ultragoal complete-goals`.
+2. Read the printed handoff.
+3. Call `get_goal`.
+4. If no active Codex goal exists, call `create_goal` with the printed payload.
+5. Complete that single goal only.
+6. Run a completion audit against the objective and real artifacts/tests.
+7. When complete, call `update_goal({status: "complete"})`.
+8. Checkpoint the durable ledger:
+   `omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>"`
+9. If blocked or failed, checkpoint failure:
+   `omx ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
+10. Resume failed goals with `omx ultragoal complete-goals --retry-failed`.
+
+## Constraints
+
+- The shell command cannot directly invoke Codex interactive `/goal`; it emits a model-facing handoff for the active Codex agent.
+- Never call `create_goal` when `get_goal` reports a different active goal.
+- Never call `update_goal` unless the current goal is actually complete.
+- Treat `ledger.jsonl` as the durable audit trail; checkpoint after every success or failure.

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-04-24T07:34:27.399Z",
+  "generatedAt": "2026-05-04T09:59:26.287Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 42,
+    "skillCount": 43,
     "promptCount": 30,
-    "activeSkillCount": 27,
+    "activeSkillCount": 28,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -67,6 +67,13 @@
     },
     {
       "name": "pipeline",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "ultragoal",
       "category": "execution",
       "status": "active",
       "core": false,

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -49,6 +49,12 @@
       "core": false
     },
     {
+      "name": "ultragoal",
+      "category": "execution",
+      "status": "active",
+      "core": false
+    },
+    {
       "name": "swarm",
       "category": "execution",
       "status": "alias",

--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ultragoalCommand, ULTRAGOAL_HELP } from '../ultragoal.js';
+
+async function withCwd<T>(run: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-ultragoal-cli-'));
+  const previous = process.cwd();
+  try {
+    process.chdir(cwd);
+    return await run(cwd);
+  } finally {
+    process.chdir(previous);
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function capture(run: () => Promise<void>): Promise<{ stdout: string[]; stderr: string[]; exitCode: string | number | undefined }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  const log = mock.method(console, 'log', (...args: unknown[]) => stdout.push(args.map(String).join(' ')));
+  const error = mock.method(console, 'error', (...args: unknown[]) => stderr.push(args.map(String).join(' ')));
+  try {
+    await run();
+    return { stdout, stderr, exitCode: process.exitCode };
+  } finally {
+    log.mock.restore();
+    error.mock.restore();
+    process.exitCode = previousExitCode;
+  }
+}
+
+describe('cli/ultragoal', () => {
+  it('prints help with artifact and goal-mode constraints', async () => {
+    assert.match(ULTRAGOAL_HELP, /create-goals/);
+    assert.match(ULTRAGOAL_HELP, /complete-goals/);
+    assert.match(ULTRAGOAL_HELP, /get_goal\/create_goal\/update_goal/);
+  });
+
+  it('creates and starts goals through the command surface', async () => {
+    await withCwd(async (cwd) => {
+      const created = await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone\n- Second milestone']));
+      assert.equal(created.exitCode, undefined);
+      assert.match(created.stdout.join('\n'), /ultragoal plan created: 2 goal/);
+
+      const next = await capture(() => ultragoalCommand(['complete-goals']));
+      const output = next.stdout.join('\n');
+      assert.match(output, /Ultragoal active-goal handoff/);
+      assert.match(output, /create_goal payload/);
+      assert.match(output, /omx ultragoal checkpoint --goal-id G001-first-milestone --status complete/);
+
+      const goals = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { activeGoalId?: string };
+      assert.equal(goals.activeGoalId, 'G001-first-milestone');
+    });
+  });
+
+  it('checkpoints a goal and reports status as json', async () => {
+    await withCwd(async () => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+      const checkpoint = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first-milestone',
+        '--status', 'complete',
+        '--evidence', 'tests passed',
+        '--json',
+      ]));
+      assert.equal(checkpoint.exitCode, undefined);
+      const parsed = JSON.parse(checkpoint.stdout.join('\n')) as { summary: { complete: number } };
+      assert.equal(parsed.summary.complete, 1);
+    });
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import { hudCommand } from "../hud/index.js";
 import { sidecarCommand } from "../sidecar/index.js";
 import { teamCommand } from "./team.js";
 import { ralphCommand } from "./ralph.js";
+import { ultragoalCommand } from "./ultragoal.js";
 import { askCommand } from "./ask.js";
 import { questionCommand } from "./question.js";
 import { stateCommand } from "./state.js";
@@ -185,6 +186,7 @@ Usage:
                 Alias for agents-init (lightweight AGENTS bootstrap only)
   omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
   omx ralph     Launch Codex with ralph persistence mode active
+  omx ultragoal Create, resume, and checkpoint durable multi-goal plans over Codex goal mode
   omx autoresearch [DEPRECATED] Use $autoresearch; direct CLI launch removed
   omx version   Show version information
   omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
@@ -353,6 +355,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "wiki",
   "mcp-serve",
   "ralph",
+  "ultragoal",
   "resume",
   "session",
   "sparkshell",
@@ -1088,6 +1091,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "ralph":
         await ralphCommand(args.slice(1));
+        break;
+      case "ultragoal":
+        await ultragoalCommand(args.slice(1));
         break;
       case "version":
         version();

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -1,0 +1,188 @@
+import { readFile } from 'node:fs/promises';
+import {
+  buildCodexGoalInstruction,
+  checkpointUltragoal,
+  createUltragoalPlan,
+  readUltragoalPlan,
+  startNextUltragoal,
+  summarizeUltragoalPlan,
+  type UltragoalItem,
+  UltragoalError,
+} from '../ultragoal/artifacts.js';
+
+export const ULTRAGOAL_HELP = `omx ultragoal - Durable repo-native multi-goal workflow over Codex goal mode
+
+Usage:
+  omx ultragoal create-goals [--brief <text> | --brief-file <path> | --from-stdin] [--goal <title::objective>] [--force] [--json]
+  omx ultragoal complete-goals [--retry-failed] [--json]
+  omx ultragoal checkpoint --goal-id <id> --status <complete|failed> [--evidence <text>] [--codex-goal-json <json-or-path>] [--json]
+  omx ultragoal status [--json]
+
+Aliases:
+  create -> create-goals, complete|next|start-next -> complete-goals
+
+Artifacts:
+  .omx/ultragoal/brief.md
+  .omx/ultragoal/goals.json
+  .omx/ultragoal/ledger.jsonl
+
+Codex goal integration:
+  This command cannot directly invoke the interactive /goal tool from a shell.
+  complete-goals writes durable state and prints a model-facing handoff that tells
+  the active Codex agent when to call get_goal/create_goal/update_goal safely.
+`;
+
+function hasFlag(args: readonly string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function readValue(args: readonly string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index >= 0) return args[index + 1];
+  const prefix = `${flag}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function readRepeated(args: readonly string[], flag: string): string[] {
+  const values: string[] = [];
+  const prefix = `${flag}=`;
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === flag && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    } else if (arg.startsWith(prefix)) {
+      values.push(arg.slice(prefix.length));
+    }
+  }
+  return values;
+}
+
+function parseGoalArg(raw: string): { title?: string; objective: string; tokenBudget?: number } {
+  const [title, ...rest] = raw.split('::');
+  if (rest.length === 0) return { objective: raw.trim() };
+  return { title: title.trim(), objective: rest.join('::').trim() };
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+function positionalText(args: readonly string[]): string {
+  const valueTaking = new Set(['--brief', '--brief-file', '--goal', '--goal-id', '--status', '--evidence', '--codex-goal-json']);
+  const words: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (valueTaking.has(arg)) { i += 1; continue; }
+    if (arg.startsWith('--')) continue;
+    words.push(arg);
+  }
+  return words.join(' ').trim();
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function printStatus(plan: Awaited<ReturnType<typeof readUltragoalPlan>>): void {
+  const summary = summarizeUltragoalPlan(plan);
+  console.log(`ultragoal: ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed`);
+  for (const goal of plan.goals) {
+    const marker = goal.id === plan.activeGoalId ? '*' : '-';
+    console.log(`${marker} ${goal.id} [${goal.status}] ${goal.title}`);
+  }
+}
+
+async function parseCodexGoalJson(raw: string | undefined): Promise<unknown> {
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    try {
+      return JSON.parse(await readFile(raw, 'utf-8'));
+    } catch {
+      return raw;
+    }
+  }
+}
+
+export async function ultragoalCommand(args: string[]): Promise<void> {
+  const command = args[0] ?? 'help';
+  const rest = args.slice(1);
+  const json = hasFlag(rest, '--json');
+  const cwd = process.cwd();
+
+  try {
+    if (command === 'help' || command === '--help' || command === '-h') {
+      console.log(ULTRAGOAL_HELP);
+      return;
+    }
+
+    if (command === 'create' || command === 'create-goals') {
+      const briefFile = readValue(rest, '--brief-file');
+      const brief = readValue(rest, '--brief')
+        ?? (briefFile ? await readFile(briefFile, 'utf-8') : undefined)
+        ?? (hasFlag(rest, '--from-stdin') ? await readStdin() : undefined)
+        ?? positionalText(rest);
+      if (!brief.trim()) throw new UltragoalError('Missing brief text. Pass --brief, --brief-file, --from-stdin, or positional text.');
+      const goals = readRepeated(rest, '--goal').map(parseGoalArg);
+      const plan = await createUltragoalPlan(cwd, { brief, goals, force: hasFlag(rest, '--force') });
+      if (json) printJson({ ok: true, plan, summary: summarizeUltragoalPlan(plan) });
+      else {
+        console.log(`ultragoal plan created: ${plan.goals.length} goal(s)`);
+        console.log(`brief: ${plan.briefPath}`);
+        console.log(`goals: ${plan.goalsPath}`);
+        console.log(`ledger: ${plan.ledgerPath}`);
+      }
+      return;
+    }
+
+    if (command === 'status') {
+      const plan = await readUltragoalPlan(cwd);
+      if (json) printJson({ plan, summary: summarizeUltragoalPlan(plan) });
+      else printStatus(plan);
+      return;
+    }
+
+    if (command === 'complete' || command === 'complete-goals' || command === 'next' || command === 'start-next') {
+      const result = await startNextUltragoal(cwd, { retryFailed: hasFlag(rest, '--retry-failed') });
+      if (!result.goal) {
+        if (json) printJson({ ok: true, done: result.done, summary: summarizeUltragoalPlan(result.plan) });
+        else console.log(result.done ? 'ultragoal: all goals complete' : 'ultragoal: no pending goals (use --retry-failed to retry failed goals)');
+        return;
+      }
+      const instruction = buildCodexGoalInstruction(result.goal, result.plan);
+      if (json) printJson({ ok: true, resumed: result.resumed, goal: result.goal, instruction });
+      else console.log(instruction);
+      return;
+    }
+
+    if (command === 'checkpoint') {
+      const goalId = readValue(rest, '--goal-id');
+      const status = readValue(rest, '--status');
+      if (!goalId) throw new UltragoalError('Missing --goal-id.');
+      if (status !== 'complete' && status !== 'failed') throw new UltragoalError('Missing or invalid --status; expected complete or failed.');
+      const evidence = readValue(rest, '--evidence');
+      const codexGoal = await parseCodexGoalJson(readValue(rest, '--codex-goal-json'));
+      const plan = await checkpointUltragoal(cwd, { goalId, status, evidence, codexGoal });
+      if (json) printJson({ ok: true, plan, summary: summarizeUltragoalPlan(plan) });
+      else {
+        const goal = plan.goals.find((candidate: UltragoalItem) => candidate.id === goalId);
+        console.log(`ultragoal checkpoint: ${goalId} -> ${goal?.status ?? status}`);
+        printStatus(plan);
+      }
+      return;
+    }
+
+    throw new UltragoalError(`Unknown ultragoal command: ${command}\n\n${ULTRAGOAL_HELP}`);
+  } catch (error) {
+    if (error instanceof UltragoalError) {
+      console.error(`[ultragoal] ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    throw error;
+  }
+}

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -1,0 +1,101 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  buildCodexGoalInstruction,
+  checkpointUltragoal,
+  createUltragoalPlan,
+  readUltragoalPlan,
+  startNextUltragoal,
+} from '../artifacts.js';
+
+async function withTempRepo<T>(run: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-ultragoal-'));
+  try {
+    return await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('ultragoal artifacts', () => {
+  it('creates brief, goals, and ledger artifacts from a brief', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: '- Build the CLI\n- Add tests\n- Write docs',
+        now: new Date('2026-05-04T10:00:00Z'),
+      });
+
+      assert.equal(plan.goals.length, 3);
+      assert.equal(plan.goals[0]?.id, 'G001-build-the-cli');
+      assert.equal(plan.goals[0]?.status, 'pending');
+      assert.equal(await readFile(join(cwd, '.omx/ultragoal/brief.md'), 'utf-8'), '- Build the CLI\n- Add tests\n- Write docs\n');
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"plan_created"/);
+    });
+  });
+
+  it('starts one goal at a time and emits a Codex goal handoff', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+          { title: 'Second', objective: 'Complete second milestone.' },
+        ],
+      });
+
+      const started = await startNextUltragoal(cwd, { now: new Date('2026-05-04T10:01:00Z') });
+      assert.equal(started.goal?.id, 'G001-first');
+      assert.equal(started.goal?.status, 'in_progress');
+      assert.equal(started.plan.activeGoalId, 'G001-first');
+
+      const resumed = await startNextUltragoal(cwd, { now: new Date('2026-05-04T10:02:00Z') });
+      assert.equal(resumed.goal?.id, 'G001-first');
+      assert.equal(resumed.resumed, true);
+
+      const instruction = buildCodexGoalInstruction(started.goal!, started.plan);
+      assert.match(instruction, /call get_goal/i);
+      assert.match(instruction, /call create_goal/i);
+      assert.match(instruction, /update_goal\(\{status: "complete"\}\)/);
+      assert.match(instruction, /Complete first milestone/);
+    });
+  });
+
+  it('checkpoints success, advances, and supports failed-goal retry', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+          { title: 'Second', objective: 'Complete second milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      await checkpointUltragoal(cwd, { goalId: first.goal!.id, status: 'complete', evidence: 'unit tests passed' });
+      const second = await startNextUltragoal(cwd);
+      assert.equal(second.goal?.id, 'G002-second');
+
+      await checkpointUltragoal(cwd, { goalId: second.goal!.id, status: 'failed', evidence: 'blocked' });
+      const noPending = await startNextUltragoal(cwd);
+      assert.equal(noPending.goal, null);
+      assert.equal(noPending.done, false);
+
+      const retry = await startNextUltragoal(cwd, { retryFailed: true });
+      assert.equal(retry.goal?.id, 'G002-second');
+      assert.equal(retry.goal?.status, 'in_progress');
+      assert.equal(retry.goal?.attempt, 2);
+
+      const plan = await readUltragoalPlan(cwd);
+      assert.equal(plan.goals[0]?.evidence, 'unit tests passed');
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"goal_completed"/);
+      assert.match(ledger, /"event":"goal_failed"/);
+      assert.match(ledger, /"event":"goal_retried"/);
+    });
+  });
+});

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1,0 +1,305 @@
+import { existsSync } from 'node:fs';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+export const ULTRAGOAL_DIR = '.omx/ultragoal';
+export const ULTRAGOAL_BRIEF = 'brief.md';
+export const ULTRAGOAL_GOALS = 'goals.json';
+export const ULTRAGOAL_LEDGER = 'ledger.jsonl';
+
+export type UltragoalStatus = 'pending' | 'in_progress' | 'complete' | 'failed';
+
+export interface UltragoalItem {
+  id: string;
+  title: string;
+  objective: string;
+  status: UltragoalStatus;
+  tokenBudget?: number;
+  attempt: number;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  failedAt?: string;
+  evidence?: string;
+  failureReason?: string;
+}
+
+export interface UltragoalPlan {
+  version: 1;
+  createdAt: string;
+  updatedAt: string;
+  briefPath: string;
+  goalsPath: string;
+  ledgerPath: string;
+  activeGoalId?: string;
+  goals: UltragoalItem[];
+}
+
+export interface UltragoalLedgerEntry {
+  ts: string;
+  event:
+    | 'plan_created'
+    | 'goal_started'
+    | 'goal_resumed'
+    | 'goal_completed'
+    | 'goal_failed'
+    | 'goal_retried';
+  goalId?: string;
+  status?: UltragoalStatus;
+  message?: string;
+  codexGoal?: unknown;
+  evidence?: string;
+}
+
+export interface CreateUltragoalOptions {
+  brief: string;
+  goals?: Array<{ title?: string; objective: string; tokenBudget?: number }>;
+  now?: Date;
+  force?: boolean;
+}
+
+export interface StartNextOptions {
+  now?: Date;
+  retryFailed?: boolean;
+}
+
+export interface CheckpointOptions {
+  goalId: string;
+  status: Extract<UltragoalStatus, 'complete' | 'failed'>;
+  evidence?: string;
+  codexGoal?: unknown;
+  now?: Date;
+}
+
+export class UltragoalError extends Error {}
+
+function iso(now = new Date()): string {
+  return now.toISOString();
+}
+
+export function ultragoalDir(cwd: string): string {
+  return join(cwd, ULTRAGOAL_DIR);
+}
+
+export function ultragoalBriefPath(cwd: string): string {
+  return join(ultragoalDir(cwd), ULTRAGOAL_BRIEF);
+}
+
+export function ultragoalGoalsPath(cwd: string): string {
+  return join(ultragoalDir(cwd), ULTRAGOAL_GOALS);
+}
+
+export function ultragoalLedgerPath(cwd: string): string {
+  return join(ultragoalDir(cwd), ULTRAGOAL_LEDGER);
+}
+
+function repoRelative(cwd: string, path: string): string {
+  return relative(cwd, path).split('\\').join('/');
+}
+
+function cleanLine(line: string): string {
+  return line.replace(/^\s*(?:[-*+]\s+|\d+[.)]\s+)/, '').trim();
+}
+
+function titleFromObjective(objective: string, fallback: string): string {
+  const firstLine = objective.split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? fallback;
+  return firstLine.length > 72 ? `${firstLine.slice(0, 69).trimEnd()}...` : firstLine;
+}
+
+export function deriveGoalCandidates(brief: string): Array<{ title: string; objective: string }> {
+  const lines = brief.split(/\r?\n/);
+  const bulletGoals = lines
+    .map((line) => ({ original: line, cleaned: cleanLine(line) }))
+    .filter(({ cleaned }) => cleaned.length > 0 && cleaned.length <= 1200)
+    .filter(({ original, cleaned }, index, all) => (
+      /^\s*(?:[-*+]\s+|\d+[.)]\s+)/.test(original)
+      && all.findIndex((candidate) => candidate.cleaned === cleaned) === index
+    ))
+    .map(({ cleaned }) => cleaned);
+
+  const objectives = bulletGoals.length > 0
+    ? bulletGoals
+    : brief
+      .split(/\n\s*\n/)
+      .map((paragraph) => paragraph.trim())
+      .filter((paragraph) => paragraph.length > 0 && !paragraph.startsWith('#'));
+
+  const selected = objectives.length > 0 ? objectives : [brief.trim() || 'Complete the requested project objective.'];
+  return selected.map((objective, index) => ({
+    title: titleFromObjective(objective, `Goal ${index + 1}`),
+    objective,
+  }));
+}
+
+function normalizeGoalId(title: string, index: number): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 36)
+    .replace(/-+$/g, '');
+  return `G${String(index + 1).padStart(3, '0')}${slug ? `-${slug}` : ''}`;
+}
+
+async function appendLedger(cwd: string, entry: UltragoalLedgerEntry): Promise<void> {
+  await mkdir(ultragoalDir(cwd), { recursive: true });
+  const path = ultragoalLedgerPath(cwd);
+  await appendFile(path, `${JSON.stringify(entry)}\n`);
+}
+
+export async function readUltragoalPlan(cwd: string): Promise<UltragoalPlan> {
+  const path = ultragoalGoalsPath(cwd);
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf-8');
+  } catch {
+    throw new UltragoalError(`No ultragoal plan found at ${repoRelative(cwd, path)}. Run \`omx ultragoal create-goals ...\` first.`);
+  }
+  const parsed = JSON.parse(raw) as UltragoalPlan;
+  if (parsed.version !== 1 || !Array.isArray(parsed.goals)) {
+    throw new UltragoalError(`Invalid ultragoal plan at ${repoRelative(cwd, path)}.`);
+  }
+  return parsed;
+}
+
+async function writePlan(cwd: string, plan: UltragoalPlan): Promise<void> {
+  await mkdir(ultragoalDir(cwd), { recursive: true });
+  await writeFile(ultragoalGoalsPath(cwd), `${JSON.stringify(plan, null, 2)}\n`);
+}
+
+export async function createUltragoalPlan(cwd: string, options: CreateUltragoalOptions): Promise<UltragoalPlan> {
+  if (!options.force && existsSync(ultragoalGoalsPath(cwd))) {
+    throw new UltragoalError(`Refusing to overwrite existing ${ULTRAGOAL_DIR}/${ULTRAGOAL_GOALS}; pass --force to recreate it.`);
+  }
+  const now = iso(options.now);
+  const sourceGoals: Array<{ title?: string; objective: string; tokenBudget?: number }> = options.goals?.length
+    ? options.goals
+    : deriveGoalCandidates(options.brief);
+  const candidates = sourceGoals
+    .map((goal, index): UltragoalItem => ({
+      id: normalizeGoalId(goal.title ?? titleFromObjective(goal.objective, `Goal ${index + 1}`), index),
+      title: goal.title ?? titleFromObjective(goal.objective, `Goal ${index + 1}`),
+      objective: goal.objective.trim(),
+      status: 'pending',
+      tokenBudget: goal.tokenBudget,
+      attempt: 0,
+      createdAt: now,
+      updatedAt: now,
+    }));
+
+  const plan: UltragoalPlan = {
+    version: 1,
+    createdAt: now,
+    updatedAt: now,
+    briefPath: `${ULTRAGOAL_DIR}/${ULTRAGOAL_BRIEF}`,
+    goalsPath: `${ULTRAGOAL_DIR}/${ULTRAGOAL_GOALS}`,
+    ledgerPath: `${ULTRAGOAL_DIR}/${ULTRAGOAL_LEDGER}`,
+    goals: candidates,
+  };
+
+  await mkdir(ultragoalDir(cwd), { recursive: true });
+  await writeFile(ultragoalBriefPath(cwd), options.brief.endsWith('\n') ? options.brief : `${options.brief}\n`);
+  await writePlan(cwd, plan);
+  await writeFile(ultragoalLedgerPath(cwd), '');
+  await appendLedger(cwd, { ts: now, event: 'plan_created', message: `${candidates.length} goal(s) created` });
+  return plan;
+}
+
+export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; activeGoalId?: string } {
+  return {
+    total: plan.goals.length,
+    pending: plan.goals.filter((goal) => goal.status === 'pending').length,
+    inProgress: plan.goals.filter((goal) => goal.status === 'in_progress').length,
+    complete: plan.goals.filter((goal) => goal.status === 'complete').length,
+    failed: plan.goals.filter((goal) => goal.status === 'failed').length,
+    activeGoalId: plan.activeGoalId,
+  };
+}
+
+export async function startNextUltragoal(cwd: string, options: StartNextOptions = {}): Promise<{ plan: UltragoalPlan; goal: UltragoalItem | null; resumed: boolean; done: boolean }> {
+  const plan = await readUltragoalPlan(cwd);
+  const now = iso(options.now);
+  const existing = plan.goals.find((goal) => goal.status === 'in_progress');
+  if (existing) {
+    await appendLedger(cwd, { ts: now, event: 'goal_resumed', goalId: existing.id, status: existing.status, message: 'Resuming active ultragoal' });
+    return { plan, goal: existing, resumed: true, done: false };
+  }
+
+  let next = plan.goals.find((goal) => goal.status === 'pending');
+  if (!next && options.retryFailed) {
+    next = plan.goals.find((goal) => goal.status === 'failed');
+    if (next) await appendLedger(cwd, { ts: now, event: 'goal_retried', goalId: next.id, status: 'pending', message: next.failureReason });
+  }
+  if (!next) return { plan, goal: null, resumed: false, done: plan.goals.every((goal) => goal.status === 'complete') };
+
+  next.status = 'in_progress';
+  next.attempt += 1;
+  next.startedAt = now;
+  next.failedAt = undefined;
+  next.failureReason = undefined;
+  next.updatedAt = now;
+  plan.activeGoalId = next.id;
+  plan.updatedAt = now;
+  await writePlan(cwd, plan);
+  await appendLedger(cwd, { ts: now, event: 'goal_started', goalId: next.id, status: next.status, message: `Attempt ${next.attempt}` });
+  return { plan, goal: next, resumed: false, done: false };
+}
+
+export async function checkpointUltragoal(cwd: string, options: CheckpointOptions): Promise<UltragoalPlan> {
+  const plan = await readUltragoalPlan(cwd);
+  const goal = plan.goals.find((candidate) => candidate.id === options.goalId);
+  if (!goal) throw new UltragoalError(`Unknown ultragoal id: ${options.goalId}`);
+  const now = iso(options.now);
+  goal.status = options.status;
+  goal.updatedAt = now;
+  if (options.status === 'complete') {
+    goal.completedAt = now;
+    goal.evidence = options.evidence;
+    goal.failureReason = undefined;
+    goal.failedAt = undefined;
+    if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
+  } else {
+    goal.failedAt = now;
+    goal.failureReason = options.evidence;
+    if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
+  }
+  plan.updatedAt = now;
+  await writePlan(cwd, plan);
+  await appendLedger(cwd, {
+    ts: now,
+    event: options.status === 'complete' ? 'goal_completed' : 'goal_failed',
+    goalId: goal.id,
+    status: goal.status,
+    evidence: options.evidence,
+    codexGoal: options.codexGoal,
+  });
+  return plan;
+}
+
+export function buildCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan): string {
+  const createPayload = {
+    objective: goal.objective,
+    ...(goal.tokenBudget ? { token_budget: goal.tokenBudget } : {}),
+  };
+  return [
+    'Ultragoal active-goal handoff',
+    `Plan: ${plan.goalsPath}`,
+    `Ledger: ${plan.ledgerPath}`,
+    `Goal: ${goal.id} — ${goal.title}`,
+    '',
+    'Codex goal integration constraints:',
+    '- First call get_goal. If no active goal exists, call create_goal with the payload below.',
+    '- If a different active Codex goal exists, finish/checkpoint that goal before starting this ultragoal.',
+    '- Work only this goal until its completion audit passes.',
+    '- After the goal is actually complete, call update_goal({status: "complete"}), then checkpoint the ledger with:',
+    `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>"`,
+    '- If blocked or failed, checkpoint with --status failed and the failure evidence; rerun complete-goals --retry-failed to resume.',
+    '',
+    'create_goal payload:',
+    JSON.stringify(createPayload, null, 2),
+    '',
+    'Objective:',
+    goal.objective,
+  ].join('\n');
+}

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -60,6 +60,13 @@
       "internalRequired": false
     },
     {
+      "name": "ultragoal",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "swarm",
       "category": "execution",
       "status": "alias",


### PR DESCRIPTION
Resolves #2096.

## Summary
- Adds `omx ultragoal` with `create-goals`, `complete-goals`, `checkpoint`, and `status` commands.
- Persists durable repo-native workflow artifacts under `.omx/ultragoal/`: `brief.md`, `goals.json`, and append-only `ledger.jsonl`.
- Supports sequential goal activation, resume of in-progress goals, failed-goal retry, and per-goal checkpoint ledger entries.
- Adds model-facing Codex `/goal` handoff instructions so each ultragoal item becomes the active Codex thread goal/objective.
- Adds docs plus skill/catalog/plugin-bundle entries for the new workflow.

## Codex `/goal` integration constraints found
- `codex-cli 0.128.0` exposes no shell `goal` subcommand in `codex --help`.
- `codex features list` shows `goals` enabled/under development.
- Goal state is available to an active Codex thread through model tools (`get_goal`, `create_goal`, `update_goal`), not as a repo-global shell API.
- `create_goal` fails if a thread goal already exists, and `update_goal` can only mark the existing goal complete, so ultragoal owns durable multi-goal state while Codex owns one active thread goal at a time.

## Verification
- `npm test` before cleanup/deslop: full pass, 4495 passed / 0 failed, catalog check ok.
- Post-cleanup targeted verification passed: `npm run build && node --test dist/ultragoal/__tests__/artifacts.test.js dist/cli/__tests__/ultragoal.test.js && npm run lint && npm run check:no-unused`.
- `git diff --check` passed before commit.

## Not completed / caveats
- A post-cleanup full `npm test` rerun was started but did not complete due timeout/hang in the long suite; per instruction, it was stopped and the targeted post-cleanup verification plus earlier full-suite pass were used as evidence.
- Architect subagent verification timed out and was closed; local Ralph verification evidence was used.
