### PR TITLE
docs(help): tighten launch policy output

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1269,13 +1269,17 @@ describe("resolveCliInvocation", () => {
     assert.match(HELP, /omx update\s+Check npm now, update the global install immediately, then refresh setup/);
   });
 
-  it("advertises direct launch policy controls in top-level help", () => {
+  it("advertises concise launch policy controls in top-level help", () => {
     assert.match(HELP, /--direct\s+Launch the interactive leader directly/);
-    assert.match(HELP, /OMX_LAUNCH_POLICY=direct\|tmux\|detached-tmux\|auto/);
-    assert.match(HELP, /unset OMX_LAUNCH_POLICY/);
-    assert.match(HELP, /omx --direct --yolo/);
-    assert.match(HELP, /OMX_LAUNCH_POLICY=direct omx --tmux --yolo/);
+    assert.match(HELP, /OMX_LAUNCH_POLICY=auto[\s\S]*Use the default policy/);
+    assert.match(HELP, /OMX_LAUNCH_POLICY=direct[\s\S]*Run without OMX tmux\/HUD management/);
+    assert.match(HELP, /OMX_LAUNCH_POLICY=tmux[\s\S]*Force OMX-managed detached tmux launch/);
+    assert.match(HELP, /OMX_LAUNCH_POLICY=detached-tmux[\s\S]*Force OMX-managed detached tmux launch/);
+    assert.match(HELP, /CLI policy flags \(--direct\/--tmux\) override OMX_LAUNCH_POLICY/);
+    assert.match(HELP, /Unset or empty OMX_LAUNCH_POLICY returns to auto\/default behavior/);
     assert.match(HELP, /Config files are intentionally not used/);
+    assert.doesNotMatch(HELP, /OMX_LAUNCH_POLICY=direct\|tmux\|detached-tmux\|auto/);
+    assert.doesNotMatch(HELP, /OMX_LAUNCH_POLICY=direct omx --tmux --yolo/);
   });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -258,16 +258,16 @@ Options:
                 user | project
 
 Launch policy:
-  OMX_LAUNCH_POLICY=direct|tmux|detached-tmux|auto
-                Choose the default leader launch policy when no CLI policy flag is present
-  unset OMX_LAUNCH_POLICY
-                Return to the auto/default policy (detached tmux on supported interactive terminals)
-  omx --direct --yolo
-                Run this launch without OMX tmux/HUD management
-  OMX_LAUNCH_POLICY=direct omx --yolo
-                Use direct launch from the environment
-  OMX_LAUNCH_POLICY=direct omx --tmux --yolo
-                CLI policy flags override the environment for one launch
+  OMX_LAUNCH_POLICY=auto
+                Use the default policy: detached tmux when supported, direct otherwise
+  OMX_LAUNCH_POLICY=direct
+                Run without OMX tmux/HUD management
+  OMX_LAUNCH_POLICY=tmux
+                Force OMX-managed detached tmux launch
+  OMX_LAUNCH_POLICY=detached-tmux
+                Force OMX-managed detached tmux launch
+  CLI policy flags (--direct/--tmux) override OMX_LAUNCH_POLICY; the last flag before -- wins.
+  Unset or empty OMX_LAUNCH_POLICY returns to auto/default behavior.
   Config files are intentionally not used for launch policy in this release.
 `;
 


### PR DESCRIPTION
## Summary\n- replace the long launch-policy examples in top-level help with concise supported-value descriptions\n- keep CLI/env precedence and unset/default behavior explicit\n- update help tests to require the concise contract and reject the old example-heavy block\n\n## Verification\n- npm run lint\n- npm run build\n- node --test --test-name-pattern "advertises concise launch policy controls" dist/cli/__tests__/index.test.js\n- npm run verify:native-agents\n- npm run verify:plugin-bundle\n- node dist/scripts/generate-catalog-docs.js --check\n\nNote: full compiled test suite was attempted but remains red from unrelated environment/runtime state failures (adapt/autoresearch/team/tmux/state routes); the changed help assertion passed.\n\nCloses #2123\n\n—\n*[repo owner's gaebal-gajae (clawdbot) 🦞]*