### PR TITLE
Bound explore execution before semantic fallback

### DIFF
--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -803,6 +803,51 @@ describe('exploreCommand', () => {
     }
   });
 
+  it('answers explicit file-read prompts with bounded file content instead of metadata only', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-local-file-read-'));
+    try {
+      await writeFile(join(wd, 'README.md'), '# Demo README\n\nThis content must be visible.\n');
+      const harnessStub = join(wd, 'explore-stub.sh');
+      await writeFile(harnessStub, '#!/bin/sh\nprintf harness-should-not-run\n');
+      await chmod(harnessStub, 0o755);
+
+      const result = await runExploreCommandForTest(wd, ['--prompt', 'read README.md'], {
+        OMX_EXPLORE_BIN: harnessStub,
+      });
+
+      assert.equal(result.exitCode, 0);
+      assert.match(result.stdout, /local fast-path used \(file lookup\)/);
+      assert.match(result.stdout, /README\.md \(\d+ bytes; showing up to/);
+      assert.match(result.stdout, /# Demo README/);
+      assert.match(result.stdout, /This content must be visible\./);
+      assert.doesNotMatch(result.stdout.trim(), /^.*README\.md \(\d+ bytes\)$/);
+      assert.equal(result.stderr, '');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('marks explicit file-read fast-path output when file content is truncated', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-local-file-truncated-'));
+    try {
+      await writeFile(join(wd, 'README.md'), `# Demo README\n${'x'.repeat(20_000)}\n`);
+      const harnessStub = join(wd, 'explore-stub.sh');
+      await writeFile(harnessStub, '#!/bin/sh\nprintf harness-should-not-run\n');
+      await chmod(harnessStub, 0o755);
+
+      const result = await runExploreCommandForTest(wd, ['--prompt', 'show README.md'], {
+        OMX_EXPLORE_BIN: harnessStub,
+      });
+
+      assert.equal(result.exitCode, 0);
+      assert.match(result.stdout, /# Demo README/);
+      assert.match(result.stdout, /\[truncated: file exceeds local fast-path limit/);
+      assert.equal(result.stderr, '');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('times out Codex-backed harness process trees with an explicit runaway error', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-explore-timeout-'));
     try {

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -781,6 +781,50 @@ describe('resolveExploreSparkShellRoute', () => {
 });
 
 describe('exploreCommand', () => {
+  it('answers simple text lookups with the local fast-path before spawning Codex-backed harnesses', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-local-fast-path-'));
+    try {
+      await mkdir(join(wd, 'src'), { recursive: true });
+      await writeFile(join(wd, 'src', 'auth.ts'), 'export const token = "local-only";\n');
+      const harnessStub = join(wd, 'explore-stub.sh');
+      await writeFile(harnessStub, '#!/bin/sh\nprintf harness-should-not-run\n');
+      await chmod(harnessStub, 0o755);
+
+      const result = await runExploreCommandForTest(wd, ['--prompt', 'search for local-only'], {
+        OMX_EXPLORE_BIN: harnessStub,
+      });
+
+      assert.equal(result.exitCode, 0);
+      assert.match(result.stdout, /local fast-path used \(text lookup\)/);
+      assert.match(result.stdout, /src\/auth\.ts:1/);
+      assert.equal(result.stderr, '');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('times out Codex-backed harness process trees with an explicit runaway error', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-timeout-'));
+    try {
+      const harnessStub = join(wd, 'explore-stub.sh');
+      await writeFile(
+        harnessStub,
+        '#!/bin/sh\nprintf "started\\n"\nsleep 5\n',
+      );
+      await chmod(harnessStub, 0o755);
+
+      await assert.rejects(
+        () => runExploreCommandForTest(wd, ['--prompt', 'map the runtime timeout behavior'], {
+          OMX_EXPLORE_BIN: harnessStub,
+          OMX_EXPLORE_TIMEOUT_MS: '50',
+        }),
+        /harness timed out after 50ms; terminated the process tree/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('routes qualifying read-only shell commands through sparkshell instead of the direct harness', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-explore-sparkshell-route-'));
     try {

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir, stat } from 'fs/promises';
+import { open as openFile, readFile, readdir, stat } from 'fs/promises';
 import { isAbsolute, join, relative, resolve, sep } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { getPackageRoot } from '../utils/package.js';
@@ -42,6 +42,8 @@ const EXPLORE_TIMEOUT_MS_ENV = 'OMX_EXPLORE_TIMEOUT_MS';
 const DEFAULT_EXPLORE_TIMEOUT_MS = 120_000;
 const LOCAL_FAST_PATH_MAX_FILES = 2_000;
 const LOCAL_FAST_PATH_MAX_MATCHES = 40;
+const LOCAL_FAST_PATH_FILE_MAX_BYTES = 16_384;
+const LOCAL_FAST_PATH_FILE_MAX_LINES = 240;
 const LOCAL_FAST_PATH_EXCLUDED_DIRS = new Set(['.git', 'node_modules', 'dist', 'target', '.omx']);
 const WINDOWS_BUILTIN_EXPLORE_HARNESS_REASON =
   'the built-in explore harness is not ready on Windows because its allowlist runtime relies on POSIX sh/bash wrappers. Set OMX_EXPLORE_BIN to a compatible custom harness, prefer `omx sparkshell` for shell-native read-only lookups, or run `omx doctor` for readiness details.';
@@ -146,18 +148,27 @@ export function buildExplorePromptWithWikiContext(prompt: string, cwd: string): 
 }
 
 interface ExploreLocalFastPathResult {
-  kind: 'path' | 'text';
+  kind: 'file' | 'path' | 'text';
   lines: string[];
 }
 
-function normalizeRelativeLookupPath(prompt: string): string | undefined {
+interface RelativeLookupPath {
+  path: string;
+  mode: 'content' | 'metadata';
+}
+
+function normalizeRelativeLookupPath(prompt: string): RelativeLookupPath | undefined {
   const trimmed = prompt.trim();
   const match = trimmed.match(/^(?:open|show|cat|read|find|locate)\s+([A-Za-z0-9._/@+-][A-Za-z0-9._/@+\-/]*)$/i);
   const candidate = match?.[1] ?? (
     /^[A-Za-z0-9._/@+-][A-Za-z0-9._/@+\-/]*$/.test(trimmed) ? trimmed : undefined
   );
   if (!candidate || candidate.startsWith('/') || candidate.includes('..')) return undefined;
-  return candidate;
+  const command = match?.[0].split(/\s+/, 1)[0]?.toLowerCase();
+  return {
+    path: candidate,
+    mode: command && ['cat', 'read', 'show'].includes(command) ? 'content' : 'metadata',
+  };
 }
 
 function normalizeTextLookup(prompt: string): string | undefined {
@@ -195,10 +206,31 @@ async function collectRepositoryFiles(cwd: string): Promise<string[]> {
   return files;
 }
 
+async function readBoundedTextFile(path: string, size: number): Promise<{ lines: string[]; truncated: boolean }> {
+  const bytesToRead = Math.min(size, LOCAL_FAST_PATH_FILE_MAX_BYTES + 1);
+  const buffer = Buffer.alloc(bytesToRead);
+  const handle = await openFile(path, 'r');
+  try {
+    const { bytesRead } = await handle.read(buffer, 0, bytesToRead, 0);
+    const raw = buffer.subarray(0, bytesRead);
+    const truncatedByBytes = bytesRead > LOCAL_FAST_PATH_FILE_MAX_BYTES || size > LOCAL_FAST_PATH_FILE_MAX_BYTES;
+    const content = raw.subarray(0, LOCAL_FAST_PATH_FILE_MAX_BYTES).toString('utf-8').replace(/\r\n/g, '\n');
+    const allLines = content.split('\n');
+    const truncatedByLines = allLines.length > LOCAL_FAST_PATH_FILE_MAX_LINES;
+    const lines = allLines.slice(0, LOCAL_FAST_PATH_FILE_MAX_LINES);
+    return {
+      lines,
+      truncated: truncatedByBytes || truncatedByLines,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
 async function resolveExploreLocalFastPath(prompt: string, cwd: string): Promise<ExploreLocalFastPathResult | undefined> {
-  const relativeLookupPath = normalizeRelativeLookupPath(prompt);
-  if (relativeLookupPath) {
-    const targetPath = resolve(cwd, relativeLookupPath);
+  const relativeLookup = normalizeRelativeLookupPath(prompt);
+  if (relativeLookup) {
+    const targetPath = resolve(cwd, relativeLookup.path);
     const cwdRoot = resolve(cwd);
     if ((targetPath === cwdRoot || targetPath.startsWith(`${cwdRoot}${sep}`)) && existsSync(targetPath)) {
       const targetStat = await stat(targetPath);
@@ -214,6 +246,18 @@ async function resolveExploreLocalFastPath(prompt: string, cwd: string): Promise
         };
       }
       if (targetStat.isFile()) {
+        if (relativeLookup.mode === 'content') {
+          const { lines, truncated } = await readBoundedTextFile(targetPath, targetStat.size);
+          return {
+            kind: 'file',
+            lines: [
+              `${relativePath} (${targetStat.size} bytes; showing up to ${LOCAL_FAST_PATH_FILE_MAX_BYTES} bytes / ${LOCAL_FAST_PATH_FILE_MAX_LINES} lines)`,
+              '---',
+              ...lines,
+              ...(truncated ? [`--- [truncated: file exceeds local fast-path limit of ${LOCAL_FAST_PATH_FILE_MAX_BYTES} bytes or ${LOCAL_FAST_PATH_FILE_MAX_LINES} lines]`] : []),
+            ],
+          };
+        }
         return {
           kind: 'path',
           lines: [`${relativePath} (${targetStat.size} bytes)`],
@@ -583,6 +627,14 @@ export async function exploreCommand(args: string[]): Promise<void> {
   const exploreEnv = resolveExploreEnv(cwd, process.env);
   const localFastPath = await resolveExploreLocalFastPath(prompt, cwd);
   if (localFastPath) {
+    if (localFastPath.kind === 'file') {
+      process.stdout.write([
+        `[omx explore] local fast-path used (file lookup).`,
+        ...localFastPath.lines,
+        '',
+      ].join('\n'));
+      return;
+    }
     process.stdout.write([
       `[omx explore] local fast-path used (${localFastPath.kind} lookup).`,
       ...localFastPath.lines.map((line) => `- ${line}`),

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -1,8 +1,7 @@
-import { readFile } from 'fs/promises';
-import { isAbsolute, join } from 'path';
+import { readFile, readdir, stat } from 'fs/promises';
+import { isAbsolute, join, relative, resolve, sep } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { getPackageRoot } from '../utils/package.js';
-import { spawnPlatformCommandSync } from '../utils/platform-command.js';
 import {
   isSparkShellNativeCompatibilityFailure,
   resolveSparkShellBinaryPathWithHydration,
@@ -27,6 +26,7 @@ import {
 } from './native-assets.js';
 import { getWikiDir, queryWiki } from '../wiki/index.js';
 import { resolveCodexHomeForLaunch } from './codex-home.js';
+import { runProcessTreeWithTimeout } from '../runtime/process-tree.js';
 
 export const EXPLORE_USAGE = [
   'Usage: omx explore --prompt "<prompt>"',
@@ -38,6 +38,11 @@ const PROMPT_FILE_FLAG = '--prompt-file';
 export const EXPLORE_BIN_ENV = EXPLORE_BIN_ENV_SHARED;
 const EXPLORE_SPARK_MODEL_ENV = 'OMX_EXPLORE_SPARK_MODEL';
 const EXPLORE_INSTRUCTIONS_FILE_ENV = 'OMX_EXPLORE_MODEL_INSTRUCTIONS_FILE';
+const EXPLORE_TIMEOUT_MS_ENV = 'OMX_EXPLORE_TIMEOUT_MS';
+const DEFAULT_EXPLORE_TIMEOUT_MS = 120_000;
+const LOCAL_FAST_PATH_MAX_FILES = 2_000;
+const LOCAL_FAST_PATH_MAX_MATCHES = 40;
+const LOCAL_FAST_PATH_EXCLUDED_DIRS = new Set(['.git', 'node_modules', 'dist', 'target', '.omx']);
 const WINDOWS_BUILTIN_EXPLORE_HARNESS_REASON =
   'the built-in explore harness is not ready on Windows because its allowlist runtime relies on POSIX sh/bash wrappers. Set OMX_EXPLORE_BIN to a compatible custom harness, prefer `omx sparkshell` for shell-native read-only lookups, or run `omx doctor` for readiness details.';
 
@@ -138,6 +143,115 @@ function formatWikiContextBlock(prompt: string, cwd: string): string | null {
 export function buildExplorePromptWithWikiContext(prompt: string, cwd: string): string {
   const wikiContext = formatWikiContextBlock(prompt, cwd);
   return wikiContext ?? prompt;
+}
+
+interface ExploreLocalFastPathResult {
+  kind: 'path' | 'text';
+  lines: string[];
+}
+
+function normalizeRelativeLookupPath(prompt: string): string | undefined {
+  const trimmed = prompt.trim();
+  const match = trimmed.match(/^(?:open|show|cat|read|find|locate)\s+([A-Za-z0-9._/@+-][A-Za-z0-9._/@+\-/]*)$/i);
+  const candidate = match?.[1] ?? (
+    /^[A-Za-z0-9._/@+-][A-Za-z0-9._/@+\-/]*$/.test(trimmed) ? trimmed : undefined
+  );
+  if (!candidate || candidate.startsWith('/') || candidate.includes('..')) return undefined;
+  return candidate;
+}
+
+function normalizeTextLookup(prompt: string): string | undefined {
+  const match = prompt.trim().match(/^(?:search(?:\s+for)?|grep|find\s+text)\s+(.+)$/i);
+  const term = match?.[1]?.trim().replace(/^["']|["']$/g, '');
+  if (!term || term.length < 2) return undefined;
+  if (/[|&;><`$()]/.test(term) || term.includes('\n')) return undefined;
+  return term;
+}
+
+async function collectRepositoryFiles(cwd: string): Promise<string[]> {
+  const files: string[] = [];
+  const pending = [cwd];
+
+  while (pending.length > 0 && files.length < LOCAL_FAST_PATH_MAX_FILES) {
+    const directory = pending.pop()!;
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!LOCAL_FAST_PATH_EXCLUDED_DIRS.has(entry.name)) pending.push(fullPath);
+        continue;
+      }
+      if (entry.isFile()) files.push(fullPath);
+      if (files.length >= LOCAL_FAST_PATH_MAX_FILES) break;
+    }
+  }
+
+  return files;
+}
+
+async function resolveExploreLocalFastPath(prompt: string, cwd: string): Promise<ExploreLocalFastPathResult | undefined> {
+  const relativeLookupPath = normalizeRelativeLookupPath(prompt);
+  if (relativeLookupPath) {
+    const targetPath = resolve(cwd, relativeLookupPath);
+    const cwdRoot = resolve(cwd);
+    if ((targetPath === cwdRoot || targetPath.startsWith(`${cwdRoot}${sep}`)) && existsSync(targetPath)) {
+      const targetStat = await stat(targetPath);
+      const relativePath = relative(cwd, targetPath) || '.';
+      if (targetStat.isDirectory()) {
+        const entries = (await readdir(targetPath)).slice(0, LOCAL_FAST_PATH_MAX_MATCHES);
+        return {
+          kind: 'path',
+          lines: [
+            `${relativePath}/`,
+            ...entries.map((entry) => `${relativePath === '.' ? '' : `${relativePath}/`}${entry}`),
+          ],
+        };
+      }
+      if (targetStat.isFile()) {
+        return {
+          kind: 'path',
+          lines: [`${relativePath} (${targetStat.size} bytes)`],
+        };
+      }
+    }
+  }
+
+  const textLookup = normalizeTextLookup(prompt);
+  if (!textLookup) return undefined;
+  const needle = textLookup.toLowerCase();
+  const matches: string[] = [];
+  for (const filePath of await collectRepositoryFiles(cwd)) {
+    if (matches.length >= LOCAL_FAST_PATH_MAX_MATCHES) break;
+    const relativePath = relative(cwd, filePath);
+    if (relativePath.toLowerCase().includes(needle)) {
+      matches.push(relativePath);
+      continue;
+    }
+    let content: string;
+    try {
+      content = await readFile(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+    const line = content.split(/\r?\n/).findIndex((value) => value.toLowerCase().includes(needle));
+    if (line >= 0) matches.push(`${relativePath}:${line + 1}`);
+  }
+
+  if (matches.length === 0) return undefined;
+  return { kind: 'text', lines: matches };
+}
+
+function parseExploreTimeoutMs(env: NodeJS.ProcessEnv): number {
+  const raw = env[EXPLORE_TIMEOUT_MS_ENV]?.trim();
+  if (!raw) return DEFAULT_EXPLORE_TIMEOUT_MS;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_EXPLORE_TIMEOUT_MS;
 }
 
 function tokenizeExploreShellCommand(commandText: string): string[] | undefined {
@@ -467,6 +581,16 @@ export async function exploreCommand(args: string[]): Promise<void> {
   const prompt = await loadExplorePrompt(parsed);
   const cwd = process.cwd();
   const exploreEnv = resolveExploreEnv(cwd, process.env);
+  const localFastPath = await resolveExploreLocalFastPath(prompt, cwd);
+  if (localFastPath) {
+    process.stdout.write([
+      `[omx explore] local fast-path used (${localFastPath.kind} lookup).`,
+      ...localFastPath.lines.map((line) => `- ${line}`),
+      '',
+    ].join('\n'));
+    return;
+  }
+
   const sparkShellRoute = resolveExploreSparkShellRoute(prompt);
   if (sparkShellRoute) {
     try {
@@ -483,15 +607,19 @@ export async function exploreCommand(args: string[]): Promise<void> {
   const harness = await resolveExploreHarnessCommandWithHydration(packageRoot, exploreEnv);
   const harnessArgs = [...harness.args, ...buildExploreHarnessArgs(prompt, cwd, exploreEnv, packageRoot)];
 
-  const { result } = spawnPlatformCommandSync(harness.command, harnessArgs, {
+  const result = await runProcessTreeWithTimeout(harness.command, harnessArgs, {
     cwd,
     env: exploreEnv,
     encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],
+    timeoutMs: parseExploreTimeoutMs(exploreEnv),
   });
 
   if (result.stdout && result.stdout.length > 0) process.stdout.write(result.stdout);
   if (result.stderr && result.stderr.length > 0) process.stderr.write(result.stderr);
+
+  if (result.timedOut) {
+    throw new Error(`[explore] harness timed out after ${parseExploreTimeoutMs(exploreEnv)}ms; terminated the process tree to avoid runaway Codex sessions. Set ${EXPLORE_TIMEOUT_MS_ENV} to adjust the bound.`);
+  }
 
   if (result.error) {
     const errno = result.error as NodeJS.ErrnoException;

--- a/src/runtime/__tests__/process-tree.test.ts
+++ b/src/runtime/__tests__/process-tree.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { runProcessTreeWithTimeout } from '../process-tree.js';
+
+describe('runProcessTreeWithTimeout', () => {
+  it('captures successful command output', async () => {
+    const result = await runProcessTreeWithTimeout(process.execPath, [
+      '-e',
+      'process.stdout.write("ok"); process.stderr.write("warn");',
+    ], { timeoutMs: 1_000 });
+
+    assert.equal(result.status, 0);
+    assert.equal(result.timedOut, false);
+    assert.equal(result.stdout, 'ok');
+    assert.equal(result.stderr, 'warn');
+  });
+
+  it('marks timed out commands after terminating the process tree', async () => {
+    const result = await runProcessTreeWithTimeout(process.execPath, [
+      '-e',
+      'setTimeout(() => {}, 5_000);',
+    ], { timeoutMs: 50, sigkillGraceMs: 10 });
+
+    assert.equal(result.timedOut, true);
+    assert.notEqual(result.status, 0);
+  });
+});

--- a/src/runtime/process-tree.ts
+++ b/src/runtime/process-tree.ts
@@ -1,0 +1,117 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { buildPlatformCommandSpec } from '../utils/platform-command.js';
+
+const DEFAULT_SIGTERM_GRACE_MS = 1_000;
+
+export interface ProcessTreeRunOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  encoding?: BufferEncoding;
+  timeoutMs?: number;
+  killSignal?: NodeJS.Signals;
+  sigkillGraceMs?: number;
+  platform?: NodeJS.Platform;
+  spawnImpl?: typeof spawn;
+  existsImpl?: (path: string) => boolean;
+}
+
+export interface ProcessTreeRunResult {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  error?: NodeJS.ErrnoException;
+}
+
+function parsePositiveTimeout(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  return Math.floor(value);
+}
+
+function killProcessTree(child: ChildProcess, platform: NodeJS.Platform, signal: NodeJS.Signals): void {
+  if (child.pid === undefined) return;
+  try {
+    if (platform === 'win32') {
+      child.kill(signal);
+      return;
+    }
+    // Children are launched as a detached process group on POSIX so a negative
+    // PID targets the whole tree instead of only the direct wrapper process.
+    process.kill(-child.pid, signal);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return;
+    try {
+      child.kill(signal);
+    } catch (fallbackErr) {
+      if ((fallbackErr as NodeJS.ErrnoException).code !== 'ESRCH') throw fallbackErr;
+    }
+  }
+}
+
+export function runProcessTreeWithTimeout(
+  command: string,
+  args: string[],
+  options: ProcessTreeRunOptions = {},
+): Promise<ProcessTreeRunResult> {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const spec = buildPlatformCommandSpec(command, args, platform, env, options.existsImpl);
+  const spawnImpl = options.spawnImpl ?? spawn;
+  const timeoutMs = parsePositiveTimeout(options.timeoutMs);
+  const killSignal = options.killSignal ?? 'SIGTERM';
+  const sigkillGraceMs = options.sigkillGraceMs ?? DEFAULT_SIGTERM_GRACE_MS;
+  const encoding = options.encoding ?? 'utf-8';
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let settled = false;
+    let timeoutTimer: NodeJS.Timeout | undefined;
+    let sigkillTimer: NodeJS.Timeout | undefined;
+
+    const child = spawnImpl(spec.command, spec.args, {
+      cwd: options.cwd,
+      env,
+      detached: platform !== 'win32',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    const finish = (result: Omit<ProcessTreeRunResult, 'stdout' | 'stderr' | 'timedOut'>): void => {
+      if (settled) return;
+      settled = true;
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      if (sigkillTimer) clearTimeout(sigkillTimer);
+      resolve({ ...result, stdout, stderr, timedOut });
+    };
+
+    child.stdout.setEncoding(encoding);
+    child.stderr.setEncoding(encoding);
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on('error', (error: NodeJS.ErrnoException) => {
+      finish({ status: null, signal: null, error });
+    });
+    child.on('close', (status: number | null, signal: NodeJS.Signals | null) => {
+      finish({ status, signal });
+    });
+
+    if (timeoutMs !== undefined) {
+      timeoutTimer = setTimeout(() => {
+        if (settled) return;
+        timedOut = true;
+        killProcessTree(child, platform, killSignal);
+        sigkillTimer = setTimeout(() => {
+          if (!settled) killProcessTree(child, platform, 'SIGKILL');
+        }, sigkillGraceMs);
+      }, timeoutMs);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add a bounded process-tree runner for child CLI execution with timeout cleanup
- route `omx explore` Codex harness calls through that timeout guard
- add a local read-only fast path for simple path/text lookups before semantic fallback

## Plan context
- Implements Worker 1 Task 1 from the approved OMX improvement plan
- Covers the runtime/explore safety + fast-path slice (PR2/PR6 scope)
- Based on upstream/dev `c7c5ffc478bb50f5bb2f9016ac4a2af7f3454f95`

## Validation
- `npm run build`
- `npm run test:explore`
- `node --test dist/runtime/__tests__/process-tree.test.js dist/cli/__tests__/explore.test.js`
