### PR TITLE
Keep Codex goal state durable in project-scoped sessions

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -64,6 +64,7 @@ import {
   resolveNativeSessionName,
   releaseTmuxExtendedKeysLease,
   withTmuxExtendedKeys,
+  CODEX_SQLITE_HOME_ENV,
 } from "../index.js";
 import { ensureReusableNodeModules } from "../../utils/repo-deps.js";
 import { readAllState } from "../../hud/state.js";
@@ -1424,12 +1425,16 @@ describe("project launch scope helpers", () => {
       ].join("\n");
       await writeFile(configPath, originalConfig);
       await writeFile(join(projectCodexHome, "agents", "planner.toml"), 'name = "planner"\n');
+      await writeFile(join(projectCodexHome, "state_5.sqlite"), "state db placeholder");
+      await writeFile(join(projectCodexHome, "state_5.sqlite-wal"), "state db wal placeholder");
+      await writeFile(join(projectCodexHome, "logs_2.sqlite-shm"), "logs db shm placeholder");
       const beforeStat = await stat(configPath);
 
       const prepared = await prepareCodexHomeForLaunch(wd, "session-2033", {});
       const runtimeCodexHome = runtimeCodexHomePath(wd, "session-2033");
 
       assert.equal(prepared.codexHomeOverride, runtimeCodexHome);
+      assert.equal(prepared.sqliteHomeOverride, projectCodexHome);
       assert.equal(prepared.projectLocalCodexHomeForCleanup, projectCodexHome);
       assert.equal(prepared.runtimeCodexHomeForCleanup, runtimeCodexHome);
       assert.equal(await readFile(join(runtimeCodexHome, "config.toml"), "utf-8"), originalConfig);
@@ -1437,6 +1442,9 @@ describe("project launch scope helpers", () => {
         await readFile(join(runtimeCodexHome, "agents", "planner.toml"), "utf-8"),
         'name = "planner"\n',
       );
+      assert.equal(existsSync(join(runtimeCodexHome, "state_5.sqlite")), false);
+      assert.equal(existsSync(join(runtimeCodexHome, "state_5.sqlite-wal")), false);
+      assert.equal(existsSync(join(runtimeCodexHome, "logs_2.sqlite-shm")), false);
 
       await writeFile(
         join(runtimeCodexHome, "config.toml"),
@@ -1502,8 +1510,31 @@ describe("project launch scope helpers", () => {
       });
 
       assert.equal(prepared.codexHomeOverride, "/tmp/explicit-codex-home");
+      assert.equal(prepared.sqliteHomeOverride, undefined);
       assert.equal(prepared.projectLocalCodexHomeForCleanup, undefined);
       assert.equal(prepared.runtimeCodexHomeForCleanup, undefined);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("respects explicit CODEX_SQLITE_HOME for project-scope launches", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-sqlite-home-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await mkdir(join(wd, ".codex"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      await writeFile(join(wd, ".codex", "config.toml"), 'model = "gpt-5.5"\n');
+
+      const prepared = await prepareCodexHomeForLaunch(wd, "session-explicit-sqlite", {
+        [CODEX_SQLITE_HOME_ENV]: "/tmp/explicit-sqlite-home",
+      });
+
+      assert.equal(prepared.codexHomeOverride, runtimeCodexHomePath(wd, "session-explicit-sqlite"));
+      assert.equal(prepared.sqliteHomeOverride, undefined);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1981,6 +2012,32 @@ describe("detached tmux new-session sequencing", () => {
     assert.equal(
       newSession!.args.includes("-e") &&
         newSession!.args.some((arg) => arg === "CODEX_HOME=/tmp/project/.codex"),
+      true,
+    );
+  });
+
+  it("buildDetachedSessionBootstrapSteps forwards CODEX_SQLITE_HOME override to detached tmux session", () => {
+    const steps = buildDetachedSessionBootstrapSteps(
+      "omx-demo",
+      "/tmp/project",
+      "'codex' '--model' 'gpt-5'",
+      "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null,
+      "/tmp/project/.omx/runtime/codex-home/session-1",
+      null,
+      false,
+      "sess-detached-managed",
+      undefined,
+      undefined,
+      undefined,
+      {},
+      "/tmp/project/.codex",
+    );
+    const newSession = steps.find((step) => step.name === "new-session");
+    assert.ok(newSession);
+    assert.equal(
+      newSession!.args.includes("-e") &&
+        newSession!.args.some((arg) => arg === `${CODEX_SQLITE_HOME_ENV}=/tmp/project/.codex`),
       true,
     );
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -596,9 +596,12 @@ function resolveTmuxExecutableForLaunch(): string {
 
 export interface PreparedCodexHomeForLaunch {
   codexHomeOverride?: string;
+  sqliteHomeOverride?: string;
   projectLocalCodexHomeForCleanup?: string;
   runtimeCodexHomeForCleanup?: string;
 }
+
+export const CODEX_SQLITE_HOME_ENV = "CODEX_SQLITE_HOME";
 
 export function runtimeCodexHomePath(
   cwd: string,
@@ -620,6 +623,10 @@ async function linkOrCopyCodexHomeEntry(source: string, destination: string): Pr
   }
 }
 
+function isCodexSqliteArtifact(entryName: string): boolean {
+  return /^(?:state|logs)_\d+\.sqlite(?:-(?:shm|wal))?$/.test(entryName);
+}
+
 /**
  * Project-scope setup keeps durable Codex config under <repo>/.codex, but the
  * Codex TUI also stores model-availability NUX counters in CODEX_HOME/config.toml.
@@ -638,6 +645,7 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
   if (!existsSync(projectCodexHome)) return runtimeCodexHome;
 
   for (const entry of await readdir(projectCodexHome, { withFileTypes: true })) {
+    if (isCodexSqliteArtifact(entry.name)) continue;
     const source = join(projectCodexHome, entry.name);
     const destination = join(runtimeCodexHome, entry.name);
     if (entry.name === "config.toml") {
@@ -648,6 +656,15 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
   }
 
   return runtimeCodexHome;
+}
+
+function resolveProjectSqliteHomeForLaunch(
+  projectCodexHome: string,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const configured = env[CODEX_SQLITE_HOME_ENV];
+  if (typeof configured === "string" && configured.trim() !== "") return undefined;
+  return projectCodexHome;
 }
 
 export async function prepareCodexHomeForLaunch(
@@ -664,6 +681,7 @@ export async function prepareCodexHomeForLaunch(
     );
     return {
       codexHomeOverride: runtimeCodexHome,
+      sqliteHomeOverride: resolveProjectSqliteHomeForLaunch(projectLocalCodexHomeForCleanup, env),
       projectLocalCodexHomeForCleanup,
       runtimeCodexHomeForCleanup: runtimeCodexHome,
     };
@@ -1431,6 +1449,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
 
   const preparedCodexHome = await prepareCodexHomeForLaunch(launchCwd, sessionId, process.env);
   const codexHomeOverride = preparedCodexHome.codexHomeOverride;
+  const sqliteHomeOverride = preparedCodexHome.sqliteHomeOverride;
   const projectLocalCodexHomeForCleanup = preparedCodexHome.projectLocalCodexHomeForCleanup;
 
   // ── Phase 1: preLaunch ──────────────────────────────────────────────────
@@ -1455,6 +1474,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
       sessionId,
       workerSparkModel,
       codexHomeOverride,
+      sqliteHomeOverride,
       notifyTempContractRaw,
       effectiveExplicitLaunchPolicy,
       projectLocalCodexHomeForCleanup,
@@ -1536,6 +1556,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
 
   const preparedCodexHome = await prepareCodexHomeForLaunch(launchCwd, sessionId, process.env);
   const codexHomeOverride = preparedCodexHome.codexHomeOverride;
+  const sqliteHomeOverride = preparedCodexHome.sqliteHomeOverride;
   const projectLocalCodexHomeForCleanup = preparedCodexHome.projectLocalCodexHomeForCleanup;
 
   try {
@@ -1560,6 +1581,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
     const codexEnvBase = {
       ...process.env,
       ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
+      ...(sqliteHomeOverride ? { [CODEX_SQLITE_HOME_ENV]: sqliteHomeOverride } : {}),
       ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
     };
     const codexEnv = notifyTempContractRaw
@@ -2469,6 +2491,7 @@ export function buildDetachedSessionBootstrapSteps(
   runtimeCodexHomeForCleanup?: string,
   omxRootOverride?: string,
   env: NodeJS.ProcessEnv = process.env,
+  sqliteHomeOverride?: string,
 ): DetachedSessionTmuxStep[] {
   const detachedLeaderCmd = nativeWindows
     ? "powershell.exe"
@@ -2497,6 +2520,7 @@ export function buildDetachedSessionBootstrapSteps(
     ...(sessionId ? ["-e", `OMX_SESSION_ID=${sessionId}`] : []),
     ...(sessionId ? ["-e", `${OMX_TMUX_HUD_OWNER_ENV}=1`] : []),
     ...(codexHomeOverride ? ["-e", `CODEX_HOME=${codexHomeOverride}`] : []),
+    ...(sqliteHomeOverride ? ["-e", `${CODEX_SQLITE_HOME_ENV}=${sqliteHomeOverride}`] : []),
     ...(omxRootOverride ? ["-e", `OMX_ROOT=${omxRootOverride}`] : []),
     ...(env.OMX_STATE_ROOT ? ["-e", `OMX_STATE_ROOT=${env.OMX_STATE_ROOT}`] : []),
     ...(env.OMXBOX_ACTIVE ? ["-e", `OMXBOX_ACTIVE=${env.OMXBOX_ACTIVE}`] : []),
@@ -3089,6 +3113,7 @@ function runCodex(
   sessionId: string,
   workerDefaultModel?: string,
   codexHomeOverride?: string,
+  sqliteHomeOverride?: string,
   notifyTempContractRaw?: string | null,
   explicitLaunchPolicy?: CodexLaunchPolicy,
   projectLocalCodexHomeForCleanup?: string,
@@ -3119,6 +3144,7 @@ function runCodex(
   const codexBaseEnv = {
     ...process.env,
     ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
+    ...(sqliteHomeOverride ? { [CODEX_SQLITE_HOME_ENV]: sqliteHomeOverride } : {}),
     ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
   };
   const codexEnvWithSession = {
@@ -3237,6 +3263,7 @@ function runCodex(
         runtimeCodexHomeForCleanup,
         omxRootOverride,
         process.env,
+        sqliteHomeOverride,
       );
       for (const step of bootstrapSteps) {
         const output = execTmuxFileSync(step.args, {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -2133,10 +2133,13 @@ describe('team worker launch mode helpers', () => {
   it('buildWorkerProcessLaunchSpec preserves ambient CODEX_HOME so Codex workers keep provider websocket metadata', async () => {
     const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
     const prevCodexHome = process.env.CODEX_HOME;
+    const prevSqliteHome = process.env.CODEX_SQLITE_HOME;
     const prevProviderEnv = process.env.CUSTOM_PROVIDER_API_KEY;
     const codexHome = await mkdtemp(join(tmpdir(), 'omx-team-provider-websocket-'));
+    const sqliteHome = await mkdtemp(join(tmpdir(), 'omx-team-provider-sqlite-'));
     process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
     process.env.CODEX_HOME = codexHome;
+    process.env.CODEX_SQLITE_HOME = sqliteHome;
     process.env.CUSTOM_PROVIDER_API_KEY = 'test-secret';
 
     try {
@@ -2164,15 +2167,19 @@ describe('team worker launch mode helpers', () => {
       );
 
       assert.equal(spec.env.CODEX_HOME, codexHome);
+      assert.equal(spec.env.CODEX_SQLITE_HOME, sqliteHome);
       assert.equal(spec.env.CUSTOM_PROVIDER_API_KEY, 'test-secret');
     } finally {
       if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
       else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
       if (typeof prevCodexHome === 'string') process.env.CODEX_HOME = prevCodexHome;
       else delete process.env.CODEX_HOME;
+      if (typeof prevSqliteHome === 'string') process.env.CODEX_SQLITE_HOME = prevSqliteHome;
+      else delete process.env.CODEX_SQLITE_HOME;
       if (typeof prevProviderEnv === 'string') process.env.CUSTOM_PROVIDER_API_KEY = prevProviderEnv;
       else delete process.env.CUSTOM_PROVIDER_API_KEY;
       await rm(codexHome, { recursive: true, force: true });
+      await rm(sqliteHome, { recursive: true, force: true });
     }
   });
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -61,6 +61,7 @@ const OMX_TEAM_WORKER_CLI_ENV = 'OMX_TEAM_WORKER_CLI';
 const OMX_TEAM_WORKER_CLI_MAP_ENV = 'OMX_TEAM_WORKER_CLI_MAP';
 const OMX_TEAM_WORKER_LAUNCH_MODE_ENV = 'OMX_TEAM_WORKER_LAUNCH_MODE';
 const OMX_TEAM_AUTO_INTERRUPT_RETRY_ENV = 'OMX_TEAM_AUTO_INTERRUPT_RETRY';
+const CODEX_SQLITE_HOME_ENV = 'CODEX_SQLITE_HOME';
 const GEMINI_PROMPT_INTERACTIVE_FLAG = '-i';
 const GEMINI_APPROVAL_MODE_FLAG = '--approval-mode';
 const GEMINI_APPROVAL_MODE_YOLO = 'yolo';
@@ -931,6 +932,9 @@ export function buildWorkerProcessLaunchSpec(
   const workerCodexHomeOverride = typeof effectiveEnv.CODEX_HOME === 'string'
     ? effectiveEnv.CODEX_HOME.trim()
     : undefined;
+  const workerSqliteHomeOverride = typeof effectiveEnv[CODEX_SQLITE_HOME_ENV] === 'string'
+    ? effectiveEnv[CODEX_SQLITE_HOME_ENV].trim()
+    : undefined;
   const providerLookupCodexHome = workerCodexHomeOverride
     ? (isAbsolute(workerCodexHomeOverride) ? workerCodexHomeOverride : resolve(cwd, workerCodexHomeOverride))
     : undefined;
@@ -965,6 +969,9 @@ export function buildWorkerProcessLaunchSpec(
     [OMX_TMUX_HUD_OWNER_ENV]: '1',
     ...(workerCli === 'codex' && workerCodexHomeOverride
       ? { CODEX_HOME: workerCodexHomeOverride }
+      : {}),
+    ...(workerCli === 'codex' && workerSqliteHomeOverride
+      ? { [CODEX_SQLITE_HOME_ENV]: workerSqliteHomeOverride }
       : {}),
     ...codexProviderEnv,
   };


### PR DESCRIPTION
## Summary

Project-scoped OMX launches currently isolate `CODEX_HOME` into a session-scoped runtime mirror so Codex TUI config writes do not mutate the durable project `.codex/config.toml`. With Codex CLI goal mode, that also means Codex SQLite state can follow the temporary mirror instead of the durable project `.codex` directory.

This PR keeps the existing `CODEX_HOME` mirror behavior, but routes Codex-owned SQLite state through `CODEX_SQLITE_HOME=<repo>/.codex` for project-scope launches when the user has not already set `CODEX_SQLITE_HOME`.

## Changes

- Add project-scope `CODEX_SQLITE_HOME` routing while preserving explicit user-provided `CODEX_SQLITE_HOME` values.
- Forward the SQLite home override through direct launch, exec overlay, detached tmux bootstrap, and team worker launch paths.
- Exclude Codex SQLite artifacts (`state_*.sqlite*`, `logs_*.sqlite*`) from the runtime `CODEX_HOME` mirror so state DB ownership stays with Codex.
- Add regression coverage for project launch preparation, detached tmux env propagation, and team worker env preservation.

## Validation

- [x] `npm run build`
- [ ] `npm test` (not run end-to-end; a prior `npm run test:ci:compiled` attempt in this checkout surfaced unrelated/local-environment failures outside this change surface)
- [ ] `omx doctor` (not run; this change is launch env routing, not setup repair)
- [x] `npm run check:no-unused`
- [x] `npm run lint -- src/cli/index.ts src/cli/__tests__/index.test.ts src/team/tmux-session.ts src/team/__tests__/tmux-session.test.ts`
- [x] `node --test --test-name-pattern='project launch scope helpers|CODEX_SQLITE_HOME|preserves ambient CODEX_HOME' dist/cli/__tests__/index.test.js dist/team/__tests__/tmux-session.test.js`
- [x] `node --test dist/team/__tests__/tmux-session.test.js`
- [x] `git diff --check`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — not needed; behavior is covered by launch/env tests and does not alter user-facing commands
- [x] Backward-compatibility impact considered — explicit `CODEX_SQLITE_HOME` is preserved, non-project-scope launches are unchanged

## Related

Closes #2150
