### PR TITLE
Clarify plugin MCP launch truth

### DIFF
--- a/docs/reference/project-wiki.md
+++ b/docs/reference/project-wiki.md
@@ -17,13 +17,15 @@ It is intentionally **not** a literal OMC port.
 
 ```toml
 [mcp_servers.omx_wiki]
-command = "node"
+command = "<absolute Node executable used by omx setup>"
 args = ["<repo>/dist/mcp/wiki-server.js"]
 enabled = true
 ```
 
 The bootstrap/config path should treat `omx_wiki` as a first-party OMX server
 alongside the existing built-ins, while keeping the diff small and idempotent.
+Setup-managed first-party MCP blocks must use the stable absolute Node
+executable that ran `omx setup` rather than a PATH-dependent bare `node`.
 
 ## Storage contract
 

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -175,6 +175,7 @@ describe('official Codex plugin layout', () => {
 
     for (const [serverName, server] of Object.entries(mcpManifest.mcpServers ?? {})) {
       assert.equal(server.command, OMX_PLUGIN_MCP_COMMAND, `${serverName} should run via omx`);
+      assert.notEqual(server.command, 'node', `${serverName} should not depend on a bare node command`);
       assert.equal(server.enabled, true, `${serverName} should be enabled`);
       assert.equal(server.args?.length, 2, `${serverName} should have serve subcommand + public target args`);
       assert.equal(server.args?.[0], OMX_PLUGIN_MCP_SERVE_SUBCOMMAND, `${serverName} should launch through omx mcp-serve`);


### PR DESCRIPTION
## Summary
- clarify that setup-managed first-party MCP config should use a stable absolute Node executable
- keep plugin MCP metadata truth aligned with the current `omx mcp-serve` launch contract
- add a regression assertion that plugin MCP manifests do not use bare `node`

## Plan context
- Implements the minimal PR7 setup/plugin truth slice from the approved OMX improvement plan
- Based on upstream/dev `c7c5ffc478bb50f5bb2f9016ac4a2af7f3454f95`

## Validation
- `npm run build`
- `node --test dist/cli/__tests__/codex-plugin-layout.test.js`
- `npm run lint`
