### PR TITLE
Add config-level xhigh reasoning overrides for agents

### DIFF
--- a/docs/reference/omx-config-schema-routing.md
+++ b/docs/reference/omx-config-schema-routing.md
@@ -25,6 +25,7 @@ Current code recognizes these top-level `.omx-config.json` keys:
 
 | Top-level key | Supported shape | Primary use |
 | --- | --- | --- |
+| `agentReasoning` | Object mapping agent names to `low`, `medium`, `high`, or `xhigh` | Optional per-agent reasoning overrides for generated native agent TOML and role-based worker/Ralph staffing guidance. |
 | `env` | Object of non-empty string values | Fallback environment values for model routing and helper launch paths. Model-related supported keys are listed below. |
 | `models` | Object of non-empty string values | Mode defaults and low-complexity model aliases. Supported model-routing keys are listed below. |
 | `notifications` | Object | Notification transports, profiles, templates, cooldowns, replies, and OpenClaw/custom aliases. See the notification summary below and the OpenClaw guide for full examples. |
@@ -49,10 +50,14 @@ Use [`docs/discord-integration.md`](../discord-integration.md) for Discord webho
 
 ## Supported model/env keys
 
-The model-routing reader supports two top-level objects: `env` and `models`.
+The model-routing reader supports `env`, `models`, and the role-reasoning override map `agentReasoning`.
 
 ```json
 {
+  "agentReasoning": {
+    "architect": "xhigh",
+    "critic": "xhigh"
+  },
   "env": {
     "OMX_DEFAULT_FRONTIER_MODEL": "gpt-5.5",
     "OMX_DEFAULT_STANDARD_MODEL": "gpt-5.4-mini",
@@ -97,6 +102,21 @@ Supported model-routing keys:
 | `teamLowComplexity` | Alias for `team_low_complexity`. |
 
 Do not invent per-role maps such as `models.executor`, `models.architect`, or `models.roles` unless your installed version documents that exact key. Current role routing is based on agent definitions and model class, not arbitrary per-role JSON maps.
+
+### `agentReasoning`
+
+`agentReasoning` is the supported per-agent reasoning override map. Keys are agent names and values must be one of `low`, `medium`, `high`, or `xhigh`.
+
+```json
+{
+  "agentReasoning": {
+    "architect": "xhigh",
+    "critic": "xhigh"
+  }
+}
+```
+
+These overrides do not change built-in defaults in source. They are user/project configuration that applies when OMX resolves role reasoning for generated native agent TOML and role-based team/Ralph staffing/worker guidance. Rerun `omx setup` after changing this map so setup-managed native agent TOML files are regenerated. Malformed agent names, empty values, and unsupported effort values are ignored.
 
 ## Effective model precedence
 
@@ -166,7 +186,7 @@ Use `omx team status <team-name> --model-inspect` when you need inspect hints fo
 
 ## Reasoning effort: supported places only
 
-`.omx-config.json` is **not** the general place to configure `model_reasoning_effort`. Do not add keys such as `reasoningEffort`, `modelReasoningEffort`, `reasoning`, or per-role reasoning maps to `.omx-config.json`.
+`.omx-config.json` is **not** the general place to configure root `model_reasoning_effort`. Do not add arbitrary keys such as `reasoningEffort`, `modelReasoningEffort`, `reasoning`, or undeclared per-role reasoning maps. The supported per-agent override map is exactly `agentReasoning`.
 
 Supported reasoning-effort surfaces are:
 
@@ -174,6 +194,7 @@ Supported reasoning-effort surfaces are:
 - `omx reasoning <low|medium|high|xhigh>`, which edits the active Codex `config.toml`.
 - `omx --high` and `omx --xhigh`, which pass `-c model_reasoning_effort="high|xhigh"` to Codex launch.
 - Generated native agent TOML files, where OMX writes each role's built-in `reasoningEffort` metadata.
+- `.omx-config.json` `agentReasoning`, which overrides selected role defaults for generated native agent TOML and role-based team/Ralph reasoning allocation without changing built-in defaults.
 - Team worker launch args, for example:
 
 ```bash
@@ -181,7 +202,7 @@ OMX_TEAM_WORKER_LAUNCH_ARGS='-c model_reasoning_effort="low" --model gpt-5.3-cod
   omx team 3:explore "map the config surfaces"
 ```
 
-Team runtime can also inject role-default reasoning for Codex workers when no explicit reasoning override is present. Explicit launch args win.
+Team runtime can also inject role-default or `agentReasoning`-overridden reasoning for Codex workers when no explicit reasoning override is present. Explicit launch args win.
 
 ## Starter configs
 
@@ -212,6 +233,10 @@ This keeps standard agents inheriting the frontier model by omitting `OMX_DEFAUL
 
 ```json
 {
+  "agentReasoning": {
+    "architect": "xhigh",
+    "critic": "xhigh"
+  },
   "env": {
     "OMX_DEFAULT_FRONTIER_MODEL": "gpt-5.5",
     "OMX_DEFAULT_SPARK_MODEL": "gpt-5.3-codex-spark"

--- a/plugins/oh-my-codex/skills/team/SKILL.md
+++ b/plugins/oh-my-codex/skills/team/SKILL.md
@@ -183,7 +183,7 @@ Default-model rule:
 Thinking-level rule (critical):
 - **No model-name heuristic mapping.**
 - Team runtime must **not** infer `model_reasoning_effort` from model-name substrings (e.g., `spark`, `high-capability`, `mini`).
-- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role (`low`, `medium`, `high`).
+- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role and `agentReasoning` overrides (`low`, `medium`, `high`, `xhigh`).
 - Explicit launch args still win: if `OMX_TEAM_WORKER_LAUNCH_ARGS` already includes `-c model_reasoning_effort=...`, that explicit value overrides dynamic allocation for every worker.
 
 Normalization requirements:
@@ -191,7 +191,7 @@ Normalization requirements:
 - Remove duplicate/conflicting model flags
 - Emit exactly one final canonical flag: `--model <value>`
 - Preserve unrelated args in worker launch config
-- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default reasoning level
+- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default or `agentReasoning`-overridden reasoning level
 
 ## Required Lifecycle (Operator Contract)
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -183,7 +183,7 @@ Default-model rule:
 Thinking-level rule (critical):
 - **No model-name heuristic mapping.**
 - Team runtime must **not** infer `model_reasoning_effort` from model-name substrings (e.g., `spark`, `high-capability`, `mini`).
-- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role (`low`, `medium`, `high`).
+- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role and `agentReasoning` overrides (`low`, `medium`, `high`, `xhigh`).
 - Explicit launch args still win: if `OMX_TEAM_WORKER_LAUNCH_ARGS` already includes `-c model_reasoning_effort=...`, that explicit value overrides dynamic allocation for every worker.
 
 Normalization requirements:
@@ -191,7 +191,7 @@ Normalization requirements:
 - Remove duplicate/conflicting model flags
 - Emit exactly one final canonical flag: `--model <value>`
 - Preserve unrelated args in worker launch config
-- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default reasoning level
+- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default or `agentReasoning`-overridden reasoning level
 
 ## Required Lifecycle (Operator Contract)
 

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -104,6 +104,33 @@ describe("agents/native-config", () => {
     );
   });
 
+  it("applies per-agent reasoning overrides when generating native TOML", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "omx-native-config-reasoning-"));
+    try {
+      await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({
+        agentReasoning: {
+          architect: "xhigh",
+        },
+      }));
+      const agent: AgentDefinition = {
+        name: "architect",
+        description: "System design",
+        reasoningEffort: "high",
+        posture: "frontier-orchestrator",
+        modelClass: "frontier",
+        routingRole: "leader",
+        tools: "read-only",
+        category: "build",
+      };
+
+      const toml = generateAgentToml(agent, "Architect prompt", { codexHomeOverride: codexHome });
+
+      assert.match(toml, /model_reasoning_effort = "xhigh"/);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
   it("applies exact-model mini guidance only for resolved gpt-5.4-mini standard roles", () => {
     const agent: AgentDefinition = {
       name: "debugger",
@@ -166,6 +193,34 @@ describe("agents/native-config", () => {
         catalogManifest: manifestWithAgents(["executor", "planner"]),
       });
       assert.equal(skipped, 0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("installs native agent TOML with configured per-agent reasoning overrides", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-config-install-reasoning-"));
+    const codexHome = join(root, ".codex");
+    const promptsDir = join(root, "prompts");
+    const outDir = join(codexHome, "agents");
+
+    try {
+      await mkdir(promptsDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({
+        agentReasoning: {
+          architect: "xhigh",
+        },
+      }));
+      await writeFile(join(promptsDir, "architect.md"), "architect prompt");
+
+      await installNativeAgentConfigs(root, {
+        agentsDir: outDir,
+        catalogManifest: manifestWithAgents(["architect"]),
+      });
+
+      const architectToml = await readFile(join(outDir, "architect.toml"), "utf8");
+      assert.match(architectToml, /model_reasoning_effort = "xhigh"/);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -13,6 +13,7 @@ import { getInstallableNativeAgentNames } from "./policy.js";
 import {
   getCodexConfigRootModelProvider,
   getEnvConfiguredStandardDefaultModel,
+  getAgentReasoningOverride,
   getMainDefaultModel,
   getSparkDefaultModel,
   getStandardDefaultModel,
@@ -312,7 +313,8 @@ export function generateAgentToml(
     developerInstructions: composeRoleInstructions(promptContent, agent, resolvedModel),
     model: resolvedModel,
     modelProvider: resolvedModelProvider,
-    reasoningEffort: agent.reasoningEffort,
+    reasoningEffort: getAgentReasoningOverride(agent.name, options.codexHomeOverride)
+      ?? agent.reasoningEffort,
   });
 }
 

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -12,6 +12,7 @@ import { readModeState } from '../../modes/base.js';
 import { readApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
 import { sameFilePath } from '../../utils/paths.js';
+import { shutdownTeam } from '../../team/runtime.js';
 import {
   appendTeamEvent,
   createTask,
@@ -2275,6 +2276,115 @@ describe('teamCommand status', () => {
 });
 
 describe('teamCommand await', () => {
+  it('applies project-scope agentReasoning overrides when CODEX_HOME is unset', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-project-reasoning-'));
+    const binDir = join(wd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const captureDir = join(wd, 'captures');
+    const previousCwd = process.cwd();
+    const previousPath = process.env.PATH;
+    const previousCodexHome = process.env.CODEX_HOME;
+    const previousTmux = process.env.TMUX;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
+    const previousLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+    const previousSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+    const logs: string[] = [];
+    const originalLog = console.log;
+    const teamTask = 'project scoped architect reasoning override';
+    let displayTeamName = '';
+
+    await mkdir(binDir, { recursive: true });
+    await mkdir(captureDir, { recursive: true });
+    await mkdir(join(wd, '.omx'), { recursive: true });
+    await mkdir(join(wd, '.codex', 'prompts'), { recursive: true });
+    await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }, null, 2));
+    await writeFile(join(wd, '.codex', '.omx-config.json'), JSON.stringify({
+      agentReasoning: {
+        architect: 'xhigh',
+      },
+    }, null, 2));
+    await writeFile(join(wd, '.codex', 'prompts', 'architect.md'), '<identity>You are Architect.</identity>');
+    await writeFile(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const worker = String(process.env.OMX_TEAM_WORKER || 'unknown').replace(/[^a-zA-Z0-9_-]+/g, '__');
+const out = path.join(process.env.OMX_ARGV_CAPTURE_DIR, worker + '.json');
+fs.writeFileSync(out, JSON.stringify({
+  argv: process.argv.slice(2),
+  codexHome: process.env.CODEX_HOME || null,
+  worker,
+}, null, 2));
+process.stdin.resume();
+setTimeout(() => process.exit(0), 5000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+      { mode: 0o755 },
+    );
+
+    let runtimeTeamName: string | null = null;
+    try {
+      process.chdir(wd);
+      process.env.PATH = `${binDir}:${previousPath ?? ''}`;
+      delete process.env.CODEX_HOME;
+      delete process.env.TMUX;
+      delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      process.env.OMX_TEAM_WORKER_CLI = 'codex';
+      process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
+      process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+      displayTeamName = parseTeamStartArgs(['1:architect', teamTask]).parsed.teamName;
+
+      await withMockPromptModeCodexAllowed(() =>
+        withoutTeamTestWorkerEnv(() => teamCommand(['1:architect', teamTask])));
+
+      const startedState = await readModeState('team', wd);
+      runtimeTeamName = String(startedState?.team_name ?? parseTeamStartArgs(['1:architect', teamTask]).parsed.teamName);
+
+      let captured: { argv: string[]; codexHome: string | null } | null = null;
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        const capturePath = join(captureDir, `${displayTeamName}__worker-1.json`);
+        if (existsSync(capturePath)) {
+          captured = JSON.parse(await readFile(capturePath, 'utf-8')) as { argv: string[]; codexHome: string | null };
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      assert.ok(captured, 'worker argv capture file should be written');
+      assert.equal(captured!.codexHome, join(process.cwd(), '.codex'));
+      assert.match(captured!.argv.join(' '), /model_reasoning_effort="xhigh"/);
+      assert.match(logs.join('\n'), /architect x1 .*xhigh reasoning/);
+    } finally {
+      console.log = originalLog;
+      if (runtimeTeamName) {
+        await shutdownTeam(runtimeTeamName, wd, { force: true }).catch(() => {});
+      }
+      process.chdir(previousCwd);
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousCodexHome === 'string') process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousCaptureDir === 'string') process.env.OMX_ARGV_CAPTURE_DIR = previousCaptureDir;
+      else delete process.env.OMX_ARGV_CAPTURE_DIR;
+      if (typeof previousLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = previousLaunchArgs;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+      if (typeof previousSkipReadyWait === 'string') process.env.OMX_TEAM_SKIP_READY_WAIT = previousSkipReadyWait;
+      else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('returns next canonical event for a team in JSON mode', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-await-'));
     const previousCwd = process.cwd();

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { startMode, updateModeState } from '../modes/base.js';
 import { readApprovedExecutionLaunchHint, type ApprovedExecutionLaunchHint } from '../planning/artifacts.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
+import { resolveCodexHomeForLaunch } from './codex-home.js';
 import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
@@ -296,7 +297,10 @@ export async function ralphCommand(args: string[]): Promise<void> {
   const task = explicitTask === 'ralph-cli-launch' ? approvedHint?.task ?? explicitTask : explicitTask;
   const noDeslop = normalizedArgs.some((arg) => arg.toLowerCase() === '--no-deslop');
   const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
-  const staffingPlan = buildFollowupStaffingPlan('ralph', task, availableAgentTypes);
+  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, process.env);
+  const staffingPlan = buildFollowupStaffingPlan('ralph', task, availableAgentTypes, {
+    codexHomeOverride,
+  });
   await startMode('ralph', task, 50);
   const sessionFiles = await writeRalphSessionFiles(cwd, task, { noDeslop, approvedHint });
   await updateModeState('ralph', {

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -38,6 +38,7 @@ import {
   resolvePersistedApprovedTeamExecutionContinuityStateSync,
   type ApprovedTeamExecutionBinding,
 } from '../team/approved-execution.js';
+import { resolveCodexHomeForLaunch } from './codex-home.js';
 
 interface TeamCliOptions {
   verbose?: boolean;
@@ -1309,6 +1310,7 @@ export function buildLeaderMonitoringHints(teamName: string): string[] {
 
 export async function teamCommand(args: string[], _options: TeamCliOptions = {}): Promise<void> {
   const cwd = process.cwd();
+  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, process.env);
   const parsedWorktree = parseWorktreeMode(args);
   const worktreeMode = resolveDefaultTeamWorktreeMode(parsedWorktree.mode);
   const teamArgs = parsedWorktree.remainingArgs;
@@ -1559,6 +1561,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     const staffingPlan = buildFollowupStaffingPlan('team', runtime.config.task, availableAgentTypes, {
       workerCount: runtime.config.worker_count,
       fallbackRole: resolveImplicitTeamFallbackRole(runtime.config.agent_type, false),
+      codexHomeOverride,
     });
     await renderStartSummary(runtime, staffingPlan);
     return;
@@ -1616,6 +1619,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
   const staffingPlan = buildFollowupStaffingPlan('team', parsed.task, availableAgentTypes, {
     workerCount: executionPlan.workerCount,
     fallbackRole: resolveImplicitTeamFallbackRole(parsed.agentType, parsed.explicitAgentType),
+    codexHomeOverride,
   });
   const runtime = await startTeam(
     parsed.teamName,
@@ -1625,6 +1629,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     tasks,
     cwd,
     {
+      codexHomeOverride,
       worktreeMode,
       decompositionMetadata: executionPlan.metadata,
       approvedExecution: parsed.approvedExecution ?? null,

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_FRONTIER_MODEL,
   DEFAULT_SPARK_MODEL,
   DEFAULT_TEAM_CHILD_MODEL,
+  getAgentReasoningOverride,
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
   getModelForMode,
@@ -14,6 +15,7 @@ import {
   getStandardDefaultModel,
   getTeamChildModel,
   getTeamLowComplexityModel,
+  readAgentReasoningOverrides,
   readConfiguredEnvOverrides,
 } from '../models.js';
 
@@ -243,6 +245,25 @@ describe('getModelForMode', () => {
       OMX_DEFAULT_STANDARD_MODEL: 'standard-local',
       OMX_DEFAULT_SPARK_MODEL: 'spark-local',
     });
+  });
+
+  it('reads normalized per-agent reasoning overrides from .omx-config.json', async () => {
+    await writeConfig({
+      agentReasoning: {
+        Architect: ' xhigh ',
+        critic: 'high',
+        executor: 'invalid',
+        'bad role': 'low',
+        empty: '   ',
+      },
+    });
+
+    assert.deepEqual(readAgentReasoningOverrides(), {
+      architect: 'xhigh',
+      critic: 'high',
+    });
+    assert.equal(getAgentReasoningOverride('ARCHITECT'), 'xhigh');
+    assert.equal(getAgentReasoningOverride('executor'), undefined);
   });
 
   it('keeps explicit low-complexity config ahead of OMX_DEFAULT_SPARK_MODEL', async () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -13,6 +13,9 @@
  *   "models": {
  *     "default": "o4-mini",
  *     "team": "gpt-4.1"
+ *   },
+ *   "agentReasoning": {
+ *     "architect": "xhigh"
  *   }
  * }
  *
@@ -32,7 +35,10 @@ export interface OmxConfigEnv {
   [key: string]: string | undefined;
 }
 
+export type ConfiguredAgentReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+
 interface OmxConfigFile {
+  agentReasoning?: Record<string, unknown>;
   env?: OmxConfigEnv;
   models?: ModelsConfig;
 }
@@ -95,6 +101,24 @@ function normalizeConfiguredValue(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function normalizeAgentReasoningEffort(value: unknown): ConfiguredAgentReasoningEffort | undefined {
+  const normalized = normalizeConfiguredValue(value)?.toLowerCase();
+  if (
+    normalized === 'low' ||
+    normalized === 'medium' ||
+    normalized === 'high' ||
+    normalized === 'xhigh'
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeAgentName(value: unknown): string | undefined {
+  const normalized = normalizeConfiguredValue(value)?.toLowerCase();
+  return normalized && /^[a-z0-9][a-z0-9_-]*$/.test(normalized) ? normalized : undefined;
+}
+
 function readConfigEnvValue(key: string, codexHomeOverride?: string): string | undefined {
   const config = readOmxConfigFile(codexHomeOverride);
   if (!config || !config.env || typeof config.env !== 'object' || Array.isArray(config.env)) {
@@ -125,6 +149,31 @@ export function readConfiguredEnvOverrides(codexHomeOverride?: string): NodeJS.P
     if (normalized) resolved[key] = normalized;
   }
   return resolved;
+}
+
+export function readAgentReasoningOverrides(
+  codexHomeOverride?: string,
+): Record<string, ConfiguredAgentReasoningEffort> {
+  const config = readOmxConfigFile(codexHomeOverride);
+  const raw = config?.agentReasoning;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+
+  const resolved: Record<string, ConfiguredAgentReasoningEffort> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const role = normalizeAgentName(key);
+    const effort = normalizeAgentReasoningEffort(value);
+    if (role && effort) resolved[role] = effort;
+  }
+  return resolved;
+}
+
+export function getAgentReasoningOverride(
+  agentName: string | undefined,
+  codexHomeOverride?: string,
+): ConfiguredAgentReasoningEffort | undefined {
+  const normalized = normalizeAgentName(agentName);
+  if (!normalized) return undefined;
+  return readAgentReasoningOverrides(codexHomeOverride)[normalized];
 }
 
 export function readActiveProviderEnvOverrides(

--- a/src/scripts/verify-native-agents.ts
+++ b/src/scripts/verify-native-agents.ts
@@ -188,7 +188,9 @@ export async function verifyNativeAgents(
     const promptContent = options.promptNames
       ? `${name} prompt fixture`
       : await readFile(promptPath, "utf-8");
-    const toml = generateAgentToml(agent, promptContent);
+    const toml = generateAgentToml(agent, promptContent, {
+      codexHomeOverride: join(root, ".omx", "verify-native-agents-codex-home"),
+    });
     assertTomlStructure(name, agent, toml);
   }
 

--- a/src/team/__tests__/followup-planner.test.ts
+++ b/src/team/__tests__/followup-planner.test.ts
@@ -78,6 +78,33 @@ describe('followup-planner', () => {
     assert.equal(plan.verificationPlan.checkpoints.length, 3);
   });
 
+  it('applies per-agent reasoning overrides to Ralph sign-off staffing guidance', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-followup-reasoning-'));
+    try {
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        agentReasoning: {
+          architect: 'xhigh',
+        },
+      }));
+
+      const plan = buildFollowupStaffingPlan(
+        'ralph',
+        'Investigate auth regression and verify the fix',
+        ['architect', 'debugger', 'executor', 'test-engineer'],
+        { codexHomeOverride: codexHome },
+      );
+
+      assert.ok(
+        plan.allocations.some(
+          (allocation) => allocation.role === 'architect' && allocation.reasoningEffort === 'xhigh',
+        ),
+      );
+      assert.match(plan.staffingSummary, /architect x1 .*xhigh reasoning/);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
   it('allocates explore plus researcher lanes for mixed local+official-doc follow-up', () => {
     const plan = buildFollowupStaffingPlan(
       'team',

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -163,6 +164,22 @@ describe('team model contract', () => {
     assert.equal(resolveAgentReasoningEffort('executor'), 'medium');
     assert.equal(resolveAgentReasoningEffort('architect'), 'high');
     assert.equal(resolveAgentReasoningEffort('does-not-exist'), undefined);
+  });
+
+  it('maps worker roles through configured per-agent reasoning overrides', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-model-contract-reasoning-'));
+    try {
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        agentReasoning: {
+          architect: 'xhigh',
+        },
+      }));
+
+      assert.equal(resolveAgentReasoningEffort('architect', codexHome), 'xhigh');
+      assert.equal(resolveAgentReasoningEffort('critic', codexHome), 'high');
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
   });
 
   it('maps worker roles to configured default model lanes', () => {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -103,6 +103,7 @@ function withIsolatedDefaultModelEnv<T>(run: () => T): T {
     'OMX_DEFAULT_STANDARD_MODEL',
     'OMX_DEFAULT_SPARK_MODEL',
     'OMX_SPARK_MODEL',
+    'OMX_TEAM_WORKER_LAUNCH_ARGS',
   ] as const) {
     savedEnv.set(key, process.env[key]);
     delete process.env[key];
@@ -132,6 +133,7 @@ async function withIsolatedDefaultModelEnvAsync<T>(
     'OMX_DEFAULT_STANDARD_MODEL',
     'OMX_DEFAULT_SPARK_MODEL',
     'OMX_SPARK_MODEL',
+    'OMX_TEAM_WORKER_LAUNCH_ARGS',
   ] as const) {
     savedEnv.set(key, process.env[key]);
     delete process.env[key];
@@ -3249,7 +3251,7 @@ process.exit(0);
   });
 
 
-  it('startTeam preserves routed task roles into team state and worker launch args', async () => {
+  it('startTeam preserves routed task roles into team state and override-aware worker launch args', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-role-routing-'));
     const binDir = join(cwd, 'bin');
     const fakeCodexPath = join(binDir, 'codex');
@@ -3291,8 +3293,16 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withIsolatedDefaultModelEnvAsync(async () =>
-        await withMockPromptModeCodexAllowed(() =>
+      runtime = await withIsolatedDefaultModelEnvAsync(async () => {
+        assert.ok(process.env.CODEX_HOME, 'isolated CODEX_HOME should be set');
+        await mkdir(process.env.CODEX_HOME, { recursive: true });
+        await writeFile(join(process.env.CODEX_HOME, '.omx-config.json'), JSON.stringify({
+          agentReasoning: {
+            writer: 'xhigh',
+          },
+        }));
+
+        return await withMockPromptModeCodexAllowed(() =>
           withoutTeamWorkerEnv(() =>
             startTeam(
               'team-role-routing',
@@ -3304,7 +3314,8 @@ process.on('SIGTERM', () => process.exit(0));
                 { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' },
               ],
               cwd,
-            ))));
+            )));
+      });
 
       assert.equal(runtime.config.worker_launch_mode, 'prompt');
       assert.equal(runtime.config.workers[0]?.role, 'test-engineer');
@@ -3349,7 +3360,7 @@ process.on('SIGTERM', () => process.exit(0));
       assert.match(worker1Joined, /model_reasoning_effort="medium"/);
       assert.match(worker1Joined, /model_instructions_file=.*worker-1\/AGENTS\.md/);
       assert.match(worker1Joined, /--model gpt-5\.5/);
-      assert.match(worker2Joined, /model_reasoning_effort="high"/);
+      assert.match(worker2Joined, /model_reasoning_effort="xhigh"/);
       assert.match(worker2Joined, /model_instructions_file=.*worker-2\/AGENTS\.md/);
       assert.match(worker2Joined, /--model gpt-5\.5/);
 

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -397,6 +397,125 @@ describe('scaleUp', () => {
   });
 
 
+  it('uses project-scoped CODEX_HOME for scaled worker reasoning and model defaults', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-project-reasoning-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-project-reasoning-bin-'));
+    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+    const previousStandardModel = process.env.OMX_DEFAULT_STANDARD_MODEL;
+    const previousFrontierModel = process.env.OMX_DEFAULT_FRONTIER_MODEL;
+    const previousCodeHome = process.env.CODEX_HOME;
+
+    try {
+      await writeFile(
+        tmuxStubPath,
+        [
+          '#!/bin/sh',
+          'set -eu',
+          `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+          'case "${1:-}" in',
+          '  -V)',
+          '    echo "tmux 3.2a"',
+          '    ;;',
+          '  split-window)',
+          '    echo "%31"',
+          '    ;;',
+          '  list-panes)',
+          '    echo "42424"',
+          '    ;;',
+          '  send-keys)',
+          '    ;;',
+          '  capture-pane)',
+          '    echo ""',
+          '    ;;',
+          'esac',
+          'exit 0',
+          '',
+        ].join('\n'),
+      );
+      await chmod(tmuxStubPath, 0o755);
+      await writeFile(tmuxLogPath, '');
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+      delete process.env.CODEX_HOME;
+      delete process.env.OMX_DEFAULT_STANDARD_MODEL;
+      delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
+
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await mkdir(join(cwd, '.codex'), { recursive: true });
+      await writeFile(join(cwd, '.codex', '.omx-config.json'), JSON.stringify({
+        env: {
+          OMX_DEFAULT_STANDARD_MODEL: 'project-standard-model',
+        },
+        agentReasoning: {
+          writer: 'xhigh',
+        },
+      }));
+      await mkdir(join(cwd, '.codex', 'prompts'), { recursive: true });
+      await writeFile(join(cwd, '.codex', 'prompts', 'writer.md'), '<identity>You are Writer.</identity>');
+      await mkdir(join(cwd, '.omx', 'state', 'team', 'scale-up-project-reasoning'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'team', 'scale-up-project-reasoning', 'worker-agents.md'), '# Base worker instructions\n');
+
+      await initTeamState('scale-up-project-reasoning', 'task', 'executor', 1, cwd);
+      await createTask('scale-up-project-reasoning', {
+        subject: 'existing task',
+        description: 'already persisted',
+        status: 'pending',
+        owner: 'worker-1',
+      }, cwd);
+
+      const config = await readTeamConfig('scale-up-project-reasoning', cwd);
+      assert.ok(config);
+      if (!config) return;
+      config.tmux_session = 'omx-team-scale-up-project-reasoning';
+      config.leader_pane_id = '%11';
+      config.workers[0]!.pane_id = '%21';
+      await saveTeamConfig(config, cwd);
+
+      const manifestPath = join(cwd, '.omx', 'state', 'team', 'scale-up-project-reasoning', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
+      manifest.policy = {
+        ...(manifest.policy ?? {}),
+        dispatch_mode: 'transport_direct',
+      };
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = await scaleUp(
+        'scale-up-project-reasoning',
+        1,
+        'executor',
+        [{ subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' }],
+        cwd,
+        { OMX_TEAM_SCALING_ENABLED: '1', OMX_TEAM_SKIP_READY_WAIT: '1' },
+      );
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /CODEX_HOME=.*\.codex/);
+      assert.match(tmuxLog, /model_reasoning_effort="xhigh"/);
+      assert.match(tmuxLog, /--model/);
+      assert.match(tmuxLog, /project-standard-model/);
+
+      const workerAgents = await readFile(join(cwd, '.omx', 'state', 'team', 'scale-up-project-reasoning', 'workers', 'worker-2', 'AGENTS.md'), 'utf-8');
+      assert.match(workerAgents, /You are operating as the \*\*writer\*\* role/);
+      assert.match(workerAgents, /resolved_model: project-standard-model/);
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousStandardModel === 'string') process.env.OMX_DEFAULT_STANDARD_MODEL = previousStandardModel;
+      else delete process.env.OMX_DEFAULT_STANDARD_MODEL;
+      if (typeof previousFrontierModel === 'string') process.env.OMX_DEFAULT_FRONTIER_MODEL = previousFrontierModel;
+      else delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
+      if (typeof previousCodeHome === 'string') process.env.CODEX_HOME = previousCodeHome;
+      else delete process.env.CODEX_HOME;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
+
   it('removes generated worktree-root AGENTS when scale-up rolls back', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-rollback-worktree-'));
     const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-rollback-worktree-bin-'));

--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -106,12 +106,14 @@ process.on('SIGTERM', () => process.exit(0));
     const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const prevCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
+    const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
 
     process.env.PATH = `${binDir}:${prevPath ?? ''}`;
     delete process.env.TMUX;
     process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     process.env.OMX_TEAM_WORKER_CLI = 'codex';
     process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
+    delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
 
     let runtime: TeamRuntime | null = null;
     try {
@@ -180,6 +182,8 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevCaptureDir === 'string') process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
       else delete process.env.OMX_ARGV_CAPTURE_DIR;
+      if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/followup-planner.ts
+++ b/src/team/followup-planner.ts
@@ -39,6 +39,7 @@ export interface ResolveAvailableAgentTypesOptions {
 }
 
 export interface BuildFollowupStaffingPlanOptions {
+  codexHomeOverride?: string;
   workerCount?: number;
   fallbackRole?: string;
 }
@@ -140,9 +141,10 @@ function mergeAllocation(
   role: string,
   count: number,
   reason: string,
+  codexHomeOverride?: string,
 ): void {
   if (count <= 0) return;
-  const reasoningEffort = resolveAgentReasoningEffort(role);
+  const reasoningEffort = resolveAgentReasoningEffort(role, codexHomeOverride);
   const existing = allocations.find(
     (item) => item.role === role && item.reason === reason && item.reasoningEffort === reasoningEffort,
   );
@@ -290,31 +292,37 @@ export function buildFollowupStaffingPlan(
   );
   const allocations: FollowupAllocation[] = [];
 
-  mergeAllocation(allocations, primaryRole, 1, mode === 'team' ? 'primary delivery lane' : 'primary implementation lane');
+  mergeAllocation(
+    allocations,
+    primaryRole,
+    1,
+    mode === 'team' ? 'primary delivery lane' : 'primary implementation lane',
+    options.codexHomeOverride,
+  );
 
   if (mode === 'team') {
     if (workerCount >= 2) {
-      mergeAllocation(allocations, qualityRole, 1, 'verification + regression lane');
+      mergeAllocation(allocations, qualityRole, 1, 'verification + regression lane', options.codexHomeOverride);
     }
     if (workerCount >= 3) {
       const specialistRole = pickSpecialistRole(task, availableAgentTypes, primaryRole, primaryRole);
-      mergeAllocation(allocations, specialistRole, 1, 'specialist support lane');
+      mergeAllocation(allocations, specialistRole, 1, 'specialist support lane', options.codexHomeOverride);
     }
     if (workerCount >= 4) {
-      mergeAllocation(allocations, primaryRole, workerCount - 3, 'extra implementation capacity');
+      mergeAllocation(allocations, primaryRole, workerCount - 3, 'extra implementation capacity', options.codexHomeOverride);
     }
   } else {
-    mergeAllocation(allocations, qualityRole, 1, 'evidence + regression checks');
+    mergeAllocation(allocations, qualityRole, 1, 'evidence + regression checks', options.codexHomeOverride);
     const architectRole = chooseAvailableRole(
       availableAgentTypes,
       ['architect', 'critic', 'verifier'],
       qualityRole,
     );
-    mergeAllocation(allocations, architectRole, 1, 'final architecture / completion sign-off');
+    mergeAllocation(allocations, architectRole, 1, 'final architecture / completion sign-off', options.codexHomeOverride);
 
     if (workerCount >= 4) {
       const specialistRole = pickSpecialistRole(task, availableAgentTypes, primaryRole, primaryRole);
-      mergeAllocation(allocations, specialistRole, workerCount - 3, 'parallel specialist follow-up capacity');
+      mergeAllocation(allocations, specialistRole, workerCount - 3, 'parallel specialist follow-up capacity', options.codexHomeOverride);
     }
   }
 

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -1,6 +1,7 @@
 import { getAgent } from '../agents/definitions.js';
 import {
   DEFAULT_SPARK_MODEL,
+  getAgentReasoningOverride,
   getMainDefaultModel,
   getSparkDefaultModel,
   getStandardDefaultModel,
@@ -204,9 +205,13 @@ export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgs
   return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel, options.preferredReasoning, selectedModelProvider);
 }
 
-export function resolveAgentReasoningEffort(agentType?: string): TeamReasoningEffort | undefined {
+export function resolveAgentReasoningEffort(
+  agentType?: string,
+  codexHomeOverride?: string,
+): TeamReasoningEffort | undefined {
   if (typeof agentType !== 'string' || agentType.trim() === '') return undefined;
-  return normalizeOptionalReasoning(getAgent(agentType)?.reasoningEffort);
+  return normalizeOptionalReasoning(getAgentReasoningOverride(agentType, codexHomeOverride))
+    ?? normalizeOptionalReasoning(getAgent(agentType)?.reasoningEffort);
 }
 
 export function resolveAgentDefaultModel(

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -16,6 +16,7 @@ import type { TeamRuntime, TeamShutdownSummary, StaleTeamSummary } from './runti
 import type { TeamDecompositionMetadata } from './repo-aware-decomposition.js';
 import { teamReadConfig as readTeamConfig } from './team-ops.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
+import { resolveCodexHomeForLaunch } from '../cli/codex-home.js';
 
 async function promptStaleCleanup(summary: StaleTeamSummary): Promise<boolean> {
   process.stderr.write(
@@ -393,6 +394,7 @@ async function main(): Promise<void> {
         tasks,
         cwd,
         {
+          codexHomeOverride: resolveCodexHomeForLaunch(cwd, process.env),
           confirmStaleCleanup: promptStaleCleanup,
           ...(decompositionMetadata ? { decompositionMetadata } : {}),
         },

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1262,6 +1262,7 @@ export interface StaleTeamSummary {
 }
 
 export interface TeamStartOptions {
+  codexHomeOverride?: string;
   worktreeMode?: WorktreeMode;
   decompositionMetadata?: TeamDecompositionMetadata;
   confirmStaleCleanup?: (summary: StaleTeamSummary) => Promise<boolean>;
@@ -2211,12 +2212,20 @@ export async function startTeam(
   options: TeamStartOptions = {},
 ): Promise<TeamRuntime> {
   const leaderCwd = resolve(cwd);
+  const codexHomeOverride = typeof options.codexHomeOverride === 'string' && options.codexHomeOverride.trim() !== ''
+    ? options.codexHomeOverride.trim()
+    : (typeof process.env.CODEX_HOME === 'string' && process.env.CODEX_HOME.trim() !== ''
+        ? process.env.CODEX_HOME.trim()
+        : undefined);
+  const launchEnv = codexHomeOverride
+    ? { ...process.env, CODEX_HOME: codexHomeOverride }
+    : process.env;
   await assertNestedTeamAllowed(leaderCwd);
   const effectiveWorktreeMode = resolveEffectiveTeamWorktreeMode(leaderCwd, options.worktreeMode);
   const displayName = sanitizeTeamName(teamName);
-  const workerLaunchMode = resolveTeamWorkerLaunchMode(process.env);
+  const workerLaunchMode = resolveTeamWorkerLaunchMode(launchEnv);
   const displayMode = workerLaunchMode === 'interactive' ? 'split_pane' : 'auto';
-  const rawIdentityScope = resolveTeamIdentityScope(process.env);
+  const rawIdentityScope = resolveTeamIdentityScope(launchEnv);
   const resolvedLeaderSessionId = await resolveLeaderSessionId(leaderCwd);
   const identityScope = rawIdentityScope.source === 'run-id'
     ? (resolvedLeaderSessionId
@@ -2314,21 +2323,21 @@ export async function startTeam(
   let createdLeaderPaneId: string | undefined;
   let config: TeamConfig | null = null;
   const sharedWorkerLaunchArgs = resolveTeamWorkerLaunchArgs({
-    existingRaw: process.env.OMX_TEAM_WORKER_LAUNCH_ARGS,
-    fallbackModel: resolveAgentDefaultModel(agentType, process.env.CODEX_HOME),
+    existingRaw: launchEnv.OMX_TEAM_WORKER_LAUNCH_ARGS,
+    fallbackModel: resolveAgentDefaultModel(agentType, codexHomeOverride),
   });
-  const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, sharedWorkerLaunchArgs, process.env);
+  const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, sharedWorkerLaunchArgs, launchEnv);
   if (workerLaunchMode === 'prompt') {
     assertPromptModeWorkerCliSupported(workerCliPlan);
   }
-  const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(process.env);
+  const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(launchEnv);
   const workerStartupEvidenceTimeoutMs = resolveWorkerStartupEvidenceTimeoutMs(
-    process.env,
+    launchEnv,
     workerReadyTimeoutMs,
   );
-  const startupDispatchRetries = resolveStartupDispatchRetries(process.env);
-  const startupRetryDelayS = resolveStartupDispatchRetryDelayS(process.env);
-  const skipWorkerReadyWait = shouldSkipWorkerReadyWait(process.env);
+  const startupDispatchRetries = resolveStartupDispatchRetries(launchEnv);
+  const startupRetryDelayS = resolveStartupDispatchRetryDelayS(launchEnv);
+  const skipWorkerReadyWait = shouldSkipWorkerReadyWait(launchEnv);
 
   try {
     // 3. Init state directory + config
@@ -2340,7 +2349,7 @@ export async function startTeam(
       leaderCwd,
       DEFAULT_MAX_WORKERS,
       {
-        ...process.env,
+        ...launchEnv,
         OMX_SESSION_ID: leaderSessionId,
         OMX_TEAM_DISPLAY_MODE: displayMode,
         OMX_TEAM_WORKER_LAUNCH_MODE: workerLaunchMode,
@@ -2461,10 +2470,10 @@ export async function startTeam(
       const runtimeRole = workerRole;
       const rawRolePromptContent = await loadRolePrompt(runtimeRole, join(leaderCwd, '.codex', 'prompts'))
         ?? await loadRolePrompt(runtimeRole, codexPromptsDir());
-      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, process.env.CODEX_HOME)
-        ?? resolveAgentReasoningEffort(agentType, process.env.CODEX_HOME);
+      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, codexHomeOverride)
+        ?? resolveAgentReasoningEffort(agentType, codexHomeOverride);
       const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
-        process.env,
+        launchEnv,
         runtimeRole,
         undefined,
         preferredReasoning,
@@ -2531,6 +2540,7 @@ export async function startTeam(
         [TEAM_LEADER_CWD_ENV]: leaderCwd,
         [MODEL_INSTRUCTIONS_FILE_ENV]: plan.instructionsFilePath,
         OMX_TEAM_DISPLAY_NAME: displayName,
+        ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
       };
       if (plan.workerWorkspace.worktreePath) {
         env.OMX_TEAM_WORKTREE_PATH = plan.workerWorkspace.worktreePath;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2461,7 +2461,8 @@ export async function startTeam(
       const runtimeRole = workerRole;
       const rawRolePromptContent = await loadRolePrompt(runtimeRole, join(leaderCwd, '.codex', 'prompts'))
         ?? await loadRolePrompt(runtimeRole, codexPromptsDir());
-      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole) ?? resolveAgentReasoningEffort(agentType);
+      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, process.env.CODEX_HOME)
+        ?? resolveAgentReasoningEffort(agentType, process.env.CODEX_HOME);
       const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
         process.env,
         runtimeRole,

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -355,7 +355,8 @@ export async function scaleUp(
       // Build startup command and create tmux pane
       const rawRolePromptContent = await loadRolePrompt(runtimeRole, join(leaderCwd, '.codex', 'prompts'))
         ?? await loadRolePrompt(runtimeRole, codexPromptsDir());
-      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole) ?? resolveAgentReasoningEffort(agentType);
+      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, env.CODEX_HOME)
+        ?? resolveAgentReasoningEffort(agentType, env.CODEX_HOME);
       const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, runtimeRole, preferredReasoning);
       const resolvedWorkerModel = parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
       const rolePromptContent = rawRolePromptContent

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -60,6 +60,7 @@ import { buildTeamWorkerGoalInstruction } from './goal-workflow.js';
 import { loadRolePrompt } from './role-router.js';
 import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
+import { resolveCodexHomeForLaunch } from '../cli/codex-home.js';
 import {
   parseTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchArgs,
@@ -229,6 +230,10 @@ export async function scaleUp(
     }
 
     const teamStateRoot = config.team_state_root ?? resolveCanonicalTeamStateRoot(leaderCwd);
+    const codexHomeOverride = resolveCodexHomeForLaunch(leaderCwd, env);
+    const launchEnv = codexHomeOverride
+      ? { ...env, CODEX_HOME: codexHomeOverride }
+      : env;
     const sessionName = config.tmux_session;
     const manifest = await readTeamManifestV2(sanitized, leaderCwd);
     const dispatchPolicy = normalizeTeamPolicy(manifest?.policy, {
@@ -316,8 +321,8 @@ export async function scaleUp(
     const persistedTasks = await listTasks(sanitized, leaderCwd);
 
     // Resolve shared worker launch args for CLI selection.
-    const sharedWorkerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, agentType);
-    const workerCliPlan = resolveTeamWorkerCliPlan(count, sharedWorkerLaunchArgs, env);
+    const sharedWorkerLaunchArgs = resolveWorkerLaunchArgsForScaling(launchEnv, agentType, undefined, codexHomeOverride);
+    const workerCliPlan = resolveTeamWorkerCliPlan(count, sharedWorkerLaunchArgs, launchEnv);
 
     for (let i = 0; i < count; i++) {
       const workerIndex = nextIndex;
@@ -355,9 +360,9 @@ export async function scaleUp(
       // Build startup command and create tmux pane
       const rawRolePromptContent = await loadRolePrompt(runtimeRole, join(leaderCwd, '.codex', 'prompts'))
         ?? await loadRolePrompt(runtimeRole, codexPromptsDir());
-      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, env.CODEX_HOME)
-        ?? resolveAgentReasoningEffort(agentType, env.CODEX_HOME);
-      const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, runtimeRole, preferredReasoning);
+      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, codexHomeOverride)
+        ?? resolveAgentReasoningEffort(agentType, codexHomeOverride);
+      const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(launchEnv, runtimeRole, preferredReasoning, codexHomeOverride);
       const resolvedWorkerModel = parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
       const rolePromptContent = rawRolePromptContent
         ? composeRoleInstructionsForRole(runtimeRole, rawRolePromptContent, resolvedWorkerModel)
@@ -380,6 +385,7 @@ export async function scaleUp(
         OMX_TEAM_STATE_ROOT: teamStateRoot,
         OMX_TEAM_LEADER_CWD: leaderCwd,
         OMX_MODEL_INSTRUCTIONS_FILE: instructionsFilePath,
+        ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
       };
       if (workerWorkspace) {
         extraEnv.OMX_TEAM_WORKTREE_PATH = workerWorkspace.worktreePath;
@@ -815,9 +821,10 @@ function resolveWorkerLaunchArgsForScaling(
   env: NodeJS.ProcessEnv,
   agentType: string,
   preferredReasoning?: TeamReasoningEffort,
+  codexHomeOverride?: string,
 ): string[] {
   const inheritedArgs: string[] = [];
-  const fallbackModel = resolveAgentDefaultModel(agentType, env.CODEX_HOME);
+  const fallbackModel = resolveAgentDefaultModel(agentType, codexHomeOverride ?? env.CODEX_HOME);
 
   return resolveTeamWorkerLaunchArgs({
     existingRaw: env.OMX_TEAM_WORKER_LAUNCH_ARGS,


### PR DESCRIPTION
## Summary

Focused successor to #2111 for the per-agent `xhigh` reasoning gap from #2089.

This adds a config-only way to raise high-default agents like `critic` and `architect` to `xhigh` without editing `src/agents/definitions.ts`:

```json
{
  "agentReasoning": {
    "critic": "xhigh",
    "architect": "xhigh"
  }
}
```

This intentionally does **not** change the built-in defaults; it only adds explicit per-agent overrides.

## What changed

- Parse and normalize `.omx-config.json` `agentReasoning` values: `low | medium | high | xhigh`.
- Apply per-agent reasoning overrides to:
  - native agent TOML generation/install
  - Team worker reasoning resolution
  - Ralph/follow-up staffing guidance
  - Team scale-up launches
- Preserve project-scoped `CODEX_HOME` resolution so project-local `.codex/.omx-config.json` overrides are honored when `CODEX_HOME` is unset.
- Update docs/skills for the new `agentReasoning` config key.
- Keep canonical native-agent verification isolated from user/project config.

## Focus / non-goals

- No `question.test` or batch-handshake stabilization changes are included here.
- No built-in role default changes are included here.
- This PR is only about explicit, config-level agent reasoning overrides, especially `xhigh` for agents that currently default to `high`.

## Validation

- `npm run build`
- `node --test dist/config/__tests__/models.test.js dist/team/__tests__/model-contract.test.js dist/team/__tests__/scaling.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/followup-planner.test.js dist/cli/__tests__/team.test.js dist/agents/__tests__/native-config.test.js`
  - 286 pass, 0 fail, elapsed 349s
  - Note: `runtime.test.js` contains intentionally slow startup-window tests, so this focused command takes about 6 minutes locally.
- `npx -y node@20 dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`
  - 1508 pass, 0 fail, elapsed 56s

Refs #2089.
