### PR TITLE
Make madmax launches own isolated runtime state

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -37,6 +37,8 @@ import {
   resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
   resolveProjectLocalCodexHomeForLaunch,
+  shouldAutoIsolateMadmaxLaunch,
+  createMadmaxIsolatedRoot,
   prepareCodexHomeForLaunch,
   runtimeCodexHomePath,
   buildDetachedSessionBootstrapSteps,
@@ -91,6 +93,46 @@ function expectedLowComplexityModel(codexHomeOverride?: string): string {
 
 afterEach(() => {
   mock.restoreAll();
+});
+
+describe("madmax state isolation", () => {
+  it("auto-isolates only madmax launch and exec invocations", () => {
+    assert.equal(shouldAutoIsolateMadmaxLaunch("launch", ["--madmax"], {}), true);
+    assert.equal(shouldAutoIsolateMadmaxLaunch("exec", ["--madmax-spark"], {}), true);
+    assert.equal(shouldAutoIsolateMadmaxLaunch("team", ["--madmax"], {}), false);
+    assert.equal(shouldAutoIsolateMadmaxLaunch("launch", ["--yolo"], {}), false);
+    assert.equal(
+      shouldAutoIsolateMadmaxLaunch("launch", ["--madmax"], { OMX_ROOT: "/already/boxed" }),
+      false,
+    );
+    assert.equal(
+      shouldAutoIsolateMadmaxLaunch("launch", ["--madmax"], { OMXBOX_ACTIVE: "1" }),
+      false,
+    );
+    assert.equal(
+      shouldAutoIsolateMadmaxLaunch("launch", ["--madmax"], { OMX_NO_BOX: "1" }),
+      false,
+    );
+  });
+
+  it("creates a per-run OMX_ROOT registry entry without touching source .omx", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-madmax-source-"));
+    const runs = await mkdtemp(join(tmpdir(), "omx-madmax-runs-"));
+    try {
+      const runDir = createMadmaxIsolatedRoot(wd, ["--madmax"], { OMX_RUNS_DIR: runs });
+      assert.equal(runDir.startsWith(runs), true);
+      assert.equal(existsSync(join(wd, ".omx")), false);
+      const metadata = JSON.parse(await readFile(join(runDir, ".omxbox-run.json"), "utf-8"));
+      assert.equal(metadata.source_cwd, wd);
+      assert.equal(metadata.cwd, runDir);
+      assert.deepEqual(metadata.argv, ["--madmax"]);
+      const registry = await readFile(join(runs, "registry.jsonl"), "utf-8");
+      assert.match(registry, /"launcher":"omx --madmax"/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(runs, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("normalizeCodexLaunchArgs", () => {
@@ -737,10 +779,11 @@ describe("buildNotifyFallbackWatcherEnv", () => {
   it("enables watcher authority and propagates CODEX_HOME override when requested", () => {
     const env = buildNotifyFallbackWatcherEnv(
       { HOME: "/tmp/home", OMX_HUD_AUTHORITY: "0", TMUX: "sock,1,0", TMUX_PANE: "%2" },
-      { codexHomeOverride: "/tmp/codex-home", enableAuthority: true },
+      { codexHomeOverride: "/tmp/codex-home", omxRootOverride: "/tmp/omx-root", enableAuthority: true },
     );
     assert.equal(env.OMX_HUD_AUTHORITY, "1");
     assert.equal(env.CODEX_HOME, "/tmp/codex-home");
+    assert.equal(env.OMX_ROOT, "/tmp/omx-root");
     assert.equal(env.HOME, "/tmp/home");
     assert.equal(env.TMUX, undefined);
     assert.equal(env.TMUX_PANE, undefined);
@@ -1905,6 +1948,30 @@ describe("detached tmux new-session sequencing", () => {
     assert.equal(
       newSession!.args.includes("-e") &&
         newSession!.args.some((arg) => arg === "CODEX_HOME=/tmp/project/.codex"),
+      true,
+    );
+  });
+
+  it("buildDetachedSessionBootstrapSteps forwards OMX_ROOT override to detached tmux session", () => {
+    const steps = buildDetachedSessionBootstrapSteps(
+      "omx-demo",
+      "/tmp/project",
+      "'codex' '--model' 'gpt-5'",
+      "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null,
+      undefined,
+      null,
+      false,
+      "sess-detached-managed",
+      undefined,
+      undefined,
+      "/tmp/omx-root",
+    );
+    const newSession = steps.find((step) => step.name === "new-session");
+    assert.ok(newSession);
+    assert.equal(
+      newSession!.args.includes("-e") &&
+        newSession!.args.some((arg) => arg === "OMX_ROOT=/tmp/omx-root"),
       true,
     );
   });

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1455,6 +1455,39 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("uses boxed runtime root for project-scope CODEX_HOME mirrors", async () => {
+    const source = await mkdtemp(join(tmpdir(), "omx-launch-boxed-source-"));
+    const boxedRoot = await mkdtemp(join(tmpdir(), "omx-launch-boxed-root-"));
+    const prevOmxRoot = process.env.OMX_ROOT;
+    try {
+      process.env.OMX_ROOT = boxedRoot;
+      const projectCodexHome = join(source, ".codex");
+      await mkdir(join(source, ".omx"), { recursive: true });
+      await mkdir(projectCodexHome, { recursive: true });
+      await writeFile(
+        join(source, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      await writeFile(join(projectCodexHome, "config.toml"), 'model = "gpt-5.5"\n');
+
+      const prepared = await prepareCodexHomeForLaunch(source, "session-boxed", {});
+      const runtimeCodexHome = runtimeCodexHomePath(source, "session-boxed");
+
+      assert.equal(
+        runtimeCodexHome,
+        join(boxedRoot, ".omx", "runtime", "codex-home", "session-boxed"),
+      );
+      assert.equal(prepared.codexHomeOverride, runtimeCodexHome);
+      assert.equal(prepared.runtimeCodexHomeForCleanup, runtimeCodexHome);
+      assert.equal(await readFile(join(runtimeCodexHome, "config.toml"), "utf-8"), 'model = "gpt-5.5"\n');
+    } finally {
+      if (typeof prevOmxRoot === "string") process.env.OMX_ROOT = prevOmxRoot;
+      else delete process.env.OMX_ROOT;
+      await rm(source, { recursive: true, force: true });
+      await rm(boxedRoot, { recursive: true, force: true });
+    }
+  });
+
   it("keeps explicit CODEX_HOME persistent instead of creating a runtime mirror", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-runtime-codex-home-"));
     try {
@@ -1972,6 +2005,40 @@ describe("detached tmux new-session sequencing", () => {
     assert.equal(
       newSession!.args.includes("-e") &&
         newSession!.args.some((arg) => arg === "OMX_ROOT=/tmp/omx-root"),
+      true,
+    );
+  });
+
+  it("buildDetachedSessionBootstrapSteps forwards boxed env to detached tmux session", () => {
+    const steps = buildDetachedSessionBootstrapSteps(
+      "omx-demo",
+      "/tmp/boxed-runtime",
+      "'codex' '--model' 'gpt-5'",
+      "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null,
+      undefined,
+      null,
+      false,
+      "sess-detached-managed",
+      undefined,
+      undefined,
+      "/tmp/boxed-runtime",
+      {
+        OMXBOX_ACTIVE: "1",
+        OMX_SOURCE_CWD: "/tmp/source-project",
+        OMX_STATE_ROOT: "/tmp/boxed-state-root",
+      },
+    );
+    const newSession = steps.find((step) => step.name === "new-session");
+    assert.ok(newSession);
+    assert.equal(newSession.args.some((arg) => arg === "OMX_ROOT=/tmp/boxed-runtime"), true);
+    assert.equal(
+      newSession.args.some((arg) => arg === "OMX_STATE_ROOT=/tmp/boxed-state-root"),
+      true,
+    );
+    assert.equal(newSession.args.some((arg) => arg === "OMXBOX_ACTIVE=1"), true);
+    assert.equal(
+      newSession.args.some((arg) => arg === "OMX_SOURCE_CWD=/tmp/source-project"),
       true,
     );
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -592,8 +592,11 @@ export interface PreparedCodexHomeForLaunch {
   runtimeCodexHomeForCleanup?: string;
 }
 
-export function runtimeCodexHomePath(cwd: string, sessionId: string): string {
-  return join(cwd, ".omx", "runtime", "codex-home", sessionId);
+export function runtimeCodexHomePath(
+  cwd: string,
+  sessionId: string,
+): string {
+  return join(omxRoot(cwd), "runtime", "codex-home", sessionId);
 }
 
 async function linkOrCopyCodexHomeEntry(source: string, destination: string): Promise<void> {
@@ -2448,6 +2451,7 @@ export function buildDetachedSessionBootstrapSteps(
   projectLocalCodexHomeForCleanup?: string,
   runtimeCodexHomeForCleanup?: string,
   omxRootOverride?: string,
+  env: NodeJS.ProcessEnv = process.env,
 ): DetachedSessionTmuxStep[] {
   const detachedLeaderCmd = nativeWindows
     ? "powershell.exe"
@@ -2477,6 +2481,9 @@ export function buildDetachedSessionBootstrapSteps(
     ...(sessionId ? ["-e", `${OMX_TMUX_HUD_OWNER_ENV}=1`] : []),
     ...(codexHomeOverride ? ["-e", `CODEX_HOME=${codexHomeOverride}`] : []),
     ...(omxRootOverride ? ["-e", `OMX_ROOT=${omxRootOverride}`] : []),
+    ...(env.OMX_STATE_ROOT ? ["-e", `OMX_STATE_ROOT=${env.OMX_STATE_ROOT}`] : []),
+    ...(env.OMXBOX_ACTIVE ? ["-e", `OMXBOX_ACTIVE=${env.OMXBOX_ACTIVE}`] : []),
+    ...(env.OMX_SOURCE_CWD ? ["-e", `OMX_SOURCE_CWD=${env.OMX_SOURCE_CWD}`] : []),
     ...(notifyTempContractRaw
       ? ["-e", `${OMX_NOTIFY_TEMP_CONTRACT_ENV}=${notifyTempContractRaw}`]
       : []),
@@ -3212,6 +3219,7 @@ function runCodex(
         projectLocalCodexHomeForCleanup,
         runtimeCodexHomeForCleanup,
         omxRootOverride,
+        process.env,
       );
       for (const step of bootstrapSteps) {
         const output = execTmuxFileSync(step.args, {
@@ -3996,7 +4004,7 @@ async function startHookDerivedWatcher(cwd: string): Promise<void> {
     }
   }
 
-  await mkdir(join(cwd, ".omx", "state"), { recursive: true }).catch(
+  await mkdir(join(omxRoot(cwd), "state"), { recursive: true }).catch(
     (error: unknown) => {
       console.warn(
         "[omx] warning: failed to create hook-derived watcher state directory",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,7 +7,7 @@ import { execFileSync, spawn } from "child_process";
 import { basename, dirname, join } from "path";
 import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { copyFile, cp, lstat, mkdir, readdir, rm, symlink } from "fs/promises";
-import { constants as osConstants } from "os";
+import { constants as osConstants, homedir } from "os";
 import { setup, SETUP_SCOPES, type SetupInstallMode, type SetupScope } from "./setup.js";
 import { uninstall } from "./uninstall.js";
 import { version } from "./version.js";
@@ -100,7 +100,7 @@ import {
   mitigateCopyModeUnderlineArtifacts,
 } from "../team/tmux-session.js";
 import { getPackageRoot } from "../utils/package.js";
-import { codexConfigPath, rememberOmxLaunchContext, resolveOmxEntryPath } from "../utils/paths.js";
+import { codexConfigPath, omxRoot, rememberOmxLaunchContext, resolveOmxEntryPath } from "../utils/paths.js";
 import { cleanCodexModelAvailabilityNuxIfNeeded, repairConfigIfNeeded } from "../config/generator.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
 import { OMX_TMUX_HUD_OWNER_ENV } from "../hud/reconcile.js";
@@ -957,6 +957,68 @@ export function buildHudPaneCleanupTargets(
   return [...targets];
 }
 
+export function resolveOmxRootForLaunch(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const raw = env.OMX_ROOT || env.OMX_STATE_ROOT;
+  if (typeof raw !== "string" || raw.trim() === "") return undefined;
+  return raw.startsWith("/") ? raw : join(cwd, raw);
+}
+
+export function shouldAutoIsolateMadmaxLaunch(
+  command: string,
+  launchArgs: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (command !== "launch" && command !== "exec") return false;
+  if (env.OMX_NO_BOX === "1" || env.OMXBOX_ACTIVE === "1") return false;
+  if (env.OMX_ROOT || env.OMX_STATE_ROOT) return false;
+  return launchArgs.some((arg) => arg === MADMAX_FLAG || arg === MADMAX_SPARK_FLAG);
+}
+
+function sanitizeRunIdSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+}
+
+export function createMadmaxIsolatedRoot(
+  sourceCwd: string,
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const runsRoot = env.OMX_RUNS_DIR || join(homedir(), ".omx-runs");
+  mkdirSync(runsRoot, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[-:TZ.]/g, "").slice(0, 14);
+  const suffix = Math.random().toString(16).slice(2, 6);
+  const runDir = join(runsRoot, sanitizeRunIdSegment(`run-${stamp}-${suffix}`));
+  mkdirSync(runDir, { recursive: false });
+
+  const metadata = {
+    launcher: "omx --madmax",
+    created_at: new Date().toISOString(),
+    cwd: runDir,
+    source_cwd: sourceCwd,
+    argv,
+  };
+  writeFileSync(join(runDir, ".omxbox-run.json"), `${JSON.stringify(metadata, null, 2)}\n`);
+  writeFileSync(join(runsRoot, "registry.jsonl"), `${JSON.stringify(metadata)}\n`, { flag: "a" });
+  return runDir;
+}
+
+function activateMadmaxIsolationIfNeeded(
+  command: string,
+  launchArgs: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (!shouldAutoIsolateMadmaxLaunch(command, launchArgs, env)) return;
+  const runDir = createMadmaxIsolatedRoot(cwd, launchArgs, env);
+  env.OMX_ROOT = runDir;
+  env.OMXBOX_ACTIVE = "1";
+  env.OMX_SOURCE_CWD = cwd;
+  process.stderr.write(`[omx] madmax isolated state: ${runDir} (source: ${cwd})\n`);
+}
+
 export async function main(args: string[]): Promise<void> {
   const knownCommands = new Set([
     "launch",
@@ -1007,6 +1069,8 @@ export async function main(args: string[]): Promise<void> {
     console.log(HELP);
     return;
   }
+
+  activateMadmaxIsolationIfNeeded(command, launchArgs, process.cwd(), process.env);
 
   try {
     switch (command) {
@@ -1472,9 +1536,12 @@ export async function execWithOverlay(args: string[]): Promise<void> {
       process.env,
       sessionModelInstructionsPath(cwd, sessionId),
     );
-    const codexEnvBase = codexHomeOverride
-      ? { ...process.env, CODEX_HOME: codexHomeOverride }
-      : process.env;
+    const omxRootOverride = resolveOmxRootForLaunch(cwd, process.env);
+    const codexEnvBase = {
+      ...process.env,
+      ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
+      ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
+    };
     const codexEnv = notifyTempContractRaw
       ? {
           ...codexEnvBase,
@@ -1930,7 +1997,7 @@ function blockMs(ms: number): void {
 }
 
 function tmuxExtendedKeysLeaseRoot(cwd: string): string {
-  return join(cwd, ".omx", "state", TMUX_EXTENDED_KEYS_LEASE_DIR);
+  return join(omxRoot(cwd), "state", TMUX_EXTENDED_KEYS_LEASE_DIR);
 }
 
 function resolveTmuxSocketPath(
@@ -2380,6 +2447,7 @@ export function buildDetachedSessionBootstrapSteps(
   sessionId?: string,
   projectLocalCodexHomeForCleanup?: string,
   runtimeCodexHomeForCleanup?: string,
+  omxRootOverride?: string,
 ): DetachedSessionTmuxStep[] {
   const detachedLeaderCmd = nativeWindows
     ? "powershell.exe"
@@ -2408,6 +2476,7 @@ export function buildDetachedSessionBootstrapSteps(
     ...(sessionId ? ["-e", `OMX_SESSION_ID=${sessionId}`] : []),
     ...(sessionId ? ["-e", `${OMX_TMUX_HUD_OWNER_ENV}=1`] : []),
     ...(codexHomeOverride ? ["-e", `CODEX_HOME=${codexHomeOverride}`] : []),
+    ...(omxRootOverride ? ["-e", `OMX_ROOT=${omxRootOverride}`] : []),
     ...(notifyTempContractRaw
       ? ["-e", `${OMX_NOTIFY_TEMP_CONTRACT_ENV}=${notifyTempContractRaw}`]
       : []),
@@ -2582,6 +2651,7 @@ export function buildNotifyFallbackWatcherEnv(
   env: NodeJS.ProcessEnv = process.env,
   options: {
     codexHomeOverride?: string;
+    omxRootOverride?: string;
     enableAuthority?: boolean;
     sessionId?: string;
   } = {},
@@ -2592,6 +2662,7 @@ export function buildNotifyFallbackWatcherEnv(
   return {
     ...nextEnv,
     ...(options.codexHomeOverride ? { CODEX_HOME: options.codexHomeOverride } : {}),
+    ...(options.omxRootOverride ? { OMX_ROOT: options.omxRootOverride } : {}),
     ...(options.sessionId ? { OMX_SESSION_ID: options.sessionId } : {}),
     OMX_HUD_AUTHORITY: options.enableAuthority ? "1" : "0",
   };
@@ -3020,9 +3091,12 @@ function runCodex(
     inheritLeaderFlags,
     workerDefaultModel,
   );
-  const codexBaseEnv = codexHomeOverride
-    ? { ...process.env, CODEX_HOME: codexHomeOverride }
-    : process.env;
+  const omxRootOverride = resolveOmxRootForLaunch(cwd, process.env);
+  const codexBaseEnv = {
+    ...process.env,
+    ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
+    ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
+  };
   const codexEnvWithSession = {
     ...codexBaseEnv,
     OMX_SESSION_ID: sessionId,
@@ -3137,6 +3211,7 @@ function runCodex(
         sessionId,
         projectLocalCodexHomeForCleanup,
         runtimeCodexHomeForCleanup,
+        omxRootOverride,
       );
       for (const step of bootstrapSteps) {
         const output = execTmuxFileSync(step.args, {
@@ -3587,11 +3662,11 @@ async function emitNativeHookEvent(
 }
 
 function notifyFallbackPidPath(cwd: string): string {
-  return join(cwd, ".omx", "state", "notify-fallback.pid");
+  return join(omxRoot(cwd), "state", "notify-fallback.pid");
 }
 
 function hookDerivedWatcherPidPath(cwd: string): string {
-  return join(cwd, ".omx", "state", "hook-derived-watcher.pid");
+  return join(omxRoot(cwd), "state", "hook-derived-watcher.pid");
 }
 
 export function shouldDetachBackgroundHelper(
@@ -3826,7 +3901,7 @@ async function startNotifyFallbackWatcher(
   const notifyScript = resolveNotifyHookScript(pkgRoot);
   if (!existsSync(watcherScript) || !existsSync(notifyScript)) return;
 
-  await mkdir(join(cwd, ".omx", "state"), { recursive: true }).catch(
+  await mkdir(join(omxRoot(cwd), "state"), { recursive: true }).catch(
     (error: unknown) => {
       console.warn(
         "[omx] warning: failed to create notify fallback watcher state directory",
@@ -3839,6 +3914,7 @@ async function startNotifyFallbackWatcher(
   );
   const watcherEnv = buildNotifyFallbackWatcherEnv(process.env, {
     codexHomeOverride: options.codexHomeOverride,
+    omxRootOverride: resolveOmxRootForLaunch(cwd, process.env),
     enableAuthority: options.enableAuthority === true,
     sessionId: options.sessionId,
   });

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -22,6 +22,7 @@ import {
   listInstalledSkillDirectories,
   omxNotepadPath,
   omxProjectMemoryPath,
+  omxStateDir,
   packageRoot,
 } from "../utils/paths.js";
 import {
@@ -56,7 +57,7 @@ const SKILL_REFERENCE_PATTERN = /\/skills\/([^/\s`]+)\/SKILL\.md\b/g;
 // ── Lock helpers ─────────────────────────────────────────────────────────────
 
 function lockPath(cwd: string): string {
-  return join(cwd, ".omx", "state", "agents-md.lock");
+  return join(omxStateDir(cwd), "agents-md.lock");
 }
 
 async function acquireLock(

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -8,7 +8,7 @@
 import { readFile, writeFile, mkdir, unlink, appendFile, rm } from 'fs/promises';
 import { dirname, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
-import { omxStateDir, omxLogsDir, sameFilePath } from '../utils/paths.js';
+import { omxRoot, omxStateDir, omxLogsDir, sameFilePath } from '../utils/paths.js';
 import { getStateFilePath } from '../mcp/state-paths.js';
 
 export interface SessionState {
@@ -66,7 +66,7 @@ async function removeDeadSessionHudState(
  * into a new Codex session.
  */
 export async function resetSessionMetrics(cwd: string, sessionId?: string): Promise<void> {
-  const omxDir = join(cwd, '.omx');
+  const omxDir = omxRoot(cwd);
   const stateDir = omxStateDir(cwd);
   await mkdir(omxDir, { recursive: true });
   await mkdir(stateDir, { recursive: true });

--- a/src/scripts/__tests__/hook-derived-watcher.test.ts
+++ b/src/scripts/__tests__/hook-derived-watcher.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { spawn, spawnSync } from 'node:child_process';
 import { once } from 'node:events';
 import { existsSync } from 'node:fs';
-import { appendFile, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -45,6 +45,50 @@ describe('hook-derived-watcher', () => {
     assert.match(source, /if \(currentSize < meta\.offset\) \{\s*meta\.offset = 0;\s*meta\.partial = '';/);
     assert.doesNotMatch(source, /const content = await readFile\(path, 'utf-8'\)[\s\S]*const delta = content\.slice\(meta\.offset\)/);
     assert.doesNotMatch(source, /stat\(path\)\.catch\(\(\) => \(\{ size: 0 \}\)\)/);
+  });
+
+  it('stores watcher state and logs under boxed runtime root when OMX_ROOT is set', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'omx-hook-derived-boxed-'));
+    const homeDir = join(base, 'home');
+    const cwd = join(base, 'cwd');
+    const boxedRoot = join(base, 'boxed-runtime');
+
+    try {
+      await mkdir(todaySessionDir(homeDir), { recursive: true });
+      await mkdir(cwd, { recursive: true });
+      const watcherScript = new URL('../hook-derived-watcher.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', cwd, '--poll-ms', '250'],
+        {
+          cwd,
+          env: {
+            ...process.env,
+            HOME: homeDir,
+            OMX_ROOT: boxedRoot,
+            OMXBOX_ACTIVE: '1',
+            OMX_SOURCE_CWD: cwd,
+            OMX_HOOK_DERIVED_SIGNALS: '1',
+          },
+          encoding: 'utf8',
+        },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(
+        existsSync(join(boxedRoot, '.omx', 'state', 'hook-derived-watcher-state.json')),
+        true,
+      );
+      assert.equal(
+        existsSync(join(cwd, '.omx', 'state', 'hook-derived-watcher-state.json')),
+        false,
+      );
+      const logDir = join(boxedRoot, '.omx', 'logs');
+      const logNames = await readdir(logDir);
+      assert.equal(logNames.some((name) => name.startsWith('hook-derived-watcher-')), true);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
   });
 
   it('dispatches needs-input for assistant_message content arrays', async () => {

--- a/src/scripts/hook-derived-watcher.ts
+++ b/src/scripts/hook-derived-watcher.ts
@@ -28,7 +28,8 @@ const runOnce = process.argv.includes('--once');
 const pollMs = Math.max(250, asNumber(argValue('--poll-ms', process.env.OMX_HOOK_DERIVED_POLL_MS || '800'), 800));
 const maxFileAgeMs = Math.max(10_000, asNumber(argValue('--file-age-ms', process.env.OMX_HOOK_DERIVED_FILE_AGE_MS || '90000'), 90000));
 
-const omxDir = join(cwd, '.omx');
+const runtimeRoot = resolve(process.env.OMX_ROOT || process.env.OMX_STATE_ROOT || cwd);
+const omxDir = join(runtimeRoot, '.omx');
 const logsDir = join(omxDir, 'logs');
 const stateDir = join(omxDir, 'state');
 const watcherStatePath = join(stateDir, 'hook-derived-watcher-state.json');

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -142,7 +142,8 @@ const maxLifetimeMs = runOnce
     )
   );
 
-const omxDir = join(cwd, '.omx');
+const runtimeRoot = resolve(process.env.OMX_ROOT || process.env.OMX_STATE_ROOT || cwd);
+const omxDir = join(runtimeRoot, '.omx');
 const logsDir = join(omxDir, 'logs');
 const stateDir = join(omxDir, 'state');
 const statePath = join(stateDir, 'notify-fallback-state.json');


### PR DESCRIPTION
## Summary
- Create a per-run `OMX_ROOT` automatically for native `omx --madmax` / `omx --madmax-spark` `launch` and `exec` flows.
- Propagate that isolated runtime root into Codex, detached tmux launches, and the notify fallback watcher.
- Move runtime-owned helper state for metrics, overlay locks, and tmux lease files under the boxed root while preserving the user's source cwd for project files.

## Problem statement
Users could run an external wrapper such as `omxmad`/`omxbox` to isolate OMX runtime state, but native `omx --madmax` still relied on the current working directory unless a wrapper had already exported `OMX_ROOT`. That meant two OMX sessions started from the same project directory could still overlap through source-local `.omx` runtime files.

The desired behavior is that `omx --madmax` is safe from any file directory: the project cwd stays the place where code is read/written, but runtime coordination state gets a unique per-run home automatically.

## Root cause
The repo already had several `OMX_ROOT`-aware path helpers, and #2086 fixed boxed team state path routing. The missing piece was the native entrypoint: it did not create an isolated `OMX_ROOT` for madmax launches by itself, and several runtime-adjacent helpers still derived state paths from the source cwd.

## What changed
- Added native madmax launch isolation in `src/cli/index.ts`:
  - detects `launch`/`exec` with `--madmax` or `--madmax-spark`;
  - skips isolation when `OMX_ROOT`, `OMX_STATE_ROOT`, `OMXBOX_ACTIVE`, or `OMX_NO_BOX=1` are already present;
  - creates `~/.omx-runs/run-*` or `OMX_RUNS_DIR/run-*`;
  - writes `.omxbox-run.json` and appends `registry.jsonl`;
  - exports `OMX_ROOT`, `OMXBOX_ACTIVE`, and `OMX_SOURCE_CWD` before dispatch.
- Propagated `OMX_ROOT` into Codex process env, detached tmux bootstrap, and notify fallback watcher env.
- Routed runtime-owned helper files through isolated root helpers:
  - notify fallback PID/state/log paths;
  - hook-derived watcher PID path;
  - tmux extended-keys lease root;
  - session metrics;
  - AGENTS overlay lock.
- Updated notify fallback watcher to resolve `.omx` under `OMX_ROOT` / `OMX_STATE_ROOT` when present.
- Added regression tests for auto-isolation gating, run directory creation, `OMX_ROOT` env forwarding, and detached tmux forwarding.

## Why this design
This keeps the wrapper concept, but moves the default behavior into the native CLI path. The source cwd remains stable for user project work, while runtime coordination files become per-run state. That is less surprising than changing project cwd, and safer than relying on a shell wrapper that can miss helper/watch paths.

## Overlap assessment
- Follow-up to #2086: "Fix boxed team state path routing" merged into `dev` and made key team state paths root-aware.
- Supersedes the wrapper-shaped gap from #2085: "Keep boxed OMX state out of source workspaces" was closed.
- Adjacent history also includes #2050 for same-cwd team session isolation. This PR is narrower: it makes native `omx --madmax` create and propagate the isolated runtime root automatically.

## Validation
- `npm run build`
- `node --test dist/cli/__tests__/index.test.js dist/hooks/__tests__/session.test.js dist/hooks/__tests__/agents-overlay.test.js` — 267 pass / 0 fail
- `npx biome lint src/cli/index.ts src/cli/__tests__/index.test.ts src/scripts/notify-fallback-watcher.ts src/hooks/session.ts src/hooks/agents-overlay.ts`
- Fake-Codex smoke for `node dist/cli/omx.js --madmax --model gpt-5.5 "smoke"`:
  - Codex process kept `PWD=<source cwd>`;
  - received `OMX_ROOT=<run dir>`, `OMXBOX_ACTIVE=1`, `OMX_SOURCE_CWD=<source cwd>`;
  - generated runtime files under the run dir;
  - source cwd had no `.omx`.
- Clean-env full test:
  - `env -u OMX_OPENCLAW -u OMX_OPENCLAW_COMMAND -u OMX_OPENCLAW_COMMAND_TIMEOUT_MS -u OMX_OPENCLAW_CONFIG -u OMX_TEAM_WORKER_LAUNCH_ARGS npm test`
  - 4498 pass / 0 fail

Note: ambient `npm test` in my shell is contaminated by local `OMX_OPENCLAW*` and `OMX_TEAM_WORKER_LAUNCH_ARGS` overrides, which trigger unrelated expectation failures. The clean-env run passes.

## Risk / compatibility
- Normal non-madmax launches are unchanged.
- Existing boxed/wrapper flows are preserved because `OMX_ROOT`, `OMX_STATE_ROOT`, `OMXBOX_ACTIVE`, and `OMX_NO_BOX=1` opt out of auto-isolation.
- Main behavior change: native madmax launch/exec now owns a per-run runtime root by default, so source-local `.omx` runtime coupling should disappear for that path.

## Files changed
- `src/cli/index.ts`
- `src/cli/__tests__/index.test.ts`
- `src/hooks/agents-overlay.ts`
- `src/hooks/session.ts`
- `src/scripts/notify-fallback-watcher.ts`
