### PR TITLE
Handle blocked ultragoal Codex goal handoffs

### DIFF
--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -18,7 +18,7 @@ All artifacts live under `.omx/ultragoal/`:
 
 - `brief.md` — original project/conversation brief.
 - `goals.json` — ordered durable plan with status, attempts, evidence, and the active goal id.
-- `ledger.jsonl` — append-only checkpoint events (`plan_created`, `goal_started`, `goal_resumed`, `goal_completed`, `goal_failed`, `goal_retried`).
+- `ledger.jsonl` — append-only checkpoint events (`plan_created`, `goal_started`, `goal_resumed`, `goal_completed`, `goal_blocked`, `goal_failed`, `goal_retried`).
 
 ## Commands
 
@@ -49,6 +49,14 @@ omx ultragoal checkpoint --goal-id G001-example --status failed --evidence "bloc
 omx ultragoal complete-goals --retry-failed
 ```
 
+Completed legacy thread-goal blocker handling:
+
+```sh
+omx ultragoal checkpoint --goal-id G001-example --status blocked --evidence "completed legacy Codex goal blocks create_goal in this thread" --codex-goal-json ./get-goal.json
+```
+
+`--status blocked` is a non-terminal ledger checkpoint for issue #2139-style sessions: a previous, different Codex thread goal is already `complete`, and the current `get_goal`/`create_goal` tool surface has no reset/new-goal operation that can clear that completed goal from the same thread. This writes a `goal_blocked` event, preserves the ultragoal as `in_progress`, and records that the agent must continue the same repo/worktree from a fresh Codex thread where `create_goal` can start the active ultragoal objective.
+
 Status:
 
 ```sh
@@ -62,7 +70,9 @@ omx ultragoal status --json
 - One Codex thread can have at most one active goal.
 - `create_goal` starts the active objective; it is not a general plan store.
 - `update_goal` is completion-only; pause/resume/budget state is controlled by Codex/user/system, not OMX.
+- There is currently no Codex goal-tool reset/new-goal surface for replacing a completed legacy thread goal. If `get_goal` returns a different completed objective and `create_goal` rejects because the thread already has a goal, record `omx ultragoal checkpoint --status blocked` with that `get_goal` JSON, then continue in a fresh Codex thread on the same branch/worktree and call `create_goal` there for the ultragoal payload.
 - Ultragoal owns durable plan and ledger state; Codex goal mode owns active-thread focus and accounting.
 - OMX never edits upstream Codex source such as `../../codex`, never shells out to a hidden `/goal` mutator, and never claims that `omx ultragoal checkpoint` changes Codex's active thread goal. The only Codex goal-mode handoff is explicit: `get_goal`, then `create_goal` when no active goal exists, then `update_goal({status: "complete"})` after the real completion audit passes.
 - Completion checkpoints require a fresh `get_goal` snapshot. Save or pass the JSON from `get_goal` with `--codex-goal-json <json-or-path>`; OMX compares the objective and requires Codex status `complete` before accepting `--status complete`.
+- Active or incomplete wrong Codex goals remain strict mismatch errors. The `--status blocked` workaround only applies when the blocking Codex snapshot is `complete` and has a different objective from the active ultragoal; it must not be used to bypass active-goal mismatch protection.
 - A goal is not complete merely because tests pass or a ledger entry exists. The agent must audit the objective against files, commands, tests, PR state, or other concrete evidence.

--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -38,6 +38,8 @@ describe('cli/ultragoal', () => {
   it('prints help with artifact and goal-mode constraints', async () => {
     assert.match(ULTRAGOAL_HELP, /create-goals/);
     assert.match(ULTRAGOAL_HELP, /complete-goals/);
+    assert.match(ULTRAGOAL_HELP, /blocked/);
+    assert.match(ULTRAGOAL_HELP, /fresh Codex thread/);
     assert.match(ULTRAGOAL_HELP, /get_goal\/create_goal\/update_goal/);
   });
 
@@ -51,6 +53,8 @@ describe('cli/ultragoal', () => {
       const output = next.stdout.join('\n');
       assert.match(output, /Ultragoal active-goal handoff/);
       assert.match(output, /create_goal payload/);
+      assert.match(output, /fresh Codex thread/);
+      assert.match(output, /--status blocked/);
       assert.match(output, /omx ultragoal checkpoint --goal-id G001-first-milestone --status complete/);
 
       const goals = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { activeGoalId?: string };
@@ -109,6 +113,49 @@ describe('cli/ultragoal', () => {
       ]));
       assert.equal(mismatch.exitCode, 1);
       assert.match(mismatch.stderr.join('\n'), /objective mismatch/);
+    });
+  });
+
+  it('records blocked legacy Codex-goal checkpoints as non-terminal', async () => {
+    await withCwd(async (cwd) => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+
+      const blocked = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first-milestone',
+        '--status', 'blocked',
+        '--evidence', 'completed aggregate Codex goal blocks create_goal',
+        '--codex-goal-json', '{"goal":{"objective":"achieve all goals on this repo ultragoal status","status":"complete"}}',
+        '--json',
+      ]));
+
+      assert.equal(blocked.exitCode, undefined);
+      const parsed = JSON.parse(blocked.stdout.join('\n')) as { summary: { inProgress: number; failed: number }; plan: { activeGoalId?: string } };
+      assert.equal(parsed.summary.inProgress, 1);
+      assert.equal(parsed.summary.failed, 0);
+      assert.equal(parsed.plan.activeGoalId, 'G001-first-milestone');
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"goal_blocked"/);
+    });
+  });
+
+  it('does not let blocked checkpoints bypass active Codex-goal mismatch protection', async () => {
+    await withCwd(async () => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+
+      const blocked = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first-milestone',
+        '--status', 'blocked',
+        '--evidence', 'active wrong goal',
+        '--codex-goal-json', '{"goal":{"objective":"Different active work","status":"active"}}',
+      ]));
+
+      assert.equal(blocked.exitCode, 1);
+      assert.match(blocked.stderr.join('\n'), /strict objective mismatch protection remains required/);
     });
   });
 });

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -21,7 +21,7 @@ export const ULTRAGOAL_HELP = `omx ultragoal - Durable repo-native multi-goal wo
 Usage:
   omx ultragoal create-goals [--brief <text> | --brief-file <path> | --from-stdin] [--goal <title::objective>] [--force] [--json]
   omx ultragoal complete-goals [--retry-failed] [--json]
-  omx ultragoal checkpoint --goal-id <id> --status <complete|failed> [--evidence <text>] [--codex-goal-json <json-or-path>] [--json]
+  omx ultragoal checkpoint --goal-id <id> --status <complete|failed|blocked> [--evidence <text>] [--codex-goal-json <json-or-path>] [--json]
   omx ultragoal status [--codex-goal-json <json-or-path>] [--json]
 
 Aliases:
@@ -36,6 +36,9 @@ Codex goal integration:
   This command cannot directly invoke the interactive /goal tool from a shell.
   complete-goals writes durable state and prints a model-facing handoff that tells
   the active Codex agent when to call get_goal/create_goal/update_goal safely.
+  If a completed legacy thread goal blocks create_goal for the next ultragoal,
+  checkpoint --status blocked records that non-terminal blocker and the handoff
+  should continue in a fresh Codex thread for the same repo/worktree.
 `;
 
 function hasFlag(args: readonly string[], flag: string): boolean {
@@ -174,7 +177,7 @@ export async function ultragoalCommand(args: string[]): Promise<void> {
       const goalId = readValue(rest, '--goal-id');
       const status = readValue(rest, '--status');
       if (!goalId) throw new UltragoalError('Missing --goal-id.');
-      if (status !== 'complete' && status !== 'failed') throw new UltragoalError('Missing or invalid --status; expected complete or failed.');
+      if (status !== 'complete' && status !== 'failed' && status !== 'blocked') throw new UltragoalError('Missing or invalid --status; expected complete, failed, or blocked.');
       const evidence = readValue(rest, '--evidence');
       const codexGoal = await parseCodexGoalJson(readValue(rest, '--codex-goal-json'));
       const plan = await checkpointUltragoal(cwd, { goalId, status, evidence, codexGoal });

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -60,6 +60,9 @@ describe('ultragoal artifacts', () => {
       const instruction = buildCodexGoalInstruction(started.goal!, started.plan);
       assert.match(instruction, /call get_goal/i);
       assert.match(instruction, /call create_goal/i);
+      assert.match(instruction, /different completed legacy\/thread goal/i);
+      assert.match(instruction, /fresh Codex thread/i);
+      assert.match(instruction, /--status blocked/);
       assert.match(instruction, /update_goal\(\{status: "complete"\}\)/);
       assert.match(instruction, /--codex-goal-json/);
       assert.match(instruction, /Complete first milestone/);
@@ -105,6 +108,67 @@ describe('ultragoal artifacts', () => {
       assert.match(ledger, /"event":"goal_completed"/);
       assert.match(ledger, /"event":"goal_failed"/);
       assert.match(ledger, /"event":"goal_retried"/);
+    });
+  });
+
+  it('records a completed legacy Codex-goal blocker without failing the active ultragoal', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      const blocked = await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'blocked',
+        evidence: 'completed aggregate Codex goal blocks create_goal',
+        codexGoal: { goal: { objective: 'achieve all goals on this repo ultragoal status', status: 'complete' } },
+        now: new Date('2026-05-04T10:03:00Z'),
+      });
+
+      assert.equal(blocked.activeGoalId, first.goal!.id);
+      assert.equal(blocked.goals[0]?.status, 'in_progress');
+      assert.equal(blocked.goals[0]?.failureReason, undefined);
+      assert.equal(blocked.goals[0]?.failedAt, undefined);
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"goal_blocked"/);
+      assert.match(ledger, /completed aggregate Codex goal blocks create_goal/);
+    });
+  });
+
+  it('rejects blocked checkpoints for active or same-objective Codex goals', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'blocked',
+          evidence: 'active wrong goal',
+          codexGoal: { goal: { objective: 'Different active work', status: 'active' } },
+        }),
+        /strict objective mismatch protection remains required/,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'blocked',
+          evidence: 'same complete goal',
+          codexGoal: { goal: { objective: first.goal!.objective, status: 'complete' } },
+        }),
+        /different completed legacy Codex goal/,
+      );
     });
   });
 });

--- a/src/ultragoal/__tests__/docs-contract.test.ts
+++ b/src/ultragoal/__tests__/docs-contract.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../../../');
+
+function loadDoc(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf-8');
+}
+
+describe('ultragoal docs contract', () => {
+  it('documents the completed legacy Codex-goal blocked checkpoint workaround', () => {
+    const doc = loadDoc('docs/ultragoal.md');
+
+    assert.match(doc, /checkpoint --goal-id G001-example --status blocked/);
+    assert.match(doc, /`goal_blocked`/);
+    assert.match(doc, /no Codex goal-tool reset\/new-goal surface/i);
+    assert.match(doc, /fresh Codex thread/i);
+    assert.match(doc, /same branch\/worktree/i);
+    assert.match(doc, /Active or incomplete wrong Codex goals remain strict mismatch errors/i);
+    assert.match(doc, /must not be used to bypass active-goal mismatch protection/i);
+  });
+});

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -48,6 +48,7 @@ export interface UltragoalLedgerEntry {
     | 'goal_started'
     | 'goal_resumed'
     | 'goal_completed'
+    | 'goal_blocked'
     | 'goal_failed'
     | 'goal_retried';
   goalId?: string;
@@ -71,7 +72,7 @@ export interface StartNextOptions {
 
 export interface CheckpointOptions {
   goalId: string;
-  status: Extract<UltragoalStatus, 'complete' | 'failed'>;
+  status: Extract<UltragoalStatus, 'complete' | 'failed'> | 'blocked';
   evidence?: string;
   codexGoal?: unknown;
   now?: Date;
@@ -105,6 +106,10 @@ function repoRelative(cwd: string, path: string): string {
 
 function cleanLine(line: string): string {
   return line.replace(/^\s*(?:[-*+]\s+|\d+[.)]\s+)/, '').trim();
+}
+
+function normalizeObjective(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
 }
 
 function titleFromObjective(objective: string, fallback: string): string {
@@ -255,6 +260,38 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
   const plan = await readUltragoalPlan(cwd);
   const goal = plan.goals.find((candidate) => candidate.id === options.goalId);
   if (!goal) throw new UltragoalError(`Unknown ultragoal id: ${options.goalId}`);
+  const now = iso(options.now);
+  if (options.status === 'blocked') {
+    if (goal.status !== 'in_progress') {
+      throw new UltragoalError(`Cannot record a blocked checkpoint for ${goal.id} while it is ${goal.status}; start or resume the ultragoal before recording a non-terminal blocker.`);
+    }
+    const snapshot = options.codexGoal === undefined ? null : parseCodexGoalSnapshot(options.codexGoal);
+    if (!snapshot?.available) {
+      throw new UltragoalError('Blocked ultragoal checkpoints require a get_goal snapshot for the completed legacy Codex goal that blocked create_goal; pass --codex-goal-json.');
+    }
+    if (snapshot.status !== 'complete') {
+      throw new UltragoalError(`Cannot record a blocked ultragoal checkpoint while the existing Codex goal is ${snapshot.status ?? 'unknown'}; strict objective mismatch protection remains required for active or incomplete goals.`);
+    }
+    if (!snapshot.objective) {
+      throw new UltragoalError('Blocked ultragoal checkpoint Codex snapshot is missing objective text.');
+    }
+    if (normalizeObjective(snapshot.objective) === normalizeObjective(goal.objective)) {
+      throw new UltragoalError('Blocked ultragoal checkpoint is only for a different completed legacy Codex goal; complete this ultragoal with --status complete after its audit passes.');
+    }
+    goal.updatedAt = now;
+    plan.activeGoalId = goal.id;
+    plan.updatedAt = now;
+    await writePlan(cwd, plan);
+    await appendLedger(cwd, {
+      ts: now,
+      event: 'goal_blocked',
+      goalId: goal.id,
+      status: goal.status,
+      evidence: options.evidence,
+      codexGoal: options.codexGoal,
+    });
+    return plan;
+  }
   if (options.status === 'complete') {
     const reconciliation = reconcileCodexGoalSnapshot(
       options.codexGoal === undefined ? null : parseCodexGoalSnapshot(options.codexGoal),
@@ -269,7 +306,6 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       throw new UltragoalError(formatCodexGoalReconciliation(reconciliation));
     }
   }
-  const now = iso(options.now);
   goal.status = options.status;
   goal.updatedAt = now;
   if (options.status === 'complete') {
@@ -310,6 +346,8 @@ export function buildCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalPl
     'Codex goal integration constraints:',
     '- First call get_goal. If no active goal exists, call create_goal with the payload below.',
     '- If a different active Codex goal exists, finish/checkpoint that goal before starting this ultragoal.',
+    '- If get_goal returns a different completed legacy/thread goal and create_goal rejects because this thread already has a completed goal, continue this ultragoal in a fresh Codex thread (same repo/worktree) and create the payload there.',
+    `- To preserve the durable ledger before switching threads, record the non-terminal blocker without failing this goal: omx ultragoal checkpoint --goal-id ${goal.id} --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json "<get_goal JSON or path>"`,
     '- Work only this goal until its completion audit passes.',
     '- After the goal is actually complete, call update_goal({status: "complete"}), call get_goal again for a fresh completion snapshot, then checkpoint the ledger with:',
     `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh get_goal JSON or path>"`,


### PR DESCRIPTION
## Summary

- Treat the completed-thread-goal case as a Codex goal-tool limitation: the exposed tool surface has `get_goal`, `create_goal`, and `update_goal({status:"complete"})`, but no reset/delete/archive/new-goal-in-same-thread or objective-changing update operation.
- Add a first-class ultragoal handoff path for this limitation: if a different completed legacy Codex goal blocks `create_goal`, checkpoint the blocker as non-terminal and continue the active ultragoal in a fresh Codex thread for the same repo/worktree.
- Preserve strict mismatch safety by allowing `--status blocked` only for an in-progress ultragoal plus a different **complete** Codex goal snapshot; active/incomplete snapshots still fail.

## Findings

Supported workaround exists: **no**.

Codex limitation; OMX workaround is:
1. keep `complete` checkpoints strictly bound to a matching complete `get_goal` snapshot;
2. record `omx ultragoal checkpoint --status blocked --codex-goal-json ...` only for a different completed legacy thread goal that blocks `create_goal`;
3. continue the ultragoal in a fresh Codex thread and call `create_goal` there.

## Verification

- `npm run build`
- `node --test dist/ultragoal/__tests__/artifacts.test.js dist/cli/__tests__/ultragoal.test.js dist/goal-workflows/__tests__/codex-goal-snapshot.test.js`
- `npm run lint`
- `npm run check:no-unused`

Fixes #2139
