### PR TITLE
Make team worker reports reviewable without pane inspection

### DIFF
--- a/plugins/oh-my-codex/skills/worker/SKILL.md
+++ b/plugins/oh-my-codex/skills/worker/SKILL.md
@@ -101,6 +101,17 @@ Worker sessions should treat team state + CLI interop as the source of truth.
 - Do **not** rely on ad-hoc tmux keystrokes as a primary delivery channel.
 - If a manual trigger arrives (for example `tmux send-keys` nudge), treat it only as a prompt to re-check state and continue through the normal claim-safe lifecycle.
 
+## Unattended Worker Operating Contract
+
+Most team workers are supervised through state files and leader/runtime checks, not direct human pane watching. Keep every report durable and leader-readable.
+
+1. **Lifecycle:** ACK -> read inbox/mailbox/task -> claim -> execute assigned scope -> verify/report -> transition complete/fail -> update status/idle.
+2. **Report fields:** Use existing `result`, `error`, mailbox, or status text to include `Conclusion`, `Evidence`, `Changed files`, `Verification:`, `commit_status`, `Blocker`, and `Next action` when applicable. These are text guidance for existing payloads, not a new runtime schema/API.
+3. **Self-verification:** Completed code-change task `result` text should include `Verification:` plus PASS/FAIL command evidence. If validation cannot run, report the validation gap.
+4. **Commit status:** Report one of `committed:<sha>`, `dirty:auto-commit-expected`, `not-needed`, or `blocked:<reason>`.
+5. **Ownership:** Stay inside assigned files/tasks; escalate shared-file conflicts, scope expansion, missing authority, and ambiguous instructions upward.
+6. **Low-noise communication:** Prefer durable state/mailbox/task evidence over pane narrative; keep ACKs and progress terse.
+
 ## Shutdown
 
 If the lead sends a shutdown request, follow the shutdown inbox instructions exactly, write your shutdown ack file, then exit the Codex session.

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -101,6 +101,17 @@ Worker sessions should treat team state + CLI interop as the source of truth.
 - Do **not** rely on ad-hoc tmux keystrokes as a primary delivery channel.
 - If a manual trigger arrives (for example `tmux send-keys` nudge), treat it only as a prompt to re-check state and continue through the normal claim-safe lifecycle.
 
+## Unattended Worker Operating Contract
+
+Most team workers are supervised through state files and leader/runtime checks, not direct human pane watching. Keep every report durable and leader-readable.
+
+1. **Lifecycle:** ACK -> read inbox/mailbox/task -> claim -> execute assigned scope -> verify/report -> transition complete/fail -> update status/idle.
+2. **Report fields:** Use existing `result`, `error`, mailbox, or status text to include `Conclusion`, `Evidence`, `Changed files`, `Verification:`, `commit_status`, `Blocker`, and `Next action` when applicable. These are text guidance for existing payloads, not a new runtime schema/API.
+3. **Self-verification:** Completed code-change task `result` text should include `Verification:` plus PASS/FAIL command evidence. If validation cannot run, report the validation gap.
+4. **Commit status:** Report one of `committed:<sha>`, `dirty:auto-commit-expected`, `not-needed`, or `blocked:<reason>`.
+5. **Ownership:** Stay inside assigned files/tasks; escalate shared-file conflicts, scope expansion, missing authority, and ambiguous instructions upward.
+6. **Low-noise communication:** Prefer durable state/mailbox/task evidence over pane narrative; keep ACKs and progress terse.
+
 ## Shutdown
 
 If the lead sends a shutdown request, follow the shutdown inbox instructions exactly, write your shutdown ack file, then exit the Codex session.

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -26,6 +26,49 @@ import {
 import { composeRoleInstructionsForRole } from "../../agents/native-config.js";
 import type { TeamTask } from "../state.js";
 
+function assertUnattendedWorkerContractTerms(
+  content: string,
+  options: { full?: boolean } = {},
+): void {
+  assert.match(content, /Unattended Worker Operating Contract/);
+  assert.match(content, /ACK/);
+  assert.match(content, /inbox\/mailbox\/task/);
+  assert.match(content, /claim/);
+  assert.match(content, /verify\/report/);
+  assert.match(content, /transition complete\/fail/);
+  assert.match(content, /status\/idle|update status/);
+  assert.match(content, /Conclusion/);
+  assert.match(content, /Evidence/);
+  assert.match(content, /Changed files/);
+  assert.match(content, /Verification:/);
+  assert.match(content, /PASS\/FAIL/);
+  assert.match(content, /commit_status/);
+  assert.match(content, /committed:<sha>/);
+  assert.match(content, /dirty:auto-commit-expected/);
+  assert.match(content, /not-needed/);
+  assert.match(content, /blocked:<reason>/);
+  assert.match(content, /Blocker/);
+  assert.match(content, /Next action/);
+  assert.match(content, /shared-file conflicts?/);
+  assert.match(content, /scope expansion/);
+  assert.match(content, /self-verification|Self-verification|Self-verify/);
+  assert.match(content, /validation gap/);
+  assert.match(content, /low-noise|Low-noise/);
+  assert.match(content, /durable state\/mailbox\/task evidence/);
+  assert.match(content, /existing `result`/);
+  assert.match(content, /`error`/);
+  assert.match(content, /mailbox/);
+  assert.match(content, /status/);
+  assert.match(content, /not a new runtime schema\/API/);
+
+  if (options.full) {
+    assert.match(
+      content,
+      /lifecycle transition `result` must include `Verification:` plus PASS\/FAIL evidence/,
+    );
+  }
+}
+
 function setMockCodexHome(codexHomePath: string): () => void {
   const previous = process.env.CODEX_HOME;
   process.env.CODEX_HOME = codexHomePath;
@@ -58,6 +101,7 @@ describe("worker bootstrap", () => {
       workerSkill,
       /`?\{"status":"failed","error":"\.\.\."\}`?/,
     );
+    assertUnattendedWorkerContractTerms(workerSkill);
   });
 
   it("generateWorkerOverlay produces markdown with correct start/end markers", () => {
@@ -98,6 +142,7 @@ describe("worker bootstrap", () => {
       overlay,
       /do not pass workingDirectory unless the lead explicitly tells you to/,
     );
+    assertUnattendedWorkerContractTerms(overlay);
     assert.doesNotMatch(overlay, /tasks\/\{id\}\.json/);
   });
 
@@ -276,6 +321,7 @@ describe("worker bootstrap", () => {
     );
     assert.match(inbox, /Verification Requirements/);
     assert.match(inbox, /Fix-Verify Loop/);
+    assertUnattendedWorkerContractTerms(inbox);
   });
 
 
@@ -495,6 +541,7 @@ describe("worker bootstrap", () => {
     );
     assert.match(inbox, /Verification Requirements/);
     assert.match(inbox, /PASS\/FAIL/);
+    assertUnattendedWorkerContractTerms(inbox);
   });
 
 
@@ -786,6 +833,15 @@ describe("worker bootstrap", () => {
     assert.match(content, /Worker: worker-3/);
     assert.match(content, /Inbox path: \/tmp\/state\/team\/root-team\/workers\/worker-3\/inbox\.md/);
     assert.match(content, /mailbox\/worker-3\.json/);
+    assertUnattendedWorkerContractTerms(content, { full: true });
+    assert.ok(
+      content.indexOf("## Unattended Worker Operating Contract") <
+        content.indexOf("## Protocol"),
+    );
+    assert.ok(
+      content.indexOf("## Unattended Worker Operating Contract") <
+        content.indexOf("<!-- OMX:TEAM:ROLE:START -->"),
+    );
     assert.match(content, /<identity>You are Writer\.<\/identity>/);
     assert.doesNotMatch(content, /# Project Instructions/);
     assert.doesNotMatch(content, /# User Instructions/);

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -22,6 +22,9 @@ const LOCK_TIMEOUT_MS = 5000;
 const LOCK_POLL_INTERVAL_MS = 100;
 const LOCK_STALE_MS = 30_000;
 
+const UNATTENDED_WORKER_CONTRACT_ANCHOR =
+  "Unattended Worker Operating Contract";
+
 interface WorkerRootAgentsOptions {
   teamName: string;
   workerName: string;
@@ -83,6 +86,8 @@ This file is generated for a live OMX team worker run and is disposable.
 - Worker status path: ${options.teamStateRoot}/team/${options.teamName}/workers/${options.workerName}/status.json
 - Worker identity path: ${options.teamStateRoot}/team/${options.teamName}/workers/${options.workerName}/identity.json
 
+${buildUnattendedWorkerOperatingContract("full")}
+
 ## Protocol
 1. Read your inbox at \`${options.teamStateRoot}/team/${options.teamName}/workers/${options.workerName}/inbox.md\`.
 2. Load the worker skill from the first existing path:
@@ -121,6 +126,34 @@ ${options.rolePromptContent.trim()}
 </team_worker_role>
 <!-- OMX:TEAM:ROLE:END -->
 `;
+}
+
+function buildUnattendedWorkerOperatingContract(
+  depth: "full" | "compact",
+): string {
+  if (depth === "compact") {
+    return `## ${UNATTENDED_WORKER_CONTRACT_ANCHOR} (Compact Reminder)
+
+- Follow the lifecycle: ACK -> read inbox/mailbox/task -> claim -> execute assigned scope -> verify/report -> transition complete/fail -> update status/idle.
+- Put leader-readable text in existing \`result\`, \`error\`, mailbox, or status payloads only; this is guidance for existing text fields, not a new runtime schema/API.
+- Completion/failure reports should include: \`Conclusion\`, \`Evidence\`, \`Changed files\`, \`Verification:\` with PASS/FAIL command evidence, \`commit_status\`, \`Blocker\`, and \`Next action\`.
+- Use \`commit_status\` values such as \`committed:<sha>\`, \`dirty:auto-commit-expected\`, \`not-needed\`, or \`blocked:<reason>\`.
+- Stay inside assigned ownership; escalate shared-file conflicts, scope expansion, missing authority, or ambiguous instructions upward.
+- Self-verify with the smallest useful validation before completion, or explicitly report a validation gap.
+- Keep communication low-noise: prefer durable state/mailbox/task evidence over pane narrative.`;
+  }
+
+  return `## ${UNATTENDED_WORKER_CONTRACT_ANCHOR}
+
+You are usually not watched directly by a human. Leave durable, leader-readable evidence in existing team state and mailbox text so the leader/runtime can integrate your work without pane inspection.
+
+1. **State-machine lifecycle:** ACK -> read inbox/mailbox/task -> claim -> execute assigned scope -> verify/report -> transition complete/fail -> update status/idle.
+2. **Leader-readable reports:** Shape existing \`result\`, \`error\`, mailbox, and status text with these fields when applicable: \`Conclusion\`, \`Evidence\`, \`Changed files\`, \`Verification:\`, \`commit_status\`, \`Blocker\`, and \`Next action\`. These fields are text guidance for existing payloads, not a new runtime schema/API.
+3. **Verification-gate compatibility:** For completed code-change tasks, the lifecycle transition \`result\` must include \`Verification:\` plus PASS/FAIL evidence and commands when available, so the existing team verification gate can recognize self-verification.
+4. **Commit status clarity:** Report exactly one clear \`commit_status\`: \`committed:<sha>\`, \`dirty:auto-commit-expected\`, \`not-needed\`, or \`blocked:<reason>\`.
+5. **Bounded ownership:** Stay inside assigned files/tasks. Escalate shared-file conflicts, scope expansion, missing authority, and ambiguous instructions upward instead of silently broadening scope.
+6. **Self-verification:** Run the smallest useful validation before completion; if validation cannot run, explicitly report the validation gap and why.
+7. **Low-noise communication:** Keep ACKs/progress short and prefer durable state/mailbox/task evidence over pane narrative.`;
 }
 
 function tryReadGitValue(cwd: string, args: string[]): string | null {
@@ -282,9 +315,10 @@ ${verification}
 
 ${fixLoop}
 
-When marking completion, include structured verification evidence in your task result:
+When marking completion, include plain-text evidence in your task result without changing the lifecycle result schema/API:
 - \`Verification:\`
-- One or more PASS/FAIL checks with command/output references
+- One or more \`PASS\`/\`FAIL\` lines with command/output references for each required check
+- \`commit_status:\` with either the committed short SHA or a clear not-committed reason
 `;
 }
 
@@ -345,6 +379,8 @@ When your mailbox receives a message, process delivery explicitly:
 1. Read: \`omx team api mailbox-list --input "{\"team_name\":\"${teamName}\",\"worker\":\"<your-worker-name>\"}" --json\`
 2. Mark delivered: \`omx team api mailbox-mark-delivered --input "{\"team_name\":\"${teamName}\",\"worker\":\"<your-worker-name>\",\"message_id\":\"<MESSAGE_ID>\"}" --json\`
 3. If you reply, include concrete progress and keep executing your assigned work or the next feasible task after replying.
+
+${buildUnattendedWorkerOperatingContract("compact")}
 
 ## Rules
 - Do NOT edit files outside the paths listed in your task description
@@ -811,6 +847,8 @@ When using \`omx team api send-message\`, ALWAYS include from_worker with YOUR w
 
 Example: omx team api send-message --input "{\"team_name\":\"${teamName}\",\"from_worker\":\"${workerName}\",\"to_worker\":\"leader-fixed\",\"body\":\"ACK: initialized\"}" --json
 
+${buildUnattendedWorkerOperatingContract("compact")}
+
 ${delegationSection}
 ${buildVerificationSection("each assigned task")}
 
@@ -872,6 +910,8 @@ ${taskDescription}
 6. Complete/fail via lifecycle transition API (\`omx team api transition-task-status --json\`) from \`"in_progress"\` to \`"completed"\` or \`"failed"\` (include \`result\`/\`error\`)
 7. Use \`omx team api release-task-claim --json\` only for rollback to \`pending\`
 8. Write \`{"state": "idle", "updated_at": "<current ISO timestamp>"}\` to your status file
+
+${buildUnattendedWorkerOperatingContract("compact")}
 
 ${delegationSection}
 ${buildVerificationSection(taskDescription)}


### PR DESCRIPTION
## Summary

Make team worker handoff reports durable and leader-readable for unattended team runs.

This PR adds an explicit unattended worker operating contract to:

- generated worker root `AGENTS.md` content
- compact worker overlay / initial inbox / follow-up inbox reminders
- the fallback `skills/worker/SKILL.md` mirror
- focused worker-bootstrap tests that lock the contract in place

## Problem statement

Team workers already receive isolated worktrees and can edit, test, and commit independently. The weak point was not file access; it was handoff quality. When a worker completed with free-form or sparse text, the leader/operator often had to inspect the tmux pane to answer basic questions:

- What changed?
- Which files changed?
- Was validation run?
- Did checks pass or fail?
- Was there a commit?
- Is any failure caused by this change or by baseline drift?
- What should the leader do next?

That makes unattended team mode less useful because the leader cannot reliably integrate worker results from state/mailbox/task payloads alone.

## Root cause

Worker bootstrap guidance focused on lifecycle mechanics: ACK, inbox, claim, lifecycle transition, mailbox handling, and status updates. It did not consistently require a structured result shape for unattended operation.

As a result, workers could technically finish the task while leaving evidence in a human-pane-readable narrative instead of a durable leader-readable result.

## What changed

- Added a full `Unattended Worker Operating Contract` to generated worker root `AGENTS.md` content.
- Added compact contract reminders to generated worker overlay, initial inbox, and follow-up task inboxes.
- Updated completion guidance to require plain-text `Verification:` evidence and `commit_status:` inside the existing lifecycle result text.
- Mirrored the same contract in `skills/worker/SKILL.md` for fallback/manual skill loading.
- Added focused assertions to `worker-bootstrap.test.ts` to verify the generated surfaces include:
  - lifecycle sequence
  - leader-readable fields
  - `Verification:` PASS/FAIL command evidence
  - `commit_status` values
  - blocker / next-action reporting
  - ownership escalation rules
  - explicit no-new-schema/API wording

## Why this design

This keeps the change at the correct control surface: worker startup instructions and worker skill guidance.

It intentionally does **not** add a new result schema or runtime API. The existing `result`, `error`, mailbox, and status text payloads remain the durable handoff surface. The PR only makes workers format those payloads consistently enough that the leader can decide the next step without pane inspection.

Rejected alternatives:

- **New skill as the primary mechanism:** less efficient than putting the contract into worker root instructions that every team worker already receives.
- **New runtime result schema:** higher compatibility risk and not required for the current problem.
- **More pane inspection automation:** treats the symptom instead of making worker handoffs durable at the source.

## Overlap assessment

Classification: **adjacent but distinct**.

Checked existing issues/PRs for worker bootstrap, team worker, pane inspection, leader-readable reports, `Verification:`, and `commit_status`.

Relevant prior work:

- #461 fixed claim-safe lifecycle API usage in worker bootstrap instructions.
- #930 canonicalized worker role guidance at the worktree root.
- #1924 added worker subagent delegation contracts.
- #1976 required delegation evidence for broad team tasks.
- #1981 reduced model-backed team status inspection by default.
- #1774 simplified pane status inspection rendering.
- #710 described broader team progress inference/orchestration brittleness.

This PR is not a duplicate: it specifically closes the unattended handoff/reporting gap by standardizing worker result text, not lifecycle claiming, role propagation, delegation policy, or status-pane rendering.

## Validation

- PASS: `npm install`
- PASS: `npm run build`
- PASS: `node --test dist/team/__tests__/worker-bootstrap.test.js` -> 46/46 tests passed
- PASS: `npx biome lint src/team/worker-bootstrap.ts src/team/__tests__/worker-bootstrap.test.ts skills/worker/SKILL.md` -> checked 2 files, no fixes applied
- PASS: `git diff --check`

## Risk / compatibility

Compatibility risk is low:

- No runtime API changes.
- No task schema changes.
- No mailbox/status schema changes.
- No change to worker claim/transition mechanics.
- Existing consumers can continue reading plain `result` / `error` strings.

Main residual risk: prompt text can guide workers but cannot guarantee perfect compliance from every model invocation. The added tests only guarantee that the contract is present on generated worker surfaces.

## Files changed

- `src/team/worker-bootstrap.ts`
- `src/team/__tests__/worker-bootstrap.test.ts`
- `skills/worker/SKILL.md`
