### PR TITLE
fix: preserve ambiguous approved team bindings

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -518,6 +518,50 @@ describe('parseTeamStartArgs', () => {
     }
   });
 
+  it('fails closed for a short follow-up when the persisted approved binding is ambiguous', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-bound-ambiguous-'));
+    const previousCwd = process.cwd();
+    const approvedTask = 'Execute approved issue 956 plan';
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(plansDir, { recursive: true });
+      await writeFile(
+        join(plansDir, 'prd-issue-956.md'),
+        [
+          '# Approved plan',
+          '',
+          `Launch via omx team 4:executor "${approvedTask}"`,
+          `Launch via omx team 6:debugger "${approvedTask}"`,
+        ].join('\n'),
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-956.md'), '# Test spec\n');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(stateDir, 'team-state.json'),
+        JSON.stringify({
+          active: true,
+          team_name: 'bound-team-ambiguous',
+          task_description: approvedTask,
+          agent_count: 4,
+        }, null, 2),
+      );
+      await writePersistedApprovedTeamExecutionBinding('bound-team-ambiguous', wd, {
+        prd_path: join(plansDir, 'prd-issue-956.md'),
+        task: approvedTask,
+      });
+
+      assert.throws(
+        () => parseTeamStartArgs(['team']),
+        /approved_execution_binding_ambiguous:.*Execute approved issue 956 plan/,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed for a short team follow-up when the selected PRD lists multiple team launch hints', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-ambiguous-'));
     const previousCwd = process.cwd();

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -181,6 +181,11 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
     if (continuity.status === 'malformed') {
       throw new Error(`approved_execution_binding_malformed:${persistedTeamName}`);
     }
+    if (continuity.status === 'ambiguous') {
+      throw new Error(
+        `approved_execution_binding_ambiguous:${continuity.binding.prd_path}:${continuity.binding.task}`,
+      );
+    }
     if (continuity.status === 'stale') {
       throw new Error(`approved_execution_binding_stale:${continuity.binding.prd_path}:${continuity.binding.task}`);
     }

--- a/src/team/__tests__/approved-execution.test.ts
+++ b/src/team/__tests__/approved-execution.test.ts
@@ -102,6 +102,91 @@ describe('approved execution binding', () => {
     });
   });
 
+  it('reports an ambiguous continuity state when a task-only binding matches multiple team launch hints', async () => {
+    await withUnboxedOmxRoot(async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-ambiguous-'));
+      const stateRoot = join(cwd, '.omx', 'state');
+      const approvedTask = 'Execute approved issue 1316 plan';
+      try {
+        const plansDir = join(cwd, '.omx', 'plans');
+        await mkdir(plansDir, { recursive: true });
+        const prdPath = join(plansDir, 'prd-issue-1316.md');
+        await writeFile(
+          prdPath,
+          [
+            '# Approved plan',
+            '',
+            `Launch via omx team 2:executor "${approvedTask}"`,
+            `Launch via omx team 5:debugger "${approvedTask}"`,
+          ].join('\n'),
+        );
+        await writeFile(join(plansDir, 'test-spec-issue-1316.md'), '# Test spec\n');
+        await writePersistedApprovedTeamExecutionBinding('bound-team', cwd, {
+          prd_path: prdPath,
+          task: approvedTask,
+        }, stateRoot);
+
+        const state = await resolvePersistedApprovedTeamExecutionContinuityState(
+          'bound-team',
+          cwd,
+          stateRoot,
+        );
+        assert.equal(state.status, 'ambiguous');
+        if (state.status !== 'ambiguous') {
+          throw new Error('expected ambiguous continuity state');
+        }
+        assert.equal(state.binding.prd_path, prdPath);
+        assert.equal(state.binding.task, approvedTask);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('keeps an exact-command binding valid when the task text alone would be ambiguous', async () => {
+    await withUnboxedOmxRoot(async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-command-'));
+      const stateRoot = join(cwd, '.omx', 'state');
+      const approvedTask = 'Execute approved issue 1317 plan';
+      const exactCommand = `omx team 2:executor "${approvedTask}"`;
+      try {
+        const plansDir = join(cwd, '.omx', 'plans');
+        await mkdir(plansDir, { recursive: true });
+        const prdPath = join(plansDir, 'prd-issue-1317.md');
+        await writeFile(
+          prdPath,
+          [
+            '# Approved plan',
+            '',
+            `Launch via ${exactCommand}`,
+            `Launch via omx team 5:debugger "${approvedTask}"`,
+          ].join('\n'),
+        );
+        await writeFile(join(plansDir, 'test-spec-issue-1317.md'), '# Test spec\n');
+        await writePersistedApprovedTeamExecutionBinding('bound-team', cwd, {
+          prd_path: prdPath,
+          task: approvedTask,
+          command: exactCommand,
+        }, stateRoot);
+
+        const state = await resolvePersistedApprovedTeamExecutionContinuityState(
+          'bound-team',
+          cwd,
+          stateRoot,
+        );
+        assert.equal(state.status, 'valid');
+        if (state.status !== 'valid') {
+          throw new Error('expected valid continuity state');
+        }
+        assert.equal(state.approvedHint.command, exactCommand);
+        assert.equal(state.approvedHint.workerCount, 2);
+        assert.equal(state.approvedHint.agentType, 'executor');
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  });
+
   it('reports malformed and stale binding states explicitly', async () => {
     await withUnboxedOmxRoot(async () => {
       const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-invalid-'));

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6017,6 +6017,37 @@ esac
     }
   });
 
+  it('resumeTeam fails closed when the persisted approved binding is ambiguous', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-resume-ambiguous-'));
+    const approvedTask = 'Execute approved issue 2111 plan';
+    try {
+      await initTeamState('team-approved-resume', 'approved resume test', 'executor', 1, cwd);
+      await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+      const prdPath = join(cwd, '.omx', 'plans', 'prd-issue-2111.md');
+      await writeFile(
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          `Launch via omx team 2:executor "${approvedTask}"`,
+          `Launch via omx team 5:debugger "${approvedTask}"`,
+        ].join('\n'),
+      );
+      await writeFile(join(cwd, '.omx', 'plans', 'test-spec-issue-2111.md'), '# Test spec\n');
+      await writePersistedApprovedTeamExecutionBinding('team-approved-resume', cwd, {
+        prd_path: prdPath,
+        task: approvedTask,
+      });
+
+      await assert.rejects(
+        () => resumeTeam('team-approved-resume', cwd),
+        /approved_execution_binding_ambiguous:.*Execute approved issue 2111 plan/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('resumeTeam resolves approved binding continuity against the persisted leader cwd', async () => {
     const teamName = 'team-approved-shared-root';
     const leaderCwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-leader-'));
@@ -6390,6 +6421,60 @@ esac
       );
       assert.equal(
         existsSync(join(cwd, '.omx', 'state', 'team', 'team-approved-binding-stale')),
+        false,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam fails closed when an explicit approved execution binding is ambiguous', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-binding-ambiguous-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const approvedTask = 'Execute approved issue 1316 plan';
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+    const prdPath = join(cwd, '.omx', 'plans', 'prd-issue-1316.md');
+    await writeFile(
+      prdPath,
+      [
+        '# Approved plan',
+        '',
+        `Launch via omx team 2:executor "${approvedTask}"`,
+        `Launch via omx team 5:debugger "${approvedTask}"`,
+      ].join('\n'),
+    );
+    await writeFile(join(cwd, '.omx', 'plans', 'test-spec-issue-1316.md'), '# Test spec\n');
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    try {
+      await assert.rejects(
+        () => withPromptModeCodexEnv(binDir, {}, () =>
+          withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-approved-binding-ambiguous',
+              'approved binding ambiguous start test',
+              'executor',
+              1,
+              [{ subject: 's', description: 'd', owner: 'worker-1' }],
+              cwd,
+              {
+                approvedExecution: {
+                  prd_path: prdPath,
+                  task: approvedTask,
+                },
+              },
+            ),
+          ),
+        ),
+        /approved_execution_binding_ambiguous:.*Execute approved issue 1316 plan/,
+      );
+      assert.equal(
+        existsSync(join(cwd, '.omx', 'state', 'team', 'team-approved-binding-ambiguous')),
         false,
       );
     } finally {

--- a/src/team/approved-execution.ts
+++ b/src/team/approved-execution.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import {
-  readApprovedExecutionLaunchHint,
+  readApprovedExecutionLaunchHintOutcome,
   readPlanningArtifacts,
   type ApprovedExecutionLaunchHint,
 } from '../planning/artifacts.js';
@@ -25,7 +25,13 @@ export type PersistedApprovedTeamExecutionContinuityState =
   | { status: 'missing' }
   | { status: 'malformed' }
   | { status: 'stale'; binding: ApprovedTeamExecutionBinding }
+  | { status: 'ambiguous'; binding: ApprovedTeamExecutionBinding }
   | { status: 'valid'; binding: ApprovedTeamExecutionBinding; approvedHint: ApprovedExecutionLaunchHint };
+
+type ApprovedTeamExecutionHintBindingOutcome =
+  | { status: 'resolved'; approvedHint: ApprovedExecutionLaunchHint }
+  | { status: 'stale' }
+  | { status: 'ambiguous' };
 
 export function normalizeApprovedTeamExecutionBinding(
   value: unknown,
@@ -155,35 +161,54 @@ export async function writePersistedApprovedTeamExecutionBinding(
   await writeFile(path, `${JSON.stringify(normalized, null, 2)}\n`, 'utf-8');
 }
 
-export function readApprovedTeamExecutionHintFromBinding(
+function readApprovedTeamExecutionHintOutcomeForPrdPath(
+  cwd: string,
+  binding: ApprovedTeamExecutionBinding,
+  prdPath: string,
+): ApprovedTeamExecutionHintBindingOutcome {
+  const outcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team', {
+    prdPath,
+    task: binding.task,
+    command: binding.command,
+  });
+  if (outcome.status === 'resolved') {
+    return { status: 'resolved', approvedHint: outcome.hint };
+  }
+  if (outcome.status === 'ambiguous') {
+    return { status: 'ambiguous' };
+  }
+  return { status: 'stale' };
+}
+
+export function readApprovedTeamExecutionHintOutcomeFromBinding(
   cwd: string,
   binding: ApprovedTeamExecutionBinding | null | undefined,
-): ApprovedExecutionLaunchHint | null {
+): ApprovedTeamExecutionHintBindingOutcome | null {
   const normalized = normalizeApprovedTeamExecutionBinding(binding);
   if (!normalized) {
     return null;
   }
 
-  const direct = readApprovedExecutionLaunchHint(cwd, 'team', {
-    prdPath: normalized.prd_path,
-    task: normalized.task,
-    command: normalized.command,
-  });
-  if (direct) {
+  const direct = readApprovedTeamExecutionHintOutcomeForPrdPath(cwd, normalized, normalized.prd_path);
+  if (direct.status !== 'stale') {
     return direct;
   }
 
   const matchedPrdPath = readPlanningArtifacts(cwd).prdPaths.find((candidatePath) =>
     sameFilePath(candidatePath, normalized.prd_path));
   if (!matchedPrdPath || matchedPrdPath === normalized.prd_path) {
-    return null;
+    return direct;
   }
 
-  return readApprovedExecutionLaunchHint(cwd, 'team', {
-    prdPath: matchedPrdPath,
-    task: normalized.task,
-    command: normalized.command,
-  });
+  return readApprovedTeamExecutionHintOutcomeForPrdPath(cwd, normalized, matchedPrdPath);
+}
+
+export function readApprovedTeamExecutionHintFromBinding(
+  cwd: string,
+  binding: ApprovedTeamExecutionBinding | null | undefined,
+): ApprovedExecutionLaunchHint | null {
+  const outcome = readApprovedTeamExecutionHintOutcomeFromBinding(cwd, binding);
+  return outcome?.status === 'resolved' ? outcome.approvedHint : null;
 }
 
 export async function resolvePersistedApprovedTeamExecutionContinuityState(
@@ -196,10 +221,14 @@ export async function resolvePersistedApprovedTeamExecutionContinuityState(
     return state;
   }
 
-  const approvedHint = readApprovedTeamExecutionHintFromBinding(cwd, state.binding);
-  return approvedHint
-    ? { status: 'valid', binding: state.binding, approvedHint }
-    : { status: 'stale', binding: state.binding };
+  const approvedHintOutcome = readApprovedTeamExecutionHintOutcomeFromBinding(cwd, state.binding);
+  if (!approvedHintOutcome || approvedHintOutcome.status === 'stale') {
+    return { status: 'stale', binding: state.binding };
+  }
+  if (approvedHintOutcome.status === 'ambiguous') {
+    return { status: 'ambiguous', binding: state.binding };
+  }
+  return { status: 'valid', binding: state.binding, approvedHint: approvedHintOutcome.approvedHint };
 }
 
 export function resolvePersistedApprovedTeamExecutionContinuityStateSync(
@@ -212,8 +241,12 @@ export function resolvePersistedApprovedTeamExecutionContinuityStateSync(
     return state;
   }
 
-  const approvedHint = readApprovedTeamExecutionHintFromBinding(cwd, state.binding);
-  return approvedHint
-    ? { status: 'valid', binding: state.binding, approvedHint }
-    : { status: 'stale', binding: state.binding };
+  const approvedHintOutcome = readApprovedTeamExecutionHintOutcomeFromBinding(cwd, state.binding);
+  if (!approvedHintOutcome || approvedHintOutcome.status === 'stale') {
+    return { status: 'stale', binding: state.binding };
+  }
+  if (approvedHintOutcome.status === 'ambiguous') {
+    return { status: 'ambiguous', binding: state.binding };
+  }
+  return { status: 'valid', binding: state.binding, approvedHint: approvedHintOutcome.approvedHint };
 }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -135,7 +135,7 @@ import { readModeState, updateModeState } from '../modes/base.js';
 import {
   buildApprovedTeamExecutionBinding,
   normalizeApprovedTeamExecutionBinding,
-  readApprovedTeamExecutionHintFromBinding,
+  readApprovedTeamExecutionHintOutcomeFromBinding,
   resolvePersistedApprovedTeamExecutionContinuityState,
   writePersistedApprovedTeamExecutionBinding,
   type ApprovedTeamExecutionBinding,
@@ -2257,8 +2257,16 @@ export async function startTeam(
 
   const teamStateRoot = resolveCanonicalTeamStateRoot(leaderCwd);
   const requestedApprovedExecution = normalizeApprovedTeamExecutionBinding(options.approvedExecution);
-  const selectedApprovedExecutionHint = requestedApprovedExecution
-    ? readApprovedTeamExecutionHintFromBinding(leaderCwd, requestedApprovedExecution)
+  const requestedApprovedExecutionOutcome = requestedApprovedExecution
+    ? readApprovedTeamExecutionHintOutcomeFromBinding(leaderCwd, requestedApprovedExecution)
+    : null;
+  if (requestedApprovedExecution && requestedApprovedExecutionOutcome?.status === 'ambiguous') {
+    throw new Error(
+      `approved_execution_binding_ambiguous:${requestedApprovedExecution.prd_path}:${requestedApprovedExecution.task}`,
+    );
+  }
+  const selectedApprovedExecutionHint = requestedApprovedExecutionOutcome?.status === 'resolved'
+    ? requestedApprovedExecutionOutcome.approvedHint
     : null;
   if (requestedApprovedExecution && !selectedApprovedExecutionHint) {
     throw new Error(
@@ -3754,6 +3762,11 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
   );
   if (approvedExecutionState.status === 'malformed') {
     throw new Error(`approved_execution_binding_malformed:${sanitized}`);
+  }
+  if (approvedExecutionState.status === 'ambiguous') {
+    throw new Error(
+      `approved_execution_binding_ambiguous:${approvedExecutionState.binding.prd_path}:${approvedExecutionState.binding.task}`,
+    );
   }
   if (approvedExecutionState.status === 'stale') {
     throw new Error(


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Current upstream approved Team binding continuity stores the persisted
binding, but it collapses multiple matching Team launch hints into the same
`stale` path used for missing targets. That makes short follow-ups,
explicit approved starts, and resume emit the wrong failure and hides a
real binding conflict.

## Changes

- preserve a distinct `ambiguous` continuity state for approved Team bindings
- add a small outcome-preserving binding helper under the existing nullable
  hint reader
- fail closed with `approved_execution_binding_ambiguous:<prd_path>:<task>`
  in short follow-up parsing, explicit approved starts, and resume
- add focused tests for ambiguous task-only bindings, exact-command
  disambiguation, and the CLI/runtime fail-closed callers

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Focused validation run for this PR:
- `node --test dist/team/__tests__/approved-execution.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/runtime.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- No tracked issue for this narrow continuity fix.
