### PR TITLE
Integrate Codex goal-mode workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ If this happens, try:
 - [Agent catalog](./docs/agents.html)
 - [Skills reference](./docs/skills.html)
 - [Codex native hook mapping](./docs/codex-native-hooks.md)
+- [GitHub / PR / package identity pipeline](./docs/pipeline/github-pr-package-identity.md)
 - [Integrations](./docs/integrations.html)
 - [Troubleshooting execution readiness](./docs/troubleshooting.md)
 - [OpenClaw / notification gateway guide](./docs/openclaw-integration.md)

--- a/docs/autoresearch-goal.md
+++ b/docs/autoresearch-goal.md
@@ -1,0 +1,26 @@
+# Autoresearch Goal
+
+`omx autoresearch-goal` is a durable goal-mode adapter for semantic research missions. It is intentionally separate from the hard-deprecated `omx autoresearch` direct launch command.
+
+## Contract
+
+- OMX writes durable artifacts under `.omx/goals/autoresearch/<slug>/`.
+- The CLI does not mutate hidden Codex `/goal` state; it prints a handoff for the active Codex agent.
+- The handoff instructs the agent to call `get_goal`, call `create_goal` only when no active goal exists, and call `update_goal({status: "complete"})` only after completion audit.
+- Completion requires a professor-critic `verdict=pass` artifact.
+
+## Commands
+
+```sh
+omx autoresearch-goal create --topic "Research migration risk" --rubric "Professor critic rubric" --critic-command "node scripts/critic.js"
+omx autoresearch-goal handoff --slug research-migration-risk
+omx autoresearch-goal verdict --slug research-migration-risk --verdict pass --evidence ".omx/specs/report.md approved by critic"
+omx autoresearch-goal complete --slug research-migration-risk
+```
+
+## Artifacts
+
+- `mission.json` — topic, rubric, status, paths, and optional critic command.
+- `rubric.md` — semantic professor-critic rubric.
+- `ledger.jsonl` — workflow and validation events.
+- `completion.json` — latest pass/fail/blocked verdict and evidence.

--- a/docs/autoresearch-goal.md
+++ b/docs/autoresearch-goal.md
@@ -6,7 +6,7 @@
 
 - OMX writes durable artifacts under `.omx/goals/autoresearch/<slug>/`.
 - The CLI does not mutate hidden Codex `/goal` state; it prints a handoff for the active Codex agent.
-- The handoff instructs the agent to call `get_goal`, call `create_goal` only when no active goal exists, and call `update_goal({status: "complete"})` only after completion audit.
+- The handoff instructs the agent to call `get_goal`, call `create_goal` only when no active goal exists, and call `update_goal({status: "complete"})` only after `omx autoresearch-goal complete` records the mission as `complete` and the completion audit passes.
 - Completion requires a professor-critic `verdict=pass` artifact.
 
 ## Commands

--- a/docs/autoresearch-goal.md
+++ b/docs/autoresearch-goal.md
@@ -7,14 +7,14 @@
 - OMX writes durable artifacts under `.omx/goals/autoresearch/<slug>/`.
 - The CLI does not mutate hidden Codex `/goal` state; it prints a handoff for the active Codex agent.
 - The handoff instructs the agent to call `get_goal`, call `create_goal` only when no active goal exists, and call `update_goal({status: "complete"})` only after `omx autoresearch-goal complete` records the mission as `complete` and the completion audit passes.
-- Completion requires a professor-critic `verdict=pass` artifact.
+- Completion requires a professor-critic `verdict=pass` with a durable `--artifact <path>`; assistant prose alone is not sufficient.
 
 ## Commands
 
 ```sh
 omx autoresearch-goal create --topic "Research migration risk" --rubric "Professor critic rubric" --critic-command "node scripts/critic.js"
 omx autoresearch-goal handoff --slug research-migration-risk
-omx autoresearch-goal verdict --slug research-migration-risk --verdict pass --evidence ".omx/specs/report.md approved by critic"
+omx autoresearch-goal verdict --slug research-migration-risk --verdict pass --evidence ".omx/specs/report.md approved by critic" --artifact .omx/specs/report.md
 omx autoresearch-goal complete --slug research-migration-risk
 ```
 
@@ -23,4 +23,4 @@ omx autoresearch-goal complete --slug research-migration-risk
 - `mission.json` — topic, rubric, status, paths, and optional critic command.
 - `rubric.md` — semantic professor-critic rubric.
 - `ledger.jsonl` — workflow and validation events.
-- `completion.json` — latest pass/fail/blocked verdict and evidence.
+- `completion.json` — latest pass/fail/blocked verdict, evidence, and required artifact path for passing verdicts.

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,6 +77,7 @@
       <h2>Reference Guides</h2>
       <ul>
         <li><a href="./reference/omx-config-schema-routing.md">.omx-config.json model/env routing reference</a></li>
+        <li><a href="./pipeline/github-pr-package-identity.md">GitHub / PR / package identity pipeline</a></li>
       </ul>
 
       <h2>Integration Guides</h2>

--- a/docs/performance-goal.md
+++ b/docs/performance-goal.md
@@ -1,0 +1,38 @@
+# Performance Goal Workflow
+
+`omx performance-goal` is an evaluator-gated optimization workflow layered over Codex goal mode.
+
+It records a local evaluator contract before optimization starts, emits a truthful Codex goal-mode handoff, and blocks completion until evaluator evidence passes.
+
+## Artifacts
+
+Each workflow is stored under:
+
+```text
+.omx/goals/performance/<slug>/
+  state.json
+  evaluator.md
+  ledger.jsonl
+```
+
+## Boundary
+
+- OMX persists workflow state, evaluator contracts, validation evidence, and ledgers.
+- Codex goal mode owns active-thread focus/accounting.
+- The CLI cannot secretly mutate the interactive Codex goal. `start` prints instructions for the active agent to call `get_goal`, `create_goal`, and later `update_goal({status: "complete"})` safely.
+
+## Minimal flow
+
+```sh
+omx performance-goal create \
+  --objective "Reduce startup latency by 20%" \
+  --evaluator-command "npm run perf:startup" \
+  --evaluator-contract "PASS when p95 latency improves by 20% and regression tests pass" \
+  --slug startup-latency
+
+omx performance-goal start --slug startup-latency
+omx performance-goal checkpoint --slug startup-latency --status pass --evidence "benchmark and tests passed"
+omx performance-goal complete --slug startup-latency --evidence "final evaluator evidence"
+```
+
+Completion fails until a passing checkpoint exists.

--- a/docs/performance-goal.md
+++ b/docs/performance-goal.md
@@ -19,7 +19,7 @@ Each workflow is stored under:
 
 - OMX persists workflow state, evaluator contracts, validation evidence, and ledgers.
 - Codex goal mode owns active-thread focus/accounting.
-- The CLI cannot secretly mutate the interactive Codex goal. `start` prints instructions for the active agent to call `get_goal`, `create_goal`, and later `update_goal({status: "complete"})` safely.
+- The CLI cannot secretly mutate the interactive Codex goal. `start` prints instructions for the active agent to call `get_goal`, call `create_goal` only when appropriate, then run `omx performance-goal complete` before later calling `update_goal({status: "complete"})` safely.
 
 ## Minimal flow
 
@@ -33,6 +33,8 @@ omx performance-goal create \
 omx performance-goal start --slug startup-latency
 omx performance-goal checkpoint --slug startup-latency --status pass --evidence "benchmark and tests passed"
 omx performance-goal complete --slug startup-latency --evidence "final evaluator evidence"
+# after this succeeds and the active Codex goal still owns the objective:
+# update_goal({status: "complete"})
 ```
 
 Completion fails until a passing checkpoint exists.

--- a/docs/pipeline/github-pr-package-identity.md
+++ b/docs/pipeline/github-pr-package-identity.md
@@ -1,0 +1,233 @@
+# GitHub / PR / package identity pipeline
+
+This guide documents the public contract for turning GitHub or community reports into traceable OMX work packages, worktrees, pull requests, reviews, and merge decisions. It is intentionally infrastructure-neutral: repositories may implement the glue with GitHub Actions, bots, scheduled scripts, or manual maintainer commands, but the artifacts and gates below are the source of truth.
+
+## Public scope and source of truth
+
+- **Repo-available contract:** the Markdown templates in [`docs/pipeline/templates/`](./templates/) and this workflow contract are safe to copy, review, and version in the repository.
+- **External orchestration glue:** webhook listeners, Discord bots, queue workers, credential stores, deployment targets, and scheduler internals live outside this contract. Do not document secrets, hostnames, queue names, tokens, private channels, or operational topology here.
+- **Truth model:** chat messages are coordination hints, not truth. The truth lives in GitHub issues, pull requests, and package artifacts committed to branches or attached to issues/PRs.
+- **Mutation safety:** any state-changing action must pass an explicit gate. Only one active mutating runtime may own a worktree at a time; observers and reviewers may read concurrently.
+
+## Pipeline overview
+
+1. **GitHub/Discord intake**
+   - Accept reports from GitHub issues and optional Discord/community threads.
+   - Mirror external context into the GitHub issue when it is needed for future maintainers.
+   - Record the canonical identity with [`issue-package-identity.md`](./templates/issue-package-identity.md).
+2. **Classify, dedupe, reproduce, and risk-gate**
+   - Classify as bug, feature/contract proposal, duplicate, support question, or invalid/spam.
+   - Search for existing issues and PRs before creating a package.
+   - Ask for a minimal reproduction when a bug report is not actionable.
+   - Apply a risk gate before any mutating runtime starts: branch target, affected surfaces, expected tests, and whether credentials or destructive commands are involved.
+3. **Package identity**
+   - Create a stable `package_id` for actionable work, usually `issue-<number>-<short-slug>`.
+   - Bind the package to one repo, one issue, one branch, one worktree, and optional external thread reference.
+   - Store package state transitions in the issue/PR/package artifacts, not only in chat.
+4. **Worktree/session/branch mapping**
+   - Branch: `<kind>/issue-<number>-<short-slug>` such as `fix/issue-1234-repro-timeout` or `docs/issue-2087-pipeline-templates`.
+   - Worktree: a deterministic path containing the `package_id`, for example `../oh-my-codex-worktrees/<package_id>`.
+   - OMX session: a runtime label containing or linking to the `package_id`; it may be implementation-specific, but the package artifact must say which runtime owned mutation.
+5. **Execution artifacts**
+   - `package.md` records identity, scope, gates, and state.
+   - `plan.md` records planned changes and validation.
+   - `execution-result.md` records what changed and evidence.
+   - `review.md` records review findings and approval/rejection.
+   - `merge-decision.md` records final gate outcome.
+6. **PR, review, and merge gates**
+   - PRs target the agreed base branch, usually `dev`.
+   - The PR links the issue and package artifacts.
+   - Review checks traceability, validation, risk, and single-owner worktree mutation.
+   - Merge only after validation evidence and review approval are recorded.
+
+## States
+
+Recommended package states:
+
+- `intake`: report received; no package created yet.
+- `needs_repro`: bug-like report needs exact reproduction details.
+- `duplicate`: closed or redirected to canonical issue.
+- `proposal`: feature/contract idea needs maintainer scope gate.
+- `ready`: package identity exists and mutation has not started.
+- `executing`: one mutating runtime owns the worktree.
+- `review`: implementation submitted; mutation paused except requested fixes.
+- `merge_ready`: review and validation gates passed.
+- `merged`: PR merged and issue closure recorded.
+- `closed`: no further work planned.
+
+## Issue/package identity
+
+Use [`templates/issue-package-identity.md`](./templates/issue-package-identity.md) in the issue body, a package artifact, or both. Required fields are:
+
+- `source`
+- `repo`
+- `issue`
+- `package_id`
+- `branch`
+- `worktree`
+- `discord_thread`
+- `state`
+
+## Triage policy templates
+
+Use the templates in [`templates/triage/`](./templates/triage/) for common issue outcomes:
+
+- [`needs-repro-question.md`](./templates/triage/needs-repro-question.md)
+- [`timeout-close.md`](./templates/triage/timeout-close.md)
+- [`duplicate-close.md`](./templates/triage/duplicate-close.md)
+- [`reproducible-bug-package.md`](./templates/triage/reproducible-bug-package.md)
+- [`feature-contract-proposal-gate.md`](./templates/triage/feature-contract-proposal-gate.md)
+
+## Execution artifact templates
+
+Use the templates in [`templates/execution/`](./templates/execution/) for package lifecycle records:
+
+- [`package.md`](./templates/execution/package.md)
+- [`plan.md`](./templates/execution/plan.md)
+- [`execution-result.md`](./templates/execution/execution-result.md)
+- [`review.md`](./templates/execution/review.md)
+- [`merge-decision.md`](./templates/execution/merge-decision.md)
+
+## Coordinator skeleton
+
+The coordinator is orchestration glue. Keep implementation-specific endpoints, credentials, process managers, queue names, and private channel identifiers outside public docs.
+
+```ts
+type IntakeEvent = {
+  source: "github" | "discord";
+  repo: string;
+  issue?: number;
+  externalThread?: string;
+  title: string;
+  body: string;
+  author: string;
+  receivedAt: string;
+};
+
+type Classification = {
+  kind: "bug" | "feature" | "contract" | "duplicate" | "support" | "invalid";
+  confidence: number;
+  canonicalIssue?: number;
+  needsRepro: boolean;
+  risk: "low" | "medium" | "high";
+  rationale: string;
+  suggestedPackageId?: string;
+};
+
+async function intakeLoop() {
+  for await (const event of pollOrReceiveWebhookEvents()) {
+    const issue = await ensureCanonicalGitHubIssue(event);
+    const classification = await classify(issue);
+
+    if (classification.kind === "duplicate") {
+      await commentFromTemplate(issue, "triage/duplicate-close.md", classification);
+      await closeIssue(issue, "not planned");
+      continue;
+    }
+
+    if (classification.needsRepro) {
+      await commentFromTemplate(issue, "triage/needs-repro-question.md", classification);
+      await label(issue, ["needs-repro"]);
+      continue;
+    }
+
+    if (classification.kind === "feature" || classification.kind === "contract") {
+      await commentFromTemplate(issue, "triage/feature-contract-proposal-gate.md", classification);
+      await label(issue, ["proposal", "needs-maintainer-gate"]);
+      continue;
+    }
+
+    if (classification.kind === "bug") {
+      await createPackageIdempotently(issue, classification);
+    }
+  }
+}
+
+async function createPackageIdempotently(issue: Issue, classification: Classification) {
+  const packageId = classification.suggestedPackageId ?? `issue-${issue.number}-${slug(issue.title)}`;
+  const existing = await findPackageByIssue(issue.repo, issue.number);
+  if (existing) return existing;
+
+  const branch = `fix/${packageId}`;
+  const worktree = `../oh-my-codex-worktrees/${packageId}`;
+  const session = `tmux-or-omx-${packageId}`;
+
+  await requireGate("risk", {
+    issue: issue.number,
+    packageId,
+    risk: classification.risk,
+    mutationOwner: session,
+  });
+
+  await run(`git fetch origin dev`);
+  await run(`git worktree add ${shellQuote(worktree)} -b ${shellQuote(branch)} origin/dev`);
+  await writeTemplate(`${worktree}/package.md`, "execution/package.md", {
+    source: "github",
+    repo: issue.repo,
+    issue: issue.number,
+    package_id: packageId,
+    branch,
+    worktree,
+    discord_thread: "n/a",
+    state: "ready",
+  });
+
+  await commentFromTemplate(issue, "triage/reproducible-bug-package.md", {
+    packageId,
+    branch,
+    worktree,
+    session,
+  });
+
+  // Dispatch is explicit: the coordinator records the command it asked a runtime to run.
+  const prompt = `Implement ${packageId}; keep package.md and execution-result.md current.`;
+  const command = `OMX_PACKAGE_ID=${packageId} omx team 1:executor ${shellQuote(prompt)}`;
+  await runInWorktree(worktree, command);
+  await recordDispatch(issue, {
+    command,
+    worktree,
+    branch,
+    packageId,
+  });
+}
+```
+
+## Explicit dispatch command examples
+
+These examples are placeholders; adapt them to the public CLI commands available in your environment and record the actual command in `package.md` or `execution-result.md`.
+
+```sh
+# Create a deterministic worktree for the package.
+git fetch origin dev
+git worktree add ../oh-my-codex-worktrees/issue-2087-pipeline-templates \
+  -b docs/issue-2087-pipeline-templates origin/dev
+
+# Start exactly one mutating runtime for that worktree and record the command.
+cd ../oh-my-codex-worktrees/issue-2087-pipeline-templates
+OMX_PACKAGE_ID=issue-2087-pipeline-templates \
+  omx team 1:executor "Implement issue-2087; keep package artifacts current."
+
+# Open a pull request after validation evidence exists.
+gh pr create --base dev --head docs/issue-2087-pipeline-templates \
+  --title "docs: add issue package pipeline templates" \
+  --body-file .github/pr-body.md
+```
+
+## Public safety checklist
+
+Before dispatch:
+
+- [ ] A canonical GitHub issue exists.
+- [ ] Duplicate search completed.
+- [ ] Reproduction or proposal scope is sufficient.
+- [ ] Risk gate is recorded.
+- [ ] `package_id`, branch, worktree, and optional external thread are recorded.
+- [ ] No secret, credential, private URL, queue name, or host-specific topology is present in public artifacts.
+- [ ] Exactly one mutating runtime owns the worktree.
+
+Before merge:
+
+- [ ] PR links the issue and package artifacts.
+- [ ] Validation evidence is current.
+- [ ] Review decision is recorded.
+- [ ] Merge decision states whether the PR closes the issue.

--- a/docs/pipeline/templates/README.md
+++ b/docs/pipeline/templates/README.md
@@ -1,0 +1,9 @@
+# Pipeline templates
+
+These public templates support the GitHub / PR / package identity pipeline documented in [`../github-pr-package-identity.md`](../github-pr-package-identity.md).
+
+- [`issue-package-identity.md`](./issue-package-identity.md): canonical identity block.
+- [`triage/`](./triage/): issue comments for common triage outcomes.
+- [`execution/`](./execution/): package, plan, result, review, and merge artifacts.
+
+Keep secrets and internal orchestration details out of these files. Chat can summarize status, but GitHub issues, PRs, and package artifacts remain the source of truth.

--- a/docs/pipeline/templates/execution/execution-result.md
+++ b/docs/pipeline/templates/execution/execution-result.md
@@ -1,0 +1,30 @@
+# Execution result
+
+## Package
+
+- package_id:
+- issue:
+- branch:
+- PR:
+
+## Changes made
+
+-
+
+## Validation evidence
+
+- Command:
+  - Result:
+- Command:
+  - Result:
+
+## Artifact updates
+
+- [ ] package.md updated.
+- [ ] plan.md updated.
+- [ ] review.md linked or pending.
+- [ ] merge-decision.md linked or pending.
+
+## Notes
+
+Do not rely on chat-only status. Copy durable evidence into the issue, PR, or package artifacts.

--- a/docs/pipeline/templates/execution/merge-decision.md
+++ b/docs/pipeline/templates/execution/merge-decision.md
@@ -1,0 +1,30 @@
+# Merge decision
+
+## Package
+
+- package_id:
+- issue:
+- PR:
+- base branch:
+- head branch:
+
+## Preconditions
+
+- [ ] PR review approved.
+- [ ] Required checks passed.
+- [ ] Latest validation evidence reviewed.
+- [ ] Merge closes or updates the issue intentionally.
+- [ ] Runtime ownership released or no longer mutating.
+
+## Decision
+
+- [ ] Merge
+- [ ] Do not merge yet
+- [ ] Close without merge
+
+## Closure text
+
+Closes #0000
+
+## Notes
+

--- a/docs/pipeline/templates/execution/merge-decision.md
+++ b/docs/pipeline/templates/execution/merge-decision.md
@@ -27,4 +27,3 @@
 Closes #0000
 
 ## Notes
-

--- a/docs/pipeline/templates/execution/package.md
+++ b/docs/pipeline/templates/execution/package.md
@@ -1,0 +1,34 @@
+# Package
+
+## Identity
+
+```yaml
+source: github
+repo: Yeachan-Heo/oh-my-codex
+issue: 0000
+package_id: issue-0000-short-slug
+branch: kind/issue-0000-short-slug
+worktree: ../oh-my-codex-worktrees/issue-0000-short-slug
+discord_thread: n/a
+state: ready
+```
+
+## Scope
+
+- Problem:
+- In scope:
+- Out of scope:
+
+## Gates
+
+- [ ] Duplicate search complete.
+- [ ] Repro or proposal contract recorded.
+- [ ] Risk gate recorded.
+- [ ] One active mutating runtime assigned to this worktree.
+- [ ] No secrets or internal infrastructure details in public artifacts.
+
+## Runtime ownership
+
+- Mutating runtime/session:
+- Started at:
+- Released at:

--- a/docs/pipeline/templates/execution/plan.md
+++ b/docs/pipeline/templates/execution/plan.md
@@ -1,0 +1,26 @@
+# Plan
+
+## Package
+
+- package_id:
+- issue:
+- branch:
+- worktree:
+
+## Intended changes
+
+1.
+2.
+3.
+
+## Validation plan
+
+- [ ] Build/typecheck:
+- [ ] Tests:
+- [ ] Docs-safe checks:
+- [ ] Manual review:
+
+## Risks and mitigations
+
+- Risk:
+  - Mitigation:

--- a/docs/pipeline/templates/execution/review.md
+++ b/docs/pipeline/templates/execution/review.md
@@ -1,0 +1,29 @@
+# Review
+
+## Package
+
+- package_id:
+- issue:
+- PR:
+- reviewer:
+
+## Checks
+
+- [ ] Scope matches issue/package.
+- [ ] Validation evidence is current.
+- [ ] Risk gate satisfied.
+- [ ] No secrets or internal infrastructure details added.
+- [ ] Worktree mutation ownership was singular.
+- [ ] Docs/code quality acceptable.
+
+## Findings
+
+-
+
+## Decision
+
+- [ ] Approved
+- [ ] Changes requested
+- [ ] Rejected
+
+Rationale:

--- a/docs/pipeline/templates/issue-package-identity.md
+++ b/docs/pipeline/templates/issue-package-identity.md
@@ -1,0 +1,18 @@
+# Issue/package identity
+
+```yaml
+source: github # github | discord | other
+repo: Yeachan-Heo/oh-my-codex
+issue: 0000
+package_id: issue-0000-short-slug
+branch: kind/issue-0000-short-slug
+worktree: ../oh-my-codex-worktrees/issue-0000-short-slug
+discord_thread: n/a
+state: intake # intake | needs_repro | duplicate | proposal | ready | executing | review | merge_ready | merged | closed
+```
+
+Notes:
+
+- The GitHub issue is canonical even when intake starts elsewhere.
+- `discord_thread` may be `n/a` or a public-safe reference; do not include private channel IDs or tokens.
+- Update `state` only when the matching gate or artifact has been recorded.

--- a/docs/pipeline/templates/triage/duplicate-close.md
+++ b/docs/pipeline/templates/triage/duplicate-close.md
@@ -1,0 +1,3 @@
+Closing as a duplicate of #CANONICAL_ISSUE.
+
+Please continue discussion and validation on the canonical issue so the package identity, branch, worktree, PR, and review history stay in one place.

--- a/docs/pipeline/templates/triage/feature-contract-proposal-gate.md
+++ b/docs/pipeline/templates/triage/feature-contract-proposal-gate.md
@@ -1,0 +1,9 @@
+Thanks for the proposal. Before implementation, a maintainer should confirm the contract:
+
+- User problem and expected behavior.
+- Public CLI/API/docs surface affected.
+- Compatibility impact and migration path.
+- Validation plan.
+- Whether this should be solved in repo docs/code or by external orchestration glue.
+
+Until this gate is approved, do not create a mutating worktree. Discussion can continue here, but the accepted contract must be captured in the issue or PR artifacts.

--- a/docs/pipeline/templates/triage/needs-repro-question.md
+++ b/docs/pipeline/templates/triage/needs-repro-question.md
@@ -1,0 +1,5 @@
+Thanks for the report. I need one focused reproduction detail before this can become an executable package:
+
+**What is the smallest exact command or prompt that reproduces the problem, and what output do you get?**
+
+Please include only the environment facts needed to run that command (`oh-my-codex` version, OS/shell, Node.js version) and redact secrets from logs. We will keep this labeled `needs-repro` until the issue can be reproduced or narrowed to a specific contract. If there is no follow-up after the timeout window, maintainers may close it as not actionable.

--- a/docs/pipeline/templates/triage/reproducible-bug-package.md
+++ b/docs/pipeline/templates/triage/reproducible-bug-package.md
@@ -1,0 +1,17 @@
+This looks reproducible and is ready for a package/worktree/OMX session.
+
+```yaml
+package_id: issue-0000-short-slug
+branch: fix/issue-0000-short-slug
+worktree: ../oh-my-codex-worktrees/issue-0000-short-slug
+omx_session: issue-0000-short-slug
+state: ready
+```
+
+Mutation gate:
+
+- [ ] Duplicate search completed.
+- [ ] Reproduction steps are present in the issue.
+- [ ] Risk level recorded.
+- [ ] Exactly one mutating runtime is assigned to the worktree.
+- [ ] Package artifact exists or will be committed with the implementation.

--- a/docs/pipeline/templates/triage/timeout-close.md
+++ b/docs/pipeline/templates/triage/timeout-close.md
@@ -1,0 +1,10 @@
+Closing because the requested reproduction details were not provided within the timeout window.
+
+If you can still reproduce this, please open a new issue or ask to reopen with:
+
+- the exact command or prompt,
+- environment details,
+- expected vs actual behavior,
+- redacted logs/screenshots.
+
+Chat context alone is not enough to reopen; the GitHub issue must contain the actionable evidence.

--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -62,4 +62,5 @@ omx ultragoal status --json
 - `create_goal` starts the active objective; it is not a general plan store.
 - `update_goal` is completion-only; pause/resume/budget state is controlled by Codex/user/system, not OMX.
 - Ultragoal owns durable plan and ledger state; Codex goal mode owns active-thread focus and accounting.
+- OMX never edits upstream Codex source such as `../../codex`, never shells out to a hidden `/goal` mutator, and never claims that `omx ultragoal checkpoint` changes Codex's active thread goal. The only Codex goal-mode handoff is explicit: `get_goal`, then `create_goal` when no active goal exists, then `update_goal({status: "complete"})` after the real completion audit passes.
 - A goal is not complete merely because tests pass or a ledger entry exists. The agent must audit the objective against files, commands, tests, PR state, or other concrete evidence.

--- a/plugins/oh-my-codex/skills/autoresearch-goal/SKILL.md
+++ b/plugins/oh-my-codex/skills/autoresearch-goal/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: autoresearch-goal
+description: Durable professor-critic research workflow over Codex goal mode without reviving deprecated omx autoresearch
+---
+
+# Autoresearch Goal
+
+Use this workflow when a research mission should be bound to Codex goal-mode focus while OMX remains the durable state owner.
+
+## Boundary
+- Do **not** use or revive the deprecated `omx autoresearch` direct launch surface.
+- Do **not** claim shell commands mutate hidden Codex `/goal` state.
+- Do **not** edit upstream `../../codex` or add dependencies.
+- Use `get_goal`, `create_goal`, and `update_goal({status: "complete"})` only through the active Codex thread when those tools are available.
+
+## Artifacts
+`omx autoresearch-goal` writes:
+- `.omx/goals/autoresearch/<slug>/mission.json`
+- `.omx/goals/autoresearch/<slug>/rubric.md`
+- `.omx/goals/autoresearch/<slug>/ledger.jsonl`
+- `.omx/goals/autoresearch/<slug>/completion.json`
+
+## Flow
+1. Create the mission and professor-critic rubric:
+   `omx autoresearch-goal create --topic "..." --rubric "..." --critic-command "..."`
+2. Emit the model-facing handoff:
+   `omx autoresearch-goal handoff --slug <slug>`
+3. In the active Codex thread, call `get_goal`; call `create_goal` only if no active goal exists and the printed payload is the intended objective.
+4. Research iteratively against the rubric. Record every critic outcome:
+   `omx autoresearch-goal verdict --slug <slug> --verdict <pass|fail|blocked> --evidence "..."`
+5. Completion is blocked until professor-critic validation records `verdict=pass`:
+   `omx autoresearch-goal complete --slug <slug>`
+6. Only after the completion audit passes, call `update_goal({status: "complete"})` for the active Codex goal.
+
+## Completion gate
+A passing professor-critic artifact is required. Assistant prose, partial tests, or a failed/blocked verdict are not sufficient.

--- a/plugins/oh-my-codex/skills/autoresearch-goal/SKILL.md
+++ b/plugins/oh-my-codex/skills/autoresearch-goal/SKILL.md
@@ -30,7 +30,7 @@ Use this workflow when a research mission should be bound to Codex goal-mode foc
    `omx autoresearch-goal verdict --slug <slug> --verdict <pass|fail|blocked> --evidence "..."`
 5. Completion is blocked until professor-critic validation records `verdict=pass`:
    `omx autoresearch-goal complete --slug <slug>`
-6. Only after the completion audit passes, call `update_goal({status: "complete"})` for the active Codex goal.
+6. Only after `omx autoresearch-goal complete` updates the mission to `complete` and the completion audit passes, call `update_goal({status: "complete"})` for the active Codex goal.
 
 ## Completion gate
 A passing professor-critic artifact is required. Assistant prose, partial tests, or a failed/blocked verdict are not sufficient.

--- a/plugins/oh-my-codex/skills/autoresearch-goal/SKILL.md
+++ b/plugins/oh-my-codex/skills/autoresearch-goal/SKILL.md
@@ -28,7 +28,9 @@ Use this workflow when a research mission should be bound to Codex goal-mode foc
 3. In the active Codex thread, call `get_goal`; call `create_goal` only if no active goal exists and the printed payload is the intended objective.
 4. Research iteratively against the rubric. Record every critic outcome:
    `omx autoresearch-goal verdict --slug <slug> --verdict <pass|fail|blocked> --evidence "..."`
-5. Completion is blocked until professor-critic validation records `verdict=pass`:
+   Passing verdicts must include a durable critic artifact path:
+   `omx autoresearch-goal verdict --slug <slug> --verdict pass --evidence "..." --artifact <path>`
+5. Completion is blocked until professor-critic validation records `verdict=pass` with the artifact path:
    `omx autoresearch-goal complete --slug <slug>`
 6. Only after `omx autoresearch-goal complete` updates the mission to `complete` and the completion audit passes, call `update_goal({status: "complete"})` for the active Codex goal.
 

--- a/plugins/oh-my-codex/skills/performance-goal/SKILL.md
+++ b/plugins/oh-my-codex/skills/performance-goal/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: performance-goal
+description: "Run an evaluator-gated performance optimization workflow over Codex goal mode with durable OMX artifacts and safe goal handoffs."
+---
+
+# Performance Goal Workflow
+
+Use this skill when a user asks OMX to optimize performance and wants a goal-oriented loop rather than a one-off review.
+
+## Contract
+
+- OMX owns durable workflow state under `.omx/goals/performance/<slug>/`.
+- Codex goal mode owns only the active-thread focus/accounting primitive.
+- Shell commands do **not** mutate hidden Codex goal state. They write artifacts and emit model-facing handoff text.
+- No optimization work may start until an evaluator command and pass/fail contract exist.
+- Do not call `update_goal({status: "complete"})` until the evaluator has a passing checkpoint and a completion audit proves the objective is done.
+
+## CLI
+
+Create the workflow and evaluator contract:
+
+```sh
+omx performance-goal create \
+  --objective "Reduce CLI startup latency by 20%" \
+  --evaluator-command "npm run perf:startup" \
+  --evaluator-contract "PASS when p95 latency improves by 20% and regression tests pass" \
+  --slug startup-latency
+```
+
+Emit the Codex goal handoff:
+
+```sh
+omx performance-goal start --slug startup-latency
+```
+
+Record evaluator evidence:
+
+```sh
+omx performance-goal checkpoint --slug startup-latency --status pass --evidence "benchmark + tests passed"
+omx performance-goal checkpoint --slug startup-latency --status fail --evidence "benchmark regressed"
+omx performance-goal checkpoint --slug startup-latency --status blocked --evidence "missing fixture"
+```
+
+Complete only after a passing checkpoint:
+
+```sh
+omx performance-goal complete --slug startup-latency --evidence "final evaluator evidence"
+```
+
+## Agent Loop
+
+1. Run `omx performance-goal create` if no workflow exists.
+2. Run `omx performance-goal start` and follow the handoff:
+   - call `get_goal`;
+   - call `create_goal` only when no active goal exists and the objective is explicit;
+   - work only against the evaluator contract;
+   - call `update_goal({status: "complete"})` only after evaluator pass + completion audit.
+3. Optimize in small reversible patches.
+4. Run the evaluator and related regression tests.
+5. Record each pass/fail/blocker with `checkpoint`.
+6. Complete only when the pass artifact exists and no required work remains.
+
+## Completion Gate
+
+A performance goal is incomplete unless `.omx/goals/performance/<slug>/state.json` contains a `lastValidation.status` of `pass`. Passing ordinary tests alone is not sufficient unless they are the declared evaluator contract.

--- a/plugins/oh-my-codex/skills/performance-goal/SKILL.md
+++ b/plugins/oh-my-codex/skills/performance-goal/SKILL.md
@@ -13,7 +13,7 @@ Use this skill when a user asks OMX to optimize performance and wants a goal-ori
 - Codex goal mode owns only the active-thread focus/accounting primitive.
 - Shell commands do **not** mutate hidden Codex goal state. They write artifacts and emit model-facing handoff text.
 - No optimization work may start until an evaluator command and pass/fail contract exist.
-- Do not call `update_goal({status: "complete"})` until the evaluator has a passing checkpoint and a completion audit proves the objective is done.
+- Do not call `update_goal({status: "complete"})` until the evaluator has a passing checkpoint, a completion audit proves the objective is done, and `omx performance-goal complete` has succeeded.
 
 ## CLI
 
@@ -54,7 +54,7 @@ omx performance-goal complete --slug startup-latency --evidence "final evaluator
    - call `get_goal`;
    - call `create_goal` only when no active goal exists and the objective is explicit;
    - work only against the evaluator contract;
-   - call `update_goal({status: "complete"})` only after evaluator pass + completion audit.
+   - call `update_goal({status: "complete"})` only after evaluator pass + completion audit + successful `omx performance-goal complete`.
 3. Optimize in small reversible patches.
 4. Run the evaluator and related regression tests.
 5. Record each pass/fail/blocker with `checkpoint`.

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: autoresearch-goal
+description: Durable professor-critic research workflow over Codex goal mode without reviving deprecated omx autoresearch
+---
+
+# Autoresearch Goal
+
+Use this workflow when a research mission should be bound to Codex goal-mode focus while OMX remains the durable state owner.
+
+## Boundary
+- Do **not** use or revive the deprecated `omx autoresearch` direct launch surface.
+- Do **not** claim shell commands mutate hidden Codex `/goal` state.
+- Do **not** edit upstream `../../codex` or add dependencies.
+- Use `get_goal`, `create_goal`, and `update_goal({status: "complete"})` only through the active Codex thread when those tools are available.
+
+## Artifacts
+`omx autoresearch-goal` writes:
+- `.omx/goals/autoresearch/<slug>/mission.json`
+- `.omx/goals/autoresearch/<slug>/rubric.md`
+- `.omx/goals/autoresearch/<slug>/ledger.jsonl`
+- `.omx/goals/autoresearch/<slug>/completion.json`
+
+## Flow
+1. Create the mission and professor-critic rubric:
+   `omx autoresearch-goal create --topic "..." --rubric "..." --critic-command "..."`
+2. Emit the model-facing handoff:
+   `omx autoresearch-goal handoff --slug <slug>`
+3. In the active Codex thread, call `get_goal`; call `create_goal` only if no active goal exists and the printed payload is the intended objective.
+4. Research iteratively against the rubric. Record every critic outcome:
+   `omx autoresearch-goal verdict --slug <slug> --verdict <pass|fail|blocked> --evidence "..."`
+5. Completion is blocked until professor-critic validation records `verdict=pass`:
+   `omx autoresearch-goal complete --slug <slug>`
+6. Only after the completion audit passes, call `update_goal({status: "complete"})` for the active Codex goal.
+
+## Completion gate
+A passing professor-critic artifact is required. Assistant prose, partial tests, or a failed/blocked verdict are not sufficient.

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -30,7 +30,7 @@ Use this workflow when a research mission should be bound to Codex goal-mode foc
    `omx autoresearch-goal verdict --slug <slug> --verdict <pass|fail|blocked> --evidence "..."`
 5. Completion is blocked until professor-critic validation records `verdict=pass`:
    `omx autoresearch-goal complete --slug <slug>`
-6. Only after the completion audit passes, call `update_goal({status: "complete"})` for the active Codex goal.
+6. Only after `omx autoresearch-goal complete` updates the mission to `complete` and the completion audit passes, call `update_goal({status: "complete"})` for the active Codex goal.
 
 ## Completion gate
 A passing professor-critic artifact is required. Assistant prose, partial tests, or a failed/blocked verdict are not sufficient.

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -28,7 +28,9 @@ Use this workflow when a research mission should be bound to Codex goal-mode foc
 3. In the active Codex thread, call `get_goal`; call `create_goal` only if no active goal exists and the printed payload is the intended objective.
 4. Research iteratively against the rubric. Record every critic outcome:
    `omx autoresearch-goal verdict --slug <slug> --verdict <pass|fail|blocked> --evidence "..."`
-5. Completion is blocked until professor-critic validation records `verdict=pass`:
+   Passing verdicts must include a durable critic artifact path:
+   `omx autoresearch-goal verdict --slug <slug> --verdict pass --evidence "..." --artifact <path>`
+5. Completion is blocked until professor-critic validation records `verdict=pass` with the artifact path:
    `omx autoresearch-goal complete --slug <slug>`
 6. Only after `omx autoresearch-goal complete` updates the mission to `complete` and the completion audit passes, call `update_goal({status: "complete"})` for the active Codex goal.
 

--- a/skills/performance-goal/SKILL.md
+++ b/skills/performance-goal/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: performance-goal
+description: "Run an evaluator-gated performance optimization workflow over Codex goal mode with durable OMX artifacts and safe goal handoffs."
+---
+
+# Performance Goal Workflow
+
+Use this skill when a user asks OMX to optimize performance and wants a goal-oriented loop rather than a one-off review.
+
+## Contract
+
+- OMX owns durable workflow state under `.omx/goals/performance/<slug>/`.
+- Codex goal mode owns only the active-thread focus/accounting primitive.
+- Shell commands do **not** mutate hidden Codex goal state. They write artifacts and emit model-facing handoff text.
+- No optimization work may start until an evaluator command and pass/fail contract exist.
+- Do not call `update_goal({status: "complete"})` until the evaluator has a passing checkpoint and a completion audit proves the objective is done.
+
+## CLI
+
+Create the workflow and evaluator contract:
+
+```sh
+omx performance-goal create \
+  --objective "Reduce CLI startup latency by 20%" \
+  --evaluator-command "npm run perf:startup" \
+  --evaluator-contract "PASS when p95 latency improves by 20% and regression tests pass" \
+  --slug startup-latency
+```
+
+Emit the Codex goal handoff:
+
+```sh
+omx performance-goal start --slug startup-latency
+```
+
+Record evaluator evidence:
+
+```sh
+omx performance-goal checkpoint --slug startup-latency --status pass --evidence "benchmark + tests passed"
+omx performance-goal checkpoint --slug startup-latency --status fail --evidence "benchmark regressed"
+omx performance-goal checkpoint --slug startup-latency --status blocked --evidence "missing fixture"
+```
+
+Complete only after a passing checkpoint:
+
+```sh
+omx performance-goal complete --slug startup-latency --evidence "final evaluator evidence"
+```
+
+## Agent Loop
+
+1. Run `omx performance-goal create` if no workflow exists.
+2. Run `omx performance-goal start` and follow the handoff:
+   - call `get_goal`;
+   - call `create_goal` only when no active goal exists and the objective is explicit;
+   - work only against the evaluator contract;
+   - call `update_goal({status: "complete"})` only after evaluator pass + completion audit.
+3. Optimize in small reversible patches.
+4. Run the evaluator and related regression tests.
+5. Record each pass/fail/blocker with `checkpoint`.
+6. Complete only when the pass artifact exists and no required work remains.
+
+## Completion Gate
+
+A performance goal is incomplete unless `.omx/goals/performance/<slug>/state.json` contains a `lastValidation.status` of `pass`. Passing ordinary tests alone is not sufficient unless they are the declared evaluator contract.

--- a/skills/performance-goal/SKILL.md
+++ b/skills/performance-goal/SKILL.md
@@ -13,7 +13,7 @@ Use this skill when a user asks OMX to optimize performance and wants a goal-ori
 - Codex goal mode owns only the active-thread focus/accounting primitive.
 - Shell commands do **not** mutate hidden Codex goal state. They write artifacts and emit model-facing handoff text.
 - No optimization work may start until an evaluator command and pass/fail contract exist.
-- Do not call `update_goal({status: "complete"})` until the evaluator has a passing checkpoint and a completion audit proves the objective is done.
+- Do not call `update_goal({status: "complete"})` until the evaluator has a passing checkpoint, a completion audit proves the objective is done, and `omx performance-goal complete` has succeeded.
 
 ## CLI
 
@@ -54,7 +54,7 @@ omx performance-goal complete --slug startup-latency --evidence "final evaluator
    - call `get_goal`;
    - call `create_goal` only when no active goal exists and the objective is explicit;
    - work only against the evaluator contract;
-   - call `update_goal({status: "complete"})` only after evaluator pass + completion audit.
+   - call `update_goal({status: "complete"})` only after evaluator pass + completion audit + successful `omx performance-goal complete`.
 3. Optimize in small reversible patches.
 4. Run the evaluator and related regression tests.
 5. Record each pass/fail/blocker with `checkpoint`.

--- a/src/autoresearch/goal.ts
+++ b/src/autoresearch/goal.ts
@@ -1,0 +1,275 @@
+import { existsSync } from 'node:fs';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { slugifyMissionName } from './contracts.js';
+
+export const AUTORESEARCH_GOAL_ROOT = '.omx/goals/autoresearch';
+export const AUTORESEARCH_GOAL_MISSION = 'mission.json';
+export const AUTORESEARCH_GOAL_RUBRIC = 'rubric.md';
+export const AUTORESEARCH_GOAL_LEDGER = 'ledger.jsonl';
+export const AUTORESEARCH_GOAL_COMPLETION = 'completion.json';
+
+export type AutoresearchGoalStatus = 'created' | 'in_progress' | 'passed' | 'failed' | 'blocked';
+export type AutoresearchGoalVerdict = 'pass' | 'fail' | 'blocked';
+
+export interface AutoresearchGoalMission {
+  schema_version: 1;
+  workflow: 'autoresearch-goal';
+  slug: string;
+  topic: string;
+  rubric: string;
+  critic_command?: string;
+  status: AutoresearchGoalStatus;
+  created_at: string;
+  updated_at: string;
+  mission_path: string;
+  rubric_path: string;
+  ledger_path: string;
+  completion_path: string;
+}
+
+export interface AutoresearchGoalCompletion {
+  schema_version: 1;
+  slug: string;
+  verdict: AutoresearchGoalVerdict;
+  passed: boolean;
+  summary: string;
+  evidence: string;
+  artifact_path?: string;
+  critic_command?: string;
+  recorded_at: string;
+}
+
+export interface AutoresearchGoalLedgerEntry {
+  ts: string;
+  event:
+    | 'workflow_created'
+    | 'goal_handoff_emitted'
+    | 'validation_passed'
+    | 'validation_failed'
+    | 'validation_blocked'
+    | 'goal_completed';
+  slug: string;
+  status?: AutoresearchGoalStatus;
+  message?: string;
+  evidence?: string;
+  artifact_path?: string;
+}
+
+export interface CreateAutoresearchGoalOptions {
+  topic: string;
+  rubric: string;
+  slug?: string;
+  criticCommand?: string;
+  force?: boolean;
+  now?: Date;
+}
+
+export interface RecordAutoresearchGoalVerdictOptions {
+  slug: string;
+  verdict: AutoresearchGoalVerdict;
+  evidence: string;
+  summary?: string;
+  artifactPath?: string;
+  now?: Date;
+}
+
+export class AutoresearchGoalError extends Error {}
+
+function iso(now = new Date()): string {
+  return now.toISOString();
+}
+
+function requireText(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new AutoresearchGoalError(`Missing ${field}.`);
+  return trimmed;
+}
+
+function repoRelative(cwd: string, path: string): string {
+  return relative(cwd, path).split('\\').join('/');
+}
+
+export function autoresearchGoalDir(cwd: string, slug: string): string {
+  return join(cwd, AUTORESEARCH_GOAL_ROOT, slug);
+}
+
+export function autoresearchGoalMissionPath(cwd: string, slug: string): string {
+  return join(autoresearchGoalDir(cwd, slug), AUTORESEARCH_GOAL_MISSION);
+}
+
+export function autoresearchGoalRubricPath(cwd: string, slug: string): string {
+  return join(autoresearchGoalDir(cwd, slug), AUTORESEARCH_GOAL_RUBRIC);
+}
+
+export function autoresearchGoalLedgerPath(cwd: string, slug: string): string {
+  return join(autoresearchGoalDir(cwd, slug), AUTORESEARCH_GOAL_LEDGER);
+}
+
+export function autoresearchGoalCompletionPath(cwd: string, slug: string): string {
+  return join(autoresearchGoalDir(cwd, slug), AUTORESEARCH_GOAL_COMPLETION);
+}
+
+async function appendLedger(cwd: string, slug: string, entry: AutoresearchGoalLedgerEntry): Promise<void> {
+  await mkdir(autoresearchGoalDir(cwd, slug), { recursive: true });
+  await appendFile(autoresearchGoalLedgerPath(cwd, slug), `${JSON.stringify(entry)}\n`, 'utf-8');
+}
+
+async function writeMission(cwd: string, mission: AutoresearchGoalMission): Promise<void> {
+  await mkdir(autoresearchGoalDir(cwd, mission.slug), { recursive: true });
+  await writeFile(autoresearchGoalMissionPath(cwd, mission.slug), `${JSON.stringify(mission, null, 2)}\n`, 'utf-8');
+}
+
+export async function createAutoresearchGoal(cwd: string, options: CreateAutoresearchGoalOptions): Promise<AutoresearchGoalMission> {
+  const topic = requireText(options.topic, '--topic');
+  const rubric = requireText(options.rubric, '--rubric');
+  const slug = slugifyMissionName(options.slug ?? topic);
+  const missionPath = autoresearchGoalMissionPath(cwd, slug);
+  if (!options.force && existsSync(missionPath)) {
+    throw new AutoresearchGoalError(`Refusing to overwrite existing ${repoRelative(cwd, missionPath)}; pass --force to recreate it.`);
+  }
+
+  const now = iso(options.now);
+  const mission: AutoresearchGoalMission = {
+    schema_version: 1,
+    workflow: 'autoresearch-goal',
+    slug,
+    topic,
+    rubric,
+    ...(options.criticCommand?.trim() ? { critic_command: options.criticCommand.trim() } : {}),
+    status: 'created',
+    created_at: now,
+    updated_at: now,
+    mission_path: repoRelative(cwd, missionPath),
+    rubric_path: repoRelative(cwd, autoresearchGoalRubricPath(cwd, slug)),
+    ledger_path: repoRelative(cwd, autoresearchGoalLedgerPath(cwd, slug)),
+    completion_path: repoRelative(cwd, autoresearchGoalCompletionPath(cwd, slug)),
+  };
+
+  await mkdir(autoresearchGoalDir(cwd, slug), { recursive: true });
+  await writeFile(autoresearchGoalRubricPath(cwd, slug), `${rubric}\n`, 'utf-8');
+  await writeFile(autoresearchGoalLedgerPath(cwd, slug), '', 'utf-8');
+  await writeMission(cwd, mission);
+  await appendLedger(cwd, slug, { ts: now, event: 'workflow_created', slug, status: mission.status, message: `Autoresearch goal created: ${topic}` });
+  return mission;
+}
+
+export async function readAutoresearchGoal(cwd: string, slug: string): Promise<AutoresearchGoalMission> {
+  const normalizedSlug = slugifyMissionName(slug);
+  const path = autoresearchGoalMissionPath(cwd, normalizedSlug);
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf-8');
+  } catch {
+    throw new AutoresearchGoalError(`No autoresearch-goal mission found at ${repoRelative(cwd, path)}. Run \`omx autoresearch-goal create ...\` first.`);
+  }
+  const parsed = JSON.parse(raw) as AutoresearchGoalMission;
+  if (parsed.schema_version !== 1 || parsed.workflow !== 'autoresearch-goal') {
+    throw new AutoresearchGoalError(`Invalid autoresearch-goal mission at ${repoRelative(cwd, path)}.`);
+  }
+  return parsed;
+}
+
+export async function readAutoresearchGoalCompletion(cwd: string, slug: string): Promise<AutoresearchGoalCompletion | null> {
+  const path = autoresearchGoalCompletionPath(cwd, slugifyMissionName(slug));
+  if (!existsSync(path)) return null;
+  const parsed = JSON.parse(await readFile(path, 'utf-8')) as AutoresearchGoalCompletion;
+  return parsed;
+}
+
+export async function recordAutoresearchGoalVerdict(
+  cwd: string,
+  options: RecordAutoresearchGoalVerdictOptions,
+): Promise<{ mission: AutoresearchGoalMission; completion: AutoresearchGoalCompletion }> {
+  const mission = await readAutoresearchGoal(cwd, options.slug);
+  const evidence = requireText(options.evidence, '--evidence');
+  const now = iso(options.now);
+  const completion: AutoresearchGoalCompletion = {
+    schema_version: 1,
+    slug: mission.slug,
+    verdict: options.verdict,
+    passed: options.verdict === 'pass',
+    summary: options.summary?.trim() || evidence,
+    evidence,
+    ...(options.artifactPath?.trim() ? { artifact_path: options.artifactPath.trim() } : {}),
+    ...(mission.critic_command ? { critic_command: mission.critic_command } : {}),
+    recorded_at: now,
+  };
+
+  mission.status = options.verdict === 'pass' ? 'passed' : options.verdict === 'fail' ? 'failed' : 'blocked';
+  mission.updated_at = now;
+  await writeMission(cwd, mission);
+  await writeFile(autoresearchGoalCompletionPath(cwd, mission.slug), `${JSON.stringify(completion, null, 2)}\n`, 'utf-8');
+  await appendLedger(cwd, mission.slug, {
+    ts: now,
+    event: options.verdict === 'pass' ? 'validation_passed' : options.verdict === 'fail' ? 'validation_failed' : 'validation_blocked',
+    slug: mission.slug,
+    status: mission.status,
+    evidence,
+    artifact_path: options.artifactPath,
+  });
+  return { mission, completion };
+}
+
+export async function completeAutoresearchGoal(cwd: string, slug: string, now = new Date()): Promise<{ mission: AutoresearchGoalMission; completion: AutoresearchGoalCompletion }> {
+  const mission = await readAutoresearchGoal(cwd, slug);
+  const completion = await readAutoresearchGoalCompletion(cwd, mission.slug);
+  if (!completion || !completion.passed || completion.verdict !== 'pass') {
+    throw new AutoresearchGoalError(`Autoresearch goal ${mission.slug} cannot complete until professor-critic validation records verdict=pass in ${mission.completion_path}.`);
+  }
+  await appendLedger(cwd, mission.slug, {
+    ts: iso(now),
+    event: 'goal_completed',
+    slug: mission.slug,
+    status: mission.status,
+    evidence: completion.evidence,
+    artifact_path: completion.artifact_path,
+  });
+  return { mission, completion };
+}
+
+export async function buildAutoresearchGoalHandoff(cwd: string, slug: string, now = new Date()): Promise<string> {
+  const mission = await readAutoresearchGoal(cwd, slug);
+  if (mission.status === 'created') {
+    mission.status = 'in_progress';
+    mission.updated_at = iso(now);
+    await writeMission(cwd, mission);
+  }
+  await appendLedger(cwd, mission.slug, { ts: iso(now), event: 'goal_handoff_emitted', slug: mission.slug, status: mission.status });
+  const createPayload = {
+    objective: [
+      `Autoresearch goal: ${mission.topic}`,
+      '',
+      'Research methodology / professor-critic rubric:',
+      mission.rubric,
+      '',
+      `Completion gate: record a passing professor-critic verdict with omx autoresearch-goal verdict --slug ${mission.slug} --verdict pass --evidence "<critic artifact/evidence>", then run omx autoresearch-goal complete --slug ${mission.slug}.`,
+    ].join('\n'),
+  };
+
+  return [
+    'Autoresearch-goal active-goal handoff',
+    `Mission: ${mission.mission_path}`,
+    `Rubric: ${mission.rubric_path}`,
+    `Ledger: ${mission.ledger_path}`,
+    `Completion artifact: ${mission.completion_path}`,
+    '',
+    'Codex goal integration constraints:',
+    '- This shell command does not mutate hidden Codex /goal state; it writes durable OMX artifacts and prints this handoff only.',
+    '- First call get_goal. If no active goal exists, call create_goal with the payload below.',
+    '- If a different active Codex goal exists, finish/checkpoint that goal before starting this autoresearch goal.',
+    '- Iterate research until the professor-critic evaluator records a concrete pass/fail/blocker artifact.',
+    '- Do not call update_goal({status: "complete"}) until the professor-critic verdict is pass and omx autoresearch-goal complete succeeds.',
+    '- If validation fails or blocks, keep iterating or report the blocker with the recorded evidence; do not revive deprecated omx autoresearch.',
+    '',
+    'create_goal payload:',
+    JSON.stringify(createPayload, null, 2),
+    '',
+    'Topic:',
+    mission.topic,
+    '',
+    'Professor-critic rubric:',
+    mission.rubric,
+    ...(mission.critic_command ? ['', 'Professor-critic command:', mission.critic_command] : []),
+  ].join('\n');
+}

--- a/src/autoresearch/goal.ts
+++ b/src/autoresearch/goal.ts
@@ -9,7 +9,7 @@ export const AUTORESEARCH_GOAL_RUBRIC = 'rubric.md';
 export const AUTORESEARCH_GOAL_LEDGER = 'ledger.jsonl';
 export const AUTORESEARCH_GOAL_COMPLETION = 'completion.json';
 
-export type AutoresearchGoalStatus = 'created' | 'in_progress' | 'passed' | 'failed' | 'blocked';
+export type AutoresearchGoalStatus = 'created' | 'in_progress' | 'passed' | 'failed' | 'blocked' | 'complete';
 export type AutoresearchGoalVerdict = 'pass' | 'fail' | 'blocked';
 
 export interface AutoresearchGoalMission {
@@ -22,6 +22,7 @@ export interface AutoresearchGoalMission {
   status: AutoresearchGoalStatus;
   created_at: string;
   updated_at: string;
+  completed_at?: string;
   mission_path: string;
   rubric_path: string;
   ledger_path: string;
@@ -182,6 +183,9 @@ export async function recordAutoresearchGoalVerdict(
   options: RecordAutoresearchGoalVerdictOptions,
 ): Promise<{ mission: AutoresearchGoalMission; completion: AutoresearchGoalCompletion }> {
   const mission = await readAutoresearchGoal(cwd, options.slug);
+  if (mission.status === 'complete') {
+    throw new AutoresearchGoalError(`Autoresearch goal ${mission.slug} is already complete; create a new goal or explicitly reopen via a future workflow before recording more verdicts.`);
+  }
   const evidence = requireText(options.evidence, '--evidence');
   const now = iso(options.now);
   const completion: AutoresearchGoalCompletion = {
@@ -217,8 +221,13 @@ export async function completeAutoresearchGoal(cwd: string, slug: string, now = 
   if (!completion || !completion.passed || completion.verdict !== 'pass') {
     throw new AutoresearchGoalError(`Autoresearch goal ${mission.slug} cannot complete until professor-critic validation records verdict=pass in ${mission.completion_path}.`);
   }
+  const completedAt = iso(now);
+  mission.status = 'complete';
+  mission.updated_at = completedAt;
+  mission.completed_at = completedAt;
+  await writeMission(cwd, mission);
   await appendLedger(cwd, mission.slug, {
-    ts: iso(now),
+    ts: completedAt,
     event: 'goal_completed',
     slug: mission.slug,
     status: mission.status,

--- a/src/autoresearch/goal.ts
+++ b/src/autoresearch/goal.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
-import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { appendFile, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
 import { slugifyMissionName } from './contracts.js';
 
 export const AUTORESEARCH_GOAL_ROOT = '.omx/goals/autoresearch';
@@ -84,6 +84,23 @@ function iso(now = new Date()): string {
 function requireText(value: string, field: string): string {
   const trimmed = value.trim();
   if (!trimmed) throw new AutoresearchGoalError(`Missing ${field}.`);
+  return trimmed;
+}
+
+async function requirePassingArtifact(cwd: string, artifactPath: string | undefined): Promise<string> {
+  const trimmed = artifactPath?.trim();
+  if (!trimmed) {
+    throw new AutoresearchGoalError('Passing professor-critic validation requires --artifact <path>; assistant prose alone is not sufficient.');
+  }
+  let artifactStat;
+  try {
+    artifactStat = await stat(resolve(cwd, trimmed));
+  } catch {
+    throw new AutoresearchGoalError(`Passing professor-critic artifact not found: ${trimmed}.`);
+  }
+  if (!artifactStat.isFile()) {
+    throw new AutoresearchGoalError(`Passing professor-critic artifact must be a file: ${trimmed}.`);
+  }
   return trimmed;
 }
 
@@ -187,6 +204,7 @@ export async function recordAutoresearchGoalVerdict(
     throw new AutoresearchGoalError(`Autoresearch goal ${mission.slug} is already complete; create a new goal or explicitly reopen via a future workflow before recording more verdicts.`);
   }
   const evidence = requireText(options.evidence, '--evidence');
+  const artifactPath = options.verdict === 'pass' ? await requirePassingArtifact(cwd, options.artifactPath) : options.artifactPath?.trim();
   const now = iso(options.now);
   const completion: AutoresearchGoalCompletion = {
     schema_version: 1,
@@ -195,7 +213,7 @@ export async function recordAutoresearchGoalVerdict(
     passed: options.verdict === 'pass',
     summary: options.summary?.trim() || evidence,
     evidence,
-    ...(options.artifactPath?.trim() ? { artifact_path: options.artifactPath.trim() } : {}),
+    ...(artifactPath ? { artifact_path: artifactPath } : {}),
     ...(mission.critic_command ? { critic_command: mission.critic_command } : {}),
     recorded_at: now,
   };
@@ -210,7 +228,7 @@ export async function recordAutoresearchGoalVerdict(
     slug: mission.slug,
     status: mission.status,
     evidence,
-    artifact_path: options.artifactPath,
+    artifact_path: artifactPath,
   });
   return { mission, completion };
 }

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-05-04T09:59:26.287Z",
+  "generatedAt": "2026-05-04T12:22:07.528Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 43,
+    "skillCount": 45,
     "promptCount": 30,
-    "activeSkillCount": 28,
+    "activeSkillCount": 30,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -60,6 +60,20 @@
     },
     {
       "name": "autoresearch",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "autoresearch-goal",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "performance-goal",
       "category": "execution",
       "status": "active",
       "core": false,

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-05-04T12:26:48.621Z",
+  "generatedAt": "2026-05-04T12:28:00.013Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 44,
+    "skillCount": 45,
     "promptCount": 30,
-    "activeSkillCount": 29,
+    "activeSkillCount": 30,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -67,6 +67,13 @@
     },
     {
       "name": "autoresearch-goal",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "performance-goal",
       "category": "execution",
       "status": "active",
       "core": false,

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-04T12:28:00.013Z",
+  "generatedAt": "2026-05-04T12:29:32.889Z",
   "version": "2026.02.28.1",
   "counts": {
     "skillCount": 45,

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-05-04T12:22:07.528Z",
+  "generatedAt": "2026-05-04T12:26:48.621Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 45,
+    "skillCount": 44,
     "promptCount": 30,
-    "activeSkillCount": 30,
+    "activeSkillCount": 29,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -67,13 +67,6 @@
     },
     {
       "name": "autoresearch-goal",
-      "category": "execution",
-      "status": "active",
-      "core": false,
-      "internalRequired": false
-    },
-    {
-      "name": "performance-goal",
       "category": "execution",
       "status": "active",
       "core": false,

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -49,12 +49,6 @@
       "core": false
     },
     {
-      "name": "performance-goal",
-      "category": "execution",
-      "status": "active",
-      "core": false
-    },
-    {
       "name": "pipeline",
       "category": "execution",
       "status": "active",

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -43,6 +43,18 @@
       "status": "active"
     },
     {
+      "name": "autoresearch-goal",
+      "category": "execution",
+      "status": "active",
+      "core": false
+    },
+    {
+      "name": "performance-goal",
+      "category": "execution",
+      "status": "active",
+      "core": false
+    },
+    {
       "name": "pipeline",
       "category": "execution",
       "status": "active",

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -49,6 +49,12 @@
       "core": false
     },
     {
+      "name": "performance-goal",
+      "category": "execution",
+      "status": "active",
+      "core": false
+    },
+    {
       "name": "pipeline",
       "category": "execution",
       "status": "active",

--- a/src/cli/__tests__/autoresearch-goal.test.ts
+++ b/src/cli/__tests__/autoresearch-goal.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { autoresearchGoalCommand, AUTORESEARCH_GOAL_HELP } from '../autoresearch-goal.js';
+
+async function withCwd<T>(run: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-goal-'));
+  const previous = process.cwd();
+  try {
+    process.chdir(cwd);
+    return await run(cwd);
+  } finally {
+    process.chdir(previous);
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function capture(run: () => Promise<void>): Promise<{ stdout: string[]; stderr: string[]; exitCode: string | number | undefined }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  const log = mock.method(console, 'log', (...args: unknown[]) => stdout.push(args.map(String).join(' ')));
+  const error = mock.method(console, 'error', (...args: unknown[]) => stderr.push(args.map(String).join(' ')));
+  try {
+    await run();
+    return { stdout, stderr, exitCode: process.exitCode };
+  } finally {
+    log.mock.restore();
+    error.mock.restore();
+    process.exitCode = previousExitCode;
+  }
+}
+
+describe('cli/autoresearch-goal', () => {
+  it('prints help with goal-mode and deprecated-command boundaries', () => {
+    assert.match(AUTORESEARCH_GOAL_HELP, /professor-critic/i);
+    assert.match(AUTORESEARCH_GOAL_HELP, /does not revive deprecated omx autoresearch/i);
+    assert.match(AUTORESEARCH_GOAL_HELP, /get_goal\/create_goal\/update_goal/i);
+    assert.match(AUTORESEARCH_GOAL_HELP, /blocked until professor-critic validation records verdict=pass/i);
+  });
+
+  it('creates durable artifacts and emits a safe Codex goal handoff', async () => {
+    await withCwd(async (cwd) => {
+      const created = await capture(() => autoresearchGoalCommand([
+        'create',
+        '--topic', 'Map migration risk',
+        '--rubric', 'Professor critic must verify source citations and reject unsupported claims.',
+        '--critic-command', 'node scripts/critic.js',
+      ]));
+      assert.equal(created.exitCode, undefined);
+      assert.match(created.stdout.join('\n'), /autoresearch-goal created: map-migration-risk/);
+
+      const handoff = await capture(() => autoresearchGoalCommand(['handoff', '--slug', 'map-migration-risk']));
+      const output = handoff.stdout.join('\n');
+      assert.match(output, /Autoresearch-goal active-goal handoff/);
+      assert.match(output, /This shell command does not mutate hidden Codex \/goal state/);
+      assert.match(output, /First call get_goal/);
+      assert.match(output, /call create_goal with the payload below/);
+      assert.match(output, /Do not call update_goal\(\{status: "complete"\}\) until the professor-critic verdict is pass/);
+      assert.match(output, /do not revive deprecated omx autoresearch/i);
+
+      const mission = JSON.parse(await readFile(join(cwd, '.omx/goals/autoresearch/map-migration-risk/mission.json'), 'utf-8')) as { status: string; critic_command: string };
+      assert.equal(mission.status, 'in_progress');
+      assert.equal(mission.critic_command, 'node scripts/critic.js');
+    });
+  });
+
+  it('blocks completion until a passing professor-critic verdict is recorded', async () => {
+    await withCwd(async (cwd) => {
+      await capture(() => autoresearchGoalCommand([
+        'create',
+        '--topic', 'Research flaky tests',
+        '--rubric', 'Professor critic requires reproduction evidence and a cited root cause.',
+      ]));
+
+      const initiallyBlocked = await capture(() => autoresearchGoalCommand(['complete', '--slug', 'research-flaky-tests']));
+      assert.equal(initiallyBlocked.exitCode, 1);
+      assert.match(initiallyBlocked.stderr.join('\n'), /cannot complete until professor-critic validation records verdict=pass/);
+
+      await capture(() => autoresearchGoalCommand([
+        'verdict',
+        '--slug', 'research-flaky-tests',
+        '--verdict', 'fail',
+        '--evidence', 'critic rejected missing reproduction logs',
+      ]));
+      const stillBlocked = await capture(() => autoresearchGoalCommand(['complete', '--slug', 'research-flaky-tests']));
+      assert.equal(stillBlocked.exitCode, 1);
+
+      await capture(() => autoresearchGoalCommand([
+        'verdict',
+        '--slug', 'research-flaky-tests',
+        '--verdict', 'pass',
+        '--evidence', 'critic approved report.md with reproduction logs and citations',
+        '--artifact', '.omx/specs/autoresearch-flaky-tests/report.md',
+      ]));
+      const completed = await capture(() => autoresearchGoalCommand(['complete', '--slug', 'research-flaky-tests']));
+      assert.equal(completed.exitCode, undefined);
+      assert.match(completed.stdout.join('\n'), /autoresearch-goal complete: research-flaky-tests/);
+      assert.match(completed.stdout.join('\n'), /update_goal\(\{status: "complete"\}\)/);
+
+      const completion = JSON.parse(await readFile(join(cwd, '.omx/goals/autoresearch/research-flaky-tests/completion.json'), 'utf-8')) as { verdict: string; passed: boolean };
+      assert.equal(completion.verdict, 'pass');
+      assert.equal(completion.passed, true);
+    });
+  });
+});

--- a/src/cli/__tests__/autoresearch-goal.test.ts
+++ b/src/cli/__tests__/autoresearch-goal.test.ts
@@ -68,6 +68,21 @@ describe('cli/autoresearch-goal', () => {
     });
   });
 
+
+  it('rejects missing values for value-taking flags instead of consuming the next flag', async () => {
+    await withCwd(async () => {
+      const result = await capture(() => autoresearchGoalCommand([
+        'create',
+        '--topic', 'Map risk',
+        '--rubric',
+        '--slug', 'map-risk',
+      ]));
+
+      assert.equal(result.exitCode, 1);
+      assert.match(result.stderr.join('\n'), /Missing value for --rubric/);
+    });
+  });
+
   it('blocks completion until a passing professor-critic verdict is recorded', async () => {
     await withCwd(async (cwd) => {
       await capture(() => autoresearchGoalCommand([
@@ -104,6 +119,22 @@ describe('cli/autoresearch-goal', () => {
       const completion = JSON.parse(await readFile(join(cwd, '.omx/goals/autoresearch/research-flaky-tests/completion.json'), 'utf-8')) as { verdict: string; passed: boolean };
       assert.equal(completion.verdict, 'pass');
       assert.equal(completion.passed, true);
+
+      const mission = JSON.parse(await readFile(join(cwd, '.omx/goals/autoresearch/research-flaky-tests/mission.json'), 'utf-8')) as { status: string; completed_at?: string };
+      assert.equal(mission.status, 'complete');
+      assert.match(mission.completed_at ?? '', /^\d{4}-\d{2}-\d{2}T/);
+
+      const status = await capture(() => autoresearchGoalCommand(['status', '--slug', 'research-flaky-tests']));
+      assert.match(status.stdout.join('\n'), /autoresearch-goal: research-flaky-tests \[complete\]/);
+
+      const afterComplete = await capture(() => autoresearchGoalCommand([
+        'verdict',
+        '--slug', 'research-flaky-tests',
+        '--verdict', 'fail',
+        '--evidence', 'late critic rejection',
+      ]));
+      assert.equal(afterComplete.exitCode, 1);
+      assert.match(afterComplete.stderr.join('\n'), /already complete/);
     });
   });
 });

--- a/src/cli/__tests__/autoresearch-goal.test.ts
+++ b/src/cli/__tests__/autoresearch-goal.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { autoresearchGoalCommand, AUTORESEARCH_GOAL_HELP } from '../autoresearch-goal.js';
@@ -40,6 +40,8 @@ describe('cli/autoresearch-goal', () => {
     assert.match(AUTORESEARCH_GOAL_HELP, /does not revive deprecated omx autoresearch/i);
     assert.match(AUTORESEARCH_GOAL_HELP, /get_goal\/create_goal\/update_goal/i);
     assert.match(AUTORESEARCH_GOAL_HELP, /blocked until professor-critic validation records verdict=pass/i);
+    assert.match(AUTORESEARCH_GOAL_HELP, /--rubric accepts inline text, an existing filesystem path, or @path/i);
+    assert.match(AUTORESEARCH_GOAL_HELP, /Passing verdicts require --artifact <path>/i);
   });
 
   it('creates durable artifacts and emits a safe Codex goal handoff', async () => {
@@ -68,6 +70,22 @@ describe('cli/autoresearch-goal', () => {
     });
   });
 
+  it('accepts an existing rubric file path without @file syntax', async () => {
+    await withCwd(async (cwd) => {
+      const rubricPath = join(cwd, 'rubric.txt');
+      await writeFile(rubricPath, 'Professor critic must verify file-backed rubric input.\n', 'utf-8');
+
+      const created = await capture(() => autoresearchGoalCommand([
+        'create',
+        '--topic', 'File backed rubric',
+        '--rubric', rubricPath,
+      ]));
+
+      assert.equal(created.exitCode, undefined);
+      const storedRubric = await readFile(join(cwd, '.omx/goals/autoresearch/file-backed-rubric/rubric.md'), 'utf-8');
+      assert.equal(storedRubric, 'Professor critic must verify file-backed rubric input.\n');
+    });
+  });
 
   it('rejects missing values for value-taking flags instead of consuming the next flag', async () => {
     await withCwd(async () => {
@@ -104,12 +122,24 @@ describe('cli/autoresearch-goal', () => {
       const stillBlocked = await capture(() => autoresearchGoalCommand(['complete', '--slug', 'research-flaky-tests']));
       assert.equal(stillBlocked.exitCode, 1);
 
+      const proseOnlyPass = await capture(() => autoresearchGoalCommand([
+        'verdict',
+        '--slug', 'research-flaky-tests',
+        '--verdict', 'pass',
+        '--evidence', 'critic approved in assistant prose only',
+      ]));
+      assert.equal(proseOnlyPass.exitCode, 1);
+      assert.match(proseOnlyPass.stderr.join('\n'), /requires --artifact <path>/);
+
+      const artifactPath = '.omx/specs/autoresearch-flaky-tests/report.md';
+      await mkdir(join(cwd, '.omx/specs/autoresearch-flaky-tests'), { recursive: true });
+      await writeFile(join(cwd, artifactPath), 'critic approved report with reproduction logs and citations\n', 'utf-8');
       await capture(() => autoresearchGoalCommand([
         'verdict',
         '--slug', 'research-flaky-tests',
         '--verdict', 'pass',
         '--evidence', 'critic approved report.md with reproduction logs and citations',
-        '--artifact', '.omx/specs/autoresearch-flaky-tests/report.md',
+        '--artifact', artifactPath,
       ]));
       const completed = await capture(() => autoresearchGoalCommand(['complete', '--slug', 'research-flaky-tests']));
       assert.equal(completed.exitCode, undefined);

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -256,6 +256,9 @@ describe('official Codex plugin layout', () => {
 
     assert.deepEqual(actualSkillNames, expectedSkillNames);
     assert.ok(actualSkillNames.includes('worker'), 'internal setup-installed worker skill should be mirrored');
+    assert.ok(actualSkillNames.includes('performance-goal'), 'performance-goal should be available through setup/plugin skill delivery');
+    assert.ok(actualSkillNames.includes('autoresearch-goal'), 'autoresearch-goal should be available through setup/plugin skill delivery');
+    assert.ok(actualSkillNames.includes('ultragoal'), 'ultragoal should remain available through setup/plugin skill delivery');
     assert.equal(actualSkillNames.includes('ecomode'), false, 'merged skills should not be mirrored');
     assert.equal(actualSkillNames.includes('swarm'), false, 'alias skills should not be mirrored');
     assert.equal(actualSkillNames.includes('configure-discord'), false, 'merged notification aliases should not be mirrored');

--- a/src/cli/__tests__/performance-goal.test.ts
+++ b/src/cli/__tests__/performance-goal.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { performanceGoalCommand, PERFORMANCE_GOAL_HELP } from '../performance-goal.js';
+
+async function withCwd<T>(run: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-performance-goal-cli-'));
+  const previous = process.cwd();
+  try {
+    process.chdir(cwd);
+    return await run(cwd);
+  } finally {
+    process.chdir(previous);
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function capture(run: () => Promise<void>): Promise<{ stdout: string[]; stderr: string[]; exitCode: string | number | undefined }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  const log = mock.method(console, 'log', (...args: unknown[]) => stdout.push(args.map(String).join(' ')));
+  const error = mock.method(console, 'error', (...args: unknown[]) => stderr.push(args.map(String).join(' ')));
+  try {
+    await run();
+    return { stdout, stderr, exitCode: process.exitCode };
+  } finally {
+    log.mock.restore();
+    error.mock.restore();
+    process.exitCode = previousExitCode;
+  }
+}
+
+describe('cli/performance-goal', () => {
+  it('prints help with evaluator gate and goal-mode constraints', () => {
+    assert.match(PERFORMANCE_GOAL_HELP, /evaluator-gated performance optimization/i);
+    assert.match(PERFORMANCE_GOAL_HELP, /get_goal\/create_goal\/update_goal/);
+    assert.match(PERFORMANCE_GOAL_HELP, /passing checkpoint/i);
+  });
+
+  it('creates artifacts and emits a truthful Codex goal handoff', async () => {
+    await withCwd(async (cwd) => {
+      const created = await capture(() => performanceGoalCommand([
+        'create',
+        '--objective', 'Reduce CLI startup latency by 20%',
+        '--evaluator-command', 'npm run perf:startup',
+        '--evaluator-contract', 'PASS when p95 startup latency improves by at least 20% with no regression failures.',
+        '--slug', 'startup-latency',
+      ]));
+      assert.equal(created.exitCode, undefined);
+      assert.match(created.stdout.join('\n'), /performance goal created: startup-latency/);
+
+      const handoff = await capture(() => performanceGoalCommand(['start', '--slug', 'startup-latency']));
+      const output = handoff.stdout.join('\n');
+      assert.match(output, /Performance goal handoff/);
+      assert.match(output, /First call get_goal/);
+      assert.match(output, /call create_goal/);
+      assert.match(output, /Do not treat this shell command as hidden Codex goal mutation/);
+      assert.match(output, /update_goal\(\{status: "complete"\}\)/);
+      assert.match(output, /npm run perf:startup/);
+
+      const state = JSON.parse(await readFile(join(cwd, '.omx/goals/performance/startup-latency/state.json'), 'utf-8')) as { status: string; artifactPaths: { evaluator: string } };
+      assert.equal(state.status, 'in_progress');
+      assert.equal(state.artifactPaths.evaluator, '.omx/goals/performance/startup-latency/evaluator.md');
+    });
+  });
+
+  it('blocks completion until evaluator validation passes', async () => {
+    await withCwd(async () => {
+      await capture(() => performanceGoalCommand([
+        'create',
+        '--objective', 'Improve hot path throughput',
+        '--evaluator-command', 'node bench.js',
+        '--evaluator-contract', 'PASS when throughput is above baseline and tests pass.',
+        '--slug', 'throughput',
+      ]));
+
+      const premature = await capture(() => performanceGoalCommand(['complete', '--slug', 'throughput']));
+      assert.equal(premature.exitCode, 1);
+      assert.match(premature.stderr.join('\n'), /Cannot complete performance goal until evaluator validation has a passing checkpoint/);
+
+      const failed = await capture(() => performanceGoalCommand(['checkpoint', '--slug', 'throughput', '--status', 'fail', '--evidence', 'benchmark regressed']));
+      assert.equal(failed.exitCode, undefined);
+      const stillBlocked = await capture(() => performanceGoalCommand(['complete', '--slug', 'throughput']));
+      assert.equal(stillBlocked.exitCode, 1);
+
+      const passed = await capture(() => performanceGoalCommand(['checkpoint', '--slug', 'throughput', '--status', 'pass', '--evidence', 'benchmark and tests passed']));
+      assert.equal(passed.exitCode, undefined);
+      const completed = await capture(() => performanceGoalCommand(['complete', '--slug', 'throughput', '--json']));
+      assert.equal(completed.exitCode, undefined);
+      const parsed = JSON.parse(completed.stdout.join('\n')) as { state: { status: string } };
+      assert.equal(parsed.state.status, 'complete');
+    });
+  });
+});

--- a/src/cli/__tests__/performance-goal.test.ts
+++ b/src/cli/__tests__/performance-goal.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { performanceGoalCommand, PERFORMANCE_GOAL_HELP } from '../performance-goal.js';
+import { HELP } from '../index.js';
 
 async function withCwd<T>(run: (cwd: string) => Promise<T>): Promise<T> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-performance-goal-cli-'));
@@ -39,6 +40,7 @@ describe('cli/performance-goal', () => {
     assert.match(PERFORMANCE_GOAL_HELP, /evaluator-gated performance optimization/i);
     assert.match(PERFORMANCE_GOAL_HELP, /get_goal\/create_goal\/update_goal/);
     assert.match(PERFORMANCE_GOAL_HELP, /passing checkpoint/i);
+    assert.match(HELP, /omx performance-goal[\s\S]*evaluator-backed performance goals/);
   });
 
   it('creates artifacts and emits a truthful Codex goal handoff', async () => {
@@ -60,11 +62,27 @@ describe('cli/performance-goal', () => {
       assert.match(output, /call create_goal/);
       assert.match(output, /Do not treat this shell command as hidden Codex goal mutation/);
       assert.match(output, /update_goal\(\{status: "complete"\}\)/);
+      assert.ok(output.indexOf('omx performance-goal complete --slug startup-latency') < output.indexOf('update_goal({status: "complete"})'));
       assert.match(output, /npm run perf:startup/);
 
       const state = JSON.parse(await readFile(join(cwd, '.omx/goals/performance/startup-latency/state.json'), 'utf-8')) as { status: string; artifactPaths: { evaluator: string } };
       assert.equal(state.status, 'in_progress');
       assert.equal(state.artifactPaths.evaluator, '.omx/goals/performance/startup-latency/evaluator.md');
+    });
+  });
+
+
+  it('rejects missing values for value-taking flags instead of consuming the next flag', async () => {
+    await withCwd(async () => {
+      const result = await capture(() => performanceGoalCommand([
+        'create',
+        '--objective', 'Reduce latency',
+        '--evaluator-command',
+        '--evaluator-contract', 'PASS when evaluator succeeds.',
+      ]));
+
+      assert.equal(result.exitCode, 1);
+      assert.match(result.stderr.join('\n'), /Missing value for --evaluator-command/);
     });
   });
 
@@ -93,6 +111,10 @@ describe('cli/performance-goal', () => {
       assert.equal(completed.exitCode, undefined);
       const parsed = JSON.parse(completed.stdout.join('\n')) as { state: { status: string } };
       assert.equal(parsed.state.status, 'complete');
+
+      const afterComplete = await capture(() => performanceGoalCommand(['checkpoint', '--slug', 'throughput', '--status', 'fail', '--evidence', 'late regression']));
+      assert.equal(afterComplete.exitCode, 1);
+      assert.match(afterComplete.stderr.join('\n'), /already complete/);
     });
   });
 });

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -134,6 +134,32 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("installs goal workflow skills during project-scoped legacy setup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await runSetupInTempDir(wd, { scope: "project", installMode: "legacy" });
+
+      for (const skillName of [
+        "performance-goal",
+        "autoresearch-goal",
+        "ultragoal",
+      ]) {
+        const skillPath = join(wd, ".codex", "skills", skillName, "SKILL.md");
+        assert.equal(
+          existsSync(skillPath),
+          true,
+          `expected omx setup to install ${skillName}`,
+        );
+        assert.match(await readFile(skillPath, "utf-8"), /^description: "\[OMX\] /m);
+      }
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.match(config, /^goals = true$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("appends missing OMX project ignore rules to an existing project .gitignore without duplicating them", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {

--- a/src/cli/autoresearch-goal.ts
+++ b/src/cli/autoresearch-goal.ts
@@ -1,0 +1,162 @@
+import { readFile } from 'node:fs/promises';
+import {
+  AutoresearchGoalError,
+  buildAutoresearchGoalHandoff,
+  completeAutoresearchGoal,
+  createAutoresearchGoal,
+  readAutoresearchGoal,
+  readAutoresearchGoalCompletion,
+  recordAutoresearchGoalVerdict,
+  type AutoresearchGoalVerdict,
+} from '../autoresearch/goal.js';
+
+export const AUTORESEARCH_GOAL_HELP = `omx autoresearch-goal - Durable professor-critic research workflow over Codex goal mode
+
+Usage:
+  omx autoresearch-goal create --topic <text> --rubric <text|path> [--critic-command <cmd>] [--slug <slug>] [--force] [--json]
+  omx autoresearch-goal handoff --slug <slug> [--json]
+  omx autoresearch-goal verdict --slug <slug> --verdict <pass|fail|blocked> --evidence <text> [--summary <text>] [--artifact <path>] [--json]
+  omx autoresearch-goal complete --slug <slug> [--json]
+  omx autoresearch-goal status --slug <slug> [--json]
+
+Artifacts:
+  .omx/goals/autoresearch/<slug>/mission.json
+  .omx/goals/autoresearch/<slug>/rubric.md
+  .omx/goals/autoresearch/<slug>/ledger.jsonl
+  .omx/goals/autoresearch/<slug>/completion.json
+
+Goal-mode boundary:
+  This command does not revive deprecated omx autoresearch and does not mutate hidden Codex /goal state.
+  It writes durable OMX artifacts and prints a model-facing handoff for get_goal/create_goal/update_goal.
+  Completion is blocked until professor-critic validation records verdict=pass.
+`;
+
+function hasFlag(args: readonly string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function readValue(args: readonly string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index >= 0) return args[index + 1];
+  const prefix = `${flag}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+async function readMaybeFile(value: string | undefined): Promise<string | undefined> {
+  if (!value) return undefined;
+  if (value.startsWith('@')) return readFile(value.slice(1), 'utf-8');
+  return value;
+}
+
+function positionalText(args: readonly string[]): string {
+  const valueTaking = new Set(['--topic', '--rubric', '--critic-command', '--slug', '--verdict', '--evidence', '--summary', '--artifact']);
+  const words: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (valueTaking.has(arg)) { i += 1; continue; }
+    if (arg.startsWith('--')) continue;
+    words.push(arg);
+  }
+  return words.join(' ').trim();
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function parseVerdict(value: string | undefined): AutoresearchGoalVerdict {
+  if (value === 'pass' || value === 'fail' || value === 'blocked') return value;
+  throw new AutoresearchGoalError('Missing or invalid --verdict; expected pass, fail, or blocked.');
+}
+
+export async function autoresearchGoalCommand(args: string[]): Promise<void> {
+  const command = args[0] ?? 'help';
+  const rest = args.slice(1);
+  const json = hasFlag(rest, '--json');
+  const cwd = process.cwd();
+
+  try {
+    if (command === 'help' || command === '--help' || command === '-h') {
+      console.log(AUTORESEARCH_GOAL_HELP);
+      return;
+    }
+
+    if (command === 'create' || command === 'init') {
+      const topic = readValue(rest, '--topic') ?? positionalText(rest);
+      const rubric = await readMaybeFile(readValue(rest, '--rubric'));
+      const mission = await createAutoresearchGoal(cwd, {
+        topic: topic ?? '',
+        rubric: rubric ?? '',
+        slug: readValue(rest, '--slug'),
+        criticCommand: readValue(rest, '--critic-command'),
+        force: hasFlag(rest, '--force'),
+      });
+      if (json) printJson({ ok: true, mission });
+      else {
+        console.log(`autoresearch-goal created: ${mission.slug}`);
+        console.log(`mission: ${mission.mission_path}`);
+        console.log(`rubric: ${mission.rubric_path}`);
+        console.log(`ledger: ${mission.ledger_path}`);
+      }
+      return;
+    }
+
+    if (command === 'handoff' || command === 'start') {
+      const slug = readValue(rest, '--slug');
+      if (!slug) throw new AutoresearchGoalError('Missing --slug.');
+      const instruction = await buildAutoresearchGoalHandoff(cwd, slug);
+      if (json) printJson({ ok: true, instruction });
+      else console.log(instruction);
+      return;
+    }
+
+    if (command === 'verdict' || command === 'checkpoint') {
+      const slug = readValue(rest, '--slug');
+      if (!slug) throw new AutoresearchGoalError('Missing --slug.');
+      const result = await recordAutoresearchGoalVerdict(cwd, {
+        slug,
+        verdict: parseVerdict(readValue(rest, '--verdict')),
+        evidence: readValue(rest, '--evidence') ?? '',
+        summary: readValue(rest, '--summary'),
+        artifactPath: readValue(rest, '--artifact'),
+      });
+      if (json) printJson({ ok: true, ...result });
+      else console.log(`autoresearch-goal verdict: ${result.mission.slug} -> ${result.completion.verdict}`);
+      return;
+    }
+
+    if (command === 'complete') {
+      const slug = readValue(rest, '--slug');
+      if (!slug) throw new AutoresearchGoalError('Missing --slug.');
+      const result = await completeAutoresearchGoal(cwd, slug);
+      if (json) printJson({ ok: true, ...result });
+      else {
+        console.log(`autoresearch-goal complete: ${result.mission.slug}`);
+        console.log('Codex goal completion: after auditing the active objective, call update_goal({status: "complete"}) in the Codex thread if this handoff owns the active goal.');
+      }
+      return;
+    }
+
+    if (command === 'status') {
+      const slug = readValue(rest, '--slug');
+      if (!slug) throw new AutoresearchGoalError('Missing --slug.');
+      const mission = await readAutoresearchGoal(cwd, slug);
+      const completion = await readAutoresearchGoalCompletion(cwd, slug);
+      if (json) printJson({ mission, completion });
+      else {
+        console.log(`autoresearch-goal: ${mission.slug} [${mission.status}] ${mission.topic}`);
+        console.log(`completion: ${completion ? `${completion.verdict} (${completion.recorded_at})` : 'missing'}`);
+      }
+      return;
+    }
+
+    throw new AutoresearchGoalError(`Unknown autoresearch-goal command: ${command}\n\n${AUTORESEARCH_GOAL_HELP}`);
+  } catch (error) {
+    if (error instanceof AutoresearchGoalError) {
+      console.error(`[autoresearch-goal] ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    throw error;
+  }
+}

--- a/src/cli/autoresearch-goal.ts
+++ b/src/cli/autoresearch-goal.ts
@@ -36,10 +36,14 @@ function hasFlag(args: readonly string[], flag: string): boolean {
 }
 
 function readValue(args: readonly string[], flag: string): string | undefined {
-  const index = args.indexOf(flag);
-  if (index >= 0) return args[index + 1];
   const prefix = `${flag}=`;
-  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  const inline = args.find((arg) => arg.startsWith(prefix));
+  if (inline !== undefined) return inline.slice(prefix.length);
+  const index = args.indexOf(flag);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) throw new AutoresearchGoalError(`Missing value for ${flag}.`);
+  return value;
 }
 
 async function readMaybeFile(value: string | undefined): Promise<string | undefined> {

--- a/src/cli/autoresearch-goal.ts
+++ b/src/cli/autoresearch-goal.ts
@@ -1,4 +1,6 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import {
   AutoresearchGoalError,
   buildAutoresearchGoalHandoff,
@@ -28,7 +30,13 @@ Artifacts:
 Goal-mode boundary:
   This command does not revive deprecated omx autoresearch and does not mutate hidden Codex /goal state.
   It writes durable OMX artifacts and prints a model-facing handoff for get_goal/create_goal/update_goal.
-  Completion is blocked until professor-critic validation records verdict=pass.
+  Completion is blocked until professor-critic validation records verdict=pass with a critic artifact path.
+
+Rubric input:
+  --rubric accepts inline text, an existing filesystem path, or @path.
+
+Completion gate:
+  Passing verdicts require --artifact <path>; assistant prose alone is not sufficient.
 `;
 
 function hasFlag(args: readonly string[], flag: string): boolean {
@@ -46,9 +54,11 @@ function readValue(args: readonly string[], flag: string): string | undefined {
   return value;
 }
 
-async function readMaybeFile(value: string | undefined): Promise<string | undefined> {
+async function readMaybeFile(value: string | undefined, cwd = process.cwd()): Promise<string | undefined> {
   if (!value) return undefined;
   if (value.startsWith('@')) return readFile(value.slice(1), 'utf-8');
+  const candidate = resolve(cwd, value);
+  if (existsSync(candidate)) return readFile(candidate, 'utf-8');
   return value;
 }
 
@@ -87,7 +97,7 @@ export async function autoresearchGoalCommand(args: string[]): Promise<void> {
 
     if (command === 'create' || command === 'init') {
       const topic = readValue(rest, '--topic') ?? positionalText(rest);
-      const rubric = await readMaybeFile(readValue(rest, '--rubric'));
+      const rubric = await readMaybeFile(readValue(rest, '--rubric'), cwd);
       const mission = await createAutoresearchGoal(cwd, {
         topic: topic ?? '',
         rubric: rubric ?? '',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -189,6 +189,8 @@ Usage:
   omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
   omx ralph     Launch Codex with ralph persistence mode active
   omx ultragoal Create, resume, and checkpoint durable multi-goal plans over Codex goal mode
+  omx performance-goal
+                Create, hand off, and gate evaluator-backed performance goals
   omx autoresearch-goal
                 Create, hand off, and gate professor-critic research goals
   omx autoresearch [DEPRECATED] Use $autoresearch; direct CLI launch removed

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,6 +35,7 @@ import { agentsInitCommand } from "./agents-init.js";
 import { agentsCommand } from "./agents.js";
 import { sessionCommand } from "./session-search.js";
 import { autoresearchCommand } from "./autoresearch.js";
+import { autoresearchGoalCommand } from "./autoresearch-goal.js";
 import { mcpParityCommand } from "./mcp-parity.js";
 import { mcpServeCommand } from "./mcp-serve.js";
 import { adaptCommand } from "./adapt.js";
@@ -188,8 +189,8 @@ Usage:
   omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
   omx ralph     Launch Codex with ralph persistence mode active
   omx ultragoal Create, resume, and checkpoint durable multi-goal plans over Codex goal mode
-  omx performance-goal
-                Create evaluator-gated performance optimization goals over Codex goal mode
+  omx autoresearch-goal
+                Create, hand off, and gate professor-critic research goals
   omx autoresearch [DEPRECATED] Use $autoresearch; direct CLI launch removed
   omx version   Show version information
   omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
@@ -346,6 +347,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "cleanup",
   "adapt",
   "autoresearch",
+  "autoresearch-goal",
   "agents",
   "agents-init",
   "deepinit",
@@ -977,6 +979,7 @@ export async function main(args: string[]): Promise<void> {
     "ask",
     "question",
     "autoresearch",
+  "autoresearch-goal",
     "explore",
     "sparkshell",
     "team",
@@ -1075,6 +1078,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "autoresearch":
         await autoresearchCommand(args.slice(1));
+        break;
+      case "autoresearch-goal":
+        await autoresearchGoalCommand(args.slice(1));
         break;
       case "explore":
         await exploreCommand(args.slice(1));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,7 @@ import { sidecarCommand } from "../sidecar/index.js";
 import { teamCommand } from "./team.js";
 import { ralphCommand } from "./ralph.js";
 import { ultragoalCommand } from "./ultragoal.js";
+import { performanceGoalCommand } from "./performance-goal.js";
 import { askCommand } from "./ask.js";
 import { questionCommand } from "./question.js";
 import { stateCommand } from "./state.js";
@@ -187,6 +188,8 @@ Usage:
   omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
   omx ralph     Launch Codex with ralph persistence mode active
   omx ultragoal Create, resume, and checkpoint durable multi-goal plans over Codex goal mode
+  omx performance-goal
+                Create evaluator-gated performance optimization goals over Codex goal mode
   omx autoresearch [DEPRECATED] Use $autoresearch; direct CLI launch removed
   omx version   Show version information
   omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
@@ -356,6 +359,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "mcp-serve",
   "ralph",
   "ultragoal",
+  "performance-goal",
   "resume",
   "session",
   "sparkshell",
@@ -977,6 +981,8 @@ export async function main(args: string[]): Promise<void> {
     "sparkshell",
     "team",
     "ralph",
+    "ultragoal",
+    "performance-goal",
     "session",
     "resume",
     "version",
@@ -1094,6 +1100,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "ultragoal":
         await ultragoalCommand(args.slice(1));
+        break;
+      case "performance-goal":
+        await performanceGoalCommand(args.slice(1));
         break;
       case "version":
         version();

--- a/src/cli/performance-goal.ts
+++ b/src/cli/performance-goal.ts
@@ -1,0 +1,170 @@
+import { readFile } from 'node:fs/promises';
+import {
+  buildPerformanceGoalInstruction,
+  checkpointPerformanceGoal,
+  completePerformanceGoal,
+  createPerformanceGoal,
+  readPerformanceGoal,
+  startPerformanceGoal,
+  type PerformanceGoalState,
+  PerformanceGoalError,
+  type PerformanceValidationStatus,
+} from '../performance-goal/artifacts.js';
+
+export const PERFORMANCE_GOAL_HELP = `omx performance-goal - Evaluator-gated performance optimization workflow over Codex goal mode
+
+Usage:
+  omx performance-goal create --objective <text> --evaluator-command <cmd> --evaluator-contract <text> [--slug <slug>] [--force] [--json]
+  omx performance-goal start --slug <slug> [--json]
+  omx performance-goal checkpoint --slug <slug> --status <pass|fail|blocked> --evidence <text> [--json]
+  omx performance-goal complete --slug <slug> [--evidence <text>] [--json]
+  omx performance-goal status --slug <slug> [--json]
+
+Aliases:
+  create/start/checkpoint/complete/status may be used as shown above.
+
+Artifacts:
+  .omx/goals/performance/<slug>/state.json
+  .omx/goals/performance/<slug>/evaluator.md
+  .omx/goals/performance/<slug>/ledger.jsonl
+
+Codex goal integration:
+  This command cannot directly invoke the interactive /goal tool from a shell.
+  start writes durable OMX state and prints a model-facing handoff that tells the
+  active Codex agent when to call get_goal/create_goal/update_goal safely.
+  Performance goals cannot complete until evaluator artifacts have a passing checkpoint.
+`;
+
+function hasFlag(args: readonly string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function readValue(args: readonly string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index >= 0) return args[index + 1];
+  const prefix = `${flag}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function positionalText(args: readonly string[]): string {
+  const valueTaking = new Set(['--objective', '--objective-file', '--evaluator-command', '--evaluator-contract', '--evaluator-contract-file', '--slug', '--status', '--evidence']);
+  const words: string[] = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (valueTaking.has(arg)) { i += 1; continue; }
+    if (arg.startsWith('--')) continue;
+    words.push(arg);
+  }
+  return words.join(' ').trim();
+}
+
+async function readTextArg(args: readonly string[], valueFlag: string, fileFlag: string): Promise<string | undefined> {
+  const direct = readValue(args, valueFlag);
+  if (direct !== undefined) return direct;
+  const file = readValue(args, fileFlag);
+  return file ? readFile(file, 'utf-8') : undefined;
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function printStatus(state: PerformanceGoalState): void {
+  console.log(`performance-goal: ${state.slug} [${state.status}]`);
+  console.log(`objective: ${state.objective}`);
+  console.log(`evaluator: ${state.evaluator.command}`);
+  if (state.lastValidation) {
+    console.log(`last validation: ${state.lastValidation.status} — ${state.lastValidation.evidence}`);
+  }
+  console.log(`state: ${state.artifactPaths.state}`);
+  console.log(`ledger: ${state.artifactPaths.ledger}`);
+}
+
+function parseValidationStatus(raw: string | undefined): PerformanceValidationStatus {
+  if (raw === 'pass' || raw === 'fail' || raw === 'blocked') return raw;
+  throw new PerformanceGoalError('Missing or invalid --status; expected pass, fail, or blocked.');
+}
+
+export async function performanceGoalCommand(args: string[]): Promise<void> {
+  const command = args[0] ?? 'help';
+  const rest = args.slice(1);
+  const json = hasFlag(rest, '--json');
+  const cwd = process.cwd();
+
+  try {
+    if (command === 'help' || command === '--help' || command === '-h') {
+      console.log(PERFORMANCE_GOAL_HELP);
+      return;
+    }
+
+    if (command === 'create') {
+      const objective = (await readTextArg(rest, '--objective', '--objective-file')) ?? positionalText(rest);
+      const evaluatorCommand = readValue(rest, '--evaluator-command');
+      const evaluatorContract = await readTextArg(rest, '--evaluator-contract', '--evaluator-contract-file');
+      const state = await createPerformanceGoal(cwd, {
+        objective,
+        evaluatorCommand: evaluatorCommand ?? '',
+        evaluatorContract: evaluatorContract ?? '',
+        slug: readValue(rest, '--slug'),
+        force: hasFlag(rest, '--force'),
+      });
+      if (json) printJson({ ok: true, state });
+      else {
+        console.log(`performance goal created: ${state.slug}`);
+        console.log(`state: ${state.artifactPaths.state}`);
+        console.log(`evaluator: ${state.artifactPaths.evaluator}`);
+        console.log(`ledger: ${state.artifactPaths.ledger}`);
+      }
+      return;
+    }
+
+    if (command === 'start') {
+      const slug = readValue(rest, '--slug');
+      if (!slug) throw new PerformanceGoalError('Missing --slug.');
+      const result = await startPerformanceGoal(cwd, slug);
+      if (json) printJson({ ok: true, state: result.state, instruction: result.instruction });
+      else console.log(result.instruction);
+      return;
+    }
+
+    if (command === 'checkpoint') {
+      const slug = readValue(rest, '--slug');
+      if (!slug) throw new PerformanceGoalError('Missing --slug.');
+      const state = await checkpointPerformanceGoal(cwd, {
+        slug,
+        status: parseValidationStatus(readValue(rest, '--status')),
+        evidence: readValue(rest, '--evidence') ?? '',
+      });
+      if (json) printJson({ ok: true, state });
+      else printStatus(state);
+      return;
+    }
+
+    if (command === 'complete') {
+      const slug = readValue(rest, '--slug');
+      if (!slug) throw new PerformanceGoalError('Missing --slug.');
+      const state = await completePerformanceGoal(cwd, { slug, evidence: readValue(rest, '--evidence') });
+      if (json) printJson({ ok: true, state, instruction: buildPerformanceGoalInstruction(state) });
+      else printStatus(state);
+      return;
+    }
+
+    if (command === 'status') {
+      const slug = readValue(rest, '--slug');
+      if (!slug) throw new PerformanceGoalError('Missing --slug.');
+      const state = await readPerformanceGoal(cwd, slug);
+      if (json) printJson({ state });
+      else printStatus(state);
+      return;
+    }
+
+    throw new PerformanceGoalError(`Unknown performance-goal command: ${command}\n\n${PERFORMANCE_GOAL_HELP}`);
+  } catch (error) {
+    if (error instanceof PerformanceGoalError) {
+      console.error(`[performance-goal] ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    throw error;
+  }
+}

--- a/src/cli/performance-goal.ts
+++ b/src/cli/performance-goal.ts
@@ -40,10 +40,14 @@ function hasFlag(args: readonly string[], flag: string): boolean {
 }
 
 function readValue(args: readonly string[], flag: string): string | undefined {
-  const index = args.indexOf(flag);
-  if (index >= 0) return args[index + 1];
   const prefix = `${flag}=`;
-  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  const inline = args.find((arg) => arg.startsWith(prefix));
+  if (inline !== undefined) return inline.slice(prefix.length);
+  const index = args.indexOf(flag);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) throw new PerformanceGoalError(`Missing value for ${flag}.`);
+  return value;
 }
 
 function positionalText(args: readonly string[]): string {

--- a/src/goal-workflows/__tests__/artifacts.test.ts
+++ b/src/goal-workflows/__tests__/artifacts.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  createGoalWorkflowRun,
+  readGoalWorkflowRun,
+  transitionGoalWorkflowRun,
+} from '../artifacts.js';
+import { buildGoalWorkflowHandoff } from '../handoff.js';
+import {
+  assertGoalWorkflowCanComplete,
+  normalizeGoalWorkflowValidation,
+  GoalWorkflowValidationError,
+} from '../validation.js';
+
+async function withTempRepo<T>(run: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-goal-workflow-'));
+  try {
+    return await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('goal-workflow artifacts', () => {
+  it('creates durable status and ledger artifacts under .omx/goals', async () => {
+    await withTempRepo(async (cwd) => {
+      const run = await createGoalWorkflowRun(cwd, {
+        workflow: 'performance-goal',
+        slug: 'Latency Pass',
+        objective: 'Reduce p95 latency below 100ms.',
+        now: new Date('2026-05-04T10:00:00Z'),
+      });
+
+      assert.equal(run.artifactDir, '.omx/goals/performance-goal/latency-pass');
+      assert.equal(run.status, 'pending');
+      assert.equal((await readGoalWorkflowRun(cwd, 'performance-goal', 'latency-pass')).objective, 'Reduce p95 latency below 100ms.');
+
+      const ledger = await readFile(join(cwd, '.omx/goals/performance-goal/latency-pass/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"workflow_created"/);
+    });
+  });
+
+  it('blocks completion until validation passes and records ledger transitions', async () => {
+    await withTempRepo(async (cwd) => {
+      await createGoalWorkflowRun(cwd, { workflow: 'scrum-goal', slug: 'release', objective: 'Ship release.' });
+      await transitionGoalWorkflowRun(cwd, 'scrum-goal', 'release', { status: 'in_progress', now: new Date('2026-05-04T10:01:00Z') });
+
+      await assert.rejects(
+        () => transitionGoalWorkflowRun(cwd, 'scrum-goal', 'release', { status: 'complete', evidence: 'looks done' }),
+        /passing validation artifact/,
+      );
+
+      const validation = normalizeGoalWorkflowValidation({
+        status: 'pass',
+        summary: 'Worker evidence matrix passed leader audit.',
+        artifactPath: '.omx/goals/scrum-goal/release/audit.json',
+        checkedAt: new Date('2026-05-04T10:02:00Z'),
+      });
+      assertGoalWorkflowCanComplete(validation);
+
+      await transitionGoalWorkflowRun(cwd, 'scrum-goal', 'release', { status: 'validation_passed', validation });
+      const completed = await transitionGoalWorkflowRun(cwd, 'scrum-goal', 'release', { status: 'complete', evidence: 'audit passed' });
+      assert.equal(completed.status, 'complete');
+
+      const ledger = await readFile(join(cwd, '.omx/goals/scrum-goal/release/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"goal_started"/);
+      assert.match(ledger, /"event":"validation_passed"/);
+      assert.match(ledger, /"event":"goal_completed"/);
+    });
+  });
+});
+
+describe('goal-workflow handoff and validation', () => {
+  it('renders truthful Codex goal handoff instructions for degraded mode', async () => {
+    await withTempRepo(async (cwd) => {
+      const run = await createGoalWorkflowRun(cwd, { workflow: 'autoresearch-goal', objective: 'Research safe rollout options.' });
+      const handoff = buildGoalWorkflowHandoff({ run, degradedMode: true });
+
+      assert.match(handoff, /call get_goal/i);
+      assert.match(handoff, /Call create_goal only if no active goal exists/i);
+      assert.match(handoff, /update_goal\(\{status: "complete"\}\) only after/i);
+      assert.match(handoff, /did not mutate hidden Codex goal state/i);
+      assert.match(handoff, /Research safe rollout options/);
+    });
+  });
+
+  it('rejects placeholder validation evidence', () => {
+    const validation = normalizeGoalWorkflowValidation({
+      status: true,
+      summary: 'TODO placeholder evaluator says pass.',
+      artifactPath: '.omx/goals/demo/evaluator.json',
+    });
+
+    assert.throws(() => assertGoalWorkflowCanComplete(validation), GoalWorkflowValidationError);
+  });
+});

--- a/src/goal-workflows/__tests__/artifacts.test.ts
+++ b/src/goal-workflows/__tests__/artifacts.test.ts
@@ -43,6 +43,37 @@ describe('goal-workflow artifacts', () => {
     });
   });
 
+
+  it('requires a real validation artifact when entering validation_passed', async () => {
+    await withTempRepo(async (cwd) => {
+      await createGoalWorkflowRun(cwd, { workflow: 'scrum-goal', slug: 'strict', objective: 'Strictly validate release.' });
+
+      await assert.rejects(
+        () => transitionGoalWorkflowRun(cwd, 'scrum-goal', 'strict', { status: 'validation_passed' }),
+        /Completion requires a validation artifact/,
+      );
+
+      const placeholder = normalizeGoalWorkflowValidation({
+        status: 'pass',
+        summary: 'TODO placeholder evaluator says pass.',
+        artifactPath: '.omx/goals/scrum-goal/strict/audit.json',
+      });
+      await assert.rejects(
+        () => transitionGoalWorkflowRun(cwd, 'scrum-goal', 'strict', { status: 'validation_passed', validation: placeholder }),
+        /real validation evidence/,
+      );
+
+      const missingArtifact = normalizeGoalWorkflowValidation({
+        status: 'pass',
+        summary: 'Leader audit passed with concrete test output.',
+        artifactPath: '   ',
+      });
+      await assert.rejects(
+        () => transitionGoalWorkflowRun(cwd, 'scrum-goal', 'strict', { status: 'validation_passed', validation: missingArtifact }),
+        /validation artifact path/,
+      );
+    });
+  });
   it('blocks completion until validation passes and records ledger transitions', async () => {
     await withTempRepo(async (cwd) => {
       await createGoalWorkflowRun(cwd, { workflow: 'scrum-goal', slug: 'release', objective: 'Ship release.' });

--- a/src/goal-workflows/artifacts.ts
+++ b/src/goal-workflows/artifacts.ts
@@ -1,0 +1,202 @@
+import { existsSync } from 'node:fs';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+export const GOAL_WORKFLOWS_DIR = '.omx/goals';
+export const GOAL_WORKFLOW_STATUS = 'status.json';
+export const GOAL_WORKFLOW_LEDGER = 'ledger.jsonl';
+
+export type GoalWorkflowStatus = 'pending' | 'in_progress' | 'validation_passed' | 'blocked' | 'failed' | 'complete';
+
+export type GoalWorkflowLedgerEvent =
+  | 'workflow_created'
+  | 'goal_started'
+  | 'validation_passed'
+  | 'validation_failed'
+  | 'goal_handoff_emitted'
+  | 'goal_completed'
+  | 'goal_failed';
+
+export interface GoalWorkflowRun {
+  version: 1;
+  workflow: string;
+  slug: string;
+  objective: string;
+  status: GoalWorkflowStatus;
+  createdAt: string;
+  updatedAt: string;
+  artifactDir: string;
+  statusPath: string;
+  ledgerPath: string;
+  metadata?: Record<string, unknown>;
+  validation?: GoalWorkflowValidationSummary;
+  evidence?: string;
+}
+
+export interface GoalWorkflowValidationSummary {
+  status: Extract<GoalWorkflowStatus, 'validation_passed' | 'blocked' | 'failed'>;
+  summary: string;
+  artifactPath?: string;
+  checkedAt: string;
+}
+
+export interface GoalWorkflowLedgerEntry {
+  ts: string;
+  event: GoalWorkflowLedgerEvent;
+  status?: GoalWorkflowStatus;
+  message?: string;
+  evidence?: string;
+  validation?: GoalWorkflowValidationSummary;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateGoalWorkflowRunOptions {
+  workflow: string;
+  slug?: string;
+  objective: string;
+  metadata?: Record<string, unknown>;
+  now?: Date;
+  force?: boolean;
+}
+
+export interface TransitionGoalWorkflowOptions {
+  status: Exclude<GoalWorkflowStatus, 'pending'>;
+  message?: string;
+  evidence?: string;
+  validation?: GoalWorkflowValidationSummary;
+  metadata?: Record<string, unknown>;
+  now?: Date;
+}
+
+export class GoalWorkflowError extends Error {}
+
+function iso(now = new Date()): string {
+  return now.toISOString();
+}
+
+function cleanSegment(value: string, fallback: string): string {
+  const segment = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 72)
+    .replace(/-+$/g, '');
+  return segment || fallback;
+}
+
+function slugFromObjective(objective: string): string {
+  const firstLine = objective.split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? 'goal-workflow';
+  return cleanSegment(firstLine, 'goal-workflow');
+}
+
+function repoRelative(cwd: string, path: string): string {
+  return relative(cwd, path).split('\\').join('/');
+}
+
+export function normalizeGoalWorkflowSegment(value: string, fallback = 'workflow'): string {
+  return cleanSegment(value, fallback);
+}
+
+export function goalWorkflowDir(cwd: string, workflow: string, slug: string): string {
+  return join(cwd, GOAL_WORKFLOWS_DIR, normalizeGoalWorkflowSegment(workflow), normalizeGoalWorkflowSegment(slug, 'goal-workflow'));
+}
+
+export function goalWorkflowStatusPath(cwd: string, workflow: string, slug: string): string {
+  return join(goalWorkflowDir(cwd, workflow, slug), GOAL_WORKFLOW_STATUS);
+}
+
+export function goalWorkflowLedgerPath(cwd: string, workflow: string, slug: string): string {
+  return join(goalWorkflowDir(cwd, workflow, slug), GOAL_WORKFLOW_LEDGER);
+}
+
+export async function appendGoalWorkflowLedger(cwd: string, run: GoalWorkflowRun, entry: GoalWorkflowLedgerEntry): Promise<void> {
+  await mkdir(join(cwd, run.artifactDir), { recursive: true });
+  await appendFile(join(cwd, run.ledgerPath), `${JSON.stringify(entry)}\n`);
+}
+
+async function writeRun(cwd: string, run: GoalWorkflowRun): Promise<void> {
+  await mkdir(join(cwd, run.artifactDir), { recursive: true });
+  await writeFile(join(cwd, run.statusPath), `${JSON.stringify(run, null, 2)}\n`);
+}
+
+export async function createGoalWorkflowRun(cwd: string, options: CreateGoalWorkflowRunOptions): Promise<GoalWorkflowRun> {
+  if (!options.objective.trim()) throw new GoalWorkflowError('Missing goal workflow objective.');
+  const workflow = normalizeGoalWorkflowSegment(options.workflow);
+  const slug = normalizeGoalWorkflowSegment(options.slug ?? slugFromObjective(options.objective), 'goal-workflow');
+  const statusPath = goalWorkflowStatusPath(cwd, workflow, slug);
+  if (!options.force && existsSync(statusPath)) {
+    throw new GoalWorkflowError(`Refusing to overwrite existing ${repoRelative(cwd, statusPath)}; pass force to recreate it.`);
+  }
+
+  const now = iso(options.now);
+  const artifactDir = repoRelative(cwd, goalWorkflowDir(cwd, workflow, slug));
+  const run: GoalWorkflowRun = {
+    version: 1,
+    workflow,
+    slug,
+    objective: options.objective.trim(),
+    status: 'pending',
+    createdAt: now,
+    updatedAt: now,
+    artifactDir,
+    statusPath: `${artifactDir}/${GOAL_WORKFLOW_STATUS}`,
+    ledgerPath: `${artifactDir}/${GOAL_WORKFLOW_LEDGER}`,
+    metadata: options.metadata,
+  };
+
+  await writeRun(cwd, run);
+  await writeFile(join(cwd, run.ledgerPath), '');
+  await appendGoalWorkflowLedger(cwd, run, { ts: now, event: 'workflow_created', status: run.status, message: 'Goal workflow created' });
+  return run;
+}
+
+export async function readGoalWorkflowRun(cwd: string, workflow: string, slug: string): Promise<GoalWorkflowRun> {
+  const path = goalWorkflowStatusPath(cwd, workflow, slug);
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf-8');
+  } catch {
+    throw new GoalWorkflowError(`No goal workflow run found at ${repoRelative(cwd, path)}.`);
+  }
+  const parsed = JSON.parse(raw) as GoalWorkflowRun;
+  if (parsed.version !== 1 || !parsed.workflow || !parsed.slug || !parsed.objective) {
+    throw new GoalWorkflowError(`Invalid goal workflow run at ${repoRelative(cwd, path)}.`);
+  }
+  return parsed;
+}
+
+function eventForStatus(status: TransitionGoalWorkflowOptions['status']): GoalWorkflowLedgerEvent {
+  switch (status) {
+    case 'in_progress': return 'goal_started';
+    case 'validation_passed': return 'validation_passed';
+    case 'blocked':
+    case 'failed': return 'goal_failed';
+    case 'complete': return 'goal_completed';
+  }
+}
+
+export async function transitionGoalWorkflowRun(cwd: string, workflow: string, slug: string, options: TransitionGoalWorkflowOptions): Promise<GoalWorkflowRun> {
+  const run = await readGoalWorkflowRun(cwd, workflow, slug);
+  if (options.status === 'complete' && run.status !== 'validation_passed') {
+    throw new GoalWorkflowError('Goal workflow completion requires a passing validation artifact first.');
+  }
+
+  const now = iso(options.now);
+  run.status = options.status;
+  run.updatedAt = now;
+  run.evidence = options.evidence ?? run.evidence;
+  run.metadata = { ...run.metadata, ...options.metadata };
+  if (options.validation) run.validation = options.validation;
+
+  await writeRun(cwd, run);
+  await appendGoalWorkflowLedger(cwd, run, {
+    ts: now,
+    event: eventForStatus(options.status),
+    status: run.status,
+    message: options.message,
+    evidence: options.evidence,
+    validation: options.validation,
+    metadata: options.metadata,
+  });
+  return run;
+}

--- a/src/goal-workflows/artifacts.ts
+++ b/src/goal-workflows/artifacts.ts
@@ -1,11 +1,16 @@
 import { existsSync } from 'node:fs';
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
+import { assertGoalWorkflowCanComplete } from './validation.js';
 
 export const GOAL_WORKFLOWS_DIR = '.omx/goals';
 export const GOAL_WORKFLOW_STATUS = 'status.json';
 export const GOAL_WORKFLOW_LEDGER = 'ledger.jsonl';
 
+// Shared goal-workflow artifacts are a narrow substrate for durable, validator-gated
+// handoffs. Concrete workflows may keep dedicated schemas until explicitly migrated,
+// but any generic completion must pass a real validation summary: non-placeholder
+// evidence plus a non-empty artifact path recorded in the status artifact.
 export type GoalWorkflowStatus = 'pending' | 'in_progress' | 'validation_passed' | 'blocked' | 'failed' | 'complete';
 
 export type GoalWorkflowLedgerEvent =
@@ -177,8 +182,14 @@ function eventForStatus(status: TransitionGoalWorkflowOptions['status']): GoalWo
 
 export async function transitionGoalWorkflowRun(cwd: string, workflow: string, slug: string, options: TransitionGoalWorkflowOptions): Promise<GoalWorkflowRun> {
   const run = await readGoalWorkflowRun(cwd, workflow, slug);
-  if (options.status === 'complete' && run.status !== 'validation_passed') {
-    throw new GoalWorkflowError('Goal workflow completion requires a passing validation artifact first.');
+  if (options.status === 'validation_passed') {
+    assertGoalWorkflowCanComplete(options.validation);
+  }
+  if (options.status === 'complete') {
+    if (run.status !== 'validation_passed') {
+      throw new GoalWorkflowError('Goal workflow completion requires a passing validation artifact first.');
+    }
+    assertGoalWorkflowCanComplete(run.validation);
   }
 
   const now = iso(options.now);

--- a/src/goal-workflows/handoff.ts
+++ b/src/goal-workflows/handoff.ts
@@ -1,0 +1,40 @@
+import type { GoalWorkflowRun } from './artifacts.js';
+
+export interface GoalWorkflowHandoffOptions {
+  run: GoalWorkflowRun;
+  title?: string;
+  tokenBudget?: number;
+  completionCommand?: string;
+  degradedMode?: boolean;
+}
+
+export function buildGoalWorkflowHandoff(options: GoalWorkflowHandoffOptions): string {
+  const createPayload = {
+    objective: options.run.objective,
+    ...(options.tokenBudget ? { token_budget: options.tokenBudget } : {}),
+  };
+  return [
+    options.title ?? `${options.run.workflow} goal-workflow handoff`,
+    `Status: ${options.run.status}`,
+    `Artifacts: ${options.run.artifactDir}`,
+    `Ledger: ${options.run.ledgerPath}`,
+    '',
+    'Codex goal integration constraints:',
+    '- First call get_goal to inspect the active Codex thread goal.',
+    '- Call create_goal only if no active goal exists and this handoff is the explicit objective to start.',
+    '- If a different active Codex goal exists, finish, checkpoint, or ask the leader before replacing focus.',
+    '- Work only this objective until the workflow-specific completion audit passes.',
+    '- Call update_goal({status: "complete"}) only after the OMX completion audit and validation artifacts pass.',
+    options.completionCommand ? `- Then record OMX completion evidence with: ${options.completionCommand}` : '- Then record OMX completion evidence in the workflow ledger/status artifacts.',
+    '',
+    options.degradedMode
+      ? 'Degraded-mode warning: this shell-rendered handoff did not mutate hidden Codex goal state; the active agent must use get_goal/create_goal/update_goal when those tools are available.'
+      : 'Truth boundary: OMX owns durable workflow artifacts; Codex owns active-thread focus/accounting.',
+    '',
+    'create_goal payload:',
+    JSON.stringify(createPayload, null, 2),
+    '',
+    'Objective:',
+    options.run.objective,
+  ].join('\n');
+}

--- a/src/goal-workflows/validation.ts
+++ b/src/goal-workflows/validation.ts
@@ -1,0 +1,46 @@
+import type { GoalWorkflowValidationSummary } from './artifacts.js';
+
+export type GoalWorkflowValidationStatus = 'pass' | 'fail' | 'blocker';
+
+export interface GoalWorkflowValidationInput {
+  status: GoalWorkflowValidationStatus | boolean;
+  summary: string;
+  artifactPath?: string;
+  checkedAt?: Date;
+}
+
+export class GoalWorkflowValidationError extends Error {}
+
+function iso(now = new Date()): string {
+  return now.toISOString();
+}
+
+function hasPlaceholderEvidence(summary: string): boolean {
+  return /\b(?:todo|tbd|placeholder|stub|not\s+implemented|fake\s+pass)\b/i.test(summary);
+}
+
+export function normalizeGoalWorkflowValidation(input: GoalWorkflowValidationInput): GoalWorkflowValidationSummary {
+  if (!input.summary.trim()) throw new GoalWorkflowValidationError('Validation summary is required.');
+  const status = input.status === true || input.status === 'pass'
+    ? 'validation_passed'
+    : input.status === 'blocker'
+      ? 'blocked'
+      : 'failed';
+  return {
+    status,
+    summary: input.summary.trim(),
+    artifactPath: input.artifactPath,
+    checkedAt: iso(input.checkedAt),
+  };
+}
+
+export function assertGoalWorkflowCanComplete(validation: GoalWorkflowValidationSummary | undefined): void {
+  if (!validation) throw new GoalWorkflowValidationError('Completion requires a validation artifact.');
+  if (validation.status !== 'validation_passed') {
+    throw new GoalWorkflowValidationError(`Completion requires validation_passed; got ${validation.status}.`);
+  }
+  if (!validation.artifactPath) throw new GoalWorkflowValidationError('Completion requires a validation artifact path.');
+  if (hasPlaceholderEvidence(validation.summary)) {
+    throw new GoalWorkflowValidationError('Completion requires real validation evidence, not placeholder evaluator text.');
+  }
+}

--- a/src/goal-workflows/validation.ts
+++ b/src/goal-workflows/validation.ts
@@ -29,7 +29,7 @@ export function normalizeGoalWorkflowValidation(input: GoalWorkflowValidationInp
   return {
     status,
     summary: input.summary.trim(),
-    artifactPath: input.artifactPath,
+    artifactPath: input.artifactPath?.trim() || undefined,
     checkedAt: iso(input.checkedAt),
   };
 }
@@ -39,7 +39,7 @@ export function assertGoalWorkflowCanComplete(validation: GoalWorkflowValidation
   if (validation.status !== 'validation_passed') {
     throw new GoalWorkflowValidationError(`Completion requires validation_passed; got ${validation.status}.`);
   }
-  if (!validation.artifactPath) throw new GoalWorkflowValidationError('Completion requires a validation artifact path.');
+  if (!validation.artifactPath?.trim()) throw new GoalWorkflowValidationError('Completion requires a validation artifact path.');
   if (hasPlaceholderEvidence(validation.summary)) {
     throw new GoalWorkflowValidationError('Completion requires real validation evidence, not placeholder evaluator text.');
   }

--- a/src/performance-goal/artifacts.ts
+++ b/src/performance-goal/artifacts.ts
@@ -1,0 +1,296 @@
+import { existsSync } from 'node:fs';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+export const PERFORMANCE_GOAL_ROOT = '.omx/goals/performance';
+export const PERFORMANCE_GOAL_STATE = 'state.json';
+export const PERFORMANCE_GOAL_LEDGER = 'ledger.jsonl';
+export const PERFORMANCE_GOAL_EVALUATOR = 'evaluator.md';
+
+export type PerformanceGoalStatus = 'created' | 'in_progress' | 'validation_passed' | 'validation_failed' | 'blocked' | 'complete';
+export type PerformanceValidationStatus = 'pass' | 'fail' | 'blocked';
+
+export interface PerformanceEvaluatorContract {
+  command: string;
+  contract: string;
+}
+
+export interface PerformanceValidationRecord {
+  status: PerformanceValidationStatus;
+  evidence: string;
+  recordedAt: string;
+}
+
+export interface PerformanceGoalState {
+  version: 1;
+  workflow: 'performance-goal';
+  slug: string;
+  objective: string;
+  status: PerformanceGoalStatus;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  evaluator: PerformanceEvaluatorContract;
+  lastValidation?: PerformanceValidationRecord;
+  artifactPaths: {
+    state: string;
+    ledger: string;
+    evaluator: string;
+  };
+}
+
+export interface CreatePerformanceGoalOptions {
+  objective: string;
+  evaluatorCommand: string;
+  evaluatorContract: string;
+  slug?: string;
+  force?: boolean;
+  now?: Date;
+}
+
+export interface CheckpointPerformanceGoalOptions {
+  slug: string;
+  status: PerformanceValidationStatus;
+  evidence: string;
+  now?: Date;
+}
+
+export interface CompletePerformanceGoalOptions {
+  slug: string;
+  evidence?: string;
+  now?: Date;
+}
+
+export interface PerformanceGoalLedgerEntry {
+  ts: string;
+  event:
+    | 'workflow_created'
+    | 'goal_handoff_emitted'
+    | 'validation_passed'
+    | 'validation_failed'
+    | 'validation_blocked'
+    | 'goal_completed';
+  status?: PerformanceGoalStatus;
+  validationStatus?: PerformanceValidationStatus;
+  evidence?: string;
+  message?: string;
+}
+
+export class PerformanceGoalError extends Error {}
+
+function iso(now = new Date()): string {
+  return now.toISOString();
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+    .replace(/-+$/g, '');
+  return slug || 'performance-goal';
+}
+
+function repoRelative(cwd: string, path: string): string {
+  return relative(cwd, path).split('\\').join('/');
+}
+
+function workflowDir(cwd: string, slug: string): string {
+  return join(cwd, PERFORMANCE_GOAL_ROOT, slug);
+}
+
+export function performanceGoalStatePath(cwd: string, slug: string): string {
+  return join(workflowDir(cwd, slug), PERFORMANCE_GOAL_STATE);
+}
+
+export function performanceGoalLedgerPath(cwd: string, slug: string): string {
+  return join(workflowDir(cwd, slug), PERFORMANCE_GOAL_LEDGER);
+}
+
+export function performanceGoalEvaluatorPath(cwd: string, slug: string): string {
+  return join(workflowDir(cwd, slug), PERFORMANCE_GOAL_EVALUATOR);
+}
+
+async function writeState(cwd: string, state: PerformanceGoalState): Promise<void> {
+  await mkdir(workflowDir(cwd, state.slug), { recursive: true });
+  await writeFile(performanceGoalStatePath(cwd, state.slug), `${JSON.stringify(state, null, 2)}\n`);
+}
+
+async function appendLedger(cwd: string, slug: string, entry: PerformanceGoalLedgerEntry): Promise<void> {
+  await mkdir(workflowDir(cwd, slug), { recursive: true });
+  await appendFile(performanceGoalLedgerPath(cwd, slug), `${JSON.stringify(entry)}\n`);
+}
+
+function evaluatorMarkdown(state: PerformanceGoalState): string {
+  return [
+    `# Performance Evaluator: ${state.slug}`,
+    '',
+    '## Objective',
+    state.objective,
+    '',
+    '## Evaluator Command',
+    '```sh',
+    state.evaluator.command,
+    '```',
+    '',
+    '## Pass/Fail Contract',
+    state.evaluator.contract,
+    '',
+    'This evaluator must exist and produce concrete pass/fail evidence before the performance goal can be completed.',
+    '',
+  ].join('\n');
+}
+
+function requireText(value: string, name: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new PerformanceGoalError(`Missing ${name}.`);
+  return trimmed;
+}
+
+export async function createPerformanceGoal(cwd: string, options: CreatePerformanceGoalOptions): Promise<PerformanceGoalState> {
+  const objective = requireText(options.objective, 'objective');
+  const evaluatorCommand = requireText(options.evaluatorCommand, 'evaluator command');
+  const evaluatorContract = requireText(options.evaluatorContract, 'evaluator contract');
+  const slug = slugify(options.slug ?? objective);
+  const statePath = performanceGoalStatePath(cwd, slug);
+  if (!options.force && existsSync(statePath)) {
+    throw new PerformanceGoalError(`Refusing to overwrite existing ${repoRelative(cwd, statePath)}; pass --force to recreate it.`);
+  }
+
+  const now = iso(options.now);
+  const state: PerformanceGoalState = {
+    version: 1,
+    workflow: 'performance-goal',
+    slug,
+    objective,
+    status: 'created',
+    createdAt: now,
+    updatedAt: now,
+    evaluator: {
+      command: evaluatorCommand,
+      contract: evaluatorContract,
+    },
+    artifactPaths: {
+      state: repoRelative(cwd, statePath),
+      ledger: repoRelative(cwd, performanceGoalLedgerPath(cwd, slug)),
+      evaluator: repoRelative(cwd, performanceGoalEvaluatorPath(cwd, slug)),
+    },
+  };
+
+  await mkdir(workflowDir(cwd, slug), { recursive: true });
+  await writeFile(performanceGoalLedgerPath(cwd, slug), '');
+  await writeFile(performanceGoalEvaluatorPath(cwd, slug), evaluatorMarkdown(state));
+  await writeState(cwd, state);
+  await appendLedger(cwd, slug, {
+    ts: now,
+    event: 'workflow_created',
+    status: state.status,
+    message: 'Performance goal created with evaluator contract',
+  });
+  return state;
+}
+
+export async function readPerformanceGoal(cwd: string, slug: string): Promise<PerformanceGoalState> {
+  const path = performanceGoalStatePath(cwd, slugify(slug));
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf-8');
+  } catch {
+    throw new PerformanceGoalError(`No performance goal found at ${repoRelative(cwd, path)}. Run \`omx performance-goal create ...\` first.`);
+  }
+  const parsed = JSON.parse(raw) as PerformanceGoalState;
+  if (parsed.version !== 1 || parsed.workflow !== 'performance-goal' || !parsed.evaluator?.command) {
+    throw new PerformanceGoalError(`Invalid performance goal state at ${repoRelative(cwd, path)}.`);
+  }
+  return parsed;
+}
+
+export async function startPerformanceGoal(cwd: string, slug: string, nowDate = new Date()): Promise<{ state: PerformanceGoalState; instruction: string }> {
+  const state = await readPerformanceGoal(cwd, slug);
+  const now = iso(nowDate);
+  if (state.status === 'created') {
+    state.status = 'in_progress';
+    state.startedAt = now;
+    state.updatedAt = now;
+    await writeState(cwd, state);
+  }
+  const instruction = buildPerformanceGoalInstruction(state);
+  await appendLedger(cwd, state.slug, {
+    ts: now,
+    event: 'goal_handoff_emitted',
+    status: state.status,
+    message: 'Emitted model-facing Codex goal handoff; shell command did not mutate Codex goal state',
+  });
+  return { state, instruction };
+}
+
+export async function checkpointPerformanceGoal(cwd: string, options: CheckpointPerformanceGoalOptions): Promise<PerformanceGoalState> {
+  const state = await readPerformanceGoal(cwd, options.slug);
+  const evidence = requireText(options.evidence, 'validation evidence');
+  const now = iso(options.now);
+  state.lastValidation = { status: options.status, evidence, recordedAt: now };
+  state.status = options.status === 'pass' ? 'validation_passed' : options.status === 'fail' ? 'validation_failed' : 'blocked';
+  state.updatedAt = now;
+  await writeState(cwd, state);
+  await appendLedger(cwd, state.slug, {
+    ts: now,
+    event: options.status === 'pass' ? 'validation_passed' : options.status === 'fail' ? 'validation_failed' : 'validation_blocked',
+    status: state.status,
+    validationStatus: options.status,
+    evidence,
+  });
+  return state;
+}
+
+export async function completePerformanceGoal(cwd: string, options: CompletePerformanceGoalOptions): Promise<PerformanceGoalState> {
+  const state = await readPerformanceGoal(cwd, options.slug);
+  if (state.lastValidation?.status !== 'pass') {
+    throw new PerformanceGoalError('Cannot complete performance goal until evaluator validation has a passing checkpoint. Run `omx performance-goal checkpoint --status pass ...` first.');
+  }
+  const now = iso(options.now);
+  state.status = 'complete';
+  state.completedAt = now;
+  state.updatedAt = now;
+  await writeState(cwd, state);
+  await appendLedger(cwd, state.slug, {
+    ts: now,
+    event: 'goal_completed',
+    status: state.status,
+    evidence: options.evidence ?? state.lastValidation.evidence,
+  });
+  return state;
+}
+
+export function buildPerformanceGoalInstruction(state: PerformanceGoalState): string {
+  const createPayload = { objective: state.objective };
+  return [
+    'Performance goal handoff',
+    `State: ${state.artifactPaths.state}`,
+    `Ledger: ${state.artifactPaths.ledger}`,
+    `Evaluator: ${state.artifactPaths.evaluator}`,
+    '',
+    'Codex goal integration constraints:',
+    '- First call get_goal. If no active goal exists, call create_goal with the payload below.',
+    '- If a different active Codex goal exists, finish or checkpoint that goal before starting this performance goal.',
+    '- Do not treat this shell command as hidden Codex goal mutation; it only wrote OMX artifacts and this handoff.',
+    '- Optimize only against the evaluator command/contract below; do not begin optimization without that evaluator.',
+    '- Completion is blocked until evaluator evidence passes and is recorded with `omx performance-goal checkpoint --status pass ...`.',
+    '- After evaluator pass and a completion audit prove the objective is complete, call update_goal({status: "complete"}), then run:',
+    `  omx performance-goal complete --slug ${state.slug} --evidence "<passing evaluator/tests/files evidence>"`,
+    '- If the evaluator fails or blocks, checkpoint with --status fail or --status blocked and continue iterating.',
+    '',
+    'create_goal payload:',
+    JSON.stringify(createPayload, null, 2),
+    '',
+    'Evaluator command:',
+    state.evaluator.command,
+    '',
+    'Evaluator pass/fail contract:',
+    state.evaluator.contract,
+    '',
+    'Objective:',
+    state.objective,
+  ].join('\n');
+}

--- a/src/performance-goal/artifacts.ts
+++ b/src/performance-goal/artifacts.ts
@@ -228,6 +228,9 @@ export async function startPerformanceGoal(cwd: string, slug: string, nowDate = 
 
 export async function checkpointPerformanceGoal(cwd: string, options: CheckpointPerformanceGoalOptions): Promise<PerformanceGoalState> {
   const state = await readPerformanceGoal(cwd, options.slug);
+  if (state.status === 'complete') {
+    throw new PerformanceGoalError(`Performance goal ${state.slug} is already complete; create a new goal or explicitly reopen via a future workflow before recording more checkpoints.`);
+  }
   const evidence = requireText(options.evidence, 'validation evidence');
   const now = iso(options.now);
   state.lastValidation = { status: options.status, evidence, recordedAt: now };
@@ -277,8 +280,9 @@ export function buildPerformanceGoalInstruction(state: PerformanceGoalState): st
     '- Do not treat this shell command as hidden Codex goal mutation; it only wrote OMX artifacts and this handoff.',
     '- Optimize only against the evaluator command/contract below; do not begin optimization without that evaluator.',
     '- Completion is blocked until evaluator evidence passes and is recorded with `omx performance-goal checkpoint --status pass ...`.',
-    '- After evaluator pass and a completion audit prove the objective is complete, call update_goal({status: "complete"}), then run:',
+    '- After evaluator pass and a completion audit prove the objective is complete, first run the durable OMX completion command:',
     `  omx performance-goal complete --slug ${state.slug} --evidence "<passing evaluator/tests/files evidence>"`,
+    '- Only after that command succeeds and the active-goal audit still owns this objective, call update_goal({status: "complete"}) in the Codex thread.',
     '- If the evaluator fails or blocks, checkpoint with --status fail or --status blocked and continue iterating.',
     '',
     'create_goal payload:',

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7906,7 +7906,8 @@ exit 0
         {
           hook_event_name: "Stop",
           cwd,
-          turn_id: "turn-stop-auto-mode-1",
+          thread_id: "thread-stop-auto-env-session",
+          turn_id: "turn-stop-auto-env-session-1",
           last_assistant_message: "Keep going and finish the cleanup.",
         },
         { cwd },

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7862,12 +7862,11 @@ exit 0
     }
   });
 
-  it("suppresses native auto-nudge when root deep-interview mode state is active without an explicit session", async () => {
+  it("suppresses native auto-nudge when root deep-interview mode state is active and no session is known", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-deep-interview-mode-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
-      process.env.OMX_SESSION_ID = "sess-stop-auto-mode";
       await writeJson(join(stateDir, "deep-interview-state.json"), {
         active: true,
         mode: "deep-interview",
@@ -7886,6 +7885,41 @@ exit 0
 
       assert.equal(result.omxEventName, "stop");
       assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("treats inherited OMX_SESSION_ID as session-aware for native auto-nudge Stop checks", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-env-session-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-mode";
+      await writeJson(join(stateDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          turn_id: "turn-stop-auto-mode-1",
+          last_assistant_message: "Keep going and finish the cleanup.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -188,6 +188,7 @@ const TEAM_ENV_KEYS = [
   "OMX_TEAM_STATE_ROOT",
   "OMX_TEAM_LEADER_CWD",
   "OMX_SESSION_ID",
+  "SESSION_ID",
   "OMX_QUESTION_RETURN_PANE",
   "OMX_LEADER_PANE_ID",
   "TMUX",
@@ -1475,7 +1476,6 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-
   it("includes leader-pane preservation guidance when a pane hint is available", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-pane-hint-"));
     try {
@@ -1614,7 +1614,6 @@ describe("codex native hook dispatch", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
-
 
   it("ignores generic wrapper fields so metadata cannot trigger workflow routing or Stop blocking", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-wrapper-metadata-"));
@@ -2705,7 +2704,6 @@ exit 0
     }
   });
 
-
   it("blocks Stop for untracked non-Bash-style sloppy fallback source edits", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-untracked-");
     try {
@@ -2735,7 +2733,6 @@ exit 0
     }
   });
 
-
   it("keeps blocking repeated Stop while sloppy fallback diff remains", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-repeat-");
     try {
@@ -2761,7 +2758,6 @@ exit 0
       await rm(cwd, { recursive: true, force: true });
     }
   });
-
 
   it("blocks Stop for unstaged tracked sloppy fallback source edits", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-unstaged-");
@@ -2880,7 +2876,6 @@ exit 0
     }
   });
 
-
   it("does not block Stop when existing nearby source context grounds a new fallback line", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-existing-ground-");
     try {
@@ -2918,7 +2913,6 @@ exit 0
       await rm(cwd, { recursive: true, force: true });
     }
   });
-
 
   it("does not block Stop for source-adjacent test file fallback wording", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-test-file-");
@@ -5627,7 +5621,6 @@ exit 0
     }
   });
 
-
   it("reads canonical Stop fallback team state from OMX_TEAM_STATE_ROOT when configured", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-root-"));
     const sharedRoot = join(cwd, "shared-root");
@@ -7482,7 +7475,6 @@ exit 0
     }
   });
 
-
   it("returns Stop continuation output for native auto-nudge stall prompts", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-"));
     try {
@@ -7923,6 +7915,35 @@ exit 0
     }
   });
 
+
+  it("ignores generic SESSION_ID for native auto-nudge Stop session scoping", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-generic-session-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      process.env.SESSION_ID = "generic-shell-session";
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          thread_id: "thread-stop-auto-generic-session",
+          turn_id: "turn-stop-auto-generic-session-1",
+          last_assistant_message: "Keep going and finish the cleanup.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      const stopState = JSON.parse(await readFile(join(stateDir, "native-stop-state.json"), "utf-8")) as Record<string, unknown>;
+      const sessions = stopState.sessions as Record<string, unknown>;
+      assert.equal(sessions["generic-shell-session"], undefined);
+      assert.ok(sessions["thread-stop-auto-generic-session"]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
   it("does not suppress native auto-nudge from stale root deep-interview mode state when the explicit session-scoped mode state is absent", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-stale-root-mode-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7896,11 +7896,6 @@ exit 0
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
       process.env.OMX_SESSION_ID = "sess-stop-auto-mode";
-      await writeJson(join(stateDir, "deep-interview-state.json"), {
-        active: true,
-        mode: "deep-interview",
-        current_phase: "intent-first",
-      });
 
       const result = await dispatchCodexNativeHook(
         {
@@ -7921,6 +7916,8 @@ exit 0
         systemMessage:
           "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
       });
+      const stopState = JSON.parse(await readFile(join(stateDir, "native-stop-state.json"), "utf-8")) as Record<string, unknown>;
+      assert.ok((stopState.sessions as Record<string, unknown>)["sess-stop-auto-mode"]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1987,7 +1987,7 @@ function resolveRepeatableStopSessionId(
   payload: CodexHookPayload,
   canonicalSessionId?: string,
 ): string {
-  const inheritedSessionId = safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID || process.env.SESSION_ID).trim();
+  const inheritedSessionId = safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID).trim();
   return canonicalSessionId?.trim() || readPayloadSessionId(payload) || inheritedSessionId || "";
 }
 
@@ -2678,7 +2678,7 @@ export async function dispatchCodexNativeHook(
   }
 
   if (hookEventName === "Stop") {
-    const inheritedSessionId = safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID || process.env.SESSION_ID).trim();
+    const inheritedSessionId = safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID).trim();
     const stopCanonicalSessionId = await resolveInternalSessionIdForPayload(
       cwd,
       readPayloadSessionId(payload) || inheritedSessionId,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2677,9 +2677,10 @@ export async function dispatchCodexNativeHook(
   }
 
   if (hookEventName === "Stop") {
+    const inheritedSessionId = safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID || process.env.SESSION_ID).trim();
     const stopCanonicalSessionId = await resolveInternalSessionIdForPayload(
       cwd,
-      readPayloadSessionId(payload),
+      readPayloadSessionId(payload) || inheritedSessionId,
     );
     if (stopCanonicalSessionId) {
       canonicalSessionId = stopCanonicalSessionId;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1987,7 +1987,8 @@ function resolveRepeatableStopSessionId(
   payload: CodexHookPayload,
   canonicalSessionId?: string,
 ): string {
-  return canonicalSessionId?.trim() || readPayloadSessionId(payload) || "";
+  const inheritedSessionId = safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID || process.env.SESSION_ID).trim();
+  return canonicalSessionId?.trim() || readPayloadSessionId(payload) || inheritedSessionId || "";
 }
 
 function isStateLevelStopSignatureKind(kind: string): boolean {

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -24,6 +24,7 @@ import {
   buildLeaderMailboxTriggerDirective,
 } from "../worker-bootstrap.js";
 import { composeRoleInstructionsForRole } from "../../agents/native-config.js";
+import { buildTeamWorkerGoalInstruction } from "../goal-workflow.js";
 import type { TeamTask } from "../state.js";
 
 function setMockCodexHome(codexHomePath: string): () => void {
@@ -279,6 +280,46 @@ describe("worker bootstrap", () => {
   });
 
 
+
+
+  it("generateInitialInbox includes scrum/team worker goal handoff tied to task IDs and claims", () => {
+    const tasks: TeamTask[] = [{
+      id: "4",
+      subject: "Implement team goal workflow",
+      description: "Wire per-worker goals into bootstrap",
+      status: "in_progress",
+      owner: "worker-4",
+      created_at: new Date(0).toISOString(),
+      claim: {
+        owner: "worker-4",
+        token: "claim-token",
+        leased_until: "2026-05-04T12:32:13.456Z",
+      },
+    }];
+
+    const workerGoalInstruction = buildTeamWorkerGoalInstruction(
+      "team-goal",
+      "worker-4",
+      tasks,
+      { teamStateRoot: "/tmp/.omx/state" },
+    );
+    const inbox = generateInitialInbox("worker-4", "team-goal", "executor", tasks, {
+      teamStateRoot: "/tmp/.omx/state",
+      workerGoalInstruction,
+    });
+
+    assert.match(inbox, /## Scrum \/ Team Goal Workflow/);
+    assert.match(inbox, /task IDs 4 instead of creating a duplicate task list/);
+    assert.match(inbox, /Task 4: Implement team goal workflow/);
+    assert.match(inbox, /active claim owner: worker-4 until 2026-05-04T12:32:13\.456Z/);
+    assert.match(inbox, /\/tmp\/\.omx\/state\/goals\/team\/team-goal\/workers\/worker-4\.json/);
+    assert.match(inbox, /get_goal/);
+    assert.match(inbox, /create_goal.*only when no active goal exists/i);
+    assert.match(inbox, /update_goal\(\{status: "complete"\}\).*verification evidence/i);
+    assert.match(inbox, /shell\/team APIs persist only OMX artifacts and task state/);
+  });
+
+
   it("generateInitialInbox includes repo-aware decomposition ownership hints", () => {
     const inbox = generateInitialInbox(
       "worker-1",
@@ -497,6 +538,29 @@ describe("worker bootstrap", () => {
     assert.match(inbox, /PASS\/FAIL/);
   });
 
+
+
+
+
+  it("generateTaskAssignmentInbox includes worker goal handoff for task-object follow-ups", () => {
+    const inbox = generateTaskAssignmentInbox(
+      "worker-2",
+      "team-followup-goal",
+      {
+        id: "9",
+        subject: "Finish worker audit",
+        description: "Complete the worker audit slice",
+        status: "pending",
+        created_at: new Date(0).toISOString(),
+      },
+    );
+
+    assert.match(inbox, /## Scrum \/ Team Goal Workflow/);
+    assert.match(inbox, /Task 9: Finish worker audit/);
+    assert.match(inbox, /claim required before work/);
+    assert.match(inbox, /<team_state_root>\/goals\/team\/team-followup-goal\/workers\/worker-2\.json/);
+    assert.match(inbox, /leader-audit\.json/);
+  });
 
 
   it("generateTaskAssignmentInbox includes delegation contract for follow-up task object", () => {

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -312,7 +312,10 @@ describe("worker bootstrap", () => {
     assert.match(inbox, /task IDs 4 instead of creating a duplicate task list/);
     assert.match(inbox, /Task 4: Implement team goal workflow/);
     assert.match(inbox, /active claim owner: worker-4 until 2026-05-04T12:32:13\.456Z/);
-    assert.match(inbox, /\/tmp\/\.omx\/state\/goals\/team\/team-goal\/workers\/worker-4\.json/);
+    assert.match(inbox, /Durable OMX source of truth/);
+    assert.match(inbox, /logical Codex goal handoff only/);
+    assert.doesNotMatch(inbox, /\/tmp\/\.omx\/state\/goals\/team/);
+    assert.doesNotMatch(inbox, /leader-audit\.json/);
     assert.match(inbox, /get_goal/);
     assert.match(inbox, /create_goal.*only when no active goal exists/i);
     assert.match(inbox, /update_goal\(\{status: "complete"\}\).*verification evidence/i);
@@ -558,8 +561,11 @@ describe("worker bootstrap", () => {
     assert.match(inbox, /## Scrum \/ Team Goal Workflow/);
     assert.match(inbox, /Task 9: Finish worker audit/);
     assert.match(inbox, /claim required before work/);
-    assert.match(inbox, /<team_state_root>\/goals\/team\/team-followup-goal\/workers\/worker-2\.json/);
-    assert.match(inbox, /leader-audit\.json/);
+    assert.match(inbox, /Durable OMX source of truth/);
+    assert.match(inbox, /logical Codex goal handoff only/);
+    assert.match(inbox, /omx team api transition-task-status/);
+    assert.doesNotMatch(inbox, /<team_state_root>\/goals\/team/);
+    assert.doesNotMatch(inbox, /leader-audit\.json/);
   });
 
 

--- a/src/team/goal-workflow.ts
+++ b/src/team/goal-workflow.ts
@@ -1,0 +1,94 @@
+import type { TeamTask } from "./state.js";
+
+export interface TeamWorkerGoalInstruction {
+  teamName: string;
+  workerName: string;
+  objective: string;
+  taskIds: string[];
+  taskReferences: Array<{
+    id: string;
+    subject: string;
+    status: TeamTask["status"];
+    claimOwner?: string;
+    claimLeasedUntil?: string;
+  }>;
+  artifactPath: string;
+  leaderAuditPath: string;
+}
+
+function normalizeGoalPath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+export function buildTeamWorkerGoalInstruction(
+  teamName: string,
+  workerName: string,
+  tasks: TeamTask[],
+  options: { teamStateRoot?: string; objective?: string } = {},
+): TeamWorkerGoalInstruction | undefined {
+  if (tasks.length === 0) return undefined;
+
+  const teamStateRoot = normalizeGoalPath(options.teamStateRoot ?? "<team_state_root>");
+  const taskIds = tasks.map((task) => task.id);
+  const objective = options.objective ??
+    `Complete assigned OMX team task${taskIds.length === 1 ? "" : "s"} ${taskIds.join(", ")} for ${teamName} with verified evidence, preserving leader-owned audit.`;
+
+  return {
+    teamName,
+    workerName,
+    objective,
+    taskIds,
+    taskReferences: tasks.map((task) => ({
+      id: task.id,
+      subject: task.subject,
+      status: task.status,
+      claimOwner: task.claim?.owner,
+      claimLeasedUntil: task.claim?.leased_until,
+    })),
+    artifactPath: normalizeGoalPath(
+      `${teamStateRoot}/goals/team/${teamName}/workers/${workerName}.json`,
+    ),
+    leaderAuditPath: normalizeGoalPath(
+      `${teamStateRoot}/goals/team/${teamName}/leader-audit.json`,
+    ),
+  };
+}
+
+export function renderTeamWorkerGoalInstruction(
+  instruction: TeamWorkerGoalInstruction | undefined,
+): string {
+  if (!instruction) return "";
+
+  const taskLines = instruction.taskReferences
+    .map((task) => {
+      const claim = task.claimOwner
+        ? `; active claim owner: ${task.claimOwner}${task.claimLeasedUntil ? ` until ${task.claimLeasedUntil}` : ""}`
+        : "; claim required before work";
+      return `- Task ${task.id}: ${task.subject} (status: ${task.status}${claim})`;
+    })
+    .join("\n");
+
+  return `
+## Scrum / Team Goal Workflow
+
+Objective: ${instruction.objective}
+
+Durable OMX goal artifacts:
+- Worker goal artifact: ${instruction.artifactPath}
+- Leader audit artifact: ${instruction.leaderAuditPath}
+
+Source-of-truth rules:
+- Existing team task files and claim lifecycle remain authoritative; this worker goal must reference task IDs ${instruction.taskIds.join(", ")} instead of creating a duplicate task list.
+- Claim each task with \`omx team api claim-task\` before editing; use the task file claim/status as the current assignment record.
+- Record completion evidence through \`omx team api transition-task-status\`; leader audit owns aggregate team completion.
+
+Assigned task/claim references:
+${taskLines}
+
+Codex goal handoff guidance (truthful fallback only):
+1. If goal tools are available in this worker thread, call \`get_goal\` before creating or completing a goal.
+2. Call \`create_goal\` only when no active goal exists and the explicit worker objective above should become this thread's active objective.
+3. Do not claim OMX shell commands mutated Codex goal state; shell/team APIs persist only OMX artifacts and task state.
+4. Call \`update_goal({status: "complete"})\` only after assigned task transitions are complete and verification evidence is present for leader audit.
+`;
+}

--- a/src/team/goal-workflow.ts
+++ b/src/team/goal-workflow.ts
@@ -12,12 +12,6 @@ export interface TeamWorkerGoalInstruction {
     claimOwner?: string;
     claimLeasedUntil?: string;
   }>;
-  artifactPath: string;
-  leaderAuditPath: string;
-}
-
-function normalizeGoalPath(path: string): string {
-  return path.replaceAll("\\", "/");
 }
 
 export function buildTeamWorkerGoalInstruction(
@@ -28,7 +22,7 @@ export function buildTeamWorkerGoalInstruction(
 ): TeamWorkerGoalInstruction | undefined {
   if (tasks.length === 0) return undefined;
 
-  const teamStateRoot = normalizeGoalPath(options.teamStateRoot ?? "<team_state_root>");
+  void options.teamStateRoot;
   const taskIds = tasks.map((task) => task.id);
   const objective = options.objective ??
     `Complete assigned OMX team task${taskIds.length === 1 ? "" : "s"} ${taskIds.join(", ")} for ${teamName} with verified evidence, preserving leader-owned audit.`;
@@ -45,12 +39,6 @@ export function buildTeamWorkerGoalInstruction(
       claimOwner: task.claim?.owner,
       claimLeasedUntil: task.claim?.leased_until,
     })),
-    artifactPath: normalizeGoalPath(
-      `${teamStateRoot}/goals/team/${teamName}/workers/${workerName}.json`,
-    ),
-    leaderAuditPath: normalizeGoalPath(
-      `${teamStateRoot}/goals/team/${teamName}/leader-audit.json`,
-    ),
   };
 }
 
@@ -73,9 +61,9 @@ export function renderTeamWorkerGoalInstruction(
 
 Objective: ${instruction.objective}
 
-Durable OMX goal artifacts:
-- Worker goal artifact: ${instruction.artifactPath}
-- Leader audit artifact: ${instruction.leaderAuditPath}
+Durable OMX source of truth:
+- Existing team task files, task claims, lifecycle events, and leader audit remain the durable artifacts.
+- This section is a logical Codex goal handoff only; it does not create separate per-worker goal JSON or leader-audit artifacts.
 
 Source-of-truth rules:
 - Existing team task files and claim lifecycle remain authoritative; this worker goal must reference task IDs ${instruction.taskIds.join(", ")} instead of creating a duplicate task list.

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -109,6 +109,7 @@ import {
   buildLeaderMailboxTriggerDirective,
   writeWorkerRoleInstructionsFile,
 } from './worker-bootstrap.js';
+import { buildTeamWorkerGoalInstruction } from './goal-workflow.js';
 import { synthesizeDelegationPlan } from './delegation-policy.js';
 import { loadRolePrompt } from './role-router.js';
 import { composeRoleInstructionsForRole } from '../agents/native-config.js';
@@ -2461,6 +2462,7 @@ export async function startTeam(
         worktreeRootAgentsCanonical: Boolean(workerWorkspace.worktreePath),
         taskHints: effectiveDecompositionMetadata?.task_hints,
         approvedContextSummary: effectiveDecompositionMetadata?.approved_context_summary,
+        workerGoalInstruction: buildTeamWorkerGoalInstruction(sanitized, workerName, workerTasks, { teamStateRoot }),
       });
       const triggerDirective = buildTriggerDirective(
         workerName,

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -56,6 +56,7 @@ import {
   writeWorkerWorktreeRootAgentsFile,
   removeWorkerWorktreeRootAgentsFile,
 } from './worker-bootstrap.js';
+import { buildTeamWorkerGoalInstruction } from './goal-workflow.js';
 import { loadRolePrompt } from './role-router.js';
 import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
@@ -469,6 +470,7 @@ export async function scaleUp(
         workerRole: runtimeRole,
         rolePromptContent: rawRolePromptContent ?? undefined,
         worktreeRootAgentsCanonical: Boolean(workerWorkspace?.worktreePath),
+        workerGoalInstruction: buildTeamWorkerGoalInstruction(sanitized, workerName, workerTasks, { teamStateRoot }),
       });
 
       const triggerDirective = buildTriggerDirective(

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -854,25 +854,23 @@ export function generateTaskAssignmentInbox(
     : taskOrId;
   const taskId = task.id;
   const taskDescription = task.description;
-  const workerGoalSection = renderTeamWorkerGoalInstruction(
-    typeof taskOrId === "string"
-      ? undefined
-      : {
-          teamName,
-          workerName,
-          objective: `Complete assigned OMX team task ${task.id} with verified evidence, preserving leader-owned audit.`,
-          taskIds: [task.id],
-          taskReferences: [{
-            id: task.id,
-            subject: task.subject,
-            status: task.status,
-            claimOwner: task.claim?.owner,
-            claimLeasedUntil: task.claim?.leased_until,
-          }],
-          artifactPath: `<team_state_root>/goals/team/${teamName}/workers/${workerName}.json`,
-          leaderAuditPath: `<team_state_root>/goals/team/${teamName}/leader-audit.json`,
-        },
-  );
+  const workerGoalSection = typeof taskOrId === "string"
+    ? ""
+    : renderTeamWorkerGoalInstruction({
+        teamName,
+        workerName,
+        objective: `Complete assigned OMX team task ${taskOrId.id} with verified evidence, preserving leader-owned audit.`,
+        taskIds: [taskOrId.id],
+        taskReferences: [{
+          id: taskOrId.id,
+          subject: taskOrId.subject,
+          status: taskOrId.status,
+          claimOwner: taskOrId.claim?.owner,
+          claimLeasedUntil: taskOrId.claim?.leased_until,
+        }],
+        artifactPath: `<team_state_root>/goals/team/${teamName}/workers/${workerName}.json`,
+        leaderAuditPath: `<team_state_root>/goals/team/${teamName}/leader-audit.json`,
+      });
   const delegationSection = renderDelegationContracts([task as TeamTask]);
 
   return `# New Task Assignment

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -12,6 +12,10 @@ import { sleep } from "../utils/sleep.js";
 import type { ApprovedRepositoryContextSummary } from "../planning/artifacts.js";
 import type { TeamReminderDirective } from "./reminder-intents.js";
 import type { TaskHintSummary } from "./repo-aware-decomposition.js";
+import {
+  renderTeamWorkerGoalInstruction,
+  type TeamWorkerGoalInstruction,
+} from "./goal-workflow.js";
 
 const TEAM_OVERLAY_START = "<!-- OMX:TEAM:WORKER:START -->";
 const TEAM_OVERLAY_END = "<!-- OMX:TEAM:WORKER:END -->";
@@ -701,6 +705,7 @@ export function generateInitialInbox(
     worktreeRootAgentsCanonical?: boolean;
     taskHints?: Record<string, TaskHintSummary>;
     approvedContextSummary?: ApprovedRepositoryContextSummary;
+    workerGoalInstruction?: TeamWorkerGoalInstruction;
   } = {},
 ): string {
   const taskList = tasks
@@ -740,6 +745,7 @@ export function generateInitialInbox(
   const leaderCwd = options.leaderCwd || "<leader_cwd>";
   const displayRole = options.workerRole ?? agentType;
   const delegationSection = renderDelegationContracts(tasks);
+  const workerGoalSection = renderTeamWorkerGoalInstruction(options.workerGoalInstruction);
 
   const approvedContextSection = options.approvedContextSummary
     ? `
@@ -766,7 +772,7 @@ ${options.approvedContextSummary.content}
 ## Your Assigned Tasks
 
 ${taskList}
-${approvedContextSection}
+${approvedContextSection}${workerGoalSection}
 ## Instructions
 
 1. Load and follow the worker skill from the first existing path:
@@ -848,6 +854,25 @@ export function generateTaskAssignmentInbox(
     : taskOrId;
   const taskId = task.id;
   const taskDescription = task.description;
+  const workerGoalSection = renderTeamWorkerGoalInstruction(
+    typeof taskOrId === "string"
+      ? undefined
+      : {
+          teamName,
+          workerName,
+          objective: `Complete assigned OMX team task ${task.id} with verified evidence, preserving leader-owned audit.`,
+          taskIds: [task.id],
+          taskReferences: [{
+            id: task.id,
+            subject: task.subject,
+            status: task.status,
+            claimOwner: task.claim?.owner,
+            claimLeasedUntil: task.claim?.leased_until,
+          }],
+          artifactPath: `<team_state_root>/goals/team/${teamName}/workers/${workerName}.json`,
+          leaderAuditPath: `<team_state_root>/goals/team/${teamName}/leader-audit.json`,
+        },
+  );
   const delegationSection = renderDelegationContracts([task as TeamTask]);
 
   return `# New Task Assignment
@@ -858,7 +883,7 @@ export function generateTaskAssignmentInbox(
 ## Task Description
 
 ${taskDescription}
-
+${workerGoalSection}
 ## Instructions
 
 1. Resolve canonical team state root and read the task file at \`<team_state_root>/team/${teamName}/tasks/task-${taskId}.json\`

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -868,8 +868,6 @@ export function generateTaskAssignmentInbox(
           claimOwner: taskOrId.claim?.owner,
           claimLeasedUntil: taskOrId.claim?.leased_until,
         }],
-        artifactPath: `<team_state_root>/goals/team/${teamName}/workers/${workerName}.json`,
-        leaderAuditPath: `<team_state_root>/goals/team/${teamName}/leader-audit.json`,
       });
   const delegationSection = renderDelegationContracts([task as TeamTask]);
 

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -64,7 +64,7 @@ describe('ultragoal artifacts', () => {
       assert.match(instruction, /Complete first milestone/);
       assert.doesNotMatch(instruction, /\/goal\b/);
       assert.doesNotMatch(instruction, /\.\.\/\.\.\/codex/);
-      assert.doesNotMatch(instruction, /^\s*codex\s+goal\b/im);
+      assert.doesNotMatch(instruction, /`codex\s+goal\b/i);
     });
   });
 

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -64,7 +64,7 @@ describe('ultragoal artifacts', () => {
       assert.match(instruction, /Complete first milestone/);
       assert.doesNotMatch(instruction, /\/goal\b/);
       assert.doesNotMatch(instruction, /\.\.\/\.\.\/codex/);
-      assert.doesNotMatch(instruction, /codex\s+goal/i);
+      assert.doesNotMatch(instruction, /^\s*codex\s+goal\b/im);
     });
   });
 

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -62,6 +62,9 @@ describe('ultragoal artifacts', () => {
       assert.match(instruction, /call create_goal/i);
       assert.match(instruction, /update_goal\(\{status: "complete"\}\)/);
       assert.match(instruction, /Complete first milestone/);
+      assert.doesNotMatch(instruction, /\/goal\b/);
+      assert.doesNotMatch(instruction, /\.\.\/\.\.\/codex/);
+      assert.doesNotMatch(instruction, /codex\s+goal/i);
     });
   });
 

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -60,6 +60,13 @@
       "internalRequired": false
     },
     {
+      "name": "performance-goal",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "pipeline",
       "category": "execution",
       "status": "active",

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -56,7 +56,8 @@
       "name": "autoresearch-goal",
       "category": "execution",
       "status": "active",
-      "core": false
+      "core": false,
+      "internalRequired": false
     },
     {
       "name": "pipeline",

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -53,6 +53,20 @@
       "internalRequired": false
     },
     {
+      "name": "autoresearch-goal",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "performance-goal",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "pipeline",
       "category": "execution",
       "status": "active",

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -56,15 +56,7 @@
       "name": "autoresearch-goal",
       "category": "execution",
       "status": "active",
-      "core": false,
-      "internalRequired": false
-    },
-    {
-      "name": "performance-goal",
-      "category": "execution",
-      "status": "active",
-      "core": false,
-      "internalRequired": false
+      "core": false
     },
     {
       "name": "pipeline",


### PR DESCRIPTION
## Summary
- Add Codex goal-mode OMX workflow skills and CLI bindings for performance optimization, autoresearch goals, and team/ultragoal orchestration.
- Persist durable OMX artifacts and explicit Codex goal handoff prompts without directly mutating upstream Codex /goal state.
- Integrate per-worker team goal handoffs, evaluator/critic validation gates, setup feature enablement, docs, catalog, and plugin bundle mirrors.

## Constraints honored
- No upstream Codex repo edits.
- No hidden goal mutation; handoff-only fallback for Codex /goal.
- No full Jira clone; team mode remains task/claim-backed with per-worker goal guidance.
- No new dependencies.

## Validation
- npm run build
- npm run verify:plugin-bundle
- npx biome lint changed merge files
- node --test focused compiled goal/setup/hook/team suites: 527 pass, 0 fail
- Earlier full compiled CI on branch: 4512 pass, 0 fail
- CLI smoke for performance-goal, autoresearch-goal, and ultragoal
- Code-review APPROVE and architect CLEAR after terminal-state guard fixes

## Not tested
- Live interactive Codex /goal UI mutation
- Production evaluator farm
