### PR TITLE
feat: add read-only context-pack handoff status

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -150,6 +150,10 @@ const approvedHint: ApprovedExecutionLaunchHint = {
   sourcePath: '.omx/plans/prd-issue-1072.md',
   testSpecPaths: ['.omx/plans/test-spec-issue-1072.md'],
   deepInterviewSpecPaths: ['.omx/specs/deep-interview-issue-1072.md'],
+  contextPack: null,
+  contextPackStatus: 'plan-only',
+  missingRequiredContextPackRoles: [],
+  contextPackIssues: [],
   repositoryContextSummary: {
     sourcePath: '.omx/plans/repo-context-issue-1072.md',
     content: 'Key files: src/cli/ralph.ts and src/planning/artifacts.ts',

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -41,7 +41,7 @@ function buildContextPackOutcome(relativePackPath: string): string {
   return [
     '## Context Pack Outcome',
     '',
-    `- pack: \`${relativePackPath}\``,
+    `- pack: created \`${relativePackPath}\``,
   ].join('\n');
 }
 

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import {
   decodeApprovedExecutionQuotedValue,
   isPlanningComplete,
@@ -20,6 +21,59 @@ function encodeApprovedExecutionTask(task: string, quote: 'single' | 'double'): 
   return quote === 'single'
     ? `'${task.replace(/'/g, "\\'")}'`
     : `"${task.replace(/"/g, '\\"')}"`;
+}
+
+function computeGitBlobSha1(content: string): string {
+  const buffer = Buffer.from(content, 'utf-8');
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function relativeToRepo(path: string): string {
+  return relative(tempDir, path).replaceAll('\\', '/');
+}
+
+function canonicalContextPackRelativePath(slug: string): string {
+  return `.omx/context/context-20260507T120000Z-${slug}.json`;
+}
+
+function buildContextPackOutcome(relativePackPath: string): string {
+  return [
+    '## Context Pack Outcome',
+    '',
+    `- pack: \`${relativePackPath}\``,
+  ].join('\n');
+}
+
+async function writeContextPack(
+  slug: string,
+  prdPath: string,
+  testSpecPath: string,
+  roles: string[],
+): Promise<string> {
+  const contextDir = join(tempDir, '.omx', 'context');
+  await mkdir(contextDir, { recursive: true });
+  const packPath = join(tempDir, canonicalContextPackRelativePath(slug));
+  const prdContent = await readFile(prdPath, 'utf-8');
+  const testSpecContent = await readFile(testSpecPath, 'utf-8');
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relativeToRepo(prdPath),
+        sha1: computeGitBlobSha1(prdContent),
+      },
+      testSpecs: [{
+        path: relativeToRepo(testSpecPath),
+        sha1: computeGitBlobSha1(testSpecContent),
+      }],
+    },
+    entries: roles.map((role, index) => ({
+      path: `src/${role}-${index}.ts`,
+      roles: [role],
+    })),
+  }, null, 2));
+  return packPath;
 }
 
 async function setup(): Promise<void> {
@@ -228,6 +282,9 @@ describe('planning artifacts', () => {
     const selection = readLatestPlanningArtifacts(tempDir);
     assert.equal(selection.prdPath, join(plansDir, 'prd-20260427T153100Z-alpha.md'));
     assert.deepEqual(selection.testSpecPaths, []);
+    assert.equal(selection.contextPackStatus, 'missing-baseline');
+    assert.deepEqual(selection.missingRequiredContextPackRoles, []);
+    assert.deepEqual(selection.contextPackIssues, ['Approved plan is missing a matching test spec.']);
 
     assert.equal(readApprovedExecutionLaunchHint(tempDir, 'ralph'), null);
 
@@ -236,6 +293,56 @@ describe('planning artifacts', () => {
     assert.equal(resolution.prdPath, join(plansDir, 'prd-20260427T153100Z-alpha.md'));
     assert.equal(resolution.planSlug, '20260427T153100Z-alpha');
     assert.deepEqual(resolution.warnings, ['missing_matching_test_spec']);
+  });
+
+  it('surfaces plan-only context-pack status on approved hints when no pack is declared', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-plan-only.md'),
+      '# PRD\n\nLaunch via omx ralph "Execute plan-only handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-plan-only.md'), '# Test Spec\n');
+
+    const selection = readLatestPlanningArtifacts(tempDir);
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+
+    assert.equal(selection.contextPack, null);
+    assert.equal(selection.contextPackStatus, 'plan-only');
+    assert.deepEqual(selection.missingRequiredContextPackRoles, []);
+    assert.deepEqual(selection.contextPackIssues, []);
+    assert.ok(hint);
+    assert.equal(hint?.contextPack, null);
+    assert.equal(hint?.contextPackStatus, 'plan-only');
+    assert.deepEqual(hint?.missingRequiredContextPackRoles, []);
+    assert.deepEqual(hint?.contextPackIssues, []);
+  });
+
+  it('surfaces ready context-pack status on approved hints when the latest plan declares a fresh pack', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-context-ready.md');
+    const testSpecPath = join(plansDir, 'test-spec-context-ready.md');
+    await writeFile(
+      prdPath,
+      [
+        '# PRD',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath('context-ready')),
+        '',
+        'Launch via omx ralph "Execute context-ready handoff"',
+      ].join('\n'),
+    );
+    await writeFile(testSpecPath, '# Test Spec\n');
+    const packPath = await writeContextPack('context-ready', prdPath, testSpecPath, ['scope', 'build', 'verify']);
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+
+    assert.ok(hint);
+    assert.deepEqual(hint?.contextPack, { path: packPath });
+    assert.equal(hint?.contextPackStatus, 'ready');
+    assert.deepEqual(hint?.missingRequiredContextPackRoles, []);
+    assert.deepEqual(hint?.contextPackIssues, []);
   });
 
 

--- a/src/planning/__tests__/context-pack-status.test.ts
+++ b/src/planning/__tests__/context-pack-status.test.ts
@@ -231,6 +231,24 @@ describe('context pack handoff status', () => {
     assert.equal(status.outcomeState, 'absent');
   });
 
+  it('rejects nested outcome paths that are not canonical context-pack files', async () => {
+    await writeApprovedPlan('eta', [
+      '# PRD',
+      '',
+      buildContextPackOutcome('.omx/context/context-20260507T120000Z-eta/nested.json'),
+      '',
+      'Launch via omx ralph "Execute eta plan"',
+    ]);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'invalid');
+    assert.equal(status.outcomeState, 'malformed');
+    assert.ok(status.contextPackIssues.some((issue) => issue.includes(
+      '.omx/context/context-<timestamp>-<slug>.json',
+    )));
+  });
+
   it('reports invalid when the approved plan declares multiple outcome sections', async () => {
     await writeApprovedPlan('zeta', [
       '# PRD',

--- a/src/planning/__tests__/context-pack-status.test.ts
+++ b/src/planning/__tests__/context-pack-status.test.ts
@@ -30,7 +30,7 @@ function buildContextPackOutcome(relativePackPath: string): string {
   return [
     '## Context Pack Outcome',
     '',
-    `- pack: \`${relativePackPath}\``,
+    `- pack: created \`${relativePackPath}\``,
   ].join('\n');
 }
 
@@ -219,7 +219,7 @@ describe('context pack handoff status', () => {
       '```md',
       '## Context Pack Outcome',
       '',
-      `- pack: \`${canonicalContextPackRelativePath('epsilon')}\``,
+      `- pack: created \`${canonicalContextPackRelativePath('epsilon')}\``,
       '```',
       '',
       'Launch via omx ralph "Execute epsilon plan"',
@@ -246,6 +246,25 @@ describe('context pack handoff status', () => {
     assert.equal(status.outcomeState, 'malformed');
     assert.ok(status.contextPackIssues.some((issue) => issue.includes(
       '.omx/context/context-<timestamp>-<slug>.json',
+    )));
+  });
+
+  it('reports invalid when the declared pack slug does not match the approved plan even if the file is missing', async () => {
+    await writeApprovedPlan('theta', [
+      '# PRD',
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath('other')),
+      '',
+      'Launch via omx ralph "Execute theta plan"',
+    ]);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'invalid');
+    assert.equal(status.outcomeState, 'declared');
+    assert.equal(status.packState, 'invalid');
+    assert.ok(status.contextPackIssues.some((issue) => issue.includes(
+      'does not match approved plan slug theta',
     )));
   });
 

--- a/src/planning/__tests__/context-pack-status.test.ts
+++ b/src/planning/__tests__/context-pack-status.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import {
+  readContextPackHandoffStatus,
+  resolveContextPackHandoffState,
+} from '../artifacts.js';
+
+let tempDir: string;
+
+function computeGitBlobSha1(content: string): string {
+  const buffer = Buffer.from(content, 'utf-8');
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function relativeToRepo(path: string): string {
+  return relative(tempDir, path).replaceAll('\\', '/');
+}
+
+function canonicalContextPackRelativePath(slug: string): string {
+  return `.omx/context/context-20260507T120000Z-${slug}.json`;
+}
+
+function buildContextPackOutcome(relativePackPath: string): string {
+  return [
+    '## Context Pack Outcome',
+    '',
+    `- pack: \`${relativePackPath}\``,
+  ].join('\n');
+}
+
+async function setup(): Promise<void> {
+  tempDir = await mkdtemp(join(tmpdir(), 'omx-context-pack-status-'));
+}
+
+async function cleanup(): Promise<void> {
+  if (tempDir && existsSync(tempDir)) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function writeApprovedPlan(
+  slug: string,
+  bodyLines: string[],
+): Promise<{ prdPath: string; testSpecPath: string; packPath: string; packRelativePath: string }> {
+  const plansDir = join(tempDir, '.omx', 'plans');
+  const contextDir = join(tempDir, '.omx', 'context');
+  await mkdir(plansDir, { recursive: true });
+  await mkdir(contextDir, { recursive: true });
+
+  const prdPath = join(plansDir, `prd-${slug}.md`);
+  const testSpecPath = join(plansDir, `test-spec-${slug}.md`);
+  const packRelativePath = canonicalContextPackRelativePath(slug);
+  const packPath = join(tempDir, packRelativePath);
+
+  await writeFile(prdPath, bodyLines.join('\n'));
+  await writeFile(testSpecPath, '# Test Spec\n');
+
+  return { prdPath, testSpecPath, packPath, packRelativePath };
+}
+
+async function writeContextPack(
+  slug: string,
+  prdPath: string,
+  testSpecPath: string,
+  roles: string[],
+): Promise<void> {
+  const packPath = join(tempDir, canonicalContextPackRelativePath(slug));
+  const prdActual = await readFile(prdPath, 'utf-8');
+  const testSpecActual = await readFile(testSpecPath, 'utf-8');
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relativeToRepo(prdPath),
+        sha1: computeGitBlobSha1(prdActual),
+      },
+      testSpecs: [{
+        path: relativeToRepo(testSpecPath),
+        sha1: computeGitBlobSha1(testSpecActual),
+      }],
+    },
+    entries: roles.map((role, index) => ({
+      path: `src/${role}-${index}.ts`,
+      roles: [role],
+    })),
+  }, null, 2));
+}
+
+describe('context pack handoff status', () => {
+  beforeEach(async () => { await setup(); });
+  afterEach(async () => { await cleanup(); });
+
+  it('maps the public context-pack state matrix into handoff status', () => {
+    assert.equal(resolveContextPackHandoffState({
+      baselineState: 'missing-prd',
+      outcomeState: 'absent',
+      packState: 'missing',
+      roleCoverage: 'missing-required-roles',
+      basisState: 'stale',
+    }), 'missing-baseline');
+    assert.equal(resolveContextPackHandoffState({
+      baselineState: 'present',
+      outcomeState: 'absent',
+      packState: 'missing',
+      roleCoverage: 'missing-required-roles',
+      basisState: 'stale',
+    }), 'plan-only');
+    assert.equal(resolveContextPackHandoffState({
+      baselineState: 'present',
+      outcomeState: 'declared',
+      packState: 'missing',
+      roleCoverage: 'missing-required-roles',
+      basisState: 'stale',
+    }), 'incomplete');
+    assert.equal(resolveContextPackHandoffState({
+      baselineState: 'present',
+      outcomeState: 'declared',
+      packState: 'valid',
+      roleCoverage: 'covered',
+      basisState: 'fresh',
+    }), 'ready');
+    assert.equal(resolveContextPackHandoffState({
+      baselineState: 'present',
+      outcomeState: 'malformed',
+      packState: 'valid',
+      roleCoverage: 'covered',
+      basisState: 'fresh',
+    }), 'invalid');
+    assert.equal(resolveContextPackHandoffState({
+      baselineState: 'present',
+      outcomeState: 'declared',
+      packState: 'valid',
+      roleCoverage: 'covered',
+      basisState: 'stale',
+    }), 'invalid');
+  });
+
+  it('reports plan-only when the approved baseline has no declared context pack', async () => {
+    await writeApprovedPlan('alpha', [
+      '# PRD',
+      '',
+      'Launch via omx ralph "Execute alpha plan"',
+    ]);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPack, null);
+    assert.equal(status.contextPackStatus, 'plan-only');
+    assert.equal(status.baselineState, 'present');
+    assert.equal(status.outcomeState, 'absent');
+    assert.deepEqual(status.missingRequiredContextPackRoles, []);
+    assert.deepEqual(status.contextPackIssues, []);
+  });
+
+  it('reports ready when the declared pack has fresh basis and all required roles', async () => {
+    const { prdPath, testSpecPath, packPath } = await writeApprovedPlan('beta', [
+      '# PRD',
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath('beta')),
+      '',
+      'Launch via omx ralph "Execute beta plan"',
+    ]);
+    await writeContextPack('beta', prdPath, testSpecPath, ['scope', 'build', 'verify']);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.deepEqual(status.contextPack, { path: packPath });
+    assert.equal(status.contextPackStatus, 'ready');
+    assert.equal(status.packState, 'valid');
+    assert.equal(status.roleCoverage, 'covered');
+    assert.equal(status.basisState, 'fresh');
+    assert.deepEqual(status.missingRequiredContextPackRoles, []);
+    assert.deepEqual(status.contextPackIssues, []);
+  });
+
+  it('reports incomplete when the declared pack omits required execution roles', async () => {
+    const { prdPath, testSpecPath } = await writeApprovedPlan('gamma', [
+      '# PRD',
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath('gamma')),
+      '',
+      'Launch via omx ralph "Execute gamma plan"',
+    ]);
+    await writeContextPack('gamma', prdPath, testSpecPath, ['scope']);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'incomplete');
+    assert.deepEqual(status.missingRequiredContextPackRoles, ['build', 'verify']);
+  });
+
+  it('reports invalid when the declared pack basis drifts from the approved test spec', async () => {
+    const { prdPath, testSpecPath } = await writeApprovedPlan('delta', [
+      '# PRD',
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath('delta')),
+      '',
+      'Launch via omx ralph "Execute delta plan"',
+    ]);
+    await writeContextPack('delta', prdPath, testSpecPath, ['scope', 'build', 'verify']);
+    await writeFile(testSpecPath, '# Drifted Test Spec\n');
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'invalid');
+    assert.ok(status.contextPackIssues.some((issue) => issue.includes('basis test-spec hash')));
+  });
+
+  it('ignores fenced outcome declarations and keeps the plan in plan-only status', async () => {
+    await writeApprovedPlan('epsilon', [
+      '# PRD',
+      '',
+      '```md',
+      '## Context Pack Outcome',
+      '',
+      `- pack: \`${canonicalContextPackRelativePath('epsilon')}\``,
+      '```',
+      '',
+      'Launch via omx ralph "Execute epsilon plan"',
+    ]);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'plan-only');
+    assert.equal(status.outcomeState, 'absent');
+  });
+
+  it('reports invalid when the approved plan declares multiple outcome sections', async () => {
+    await writeApprovedPlan('zeta', [
+      '# PRD',
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath('zeta')),
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath('zeta')),
+      '',
+      'Launch via omx ralph "Execute zeta plan"',
+    ]);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'invalid');
+    assert.equal(status.outcomeState, 'ambiguous');
+    assert.ok(status.contextPackIssues.some((issue) => issue.includes('multiple Context Pack Outcome sections')));
+  });
+});

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -8,8 +8,6 @@ import {
   selectMatchingTestSpecsForPrd,
 } from './artifact-names.js';
 import {
-  isApprovedExecutionContextReadyStatus,
-  isApprovedExecutionFollowupReadyStatus,
   resolveContextPackHandoffStatus,
   type ContextPackHandoffStatusSnapshot,
   type ContextPackRef,

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -1,5 +1,6 @@
+import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, dirname, join, relative, resolve } from 'node:path';
 import {
   comparePlanningArtifactPaths,
   parsePlanningArtifactFileName,
@@ -12,8 +13,70 @@ import { omxPlansDir } from '../utils/paths.js';
 const PRD_PATTERN = /^prd-.*\.md$/i;
 const TEST_SPEC_PATTERN = /^test-?spec-.*\.md$/i;
 const DEEP_INTERVIEW_SPEC_PATTERN = /^deep-interview-.*\.md$/i;
+const CONTEXT_PACK_OUTCOME_HEADING_PATTERN = /^#{1,6}\s+Context Pack Outcome\s*$/i;
+const CONTEXT_PACK_OUTCOME_DECLARATION_PATTERN = /^[*-]\s*pack\s*:/i;
+const CONTEXT_PACK_OUTCOME_LINE_PATTERN = /^[*-]\s*pack\s*:\s*(?:(?:created|refreshed|revalidated)\s+)?(?:`(?<quotedPath>[^`]+\.json)`|(?<barePath>\S+\.json))\s*$/i;
+const CONTEXT_PACK_PATH_PATTERN = /^\.omx\/context\/context-(?<timestamp>\d{8}T\d{6}Z)-(?<slug>.+)\.json$/i;
+const SHA1_PATTERN = /^[0-9a-f]{40}$/i;
 const APPROVED_REPOSITORY_CONTEXT_MAX_CHARS = 4_000;
 const APPROVED_REPOSITORY_CONTEXT_MAX_LINES = 80;
+export const REQUIRED_CONTEXT_PACK_ROLES = ['scope', 'build', 'verify'] as const;
+export type ContextPackRole = (typeof REQUIRED_CONTEXT_PACK_ROLES)[number];
+export type ContextPackStatus = 'missing-baseline' | 'plan-only' | 'ready' | 'incomplete' | 'invalid';
+export type ContextPackBaselineState = 'missing-prd' | 'missing-test-spec' | 'present';
+export type ContextPackOutcomeState = 'absent' | 'malformed' | 'ambiguous' | 'declared';
+export type ContextPackPackState = 'missing' | 'unreadable' | 'invalid' | 'valid';
+export type ContextPackRoleCoverageState = 'missing-required-roles' | 'covered';
+export type ContextPackBasisState = 'stale' | 'fresh';
+
+export interface ContextPackRef {
+  path: string;
+}
+
+export interface ContextPackHandoffStatusSnapshot {
+  prdPath: string | null;
+  testSpecPaths: string[];
+  contextPack: ContextPackRef | null;
+  contextPackStatus: ContextPackStatus;
+  baselineState: ContextPackBaselineState;
+  outcomeState: ContextPackOutcomeState;
+  packState: ContextPackPackState;
+  roleCoverage: ContextPackRoleCoverageState;
+  basisState: ContextPackBasisState;
+  missingRequiredContextPackRoles: ContextPackRole[];
+  contextPackIssues: string[];
+}
+
+interface ContextPackBasisObject {
+  path: string;
+  sha1: string;
+}
+
+interface ContextPackDocument {
+  slug: string;
+  basis: {
+    prd: ContextPackBasisObject;
+    testSpecs: ContextPackBasisObject[];
+  };
+  entries: Array<{
+    path: string;
+    roles: ContextPackRole[];
+  }>;
+}
+
+interface PlanningArtifactSelectionBase {
+  prdPath: string | null;
+  testSpecPaths: string[];
+  deepInterviewSpecPaths: string[];
+}
+
+interface ContextPackOutcomeInspection {
+  outcomeState: ContextPackOutcomeState;
+  contextPack: ContextPackRef | null;
+  declaredPackPath: string | null;
+  declaredSlug: string | null;
+  issues: string[];
+}
 
 export interface PlanningArtifacts {
   plansDir: string;
@@ -33,6 +96,10 @@ export interface ApprovedPlanContext {
   sourcePath: string;
   testSpecPaths: string[];
   deepInterviewSpecPaths: string[];
+  contextPack: ContextPackRef | null;
+  contextPackStatus: ContextPackStatus;
+  missingRequiredContextPackRoles: ContextPackRole[];
+  contextPackIssues: string[];
   repositoryContextSummary?: ApprovedRepositoryContextSummary;
 }
 
@@ -49,6 +116,10 @@ export interface LatestPlanningArtifactSelection {
   prdPath: string | null;
   testSpecPaths: string[];
   deepInterviewSpecPaths: string[];
+  contextPack: ContextPackRef | null;
+  contextPackStatus: ContextPackStatus;
+  missingRequiredContextPackRoles: ContextPackRole[];
+  contextPackIssues: string[];
 }
 
 interface ApprovedExecutionLaunchHintReadOptions {
@@ -101,8 +172,16 @@ export function readPlanningArtifacts(cwd: string): PlanningArtifacts {
 }
 
 export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
-  const selection = selectLatestPlanningArtifacts(artifacts);
+  const selection = selectPlanningArtifactsBase(artifacts);
   return Boolean(selection.prdPath) && selection.testSpecPaths.length > 0;
+}
+
+export function isApprovedExecutionFollowupReadyStatus(status: ContextPackStatus): boolean {
+  return status === 'ready' || status === 'plan-only';
+}
+
+export function isApprovedExecutionContextReadyStatus(status: ContextPackStatus): boolean {
+  return status === 'ready';
 }
 
 export function decodeApprovedExecutionQuotedValue(raw: string): string | null {
@@ -130,10 +209,10 @@ function selectDeepInterviewSpecPathsForSlug(paths: readonly string[], slug: str
     .sort(comparePlanningArtifactPaths);
 }
 
-function selectPlanningArtifacts(
+function selectPlanningArtifactsBase(
   artifacts: PlanningArtifacts,
   prdPath?: string,
-): LatestPlanningArtifactSelection {
+): PlanningArtifactSelectionBase {
   const selectedPrdPath = prdPath == null
     ? selectLatestPlanningArtifactPath(artifacts.prdPaths)
     : artifacts.prdPaths.includes(prdPath)
@@ -147,6 +226,530 @@ function selectPlanningArtifacts(
     prdPath: selectedPrdPath,
     testSpecPaths: selectMatchingTestSpecsForPrd(selectedPrdPath, artifacts.testSpecPaths),
     deepInterviewSpecPaths: selectDeepInterviewSpecPathsForSlug(artifacts.deepInterviewSpecPaths, slug),
+  };
+}
+
+function normalizeRepoRelativePath(rawPath: string): string | null {
+  const trimmed = rawPath.trim().replace(/^`|`$/g, '').replaceAll('\\', '/');
+  if (!trimmed) {
+    return null;
+  }
+  const withoutLeadingDot = trimmed.startsWith('./') ? trimmed.slice(2) : trimmed;
+  if (!withoutLeadingDot || withoutLeadingDot.startsWith('/') || /^[A-Za-z]:/.test(withoutLeadingDot)) {
+    return null;
+  }
+  const segments = withoutLeadingDot.split('/').filter((segment) => segment.length > 0);
+  if (segments.length === 0 || segments.includes('..')) {
+    return null;
+  }
+  return segments.join('/');
+}
+
+function computeGitBlobSha1(filePath: string): string {
+  const buffer = readFileSync(filePath);
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function isMarkdownFenceLine(line: string): boolean {
+  return /^(```|~~~)/.test(line.trimStart());
+}
+
+function isIndentedMarkdownCodeLine(line: string): boolean {
+  return /^(?: {4,}|\t)/.test(line);
+}
+
+function extractContextPackOutcomeSections(content: string): string[][] {
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+  const sections: string[][] = [];
+  let inFence = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    if (isMarkdownFenceLine(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence || isIndentedMarkdownCodeLine(line)) {
+      continue;
+    }
+    if (!CONTEXT_PACK_OUTCOME_HEADING_PATTERN.test(line.trim())) {
+      continue;
+    }
+
+    const section: string[] = [];
+    for (let sectionIndex = index + 1; sectionIndex < lines.length; sectionIndex += 1) {
+      const sectionLine = lines[sectionIndex]!;
+      const trimmed = sectionLine.trim();
+      if (
+        isMarkdownFenceLine(sectionLine)
+        || isIndentedMarkdownCodeLine(sectionLine)
+        || /^#{1,6}\s+\S/.test(trimmed)
+        || (trimmed !== '' && !/^[*-]\s+/.test(trimmed))
+      ) {
+        break;
+      }
+      section.push(sectionLine);
+    }
+    sections.push(section);
+  }
+
+  return sections;
+}
+
+function resolveDeclaredContextPackPath(
+  repoRoot: string,
+  rawPath: string,
+): { normalizedPath: string; resolvedPath: string; slug: string } | null {
+  const normalizedPath = normalizeRepoRelativePath(rawPath);
+  if (!normalizedPath) {
+    return null;
+  }
+  const pathMatch = normalizedPath.match(CONTEXT_PACK_PATH_PATTERN);
+  if (!pathMatch?.groups?.slug) {
+    return null;
+  }
+  const resolvedPath = resolve(repoRoot, normalizedPath);
+  const roundTripPath = normalizeRepoRelativePath(relative(repoRoot, resolvedPath));
+  if (!roundTripPath || roundTripPath !== normalizedPath) {
+    return null;
+  }
+  return {
+    normalizedPath,
+    resolvedPath,
+    slug: pathMatch.groups.slug,
+  };
+}
+
+function inspectContextPackOutcome(repoRoot: string, content: string): ContextPackOutcomeInspection {
+  const outcomeSections = extractContextPackOutcomeSections(content);
+  if (outcomeSections.length === 0) {
+    return {
+      outcomeState: 'absent',
+      contextPack: null,
+      declaredPackPath: null,
+      declaredSlug: null,
+      issues: [],
+    };
+  }
+  if (outcomeSections.length > 1) {
+    return {
+      outcomeState: 'ambiguous',
+      contextPack: null,
+      declaredPackPath: null,
+      declaredSlug: null,
+      issues: ['Approved plan contains multiple Context Pack Outcome sections.'],
+    };
+  }
+
+  let declarationCount = 0;
+  let resolvedPackPath: string | null = null;
+  let resolvedSlug: string | null = null;
+  let resolvedPack: ContextPackRef | null = null;
+  const issues: string[] = [];
+
+  for (const line of outcomeSections[0]!) {
+    const trimmed = line.trim();
+    if (!trimmed || !CONTEXT_PACK_OUTCOME_DECLARATION_PATTERN.test(trimmed)) {
+      continue;
+    }
+    declarationCount += 1;
+    const lineMatch = trimmed.match(CONTEXT_PACK_OUTCOME_LINE_PATTERN);
+    if (!lineMatch?.groups) {
+      issues.push(`Invalid Context Pack Outcome line: ${trimmed}`);
+      continue;
+    }
+    const resolvedPath = resolveDeclaredContextPackPath(
+      repoRoot,
+      lineMatch.groups.quotedPath ?? lineMatch.groups.barePath,
+    );
+    if (!resolvedPath) {
+      issues.push('Context Pack Outcome must point to .omx/context/context-<timestamp>-<slug>.json.');
+      continue;
+    }
+    if (declarationCount > 1) {
+      issues.push('Context Pack Outcome may declare only one pack.');
+      continue;
+    }
+    resolvedPackPath = resolvedPath.normalizedPath;
+    resolvedSlug = resolvedPath.slug;
+    resolvedPack = { path: resolvedPath.resolvedPath };
+  }
+
+  if (declarationCount === 0) {
+    return {
+      outcomeState: 'malformed',
+      contextPack: null,
+      declaredPackPath: null,
+      declaredSlug: null,
+      issues: ['Context Pack Outcome must declare exactly one pack.'],
+    };
+  }
+  if (declarationCount > 1) {
+    return {
+      outcomeState: 'ambiguous',
+      contextPack: resolvedPack,
+      declaredPackPath: resolvedPackPath,
+      declaredSlug: resolvedSlug,
+      issues: issues.length > 0 ? issues : ['Context Pack Outcome may declare only one pack.'],
+    };
+  }
+  if (issues.length > 0 || !resolvedPack || !resolvedPackPath || !resolvedSlug) {
+    return {
+      outcomeState: 'malformed',
+      contextPack: resolvedPack,
+      declaredPackPath: resolvedPackPath,
+      declaredSlug: resolvedSlug,
+      issues,
+    };
+  }
+  return {
+    outcomeState: 'declared',
+    contextPack: resolvedPack,
+    declaredPackPath: resolvedPackPath,
+    declaredSlug: resolvedSlug,
+    issues: [],
+  };
+}
+
+function readContextPackDocument(packPath: string): {
+  packState: ContextPackPackState;
+  document: ContextPackDocument | null;
+  issues: string[];
+} {
+  let rawContent = '';
+  try {
+    rawContent = readFileSync(packPath, 'utf-8');
+  } catch {
+    return {
+      packState: 'unreadable',
+      document: null,
+      issues: ['Declared context pack could not be read.'],
+    };
+  }
+
+  let rawDocument: unknown;
+  try {
+    rawDocument = JSON.parse(rawContent);
+  } catch {
+    return {
+      packState: 'invalid',
+      document: null,
+      issues: ['Declared context pack contains invalid JSON.'],
+    };
+  }
+  if (!rawDocument || typeof rawDocument !== 'object' || Array.isArray(rawDocument)) {
+    return {
+      packState: 'invalid',
+      document: null,
+      issues: ['Declared context pack must be a JSON object.'],
+    };
+  }
+
+  const documentRecord = rawDocument as Record<string, unknown>;
+  const issues: string[] = [];
+
+  const slug = typeof documentRecord.slug === 'string' ? documentRecord.slug.trim() : '';
+  if (!slug) {
+    issues.push('Declared context pack must declare a non-empty slug.');
+  }
+
+  const basisRecord = documentRecord.basis;
+  if (!basisRecord || typeof basisRecord !== 'object' || Array.isArray(basisRecord)) {
+    issues.push('Declared context pack must declare basis PRD and test-spec hashes.');
+  }
+  const prdBasisRecord = !basisRecord || typeof basisRecord !== 'object' || Array.isArray(basisRecord)
+    ? null
+    : (basisRecord as Record<string, unknown>).prd;
+  const testSpecsBasisRecord = !basisRecord || typeof basisRecord !== 'object' || Array.isArray(basisRecord)
+    ? null
+    : (basisRecord as Record<string, unknown>).testSpecs;
+
+  const normalizeBasisObject = (value: unknown, label: string): ContextPackBasisObject | null => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      issues.push(`Declared context pack ${label} basis must be an object.`);
+      return null;
+    }
+    const record = value as Record<string, unknown>;
+    const path = typeof record.path === 'string' ? normalizeRepoRelativePath(record.path) : null;
+    if (!path) {
+      issues.push(`Declared context pack ${label} basis path must be repo-relative.`);
+    }
+    const sha1 = typeof record.sha1 === 'string' && SHA1_PATTERN.test(record.sha1.trim())
+      ? record.sha1.trim().toLowerCase()
+      : null;
+    if (!sha1) {
+      issues.push(`Declared context pack ${label} basis sha1 must be a 40-character hex string.`);
+    }
+    return path && sha1 ? { path, sha1 } : null;
+  };
+
+  const prdBasis = normalizeBasisObject(prdBasisRecord, 'prd');
+  const testSpecBasis = Array.isArray(testSpecsBasisRecord)
+    ? testSpecsBasisRecord
+      .map((value, index) => normalizeBasisObject(value, `test-spec[${index}]`))
+      .filter((value): value is ContextPackBasisObject => value !== null)
+    : [];
+  if (!Array.isArray(testSpecsBasisRecord) || testSpecBasis.length === 0) {
+    issues.push('Declared context pack must declare at least one test-spec basis entry.');
+  }
+
+  const rawEntries = documentRecord.entries;
+  if (!Array.isArray(rawEntries) || rawEntries.length === 0) {
+    issues.push('Declared context pack must declare at least one entry.');
+  }
+  const entries = Array.isArray(rawEntries)
+    ? rawEntries.flatMap((rawEntry) => {
+      if (!rawEntry || typeof rawEntry !== 'object' || Array.isArray(rawEntry)) {
+        issues.push('Declared context pack entries must be objects.');
+        return [];
+      }
+      const record = rawEntry as Record<string, unknown>;
+      const path = typeof record.path === 'string' ? normalizeRepoRelativePath(record.path) : null;
+      if (!path) {
+        issues.push('Declared context pack entries must provide a repo-relative path.');
+      }
+      if (!Array.isArray(record.roles) || record.roles.length === 0) {
+        issues.push('Declared context pack entries must declare at least one role.');
+        return [];
+      }
+      const roles = [...new Set(record.roles.flatMap((role) => {
+        if (typeof role !== 'string') {
+          issues.push('Declared context pack entry roles must be strings.');
+          return [];
+        }
+        const normalizedRole = role.trim();
+        if (!REQUIRED_CONTEXT_PACK_ROLES.includes(normalizedRole as ContextPackRole)) {
+          issues.push(`Declared context pack entry role "${normalizedRole}" is not supported.`);
+          return [];
+        }
+        return [normalizedRole as ContextPackRole];
+      }))];
+      if (!path || roles.length === 0) {
+        return [];
+      }
+      return [{ path, roles }];
+    })
+    : [];
+
+  if (issues.length > 0 || !prdBasis || testSpecBasis.length === 0 || entries.length === 0 || !slug) {
+    return {
+      packState: 'invalid',
+      document: null,
+      issues,
+    };
+  }
+
+  return {
+    packState: 'valid',
+    document: {
+      slug,
+      basis: {
+        prd: prdBasis,
+        testSpecs: testSpecBasis,
+      },
+      entries,
+    },
+    issues: [],
+  };
+}
+
+function findMissingRequiredContextPackRoles(document: ContextPackDocument): ContextPackRole[] {
+  const presentRoles = new Set(document.entries.flatMap((entry) => entry.roles));
+  return REQUIRED_CONTEXT_PACK_ROLES.filter((role) => !presentRoles.has(role));
+}
+
+function validateContextPackBasis(
+  repoRoot: string,
+  prdPath: string,
+  testSpecPaths: readonly string[],
+  document: ContextPackDocument,
+): string[] {
+  const issues: string[] = [];
+  const expectedSlug = planningArtifactSlug(prdPath, 'prd');
+  if (!expectedSlug) {
+    issues.push('Approved plan slug could not be resolved for context pack validation.');
+  } else if (document.slug !== expectedSlug) {
+    issues.push(`Declared context pack slug ${document.slug} does not match approved plan slug ${expectedSlug}.`);
+  }
+
+  const expectedPrdRelativePath = normalizeRepoRelativePath(relative(repoRoot, prdPath));
+  if (!expectedPrdRelativePath) {
+    issues.push('Approved plan path could not be normalized for context pack validation.');
+  } else if (document.basis.prd.path !== expectedPrdRelativePath) {
+    issues.push(`Declared context pack basis prd path ${document.basis.prd.path} does not match ${expectedPrdRelativePath}.`);
+  } else if (document.basis.prd.sha1 !== computeGitBlobSha1(prdPath)) {
+    issues.push(`Declared context pack basis prd hash for ${document.basis.prd.path} does not match the current approved PRD.`);
+  }
+
+  const expectedTestSpecMap = new Map(testSpecPaths.flatMap((testSpecPath) => {
+    const normalizedPath = normalizeRepoRelativePath(relative(repoRoot, testSpecPath));
+    return normalizedPath
+      ? [[normalizedPath, computeGitBlobSha1(testSpecPath)]]
+      : [];
+  }));
+  const storedTestSpecMap = new Map(document.basis.testSpecs.map((testSpec) => [testSpec.path, testSpec.sha1]));
+
+  for (const [expectedPath, expectedSha1] of expectedTestSpecMap.entries()) {
+    const storedSha1 = storedTestSpecMap.get(expectedPath);
+    if (!storedSha1) {
+      issues.push(`Declared context pack basis is missing test-spec ${expectedPath}.`);
+      continue;
+    }
+    if (storedSha1 !== expectedSha1) {
+      issues.push(`Declared context pack basis test-spec hash for ${expectedPath} does not match the current approved test spec.`);
+    }
+  }
+  for (const storedPath of storedTestSpecMap.keys()) {
+    if (!expectedTestSpecMap.has(storedPath)) {
+      issues.push(`Declared context pack basis includes unexpected test-spec ${storedPath}.`);
+    }
+  }
+
+  return issues;
+}
+
+export function resolveContextPackHandoffState(input: {
+  baselineState: ContextPackBaselineState;
+  outcomeState: ContextPackOutcomeState;
+  packState: ContextPackPackState;
+  roleCoverage: ContextPackRoleCoverageState;
+  basisState: ContextPackBasisState;
+}): ContextPackStatus {
+  if (input.baselineState !== 'present') {
+    return 'missing-baseline';
+  }
+  if (input.outcomeState === 'absent') {
+    return 'plan-only';
+  }
+  if (input.outcomeState === 'malformed' || input.outcomeState === 'ambiguous') {
+    return 'invalid';
+  }
+  if (input.packState === 'missing') {
+    return 'incomplete';
+  }
+  if (input.packState === 'unreadable' || input.packState === 'invalid') {
+    return 'invalid';
+  }
+  if (input.basisState !== 'fresh') {
+    return 'invalid';
+  }
+  if (input.roleCoverage !== 'covered') {
+    return 'incomplete';
+  }
+  return 'ready';
+}
+
+function resolveContextPackHandoffStatus(
+  artifacts: PlanningArtifacts,
+  selection: PlanningArtifactSelectionBase,
+): ContextPackHandoffStatusSnapshot {
+  const prdPath = selection.prdPath;
+  const repoRoot = dirname(dirname(artifacts.plansDir));
+  const baselineState: ContextPackBaselineState = !prdPath || !existsSync(prdPath)
+    ? 'missing-prd'
+    : selection.testSpecPaths.length === 0
+      ? 'missing-test-spec'
+      : 'present';
+  const contextPackIssues: string[] = selection.testSpecPaths.length === 0 && prdPath
+    ? ['Approved plan is missing a matching test spec.']
+    : [];
+
+  let contextPack: ContextPackRef | null = null;
+  let outcomeState: ContextPackOutcomeState = 'absent';
+  let packState: ContextPackPackState = 'missing';
+  let roleCoverage: ContextPackRoleCoverageState = 'missing-required-roles';
+  let basisState: ContextPackBasisState = 'stale';
+  let missingRequiredContextPackRoles: ContextPackRole[] = [];
+  let declarationMismatch = false;
+
+  if (prdPath && existsSync(prdPath)) {
+    try {
+      const outcome = inspectContextPackOutcome(repoRoot, readFileSync(prdPath, 'utf-8'));
+      outcomeState = outcome.outcomeState;
+      contextPack = outcome.contextPack;
+      contextPackIssues.push(...outcome.issues);
+
+      const expectedSlug = planningArtifactSlug(prdPath, 'prd');
+      if (
+        contextPack
+        && outcome.declaredSlug
+        && expectedSlug
+        && outcome.declaredSlug !== expectedSlug
+      ) {
+        declarationMismatch = true;
+        contextPackIssues.push(`Declared context pack slug ${outcome.declaredSlug} does not match approved plan slug ${expectedSlug}.`);
+      }
+
+      if (outcome.outcomeState === 'declared' && contextPack) {
+        if (!existsSync(contextPack.path)) {
+          packState = 'missing';
+          contextPackIssues.push(`Declared context pack file is missing: ${outcome.declaredPackPath ?? contextPack.path}.`);
+        } else {
+          const packDocument = readContextPackDocument(contextPack.path);
+          packState = packDocument.packState;
+          contextPackIssues.push(...packDocument.issues);
+          if (packDocument.document) {
+            missingRequiredContextPackRoles = findMissingRequiredContextPackRoles(packDocument.document);
+            roleCoverage = missingRequiredContextPackRoles.length === 0 ? 'covered' : 'missing-required-roles';
+            if (baselineState === 'present') {
+              const basisIssues = validateContextPackBasis(
+                repoRoot,
+                prdPath,
+                selection.testSpecPaths,
+                packDocument.document,
+              );
+              if (basisIssues.length === 0) {
+                basisState = 'fresh';
+              } else {
+                contextPackIssues.push(...basisIssues);
+              }
+            }
+          }
+        }
+      }
+    } catch {
+      outcomeState = 'malformed';
+      contextPackIssues.push('Approved plan could not be read while resolving context pack status.');
+    }
+  }
+  if (declarationMismatch && packState === 'valid') {
+    packState = 'invalid';
+  }
+
+  return {
+    prdPath,
+    testSpecPaths: selection.testSpecPaths,
+    contextPack,
+    contextPackStatus: resolveContextPackHandoffState({
+      baselineState,
+      outcomeState,
+      packState,
+      roleCoverage,
+      basisState,
+    }),
+    baselineState,
+    outcomeState,
+    packState,
+    roleCoverage,
+    basisState,
+    missingRequiredContextPackRoles,
+    contextPackIssues,
+  };
+}
+
+function selectPlanningArtifacts(
+  artifacts: PlanningArtifacts,
+  prdPath?: string,
+): LatestPlanningArtifactSelection {
+  const selection = selectPlanningArtifactsBase(artifacts, prdPath);
+  const handoffStatus = resolveContextPackHandoffStatus(artifacts, selection);
+  return {
+    ...selection,
+    contextPack: handoffStatus.contextPack,
+    contextPackStatus: handoffStatus.contextPackStatus,
+    missingRequiredContextPackRoles: handoffStatus.missingRequiredContextPackRoles,
+    contextPackIssues: handoffStatus.contextPackIssues,
   };
 }
 
@@ -223,6 +826,10 @@ function readApprovedPlanText(
         sourcePath: latestPrdPath,
         testSpecPaths: selection.testSpecPaths,
         deepInterviewSpecPaths: selection.deepInterviewSpecPaths,
+        contextPack: selection.contextPack,
+        contextPackStatus: selection.contextPackStatus,
+        missingRequiredContextPackRoles: selection.missingRequiredContextPackRoles,
+        contextPackIssues: selection.contextPackIssues,
         ...(repositoryContextSummary ? { repositoryContextSummary } : {}),
       },
     };
@@ -239,6 +846,14 @@ export function selectLatestPlanningArtifacts(
 
 export function readLatestPlanningArtifacts(cwd: string): LatestPlanningArtifactSelection {
   return selectLatestPlanningArtifacts(readPlanningArtifacts(cwd));
+}
+
+export function readContextPackHandoffStatus(
+  cwd: string,
+  prdPath?: string,
+): ContextPackHandoffStatusSnapshot {
+  const artifacts = readPlanningArtifacts(cwd);
+  return resolveContextPackHandoffStatus(artifacts, selectPlanningArtifactsBase(artifacts, prdPath));
 }
 
 function extractTeamDagMarkdownHandoff(content: string): string | null {
@@ -263,7 +878,7 @@ export function readTeamDagArtifactResolution(cwd: string): TeamDagArtifactResol
     return { source: 'none', prdPath: null, planSlug: null, warnings: ['planning_incomplete'] };
   }
 
-  const selection = selectLatestPlanningArtifacts(artifacts);
+  const selection = selectPlanningArtifactsBase(artifacts);
   const prdPath = selection.prdPath;
   const planSlug = prdPath ? artifactPathSuffix(prdPath, /^prd-(?<slug>.*)\.md$/i) : null;
   if (!prdPath || !planSlug) {

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -1,6 +1,5 @@
-import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { basename, dirname, join, relative, resolve } from 'node:path';
+import { basename, join } from 'node:path';
 import {
   comparePlanningArtifactPaths,
   parsePlanningArtifactFileName,
@@ -8,74 +7,45 @@ import {
   selectLatestPlanningArtifactPath,
   selectMatchingTestSpecsForPrd,
 } from './artifact-names.js';
+import {
+  isApprovedExecutionContextReadyStatus,
+  isApprovedExecutionFollowupReadyStatus,
+  resolveContextPackHandoffStatus,
+  type ContextPackHandoffStatusSnapshot,
+  type ContextPackRef,
+  type ContextPackRole,
+  type ContextPackStatus,
+} from './context-pack-status.js';
 import { omxPlansDir } from '../utils/paths.js';
 
 const PRD_PATTERN = /^prd-.*\.md$/i;
 const TEST_SPEC_PATTERN = /^test-?spec-.*\.md$/i;
 const DEEP_INTERVIEW_SPEC_PATTERN = /^deep-interview-.*\.md$/i;
-const CONTEXT_PACK_OUTCOME_HEADING_PATTERN = /^#{1,6}\s+Context Pack Outcome\s*$/i;
-const CONTEXT_PACK_OUTCOME_DECLARATION_PATTERN = /^[*-]\s*pack\s*:/i;
-const CONTEXT_PACK_OUTCOME_LINE_PATTERN = /^[*-]\s*pack\s*:\s*(?:(?:created|refreshed|revalidated)\s+)?(?:`(?<quotedPath>[^`]+\.json)`|(?<barePath>\S+\.json))\s*$/i;
-const CONTEXT_PACK_PATH_PATTERN = /^\.omx\/context\/context-(?<timestamp>\d{8}T\d{6}Z)-(?<slug>.+)\.json$/i;
-const SHA1_PATTERN = /^[0-9a-f]{40}$/i;
 const APPROVED_REPOSITORY_CONTEXT_MAX_CHARS = 4_000;
 const APPROVED_REPOSITORY_CONTEXT_MAX_LINES = 80;
-export const REQUIRED_CONTEXT_PACK_ROLES = ['scope', 'build', 'verify'] as const;
-export type ContextPackRole = (typeof REQUIRED_CONTEXT_PACK_ROLES)[number];
-export type ContextPackStatus = 'missing-baseline' | 'plan-only' | 'ready' | 'incomplete' | 'invalid';
-export type ContextPackBaselineState = 'missing-prd' | 'missing-test-spec' | 'present';
-export type ContextPackOutcomeState = 'absent' | 'malformed' | 'ambiguous' | 'declared';
-export type ContextPackPackState = 'missing' | 'unreadable' | 'invalid' | 'valid';
-export type ContextPackRoleCoverageState = 'missing-required-roles' | 'covered';
-export type ContextPackBasisState = 'stale' | 'fresh';
 
-export interface ContextPackRef {
-  path: string;
-}
-
-export interface ContextPackHandoffStatusSnapshot {
-  prdPath: string | null;
-  testSpecPaths: string[];
-  contextPack: ContextPackRef | null;
-  contextPackStatus: ContextPackStatus;
-  baselineState: ContextPackBaselineState;
-  outcomeState: ContextPackOutcomeState;
-  packState: ContextPackPackState;
-  roleCoverage: ContextPackRoleCoverageState;
-  basisState: ContextPackBasisState;
-  missingRequiredContextPackRoles: ContextPackRole[];
-  contextPackIssues: string[];
-}
-
-interface ContextPackBasisObject {
-  path: string;
-  sha1: string;
-}
-
-interface ContextPackDocument {
-  slug: string;
-  basis: {
-    prd: ContextPackBasisObject;
-    testSpecs: ContextPackBasisObject[];
-  };
-  entries: Array<{
-    path: string;
-    roles: ContextPackRole[];
-  }>;
-}
+export {
+  REQUIRED_CONTEXT_PACK_ROLES,
+  isApprovedExecutionContextReadyStatus,
+  isApprovedExecutionFollowupReadyStatus,
+  resolveContextPackHandoffState,
+} from './context-pack-status.js';
+export type {
+  ContextPackHandoffStatusSnapshot,
+  ContextPackBaselineState,
+  ContextPackBasisState,
+  ContextPackOutcomeState,
+  ContextPackPackState,
+  ContextPackRef,
+  ContextPackRole,
+  ContextPackRoleCoverageState,
+  ContextPackStatus,
+} from './context-pack-status.js';
 
 interface PlanningArtifactSelectionBase {
   prdPath: string | null;
   testSpecPaths: string[];
   deepInterviewSpecPaths: string[];
-}
-
-interface ContextPackOutcomeInspection {
-  outcomeState: ContextPackOutcomeState;
-  contextPack: ContextPackRef | null;
-  declaredPackPath: string | null;
-  declaredSlug: string | null;
-  issues: string[];
 }
 
 export interface PlanningArtifacts {
@@ -176,14 +146,6 @@ export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
   return Boolean(selection.prdPath) && selection.testSpecPaths.length > 0;
 }
 
-export function isApprovedExecutionFollowupReadyStatus(status: ContextPackStatus): boolean {
-  return status === 'ready' || status === 'plan-only';
-}
-
-export function isApprovedExecutionContextReadyStatus(status: ContextPackStatus): boolean {
-  return status === 'ready';
-}
-
 export function decodeApprovedExecutionQuotedValue(raw: string): string | null {
   const normalized = raw.trim();
   if (!normalized) return null;
@@ -226,515 +188,6 @@ function selectPlanningArtifactsBase(
     prdPath: selectedPrdPath,
     testSpecPaths: selectMatchingTestSpecsForPrd(selectedPrdPath, artifacts.testSpecPaths),
     deepInterviewSpecPaths: selectDeepInterviewSpecPathsForSlug(artifacts.deepInterviewSpecPaths, slug),
-  };
-}
-
-function normalizeRepoRelativePath(rawPath: string): string | null {
-  const trimmed = rawPath.trim().replace(/^`|`$/g, '').replaceAll('\\', '/');
-  if (!trimmed) {
-    return null;
-  }
-  const withoutLeadingDot = trimmed.startsWith('./') ? trimmed.slice(2) : trimmed;
-  if (!withoutLeadingDot || withoutLeadingDot.startsWith('/') || /^[A-Za-z]:/.test(withoutLeadingDot)) {
-    return null;
-  }
-  const segments = withoutLeadingDot.split('/').filter((segment) => segment.length > 0);
-  if (segments.length === 0 || segments.includes('..')) {
-    return null;
-  }
-  return segments.join('/');
-}
-
-function computeGitBlobSha1(filePath: string): string {
-  const buffer = readFileSync(filePath);
-  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
-  return createHash('sha1').update(header).update(buffer).digest('hex');
-}
-
-function isMarkdownFenceLine(line: string): boolean {
-  return /^(```|~~~)/.test(line.trimStart());
-}
-
-function isIndentedMarkdownCodeLine(line: string): boolean {
-  return /^(?: {4,}|\t)/.test(line);
-}
-
-function extractContextPackOutcomeSections(content: string): string[][] {
-  const lines = content.replace(/\r\n/g, '\n').split('\n');
-  const sections: string[][] = [];
-  let inFence = false;
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index]!;
-    if (isMarkdownFenceLine(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence || isIndentedMarkdownCodeLine(line)) {
-      continue;
-    }
-    if (!CONTEXT_PACK_OUTCOME_HEADING_PATTERN.test(line.trim())) {
-      continue;
-    }
-
-    const section: string[] = [];
-    for (let sectionIndex = index + 1; sectionIndex < lines.length; sectionIndex += 1) {
-      const sectionLine = lines[sectionIndex]!;
-      const trimmed = sectionLine.trim();
-      if (
-        isMarkdownFenceLine(sectionLine)
-        || isIndentedMarkdownCodeLine(sectionLine)
-        || /^#{1,6}\s+\S/.test(trimmed)
-        || (trimmed !== '' && !/^[*-]\s+/.test(trimmed))
-      ) {
-        break;
-      }
-      section.push(sectionLine);
-    }
-    sections.push(section);
-  }
-
-  return sections;
-}
-
-function resolveDeclaredContextPackPath(
-  repoRoot: string,
-  rawPath: string,
-): { normalizedPath: string; resolvedPath: string; slug: string } | null {
-  const normalizedPath = normalizeRepoRelativePath(rawPath);
-  if (!normalizedPath) {
-    return null;
-  }
-  const pathMatch = normalizedPath.match(CONTEXT_PACK_PATH_PATTERN);
-  if (!pathMatch?.groups?.slug) {
-    return null;
-  }
-  const resolvedPath = resolve(repoRoot, normalizedPath);
-  const roundTripPath = normalizeRepoRelativePath(relative(repoRoot, resolvedPath));
-  if (!roundTripPath || roundTripPath !== normalizedPath) {
-    return null;
-  }
-  return {
-    normalizedPath,
-    resolvedPath,
-    slug: pathMatch.groups.slug,
-  };
-}
-
-function inspectContextPackOutcome(repoRoot: string, content: string): ContextPackOutcomeInspection {
-  const outcomeSections = extractContextPackOutcomeSections(content);
-  if (outcomeSections.length === 0) {
-    return {
-      outcomeState: 'absent',
-      contextPack: null,
-      declaredPackPath: null,
-      declaredSlug: null,
-      issues: [],
-    };
-  }
-  if (outcomeSections.length > 1) {
-    return {
-      outcomeState: 'ambiguous',
-      contextPack: null,
-      declaredPackPath: null,
-      declaredSlug: null,
-      issues: ['Approved plan contains multiple Context Pack Outcome sections.'],
-    };
-  }
-
-  let declarationCount = 0;
-  let resolvedPackPath: string | null = null;
-  let resolvedSlug: string | null = null;
-  let resolvedPack: ContextPackRef | null = null;
-  const issues: string[] = [];
-
-  for (const line of outcomeSections[0]!) {
-    const trimmed = line.trim();
-    if (!trimmed || !CONTEXT_PACK_OUTCOME_DECLARATION_PATTERN.test(trimmed)) {
-      continue;
-    }
-    declarationCount += 1;
-    const lineMatch = trimmed.match(CONTEXT_PACK_OUTCOME_LINE_PATTERN);
-    if (!lineMatch?.groups) {
-      issues.push(`Invalid Context Pack Outcome line: ${trimmed}`);
-      continue;
-    }
-    const resolvedPath = resolveDeclaredContextPackPath(
-      repoRoot,
-      lineMatch.groups.quotedPath ?? lineMatch.groups.barePath,
-    );
-    if (!resolvedPath) {
-      issues.push('Context Pack Outcome must point to .omx/context/context-<timestamp>-<slug>.json.');
-      continue;
-    }
-    if (declarationCount > 1) {
-      issues.push('Context Pack Outcome may declare only one pack.');
-      continue;
-    }
-    resolvedPackPath = resolvedPath.normalizedPath;
-    resolvedSlug = resolvedPath.slug;
-    resolvedPack = { path: resolvedPath.resolvedPath };
-  }
-
-  if (declarationCount === 0) {
-    return {
-      outcomeState: 'malformed',
-      contextPack: null,
-      declaredPackPath: null,
-      declaredSlug: null,
-      issues: ['Context Pack Outcome must declare exactly one pack.'],
-    };
-  }
-  if (declarationCount > 1) {
-    return {
-      outcomeState: 'ambiguous',
-      contextPack: resolvedPack,
-      declaredPackPath: resolvedPackPath,
-      declaredSlug: resolvedSlug,
-      issues: issues.length > 0 ? issues : ['Context Pack Outcome may declare only one pack.'],
-    };
-  }
-  if (issues.length > 0 || !resolvedPack || !resolvedPackPath || !resolvedSlug) {
-    return {
-      outcomeState: 'malformed',
-      contextPack: resolvedPack,
-      declaredPackPath: resolvedPackPath,
-      declaredSlug: resolvedSlug,
-      issues,
-    };
-  }
-  return {
-    outcomeState: 'declared',
-    contextPack: resolvedPack,
-    declaredPackPath: resolvedPackPath,
-    declaredSlug: resolvedSlug,
-    issues: [],
-  };
-}
-
-function readContextPackDocument(packPath: string): {
-  packState: ContextPackPackState;
-  document: ContextPackDocument | null;
-  issues: string[];
-} {
-  let rawContent = '';
-  try {
-    rawContent = readFileSync(packPath, 'utf-8');
-  } catch {
-    return {
-      packState: 'unreadable',
-      document: null,
-      issues: ['Declared context pack could not be read.'],
-    };
-  }
-
-  let rawDocument: unknown;
-  try {
-    rawDocument = JSON.parse(rawContent);
-  } catch {
-    return {
-      packState: 'invalid',
-      document: null,
-      issues: ['Declared context pack contains invalid JSON.'],
-    };
-  }
-  if (!rawDocument || typeof rawDocument !== 'object' || Array.isArray(rawDocument)) {
-    return {
-      packState: 'invalid',
-      document: null,
-      issues: ['Declared context pack must be a JSON object.'],
-    };
-  }
-
-  const documentRecord = rawDocument as Record<string, unknown>;
-  const issues: string[] = [];
-
-  const slug = typeof documentRecord.slug === 'string' ? documentRecord.slug.trim() : '';
-  if (!slug) {
-    issues.push('Declared context pack must declare a non-empty slug.');
-  }
-
-  const basisRecord = documentRecord.basis;
-  if (!basisRecord || typeof basisRecord !== 'object' || Array.isArray(basisRecord)) {
-    issues.push('Declared context pack must declare basis PRD and test-spec hashes.');
-  }
-  const prdBasisRecord = !basisRecord || typeof basisRecord !== 'object' || Array.isArray(basisRecord)
-    ? null
-    : (basisRecord as Record<string, unknown>).prd;
-  const testSpecsBasisRecord = !basisRecord || typeof basisRecord !== 'object' || Array.isArray(basisRecord)
-    ? null
-    : (basisRecord as Record<string, unknown>).testSpecs;
-
-  const normalizeBasisObject = (value: unknown, label: string): ContextPackBasisObject | null => {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      issues.push(`Declared context pack ${label} basis must be an object.`);
-      return null;
-    }
-    const record = value as Record<string, unknown>;
-    const path = typeof record.path === 'string' ? normalizeRepoRelativePath(record.path) : null;
-    if (!path) {
-      issues.push(`Declared context pack ${label} basis path must be repo-relative.`);
-    }
-    const sha1 = typeof record.sha1 === 'string' && SHA1_PATTERN.test(record.sha1.trim())
-      ? record.sha1.trim().toLowerCase()
-      : null;
-    if (!sha1) {
-      issues.push(`Declared context pack ${label} basis sha1 must be a 40-character hex string.`);
-    }
-    return path && sha1 ? { path, sha1 } : null;
-  };
-
-  const prdBasis = normalizeBasisObject(prdBasisRecord, 'prd');
-  const testSpecBasis = Array.isArray(testSpecsBasisRecord)
-    ? testSpecsBasisRecord
-      .map((value, index) => normalizeBasisObject(value, `test-spec[${index}]`))
-      .filter((value): value is ContextPackBasisObject => value !== null)
-    : [];
-  if (!Array.isArray(testSpecsBasisRecord) || testSpecBasis.length === 0) {
-    issues.push('Declared context pack must declare at least one test-spec basis entry.');
-  }
-
-  const rawEntries = documentRecord.entries;
-  if (!Array.isArray(rawEntries) || rawEntries.length === 0) {
-    issues.push('Declared context pack must declare at least one entry.');
-  }
-  const entries = Array.isArray(rawEntries)
-    ? rawEntries.flatMap((rawEntry) => {
-      if (!rawEntry || typeof rawEntry !== 'object' || Array.isArray(rawEntry)) {
-        issues.push('Declared context pack entries must be objects.');
-        return [];
-      }
-      const record = rawEntry as Record<string, unknown>;
-      const path = typeof record.path === 'string' ? normalizeRepoRelativePath(record.path) : null;
-      if (!path) {
-        issues.push('Declared context pack entries must provide a repo-relative path.');
-      }
-      if (!Array.isArray(record.roles) || record.roles.length === 0) {
-        issues.push('Declared context pack entries must declare at least one role.');
-        return [];
-      }
-      const roles = [...new Set(record.roles.flatMap((role) => {
-        if (typeof role !== 'string') {
-          issues.push('Declared context pack entry roles must be strings.');
-          return [];
-        }
-        const normalizedRole = role.trim();
-        if (!REQUIRED_CONTEXT_PACK_ROLES.includes(normalizedRole as ContextPackRole)) {
-          issues.push(`Declared context pack entry role "${normalizedRole}" is not supported.`);
-          return [];
-        }
-        return [normalizedRole as ContextPackRole];
-      }))];
-      if (!path || roles.length === 0) {
-        return [];
-      }
-      return [{ path, roles }];
-    })
-    : [];
-
-  if (issues.length > 0 || !prdBasis || testSpecBasis.length === 0 || entries.length === 0 || !slug) {
-    return {
-      packState: 'invalid',
-      document: null,
-      issues,
-    };
-  }
-
-  return {
-    packState: 'valid',
-    document: {
-      slug,
-      basis: {
-        prd: prdBasis,
-        testSpecs: testSpecBasis,
-      },
-      entries,
-    },
-    issues: [],
-  };
-}
-
-function findMissingRequiredContextPackRoles(document: ContextPackDocument): ContextPackRole[] {
-  const presentRoles = new Set(document.entries.flatMap((entry) => entry.roles));
-  return REQUIRED_CONTEXT_PACK_ROLES.filter((role) => !presentRoles.has(role));
-}
-
-function validateContextPackBasis(
-  repoRoot: string,
-  prdPath: string,
-  testSpecPaths: readonly string[],
-  document: ContextPackDocument,
-): string[] {
-  const issues: string[] = [];
-  const expectedSlug = planningArtifactSlug(prdPath, 'prd');
-  if (!expectedSlug) {
-    issues.push('Approved plan slug could not be resolved for context pack validation.');
-  } else if (document.slug !== expectedSlug) {
-    issues.push(`Declared context pack slug ${document.slug} does not match approved plan slug ${expectedSlug}.`);
-  }
-
-  const expectedPrdRelativePath = normalizeRepoRelativePath(relative(repoRoot, prdPath));
-  if (!expectedPrdRelativePath) {
-    issues.push('Approved plan path could not be normalized for context pack validation.');
-  } else if (document.basis.prd.path !== expectedPrdRelativePath) {
-    issues.push(`Declared context pack basis prd path ${document.basis.prd.path} does not match ${expectedPrdRelativePath}.`);
-  } else if (document.basis.prd.sha1 !== computeGitBlobSha1(prdPath)) {
-    issues.push(`Declared context pack basis prd hash for ${document.basis.prd.path} does not match the current approved PRD.`);
-  }
-
-  const expectedTestSpecMap = new Map(testSpecPaths.flatMap((testSpecPath) => {
-    const normalizedPath = normalizeRepoRelativePath(relative(repoRoot, testSpecPath));
-    return normalizedPath
-      ? [[normalizedPath, computeGitBlobSha1(testSpecPath)]]
-      : [];
-  }));
-  const storedTestSpecMap = new Map(document.basis.testSpecs.map((testSpec) => [testSpec.path, testSpec.sha1]));
-
-  for (const [expectedPath, expectedSha1] of expectedTestSpecMap.entries()) {
-    const storedSha1 = storedTestSpecMap.get(expectedPath);
-    if (!storedSha1) {
-      issues.push(`Declared context pack basis is missing test-spec ${expectedPath}.`);
-      continue;
-    }
-    if (storedSha1 !== expectedSha1) {
-      issues.push(`Declared context pack basis test-spec hash for ${expectedPath} does not match the current approved test spec.`);
-    }
-  }
-  for (const storedPath of storedTestSpecMap.keys()) {
-    if (!expectedTestSpecMap.has(storedPath)) {
-      issues.push(`Declared context pack basis includes unexpected test-spec ${storedPath}.`);
-    }
-  }
-
-  return issues;
-}
-
-export function resolveContextPackHandoffState(input: {
-  baselineState: ContextPackBaselineState;
-  outcomeState: ContextPackOutcomeState;
-  packState: ContextPackPackState;
-  roleCoverage: ContextPackRoleCoverageState;
-  basisState: ContextPackBasisState;
-}): ContextPackStatus {
-  if (input.baselineState !== 'present') {
-    return 'missing-baseline';
-  }
-  if (input.outcomeState === 'absent') {
-    return 'plan-only';
-  }
-  if (input.outcomeState === 'malformed' || input.outcomeState === 'ambiguous') {
-    return 'invalid';
-  }
-  if (input.packState === 'missing') {
-    return 'incomplete';
-  }
-  if (input.packState === 'unreadable' || input.packState === 'invalid') {
-    return 'invalid';
-  }
-  if (input.basisState !== 'fresh') {
-    return 'invalid';
-  }
-  if (input.roleCoverage !== 'covered') {
-    return 'incomplete';
-  }
-  return 'ready';
-}
-
-function resolveContextPackHandoffStatus(
-  artifacts: PlanningArtifacts,
-  selection: PlanningArtifactSelectionBase,
-): ContextPackHandoffStatusSnapshot {
-  const prdPath = selection.prdPath;
-  const repoRoot = dirname(dirname(artifacts.plansDir));
-  const baselineState: ContextPackBaselineState = !prdPath || !existsSync(prdPath)
-    ? 'missing-prd'
-    : selection.testSpecPaths.length === 0
-      ? 'missing-test-spec'
-      : 'present';
-  const contextPackIssues: string[] = selection.testSpecPaths.length === 0 && prdPath
-    ? ['Approved plan is missing a matching test spec.']
-    : [];
-
-  let contextPack: ContextPackRef | null = null;
-  let outcomeState: ContextPackOutcomeState = 'absent';
-  let packState: ContextPackPackState = 'missing';
-  let roleCoverage: ContextPackRoleCoverageState = 'missing-required-roles';
-  let basisState: ContextPackBasisState = 'stale';
-  let missingRequiredContextPackRoles: ContextPackRole[] = [];
-  let declarationMismatch = false;
-
-  if (prdPath && existsSync(prdPath)) {
-    try {
-      const outcome = inspectContextPackOutcome(repoRoot, readFileSync(prdPath, 'utf-8'));
-      outcomeState = outcome.outcomeState;
-      contextPack = outcome.contextPack;
-      contextPackIssues.push(...outcome.issues);
-
-      const expectedSlug = planningArtifactSlug(prdPath, 'prd');
-      if (
-        contextPack
-        && outcome.declaredSlug
-        && expectedSlug
-        && outcome.declaredSlug !== expectedSlug
-      ) {
-        declarationMismatch = true;
-        contextPackIssues.push(`Declared context pack slug ${outcome.declaredSlug} does not match approved plan slug ${expectedSlug}.`);
-      }
-
-      if (outcome.outcomeState === 'declared' && contextPack) {
-        if (!existsSync(contextPack.path)) {
-          packState = 'missing';
-          contextPackIssues.push(`Declared context pack file is missing: ${outcome.declaredPackPath ?? contextPack.path}.`);
-        } else {
-          const packDocument = readContextPackDocument(contextPack.path);
-          packState = packDocument.packState;
-          contextPackIssues.push(...packDocument.issues);
-          if (packDocument.document) {
-            missingRequiredContextPackRoles = findMissingRequiredContextPackRoles(packDocument.document);
-            roleCoverage = missingRequiredContextPackRoles.length === 0 ? 'covered' : 'missing-required-roles';
-            if (baselineState === 'present') {
-              const basisIssues = validateContextPackBasis(
-                repoRoot,
-                prdPath,
-                selection.testSpecPaths,
-                packDocument.document,
-              );
-              if (basisIssues.length === 0) {
-                basisState = 'fresh';
-              } else {
-                contextPackIssues.push(...basisIssues);
-              }
-            }
-          }
-        }
-      }
-    } catch {
-      outcomeState = 'malformed';
-      contextPackIssues.push('Approved plan could not be read while resolving context pack status.');
-    }
-  }
-  if (declarationMismatch && packState === 'valid') {
-    packState = 'invalid';
-  }
-
-  return {
-    prdPath,
-    testSpecPaths: selection.testSpecPaths,
-    contextPack,
-    contextPackStatus: resolveContextPackHandoffState({
-      baselineState,
-      outcomeState,
-      packState,
-      roleCoverage,
-      basisState,
-    }),
-    baselineState,
-    outcomeState,
-    packState,
-    roleCoverage,
-    basisState,
-    missingRequiredContextPackRoles,
-    contextPackIssues,
   };
 }
 

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -628,7 +628,7 @@ export function resolveContextPackHandoffStatus(
     }
   }
 
-  if (declarationMismatch && packState === 'valid') {
+  if (declarationMismatch) {
     packState = 'invalid';
   }
 

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -1,0 +1,654 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { planningArtifactSlug } from './artifact-names.js';
+
+const CONTEXT_PACK_OUTCOME_HEADING_PATTERN =
+  /^#{1,6}\s+Context Pack Outcome\s*$/i;
+const CONTEXT_PACK_OUTCOME_DECLARATION_PATTERN = /^[*-]\s*pack\s*:/i;
+const CONTEXT_PACK_OUTCOME_LINE_PATTERN =
+  /^[*-]\s*pack\s*:\s*(?:(?:created|refreshed|revalidated)\s+)?(?:`(?<quotedPath>[^`]+\.json)`|(?<barePath>\S+\.json))\s*$/i;
+const CONTEXT_PACK_PATH_PATTERN =
+  /^\.omx\/context\/context-(?<timestamp>\d{8}T\d{6}Z)-(?<slug>.+)\.json$/i;
+const SHA1_PATTERN = /^[0-9a-f]{40}$/i;
+
+export const REQUIRED_CONTEXT_PACK_ROLES = ['scope', 'build', 'verify'] as const;
+
+export type ContextPackRole = (typeof REQUIRED_CONTEXT_PACK_ROLES)[number];
+export type ContextPackStatus =
+  'missing-baseline' | 'plan-only' | 'ready' | 'incomplete' | 'invalid';
+export type ContextPackBaselineState = 'missing-prd' | 'missing-test-spec' | 'present';
+export type ContextPackOutcomeState = 'absent' | 'malformed' | 'ambiguous' | 'declared';
+export type ContextPackPackState = 'missing' | 'unreadable' | 'invalid' | 'valid';
+export type ContextPackRoleCoverageState = 'missing-required-roles' | 'covered';
+export type ContextPackBasisState = 'stale' | 'fresh';
+
+export interface ContextPackRef {
+  path: string;
+}
+
+export interface ContextPackHandoffStatusSnapshot {
+  prdPath: string | null;
+  testSpecPaths: string[];
+  contextPack: ContextPackRef | null;
+  contextPackStatus: ContextPackStatus;
+  baselineState: ContextPackBaselineState;
+  outcomeState: ContextPackOutcomeState;
+  packState: ContextPackPackState;
+  roleCoverage: ContextPackRoleCoverageState;
+  basisState: ContextPackBasisState;
+  missingRequiredContextPackRoles: ContextPackRole[];
+  contextPackIssues: string[];
+}
+
+export interface ContextPackArtifactReadModel {
+  plansDir: string;
+}
+
+export interface ContextPackBaselineSelection {
+  prdPath: string | null;
+  testSpecPaths: string[];
+}
+
+interface ContextPackBasisObject {
+  path: string;
+  sha1: string;
+}
+
+interface ContextPackDocument {
+  slug: string;
+  basis: {
+    prd: ContextPackBasisObject;
+    testSpecs: ContextPackBasisObject[];
+  };
+  entries: Array<{
+    path: string;
+    roles: ContextPackRole[];
+  }>;
+}
+
+interface ContextPackOutcomeInspection {
+  outcomeState: ContextPackOutcomeState;
+  contextPack: ContextPackRef | null;
+  declaredPackPath: string | null;
+  declaredSlug: string | null;
+  issues: string[];
+}
+
+export function isApprovedExecutionFollowupReadyStatus(
+  status: ContextPackStatus,
+): boolean {
+  return status === 'ready' || status === 'plan-only';
+}
+
+export function isApprovedExecutionContextReadyStatus(
+  status: ContextPackStatus,
+): boolean {
+  return status === 'ready';
+}
+
+function normalizeRepoRelativePath(rawPath: string): string | null {
+  const trimmed = rawPath.trim().replace(/^`|`$/g, '').replaceAll('\\', '/');
+  if (!trimmed) {
+    return null;
+  }
+  const withoutLeadingDot = trimmed.startsWith('./') ? trimmed.slice(2) : trimmed;
+  if (
+    !withoutLeadingDot
+    || withoutLeadingDot.startsWith('/')
+    || /^[A-Za-z]:/.test(withoutLeadingDot)
+  ) {
+    return null;
+  }
+  const segments = withoutLeadingDot
+    .split('/')
+    .filter((segment) => segment.length > 0);
+  if (segments.length === 0 || segments.includes('..')) {
+    return null;
+  }
+  return segments.join('/');
+}
+
+function computeGitBlobSha1(filePath: string): string {
+  const buffer = readFileSync(filePath);
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function isMarkdownFenceLine(line: string): boolean {
+  return /^(```|~~~)/.test(line.trimStart());
+}
+
+function isIndentedMarkdownCodeLine(line: string): boolean {
+  return /^(?: {4,}|\t)/.test(line);
+}
+
+function extractContextPackOutcomeSections(content: string): string[][] {
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+  const sections: string[][] = [];
+  let inFence = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    if (isMarkdownFenceLine(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence || isIndentedMarkdownCodeLine(line)) {
+      continue;
+    }
+    if (!CONTEXT_PACK_OUTCOME_HEADING_PATTERN.test(line.trim())) {
+      continue;
+    }
+
+    const section: string[] = [];
+    for (let sectionIndex = index + 1; sectionIndex < lines.length; sectionIndex += 1) {
+      const sectionLine = lines[sectionIndex]!;
+      const trimmed = sectionLine.trim();
+      if (
+        isMarkdownFenceLine(sectionLine)
+        || isIndentedMarkdownCodeLine(sectionLine)
+        || /^#{1,6}\s+\S/.test(trimmed)
+        || (trimmed !== '' && !/^[*-]\s+/.test(trimmed))
+      ) {
+        break;
+      }
+      section.push(sectionLine);
+    }
+    sections.push(section);
+  }
+
+  return sections;
+}
+
+function resolveDeclaredContextPackPath(
+  repoRoot: string,
+  rawPath: string,
+): { normalizedPath: string; resolvedPath: string; slug: string } | null {
+  const normalizedPath = normalizeRepoRelativePath(rawPath);
+  if (!normalizedPath) {
+    return null;
+  }
+  const pathMatch = normalizedPath.match(CONTEXT_PACK_PATH_PATTERN);
+  if (!pathMatch?.groups?.slug) {
+    return null;
+  }
+  const resolvedPath = resolve(repoRoot, normalizedPath);
+  const roundTripPath = normalizeRepoRelativePath(relative(repoRoot, resolvedPath));
+  if (!roundTripPath || roundTripPath !== normalizedPath) {
+    return null;
+  }
+  return {
+    normalizedPath,
+    resolvedPath,
+    slug: pathMatch.groups.slug,
+  };
+}
+
+function inspectContextPackOutcome(
+  repoRoot: string,
+  content: string,
+): ContextPackOutcomeInspection {
+  const outcomeSections = extractContextPackOutcomeSections(content);
+  if (outcomeSections.length === 0) {
+    return {
+      outcomeState: 'absent',
+      contextPack: null,
+      declaredPackPath: null,
+      declaredSlug: null,
+      issues: [],
+    };
+  }
+  if (outcomeSections.length > 1) {
+    return {
+      outcomeState: 'ambiguous',
+      contextPack: null,
+      declaredPackPath: null,
+      declaredSlug: null,
+      issues: ['Approved plan contains multiple Context Pack Outcome sections.'],
+    };
+  }
+
+  let declarationCount = 0;
+  let resolvedPackPath: string | null = null;
+  let resolvedSlug: string | null = null;
+  let resolvedPack: ContextPackRef | null = null;
+  const issues: string[] = [];
+
+  for (const line of outcomeSections[0]!) {
+    const trimmed = line.trim();
+    if (!trimmed || !CONTEXT_PACK_OUTCOME_DECLARATION_PATTERN.test(trimmed)) {
+      continue;
+    }
+    declarationCount += 1;
+    const lineMatch = trimmed.match(CONTEXT_PACK_OUTCOME_LINE_PATTERN);
+    if (!lineMatch?.groups) {
+      issues.push(`Invalid Context Pack Outcome line: ${trimmed}`);
+      continue;
+    }
+    const resolvedPath = resolveDeclaredContextPackPath(
+      repoRoot,
+      lineMatch.groups.quotedPath ?? lineMatch.groups.barePath,
+    );
+    if (!resolvedPath) {
+      issues.push(
+        'Context Pack Outcome must point to .omx/context/context-<timestamp>-<slug>.json.',
+      );
+      continue;
+    }
+    if (declarationCount > 1) {
+      issues.push('Context Pack Outcome may declare only one pack.');
+      continue;
+    }
+    resolvedPackPath = resolvedPath.normalizedPath;
+    resolvedSlug = resolvedPath.slug;
+    resolvedPack = { path: resolvedPath.resolvedPath };
+  }
+
+  if (declarationCount === 0) {
+    return {
+      outcomeState: 'malformed',
+      contextPack: null,
+      declaredPackPath: null,
+      declaredSlug: null,
+      issues: ['Context Pack Outcome must declare exactly one pack.'],
+    };
+  }
+  if (declarationCount > 1) {
+    return {
+      outcomeState: 'ambiguous',
+      contextPack: resolvedPack,
+      declaredPackPath: resolvedPackPath,
+      declaredSlug: resolvedSlug,
+      issues: issues.length > 0
+        ? issues
+        : ['Context Pack Outcome may declare only one pack.'],
+    };
+  }
+  if (issues.length > 0 || !resolvedPack || !resolvedPackPath || !resolvedSlug) {
+    return {
+      outcomeState: 'malformed',
+      contextPack: resolvedPack,
+      declaredPackPath: resolvedPackPath,
+      declaredSlug: resolvedSlug,
+      issues,
+    };
+  }
+  return {
+    outcomeState: 'declared',
+    contextPack: resolvedPack,
+    declaredPackPath: resolvedPackPath,
+    declaredSlug: resolvedSlug,
+    issues: [],
+  };
+}
+
+function readContextPackDocument(packPath: string): {
+  packState: ContextPackPackState;
+  document: ContextPackDocument | null;
+  issues: string[];
+} {
+  let rawContent = '';
+  try {
+    rawContent = readFileSync(packPath, 'utf-8');
+  } catch {
+    return {
+      packState: 'unreadable',
+      document: null,
+      issues: ['Declared context pack could not be read.'],
+    };
+  }
+
+  let rawDocument: unknown;
+  try {
+    rawDocument = JSON.parse(rawContent);
+  } catch {
+    return {
+      packState: 'invalid',
+      document: null,
+      issues: ['Declared context pack contains invalid JSON.'],
+    };
+  }
+  if (!rawDocument || typeof rawDocument !== 'object' || Array.isArray(rawDocument)) {
+    return {
+      packState: 'invalid',
+      document: null,
+      issues: ['Declared context pack must be a JSON object.'],
+    };
+  }
+
+  const documentRecord = rawDocument as Record<string, unknown>;
+  const issues: string[] = [];
+
+  const slug =
+    typeof documentRecord.slug === 'string' ? documentRecord.slug.trim() : '';
+  if (!slug) {
+    issues.push('Declared context pack must declare a non-empty slug.');
+  }
+
+  const basisRecord = documentRecord.basis;
+  if (!basisRecord || typeof basisRecord !== 'object' || Array.isArray(basisRecord)) {
+    issues.push('Declared context pack must declare basis PRD and test-spec hashes.');
+  }
+  const prdBasisRecord =
+    !basisRecord || typeof basisRecord !== 'object' || Array.isArray(basisRecord)
+      ? null
+      : (basisRecord as Record<string, unknown>).prd;
+  const testSpecsBasisRecord =
+    !basisRecord || typeof basisRecord !== 'object' || Array.isArray(basisRecord)
+      ? null
+      : (basisRecord as Record<string, unknown>).testSpecs;
+
+  const normalizeBasisObject = (
+    value: unknown,
+    label: string,
+  ): ContextPackBasisObject | null => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      issues.push(`Declared context pack ${label} basis must be an object.`);
+      return null;
+    }
+    const record = value as Record<string, unknown>;
+    const path =
+      typeof record.path === 'string' ? normalizeRepoRelativePath(record.path) : null;
+    if (!path) {
+      issues.push(`Declared context pack ${label} basis path must be repo-relative.`);
+    }
+    const sha1 =
+      typeof record.sha1 === 'string' && SHA1_PATTERN.test(record.sha1.trim())
+        ? record.sha1.trim().toLowerCase()
+        : null;
+    if (!sha1) {
+      issues.push(
+        `Declared context pack ${label} basis sha1 must be a 40-character hex string.`,
+      );
+    }
+    return path && sha1 ? { path, sha1 } : null;
+  };
+
+  const prdBasis = normalizeBasisObject(prdBasisRecord, 'prd');
+  const testSpecBasis = Array.isArray(testSpecsBasisRecord)
+    ? testSpecsBasisRecord
+      .map((value, index) => normalizeBasisObject(value, `test-spec[${index}]`))
+      .filter((value): value is ContextPackBasisObject => value !== null)
+    : [];
+  if (!Array.isArray(testSpecsBasisRecord) || testSpecBasis.length === 0) {
+    issues.push('Declared context pack must declare at least one test-spec basis entry.');
+  }
+
+  const rawEntries = documentRecord.entries;
+  if (!Array.isArray(rawEntries) || rawEntries.length === 0) {
+    issues.push('Declared context pack must declare at least one entry.');
+  }
+  const entries = Array.isArray(rawEntries)
+    ? rawEntries.flatMap((rawEntry) => {
+      if (!rawEntry || typeof rawEntry !== 'object' || Array.isArray(rawEntry)) {
+        issues.push('Declared context pack entries must be objects.');
+        return [];
+      }
+      const record = rawEntry as Record<string, unknown>;
+      const path =
+        typeof record.path === 'string' ? normalizeRepoRelativePath(record.path) : null;
+      if (!path) {
+        issues.push('Declared context pack entries must provide a repo-relative path.');
+      }
+      if (!Array.isArray(record.roles) || record.roles.length === 0) {
+        issues.push('Declared context pack entries must declare at least one role.');
+        return [];
+      }
+      const roles = [...new Set(record.roles.flatMap((role) => {
+        if (typeof role !== 'string') {
+          issues.push('Declared context pack entry roles must be strings.');
+          return [];
+        }
+        const normalizedRole = role.trim();
+        if (!REQUIRED_CONTEXT_PACK_ROLES.includes(normalizedRole as ContextPackRole)) {
+          issues.push(
+            `Declared context pack entry role "${normalizedRole}" is not supported.`,
+          );
+          return [];
+        }
+        return [normalizedRole as ContextPackRole];
+      }))];
+      if (!path || roles.length === 0) {
+        return [];
+      }
+      return [{ path, roles }];
+    })
+    : [];
+
+  if (
+    issues.length > 0
+    || !prdBasis
+    || testSpecBasis.length === 0
+    || entries.length === 0
+    || !slug
+  ) {
+    return {
+      packState: 'invalid',
+      document: null,
+      issues,
+    };
+  }
+
+  return {
+    packState: 'valid',
+    document: {
+      slug,
+      basis: {
+        prd: prdBasis,
+        testSpecs: testSpecBasis,
+      },
+      entries,
+    },
+    issues: [],
+  };
+}
+
+function findMissingRequiredContextPackRoles(
+  document: ContextPackDocument,
+): ContextPackRole[] {
+  const presentRoles = new Set(document.entries.flatMap((entry) => entry.roles));
+  return REQUIRED_CONTEXT_PACK_ROLES.filter((role) => !presentRoles.has(role));
+}
+
+function validateContextPackBasis(
+  repoRoot: string,
+  prdPath: string,
+  testSpecPaths: readonly string[],
+  document: ContextPackDocument,
+): string[] {
+  const issues: string[] = [];
+  const expectedSlug = planningArtifactSlug(prdPath, 'prd');
+  if (!expectedSlug) {
+    issues.push('Approved plan slug could not be resolved for context pack validation.');
+  } else if (document.slug !== expectedSlug) {
+    issues.push(
+      `Declared context pack slug ${document.slug} does not match approved plan slug ${expectedSlug}.`,
+    );
+  }
+
+  const expectedPrdRelativePath = normalizeRepoRelativePath(relative(repoRoot, prdPath));
+  if (!expectedPrdRelativePath) {
+    issues.push('Approved plan path could not be normalized for context pack validation.');
+  } else if (document.basis.prd.path !== expectedPrdRelativePath) {
+    issues.push(
+      `Declared context pack basis prd path ${document.basis.prd.path} does not match ${expectedPrdRelativePath}.`,
+    );
+  } else if (document.basis.prd.sha1 !== computeGitBlobSha1(prdPath)) {
+    issues.push(
+      `Declared context pack basis prd hash for ${document.basis.prd.path} does not match the current approved PRD.`,
+    );
+  }
+
+  const expectedTestSpecMap = new Map(testSpecPaths.flatMap((testSpecPath) => {
+    const normalizedPath = normalizeRepoRelativePath(relative(repoRoot, testSpecPath));
+    return normalizedPath
+      ? [[normalizedPath, computeGitBlobSha1(testSpecPath)]]
+      : [];
+  }));
+  const storedTestSpecMap = new Map(
+    document.basis.testSpecs.map((testSpec) => [testSpec.path, testSpec.sha1]),
+  );
+
+  for (const [expectedPath, expectedSha1] of expectedTestSpecMap.entries()) {
+    const storedSha1 = storedTestSpecMap.get(expectedPath);
+    if (!storedSha1) {
+      issues.push(`Declared context pack basis is missing test-spec ${expectedPath}.`);
+      continue;
+    }
+    if (storedSha1 !== expectedSha1) {
+      issues.push(
+        `Declared context pack basis test-spec hash for ${expectedPath} does not match the current approved test spec.`,
+      );
+    }
+  }
+  for (const storedPath of storedTestSpecMap.keys()) {
+    if (!expectedTestSpecMap.has(storedPath)) {
+      issues.push(`Declared context pack basis includes unexpected test-spec ${storedPath}.`);
+    }
+  }
+
+  return issues;
+}
+
+export function resolveContextPackHandoffState(input: {
+  baselineState: ContextPackBaselineState;
+  outcomeState: ContextPackOutcomeState;
+  packState: ContextPackPackState;
+  roleCoverage: ContextPackRoleCoverageState;
+  basisState: ContextPackBasisState;
+}): ContextPackStatus {
+  if (input.baselineState !== 'present') {
+    return 'missing-baseline';
+  }
+  if (input.outcomeState === 'absent') {
+    return 'plan-only';
+  }
+  if (input.outcomeState === 'malformed' || input.outcomeState === 'ambiguous') {
+    return 'invalid';
+  }
+  if (input.packState === 'missing') {
+    return 'incomplete';
+  }
+  if (input.packState === 'unreadable' || input.packState === 'invalid') {
+    return 'invalid';
+  }
+  if (input.basisState !== 'fresh') {
+    return 'invalid';
+  }
+  if (input.roleCoverage !== 'covered') {
+    return 'incomplete';
+  }
+  return 'ready';
+}
+
+export function resolveContextPackHandoffStatus(
+  artifacts: ContextPackArtifactReadModel,
+  selection: ContextPackBaselineSelection,
+): ContextPackHandoffStatusSnapshot {
+  const prdPath = selection.prdPath;
+  const repoRoot = dirname(dirname(artifacts.plansDir));
+  const baselineState: ContextPackBaselineState =
+    !prdPath || !existsSync(prdPath)
+      ? 'missing-prd'
+      : selection.testSpecPaths.length === 0
+        ? 'missing-test-spec'
+        : 'present';
+  const contextPackIssues: string[] =
+    selection.testSpecPaths.length === 0 && prdPath
+      ? ['Approved plan is missing a matching test spec.']
+      : [];
+
+  let contextPack: ContextPackRef | null = null;
+  let outcomeState: ContextPackOutcomeState = 'absent';
+  let packState: ContextPackPackState = 'missing';
+  let roleCoverage: ContextPackRoleCoverageState = 'missing-required-roles';
+  let basisState: ContextPackBasisState = 'stale';
+  let missingRequiredContextPackRoles: ContextPackRole[] = [];
+  let declarationMismatch = false;
+
+  if (prdPath && existsSync(prdPath)) {
+    try {
+      const outcome = inspectContextPackOutcome(repoRoot, readFileSync(prdPath, 'utf-8'));
+      outcomeState = outcome.outcomeState;
+      contextPack = outcome.contextPack;
+      contextPackIssues.push(...outcome.issues);
+
+      const expectedSlug = planningArtifactSlug(prdPath, 'prd');
+      if (
+        contextPack
+        && outcome.declaredSlug
+        && expectedSlug
+        && outcome.declaredSlug !== expectedSlug
+      ) {
+        declarationMismatch = true;
+        contextPackIssues.push(
+          `Declared context pack slug ${outcome.declaredSlug} does not match approved plan slug ${expectedSlug}.`,
+        );
+      }
+
+      if (outcome.outcomeState === 'declared' && contextPack) {
+        if (!existsSync(contextPack.path)) {
+          packState = 'missing';
+          contextPackIssues.push(
+            `Declared context pack file is missing: ${outcome.declaredPackPath ?? contextPack.path}.`,
+          );
+        } else {
+          const packDocument = readContextPackDocument(contextPack.path);
+          packState = packDocument.packState;
+          contextPackIssues.push(...packDocument.issues);
+          if (packDocument.document) {
+            missingRequiredContextPackRoles =
+              findMissingRequiredContextPackRoles(packDocument.document);
+            roleCoverage =
+              missingRequiredContextPackRoles.length === 0
+                ? 'covered'
+                : 'missing-required-roles';
+            if (baselineState === 'present') {
+              const basisIssues = validateContextPackBasis(
+                repoRoot,
+                prdPath,
+                selection.testSpecPaths,
+                packDocument.document,
+              );
+              if (basisIssues.length === 0) {
+                basisState = 'fresh';
+              } else {
+                contextPackIssues.push(...basisIssues);
+              }
+            }
+          }
+        }
+      }
+    } catch {
+      outcomeState = 'malformed';
+      contextPackIssues.push(
+        'Approved plan could not be read while resolving context pack status.',
+      );
+    }
+  }
+
+  if (declarationMismatch && packState === 'valid') {
+    packState = 'invalid';
+  }
+
+  return {
+    prdPath,
+    testSpecPaths: selection.testSpecPaths,
+    contextPack,
+    contextPackStatus: resolveContextPackHandoffState({
+      baselineState,
+      outcomeState,
+      packState,
+      roleCoverage,
+      basisState,
+    }),
+    baselineState,
+    outcomeState,
+    packState,
+    roleCoverage,
+    basisState,
+    missingRequiredContextPackRoles,
+    contextPackIssues,
+  };
+}

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -9,7 +9,7 @@ const CONTEXT_PACK_OUTCOME_DECLARATION_PATTERN = /^[*-]\s*pack\s*:/i;
 const CONTEXT_PACK_OUTCOME_LINE_PATTERN =
   /^[*-]\s*pack\s*:\s*(?:(?:created|refreshed|revalidated)\s+)?(?:`(?<quotedPath>[^`]+\.json)`|(?<barePath>\S+\.json))\s*$/i;
 const CONTEXT_PACK_PATH_PATTERN =
-  /^\.omx\/context\/context-(?<timestamp>\d{8}T\d{6}Z)-(?<slug>.+)\.json$/i;
+  /^\.omx\/context\/context-(?<timestamp>\d{8}T\d{6}Z)-(?<slug>[^/]+)\.json$/i;
 const SHA1_PATTERN = /^[0-9a-f]{40}$/i;
 
 export const REQUIRED_CONTEXT_PACK_ROLES = ['scope', 'build', 'verify'] as const;


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Planning artifacts already identify the approved PRD, matching test specs, and
approved Ralph or Team launch hints, but current upstream has no read-only
way to distinguish a baseline with no declared context pack from a declared
pack that is missing required execution roles or has drifted away from the
approved basis.

## Changes

- add a small planning-side context-pack handoff classifier at the selection
  boundary and isolate the pack-specific read path in
  `src/planning/context-pack-status.ts`
- surface `contextPack`, `contextPackStatus`,
  `missingRequiredContextPackRoles`, and `contextPackIssues` on latest
  planning selection and approved launch hints
- parse a single visible `Context Pack Outcome` section, resolve only
  canonical `.omx/context/context-<timestamp>-<slug>.json` paths, and validate
  declared pack basis plus required `scope | build | verify` role coverage
- fail closed on wrong-slug declarations even when the referenced pack file is
  missing, because broken approved-plan lineage is invalid rather than merely
  incomplete
- keep `src/planning/artifacts.ts` as the thinner planning-selection adapter
  instead of mixing that boundary with pack parsing and validation logic
- keep baseline-only helpers such as `isPlanningComplete()` and Team DAG
  resolution free of the new context-pack parsing in this row
- add focused proof coverage for the public status matrix, plan-only,
  missing-baseline, ready, incomplete, invalid, and fenced/ambiguous outcome
  handling

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Focused validation run for this PR:
- `node --test dist/planning/__tests__/artifacts.test.js dist/planning/__tests__/context-pack-status.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

 - Source commits: `d2d9fe31`, `4ba6bc25`, `f59eccfc`, `58d5c32a`
- No tracked issue for this planning-side bridge row.
- This row is read-only status work only; it does not add context-pack
  authoring, prompt changes, runtime ref materialization, or consumer gating.
