### PR TITLE
Keep solo worktree launch state durable

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -39,6 +39,7 @@ import {
   resolveProjectLocalCodexHomeForLaunch,
   shouldAutoIsolateMadmaxLaunch,
   createMadmaxIsolatedRoot,
+  resolveDisposableWorktreeOmxRootForLaunch,
   prepareCodexHomeForLaunch,
   runtimeCodexHomePath,
   buildDetachedSessionBootstrapSteps,
@@ -132,6 +133,43 @@ describe("madmax state isolation", () => {
       await rm(wd, { recursive: true, force: true });
       await rm(runs, { recursive: true, force: true });
     }
+  });
+});
+
+
+describe("disposable worktree state root resolution", () => {
+  it("uses the source repo root for launch worktrees when no explicit root is set", () => {
+    assert.equal(
+      resolveDisposableWorktreeOmxRootForLaunch(
+        { enabled: true, repoRoot: "/repo" },
+        {},
+      ),
+      "/repo",
+    );
+  });
+
+  it("preserves explicit OMX_ROOT and OMX_STATE_ROOT precedence", () => {
+    assert.equal(
+      resolveDisposableWorktreeOmxRootForLaunch(
+        { enabled: true, repoRoot: "/repo" },
+        { OMX_ROOT: "/explicit" },
+      ),
+      undefined,
+    );
+    assert.equal(
+      resolveDisposableWorktreeOmxRootForLaunch(
+        { enabled: true, repoRoot: "/repo" },
+        { OMX_STATE_ROOT: "/state-root" },
+      ),
+      undefined,
+    );
+  });
+
+  it("does not affect non-worktree launches", () => {
+    assert.equal(
+      resolveDisposableWorktreeOmxRootForLaunch({ enabled: false }, {}),
+      undefined,
+    );
   });
 });
 

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
 
@@ -46,6 +47,19 @@ function escapeRegExp(value: string): string {
 
 function shouldSkipForSpawnPermissions(err: string): boolean {
   return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+
+async function createGitRepo(wd: string): Promise<string> {
+  const repo = join(wd, 'repo');
+  await mkdir(repo, { recursive: true });
+  execFileSync('git', ['init'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repo, stdio: 'ignore' });
+  await writeFile(join(repo, 'README.md'), 'fixture\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd: repo, stdio: 'ignore' });
+  return repo;
 }
 
 async function writeExecutable(path: string, content: string): Promise<void> {
@@ -119,6 +133,90 @@ describe('omx launch fallback when tmux is unavailable', () => {
       assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
       assert.match(result.stdout, /fake-codex:.*model_reasoning_effort="xhigh"/);
       assert.doesNotMatch(result.stderr, /spawnSync tmux ENOENT/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('omx --worktree disposable state root', () => {
+  it('keeps launch worktree state under the source repo root by default', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-worktree-state-'));
+    try {
+      const repo = await createGitRepo(wd);
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeExecutable(
+        join(fakeBin, 'codex'),
+        `#!/bin/sh
+printf 'fake-codex-omx-root:%s\n' "$OMX_ROOT"
+printf 'fake-codex:%s\n' "$*"
+`,
+      );
+      await writeExecutable(join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n');
+
+      const result = runOmx(repo, ['--direct', '--worktree', '--version'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        OMX_ROOT: '',
+        OMX_STATE_ROOT: '',
+        TMUX: '',
+        TMUX_PANE: '',
+      });
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const worktreePath = join(dirname(repo), `${basename(repo)}.omx-worktrees`, 'launch-detached');
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, new RegExp(`fake-codex-omx-root:${escapeRegExp(repo)}`));
+      assert.equal(existsSync(join(repo, '.omx', 'state')), true);
+      assert.equal(existsSync(join(worktreePath, '.omx')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves explicit OMX_ROOT for launch worktree state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-worktree-explicit-root-'));
+    try {
+      const repo = await createGitRepo(wd);
+      const explicitRoot = join(wd, 'explicit-root');
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeExecutable(
+        join(fakeBin, 'codex'),
+        `#!/bin/sh
+printf 'fake-codex-omx-root:%s\n' "$OMX_ROOT"
+printf 'fake-codex:%s\n' "$*"
+`,
+      );
+      await writeExecutable(join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n');
+
+      const result = runOmx(repo, ['--direct', '--worktree', '--version'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        OMX_ROOT: explicitRoot,
+        OMX_STATE_ROOT: '',
+        TMUX: '',
+        TMUX_PANE: '',
+      });
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, new RegExp(`fake-codex-omx-root:${escapeRegExp(explicitRoot)}`));
+      assert.equal(existsSync(join(explicitRoot, '.omx', 'state')), true);
+      assert.equal(existsSync(join(repo, '.omx')), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -977,6 +977,33 @@ export function resolveOmxRootForLaunch(
   return raw.startsWith("/") ? raw : join(cwd, raw);
 }
 
+function hasExplicitOmxRootEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return [env.OMX_ROOT, env.OMX_STATE_ROOT].some(
+    (value) => typeof value === "string" && value.trim() !== "",
+  );
+}
+
+export function resolveDisposableWorktreeOmxRootForLaunch(
+  ensuredWorktree: { enabled: true; repoRoot: string } | { enabled: false } | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (!ensuredWorktree?.enabled) return undefined;
+  if (hasExplicitOmxRootEnv(env)) return undefined;
+  return ensuredWorktree.repoRoot;
+}
+
+function applyDisposableWorktreeOmxRootForLaunch(
+  ensuredWorktree: { enabled: true; repoRoot: string } | { enabled: false } | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  const omxRootOverride = resolveDisposableWorktreeOmxRootForLaunch(
+    ensuredWorktree,
+    env,
+  );
+  if (!omxRootOverride) return;
+  env.OMX_ROOT = omxRootOverride;
+}
+
 export function shouldAutoIsolateMadmaxLaunch(
   command: string,
   launchArgs: string[],
@@ -1374,6 +1401,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
   );
   let cwd = launchCwd;
   let worktreeDirty = false;
+  let ensuredLaunchWorktree: ReturnType<typeof ensureWorktree> | undefined;
   if (parsedWorktree.mode.enabled) {
     const planned = planWorktreeTarget({
       cwd: launchCwd,
@@ -1381,6 +1409,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
       mode: parsedWorktree.mode,
     });
     const ensured = ensureWorktree(planned, { allowDirtyReuse: true });
+    ensuredLaunchWorktree = ensured;
     if (ensured.enabled) {
       cwd = ensured.worktreePath;
       if (ensured.dirty) {
@@ -1398,6 +1427,8 @@ export async function launchWithHud(args: string[]): Promise<void> {
       }
     }
   }
+  applyDisposableWorktreeOmxRootForLaunch(ensuredLaunchWorktree);
+
   const sessionId = `omx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   try {
     await maybeCheckAndPromptUpdate(cwd);
@@ -1482,6 +1513,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
   );
   let cwd = launchCwd;
   let worktreeDirty = false;
+  let ensuredLaunchWorktree: ReturnType<typeof ensureWorktree> | undefined;
 
   if (parsedWorktree.mode.enabled) {
     const planned = planWorktreeTarget({
@@ -1490,6 +1522,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
       mode: parsedWorktree.mode,
     });
     const ensured = ensureWorktree(planned, { allowDirtyReuse: true });
+    ensuredLaunchWorktree = ensured;
     if (ensured.enabled) {
       cwd = ensured.worktreePath;
       if (ensured.dirty) {
@@ -1507,6 +1540,8 @@ export async function execWithOverlay(args: string[]): Promise<void> {
       }
     }
   }
+
+  applyDisposableWorktreeOmxRootForLaunch(ensuredLaunchWorktree);
 
   const sessionId = `omx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 

--- a/src/hooks/codebase-map.ts
+++ b/src/hooks/codebase-map.ts
@@ -18,6 +18,7 @@ import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 import { execSync } from 'node:child_process';
 import { findGitLayout } from '../utils/git-layout.js';
+import { omxRoot } from '../utils/paths.js';
 
 /** Max chars for the whole map output. */
 const MAX_MAP_CHARS = 1000;
@@ -43,7 +44,7 @@ interface CodebaseMapCacheFile {
 }
 
 function cachePathForWorktree(worktreeRoot: string): string {
-  return join(worktreeRoot, '.omx', 'cache', 'codebase-map.json');
+  return join(omxRoot(worktreeRoot), 'cache', 'codebase-map.json');
 }
 
 function readGitIndexSignature(gitDir: string): { mtimeMs: number; size: number } | null {
@@ -82,7 +83,7 @@ async function writeCachedCodebaseMap(
   const targetPath = cachePathForWorktree(worktreeRoot);
   const tempPath = `${targetPath}.${process.pid}.${Date.now()}.tmp`;
   try {
-    await mkdir(join(worktreeRoot, '.omx', 'cache'), { recursive: true });
+    await mkdir(join(omxRoot(worktreeRoot), 'cache'), { recursive: true });
     const payload: CodebaseMapCacheFile = {
       version: CACHE_VERSION,
       worktreeRoot,

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs";
 import { appendFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { getPackageRoot } from "../../utils/package.js";
+import { omxRoot } from "../../utils/paths.js";
 import {
 	createLifecycleBroadcastFingerprint,
 	recordLifecycleHookBroadcastSent,
@@ -32,14 +33,14 @@ const RUNNER_SIGKILL_GRACE_MS = 250;
 
 function hooksLogPath(cwd: string): string {
 	const day = new Date().toISOString().slice(0, 10);
-	return join(cwd, ".omx", "logs", `hooks-${day}.jsonl`);
+	return join(omxRoot(cwd), "logs", `hooks-${day}.jsonl`);
 }
 
 async function appendHooksLog(
 	cwd: string,
 	payload: Record<string, unknown>,
 ): Promise<void> {
-	await mkdir(join(cwd, ".omx", "logs"), { recursive: true });
+	await mkdir(join(omxRoot(cwd), "logs"), { recursive: true });
 	await appendFile(
 		hooksLogPath(cwd),
 		`${JSON.stringify({ timestamp: new Date().toISOString(), ...payload })}\n`,
@@ -325,7 +326,7 @@ export async function dispatchHookEvent(
 	if (
 		dedupeFingerprint
 		&& !shouldSendLifecycleHookBroadcast(
-			join(cwd, ".omx", "state"),
+			join(omxRoot(cwd), "state"),
 			event.session_id,
 			event.event,
 			dedupeFingerprint,
@@ -379,7 +380,7 @@ export async function dispatchHookEvent(
 
 	if (dedupeFingerprint && summary.results.some((result) => result.ok)) {
 		recordLifecycleHookBroadcastSent(
-			join(cwd, ".omx", "state"),
+			join(omxRoot(cwd), "state"),
 			event.session_id,
 			event.event,
 			dedupeFingerprint,

--- a/src/hooks/extensibility/logging.ts
+++ b/src/hooks/extensibility/logging.ts
@@ -1,15 +1,16 @@
 import { appendFile, mkdir } from 'fs/promises';
 import { join } from 'path';
+import { omxRoot } from '../../utils/paths.js';
 import type { HookPluginLogContext } from './types.js';
 
 export function hookLogPath(cwd: string, timestamp = new Date()): string {
   const date = timestamp.toISOString().slice(0, 10);
-  return join(cwd, '.omx', 'logs', `hooks-${date}.jsonl`);
+  return join(omxRoot(cwd), 'logs', `hooks-${date}.jsonl`);
 }
 
 export async function appendHookPluginLog(cwd: string, entry: HookPluginLogContext): Promise<void> {
   const path = hookLogPath(cwd, entry.timestamp ? new Date(entry.timestamp) : new Date());
-  await mkdir(join(cwd, '.omx', 'logs'), { recursive: true });
+  await mkdir(join(omxRoot(cwd), 'logs'), { recursive: true });
   const payload = {
     timestamp: entry.timestamp || new Date().toISOString(),
     ...entry,

--- a/src/hooks/extensibility/sdk/paths.ts
+++ b/src/hooks/extensibility/sdk/paths.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { omxRoot } from '../../../utils/paths.js';
 
 export function sanitizeHookPluginName(name: string): string {
   const cleaned = (name || 'unknown-plugin').replace(/[^a-zA-Z0-9._-]/g, '-');
@@ -6,7 +7,7 @@ export function sanitizeHookPluginName(name: string): string {
 }
 
 export function hookPluginRootDir(cwd: string, pluginName: string): string {
-  return join(cwd, '.omx', 'state', 'hooks', 'plugins', sanitizeHookPluginName(pluginName));
+  return join(omxRoot(cwd), 'state', 'hooks', 'plugins', sanitizeHookPluginName(pluginName));
 }
 
 export function hookPluginTmuxStatePath(cwd: string, pluginName: string): string {
@@ -19,9 +20,9 @@ export function hookPluginDataPath(cwd: string, pluginName: string): string {
 
 export function hookPluginLogPath(cwd: string, now = new Date()): string {
   const day = now.toISOString().slice(0, 10);
-  return join(cwd, '.omx', 'logs', `hooks-${day}.jsonl`);
+  return join(omxRoot(cwd), 'logs', `hooks-${day}.jsonl`);
 }
 
 export function omxRootStateFilePath(cwd: string, fileName: string): string {
-  return join(cwd, '.omx', 'state', fileName);
+  return join(omxRoot(cwd), 'state', fileName);
 }


### PR DESCRIPTION
## Summary
- fixes #2133
- routes solo `omx --worktree` / `omx exec --worktree` runtime state through the source repo root when no explicit `OMX_ROOT` / `OMX_STATE_ROOT` is set
- preserves explicit root precedence and non-worktree cwd-local behavior
- updates hook logs/plugin state and codebase-map cache paths to honor the effective OMX root so launch worktrees stay disposable

## Verification
- `npm run build`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_SESSION_ID -u OMX_ENTRY_PATH -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD node --test dist/cli/__tests__/launch-fallback.test.js`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_SESSION_ID -u OMX_ENTRY_PATH -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD node --test dist/cli/__tests__/index.test.js dist/hooks/__tests__/codebase-map.test.js dist/hooks/extensibility/__tests__/logging.test.js dist/hooks/extensibility/__tests__/sdk.test.js`
- `npm run lint`
- `npm run check:no-unused`

## Notes
- Existing worktree-local `.omx` data is not migrated automatically.
