### PR TITLE
Fix first-party MCP app-server pre-traffic leaks

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   analyzeDuplicateSiblingState,
@@ -12,8 +13,14 @@ import {
   resolveDuplicateSiblingWatchdogInitialDelayMs,
   shouldAutoStartMcpServer,
   shouldSelfExitForDuplicateSibling,
+  shouldSelfExitForPreTrafficSiblingHardCap,
   type McpServerName,
 } from '../bootstrap.js';
+import {
+  resolveMcpLifecycleLogDir,
+  resolveMcpLifecycleLogFile,
+  writeMcpLifecycleTelemetry,
+} from '../lifecycle-telemetry.js';
 
 const ALL_SERVERS: readonly McpServerName[] = [
   'state',
@@ -412,5 +419,76 @@ describe('mcp duplicate sibling detection', () => {
       shouldSelfExitForDuplicateSibling(missingSelf, 50_000, 10_000, null),
       false,
     );
+  });
+
+  it('hard-caps only never-owned pre-traffic older duplicates', () => {
+    const processes = [
+      { pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 102, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 103, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 104, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 105, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+    ];
+
+    const oldest = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    const secondOldest = analyzeDuplicateSiblingState(processes, 102, 55, 'state-server.js');
+
+    assert.equal(shouldSelfExitForPreTrafficSiblingHardCap(oldest, null, 4), true);
+    assert.equal(
+      shouldSelfExitForPreTrafficSiblingHardCap(secondOldest, null, 4),
+      false,
+      'newest four pre-traffic siblings stay available',
+    );
+    assert.equal(
+      shouldSelfExitForPreTrafficSiblingHardCap(oldest, 1_000, 4),
+      false,
+      'hard cap must never kill a transport that has seen traffic',
+    );
+    assert.equal(
+      shouldSelfExitForPreTrafficSiblingHardCap(oldest, null, 0),
+      false,
+      'zero disables the hard cap',
+    );
+  });
+});
+
+describe('mcp lifecycle telemetry diagnostics', () => {
+  it('resolves platform log directories and honors the disable switch', () => {
+    assert.equal(
+      resolveMcpLifecycleLogDir({ OMX_MCP_LIFECYCLE_LOG: 'off' }, '/home/test', 'linux'),
+      null,
+    );
+    assert.equal(
+      resolveMcpLifecycleLogDir({ XDG_STATE_HOME: '/state' }, '/home/test', 'linux'),
+      join('/state', 'oh-my-codex', 'mcp'),
+    );
+    assert.equal(
+      resolveMcpLifecycleLogDir({}, '/Users/test', 'darwin'),
+      join('/Users/test', 'Library', 'Logs', 'oh-my-codex', 'mcp'),
+    );
+  });
+
+  it('writes bounded JSONL lifecycle diagnostics outside the repo cwd', async () => {
+    const logDir = await mkdtemp(join(tmpdir(), 'omx-mcp-lifecycle-'));
+    const env = { OMX_MCP_LIFECYCLE_LOG_DIR: logDir };
+
+    writeMcpLifecycleTelemetry({
+      event: 'marker_resolution_failed',
+      server: 'state',
+      entrypoint: 'state-server.js',
+      pid: 123,
+      ppid: 55,
+      argv1: '/opt/homebrew/bin/omx',
+    }, env);
+
+    const file = resolveMcpLifecycleLogFile('state', 'state-server.js', env);
+    assert.equal(file, join(logDir, 'state-server.js.ndjson'));
+    const lines = (await readFile(file!, 'utf8')).trim().split(/\r?\n/);
+    assert.equal(lines.length, 1);
+    const event = JSON.parse(lines[0]);
+    assert.equal(event.event, 'marker_resolution_failed');
+    assert.equal(event.server, 'state');
+    assert.equal(event.entrypoint, 'state-server.js');
+    assert.equal(event.argv1, '/opt/homebrew/bin/omx');
   });
 });

--- a/src/mcp/__tests__/server-lifecycle.test.ts
+++ b/src/mcp/__tests__/server-lifecycle.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { once } from 'node:events';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const STARTUP_SETTLE_MS = 150;
@@ -110,7 +112,7 @@ function spawnEntrypoint(entrypoint: EntryPoint): {
 } {
   const child = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
     cwd: process.cwd(),
-    env: { ...process.env },
+    env: { ...process.env, OMX_MCP_LIFECYCLE_LOG: 'off' },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
@@ -220,6 +222,7 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
       OMX_MCP_PARENT_WATCHDOG_INTERVAL_MS: '250',
       OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS: '250',
       OMX_MCP_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS: '500',
+      OMX_MCP_LIFECYCLE_LOG: 'off',
     };
     const older = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
       cwd: process.cwd(),
@@ -275,6 +278,7 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
       OMX_MCP_PARENT_WATCHDOG_INTERVAL_MS: '250',
       OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS: '250',
       OMX_MCP_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS: '500',
+      OMX_MCP_LIFECYCLE_LOG: 'off',
     };
     const older = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
       cwd: process.cwd(),
@@ -325,6 +329,62 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
       await forceCleanup(older);
       if (newer) {
         await forceCleanup(newer);
+      }
+    }
+  });
+
+  it('pre-traffic sibling hard cap cleans up no-traffic app-server children and records telemetry', async () => {
+    const entrypoint = IDLE_ENTRYPOINTS[0];
+    const logDir = await mkdtemp(join(tmpdir(), 'omx-mcp-runtime-lifecycle-'));
+    const sharedEnv = {
+      ...process.env,
+      OMX_MCP_PARENT_WATCHDOG_INTERVAL_MS: '250',
+      OMX_MCP_DUPLICATE_SIBLING_INITIAL_DELAY_MS: '0',
+      OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS: '250',
+      OMX_MCP_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS: '60000',
+      OMX_MCP_MAX_SIBLINGS_PER_ENTRYPOINT: '4',
+      OMX_MCP_LIFECYCLE_LOG_DIR: logDir,
+    };
+    const children: ChildProcess[] = [];
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const attachLogs = (child: ChildProcess) => {
+      child.stdout?.setEncoding('utf8');
+      child.stderr?.setEncoding('utf8');
+      child.stdout?.on('data', (chunk: string) => stdout.push(chunk));
+      child.stderr?.on('data', (chunk: string) => stderr.push(chunk));
+    };
+
+    try {
+      for (let index = 0; index < 5; index += 1) {
+        const child = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
+          cwd: process.cwd(),
+          env: sharedEnv,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        children.push(child);
+        attachLogs(child);
+        await waitForSpawn(child, entrypoint, stderr, stdout);
+      }
+
+      await waitForCondition(
+        () => children.filter(isChildAlive).length <= 4,
+        4_000,
+        `pre-traffic hard cap did not bound duplicate children: ${formatFailureContext(entrypoint, stderr, stdout)}`,
+      );
+
+      assert.equal(
+        children.filter(isChildAlive).length,
+        4,
+        `hard cap should preserve the newest four children: ${formatFailureContext(entrypoint, stderr, stdout)}`,
+      );
+
+      const telemetry = await readFile(join(logDir, 'state-server.js.ndjson'), 'utf8');
+      assert.match(telemetry, /duplicate_sibling_observed/);
+      assert.match(telemetry, /superseded_hard_cap_pre_traffic/);
+    } finally {
+      for (const child of children) {
+        await forceCleanup(child);
       }
     }
   });

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { resolveOmxFirstPartyMcpEntrypointForPluginTarget } from '../config/omx-first-party-mcp.js';
+import { writeMcpLifecycleTelemetry } from './lifecycle-telemetry.js';
 
 export type McpServerName = 'state' | 'memory' | 'code_intel' | 'trace' | 'wiki';
 
@@ -20,12 +21,14 @@ const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_PRE_T
 const DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS';
 const DUPLICATE_SIBLING_INITIAL_DELAY_ENV = 'OMX_MCP_DUPLICATE_SIBLING_INITIAL_DELAY_MS';
 const DUPLICATE_SIBLING_INITIAL_DELAY_MAX_ENV = 'OMX_MCP_DUPLICATE_SIBLING_INITIAL_DELAY_MAX_MS';
+const MAX_SIBLINGS_PER_ENTRYPOINT_ENV = 'OMX_MCP_MAX_SIBLINGS_PER_ENTRYPOINT';
 export const MCP_ENTRYPOINT_MARKER_ENV = 'OMX_MCP_ENTRYPOINT_MARKER';
 const DEFAULT_PARENT_WATCHDOG_INTERVAL_MS = 1_000;
 const DEFAULT_DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
 const DEFAULT_DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
 const DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS = 60_000;
 const DEFAULT_DUPLICATE_SIBLING_INITIAL_DELAY_MAX_MS = 1_000;
+const DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT = 4;
 const MCP_ENTRYPOINT_PATTERN = /\b([a-z0-9-]+-server\.(?:[cm]?js|ts))\b/i;
 const MCP_SERVE_TARGET_PATTERN = /(?:^|\s)mcp-serve\s+([^\s]+)/i;
 
@@ -54,7 +57,16 @@ interface LifecycleTimingConfig {
   duplicateSiblingPostTrafficIdleMs: number;
   duplicateSiblingInitialDelayMs: number | null;
   duplicateSiblingInitialDelayMaxMs: number;
+  maxSiblingsPerEntrypoint: number;
 }
+
+const SERVER_ENTRYPOINT: Record<McpServerName, string> = {
+  state: 'state-server.js',
+  memory: 'memory-server.js',
+  code_intel: 'code-intel-server.js',
+  trace: 'trace-server.js',
+  wiki: 'wiki-server.js',
+};
 
 function normalizeCommand(command: string): string {
   return command.replace(/\\+/g, '/').trim();
@@ -243,6 +255,11 @@ function resolveLifecycleTimingConfig(
       DUPLICATE_SIBLING_INITIAL_DELAY_MAX_ENV,
       DEFAULT_DUPLICATE_SIBLING_INITIAL_DELAY_MAX_MS,
     ),
+    maxSiblingsPerEntrypoint: readNonNegativeIntegerEnv(
+      env,
+      MAX_SIBLINGS_PER_ENTRYPOINT_ENV,
+      DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT,
+    ) ?? DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT,
   };
 }
 
@@ -301,6 +318,23 @@ export function shouldSelfExitForDuplicateSibling(
   return nowMs - duplicateObservedAtMs >= preTrafficGraceMs;
 }
 
+export function shouldSelfExitForPreTrafficSiblingHardCap(
+  observation: DuplicateSiblingObservation,
+  lastTrafficAtMs: number | null,
+  maxSiblingsPerEntrypoint = DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT,
+): boolean {
+  if (observation.status !== 'older_duplicate') return false;
+  if (lastTrafficAtMs !== null) return false;
+  if (!Number.isInteger(maxSiblingsPerEntrypoint) || maxSiblingsPerEntrypoint <= 0) return false;
+  if (observation.matchingPids.length <= maxSiblingsPerEntrypoint) return false;
+
+  // Keep the newest N same-parent same-entrypoint siblings and let only older
+  // never-owned transports self-exit. Once a server has seen any stdin byte,
+  // this hard cap no longer applies; the conservative post-traffic idle window
+  // remains responsible for initialized transports.
+  return observation.newerSiblingPids.length >= maxSiblingsPerEntrypoint;
+}
+
 export function isParentProcessAlive(
   parentPid: number,
   signalProcess: typeof process.kill = process.kill,
@@ -340,10 +374,11 @@ export function autoStartStdioMcpServer(
   const lifecycleDebugEnabled = env[LIFECYCLE_DEBUG_ENV] === '1';
   const lifecycleTiming = resolveLifecycleTimingConfig(env);
   const trackedParentPid = Number.isInteger(process.ppid) ? process.ppid : 0;
-  const trackedEntrypoint = resolveCurrentMcpEntrypointMarker(
+  const resolvedEntrypoint = resolveCurrentMcpEntrypointMarker(
     env,
     process.argv[1] ?? '',
   );
+  const trackedEntrypoint = resolvedEntrypoint ?? SERVER_ENTRYPOINT[serverName];
   let lastTrafficAtMs: number | null = null;
   let duplicateObservedAtMs: number | null = null;
 
@@ -352,6 +387,38 @@ export function autoStartStdioMcpServer(
     const detail = error ? ` ${error instanceof Error ? error.message : String(error)}` : '';
     process.stderr.write(`[omx-${serverName}-server] ${message}${detail}\n`);
   };
+
+  const emitLifecycle = (
+    event: string,
+    detail: Record<string, unknown> = {},
+  ) => {
+    writeMcpLifecycleTelemetry({
+      event,
+      server: serverName,
+      entrypoint: trackedEntrypoint,
+      pid: process.pid,
+      ppid: trackedParentPid,
+      ...detail,
+    }, env);
+  };
+
+  emitLifecycle('bootstrap_start', {
+    resolved_entrypoint: resolvedEntrypoint,
+    argv0: process.argv[0],
+    argv1: process.argv[1],
+    argv2: process.argv[2],
+    env_entrypoint_marker: env[MCP_ENTRYPOINT_MARKER_ENV],
+  });
+
+  if (!resolvedEntrypoint) {
+    emitLifecycle('marker_resolution_failed', {
+      fallback_entrypoint: trackedEntrypoint,
+      argv0: process.argv[0],
+      argv1: process.argv[1],
+      argv2: process.argv[2],
+      env_entrypoint_marker: env[MCP_ENTRYPOINT_MARKER_ENV],
+    });
+  }
 
   const parentWatchdog = trackedParentPid > 1
     ? setInterval(() => {
@@ -365,41 +432,68 @@ export function autoStartStdioMcpServer(
   let duplicateSiblingInitialDelayTimer: ReturnType<typeof setTimeout> | null = null;
 
   const runDuplicateSiblingWatchdog = () => {
-    const processes = listProcessTable();
-    if (!processes) {
+    try {
+      const processes = listProcessTable();
+      if (!processes) {
+        duplicateObservedAtMs = null;
+        return;
+      }
+
+      const observation = analyzeDuplicateSiblingState(
+        processes,
+        process.pid,
+        trackedParentPid,
+        trackedEntrypoint,
+      );
+
+      if (observation.status !== 'older_duplicate') {
+        duplicateObservedAtMs = null;
+        return;
+      }
+
+      const firstObservation = duplicateObservedAtMs === null;
+      duplicateObservedAtMs ??= Date.now();
+      if (firstObservation) {
+        emitLifecycle('duplicate_sibling_observed', {
+          matching_pids: observation.matchingPids,
+          newer_sibling_pids: observation.newerSiblingPids,
+          last_traffic_at_ms: lastTrafficAtMs,
+          max_siblings_per_entrypoint: lifecycleTiming.maxSiblingsPerEntrypoint,
+        });
+      }
+
+      if (shouldSelfExitForPreTrafficSiblingHardCap(
+        observation,
+        lastTrafficAtMs,
+        lifecycleTiming.maxSiblingsPerEntrypoint,
+      )) {
+        void shutdown('superseded_hard_cap_pre_traffic');
+        return;
+      }
+
+      if (!shouldSelfExitForDuplicateSibling(
+        observation,
+        Date.now(),
+        duplicateObservedAtMs,
+        lastTrafficAtMs,
+        lifecycleTiming.duplicateSiblingPreTrafficGraceMs,
+        lifecycleTiming.duplicateSiblingPostTrafficIdleMs,
+      )) {
+        return;
+      }
+
+      void shutdown(
+        lastTrafficAtMs !== null && lastTrafficAtMs > duplicateObservedAtMs
+          ? 'superseded_duplicate_after_idle'
+          : 'superseded_duplicate_before_traffic',
+      );
+    } catch (error) {
       duplicateObservedAtMs = null;
-      return;
+      logLifecycle('duplicate sibling watchdog failed', error);
+      emitLifecycle('duplicate_watchdog_error', {
+        reason: error instanceof Error ? error.message : String(error),
+      });
     }
-
-    const observation = analyzeDuplicateSiblingState(
-      processes,
-      process.pid,
-      trackedParentPid,
-      trackedEntrypoint,
-    );
-
-    if (observation.status !== 'older_duplicate') {
-      duplicateObservedAtMs = null;
-      return;
-    }
-
-    duplicateObservedAtMs ??= Date.now();
-    if (!shouldSelfExitForDuplicateSibling(
-      observation,
-      Date.now(),
-      duplicateObservedAtMs,
-      lastTrafficAtMs,
-      lifecycleTiming.duplicateSiblingPreTrafficGraceMs,
-      lifecycleTiming.duplicateSiblingPostTrafficIdleMs,
-    )) {
-      return;
-    }
-
-    void shutdown(
-      lastTrafficAtMs !== null && lastTrafficAtMs > duplicateObservedAtMs
-        ? 'superseded_duplicate_after_idle'
-        : 'superseded_duplicate_before_traffic',
-    );
   };
 
   if (trackedParentPid > 1 && trackedEntrypoint) {
@@ -426,6 +520,11 @@ export function autoStartStdioMcpServer(
     }
     shuttingDown = true;
     logLifecycle(`transport shutdown: ${reason}`);
+    emitLifecycle('shutdown', {
+      reason,
+      last_traffic_at_ms: lastTrafficAtMs,
+      duplicate_observed_at_ms: duplicateObservedAtMs,
+    });
     if (parentWatchdog) {
       clearInterval(parentWatchdog);
     }

--- a/src/mcp/lifecycle-telemetry.ts
+++ b/src/mcp/lifecycle-telemetry.ts
@@ -1,0 +1,121 @@
+import { appendFileSync, existsSync, mkdirSync, renameSync, statSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { McpServerName } from './bootstrap.js';
+
+const LIFECYCLE_LOG_ENV = 'OMX_MCP_LIFECYCLE_LOG';
+const LIFECYCLE_LOG_DIR_ENV = 'OMX_MCP_LIFECYCLE_LOG_DIR';
+const MAX_LOG_BYTES = 4 * 1024 * 1024;
+const MAX_LINE_BYTES = 4 * 1024;
+
+export interface McpLifecycleTelemetryEvent {
+  event: string;
+  server: McpServerName;
+  entrypoint: string | null;
+  pid?: number;
+  ppid?: number;
+  reason?: string;
+  matching_pids?: number[];
+  newer_sibling_pids?: number[];
+  [key: string]: unknown;
+}
+
+function isTelemetryDisabled(env: Record<string, string | undefined>): boolean {
+  const raw = env[LIFECYCLE_LOG_ENV]?.trim().toLowerCase();
+  return raw === '0' || raw === 'false' || raw === 'off' || raw === 'no';
+}
+
+export function resolveMcpLifecycleLogDir(
+  env: Record<string, string | undefined> = process.env,
+  home = homedir(),
+  currentPlatform = platform(),
+): string | null {
+  if (isTelemetryDisabled(env)) return null;
+
+  const explicitDir = env[LIFECYCLE_LOG_DIR_ENV]?.trim();
+  if (explicitDir) return explicitDir;
+
+  if (currentPlatform === 'darwin') {
+    return join(home, 'Library', 'Logs', 'oh-my-codex', 'mcp');
+  }
+
+  if (currentPlatform === 'win32') {
+    const localAppData = env.LOCALAPPDATA?.trim();
+    return localAppData
+      ? join(localAppData, 'oh-my-codex', 'Logs', 'mcp')
+      : join(home, 'AppData', 'Local', 'oh-my-codex', 'Logs', 'mcp');
+  }
+
+  const xdgStateHome = env.XDG_STATE_HOME?.trim();
+  return join(xdgStateHome || join(home, '.local', 'state'), 'oh-my-codex', 'mcp');
+}
+
+function sanitizeLogBasename(value: string | null): string {
+  return (value || 'unknown-server')
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'unknown-server';
+}
+
+export function resolveMcpLifecycleLogFile(
+  server: McpServerName,
+  entrypoint: string | null,
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  const dir = resolveMcpLifecycleLogDir(env);
+  if (!dir) return null;
+  return join(dir, `${sanitizeLogBasename(entrypoint ?? server)}.ndjson`);
+}
+
+function rotateIfNeeded(file: string): void {
+  if (!existsSync(file)) return;
+  if (statSync(file).size < MAX_LOG_BYTES) return;
+
+  const older = `${file}.2`;
+  const newer = `${file}.1`;
+  try {
+    if (existsSync(newer)) renameSync(newer, older);
+  } catch {
+    // Best-effort rotation only; append must remain non-fatal.
+  }
+  try {
+    renameSync(file, newer);
+  } catch {
+    // Best-effort rotation only; append must remain non-fatal.
+  }
+}
+
+export function writeMcpLifecycleTelemetry(
+  event: McpLifecycleTelemetryEvent,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  const file = resolveMcpLifecycleLogFile(event.server, event.entrypoint, env);
+  if (!file) return;
+
+  try {
+    mkdirSync(dirname(file), { recursive: true });
+    rotateIfNeeded(file);
+    const payload = {
+      ts_ms: Date.now(),
+      pid: process.pid,
+      ppid: process.ppid,
+      ...event,
+    };
+    let line = `${JSON.stringify(payload)}\n`;
+    if (Buffer.byteLength(line, 'utf8') > MAX_LINE_BYTES) {
+      line = `${JSON.stringify({
+        ts_ms: payload.ts_ms,
+        pid: payload.pid,
+        ppid: payload.ppid,
+        server: payload.server,
+        entrypoint: payload.entrypoint,
+        event: payload.event,
+        reason: payload.reason,
+        truncated: true,
+      })}\n`;
+    }
+    appendFileSync(file, line, { encoding: 'utf8', flag: 'a' });
+  } catch {
+    // Lifecycle telemetry must never affect MCP stdio behavior.
+  }
+}


### PR DESCRIPTION
## Summary\n- add first-party MCP lifecycle JSONL diagnostics outside the repo cwd, including marker-resolution failures and duplicate sibling shutdown reasons\n- fall back to the server-name entrypoint when argv/env marker resolution fails so the duplicate watchdog still runs under wrapper/app-server launch shapes\n- add a configurable pre-traffic same-entrypoint hard cap (default 4, 0 disables) that only self-exits never-owned older siblings and never broad-kills or touches active traffic\n- keep the existing conservative post-traffic idle path and wrap duplicate watchdog ticks defensively\n\nCloses #2142.\n\n## Tests\n- npm run build\n- node --test dist/mcp/__tests__/bootstrap.test.js dist/mcp/__tests__/server-lifecycle.test.js\n- node --test dist/cli/__tests__/cleanup.test.js\n- npm run lint -- src/mcp/bootstrap.ts src/mcp/lifecycle-telemetry.ts src/mcp/__tests__/bootstrap.test.ts src/mcp/__tests__/server-lifecycle.test.ts\n- npm run check:no-unused