### PR TITLE
fix: preserve team-exec approved binding transport

### DIFF
--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -258,12 +258,22 @@ describe('Team Exec Stage', () => {
       assert.equal(result.status, 'completed');
       const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
       const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+      const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
       assert.equal(descriptor.task, 'Execute zeta handoff');
+      assert.deepEqual(descriptor.approvedExecution, {
+        prd_path: approvedPrdPath,
+        task: 'Execute zeta handoff',
+        command: 'omx team 5:debugger "Execute zeta handoff"',
+      });
       assert.match(instruction, /Execute zeta handoff/);
       assert.doesNotMatch(instruction, /plan-content/);
       assert.ok(Array.isArray(descriptor.availableAgentTypes));
       assert.ok((descriptor.availableAgentTypes as unknown[]).length > 0);
       assert.equal(typeof (descriptor.staffingPlan as Record<string, unknown>).staffingSummary, 'string');
+      assert.equal(runtimeCliInput.task, 'Execute zeta handoff');
+      assert.deepEqual(runtimeCliInput.approvedExecution, descriptor.approvedExecution);
+      assert.equal(runtimeCliInput.workerCount, 2);
+      assert.equal(runtimeCliInput.agentType, 'executor');
     } finally {
       process.chdir(previousCwd);
     }
@@ -514,9 +524,13 @@ describe('Team Exec Stage', () => {
     assert.equal(result.status, 'completed');
     const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
     const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+    const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
     assert.equal(descriptor.task, 'structural pipeline task');
+    assert.equal(descriptor.approvedExecution, null);
     assert.match(instruction, /structural pipeline task/);
     assert.doesNotMatch(instruction, /plan-content/);
+    assert.equal(runtimeCliInput.task, 'structural pipeline task');
+    assert.equal(runtimeCliInput.approvedExecution, null);
   });
 
   it('does not adopt a pre-existing approved plan when latestPlanPath is absent', async () => {
@@ -545,9 +559,13 @@ describe('Team Exec Stage', () => {
     assert.equal(result.status, 'completed');
     const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
     const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+    const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
     assert.equal(descriptor.task, 'generic pipeline task');
+    assert.equal(descriptor.approvedExecution, null);
     assert.match(instruction, /generic pipeline task/);
     assert.doesNotMatch(instruction, /Execute zeta handoff/);
+    assert.equal(runtimeCliInput.task, 'generic pipeline task');
+    assert.equal(runtimeCliInput.approvedExecution, null);
   });
 
   it('fails closed when latestPlanPath has no team launch hint', async () => {
@@ -625,6 +643,7 @@ describe('Team Exec Stage', () => {
         staffingPlan,
         useWorktrees: false,
         cwd: '/tmp/test',
+        approvedExecution: null,
       });
       const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
 
@@ -645,7 +664,8 @@ describe('Team Exec Stage', () => {
       assert.equal(runtimeCliInput.cwd, '/tmp/test');
       assert.ok(Array.isArray(runtimeCliInput.tasks));
       assert.equal((runtimeCliInput.tasks as unknown[]).length > 0, true);
-      assert.equal('task' in runtimeCliInput, false);
+      assert.equal(runtimeCliInput.task, 'implement feature');
+      assert.equal(runtimeCliInput.approvedExecution, null);
       assert.equal('useWorktrees' in runtimeCliInput, false);
       assert.equal(
         (runtimeCliInput.decompositionMetadata as Record<string, unknown>).decomposition_source,
@@ -668,11 +688,14 @@ describe('Team Exec Stage', () => {
         staffingPlan,
         useWorktrees: false,
         cwd: '/tmp',
+        approvedExecution: null,
       });
       const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
 
       assert.match(instruction, /runtime-cli\.js/);
       assert.match(instruction, /--input-json-base64/);
+      assert.equal(runtimeCliInput.task, longTask);
+      assert.equal(runtimeCliInput.approvedExecution, null);
       assert.equal(runtimeCliInput.workerCount, 1);
       assert.equal(runtimeCliInput.agentType, 'executor');
       assert.match(instruction, /staffing=/);
@@ -691,6 +714,7 @@ describe('Team Exec Stage', () => {
         staffingPlan,
         useWorktrees: false,
         cwd: 'C:\\repo with spaces',
+        approvedExecution: null,
       }, { platform: 'win32' });
       const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
       const commandPrefix = instruction.split('--input-json-base64')[0] ?? '';
@@ -701,6 +725,8 @@ describe('Team Exec Stage', () => {
       assert.doesNotMatch(encodedPayload, /[%&|<>"'\s]/);
       assert.doesNotMatch(instruction, /# staffing=/);
       assert.doesNotMatch(instruction, /# verify=/);
+      assert.equal(runtimeCliInput.task, task);
+      assert.equal(runtimeCliInput.approvedExecution, null);
       assert.equal(runtimeCliInput.workerCount, 1);
       assert.equal(runtimeCliInput.agentType, 'executor');
       assert.equal('agentTypes' in runtimeCliInput, false);
@@ -749,12 +775,15 @@ describe('Team Exec Stage', () => {
         staffingPlan,
         useWorktrees: false,
         cwd: tempDir,
+        approvedExecution: null,
       });
       const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
       const tasks = runtimeCliInput.tasks as Array<Record<string, unknown>>;
       const decompositionMetadata = runtimeCliInput.decompositionMetadata as Record<string, unknown>;
 
       assert.equal(runtimeCliInput.teamName, 'execute-approved-demo-plan');
+      assert.equal(runtimeCliInput.task, 'Execute approved demo plan');
+      assert.equal(runtimeCliInput.approvedExecution, null);
       assert.equal(runtimeCliInput.workerCount, 2);
       assert.equal(runtimeCliInput.agentType, 'executor');
       assert.equal(tasks.length, 2);

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -6,7 +6,6 @@
  * canonical OMX execution surface.
  */
 
-import { readFileSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
 import { buildRepoAwareTeamExecutionPlan, type TeamDecompositionMetadata } from '../../team/repo-aware-decomposition.js';
@@ -16,11 +15,15 @@ import {
   resolveAvailableAgentTypes,
 } from '../../team/followup-planner.js';
 import {
-  decodeApprovedExecutionQuotedValue,
+  readApprovedExecutionLaunchHintOutcome,
   readLatestPlanningArtifacts,
   readPlanningArtifacts,
   type PlanningArtifacts,
 } from '../../planning/artifacts.js';
+import {
+  buildApprovedTeamExecutionBinding,
+  type ApprovedTeamExecutionBinding,
+} from '../../team/approved-execution.js';
 import { packageRoot, sameFilePath } from '../../utils/paths.js';
 
 export interface TeamExecStageOptions {
@@ -36,8 +39,6 @@ export interface TeamExecStageOptions {
   /** Additional environment variables for worker launch. */
   extraEnv?: Record<string, string>;
 }
-
-const APPROVED_TEAM_LAUNCH_PATTERN = /(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
 
 function resolveRequestedTask(ctx: StageContext, ralplanArtifacts?: Record<string, unknown>): string {
   const ralplanTask = typeof ralplanArtifacts?.task === 'string' ? ralplanArtifacts.task.trim() : '';
@@ -138,43 +139,39 @@ function resolveApprovedTeamPlanPath(
   return selectedPrdPath;
 }
 
-function resolveApprovedTeamTaskFromPlanPath(
+function resolveApprovedTeamLaunchFromPlanPath(
   cwd: string,
   latestPlanPath: string,
   ralplanArtifacts?: Record<string, unknown>,
-): string {
+): { task: string; approvedExecution: ApprovedTeamExecutionBinding } {
   const approvedPlanPath = resolveApprovedTeamPlanPath(cwd, latestPlanPath, ralplanArtifacts);
-  let content = '';
-  try {
-    content = readFileSync(approvedPlanPath, 'utf-8');
-  } catch {
-    throw new Error(`team_exec_approved_handoff_missing:${approvedPlanPath}`);
-  }
-
-  const matches = [...content.matchAll(APPROVED_TEAM_LAUNCH_PATTERN)];
-  if (matches.length === 0) {
-    throw new Error(`team_exec_approved_handoff_missing:${approvedPlanPath}`);
-  }
-  if (matches.length > 1) {
+  const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team', {
+    prdPath: approvedPlanPath,
+  });
+  if (approvedHintOutcome.status === 'ambiguous') {
     throw new Error(`team_exec_approved_handoff_ambiguous:${approvedPlanPath}`);
   }
-
-  const task = matches[0]?.groups?.task ? decodeApprovedExecutionQuotedValue(matches[0].groups.task) : null;
-  if (!task) {
+  if (approvedHintOutcome.status !== 'resolved') {
     throw new Error(`team_exec_approved_handoff_missing:${approvedPlanPath}`);
   }
-  return task;
+  return {
+    task: approvedHintOutcome.hint.task,
+    approvedExecution: buildApprovedTeamExecutionBinding(approvedHintOutcome.hint),
+  };
 }
 
-function resolveTeamExecTask(ctx: StageContext, ralplanArtifacts?: Record<string, unknown>): string {
+function resolveTeamExecLaunch(
+  ctx: StageContext,
+  ralplanArtifacts?: Record<string, unknown>,
+): { task: string; approvedExecution: ApprovedTeamExecutionBinding | null } {
   const requestedTask = resolveRequestedTask(ctx, ralplanArtifacts);
   const latestPlanPath = typeof ralplanArtifacts?.latestPlanPath === 'string'
     ? ralplanArtifacts.latestPlanPath.trim()
     : '';
   if (!latestPlanPath) {
-    return requestedTask;
+    return { task: requestedTask, approvedExecution: null };
   }
-  return resolveApprovedTeamTaskFromPlanPath(ctx.cwd, latestPlanPath, ralplanArtifacts);
+  return resolveApprovedTeamLaunchFromPlanPath(ctx.cwd, latestPlanPath, ralplanArtifacts);
 }
 
 interface BuildTeamInstructionOptions {
@@ -199,10 +196,12 @@ interface TeamRuntimeCliTaskInput {
 
 interface TeamRuntimeCliLaunchInput {
   teamName: string;
+  task: string;
   workerCount: number;
   agentType: string;
   tasks: TeamRuntimeCliTaskInput[];
   cwd: string;
+  approvedExecution: ApprovedTeamExecutionBinding | null;
   decompositionMetadata?: TeamDecompositionMetadata;
 }
 
@@ -236,6 +235,7 @@ function buildTeamRuntimeCliLaunchInput(descriptor: TeamExecDescriptor): TeamRun
   });
   return {
     teamName: parsed.teamName,
+    task: descriptor.task,
     workerCount: executionPlan.workerCount,
     agentType: descriptor.agentType,
     tasks: executionPlan.tasks.map(({
@@ -268,6 +268,7 @@ function buildTeamRuntimeCliLaunchInput(descriptor: TeamExecDescriptor): TeamRun
       ...(symbolic_id ? { symbolic_id } : {}),
     })),
     cwd: descriptor.cwd,
+    approvedExecution: descriptor.approvedExecution,
     ...(executionPlan.metadata ? { decompositionMetadata: executionPlan.metadata } : {}),
   };
 }
@@ -294,7 +295,8 @@ export function createTeamExecStage(options: TeamExecStageOptions = {}): Pipelin
         const ralplanArtifacts = typeof ctx.artifacts['ralplan'] === 'object' && ctx.artifacts['ralplan'] !== null
           ? ctx.artifacts['ralplan'] as Record<string, unknown>
           : undefined;
-        const task = resolveTeamExecTask(ctx, ralplanArtifacts);
+        const launch = resolveTeamExecLaunch(ctx, ralplanArtifacts);
+        const task = launch.task;
         const availableAgentTypes = await resolveAvailableAgentTypes(ctx.cwd);
         const staffingPlan = buildFollowupStaffingPlan('team', task, availableAgentTypes, {
           workerCount,
@@ -311,6 +313,7 @@ export function createTeamExecStage(options: TeamExecStageOptions = {}): Pipelin
           useWorktrees: options.useWorktrees ?? false,
           cwd: ctx.cwd,
           extraEnv: options.extraEnv,
+          approvedExecution: launch.approvedExecution,
         };
 
         return {
@@ -353,6 +356,7 @@ export interface TeamExecDescriptor {
   staffingPlan: ReturnType<typeof buildFollowupStaffingPlan>;
   useWorktrees: boolean;
   cwd: string;
+  approvedExecution: ApprovedTeamExecutionBinding | null;
   extraEnv?: Record<string, string>;
 }
 

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -88,6 +88,30 @@ describe('runtime-cli helpers', () => {
     );
   });
 
+  it('prefers the explicit task transport over joined subtask subjects and falls back when absent', async () => {
+    const runtimeCli = await loadRuntimeCliModule();
+
+    assert.equal(
+      runtimeCli.resolveRuntimeCliTask({
+        task: 'Execute approved demo plan',
+        tasks: [
+          { subject: 'Implement runtime', description: 'Change runtime' },
+          { subject: 'Verify runtime', description: 'Cover runtime' },
+        ],
+      }),
+      'Execute approved demo plan',
+    );
+    assert.equal(
+      runtimeCli.resolveRuntimeCliTask({
+        tasks: [
+          { subject: 'Implement runtime', description: 'Change runtime' },
+          { subject: 'Verify runtime', description: 'Cover runtime' },
+        ],
+      }),
+      'Implement runtime; Verify runtime',
+    );
+  });
+
   it('refreshes pane targets from live team config after scale changes', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-live-'));
     try {

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -13,6 +13,7 @@ import { writeFile, rename } from 'fs/promises';
 import { join } from 'path';
 import { startTeam, monitorTeam, shutdownTeam } from './runtime.js';
 import type { TeamRuntime, TeamShutdownSummary, StaleTeamSummary } from './runtime.js';
+import type { ApprovedTeamExecutionBinding } from './approved-execution.js';
 import type { TeamDecompositionMetadata } from './repo-aware-decomposition.js';
 import { teamReadConfig as readTeamConfig } from './team-ops.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
@@ -39,6 +40,7 @@ async function promptStaleCleanup(summary: StaleTeamSummary): Promise<boolean> {
 
 interface CliInput {
   teamName: string;
+  task?: string;
   workerCount?: number;
   agentType?: string;
   agentTypes?: string[];
@@ -58,6 +60,7 @@ interface CliInput {
     symbolic_id?: string;
   }>;
   cwd: string;
+  approvedExecution?: ApprovedTeamExecutionBinding | null;
   pollIntervalMs?: number;
   decompositionMetadata?: TeamDecompositionMetadata;
 }
@@ -248,6 +251,14 @@ export function resolveRuntimeCliMissingFields(input: Partial<CliInput>): string
   return missing;
 }
 
+export function resolveRuntimeCliTask(input: Pick<CliInput, 'task' | 'tasks'>): string {
+  const explicitTask = typeof input.task === 'string' ? input.task.trim() : '';
+  if (explicitTask !== '') {
+    return explicitTask;
+  }
+  return input.tasks.map((task) => task.subject).join('; ');
+}
+
 export function resolveRuntimeCliInlineInput(argv: readonly string[]): string | null {
   const index = argv.indexOf(RUNTIME_CLI_INPUT_JSON_FLAG);
   if (index !== -1) {
@@ -379,6 +390,7 @@ async function main(): Promise<void> {
 
   // Start the team — OMX's startTeam takes individual parameters
   const agentType = resolveRuntimeCliAgentType(rawAgentType);
+  const task = resolveRuntimeCliTask(input);
   try {
     const providerMap = resolveRuntimeCliProviderMap(agentTypes, workerCount);
     const previousCliMap = process.env.OMX_TEAM_WORKER_CLI_MAP;
@@ -388,7 +400,7 @@ async function main(): Promise<void> {
       }
       runtime = await startTeam(
         teamName,
-        tasks.map(t => t.subject).join('; '),
+        task,
         agentType,
         workerCount,
         tasks,
@@ -396,6 +408,9 @@ async function main(): Promise<void> {
         {
           codexHomeOverride: resolveCodexHomeForLaunch(cwd, process.env),
           confirmStaleCleanup: promptStaleCleanup,
+          ...(Object.prototype.hasOwnProperty.call(input, 'approvedExecution')
+            ? { approvedExecution: input.approvedExecution ?? null }
+            : {}),
           ...(decompositionMetadata ? { decompositionMetadata } : {}),
         },
       );


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

`team-exec` already proves that `latestPlanPath` still matches the selected
approved PRD, but it only uses that authority to rewrite the task string.
The runtime-cli payload then drops the structured approved Team binding and
rebuilds the top-level task from derived subtask subjects.

## Changes

- switched the approved Team handoff path in `team-exec` from ad hoc PRD
  scraping to the shared approved-hint resolver after the existing
  stale-plan guard passes
- carried the resolved approved Team binding through the `team-exec`
  descriptor and into the runtime-cli payload as `approvedExecution`
- added explicit `task` transport to the runtime-cli payload and taught
  runtime-cli to prefer that explicit task over joined subtask subjects when
  starting the team
- added focused proof coverage for approved binding transport, generic
  `approvedExecution: null` transport, and explicit-task runtime-cli
  resolution

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
