### PR TITLE
Keep session-scoped runtime state authoritative

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -587,11 +587,11 @@ describe("cleanupPostLaunchModeStateFiles", () => {
 
     await mkdir(sessionStateDir, { recursive: true });
     await writeFile(
-      join(stateDir, "autopilot-state.json"),
+      join(sessionStateDir, "autopilot-state.json"),
       JSON.stringify({ active: true, mode: "autopilot" }, null, 2),
       "utf-8",
     );
-    await writeFile(join(stateDir, "deep-interview-state.json"), "", "utf-8");
+    await writeFile(join(sessionStateDir, "deep-interview-state.json"), "", "utf-8");
     await writeFile(join(sessionStateDir, "ralph-state.json"), partialState, "utf-8");
 
     await cleanupPostLaunchModeStateFiles(wd, sessionId, {
@@ -599,10 +599,10 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     });
 
     const autopilot = JSON.parse(
-      await readFile(join(stateDir, "autopilot-state.json"), "utf-8"),
+      await readFile(join(sessionStateDir, "autopilot-state.json"), "utf-8"),
     ) as Record<string, unknown>;
     const deepInterview = JSON.parse(
-      await readFile(join(stateDir, "deep-interview-state.json"), "utf-8"),
+      await readFile(join(sessionStateDir, "deep-interview-state.json"), "utf-8"),
     ) as Record<string, unknown>;
     const ralph = JSON.parse(
       await readFile(join(sessionStateDir, "ralph-state.json"), "utf-8"),
@@ -638,19 +638,54 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     assert.deepEqual(warnings, []);
   });
 
+  it("does not cancel root mode state during session-scoped postLaunch cleanup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-root-preserve-"));
+    const sessionId = "sess-postlaunch-root-preserve";
+    const stateDir = join(wd, ".omx", "state");
+    const sessionStateDir = join(stateDir, "sessions", sessionId);
+    await mkdir(sessionStateDir, { recursive: true });
+    await writeFile(
+      join(stateDir, "ralph-state.json"),
+      JSON.stringify({ active: true, mode: "ralph", current_phase: "executing" }, null, 2),
+      "utf-8",
+    );
+    await writeFile(
+      join(sessionStateDir, "ralplan-state.json"),
+      JSON.stringify({ active: true, mode: "ralplan", current_phase: "planning" }, null, 2),
+      "utf-8",
+    );
+
+    try {
+      await cleanupPostLaunchModeStateFiles(wd, sessionId);
+
+      const rootRalph = JSON.parse(
+        await readFile(join(stateDir, "ralph-state.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      const sessionRalplan = JSON.parse(
+        await readFile(join(sessionStateDir, "ralplan-state.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(rootRalph.active, true);
+      assert.equal(sessionRalplan.active, false);
+      assert.equal(sessionRalplan.current_phase, "cancelled");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("retries a transient parse failure before cancelling the rewritten mode state", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-mode-retry-"));
     const sessionId = "sess-postlaunch-retry";
     const stateDir = join(wd, ".omx", "state");
-    const statePath = join(stateDir, "ralph-state.json");
+    const sessionStateDir = join(stateDir, "sessions", sessionId);
+    const statePath = join(sessionStateDir, "ralph-state.json");
     const writes: Array<{ path: string; content: string }> = [];
     const validState = JSON.stringify({ active: true, mode: "ralph" }, null, 2);
     let reads = 0;
 
-    await mkdir(stateDir, { recursive: true });
+    await mkdir(sessionStateDir, { recursive: true });
 
     const mockReaddir = (async (dir: unknown, _options: unknown) => (
-      String(dir) === stateDir ? ["ralph-state.json"] : []
+      String(dir) === sessionStateDir ? ["ralph-state.json"] : []
     )) as unknown as typeof fsReaddir;
     const mockReadFile = (async (path: unknown, _options: unknown) => {
         assert.equal(String(path), statePath);
@@ -685,13 +720,14 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-mode-malformed-"));
     const sessionId = "sess-postlaunch-malformed";
     const stateDir = join(wd, ".omx", "state");
+    const sessionStateDir = join(stateDir, "sessions", sessionId);
     const warnings: string[] = [];
     const malformedState = '{\n  "active": true,\n}\n';
 
-    await mkdir(stateDir, { recursive: true });
-    await writeFile(join(stateDir, "ralph-state.json"), malformedState, "utf-8");
+    await mkdir(sessionStateDir, { recursive: true });
+    await writeFile(join(sessionStateDir, "ralph-state.json"), malformedState, "utf-8");
     await writeFile(
-      join(stateDir, "ultrawork-state.json"),
+      join(sessionStateDir, "ultrawork-state.json"),
       JSON.stringify({ active: true, mode: "ultrawork" }, null, 2),
       "utf-8",
     );
@@ -701,7 +737,7 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     });
 
     const ultrawork = JSON.parse(
-      await readFile(join(stateDir, "ultrawork-state.json"), "utf-8"),
+      await readFile(join(sessionStateDir, "ultrawork-state.json"), "utf-8"),
     ) as Record<string, unknown>;
     assert.equal(ultrawork.active, false);
     assert.equal(typeof ultrawork.completed_at, "string");
@@ -713,7 +749,7 @@ describe("cleanupPostLaunchModeStateFiles", () => {
       assert.equal(canonical.active, false);
       assert.deepEqual(canonical.active_skills, []);
     }
-    assert.equal(await readFile(join(stateDir, "ralph-state.json"), "utf-8"), malformedState);
+    assert.equal(await readFile(join(sessionStateDir, "ralph-state.json"), "utf-8"), malformedState);
     assert.equal(warnings.length, 1);
     assert.match(warnings[0] ?? "", /skipped malformed mode state .*ralph-state\.json/);
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2845,7 +2845,9 @@ export async function cleanupPostLaunchModeStateFiles(
     dependencies.writeFile ?? (await import("fs/promises")).writeFile;
   const writeWarn = dependencies.writeWarn ?? console.warn;
   const now = dependencies.now ?? (() => new Date());
-  const scopedDirs = [getBaseStateDir(cwd), getStateDir(cwd, sessionId)];
+  const scopedDirs = sessionId
+    ? [getStateDir(cwd, sessionId)]
+    : [getBaseStateDir(cwd)];
 
   for (const stateDir of scopedDirs) {
     const files = await readdir(stateDir).catch(() => [] as string[]);

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -147,6 +147,43 @@ describe('session lifecycle manager', () => {
     }
   });
 
+  it('does not delete the current session pointer when ending a different session', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-owner-'));
+    try {
+      await writeSessionStart(cwd, 'sess-current');
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionPath = join(stateDir, 'session.json');
+      const currentHudPath = join(stateDir, 'sessions', 'sess-current', 'hud-state.json');
+      const endingHudPath = join(stateDir, 'sessions', 'sess-ending', 'hud-state.json');
+      await mkdir(join(stateDir, 'sessions', 'sess-current'), { recursive: true });
+      await mkdir(join(stateDir, 'sessions', 'sess-ending'), { recursive: true });
+      await writeFile(currentHudPath, JSON.stringify({ turn_count: 2 }), 'utf-8');
+      await writeFile(endingHudPath, JSON.stringify({ turn_count: 1 }), 'utf-8');
+
+      await writeSessionEnd(cwd, 'sess-ending');
+
+      const state = await readSessionState(cwd);
+      assert.equal(state?.session_id, 'sess-current');
+      assert.equal(existsSync(sessionPath), true);
+      assert.equal(existsSync(currentHudPath), true);
+      assert.equal(existsSync(endingHudPath), false);
+
+      const historyLines = (await readFile(join(cwd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+      assert.equal(historyLines.length, 1);
+      const historyEntry = JSON.parse(historyLines[0]) as SessionHistoryEntry & {
+        preserved_active_session_id?: string;
+      };
+      assert.equal(historyEntry.session_id, 'sess-ending');
+      assert.equal(historyEntry.started_at, 'unknown');
+      assert.equal(historyEntry.preserved_active_session_id, 'sess-current');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('removes canonical and native session-scoped hud state on session end', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-hud-cleanup-'));
     const canonicalSessionId = 'omx-launch-hud';

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -377,37 +377,47 @@ export async function reconcileNativeSessionStart(
 export async function writeSessionEnd(cwd: string, sessionId: string): Promise<void> {
   const state = await readSessionState(cwd);
   const endTime = new Date().toISOString();
+  const ownsCurrentSessionFile = state == null
+    || state.session_id === sessionId
+    || state.native_session_id === sessionId;
 
   // Archive to session history
   const logsDir = omxLogsDir(cwd);
   await mkdir(logsDir, { recursive: true });
 
   const historyEntry = {
-    session_id: state?.session_id || sessionId,
-    ...(state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
-    started_at: state?.started_at || 'unknown',
+    session_id: ownsCurrentSessionFile ? state?.session_id || sessionId : sessionId,
+    ...(ownsCurrentSessionFile && state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
+    started_at: ownsCurrentSessionFile ? state?.started_at || 'unknown' : 'unknown',
     ended_at: endTime,
     cwd,
-    pid: state?.pid || process.pid,
+    pid: ownsCurrentSessionFile ? state?.pid || process.pid : process.pid,
+    ...(!ownsCurrentSessionFile && state?.session_id
+      ? { preserved_active_session_id: state.session_id }
+      : {}),
   };
 
   await appendFile(historyPath(cwd), JSON.stringify(historyEntry) + '\n');
 
   await removeDeadSessionHudState(cwd, [
-    state?.session_id,
-    state?.native_session_id,
+    ...(ownsCurrentSessionFile ? [state?.session_id, state?.native_session_id] : []),
     sessionId,
   ]);
 
-  // Delete session.json
-  try {
-    await unlink(sessionPath(cwd));
-  } catch { /* already gone */ }
+  // Delete session.json only when this end event owns the current pointer.
+  if (ownsCurrentSessionFile) {
+    try {
+      await unlink(sessionPath(cwd));
+    } catch { /* already gone */ }
+  }
 
   await appendToLog(cwd, {
     event: 'session_end',
-    session_id: state?.session_id || sessionId,
-    ...(state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
+    session_id: ownsCurrentSessionFile ? state?.session_id || sessionId : sessionId,
+    ...(ownsCurrentSessionFile && state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
+    ...(!ownsCurrentSessionFile && state?.session_id
+      ? { preserved_active_session_id: state.session_id }
+      : {}),
     timestamp: endTime,
   });
 }

--- a/src/scripts/__tests__/notify-state-io.test.ts
+++ b/src/scripts/__tests__/notify-state-io.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  getScopedStatePath,
+  readScopedJsonIfExists,
+  resolveScopedStateDir,
+  writeScopedJson,
+} from '../notify-hook/state-io.js';
+
+describe('notify-hook state I/O session authority', () => {
+  it('uses an explicit session id before the current session pointer', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-state-io-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(join(stateDir, 'sessions', 'sess-current'), { recursive: true });
+      await mkdir(join(stateDir, 'sessions', 'sess-explicit'), { recursive: true });
+      await writeFile(
+        join(stateDir, 'session.json'),
+        JSON.stringify({ session_id: 'sess-current', cwd: wd }, null, 2),
+        'utf-8',
+      );
+
+      assert.equal(
+        await resolveScopedStateDir(stateDir, 'sess-explicit'),
+        join(stateDir, 'sessions', 'sess-explicit'),
+      );
+      assert.equal(
+        await getScopedStatePath(stateDir, 'hud-state.json', 'sess-explicit'),
+        join(stateDir, 'sessions', 'sess-explicit', 'hud-state.json'),
+      );
+
+      await writeScopedJson(stateDir, 'hud-state.json', 'sess-explicit', { turn_count: 3 });
+      const explicitHud = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-explicit', 'hud-state.json'), 'utf-8'),
+      ) as { turn_count?: unknown };
+      assert.equal(explicitHud.turn_count, 3);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not read current-session data when an explicit session has no state file', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-state-io-missing-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(join(stateDir, 'sessions', 'sess-current'), { recursive: true });
+      await writeFile(
+        join(stateDir, 'session.json'),
+        JSON.stringify({ session_id: 'sess-current', cwd: wd }, null, 2),
+        'utf-8',
+      );
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-current', 'auto-nudge-state.json'),
+        JSON.stringify({ count: 9 }, null, 2),
+        'utf-8',
+      );
+
+      const value = await readScopedJsonIfExists(
+        stateDir,
+        'auto-nudge-state.json',
+        'sess-explicit',
+        null,
+      );
+      assert.equal(value, null);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/scripts/notify-hook/state-io.ts
+++ b/src/scripts/notify-hook/state-io.ts
@@ -52,18 +52,16 @@ export async function resolveScopedStateDir(
   baseStateDir: string,
   explicitSessionId?: string,
 ): Promise<string> {
+  const normalizedExplicit = safeString(explicitSessionId).trim();
+  if (SESSION_ID_PATTERN.test(normalizedExplicit)) {
+    return join(baseStateDir, 'sessions', normalizedExplicit);
+  }
+
   const currentSessionId = await readCurrentSessionId(baseStateDir);
   if (currentSessionId) {
     return join(baseStateDir, 'sessions', currentSessionId);
   }
 
-  const normalizedExplicit = safeString(explicitSessionId).trim();
-  if (SESSION_ID_PATTERN.test(normalizedExplicit)) {
-    const explicitDir = join(baseStateDir, 'sessions', normalizedExplicit);
-    if (existsSync(explicitDir)) {
-      return explicitDir;
-    }
-  }
   return baseStateDir;
 }
 

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -1,10 +1,16 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   buildWorkflowTransitionMessage,
   buildWorkflowTransitionError,
   evaluateWorkflowTransition,
+  readActiveWorkflowModes,
 } from '../workflow-transition.js';
+import { reconcileWorkflowTransition } from '../workflow-transition-reconcile.js';
 
 describe('workflow transition rules', () => {
   it('allows the approved overlap matrix and denies unsupported combinations', () => {
@@ -95,5 +101,60 @@ describe('workflow transition rules', () => {
       buildWorkflowTransitionMessage('ralplan', 'ralph'),
       'mode transiting: ralplan -> ralph',
     );
+  });
+
+  it('ignores stale root workflow state for session-scoped active decisions', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-workflow-active-scope-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', 'sess-current');
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(
+        join(stateDir, 'ralph-state.json'),
+        JSON.stringify({ active: true, mode: 'ralph', current_phase: 'executing' }, null, 2),
+        'utf-8',
+      );
+      await writeFile(
+        join(stateDir, 'session.json'),
+        JSON.stringify({ session_id: 'sess-current', cwd: wd }, null, 2),
+        'utf-8',
+      );
+
+      assert.deepEqual(await readActiveWorkflowModes(wd, 'sess-current'), []);
+      assert.deepEqual(await readActiveWorkflowModes(wd), []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not auto-complete stale root workflow state during a session transition', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-workflow-reconcile-scope-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', 'sess-current');
+      const rootRalphPath = join(stateDir, 'ralph-state.json');
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(
+        rootRalphPath,
+        JSON.stringify({ active: true, mode: 'ralph', current_phase: 'executing' }, null, 2),
+        'utf-8',
+      );
+
+      const transition = await reconcileWorkflowTransition(wd, 'ralplan', {
+        action: 'start',
+        sessionId: 'sess-current',
+        source: 'test',
+      });
+
+      assert.equal(transition.decision.allowed, true);
+      assert.deepEqual(transition.decision.currentModes, []);
+      assert.deepEqual(transition.completedPaths, []);
+
+      const rootRalph = JSON.parse(await readFile(rootRalphPath, 'utf-8')) as { active?: unknown };
+      assert.equal(rootRalph.active, true);
+      assert.equal(existsSync(join(sessionDir, 'ralph-state.json')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -63,7 +63,7 @@ async function visibleTrackedModes(cwd: string, sessionId?: string): Promise<Tra
   const visibleModes = new Set<TrackedWorkflowMode>(canonicalModes);
   for (const mode of TRACKED_WORKFLOW_MODES) {
     const candidatePaths = sessionId
-      ? [getStatePath(mode, cwd, sessionId), getStatePath(mode, cwd)]
+      ? [getStatePath(mode, cwd, sessionId)]
       : [getStatePath(mode, cwd)];
     for (const candidatePath of candidatePaths) {
       const state = await readJsonIfExists(candidatePath, {
@@ -89,7 +89,7 @@ async function completeSourceModeState(
 ): Promise<string[]> {
   const transitionMessage = `mode transiting: ${sourceMode} -> ${destinationMode}`;
   const candidatePaths = sessionId
-    ? [getStatePath(sourceMode, cwd, sessionId), getStatePath(sourceMode, cwd)]
+    ? [getStatePath(sourceMode, cwd, sessionId)]
     : [getStatePath(sourceMode, cwd)];
   const completedPaths: string[] = [];
 

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
-import { getReadScopedStatePaths } from '../mcp/state-paths.js';
+import { getAuthoritativeActiveStatePaths } from '../mcp/state-paths.js';
 
 export const TRACKED_WORKFLOW_MODES = [
   'autopilot',
@@ -219,7 +219,7 @@ export async function readActiveWorkflowModes(
   const activeModes: TrackedWorkflowMode[] = [];
 
   for (const mode of TRACKED_WORKFLOW_MODES) {
-    const candidatePaths = await getReadScopedStatePaths(mode, cwd, sessionId);
+    const candidatePaths = await getAuthoritativeActiveStatePaths(mode, cwd, sessionId);
     for (const candidatePath of candidatePaths) {
       if (!existsSync(candidatePath)) continue;
       try {


### PR DESCRIPTION
## Summary

Make session-scoped OMX runtime state authoritative for active lifecycle decisions.

This PR prevents stale root `.omx/state/*-state.json` files from deleting a live `session.json`, driving workflow transition decisions, or being cancelled by session-scoped `postLaunch` cleanup. Root state is still preserved for compatibility/no-session reads, but session-aware execution paths now stay inside the owning session scope.

## Problem statement

OMX had multiple state authorities for the same runtime truth:

- root `.omx/state/session.json`
- root `.omx/state/<mode>-state.json`
- session-scoped `.omx/state/sessions/<sessionId>/<mode>-state.json`
- hook/notify helpers that sometimes preferred the current session pointer over the explicit event session
- postLaunch cleanup that scanned both root and session state during a session-scoped cleanup

That made stale root state able to influence a fresh/current session even when the current session had no active matching workflow state.

## Root cause

Several active-decision paths still used compatibility read semantics. Compatibility reads are allowed to fall back to root state, which is useful for older/no-session callers, but unsafe for lifecycle gates that decide whether a workflow is still active or whether a mode should be auto-completed/cancelled.

There was also a concrete ownership bug: ending one session could unlink the current root `session.json` pointer for a different live session.

## What changed

- `writeSessionEnd()` now only deletes `session.json` when the ending session owns the current pointer.
  - If another session is active, it archives the ending session and records `preserved_active_session_id` instead.
- Workflow active-mode reads now use authoritative active-state paths instead of compatibility root fallback.
- Workflow transition reconciliation no longer auto-completes stale root mode state during a session-scoped transition.
- Notify-hook state I/O now honors an explicit session id before the current-session pointer, even when the explicit session directory does not yet exist.
- Session-scoped `postLaunch` cleanup now scans only that session's state directory; root cleanup is kept for no-session cleanup only.
- Added regressions for session pointer ownership, active workflow root fallback suppression, notify explicit-session authority, and postLaunch root preservation.

## Why this design

This is a narrow authority-boundary fix instead of a broad root-state purge.

Root state still exists for compatibility and legacy/no-session workflows. The safer rule is: active lifecycle decisions must not use compatibility fallback once a session scope is known. Broadly deleting root state during every session cleanup would risk cancelling unrelated root/no-session workflows or removing diagnostics that older surfaces still expect.

## Overlap assessment

Classification: **Follow-up / adjacent but distinct**.

Related prior work:

- #1445 / #1447 tightened `session.json` ownership and root fallback semantics.
- #1766 and #1822 captured the same architectural direction: session-scoped state should be authoritative over root fallback.
- #1788 / #1789 and #2080 / #2082 fixed specific stale Ralph/Stop-hook leakage and rebinding cases.
- #2031 fixed detached tmux `postLaunch` tearing down live sessions.
- #2125 is the closest open symptom: root skill-active/runtime state can remain visible after a session-scoped planning flow completes.

This PR does not duplicate those fixes. It closes a remaining gap where active workflow decisions, transition reconciliation, notify state I/O, and postLaunch cleanup still crossed the root/session authority boundary. It intentionally does not add a broad root `skill-active-state.json` purge; future cleanup should be owner-aware if root state needs automatic pruning.

## Validation

- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_SESSION_ID -u OMX_ENTRY_PATH -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD node --test dist/hooks/__tests__/session.test.js dist/state/__tests__/workflow-transition.test.js dist/scripts/__tests__/notify-state-io.test.js dist/cli/__tests__/index.test.js`
  - 239 tests passed
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_SESSION_ID -u OMX_ENTRY_PATH -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD npm run test:recent-bug-regressions:compiled`
  - 523 tests passed

## Risk / compatibility

- Root state remains readable for compatibility/no-session paths.
- Session-aware active lifecycle checks now ignore stale root state. That is the intended behavior change.
- This does not perform owner-aware garbage collection for stale root `skill-active-state.json`; it only prevents that stale root state from driving session-scoped active decisions.
- Live Windows/PowerShell tmux/native-hook E2E was not run manually in this environment.

## Files changed

- `src/hooks/session.ts`
- `src/state/workflow-transition.ts`
- `src/state/workflow-transition-reconcile.ts`
- `src/scripts/notify-hook/state-io.ts`
- `src/cli/index.ts`
- `src/hooks/__tests__/session.test.ts`
- `src/state/__tests__/workflow-transition.test.ts`
- `src/scripts/__tests__/notify-state-io.test.ts`
- `src/cli/__tests__/index.test.ts`
