### PR TITLE
Keep Ralph continuation bound to its owner session

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -2122,6 +2122,156 @@ exit 0
     }
   });
 
+  it('allows Ralph continue steer for the matching workflow owner session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-owner-match-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const stateDir = join(wd, '.omx', 'state');
+    const sessionId = 'sess-owner';
+    const sessionStateDir = join(stateDir, 'sessions', sessionId);
+    try {
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeSessionStart(wd, sessionId);
+      await writeFile(join(sessionStateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        owner_omx_session_id: sessionId,
+        tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(join(sessionStateDir, 'hud-state.json'), JSON.stringify({
+        last_progress_at: new Date(Date.now() - 61_000).toISOString(),
+      }, null, 2));
+      await writeFile(join(stateDir, 'notify-fallback-state.json'), JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({ PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 1, 'matching owner session should allow Ralph continue steer');
+
+      const watcherState = JSON.parse(await readFile(join(stateDir, 'notify-fallback-state.json'), 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'sent');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not Ralph-continue a child/non-owner session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-owner-mismatch-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const stateDir = join(wd, '.omx', 'state');
+    const sessionId = 'sess-child';
+    const sessionStateDir = join(stateDir, 'sessions', sessionId);
+    try {
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeSessionStart(wd, sessionId);
+      await writeFile(join(sessionStateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        owner_omx_session_id: 'sess-leader',
+        tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(join(sessionStateDir, 'hud-state.json'), JSON.stringify({
+        last_progress_at: new Date(Date.now() - 61_000).toISOString(),
+      }, null, 2));
+      await writeFile(join(stateDir, 'notify-fallback-state.json'), JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({ PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 0, 'non-owner child session must not receive Ralph continue steer');
+
+      const watcherState = JSON.parse(await readFile(join(stateDir, 'notify-fallback-state.json'), 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'owner_mismatch');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed instead of Ralph-continuing when ownership is ambiguous', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-owner-ambiguous-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const stateDir = join(wd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        owner_omx_session_id: 'sess-leader',
+        tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+        last_progress_at: new Date(Date.now() - 61_000).toISOString(),
+      }, null, 2));
+      await writeFile(join(stateDir, 'notify-fallback-state.json'), JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({ PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 0, 'ambiguous ownership must fail closed');
+
+      const watcherState = JSON.parse(await readFile(join(stateDir, 'notify-fallback-state.json'), 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'owner_ambiguous');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('suppresses Ralph continue steer when hud progress is still fresh after cooldown', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-progress-fresh-'));
     const fakeBinDir = join(wd, 'fake-bin');

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -39,6 +39,7 @@ import { sameFilePath } from '../utils/paths.js';
 import { validateSessionId } from '../mcp/state-paths.js';
 import { TEAM_NAME_SAFE_PATTERN } from '../team/contracts.js';
 import { shouldContinueRun } from '../runtime/run-loop.js';
+import { resolveWorkflowOwnerSnapshot } from '../state/workflow-owner-snapshot.js';
 
 function argValue(name: string, fallback = ''): string {
   const idx = process.argv.indexOf(name);
@@ -553,66 +554,67 @@ interface ActiveModeResult {
 }
 
 async function resolveActiveModeState(mode: string): Promise<ActiveModeResult> {
-  const candidateDirs: string[] = [];
   let currentSessionId = '';
+  let currentCodexSessionId = '';
   let currentSessionIsLive = false;
   const session = await readSessionState(cwd);
-  if (session?.session_id) {
-    if (isSessionStateAuthoritativeForCwd(session, cwd)) {
-      currentSessionId = normalizeValidSessionId(session.session_id);
-      currentSessionIsLive = currentSessionId !== '' && !isSessionStale(session);
-    }
-    if (currentSessionId && currentSessionIsLive) {
-      candidateDirs.push(join(stateDir, 'sessions', currentSessionId));
-    }
+  if (session?.session_id && isSessionStateAuthoritativeForCwd(session, cwd)) {
+    currentSessionId = normalizeValidSessionId(session.session_id);
+    currentCodexSessionId = safeString(session.native_session_id).trim();
+    currentSessionIsLive = currentSessionId !== '' && !isSessionStale(session);
   }
-  if (!candidateDirs.includes(stateDir)) candidateDirs.push(stateDir);
 
-  for (const dir of candidateDirs) {
-    if (mode === 'ralph' && dir === stateDir && currentSessionId) {
-      return {
-        active: false,
-        reason: currentSessionIsLive ? 'blocked_by_current_session' : 'stale_current_session',
-        path: '',
-        state: null,
-      };
-    }
-
-    const path = join(dir, `${mode}-state.json`);
-    if (!existsSync(path)) continue;
-    const parsed = await readFile(path, 'utf-8')
-      .then((content) => JSON.parse(content) as Record<string, unknown>)
-      .catch(() => null);
-    if (!parsed || typeof parsed !== 'object') continue;
-    if (mode === 'ralph' && dir !== stateDir && isStaleRalphStartingPhase(parsed)) {
-      return {
-        active: false,
-        reason: 'starting_stale',
-        path,
-        state: parsed,
-      };
-    }
-    if (hasRalphTerminalState(parsed)) {
-      return {
-        active: false,
-        reason: 'terminal',
-        path,
-        state: parsed,
-      };
-    }
+  if (currentSessionId && !currentSessionIsLive) {
     return {
-      active: true,
-      reason: 'active',
-      path,
-      state: parsed,
+      active: false,
+      reason: 'stale_current_session',
+      path: '',
+      state: null,
     };
   }
 
+  const snapshot = await resolveWorkflowOwnerSnapshot({
+    cwd,
+    mode,
+    currentOmxSessionId: currentSessionIsLive ? currentSessionId : undefined,
+    currentCodexSessionId: currentSessionIsLive ? currentCodexSessionId : undefined,
+    terminalPhases: mode === 'ralph' ? RALPH_TERMINAL_PHASES : undefined,
+    includeCompatibility: false,
+  });
+
+  if (!snapshot.active) {
+    return {
+      active: false,
+      reason: snapshot.reason,
+      path: snapshot.statePath,
+      state: snapshot.state,
+    };
+  }
+
+  if (mode === 'ralph' && snapshot.state) {
+    if (isStaleRalphStartingPhase(snapshot.state)) {
+      return {
+        active: false,
+        reason: snapshot.source === 'session' ? 'starting_stale' : 'terminal',
+        path: snapshot.statePath,
+        state: snapshot.state,
+      };
+    }
+    if (hasRalphTerminalState(snapshot.state)) {
+      return {
+        active: false,
+        reason: 'terminal',
+        path: snapshot.statePath,
+        state: snapshot.state,
+      };
+    }
+  }
+
   return {
-    active: false,
-    reason: 'cleared',
-    path: '',
-    state: null,
+    active: true,
+    reason: snapshot.reason,
+    path: snapshot.statePath,
+    state: snapshot.state,
   };
 }
 

--- a/src/state/__tests__/workflow-owner-snapshot.test.ts
+++ b/src/state/__tests__/workflow-owner-snapshot.test.ts
@@ -1,0 +1,116 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveWorkflowOwnerSnapshot } from '../workflow-owner-snapshot.js';
+
+async function withTempRepo(prefix: string, run: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(join(path, '..'), { recursive: true });
+  await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+describe('resolveWorkflowOwnerSnapshot', () => {
+  it('prefers session-scoped mode state over root state', async () => {
+    await withTempRepo('omx-owner-snapshot-session-', async (cwd) => {
+      await writeJson(join(cwd, '.omx', 'state', 'ralph-state.json'), {
+        active: true,
+        current_phase: 'executing',
+      });
+      await writeJson(join(cwd, '.omx', 'state', 'sessions', 'sess-1', 'ralph-state.json'), {
+        active: true,
+        current_phase: 'verifying',
+      });
+
+      const snapshot = await resolveWorkflowOwnerSnapshot({
+        cwd,
+        mode: 'ralph',
+        currentOmxSessionId: 'sess-1',
+        terminalPhases: ['complete', 'failed', 'cancelled', 'blocked_on_user'],
+      });
+
+      assert.equal(snapshot.active, true);
+      assert.equal(snapshot.source, 'session');
+      assert.equal(snapshot.state?.current_phase, 'verifying');
+      assert.equal(snapshot.ownerMatches, true);
+    });
+  });
+
+  it('does not let root state override a current session without session-scoped state', async () => {
+    await withTempRepo('omx-owner-snapshot-root-block-', async (cwd) => {
+      await writeJson(join(cwd, '.omx', 'state', 'ralph-state.json'), {
+        active: true,
+        current_phase: 'executing',
+      });
+      await mkdir(join(cwd, '.omx', 'state', 'sessions', 'sess-1'), { recursive: true });
+
+      const snapshot = await resolveWorkflowOwnerSnapshot({
+        cwd,
+        mode: 'ralph',
+        currentOmxSessionId: 'sess-1',
+        terminalPhases: ['complete', 'failed', 'cancelled', 'blocked_on_user'],
+      });
+
+      assert.equal(snapshot.active, false);
+      assert.equal(snapshot.reason, 'blocked_by_current_session');
+      assert.equal(snapshot.blockingReason, 'session_scoped_state_missing');
+    });
+  });
+
+  it('does not resurrect terminal canonical state from compatibility state', async () => {
+    await withTempRepo('omx-owner-snapshot-compat-terminal-', async (cwd) => {
+      await writeJson(join(cwd, '.omx', 'state', 'ralph-state.json'), {
+        active: false,
+        current_phase: 'complete',
+        completed_at: '2026-05-05T00:00:00.000Z',
+      });
+      await writeJson(join(cwd, '.omx', 'state', 'skill-active-state.json'), {
+        active: true,
+        skill: 'ralph',
+        active_skills: [{ skill: 'ralph', active: true, phase: 'executing' }],
+      });
+
+      const snapshot = await resolveWorkflowOwnerSnapshot({
+        cwd,
+        mode: 'ralph',
+        includeCompatibility: true,
+        terminalPhases: ['complete', 'failed', 'cancelled', 'blocked_on_user'],
+      });
+
+      assert.equal(snapshot.active, false);
+      assert.equal(snapshot.terminal, true);
+      assert.equal(snapshot.source, 'root');
+      assert.equal(snapshot.reason, 'terminal');
+    });
+  });
+
+  it('marks owner-present state ambiguous when current owner identity is missing', async () => {
+    await withTempRepo('omx-owner-snapshot-ambiguous-', async (cwd) => {
+      await writeJson(join(cwd, '.omx', 'state', 'ralph-state.json'), {
+        active: true,
+        current_phase: 'executing',
+        owner_omx_session_id: 'leader-session',
+      });
+
+      const snapshot = await resolveWorkflowOwnerSnapshot({
+        cwd,
+        mode: 'ralph',
+        terminalPhases: ['complete', 'failed', 'cancelled', 'blocked_on_user'],
+      });
+
+      assert.equal(snapshot.active, false);
+      assert.equal(snapshot.ownerMatches, 'ambiguous');
+      assert.equal(snapshot.reason, 'owner_ambiguous');
+      assert.equal(snapshot.blockingReason, 'owner_present_current_session_missing');
+    });
+  });
+});

--- a/src/state/workflow-owner-snapshot.ts
+++ b/src/state/workflow-owner-snapshot.ts
@@ -1,0 +1,284 @@
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { getBaseStateDir, getStateDir, validateSessionId, validateStateModeSegment } from '../mcp/state-paths.js';
+
+export type WorkflowOwnerSnapshotSource = 'session' | 'root' | 'compatibility' | 'none';
+export type WorkflowOwnerMatch = boolean | 'ambiguous';
+
+export interface WorkflowOwnerSnapshot {
+  mode: string;
+  active: boolean;
+  terminal: boolean;
+  source: WorkflowOwnerSnapshotSource;
+  reason: string;
+  statePath: string;
+  state: Record<string, unknown> | null;
+  ownerOmxSessionId?: string;
+  ownerCodexSessionId?: string;
+  currentOmxSessionId?: string;
+  currentCodexSessionId?: string;
+  ownerMatches: WorkflowOwnerMatch;
+  blockingReason?: string;
+  sourcePaths: string[];
+}
+
+export interface ResolveWorkflowOwnerSnapshotOptions {
+  cwd: string;
+  mode: string;
+  currentOmxSessionId?: string;
+  currentCodexSessionId?: string;
+  terminalPhases?: Iterable<string>;
+  includeCompatibility?: boolean;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+async function readJsonIfExists(path: string): Promise<Record<string, unknown> | null> {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(await readFile(path, 'utf-8')) as unknown;
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeSessionId(value: string | undefined): string {
+  const trimmed = safeString(value);
+  if (!trimmed) return '';
+  try {
+    return validateSessionId(trimmed) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function isTerminalState(state: Record<string, unknown>, terminalPhases: Set<string>): boolean {
+  if (state.active !== true) return true;
+  if (safeString(state.completed_at)) return true;
+  const phase = safeString(state.current_phase).toLowerCase();
+  return phase !== '' && terminalPhases.has(phase);
+}
+
+function resolveOwnerMatches(args: {
+  source: WorkflowOwnerSnapshotSource;
+  state: Record<string, unknown>;
+  currentOmxSessionId: string;
+  currentCodexSessionId: string;
+}): {
+  ownerMatches: WorkflowOwnerMatch;
+  ownerOmxSessionId?: string;
+  ownerCodexSessionId?: string;
+  blockingReason?: string;
+} {
+  const ownerOmxSessionId = safeString(args.state.owner_omx_session_id)
+    || safeString(args.state.omx_session_id)
+    || safeString(args.state.session_id);
+  const ownerCodexSessionId = safeString(args.state.owner_codex_session_id)
+    || safeString(args.state.codex_session_id)
+    || safeString(args.state.native_session_id);
+
+  if (ownerOmxSessionId && args.currentOmxSessionId) {
+    return {
+      ownerMatches: ownerOmxSessionId === args.currentOmxSessionId,
+      ownerOmxSessionId,
+      ownerCodexSessionId: ownerCodexSessionId || undefined,
+      blockingReason: ownerOmxSessionId === args.currentOmxSessionId ? undefined : 'owner_omx_session_mismatch',
+    };
+  }
+
+  if (args.source === 'session' && args.currentOmxSessionId) {
+    return {
+      ownerMatches: true,
+      ownerOmxSessionId: ownerOmxSessionId || undefined,
+      ownerCodexSessionId: ownerCodexSessionId || undefined,
+    };
+  }
+
+  if (ownerCodexSessionId && args.currentCodexSessionId) {
+    return {
+      ownerMatches: ownerCodexSessionId === args.currentCodexSessionId,
+      ownerOmxSessionId: ownerOmxSessionId || undefined,
+      ownerCodexSessionId,
+      blockingReason: ownerCodexSessionId === args.currentCodexSessionId ? undefined : 'owner_codex_session_mismatch',
+    };
+  }
+
+  if ((ownerOmxSessionId && !args.currentOmxSessionId) || (ownerCodexSessionId && !args.currentCodexSessionId)) {
+    return {
+      ownerMatches: 'ambiguous',
+      ownerOmxSessionId: ownerOmxSessionId || undefined,
+      ownerCodexSessionId: ownerCodexSessionId || undefined,
+      blockingReason: 'owner_present_current_session_missing',
+    };
+  }
+
+  if (!args.currentOmxSessionId && !args.currentCodexSessionId) {
+    return { ownerMatches: true };
+  }
+
+  return { ownerMatches: 'ambiguous', blockingReason: 'owner_missing_current_session_present' };
+}
+
+function buildInactiveSnapshot(args: {
+  mode: string;
+  reason: string;
+  source: WorkflowOwnerSnapshotSource;
+  statePath?: string;
+  state?: Record<string, unknown> | null;
+  currentOmxSessionId: string;
+  currentCodexSessionId: string;
+  sourcePaths: string[];
+  ownerMatches?: WorkflowOwnerMatch;
+  blockingReason?: string;
+  terminal?: boolean;
+}): WorkflowOwnerSnapshot {
+  return {
+    mode: args.mode,
+    active: false,
+    terminal: args.terminal ?? false,
+    source: args.source,
+    reason: args.reason,
+    statePath: args.statePath ?? '',
+    state: args.state ?? null,
+    currentOmxSessionId: args.currentOmxSessionId || undefined,
+    currentCodexSessionId: args.currentCodexSessionId || undefined,
+    ownerMatches: args.ownerMatches ?? false,
+    blockingReason: args.blockingReason,
+    sourcePaths: args.sourcePaths,
+  };
+}
+
+function readCompatibilityEntry(skillActive: Record<string, unknown> | null, mode: string): Record<string, unknown> | null {
+  if (!skillActive) return null;
+  const entries = Array.isArray(skillActive.active_skills) ? skillActive.active_skills : [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue;
+    const candidate = entry as Record<string, unknown>;
+    if (safeString(candidate.skill) === mode && candidate.active !== false) return candidate;
+  }
+  if (safeString(skillActive.skill) === mode && skillActive.active !== false) return skillActive;
+  return null;
+}
+
+export async function resolveWorkflowOwnerSnapshot(
+  options: ResolveWorkflowOwnerSnapshotOptions,
+): Promise<WorkflowOwnerSnapshot> {
+  const mode = validateStateModeSegment(options.mode);
+  const currentOmxSessionId = normalizeSessionId(options.currentOmxSessionId);
+  const currentCodexSessionId = safeString(options.currentCodexSessionId);
+  const terminalPhases = new Set([...(options.terminalPhases ?? [])].map((phase) => safeString(phase).toLowerCase()).filter(Boolean));
+  const baseStateDir = getBaseStateDir(options.cwd);
+  const canonicalPaths: Array<{ source: 'session' | 'root'; path: string }> = [];
+  const sourcePaths: string[] = [];
+
+  if (currentOmxSessionId) {
+    canonicalPaths.push({ source: 'session', path: join(getStateDir(options.cwd, currentOmxSessionId), `${mode}-state.json`) });
+  } else {
+    canonicalPaths.push({ source: 'root', path: join(baseStateDir, `${mode}-state.json`) });
+  }
+
+  for (const candidate of canonicalPaths) {
+    sourcePaths.push(candidate.path);
+    const state = await readJsonIfExists(candidate.path);
+    if (!state) continue;
+    const owner = resolveOwnerMatches({ source: candidate.source, state, currentOmxSessionId, currentCodexSessionId });
+    const terminal = isTerminalState(state, terminalPhases);
+    if (terminal) {
+      return {
+        mode,
+        active: false,
+        terminal: true,
+        source: candidate.source,
+        reason: 'terminal',
+        statePath: candidate.path,
+        state,
+        ownerOmxSessionId: owner.ownerOmxSessionId,
+        ownerCodexSessionId: owner.ownerCodexSessionId,
+        currentOmxSessionId: currentOmxSessionId || undefined,
+        currentCodexSessionId: currentCodexSessionId || undefined,
+        ownerMatches: owner.ownerMatches,
+        blockingReason: owner.blockingReason,
+        sourcePaths,
+      };
+    }
+    if (owner.ownerMatches !== true) {
+      return {
+        mode,
+        active: false,
+        terminal: false,
+        source: candidate.source,
+        reason: owner.ownerMatches === 'ambiguous' ? 'owner_ambiguous' : 'owner_mismatch',
+        statePath: candidate.path,
+        state,
+        ownerOmxSessionId: owner.ownerOmxSessionId,
+        ownerCodexSessionId: owner.ownerCodexSessionId,
+        currentOmxSessionId: currentOmxSessionId || undefined,
+        currentCodexSessionId: currentCodexSessionId || undefined,
+        ownerMatches: owner.ownerMatches,
+        blockingReason: owner.blockingReason,
+        sourcePaths,
+      };
+    }
+    return {
+      mode,
+      active: true,
+      terminal: false,
+      source: candidate.source,
+      reason: 'active',
+      statePath: candidate.path,
+      state,
+      ownerOmxSessionId: owner.ownerOmxSessionId,
+      ownerCodexSessionId: owner.ownerCodexSessionId,
+      currentOmxSessionId: currentOmxSessionId || undefined,
+      currentCodexSessionId: currentCodexSessionId || undefined,
+      ownerMatches: true,
+      sourcePaths,
+    };
+  }
+
+  if (currentOmxSessionId) {
+    return buildInactiveSnapshot({
+      mode,
+      reason: 'blocked_by_current_session',
+      source: 'none',
+      currentOmxSessionId,
+      currentCodexSessionId,
+      sourcePaths,
+      blockingReason: 'session_scoped_state_missing',
+    });
+  }
+
+  if (options.includeCompatibility === true) {
+    const compatibilityPath = join(baseStateDir, 'skill-active-state.json');
+    sourcePaths.push(compatibilityPath);
+    const entry = readCompatibilityEntry(await readJsonIfExists(compatibilityPath), mode);
+    if (entry) {
+      return {
+        mode,
+        active: true,
+        terminal: false,
+        source: 'compatibility',
+        reason: 'compatibility_active',
+        statePath: compatibilityPath,
+        state: entry,
+        currentOmxSessionId: currentOmxSessionId || undefined,
+        currentCodexSessionId: currentCodexSessionId || undefined,
+        ownerMatches: true,
+        sourcePaths,
+      };
+    }
+  }
+
+  return buildInactiveSnapshot({
+    mode,
+    reason: 'cleared',
+    source: 'none',
+    currentOmxSessionId,
+    currentCodexSessionId,
+    sourcePaths,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a typed workflow owner snapshot helper for canonical session/root/compatibility precedence.
- Routes fallback Ralph continuation through that owner decision.
- Adds regression coverage for matching owner, child/non-owner, ambiguous owner, session precedence, and compatibility non-resurrection.

## Behavior changed
- Session-scoped mode state wins over root state for continuation decisions.
- Root state no longer drives fallback Ralph continuation while a different live session is active.
- Owner mismatch or ambiguous owner evidence fails closed instead of sending `Ralph loop active continue`.

## Validation
- [pass] npm run build
- [pass] node --test dist/state/__tests__/workflow-owner-snapshot.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js
- [pass] node --test dist/state/__tests__/*.test.js dist/hooks/__tests__/notify-hook-session-scope.test.js dist/hooks/__tests__/notify-hook-native-dispatch-contract.test.js dist/ralph/__tests__/persistence.test.js

## Notes
- Base: upstream/dev @ c7c5ffc478bb50f5bb2f9016ac4a2af7f3454f95
- This intentionally does not implement the full workflow snapshot resolver migration; it is the minimal PR1a/PR1b owner-boundary prelude from the approved ralplan.
