### PR TITLE
Fix stale autopilot skill-active HUD state

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -847,6 +847,46 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     assert.match(warnings[0] ?? "", /skipped malformed mode state .*ralph-state\.json/);
   });
 
+  it("reconciles root skill-active entries for the finished terminal session", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-root-skill-active-"));
+    const sessionId = "sess-terminal-autopilot";
+    const otherSessionId = "sess-other";
+    const stateDir = join(wd, ".omx", "state");
+    const sessionStateDir = join(stateDir, "sessions", sessionId);
+
+    try {
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeFile(
+        join(stateDir, "skill-active-state.json"),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: "autopilot",
+          phase: "ralph",
+          session_id: sessionId,
+          initialized_state_path: `.omx/state/sessions/${sessionId}/autopilot-state.json`,
+          active_skills: [
+            { skill: "autopilot", phase: "ralph", active: true, session_id: sessionId },
+            { skill: "team", phase: "running", active: true, session_id: otherSessionId },
+          ],
+        }, null, 2),
+        "utf-8",
+      );
+
+      await cleanupPostLaunchModeStateFiles(wd, sessionId);
+
+      const rootCanonical = JSON.parse(
+        await readFile(join(stateDir, "skill-active-state.json"), "utf-8"),
+      ) as { active?: boolean; active_skills?: Array<{ skill?: string; session_id?: string }> };
+      assert.equal(rootCanonical.active, true);
+      assert.deepEqual(rootCanonical.active_skills, [
+        { skill: "team", phase: "running", active: true, session_id: otherSessionId },
+      ]);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("clears canonical skill-active entries during cleanup and hides them from HUD/overlay readers", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-skill-active-cleanup-"));
     const sessionId = "sess-skill-active-cleanup";

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -887,6 +887,59 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     }
   });
 
+  it("preserves other-session active skills when session mode cleanup syncs before root scrub", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-mode-root-skill-active-"));
+    const sessionId = "sess-terminal-autopilot";
+    const otherSessionId = "sess-other-team";
+    const stateDir = join(wd, ".omx", "state");
+    const sessionStateDir = join(stateDir, "sessions", sessionId);
+
+    try {
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeFile(
+        join(stateDir, "skill-active-state.json"),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: "autopilot",
+          phase: "ralph",
+          session_id: sessionId,
+          initialized_state_path: `.omx/state/sessions/${sessionId}/autopilot-state.json`,
+          active_skills: [
+            { skill: "autopilot", phase: "ralph", active: true, session_id: sessionId },
+            { skill: "team", phase: "running", active: true, session_id: otherSessionId },
+          ],
+        }, null, 2),
+        "utf-8",
+      );
+      await writeFile(
+        join(sessionStateDir, "autopilot-state.json"),
+        JSON.stringify({ active: true, mode: "autopilot", current_phase: "ralph" }, null, 2),
+        "utf-8",
+      );
+
+      await cleanupPostLaunchModeStateFiles(wd, sessionId);
+
+      const autopilotState = JSON.parse(
+        await readFile(join(sessionStateDir, "autopilot-state.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(autopilotState.active, false);
+      assert.equal(autopilotState.current_phase, "cancelled");
+
+      const rootCanonical = JSON.parse(
+        await readFile(join(stateDir, "skill-active-state.json"), "utf-8"),
+      ) as { active?: boolean; skill?: string; phase?: string; active_skills?: Array<Record<string, unknown>> };
+      assert.equal(rootCanonical.active, true);
+      assert.equal(rootCanonical.skill, "team");
+      assert.equal(rootCanonical.phase, "running");
+      assert.deepEqual(rootCanonical.active_skills, [
+        { skill: "team", phase: "running", active: true, session_id: otherSessionId },
+      ]);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("clears canonical skill-active entries during cleanup and hides them from HUD/overlay readers", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-skill-active-cleanup-"));
     const sessionId = "sess-skill-active-cleanup";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -75,6 +75,7 @@ import {
   listActiveSkills,
   readSkillActiveState,
   syncCanonicalSkillStateForMode,
+  type SkillActiveStateLike,
 } from "../state/skill-active.js";
 import { isTrackedWorkflowMode } from "../state/workflow-transition.js";
 import { maybeCheckAndPromptUpdate, runImmediateUpdate } from "./update.js";
@@ -2900,12 +2901,13 @@ async function scrubPostLaunchRootSkillActiveForSession(
   sessionId: string,
   nowIso: string,
   writeFileFn: typeof import("fs/promises").writeFile,
+  rootStateBeforeCleanup?: SkillActiveStateLike | null,
 ): Promise<void> {
   const normalizedSessionId = cleanPostLaunchString(sessionId);
   if (!normalizedSessionId) return;
 
   const { rootPath } = getSkillActiveStatePaths(cwd);
-  const rootState = await readSkillActiveState(rootPath);
+  const rootState = rootStateBeforeCleanup ?? await readSkillActiveState(rootPath);
   if (!rootState) return;
 
   const rootSessionIds = postLaunchUniqueStrings([
@@ -2976,6 +2978,9 @@ export async function cleanupPostLaunchModeStateFiles(
   const scopedDirs = sessionId
     ? [getStateDir(cwd, sessionId)]
     : [getBaseStateDir(cwd)];
+  const rootSkillActiveStateBeforeCleanup = sessionId
+    ? await readSkillActiveState(getSkillActiveStatePaths(cwd).rootPath)
+    : null;
 
   for (const stateDir of scopedDirs) {
     const files = await readdir(stateDir).catch(() => [] as string[]);
@@ -3061,7 +3066,13 @@ export async function cleanupPostLaunchModeStateFiles(
 
   if (sessionId) {
     try {
-      await scrubPostLaunchRootSkillActiveForSession(cwd, sessionId, now().toISOString(), writeFile);
+      await scrubPostLaunchRootSkillActiveForSession(
+        cwd,
+        sessionId,
+        now().toISOString(),
+        writeFile,
+        rootSkillActiveStateBeforeCleanup,
+      );
     } catch (err) {
       writeWarn(
         `[omx] postLaunch: failed to reconcile root skill-active state: ${err instanceof Error ? err.message : err}`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -68,7 +68,14 @@ export {
   resolveCodexHomeForLaunch,
   resolveProjectLocalCodexHomeForLaunch,
 } from "./codex-home.js";
-import { SKILL_ACTIVE_STATE_MODE, syncCanonicalSkillStateForMode } from "../state/skill-active.js";
+import {
+  SKILL_ACTIVE_STATE_MODE,
+  extractSessionIdFromInitializedStatePath,
+  getSkillActiveStatePaths,
+  listActiveSkills,
+  readSkillActiveState,
+  syncCanonicalSkillStateForMode,
+} from "../state/skill-active.js";
 import { isTrackedWorkflowMode } from "../state/workflow-transition.js";
 import { maybeCheckAndPromptUpdate, runImmediateUpdate } from "./update.js";
 import { maybePromptGithubStar } from "./star-prompt.js";
@@ -2880,6 +2887,55 @@ async function readPostLaunchModeStateFile(
   return { kind: "recoverable" };
 }
 
+function cleanPostLaunchString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function postLaunchUniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+async function scrubPostLaunchRootSkillActiveForSession(
+  cwd: string,
+  sessionId: string,
+  nowIso: string,
+  writeFileFn: typeof import("fs/promises").writeFile,
+): Promise<void> {
+  const normalizedSessionId = cleanPostLaunchString(sessionId);
+  if (!normalizedSessionId) return;
+
+  const { rootPath } = getSkillActiveStatePaths(cwd);
+  const rootState = await readSkillActiveState(rootPath);
+  if (!rootState) return;
+
+  const rootSessionIds = postLaunchUniqueStrings([
+    cleanPostLaunchString(rootState.session_id),
+    cleanPostLaunchString(extractSessionIdFromInitializedStatePath(rootState.initialized_state_path)),
+  ]);
+  const rootBelongsToSession = rootSessionIds.includes(normalizedSessionId);
+  const entries = listActiveSkills(rootState);
+  const keptEntries = entries.filter((entry) => {
+    const entrySessionId = cleanPostLaunchString(entry.session_id);
+    if (entrySessionId) return entrySessionId !== normalizedSessionId;
+    return !rootBelongsToSession;
+  });
+
+  if (keptEntries.length === entries.length && rootState.active !== true) return;
+  if (keptEntries.length === entries.length && !rootBelongsToSession) return;
+
+  const nextRoot = {
+    ...rootState,
+    active: keptEntries.length > 0,
+    skill: keptEntries[0]?.skill ?? (keptEntries.length > 0 ? cleanPostLaunchString(rootState.skill) : ""),
+    phase: keptEntries[0]?.phase ?? (keptEntries.length > 0 ? cleanPostLaunchString(rootState.phase) : "complete"),
+    updated_at: nowIso,
+    active_skills: keptEntries,
+    post_launch_reconciled_at: nowIso,
+    post_launch_reconciliation_reason: "terminal_session_cleanup",
+  };
+  await writeFileFn(rootPath, JSON.stringify(nextRoot, null, 2));
+}
+
 function buildRecoveredPostLaunchModeState(
   mode: string,
   completedAt: string,
@@ -3000,6 +3056,16 @@ export async function cleanupPostLaunchModeStateFiles(
           `[omx] postLaunch: failed to update mode state ${path}: ${err instanceof Error ? err.message : err}`,
         );
       }
+    }
+  }
+
+  if (sessionId) {
+    try {
+      await scrubPostLaunchRootSkillActiveForSession(cwd, sessionId, now().toISOString(), writeFile);
+    } catch (err) {
+      writeWarn(
+        `[omx] postLaunch: failed to reconcile root skill-active state: ${err instanceof Error ? err.message : err}`,
+      );
     }
   }
 }

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -564,6 +564,32 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('does not resurrect terminal autopilot from stale canonical skill-active phase', async () => {
+    await withTempRepo('omx-hud-canonical-autopilot-terminal-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-autopilot-terminal';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'autopilot',
+        phase: 'ralph',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'ralph', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: false,
+        mode: 'autopilot',
+        current_phase: 'complete',
+        completed_at: '2026-05-07T00:00:00.000Z',
+      }));
+
+      const state = await readAllState(cwd);
+      assert.equal(state.autopilot, null);
+    });
+  });
+
   it('suppresses stale autoresearch detail when canonical session skill state excludes it', async () => {
     await withTempRepo('omx-hud-canonical-autoresearch-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -341,6 +341,25 @@ export function buildGitBranchLabel(
   return repoLabel ? `${repoLabel}/${branch}` : branch;
 }
 
+const TERMINAL_OR_INACTIVE_PHASES = new Set(['complete', 'completed', 'cancelled', 'canceled', 'failed', 'inactive', 'cleared']);
+
+function isMissingTerminalOrInactiveDetail(detail: { active?: boolean; current_phase?: string } | null): boolean {
+  if (!detail) return true;
+  if (detail.active !== true) return true;
+  const phase = sanitizeOptionalString(detail.current_phase)?.toLowerCase();
+  return phase ? TERMINAL_OR_INACTIVE_PHASES.has(phase) : false;
+}
+
+function shouldSurfaceCanonicalSkill(
+  canonicalSkills: Map<string, { phase?: string }>,
+  skill: string,
+  detail: { active?: boolean; current_phase?: string } | null,
+  useCompatibilityFallback: boolean,
+): boolean {
+  if (!canonicalSkills.has(skill) && !useCompatibilityFallback) return false;
+  return !isMissingTerminalOrInactiveDetail(detail);
+}
+
 function canonicalPhaseForSkill(
   canonicalSkills: Map<string, { phase?: string }>,
   skill: string,
@@ -416,19 +435,19 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     readSessionAwareModeState<TeamStateForHud>(cwd, 'team'),
   ]);
 
-  const ralph = canonicalSkills.has('ralph') || useCompatibilityFallback
+  const ralph = shouldSurfaceCanonicalSkill(canonicalSkills, 'ralph', ralphDetail, useCompatibilityFallback)
     ? (ralphDetail?.active === true ? mergePhase(ralphDetail, canonicalPhaseForSkill(canonicalSkills, 'ralph')) : null)
     : null;
-  const ultrawork = canonicalSkills.has('ultrawork') || useCompatibilityFallback
+  const ultrawork = shouldSurfaceCanonicalSkill(canonicalSkills, 'ultrawork', ultraworkDetail, useCompatibilityFallback)
     ? mergePhase(ultraworkDetail?.active === true ? ultraworkDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ultrawork'))
     : null;
-  const autopilot = canonicalSkills.has('autopilot') || useCompatibilityFallback
+  const autopilot = shouldSurfaceCanonicalSkill(canonicalSkills, 'autopilot', autopilotDetail, useCompatibilityFallback)
     ? mergePhase(autopilotDetail?.active === true ? autopilotDetail : null, canonicalPhaseForSkill(canonicalSkills, 'autopilot'))
     : null;
-  const ralplan = canonicalSkills.has('ralplan') || useCompatibilityFallback
+  const ralplan = shouldSurfaceCanonicalSkill(canonicalSkills, 'ralplan', ralplanDetail, useCompatibilityFallback)
     ? mergePhase(ralplanDetail?.active === true ? ralplanDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ralplan'))
     : null;
-  const deepInterview = canonicalSkills.has('deep-interview') || useCompatibilityFallback
+  const deepInterview = shouldSurfaceCanonicalSkill(canonicalSkills, 'deep-interview', deepInterviewDetail, useCompatibilityFallback)
     ? (() => {
       const merged = mergePhase(
         deepInterviewDetail?.active === true ? {
@@ -440,18 +459,18 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
       return merged;
     })()
     : null;
-  const ultraqa = canonicalSkills.has('ultraqa') || useCompatibilityFallback
+  const ultraqa = shouldSurfaceCanonicalSkill(canonicalSkills, 'ultraqa', ultraqaDetail, useCompatibilityFallback)
     ? mergePhase(ultraqaDetail?.active === true ? ultraqaDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ultraqa'))
     : null;
   const canonicalTeamPhase = await readCanonicalTeamPhase(cwd, teamDetail?.active === true ? teamDetail : null);
-  const team = canonicalSkills.has('team') || useCompatibilityFallback
+  const team = shouldSurfaceCanonicalSkill(canonicalSkills, 'team', teamDetail, useCompatibilityFallback)
     ? mergeTeamPhase(
       teamDetail?.active === true ? teamDetail : null,
       canonicalPhaseForSkill(canonicalSkills, 'team'),
       canonicalTeamPhase,
     )
     : null;
-  const autoresearch = canonicalSkills.has('autoresearch') || useCompatibilityFallback
+  const autoresearch = shouldSurfaceCanonicalSkill(canonicalSkills, 'autoresearch', autoresearchDetail, useCompatibilityFallback)
     ? mergePhase(
       autoresearchDetail?.active === true ? autoresearchDetail : null,
       canonicalPhaseForSkill(canonicalSkills, 'autoresearch'),


### PR DESCRIPTION
## Summary
- Reconcile root skill-active entries for a finished post-launch session so stale autopilot entries are removed while preserving other sessions
- Preserve other-session active skills when session-scoped post-launch mode cleanup syncs canonical skill state before the final root scrub
- Guard HUD state assembly from resurrecting canonical skills when their mode detail is missing, inactive, or terminal
- Add regressions for terminal autopilot no longer rendering as `autopilot:ralph`, root skill-active cleanup, and the review-blocker mixed-session repro

## Verification
- `npm run build`
- `npm run check:no-unused`
- `env -u OMX_SESSION_ID -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/hud/__tests__/state.test.js dist/cli/__tests__/index.test.js`
- `git diff --check origin/dev...HEAD`

Fixes #2162
