### PR TITLE
Fix generated MCP node command path

### DIFF
--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -6,9 +6,10 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import TOML from "@iarna/toml";
 import { buildMergedConfig, cleanCodexModelAvailabilityNuxIfNeeded, mergeConfig, repairConfigIfNeeded } from "../generator.js";
+import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../omx-first-party-mcp.js";
 
 /** Count occurrences of a pattern in text */
 function count(text: string, pattern: RegExp): number {
@@ -99,6 +100,28 @@ function assertSingleOmxBlock(toml: string): void {
     1,
     "USE_OMX_EXPLORE_CMD should appear once",
   );
+
+  const parsed = TOML.parse(toml) as {
+    mcp_servers?: Record<string, { command?: unknown }>;
+  };
+  for (const name of OMX_FIRST_PARTY_MCP_SERVER_NAMES) {
+    const command = parsed.mcp_servers?.[name]?.command;
+    assert.equal(
+      command,
+      process.execPath,
+      `[mcp_servers.${name}] should use the Node executable that ran setup`,
+    );
+    assert.notEqual(
+      command,
+      "node",
+      `[mcp_servers.${name}] should not depend on PATH lookup for node`,
+    );
+    assert.equal(
+      typeof command === "string" && isAbsolute(command),
+      true,
+      `[mcp_servers.${name}] command should be absolute`,
+    );
+  }
 }
 
 describe("Codex transient TUI NUX cleanup", () => {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -1402,7 +1402,7 @@ function getOmxTablesBlock(
     lines.push("");
     lines.push(server.title);
     lines.push(`[mcp_servers.${server.name}]`);
-    lines.push('command = "node"');
+    lines.push(`command = "${escapeTomlString(server.command)}"`);
     lines.push(
       `args = [${server.args
         .map((arg) => `"${escapeTomlString(arg)}"`)

--- a/src/config/omx-first-party-mcp.ts
+++ b/src/config/omx-first-party-mcp.ts
@@ -76,13 +76,17 @@ export function resolveOmxFirstPartyMcpEntrypointForPluginTarget(
   return spec?.entrypoint ?? null;
 }
 
+export function getCurrentNodeExecutablePath(): string {
+  return process.execPath;
+}
+
 export function getOmxFirstPartySetupMcpServers(
   pkgRoot: string,
 ): Array<UnifiedMcpRegistryServer & { title: string }> {
   return OMX_FIRST_PARTY_MCP_SPECS.map((spec) => ({
     name: spec.name,
     title: spec.title,
-    command: "node",
+    command: getCurrentNodeExecutablePath(),
     args: [join(pkgRoot, "dist", "mcp", spec.entrypoint)],
     enabled: true,
     startupTimeoutSec: spec.startupTimeoutSec,


### PR DESCRIPTION
## Summary
- Generate first-party MCP server commands with the absolute Node executable used by `omx setup` instead of bare `node`.
- Thread MCP command values through the config writer instead of hardcoding `node`.
- Update generator tests to assert `process.execPath` appears in generated TOML and bare `command = "node"` does not.

Fixes #2098.

## Verification
- `npm run build`
- `node --test dist/config/__tests__/generator-idempotent.test.js dist/config/__tests__/generator-status-line-presets.test.js dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/uninstall.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

## Notes
- The first build attempt failed before `npm ci` because dependencies were not installed in the fresh worktree (`@iarna/toml`, MCP SDK, etc.); after `npm ci`, the targeted gates above passed.
- The bounded architect subagent did not complete in time; local Ralph verification and targeted gates were used to avoid blocking the fix.
