### PR TITLE
fix: keep selected approved team handoffs amid incomplete drafts

### DIFF
--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -279,6 +279,48 @@ describe('Team Exec Stage', () => {
     }
   });
 
+  it('derives the team-exec task from the selected approved PRD when a newer draft is incomplete', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const approvedPrdPath = join(plansDir, 'prd-zeta.md');
+    await writeFile(
+      approvedPrdPath,
+      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+    await writeFile(join(plansDir, 'prd-zulu.md'), '# Zulu draft\n\nNo approved team launch here.\n');
+
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(tmpdir());
+      const stage = createTeamExecStage();
+      const result = await stage.run(makeCtx({
+        task: 'original request task',
+        artifacts: {
+          ralplan: {
+            task: 'original request task',
+            stage: 'ralplan',
+            latestPlanPath: join('.omx', 'plans', 'prd-zeta.md'),
+          },
+        },
+      }));
+
+      assert.equal(result.status, 'completed');
+      const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+      const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+      const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
+      assert.equal(descriptor.task, 'Execute zeta handoff');
+      assert.deepEqual(descriptor.approvedExecution, {
+        prd_path: approvedPrdPath,
+        task: 'Execute zeta handoff',
+        command: 'omx team 5:debugger "Execute zeta handoff"',
+      });
+      assert.deepEqual(runtimeCliInput.approvedExecution, descriptor.approvedExecution);
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
   it('derives the team-exec task when latestPlanPath is already cwd-prefixed', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -321,6 +321,54 @@ describe('Team Exec Stage', () => {
     }
   });
 
+  it('skips newer incomplete runtime drafts when selecting the approved team handoff', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const approvedPrdPath = join(plansDir, 'prd-zeta.md');
+    await writeFile(
+      approvedPrdPath,
+      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+    const incompleteDraftPath = join(plansDir, 'prd-zulu.md');
+    await writeFile(incompleteDraftPath, '# Zulu draft\n\nNo approved team launch here.\n');
+
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(tmpdir());
+      const stage = createTeamExecStage();
+      const result = await stage.run(makeCtx({
+        task: 'original request task',
+        artifacts: {
+          ralplan: {
+            task: 'original request task',
+            stage: 'ralplan',
+            latestPlanPath: join('.omx', 'plans', 'prd-zeta.md'),
+            drafts: [
+              { planPath: join('.omx', 'plans', 'prd-zeta.md') },
+              { planPath: join('.omx', 'plans', 'prd-zulu.md') },
+            ],
+          },
+        },
+      }));
+
+      assert.equal(result.status, 'completed');
+      const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+      const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+      const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
+      assert.equal(descriptor.task, 'Execute zeta handoff');
+      assert.deepEqual(descriptor.approvedExecution, {
+        prd_path: approvedPrdPath,
+        task: 'Execute zeta handoff',
+        command: 'omx team 5:debugger "Execute zeta handoff"',
+      });
+      assert.doesNotMatch(instruction, new RegExp(escapeRegExp(incompleteDraftPath)));
+      assert.deepEqual(runtimeCliInput.approvedExecution, descriptor.approvedExecution);
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
   it('derives the team-exec task when latestPlanPath is already cwd-prefixed', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -16,7 +16,6 @@ import {
 } from '../../team/followup-planner.js';
 import {
   readApprovedExecutionLaunchHintOutcome,
-  readLatestPlanningArtifacts,
   readPlanningArtifacts,
   type PlanningArtifacts,
 } from '../../planning/artifacts.js';
@@ -117,6 +116,19 @@ function readRuntimeLatestPlanningSelection(
   return null;
 }
 
+function readLatestApprovedPlanningSelection(
+  artifacts: PlanningArtifacts,
+): { prdPath: string | null; testSpecPaths: string[] } {
+  for (let index = artifacts.prdPaths.length - 1; index >= 0; index -= 1) {
+    const prdPath = artifacts.prdPaths[index];
+    const testSpecPaths = matchingTestSpecPathsForPrd(artifacts, prdPath);
+    if (testSpecPaths.length > 0) {
+      return { prdPath, testSpecPaths };
+    }
+  }
+  return { prdPath: null, testSpecPaths: [] };
+}
+
 function resolveApprovedTeamPlanPath(
   cwd: string,
   latestPlanPath: string,
@@ -124,7 +136,8 @@ function resolveApprovedTeamPlanPath(
 ): string {
   const artifacts = readPlanningArtifacts(cwd);
   const resolvedLatestPlanPath = resolvePlanningPrdPath(artifacts, cwd, latestPlanPath);
-  const selection = readRuntimeLatestPlanningSelection(artifacts, cwd, ralplanArtifacts) ?? readLatestPlanningArtifacts(cwd);
+  const selection = readRuntimeLatestPlanningSelection(artifacts, cwd, ralplanArtifacts)
+    ?? readLatestApprovedPlanningSelection(artifacts);
   const selectedPrdPath = selection.prdPath
     ? resolvePlanningPrdPath(artifacts, cwd, selection.prdPath).matchedPath
     : null;

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -108,9 +108,11 @@ function readRuntimeLatestPlanningSelection(
       : '';
     if (!draftPlanPath) continue;
     const resolvedDraftPlanPath = resolvePlanningPrdPath(artifacts, cwd, draftPlanPath).matchedPath;
+    const testSpecPaths = resolvedDraftPlanPath ? matchingTestSpecPathsForPrd(artifacts, resolvedDraftPlanPath) : [];
+    if (!resolvedDraftPlanPath || testSpecPaths.length === 0) continue;
     return {
       prdPath: resolvedDraftPlanPath,
-      testSpecPaths: resolvedDraftPlanPath ? matchingTestSpecPathsForPrd(artifacts, resolvedDraftPlanPath) : [],
+      testSpecPaths,
     };
   }
   return null;

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -207,8 +207,6 @@ function readApprovedPlanText(
   options: ApprovedExecutionLaunchHintReadOptions = {},
 ): { content: string; context: ApprovedPlanContext } | null {
   const artifacts = readPlanningArtifacts(cwd);
-  if (!isPlanningComplete(artifacts)) return null;
-
   const selection = selectPlanningArtifacts(artifacts, options.prdPath);
   const latestPrdPath = selection.prdPath;
   if (!latestPrdPath || selection.testSpecPaths.length === 0 || !existsSync(latestPrdPath)) return null;


### PR DESCRIPTION
## Summary

Merged PR #2165 preserved approved Team binding transport, but team-exec and the shared approved-hint reader still treated repo-global planning completeness as stronger than the selected PRD. If a newer draft PRD existed without a matching test spec, team-exec rejected the selected approved handoff as missing even though latestPlanPath still pointed at a valid approved PRD.

This follow-up keeps the fix narrow: explicit prdPath reads now validate against that PRD's own matching baseline, and the team-exec stale guard falls back to the latest approved PRD instead of the latest draft on disk.

## Changes

- let `readApprovedPlanText()` resolve an explicit `prdPath` without requiring the repo's newest draft to be complete
- keep `resolveApprovedTeamPlanPath()` comparing `latestPlanPath` against the latest approved PRD, not just the newest PRD file
- add a focused `stages.test.ts` case that proves a selected approved PRD still launches when a newer incomplete draft exists

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Focused validation run for this PR:
- `node --test --test-name-pattern "derives the team-exec task from the selected approved PRD when a newer draft is incomplete" dist/pipeline/__tests__/stages.test.js`
- `node --test dist/pipeline/__tests__/stages.test.js dist/team/__tests__/runtime-cli.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- Follow-up to merged PR #2165
- Source commit: `e9182747`
- Reference branch check: `origin/feat/context-pack` still treats approved-hint selection as PRD-scoped; this follow-up keeps only that boundary and does not import broader context-pack lifecycle/status machinery.
