### PR TITLE
fix: keep nonready approved handoffs repair-only

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -300,6 +300,23 @@ describe('ralph deslop launch wiring', () => {
     assert.match(instructions, /Carry forward the approved deep-interview requirements/i);
     assert.match(instructions, /approved repository context summary: \.omx\/plans\/repo-context-issue-1072\.md/i);
     assert.match(instructions, /Key files: src\/cli\/ralph\.ts and src\/planning\/artifacts\.ts/i);
+    assert.match(instructions, /pre-context-pack plan-only handoff baseline/i);
+    assert.match(instructions, /do not treat this as approved context-bearing execution/i);
+  });
+
+  it('surfaces repair-only guidance for invalid approved handoff context', () => {
+    const instructions = buildRalphAppendInstructions('Repair approved issue 1072 plan', {
+      changedFilesPath: '.omx/ralph/changed-files.txt',
+      noDeslop: false,
+      approvedHint: {
+        ...approvedHint,
+        contextPackStatus: 'invalid',
+        contextPackIssues: ['Declared context pack basis test-spec hash does not match the current approved test spec.'],
+      },
+    });
+    assert.match(instructions, /invalid context pack issues: Declared context pack basis test-spec hash/i);
+    assert.match(instructions, /only as repair inputs/i);
+    assert.match(instructions, /repair or recreate the canonical context pack/i);
   });
 
   it('seeds the changed-files artifact with bounded-scope guidance', () => {

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1,18 +1,19 @@
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { afterEach, beforeEach, describe, it, type TestContext } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../team.js';
 import { readModeState } from '../../modes/base.js';
 import { readApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
-import { sameFilePath } from '../../utils/paths.js';
 import { shutdownTeam } from '../../team/runtime.js';
+import { sameFilePath } from '../../utils/paths.js';
 import {
   appendTeamEvent,
   createTask,
@@ -38,6 +39,54 @@ function encodeApprovedExecutionTask(task: string, quote: 'single' | 'double'): 
   return quote === 'single'
     ? `'${task.replace(/'/g, "\\'")}'`
     : `"${task.replace(/"/g, '\\"')}"`;
+}
+
+function computeGitBlobSha1(content: string): string {
+  const buffer = Buffer.from(content, 'utf-8');
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function canonicalContextPackRelativePath(slug: string): string {
+  return `.omx/context/context-20260507T120000Z-${slug}.json`;
+}
+
+function buildContextPackOutcome(relativePackPath: string): string {
+  return [
+    '## Context Pack Outcome',
+    '',
+    `- pack: created \`${relativePackPath}\``,
+  ].join('\n');
+}
+
+async function writeReadyContextPack(
+  cwd: string,
+  slug: string,
+  prdPath: string,
+  testSpecPath: string,
+): Promise<void> {
+  const contextDir = join(cwd, '.omx', 'context');
+  const packPath = join(cwd, canonicalContextPackRelativePath(slug));
+  const prdContent = await readFile(prdPath, 'utf-8');
+  const testSpecContent = await readFile(testSpecPath, 'utf-8');
+  await mkdir(contextDir, { recursive: true });
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relative(cwd, prdPath).replaceAll('\\', '/'),
+        sha1: computeGitBlobSha1(prdContent),
+      },
+      testSpecs: [{
+        path: relative(cwd, testSpecPath).replaceAll('\\', '/'),
+        sha1: computeGitBlobSha1(testSpecContent),
+      }],
+    },
+    entries: ['scope', 'build', 'verify'].map((role, index) => ({
+      path: `src/${role}-${index}.ts`,
+      roles: [role],
+    })),
+  }, null, 2));
 }
 
 beforeEach(() => {
@@ -266,14 +315,19 @@ describe('parseTeamStartArgs', () => {
       const plansDir = join(wd, '.omx', 'plans');
       await mkdir(plansDir, { recursive: true });
       const boundPrdPath = join(plansDir, 'prd-20260501T010203Z-issue-831.md');
+      const boundTestSpecPath = join(plansDir, 'test-spec-20260501T010203Z-issue-831.md');
       await writeFile(
         boundPrdPath,
-        '# Approved plan\n\nLaunch via omx team 2:executor "Execute approved issue 831 plan"\n',
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-831')),
+          '',
+          'Launch via omx team 2:executor "Execute approved issue 831 plan"',
+        ].join('\n'),
       );
-      await writeFile(
-        join(plansDir, 'test-spec-20260501T010203Z-issue-831.md'),
-        '# Test spec\n',
-      );
+      await writeFile(boundTestSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'issue-831', boundPrdPath, boundTestSpecPath);
       await writeFile(
         join(plansDir, 'prd-20260502T010203Z-issue-999.md'),
         '# Approved plan\n\nLaunch via omx team 5:debugger "Execute newer approved issue 999 plan"\n',
@@ -302,10 +356,7 @@ describe('parseTeamStartArgs', () => {
         result.parsed.approvedExecution?.command,
         'omx team 2:executor "Execute approved issue 831 plan"',
       );
-      assert.equal(
-        sameFilePath(result.parsed.approvedExecution?.prd_path ?? '', boundPrdPath),
-        true,
-      );
+      assert.equal(sameFilePath(result.parsed.approvedExecution?.prd_path ?? '', boundPrdPath), true);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -322,11 +373,19 @@ describe('parseTeamStartArgs', () => {
       const boundTask = "Fix Bob's regression in C:\\\\tmp";
       const boundCommand = `omx team 2:executor ${encodeApprovedExecutionTask(boundTask, 'single')}`;
       const boundPrdPath = join(plansDir, 'prd-issue-831-quoted.md');
+      const boundTestSpecPath = join(plansDir, 'test-spec-issue-831-quoted.md');
       await writeFile(
         boundPrdPath,
-        `# Approved plan\n\nLaunch via ${boundCommand}\n`,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-831-quoted')),
+          '',
+          `Launch via ${boundCommand}`,
+        ].join('\n'),
       );
-      await writeFile(join(plansDir, 'test-spec-issue-831-quoted.md'), '# Test spec\n');
+      await writeFile(boundTestSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'issue-831-quoted', boundPrdPath, boundTestSpecPath);
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
       await writeFile(
         join(wd, '.omx', 'state', 'team-state.json'),
@@ -364,11 +423,19 @@ describe('parseTeamStartArgs', () => {
       const boundTask = String.raw`Use C:\tmp and keep \n literal plus "quotes"`;
       const boundCommand = `omx team 2:executor ${encodeApprovedExecutionTask(boundTask, 'double')}`;
       const boundPrdPath = join(plansDir, 'prd-issue-831-double-quoted.md');
+      const boundTestSpecPath = join(plansDir, 'test-spec-issue-831-double-quoted.md');
       await writeFile(
         boundPrdPath,
-        `# Approved plan\n\nLaunch via ${boundCommand}\n`,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-831-double-quoted')),
+          '',
+          `Launch via ${boundCommand}`,
+        ].join('\n'),
       );
-      await writeFile(join(plansDir, 'test-spec-issue-831-double-quoted.md'), '# Test spec\n');
+      await writeFile(boundTestSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'issue-831-double-quoted', boundPrdPath, boundTestSpecPath);
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
       await writeFile(
         join(wd, '.omx', 'state', 'team-state.json'),
@@ -434,6 +501,73 @@ describe('parseTeamStartArgs', () => {
       assert.equal(result.parsed.task, 'Execute approved session-scoped plan');
       assert.equal(result.parsed.workerCount, 5);
       assert.equal(result.parsed.agentType, 'executor');
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps plan-only short follow-ups on the generic path even when a persisted approved binding exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-plan-only-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-2085.md');
+      const command = 'omx team 3:executor "Execute approved issue 2085 plan"';
+      await writeFile(
+        prdPath,
+        `# Approved plan\n\nLaunch via ${command}\n`,
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-2085.md'), '# Test spec\n');
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'team-state.json'),
+        JSON.stringify({ active: true, team_name: 'bound-plan-only-team' }, null, 2),
+      );
+      await writePersistedApprovedTeamExecutionBinding('bound-plan-only-team', wd, {
+        prd_path: prdPath,
+        task: 'Execute approved issue 2085 plan',
+        command,
+      });
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, 'Execute approved issue 2085 plan');
+      assert.equal(result.parsed.workerCount, 3);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.approvedExecution, undefined);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails short follow-up reuse when the latest approved handoff is nonready', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-nonready-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      await writeFile(
+        join(plansDir, 'prd-issue-2086.md'),
+        [
+          '# Approved plan',
+          '',
+          '## Context Pack Outcome',
+          '',
+          '- pack: created `.omx/context/context-20260507T120000Z-other.json`',
+          '',
+          'Launch via omx team 3:executor "Execute approved issue 2086 plan"',
+        ].join('\n'),
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-2086.md'), '# Test spec\n');
+
+      assert.throws(
+        () => parseTeamStartArgs(['team']),
+        /approved_execution_hint_nonready:team:invalid/,
+      );
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -650,6 +784,27 @@ describe('parseTeamStartArgs', () => {
 
       const unrelated = parseTeamStartArgs(['3:executor', 'fix', 'unrelated', 'bug']);
       assert.equal(unrelated.parsed.approvedRepositoryContextSummary, undefined);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not carry approved execution for explicit plan-only team launches', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-explicit-plan-only-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-2087.md'),
+        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 2087 plan"\n',
+      );
+      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-2087.md'), '# Test spec\n');
+
+      const result = parseTeamStartArgs(['3:executor', 'Execute', 'approved', 'issue', '2087', 'plan']);
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
+      assert.equal(result.parsed.approvedExecution, undefined);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -180,6 +180,35 @@ function buildRalphApprovedContextLines(approvedHint: ApprovedExecutionLaunchHin
     lines.push('Approved repository context summary (bounded, inspectable):');
     lines.push(approvedHint.repositoryContextSummary.content);
   }
+  if (approvedHint.contextPackStatus === 'ready') {
+    return lines;
+  }
+  if (approvedHint.contextPackStatus === 'plan-only') {
+    lines.push('- context pack: not declared in the approved plan; using the pre-context-pack plan-only handoff baseline.');
+    lines.push('- Plan-only fallback: use the approved plan, matching test specs, and any deep-interview artifacts as repair inputs; do not treat this as approved context-bearing execution.');
+    return lines;
+  }
+  if (approvedHint.contextPackStatus === 'incomplete') {
+    if (approvedHint.contextPackIssues.length > 0) {
+      lines.push(`- incomplete context pack issues: ${approvedHint.contextPackIssues.join(' | ')}`);
+    }
+    if (approvedHint.missingRequiredContextPackRoles.length > 0) {
+      lines.push(`- missing required context roles: ${approvedHint.missingRequiredContextPackRoles.join(', ')}`);
+    }
+    lines.push('- Incomplete-pack fallback: use the approved plan, matching test specs, and any deep-interview artifacts only as repair inputs; repair or recreate the canonical context pack with required role coverage before broadening context.');
+    return lines;
+  }
+  if (approvedHint.contextPackStatus === 'invalid') {
+    if (approvedHint.contextPackIssues.length > 0) {
+      lines.push(`- invalid context pack issues: ${approvedHint.contextPackIssues.join(' | ')}`);
+    }
+    lines.push('- Invalid-pack fallback: use the approved plan, matching test specs, and any deep-interview artifacts only as repair inputs; repair or recreate the canonical context pack before broadening context.');
+    return lines;
+  }
+  if (approvedHint.contextPackIssues.length > 0) {
+    lines.push(`- missing-baseline issues: ${approvedHint.contextPackIssues.join(' | ')}`);
+  }
+  lines.push('- Missing-baseline fallback: the latest approved plan is missing its matching test spec, so use the surfaced plan as lineage guidance only and restore the missing baseline before broadening context.');
   return lines;
 }
 

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -11,6 +11,8 @@ import type { TeamEvent } from '../team/state.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
 import { classifyTaskSize } from '../hooks/task-size-detector.js';
 import {
+  isApprovedExecutionContextReadyStatus,
+  isApprovedExecutionFollowupReadyStatus,
   readApprovedExecutionLaunchHint,
   readApprovedExecutionLaunchHintOutcome,
   type ApprovedExecutionLaunchHint,
@@ -190,6 +192,11 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
       throw new Error(`approved_execution_binding_stale:${continuity.binding.prd_path}:${continuity.binding.task}`);
     }
     if (continuity.status === 'valid') {
+      if (!isApprovedExecutionFollowupReadyStatus(continuity.approvedHint.contextPackStatus)) {
+        throw new Error(
+          `approved_execution_binding_nonready:${continuity.approvedHint.contextPackStatus}:${continuity.binding.prd_path}:${continuity.binding.task}`,
+        );
+      }
       approvedHint = continuity.approvedHint;
     }
   }
@@ -200,6 +207,9 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
       throw new Error('approved_execution_hint_ambiguous:team');
     }
     if (approvedHintOutcome.status !== 'resolved') return null;
+    if (!isApprovedExecutionFollowupReadyStatus(approvedHintOutcome.hint.contextPackStatus)) {
+      throw new Error(`approved_execution_hint_nonready:team:${approvedHintOutcome.hint.contextPackStatus}`);
+    }
     approvedHint = approvedHintOutcome.hint;
   }
 
@@ -852,12 +862,19 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
 
   const approvedHint = followupContext?.approvedHint
     ?? readApprovedExecutionLaunchHint(cwd, 'team', { task: effectiveTask });
-  const matchesApprovedLaunchHint = approvedHint?.task.trim() === effectiveTask.trim()
-    && (approvedHint.workerCount == null || approvedHint.workerCount === workerCount)
-    && (approvedHint.agentType == null || approvedHint.agentType === agentType);
+  const followupReadyApprovedHint = approvedHint && isApprovedExecutionFollowupReadyStatus(approvedHint.contextPackStatus)
+    ? approvedHint
+    : null;
+  const contextReadyApprovedHint = followupReadyApprovedHint
+    && isApprovedExecutionContextReadyStatus(followupReadyApprovedHint.contextPackStatus)
+    ? followupReadyApprovedHint
+    : null;
+  const matchesApprovedLaunchHint = followupReadyApprovedHint?.task.trim() === effectiveTask.trim()
+    && (followupReadyApprovedHint.workerCount == null || followupReadyApprovedHint.workerCount === workerCount)
+    && (followupReadyApprovedHint.agentType == null || followupReadyApprovedHint.agentType === agentType);
   const allowRepoAwareDagHandoff = followupContext != null || matchesApprovedLaunchHint;
   const approvedRepositoryContextSummary = allowRepoAwareDagHandoff
-    ? approvedHint?.repositoryContextSummary
+    ? followupReadyApprovedHint?.repositoryContextSummary
     : undefined;
 
   const teamName = sanitizeTeamName(slugifyTask(effectiveTask));
@@ -871,7 +888,7 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     displayName: teamName,
     allowRepoAwareDagHandoff,
     ...(approvedRepositoryContextSummary ? { approvedRepositoryContextSummary } : {}),
-    ...(allowRepoAwareDagHandoff && approvedHint ? { approvedExecution: buildApprovedTeamExecutionBinding(approvedHint) } : {}),
+    ...(contextReadyApprovedHint ? { approvedExecution: buildApprovedTeamExecutionBinding(contextReadyApprovedHint) } : {}),
   };
 }
 

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
-import { basename, dirname, join } from 'path';
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, mkdir, readFile, writeFile } from 'fs/promises';
+import { basename, dirname, join, relative } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
 import type { StageContext } from '../types.js';
@@ -22,6 +23,54 @@ function encodeApprovedExecutionTask(task: string, quote: 'single' | 'double'): 
   return quote === 'single'
     ? `'${task.replace(/'/g, "\\'")}'`
     : `"${task.replace(/"/g, '\\"')}"`;
+}
+
+function computeGitBlobSha1(content: string): string {
+  const buffer = Buffer.from(content, 'utf-8');
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function canonicalContextPackRelativePath(slug: string): string {
+  return `.omx/context/context-20260507T120000Z-${slug}.json`;
+}
+
+function buildContextPackOutcome(relativePackPath: string): string {
+  return [
+    '## Context Pack Outcome',
+    '',
+    `- pack: created \`${relativePackPath}\``,
+  ].join('\n');
+}
+
+async function writeReadyContextPack(
+  cwd: string,
+  slug: string,
+  prdPath: string,
+  testSpecPath: string,
+): Promise<void> {
+  const contextDir = join(cwd, '.omx', 'context');
+  const packPath = join(cwd, canonicalContextPackRelativePath(slug));
+  const prdContent = await readFile(prdPath, 'utf-8');
+  const testSpecContent = await readFile(testSpecPath, 'utf-8');
+  await mkdir(contextDir, { recursive: true });
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relative(cwd, prdPath).replaceAll('\\', '/'),
+        sha1: computeGitBlobSha1(prdContent),
+      },
+      testSpecs: [{
+        path: relative(cwd, testSpecPath).replaceAll('\\', '/'),
+        sha1: computeGitBlobSha1(testSpecContent),
+      }],
+    },
+    entries: ['scope', 'build', 'verify'].map((role, index) => ({
+      path: `src/${role}-${index}.ts`,
+      roles: [role],
+    })),
+  }, null, 2));
 }
 
 function makeCtx(overrides: Partial<StageContext> = {}): StageContext {
@@ -233,11 +282,19 @@ describe('Team Exec Stage', () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });
     const approvedPrdPath = join(plansDir, 'prd-zeta.md');
+    const approvedTestSpecPath = join(plansDir, 'test-spec-zeta.md');
     await writeFile(
       approvedPrdPath,
-      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+      [
+        '# Zeta plan',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath('zeta')),
+        '',
+        'Launch via omx team 5:debugger "Execute zeta handoff"',
+      ].join('\n'),
     );
-    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+    await writeFile(approvedTestSpecPath, '# Zeta test spec\n');
+    await writeReadyContextPack(tempDir, 'zeta', approvedPrdPath, approvedTestSpecPath);
 
     const previousCwd = process.cwd();
     try {
@@ -283,11 +340,19 @@ describe('Team Exec Stage', () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });
     const approvedPrdPath = join(plansDir, 'prd-zeta.md');
+    const approvedTestSpecPath = join(plansDir, 'test-spec-zeta.md');
     await writeFile(
       approvedPrdPath,
-      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+      [
+        '# Zeta plan',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath('zeta')),
+        '',
+        'Launch via omx team 5:debugger "Execute zeta handoff"',
+      ].join('\n'),
     );
-    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+    await writeFile(approvedTestSpecPath, '# Zeta test spec\n');
+    await writeReadyContextPack(tempDir, 'zeta', approvedPrdPath, approvedTestSpecPath);
     await writeFile(join(plansDir, 'prd-zulu.md'), '# Zulu draft\n\nNo approved team launch here.\n');
 
     const previousCwd = process.cwd();
@@ -325,11 +390,19 @@ describe('Team Exec Stage', () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });
     const approvedPrdPath = join(plansDir, 'prd-zeta.md');
+    const approvedTestSpecPath = join(plansDir, 'test-spec-zeta.md');
     await writeFile(
       approvedPrdPath,
-      '# Zeta plan\n\nLaunch via omx team 5:debugger "Execute zeta handoff"\n',
+      [
+        '# Zeta plan',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath('zeta')),
+        '',
+        'Launch via omx team 5:debugger "Execute zeta handoff"',
+      ].join('\n'),
     );
-    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta test spec\n');
+    await writeFile(approvedTestSpecPath, '# Zeta test spec\n');
+    await writeReadyContextPack(tempDir, 'zeta', approvedPrdPath, approvedTestSpecPath);
     const incompleteDraftPath = join(plansDir, 'prd-zulu.md');
     await writeFile(incompleteDraftPath, '# Zulu draft\n\nNo approved team launch here.\n');
 
@@ -364,6 +437,86 @@ describe('Team Exec Stage', () => {
       });
       assert.doesNotMatch(instruction, new RegExp(escapeRegExp(incompleteDraftPath)));
       assert.deepEqual(runtimeCliInput.approvedExecution, descriptor.approvedExecution);
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it('keeps team-exec generic for plan-only approved handoffs while reusing the approved task text', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const approvedPrdPath = join(plansDir, 'prd-plan-only.md');
+    await writeFile(
+      approvedPrdPath,
+      '# Plan-only plan\n\nLaunch via omx team 5:debugger "Execute plan-only team handoff"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-plan-only.md'), '# Plan-only test spec\n');
+
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(tmpdir());
+      const stage = createTeamExecStage();
+      const result = await stage.run(makeCtx({
+        task: 'original request task',
+        artifacts: {
+          ralplan: {
+            task: 'original request task',
+            stage: 'ralplan',
+            latestPlanPath: join('.omx', 'plans', 'prd-plan-only.md'),
+          },
+        },
+      }));
+
+      assert.equal(result.status, 'completed');
+      const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
+      const instruction = (result.artifacts as Record<string, unknown>).instruction as string;
+      const runtimeCliInput = decodeRuntimeCliInstructionPayload(instruction);
+      assert.equal(descriptor.task, 'Execute plan-only team handoff');
+      assert.equal(descriptor.approvedExecution, null);
+      assert.equal(runtimeCliInput.task, 'Execute plan-only team handoff');
+      assert.equal(runtimeCliInput.approvedExecution, null);
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it('blocks team-exec when the selected approved handoff is nonready', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-nonready.md'),
+      [
+        '# Nonready plan',
+        '',
+        '## Context Pack Outcome',
+        '',
+        '- pack: created `.omx/context/context-20260507T120000Z-other.json`',
+        '',
+        'Launch via omx team 5:debugger "Execute nonready team handoff"',
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-nonready.md'), '# Nonready test spec\n');
+
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(tmpdir());
+      const stage = createTeamExecStage();
+      const result = await stage.run(makeCtx({
+        task: 'original request task',
+        artifacts: {
+          ralplan: {
+            task: 'original request task',
+            stage: 'ralplan',
+            latestPlanPath: join('.omx', 'plans', 'prd-issue-nonready.md'),
+          },
+        },
+      }));
+      assert.equal(result.status, 'failed');
+      assert.match(
+        result.error ?? '',
+        /team_exec_approved_handoff_nonready:invalid:.*prd-issue-nonready\.md/,
+      );
+      assert.deepEqual(result.artifacts, {});
     } finally {
       process.chdir(previousCwd);
     }

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -15,6 +15,8 @@ import {
   resolveAvailableAgentTypes,
 } from '../../team/followup-planner.js';
 import {
+  isApprovedExecutionContextReadyStatus,
+  isApprovedExecutionFollowupReadyStatus,
   readApprovedExecutionLaunchHintOutcome,
   readPlanningArtifacts,
   type PlanningArtifacts,
@@ -158,7 +160,7 @@ function resolveApprovedTeamLaunchFromPlanPath(
   cwd: string,
   latestPlanPath: string,
   ralplanArtifacts?: Record<string, unknown>,
-): { task: string; approvedExecution: ApprovedTeamExecutionBinding } {
+): { task: string; approvedExecution: ApprovedTeamExecutionBinding | null } {
   const approvedPlanPath = resolveApprovedTeamPlanPath(cwd, latestPlanPath, ralplanArtifacts);
   const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team', {
     prdPath: approvedPlanPath,
@@ -169,9 +171,16 @@ function resolveApprovedTeamLaunchFromPlanPath(
   if (approvedHintOutcome.status !== 'resolved') {
     throw new Error(`team_exec_approved_handoff_missing:${approvedPlanPath}`);
   }
+  if (!isApprovedExecutionFollowupReadyStatus(approvedHintOutcome.hint.contextPackStatus)) {
+    throw new Error(
+      `team_exec_approved_handoff_nonready:${approvedHintOutcome.hint.contextPackStatus}:${approvedPlanPath}`,
+    );
+  }
   return {
     task: approvedHintOutcome.hint.task,
-    approvedExecution: buildApprovedTeamExecutionBinding(approvedHintOutcome.hint),
+    approvedExecution: isApprovedExecutionContextReadyStatus(approvedHintOutcome.hint.contextPackStatus)
+      ? buildApprovedTeamExecutionBinding(approvedHintOutcome.hint)
+      : null,
   };
 }
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { execFileSync, spawn } from 'child_process';
 import { mkdtemp, rm, writeFile, readFile, mkdir, chmod, readdir } from 'fs/promises';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
 import { HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
@@ -69,6 +70,54 @@ async function addWorktree(repo: string, branchName: string, pathPrefix: string)
   const worktreePath = await mkdtemp(join(tmpdir(), pathPrefix));
   execFileSync('git', ['worktree', 'add', '-b', branchName, worktreePath, 'HEAD'], { cwd: repo, stdio: 'ignore' });
   return worktreePath;
+}
+
+function computeGitBlobSha1(content: string): string {
+  const buffer = Buffer.from(content, 'utf-8');
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function canonicalContextPackRelativePath(slug: string): string {
+  return `.omx/context/context-20260507T120000Z-${slug}.json`;
+}
+
+function buildContextPackOutcome(relativePackPath: string): string {
+  return [
+    '## Context Pack Outcome',
+    '',
+    `- pack: created \`${relativePackPath}\``,
+  ].join('\n');
+}
+
+async function writeReadyContextPack(
+  cwd: string,
+  slug: string,
+  prdPath: string,
+  testSpecPath: string,
+): Promise<void> {
+  const contextDir = join(cwd, '.omx', 'context');
+  const packPath = join(cwd, canonicalContextPackRelativePath(slug));
+  const prdContent = await readFile(prdPath, 'utf-8');
+  const testSpecContent = await readFile(testSpecPath, 'utf-8');
+  await mkdir(contextDir, { recursive: true });
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relative(cwd, prdPath).replaceAll('\\', '/'),
+        sha1: computeGitBlobSha1(prdContent),
+      },
+      testSpecs: [{
+        path: relative(cwd, testSpecPath).replaceAll('\\', '/'),
+        sha1: computeGitBlobSha1(testSpecContent),
+      }],
+    },
+    entries: ['scope', 'build', 'verify'].map((role, index) => ({
+      path: `src/${role}-${index}.ts`,
+      roles: [role],
+    })),
+  }, null, 2));
 }
 
 async function attachDirtyWorkerRepo(teamName: string, cwd: string, repoName: string): Promise<void> {
@@ -6048,6 +6097,39 @@ esac
     }
   });
 
+  it('resumeTeam fails closed when the persisted approved binding is nonready', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-resume-nonready-'));
+    try {
+      await initTeamState('team-approved-resume', 'approved resume test', 'executor', 1, cwd);
+      await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+      const prdPath = join(cwd, '.omx', 'plans', 'prd-issue-2112.md');
+      await writeFile(
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          '## Context Pack Outcome',
+          '',
+          '- pack: created `.omx/context/context-20260507T120000Z-other.json`',
+          '',
+          'Launch via omx team 1:executor "Execute approved issue 2112 plan"',
+        ].join('\n'),
+      );
+      await writeFile(join(cwd, '.omx', 'plans', 'test-spec-issue-2112.md'), '# Test spec\n');
+      await writePersistedApprovedTeamExecutionBinding('team-approved-resume', cwd, {
+        prd_path: prdPath,
+        task: 'Execute approved issue 2112 plan',
+      });
+
+      await assert.rejects(
+        () => resumeTeam('team-approved-resume', cwd),
+        /approved_execution_binding_nonready:invalid:.*Execute approved issue 2112 plan/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('resumeTeam resolves approved binding continuity against the persisted leader cwd', async () => {
     const teamName = 'team-approved-shared-root';
     const leaderCwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-leader-'));
@@ -6326,11 +6408,20 @@ esac
     const fakeCodexPath = join(binDir, 'codex');
     await mkdir(binDir, { recursive: true });
     await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+    const prdPath = join(cwd, '.omx', 'plans', 'prd-issue-1314.md');
+    const testSpecPath = join(cwd, '.omx', 'plans', 'test-spec-issue-1314.md');
     await writeFile(
-      join(cwd, '.omx', 'plans', 'prd-issue-1314.md'),
-      '# Approved plan\n\nLaunch via omx team 1:executor "Execute approved issue 1314 plan"\n',
+      prdPath,
+      [
+        '# Approved plan',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath('issue-1314')),
+        '',
+        'Launch via omx team 1:executor "Execute approved issue 1314 plan"',
+      ].join('\n'),
     );
-    await writeFile(join(cwd, '.omx', 'plans', 'test-spec-issue-1314.md'), '# Test spec\n');
+    await writeFile(testSpecPath, '# Test spec\n');
+    await writeReadyContextPack(cwd, 'issue-1314', prdPath, testSpecPath);
     await writeFakePromptWorkerBinary(
       fakeCodexPath,
       `setTimeout(() => {}, 5000);`,
@@ -6349,7 +6440,7 @@ esac
             cwd,
             {
               approvedExecution: {
-                prd_path: join(cwd, '.omx', 'plans', 'prd-issue-1314.md'),
+                prd_path: prdPath,
                 task: 'Execute approved issue 1314 plan',
                 command: 'omx team 1:executor "Execute approved issue 1314 plan"',
               },
@@ -6366,7 +6457,7 @@ esac
       );
       const binding = JSON.parse(await readFile(bindingPath, 'utf-8')) as Record<string, string>;
       assert.deepEqual(binding, {
-        prd_path: join(cwd, '.omx', 'plans', 'prd-issue-1314.md'),
+        prd_path: prdPath,
         task: 'Execute approved issue 1314 plan',
         command: 'omx team 1:executor "Execute approved issue 1314 plan"',
       });
@@ -6375,6 +6466,115 @@ esac
       if (runtime) {
         await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
       }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam keeps explicit plan-only approved bindings on the generic path', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-binding-plan-only-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+    await writeFile(
+      join(cwd, '.omx', 'plans', 'prd-issue-1314-plan-only.md'),
+      '# Approved plan\n\nLaunch via omx team 1:executor "Execute approved issue 1314 plan-only"\n',
+    );
+    await writeFile(join(cwd, '.omx', 'plans', 'test-spec-issue-1314-plan-only.md'), '# Test spec\n');
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withPromptModeCodexEnv(binDir, {}, () =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-approved-binding-plan-only',
+            'approved binding generic fallback test',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            cwd,
+            {
+              approvedExecution: {
+                prd_path: join(cwd, '.omx', 'plans', 'prd-issue-1314-plan-only.md'),
+                task: 'Execute approved issue 1314 plan-only',
+                command: 'omx team 1:executor "Execute approved issue 1314 plan-only"',
+              },
+            },
+          ),
+        ),
+      );
+
+      const bindingPath = join(
+        runtime.config.team_state_root ?? join(cwd, '.omx', 'state'),
+        'team',
+        runtime.teamName,
+        'approved-execution.json',
+      );
+      assert.equal(existsSync(bindingPath), false);
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam fails closed when an explicit approved execution binding is nonready', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-binding-nonready-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+    const prdPath = join(cwd, '.omx', 'plans', 'prd-issue-1314-nonready.md');
+    await writeFile(
+      prdPath,
+      [
+        '# Approved plan',
+        '',
+        '## Context Pack Outcome',
+        '',
+        '- pack: created `.omx/context/context-20260507T120000Z-other.json`',
+        '',
+        'Launch via omx team 1:executor "Execute approved issue 1314 nonready plan"',
+      ].join('\n'),
+    );
+    await writeFile(join(cwd, '.omx', 'plans', 'test-spec-issue-1314-nonready.md'), '# Test spec\n');
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    try {
+      await assert.rejects(
+        () => withPromptModeCodexEnv(binDir, {}, () =>
+          withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-approved-binding-nonready',
+              'approved binding nonready start test',
+              'executor',
+              1,
+              [{ subject: 's', description: 'd', owner: 'worker-1' }],
+              cwd,
+              {
+                approvedExecution: {
+                  prd_path: prdPath,
+                  task: 'Execute approved issue 1314 nonready plan',
+                },
+              },
+            ),
+          ),
+        ),
+        /approved_execution_binding_nonready:invalid:.*Execute approved issue 1314 nonready plan/,
+      );
+      assert.equal(
+        existsSync(join(cwd, '.omx', 'state', 'team', 'team-approved-binding-nonready')),
+        false,
+      );
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -133,6 +133,10 @@ import { buildRebalanceDecisions } from './rebalance-policy.js';
 import { getStatePath } from '../mcp/state-paths.js';
 import { readModeState, updateModeState } from '../modes/base.js';
 import {
+  isApprovedExecutionContextReadyStatus,
+  isApprovedExecutionFollowupReadyStatus,
+} from '../planning/artifacts.js';
+import {
   buildApprovedTeamExecutionBinding,
   normalizeApprovedTeamExecutionBinding,
   readApprovedTeamExecutionHintOutcomeFromBinding,
@@ -2268,12 +2272,22 @@ export async function startTeam(
   const selectedApprovedExecutionHint = requestedApprovedExecutionOutcome?.status === 'resolved'
     ? requestedApprovedExecutionOutcome.approvedHint
     : null;
+  if (
+    requestedApprovedExecution
+    && selectedApprovedExecutionHint
+    && !isApprovedExecutionFollowupReadyStatus(selectedApprovedExecutionHint.contextPackStatus)
+  ) {
+    throw new Error(
+      `approved_execution_binding_nonready:${selectedApprovedExecutionHint.contextPackStatus}:${requestedApprovedExecution.prd_path}:${requestedApprovedExecution.task}`,
+    );
+  }
   if (requestedApprovedExecution && !selectedApprovedExecutionHint) {
     throw new Error(
       `approved_execution_binding_stale:${requestedApprovedExecution.prd_path}:${requestedApprovedExecution.task}`,
     );
   }
   const approvedExecution = selectedApprovedExecutionHint
+    && isApprovedExecutionContextReadyStatus(selectedApprovedExecutionHint.contextPackStatus)
     ? buildApprovedTeamExecutionBinding(selectedApprovedExecutionHint)
     : null;
   const activeWorktreeMode: 'detached' | 'named' | null =
@@ -3771,6 +3785,14 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
   if (approvedExecutionState.status === 'stale') {
     throw new Error(
       `approved_execution_binding_stale:${approvedExecutionState.binding.prd_path}:${approvedExecutionState.binding.task}`,
+    );
+  }
+  if (
+    approvedExecutionState.status === 'valid'
+    && !isApprovedExecutionFollowupReadyStatus(approvedExecutionState.approvedHint.contextPackStatus)
+  ) {
+    throw new Error(
+      `approved_execution_binding_nonready:${approvedExecutionState.approvedHint.contextPackStatus}:${approvedExecutionState.binding.prd_path}:${approvedExecutionState.binding.task}`,
     );
   }
 


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Current upstream planning selection can classify approved handoff status, but
the downstream consumers still treated any resolved approved hint as execution
authority. That let short Team follow-up, team-exec launches, and explicit or
persisted Team bindings drift into bound execution even when the selected
handoff was only plan-only or otherwise nonready.

## Changes

- gate Team follow-up reuse on follow-up-ready status and carry
  `approvedExecution` only for context-ready handoffs
- keep `team-exec` on the generic path for plan-only approved handoffs while
  still reusing the approved task text, and fail closed on nonready approved
  handoffs
- make `startTeam()` and `resumeTeam()` reject nonready explicit or persisted
  approved bindings instead of persisting or resuming them as bound execution
- distinguish ready, plan-only, incomplete, invalid, and missing-baseline
  approved handoff guidance in the Ralph appendix text
- add focused CLI, pipeline, and runtime tests for ready fixtures, plan-only
  generic launches, and nonready fail-closed behavior

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Focused validation run for this PR:
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `node --test dist/cli/__tests__/ralph.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/approved-execution.test.js dist/team/__tests__/runtime.test.js dist/pipeline/__tests__/stages.test.js`
- `node dist/scripts/generate-catalog-docs.js --check`
- `node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__ dist/ralph/__tests__ dist/ralplan/__tests__ dist/runtime/__tests__`
- `npm run coverage:team-critical:compiled`
- `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`
  - local macOS run still shows the existing `launch-fallback` `/private/var`
    vs `/var` path assertion outside this patch boundary

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- Round 4 row: `fix-approved-nonready-fallbacks`
