### PR TITLE
Bound explore process storms before host OOM

### DIFF
--- a/crates/omx-explore/src/main.rs
+++ b/crates/omx-explore/src/main.rs
@@ -13,15 +13,26 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 const CODEX_BIN_ENV: &str = "OMX_EXPLORE_CODEX_BIN";
 const HARNESS_ROOT_ENV: &str = "OMX_EXPLORE_ROOT";
 const CODEX_TIMEOUT_MS_ENV: &str = "OMX_EXPLORE_CODEX_TIMEOUT_MS";
+const PROCESS_LIMIT_ENV: &str = "OMX_EXPLORE_PROCESS_LIMIT";
 const INTERNAL_DIRECT_WRAPPER_FLAG: &str = "--internal-allowlist-direct";
 const INTERNAL_SHELL_WRAPPER_FLAG: &str = "--internal-allowlist-shell";
 const TEMP_ALLOWLIST_DIR_PREFIX: &str = "omx-explore-allowlist-";
 const DEFAULT_CODEX_TIMEOUT_MS: u64 = 180_000;
+const DEFAULT_PROCESS_LIMIT: usize = 96;
+const PROCESS_LIMIT_POLL_MS: u64 = 100;
 const PROCESS_TERMINATION_GRACE_MS: u64 = 500;
 const PIPE_READER_READY_GRACE_MS: u64 = 25;
 const PIPE_READER_JOIN_GRACE_MS: u64 = 500;
-const EXPLORE_SUBPROCESS_ENV_VARS_TO_SCRUB: &[&str] =
-    &["BASH_ENV", "ENV", "PROMPT_COMMAND", "NODE_OPTIONS"];
+const EXPLORE_SUBPROCESS_ENV_VARS_TO_SCRUB: &[&str] = &[
+    "BASH_ENV",
+    "ENV",
+    "PROMPT_COMMAND",
+    "NODE_OPTIONS",
+    "SHELLOPTS",
+    "BASHOPTS",
+    "GREP_OPTIONS",
+    "GREP_COLORS",
+];
 const WINDOWS_UNSUPPORTED_ALLOWLIST_MESSAGE: &str =
     "omx explore built-in harness is not ready on Windows because its allowlist runtime relies on POSIX sh/bash wrappers. Set OMX_EXPLORE_BIN to a compatible custom harness, prefer `omx sparkshell` for shell-native read-only lookups, or run `omx doctor` for readiness details.";
 
@@ -334,13 +345,37 @@ fn invoke_codex(args: &Args, model: &str, prompt_contract: &str) -> io::Result<A
             ),
             output_markdown: None,
         }),
+        TimedCommandOutput::ProcessLimitExceeded {
+            stderr,
+            process_count,
+            process_limit,
+        } => Ok(AttemptResult {
+            status_code: 125,
+            stderr: format!(
+                "[omx explore] codex exec exceeded per-run process limit ({process_count}>{process_limit}); terminated process tree to avoid runaway shell storms{}{}",
+                if stderr.trim().is_empty() {
+                    ""
+                } else {
+                    ". stderr before termination: "
+                },
+                stderr.trim()
+            ),
+            output_markdown: None,
+        }),
     }
 }
 
 #[derive(Debug)]
 enum TimedCommandOutput {
     Completed(Output),
-    TimedOut { stderr: String },
+    TimedOut {
+        stderr: String,
+    },
+    ProcessLimitExceeded {
+        stderr: String,
+        process_count: usize,
+        process_limit: usize,
+    },
 }
 
 fn codex_timeout() -> Duration {
@@ -350,6 +385,14 @@ fn codex_timeout() -> Duration {
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_CODEX_TIMEOUT_MS);
     Duration::from_millis(timeout_ms)
+}
+
+fn process_limit() -> usize {
+    env::var(PROCESS_LIMIT_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_PROCESS_LIMIT)
 }
 
 fn run_command_with_timeout(
@@ -364,8 +407,14 @@ fn run_command_with_timeout(
     let stderr_reader = spawn_pipe_reader(child.stderr.take());
 
     let deadline = Instant::now() + timeout;
+    let process_limit = process_limit();
+    let mut next_process_limit_poll = Instant::now() + Duration::from_millis(PROCESS_LIMIT_POLL_MS);
     loop {
         if let Some(status) = child.try_wait()? {
+            // The wrapper may exit while grandchildren keep the process group
+            // alive. Sweep it before collecting pipes so completed harness
+            // runs cannot leave detached shells behind.
+            terminate_child_process_tree(&mut child);
             let (stdout, stderr) = collect_completed_output(
                 &mut child,
                 &stdout_reader,
@@ -391,8 +440,68 @@ fn run_command_with_timeout(
             });
         }
 
+        if Instant::now() >= next_process_limit_poll {
+            next_process_limit_poll = Instant::now() + Duration::from_millis(PROCESS_LIMIT_POLL_MS);
+            if let Some(process_count) = count_process_tree(child.id()) {
+                if process_count > process_limit {
+                    terminate_child_process_tree(&mut child);
+                    let _ = child.wait();
+                    let reader_timeout = Duration::from_millis(PIPE_READER_JOIN_GRACE_MS);
+                    let _ = receive_pipe_reader(&stdout_reader, reader_timeout);
+                    let stderr =
+                        receive_pipe_reader(&stderr_reader, reader_timeout).unwrap_or_default();
+                    return Ok(TimedCommandOutput::ProcessLimitExceeded {
+                        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+                        process_count,
+                        process_limit,
+                    });
+                }
+            }
+        }
+
         thread::sleep(Duration::from_millis(25));
     }
+}
+
+#[cfg(target_os = "linux")]
+fn count_process_tree(root_pid: u32) -> Option<usize> {
+    use std::collections::HashMap;
+    let entries = std::fs::read_dir("/proc").ok()?;
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        let Ok(pid) = name.parse::<u32>() else {
+            continue;
+        };
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            continue;
+        };
+        let Some(close_paren) = stat.rfind(')') else {
+            continue;
+        };
+        let fields: Vec<&str> = stat[close_paren + 2..].split(' ').collect();
+        let Some(ppid) = fields.get(1).and_then(|field| field.parse::<u32>().ok()) else {
+            continue;
+        };
+        children.entry(ppid).or_default().push(pid);
+    }
+    let mut count = 1;
+    let mut stack = children.remove(&root_pid).unwrap_or_default();
+    while let Some(pid) = stack.pop() {
+        count += 1;
+        if let Some(mut nested) = children.remove(&pid) {
+            stack.append(&mut nested);
+        }
+    }
+    Some(count)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn count_process_tree(_root_pid: u32) -> Option<usize> {
+    None
 }
 
 fn spawn_pipe_reader<R: Read + Send + 'static>(pipe: Option<R>) -> Receiver<io::Result<Vec<u8>>> {
@@ -2476,6 +2585,46 @@ sleep 30
         assert_eq!(read_to_string(&term_file).unwrap_or_default(), "term");
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn run_command_with_timeout_aborts_suspicious_process_storm() {
+        let _env_guard = env_lock();
+        let _process_guard = process_tree_lock();
+        let root = temp_allowlist_dir().expect("temp root");
+        let script = root.path.join("storm.sh");
+        write_executable(
+            &script,
+            r#"#!/bin/sh
+while :; do
+  sleep 30 &
+  sleep 0.01
+done
+"#,
+        )
+        .expect("write script");
+
+        unsafe {
+            env::set_var(PROCESS_LIMIT_ENV, "12");
+        }
+        let started = Instant::now();
+        let result = run_command_with_timeout(Command::new(&script), Duration::from_secs(10))
+            .expect("run with process storm");
+        unsafe {
+            env::remove_var(PROCESS_LIMIT_ENV);
+        }
+
+        let TimedCommandOutput::ProcessLimitExceeded {
+            process_count,
+            process_limit,
+            ..
+        } = result
+        else {
+            panic!("expected process limit failure");
+        };
+        assert!(process_count > process_limit);
+        assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
     #[cfg(unix)]
     #[test]
     fn run_command_with_timeout_closes_inherited_stdio_after_parent_exit() {
@@ -2508,6 +2657,44 @@ exit 0
         assert!(output.status.success());
         assert_eq!(String::from_utf8_lossy(&output.stdout), "parent stdout\n");
         assert_eq!(String::from_utf8_lossy(&output.stderr), "parent stderr\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_command_with_timeout_sweeps_detached_grandchildren_after_parent_exit() {
+        let _env_guard = env_lock();
+        let _process_guard = process_tree_lock();
+        let root = temp_allowlist_dir().expect("temp root");
+        let term_file = root.path.join("orphan.term");
+        let ready_file = root.path.join("orphan.ready");
+        let script = root.path.join("spawn-detached-grandchild.sh");
+        write_executable(
+            &script,
+            &format!(
+                r#"#!/bin/sh
+(trap 'printf term > {}; exit 0' TERM; printf ready > {}; sleep 30) >/dev/null 2>&1 &
+while [ ! -f {} ]; do
+  sleep 0.01
+done
+printf 'parent done\n'
+exit 0
+"#,
+                shell_quote(&term_file.display().to_string()),
+                shell_quote(&ready_file.display().to_string()),
+                shell_quote(&ready_file.display().to_string()),
+            ),
+        )
+        .expect("write script");
+
+        let result = run_command_with_timeout(Command::new(&script), Duration::from_secs(10))
+            .expect("run with detached grandchild");
+
+        let TimedCommandOutput::Completed(output) = result else {
+            panic!("expected parent completion");
+        };
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "parent done\n");
+        assert_eq!(read_to_string(&term_file).unwrap_or_default(), "term");
     }
 
     fn fallback_test_event() -> FallbackEvent {

--- a/crates/omx-explore/src/main.rs
+++ b/crates/omx-explore/src/main.rs
@@ -6,7 +6,7 @@ use std::fs::{
 use std::io::{self, BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, TryRecvError};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -14,11 +14,13 @@ const CODEX_BIN_ENV: &str = "OMX_EXPLORE_CODEX_BIN";
 const HARNESS_ROOT_ENV: &str = "OMX_EXPLORE_ROOT";
 const CODEX_TIMEOUT_MS_ENV: &str = "OMX_EXPLORE_CODEX_TIMEOUT_MS";
 const PROCESS_LIMIT_ENV: &str = "OMX_EXPLORE_PROCESS_LIMIT";
+const CODEX_OUTPUT_LIMIT_BYTES_ENV: &str = "OMX_EXPLORE_CODEX_OUTPUT_LIMIT_BYTES";
 const INTERNAL_DIRECT_WRAPPER_FLAG: &str = "--internal-allowlist-direct";
 const INTERNAL_SHELL_WRAPPER_FLAG: &str = "--internal-allowlist-shell";
 const TEMP_ALLOWLIST_DIR_PREFIX: &str = "omx-explore-allowlist-";
 const DEFAULT_CODEX_TIMEOUT_MS: u64 = 180_000;
 const DEFAULT_PROCESS_LIMIT: usize = 96;
+const DEFAULT_CODEX_OUTPUT_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 const PROCESS_LIMIT_POLL_MS: u64 = 100;
 const PROCESS_TERMINATION_GRACE_MS: u64 = 500;
 const PIPE_READER_READY_GRACE_MS: u64 = 25;
@@ -362,6 +364,23 @@ fn invoke_codex(args: &Args, model: &str, prompt_contract: &str) -> io::Result<A
             ),
             output_markdown: None,
         }),
+        TimedCommandOutput::OutputLimitExceeded {
+            stderr,
+            output_limit,
+            stream,
+        } => Ok(AttemptResult {
+            status_code: 126,
+            stderr: format!(
+                "[omx explore] codex exec exceeded subprocess {stream} output limit ({output_limit} bytes); terminated process tree to avoid unbounded memory growth{}{}",
+                if stderr.trim().is_empty() {
+                    ""
+                } else {
+                    ". stderr before termination: "
+                },
+                stderr.trim()
+            ),
+            output_markdown: None,
+        }),
     }
 }
 
@@ -376,6 +395,11 @@ enum TimedCommandOutput {
         process_count: usize,
         process_limit: usize,
     },
+    OutputLimitExceeded {
+        stderr: String,
+        output_limit: usize,
+        stream: &'static str,
+    },
 }
 
 fn codex_timeout() -> Duration {
@@ -385,6 +409,14 @@ fn codex_timeout() -> Duration {
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_CODEX_TIMEOUT_MS);
     Duration::from_millis(timeout_ms)
+}
+
+fn codex_output_limit_bytes() -> usize {
+    env::var(CODEX_OUTPUT_LIMIT_BYTES_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_CODEX_OUTPUT_LIMIT_BYTES)
 }
 
 fn process_limit() -> usize {
@@ -403,8 +435,9 @@ fn run_command_with_timeout(
     configure_process_group(&mut command);
     let mut child = command.spawn()?;
 
-    let stdout_reader = spawn_pipe_reader(child.stdout.take());
-    let stderr_reader = spawn_pipe_reader(child.stderr.take());
+    let output_limit = codex_output_limit_bytes();
+    let mut stdout_reader = spawn_pipe_reader("stdout", child.stdout.take(), output_limit);
+    let mut stderr_reader = spawn_pipe_reader("stderr", child.stderr.take(), output_limit);
 
     let deadline = Instant::now() + timeout;
     let process_limit = process_limit();
@@ -415,13 +448,24 @@ fn run_command_with_timeout(
             // alive. Sweep it before collecting pipes so completed harness
             // runs cannot leave detached shells behind.
             terminate_child_process_tree(&mut child);
-            let (stdout, stderr) = collect_completed_output(
+            let output = collect_completed_output(
                 &mut child,
-                &stdout_reader,
-                &stderr_reader,
+                &mut stdout_reader,
+                &mut stderr_reader,
                 Duration::from_millis(PIPE_READER_READY_GRACE_MS),
                 Duration::from_millis(PIPE_READER_JOIN_GRACE_MS),
-            )?;
+            );
+            let (stdout, stderr) = match output {
+                Ok(output) => output,
+                Err(err) if is_output_limit_error(&err) => {
+                    return Ok(TimedCommandOutput::OutputLimitExceeded {
+                        stderr: String::new(),
+                        output_limit,
+                        stream: output_limit_stream(&err),
+                    });
+                }
+                Err(err) => return Err(err),
+            };
             return Ok(TimedCommandOutput::Completed(Output {
                 status,
                 stdout,
@@ -433,8 +477,9 @@ fn run_command_with_timeout(
             terminate_child_process_tree(&mut child);
             let _ = child.wait();
             let reader_timeout = Duration::from_millis(PIPE_READER_JOIN_GRACE_MS);
-            let _ = receive_pipe_reader(&stdout_reader, reader_timeout);
-            let stderr = receive_pipe_reader(&stderr_reader, reader_timeout).unwrap_or_default();
+            let _ = receive_pipe_reader(&mut stdout_reader, reader_timeout);
+            let stderr =
+                receive_pipe_reader(&mut stderr_reader, reader_timeout).unwrap_or_default();
             return Ok(TimedCommandOutput::TimedOut {
                 stderr: String::from_utf8_lossy(&stderr).into_owned(),
             });
@@ -447,9 +492,9 @@ fn run_command_with_timeout(
                     terminate_child_process_tree(&mut child);
                     let _ = child.wait();
                     let reader_timeout = Duration::from_millis(PIPE_READER_JOIN_GRACE_MS);
-                    let _ = receive_pipe_reader(&stdout_reader, reader_timeout);
+                    let _ = receive_pipe_reader(&mut stdout_reader, reader_timeout);
                     let stderr =
-                        receive_pipe_reader(&stderr_reader, reader_timeout).unwrap_or_default();
+                        receive_pipe_reader(&mut stderr_reader, reader_timeout).unwrap_or_default();
                     return Ok(TimedCommandOutput::ProcessLimitExceeded {
                         stderr: String::from_utf8_lossy(&stderr).into_owned(),
                         process_count,
@@ -457,6 +502,22 @@ fn run_command_with_timeout(
                     });
                 }
             }
+        }
+
+        if let Some(stream) = poll_output_limit(&mut stdout_reader, &mut stderr_reader)? {
+            terminate_child_process_tree(&mut child);
+            let _ = child.wait();
+            let reader_timeout = Duration::from_millis(PIPE_READER_JOIN_GRACE_MS);
+            let stderr = if stream == "stderr" {
+                Vec::new()
+            } else {
+                receive_pipe_reader(&mut stderr_reader, reader_timeout).unwrap_or_default()
+            };
+            return Ok(TimedCommandOutput::OutputLimitExceeded {
+                stderr: String::from_utf8_lossy(&stderr).into_owned(),
+                output_limit,
+                stream,
+            });
         }
 
         thread::sleep(Duration::from_millis(25));
@@ -504,26 +565,104 @@ fn count_process_tree(_root_pid: u32) -> Option<usize> {
     None
 }
 
-fn spawn_pipe_reader<R: Read + Send + 'static>(pipe: Option<R>) -> Receiver<io::Result<Vec<u8>>> {
-    let (sender, receiver) = mpsc::channel();
-    thread::spawn(move || {
-        let _ = sender.send(read_pipe_to_end(pipe));
-    });
-    receiver
+struct PipeReader {
+    receiver: Receiver<io::Result<Vec<u8>>>,
+    cached: Option<io::Result<Vec<u8>>>,
 }
 
-fn read_pipe_to_end<R: Read + Send + 'static>(pipe: Option<R>) -> io::Result<Vec<u8>> {
-    let mut bytes = Vec::new();
-    if let Some(mut pipe) = pipe {
-        pipe.read_to_end(&mut bytes)?;
+fn spawn_pipe_reader<R: Read + Send + 'static>(
+    stream: &'static str,
+    pipe: Option<R>,
+    output_limit: usize,
+) -> PipeReader {
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = sender.send(read_pipe_bounded(pipe, stream, output_limit));
+    });
+    PipeReader {
+        receiver,
+        cached: None,
     }
-    Ok(bytes)
+}
+
+fn read_pipe_bounded<R: Read + Send + 'static>(
+    pipe: Option<R>,
+    stream: &'static str,
+    output_limit: usize,
+) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    let Some(pipe) = pipe else {
+        return Ok(bytes);
+    };
+    let mut reader = BufReader::new(pipe);
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut chunk)?;
+        if read == 0 {
+            return Ok(bytes);
+        }
+        if bytes.len().saturating_add(read) > output_limit {
+            return Err(output_limit_error(stream, output_limit));
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+    }
+}
+
+fn output_limit_error(stream: &'static str, output_limit: usize) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Other,
+        format!("subprocess {stream} exceeded output limit of {output_limit} bytes"),
+    )
+}
+
+fn is_output_limit_error(err: &io::Error) -> bool {
+    err.to_string().contains("exceeded output limit")
+}
+
+fn output_limit_stream(err: &io::Error) -> &'static str {
+    if err.to_string().contains("stderr") {
+        "stderr"
+    } else {
+        "stdout"
+    }
+}
+
+fn poll_output_limit(
+    stdout_reader: &mut PipeReader,
+    stderr_reader: &mut PipeReader,
+) -> io::Result<Option<&'static str>> {
+    if let Some(stream) = poll_one_output_limit("stdout", stdout_reader)? {
+        return Ok(Some(stream));
+    }
+    poll_one_output_limit("stderr", stderr_reader)
+}
+
+fn poll_one_output_limit(
+    stream: &'static str,
+    reader: &mut PipeReader,
+) -> io::Result<Option<&'static str>> {
+    if reader.cached.is_some() {
+        return Ok(None);
+    }
+    match reader.receiver.try_recv() {
+        Ok(Ok(bytes)) => {
+            reader.cached = Some(Ok(bytes));
+            Ok(None)
+        }
+        Ok(Err(err)) if is_output_limit_error(&err) => Ok(Some(stream)),
+        Ok(Err(err)) => Err(err),
+        Err(TryRecvError::Empty) => Ok(None),
+        Err(TryRecvError::Disconnected) => Err(io::Error::new(
+            io::ErrorKind::Other,
+            "subprocess output reader disconnected",
+        )),
+    }
 }
 
 fn collect_completed_output(
     child: &mut Child,
-    stdout_reader: &Receiver<io::Result<Vec<u8>>>,
-    stderr_reader: &Receiver<io::Result<Vec<u8>>>,
+    stdout_reader: &mut PipeReader,
+    stderr_reader: &mut PipeReader,
     ready_timeout: Duration,
     cleanup_timeout: Duration,
 ) -> io::Result<(Vec<u8>, Vec<u8>)> {
@@ -547,21 +686,21 @@ fn collect_completed_output(
 }
 
 fn receive_pipe_reader_if_ready(
-    receiver: &Receiver<io::Result<Vec<u8>>>,
+    reader: &mut PipeReader,
     timeout: Duration,
 ) -> io::Result<Option<Vec<u8>>> {
-    match receive_pipe_reader(receiver, timeout) {
+    match receive_pipe_reader(reader, timeout) {
         Ok(bytes) => Ok(Some(bytes)),
         Err(err) if err.kind() == io::ErrorKind::TimedOut => Ok(None),
         Err(err) => Err(err),
     }
 }
 
-fn receive_pipe_reader(
-    receiver: &Receiver<io::Result<Vec<u8>>>,
-    timeout: Duration,
-) -> io::Result<Vec<u8>> {
-    match receiver.recv_timeout(timeout) {
+fn receive_pipe_reader(reader: &mut PipeReader, timeout: Duration) -> io::Result<Vec<u8>> {
+    if let Some(result) = reader.cached.take() {
+        return result;
+    }
+    match reader.receiver.recv_timeout(timeout) {
         Ok(result) => result,
         Err(RecvTimeoutError::Timeout) => Err(io::Error::new(
             io::ErrorKind::TimedOut,
@@ -2623,6 +2762,86 @@ done
         };
         assert!(process_count > process_limit);
         assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_command_with_timeout_fails_closed_on_large_stdout() {
+        let _env_guard = env_lock();
+        let _process_guard = process_tree_lock();
+        let root = temp_allowlist_dir().expect("temp root");
+        let script = root.path.join("large-stdout.sh");
+        write_executable(
+            &script,
+            r#"#!/bin/sh
+while :; do
+  printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+done
+"#,
+        )
+        .expect("write script");
+
+        unsafe {
+            env::set_var(CODEX_OUTPUT_LIMIT_BYTES_ENV, "4096");
+        }
+        let started = Instant::now();
+        let result = run_command_with_timeout(Command::new(&script), Duration::from_secs(10))
+            .expect("run with large stdout");
+        unsafe {
+            env::remove_var(CODEX_OUTPUT_LIMIT_BYTES_ENV);
+        }
+
+        let TimedCommandOutput::OutputLimitExceeded {
+            stream,
+            output_limit,
+            ..
+        } = result
+        else {
+            panic!("expected stdout output limit failure");
+        };
+        assert_eq!(stream, "stdout");
+        assert_eq!(output_limit, 4096);
+        assert!(started.elapsed() < Duration::from_secs(3));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_command_with_timeout_fails_closed_on_large_stderr() {
+        let _env_guard = env_lock();
+        let _process_guard = process_tree_lock();
+        let root = temp_allowlist_dir().expect("temp root");
+        let script = root.path.join("large-stderr.sh");
+        write_executable(
+            &script,
+            r#"#!/bin/sh
+while :; do
+  printf 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' >&2
+done
+"#,
+        )
+        .expect("write script");
+
+        unsafe {
+            env::set_var(CODEX_OUTPUT_LIMIT_BYTES_ENV, "4096");
+        }
+        let started = Instant::now();
+        let result = run_command_with_timeout(Command::new(&script), Duration::from_secs(10))
+            .expect("run with large stderr");
+        unsafe {
+            env::remove_var(CODEX_OUTPUT_LIMIT_BYTES_ENV);
+        }
+
+        let TimedCommandOutput::OutputLimitExceeded {
+            stream,
+            output_limit,
+            ..
+        } = result
+        else {
+            panic!("expected stderr output limit failure");
+        };
+        assert_eq!(stream, "stderr");
+        assert_eq!(output_limit, 4096);
+        assert!(started.elapsed() < Duration::from_secs(3));
     }
 
     #[cfg(unix)]

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -39,7 +39,11 @@ export const EXPLORE_BIN_ENV = EXPLORE_BIN_ENV_SHARED;
 const EXPLORE_SPARK_MODEL_ENV = 'OMX_EXPLORE_SPARK_MODEL';
 const EXPLORE_INSTRUCTIONS_FILE_ENV = 'OMX_EXPLORE_MODEL_INSTRUCTIONS_FILE';
 const EXPLORE_TIMEOUT_MS_ENV = 'OMX_EXPLORE_TIMEOUT_MS';
+const EXPLORE_PROCESS_LIMIT_ENV = 'OMX_EXPLORE_PROCESS_LIMIT';
+const EXPLORE_ACTIVE_ENV = 'OMX_EXPLORE_ACTIVE';
 const DEFAULT_EXPLORE_TIMEOUT_MS = 120_000;
+const DEFAULT_EXPLORE_PROCESS_LIMIT = 96;
+const EXPLORE_OUTPUT_LIMIT_BYTES = 4 * 1024 * 1024;
 const LOCAL_FAST_PATH_MAX_FILES = 2_000;
 const LOCAL_FAST_PATH_MAX_MATCHES = 40;
 const LOCAL_FAST_PATH_FILE_MAX_BYTES = 16_384;
@@ -296,6 +300,13 @@ function parseExploreTimeoutMs(env: NodeJS.ProcessEnv): number {
   if (!raw) return DEFAULT_EXPLORE_TIMEOUT_MS;
   const value = Number.parseInt(raw, 10);
   return Number.isFinite(value) && value > 0 ? value : DEFAULT_EXPLORE_TIMEOUT_MS;
+}
+
+function parseExploreProcessLimit(env: NodeJS.ProcessEnv): number {
+  const raw = env[EXPLORE_PROCESS_LIMIT_ENV]?.trim();
+  if (!raw) return DEFAULT_EXPLORE_PROCESS_LIMIT;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_EXPLORE_PROCESS_LIMIT;
 }
 
 function tokenizeExploreShellCommand(commandText: string): string[] | undefined {
@@ -606,9 +617,11 @@ export function resolveExploreEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
   const codexHomeOverride = resolveCodexHomeForLaunch(cwd, env);
-  return codexHomeOverride
-    ? { ...env, CODEX_HOME: codexHomeOverride }
-    : env;
+  return {
+    ...env,
+    ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
+    [EXPLORE_ACTIVE_ENV]: '1',
+  };
 }
 
 export async function loadExplorePrompt(parsed: ParsedExploreArgs): Promise<string> {
@@ -621,6 +634,9 @@ export async function loadExplorePrompt(parsed: ParsedExploreArgs): Promise<stri
 }
 
 export async function exploreCommand(args: string[]): Promise<void> {
+  if (process.env[EXPLORE_ACTIVE_ENV] === '1') {
+    throw new Error('[explore] refusing to launch nested omx explore from an active explore run.');
+  }
   const parsed = parseExploreArgs(args);
   const prompt = await loadExplorePrompt(parsed);
   const cwd = process.cwd();
@@ -664,6 +680,9 @@ export async function exploreCommand(args: string[]): Promise<void> {
     env: exploreEnv,
     encoding: 'utf-8',
     timeoutMs: parseExploreTimeoutMs(exploreEnv),
+    maxProcessCount: parseExploreProcessLimit(exploreEnv),
+    maxOutputBytes: EXPLORE_OUTPUT_LIMIT_BYTES,
+    cleanupOnParentExit: true,
   });
 
   if (result.stdout && result.stdout.length > 0) process.stdout.write(result.stdout);
@@ -671,6 +690,14 @@ export async function exploreCommand(args: string[]): Promise<void> {
 
   if (result.timedOut) {
     throw new Error(`[explore] harness timed out after ${parseExploreTimeoutMs(exploreEnv)}ms; terminated the process tree to avoid runaway Codex sessions. Set ${EXPLORE_TIMEOUT_MS_ENV} to adjust the bound.`);
+  }
+
+  if (result.processLimitExceeded) {
+    throw new Error(`[explore] harness exceeded the per-run process limit (${parseExploreProcessLimit(exploreEnv)} processes); terminated the process tree to avoid runaway shell storms. Set ${EXPLORE_PROCESS_LIMIT_ENV} to adjust the bound.`);
+  }
+
+  if (result.outputLimitExceeded) {
+    throw new Error('[explore] harness output exceeded the safety limit; terminated the process tree to avoid unbounded memory use.');
   }
 
   if (result.error) {

--- a/src/runtime/__tests__/process-tree.test.ts
+++ b/src/runtime/__tests__/process-tree.test.ts
@@ -67,6 +67,33 @@ describe('runProcessTreeWithTimeout', () => {
     assert.notEqual(result.status, 0);
   });
 
+
+  it('returns parent output promptly when inherited-stdio grandchildren outlive the parent', { skip: process.platform === 'win32' }, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-process-tree-inherited-stdio-'));
+    const script = join(root, 'inherited-stdio.sh');
+    await writeFile(script, [
+      '#!/bin/sh',
+      '(sleep 30) &',
+      'printf "parent stdout\n"',
+      'printf "parent stderr\n" >&2',
+      'exit 7',
+      '',
+    ].join('\n'));
+    chmodSync(script, 0o755);
+
+    const started = Date.now();
+    const result = await runProcessTreeWithTimeout(script, [], {
+      timeoutMs: 10_000,
+      sigkillGraceMs: 10,
+    });
+
+    assert.equal(result.timedOut, false);
+    assert.equal(result.status, 7);
+    assert.equal(result.stdout, 'parent stdout\n');
+    assert.equal(result.stderr, 'parent stderr\n');
+    assert.ok(Date.now() - started < 3_000, 'should not wait for grandchild sleep or timeout');
+  });
+
   it('sweeps process-group grandchildren when the direct child exits', { skip: process.platform === 'win32' }, async () => {
     const root = await mkdtemp(join(tmpdir(), 'omx-process-tree-orphan-'));
     const script = join(root, 'orphan.sh');

--- a/src/runtime/__tests__/process-tree.test.ts
+++ b/src/runtime/__tests__/process-tree.test.ts
@@ -1,5 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { chmodSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { runProcessTreeWithTimeout } from '../process-tree.js';
 
 describe('runProcessTreeWithTimeout', () => {
@@ -23,5 +27,69 @@ describe('runProcessTreeWithTimeout', () => {
 
     assert.equal(result.timedOut, true);
     assert.notEqual(result.status, 0);
+  });
+
+  it('terminates commands that exceed the configured output limit', async () => {
+    const result = await runProcessTreeWithTimeout(process.execPath, [
+      '-e',
+      'while (true) process.stdout.write("x".repeat(1024));',
+    ], { timeoutMs: 5_000, sigkillGraceMs: 10, maxOutputBytes: 4096 });
+
+    assert.equal(result.outputLimitExceeded, true);
+    assert.equal(Buffer.byteLength(result.stdout), 4096);
+    assert.notEqual(result.status, 0);
+  });
+
+  it('terminates suspicious process storms before the global timeout', { skip: process.platform !== 'linux' }, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-process-tree-storm-'));
+    const script = join(root, 'storm.sh');
+    await writeFile(script, [
+      '#!/bin/sh',
+      'while :; do',
+      '  sleep 30 &',
+      '  sleep 0.01',
+      'done',
+      '',
+    ].join('\n'));
+    chmodSync(script, 0o755);
+
+    const started = Date.now();
+    const result = await runProcessTreeWithTimeout(script, [], {
+      timeoutMs: 10_000,
+      sigkillGraceMs: 10,
+      maxProcessCount: 12,
+      processLimitPollMs: 25,
+    });
+
+    assert.equal(result.processLimitExceeded, true);
+    assert.equal(result.timedOut, false);
+    assert.ok(Date.now() - started < 5_000);
+    assert.notEqual(result.status, 0);
+  });
+
+  it('sweeps process-group grandchildren when the direct child exits', { skip: process.platform === 'win32' }, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-process-tree-orphan-'));
+    const script = join(root, 'orphan.sh');
+    const ready = join(root, 'ready');
+    const term = join(root, 'term');
+    await writeFile(script, [
+      '#!/bin/sh',
+      `(trap 'printf term > ${term}; exit 0' TERM; printf ready > ${ready}; sleep 30) >/dev/null 2>&1 &`,
+      `while [ ! -f ${ready} ]; do sleep 0.01; done`,
+      'printf "parent done\\n"',
+      'exit 0',
+      '',
+    ].join('\n'));
+    chmodSync(script, 0o755);
+
+    const result = await runProcessTreeWithTimeout(script, [], { timeoutMs: 10_000 });
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, 'parent done\n');
+    for (let i = 0; i < 20 && !existsSync(term); i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.equal(existsSync(term), true);
+    assert.equal(await readFile(term, 'utf8'), 'term');
   });
 });

--- a/src/runtime/process-tree.ts
+++ b/src/runtime/process-tree.ts
@@ -202,20 +202,26 @@ export function runProcessTreeWithTimeout(
     child.stderr.on('data', (chunk: string) => {
       stderr = appendBoundedOutput(stderr, chunk);
     });
+    const sweepProcessGroupAfterParentExit = (): void => {
+      if (platform === 'win32') return;
+      killProcessTree(child, platform, killSignal);
+      const residualSigkillTimer = setTimeout(() => {
+        killProcessTree(child, platform, 'SIGKILL');
+      }, sigkillGraceMs);
+      residualSigkillTimer.unref?.();
+    };
+
     child.on('error', (error: NodeJS.ErrnoException) => {
       finish({ status: null, signal: null, error });
     });
+    child.on('exit', () => {
+      // `close` waits for stdio EOF, so a direct wrapper that exits while a
+      // grandchild keeps inherited stdout/stderr open can otherwise sit until
+      // timeout. Sweep as soon as the direct parent exits, then let `close`
+      // report the parent's status and captured output.
+      sweepProcessGroupAfterParentExit();
+    });
     child.on('close', (status: number | null, signal: NodeJS.Signals | null) => {
-      // A direct wrapper can exit while grandchildren still hold the detached
-      // process group. Always sweep the group before settling so `omx explore`
-      // cannot leave orphan shell storms behind when the parent exits early.
-      if (platform !== 'win32') {
-        killProcessTree(child, platform, killSignal);
-        const residualSigkillTimer = setTimeout(() => {
-          killProcessTree(child, platform, 'SIGKILL');
-        }, sigkillGraceMs);
-        residualSigkillTimer.unref?.();
-      }
       finish({ status, signal });
     });
 

--- a/src/runtime/process-tree.ts
+++ b/src/runtime/process-tree.ts
@@ -1,7 +1,9 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
 import { buildPlatformCommandSpec } from '../utils/platform-command.js';
 
 const DEFAULT_SIGTERM_GRACE_MS = 1_000;
+const DEFAULT_PROCESS_LIMIT_POLL_MS = 100;
 
 export interface ProcessTreeRunOptions {
   cwd?: string;
@@ -10,6 +12,10 @@ export interface ProcessTreeRunOptions {
   timeoutMs?: number;
   killSignal?: NodeJS.Signals;
   sigkillGraceMs?: number;
+  maxOutputBytes?: number;
+  maxProcessCount?: number;
+  processLimitPollMs?: number;
+  cleanupOnParentExit?: boolean;
   platform?: NodeJS.Platform;
   spawnImpl?: typeof spawn;
   existsImpl?: (path: string) => boolean;
@@ -21,6 +27,8 @@ export interface ProcessTreeRunResult {
   status: number | null;
   signal: NodeJS.Signals | null;
   timedOut: boolean;
+  processLimitExceeded: boolean;
+  outputLimitExceeded: boolean;
   error?: NodeJS.ErrnoException;
 }
 
@@ -50,6 +58,57 @@ function killProcessTree(child: ChildProcess, platform: NodeJS.Platform, signal:
   }
 }
 
+function parsePositiveInteger(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  return Math.floor(value);
+}
+
+function readLinuxProcessTable(): Map<number, number> | undefined {
+  try {
+    const entries = readdirSync('/proc', { withFileTypes: true });
+    const table = new Map<number, number>();
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !/^\d+$/.test(entry.name)) continue;
+      const pid = Number.parseInt(entry.name, 10);
+      let stat: string;
+      try {
+        stat = readFileSync(`/proc/${entry.name}/stat`, 'utf-8');
+      } catch {
+        continue;
+      }
+      const closeParen = stat.lastIndexOf(')');
+      if (closeParen < 0) continue;
+      const fields = stat.slice(closeParen + 2).split(' ');
+      const ppid = Number.parseInt(fields[1] ?? '', 10);
+      if (Number.isFinite(ppid)) table.set(pid, ppid);
+    }
+    return table;
+  } catch {
+    return undefined;
+  }
+}
+
+function countDescendantsLinux(rootPid: number): number | undefined {
+  const table = readLinuxProcessTable();
+  if (!table) return undefined;
+  const children = new Map<number, number[]>();
+  for (const [pid, ppid] of table) {
+    const list = children.get(ppid) ?? [];
+    list.push(pid);
+    children.set(ppid, list);
+  }
+  let count = 0;
+  const stack = [...(children.get(rootPid) ?? [])];
+  while (stack.length > 0) {
+    const pid = stack.pop();
+    if (pid === undefined) continue;
+    count += 1;
+    stack.push(...(children.get(pid) ?? []));
+  }
+  return count;
+}
+
 export function runProcessTreeWithTimeout(
   command: string,
   args: string[],
@@ -63,14 +122,21 @@ export function runProcessTreeWithTimeout(
   const killSignal = options.killSignal ?? 'SIGTERM';
   const sigkillGraceMs = options.sigkillGraceMs ?? DEFAULT_SIGTERM_GRACE_MS;
   const encoding = options.encoding ?? 'utf-8';
+  const maxOutputBytes = parsePositiveInteger(options.maxOutputBytes);
+  const maxProcessCount = parsePositiveInteger(options.maxProcessCount);
+  const processLimitPollMs = parsePositiveInteger(options.processLimitPollMs) ?? DEFAULT_PROCESS_LIMIT_POLL_MS;
 
   return new Promise((resolve) => {
     let stdout = '';
     let stderr = '';
     let timedOut = false;
+    let processLimitExceeded = false;
+    let outputLimitExceeded = false;
     let settled = false;
     let timeoutTimer: NodeJS.Timeout | undefined;
     let sigkillTimer: NodeJS.Timeout | undefined;
+    let processLimitTimer: NodeJS.Timeout | undefined;
+    const cleanupSignals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
 
     const child = spawnImpl(spec.command, spec.args, {
       cwd: options.cwd,
@@ -80,26 +146,76 @@ export function runProcessTreeWithTimeout(
       windowsHide: true,
     });
 
-    const finish = (result: Omit<ProcessTreeRunResult, 'stdout' | 'stderr' | 'timedOut'>): void => {
+    const terminate = (signal: NodeJS.Signals = killSignal): void => {
+      killProcessTree(child, platform, signal);
+      if (signal !== 'SIGKILL') {
+        sigkillTimer ??= setTimeout(() => {
+          if (!settled) killProcessTree(child, platform, 'SIGKILL');
+        }, sigkillGraceMs);
+      }
+    };
+
+    const parentCleanupHandler = (signal?: NodeJS.Signals | number): void => {
+      terminate(typeof signal === 'string' ? signal : killSignal);
+    };
+
+    if (options.cleanupOnParentExit) {
+      for (const signal of cleanupSignals) process.once(signal, parentCleanupHandler);
+      process.once('beforeExit', parentCleanupHandler);
+      process.once('exit', parentCleanupHandler);
+    }
+
+    const removeParentCleanupHandlers = (): void => {
+      if (!options.cleanupOnParentExit) return;
+      for (const signal of cleanupSignals) process.off(signal, parentCleanupHandler);
+      process.off('beforeExit', parentCleanupHandler);
+      process.off('exit', parentCleanupHandler);
+    };
+
+    const finish = (result: Omit<ProcessTreeRunResult, 'stdout' | 'stderr' | 'timedOut' | 'processLimitExceeded' | 'outputLimitExceeded'>): void => {
       if (settled) return;
       settled = true;
       if (timeoutTimer) clearTimeout(timeoutTimer);
       if (sigkillTimer) clearTimeout(sigkillTimer);
-      resolve({ ...result, stdout, stderr, timedOut });
+      if (processLimitTimer) clearInterval(processLimitTimer);
+      removeParentCleanupHandlers();
+      resolve({ ...result, stdout, stderr, timedOut, processLimitExceeded, outputLimitExceeded });
+    };
+
+    const appendBoundedOutput = (current: string, chunk: string): string => {
+      if (outputLimitExceeded) return current;
+      if (maxOutputBytes === undefined) return current + chunk;
+      const currentBytes = Buffer.byteLength(current, encoding);
+      const chunkBytes = Buffer.byteLength(chunk, encoding);
+      if (currentBytes + chunkBytes <= maxOutputBytes) return current + chunk;
+      outputLimitExceeded = true;
+      terminate();
+      const remaining = Math.max(0, maxOutputBytes - currentBytes);
+      return current + Buffer.from(chunk, encoding).subarray(0, remaining).toString(encoding);
     };
 
     child.stdout.setEncoding(encoding);
     child.stderr.setEncoding(encoding);
     child.stdout.on('data', (chunk: string) => {
-      stdout += chunk;
+      stdout = appendBoundedOutput(stdout, chunk);
     });
     child.stderr.on('data', (chunk: string) => {
-      stderr += chunk;
+      stderr = appendBoundedOutput(stderr, chunk);
     });
     child.on('error', (error: NodeJS.ErrnoException) => {
       finish({ status: null, signal: null, error });
     });
     child.on('close', (status: number | null, signal: NodeJS.Signals | null) => {
+      // A direct wrapper can exit while grandchildren still hold the detached
+      // process group. Always sweep the group before settling so `omx explore`
+      // cannot leave orphan shell storms behind when the parent exits early.
+      if (platform !== 'win32') {
+        killProcessTree(child, platform, killSignal);
+        const residualSigkillTimer = setTimeout(() => {
+          killProcessTree(child, platform, 'SIGKILL');
+        }, sigkillGraceMs);
+        residualSigkillTimer.unref?.();
+      }
       finish({ status, signal });
     });
 
@@ -107,11 +223,19 @@ export function runProcessTreeWithTimeout(
       timeoutTimer = setTimeout(() => {
         if (settled) return;
         timedOut = true;
-        killProcessTree(child, platform, killSignal);
-        sigkillTimer = setTimeout(() => {
-          if (!settled) killProcessTree(child, platform, 'SIGKILL');
-        }, sigkillGraceMs);
+        terminate();
       }, timeoutMs);
+    }
+    if (platform === 'linux' && maxProcessCount !== undefined) {
+      processLimitTimer = setInterval(() => {
+        if (settled || child.pid === undefined) return;
+        const descendants = countDescendantsLinux(child.pid);
+        if (descendants === undefined) return;
+        if (descendants + 1 > maxProcessCount) {
+          processLimitExceeded = true;
+          terminate();
+        }
+      }, processLimitPollMs);
     }
   });
 }


### PR DESCRIPTION
## Summary
- add fail-closed process-count and output caps around the Node `omx explore` harness launch
- sweep detached process groups on direct-child exit and parent cleanup signals to avoid orphan shell storms
- add Rust harness process-count monitoring plus stricter shell-startup env scrubbing
- add regression coverage for process storms, orphan grandchildren, output caps, and existing timeout cleanup

Closes #2145

## Tests
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node --test dist/runtime/__tests__/process-tree.test.js`
- `cargo test -p omx-explore-harness`
- `npm run test:explore` *(known unrelated failure: `buildExplorePromptWithWikiContext > does not mutate wiki logs when building read-only wiki context`; all new/explore process-tree Rust tests pass before that assertion)*