### PR TITLE
Use current JS runtime for managed OMX helpers

### DIFF
--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -8,6 +8,16 @@ import {
 } from "../codex-hooks.js";
 
 describe("codex hooks helpers", () => {
+
+  it("uses the current JavaScript runtime for managed hook commands", () => {
+    const config = buildManagedCodexHooksConfig("/repo");
+    const command = (config.hooks.SessionStart[0] as { hooks?: Array<{ command?: string }> } | undefined)?.hooks?.[0]?.command;
+
+    assert.equal(
+      command,
+      `"${process.execPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}" "/repo/dist/scripts/codex-native-hook.js"`,
+    );
+  });
   it("merges managed wrappers without dropping user hooks", () => {
     const merged = JSON.parse(
       mergeManagedCodexHooksConfig(

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -34,6 +34,10 @@ function cloneJson<T>(value: T): T {
   return structuredClone(value);
 }
 
+function quoteCommandPart(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
 function buildCommandHook(
   command: string,
   options: {
@@ -59,7 +63,7 @@ export function buildManagedCodexHooksConfig(
   pkgRoot: string,
 ): ManagedCodexHooksConfig {
   const hookScript = join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
-  const command = `node "${hookScript}"`;
+  const command = `${quoteCommandPart(process.execPath)} ${quoteCommandPart(hookScript)}`;
 
   return {
     hooks: {

--- a/src/hud/__tests__/hud-tmux-injection.test.ts
+++ b/src/hud/__tests__/hud-tmux-injection.test.ts
@@ -12,6 +12,9 @@ import assert from 'node:assert/strict';
 import { shellEscape, buildTmuxSplitArgs } from '../index.js';
 import { HUD_TMUX_HEIGHT_LINES } from '../constants.js';
 
+const runtimePrefix = shellEscape(process.execPath);
+
+
 // ── Vulnerability demonstration (old code) ──────────────────────────────────
 
 describe('VULNERABILITY – old string-interpolation approach', () => {
@@ -97,7 +100,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
       'split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES),
       // split height should come from shared HUD constants
       '-c', '/home/user/project',
-      "node '/usr/local/bin/omx.js' hud --watch",
+      `${runtimePrefix} '/usr/local/bin/omx.js' hud --watch`,
     ]);
   });
 
@@ -130,7 +133,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
       cmd.includes("'\\''"),
       `Expected escaped single quote in: ${cmd}`,
     );
-    assert.equal(cmd, "node '/tmp/it'\\''s/omx.js' hud --watch");
+    assert.equal(cmd, `${runtimePrefix} '/tmp/it'\\''s/omx.js' hud --watch`);
   });
 
   it('omxBin with $() is neutralised by single-quote wrapping', () => {
@@ -139,7 +142,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     const cmd = args[6];
 
     // Inside single quotes, $() is literal.
-    assert.equal(cmd, "node '/tmp/$(id)/omx.js' hud --watch");
+    assert.equal(cmd, `${runtimePrefix} '/tmp/$(id)/omx.js' hud --watch`);
   });
 
   it('omxBin with backticks is neutralised by single-quote wrapping', () => {
@@ -147,7 +150,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     const args = buildTmuxSplitArgs('/home/user', maliciousOmx);
     const cmd = args[6];
 
-    assert.equal(cmd, "node '/tmp/`whoami`/omx.js' hud --watch");
+    assert.equal(cmd, `${runtimePrefix} '/tmp/\`whoami\`/omx.js' hud --watch`);
   });
 
   it("omxBin with ';command' breakout attempt is neutralised", () => {
@@ -162,7 +165,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     // Raw expected value: node '/tmp/x'\'';touch /tmp/pwned;echo '\''/omx.js' hud --watch
     assert.equal(
       cmd,
-      "node '/tmp/x'\\'';touch /tmp/pwned;echo '\\''/omx.js' hud --watch",
+      `${runtimePrefix} '/tmp/x'\\'';touch /tmp/pwned;echo '\\''/omx.js' hud --watch`,
     );
 
     // Both original single quotes are escaped (two '\'' sequences).
@@ -190,13 +193,13 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
       'minimal;touch /tmp/pwned',
     );
     const cmd = args[6];
-    assert.equal(cmd, "node '/usr/bin/omx.js' hud --watch");
+    assert.equal(cmd, `${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
     assert.ok(!cmd.includes('--preset='));
   });
 
   it('prepends OMX_SESSION_ID when provided', () => {
     const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', 'focused', 'sess-managed');
     const cmd = args[6];
-    assert.equal(cmd, "OMX_SESSION_ID='sess-managed' node '/usr/bin/omx.js' hud --watch --preset=focused");
+    assert.equal(cmd, `OMX_SESSION_ID='sess-managed' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=focused`);
   });
 });

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -84,7 +84,7 @@ describe('reconcileHudForPromptSubmit', () => {
 
     assert.equal(result.status, 'recreated');
     assert.equal(created.length, 1);
-    assert.match(created[0]?.cmd || '', /^OMX_SESSION_ID='sess-canonical' node '.*omx\.js' hud --watch/);
+    assert.match(created[0]?.cmd || '', /^OMX_SESSION_ID='sess-canonical' '.*' '.*omx\.js' hud --watch/);
     assert.doesNotMatch(created[0]?.cmd || '', /sess-stale/);
   });
 

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -262,7 +262,7 @@ export function buildTmuxSplitArgs(
   const presetArg = safePreset ? ` --preset=${safePreset}` : '';
   const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
   const sessionPrefix = safeSessionId ? `OMX_SESSION_ID=${shellEscape(safeSessionId)} ` : '';
-  const cmd = `${sessionPrefix}node ${shellEscape(omxBin)} hud --watch${presetArg}`;
+  const cmd = `${sessionPrefix}${shellEscape(process.execPath)} ${shellEscape(omxBin)} hud --watch${presetArg}`;
   return ['split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES), '-c', cwd, cmd];
 }
 

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -67,7 +67,7 @@ export function buildHudWatchCommand(omxBin: string, preset?: string, sessionId?
     : '';
   const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
   const sessionPrefix = safeSessionId ? `OMX_SESSION_ID=${shellEscapeSingle(safeSessionId)} ` : '';
-  return `${sessionPrefix}node ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
+  return `${sessionPrefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
 }
 
 export function listCurrentWindowPanes(

--- a/src/sidecar/__tests__/tmux.test.ts
+++ b/src/sidecar/__tests__/tmux.test.ts
@@ -10,7 +10,7 @@ describe('sidecar tmux launcher', () => {
     assert.equal(args[8], '-F');
     assert.equal(args[9], '#{pane_id}');
     assert.match(args[10], /OMX_SESSION_ID='sess 1'/);
-    assert.match(args[10], /node '\/repo\/dist\/cli\/omx\.js' sidecar 'demo-team' --watch --width 52/);
+    assert.ok(args[10].includes(`'${process.execPath}' '/repo/dist/cli/omx.js' sidecar 'demo-team' --watch --width 52`));
   });
 
   it('uses a safe minimum sidecar width and parses the new pane id', () => {

--- a/src/sidecar/tmux.ts
+++ b/src/sidecar/tmux.ts
@@ -21,7 +21,7 @@ export function buildSidecarWatchCommand(options: SidecarTmuxOptions): string {
   const omxBin = options.omxBin ?? resolveOmxCliEntryPath();
   if (!omxBin) throw new Error('Failed to resolve OMX launcher path for sidecar startup.');
   const prefix = options.sessionId ? `OMX_SESSION_ID=${shellEscapeSingle(options.sessionId)} ` : '';
-  return `${prefix}node ${shellEscapeSingle(omxBin)} sidecar ${shellEscapeSingle(options.teamName)} --watch --width ${sidecarWidth(options.width)}`;
+  return `${prefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} sidecar ${shellEscapeSingle(options.teamName)} --watch --width ${sidecarWidth(options.width)}`;
 }
 
 export function buildSidecarTmuxSplitArgs(options: SidecarTmuxOptions): string[] {


### PR DESCRIPTION
## Summary
- Keep the npm `bin` launcher contract unchanged (`dist/cli/omx.js` remains the package bin and keeps the Node shebang required for direct npm/Codex invocation).
- Replace safe managed helper launches that previously hard-coded `node` with `process.execPath`, so hooks/HUD/sidecar helpers inherit the JS runtime that successfully launched OMX.
- Add/update tests for Codex hook command generation, HUD tmux command escaping, sidecar launch command generation, and the existing package bin contract.

## Scope / product-contract note
This is intentionally narrow. It does **not** claim full Bun/Deno support and does not remove the npm bin shebang because that would change the executable contract for `omx`, npm-installed bins, and Codex/plugin invocation. Any broader runtime-support contract should get owner confirmation before merge.

## Verification
- `npm run build`
- `node --test dist/config/__tests__/codex-hooks.test.js dist/sidecar/__tests__/tmux.test.js dist/hud/__tests__/hud-tmux-injection.test.js dist/hud/__tests__/reconcile.test.js dist/cli/__tests__/package-bin-contract.test.js`
- `npm run lint`

## Full-suite note
- `npm test` was attempted, but this attached OMX runtime environment produced pre-existing/session-sensitive failures across unrelated adapt/autoresearch/doctor/state/tmux tests and the run was terminated with exit 143 after many unrelated failures. Targeted tests above passed.

Refs #2130
