### PR TITLE
Reduce CI critical-path latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@v2
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
@@ -50,6 +52,8 @@ jobs:
         with:
           toolchain: stable
           components: llvm-tools-preview
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run Rust tests with coverage summaries
@@ -86,7 +90,14 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: npm run lint
 
   typecheck:
@@ -99,7 +110,14 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: npx tsc --noEmit
       - run: npm run check:no-unused
 
@@ -113,7 +131,14 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: npm run build
       - name: Upload prebuilt dist artifact
         uses: actions/upload-artifact@v4
@@ -179,7 +204,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - name: Download prebuilt dist artifact
         uses: actions/download-artifact@v8
         with:
@@ -213,14 +245,21 @@ jobs:
     name: Coverage Gate (Team Critical)
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: [typecheck, build-dist]
+    needs: [build-dist]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - name: Download prebuilt dist artifact
         uses: actions/download-artifact@v8
         with:
@@ -256,14 +295,21 @@ jobs:
     name: Ralph Persistence Gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [typecheck, build-dist]
+    needs: [build-dist]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - name: Download prebuilt dist artifact
         uses: actions/download-artifact@v8
         with:
@@ -276,7 +322,7 @@ jobs:
     name: Build (Full Source Build)
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: [rustfmt, clippy, lint, typecheck, build-dist]
+    needs: [build-dist]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
@@ -287,7 +333,16 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@v2
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - name: Download prebuilt dist artifact
         uses: actions/download-artifact@v8
         with:

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -51,9 +51,9 @@ describe('CI Rust gates', () => {
     assert.match(workflow, /name:\s*Build dist artifact/);
     assert.match(workflow, /name:\s*Upload prebuilt dist artifact/);
     assert.match(workflow, /name:\s*ci-dist-node20/);
-    assert.match(workflow, /^  coverage-team-critical:\s*\n(?:.*\n)*?^\s+needs:\s*\[typecheck, build-dist\]/m);
-    assert.match(workflow, /^  ralph-persistence-gate:\s*\n(?:.*\n)*?^\s+needs:\s*\[typecheck, build-dist\]/m);
-    assert.match(workflow, /^  build:\s*\n(?:.*\n)*?^\s+needs:\s*\[rustfmt, clippy, lint, typecheck, build-dist\]/m);
+    assert.match(workflow, /^  coverage-team-critical:\s*\n(?:.*\n)*?^\s+needs:\s*\[build-dist\]/m);
+    assert.match(workflow, /^  ralph-persistence-gate:\s*\n(?:.*\n)*?^\s+needs:\s*\[build-dist\]/m);
+    assert.match(workflow, /^  build:\s*\n(?:.*\n)*?^\s+needs:\s*\[build-dist\]/m);
 
     for (const jobName of ['test', 'coverage-team-critical', 'ralph-persistence-gate', 'build']) {
       assert.match(
@@ -68,6 +68,25 @@ describe('CI Rust gates', () => {
     );
     assert.match(testJob, /^\s+- name:\s*Run grouped full-suite lane\s*\n(?:.*\n)*?^\s+run:\s*\|\n\s+node dist\/scripts\/run-test-files\.js/m);
     assert.doesNotMatch(testJob, /^\s+npm run build$/m);
+  });
+
+  it('caches dependency installs without weakening the CI status gate', () => {
+    const workflow = readCiWorkflow();
+
+    for (const jobName of ['lint', 'typecheck', 'build-dist', 'test', 'coverage-team-critical', 'ralph-persistence-gate', 'build']) {
+      const job = jobBlock(workflow, jobName);
+
+      assert.match(job, /uses:\s*actions\/cache@v4/);
+      assert.match(job, /path:\s*node_modules/);
+      assert.match(job, /key:\s*\$\{\{ runner\.os \}\}-node-modules-\$\{\{ hashFiles\('package-lock\.json'\) \}\}/);
+      assert.match(job, /if:\s*steps\.node-modules-cache\.outputs\.cache-hit != 'true'/);
+    }
+
+    for (const jobName of ['clippy', 'rust-tests', 'build']) {
+      assert.match(jobBlock(workflow, jobName), /uses:\s*Swatinem\/rust-cache@v2/);
+    }
+
+    assert.match(workflow, /needs:\s*\[rustfmt, clippy, rust-tests, lint, typecheck, test, coverage-team-critical, ralph-persistence-gate, build\]/);
   });
 
   it('avoids path-filtered CI triggers so required checks cannot be skipped into a pending state', () => {

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -10,9 +10,14 @@ function readCiWorkflow(): string {
 }
 
 function jobBlock(workflow: string, jobName: string): string {
-  const match = workflow.match(new RegExp(`^  ${jobName}:\\n([\\s\\S]*?)(?=^  [a-z0-9-]+:\\n|\\Z)`, 'm'));
-  assert.ok(match?.[0], `missing CI job block for ${jobName}`);
-  return match[0];
+  const startMatch = workflow.match(new RegExp(`(^|\\n)  ${jobName}:\\n`));
+  assert.ok(startMatch?.index !== undefined, `missing CI job block for ${jobName}`);
+
+  const start = startMatch.index + startMatch[1].length;
+  const afterJobHeader = start + `  ${jobName}:\n`.length;
+  const nextJobOffset = workflow.slice(afterJobHeader).search(/\n  [a-z0-9-]+:\n/);
+  const end = nextJobOffset === -1 ? workflow.length : afterJobHeader + nextJobOffset;
+  return workflow.slice(start, end);
 }
 
 describe('CI Rust gates', () => {
@@ -98,16 +103,34 @@ describe('CI Rust gates', () => {
   });
 
 
-  it('marks Rust formatting, Clippy, and tests as required in the CI status gate', () => {
+  it('marks every required CI lane as required and reported in the CI status gate', () => {
     const workflow = readCiWorkflow();
+    const ciStatusJob = jobBlock(workflow, 'ci-status');
+    const requiredJobs = [
+      'rustfmt',
+      'clippy',
+      'rust-tests',
+      'lint',
+      'typecheck',
+      'test',
+      'coverage-team-critical',
+      'ralph-persistence-gate',
+      'build',
+    ];
 
-    assert.match(workflow, /needs:\s*\[rustfmt, clippy, rust-tests, lint, typecheck, test, coverage-team-critical, ralph-persistence-gate, build\]/);
-    assert.match(workflow, /needs\.rustfmt\.result/);
-    assert.match(workflow, /needs\.clippy\.result/);
-    assert.match(workflow, /needs\.rust-tests\.result/);
-    assert.match(workflow, /echo "  rustfmt: \$\{\{ needs\.rustfmt\.result \}\}"/);
-    assert.match(workflow, /echo "  clippy: \$\{\{ needs\.clippy\.result \}\}"/);
-    assert.match(workflow, /echo "  rust-tests: \$\{\{ needs\.rust-tests\.result \}\}"/);
+    assert.match(
+      ciStatusJob,
+      /needs:\s*\[rustfmt, clippy, rust-tests, lint, typecheck, test, coverage-team-critical, ralph-persistence-gate, build\]/,
+    );
+
+    for (const jobName of requiredJobs) {
+      assert.match(ciStatusJob, new RegExp(`needs\\.${jobName}\\.result`), `${jobName} result should be checked`);
+      assert.match(
+        ciStatusJob,
+        new RegExp(`echo \"  ${jobName}: \\$\\{\\{ needs\\.${jobName}\\.result \\}\\}\"`),
+        `${jobName} result should be reported`,
+      );
+    }
   });
 
 


### PR DESCRIPTION
## Summary
- add `node_modules` cache restore + conditional `npm ci` across Node CI jobs
- add Rust build cache restore for clippy, Rust coverage tests, and native build jobs
- remove unnecessary job serialization so coverage, Ralph persistence, and native build start after `build-dist` while `ci-status` still enforces all required gates

## Validation
- `npm run build`
- `node .omx/goals/performance/ci-speed/evaluate-ci-speed.mjs` → baselineScore=180, targetScore=60, optimizedScore=20
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`

## Notes
- Attempted `npm run test:ci:compiled`; it was stopped after unrelated active-runtime/environment-sensitive failures in existing adapt/autoresearch/doctor tests.
