### PR TITLE
Improve deep-interview fact routing

### DIFF
--- a/plugins/oh-my-codex/skills/deep-interview/SKILL.md
+++ b/plugins/oh-my-codex/skills/deep-interview/SKILL.md
@@ -55,6 +55,14 @@ If no flag is provided, use **Standard**.
 - Keep total prompt payloads within a safe budget by summarizing or trimming retained history; preserve newest/highest-signal answers and never let raw oversized context crowd out the current question
 - Reduce user effort: ask only the highest-leverage unresolved question, and never ask the user for codebase facts that can be discovered directly
 - For brownfield work, prefer evidence-backed confirmation questions such as "I found X in Y. Should this change follow that pattern?"
+- Route facts before judgment in the Ouroboros style: before presenting a user-facing interview round, classify whether the needed information is a discoverable fact, a fact needing confirmation, or a human decision. The interview is with the human for judgment, not for facts the agent can inspect.
+- Use these transcript/spec labels only; never use them as `omx question` `source` values, and never replace the runtime `source: "deep-interview"` contract for user-facing deep-interview questions:
+  - `[from-code][auto-confirmed]` — exact, high-confidence codebase facts from manifests/configs or direct source evidence, with no prescription attached.
+  - `[from-code]` — codebase findings that are useful but inferred, pattern-based, or low/medium confidence and therefore need a confirmation-style user-facing round before being treated as settled.
+  - `[from-research]` — externally sourced facts such as API limits, compatibility, or public documentation; facts only, not decisions.
+  - `[from-user]` — goals, preferences, business logic, scope, non-goals, acceptance criteria, tradeoffs, and any decision-bearing interpretation.
+- Treat `[from-code][auto-confirmed]` and other non-user fact discoveries as context/transcript updates, not interview rounds: do not call `omx question`, do not create a pending deep-interview question obligation, and do not increment the user-facing round number for facts the agent can safely establish.
+- Auto-confirm only descriptive facts. If a finding implies what the new feature should do, which pattern it should follow, which tradeoff to accept, or what should stay in/out of scope, route the entire decision-bearing question to the user as `[from-user]` even when code or research facts are available.
 - In attached-tmux Codex CLI, deep-interview uses `omx question` as the required OMX-owned structured questioning path for every interview round
 - When invoking `omx question` through attached-tmux Bash/tool paths, preserve the leader-pane return target by prefixing the command with `OMX_QUESTION_RETURN_PANE=$TMUX_PANE` (or a concrete `%pane` value)
 - If you launch `omx question` in a background terminal, immediately wait for that background terminal to finish and read its JSON answer before scoring ambiguity, asking another round, or handing off
@@ -145,6 +153,8 @@ Follow-up pressure ladder after each answer:
 4. If the answer still describes symptoms, reframe toward essence / root cause before moving on
 
 Prefer staying on the same thread for multiple rounds when it has the highest leverage. Breadth without pressure is not progress.
+
+Maintain a **Breadth Ledger** across independent ambiguity tracks: scope, constraints, outputs, verification, brownfield integration, and any user-mentioned deliverable tracks. The ledger is a guard, not a mandatory rotation rule: stay deep on the current thread until it has been pressure-tested, then zoom out only when another material track remains unresolved and would change execution.
 
 Detailed dimensions:
 - Intent Clarity — why the user wants this
@@ -268,7 +278,9 @@ Readiness gate:
 - `Non-goals` must be explicit
 - `Decision Boundaries` must be explicit
 - A pressure pass must be complete: at least one earlier answer has been revisited with an evidence, assumption, or tradeoff follow-up
+- A practical closure audit must pass: another question would change execution materially, not merely polish wording or chase a narrow edge case
 - If either gate is unresolved, or the pressure pass is incomplete, continue interviewing even when weighted ambiguity is below threshold
+- Treat a low ambiguity score as permission to audit closure, not permission to keep drilling indefinitely. If remaining uncertainty would not change implementation, crystallize the spec or ask a final closure question instead of opening a new branch.
 
 ### 2d) Report progress
 Show weighted breakdown table, readiness-gate status (`Non-goals`, `Decision Boundaries`), and the next focus dimension.
@@ -278,6 +290,7 @@ Append round result and updated scores via `state_write`.
 
 ### 2f) Round controls
 - Do not offer early exit before the first explicit assumption probe and one persistent follow-up have happened
+- Apply a **Dialectic Rhythm Guard**: track consecutive non-user fact discoveries and confirmation-style answers (`[from-code][auto-confirmed]`, `[from-code]`, or `[from-research]`). After 3 consecutive non-user or confirmation answers, the next material user-facing round must solicit direct human judgment (`[from-user]`) unless the closure audit says the interview is ready to crystallize.
 - Round 4+: allow explicit early exit with risk warning
 - Soft warning at profile midpoint (e.g., round 3/6/10 depending on profile)
 - Hard cap at profile `max_rounds`

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -55,6 +55,14 @@ If no flag is provided, use **Standard**.
 - Keep total prompt payloads within a safe budget by summarizing or trimming retained history; preserve newest/highest-signal answers and never let raw oversized context crowd out the current question
 - Reduce user effort: ask only the highest-leverage unresolved question, and never ask the user for codebase facts that can be discovered directly
 - For brownfield work, prefer evidence-backed confirmation questions such as "I found X in Y. Should this change follow that pattern?"
+- Route facts before judgment in the Ouroboros style: before presenting a user-facing interview round, classify whether the needed information is a discoverable fact, a fact needing confirmation, or a human decision. The interview is with the human for judgment, not for facts the agent can inspect.
+- Use these transcript/spec labels only; never use them as `omx question` `source` values, and never replace the runtime `source: "deep-interview"` contract for user-facing deep-interview questions:
+  - `[from-code][auto-confirmed]` — exact, high-confidence codebase facts from manifests/configs or direct source evidence, with no prescription attached.
+  - `[from-code]` — codebase findings that are useful but inferred, pattern-based, or low/medium confidence and therefore need a confirmation-style user-facing round before being treated as settled.
+  - `[from-research]` — externally sourced facts such as API limits, compatibility, or public documentation; facts only, not decisions.
+  - `[from-user]` — goals, preferences, business logic, scope, non-goals, acceptance criteria, tradeoffs, and any decision-bearing interpretation.
+- Treat `[from-code][auto-confirmed]` and other non-user fact discoveries as context/transcript updates, not interview rounds: do not call `omx question`, do not create a pending deep-interview question obligation, and do not increment the user-facing round number for facts the agent can safely establish.
+- Auto-confirm only descriptive facts. If a finding implies what the new feature should do, which pattern it should follow, which tradeoff to accept, or what should stay in/out of scope, route the entire decision-bearing question to the user as `[from-user]` even when code or research facts are available.
 - In attached-tmux Codex CLI, deep-interview uses `omx question` as the required OMX-owned structured questioning path for every interview round
 - When invoking `omx question` through attached-tmux Bash/tool paths, preserve the leader-pane return target by prefixing the command with `OMX_QUESTION_RETURN_PANE=$TMUX_PANE` (or a concrete `%pane` value)
 - If you launch `omx question` in a background terminal, immediately wait for that background terminal to finish and read its JSON answer before scoring ambiguity, asking another round, or handing off
@@ -145,6 +153,8 @@ Follow-up pressure ladder after each answer:
 4. If the answer still describes symptoms, reframe toward essence / root cause before moving on
 
 Prefer staying on the same thread for multiple rounds when it has the highest leverage. Breadth without pressure is not progress.
+
+Maintain a **Breadth Ledger** across independent ambiguity tracks: scope, constraints, outputs, verification, brownfield integration, and any user-mentioned deliverable tracks. The ledger is a guard, not a mandatory rotation rule: stay deep on the current thread until it has been pressure-tested, then zoom out only when another material track remains unresolved and would change execution.
 
 Detailed dimensions:
 - Intent Clarity — why the user wants this
@@ -268,7 +278,9 @@ Readiness gate:
 - `Non-goals` must be explicit
 - `Decision Boundaries` must be explicit
 - A pressure pass must be complete: at least one earlier answer has been revisited with an evidence, assumption, or tradeoff follow-up
+- A practical closure audit must pass: another question would change execution materially, not merely polish wording or chase a narrow edge case
 - If either gate is unresolved, or the pressure pass is incomplete, continue interviewing even when weighted ambiguity is below threshold
+- Treat a low ambiguity score as permission to audit closure, not permission to keep drilling indefinitely. If remaining uncertainty would not change implementation, crystallize the spec or ask a final closure question instead of opening a new branch.
 
 ### 2d) Report progress
 Show weighted breakdown table, readiness-gate status (`Non-goals`, `Decision Boundaries`), and the next focus dimension.
@@ -278,6 +290,7 @@ Append round result and updated scores via `state_write`.
 
 ### 2f) Round controls
 - Do not offer early exit before the first explicit assumption probe and one persistent follow-up have happened
+- Apply a **Dialectic Rhythm Guard**: track consecutive non-user fact discoveries and confirmation-style answers (`[from-code][auto-confirmed]`, `[from-code]`, or `[from-research]`). After 3 consecutive non-user or confirmation answers, the next material user-facing round must solicit direct human judgment (`[from-user]`) unless the closure audit says the interview is ready to crystallize.
 - Round 4+: allow explicit early exit with risk warning
 - Soft warning at profile midpoint (e.g., round 3/6/10 depending on profile)
 - Hard cap at profile `max_rounds`

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -32,6 +32,10 @@ const deepInterviewSkill = readFileSync(
 	join(__dirname, "../../../skills/deep-interview/SKILL.md"),
 	"utf-8",
 );
+const pluginDeepInterviewSkill = readFileSync(
+	join(__dirname, "../../../plugins/oh-my-codex/skills/deep-interview/SKILL.md"),
+	"utf-8",
+);
 const autopilotSkill = readFileSync(
 	join(__dirname, "../../../skills/autopilot/SKILL.md"),
 	"utf-8",
@@ -111,6 +115,36 @@ describe("deep-interview Ouroboros contract", () => {
 			deepInterviewSkill,
 			/Round 4\+: allow explicit early exit with risk warning/i,
 		);
+	});
+
+	it("routes facts before judgment without changing the deep-interview question source", () => {
+		assert.match(deepInterviewSkill, /Route facts before judgment/i);
+		assert.match(deepInterviewSkill, /\[from-code\]\[auto-confirmed\]/i);
+		assert.match(deepInterviewSkill, /\[from-code\]/i);
+		assert.match(deepInterviewSkill, /\[from-research\]/i);
+		assert.match(deepInterviewSkill, /\[from-user\]/i);
+		assert.match(deepInterviewSkill, /transcript\/spec labels only/i);
+		assert.match(deepInterviewSkill, /never use them as `omx question` `source` values/i);
+		assert.match(deepInterviewSkill, /runtime `source: "deep-interview"` contract/i);
+		assert.match(deepInterviewSkill, /not interview rounds/i);
+		assert.match(deepInterviewSkill, /do not call `omx question`/i);
+		assert.match(deepInterviewSkill, /do not create a pending deep-interview question obligation/i);
+		assert.match(deepInterviewSkill, /Auto-confirm only descriptive facts/i);
+		assert.match(deepInterviewSkill, /decision-bearing question to the user as `\[from-user\]`/i);
+	});
+
+	it("adds Ouroboros-style rhythm, breadth, and practical closure guards", () => {
+		assert.match(deepInterviewSkill, /Breadth Ledger/i);
+		assert.match(deepInterviewSkill, /scope, constraints, outputs, verification, brownfield integration/i);
+		assert.match(deepInterviewSkill, /guard, not a mandatory rotation rule/i);
+		assert.match(deepInterviewSkill, /zoom out only when another material track remains unresolved/i);
+		assert.match(deepInterviewSkill, /practical closure audit/i);
+		assert.match(deepInterviewSkill, /another question would change execution materially/i);
+		assert.match(deepInterviewSkill, /not merely polish wording or chase a narrow edge case/i);
+		assert.match(deepInterviewSkill, /low ambiguity score as permission to audit closure/i);
+		assert.match(deepInterviewSkill, /Dialectic Rhythm Guard/i);
+		assert.match(deepInterviewSkill, /After 3 consecutive non-user or confirmation answers/i);
+		assert.match(deepInterviewSkill, /must solicit direct human judgment/i);
 	});
 
 	it("moves challenge modes and preserved evidence discipline earlier", () => {
@@ -340,6 +374,10 @@ describe("cross-skill and AGENTS coherence for deep-interview", () => {
 	it("autopilot references deep-interview handoff", () => {
 		assert.match(autopilotSkill, /deep-interview/i);
 		assert.match(autopilotSkill, /Socratic/i);
+	});
+
+	it("plugin mirror keeps the deep-interview skill aligned", () => {
+		assert.equal(pluginDeepInterviewSkill, deepInterviewSkill);
 	});
 
 	it("tracked AGENTS surfaces include ouroboros keyword and updated description", () => {


### PR DESCRIPTION
## Summary
- Add Ouroboros-style fact-vs-judgment routing guidance to `$deep-interview`
- Clarify `[from-code]`, `[from-research]`, and `[from-user]` are transcript/spec labels only, not structured-question source values
- Add Dialectic Rhythm Guard, Breadth Ledger, and practical closure audit guidance
- Lock the new contract with deep-interview tests and plugin mirror equality

## Testing
- `npm run build`
- `npm run sync:plugin`
- `npm run sync:plugin:check`
- `npm run verify:plugin-bundle`
- `node --test dist/hooks/__tests__/deep-interview-contract.test.js`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_SESSION_ID -u CODEX_SESSION_ID -u SESSION_ID node --test dist/hooks/__tests__/keyword-detector.test.js dist/question/__tests__/deep-interview.test.js`

## Notes
- No runtime/schema files changed.
- Full `npm test` not run; targeted build, sync, plugin, and contract/regression checks passed.
