### PR TITLE
Fix plugin skill cache refresh

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -158,6 +158,28 @@ async function seedPluginCacheFromInstalledSkills(
 	);
 }
 
+async function seedStalePluginDiscoveryCache(codexHomeDir: string): Promise<string> {
+	const artifactPath = join(
+		codexHomeDir,
+		"plugins",
+		"cache",
+		"oh-my-codex-local",
+		"oh-my-codex",
+	);
+	await mkdir(join(artifactPath, ".codex-plugin"), { recursive: true });
+	await writeFile(
+		join(artifactPath, ".codex-plugin", "plugin.json"),
+		JSON.stringify(
+			{ name: "oh-my-codex", version: "0.0.0", skills: "./skills/" },
+			null,
+			2,
+		),
+	);
+	await mkdir(join(artifactPath, "skills", "old-only"), { recursive: true });
+	await writeFile(join(artifactPath, "skills", "old-only", "SKILL.md"), "# old\n");
+	return artifactPath;
+}
+
 describe("omx setup install mode behavior", () => {
 	it("summarizes and keeps persisted setup preferences when review chooses keep", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
@@ -463,6 +485,56 @@ describe("omx setup install mode behavior", () => {
 						"utf-8",
 					);
 					assert.match(hooks, /codex-native-hook\.js/);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("invalidates stale plugin discovery caches so updated plugin skills refresh", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const cacheDir = await seedStalePluginDiscoveryCache(codexHomeDir);
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					assert.equal(existsSync(cacheDir), false);
+					assert.match(
+						output,
+						/Invalidated 1 stale Codex plugin discovery cache entry/,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "skills", "old-only", "SKILL.md")),
+						false,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reports stale plugin discovery cache invalidation during dry-run without deleting it", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const cacheDir = await seedStalePluginDiscoveryCache(codexHomeDir);
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin", dryRun: true });
+					});
+
+					assert.equal(existsSync(cacheDir), true);
+					assert.match(
+						output,
+						/Would invalidate 1 stale Codex plugin discovery cache entry/,
+					);
 				});
 			});
 		} finally {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -828,15 +828,55 @@ async function readPluginManifestName(
 	}
 }
 
-async function discoverOmxPluginCacheDir(
+interface OmxPluginCacheManifest {
+	name: string | null;
+	version: string | null;
+	skills: string | null;
+}
+
+async function readPluginManifestSummary(
+	manifestPath: string,
+): Promise<OmxPluginCacheManifest | null> {
+	try {
+		const parsed = JSON.parse(await readFile(manifestPath, "utf-8")) as unknown;
+		if (typeof parsed !== "object" || parsed === null) return null;
+		const manifest = parsed as {
+			name?: unknown;
+			version?: unknown;
+			skills?: unknown;
+		};
+		return {
+			name: typeof manifest.name === "string" ? manifest.name : null,
+			version: typeof manifest.version === "string" ? manifest.version : null,
+			skills: typeof manifest.skills === "string" ? manifest.skills : null,
+		};
+	} catch {
+		return null;
+	}
+}
+
+async function listChildDirectoryNames(dir: string): Promise<string[] | null> {
+	try {
+		const entries = await readdir(dir, { withFileTypes: true });
+		return entries
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name)
+			.sort();
+	} catch {
+		return null;
+	}
+}
+
+async function discoverOmxPluginCacheDirs(
 	cacheRoot = join(codexHome(), "plugins", "cache"),
-): Promise<string | null> {
-	if (!existsSync(cacheRoot)) return null;
+): Promise<string[]> {
+	if (!existsSync(cacheRoot)) return [];
 
 	const queue: Array<{ path: string; depth: number }> = [
 		{ path: cacheRoot, depth: 0 },
 	];
 	const maxDepth = 5;
+	const matches: string[] = [];
 
 	while (queue.length > 0) {
 		const current = queue.shift();
@@ -846,7 +886,8 @@ async function discoverOmxPluginCacheDir(
 		if (existsSync(manifestPath)) {
 			const name = await readPluginManifestName(manifestPath);
 			if (name === "oh-my-codex") {
-				return current.path;
+				matches.push(current.path);
+				continue;
 			}
 		}
 
@@ -869,7 +910,80 @@ async function discoverOmxPluginCacheDir(
 		}
 	}
 
-	return null;
+	return matches.sort();
+}
+
+async function discoverOmxPluginCacheDir(
+	cacheRoot = join(codexHome(), "plugins", "cache"),
+): Promise<string | null> {
+	return (await discoverOmxPluginCacheDirs(cacheRoot))[0] ?? null;
+}
+
+interface PluginDiscoveryCacheRefreshResult {
+	status: "unavailable" | "unchanged" | "refreshed";
+	staleDirs: string[];
+}
+
+async function refreshOmxPluginDiscoveryCache(
+	pkgRoot: string,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<PluginDiscoveryCacheRefreshResult> {
+	const packagedMarketplace = await resolvePackagedOmxMarketplace(pkgRoot);
+	if (!packagedMarketplace) {
+		return { status: "unavailable", staleDirs: [] };
+	}
+
+	const [pkg, expectedSkillNames, cachedDirs] = await Promise.all([
+		readFile(join(pkgRoot, "package.json"), "utf-8").then((raw) =>
+			JSON.parse(raw) as { version?: unknown },
+		),
+		listChildDirectoryNames(join(packagedMarketplace.pluginRoot, "skills")),
+		discoverOmxPluginCacheDirs(),
+	]);
+	const expectedVersion = typeof pkg.version === "string" ? pkg.version : null;
+	const staleDirs: string[] = [];
+
+	for (const cacheDir of cachedDirs) {
+		const manifest = await readPluginManifestSummary(
+			join(cacheDir, ".codex-plugin", "plugin.json"),
+		);
+		if (manifest?.name !== "oh-my-codex") continue;
+
+		const cachedSkillNames = await listChildDirectoryNames(join(cacheDir, "skills"));
+		const versionChanged =
+			expectedVersion !== null && manifest.version !== expectedVersion;
+		const skillsPointerChanged = manifest.skills !== "./skills/";
+		const skillListChanged =
+			expectedSkillNames !== null &&
+			cachedSkillNames !== null &&
+			JSON.stringify(cachedSkillNames) !== JSON.stringify(expectedSkillNames);
+
+		if (!versionChanged && !skillsPointerChanged && !skillListChanged) continue;
+
+		staleDirs.push(cacheDir);
+		if (!options.dryRun) {
+			await rm(cacheDir, { recursive: true, force: true });
+		}
+		if (options.verbose) {
+			const reasons = [
+				versionChanged
+					? `version ${manifest.version ?? "unknown"} -> ${expectedVersion}`
+					: null,
+				skillsPointerChanged
+					? `skills pointer ${manifest.skills ?? "missing"} -> ./skills/`
+					: null,
+				skillListChanged ? "skill directory list changed" : null,
+			].filter(Boolean);
+			console.log(
+				`  ${options.dryRun ? "would invalidate" : "invalidated"} Codex plugin discovery cache ${cacheDir} (${reasons.join(", ")})`,
+			);
+		}
+	}
+
+	return {
+		status: staleDirs.length > 0 ? "refreshed" : "unchanged",
+		staleDirs,
+	};
 }
 
 async function resolveSetupInstallMode(
@@ -1789,6 +1903,17 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			console.log(
 				`  Local Codex plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} already registered (${pkgRoot}).`,
 			);
+		}
+		const pluginCacheRefresh = await refreshOmxPluginDiscoveryCache(pkgRoot, {
+			dryRun,
+			verbose,
+		});
+		if (pluginCacheRefresh.status === "refreshed") {
+			console.log(
+				`  ${dryRun ? "Would invalidate" : "Invalidated"} ${pluginCacheRefresh.staleDirs.length} stale Codex plugin discovery cache entr${pluginCacheRefresh.staleDirs.length === 1 ? "y" : "ies"} so plugin skills refresh from the packaged manifest.`,
+			);
+		} else if (pluginCacheRefresh.status === "unchanged") {
+			console.log("  Codex plugin discovery cache already matches packaged plugin metadata.");
 		}
 			resolvedConfig = existsSync(scopeDirs.codexConfigFile)
 				? await readFile(scopeDirs.codexConfigFile, "utf-8")


### PR DESCRIPTION
## Summary
- invalidate stale Codex plugin discovery cache entries during plugin-mode setup when packaged oh-my-codex metadata or skill directories change
- keep invalidation limited to cached manifests named `oh-my-codex` and preserve dry-run behavior
- add regression coverage for stale-cache removal and dry-run reporting

## Verification
- npm run build
- node --test dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/codex-plugin-layout.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js
- npm run check:no-unused
- npm run lint
- npm run verify:plugin-bundle
- Architect verification: APPROVED

Fixes #2149

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
