### PR TITLE
Add first-class $ultragoal prompt workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ $deep-interview "clarify the authentication change"
 $ralplan "approve the auth plan and review tradeoffs"
 $ralph "carry the approved plan to completion"
 $team 3:executor "execute the approved plan in parallel"
+$ultragoal "turn this launch into durable Codex goals"
 ```
 
 That is the main path.
@@ -84,6 +85,7 @@ Start OMX strongly, clarify first when needed, approve the plan, then choose `$t
 
 Use OMX if you already like Codex and want a better day-to-day runtime around it:
 - a standard workflow built around `$deep-interview`, `$ralplan`, `$team`, and `$ralph`
+- durable multi-goal handoffs with `$ultragoal` and `.omx/ultragoal` artifacts when a launch needs sequential Codex goals
 - specialist roles and supporting skills when the task needs them
 - project guidance through scoped `AGENTS.md`
 - durable state under `.omx/` for plans, logs, memory, and mode tracking

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -35,6 +35,7 @@
         <li><code>$ralph</code> - persistence loop until completion</li>
         <li><code>$autopilot</code> - strict autonomous loop over <code>$ralplan -> $ralph -> $code-review</code>, returning to planning when review is not clean</li>
         <li><code>$ultrawork</code> - max parallel execution</li>
+        <li><code>$ultragoal</code> - durable multi-goal planning and execution over <code>.omx/ultragoal</code> artifacts plus Codex goal handoff</li>
         <li><code>$visual-verdict</code> - structured visual QA loop for screenshot/reference matching</li>
         <li><code>$ecomode</code> - token-efficient model routing</li>
         <li><code>$ultraqa</code> - test/verify/fix loop</li>
@@ -76,6 +77,7 @@
 $ralplan "approve the auth plan and review tradeoffs"
 $ralph "carry the approved plan to completion"
 $team 3:executor "execute the approved plan in parallel"
+$ultragoal "split this launch into durable Codex goals"
 $code-review "review current branch"
 $doctor</code></pre>
 

--- a/src/catalog/__tests__/generator.test.ts
+++ b/src/catalog/__tests__/generator.test.ts
@@ -41,6 +41,7 @@ describe('catalog reader/contract', () => {
     assert.ok(!contract.aliases.some((a) => a.name === 'analyze'));
     assert.ok(contract.internalHidden.includes('worker'));
     assert.ok(contract.coreSkills.includes('autopilot'));
+    assert.ok(contract.coreSkills.includes('ultragoal'));
     assert.ok(contract.skills.some((s) => s.name === 'analyze' && s.status === 'active'));
     assert.ok(contract.skills.some((s) => s.name === 'ask-claude' && s.status === 'active'));
     assert.ok(contract.skills.some((s) => s.name === 'ask-gemini' && s.status === 'active'));

--- a/src/catalog/__tests__/schema.test.ts
+++ b/src/catalog/__tests__/schema.test.ts
@@ -83,4 +83,13 @@ describe('catalog schema', () => {
     assert.equal(autoresearch?.category, 'execution');
     assert.equal(autoresearch?.status, 'active');
   });
+
+  it('includes ultragoal as a core execution skill', () => {
+    const parsed = validateCatalogManifest(readSourceManifest());
+    const ultragoal = parsed.skills.find((skill) => skill.name === 'ultragoal');
+
+    assert.equal(ultragoal?.category, 'execution');
+    assert.equal(ultragoal?.status, 'active');
+    assert.equal(ultragoal?.core, true);
+  });
 });

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-04T09:59:26.287Z",
+  "generatedAt": "2026-05-04T11:42:48.831Z",
   "version": "2026.02.28.1",
   "counts": {
     "skillCount": 43,
@@ -12,6 +12,7 @@
     "ralph",
     "ultrawork",
     "team",
+    "ultragoal",
     "ralplan"
   ],
   "skills": [
@@ -76,7 +77,7 @@
       "name": "ultragoal",
       "category": "execution",
       "status": "active",
-      "core": false,
+      "core": true,
       "internalRequired": false
     },
     {

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -52,7 +52,7 @@
       "name": "ultragoal",
       "category": "execution",
       "status": "active",
-      "core": false
+      "core": true
     },
     {
       "name": "swarm",

--- a/src/catalog/schema.ts
+++ b/src/catalog/schema.ts
@@ -28,7 +28,7 @@ export interface CatalogManifest {
 const SKILL_CATEGORIES = new Set<CatalogSkillCategory>(['execution', 'planning', 'shortcut', 'utility']);
 const AGENT_CATEGORIES = new Set<CatalogAgentCategory>(['build', 'review', 'domain', 'product', 'coordination']);
 const ENTRY_STATUSES = new Set<CatalogEntryStatus>(['active', 'alias', 'merged', 'deprecated', 'internal']);
-const REQUIRED_CORE_SKILLS = new Set(['ralplan', 'team', 'ralph', 'ultrawork', 'autopilot']);
+const REQUIRED_CORE_SKILLS = new Set(['ralplan', 'team', 'ralph', 'ultrawork', 'ultragoal', 'autopilot']);
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -126,6 +126,22 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(match.keyword.toLowerCase(), '$analyze');
   });
 
+  it('maps explicit $ultragoal invocation to ultragoal workflow skill', () => {
+    const match = detectPrimaryKeyword('$ultragoal split this release into durable goals');
+    assert.ok(match);
+    assert.equal(match.skill, 'ultragoal');
+    assert.equal(match.keyword.toLowerCase(), '$ultragoal');
+  });
+
+  it('maps intentful ultragoal prose without triggering artifact path mentions', () => {
+    const intentful = detectPrimaryKeyword('please run ultragoal workflow for this launch');
+    assert.ok(intentful);
+    assert.equal(intentful.skill, 'ultragoal');
+
+    const pathOnly = detectPrimaryKeyword('inspect .omx/ultragoal/goals.json');
+    assert.notEqual(pathOnly?.skill, 'ultragoal');
+  });
+
   it('maps code-review keyword variants to code-review skill', () => {
     const hyphen = detectPrimaryKeyword('run $code-review before merge');
     assert.ok(hyphen);
@@ -380,6 +396,8 @@ describe('keyword registry coverage', () => {
     assert.ok(registryKeywords.has('wiki add'));
     assert.ok(registryKeywords.has('wiki lint'));
     assert.ok(registryKeywords.has('$autoresearch'));
+    assert.ok(registryKeywords.has('$ultragoal'));
+    assert.ok(registryKeywords.has('ultragoal'));
   });
 });
 
@@ -1332,6 +1350,27 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(result.skill, 'code-review');
       assert.equal(result.initialized_mode, undefined);
       assert.equal(result.initialized_state_path, undefined);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('records ultragoal as a prompt skill without seeding unrelated mode state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ultragoal-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ultragoal split this launch into durable goals',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'ultragoal');
+      assert.equal(result.keyword, '$ultragoal');
+      assert.equal(result.initialized_mode, undefined);
+      assert.equal(result.initialized_state_path, undefined);
+      assert.equal(existsSync(join(stateDir, 'ultragoal-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/task-size-detector.test.ts
+++ b/src/hooks/__tests__/task-size-detector.test.ts
@@ -401,7 +401,7 @@ describe('task-size-detector', () => {
 
   describe('HEAVY_MODE_KEYWORDS set', () => {
     it('contains expected heavy modes', () => {
-      const expected = ['ralph', 'autopilot', 'team', 'ultrawork', 'swarm', 'ralplan', 'ccg'];
+      const expected = ['ralph', 'autopilot', 'team', 'ultrawork', 'ultragoal', 'swarm', 'ralplan', 'ccg'];
       for (const mode of expected) {
         assert.ok(HEAVY_MODE_KEYWORDS.has(mode), `Expected HEAVY_MODE_KEYWORDS to contain "${mode}"`);
       }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -443,9 +443,9 @@ const KEYWORD_MAP: Array<{ pattern: RegExp; skill: string; priority: number }> =
   priority: entry.priority,
 }));
 
-const KEYWORDS_REQUIRING_INTENT = new Set(['ralph', 'team', 'swarm', 'stop', 'abort', 'parallel', 'autoresearch']);
+const KEYWORDS_REQUIRING_INTENT = new Set(['ralph', 'team', 'swarm', 'stop', 'abort', 'parallel', 'autoresearch', 'ultragoal']);
 
-type IntentKeyword = 'ralph' | 'team' | 'swarm' | 'stop' | 'abort' | 'parallel' | 'autoresearch';
+type IntentKeyword = 'ralph' | 'team' | 'swarm' | 'stop' | 'abort' | 'parallel' | 'autoresearch' | 'ultragoal';
 
 const DEEP_INTERVIEW_ACTIVATION_PATTERNS: RegExp[] = [
   /(?:^|[^\w])\$(?:deep-interview)\b/i,
@@ -519,6 +519,12 @@ const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
     /\/autoresearch\b/i,
     /\b(?:use|run|start|enable|launch|invoke|activate)\s+(?:the\s+)?autoresearch\b/i,
     /\bautoresearch\s+(?:mode|workflow|skill|loop)\b/i,
+  ],
+  ultragoal: [
+    /(?:^|[^\w])\$(?:ultragoal)\b/i,
+    /^\s*\/ultragoal\b/i,
+    /\b(?:use|run|start|enable|launch|invoke|activate|resume|continue)\s+(?:the\s+)?ultragoal\b/i,
+    /\bultragoal\s+(?:mode|workflow|skill|loop|plan|goals?)\b/i,
   ],
 };
 

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -18,6 +18,8 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: '$ultrawork', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
   { keyword: 'ulw', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
   { keyword: 'parallel', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
+  { keyword: '$ultragoal', skill: 'ultragoal', priority: 10, guidance: 'Activate durable ultragoal planning/execution over Codex goal mode artifacts' },
+  { keyword: 'ultragoal', skill: 'ultragoal', priority: 10, guidance: 'Activate durable ultragoal planning/execution over Codex goal mode artifacts' },
   { keyword: '$ultraqa', skill: 'ultraqa', priority: 8, guidance: 'Activate UltraQA cycling workflow' },
   { keyword: '$analyze', skill: 'analyze', priority: 7, guidance: 'Activate deep analysis workflow' },
   { keyword: 'investigate', skill: 'analyze', priority: 7, guidance: 'Activate deep analysis workflow' },

--- a/src/hooks/task-size-detector.ts
+++ b/src/hooks/task-size-detector.ts
@@ -229,6 +229,7 @@ export const HEAVY_MODE_KEYWORDS = new Set([
   'autopilot',
   'team',
   'ultrawork',
+  'ultragoal',
   'swarm',
   'ralplan',
   'ccg',

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1141,6 +1141,39 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("records ultragoal prompt skill activation with goal-tool handoff guidance", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-ultragoal-1",
+          thread_id: "thread-ultragoal-1",
+          turn_id: "turn-ultragoal-1",
+          prompt: "$ultragoal split this launch into durable goals",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "ultragoal");
+      assert.equal(result.skillState?.initialized_mode, undefined);
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /"\$ultragoal" -> ultragoal/);
+      assert.match(message, /Ultragoal protocol:/);
+      assert.match(message, /get_goal/);
+      assert.match(message, /create_goal/);
+      assert.match(message, /update_goal/);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-ultragoal-1", "ultragoal-state.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("normalizes the Korean keyboard typo for ulw during UserPromptSubmit activation", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ulw-ko-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1327,6 +1327,9 @@ function buildAdditionalContextMessage(
   const ultraworkPromptActivationNote = skillState?.initialized_mode === "ultrawork"
     ? "Ultrawork protocol: ground the task before editing, define pass/fail acceptance criteria, keep shared-file work local, and use direct-tool plus background evidence lanes only for truly independent work. Direct ultrawork provides lightweight verification only; Ralph owns persistence and the full verified-completion promise."
     : null;
+  const ultragoalPromptActivationNote = match.skill === "ultragoal"
+    ? "Ultragoal protocol: use `omx ultragoal create-goals` / `complete-goals` / `checkpoint` for `.omx/ultragoal` artifacts, then use Codex goal model tools only from the active agent handoff (`get_goal`, `create_goal`, `update_goal`) and never overwrite a different active Codex goal."
+    : null;
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;
     if (matches.length <= 1 || activeSkills.length <= 1) return skillState.transition_message;
@@ -1353,6 +1356,7 @@ function buildAdditionalContextMessage(
         ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
         : null,
       promptPriorityMessage,
+      ultragoalPromptActivationNote,
       skillState.initialized_mode && skillState.initialized_state_path
         ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
         : null,
@@ -1378,6 +1382,7 @@ function buildAdditionalContextMessage(
       initializedStateMessage,
       deepInterviewPromptActivationNote,
       ultraworkPromptActivationNote,
+      ultragoalPromptActivationNote,
       buildTeamRuntimeInstruction(cwd, payload),
       buildTeamHelpInstruction(cwd, payload),
       "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
@@ -1395,12 +1400,13 @@ function buildAdditionalContextMessage(
       `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
       deepInterviewPromptActivationNote,
       ultraworkPromptActivationNote,
+      ultragoalPromptActivationNote,
       ralphPromptActivationNote,
       "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
     ].join(" ");
   }
 
-  return [detectedKeywordMessage, promptPriorityMessage, "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules."].filter(Boolean).join(" ");
+  return [detectedKeywordMessage, promptPriorityMessage, ultragoalPromptActivationNote, "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules."].filter(Boolean).join(" ");
 }
 
 function parseTeamWorkerEnv(rawValue: string): { teamName: string; workerName: string } | null {

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -63,7 +63,7 @@
       "name": "ultragoal",
       "category": "execution",
       "status": "active",
-      "core": false,
+      "core": true,
       "internalRequired": false
     },
     {


### PR DESCRIPTION
## Summary
- add `$ultragoal` to prompt keyword routing with intent guards so artifact path mentions do not accidentally activate it
- surface ultragoal as a core discoverable execution skill in catalog/generated/plugin/docs surfaces
- add native hook guidance for safe `.omx/ultragoal` artifact usage and Codex goal model-tool handoff (`get_goal`, `create_goal`, `update_goal`)

## Verification
- `npm test` (4500 pass, 0 fail)
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `npm run verify:plugin-bundle`
- `node dist/scripts/generate-catalog-docs.js --check`
- targeted compiled keyword/native-hook/catalog/plugin/ultragoal tests
- `git diff --check`

## Notes
- External architect/verifier subagents were launched for Ralph sign-off but timed out and returned no verdict/result; per user instruction, this PR relies on the local verification evidence above.

Fixes #2101
