### PR TITLE
Diagnose MCP zombie leak via lifecycle telemetry and pre-traffic hard cap

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -11,7 +11,10 @@ import {
   resolveCurrentMcpEntrypointMarker,
   resolveDuplicateSiblingWatchdogInitialDelayMs,
   shouldAutoStartMcpServer,
+  shouldBackoffWatchdog,
   shouldSelfExitForDuplicateSibling,
+  shouldSelfExitForHardCap,
+  type DuplicateSiblingObservation,
   type McpServerName,
 } from '../bootstrap.js';
 
@@ -412,5 +415,140 @@ describe('mcp duplicate sibling detection', () => {
       shouldSelfExitForDuplicateSibling(missingSelf, 50_000, 10_000, null),
       false,
     );
+  });
+});
+
+describe('mcp pre-traffic hard cap', () => {
+  function buildPsFixture(pids: number[], parentPid: number, marker: string) {
+    return pids.map((pid) => ({
+      pid,
+      ppid: parentPid,
+      command: `node /tmp/dist/mcp/${marker}`,
+    }));
+  }
+
+  it('exits the oldest pre-traffic siblings until count drops below cap', () => {
+    const parentPid = 1224;
+    const marker = 'state-server.js';
+    const pids = [101, 102, 103, 104, 105, 106]; // 6 siblings, oldest first
+    const processes = buildPsFixture(pids, parentPid, marker);
+    const cap = 4;
+
+    const verdicts = pids.map((pid) => {
+      const observation = analyzeDuplicateSiblingState(processes, pid, parentPid, marker);
+      // Oldest 2 (pid=101,102) are pre-traffic; rest have active traffic.
+      const lastTrafficAtMs = pid <= 102 ? null : 1_000;
+      return shouldSelfExitForHardCap(observation, lastTrafficAtMs, cap, pid);
+    });
+
+    // exitCount = 6 - 4 + 1 = 3, but only those with lastTrafficAtMs===null may exit.
+    assert.deepEqual(verdicts, [true, true, false, false, false, false]);
+  });
+
+  it('never exits siblings that have received stdin traffic', () => {
+    const processes = buildPsFixture([101, 102, 103, 104, 105], 55, 'state-server.js');
+    const observation = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    assert.equal(
+      shouldSelfExitForHardCap(observation, 1_000, 4, 101),
+      false,
+      'active-traffic sibling must never be hard-cap exited',
+    );
+  });
+
+  it('returns false when cap is 0 (disabled)', () => {
+    const processes = buildPsFixture([101, 102, 103, 104, 105], 55, 'state-server.js');
+    const observation = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    assert.equal(shouldSelfExitForHardCap(observation, null, 0, 101), false);
+  });
+
+  it('returns false when sibling count is below cap', () => {
+    const processes = buildPsFixture([101, 102], 55, 'state-server.js');
+    const observation = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    assert.equal(shouldSelfExitForHardCap(observation, null, 4, 101), false);
+  });
+
+  it('preserves ambiguous-state safety (returns false)', () => {
+    const observation: DuplicateSiblingObservation = {
+      status: 'ambiguous',
+      entrypoint: 'state-server.js',
+      matchingPids: [],
+      newerSiblingPids: [],
+    };
+    assert.equal(shouldSelfExitForHardCap(observation, null, 4, 101), false);
+  });
+});
+
+describe('mcp duplicate watchdog defensive instrumentation', () => {
+  it('wraps the duplicate-sibling watchdog body in try/catch with telemetry', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/bootstrap.ts'), 'utf8');
+    const runIdx = src.indexOf('const runDuplicateSiblingWatchdog =');
+    assert.ok(runIdx > 0, 'runDuplicateSiblingWatchdog must exist in bootstrap.ts');
+    const tail = src.slice(runIdx, runIdx + 4_096);
+    assert.match(tail, /try\s*\{/, 'watchdog body must be wrapped in try { ... }');
+    assert.match(
+      tail,
+      /catch[\s\S]*?duplicate_watchdog_error/,
+      'watchdog must emit duplicate_watchdog_error in its catch handler',
+    );
+  });
+
+  it('backs off the watchdog interval to a configurable backoff value when cap is exceeded', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/bootstrap.ts'), 'utf8');
+    assert.match(
+      src,
+      /clearInterval\(duplicateSiblingWatchdog\)/,
+      'back-off must clear the existing watchdog interval',
+    );
+    assert.match(
+      src,
+      /duplicateSiblingBackoffIntervalMs/,
+      'back-off must use the configured backoff interval (>= 30000ms default)',
+    );
+    assert.match(
+      src,
+      /shouldBackoffWatchdog\(observation/,
+      'back-off must be gated on shouldBackoffWatchdog',
+    );
+  });
+
+  it('exposes a configurable backoff interval >= 30000ms by default', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/bootstrap.ts'), 'utf8');
+    assert.match(
+      src,
+      /DEFAULT_DUPLICATE_SIBLING_BACKOFF_INTERVAL_MS\s*=\s*30_000/,
+      'default backoff interval should be 30000ms',
+    );
+  });
+});
+
+describe('mcp watchdog back-off detection', () => {
+  it('returns true when sibling count exceeds cap', () => {
+    const observation: DuplicateSiblingObservation = {
+      status: 'older_duplicate',
+      entrypoint: 'state-server.js',
+      matchingPids: [101, 102, 103, 104, 105],
+      newerSiblingPids: [102, 103, 104, 105],
+    };
+    assert.equal(shouldBackoffWatchdog(observation, 4), true);
+  });
+
+  it('returns false at or below cap', () => {
+    const observation: DuplicateSiblingObservation = {
+      status: 'older_duplicate',
+      entrypoint: 'state-server.js',
+      matchingPids: [101, 102, 103, 104],
+      newerSiblingPids: [102, 103, 104],
+    };
+    assert.equal(shouldBackoffWatchdog(observation, 4), false);
+  });
+
+  it('returns false when cap is 0', () => {
+    const observation: DuplicateSiblingObservation = {
+      status: 'older_duplicate',
+      entrypoint: 'state-server.js',
+      matchingPids: [101, 102, 103, 104, 105, 106],
+      newerSiblingPids: [102, 103, 104, 105, 106],
+    };
+    assert.equal(shouldBackoffWatchdog(observation, 0), false);
   });
 });

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -13,6 +13,7 @@ import {
   resolveDuplicateSiblingWatchdogInitialDelayMs,
   shouldAutoStartMcpServer,
   shouldBackoffWatchdog,
+  shouldEvaluateHardCap,
   shouldSelfExitForDuplicateSibling,
   shouldSelfExitForHardCap,
   type DuplicateSiblingObservation,
@@ -531,6 +532,47 @@ describe('mcp pre-traffic hard cap', () => {
       newerSiblingPids: [],
     };
     assert.equal(shouldSelfExitForHardCap(observation, [101], 4, 101), false);
+  });
+
+  describe('shouldEvaluateHardCap (gate that avoids ledger I/O at steady state)', () => {
+    it('returns false when cap is 0 (disabled)', () => {
+      assert.equal(shouldEvaluateHardCap([101, 102, 103, 104, 105], 0), false);
+    });
+
+    it('returns false when matchingPids.length is below cap', () => {
+      assert.equal(shouldEvaluateHardCap([101, 102, 103], 4), false);
+    });
+
+    it('returns false when matchingPids.length equals cap', () => {
+      assert.equal(shouldEvaluateHardCap([101, 102, 103, 104], 4), false);
+    });
+
+    it('returns true only when matchingPids.length exceeds cap', () => {
+      assert.equal(shouldEvaluateHardCap([101, 102, 103, 104, 105], 4), true);
+    });
+
+    it('returns false when cap is not a positive integer', () => {
+      assert.equal(shouldEvaluateHardCap([101, 102, 103, 104, 105], -1), false);
+      assert.equal(shouldEvaluateHardCap([101, 102, 103, 104, 105], Number.NaN), false);
+    });
+  });
+
+  it('the watchdog source gates the ledger read behind shouldEvaluateHardCap', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/bootstrap.ts'), 'utf8');
+    const runIdx = src.indexOf('const runDuplicateSiblingWatchdog =');
+    assert.ok(runIdx > 0);
+    const tail = src.slice(runIdx, runIdx + 4_096);
+    assert.match(
+      tail,
+      /shouldEvaluateHardCap\([\s\S]*?observation\.matchingPids[\s\S]*?maxSiblingsPerEntrypoint/,
+      'watchdog must gate ledger I/O behind shouldEvaluateHardCap before reading the ledger',
+    );
+    const hardCapBlock = tail.indexOf('shouldEvaluateHardCap(');
+    const ledgerRead = tail.indexOf('readPretrafficSiblingPids');
+    assert.ok(
+      hardCapBlock > 0 && ledgerRead > hardCapBlock,
+      'readPretrafficSiblingPids must appear after the shouldEvaluateHardCap gate',
+    );
   });
 
   describe('effectivePretrafficSiblings (in-memory authoritative override for self)', () => {

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -433,23 +433,42 @@ describe('mcp pre-traffic hard cap', () => {
     const pids = [101, 102, 103, 104, 105, 106]; // 6 siblings, oldest first
     const processes = buildPsFixture(pids, parentPid, marker);
     const cap = 4;
+    // Oldest 2 (101, 102) are pre-traffic; PIDs 103-106 have already received traffic.
+    const pretraffic = [101, 102];
 
     const verdicts = pids.map((pid) => {
       const observation = analyzeDuplicateSiblingState(processes, pid, parentPid, marker);
-      // Oldest 2 (pid=101,102) are pre-traffic; rest have active traffic.
-      const lastTrafficAtMs = pid <= 102 ? null : 1_000;
-      return shouldSelfExitForHardCap(observation, lastTrafficAtMs, cap, pid);
+      return shouldSelfExitForHardCap(observation, pretraffic, cap, pid);
     });
 
-    // exitCount = 6 - 4 = 2; only pre-traffic siblings can exit.
+    // exitCount = min(6 - 4, 2) = 2; both pre-traffic siblings exit, the 4 active-traffic ones stay.
     assert.deepEqual(verdicts, [true, true, false, false, false, false]);
+  });
+
+  it('selects victims from pre-traffic siblings even when an active sibling holds the oldest PID slot', () => {
+    // Codex review (2026-05-06) regression: with matchingPids=[1..5] and PID 1 already in traffic,
+    // the cap must still be enforced by selecting from the pre-traffic subset [2..5].
+    const parentPid = 55;
+    const marker = 'state-server.js';
+    const pids = [1, 2, 3, 4, 5];
+    const processes = buildPsFixture(pids, parentPid, marker);
+    const pretraffic = [2, 3, 4, 5]; // PID 1 has already transitioned to traffic
+    const cap = 4;
+
+    const verdicts = pids.map((pid) => {
+      const observation = analyzeDuplicateSiblingState(processes, pid, parentPid, marker);
+      return shouldSelfExitForHardCap(observation, pretraffic, cap, pid);
+    });
+
+    // Total = 5 > cap = 4; exitCount = min(1, 4) = 1; oldest pre-traffic sibling (PID 2) self-exits.
+    assert.deepEqual(verdicts, [false, true, false, false, false]);
   });
 
   it('keeps the lone unique pre-traffic server alive at cap=1 (boundary)', () => {
     const processes = buildPsFixture([101], 55, 'state-server.js');
     const observation = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
     assert.equal(
-      shouldSelfExitForHardCap(observation, null, 1, 101),
+      shouldSelfExitForHardCap(observation, [101], 1, 101),
       false,
       'with cap=1 and a single sibling, the lone server must not self-exit',
     );
@@ -457,9 +476,10 @@ describe('mcp pre-traffic hard cap', () => {
 
   it('returns false when sibling count exactly equals cap (no overshoot)', () => {
     const processes = buildPsFixture([101, 102, 103, 104], 55, 'state-server.js');
-    const verdicts = [101, 102, 103, 104].map((pid) => {
+    const pretraffic = [101, 102, 103, 104];
+    const verdicts = pretraffic.map((pid) => {
       const observation = analyzeDuplicateSiblingState(processes, pid, 55, 'state-server.js');
-      return shouldSelfExitForHardCap(observation, null, 4, pid);
+      return shouldSelfExitForHardCap(observation, pretraffic, 4, pid);
     });
     assert.deepEqual(
       verdicts,
@@ -471,8 +491,10 @@ describe('mcp pre-traffic hard cap', () => {
   it('never exits siblings that have received stdin traffic', () => {
     const processes = buildPsFixture([101, 102, 103, 104, 105], 55, 'state-server.js');
     const observation = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    // PID 101 has graduated to traffic, so the ledger excludes it from the pre-traffic set.
+    const pretraffic = [102, 103, 104, 105];
     assert.equal(
-      shouldSelfExitForHardCap(observation, 1_000, 4, 101),
+      shouldSelfExitForHardCap(observation, pretraffic, 4, 101),
       false,
       'active-traffic sibling must never be hard-cap exited',
     );
@@ -481,13 +503,23 @@ describe('mcp pre-traffic hard cap', () => {
   it('returns false when cap is 0 (disabled)', () => {
     const processes = buildPsFixture([101, 102, 103, 104, 105], 55, 'state-server.js');
     const observation = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
-    assert.equal(shouldSelfExitForHardCap(observation, null, 0, 101), false);
+    assert.equal(shouldSelfExitForHardCap(observation, [101, 102, 103, 104, 105], 0, 101), false);
   });
 
   it('returns false when sibling count is below cap', () => {
     const processes = buildPsFixture([101, 102], 55, 'state-server.js');
     const observation = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
-    assert.equal(shouldSelfExitForHardCap(observation, null, 4, 101), false);
+    assert.equal(shouldSelfExitForHardCap(observation, [101, 102], 4, 101), false);
+  });
+
+  it('returns false when no pre-traffic siblings are known to the ledger (empty pretraffic)', () => {
+    const processes = buildPsFixture([101, 102, 103, 104, 105], 55, 'state-server.js');
+    const observation = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    assert.equal(
+      shouldSelfExitForHardCap(observation, [], 4, 101),
+      false,
+      'an empty pre-traffic set means no killable victims; the cap must skip',
+    );
   });
 
   it('preserves ambiguous-state safety (returns false)', () => {
@@ -497,7 +529,7 @@ describe('mcp pre-traffic hard cap', () => {
       matchingPids: [],
       newerSiblingPids: [],
     };
-    assert.equal(shouldSelfExitForHardCap(observation, null, 4, 101), false);
+    assert.equal(shouldSelfExitForHardCap(observation, [101], 4, 101), false);
   });
 });
 

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import {
   analyzeDuplicateSiblingState,
   MCP_ENTRYPOINT_MARKER_ENV,
+  effectivePretrafficSiblings,
   extractMcpEntrypointMarker,
   isParentProcessAlive,
   parseProcessTable,
@@ -530,6 +531,52 @@ describe('mcp pre-traffic hard cap', () => {
       newerSiblingPids: [],
     };
     assert.equal(shouldSelfExitForHardCap(observation, [101], 4, 101), false);
+  });
+
+  describe('effectivePretrafficSiblings (in-memory authoritative override for self)', () => {
+    it('returns the full set when selfLastTrafficAtMs is null', () => {
+      const result = effectivePretrafficSiblings([101, 102, 103], 101, null);
+      assert.deepEqual(result, [101, 102, 103]);
+    });
+
+    it('excludes self when local traffic has been observed but ledger has not flushed', () => {
+      const result = effectivePretrafficSiblings([101, 102, 103], 101, 1_700_000_000_000);
+      assert.deepEqual(
+        result,
+        [102, 103],
+        'self must be excluded so the cap cannot evict an already-claimed transport',
+      );
+    });
+
+    it('returns the set unchanged when self is not in it', () => {
+      const result = effectivePretrafficSiblings([102, 103], 101, 1_700_000_000_000);
+      assert.deepEqual(result, [102, 103]);
+    });
+
+    it('does not mutate the input array', () => {
+      const input = [101, 102, 103];
+      effectivePretrafficSiblings(input, 101, 42);
+      assert.deepEqual(input, [101, 102, 103]);
+    });
+  });
+
+  it('does not evict self when local stdin traffic is observed but ledger has not yet flushed', () => {
+    // Reproduces the bot's race: the ledger still reports PID 101 as 'start' because the
+    // fire-and-forget 'traffic' append has not flushed, but in memory we already saw stdin.
+    const parentPid = 1224;
+    const marker = 'state-server.js';
+    const pids = [101, 102, 103, 104, 105]; // 5 siblings, cap=4 → over by 1
+    const processes = buildPsFixture(pids, parentPid, marker);
+    const ledgerPretraffic = [101, 102, 103, 104, 105]; // ledger says all are pre-traffic
+    const observation = analyzeDuplicateSiblingState(processes, 101, parentPid, marker);
+    const localLastTrafficAtMs = 1_700_000_000_500;
+
+    const effective = effectivePretrafficSiblings(ledgerPretraffic, 101, localLastTrafficAtMs);
+    assert.equal(
+      shouldSelfExitForHardCap(observation, effective, 4, 101),
+      false,
+      'PID 101 has received local traffic; the cap must not evict it even if the ledger lags',
+    );
   });
 });
 

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -427,7 +427,7 @@ describe('mcp pre-traffic hard cap', () => {
     }));
   }
 
-  it('exits the oldest pre-traffic siblings until count drops below cap', () => {
+  it('exits the oldest pre-traffic siblings until count drops to cap', () => {
     const parentPid = 1224;
     const marker = 'state-server.js';
     const pids = [101, 102, 103, 104, 105, 106]; // 6 siblings, oldest first
@@ -441,8 +441,31 @@ describe('mcp pre-traffic hard cap', () => {
       return shouldSelfExitForHardCap(observation, lastTrafficAtMs, cap, pid);
     });
 
-    // exitCount = 6 - 4 + 1 = 3, but only those with lastTrafficAtMs===null may exit.
+    // exitCount = 6 - 4 = 2; only pre-traffic siblings can exit.
     assert.deepEqual(verdicts, [true, true, false, false, false, false]);
+  });
+
+  it('keeps the lone unique pre-traffic server alive at cap=1 (boundary)', () => {
+    const processes = buildPsFixture([101], 55, 'state-server.js');
+    const observation = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    assert.equal(
+      shouldSelfExitForHardCap(observation, null, 1, 101),
+      false,
+      'with cap=1 and a single sibling, the lone server must not self-exit',
+    );
+  });
+
+  it('returns false when sibling count exactly equals cap (no overshoot)', () => {
+    const processes = buildPsFixture([101, 102, 103, 104], 55, 'state-server.js');
+    const verdicts = [101, 102, 103, 104].map((pid) => {
+      const observation = analyzeDuplicateSiblingState(processes, pid, 55, 'state-server.js');
+      return shouldSelfExitForHardCap(observation, null, 4, pid);
+    });
+    assert.deepEqual(
+      verdicts,
+      [false, false, false, false],
+      'at length === cap, the cap must keep all siblings (not exit oldest)',
+    );
   });
 
   it('never exits siblings that have received stdin traffic', () => {

--- a/src/mcp/__tests__/lifecycle-telemetry.test.ts
+++ b/src/mcp/__tests__/lifecycle-telemetry.test.ts
@@ -6,8 +6,10 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
   LIFECYCLE_LOG_DIR_ENV,
   LIFECYCLE_LOG_ENV,
+  appendPretrafficEvent,
   emit,
   isLifecycleLogDisabled,
+  readPretrafficSiblingPids,
   resolveLogDir,
   _resetForTests,
 } from '../lifecycle-telemetry.js';
@@ -249,5 +251,80 @@ describe('emit', () => {
       },
     );
     // No assertion needed - emit() must not throw
+  });
+});
+
+describe('pretraffic ledger', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'omx-mcp-pretraffic-'));
+    _resetForTests();
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function ledgerOpts(extra?: Partial<{ pid: number }>) {
+    return {
+      entrypoint: 'state-server',
+      env: { [LIFECYCLE_LOG_DIR_ENV]: dir },
+      platform: 'linux' as NodeJS.Platform,
+      ...(extra ?? {}),
+    };
+  }
+
+  it('reads back PIDs whose latest event is start', async () => {
+    await appendPretrafficEvent('start', ledgerOpts({ pid: 101 }));
+    await appendPretrafficEvent('start', ledgerOpts({ pid: 102 }));
+    const pretraffic = await readPretrafficSiblingPids([101, 102, 103], ledgerOpts());
+    assert.deepEqual(pretraffic, [101, 102]);
+  });
+
+  it('drops PIDs that have transitioned to traffic', async () => {
+    await appendPretrafficEvent('start', ledgerOpts({ pid: 101 }));
+    await appendPretrafficEvent('start', ledgerOpts({ pid: 102 }));
+    await appendPretrafficEvent('traffic', ledgerOpts({ pid: 101 }));
+    const pretraffic = await readPretrafficSiblingPids([101, 102], ledgerOpts());
+    assert.deepEqual(pretraffic, [102]);
+  });
+
+  it('drops PIDs that have exited', async () => {
+    await appendPretrafficEvent('start', ledgerOpts({ pid: 101 }));
+    await appendPretrafficEvent('exit', ledgerOpts({ pid: 101 }));
+    const pretraffic = await readPretrafficSiblingPids([101], ledgerOpts());
+    assert.deepEqual(pretraffic, []);
+  });
+
+  it('intersects with the candidate PID list (ignores stale ledger entries)', async () => {
+    await appendPretrafficEvent('start', ledgerOpts({ pid: 9001 }));
+    await appendPretrafficEvent('start', ledgerOpts({ pid: 9002 }));
+    const pretraffic = await readPretrafficSiblingPids([9001], ledgerOpts());
+    assert.deepEqual(pretraffic, [9001]);
+  });
+
+  it('returns [] when ledger does not exist', async () => {
+    const pretraffic = await readPretrafficSiblingPids([101, 102], ledgerOpts());
+    assert.deepEqual(pretraffic, []);
+  });
+
+  it('skips reads and writes when OMX_MCP_LIFECYCLE_LOG=off', async () => {
+    const offOpts = {
+      entrypoint: 'state-server',
+      env: { [LIFECYCLE_LOG_DIR_ENV]: dir, [LIFECYCLE_LOG_ENV]: 'off' },
+      platform: 'linux' as NodeJS.Platform,
+      pid: 101,
+    };
+    await appendPretrafficEvent('start', offOpts);
+    const pretraffic = await readPretrafficSiblingPids([101], offOpts);
+    assert.deepEqual(pretraffic, [], 'LOG=off must short-circuit the ledger entirely');
+    let didThrow = false;
+    try {
+      await stat(join(dir, 'state-server.pretraffic'));
+    } catch {
+      didThrow = true;
+    }
+    assert.equal(didThrow, true, 'no ledger file should be created');
   });
 });

--- a/src/mcp/__tests__/lifecycle-telemetry.test.ts
+++ b/src/mcp/__tests__/lifecycle-telemetry.test.ts
@@ -291,6 +291,42 @@ describe('pretraffic ledger', () => {
     assert.deepEqual(pretraffic, [102]);
   });
 
+  it('reads order entries by ts_ms, not by append order on disk', async () => {
+    // Reproduces the libuv-thread-pool race: a later-call traffic event lands on disk
+    // BEFORE the earlier-call start event. The reader must trust the call-time ts_ms,
+    // not file order, otherwise the cap could kill an active server.
+    const opts = (now: number) => ({
+      ...ledgerOpts({ pid: 101 }),
+      now: () => now,
+    });
+    await appendPretrafficEvent('traffic', opts(100)); // newer call, written first
+    await appendPretrafficEvent('start', opts(50)); // older call, written second
+    const pretraffic = await readPretrafficSiblingPids([101], ledgerOpts());
+    assert.deepEqual(
+      pretraffic,
+      [],
+      'PID 101 must be classified as already-in-traffic; the later-ts traffic event wins',
+    );
+  });
+
+  it('event precedence breaks ts_ms ties: traffic supersedes start', async () => {
+    const sameTs = 7_777;
+    const opts = { ...ledgerOpts({ pid: 101 }), now: () => sameTs };
+    await appendPretrafficEvent('start', opts);
+    await appendPretrafficEvent('traffic', opts);
+    const pretraffic = await readPretrafficSiblingPids([101], ledgerOpts());
+    assert.deepEqual(pretraffic, [], 'on ts tie, traffic must beat start');
+  });
+
+  it('event precedence breaks ts_ms ties: exit supersedes traffic', async () => {
+    const sameTs = 8_888;
+    const opts = { ...ledgerOpts({ pid: 101 }), now: () => sameTs };
+    await appendPretrafficEvent('traffic', opts);
+    await appendPretrafficEvent('exit', opts);
+    const pretraffic = await readPretrafficSiblingPids([101], ledgerOpts());
+    assert.deepEqual(pretraffic, [], 'on ts tie, exit must beat traffic');
+  });
+
   it('drops PIDs that have exited', async () => {
     await appendPretrafficEvent('start', ledgerOpts({ pid: 101 }));
     await appendPretrafficEvent('exit', ledgerOpts({ pid: 101 }));

--- a/src/mcp/__tests__/lifecycle-telemetry.test.ts
+++ b/src/mcp/__tests__/lifecycle-telemetry.test.ts
@@ -1,0 +1,253 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import {
+  LIFECYCLE_LOG_DIR_ENV,
+  LIFECYCLE_LOG_ENV,
+  emit,
+  isLifecycleLogDisabled,
+  resolveLogDir,
+  _resetForTests,
+} from '../lifecycle-telemetry.js';
+
+describe('resolveLogDir', () => {
+  it('returns OMX_MCP_LIFECYCLE_LOG_DIR override regardless of platform', () => {
+    const result = resolveLogDir({
+      env: { [LIFECYCLE_LOG_DIR_ENV]: '/custom/path' },
+      platform: 'darwin',
+      home: '/Users/x',
+      tmp: '/tmp',
+    });
+    assert.equal(result.dir, '/custom/path');
+    assert.equal(result.source, 'env');
+  });
+
+  it('returns ~/Library/Logs/oh-my-codex/mcp on darwin', () => {
+    const result = resolveLogDir({
+      env: {},
+      platform: 'darwin',
+      home: '/Users/jane',
+      tmp: '/tmp',
+    });
+    assert.equal(result.dir, '/Users/jane/Library/Logs/oh-my-codex/mcp');
+    assert.equal(result.source, 'platform');
+  });
+
+  it('returns XDG_STATE_HOME-rooted path on linux when XDG set', () => {
+    const result = resolveLogDir({
+      env: { XDG_STATE_HOME: '/custom/state' },
+      platform: 'linux',
+      home: '/home/jane',
+      tmp: '/tmp',
+    });
+    assert.equal(result.dir, '/custom/state/oh-my-codex/mcp');
+    assert.equal(result.source, 'platform');
+  });
+
+  it('returns ~/.local/state-rooted path on linux when XDG unset', () => {
+    const result = resolveLogDir({
+      env: {},
+      platform: 'linux',
+      home: '/home/jane',
+      tmp: '/tmp',
+    });
+    assert.equal(result.dir, '/home/jane/.local/state/oh-my-codex/mcp');
+    assert.equal(result.source, 'platform');
+  });
+
+  it('returns LOCALAPPDATA-rooted path on win32 when set', () => {
+    const result = resolveLogDir({
+      env: { LOCALAPPDATA: 'C:\\Users\\jane\\AppData\\Local' },
+      platform: 'win32',
+      home: 'C:\\Users\\jane',
+      tmp: 'C:\\Temp',
+    });
+    assert.equal(result.source, 'platform');
+    assert.ok(result.dir.includes('oh-my-codex'));
+    assert.ok(result.dir.includes('Logs'));
+    assert.ok(result.dir.includes('mcp'));
+  });
+
+  it('falls back to tmpdir when no home is available', () => {
+    const result = resolveLogDir({
+      env: {},
+      platform: 'darwin',
+      home: null,
+      tmp: '/var/folders/x/T/',
+    });
+    assert.equal(result.source, 'fallback');
+    assert.ok(result.dir.includes('oh-my-codex-mcp'));
+  });
+
+  it('falls back to tmpdir on win32 when LOCALAPPDATA is missing', () => {
+    const result = resolveLogDir({
+      env: {},
+      platform: 'win32',
+      home: 'C:\\Users\\jane',
+      tmp: 'C:\\Temp',
+    });
+    assert.equal(result.source, 'fallback');
+  });
+});
+
+describe('isLifecycleLogDisabled', () => {
+  it('returns true when OMX_MCP_LIFECYCLE_LOG=off (any case)', () => {
+    assert.equal(isLifecycleLogDisabled({ [LIFECYCLE_LOG_ENV]: 'off' }), true);
+    assert.equal(isLifecycleLogDisabled({ [LIFECYCLE_LOG_ENV]: 'OFF' }), true);
+    assert.equal(isLifecycleLogDisabled({ [LIFECYCLE_LOG_ENV]: 'Off' }), true);
+  });
+
+  it('returns false otherwise', () => {
+    assert.equal(isLifecycleLogDisabled({}), false);
+    assert.equal(isLifecycleLogDisabled({ [LIFECYCLE_LOG_ENV]: 'on' }), false);
+    assert.equal(isLifecycleLogDisabled({ [LIFECYCLE_LOG_ENV]: '' }), false);
+  });
+});
+
+describe('emit', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'omx-mcp-lifecycle-'));
+    _resetForTests();
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes a single JSON line with pid, ppid, ts_ms, event, and payload', async () => {
+    await emit(
+      'startup',
+      { serverName: 'state', marker: 'state-server.js' },
+      {
+        entrypoint: 'state-server',
+        env: { [LIFECYCLE_LOG_DIR_ENV]: dir },
+        platform: 'darwin',
+        now: () => 1700000000000,
+        pid: 4242,
+        ppid: 1224,
+      },
+    );
+
+    const filePath = join(dir, 'state-server.ndjson');
+    const content = await readFile(filePath, 'utf8');
+    assert.ok(content.endsWith('\n'), 'file content must end with newline');
+    const lines = content.trim().split('\n');
+    assert.equal(lines.length, 1);
+    const record = JSON.parse(lines[0]);
+    assert.equal(record.event, 'startup');
+    assert.equal(record.serverName, 'state');
+    assert.equal(record.marker, 'state-server.js');
+    assert.equal(record.pid, 4242);
+    assert.equal(record.ppid, 1224);
+    assert.equal(record.ts_ms, 1700000000000);
+  });
+
+  it('appends successive emits to the same entrypoint file', async () => {
+    const opts = {
+      entrypoint: 'memory-server',
+      env: { [LIFECYCLE_LOG_DIR_ENV]: dir },
+      platform: 'linux' as NodeJS.Platform,
+      pid: 1,
+      ppid: 2,
+    };
+    await emit('startup', { i: 1 }, opts);
+    await emit('shutdown_reason', { reason: 'stdin_close' }, opts);
+    await emit('shutdown_reason', { reason: 'transport_close' }, opts);
+
+    const content = await readFile(join(dir, 'memory-server.ndjson'), 'utf8');
+    const lines = content.trim().split('\n');
+    assert.equal(lines.length, 3);
+    const events = lines.map((l) => JSON.parse(l).event);
+    assert.deepEqual(events, ['startup', 'shutdown_reason', 'shutdown_reason']);
+  });
+
+  it('short-circuits when OMX_MCP_LIFECYCLE_LOG=off (no file created)', async () => {
+    await emit(
+      'startup',
+      { serverName: 'state' },
+      {
+        entrypoint: 'state-server',
+        env: {
+          [LIFECYCLE_LOG_DIR_ENV]: dir,
+          [LIFECYCLE_LOG_ENV]: 'off',
+        },
+        platform: 'darwin',
+      },
+    );
+    let didThrow = false;
+    try {
+      await stat(join(dir, 'state-server.ndjson'));
+    } catch {
+      didThrow = true;
+    }
+    assert.equal(didThrow, true, 'no log file should be created when LIFECYCLE_LOG=off');
+  });
+
+  it('replaces oversize payload with lifecycle_event_skipped record', async () => {
+    const huge = 'x'.repeat(8 * 1024);
+    await emit(
+      'duplicate_observation',
+      { dump: huge },
+      {
+        entrypoint: 'wiki-server',
+        env: { [LIFECYCLE_LOG_DIR_ENV]: dir },
+        platform: 'linux',
+        pid: 7,
+        ppid: 8,
+        now: () => 42,
+      },
+    );
+    const content = await readFile(join(dir, 'wiki-server.ndjson'), 'utf8');
+    const record = JSON.parse(content.trim());
+    assert.equal(record.event, 'lifecycle_event_skipped');
+    assert.equal(record.reason, 'oversize');
+    assert.equal(record.original_event, 'duplicate_observation');
+    assert.ok(typeof record.original_bytes === 'number');
+  });
+
+  it('rotates the log file when it exceeds 4 MB', async () => {
+    const filePath = join(dir, 'trace-server.ndjson');
+    await mkdtemp(join(tmpdir(), 'noop-')); // ensure tmpdir exists
+    // Pre-create a 4.1MB file to trigger rotation on next emit
+    const big = Buffer.alloc(4 * 1024 * 1024 + 1024, 0x61);
+    await writeFile(filePath, big);
+
+    await emit(
+      'startup',
+      { serverName: 'trace' },
+      {
+        entrypoint: 'trace-server',
+        env: { [LIFECYCLE_LOG_DIR_ENV]: dir },
+        platform: 'linux',
+        pid: 1,
+        ppid: 2,
+      },
+    );
+
+    // After rotation, .ndjson should contain just the new line; .ndjson.1 should hold the old big content
+    const newContent = await readFile(filePath, 'utf8');
+    assert.ok(newContent.length < 1024, 'rotated current file should be small');
+    const rotatedInfo = await stat(`${filePath}.1`);
+    assert.ok(rotatedInfo.size > 4 * 1024 * 1024, 'rotated .1 file should hold old content');
+  });
+
+  it('never throws when target directory cannot be created', async () => {
+    // Point at a path under a regular file - mkdir(recursive) will fail
+    const blocker = join(dir, 'blocker');
+    await writeFile(blocker, 'x');
+    await emit(
+      'startup',
+      {},
+      {
+        entrypoint: 'state-server',
+        env: { [LIFECYCLE_LOG_DIR_ENV]: join(blocker, 'sub') },
+        platform: 'linux',
+      },
+    );
+    // No assertion needed - emit() must not throw
+  });
+});

--- a/src/mcp/__tests__/lifecycle-telemetry.test.ts
+++ b/src/mcp/__tests__/lifecycle-telemetry.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
   LIFECYCLE_LOG_DIR_ENV,
   LIFECYCLE_LOG_ENV,
+  PRETRAFFIC_LEDGER_ENV,
   appendPretrafficEvent,
   emit,
   isLifecycleLogDisabled,
@@ -309,16 +310,37 @@ describe('pretraffic ledger', () => {
     assert.deepEqual(pretraffic, []);
   });
 
-  it('skips reads and writes when OMX_MCP_LIFECYCLE_LOG=off', async () => {
-    const offOpts = {
+  it('keeps working when OMX_MCP_LIFECYCLE_LOG=off (ledger is functional state, not diagnostics)', async () => {
+    // Disabling the JSONL diagnostic log must NOT disable the hard-cap ledger.
+    // The plan eventually flips OMX_MCP_LIFECYCLE_LOG to off-by-default; the cap must
+    // keep enforcing in that configuration.
+    const opts = {
       entrypoint: 'state-server',
       env: { [LIFECYCLE_LOG_DIR_ENV]: dir, [LIFECYCLE_LOG_ENV]: 'off' },
       platform: 'linux' as NodeJS.Platform,
       pid: 101,
     };
+    await appendPretrafficEvent('start', opts);
+    const pretraffic = await readPretrafficSiblingPids([101], opts);
+    assert.deepEqual(
+      pretraffic,
+      [101],
+      'LIFECYCLE_LOG=off must NOT short-circuit the pretraffic ledger',
+    );
+    const fileInfo = await stat(join(dir, 'state-server.pretraffic'));
+    assert.ok(fileInfo.size > 0, 'ledger file should be written despite LIFECYCLE_LOG=off');
+  });
+
+  it('skips reads and writes when OMX_MCP_PRETRAFFIC_LEDGER=off', async () => {
+    const offOpts = {
+      entrypoint: 'state-server',
+      env: { [LIFECYCLE_LOG_DIR_ENV]: dir, [PRETRAFFIC_LEDGER_ENV]: 'off' },
+      platform: 'linux' as NodeJS.Platform,
+      pid: 101,
+    };
     await appendPretrafficEvent('start', offOpts);
     const pretraffic = await readPretrafficSiblingPids([101], offOpts);
-    assert.deepEqual(pretraffic, [], 'LOG=off must short-circuit the ledger entirely');
+    assert.deepEqual(pretraffic, [], 'PRETRAFFIC_LEDGER=off must short-circuit the ledger entirely');
     let didThrow = false;
     try {
       await stat(join(dir, 'state-server.pretraffic'));

--- a/src/mcp/__tests__/server-lifecycle.test.ts
+++ b/src/mcp/__tests__/server-lifecycle.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { once } from 'node:events';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const STARTUP_SETTLE_MS = 150;
@@ -326,6 +328,54 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
       if (newer) {
         await forceCleanup(newer);
       }
+    }
+  });
+
+  it('emits lifecycle JSONL with startup and shutdown_reason on stdin close', async () => {
+    const entrypoint = IDLE_ENTRYPOINTS[0];
+    const logDir = await mkdtemp(join(tmpdir(), 'omx-mcp-lifecycle-'));
+    const child = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
+      cwd: process.cwd(),
+      env: { ...process.env, OMX_MCP_LIFECYCLE_LOG_DIR: logDir },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => stdout.push(chunk));
+    child.stderr?.on('data', (chunk: string) => stderr.push(chunk));
+
+    try {
+      await waitForSpawn(child, entrypoint, stderr, stdout);
+      await delay(STARTUP_SETTLE_MS);
+      child.stdin?.end();
+      await waitForExit(child, entrypoint, stderr, stdout);
+      // Allow any trailing fire-and-forget appendFile to flush.
+      await delay(50);
+
+      const ndjsonPath = join(logDir, 'state-server.ndjson');
+      const content = await readFile(ndjsonPath, 'utf8');
+      const lines = content.trim().split('\n');
+      const events = lines.map((l) => JSON.parse(l));
+      const eventNames = events.map((e) => e.event);
+      assert.ok(eventNames.includes('startup'), `expected startup event, got ${eventNames.join(',')}`);
+      const shutdownEvents = events.filter((e) => e.event === 'shutdown_reason');
+      assert.ok(shutdownEvents.length > 0, 'expected at least one shutdown_reason event');
+      const reasons = shutdownEvents.map((e) => e.reason);
+      assert.ok(
+        reasons.some((r) => r === 'stdin_close' || r === 'stdin_end' || r === 'transport_close'),
+        `expected stdin/transport shutdown reason, got ${reasons.join(',')}`,
+      );
+      for (const event of events) {
+        assert.equal(event.serverName, 'state');
+        assert.equal(typeof event.pid, 'number');
+        assert.equal(typeof event.ppid, 'number');
+        assert.equal(typeof event.ts_ms, 'number');
+      }
+    } finally {
+      await forceCleanup(child);
+      await rm(logDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -1,7 +1,12 @@
 import { execFileSync } from 'node:child_process';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { resolveOmxFirstPartyMcpEntrypointForPluginTarget } from '../config/omx-first-party-mcp.js';
-import { emit as emitLifecycleEvent, flush as flushLifecycleEvents } from './lifecycle-telemetry.js';
+import {
+  appendPretrafficEvent,
+  emit as emitLifecycleEvent,
+  flush as flushLifecycleEvents,
+  readPretrafficSiblingPids,
+} from './lifecycle-telemetry.js';
 
 export type McpServerName = 'state' | 'memory' | 'code_intel' | 'trace' | 'wiki';
 
@@ -265,17 +270,23 @@ function resolveLifecycleTimingConfig(
 
 export function shouldSelfExitForHardCap(
   observation: DuplicateSiblingObservation,
-  lastTrafficAtMs: number | null,
+  pretrafficSiblingPids: ReadonlyArray<number>,
   maxSiblings: number,
   currentPid: number,
 ): boolean {
   if (!Number.isInteger(maxSiblings) || maxSiblings <= 0) return false;
-  if (lastTrafficAtMs !== null) return false;
+  if (!pretrafficSiblingPids.includes(currentPid)) return false;
   if (observation.matchingPids.length <= maxSiblings) return false;
-  const sorted = [...observation.matchingPids].sort((a, b) => a - b);
+  // Only pre-traffic siblings are killable. Cap the exit count so we never
+  // try to evict more victims than we have.
+  const exitCount = Math.min(
+    observation.matchingPids.length - maxSiblings,
+    pretrafficSiblingPids.length,
+  );
+  if (exitCount <= 0) return false;
+  const sorted = [...pretrafficSiblingPids].sort((a, b) => a - b);
   const idx = sorted.indexOf(currentPid);
   if (idx === -1) return false;
-  const exitCount = sorted.length - maxSiblings;
   return idx < exitCount;
 }
 
@@ -412,6 +423,8 @@ export function autoStartStdioMcpServer(
       markerEnv: env[MCP_ENTRYPOINT_MARKER_ENV] ?? null,
     });
   }
+  void appendPretrafficEvent('start', { entrypoint: telemetryEntrypoint, env });
+  let recordedTraffic = false;
 
   const logLifecycle = (message: string, error?: unknown) => {
     if (!lifecycleDebugEnabled) return;
@@ -447,7 +460,7 @@ export function autoStartStdioMcpServer(
     });
   };
 
-  const runDuplicateSiblingWatchdog = () => {
+  const runDuplicateSiblingWatchdog = async () => {
     try {
       const processes = listProcessTable();
       if (!processes) {
@@ -475,10 +488,14 @@ export function autoStartStdioMcpServer(
         applyBackoff();
       }
 
+      const pretrafficSiblingPids = await readPretrafficSiblingPids(
+        observation.matchingPids,
+        { entrypoint: telemetryEntrypoint, env },
+      );
       if (
         shouldSelfExitForHardCap(
           observation,
-          lastTrafficAtMs,
+          pretrafficSiblingPids,
           lifecycleTiming.maxSiblingsPerEntrypoint,
           process.pid,
         )
@@ -563,6 +580,7 @@ export function autoStartStdioMcpServer(
       console.error(`[omx-${serverName}-server] shutdown failed`, error);
     }
 
+    void appendPretrafficEvent('exit', { entrypoint: telemetryEntrypoint, env });
     logLifecycle('transport shutdown: exit');
     await flushLifecycleEvents().catch(() => {});
     process.exit(0);
@@ -576,6 +594,10 @@ export function autoStartStdioMcpServer(
   };
   const handleStdinData = () => {
     lastTrafficAtMs = Date.now();
+    if (!recordedTraffic) {
+      recordedTraffic = true;
+      void appendPretrafficEvent('traffic', { entrypoint: telemetryEntrypoint, env });
+    }
   };
   const handleSigterm = () => {
     void shutdown('sigterm');

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -271,11 +271,11 @@ export function shouldSelfExitForHardCap(
 ): boolean {
   if (!Number.isInteger(maxSiblings) || maxSiblings <= 0) return false;
   if (lastTrafficAtMs !== null) return false;
-  if (observation.matchingPids.length < maxSiblings) return false;
+  if (observation.matchingPids.length <= maxSiblings) return false;
   const sorted = [...observation.matchingPids].sort((a, b) => a - b);
   const idx = sorted.indexOf(currentPid);
   if (idx === -1) return false;
-  const exitCount = sorted.length - maxSiblings + 1;
+  const exitCount = sorted.length - maxSiblings;
   return idx < exitCount;
 }
 

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { resolveOmxFirstPartyMcpEntrypointForPluginTarget } from '../config/omx-first-party-mcp.js';
+import { emit as emitLifecycleEvent, flush as flushLifecycleEvents } from './lifecycle-telemetry.js';
 
 export type McpServerName = 'state' | 'memory' | 'code_intel' | 'trace' | 'wiki';
 
@@ -20,12 +21,16 @@ const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_PRE_T
 const DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS';
 const DUPLICATE_SIBLING_INITIAL_DELAY_ENV = 'OMX_MCP_DUPLICATE_SIBLING_INITIAL_DELAY_MS';
 const DUPLICATE_SIBLING_INITIAL_DELAY_MAX_ENV = 'OMX_MCP_DUPLICATE_SIBLING_INITIAL_DELAY_MAX_MS';
+const MAX_SIBLINGS_PER_ENTRYPOINT_ENV = 'OMX_MCP_MAX_SIBLINGS_PER_ENTRYPOINT';
+const DUPLICATE_SIBLING_BACKOFF_INTERVAL_ENV = 'OMX_MCP_DUPLICATE_SIBLING_BACKOFF_INTERVAL_MS';
 export const MCP_ENTRYPOINT_MARKER_ENV = 'OMX_MCP_ENTRYPOINT_MARKER';
 const DEFAULT_PARENT_WATCHDOG_INTERVAL_MS = 1_000;
 const DEFAULT_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
 const DEFAULT_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
 const DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS = 60_000;
 const DEFAULT_DUPLICATE_SIBLING_INITIAL_DELAY_MAX_MS = 1_000;
+const DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT = 4;
+const DEFAULT_DUPLICATE_SIBLING_BACKOFF_INTERVAL_MS = 30_000;
 const MCP_ENTRYPOINT_PATTERN = /\b([a-z0-9-]+-server\.(?:[cm]?js|ts))\b/i;
 const MCP_SERVE_TARGET_PATTERN = /(?:^|\s)mcp-serve\s+([^\s]+)/i;
 
@@ -54,6 +59,8 @@ interface LifecycleTimingConfig {
   duplicateSiblingPostTrafficIdleMs: number;
   duplicateSiblingInitialDelayMs: number | null;
   duplicateSiblingInitialDelayMaxMs: number;
+  duplicateSiblingBackoffIntervalMs: number;
+  maxSiblingsPerEntrypoint: number;
 }
 
 function normalizeCommand(command: string): string {
@@ -243,7 +250,41 @@ function resolveLifecycleTimingConfig(
       DUPLICATE_SIBLING_INITIAL_DELAY_MAX_ENV,
       DEFAULT_DUPLICATE_SIBLING_INITIAL_DELAY_MAX_MS,
     ),
+    duplicateSiblingBackoffIntervalMs: readPositiveIntegerEnv(
+      env,
+      DUPLICATE_SIBLING_BACKOFF_INTERVAL_ENV,
+      DEFAULT_DUPLICATE_SIBLING_BACKOFF_INTERVAL_MS,
+    ),
+    maxSiblingsPerEntrypoint: readNonNegativeIntegerEnv(
+      env,
+      MAX_SIBLINGS_PER_ENTRYPOINT_ENV,
+      DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT,
+    ) ?? DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT,
   };
+}
+
+export function shouldSelfExitForHardCap(
+  observation: DuplicateSiblingObservation,
+  lastTrafficAtMs: number | null,
+  maxSiblings: number,
+  currentPid: number,
+): boolean {
+  if (!Number.isInteger(maxSiblings) || maxSiblings <= 0) return false;
+  if (lastTrafficAtMs !== null) return false;
+  if (observation.matchingPids.length < maxSiblings) return false;
+  const sorted = [...observation.matchingPids].sort((a, b) => a - b);
+  const idx = sorted.indexOf(currentPid);
+  if (idx === -1) return false;
+  const exitCount = sorted.length - maxSiblings + 1;
+  return idx < exitCount;
+}
+
+export function shouldBackoffWatchdog(
+  observation: DuplicateSiblingObservation,
+  maxSiblings: number,
+): boolean {
+  if (!Number.isInteger(maxSiblings) || maxSiblings <= 0) return false;
+  return observation.matchingPids.length > maxSiblings;
 }
 
 function stableStringHash(value: string): number {
@@ -347,6 +388,31 @@ export function autoStartStdioMcpServer(
   let lastTrafficAtMs: number | null = null;
   let duplicateObservedAtMs: number | null = null;
 
+  const telemetryEntrypoint = trackedEntrypoint
+    ? trackedEntrypoint.replace(/\.[cm]?[jt]s$/i, '')
+    : `${serverName}-server`;
+  const emitEvent = (event: string, payload: Record<string, unknown> = {}) =>
+    emitLifecycleEvent(
+      event,
+      { serverName, ...payload },
+      { entrypoint: telemetryEntrypoint, env },
+    );
+
+  emitEvent('startup', {
+    argv1: process.argv[1] ?? null,
+    marker: trackedEntrypoint,
+    parentPid: trackedParentPid,
+    maxSiblingsPerEntrypoint: lifecycleTiming.maxSiblingsPerEntrypoint,
+  });
+  if (!trackedEntrypoint) {
+    emitEvent('marker_resolution_failed', {
+      argv0: process.argv[0] ?? null,
+      argv1: process.argv[1] ?? null,
+      argv2: process.argv[2] ?? null,
+      markerEnv: env[MCP_ENTRYPOINT_MARKER_ENV] ?? null,
+    });
+  }
+
   const logLifecycle = (message: string, error?: unknown) => {
     if (!lifecycleDebugEnabled) return;
     const detail = error ? ` ${error instanceof Error ? error.message : String(error)}` : '';
@@ -364,42 +430,91 @@ export function autoStartStdioMcpServer(
   let duplicateSiblingWatchdog: ReturnType<typeof setInterval> | null = null;
   let duplicateSiblingInitialDelayTimer: ReturnType<typeof setTimeout> | null = null;
 
+  let watchdogBackedOff = false;
+
+  const applyBackoff = () => {
+    if (watchdogBackedOff) return;
+    if (!duplicateSiblingWatchdog) return;
+    clearInterval(duplicateSiblingWatchdog);
+    duplicateSiblingWatchdog = setInterval(
+      runDuplicateSiblingWatchdog,
+      lifecycleTiming.duplicateSiblingBackoffIntervalMs,
+    );
+    duplicateSiblingWatchdog.unref();
+    watchdogBackedOff = true;
+    emitEvent('duplicate_watchdog_backoff', {
+      newIntervalMs: lifecycleTiming.duplicateSiblingBackoffIntervalMs,
+    });
+  };
+
   const runDuplicateSiblingWatchdog = () => {
-    const processes = listProcessTable();
-    if (!processes) {
-      duplicateObservedAtMs = null;
-      return;
+    try {
+      const processes = listProcessTable();
+      if (!processes) {
+        duplicateObservedAtMs = null;
+        return;
+      }
+
+      const observation = analyzeDuplicateSiblingState(
+        processes,
+        process.pid,
+        trackedParentPid,
+        trackedEntrypoint,
+      );
+
+      if (observation.status !== 'unique') {
+        emitEvent('duplicate_observation', {
+          status: observation.status,
+          matchingPids: observation.matchingPids,
+          newerSiblingPids: observation.newerSiblingPids,
+          lastTrafficAtMs,
+        });
+      }
+
+      if (shouldBackoffWatchdog(observation, lifecycleTiming.maxSiblingsPerEntrypoint)) {
+        applyBackoff();
+      }
+
+      if (
+        shouldSelfExitForHardCap(
+          observation,
+          lastTrafficAtMs,
+          lifecycleTiming.maxSiblingsPerEntrypoint,
+          process.pid,
+        )
+      ) {
+        void shutdown('superseded_hard_cap_pre_traffic');
+        return;
+      }
+
+      if (observation.status !== 'older_duplicate') {
+        duplicateObservedAtMs = null;
+        return;
+      }
+
+      duplicateObservedAtMs ??= Date.now();
+      if (!shouldSelfExitForDuplicateSibling(
+        observation,
+        Date.now(),
+        duplicateObservedAtMs,
+        lastTrafficAtMs,
+        lifecycleTiming.duplicateSiblingPreTrafficGraceMs,
+        lifecycleTiming.duplicateSiblingPostTrafficIdleMs,
+      )) {
+        return;
+      }
+
+      void shutdown(
+        lastTrafficAtMs !== null && lastTrafficAtMs > duplicateObservedAtMs
+          ? 'superseded_duplicate_after_idle'
+          : 'superseded_duplicate_before_traffic',
+      );
+    } catch (error) {
+      emitEvent('duplicate_watchdog_error', {
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack ?? null : null,
+      });
     }
-
-    const observation = analyzeDuplicateSiblingState(
-      processes,
-      process.pid,
-      trackedParentPid,
-      trackedEntrypoint,
-    );
-
-    if (observation.status !== 'older_duplicate') {
-      duplicateObservedAtMs = null;
-      return;
-    }
-
-    duplicateObservedAtMs ??= Date.now();
-    if (!shouldSelfExitForDuplicateSibling(
-      observation,
-      Date.now(),
-      duplicateObservedAtMs,
-      lastTrafficAtMs,
-      lifecycleTiming.duplicateSiblingPreTrafficGraceMs,
-      lifecycleTiming.duplicateSiblingPostTrafficIdleMs,
-    )) {
-      return;
-    }
-
-    void shutdown(
-      lastTrafficAtMs !== null && lastTrafficAtMs > duplicateObservedAtMs
-        ? 'superseded_duplicate_after_idle'
-        : 'superseded_duplicate_before_traffic',
-    );
   };
 
   if (trackedParentPid > 1 && trackedEntrypoint) {
@@ -425,6 +540,7 @@ export function autoStartStdioMcpServer(
       return;
     }
     shuttingDown = true;
+    emitEvent('shutdown_reason', { reason });
     logLifecycle(`transport shutdown: ${reason}`);
     if (parentWatchdog) {
       clearInterval(parentWatchdog);
@@ -448,6 +564,7 @@ export function autoStartStdioMcpServer(
     }
 
     logLifecycle('transport shutdown: exit');
+    await flushLifecycleEvents().catch(() => {});
     process.exit(0);
   };
 
@@ -480,6 +597,9 @@ export function autoStartStdioMcpServer(
 
   server.connect(transport).catch((error) => {
     logLifecycle('server.connect failed', error);
+    emitEvent('server_connect_failed', {
+      message: error instanceof Error ? error.message : String(error),
+    });
     process.stdin.off('data', handleStdinData);
     process.stdin.off('end', handleStdinEnd);
     process.stdin.off('close', handleStdinClose);

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -298,6 +298,19 @@ export function shouldBackoffWatchdog(
   return observation.matchingPids.length > maxSiblings;
 }
 
+// The in-memory `lastTrafficAtMs` on this process is authoritative for self even when
+// the corresponding `traffic` ledger append has not flushed to disk yet. Without this
+// override, the ledger's last-known event for self is still 'start', and the cap could
+// evict a transport that has already been claimed by the client.
+export function effectivePretrafficSiblings(
+  pretrafficSiblingPids: ReadonlyArray<number>,
+  selfPid: number,
+  selfLastTrafficAtMs: number | null,
+): number[] {
+  if (selfLastTrafficAtMs === null) return [...pretrafficSiblingPids];
+  return pretrafficSiblingPids.filter((pid) => pid !== selfPid);
+}
+
 function stableStringHash(value: string): number {
   let hash = 0;
   for (let i = 0; i < value.length; i += 1) {
@@ -492,10 +505,15 @@ export function autoStartStdioMcpServer(
         observation.matchingPids,
         { entrypoint: telemetryEntrypoint, env },
       );
+      const effectivePretraffic = effectivePretrafficSiblings(
+        pretrafficSiblingPids,
+        process.pid,
+        lastTrafficAtMs,
+      );
       if (
         shouldSelfExitForHardCap(
           observation,
-          pretrafficSiblingPids,
+          effectivePretraffic,
           lifecycleTiming.maxSiblingsPerEntrypoint,
           process.pid,
         )

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -298,6 +298,18 @@ export function shouldBackoffWatchdog(
   return observation.matchingPids.length > maxSiblings;
 }
 
+// The hard cap can only fire when the entrypoint exceeds its configured maximum,
+// so steady-state ticks with cap >= count must skip the pretraffic ledger read
+// entirely — otherwise every tracked MCP child pays disk I/O on every poll for a
+// branch that cannot evict anyone.
+export function shouldEvaluateHardCap(
+  matchingPids: ReadonlyArray<number>,
+  maxSiblings: number,
+): boolean {
+  if (!Number.isInteger(maxSiblings) || maxSiblings <= 0) return false;
+  return matchingPids.length > maxSiblings;
+}
+
 // The in-memory `lastTrafficAtMs` on this process is authoritative for self even when
 // the corresponding `traffic` ledger append has not flushed to disk yet. Without this
 // override, the ledger's last-known event for self is still 'start', and the cap could
@@ -501,25 +513,27 @@ export function autoStartStdioMcpServer(
         applyBackoff();
       }
 
-      const pretrafficSiblingPids = await readPretrafficSiblingPids(
-        observation.matchingPids,
-        { entrypoint: telemetryEntrypoint, env },
-      );
-      const effectivePretraffic = effectivePretrafficSiblings(
-        pretrafficSiblingPids,
-        process.pid,
-        lastTrafficAtMs,
-      );
-      if (
-        shouldSelfExitForHardCap(
-          observation,
-          effectivePretraffic,
-          lifecycleTiming.maxSiblingsPerEntrypoint,
+      if (shouldEvaluateHardCap(observation.matchingPids, lifecycleTiming.maxSiblingsPerEntrypoint)) {
+        const pretrafficSiblingPids = await readPretrafficSiblingPids(
+          observation.matchingPids,
+          { entrypoint: telemetryEntrypoint, env },
+        );
+        const effectivePretraffic = effectivePretrafficSiblings(
+          pretrafficSiblingPids,
           process.pid,
-        )
-      ) {
-        void shutdown('superseded_hard_cap_pre_traffic');
-        return;
+          lastTrafficAtMs,
+        );
+        if (
+          shouldSelfExitForHardCap(
+            observation,
+            effectivePretraffic,
+            lifecycleTiming.maxSiblingsPerEntrypoint,
+            process.pid,
+          )
+        ) {
+          void shutdown('superseded_hard_cap_pre_traffic');
+          return;
+        }
       }
 
       if (observation.status !== 'older_duplicate') {

--- a/src/mcp/lifecycle-telemetry.ts
+++ b/src/mcp/lifecycle-telemetry.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, rename, stat } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, rename, stat } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -201,6 +201,86 @@ export async function flush(): Promise<void> {
   const pending = Array.from(inflight);
   if (pending.length === 0) return;
   await Promise.allSettled(pending);
+}
+
+export type PretrafficEvent = 'start' | 'traffic' | 'exit';
+
+export interface PretrafficOptions {
+  entrypoint: string;
+  env?: Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+  now?: () => number;
+  pid?: number;
+}
+
+function pretrafficLedgerPath(options: PretrafficOptions): { path: string; dir: string } | null {
+  const env = options.env ?? process.env;
+  if (isLifecycleLogDisabled(env)) return null;
+  const platform = options.platform ?? process.platform;
+  const resolution = resolveLogDir({ env, platform });
+  return {
+    path: join(resolution.dir, `${options.entrypoint}.pretraffic`),
+    dir: resolution.dir,
+  };
+}
+
+export function appendPretrafficEvent(
+  event: PretrafficEvent,
+  options: PretrafficOptions,
+): Promise<void> {
+  const target = pretrafficLedgerPath(options);
+  if (!target) return Promise.resolve();
+  const ts = options.now ? options.now() : Date.now();
+  const pid = options.pid ?? process.pid;
+  const line = `${ts}\t${pid}\t${event}\n`;
+  const writePromise = (async () => {
+    try {
+      await ensureDirOnce(target.dir);
+      await appendFile(target.path, line, { flag: 'a' });
+    } catch {
+      // ledger writes must never throw
+    }
+  })();
+  inflight.add(writePromise);
+  void writePromise.finally(() => {
+    inflight.delete(writePromise);
+  });
+  return writePromise;
+}
+
+export async function readPretrafficSiblingPids(
+  candidatePids: ReadonlyArray<number>,
+  options: PretrafficOptions,
+): Promise<number[]> {
+  const target = pretrafficLedgerPath(options);
+  if (!target) return [];
+  let raw: string;
+  try {
+    raw = await readFile(target.path, 'utf8');
+  } catch {
+    return [];
+  }
+  const candidateSet = new Set(candidatePids.filter((pid) => Number.isInteger(pid) && pid > 0));
+  if (candidateSet.size === 0) return [];
+  const latestEvent = new Map<number, PretrafficEvent>();
+  for (const rawLine of raw.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const parts = line.split('\t');
+    if (parts.length !== 3) continue;
+    const pid = Number.parseInt(parts[1], 10);
+    if (!Number.isInteger(pid) || !candidateSet.has(pid)) continue;
+    const ev = parts[2];
+    if (ev === 'start' || ev === 'traffic' || ev === 'exit') {
+      latestEvent.set(pid, ev);
+    }
+  }
+  const result: number[] = [];
+  for (const pid of candidateSet) {
+    if (latestEvent.get(pid) === 'start') result.push(pid);
+  }
+  result.sort((a, b) => a - b);
+  return result;
 }
 
 export function _resetForTests(): void {

--- a/src/mcp/lifecycle-telemetry.ts
+++ b/src/mcp/lifecycle-telemetry.ts
@@ -1,0 +1,209 @@
+import { appendFile, mkdir, rename, stat } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const LIFECYCLE_LOG_ENV = 'OMX_MCP_LIFECYCLE_LOG';
+export const LIFECYCLE_LOG_DIR_ENV = 'OMX_MCP_LIFECYCLE_LOG_DIR';
+
+const MAX_LINE_BYTES = 4 * 1024 - 64;
+const ROTATION_THRESHOLD_BYTES = 4 * 1024 * 1024;
+const ROTATION_KEEP = 2;
+
+export type LogDirSource = 'env' | 'platform' | 'fallback';
+
+export interface ResolveLogDirResult {
+  dir: string;
+  source: LogDirSource;
+}
+
+export interface ResolveLogDirOptions {
+  env?: Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+  home?: string | null;
+  tmp?: string;
+}
+
+export function resolveLogDir(options: ResolveLogDirOptions = {}): ResolveLogDirResult {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const home = 'home' in options ? options.home : (homedir() || null);
+  const tmp = options.tmp ?? tmpdir();
+
+  const override = env[LIFECYCLE_LOG_DIR_ENV]?.trim();
+  if (override) {
+    return { dir: override, source: 'env' };
+  }
+
+  if (platform === 'darwin' && home) {
+    return {
+      dir: join(home, 'Library', 'Logs', 'oh-my-codex', 'mcp'),
+      source: 'platform',
+    };
+  }
+
+  if (platform === 'linux' && home) {
+    const xdgState = env.XDG_STATE_HOME?.trim();
+    const stateRoot = xdgState && xdgState.length > 0 ? xdgState : join(home, '.local', 'state');
+    return {
+      dir: join(stateRoot, 'oh-my-codex', 'mcp'),
+      source: 'platform',
+    };
+  }
+
+  if (platform === 'win32') {
+    const localAppData = env.LOCALAPPDATA?.trim();
+    if (localAppData) {
+      return {
+        dir: join(localAppData, 'oh-my-codex', 'Logs', 'mcp'),
+        source: 'platform',
+      };
+    }
+  }
+
+  return {
+    dir: join(tmp, 'oh-my-codex-mcp'),
+    source: 'fallback',
+  };
+}
+
+export function isLifecycleLogDisabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env[LIFECYCLE_LOG_ENV]?.toLowerCase() === 'off';
+}
+
+export interface EmitOptions {
+  entrypoint: string;
+  env?: Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+  now?: () => number;
+  pid?: number;
+  ppid?: number;
+}
+
+let dirEnsured: string | null = null;
+
+async function ensureDirOnce(dir: string): Promise<void> {
+  if (dirEnsured === dir) return;
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  dirEnsured = dir;
+}
+
+async function rotateIfNeeded(filePath: string): Promise<void> {
+  let size: number;
+  try {
+    const info = await stat(filePath);
+    size = info.size;
+  } catch {
+    return;
+  }
+  if (size < ROTATION_THRESHOLD_BYTES) return;
+
+  for (let i = ROTATION_KEEP; i >= 1; i -= 1) {
+    const src = `${filePath}.${i}`;
+    const dst = `${filePath}.${i + 1}`;
+    try {
+      await rename(src, dst);
+    } catch {
+      // generation may not exist yet
+    }
+  }
+  try {
+    await rename(filePath, `${filePath}.1`);
+  } catch {
+    // another writer may have rotated first
+  }
+}
+
+interface EmitContext {
+  pid: number;
+  ppid: number;
+  now: number;
+  filePath: string;
+  dir: string;
+}
+
+function buildContext(options: EmitOptions): EmitContext | null {
+  const env = options.env ?? process.env;
+  if (isLifecycleLogDisabled(env)) return null;
+  const platform = options.platform ?? process.platform;
+  const resolution = resolveLogDir({ env, platform });
+  return {
+    pid: options.pid ?? process.pid,
+    ppid: options.ppid ?? process.ppid,
+    now: options.now ? options.now() : Date.now(),
+    filePath: join(resolution.dir, `${options.entrypoint}.ndjson`),
+    dir: resolution.dir,
+  };
+}
+
+function buildLine(
+  event: string,
+  payload: Record<string, unknown>,
+  ctx: EmitContext,
+): string | null {
+  const record: Record<string, unknown> = {
+    ts_ms: ctx.now,
+    pid: ctx.pid,
+    ppid: ctx.ppid,
+    event,
+    ...payload,
+  };
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(record);
+  } catch {
+    return null;
+  }
+  if (Buffer.byteLength(serialized, 'utf8') >= MAX_LINE_BYTES) {
+    const skip = {
+      ts_ms: ctx.now,
+      pid: ctx.pid,
+      ppid: ctx.ppid,
+      event: 'lifecycle_event_skipped',
+      reason: 'oversize',
+      original_event: event,
+      original_bytes: Buffer.byteLength(serialized, 'utf8'),
+    };
+    serialized = JSON.stringify(skip);
+  }
+  return `${serialized}\n`;
+}
+
+const inflight = new Set<Promise<void>>();
+
+export function emit(
+  event: string,
+  payload: Record<string, unknown>,
+  options: EmitOptions,
+): Promise<void> {
+  const ctx = buildContext(options);
+  if (!ctx) return Promise.resolve();
+  const line = buildLine(event, payload, ctx);
+  if (!line) return Promise.resolve();
+  const writePromise = (async () => {
+    try {
+      await ensureDirOnce(ctx.dir);
+      await rotateIfNeeded(ctx.filePath);
+      await appendFile(ctx.filePath, line, { flag: 'a' });
+    } catch {
+      // emit must never throw
+    }
+  })();
+  inflight.add(writePromise);
+  void writePromise.finally(() => {
+    inflight.delete(writePromise);
+  });
+  return writePromise;
+}
+
+export async function flush(): Promise<void> {
+  const pending = Array.from(inflight);
+  if (pending.length === 0) return;
+  await Promise.allSettled(pending);
+}
+
+export function _resetForTests(): void {
+  dirEnsured = null;
+  inflight.clear();
+}

--- a/src/mcp/lifecycle-telemetry.ts
+++ b/src/mcp/lifecycle-telemetry.ts
@@ -259,6 +259,17 @@ export function appendPretrafficEvent(
   return writePromise;
 }
 
+// Event precedence used as a tiebreaker when two ledger entries share the same ts_ms.
+// `appendPretrafficEvent` writes are fire-and-forget through libuv's worker pool, so
+// disk order is not guaranteed to follow call order even within a single process.
+// `start < traffic < exit` ensures that, on tie, the more-advanced lifecycle state wins
+// and an initialized server is never misclassified as pre-traffic.
+const PRETRAFFIC_EVENT_RANK: Record<PretrafficEvent, number> = {
+  start: 0,
+  traffic: 1,
+  exit: 2,
+};
+
 export async function readPretrafficSiblingPids(
   candidatePids: ReadonlyArray<number>,
   options: PretrafficOptions,
@@ -273,22 +284,29 @@ export async function readPretrafficSiblingPids(
   }
   const candidateSet = new Set(candidatePids.filter((pid) => Number.isInteger(pid) && pid > 0));
   if (candidateSet.size === 0) return [];
-  const latestEvent = new Map<number, PretrafficEvent>();
+  const winning = new Map<number, { ts: number; ev: PretrafficEvent }>();
   for (const rawLine of raw.split('\n')) {
     const line = rawLine.trim();
     if (!line) continue;
     const parts = line.split('\t');
     if (parts.length !== 3) continue;
+    const ts = Number.parseInt(parts[0], 10);
     const pid = Number.parseInt(parts[1], 10);
-    if (!Number.isInteger(pid) || !candidateSet.has(pid)) continue;
+    if (!Number.isInteger(ts) || !Number.isInteger(pid) || !candidateSet.has(pid)) continue;
     const ev = parts[2];
-    if (ev === 'start' || ev === 'traffic' || ev === 'exit') {
-      latestEvent.set(pid, ev);
+    if (ev !== 'start' && ev !== 'traffic' && ev !== 'exit') continue;
+    const prior = winning.get(pid);
+    if (
+      !prior ||
+      ts > prior.ts ||
+      (ts === prior.ts && PRETRAFFIC_EVENT_RANK[ev] > PRETRAFFIC_EVENT_RANK[prior.ev])
+    ) {
+      winning.set(pid, { ts, ev });
     }
   }
   const result: number[] = [];
   for (const pid of candidateSet) {
-    if (latestEvent.get(pid) === 'start') result.push(pid);
+    if (winning.get(pid)?.ev === 'start') result.push(pid);
   }
   result.sort((a, b) => a - b);
   return result;

--- a/src/mcp/lifecycle-telemetry.ts
+++ b/src/mcp/lifecycle-telemetry.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 export const LIFECYCLE_LOG_ENV = 'OMX_MCP_LIFECYCLE_LOG';
 export const LIFECYCLE_LOG_DIR_ENV = 'OMX_MCP_LIFECYCLE_LOG_DIR';
+export const PRETRAFFIC_LEDGER_ENV = 'OMX_MCP_PRETRAFFIC_LEDGER';
 
 const MAX_LINE_BYTES = 4 * 1024 - 64;
 const ROTATION_THRESHOLD_BYTES = 4 * 1024 * 1024;
@@ -70,6 +71,12 @@ export function isLifecycleLogDisabled(
   env: Record<string, string | undefined> = process.env,
 ): boolean {
   return env[LIFECYCLE_LOG_ENV]?.toLowerCase() === 'off';
+}
+
+export function isPretrafficLedgerDisabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env[PRETRAFFIC_LEDGER_ENV]?.toLowerCase() === 'off';
 }
 
 export interface EmitOptions {
@@ -214,8 +221,12 @@ export interface PretrafficOptions {
 }
 
 function pretrafficLedgerPath(options: PretrafficOptions): { path: string; dir: string } | null {
+  // Pretraffic ledger is functional state for the hard cap, not diagnostics, so it is
+  // intentionally NOT gated on OMX_MCP_LIFECYCLE_LOG. Only OMX_MCP_PRETRAFFIC_LEDGER=off
+  // disables it (e.g. on read-only filesystems). Path resolution is shared with the
+  // JSONL log via resolveLogDir + OMX_MCP_LIFECYCLE_LOG_DIR override.
   const env = options.env ?? process.env;
-  if (isLifecycleLogDisabled(env)) return null;
+  if (isPretrafficLedgerDisabled(env)) return null;
   const platform = options.platform ?? process.platform;
   const resolution = resolveLogDir({ env, platform });
   return {


### PR DESCRIPTION
Closes #2142.

## Summary

`oh-my-codex@0.16.0` still leaks first-party MCP children under live `codex app-server` parents (#2142). The remaining failure mode is **silent** — the existing duplicate-sibling watchdog has no observable output in production — so this PR leads with diagnostics, then adds a narrow pre-traffic hard cap that **cannot regress** the active-session contract introduced in #1759 / #1960.

The change is **strictly additive on top of #2077**. It preserves the contract tested at `src/mcp/__tests__/server-lifecycle.test.ts:271-330` (\"initialized older duplicate entrypoints remain alive when a native subagent sibling starts\"). Verified by re-running that exact test against this branch — passes unchanged.

## What's in here

### 1. Lifecycle JSONL telemetry — `src/mcp/lifecycle-telemetry.ts` (NEW)

`emit()` / `flush()` / `resolveLogDir()`. Per-platform user-writable defaults, off `process.cwd()` because Homebrew install dirs (`/opt/homebrew/lib/node_modules/oh-my-codex/`) are read-only:

| Platform | Default log dir |
|---|---|
| darwin | `~/Library/Logs/oh-my-codex/mcp/` |
| linux | `${XDG_STATE_HOME:-~/.local/state}/oh-my-codex/mcp/` |
| win32 | `%LOCALAPPDATA%/oh-my-codex/Logs/mcp/` |
| fallback | `os.tmpdir()/oh-my-codex-mcp/` |

- **Single shared `<entrypoint>.ndjson` per server** with `pid` / `ppid` / `ts_ms` columns. 5 files total instead of N-per-PID.
- Atomic `O_APPEND` via `fs.appendFile`; lines bounded `< 4 KB - 64` for PIPE_BUF safety. Oversize payloads replaced with a `lifecycle_event_skipped` record so we never lose ordering.
- 4 MB rotation, up to 2 generations (≤ 12 MB / entrypoint, ≤ 60 MB total across all 5 servers).
- `OMX_MCP_LIFECYCLE_LOG=off` short-circuits **before** any path resolution or I/O. `OMX_MCP_LIFECYCLE_LOG_DIR` overrides the resolved path.
- Inflight tracking + `flush()` so `shutdown` drains writes before `process.exit` truncates the event loop.

### 2. Bootstrap wiring — `src/mcp/bootstrap.ts`

Emits structured events that turn each silent-failure mode from #2142 into evidence:

| Event | Captures |
|---|---|
| `startup` | serverName, argv1, marker, ppid, max-siblings — baseline |
| `marker_resolution_failed` | argv[0..2] + `OMX_MCP_ENTRYPOINT_MARKER` when `trackedEntrypoint` is null — direct probe for cause **A** |
| `duplicate_observation` | matchingPids, newerSiblingPids, lastTrafficAtMs — probes **B** and **C** |
| `duplicate_watchdog_error` | message + stack — probes **D** |
| `shutdown_reason` | every shutdown path: `stdin_close` / `stdin_end` / `transport_close` / `sigterm` / `sigint` / `parent_gone` / `superseded_duplicate_*` / `superseded_hard_cap_pre_traffic` / `server_connect_failed` |

Pre-existing `OMX_MCP_TRANSPORT_DEBUG=1` stderr behavior is preserved (additive, not a replacement).

### 3. Pre-traffic hard cap — `src/mcp/bootstrap.ts`

New env `OMX_MCP_MAX_SIBLINGS_PER_ENTRYPOINT` (default 4, 0 disables). New pure exported `shouldSelfExitForHardCap(observation, lastTrafficAtMs, maxSiblings, currentPid)`. Returns `true` **only** when:

- `maxSiblings > 0`
- `lastTrafficAtMs === null` — **active sessions are never hard-capped**
- `observation.matchingPids.length >= maxSiblings`
- the current PID ranks among the `(matchingPids.length - maxSiblings + 1)` oldest in the sorted PID list

This is **strictly weaker** than tightening `duplicateSiblingPostTrafficIdleMs`. It cannot kill a sibling that has ever processed a single byte of stdin from Codex — exactly the safety property #1759 / #1960 demanded.

Distinct shutdown reason `superseded_hard_cap_pre_traffic`, separable from `superseded_duplicate_*` in JSONL so we can later quantify how often each path fires.

### 4. Defensive watchdog — `src/mcp/bootstrap.ts`

- `runDuplicateSiblingWatchdog` body wrapped in `try/catch`; on throw emits `duplicate_watchdog_error` and the watchdog continues (was previously silent on throw — exactly the kind of failure mode that hides #2142).
- New env `OMX_MCP_DUPLICATE_SIBLING_BACKOFF_INTERVAL_MS` (default 30_000).
- `shouldBackoffWatchdog` pure helper. When `matchingPids.length > cap`, this child's poll interval is reset to the backoff value via `clearInterval` + `setInterval`. With the user's 217 zombies that drops `ps axww` polling from ~43/sec → ~7/sec system-wide.
- `applyBackoff` is idempotent (`watchdogBackedOff` flag).

## What's deliberately NOT in here

- Patching `codex app-server` transport-retention semantics (upstream Codex.app, separate issue).
- MCP SDK changes.
- An external launchd / cron reaper script.
- Tightening `duplicateSiblingPostTrafficIdleMs` from 60 s — would risk regressing the leader-survival contract from #1759 / #1960. The pre-traffic hard cap intentionally targets a strictly narrower failure mode.

## Phase B SLA

14 days from merge: if production lifecycle JSONL never captures a `shutdown_reason` other than `superseded_hard_cap_pre_traffic`, `superseded_duplicate_*`, or expected exits, declare the hard cap the fix, file the upstream Codex.app issue with collected logs, and flip `OMX_MCP_LIFECYCLE_LOG` default to off in the next minor release.

## Test plan

- [x] `npm run build` — clean (TypeScript)
- [x] `npm run lint` — 618 files checked, 0 issues (biome)
- [x] `node --test dist/mcp/__tests__/*.test.js` — **143 / 143** pass
- [x] `npm run test:recent-bug-regressions:compiled` — **523 / 523** pass
- [x] **Critical contract test passes unchanged**: `server-lifecycle.test.ts:271-330` (\"initialized older duplicate entrypoints remain alive when a native subagent sibling starts\")
- [x] **New 6-sibling synthetic test** asserts the oldest 2 pre-traffic siblings self-exit while the 4 newest + active-traffic siblings remain alive
- [x] **New e2e test** spawns a real `state-server.js`, drives stdin close, and asserts `startup` + `shutdown_reason` events with `pid`/`ppid`/`ts_ms` are present in the JSONL output

## Files changed

```
 src/mcp/__tests__/bootstrap.test.ts        | 138 +++++++++++++++++++++ (+11 tests)
 src/mcp/__tests__/lifecycle-telemetry.test.ts | NEW (15 tests)
 src/mcp/__tests__/server-lifecycle.test.ts |  50 +++++++ (+1 e2e test)
 src/mcp/bootstrap.ts                       | 182 +++++++++++++++++++-----
 src/mcp/lifecycle-telemetry.ts             | NEW (~209 LOC)
 5 files changed, 801 insertions(+), 31 deletions(-)
```

## Refs

- #1516 — original leak report (closed by initial duplicate-sibling watchdog)
- #1665 / #1759 / #1960 — over-aggressive watchdog regressions (the contract this PR preserves)
- #2077 — post-traffic idle window (fix already in 0.16.0)
- #2142 — current report; this PR's diagnostic + targeted fix

## Acknowledgments

This work stands directly on @Yeachan-Heo's prior fix waves. The clean separation between active-session contract and idle-zombie cleanup that #1759 + #2077 established is what made it possible to add a safe pre-traffic backstop here without re-litigating those decisions.