### PR TITLE
Quiet native hook background output

### DIFF
--- a/src/hooks/__tests__/foreground-isolation-contract.test.ts
+++ b/src/hooks/__tests__/foreground-isolation-contract.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+describe('foreground isolation contract for hook background helpers', () => {
+  it('keeps notify-hook subprocess probes hidden while capturing output', async () => {
+    const source = await readFile(join(process.cwd(), 'dist', 'scripts', 'notify-hook', 'process-runner.js'), 'utf-8');
+    assert.match(source, /stdio:\s*\[\s*['"]ignore['"],\s*['"]pipe['"],\s*['"]pipe['"]\s*\]/);
+    assert.match(source, /windowsHide:\s*true/);
+  });
+
+  it('keeps hook plugin runner subprocesses hidden while capturing output', async () => {
+    const source = await readFile(join(process.cwd(), 'dist', 'hooks', 'extensibility', 'dispatcher.js'), 'utf-8');
+    assert.match(source, /stdio:\s*\[\s*['"]pipe['"],\s*['"]pipe['"],\s*['"]pipe['"]\s*\]/);
+    assert.match(source, /windowsHide:\s*true/);
+  });
+
+  it('does not print managed-tmux pane-instance fallbacks into notify/native hook stderr', async () => {
+    const source = await readFile(join(process.cwd(), 'dist', 'scripts', 'notify-hook', 'managed-tmux.js'), 'utf-8');
+    const fallbackFunction = source.match(/function warnPaneInstanceFallback[\s\S]*?^}/m)?.[0] ?? '';
+    assert.notEqual(fallbackFunction, '');
+    assert.doesNotMatch(fallbackFunction, /console\.(?:warn|error|log)/);
+  });
+
+  it('logs notify-hook fatal errors instead of printing them to foreground stderr', async () => {
+    const source = await readFile(join(process.cwd(), 'dist', 'scripts', 'notify-hook.js'), 'utf-8');
+    assert.match(source, /notify_hook_fatal_error/);
+    assert.doesNotMatch(source, /console\.error\(\s*['"]\[notify-hook]/);
+  });
+});

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -95,6 +95,7 @@ async function runPluginRunner(
 		const child = spawn(process.execPath, [runnerPath], {
 			cwd: options.cwd,
 			stdio: ["pipe", "pipe", "pipe"],
+			windowsHide: true,
 			env: {
 				...process.env,
 				...(options.env || {}),

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -434,6 +434,73 @@ describe("codex native hook dispatch", () => {
       assert.equal(output.stopReason, "native_stop_dispatch_failure");
       assert.match(String(output.reason), /failed before normal continuation handling/);
       assert.match(String(output.systemMessage), /test-induced Stop dispatch failure/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("logs Stop dispatch failures without foreground stderr noise", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-dispatch-silent-"));
+    try {
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: JSON.stringify({
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-cli-stop-dispatch-silent",
+          thread_id: "thread-cli-stop-dispatch-silent",
+          turn_id: "turn-cli-stop-dispatch-silent",
+        }),
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          NODE_ENV: "test",
+          OMX_NATIVE_HOOK_TEST_THROW_STOP_DISPATCH: "1",
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stderr, "");
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.stopReason, "native_stop_dispatch_failure");
+
+      const logFiles = await readdir(join(cwd, ".omx", "logs"));
+      assert.equal(logFiles.some((name) => /^native-hook-\d{4}-\d{2}-\d{2}\.jsonl$/.test(name)), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps non-Stop dispatch failures fail-closed without foreground stderr noise", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-pretool-dispatch-silent-"));
+    try {
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: JSON.stringify({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-cli-pretool-dispatch-silent",
+          thread_id: "thread-cli-pretool-dispatch-silent",
+          turn_id: "turn-cli-pretool-dispatch-silent",
+          tool_name: "Bash",
+          tool_input: { command: "pwd" },
+        }),
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          NODE_ENV: "test",
+          OMX_NATIVE_HOOK_TEST_THROW_DISPATCH: "1",
+        },
+      });
+
+      assert.equal(result.status, 1);
+      assert.equal(result.stdout, "");
+      assert.equal(result.stderr, "");
+
+      const logFiles = await readdir(join(cwd, ".omx", "logs"));
+      assert.equal(logFiles.some((name) => /^native-hook-\d{4}-\d{2}-\d{2}\.jsonl$/.test(name)), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "child_process";
 import { closeSync, existsSync, openSync, readFileSync, readSync } from "fs";
-import { mkdir, readFile, readdir, writeFile } from "fs/promises";
+import { appendFile, mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { extname, join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
 import { readModeState, readModeStateForActiveDecision, readModeStateForSession, updateModeState } from "../modes/base.js";
@@ -655,6 +655,7 @@ function readParentPid(pid: number): number | null {
     const raw = execFileSync("ps", ["-o", "ppid=", "-p", String(pid)], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     }).trim();
     const ppid = Number.parseInt(raw, 10);
     return Number.isFinite(ppid) && ppid > 0 ? ppid : null;
@@ -674,6 +675,7 @@ function readProcessCommand(pid: number): string {
     return execFileSync("ps", ["-o", "command=", "-p", String(pid)], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     }).trim();
   } catch {
     return "";
@@ -3089,10 +3091,38 @@ function writeNativeHookJsonStdout(output: Record<string, unknown>): void {
   process.stdout.write(`${JSON.stringify(output)}\n`);
 }
 
+async function logNativeHookCliError(
+  cwd: string,
+  type: string,
+  error: unknown,
+  payload: CodexHookPayload = {},
+): Promise<void> {
+  const logsDir = join(cwd || process.cwd(), ".omx", "logs");
+  await mkdir(logsDir, { recursive: true }).catch(() => {});
+  const logPath = join(logsDir, `native-hook-${new Date().toISOString().split("T")[0]}.jsonl`);
+  await appendFile(
+    logPath,
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      type,
+      hook_event_name: readHookEventName(payload) ?? "Unknown",
+      session_id: readPayloadSessionId(payload) || undefined,
+      thread_id: readPayloadThreadId(payload) || undefined,
+      turn_id: readPayloadTurnId(payload) || undefined,
+      error: error instanceof Error ? error.message : String(error),
+    }) + "\n",
+  ).catch(() => {});
+}
+
 function isStopDispatchFailureTestTrigger(payload: CodexHookPayload): boolean {
   return process.env.NODE_ENV === "test"
     && process.env.OMX_NATIVE_HOOK_TEST_THROW_STOP_DISPATCH === "1"
     && readHookEventName(payload) === "Stop";
+}
+
+function isDispatchFailureTestTrigger(): boolean {
+  return process.env.NODE_ENV === "test"
+    && process.env.OMX_NATIVE_HOOK_TEST_THROW_DISPATCH === "1";
 }
 
 function buildStopDispatchFailureOutput(error: unknown): Record<string, unknown> {
@@ -3110,6 +3140,7 @@ function buildStopDispatchFailureOutput(error: unknown): Record<string, unknown>
 export async function runCodexNativeHookCli(): Promise<void> {
   const { payload, parseError } = await readStdinJson();
   if (parseError) {
+    await logNativeHookCliError(process.cwd(), "native_hook_stdin_parse_error", parseError);
     writeNativeHookJsonStdout({
       decision: "block",
       reason: "OMX native hook received malformed JSON input. Preserve runtime state, inspect the emitting hook payload yourself, and retry with valid JSON.",
@@ -3126,6 +3157,9 @@ export async function runCodexNativeHookCli(): Promise<void> {
     if (isStopDispatchFailureTestTrigger(payload)) {
       throw new Error("test-induced Stop dispatch failure");
     }
+    if (isDispatchFailureTestTrigger()) {
+      throw new Error("test-induced dispatch failure");
+    }
 
     const result = await dispatchCodexNativeHook(payload);
     if (result.outputJson) {
@@ -3134,25 +3168,19 @@ export async function runCodexNativeHookCli(): Promise<void> {
       writeNativeHookJsonStdout({});
     }
   } catch (error) {
-    if (readHookEventName(payload) !== "Stop") {
-      throw error;
+    const cwd = safeString(payload.cwd).trim() || process.cwd();
+    await logNativeHookCliError(cwd, "native_hook_dispatch_error", error, payload);
+    if (readHookEventName(payload) === "Stop") {
+      writeNativeHookJsonStdout(buildStopDispatchFailureOutput(error));
+    } else {
+      process.exitCode = 1;
     }
-    process.stderr.write(
-      `[omx] codex-native Stop hook dispatch failed: ${
-        error instanceof Error ? error.message : String(error)
-      }\n`,
-    );
-    writeNativeHookJsonStdout(buildStopDispatchFailureOutput(error));
   }
 }
 
 if (isCodexNativeHookMainModule(import.meta.url, process.argv[1])) {
   runCodexNativeHookCli().catch((error) => {
-    process.stderr.write(
-      `[omx] codex-native-hook failed: ${
-        error instanceof Error ? error.message : String(error)
-      }\n`,
-    );
     process.exitCode = 1;
+    void logNativeHookCliError(process.cwd(), "native_hook_fatal_error", error);
   });
 }

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -771,8 +771,31 @@ async function main() {
   }
 }
 
+async function logFatalNotifyHookError(err: unknown): Promise<void> {
+  let cwd = process.cwd();
+  try {
+    const rawPayload = process.argv[process.argv.length - 1];
+    if (rawPayload && !rawPayload.startsWith('-')) {
+      const payload = JSON.parse(rawPayload) as Record<string, unknown>;
+      cwd = safeString(payload.cwd || payload['cwd'] || cwd) || cwd;
+    }
+  } catch {
+    // Keep notification hook failures silent in Codex TUI surfaces.
+  }
+
+  const logsDir = join(cwd, '.omx', 'logs');
+  await mkdir(logsDir, { recursive: true }).catch(() => {});
+  const logPath = join(logsDir, `notify-hook-${new Date().toISOString().split('T')[0]}.jsonl`);
+  await appendFile(logPath, JSON.stringify({
+    timestamp: new Date().toISOString(),
+    type: 'notify_hook_fatal_error',
+    error: err instanceof Error ? err.message : String(err),
+  }) + '\n').catch(() => {});
+}
+
 main().catch((err) => {
-  process.exitCode = 1;
-  // eslint-disable-next-line no-console
-  console.error('[notify-hook] fatal error:', err);
+  // Notify hooks are auxiliary background work. Avoid printing stack traces into
+  // Codex TUI/PowerShell foreground panes; record diagnostics in .omx/logs.
+  process.exitCode = 0;
+  void logFatalNotifyHookError(err);
 });

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -75,6 +75,7 @@ function readCurrentTmuxSessionName(): string {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 2000,
+      windowsHide: true,
     }).trim();
   } catch {
     return '';
@@ -104,13 +105,10 @@ async function readTmuxPaneInstanceId(paneTarget: string): Promise<string> {
 }
 
 function warnPaneInstanceFallback(paneTarget: string): void {
-  const target = safeString(paneTarget).trim();
-  if (!target) return;
-  try {
-    console.warn(`[omx] missing ${OMX_PANE_INSTANCE_OPTION} on ${target}; falling back to ${OMX_INSTANCE_OPTION}`);
-  } catch {
-    // warning is best effort only
-  }
+  // Notify hooks run inside Codex foreground hook surfaces. Keep this
+  // compatibility fallback silent; downstream tmux-hook events still record
+  // skipped/failed injection decisions in .omx/logs.
+  void paneTarget;
 }
 
 export async function resolveTmuxSessionForInstance(instanceId: string): Promise<string> {
@@ -146,6 +144,7 @@ function readParentPid(pid: number): number | null {
     const raw = execFileSync('ps', ['-o', 'ppid=', '-p', String(pid)], {
       encoding: 'utf-8',
       timeout: 2000,
+      windowsHide: true,
     }).trim();
     const ppid = Number(raw);
     return Number.isFinite(ppid) && ppid > 0 ? ppid : null;

--- a/src/scripts/notify-hook/process-runner.ts
+++ b/src/scripts/notify-hook/process-runner.ts
@@ -10,7 +10,10 @@ export function runProcess(command: string, args: string[], timeoutMs = 3000): P
     const relaxingTestTmuxTimeout = command === 'tmux' && process.env.OMX_TEST_RELAX_TMUX_TIMEOUT === '1';
     const executable = usingTestTmux ? process.env.OMX_TEST_TMUX_BIN as string : command;
     const effectiveTimeoutMs = usingTestTmux || relaxingTestTmuxTimeout ? Math.max(timeoutMs, 10_000) : timeoutMs;
-    const child = spawn(executable, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn(executable, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
     let stdout = '';
     let stderr = '';
     let finished = false;


### PR DESCRIPTION
## Summary
- keep native hook and notify-hook fatal diagnostics out of Codex foreground stderr/stdout while preserving fail-closed behavior
- hide Windows child process surfaces for notify tmux probes, hook plugin runners, and native hook `ps` probes
- silence managed tmux pane-instance fallback warnings and add foreground-isolation regressions

## Verification
- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/foreground-isolation-contract.test.js dist/hud/__tests__/reconcile.test.js dist/config/__tests__/codex-hooks.test.js dist/config/__tests__/generator-notify.test.js`
- `npm run check:no-unused`
- `npx biome lint src/scripts/codex-native-hook.ts src/scripts/notify-hook.ts src/scripts/notify-hook/process-runner.ts src/scripts/notify-hook/managed-tmux.ts src/hooks/extensibility/dispatcher.ts src/scripts/__tests__/codex-native-hook.test.ts src/hooks/__tests__/foreground-isolation-contract.test.ts src/hooks/__tests__/notify-hook-modules.test.ts`

Fixes #2126.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
