### PR TITLE
fix: preserve invalid context-pack role diagnostics

### DIFF
--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -345,6 +345,60 @@ describe('planning artifacts', () => {
     assert.deepEqual(hint?.contextPackIssues, []);
   });
 
+  it('preserves invalid context-pack issues on approved hints without widening them into missing roles', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-context-invalid.md');
+    const testSpecPath = join(plansDir, 'test-spec-context-invalid.md');
+    await writeFile(
+      prdPath,
+      [
+        '# PRD',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath('context-invalid')),
+        '',
+        'Launch via omx ralph "Execute invalid context handoff"',
+      ].join('\n'),
+    );
+    await writeFile(testSpecPath, '# Test Spec\n');
+    await writeContextPack('context-invalid', prdPath, testSpecPath, ['scope', 'build', 'verify']);
+    await writeFile(testSpecPath, '# Drifted Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+
+    assert.ok(hint);
+    assert.equal(hint?.contextPackStatus, 'invalid');
+    assert.deepEqual(hint?.missingRequiredContextPackRoles, []);
+    assert.ok(hint?.contextPackIssues.some((issue) => issue.includes('basis test-spec hash')));
+  });
+
+  it('preserves inspectable missing roles on approved hints even when the pack is invalid', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-context-invalid-missing-roles.md');
+    const testSpecPath = join(plansDir, 'test-spec-context-invalid-missing-roles.md');
+    await writeFile(
+      prdPath,
+      [
+        '# PRD',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath('context-invalid-missing-roles')),
+        '',
+        'Launch via omx ralph "Execute invalid missing roles handoff"',
+      ].join('\n'),
+    );
+    await writeFile(testSpecPath, '# Test Spec\n');
+    await writeContextPack('context-invalid-missing-roles', prdPath, testSpecPath, ['scope']);
+    await writeFile(testSpecPath, '# Drifted Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+
+    assert.ok(hint);
+    assert.equal(hint?.contextPackStatus, 'invalid');
+    assert.deepEqual(hint?.missingRequiredContextPackRoles, ['build', 'verify']);
+    assert.ok(hint?.contextPackIssues.some((issue) => issue.includes('basis test-spec hash')));
+  });
+
 
   it('parses $ralph aliases with single-quoted task text for approved launch hints', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');

--- a/src/planning/__tests__/context-pack-status.test.ts
+++ b/src/planning/__tests__/context-pack-status.test.ts
@@ -101,21 +101,21 @@ describe('context pack handoff status', () => {
       baselineState: 'missing-prd',
       outcomeState: 'absent',
       packState: 'missing',
-      roleCoverage: 'missing-required-roles',
+      roleCoverage: 'unknown',
       basisState: 'stale',
     }), 'missing-baseline');
     assert.equal(resolveContextPackHandoffState({
       baselineState: 'present',
       outcomeState: 'absent',
       packState: 'missing',
-      roleCoverage: 'missing-required-roles',
+      roleCoverage: 'unknown',
       basisState: 'stale',
     }), 'plan-only');
     assert.equal(resolveContextPackHandoffState({
       baselineState: 'present',
       outcomeState: 'declared',
       packState: 'missing',
-      roleCoverage: 'missing-required-roles',
+      roleCoverage: 'unknown',
       basisState: 'stale',
     }), 'incomplete');
     assert.equal(resolveContextPackHandoffState({
@@ -129,7 +129,7 @@ describe('context pack handoff status', () => {
       baselineState: 'present',
       outcomeState: 'malformed',
       packState: 'valid',
-      roleCoverage: 'covered',
+      roleCoverage: 'unknown',
       basisState: 'fresh',
     }), 'invalid');
     assert.equal(resolveContextPackHandoffState({
@@ -154,6 +154,7 @@ describe('context pack handoff status', () => {
     assert.equal(status.contextPackStatus, 'plan-only');
     assert.equal(status.baselineState, 'present');
     assert.equal(status.outcomeState, 'absent');
+    assert.equal(status.roleCoverage, 'unknown');
     assert.deepEqual(status.missingRequiredContextPackRoles, []);
     assert.deepEqual(status.contextPackIssues, []);
   });
@@ -209,7 +210,47 @@ describe('context pack handoff status', () => {
     const status = readContextPackHandoffStatus(tempDir);
 
     assert.equal(status.contextPackStatus, 'invalid');
+    assert.equal(status.roleCoverage, 'covered');
+    assert.deepEqual(status.missingRequiredContextPackRoles, []);
     assert.ok(status.contextPackIssues.some((issue) => issue.includes('basis test-spec hash')));
+  });
+
+  it('preserves inspectable missing roles even when the declared pack is otherwise invalid', async () => {
+    const { prdPath, testSpecPath } = await writeApprovedPlan('delta-missing-roles', [
+      '# PRD',
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath('delta-missing-roles')),
+      '',
+      'Launch via omx ralph "Execute delta missing roles plan"',
+    ]);
+    await writeContextPack('delta-missing-roles', prdPath, testSpecPath, ['scope']);
+    await writeFile(testSpecPath, '# Drifted Test Spec\n');
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'invalid');
+    assert.equal(status.roleCoverage, 'missing-required-roles');
+    assert.deepEqual(status.missingRequiredContextPackRoles, ['build', 'verify']);
+    assert.ok(status.contextPackIssues.some((issue) => issue.includes('basis test-spec hash')));
+  });
+
+  it('keeps role coverage unknown when the declared pack cannot be inspected', async () => {
+    const { packPath } = await writeApprovedPlan('invalid-json', [
+      '# PRD',
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath('invalid-json')),
+      '',
+      'Launch via omx ralph "Execute invalid json plan"',
+    ]);
+    await writeFile(packPath, '{not json');
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'invalid');
+    assert.equal(status.packState, 'invalid');
+    assert.equal(status.roleCoverage, 'unknown');
+    assert.deepEqual(status.missingRequiredContextPackRoles, []);
+    assert.ok(status.contextPackIssues.some((issue) => issue.includes('invalid JSON')));
   });
 
   it('ignores fenced outcome declarations and keeps the plan in plan-only status', async () => {

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -20,7 +20,8 @@ export type ContextPackStatus =
 export type ContextPackBaselineState = 'missing-prd' | 'missing-test-spec' | 'present';
 export type ContextPackOutcomeState = 'absent' | 'malformed' | 'ambiguous' | 'declared';
 export type ContextPackPackState = 'missing' | 'unreadable' | 'invalid' | 'valid';
-export type ContextPackRoleCoverageState = 'missing-required-roles' | 'covered';
+export type ContextPackRoleCoverageState =
+  'unknown' | 'missing-required-roles' | 'covered';
 export type ContextPackBasisState = 'stale' | 'fresh';
 
 export interface ContextPackRef {
@@ -536,7 +537,7 @@ export function resolveContextPackHandoffState(input: {
   if (input.basisState !== 'fresh') {
     return 'invalid';
   }
-  if (input.roleCoverage !== 'covered') {
+  if (input.roleCoverage === 'missing-required-roles') {
     return 'incomplete';
   }
   return 'ready';
@@ -562,7 +563,7 @@ export function resolveContextPackHandoffStatus(
   let contextPack: ContextPackRef | null = null;
   let outcomeState: ContextPackOutcomeState = 'absent';
   let packState: ContextPackPackState = 'missing';
-  let roleCoverage: ContextPackRoleCoverageState = 'missing-required-roles';
+  let roleCoverage: ContextPackRoleCoverageState = 'unknown';
   let basisState: ContextPackBasisState = 'stale';
   let missingRequiredContextPackRoles: ContextPackRole[] = [];
   let declarationMismatch = false;


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

The read-only context-pack status row already preserved concrete invalid
issues and the surfaced missing-role list, but the snapshot still defaulted
`roleCoverage` to `missing-required-roles` before any pack inspection. That
made invalid or unreadable packs look like generic role-coverage failures
even when no role coverage had been inspected.

## Changes

- add an `unknown` role-coverage state until a declared pack is parsed
  successfully
- keep the public handoff status mapping unchanged while preserving actual
  missing roles only when the pack document was inspectable
- add focused status-snapshot and approved-hint tests for stale-basis,
  invalid-JSON, and invalid-plus-missing-role combinations

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Focused validation run for this PR:
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `node --test dist/planning/__tests__/artifacts.test.js dist/planning/__tests__/context-pack-status.test.js`
- `node dist/scripts/generate-catalog-docs.js --check`
- `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`
  - local macOS run still shows the existing `launch-fallback` `/private/var`
    vs `/var` path assertion outside this patch boundary

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- Round 4 row: `fix-context-pack-invalid-diagnostics`
