### PR TITLE
Stabilize tmux-heavy local test timing

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -792,6 +792,9 @@ describe("codex native hook dispatch", () => {
     try {
       await writeFile(join(cwd, ".gitignore"), "node_modules/\n");
       execFileSync("git", ["init"], { cwd, stdio: "pipe" });
+      const emptyExcludesFile = join(cwd, "empty-global-ignore");
+      await writeFile(emptyExcludesFile, "");
+      execFileSync("git", ["config", "core.excludesfile", emptyExcludesFile], { cwd, stdio: "pipe" });
 
       const result = await dispatchCodexNativeHook(
         {

--- a/src/scripts/__tests__/run-test-files.test.ts
+++ b/src/scripts/__tests__/run-test-files.test.ts
@@ -70,6 +70,29 @@ describe('run-test-files diagnostics', () => {
     }
   });
 
+  it('serializes test files by default outside CI to avoid tmux and process watcher races', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omx-run-test-files-'));
+    try {
+      const testsDir = join(wd, '__tests__');
+      mkdirSync(testsDir, { recursive: true });
+      writeFileSync(
+        join(testsDir, 'pass.test.js'),
+        [
+          "import { test } from 'node:test';",
+          "test('passes', () => {});",
+          '',
+        ].join('\n'),
+      );
+
+      const result = runCompiledRunner(wd);
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /test concurrency 1/);
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
   it('serializes test files by default in CI to avoid cross-file child-process leaks', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omx-run-test-files-'));
     try {
@@ -111,6 +134,29 @@ describe('run-test-files diagnostics', () => {
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.match(result.stderr, /test concurrency 2/);
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to serialized execution when test concurrency override is invalid', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omx-run-test-files-'));
+    try {
+      const testsDir = join(wd, '__tests__');
+      mkdirSync(testsDir, { recursive: true });
+      writeFileSync(
+        join(testsDir, 'pass.test.js'),
+        [
+          "import { test } from 'node:test';",
+          "test('passes', () => {});",
+          '',
+        ].join('\n'),
+      );
+
+      const result = runCompiledRunner(wd, { OMX_NODE_TEST_CONCURRENCY: '0' });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /test concurrency 1/);
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }

--- a/src/scripts/notify-hook/__tests__/team-worker-posttooluse.test.ts
+++ b/src/scripts/notify-hook/__tests__/team-worker-posttooluse.test.ts
@@ -8,11 +8,14 @@ import { tmpdir } from 'node:os';
 import { handleTeamWorkerPostToolUseSuccess, teamWorkerPostToolUseInternals } from '../team-worker-posttooluse.js';
 import { readTeamEvents } from '../../../team/state/events.js';
 
-async function initWorkerFixture(): Promise<{ cwd: string; stateRoot: string; env: NodeJS.ProcessEnv }> {
+async function initWorkerFixture(): Promise<{ cwd: string; hooksDir: string; stateRoot: string; env: NodeJS.ProcessEnv }> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-posttooluse-worker-'));
   execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  const hooksDir = join(cwd, 'test-hooks');
+  await mkdir(hooksDir, { recursive: true });
+  execFileSync('git', ['config', 'core.hooksPath', hooksDir], { cwd, stdio: 'ignore' });
   await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
   execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
@@ -29,6 +32,7 @@ async function initWorkerFixture(): Promise<{ cwd: string; stateRoot: string; en
   await writeFile(join(stateRoot, 'team', 'demo-team', 'config.json'), JSON.stringify({ leader_cwd: cwd }, null, 2), 'utf-8');
   return {
     cwd,
+    hooksDir,
     stateRoot,
     env: {
       ...process.env,
@@ -138,7 +142,7 @@ describe('handleTeamWorkerPostToolUseSuccess', () => {
 
   it('unstages checkpointable paths when checkpoint commit fails after staging', async () => {
     const fixture = await initWorkerFixture();
-    const hookPath = join(fixture.cwd, '.git', 'hooks', 'prepare-commit-msg');
+    const hookPath = join(fixture.hooksDir, 'prepare-commit-msg');
     await writeFile(hookPath, '#!/bin/sh\nexit 42\n', 'utf-8');
     await chmod(hookPath, 0o755);
     await writeFile(join(fixture.cwd, 'commit-fail.txt'), 'must not remain staged\n', 'utf-8');

--- a/src/scripts/run-test-files.ts
+++ b/src/scripts/run-test-files.ts
@@ -4,7 +4,7 @@ import { join, resolve } from 'node:path';
 
 const DEFAULT_TEST_TIMEOUT_MS = 0;
 const DEFAULT_RUNNER_TIMEOUT_MS = 30 * 60 * 1_000;
-const DEFAULT_CI_TEST_CONCURRENCY = 1;
+const DEFAULT_TEST_CONCURRENCY = 1;
 
 function collectTests(path: string, out: string[]): void {
   let stats;
@@ -38,10 +38,10 @@ function parseTestConcurrency(env: NodeJS.ProcessEnv): number | undefined {
   if (rawValue) {
     const parsed = Number(rawValue);
     if (Number.isFinite(parsed) && parsed >= 1) return Math.floor(parsed);
-    return undefined;
+    return DEFAULT_TEST_CONCURRENCY;
   }
 
-  return env.CI === 'true' || env.GITHUB_ACTIONS === 'true' ? DEFAULT_CI_TEST_CONCURRENCY : undefined;
+  return DEFAULT_TEST_CONCURRENCY;
 }
 
 const roots = process.argv.slice(2);


### PR DESCRIPTION
## Summary
- Default the Node test-file runner to serialized execution (`--test-concurrency=1`) for local and CI runs so tmux, watcher, and process-heavy suites do not race under Node default parallelism.
- Keep `OMX_NODE_TEST_CONCURRENCY` as the explicit opt-in for parallel runs, and fall back to serialized execution when the override is invalid.
- Make Git-based tests hermetic against developer-machine `core.excludesfile` and `core.hooksPath` settings.

## Validation
- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js --test-name-pattern 'adds .omx/'`
- `node --test dist/scripts/notify-hook/__tests__/team-worker-posttooluse.test.js --test-name-pattern 'unstages checkpointable paths'`
- `node --test dist/scripts/__tests__/run-test-files.test.js`
- `npm run lint`
- `npm run test:node` (4,566 tests, 0 failures; runner reported `test concurrency 1`)