### PR TITLE
Fix Windows OMX root launch paths

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -39,6 +39,7 @@ import {
   resolveProjectLocalCodexHomeForLaunch,
   shouldAutoIsolateMadmaxLaunch,
   createMadmaxIsolatedRoot,
+  resolveOmxRootForLaunch,
   resolveDisposableWorktreeOmxRootForLaunch,
   prepareCodexHomeForLaunch,
   runtimeCodexHomePath,
@@ -137,6 +138,59 @@ describe("madmax state isolation", () => {
   });
 });
 
+describe("resolveOmxRootForLaunch", () => {
+  it("preserves POSIX absolute OMX_ROOT", () => {
+    assert.equal(
+      resolveOmxRootForLaunch("/repo", { OMX_ROOT: "/var/tmp/omx" }),
+      "/var/tmp/omx",
+    );
+  });
+
+  it("preserves Windows drive-letter absolute OMX_ROOT", () => {
+    assert.equal(
+      resolveOmxRootForLaunch("/repo", { OMX_ROOT: "C:\\Users\\me\\omx" }),
+      "C:\\Users\\me\\omx",
+    );
+  });
+
+  it("preserves Windows drive-letter absolute OMX_STATE_ROOT", () => {
+    assert.equal(
+      resolveOmxRootForLaunch("/repo", { OMX_STATE_ROOT: "D:\\omx-state" }),
+      "D:\\omx-state",
+    );
+  });
+
+  it("preserves UNC absolute OMX_ROOT", () => {
+    assert.equal(
+      resolveOmxRootForLaunch("/repo", { OMX_ROOT: "\\\\server\\share\\omx" }),
+      "\\\\server\\share\\omx",
+    );
+  });
+
+  it("joins relative OMX_ROOT to cwd", () => {
+    assert.equal(
+      resolveOmxRootForLaunch("/repo", { OMX_ROOT: "relative/omx" }),
+      join("/repo", "relative/omx"),
+    );
+  });
+
+  it("returns undefined for blank OMX_ROOT and OMX_STATE_ROOT", () => {
+    assert.equal(
+      resolveOmxRootForLaunch("/repo", { OMX_ROOT: "  ", OMX_STATE_ROOT: "" }),
+      undefined,
+    );
+  });
+
+  it("prefers OMX_ROOT over OMX_STATE_ROOT", () => {
+    assert.equal(
+      resolveOmxRootForLaunch("/repo", {
+        OMX_ROOT: "C:\\Users\\me\\root",
+        OMX_STATE_ROOT: "/state-root",
+      }),
+      "C:\\Users\\me\\root",
+    );
+  });
+});
 
 describe("disposable worktree state root resolution", () => {
   it("uses the source repo root for launch worktrees when no explicit root is set", () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFileSync, spawn } from "child_process";
-import { basename, dirname, join } from "path";
+import { basename, dirname, join, posix, win32 } from "path";
 import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { copyFile, cp, lstat, mkdir, readdir, rm, symlink } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
@@ -991,13 +991,17 @@ export function buildHudPaneCleanupTargets(
   return [...targets];
 }
 
+function isCrossPlatformAbsolutePath(raw: string): boolean {
+  return posix.isAbsolute(raw) || win32.isAbsolute(raw);
+}
+
 export function resolveOmxRootForLaunch(
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
   const raw = env.OMX_ROOT || env.OMX_STATE_ROOT;
   if (typeof raw !== "string" || raw.trim() === "") return undefined;
-  return raw.startsWith("/") ? raw : join(cwd, raw);
+  return isCrossPlatformAbsolutePath(raw) ? raw : join(cwd, raw);
 }
 
 function hasExplicitOmxRootEnv(env: NodeJS.ProcessEnv = process.env): boolean {


### PR DESCRIPTION
## Summary
- Detect absolute launch OMX roots with POSIX and Windows path rules
- Preserve Windows drive-letter and UNC OMX_ROOT/OMX_STATE_ROOT values instead of joining them to cwd
- Add focused resolveOmxRootForLaunch coverage for absolute, relative, blank, and precedence cases

Closes #2156

## Tests
- npm run build
- node --test --test-name-pattern 'resolveOmxRootForLaunch' dist/cli/__tests__/index.test.js
- npm run lint
- npm run check:no-unused

Note: full `node --test dist/cli/__tests__/index.test.js` was also run and currently fails in unrelated existing cleanupPostLaunchModeStateFiles/tmux extended-keys tests; the new resolveOmxRootForLaunch tests passed in that run.