### PR TITLE
fix(team): preserve approved handoff bindings

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -29,6 +29,12 @@ const OMX_CLI_PATH = fileURLToPath(new URL('../omx.js', import.meta.url));
 const ORIGINAL_OMX_TEAM_WORKER = process.env.OMX_TEAM_WORKER;
 const ORIGINAL_OMX_TEAM_STATE_ROOT = process.env.OMX_TEAM_STATE_ROOT;
 
+function encodeApprovedExecutionTask(task: string, quote: 'single' | 'double'): string {
+  return quote === 'single'
+    ? `'${task.replace(/'/g, "\\'")}'`
+    : `"${task.replace(/"/g, '\\"')}"`;
+}
+
 beforeEach(() => {
   delete process.env.OMX_TEAM_WORKER;
   delete process.env.OMX_TEAM_STATE_ROOT;
@@ -295,6 +301,82 @@ describe('parseTeamStartArgs', () => {
         sameFilePath(result.parsed.approvedExecution?.prd_path ?? '', boundPrdPath),
         true,
       );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves escaped apostrophes while keeping other backslashes in persisted approved follow-ups', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-bound-quoted-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const boundTask = "Fix Bob's regression in C:\\\\tmp";
+      const boundCommand = `omx team 2:executor ${encodeApprovedExecutionTask(boundTask, 'single')}`;
+      const boundPrdPath = join(plansDir, 'prd-issue-831-quoted.md');
+      await writeFile(
+        boundPrdPath,
+        `# Approved plan\n\nLaunch via ${boundCommand}\n`,
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-831-quoted.md'), '# Test spec\n');
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'team-state.json'),
+        JSON.stringify({ active: true, team_name: 'bound-team-quoted' }, null, 2),
+      );
+      await writePersistedApprovedTeamExecutionBinding('bound-team-quoted', wd, {
+        prd_path: boundPrdPath,
+        task: boundTask,
+        command: boundCommand,
+      });
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, boundTask);
+      assert.equal(result.parsed.workerCount, 2);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.approvedExecution?.task, boundTask);
+      assert.equal(result.parsed.approvedExecution?.command, boundCommand);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves literal backslashes in double-quoted persisted approved follow-ups', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-bound-double-quoted-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const boundTask = String.raw`Use C:\tmp and keep \n literal plus "quotes"`;
+      const boundCommand = `omx team 2:executor ${encodeApprovedExecutionTask(boundTask, 'double')}`;
+      const boundPrdPath = join(plansDir, 'prd-issue-831-double-quoted.md');
+      await writeFile(
+        boundPrdPath,
+        `# Approved plan\n\nLaunch via ${boundCommand}\n`,
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-831-double-quoted.md'), '# Test spec\n');
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'team-state.json'),
+        JSON.stringify({ active: true, team_name: 'bound-team-double-quoted' }, null, 2),
+      );
+      await writePersistedApprovedTeamExecutionBinding('bound-team-double-quoted', wd, {
+        prd_path: boundPrdPath,
+        task: boundTask,
+        command: boundCommand,
+      });
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, boundTask);
+      assert.equal(result.parsed.workerCount, 2);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.approvedExecution?.task, boundTask);
+      assert.equal(result.parsed.approvedExecution?.command, boundCommand);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../team.js';
 import { readModeState } from '../../modes/base.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
+import { sameFilePath } from '../../utils/paths.js';
 import {
   appendTeamEvent,
   createTask,
@@ -21,6 +22,7 @@ import {
   writeTaskApproval,
   writeWorkerStatus,
 } from '../../team/state.js';
+import { writePersistedApprovedTeamExecutionBinding } from '../../team/approved-execution.js';
 import { isRealTmuxAvailable, withTempTmuxSession, type TempTmuxSessionFixture } from '../../team/__tests__/tmux-test-fixture.js';
 
 const OMX_CLI_PATH = fileURLToPath(new URL('../omx.js', import.meta.url));
@@ -239,6 +241,182 @@ describe('parseTeamStartArgs', () => {
       const result = parseTeamStartArgs(['team으로', '해줘']);
       assert.equal(result.parsed.task, 'Execute approved issue 831 plan');
       assert.equal(result.parsed.workerCount, 3);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers the persisted approved binding over a newer latest approved hint for a short follow-up', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-bound-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const boundPrdPath = join(plansDir, 'prd-20260501T010203Z-issue-831.md');
+      await writeFile(
+        boundPrdPath,
+        '# Approved plan\n\nLaunch via omx team 2:executor "Execute approved issue 831 plan"\n',
+      );
+      await writeFile(
+        join(plansDir, 'test-spec-20260501T010203Z-issue-831.md'),
+        '# Test spec\n',
+      );
+      await writeFile(
+        join(plansDir, 'prd-20260502T010203Z-issue-999.md'),
+        '# Approved plan\n\nLaunch via omx team 5:debugger "Execute newer approved issue 999 plan"\n',
+      );
+      await writeFile(
+        join(plansDir, 'test-spec-20260502T010203Z-issue-999.md'),
+        '# Test spec\n',
+      );
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'team-state.json'),
+        JSON.stringify({ active: true, team_name: 'bound-team' }, null, 2),
+      );
+      await writePersistedApprovedTeamExecutionBinding('bound-team', wd, {
+        prd_path: boundPrdPath,
+        task: 'Execute approved issue 831 plan',
+        command: 'omx team 2:executor "Execute approved issue 831 plan"',
+      });
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, 'Execute approved issue 831 plan');
+      assert.equal(result.parsed.workerCount, 2);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.approvedExecution?.task, 'Execute approved issue 831 plan');
+      assert.equal(
+        result.parsed.approvedExecution?.command,
+        'omx team 2:executor "Execute approved issue 831 plan"',
+      );
+      assert.equal(
+        sameFilePath(result.parsed.approvedExecution?.prd_path ?? '', boundPrdPath),
+        true,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses the persisted approved binding from session-scoped team state for a short follow-up', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-bound-session-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const sessionId = 'sess-team-followup-bound';
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-954.md');
+      await writeFile(
+        prdPath,
+        '# Approved plan\n\nLaunch via omx team 5:executor "Execute approved session-scoped plan"\n',
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-954.md'), '# Test spec\n');
+      await mkdir(join(wd, '.omx', 'state', 'sessions', sessionId), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'session.json'),
+        JSON.stringify({ session_id: sessionId }, null, 2),
+      );
+      await writeFile(
+        join(wd, '.omx', 'state', 'sessions', sessionId, 'team-state.json'),
+        JSON.stringify({
+          active: true,
+          team_name: 'bound-team-session',
+          task_description: 'Execute approved session-scoped plan',
+          agent_count: 5,
+        }, null, 2),
+      );
+      await writePersistedApprovedTeamExecutionBinding('bound-team-session', wd, {
+        prd_path: prdPath,
+        task: 'Execute approved session-scoped plan',
+        command: 'omx team 5:executor "Execute approved session-scoped plan"',
+      });
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, 'Execute approved session-scoped plan');
+      assert.equal(result.parsed.workerCount, 5);
+      assert.equal(result.parsed.agentType, 'executor');
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for a short follow-up when the persisted approved binding is malformed', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-malformed-binding-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(plansDir, { recursive: true });
+      await mkdir(join(stateDir, 'team', 'broken-team'), { recursive: true });
+      await writeFile(
+        join(plansDir, 'prd-issue-831.md'),
+        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 831 plan"\n',
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-831.md'), '# Test spec\n');
+      await writeFile(
+        join(stateDir, 'team-state.json'),
+        JSON.stringify({ active: true, team_name: 'broken-team' }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'team', 'broken-team', 'approved-execution.json'),
+        '{"prd_path":42}',
+        'utf-8',
+      );
+
+      assert.throws(
+        () => parseTeamStartArgs(['team']),
+        /approved_execution_binding_malformed:broken-team/,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for a short follow-up when the persisted approved binding is stale even if a newer PRD is ready', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-bound-stale-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const stalePrdPath = join(plansDir, 'prd-issue-955-alpha.md');
+      await writeFile(
+        stalePrdPath,
+        '# Approved plan\n\nLaunch via omx team 4:executor "Execute approved alpha plan"\n',
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-955-alpha.md'), '# Test spec\n');
+      await writeFile(
+        join(plansDir, 'prd-issue-955-zeta.md'),
+        '# Approved plan\n\nLaunch via omx team 6:debugger "Execute approved zeta plan"\n',
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-955-zeta.md'), '# Test spec\n');
+      await rm(stalePrdPath, { force: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'team-state.json'),
+        JSON.stringify({
+          active: true,
+          team_name: 'bound-team-stale',
+          task_description: 'Execute approved alpha plan',
+          agent_count: 4,
+        }, null, 2),
+      );
+      await writePersistedApprovedTeamExecutionBinding('bound-team-stale', wd, {
+        prd_path: stalePrdPath,
+        task: 'Execute approved alpha plan',
+      });
+
+      assert.throws(
+        () => parseTeamStartArgs(['team']),
+        /approved_execution_binding_stale:.*Execute approved alpha plan/,
+      );
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../team.js';
 import { readModeState } from '../../modes/base.js';
+import { readApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
 import { sameFilePath } from '../../utils/paths.js';
 import {
@@ -22,7 +23,10 @@ import {
   writeTaskApproval,
   writeWorkerStatus,
 } from '../../team/state.js';
-import { writePersistedApprovedTeamExecutionBinding } from '../../team/approved-execution.js';
+import {
+  buildApprovedTeamExecutionBinding,
+  writePersistedApprovedTeamExecutionBinding,
+} from '../../team/approved-execution.js';
 import { isRealTmuxAvailable, withTempTmuxSession, type TempTmuxSessionFixture } from '../../team/__tests__/tmux-test-fixture.js';
 
 const OMX_CLI_PATH = fileURLToPath(new URL('../omx.js', import.meta.url));
@@ -307,7 +311,7 @@ describe('parseTeamStartArgs', () => {
     }
   });
 
-  it('preserves escaped apostrophes while keeping other backslashes in persisted approved follow-ups', async () => {
+  it('round-trips single-quoted approved follow-ups from launch hint encoding through persisted binding', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-bound-quoted-'));
     const previousCwd = process.cwd();
     try {
@@ -327,11 +331,15 @@ describe('parseTeamStartArgs', () => {
         join(wd, '.omx', 'state', 'team-state.json'),
         JSON.stringify({ active: true, team_name: 'bound-team-quoted' }, null, 2),
       );
-      await writePersistedApprovedTeamExecutionBinding('bound-team-quoted', wd, {
-        prd_path: boundPrdPath,
-        task: boundTask,
-        command: boundCommand,
-      });
+      const approvedHint = readApprovedExecutionLaunchHint(wd, 'team');
+      assert.ok(approvedHint);
+      assert.equal(approvedHint?.task, boundTask);
+      assert.equal(approvedHint?.command, boundCommand);
+      await writePersistedApprovedTeamExecutionBinding(
+        'bound-team-quoted',
+        wd,
+        buildApprovedTeamExecutionBinding(approvedHint),
+      );
 
       const result = parseTeamStartArgs(['team']);
       assert.equal(result.parsed.task, boundTask);
@@ -345,7 +353,7 @@ describe('parseTeamStartArgs', () => {
     }
   });
 
-  it('preserves literal backslashes in double-quoted persisted approved follow-ups', async () => {
+  it('round-trips double-quoted approved follow-ups from launch hint encoding through persisted binding', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-bound-double-quoted-'));
     const previousCwd = process.cwd();
     try {
@@ -365,11 +373,15 @@ describe('parseTeamStartArgs', () => {
         join(wd, '.omx', 'state', 'team-state.json'),
         JSON.stringify({ active: true, team_name: 'bound-team-double-quoted' }, null, 2),
       );
-      await writePersistedApprovedTeamExecutionBinding('bound-team-double-quoted', wd, {
-        prd_path: boundPrdPath,
-        task: boundTask,
-        command: boundCommand,
-      });
+      const approvedHint = readApprovedExecutionLaunchHint(wd, 'team');
+      assert.ok(approvedHint);
+      assert.equal(approvedHint?.task, boundTask);
+      assert.equal(approvedHint?.command, boundCommand);
+      await writePersistedApprovedTeamExecutionBinding(
+        'bound-team-double-quoted',
+        wd,
+        buildApprovedTeamExecutionBinding(approvedHint),
+      );
 
       const result = parseTeamStartArgs(['team']);
       assert.equal(result.parsed.task, boundTask);

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,8 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { omxStateDir } from '../utils/paths.js';
 import { updateModeState, startMode, readModeState } from '../modes/base.js';
-import { getStatePath, validateSessionId } from '../mcp/state-paths.js';
+import { getStateFilePath, getStatePath, validateSessionId } from '../mcp/state-paths.js';
 import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime, type TeamSnapshot } from '../team/runtime.js';
 import { buildRepoAwareTeamExecutionPlan } from '../team/repo-aware-decomposition.js';
 import { DEFAULT_MAX_WORKERS } from '../team/state.js';
@@ -14,6 +13,7 @@ import { classifyTaskSize } from '../hooks/task-size-detector.js';
 import {
   readApprovedExecutionLaunchHint,
   readApprovedExecutionLaunchHintOutcome,
+  type ApprovedExecutionLaunchHint,
   type ApprovedRepositoryContextSummary,
 } from '../planning/artifacts.js';
 import { routeTaskToRole } from '../team/role-router.js';
@@ -33,6 +33,11 @@ import { teamReadConfig as readTeamConfig, teamReadPhase as readTeamPhase } from
 import { resolveTeamNameForCurrentContext } from '../team/team-identity.js';
 import { recordLeaderRuntimeActivity } from '../team/leader-activity.js';
 import { readTeamPaneStatus } from '../team/pane-status.js';
+import {
+  buildApprovedTeamExecutionBinding,
+  resolvePersistedApprovedTeamExecutionContinuityStateSync,
+  type ApprovedTeamExecutionBinding,
+} from '../team/approved-execution.js';
 
 interface TeamCliOptions {
   verbose?: boolean;
@@ -48,6 +53,7 @@ interface ParsedTeamArgs {
   displayName?: string;
   allowRepoAwareDagHandoff: boolean;
   approvedRepositoryContextSummary?: ApprovedRepositoryContextSummary;
+  approvedExecution?: ApprovedTeamExecutionBinding;
 }
 
 interface TeamFollowupContext {
@@ -56,6 +62,7 @@ interface TeamFollowupContext {
   explicitWorkerCount: boolean;
   agentType?: string;
   explicitAgentType?: boolean;
+  approvedHint?: ApprovedExecutionLaunchHint;
 }
 
 function persistExactTeamModeState(
@@ -76,6 +83,9 @@ function persistExactTeamModeState(
 }
 
 function readPersistedTeamFollowupState(cwd: string): {
+  active?: boolean;
+  team_name?: string;
+  team_state_root?: string;
   task?: string;
   task_description?: string;
   workerCount?: number;
@@ -84,21 +94,64 @@ function readPersistedTeamFollowupState(cwd: string): {
   agent_types?: string;
   linkedRalph?: boolean;
 } | null {
-  const path = join(omxStateDir(cwd), 'team-state.json');
-  if (!existsSync(path)) return null;
-  try {
-    return JSON.parse(readFileSync(path, 'utf-8')) as {
-      task?: string;
-      workerCount?: number;
-      agentType?: string;
-      linkedRalph?: boolean;
-      task_description?: string;
-      agent_count?: number;
-      agent_types?: string;
-    };
-  } catch {
-    return null;
+  const readState = (path: string) => {
+    if (!existsSync(path)) return null;
+    try {
+      return JSON.parse(readFileSync(path, 'utf-8')) as {
+        active?: boolean;
+        team_name?: string;
+        team_state_root?: string;
+        task?: string;
+        workerCount?: number;
+        agentType?: string;
+        linkedRalph?: boolean;
+        task_description?: string;
+        agent_count?: number;
+        agent_types?: string;
+      };
+    } catch {
+      return null;
+    }
+  };
+
+  const isActiveTeamState = (state: {
+    active?: boolean;
+    team_name?: string;
+  } | null): state is {
+    active: true;
+    team_name: string;
+    team_state_root?: string;
+    task?: string;
+    task_description?: string;
+    workerCount?: number;
+    agent_count?: number;
+    agentType?: string;
+    agent_types?: string;
+    linkedRalph?: boolean;
+  } => state?.active === true && typeof state.team_name === 'string' && state.team_name.trim() !== '';
+
+  const sessionStatePath = getStateFilePath('session.json', cwd);
+  let scopedSessionId: string | undefined;
+  if (existsSync(sessionStatePath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(sessionStatePath, 'utf-8')) as { session_id?: unknown };
+      scopedSessionId = validateSessionId(parsed.session_id);
+    } catch {
+      // Best-effort state lookup only.
+    }
   }
+
+  if (scopedSessionId) {
+    const scopedState = readState(getStatePath('team', cwd, scopedSessionId));
+    if (isActiveTeamState(scopedState)) {
+      return scopedState;
+    }
+  }
+
+  const path = getStatePath('team', cwd);
+  if (!existsSync(path)) return null;
+  const state = readState(path);
+  return isActiveTeamState(state) ? state : null;
 }
 
 function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFollowupContext | null {
@@ -109,12 +162,40 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
   const shortFollowup = ['team', 'team으로 해줘', 'team으로 해주세요'].includes(normalizedTask);
   if (!shortFollowup) return null;
 
-  const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team');
-  if (approvedHintOutcome.status === 'ambiguous') {
-    throw new Error('approved_execution_hint_ambiguous:team');
+  const persistedTeamName = typeof existingTeamState?.team_name === 'string'
+    ? existingTeamState.team_name.trim()
+    : '';
+  const persistedTeamStateRoot = typeof existingTeamState?.team_state_root === 'string'
+    && existingTeamState.team_state_root.trim() !== ''
+    ? existingTeamState.team_state_root.trim()
+    : undefined;
+  let approvedHint: ApprovedExecutionLaunchHint | null = null;
+
+  if (persistedTeamName !== '') {
+    const continuity = resolvePersistedApprovedTeamExecutionContinuityStateSync(
+      persistedTeamName,
+      cwd,
+      persistedTeamStateRoot,
+    );
+    if (continuity.status === 'malformed') {
+      throw new Error(`approved_execution_binding_malformed:${persistedTeamName}`);
+    }
+    if (continuity.status === 'stale') {
+      throw new Error(`approved_execution_binding_stale:${continuity.binding.prd_path}:${continuity.binding.task}`);
+    }
+    if (continuity.status === 'valid') {
+      approvedHint = continuity.approvedHint;
+    }
   }
-  if (approvedHintOutcome.status !== 'resolved') return null;
-  const approvedHint = approvedHintOutcome.hint;
+
+  if (!approvedHint) {
+    const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team');
+    if (approvedHintOutcome.status === 'ambiguous') {
+      throw new Error('approved_execution_hint_ambiguous:team');
+    }
+    if (approvedHintOutcome.status !== 'resolved') return null;
+    approvedHint = approvedHintOutcome.hint;
+  }
 
   const persistedTask = typeof existingTeamState?.task_description === 'string'
     ? existingTeamState.task_description
@@ -133,6 +214,7 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
       explicitWorkerCount: true,
       agentType: approvedHint.agentType,
       explicitAgentType: approvedHint.agentType != null,
+      approvedHint,
     };
   }
 
@@ -142,6 +224,7 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
     explicitWorkerCount: approvedHint.workerCount != null,
     agentType: approvedHint.agentType,
     explicitAgentType: approvedHint.agentType != null,
+    approvedHint,
   };
 }
 
@@ -761,7 +844,8 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     }
   }
 
-  const approvedHint = readApprovedExecutionLaunchHint(cwd, 'team', { task: effectiveTask });
+  const approvedHint = followupContext?.approvedHint
+    ?? readApprovedExecutionLaunchHint(cwd, 'team', { task: effectiveTask });
   const matchesApprovedLaunchHint = approvedHint?.task.trim() === effectiveTask.trim()
     && (approvedHint.workerCount == null || approvedHint.workerCount === workerCount)
     && (approvedHint.agentType == null || approvedHint.agentType === agentType);
@@ -781,6 +865,7 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     displayName: teamName,
     allowRepoAwareDagHandoff,
     ...(approvedRepositoryContextSummary ? { approvedRepositoryContextSummary } : {}),
+    ...(allowRepoAwareDagHandoff && approvedHint ? { approvedExecution: buildApprovedTeamExecutionBinding(approvedHint) } : {}),
   };
 }
 
@@ -1539,7 +1624,11 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     executionPlan.workerCount,
     tasks,
     cwd,
-    { worktreeMode, decompositionMetadata: executionPlan.metadata },
+    {
+      worktreeMode,
+      decompositionMetadata: executionPlan.metadata,
+      approvedExecution: parsed.approvedExecution ?? null,
+    },
   );
 
   await ensureTeamModeState({ ...effectiveParsed, teamName: runtime.teamName, displayName: runtime.config.display_name ?? effectiveParsed.displayName }, tasks);

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -158,10 +158,10 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
   const normalizedTask = task.trim();
   if (!normalizedTask) return null;
 
-  const existingTeamState = readPersistedTeamFollowupState(cwd);
   const shortFollowup = ['team', 'team으로 해줘', 'team으로 해주세요'].includes(normalizedTask);
   if (!shortFollowup) return null;
 
+  const existingTeamState = readPersistedTeamFollowupState(cwd);
   const persistedTeamName = typeof existingTeamState?.team_name === 'string'
     ? existingTeamState.team_name.trim()
     : '';

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -18,6 +18,12 @@ import { packageRoot } from '../../utils/paths.js';
 
 let tempDir: string;
 
+function encodeApprovedExecutionTask(task: string, quote: 'single' | 'double'): string {
+  return quote === 'single'
+    ? `'${task.replace(/'/g, "\\'")}'`
+    : `"${task.replace(/"/g, '\\"')}"`;
+}
+
 function makeCtx(overrides: Partial<StageContext> = {}): StageContext {
   return {
     task: 'test task',
@@ -363,12 +369,10 @@ describe('Team Exec Stage', () => {
   it('preserves literal backslashes in single-quoted approved handoff text', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });
+    const expectedTask = String.raw`Fix C:\\tmp and keep \n literal`;
     await writeFile(
       join(plansDir, 'prd-zeta.md'),
-      String.raw`# Zeta plan
-
-Launch via $team 2:executor 'Fix C:\\tmp and keep \n literal'
-`,
+      `# Zeta plan\n\nLaunch via $team 2:executor ${encodeApprovedExecutionTask(expectedTask, 'single')}\n`,
     );
     await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
 
@@ -387,7 +391,35 @@ Launch via $team 2:executor 'Fix C:\\tmp and keep \n literal'
     assert.equal(result.status, 'completed');
     const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
     const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
-    const expectedTask = String.raw`Fix C:\\tmp and keep \n literal`;
+    assert.equal(descriptor.task, expectedTask);
+    assert.ok(instruction.includes(JSON.stringify(expectedTask)));
+  });
+
+  it('preserves literal backslashes in double-quoted approved handoff text', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const expectedTask = String.raw`Use C:\tmp and keep \n literal plus "quotes"`;
+    await writeFile(
+      join(plansDir, 'prd-zeta.md'),
+      `# Zeta plan\n\nLaunch via omx team 2:executor ${encodeApprovedExecutionTask(expectedTask, 'double')}\n`,
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+
+    const stage = createTeamExecStage();
+    const result = await stage.run(makeCtx({
+      task: 'original request task',
+      artifacts: {
+        ralplan: {
+          task: 'original request task',
+          stage: 'ralplan',
+          latestPlanPath: join('.omx', 'plans', 'prd-zeta.md'),
+        },
+      },
+    }));
+
+    assert.equal(result.status, 'completed');
+    const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+    const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
     assert.equal(descriptor.task, expectedTask);
     assert.ok(instruction.includes(JSON.stringify(expectedTask)));
   });

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -15,7 +15,12 @@ import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
 } from '../../team/followup-planner.js';
-import { readLatestPlanningArtifacts, readPlanningArtifacts, type PlanningArtifacts } from '../../planning/artifacts.js';
+import {
+  decodeApprovedExecutionQuotedValue,
+  readLatestPlanningArtifacts,
+  readPlanningArtifacts,
+  type PlanningArtifacts,
+} from '../../planning/artifacts.js';
 import { packageRoot, sameFilePath } from '../../utils/paths.js';
 
 export interface TeamExecStageOptions {
@@ -33,23 +38,6 @@ export interface TeamExecStageOptions {
 }
 
 const APPROVED_TEAM_LAUNCH_PATTERN = /(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
-
-function decodeQuotedValue(raw: string): string | null {
-  const normalized = raw.trim();
-  if (!normalized) return null;
-
-  try {
-    return JSON.parse(normalized) as string;
-  } catch {
-    if (normalized.startsWith('"') && normalized.endsWith('"')) {
-      return normalized.slice(1, -1);
-    }
-    if (normalized.startsWith("'") && normalized.endsWith("'")) {
-      return normalized.slice(1, -1).replace(/\\'/g, "'");
-    }
-    return null;
-  }
-}
 
 function resolveRequestedTask(ctx: StageContext, ralplanArtifacts?: Record<string, unknown>): string {
   const ralplanTask = typeof ralplanArtifacts?.task === 'string' ? ralplanArtifacts.task.trim() : '';
@@ -171,7 +159,7 @@ function resolveApprovedTeamTaskFromPlanPath(
     throw new Error(`team_exec_approved_handoff_ambiguous:${approvedPlanPath}`);
   }
 
-  const task = matches[0]?.groups?.task ? decodeQuotedValue(matches[0].groups.task) : null;
+  const task = matches[0]?.groups?.task ? decodeApprovedExecutionQuotedValue(matches[0].groups.task) : null;
   if (!task) {
     throw new Error(`team_exec_approved_handoff_missing:${approvedPlanPath}`);
   }

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  decodeApprovedExecutionQuotedValue,
   isPlanningComplete,
   readApprovedExecutionLaunchHint,
   readLatestPlanningArtifacts,
@@ -14,6 +15,12 @@ import {
 import { readTeamDagHandoffForLatestPlan } from '../../team/dag-schema.js';
 
 let tempDir: string;
+
+function encodeApprovedExecutionTask(task: string, quote: 'single' | 'double'): string {
+  return quote === 'single'
+    ? `'${task.replace(/'/g, "\\'")}'`
+    : `"${task.replace(/"/g, '\\"')}"`;
+}
 
 async function setup(): Promise<void> {
   tempDir = await mkdtemp(join(tmpdir(), 'omx-planning-artifacts-'));
@@ -28,6 +35,27 @@ async function cleanup(): Promise<void> {
 describe('planning artifacts', () => {
   beforeEach(async () => { await setup(); });
   afterEach(async () => { await cleanup(); });
+
+  it('round-trips single-quoted approved execution tasks with only escaped apostrophes normalized', () => {
+    const task = String.raw`Fix Bob's regression in C:\\tmp`;
+    assert.equal(
+      decodeApprovedExecutionQuotedValue(encodeApprovedExecutionTask(task, 'single')),
+      task,
+    );
+  });
+
+  it('round-trips double-quoted approved execution tasks without applying JSON escapes', () => {
+    const task = String.raw`Use C:\tmp and keep \n literal plus "quotes"`;
+    assert.equal(
+      decodeApprovedExecutionQuotedValue(encodeApprovedExecutionTask(task, 'double')),
+      task,
+    );
+    const literalEscapeTask = String.raw`Keep \t and \u1234 literal`;
+    assert.equal(
+      decodeApprovedExecutionQuotedValue(encodeApprovedExecutionTask(literalEscapeTask, 'double')),
+      literalEscapeTask,
+    );
+  });
 
   it('requires both PRD and test spec for planning completion', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -105,20 +105,16 @@ export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
   return Boolean(selection.prdPath) && selection.testSpecPaths.length > 0;
 }
 
-function decodeQuotedValue(raw: string): string | null {
+export function decodeApprovedExecutionQuotedValue(raw: string): string | null {
   const normalized = raw.trim();
   if (!normalized) return null;
-  try {
-    return JSON.parse(normalized) as string;
-  } catch {
-    if (
-      (normalized.startsWith('"') && normalized.endsWith('"'))
-      || (normalized.startsWith("'") && normalized.endsWith("'"))
-    ) {
-      return normalized.slice(1, -1);
-    }
-    return null;
+  if (normalized.startsWith('"') && normalized.endsWith('"')) {
+    return normalized.slice(1, -1).replace(/\\"/g, '"');
   }
+  if (normalized.startsWith("'") && normalized.endsWith("'")) {
+    return normalized.slice(1, -1).replace(/\\'/g, "'");
+  }
+  return null;
 }
 
 function artifactPathSuffix(path: string, prefixPattern: RegExp): string | null {
@@ -337,7 +333,7 @@ function selectLaunchHintMatch(
       if (!command || command !== normalizedCommand) {
         return [];
       }
-      const task = match.groups?.task ? decodeQuotedValue(match.groups.task) : null;
+      const task = match.groups?.task ? decodeApprovedExecutionQuotedValue(match.groups.task) : null;
       return task ? [{ match, task }] : [];
     });
     if (exactMatches.length === 0) return { status: 'no-match' };
@@ -347,7 +343,7 @@ function selectLaunchHintMatch(
 
   if (!normalizedTask) {
     const decodedMatches = matches.flatMap((match) => {
-      const task = match.groups?.task ? decodeQuotedValue(match.groups.task) : null;
+      const task = match.groups?.task ? decodeApprovedExecutionQuotedValue(match.groups.task) : null;
       return task ? [{ match, task }] : [];
     });
     if (decodedMatches.length === 0) return { status: 'no-match' };
@@ -356,7 +352,7 @@ function selectLaunchHintMatch(
   }
 
   const exactMatches = matches.flatMap((match) => {
-    const task = match.groups?.task ? decodeQuotedValue(match.groups.task) : null;
+    const task = match.groups?.task ? decodeApprovedExecutionQuotedValue(match.groups.task) : null;
     return task && task.trim() === normalizedTask ? [{ match, task }] : [];
   });
   if (exactMatches.length === 0) return { status: 'no-match' };

--- a/src/team/__tests__/approved-execution.test.ts
+++ b/src/team/__tests__/approved-execution.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  readPersistedApprovedTeamExecutionBinding,
+  readPersistedApprovedTeamExecutionBindingStateSync,
+  resolvePersistedApprovedTeamExecutionContinuityState,
+  writePersistedApprovedTeamExecutionBinding,
+} from '../approved-execution.js';
+
+describe('approved execution binding', () => {
+  it('writes and reads a normalized approved execution binding under the team state root', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-write-'));
+    try {
+      await writePersistedApprovedTeamExecutionBinding('alpha-team', cwd, {
+        prd_path: '  /tmp/prd-alpha.md  ',
+        task: '  Execute approved alpha plan  ',
+        command: '  omx team 1:executor "Execute approved alpha plan"  ',
+      });
+
+      const binding = await readPersistedApprovedTeamExecutionBinding('alpha-team', cwd);
+      assert.deepEqual(binding, {
+        prd_path: '/tmp/prd-alpha.md',
+        task: 'Execute approved alpha plan',
+        command: 'omx team 1:executor "Execute approved alpha plan"',
+      });
+      assert.deepEqual(
+        Object.keys(
+          JSON.parse(
+            readFileSync(
+              join(cwd, '.omx', 'state', 'team', 'alpha-team', 'approved-execution.json'),
+              'utf-8',
+            ),
+          ) as Record<string, unknown>,
+        ).sort(),
+        ['command', 'prd_path', 'task'],
+      );
+      assert.equal(
+        existsSync(join(cwd, '.omx', 'state', 'team', 'alpha-team', 'approved-execution.json')),
+        true,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves a valid continuity state for an exact approved team binding', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-valid-'));
+    try {
+      const plansDir = join(cwd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-1314.md');
+      await writeFile(
+        prdPath,
+        '# Approved plan\n\nLaunch via omx team 1:executor "Execute approved issue 1314 plan"\n',
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-1314.md'), '# Test spec\n');
+      await writePersistedApprovedTeamExecutionBinding('bound-team', cwd, {
+        prd_path: prdPath,
+        task: 'Execute approved issue 1314 plan',
+        command: 'omx team 1:executor "Execute approved issue 1314 plan"',
+      });
+
+      const state = await resolvePersistedApprovedTeamExecutionContinuityState('bound-team', cwd);
+      assert.equal(state.status, 'valid');
+      if (state.status !== 'valid') {
+        throw new Error('expected valid continuity state');
+      }
+      assert.equal(state.binding.prd_path, prdPath);
+      assert.equal(state.approvedHint.sourcePath, prdPath);
+      assert.equal(state.approvedHint.task, 'Execute approved issue 1314 plan');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports malformed and stale binding states explicitly', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-invalid-'));
+    try {
+      const teamRoot = join(cwd, '.omx', 'state', 'team', 'broken-team');
+      await mkdir(teamRoot, { recursive: true });
+      await writeFile(join(teamRoot, 'approved-execution.json'), '{"prd_path":42}', 'utf-8');
+      assert.equal(
+        readPersistedApprovedTeamExecutionBindingStateSync('broken-team', cwd).status,
+        'malformed',
+      );
+
+      await writePersistedApprovedTeamExecutionBinding('broken-team', cwd, {
+        prd_path: join(cwd, '.omx', 'plans', 'prd-missing.md'),
+        task: 'Execute missing approved plan',
+      });
+      const state = await resolvePersistedApprovedTeamExecutionContinuityState('broken-team', cwd);
+      assert.equal(state.status, 'stale');
+      if (state.status !== 'stale') {
+        throw new Error('expected stale continuity state');
+      }
+      assert.equal(state.binding.task, 'Execute missing approved plan');
+      assert.equal(
+        JSON.parse(readFileSync(join(teamRoot, 'approved-execution.json'), 'utf-8')).task,
+        'Execute missing approved plan',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/team/__tests__/approved-execution.test.ts
+++ b/src/team/__tests__/approved-execution.test.ts
@@ -106,4 +106,27 @@ describe('approved execution binding', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('rejects unsafe team names before resolving approved binding paths', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-unsafe-team-'));
+    try {
+      await assert.rejects(
+        () => writePersistedApprovedTeamExecutionBinding('../escape', cwd, {
+          prd_path: join(cwd, '.omx', 'plans', 'prd-alpha.md'),
+          task: 'Execute approved alpha plan',
+        }),
+        /invalid_team_name:\.\.\/escape/,
+      );
+      assert.equal(
+        existsSync(join(cwd, '.omx', 'state', 'escape', 'approved-execution.json')),
+        false,
+      );
+      assert.throws(
+        () => readPersistedApprovedTeamExecutionBindingStateSync('../escape', cwd),
+        /invalid_team_name:\.\.\/escape/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -46,6 +46,7 @@ import { resolveAgentReasoningEffort, resolveTeamLowComplexityDefaultModel } fro
 import { readTeamEvents } from '../state/events.js';
 import { sanitizeTeamName } from '../tmux-session.js';
 import { buildInternalTeamName, resolveTeamIdentityScope } from '../team-identity.js';
+import { writePersistedApprovedTeamExecutionBinding } from '../approved-execution.js';
 
 async function initRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-repo-'));
@@ -5966,6 +5967,24 @@ esac
     }
   });
 
+  it('resumeTeam fails closed when the persisted approved binding is stale', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-resume-'));
+    try {
+      await initTeamState('team-approved-resume', 'approved resume test', 'executor', 1, cwd);
+      await writePersistedApprovedTeamExecutionBinding('team-approved-resume', cwd, {
+        prd_path: join(cwd, '.omx', 'plans', 'prd-missing.md'),
+        task: 'Execute missing approved plan',
+      });
+
+      await assert.rejects(
+        () => resumeTeam('team-approved-resume', cwd),
+        /approved_execution_binding_stale:.*Execute missing approved plan/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('resumeTeam returns null for prompt teams when worker handles are missing after restart', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-resume-'));
     const sleeper = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
@@ -6182,6 +6201,114 @@ esac
       if (runtime) {
         await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
       }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam persists approved execution binding under the team state root', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-binding-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+    await writeFile(
+      join(cwd, '.omx', 'plans', 'prd-issue-1314.md'),
+      '# Approved plan\n\nLaunch via omx team 1:executor "Execute approved issue 1314 plan"\n',
+    );
+    await writeFile(join(cwd, '.omx', 'plans', 'test-spec-issue-1314.md'), '# Test spec\n');
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withPromptModeCodexEnv(binDir, {}, () =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-approved-binding',
+            'approved binding persistence test',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            cwd,
+            {
+              approvedExecution: {
+                prd_path: join(cwd, '.omx', 'plans', 'prd-issue-1314.md'),
+                task: 'Execute approved issue 1314 plan',
+                command: 'omx team 1:executor "Execute approved issue 1314 plan"',
+              },
+            },
+          ),
+        ),
+      );
+
+      const bindingPath = join(
+        runtime.config.team_state_root ?? join(cwd, '.omx', 'state'),
+        'team',
+        runtime.teamName,
+        'approved-execution.json',
+      );
+      const binding = JSON.parse(await readFile(bindingPath, 'utf-8')) as Record<string, string>;
+      assert.deepEqual(binding, {
+        prd_path: join(cwd, '.omx', 'plans', 'prd-issue-1314.md'),
+        task: 'Execute approved issue 1314 plan',
+        command: 'omx team 1:executor "Execute approved issue 1314 plan"',
+      });
+      assert.deepEqual(Object.keys(binding).sort(), ['command', 'prd_path', 'task']);
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam fails closed when an explicit approved execution binding is stale', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-binding-stale-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+    const stalePrdPath = join(cwd, '.omx', 'plans', 'prd-issue-1315.md');
+    await writeFile(
+      stalePrdPath,
+      '# Approved plan\n\nLaunch via omx team 1:executor "Execute approved issue 1315 plan"\n',
+    );
+    await writeFile(join(cwd, '.omx', 'plans', 'test-spec-issue-1315.md'), '# Test spec\n');
+    await rm(stalePrdPath, { force: true });
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    try {
+      await assert.rejects(
+        () => withPromptModeCodexEnv(binDir, {}, () =>
+          withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-approved-binding-stale',
+              'approved binding stale start test',
+              'executor',
+              1,
+              [{ subject: 's', description: 'd', owner: 'worker-1' }],
+              cwd,
+              {
+                approvedExecution: {
+                  prd_path: stalePrdPath,
+                  task: 'Execute approved issue 1315 plan',
+                },
+              },
+            ),
+          ),
+        ),
+        /approved_execution_binding_stale:.*Execute approved issue 1315 plan/,
+      );
+      assert.equal(
+        existsSync(join(cwd, '.omx', 'state', 'team', 'team-approved-binding-stale')),
+        false,
+      );
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'os';
 import { existsSync } from 'fs';
 import { HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
 import {
+  DEFAULT_MAX_WORKERS,
   initTeamState,
   createTask,
   writeWorkerIdentity,
@@ -5982,6 +5983,58 @@ esac
       );
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('resumeTeam resolves approved binding continuity against the persisted leader cwd', async () => {
+    const teamName = 'team-approved-shared-root';
+    const leaderCwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-leader-'));
+    const resumeCwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-resume-alt-'));
+    const sharedStateRoot = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-state-'));
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    process.env.OMX_TEAM_STATE_ROOT = sharedStateRoot;
+
+    try {
+      await initTeamState(
+        teamName,
+        'approved resume shared-root test',
+        'executor',
+        1,
+        leaderCwd,
+        DEFAULT_MAX_WORKERS,
+        process.env,
+        {
+          leader_cwd: leaderCwd,
+          team_state_root: sharedStateRoot,
+        },
+      );
+      const plansDir = join(leaderCwd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-2110.md');
+      await writeFile(
+        prdPath,
+        '# Approved plan\n\nLaunch via omx team 1:executor "Execute approved issue 2110 plan"\n',
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-2110.md'), '# Test spec\n');
+      await writePersistedApprovedTeamExecutionBinding(
+        teamName,
+        leaderCwd,
+        {
+          prd_path: prdPath,
+          task: 'Execute approved issue 2110 plan',
+          command: 'omx team 1:executor "Execute approved issue 2110 plan"',
+        },
+        sharedStateRoot,
+      );
+
+      const resumed = await resumeTeam(teamName, resumeCwd);
+      assert.equal(resumed, null);
+    } finally {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(leaderCwd, { recursive: true, force: true });
+      await rm(resumeCwd, { recursive: true, force: true });
+      await rm(sharedStateRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/team/approved-execution.ts
+++ b/src/team/approved-execution.ts
@@ -1,0 +1,211 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import {
+  readApprovedExecutionLaunchHint,
+  readPlanningArtifacts,
+  type ApprovedExecutionLaunchHint,
+} from '../planning/artifacts.js';
+import { resolveCanonicalTeamStateRoot } from './state-root.js';
+import { sameFilePath } from '../utils/paths.js';
+
+export interface ApprovedTeamExecutionBinding {
+  prd_path: string;
+  task: string;
+  command?: string;
+}
+
+export type PersistedApprovedTeamExecutionBindingReadResult =
+  | { status: 'missing' }
+  | { status: 'malformed' }
+  | { status: 'valid'; binding: ApprovedTeamExecutionBinding };
+
+export type PersistedApprovedTeamExecutionContinuityState =
+  | { status: 'missing' }
+  | { status: 'malformed' }
+  | { status: 'stale'; binding: ApprovedTeamExecutionBinding }
+  | { status: 'valid'; binding: ApprovedTeamExecutionBinding; approvedHint: ApprovedExecutionLaunchHint };
+
+export function normalizeApprovedTeamExecutionBinding(
+  value: unknown,
+): ApprovedTeamExecutionBinding | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const binding = value as Record<string, unknown>;
+  if (typeof binding.prd_path !== 'string' || typeof binding.task !== 'string') {
+    return null;
+  }
+
+  const prdPath = binding.prd_path.trim();
+  const task = binding.task.trim();
+  if (prdPath === '' || task === '') {
+    return null;
+  }
+
+  const command = typeof binding.command === 'string'
+    ? binding.command.trim()
+    : '';
+
+  return {
+    prd_path: prdPath,
+    task,
+    ...(command !== '' ? { command } : {}),
+  };
+}
+
+export function buildApprovedTeamExecutionBinding(
+  approvedHint: ApprovedExecutionLaunchHint,
+): ApprovedTeamExecutionBinding {
+  return {
+    prd_path: approvedHint.sourcePath,
+    task: approvedHint.task,
+    ...(approvedHint.command ? { command: approvedHint.command } : {}),
+  };
+}
+
+function approvedTeamExecutionBindingPath(
+  teamName: string,
+  cwd: string,
+  teamStateRoot?: string | null,
+): string {
+  const stateRoot = resolve(teamStateRoot ?? resolveCanonicalTeamStateRoot(cwd));
+  return join(stateRoot, 'team', teamName, 'approved-execution.json');
+}
+
+export async function readPersistedApprovedTeamExecutionBindingState(
+  teamName: string,
+  cwd: string,
+  teamStateRoot?: string | null,
+): Promise<PersistedApprovedTeamExecutionBindingReadResult> {
+  const path = approvedTeamExecutionBindingPath(teamName, cwd, teamStateRoot);
+  if (!existsSync(path)) {
+    return { status: 'missing' };
+  }
+
+  try {
+    const raw = await readFile(path, 'utf-8');
+    const binding = normalizeApprovedTeamExecutionBinding(JSON.parse(raw) as unknown);
+    return binding ? { status: 'valid', binding } : { status: 'malformed' };
+  } catch {
+    return { status: 'malformed' };
+  }
+}
+
+export function readPersistedApprovedTeamExecutionBindingStateSync(
+  teamName: string,
+  cwd: string,
+  teamStateRoot?: string | null,
+): PersistedApprovedTeamExecutionBindingReadResult {
+  const path = approvedTeamExecutionBindingPath(teamName, cwd, teamStateRoot);
+  if (!existsSync(path)) {
+    return { status: 'missing' };
+  }
+
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const binding = normalizeApprovedTeamExecutionBinding(JSON.parse(raw) as unknown);
+    return binding ? { status: 'valid', binding } : { status: 'malformed' };
+  } catch {
+    return { status: 'malformed' };
+  }
+}
+
+export async function readPersistedApprovedTeamExecutionBinding(
+  teamName: string,
+  cwd: string,
+  teamStateRoot?: string | null,
+): Promise<ApprovedTeamExecutionBinding | null> {
+  const state = await readPersistedApprovedTeamExecutionBindingState(teamName, cwd, teamStateRoot);
+  return state.status === 'valid' ? state.binding : null;
+}
+
+export function readPersistedApprovedTeamExecutionBindingSync(
+  teamName: string,
+  cwd: string,
+  teamStateRoot?: string | null,
+): ApprovedTeamExecutionBinding | null {
+  const state = readPersistedApprovedTeamExecutionBindingStateSync(teamName, cwd, teamStateRoot);
+  return state.status === 'valid' ? state.binding : null;
+}
+
+export async function writePersistedApprovedTeamExecutionBinding(
+  teamName: string,
+  cwd: string,
+  binding: ApprovedTeamExecutionBinding | null | undefined,
+  teamStateRoot?: string | null,
+): Promise<void> {
+  const path = approvedTeamExecutionBindingPath(teamName, cwd, teamStateRoot);
+  const normalized = normalizeApprovedTeamExecutionBinding(binding);
+  if (!normalized) {
+    await rm(path, { force: true }).catch(() => {});
+    return;
+  }
+
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(normalized, null, 2)}\n`, 'utf-8');
+}
+
+export function readApprovedTeamExecutionHintFromBinding(
+  cwd: string,
+  binding: ApprovedTeamExecutionBinding | null | undefined,
+): ApprovedExecutionLaunchHint | null {
+  const normalized = normalizeApprovedTeamExecutionBinding(binding);
+  if (!normalized) {
+    return null;
+  }
+
+  const direct = readApprovedExecutionLaunchHint(cwd, 'team', {
+    prdPath: normalized.prd_path,
+    task: normalized.task,
+    command: normalized.command,
+  });
+  if (direct) {
+    return direct;
+  }
+
+  const matchedPrdPath = readPlanningArtifacts(cwd).prdPaths.find((candidatePath) =>
+    sameFilePath(candidatePath, normalized.prd_path));
+  if (!matchedPrdPath || matchedPrdPath === normalized.prd_path) {
+    return null;
+  }
+
+  return readApprovedExecutionLaunchHint(cwd, 'team', {
+    prdPath: matchedPrdPath,
+    task: normalized.task,
+    command: normalized.command,
+  });
+}
+
+export async function resolvePersistedApprovedTeamExecutionContinuityState(
+  teamName: string,
+  cwd: string,
+  teamStateRoot?: string | null,
+): Promise<PersistedApprovedTeamExecutionContinuityState> {
+  const state = await readPersistedApprovedTeamExecutionBindingState(teamName, cwd, teamStateRoot);
+  if (state.status === 'missing' || state.status === 'malformed') {
+    return state;
+  }
+
+  const approvedHint = readApprovedTeamExecutionHintFromBinding(cwd, state.binding);
+  return approvedHint
+    ? { status: 'valid', binding: state.binding, approvedHint }
+    : { status: 'stale', binding: state.binding };
+}
+
+export function resolvePersistedApprovedTeamExecutionContinuityStateSync(
+  teamName: string,
+  cwd: string,
+  teamStateRoot?: string | null,
+): PersistedApprovedTeamExecutionContinuityState {
+  const state = readPersistedApprovedTeamExecutionBindingStateSync(teamName, cwd, teamStateRoot);
+  if (state.status === 'missing' || state.status === 'malformed') {
+    return state;
+  }
+
+  const approvedHint = readApprovedTeamExecutionHintFromBinding(cwd, state.binding);
+  return approvedHint
+    ? { status: 'valid', binding: state.binding, approvedHint }
+    : { status: 'stale', binding: state.binding };
+}

--- a/src/team/approved-execution.ts
+++ b/src/team/approved-execution.ts
@@ -6,6 +6,7 @@ import {
   readPlanningArtifacts,
   type ApprovedExecutionLaunchHint,
 } from '../planning/artifacts.js';
+import { TEAM_NAME_SAFE_PATTERN } from './contracts.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import { sameFilePath } from '../utils/paths.js';
 
@@ -65,11 +66,18 @@ export function buildApprovedTeamExecutionBinding(
   };
 }
 
+function assertSafeTeamName(teamName: string): void {
+  if (!TEAM_NAME_SAFE_PATTERN.test(teamName)) {
+    throw new Error(`invalid_team_name:${teamName}`);
+  }
+}
+
 function approvedTeamExecutionBindingPath(
   teamName: string,
   cwd: string,
   teamStateRoot?: string | null,
 ): string {
+  assertSafeTeamName(teamName);
   const stateRoot = resolve(teamStateRoot ?? resolveCanonicalTeamStateRoot(cwd));
   return join(stateRoot, 'team', teamName, 'approved-execution.json');
 }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -132,6 +132,14 @@ import { buildRebalanceDecisions } from './rebalance-policy.js';
 import { getStatePath } from '../mcp/state-paths.js';
 import { readModeState, updateModeState } from '../modes/base.js';
 import {
+  buildApprovedTeamExecutionBinding,
+  normalizeApprovedTeamExecutionBinding,
+  readApprovedTeamExecutionHintFromBinding,
+  resolvePersistedApprovedTeamExecutionContinuityState,
+  writePersistedApprovedTeamExecutionBinding,
+  type ApprovedTeamExecutionBinding,
+} from './approved-execution.js';
+import {
   appendTeamCommitHygieneEntries,
   buildTeamCommitHygieneContext,
   resolveTeamCommitHygieneArtifactCwd,
@@ -1258,6 +1266,7 @@ export interface TeamStartOptions {
   confirmStaleCleanup?: (summary: StaleTeamSummary) => Promise<boolean>;
   cleanupLaunchOrphanedMcpProcesses?: () => Promise<CleanupResult>;
   writeCleanupWarning?: (message: string) => void;
+  approvedExecution?: ApprovedTeamExecutionBinding | null;
 }
 
 interface ShutdownGateCounts {
@@ -2230,6 +2239,18 @@ export async function startTeam(
   }
 
   const teamStateRoot = resolveCanonicalTeamStateRoot(leaderCwd);
+  const requestedApprovedExecution = normalizeApprovedTeamExecutionBinding(options.approvedExecution);
+  const selectedApprovedExecutionHint = requestedApprovedExecution
+    ? readApprovedTeamExecutionHintFromBinding(leaderCwd, requestedApprovedExecution)
+    : null;
+  if (requestedApprovedExecution && !selectedApprovedExecutionHint) {
+    throw new Error(
+      `approved_execution_binding_stale:${requestedApprovedExecution.prd_path}:${requestedApprovedExecution.task}`,
+    );
+  }
+  const approvedExecution = selectedApprovedExecutionHint
+    ? buildApprovedTeamExecutionBinding(selectedApprovedExecutionHint)
+    : null;
   const activeWorktreeMode: 'detached' | 'named' | null =
     effectiveWorktreeMode.enabled
       ? (effectiveWorktreeMode.detached ? 'detached' : 'named')
@@ -2337,6 +2358,12 @@ export async function startTeam(
     config.requested_name = displayName;
     config.identity_source = identityScope.source;
     config.worktree_mode = effectiveWorktreeMode;
+    await writePersistedApprovedTeamExecutionBinding(
+      sanitized,
+      leaderCwd,
+      approvedExecution,
+      teamStateRoot,
+    );
 
     // 4. Create tasks. Repo-aware DAG dependencies are symbolic until the
     // state layer returns concrete task IDs, so create those tasks dependency
@@ -3699,6 +3726,19 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
   const config = await readTeamConfig(sanitized, cwd);
   if (!config) return null;
   config.lifecycle_profile = 'default';
+  const approvedExecutionState = await resolvePersistedApprovedTeamExecutionContinuityState(
+    sanitized,
+    cwd,
+    config.team_state_root ?? resolveCanonicalTeamStateRoot(cwd),
+  );
+  if (approvedExecutionState.status === 'malformed') {
+    throw new Error(`approved_execution_binding_malformed:${sanitized}`);
+  }
+  if (approvedExecutionState.status === 'stale') {
+    throw new Error(
+      `approved_execution_binding_stale:${approvedExecutionState.binding.prd_path}:${approvedExecutionState.binding.task}`,
+    );
+  }
 
   if (config.worker_launch_mode === 'prompt') {
     const handleTeamConfig = { ...config, name: sanitized };

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3726,10 +3726,11 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
   const config = await readTeamConfig(sanitized, cwd);
   if (!config) return null;
   config.lifecycle_profile = 'default';
+  const leaderCwd = config.leader_cwd ?? cwd;
   const approvedExecutionState = await resolvePersistedApprovedTeamExecutionContinuityState(
     sanitized,
-    cwd,
-    config.team_state_root ?? resolveCanonicalTeamStateRoot(cwd),
+    leaderCwd,
+    config.team_state_root ?? resolveCanonicalTeamStateRoot(leaderCwd),
   );
   if (approvedExecutionState.status === 'malformed') {
     throw new Error(`approved_execution_binding_malformed:${sanitized}`);


### PR DESCRIPTION
## Summary

Preserve approved handoff bindings across team start, short approved
follow-ups, and resume without widening the surrounding lifecycle or
state machinery. The patch writes a minimal approved-execution
binding under the team state root, rehydrates exact approved team
launch hints from that binding, and keeps malformed or stale
bindings fail-closed.

This also shares approved handoff task decoding between planning
selection and `team-exec` so the same approved PRD text round-trips
to the same task through follow-up continuity and pipeline handoff
execution.

## Changes

- add `src/team/approved-execution.ts` for minimal binding
  persistence, normalization, and continuity checks against exact
  approved team launch hints
- persist approved bindings on approved team starts and consult them
  before the latest global approved hint on short follow-ups and
  resume
- fail closed on malformed or stale persisted bindings with explicit
  errors instead of silently rebinding to a different approved plan
- share approved handoff task decoding between planning artifacts
  and `team-exec`, with focused round-trip tests for supported
  single- and double-quoted task text

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/cli/__tests__/team.test.js dist/team/__tests__/approved-execution.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/worker-bootstrap.test.js`
- [x] `node --test dist/planning/__tests__/artifacts.test.js`
- [x] `node --test --test-name-pattern "derives the team-exec task from single-quoted approved handoff text with escapes|preserves literal backslashes in single-quoted approved handoff text|preserves literal backslashes in double-quoted approved handoff text" dist/pipeline/__tests__/stages.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
