### PR TITLE
Make runtime doctor checks explicit

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
 	mkdir,
 	mkdtemp,
+	chmod,
 	readFile,
 	rm,
 	symlink,
@@ -52,6 +53,91 @@ function shouldSkipForSpawnPermissions(err?: string): boolean {
 }
 
 describe("omx doctor onboarding warning copy", () => {
+
+	it("keeps runtime readiness behind explicit --runtime", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-runtime-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			const fakeBin = join(wd, "bin");
+			await mkdir(codexDir, { recursive: true });
+			await mkdir(fakeBin, { recursive: true });
+			await writeFile(join(codexDir, "config.toml"), "codex_hooks = true\n");
+			const fakeCodex = join(fakeBin, "codex");
+			await writeFile(
+				fakeCodex,
+				`#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex 0.999.0"
+  exit 0
+fi
+if [ "$1" = "exec" ]; then
+  echo "OMX-EXEC-OK"
+  exit 0
+fi
+echo "unexpected codex args: $*" >&2
+exit 2
+`,
+			);
+			await chmod(fakeCodex, 0o755);
+
+			const env = {
+				HOME: home,
+				CODEX_HOME: codexDir,
+				OPENAI_API_KEY: "test-key",
+				PATH: `${fakeBin}:${process.env.PATH || ""}`,
+			};
+			const defaultRes = runOmx(wd, ["doctor"], env);
+			if (shouldSkipForSpawnPermissions(defaultRes.error)) return;
+			assert.equal(defaultRes.status, 0, defaultRes.stderr || defaultRes.stdout);
+			assert.doesNotMatch(defaultRes.stdout, /Runtime mode:/);
+			assert.doesNotMatch(defaultRes.stdout, /Runtime smoke:/);
+
+			const runtimeRes = runOmx(wd, ["doctor", "--runtime"], env);
+			if (shouldSkipForSpawnPermissions(runtimeRes.error)) return;
+			assert.equal(runtimeRes.status, 0, runtimeRes.stderr || runtimeRes.stdout);
+			assert.match(
+				runtimeRes.stdout,
+				/Runtime mode: explicit runtime readiness checks enabled; default omx doctor remains install-only/,
+			);
+			assert.match(runtimeRes.stdout, /Runtime auth: OPENAI_API_KEY is present/);
+			assert.match(runtimeRes.stdout, /Runtime config: config\.toml resolved/);
+			assert.match(runtimeRes.stdout, /Runtime smoke: bounded codex exec smoke returned OMX-EXEC-OK/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("warns when first-party MCP config still uses PATH-dependent node commands", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-mcp-node-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				`
+[mcp_servers.omx_state]
+command = "node"
+args = ["/repo/dist/mcp/state-server.js"]
+enabled = true
+`.trimStart(),
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/MCP Servers: OMX MCP servers omx_state use PATH-dependent node commands; run "omx setup --force" so setup writes the stable Node executable path/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 	it("warns that the built-in explore harness is not ready on Windows", () => {
 		const check = checkExploreHarness("win32", {} as NodeJS.ProcessEnv);
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -4,7 +4,7 @@
 
 import { existsSync } from "fs";
 import { readdir, readFile } from "fs/promises";
-import { join } from "path";
+import { isAbsolute, join } from "path";
 import {
 	codexHome,
 	codexConfigPath,
@@ -58,6 +58,7 @@ interface DoctorOptions {
 	force?: boolean;
 	dryRun?: boolean;
 	team?: boolean;
+	runtime?: boolean;
 }
 
 interface Check {
@@ -209,6 +210,10 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
 	// Check 10: Prompt triage
 	checks.push(checkPromptTriage());
+
+	if (options.runtime) {
+		checks.push(...(await checkRuntimeReadiness(paths, scopeResolution.installMode)));
+	}
 
 	// Print results
 	let passCount = 0;
@@ -558,6 +563,117 @@ function listTeamTmuxSessions(): Set<string> | null {
 		.map((s) => s.trim())
 		.filter((s) => s.startsWith("omx-team-"));
 	return new Set(sessions);
+}
+
+async function checkRuntimeReadiness(
+	paths: DoctorPaths,
+	installMode?: SetupInstallMode,
+): Promise<Check[]> {
+	const checks: Check[] = [];
+
+	checks.push({
+		name: "Runtime mode",
+		status: "pass",
+		message:
+			"explicit runtime readiness checks enabled; default omx doctor remains install-only",
+	});
+
+	const hasApiKey =
+		typeof process.env.OPENAI_API_KEY === "string" &&
+		process.env.OPENAI_API_KEY.trim() !== "";
+	const authPath = join(paths.codexHomeDir, "auth.json");
+	const authStatusPath = join(paths.codexHomeDir, "auth-status.json");
+	if (hasApiKey || existsSync(authPath) || existsSync(authStatusPath)) {
+		checks.push({
+			name: "Runtime auth",
+			status: "pass",
+			message: hasApiKey
+				? "OPENAI_API_KEY is present for Codex runtime use"
+				: `Codex auth artifact found in ${paths.codexHomeDir}`,
+		});
+	} else {
+		checks.push({
+			name: "Runtime auth",
+			status: "warn",
+			message: `no OPENAI_API_KEY or Codex auth artifact found in ${paths.codexHomeDir}; run codex login or provide runtime credentials before real model smoke`,
+		});
+	}
+
+	if (!existsSync(paths.configPath)) {
+		checks.push({
+			name: "Runtime config",
+			status: "warn",
+			message: `config.toml not found at ${paths.configPath}; run omx setup before runtime smoke`,
+		});
+	} else {
+		checks.push({
+			name: "Runtime config",
+			status: "pass",
+			message: `config.toml resolved at ${paths.configPath}`,
+		});
+	}
+
+	const mcpCheck = await checkMcpServers(paths.configPath, installMode);
+	checks.push({
+		...mcpCheck,
+		name: "Runtime MCP",
+	});
+
+	const hooksCheck = await checkNativeHooks(paths.hooksPath, paths.configPath);
+	checks.push({
+		...hooksCheck,
+		name: "Runtime hooks",
+	});
+
+	if (!hasApiKey && !existsSync(authPath) && !existsSync(authStatusPath)) {
+		checks.push({
+			name: "Runtime smoke",
+			status: "warn",
+			message:
+				"bounded Codex execution smoke skipped because runtime auth was not detected",
+		});
+	} else {
+		const { result } = spawnPlatformCommandSync(
+			"codex",
+			[
+				"exec",
+				"--skip-git-repo-check",
+				"Reply with exactly OMX-EXEC-OK",
+			],
+			{
+				encoding: "utf-8",
+				stdio: ["pipe", "pipe", "pipe"],
+				timeout: 30_000,
+			},
+		);
+		if (result.error) {
+			const kind = classifySpawnError(result.error as NodeJS.ErrnoException);
+			checks.push({
+				name: "Runtime smoke",
+				status: kind === "missing" ? "fail" : "warn",
+				message: `bounded codex exec smoke could not run (${result.error.message})`,
+			});
+		} else if (result.status === 0 && (result.stdout || "").includes("OMX-EXEC-OK")) {
+			checks.push({
+				name: "Runtime smoke",
+				status: "pass",
+				message: "bounded codex exec smoke returned OMX-EXEC-OK",
+			});
+		} else {
+			const stderr = (result.stderr || "").trim();
+			const stdout = (result.stdout || "").trim();
+			checks.push({
+				name: "Runtime smoke",
+				status: "warn",
+				message:
+					stderr !== ""
+						? `bounded codex exec smoke exited ${result.status}: ${stderr}`
+						: `bounded codex exec smoke exited ${result.status} without OMX-EXEC-OK${stdout ? ` (stdout: ${stdout})` : ""}`,
+			});
+		}
+	}
+
+	return checks;
 }
 
 function checkCodexCli(): Check {
@@ -1375,6 +1491,23 @@ async function checkMcpServers(
 			};
 		}
 		if (mcpCount > 0) {
+			const parsed = parseToml(content) as {
+				mcp_servers?: Record<string, { command?: unknown }>;
+			};
+			const staleOmxCommands = OMX_FIRST_PARTY_MCP_SERVER_NAMES.filter((name) => {
+				const command = parsed.mcp_servers?.[name]?.command;
+				return (
+					typeof command === "string" &&
+					(command === "node" || !isAbsolute(command))
+				);
+			});
+			if (staleOmxCommands.length > 0) {
+				return {
+					name: "MCP Servers",
+					status: "warn",
+					message: `OMX MCP servers ${staleOmxCommands.join(", ")} use PATH-dependent node commands; run "omx setup --force" so setup writes the stable Node executable path`,
+				};
+			}
 			const hasOmx = OMX_FIRST_PARTY_MCP_SERVER_NAMES.some((name) =>
 				content.includes(name),
 			);
@@ -1382,7 +1515,7 @@ async function checkMcpServers(
 				return {
 					name: "MCP Servers",
 					status: "pass",
-					message: `${mcpCount} servers configured (OMX present)`,
+					message: `${mcpCount} servers configured (OMX present; first-party commands use stable Node executable paths)`,
 				};
 			}
 			return {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -173,6 +173,7 @@ Usage:
   omx list      List packaged OMX skills and native agent prompts (--json)
   omx cleanup   Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories
   omx doctor --team  Check team/swarm runtime health diagnostics
+  omx doctor --runtime  Run explicit bounded Codex runtime readiness checks
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
   omx question  OMX-owned blocking question UI entrypoint for agent-invoked user questions
   omx adapt     Scaffold OMX-owned adapter foundations for persistent external targets
@@ -1066,6 +1067,7 @@ export async function main(args: string[]): Promise<void> {
     dryRun: flags.has("--dry-run"),
     verbose: flags.has("--verbose"),
     team: flags.has("--team"),
+    runtime: flags.has("--runtime") || flags.has("--smoke"),
   };
 
   if (flags.has("--help") && !commandOwnsLocalHelp(command)) {


### PR DESCRIPTION
## Summary
- add explicit `omx doctor --runtime` / `--smoke` readiness checks
- keep default `omx doctor` install/onboarding-focused and non-runtime-gated
- warn on first-party MCP config that still uses PATH-dependent `node` commands

## Plan context
- Implements the minimal PR4 doctor runtime-readiness slice from the approved OMX improvement plan
- Based on upstream/dev `c7c5ffc478bb50f5bb2f9016ac4a2af7f3454f95`

## Validation
- `npm run build`
- `node --test dist/cli/__tests__/doctor-warning-copy.test.js`
- `npm run lint`
