### PR TITLE
Fix stale root skill state after terminal ralplan/Ralph

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -188,6 +188,8 @@ const TEAM_ENV_KEYS = [
   "OMX_TEAM_STATE_ROOT",
   "OMX_TEAM_LEADER_CWD",
   "OMX_SESSION_ID",
+  "OMX_ROOT",
+  "OMX_STATE_ROOT",
   "SESSION_ID",
   "OMX_QUESTION_RETURN_PANE",
   "OMX_LEADER_PANE_ID",
@@ -8404,6 +8406,109 @@ exit 0
         systemMessage:
           "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
       });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("clears stale root skill-active state when current session ralplan is terminal", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-root-skill-terminal-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stop-terminal-ralplan";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: false,
+        mode: "ralplan",
+        current_phase: "completed",
+        lifecycle_outcome: "finished",
+        run_outcome: "finish",
+        final_artifact: "proposed_plan",
+      });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: true,
+        skill: "ultrawork",
+        phase: "planning",
+        source: "keyword-detector",
+        active_skills: [
+          { skill: "ultrawork", phase: "planning", active: true },
+        ],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-stop-terminal-ralplan",
+          turn_id: "turn-stop-terminal-ralplan-1",
+          last_assistant_message: "Done.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+
+      const rootSkillState = JSON.parse(
+        await readFile(join(stateDir, "skill-active-state.json"), "utf-8"),
+      ) as { active?: boolean; active_skills?: unknown[]; reconciliation_reason?: string };
+      assert.equal(rootSkillState.active, false);
+      assert.deepEqual(rootSkillState.active_skills, []);
+      assert.equal(rootSkillState.reconciliation_reason, "stop_hook_session_state_terminal");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves legitimate session-scoped ultrawork blocking while reconciling root skill-active state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-active-root-skill-session-mode-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stop-active-ultrawork";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "ultrawork-state.json"), {
+        active: true,
+        mode: "ultrawork",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: true,
+        skill: "ultrawork",
+        phase: "planning",
+        source: "keyword-detector",
+        active_skills: [
+          { skill: "ultrawork", phase: "planning", active: true, session_id: sessionId },
+        ],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-stop-active-ultrawork",
+          turn_id: "turn-stop-active-ultrawork-1",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: "OMX ultrawork is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ultrawork_executing",
+        systemMessage: "OMX ultrawork is still active (phase: executing).",
+      });
+
+      const rootSkillState = JSON.parse(
+        await readFile(join(stateDir, "skill-active-state.json"), "utf-8"),
+      ) as { active?: boolean; active_skills?: Array<{ skill?: string }> };
+      assert.equal(rootSkillState.active, true);
+      assert.deepEqual(rootSkillState.active_skills?.map((entry) => entry.skill), ["ultrawork"]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -8514,6 +8514,64 @@ exit 0
     }
   });
 
+  it("reconciles stale root skill-active state under OMX_ROOT boxed state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-boxed-source-"));
+    const omxRoot = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-boxed-root-"));
+    const previousOmxRoot = process.env.OMX_ROOT;
+    try {
+      process.env.OMX_ROOT = omxRoot;
+      const stateDir = join(omxRoot, ".omx", "state");
+      const sourceStateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stop-boxed-ralplan";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: false,
+        mode: "ralplan",
+        current_phase: "completed",
+        lifecycle_outcome: "finished",
+        run_outcome: "finish",
+      });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: true,
+        skill: "ultrawork",
+        phase: "planning",
+        source: "keyword-detector",
+        active_skills: [
+          { skill: "ultrawork", phase: "planning", active: true },
+        ],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-stop-boxed-ralplan",
+          turn_id: "turn-stop-boxed-ralplan-1",
+          last_assistant_message: "Done.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+
+      const boxedRootSkillState = JSON.parse(
+        await readFile(join(stateDir, "skill-active-state.json"), "utf-8"),
+      ) as { active?: boolean; active_skills?: unknown[]; reconciliation_reason?: string };
+      assert.equal(boxedRootSkillState.active, false);
+      assert.deepEqual(boxedRootSkillState.active_skills, []);
+      assert.equal(boxedRootSkillState.reconciliation_reason, "stop_hook_session_state_terminal");
+      assert.equal(existsSync(join(sourceStateDir, "skill-active-state.json")), false);
+    } finally {
+      if (previousOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = previousOmxRoot;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(omxRoot, { recursive: true, force: true });
+    }
+  });
+
   it("auto-continues native Stop for permission-seeking prompts even outside OMX runtime", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-plain-session-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "url";
 import { readModeState, readModeStateForActiveDecision, readModeStateForSession, updateModeState } from "../modes/base.js";
 import {
   extractSessionIdFromInitializedStatePath,
+  getSkillActiveStatePaths,
   listActiveSkills,
   readSkillActiveState,
   readVisibleSkillActiveState,
@@ -1944,7 +1945,7 @@ async function readSessionScopedModeStateForRootSkill(
   sessionIds: string[],
 ): Promise<Record<string, unknown> | null> {
   for (const sessionId of sessionIds) {
-    const state = await readJsonIfExists(join(cwd, ".omx", "state", "sessions", sessionId, `${skill}-state.json`));
+    const state = await readJsonIfExists(getStateFilePath(`${skill}-state.json`, cwd, sessionId));
     if (state) return state;
   }
   return null;
@@ -1954,7 +1955,7 @@ async function reconcileStaleRootSkillActiveStateForStop(
   cwd: string,
   sessionId: string,
 ): Promise<void> {
-  const rootPath = join(cwd, ".omx", "state", "skill-active-state.json");
+  const { rootPath } = getSkillActiveStatePaths(cwd);
   const rootState = await readSkillActiveState(rootPath);
   if (!rootState?.active) return;
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -7,7 +7,9 @@ import { readModeState, readModeStateForActiveDecision, readModeStateForSession,
 import {
   extractSessionIdFromInitializedStatePath,
   listActiveSkills,
+  readSkillActiveState,
   readVisibleSkillActiveState,
+  type SkillActiveStateLike,
 } from "../state/skill-active.js";
 import {
   readSubagentSessionSummary,
@@ -1924,6 +1926,87 @@ async function readBlockingSkillForStop(
   return null;
 }
 
+function uniqueNonEmpty(values: Array<string | undefined>): string[] {
+  return [...new Set(values.map((value) => safeString(value).trim()).filter(Boolean))];
+}
+
+function isTerminalOrInactiveModeState(state: Record<string, unknown> | null): boolean {
+  if (!state) return true;
+  if (state.active !== true) return true;
+  if (getRunContinuationSnapshot(state)?.terminal === true) return true;
+  const phase = safeString(state.current_phase ?? state.currentPhase).trim().toLowerCase();
+  return phase !== "" && TERMINAL_MODE_PHASES.has(phase);
+}
+
+async function readSessionScopedModeStateForRootSkill(
+  cwd: string,
+  skill: string,
+  sessionIds: string[],
+): Promise<Record<string, unknown> | null> {
+  for (const sessionId of sessionIds) {
+    const state = await readJsonIfExists(join(cwd, ".omx", "state", "sessions", sessionId, `${skill}-state.json`));
+    if (state) return state;
+  }
+  return null;
+}
+
+async function reconcileStaleRootSkillActiveStateForStop(
+  cwd: string,
+  sessionId: string,
+): Promise<void> {
+  const rootPath = join(cwd, ".omx", "state", "skill-active-state.json");
+  const rootState = await readSkillActiveState(rootPath);
+  if (!rootState?.active) return;
+
+  const initializedSessionId = extractSessionIdFromInitializedStatePath(rootState.initialized_state_path);
+  const rootSessionIds = uniqueNonEmpty([
+    sessionId,
+    safeString(rootState.session_id),
+    initializedSessionId,
+    ...listActiveSkills(rootState).map((entry) => safeString(entry.session_id)),
+  ]);
+  if (rootSessionIds.length === 0) return;
+
+  const activeEntries = listActiveSkills(rootState);
+  let changed = false;
+  const keptEntries = [];
+  for (const entry of activeEntries) {
+    const skill = safeString(entry.skill).trim();
+    if (!skill) continue;
+    const entrySessionId = safeString(entry.session_id).trim();
+    const candidateSessionIds = uniqueNonEmpty([
+      entrySessionId,
+      sessionId,
+      initializedSessionId,
+      safeString(rootState.session_id),
+    ]);
+    const modeState = await readSessionScopedModeStateForRootSkill(cwd, skill, candidateSessionIds);
+    if (isTerminalOrInactiveModeState(modeState)) {
+      changed = true;
+      continue;
+    }
+    keptEntries.push(entry);
+  }
+
+  if (!changed) return;
+
+  const nowIso = new Date().toISOString();
+  const nextRoot: SkillActiveStateLike = {
+    ...rootState,
+    active: keptEntries.length > 0,
+    skill: keptEntries[0]?.skill ?? safeString(rootState.skill).trim(),
+    phase: keptEntries[0]?.phase ?? safeString(rootState.phase).trim(),
+    updated_at: nowIso,
+    active_skills: keptEntries,
+    reconciled_at: nowIso,
+    reconciliation_reason: "stop_hook_session_state_terminal",
+  };
+  if (keptEntries.length === 0) {
+    nextRoot.phase = "inactive";
+  }
+  await writeFile(rootPath, JSON.stringify(nextRoot, null, 2));
+}
+
 function buildRalplanContinuationStatus(
   blocker: { phase: string; latestPlanPath?: string; planningComplete?: boolean; runOutcome?: string },
   activeSubagentCount: number,
@@ -2446,6 +2529,9 @@ async function buildStopHookOutput(
   const sessionId = readPayloadSessionId(payload);
   const canonicalSessionId = await resolveInternalSessionIdForPayload(cwd, sessionId);
   const threadId = readPayloadThreadId(payload);
+  if (canonicalSessionId) {
+    await reconcileStaleRootSkillActiveStateForStop(cwd, canonicalSessionId);
+  }
   const execFollowupOutput = await buildExecFollowupStopOutput(cwd, canonicalSessionId);
   if (execFollowupOutput) return execFollowupOutput;
   const ralphState = options.skipRalphStopBlock === true


### PR DESCRIPTION
## Summary\n- reconcile root .omx/state/skill-active-state.json during native Stop when the current session-scoped workflow state is terminal/inactive/missing\n- clear stale root active skill entries so completed ralplan/Ralph handoffs cannot keep Stop loops alive\n- preserve legitimate blocking when the session-scoped workflow mode is still active\n\nFixes #2125.\n\n## Verification\n- npm run build\n- node --test --test-name-pattern "stale root skill-active|legitimate session-scoped ultrawork" dist/scripts/__tests__/codex-native-hook.test.js\n- node --test dist/scripts/__tests__/codex-native-hook.test.js\n- npm run check:no-unused\n- npm run lint\n\nNote: attempted full npm test in this active OMX boxed runtime, but parent OMX_ROOT/interactive tmux environment contaminated unrelated suites; stopped after unrelated failures in adapt/autoresearch/question/wiki/setup tests. Targeted native Stop hook suite passes cleanly.