### PR TITLE
Honor proxy envs for notification transports

### DIFF
--- a/src/notifications/__tests__/http-client.test.ts
+++ b/src/notifications/__tests__/http-client.test.ts
@@ -1,0 +1,104 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getProxyForUrl, noProxyMatches, requestJson, type ProxyEnv } from '../http-client.js';
+
+describe('proxy env resolution', () => {
+  it('uses scheme-specific lowercase proxy before uppercase and ALL_PROXY', () => {
+    const env: ProxyEnv = {
+      HTTPS_PROXY: 'http://upper.example:8080',
+      https_proxy: 'http://lower.example:8080',
+      ALL_PROXY: 'http://all.example:8080',
+    };
+    assert.equal(getProxyForUrl('https://discord.com/api/webhooks/1/abc', env)?.url.hostname, 'lower.example');
+  });
+
+  it('falls back to ALL_PROXY for https when no scheme proxy exists', () => {
+    const env: ProxyEnv = { ALL_PROXY: 'http://all.example:8080' };
+    assert.equal(getProxyForUrl('https://hooks.slack.com/services/T/B/C', env)?.url.hostname, 'all.example');
+  });
+
+  it('bypasses proxy when NO_PROXY matches exact host, suffix, port, or wildcard', () => {
+    assert.equal(noProxyMatches(new URL('https://api.telegram.org/bot/sendMessage'), 'api.telegram.org'), true);
+    assert.equal(noProxyMatches(new URL('https://sub.example.com/hook'), '.example.com'), true);
+    assert.equal(noProxyMatches(new URL('https://example.com:8443/hook'), 'example.com:8443'), true);
+    assert.equal(noProxyMatches(new URL('https://anything.invalid/hook'), '*'), true);
+  });
+
+  it('does not bypass when NO_PROXY host port differs', () => {
+    assert.equal(noProxyMatches(new URL('https://example.com:443/hook'), 'example.com:8443'), false);
+  });
+});
+
+describe('requestJson proxy routing', () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((server) => server.close()));
+  });
+
+  async function listen(handler: (req: IncomingMessage, res: ServerResponse) => void): Promise<{ url: string; close: () => Promise<void> }> {
+    const server = createServer(handler);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    assert.equal(typeof address, 'object');
+    assert.ok(address);
+    const { port } = address as AddressInfo;
+    const handle = {
+      url: `http://127.0.0.1:${port}`,
+      close: () => new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve())),
+    };
+    servers.push(handle);
+    return handle;
+  }
+
+  it('sends HTTP requests through HTTP_PROXY when configured', async () => {
+    const seen: string[] = [];
+    const target = await listen((_req, res) => {
+      res.statusCode = 500;
+      res.end('direct path should not be used');
+    });
+    const proxy = await listen((req, res) => {
+      seen.push(req.url ?? '');
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    const response = await requestJson(`${target.url}/notify?x=1`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'hello' }),
+      timeoutMs: 1000,
+    }, { HTTP_PROXY: proxy.url });
+
+    assert.equal(response.ok, true);
+    assert.deepEqual(seen, [`${target.url}/notify?x=1`]);
+  });
+
+  it('bypasses proxy when NO_PROXY matches the target host', async () => {
+    let directHits = 0;
+    let proxyHits = 0;
+    const target = await listen((_req, res) => {
+      directHits += 1;
+      res.end('ok');
+    });
+    const proxy = await listen((_req, res) => {
+      proxyHits += 1;
+      res.statusCode = 502;
+      res.end('proxy should not be used');
+    });
+
+    const response = await requestJson(`${target.url}/notify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+      timeoutMs: 1000,
+    }, { HTTP_PROXY: proxy.url, NO_PROXY: '127.0.0.1' });
+
+    assert.equal(response.ok, true);
+    assert.equal(directHits, 1);
+    assert.equal(proxyHits, 0);
+  });
+});

--- a/src/notifications/__tests__/notifier.test.ts
+++ b/src/notifications/__tests__/notifier.test.ts
@@ -1,10 +1,11 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
-import { EventEmitter } from 'events';
 import { loadNotificationConfig, notify, _buildDesktopArgs, _sendJsonHttpsRequest } from '../notifier.js';
 import type { NotificationConfig, NotificationPayload } from '../notifier.js';
 
@@ -169,42 +170,28 @@ describe('NotificationPayload type', () => {
 });
 
 describe('_sendJsonHttpsRequest', () => {
-  async function withMockedHttpsRequest(
-    mockRequest: (options: unknown, callback: (res: { statusCode?: number; resume(): void }) => void) => EventEmitter,
-    run: () => Promise<void>,
+  async function withServer(
+    handler: (req: IncomingMessage, res: ServerResponse) => void,
+    run: (baseUrl: string) => Promise<void>,
   ): Promise<void> {
-    const httpsModule = await import('https');
-    const originalRequest = httpsModule.default.request;
-    (httpsModule.default as { request: typeof originalRequest }).request = mockRequest as typeof originalRequest;
+    const server = createServer(handler);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
     try {
-      await run();
+      const address = server.address() as AddressInfo;
+      await run(`http://127.0.0.1:${address.port}`);
     } finally {
-      (httpsModule.default as { request: typeof originalRequest }).request = originalRequest;
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
     }
   }
 
   it('rejects non-2xx HTTP responses', async () => {
-    await withMockedHttpsRequest((_options, callback) => {
-      const req = new EventEmitter() as EventEmitter & {
-        write(chunk: string): void;
-        end(): void;
-        setTimeout(ms: number, cb: () => void): EventEmitter;
-        destroy(error?: Error): void;
-      };
-      req.write = () => {};
-      req.setTimeout = () => req;
-      req.destroy = (error?: Error) => {
-        if (error) req.emit('error', error);
-      };
-      req.end = () => {
-        callback({ statusCode: 500, resume: () => {} });
-      };
-      return req;
-    }, async () => {
+    await withServer((_req, res) => {
+      res.statusCode = 500;
+      res.end('failed');
+    }, async (baseUrl) => {
       await assert.rejects(
         _sendJsonHttpsRequest({
-          hostname: 'discord.com',
-          path: '/api/webhooks/test',
+          url: `${baseUrl}/api/webhooks/test`,
           body: '{}',
           errorPrefix: 'discord',
         }),
@@ -214,64 +201,28 @@ describe('_sendJsonHttpsRequest', () => {
   });
 
   it('configures request timeout and rejects on timeout', async () => {
-    let seenTimeoutMs = 0;
-    await withMockedHttpsRequest((_options, _callback) => {
-      const req = new EventEmitter() as EventEmitter & {
-        write(chunk: string): void;
-        end(): void;
-        setTimeout(ms: number, cb: () => void): EventEmitter;
-        destroy(error?: Error): void;
-      };
-      let onTimeout: (() => void) | undefined;
-      req.write = () => {};
-      req.setTimeout = (ms: number, cb: () => void) => {
-        seenTimeoutMs = ms;
-        onTimeout = cb;
-        return req;
-      };
-      req.destroy = (error?: Error) => {
-        if (error) req.emit('error', error);
-      };
-      req.end = () => {
-        onTimeout?.();
-      };
-      return req;
-    }, async () => {
+    await withServer((_req, _res) => {
+      // Leave the response open so the client timeout fires.
+    }, async (baseUrl) => {
       await assert.rejects(
         _sendJsonHttpsRequest({
-          hostname: 'api.telegram.org',
-          path: '/botabc/sendMessage',
+          url: `${baseUrl}/botabc/sendMessage`,
           body: '{}',
           errorPrefix: 'telegram',
-          timeoutMs: 1234,
+          timeoutMs: 50,
         }),
         /telegram_request_timeout/,
       );
-      assert.equal(seenTimeoutMs, 1234);
     });
   });
 
   it('resolves for 2xx responses', async () => {
-    await withMockedHttpsRequest((_options, callback) => {
-      const req = new EventEmitter() as EventEmitter & {
-        write(chunk: string): void;
-        end(): void;
-        setTimeout(ms: number, cb: () => void): EventEmitter;
-        destroy(error?: Error): void;
-      };
-      req.write = () => {};
-      req.setTimeout = () => req;
-      req.destroy = (error?: Error) => {
-        if (error) req.emit('error', error);
-      };
-      req.end = () => {
-        callback({ statusCode: 204, resume: () => {} });
-      };
-      return req;
-    }, async () => {
+    await withServer((_req, res) => {
+      res.statusCode = 204;
+      res.end();
+    }, async (baseUrl) => {
       await _sendJsonHttpsRequest({
-        hostname: 'discord.com',
-        path: '/api/webhooks/test',
+        url: `${baseUrl}/api/webhooks/test`,
         body: '{}',
         errorPrefix: 'discord',
       });

--- a/src/notifications/dispatcher.ts
+++ b/src/notifications/dispatcher.ts
@@ -6,7 +6,7 @@
  * blocking hooks.
  */
 
-import { request as httpsRequest } from "https";
+import { requestJson } from "./http-client.js";
 import type {
   DiscordNotificationConfig,
   DiscordBotNotificationConfig,
@@ -129,11 +129,11 @@ export async function sendDiscord(
       body.username = config.username;
     }
 
-    const response = await fetch(config.webhookUrl, {
+    const response = await requestJson(config.webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+      timeoutMs: SEND_TIMEOUT_MS,
     });
 
     if (!response.ok) {
@@ -179,14 +179,14 @@ export async function sendDiscordBot(
       config.mention,
     );
     const url = `https://discord.com/api/v10/channels/${channelId}/messages`;
-    const response = await fetch(url, {
+    const response = await requestJson(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bot ${botToken}`,
       },
       body: JSON.stringify({ content, allowed_mentions }),
-      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+      timeoutMs: SEND_TIMEOUT_MS,
     });
 
     if (!response.ok) {
@@ -238,62 +238,35 @@ export async function sendTelegram(
       parse_mode: config.parseMode || "Markdown",
     });
 
-    const result = await new Promise<NotificationResult>((resolve) => {
-      const req = httpsRequest(
-        {
-          hostname: "api.telegram.org",
-          path: `/bot${config.botToken}/sendMessage`,
-          method: "POST",
-          family: 4,
-          headers: {
-            "Content-Type": "application/json",
-            "Content-Length": Buffer.byteLength(body),
-          },
-          timeout: SEND_TIMEOUT_MS,
-        },
-        (res) => {
-          const chunks: Buffer[] = [];
-          res.on("data", (chunk: Buffer) => chunks.push(chunk));
-          res.on("end", () => {
-            if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-              let messageId: string | undefined;
-              try {
-                const body = JSON.parse(Buffer.concat(chunks).toString("utf-8"));
-                if (body?.result?.message_id !== undefined) {
-                  messageId = String(body.result.message_id);
-                }
-              } catch {
-                // Non-fatal
-              }
-              resolve({ platform: "telegram", success: true, messageId });
-            } else {
-              resolve({
-                platform: "telegram",
-                success: false,
-                error: `HTTP ${res.statusCode}`,
-              });
-            }
-          });
-        },
-      );
-
-      req.on("error", (e) => {
-        resolve({ platform: "telegram", success: false, error: e.message });
-      });
-      req.on("timeout", () => {
-        req.destroy();
-        resolve({
-          platform: "telegram",
-          success: false,
-          error: "Request timeout",
-        });
-      });
-
-      req.write(body);
-      req.end();
+    const response = await requestJson(`https://api.telegram.org/bot${config.botToken}/sendMessage`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(Buffer.byteLength(body)),
+      },
+      body,
+      timeoutMs: SEND_TIMEOUT_MS,
     });
 
-    return result;
+    if (!response.ok) {
+      return {
+        platform: "telegram",
+        success: false,
+        error: `HTTP ${response.status}`,
+      };
+    }
+
+    let messageId: string | undefined;
+    try {
+      const responseBody = await response.json() as { result?: { message_id?: unknown } };
+      if (responseBody?.result?.message_id !== undefined) {
+        messageId = String(responseBody.result.message_id);
+      }
+    } catch {
+      // Non-fatal
+    }
+
+    return { platform: "telegram", success: true, messageId };
   } catch (error) {
     return {
       platform: "telegram",
@@ -324,11 +297,11 @@ export async function sendSlack(
       body.username = config.username;
     }
 
-    const response = await fetch(config.webhookUrl, {
+    const response = await requestJson(config.webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+      timeoutMs: SEND_TIMEOUT_MS,
     });
 
     if (!response.ok) {
@@ -371,7 +344,7 @@ export async function sendWebhook(
       ...config.headers,
     };
 
-    const response = await fetch(config.url, {
+    const response = await requestJson(config.url, {
       method: config.method || "POST",
       headers,
       body: JSON.stringify({
@@ -388,7 +361,7 @@ export async function sendWebhook(
         active_mode: payload.activeMode,
         question: payload.question,
       }),
-      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+      timeoutMs: SEND_TIMEOUT_MS,
     });
 
     if (!response.ok) {

--- a/src/notifications/http-client.ts
+++ b/src/notifications/http-client.ts
@@ -1,0 +1,337 @@
+import { request as httpRequest } from "http";
+import { request as httpsRequest } from "https";
+import { connect as netConnect } from "net";
+import { connect as tlsConnect } from "tls";
+import type { IncomingMessage } from "http";
+import type { Socket } from "net";
+
+export interface ProxyEnv {
+  [key: string]: string | undefined;
+}
+
+export interface ProxyConfig {
+  url: URL;
+}
+
+export interface JsonHttpRequestOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  timeoutMs: number;
+}
+
+export interface JsonHttpResponse {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+class BufferedHttpResponse implements JsonHttpResponse {
+  ok: boolean;
+
+  constructor(
+    public status: number,
+    private readonly bodyText: string,
+  ) {
+    this.ok = status >= 200 && status < 300;
+  }
+
+  async json(): Promise<unknown> {
+    return JSON.parse(this.bodyText);
+  }
+
+  async text(): Promise<string> {
+    return this.bodyText;
+  }
+}
+
+function firstEnv(env: ProxyEnv, names: string[]): string | undefined {
+  for (const name of names) {
+    const value = env[name];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function normalizeProxyUrl(value: string): URL | undefined {
+  try {
+    const withProtocol = /^[a-z][a-z0-9+.-]*:/i.test(value) ? value : `http://${value}`;
+    const parsed = new URL(withProtocol);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function splitNoProxyEntry(entry: string): { host: string; port?: string } {
+  const trimmed = entry.trim().toLowerCase();
+  if (!trimmed) return { host: "" };
+  if (trimmed.startsWith("[")) {
+    const end = trimmed.indexOf("]");
+    if (end !== -1) {
+      const host = trimmed.slice(1, end);
+      const rest = trimmed.slice(end + 1);
+      return { host, port: rest.startsWith(":") ? rest.slice(1) : undefined };
+    }
+  }
+  const colon = trimmed.lastIndexOf(":");
+  if (colon > 0 && trimmed.indexOf(":") === colon) {
+    const maybePort = trimmed.slice(colon + 1);
+    if (/^\d+$/.test(maybePort)) {
+      return { host: trimmed.slice(0, colon), port: maybePort };
+    }
+  }
+  return { host: trimmed };
+}
+
+export function noProxyMatches(target: URL, noProxyValue: string | undefined): boolean {
+  if (!noProxyValue) return false;
+  const targetHost = target.hostname.replace(/^\[(.*)\]$/, "$1").toLowerCase();
+  const targetPort = target.port || (target.protocol === "https:" ? "443" : "80");
+
+  for (const rawEntry of noProxyValue.split(",")) {
+    const { host, port } = splitNoProxyEntry(rawEntry);
+    if (!host) continue;
+    if (host === "*") return true;
+    if (port && port !== targetPort) continue;
+
+    if (host.startsWith(".")) {
+      const suffix = host.slice(1);
+      if (targetHost === suffix || targetHost.endsWith(`.${suffix}`)) return true;
+      continue;
+    }
+
+    if (targetHost === host || targetHost.endsWith(`.${host}`)) return true;
+  }
+
+  return false;
+}
+
+export function getProxyForUrl(targetUrl: string | URL, env: ProxyEnv = process.env): ProxyConfig | undefined {
+  const target = typeof targetUrl === "string" ? new URL(targetUrl) : targetUrl;
+  const noProxy = firstEnv(env, ["no_proxy", "NO_PROXY"]);
+  if (noProxyMatches(target, noProxy)) return undefined;
+
+  const proxyValue =
+    target.protocol === "https:"
+      ? firstEnv(env, ["https_proxy", "HTTPS_PROXY", "all_proxy", "ALL_PROXY"])
+      : firstEnv(env, ["http_proxy", "HTTP_PROXY", "all_proxy", "ALL_PROXY"]);
+  if (!proxyValue) return undefined;
+
+  const url = normalizeProxyUrl(proxyValue);
+  return url ? { url } : undefined;
+}
+
+function collectIncoming(res: IncomingMessage, timeout: NodeJS.Timeout, resolve: (value: JsonHttpResponse) => void): void {
+  const chunks: Buffer[] = [];
+  res.on("data", (chunk: Buffer) => chunks.push(chunk));
+  res.on("end", () => {
+    clearTimeout(timeout);
+    resolve(new BufferedHttpResponse(res.statusCode ?? 0, Buffer.concat(chunks).toString("utf-8")));
+  });
+}
+
+async function requestDirect(url: URL, options: JsonHttpRequestOptions): Promise<JsonHttpResponse> {
+  if (globalThis.fetch) {
+    return globalThis.fetch(url, {
+      method: options.method ?? "POST",
+      headers: options.headers,
+      body: options.body,
+      signal: AbortSignal.timeout(options.timeoutMs),
+    }) as Promise<JsonHttpResponse>;
+  }
+
+  return new Promise<JsonHttpResponse>((resolve, reject) => {
+    const request = url.protocol === "https:" ? httpsRequest : httpRequest;
+    const req = request(
+      url,
+      {
+        method: options.method ?? "POST",
+        headers: options.headers,
+        timeout: options.timeoutMs,
+      },
+      (res) => collectIncoming(res, timeout, resolve),
+    );
+    const timeout = setTimeout(() => {
+      req.destroy(new Error("Request timeout"));
+    }, options.timeoutMs);
+    req.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+}
+
+function proxyAuthority(proxy: URL): { host: string; port: number } {
+  return {
+    host: proxy.hostname,
+    port: Number(proxy.port || (proxy.protocol === "https:" ? 443 : 80)),
+  };
+}
+
+function openProxySocket(proxy: URL, timeoutMs: number): Promise<Socket> {
+  const { host, port } = proxyAuthority(proxy);
+  return new Promise((resolve, reject) => {
+    const socket = proxy.protocol === "https:"
+      ? tlsConnect({ host, port, servername: host })
+      : netConnect({ host, port });
+    const readyEvent = proxy.protocol === "https:" ? "secureConnect" : "connect";
+    const timeout = setTimeout(() => {
+      socket.destroy(new Error("Proxy connection timeout"));
+    }, timeoutMs);
+    socket.once(readyEvent, () => {
+      clearTimeout(timeout);
+      resolve(socket);
+    });
+    socket.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
+function proxyAuthorizationHeader(proxy: URL): string | undefined {
+  if (!proxy.username && !proxy.password) return undefined;
+  const user = decodeURIComponent(proxy.username);
+  const password = decodeURIComponent(proxy.password);
+  return `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`;
+}
+
+function readUntilHeaders(socket: Socket, timeoutMs: number): Promise<{ head: string; rest: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const timeout = setTimeout(() => reject(new Error("Proxy response timeout")), timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("data", onData);
+      socket.off("error", onError);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onData = (chunk: Buffer) => {
+      chunks.push(chunk);
+      const buffer = Buffer.concat(chunks);
+      const headerEnd = buffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+      cleanup();
+      resolve({
+        head: buffer.slice(0, headerEnd).toString("latin1"),
+        rest: buffer.slice(headerEnd + 4),
+      });
+    };
+    socket.on("data", onData);
+    socket.once("error", onError);
+  });
+}
+
+function decodeChunked(body: Buffer): Buffer {
+  const chunks: Buffer[] = [];
+  let offset = 0;
+  while (offset < body.length) {
+    const lineEnd = body.indexOf("\r\n", offset);
+    if (lineEnd === -1) break;
+    const sizeText = body.slice(offset, lineEnd).toString("ascii").split(";", 1)[0]?.trim() ?? "";
+    const size = Number.parseInt(sizeText, 16);
+    if (!Number.isFinite(size)) break;
+    offset = lineEnd + 2;
+    if (size === 0) break;
+    chunks.push(body.slice(offset, offset + size));
+    offset += size + 2;
+  }
+  return Buffer.concat(chunks);
+}
+
+async function sendRawHttp(socket: Socket, rawRequest: string, timeoutMs: number): Promise<JsonHttpResponse> {
+  socket.write(rawRequest);
+  const chunks: Buffer[] = [];
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      socket.destroy(new Error("Request timeout"));
+    }, timeoutMs);
+    socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+    socket.once("end", () => {
+      clearTimeout(timeout);
+      const buffer = Buffer.concat(chunks);
+      const headerEnd = buffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) {
+        reject(new Error("Invalid HTTP response"));
+        return;
+      }
+      const head = buffer.slice(0, headerEnd).toString("latin1");
+      const status = Number(head.match(/^HTTP\/\d(?:\.\d)?\s+(\d+)/)?.[1] ?? 0);
+      const isChunked = /^transfer-encoding:\s*chunked$/im.test(head);
+      const rawBody = buffer.slice(headerEnd + 4);
+      const body = isChunked ? decodeChunked(rawBody) : rawBody;
+      resolve(new BufferedHttpResponse(status, body.toString("utf-8")));
+    });
+    socket.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
+function formatHeaders(headers: Record<string, string>, target: URL, body?: string): string {
+  const allHeaders: Record<string, string> = {
+    Host: target.host,
+    Connection: "close",
+    ...headers,
+  };
+  if (body !== undefined && !Object.keys(allHeaders).some((key) => key.toLowerCase() === "content-length")) {
+    allHeaders["Content-Length"] = String(Buffer.byteLength(body));
+  }
+  return Object.entries(allHeaders)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join("\r\n");
+}
+
+async function requestViaProxy(url: URL, proxy: URL, options: JsonHttpRequestOptions): Promise<JsonHttpResponse> {
+  const method = options.method ?? "POST";
+  const body = options.body ?? "";
+  const auth = proxyAuthorizationHeader(proxy);
+
+  if (url.protocol === "https:") {
+    const proxySocket = await openProxySocket(proxy, options.timeoutMs);
+    const targetPort = url.port || "443";
+    const connectHeaders = [`CONNECT ${url.hostname}:${targetPort} HTTP/1.1`, `Host: ${url.hostname}:${targetPort}`, "Proxy-Connection: close"];
+    if (auth) connectHeaders.push(`Proxy-Authorization: ${auth}`);
+    proxySocket.write(`${connectHeaders.join("\r\n")}\r\n\r\n`);
+    const connectResponse = await readUntilHeaders(proxySocket, options.timeoutMs);
+    const status = Number(connectResponse.head.match(/^HTTP\/\d(?:\.\d)?\s+(\d+)/)?.[1] ?? 0);
+    if (status < 200 || status >= 300) {
+      proxySocket.destroy();
+      throw new Error(`Proxy CONNECT failed with HTTP ${status}`);
+    }
+    const tlsSocket = tlsConnect({ socket: proxySocket, servername: url.hostname });
+    await new Promise<void>((resolve, reject) => {
+      tlsSocket.once("secureConnect", resolve);
+      tlsSocket.once("error", reject);
+    });
+    const path = `${url.pathname}${url.search}` || "/";
+    const raw = `${method} ${path} HTTP/1.1\r\n${formatHeaders(options.headers ?? {}, url, body)}\r\n\r\n${body}`;
+    return sendRawHttp(tlsSocket, raw, options.timeoutMs);
+  }
+
+  const socket = await openProxySocket(proxy, options.timeoutMs);
+  const headers: Record<string, string> = { ...(options.headers ?? {}) };
+  if (auth) headers["Proxy-Authorization"] = auth;
+  const raw = `${method} ${url.href} HTTP/1.1\r\n${formatHeaders(headers, url, body)}\r\n\r\n${body}`;
+  return sendRawHttp(socket, raw, options.timeoutMs);
+}
+
+export async function requestJson(
+  url: string,
+  options: JsonHttpRequestOptions,
+  env: ProxyEnv = process.env,
+): Promise<JsonHttpResponse> {
+  const target = new URL(url);
+  const proxy = getProxyForUrl(target, env);
+  if (!proxy) return requestDirect(target, options);
+  return requestViaProxy(target, proxy.url, options);
+}

--- a/src/notifications/notifier.ts
+++ b/src/notifications/notifier.ts
@@ -8,6 +8,7 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { promisify } from 'util';
+import { requestJson } from './http-client.js';
 
 const execFileAsync = promisify(execFile);
 const HTTP_REQUEST_TIMEOUT_MS = 10_000;
@@ -32,8 +33,9 @@ export interface NotificationPayload {
 }
 
 interface JsonHttpsRequestOptions {
-  hostname: string;
-  path: string;
+  url?: string;
+  hostname?: string;
+  path?: string;
   body: string;
   errorPrefix: string;
   timeoutMs?: number;
@@ -123,29 +125,24 @@ async function sendDesktopNotification(payload: NotificationPayload): Promise<vo
 }
 
 export async function _sendJsonHttpsRequest(options: JsonHttpsRequestOptions): Promise<void> {
-  const { default: https } = await import('https');
-  await new Promise<void>((resolve, reject) => {
-    const req = https.request({
-      hostname: options.hostname,
-      path: options.path,
+  const url = options.url ?? `https://${options.hostname}${options.path ?? ''}`;
+  try {
+    const response = await requestJson(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-    }, (res) => {
-      res.resume();
-      if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
-        reject(new Error(`${options.errorPrefix}_http_${res.statusCode || 'unknown'}`));
-        return;
-      }
-      resolve();
+      body: options.body,
+      timeoutMs: options.timeoutMs ?? HTTP_REQUEST_TIMEOUT_MS,
     });
 
-    req.setTimeout(options.timeoutMs ?? HTTP_REQUEST_TIMEOUT_MS, () => {
-      req.destroy(new Error(`${options.errorPrefix}_request_timeout`));
-    });
-    req.on('error', reject);
-    req.write(options.body);
-    req.end();
-  });
+    if (!response.ok) {
+      throw new Error(`${options.errorPrefix}_http_${response.status || 'unknown'}`);
+    }
+  } catch (error) {
+    if (error instanceof Error && /timeout|aborted/i.test(`${error.name} ${error.message}`)) {
+      throw new Error(`${options.errorPrefix}_request_timeout`);
+    }
+    throw error;
+  }
 }
 
 async function sendDiscordNotification(payload: NotificationPayload, webhookUrl: string): Promise<void> {
@@ -161,10 +158,8 @@ async function sendDiscordNotification(payload: NotificationPayload, webhookUrl:
   });
 
   try {
-    const url = new URL(webhookUrl);
     await _sendJsonHttpsRequest({
-      hostname: url.hostname,
-      path: url.pathname,
+      url: webhookUrl,
       body,
       errorPrefix: 'discord',
     });

--- a/src/openclaw/__tests__/dispatcher.test.ts
+++ b/src/openclaw/__tests__/dispatcher.test.ts
@@ -2,6 +2,8 @@
  * Tests for OpenClaw gateway dispatcher.
  */
 
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -11,7 +13,73 @@ import {
   interpolateInstruction,
   isCommandGateway,
   resolveCommandTimeoutMs,
+  wakeGateway,
 } from '../dispatcher.js';
+
+
+describe('wakeGateway proxy routing', () => {
+  const ORIGINAL_ENV = {
+    HTTP_PROXY: process.env.HTTP_PROXY,
+    http_proxy: process.env.http_proxy,
+    HTTPS_PROXY: process.env.HTTPS_PROXY,
+    https_proxy: process.env.https_proxy,
+    ALL_PROXY: process.env.ALL_PROXY,
+    all_proxy: process.env.all_proxy,
+    NO_PROXY: process.env.NO_PROXY,
+    no_proxy: process.env.no_proxy,
+  };
+
+  afterEach(() => {
+    for (const key of Object.keys(ORIGINAL_ENV) as Array<keyof typeof ORIGINAL_ENV>) {
+      const value = ORIGINAL_ENV[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  async function withServer(
+    handler: (req: IncomingMessage, res: ServerResponse) => void,
+    run: (baseUrl: string) => Promise<void>,
+  ): Promise<void> {
+    const server = createServer(handler);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const address = server.address() as AddressInfo;
+      await run(`http://127.0.0.1:${address.port}`);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  }
+
+  it('uses HTTP_PROXY for OpenClaw HTTP gateways', async () => {
+    const seen: string[] = [];
+    await withServer((_req, res) => {
+      res.statusCode = 500;
+      res.end('direct path should not be used');
+    }, async (targetUrl) => {
+      await withServer((req, res) => {
+        seen.push(req.url ?? '');
+        res.end('ok');
+      }, async (proxyUrl) => {
+        delete process.env.NO_PROXY;
+        delete process.env.no_proxy;
+        delete process.env.ALL_PROXY;
+        delete process.env.all_proxy;
+        process.env.HTTP_PROXY = proxyUrl;
+        delete process.env.http_proxy;
+        const result = await wakeGateway('local', { url: `${targetUrl}/wake` }, {
+          event: 'session-idle',
+          instruction: 'wake',
+          text: 'wake',
+          timestamp: '2026-05-05T00:00:00.000Z',
+          context: {},
+        });
+        assert.equal(result.success, true);
+        assert.deepEqual(seen, [`${targetUrl}/wake`]);
+      });
+    });
+  });
+});
 
 describe('validateGatewayUrl', () => {
   it('accepts https URLs', () => {

--- a/src/openclaw/dispatcher.ts
+++ b/src/openclaw/dispatcher.ts
@@ -10,6 +10,8 @@
  * Prefers execFile for simple commands; falls back to sh -c only for shell metacharacters.
  */
 
+import { requestJson } from "../notifications/http-client.js";
+
 import type {
   OpenClawCommandGatewayConfig,
   OpenClawGatewayConfig,
@@ -155,11 +157,11 @@ export async function wakeGateway(
 
     const timeout = gatewayConfig.timeout ?? DEFAULT_HTTP_TIMEOUT_MS;
 
-    const response = await fetch(gatewayConfig.url, {
+    const response = await requestJson(gatewayConfig.url, {
       method: gatewayConfig.method || "POST",
       headers,
       body: JSON.stringify(payload),
-      signal: AbortSignal.timeout(timeout),
+      timeoutMs: timeout,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- Route Discord, Discord bot, Telegram, Slack, generic webhook, legacy notifier, and OpenClaw HTTP gateway sends through one shared proxy-aware HTTP layer.
- Honor `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY` and lowercase variants with shared scheme selection and bypass matching.
- Add focused tests for proxy env resolution, proxy routing, notifier behavior, and OpenClaw HTTP gateway proxy use.

Closes #2112

## Verification
- `npm run build`
- `node --test dist/notifications/__tests__/http-client.test.js dist/notifications/__tests__/dispatcher.test.js dist/notifications/__tests__/notifier.test.js dist/openclaw/__tests__/dispatcher.test.js`
- `npm run check:no-unused`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
