### PR TITLE
feat(commit): add Lore guard opt-out

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -31,7 +31,7 @@ OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js
 | `session-start` | `SessionStart` | `session-start` | native | Native adapter refreshes leader session bookkeeping, preserves the canonical leader scope when a native subagent `SessionStart` is detected from rollout `session_meta`, restores startup developer context, and ensures `.omx/` is gitignored at the repo root |
 | wiki startup context | `SessionStart` | `session-start` | native | Wiki session-start context can append a compact `.omx/wiki/` summary when wiki pages exist; startup writes stay config-gated |
 | `keyword-detector` | `UserPromptSubmit` | `keyword-detector` | native | Persists skill activation state and can add prompt-side developer context for top-level prompts; native subagent prompt text is treated as delegated task text, so literal workflow keywords inside a child prompt do not activate nested workflow state; `$ralph` prompt routing seeds workflow state only and does not launch `omx ralph --prd ...` |
-| `pre-tool-use` | `PreToolUse` (`Bash`) | `pre-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior cautions on `rm -rf dist`, blocks inspectable inline `git commit` commands until Lore-format structure + the required `Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer are present, and emits non-blocking document-refresh warnings for mapped staged commit changes that lack rule-scoped docs/spec refresh evidence |
+| `pre-tool-use` | `PreToolUse` (`Bash`) | `pre-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior cautions on `rm -rf dist`, blocks inspectable inline `git commit` commands until Lore-format structure + the required `Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer are present unless explicitly opted out with `OMX_LORE_COMMIT_GUARD=0`, and emits non-blocking document-refresh warnings for mapped staged commit changes that lack rule-scoped docs/spec refresh evidence |
 | `post-tool-use` | `PostToolUse` (`Bash`) | `post-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior covers command-not-found / permission-denied / missing-path guidance only from stderr or non-zero Bash results, ignores failure-looking strings from successful source/log reads, and keeps MCP transport-death guidance scoped to MCP-like tool calls; document-refresh commit warnings use PreToolUse advisory output, with PostToolUse reserved as a future fallback if Codex advisory semantics change |
 | Ralph/persistence stop handling | `Stop` | `stop` | native-partial | Native adapter uses the documented native Stop continuation contract (`decision: "block"` + `reason`) for active Ralph runs, emits a single JSON object on Stop stdout even for no-op Stop decisions, and emits deterministic JSON continuation output if Stop dispatch fails before normal handling |
 | Autopilot continuation | `Stop` | `stop` | native-partial | Native adapter continues non-terminal autopilot sessions from active session/root mode state |
@@ -58,7 +58,26 @@ The native hook adapter includes an agent-only document-refresh warning MVP for
 spec-driven development hygiene. It does **not** install a generic CI gate, does
 **not** add a repo-wide pre-commit framework, and must not hard-block `git
 commit` for document-refresh reasons. Existing Lore commit blocking remains
-separate and still wins when an inline commit message is not Lore-compliant.
+separate and still wins when an inline commit message is not Lore-compliant,
+unless the Lore commit guard is explicitly disabled.
+
+## Lore commit guard opt-out
+
+Lore commit enforcement is enabled by default. To use conventional commits or
+another local commit policy while keeping OMX-managed native hooks installed,
+set `OMX_LORE_COMMIT_GUARD` to `0`, `false`, `no`, or `off`.
+
+For persistent Codex CLI usage, place the opt-out in `config.toml`:
+
+```toml
+[shell_environment_policy.set]
+OMX_LORE_COMMIT_GUARD = "0"
+```
+
+The opt-out disables only the Lore-style `git commit` blocking guard. Other
+native `PreToolUse` checks, including document-refresh warnings and command
+safety checks, still run. `omx doctor` reports when the guard is explicitly
+disabled by environment or config.
 
 Warning scope is intentionally narrow and rule-scoped:
 

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -410,6 +410,35 @@ USE_OMX_EXPLORE_CMD = "off"
 		}
 	});
 
+	it("warns when Lore commit guard is explicitly disabled in config.toml", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-lore-commit-guard-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				`
+[shell_environment_policy.set]
+OMX_LORE_COMMIT_GUARD = "off"
+`.trimStart(),
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: join(home, ".codex"),
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Lore commit guard: disabled in config\.toml; set OMX_LORE_COMMIT_GUARD = "1" under \[shell_environment_policy\.set\] to restore default Lore commit enforcement/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("warns when canonical and legacy skill roots overlap", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-skill-overlap-"));
 		try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -37,6 +37,10 @@ import {
 	OMX_EXPLORE_CMD_ENV,
 	isExploreCommandRoutingEnabled,
 } from "../hooks/explore-routing.js";
+import {
+	OMX_LORE_COMMIT_GUARD_ENV,
+	isLoreCommitGuardEnabled,
+} from "../config/commit-lore-guard.js";
 import { isLeaderRuntimeStale } from "../team/leader-activity.js";
 import { triagePrompt } from "../hooks/triage-heuristic.js";
 import { readTriageConfig } from "../hooks/triage-config.js";
@@ -169,6 +173,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
 	// Check 4.5: Explore routing default
 	checks.push(await checkExploreRouting(paths.configPath));
+
+	// Check 4.6: Lore commit guard default
+	checks.push(await checkLoreCommitGuard(paths.configPath));
 
 	// Check 5: Prompts installed
 	checks.push(
@@ -903,6 +910,66 @@ async function checkExploreRouting(configPath: string): Promise<Check> {
 			name: "Explore routing",
 			status: "fail",
 			message: "cannot read config.toml for explore routing check",
+		};
+	}
+}
+
+async function checkLoreCommitGuard(configPath: string): Promise<Check> {
+	const envValue = process.env[OMX_LORE_COMMIT_GUARD_ENV];
+	if (
+		typeof envValue === "string" &&
+		!isLoreCommitGuardEnabled(process.env)
+	) {
+		return {
+			name: "Lore commit guard",
+			status: "warn",
+			message:
+				"disabled by environment override; enable with OMX_LORE_COMMIT_GUARD=1 (or remove the explicit opt-out)",
+		};
+	}
+
+	if (!existsSync(configPath)) {
+		return {
+			name: "Lore commit guard",
+			status: "pass",
+			message: "enabled by default (config.toml not found yet)",
+		};
+	}
+
+	try {
+		const content = await readFile(configPath, "utf-8");
+		const parsed = parseToml(content) as {
+			env?: Record<string, unknown>;
+			shell_environment_policy?: { set?: Record<string, unknown> };
+		};
+		const configuredValue =
+			parsed?.shell_environment_policy?.set?.[OMX_LORE_COMMIT_GUARD_ENV] ??
+			parsed?.env?.[OMX_LORE_COMMIT_GUARD_ENV];
+
+		if (
+			typeof configuredValue === "string" &&
+			!isLoreCommitGuardEnabled({
+				[OMX_LORE_COMMIT_GUARD_ENV]: configuredValue,
+			})
+		) {
+			return {
+				name: "Lore commit guard",
+				status: "warn",
+				message:
+					'disabled in config.toml; set OMX_LORE_COMMIT_GUARD = "1" under [shell_environment_policy.set] to restore default Lore commit enforcement',
+			};
+		}
+
+		return {
+			name: "Lore commit guard",
+			status: "pass",
+			message: "enabled by default",
+		};
+	} catch {
+		return {
+			name: "Lore commit guard",
+			status: "fail",
+			message: "cannot read config.toml for Lore commit guard check",
 		};
 	}
 }

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -10,6 +10,7 @@ Resolved setup scope: user
   [!!] Config: config.toml exists but no OMX entries yet (expected before first setup; run "omx setup --force" once)
   [OK] Native hooks: hooks.json not found yet (expected before first setup)
   [OK] Explore routing: enabled by default
+  [OK] Lore commit guard: enabled by default
   [!!] Prompts: prompts directory not found
   [!!] Skills: skills directory not found
   [OK] Legacy skill roots: no ~/.agents/skills overlap detected

--- a/src/config/commit-lore-guard.ts
+++ b/src/config/commit-lore-guard.ts
@@ -1,0 +1,11 @@
+export const OMX_LORE_COMMIT_GUARD_ENV = "OMX_LORE_COMMIT_GUARD";
+
+const DISABLED_VALUES = new Set(["0", "false", "no", "off"]);
+
+export function isLoreCommitGuardEnabled(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	const raw = env[OMX_LORE_COMMIT_GUARD_ENV];
+	if (typeof raw !== "string") return true;
+	return !DISABLED_VALUES.has(raw.trim().toLowerCase());
+}

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3023,6 +3023,108 @@ exit 0
     }
   });
 
+  it("allows non-Lore git commit messages when the Lore commit guard is explicitly disabled", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-disabled-"));
+    const original = process.env.OMX_LORE_COMMIT_GUARD;
+    try {
+      process.env.OMX_LORE_COMMIT_GUARD = "0";
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-disabled",
+          tool_input: { command: 'git commit -m "fix: use conventional commit"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      if (original === undefined) delete process.env.OMX_LORE_COMMIT_GUARD;
+      else process.env.OMX_LORE_COMMIT_GUARD = original;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("treats Lore commit guard disabled values as trim and case tolerant", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-off-"));
+    const original = process.env.OMX_LORE_COMMIT_GUARD;
+    try {
+      process.env.OMX_LORE_COMMIT_GUARD = " OFF ";
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-off",
+          tool_input: { command: 'git commit -m "chore: conventional commit"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      if (original === undefined) delete process.env.OMX_LORE_COMMIT_GUARD;
+      else process.env.OMX_LORE_COMMIT_GUARD = original;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps Lore commit enforcement enabled for unknown guard values", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-unknown-"));
+    const original = process.env.OMX_LORE_COMMIT_GUARD;
+    try {
+      process.env.OMX_LORE_COMMIT_GUARD = "maybe";
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-unknown",
+          tool_input: { command: 'git commit -m "fix tests"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /Lore protocol/);
+    } finally {
+      if (original === undefined) delete process.env.OMX_LORE_COMMIT_GUARD;
+      else process.env.OMX_LORE_COMMIT_GUARD = original;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("continues to later PreToolUse checks when Lore commit guard is disabled", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-lore-disabled-destructive-"));
+    const original = process.env.OMX_LORE_COMMIT_GUARD;
+    try {
+      process.env.OMX_LORE_COMMIT_GUARD = "false";
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-lore-disabled-destructive",
+          tool_input: { command: "rm -rf dist" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /Lore protocol/);
+      assert.match(JSON.stringify(result.outputJson), /Destructive Bash command detected/);
+    } finally {
+      if (original === undefined) delete process.env.OMX_LORE_COMMIT_GUARD;
+      else process.env.OMX_LORE_COMMIT_GUARD = original;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("stays silent on PreToolUse for `git help commit`", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-help-commit-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3048,6 +3048,49 @@ exit 0
     }
   });
 
+  it("allows non-Lore git commit messages when the Lore commit guard is disabled inline", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-inline-disabled-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-inline-disabled",
+          tool_input: { command: 'OMX_LORE_COMMIT_GUARD=0 git commit -m "fix: conventional"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps Lore commit enforcement enabled for unknown inline guard values", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-inline-unknown-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-inline-unknown",
+          tool_input: { command: 'OMX_LORE_COMMIT_GUARD=maybe git commit -m "fix: conventional"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /Lore protocol/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("treats Lore commit guard disabled values as trim and case tolerant", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-off-"));
     const original = process.env.OMX_LORE_COMMIT_GUARD;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3069,6 +3069,80 @@ exit 0
     }
   });
 
+  it("does not treat newline-separated Lore guard assignment as inline git commit env", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-newline-assignment-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-newline-assignment",
+          tool_input: { command: 'OMX_LORE_COMMIT_GUARD=0\ngit commit -m "fix: conventional"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /Lore protocol/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("restores default-on Lore guard when env -u unsets a disabled process env", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-env-unset-"));
+    const original = process.env.OMX_LORE_COMMIT_GUARD;
+    try {
+      process.env.OMX_LORE_COMMIT_GUARD = "0";
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-env-unset",
+          tool_input: { command: 'env -u OMX_LORE_COMMIT_GUARD git commit -m "fix: conventional"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /Lore protocol/);
+    } finally {
+      if (original === undefined) delete process.env.OMX_LORE_COMMIT_GUARD;
+      else process.env.OMX_LORE_COMMIT_GUARD = original;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("restores default-on Lore guard when env -i clears a disabled process env", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-env-ignore-"));
+    const original = process.env.OMX_LORE_COMMIT_GUARD;
+    try {
+      process.env.OMX_LORE_COMMIT_GUARD = "0";
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-env-ignore",
+          tool_input: { command: 'env -i PATH=/usr/bin git commit -m "fix: conventional"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /Lore protocol/);
+    } finally {
+      if (original === undefined) delete process.env.OMX_LORE_COMMIT_GUARD;
+      else process.env.OMX_LORE_COMMIT_GUARD = original;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps Lore commit enforcement enabled for unknown inline guard values", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-inline-unknown-"));
     try {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -2,6 +2,7 @@ import {
   buildDocumentRefreshAdvisoryOutput,
   evaluateStagedDocumentRefresh,
 } from "../document-refresh/enforcer.js";
+import { isLoreCommitGuardEnabled } from "../config/commit-lore-guard.js";
 import { resolveCodexExecutionSurface } from "./codex-execution-surface.js";
 
 type CodexHookPayload = Record<string, unknown>;
@@ -575,6 +576,8 @@ function buildGitCommitComplianceErrors(message: string | null): string[] {
 }
 
 function buildGitCommitEnforcementOutput(commandText: string): Record<string, unknown> | null {
+  if (!isLoreCommitGuardEnabled()) return null;
+
   const parsed = parseGitCommitCommand(commandText);
   if (!parsed.isGitCommit) return null;
 

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -285,9 +285,91 @@ function tokenizeShellCommand(commandText: string): string[] | null {
   return tokens.length > 0 ? tokens : null;
 }
 
+interface ShellToken {
+  value: string;
+  startsCommand: boolean;
+}
+
+function tokenizeShellCommandWithBoundaries(commandText: string): ShellToken[] | null {
+  const trimmed = commandText.trim();
+  if (!trimmed) return null;
+
+  const tokens: ShellToken[] = [];
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+  let escaping = false;
+  let nextTokenStartsCommand = false;
+
+  const pushCurrent = () => {
+    if (!current) return;
+    tokens.push({ value: current, startsCommand: tokens.length === 0 || nextTokenStartsCommand });
+    current = "";
+    nextTokenStartsCommand = false;
+  };
+
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const char = trimmed[index] ?? "";
+
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+
+    if (quote === "'") {
+      if (char === "'") {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (quote === "\"") {
+      if (char === "\"") quote = null;
+      else if (char === "\\") {
+        if (isDoubleQuotedShellEscapeTarget(trimmed[index + 1])) escaping = true;
+        else current += char;
+      }
+      else current += char;
+      continue;
+    }
+
+    if (char === "\n" || char === ";" || char === "&" || char === "|") {
+      pushCurrent();
+      nextTokenStartsCommand = true;
+      if ((char === "&" || char === "|") && trimmed[index + 1] === char) index += 1;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      pushCurrent();
+      continue;
+    }
+
+    if (char === "'" || char === "\"") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaping = true;
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaping || quote) return null;
+  pushCurrent();
+  return tokens.length > 0 ? tokens : null;
+}
+
 interface GitCommitCommandParseResult {
   isGitCommit: boolean;
   inlineEnvironment: NodeJS.ProcessEnv;
+  environmentStartsClean: boolean;
+  unsetEnvironmentNames: string[];
   inlineMessage: string | null;
   repositorySelection: GitRepositorySelection;
   requiresExternalMessageSource: boolean;
@@ -324,38 +406,166 @@ function envOptionConsumesNextValue(token: string): boolean {
     || token === "--split-string";
 }
 
-function findGitCommandTokenIndex(tokens: string[]): number {
-  let index = 0;
+function tokenStartsCommand(tokens: ShellToken[], index: number): boolean {
+  return index <= 0 || (tokens[index]?.startsCommand ?? false);
+}
 
-  while (index < tokens.length && isInlineShellEnvAssignment(tokens[index] ?? "")) {
+function nextCommandStart(tokens: ShellToken[], startIndex: number): number {
+  let index = startIndex + 1;
+  while (index < tokens.length && !tokenStartsCommand(tokens, index)) {
+    index += 1;
+  }
+  return index;
+}
+
+function findGitCommandTokenIndex(tokens: ShellToken[]): number {
+  for (let commandStart = 0; commandStart < tokens.length; commandStart = nextCommandStart(tokens, commandStart)) {
+    let index = commandStart;
+    const commandEnd = nextCommandStart(tokens, commandStart);
+
+    while (index < commandEnd && isInlineShellEnvAssignment(tokens[index]?.value ?? "")) {
+      index += 1;
+    }
+
+    while (index < commandEnd && isEnvExecutableToken(tokens[index]?.value ?? "")) {
+      index += 1;
+      while (index < commandEnd) {
+        const token = tokens[index]?.value ?? "";
+        if (token === "--") {
+          index += 1;
+          break;
+        }
+        if (isInlineShellEnvAssignment(token)) {
+          index += 1;
+          continue;
+        }
+        if (token === "-i" || token === "--ignore-environment" || token.startsWith("--unset=")) {
+          index += 1;
+          continue;
+        }
+        if (token.startsWith("-")) {
+          index += envOptionConsumesNextValue(token) ? 2 : 1;
+          continue;
+        }
+        break;
+      }
+      while (index < commandEnd && isInlineShellEnvAssignment(tokens[index]?.value ?? "")) {
+        index += 1;
+      }
+    }
+
+    if (index < commandEnd && isGitExecutableToken(tokens[index]?.value ?? "")) return index;
+    if (commandEnd <= commandStart) break;
+    commandStart = commandEnd - 1;
+  }
+
+  return -1;
+}
+
+function tokenValues(tokens: ShellToken[]): string[] {
+  return tokens.map((token) => token.value);
+}
+
+function findCommandStart(tokens: ShellToken[], tokenIndex: number): number {
+  let index = tokenIndex;
+  while (index > 0 && !tokenStartsCommand(tokens, index)) {
+    index -= 1;
+  }
+  return index;
+}
+
+function findCommandEnd(tokens: ShellToken[], tokenIndex: number): number {
+  let index = tokenIndex + 1;
+  while (index < tokens.length && !tokenStartsCommand(tokens, index)) {
+    index += 1;
+  }
+  return index;
+}
+
+interface InlineEnvironmentRead {
+  inlineEnvironment: NodeJS.ProcessEnv;
+  environmentStartsClean: boolean;
+  unsetEnvironmentNames: string[];
+}
+
+function readUnsetEnvNameFromOption(token: string, nextToken: string | undefined): {
+  name: string | null;
+  consumedNext: boolean;
+} {
+  if (token === "-u" || token === "--unset") {
+    return { name: nextToken ?? null, consumedNext: true };
+  }
+  if (token.startsWith("--unset=")) {
+    return { name: token.slice("--unset=".length), consumedNext: false };
+  }
+  return { name: null, consumedNext: false };
+}
+
+function readInlineEnvironmentAssignments(tokens: ShellToken[], gitTokenIndex: number): InlineEnvironmentRead {
+  const inlineEnvironment: NodeJS.ProcessEnv = {};
+  const unsetEnvironmentNames = new Set<string>();
+  let environmentStartsClean = false;
+  const commandStart = findCommandStart(tokens, gitTokenIndex);
+  const recordAssignment = (token: string) => {
+    const separatorIndex = token.indexOf("=");
+    const name = token.slice(0, separatorIndex);
+    inlineEnvironment[name] = token.slice(separatorIndex + 1);
+    unsetEnvironmentNames.delete(name);
+  };
+  const recordUnset = (name: string | null) => {
+    if (!name) return;
+    delete inlineEnvironment[name];
+    unsetEnvironmentNames.add(name);
+  };
+
+  let index = commandStart;
+  while (index < gitTokenIndex && isInlineShellEnvAssignment(tokens[index]?.value ?? "")) {
+    recordAssignment(tokens[index]?.value ?? "");
     index += 1;
   }
 
-  while (index < tokens.length && isEnvExecutableToken(tokens[index] ?? "")) {
+  while (index < gitTokenIndex && isEnvExecutableToken(tokens[index]?.value ?? "")) {
     index += 1;
-    while (index < tokens.length) {
-      const token = tokens[index] ?? "";
+    while (index < gitTokenIndex) {
+      const token = tokens[index]?.value ?? "";
       if (token === "--") {
         index += 1;
         break;
       }
-      if (isInlineShellEnvAssignment(token) || token.startsWith("-")) {
-        if (envOptionConsumesNextValue(token)) {
-          index += 1;
-        }
+      if (isInlineShellEnvAssignment(token)) {
+        recordAssignment(token);
         index += 1;
+        continue;
+      }
+      if (token === "-i" || token === "--ignore-environment") {
+        environmentStartsClean = true;
+        unsetEnvironmentNames.clear();
+        index += 1;
+        continue;
+      }
+      const unset = readUnsetEnvNameFromOption(token, tokens[index + 1]?.value);
+      if (unset.name !== null || unset.consumedNext) {
+        recordUnset(unset.name);
+        index += unset.consumedNext ? 2 : 1;
+        continue;
+      }
+      if (token.startsWith("-")) {
+        index += envOptionConsumesNextValue(token) ? 2 : 1;
         continue;
       }
       break;
     }
-    while (index < tokens.length && isInlineShellEnvAssignment(tokens[index] ?? "")) {
+    while (index < gitTokenIndex && isInlineShellEnvAssignment(tokens[index]?.value ?? "")) {
+      recordAssignment(tokens[index]?.value ?? "");
       index += 1;
     }
   }
 
-  return index < tokens.length && isGitExecutableToken(tokens[index] ?? "")
-    ? index
-    : -1;
+  return {
+    inlineEnvironment,
+    environmentStartsClean,
+    unsetEnvironmentNames: [...unsetEnvironmentNames],
+  };
 }
 
 function gitOptionConsumesNextValue(token: string): boolean {
@@ -421,65 +631,28 @@ function readGitRepositorySelection(tokens: string[], gitTokenIndex: number, sub
   return "current-cwd";
 }
 
-function readInlineEnvironmentAssignments(tokens: string[], gitTokenIndex: number): NodeJS.ProcessEnv {
-  const inlineEnvironment: NodeJS.ProcessEnv = {};
-  const recordAssignment = (token: string) => {
-    const separatorIndex = token.indexOf("=");
-    const name = token.slice(0, separatorIndex);
-    inlineEnvironment[name] = token.slice(separatorIndex + 1);
-  };
-
-  let index = 0;
-  while (index < gitTokenIndex && isInlineShellEnvAssignment(tokens[index] ?? "")) {
-    recordAssignment(tokens[index] ?? "");
-    index += 1;
-  }
-
-  while (index < gitTokenIndex && isEnvExecutableToken(tokens[index] ?? "")) {
-    index += 1;
-    while (index < gitTokenIndex) {
-      const token = tokens[index] ?? "";
-      if (token === "--") {
-        index += 1;
-        break;
-      }
-      if (isInlineShellEnvAssignment(token)) {
-        recordAssignment(token);
-        index += 1;
-        continue;
-      }
-      if (token.startsWith("-")) {
-        index += envOptionConsumesNextValue(token) ? 2 : 1;
-        continue;
-      }
-      break;
-    }
-    while (index < gitTokenIndex && isInlineShellEnvAssignment(tokens[index] ?? "")) {
-      recordAssignment(tokens[index] ?? "");
-      index += 1;
-    }
-  }
-
-  return inlineEnvironment;
-}
-
 export function parseGitCommitCommand(commandText: string): GitCommitCommandParseResult {
-  const tokens = tokenizeShellCommand(commandText);
+  const shellTokens = tokenizeShellCommandWithBoundaries(commandText);
+  const tokens = shellTokens ? tokenValues(shellTokens) : null;
   if (!tokens) {
     return {
       isGitCommit: false,
       inlineEnvironment: {},
+      environmentStartsClean: false,
+      unsetEnvironmentNames: [],
       inlineMessage: null,
       repositorySelection: "current-cwd",
       requiresExternalMessageSource: false,
     };
   }
 
-  const gitTokenIndex = findGitCommandTokenIndex(tokens);
+  const gitTokenIndex = findGitCommandTokenIndex(shellTokens ?? []);
   if (gitTokenIndex < 0 || !isGitExecutableToken(tokens[gitTokenIndex] ?? "")) {
     return {
       isGitCommit: false,
       inlineEnvironment: {},
+      environmentStartsClean: false,
+      unsetEnvironmentNames: [],
       inlineMessage: null,
       repositorySelection: "current-cwd",
       requiresExternalMessageSource: false,
@@ -491,6 +664,8 @@ export function parseGitCommitCommand(commandText: string): GitCommitCommandPars
     return {
       isGitCommit: false,
       inlineEnvironment: {},
+      environmentStartsClean: false,
+      unsetEnvironmentNames: [],
       inlineMessage: null,
       repositorySelection: "current-cwd",
       requiresExternalMessageSource: false,
@@ -498,7 +673,7 @@ export function parseGitCommitCommand(commandText: string): GitCommitCommandPars
   }
 
   const repositorySelection = readGitRepositorySelection(tokens, gitTokenIndex, subcommandIndex);
-  const inlineEnvironment = readInlineEnvironmentAssignments(tokens, gitTokenIndex);
+  const { inlineEnvironment, environmentStartsClean, unsetEnvironmentNames } = readInlineEnvironmentAssignments(shellTokens ?? [], gitTokenIndex);
   const messageParts: string[] = [];
   let requiresExternalMessageSource = false;
   const args = tokens.slice(subcommandIndex + 1);
@@ -541,10 +716,23 @@ export function parseGitCommitCommand(commandText: string): GitCommitCommandPars
   return {
     isGitCommit: true,
     inlineEnvironment,
+    environmentStartsClean,
+    unsetEnvironmentNames,
     inlineMessage: messageParts.length > 0 ? messageParts.join("\n\n").trim() : null,
     repositorySelection,
     requiresExternalMessageSource,
   };
+}
+
+function buildEffectiveLoreCommitGuardEnv(parsed: GitCommitCommandParseResult): NodeJS.ProcessEnv {
+  const effectiveEnvironment: NodeJS.ProcessEnv = parsed.environmentStartsClean ? {} : { ...process.env };
+  for (const name of parsed.unsetEnvironmentNames) {
+    delete effectiveEnvironment[name];
+  }
+  for (const [name, value] of Object.entries(parsed.inlineEnvironment)) {
+    if (typeof value === "string") effectiveEnvironment[name] = value;
+  }
+  return effectiveEnvironment;
 }
 
 function isLoreTrailerLine(line: string): boolean {
@@ -627,7 +815,7 @@ function buildGitCommitEnforcementOutput(commandText: string): Record<string, un
   const parsed = parseGitCommitCommand(commandText);
   if (!parsed.isGitCommit) return null;
 
-  if (!isLoreCommitGuardEnabled({ ...process.env, ...parsed.inlineEnvironment })) return null;
+  if (!isLoreCommitGuardEnabled(buildEffectiveLoreCommitGuardEnv(parsed))) return null;
 
   const errors = parsed.requiresExternalMessageSource
     ? [

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -474,13 +474,6 @@ function findCommandStart(tokens: ShellToken[], tokenIndex: number): number {
   return index;
 }
 
-function findCommandEnd(tokens: ShellToken[], tokenIndex: number): number {
-  let index = tokenIndex + 1;
-  while (index < tokens.length && !tokenStartsCommand(tokens, index)) {
-    index += 1;
-  }
-  return index;
-}
 
 interface InlineEnvironmentRead {
   inlineEnvironment: NodeJS.ProcessEnv;

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -287,6 +287,7 @@ function tokenizeShellCommand(commandText: string): string[] | null {
 
 interface GitCommitCommandParseResult {
   isGitCommit: boolean;
+  inlineEnvironment: NodeJS.ProcessEnv;
   inlineMessage: string | null;
   repositorySelection: GitRepositorySelection;
   requiresExternalMessageSource: boolean;
@@ -420,11 +421,54 @@ function readGitRepositorySelection(tokens: string[], gitTokenIndex: number, sub
   return "current-cwd";
 }
 
+function readInlineEnvironmentAssignments(tokens: string[], gitTokenIndex: number): NodeJS.ProcessEnv {
+  const inlineEnvironment: NodeJS.ProcessEnv = {};
+  const recordAssignment = (token: string) => {
+    const separatorIndex = token.indexOf("=");
+    const name = token.slice(0, separatorIndex);
+    inlineEnvironment[name] = token.slice(separatorIndex + 1);
+  };
+
+  let index = 0;
+  while (index < gitTokenIndex && isInlineShellEnvAssignment(tokens[index] ?? "")) {
+    recordAssignment(tokens[index] ?? "");
+    index += 1;
+  }
+
+  while (index < gitTokenIndex && isEnvExecutableToken(tokens[index] ?? "")) {
+    index += 1;
+    while (index < gitTokenIndex) {
+      const token = tokens[index] ?? "";
+      if (token === "--") {
+        index += 1;
+        break;
+      }
+      if (isInlineShellEnvAssignment(token)) {
+        recordAssignment(token);
+        index += 1;
+        continue;
+      }
+      if (token.startsWith("-")) {
+        index += envOptionConsumesNextValue(token) ? 2 : 1;
+        continue;
+      }
+      break;
+    }
+    while (index < gitTokenIndex && isInlineShellEnvAssignment(tokens[index] ?? "")) {
+      recordAssignment(tokens[index] ?? "");
+      index += 1;
+    }
+  }
+
+  return inlineEnvironment;
+}
+
 export function parseGitCommitCommand(commandText: string): GitCommitCommandParseResult {
   const tokens = tokenizeShellCommand(commandText);
   if (!tokens) {
     return {
       isGitCommit: false,
+      inlineEnvironment: {},
       inlineMessage: null,
       repositorySelection: "current-cwd",
       requiresExternalMessageSource: false,
@@ -435,6 +479,7 @@ export function parseGitCommitCommand(commandText: string): GitCommitCommandPars
   if (gitTokenIndex < 0 || !isGitExecutableToken(tokens[gitTokenIndex] ?? "")) {
     return {
       isGitCommit: false,
+      inlineEnvironment: {},
       inlineMessage: null,
       repositorySelection: "current-cwd",
       requiresExternalMessageSource: false,
@@ -445,6 +490,7 @@ export function parseGitCommitCommand(commandText: string): GitCommitCommandPars
   if (subcommandIndex < 0 || tokens[subcommandIndex]?.toLowerCase() !== "commit") {
     return {
       isGitCommit: false,
+      inlineEnvironment: {},
       inlineMessage: null,
       repositorySelection: "current-cwd",
       requiresExternalMessageSource: false,
@@ -452,6 +498,7 @@ export function parseGitCommitCommand(commandText: string): GitCommitCommandPars
   }
 
   const repositorySelection = readGitRepositorySelection(tokens, gitTokenIndex, subcommandIndex);
+  const inlineEnvironment = readInlineEnvironmentAssignments(tokens, gitTokenIndex);
   const messageParts: string[] = [];
   let requiresExternalMessageSource = false;
   const args = tokens.slice(subcommandIndex + 1);
@@ -493,6 +540,7 @@ export function parseGitCommitCommand(commandText: string): GitCommitCommandPars
 
   return {
     isGitCommit: true,
+    inlineEnvironment,
     inlineMessage: messageParts.length > 0 ? messageParts.join("\n\n").trim() : null,
     repositorySelection,
     requiresExternalMessageSource,
@@ -576,10 +624,10 @@ function buildGitCommitComplianceErrors(message: string | null): string[] {
 }
 
 function buildGitCommitEnforcementOutput(commandText: string): Record<string, unknown> | null {
-  if (!isLoreCommitGuardEnabled()) return null;
-
   const parsed = parseGitCommitCommand(commandText);
   if (!parsed.isGitCommit) return null;
+
+  if (!isLoreCommitGuardEnabled({ ...process.env, ...parsed.inlineEnvironment })) return null;
 
   const errors = parsed.requiresExternalMessageSource
     ? [


### PR DESCRIPTION
## Summary
- Fixes #2103
- Add default-on `OMX_LORE_COMMIT_GUARD` handling so `0`, `false`, `no`, or `off` disables only the Lore-style git commit PreToolUse block
- Surface explicit disabled state in `omx doctor` for env/config opt-outs
- Document the opt-out for conventional commits while preserving managed hooks

## Tests
- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/doctor-warning-copy.test.js`

## Notes
- Default behavior is unchanged unless the opt-out is explicit.
