### PR TITLE
fix: close remaining approved handoff fallback gaps

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -95,6 +95,38 @@ describe('readMatchedApprovedRalphExecutionHint', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('preserves missing-baseline approved Ralph hints for repair-only follow-up guidance', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-missing-baseline-'));
+    try {
+      await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'plans', 'prd-issue-910.md'),
+        [
+          '# PRD',
+          '',
+          'Launch via omx ralph "Repair approved issue 910 plan"',
+        ].join('\n'),
+      );
+
+      const hint = readMatchedApprovedRalphExecutionHint(cwd, 'ralph-cli-launch');
+      assert.ok(hint);
+      assert.equal(hint?.task, 'Repair approved issue 910 plan');
+      assert.equal(hint?.contextPackStatus, 'missing-baseline');
+      assert.deepEqual(hint?.testSpecPaths, []);
+
+      const instructions = buildRalphAppendInstructions('Repair approved issue 910 plan', {
+        changedFilesPath: '.omx/ralph/changed-files.txt',
+        noDeslop: false,
+        approvedHint: hint,
+      });
+      assert.match(instructions, /Approved planning handoff context/i);
+      assert.match(instructions, /Missing-baseline fallback/i);
+      assert.match(instructions, /restore the missing baseline before broadening context/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('isRalphPrdMode', () => {
@@ -317,6 +349,22 @@ describe('ralph deslop launch wiring', () => {
     assert.match(instructions, /invalid context pack issues: Declared context pack basis test-spec hash/i);
     assert.match(instructions, /only as repair inputs/i);
     assert.match(instructions, /repair or recreate the canonical context pack/i);
+  });
+
+  it('surfaces repair-only guidance for incomplete approved handoff context', () => {
+    const instructions = buildRalphAppendInstructions('Repair approved issue 1072 plan', {
+      changedFilesPath: '.omx/ralph/changed-files.txt',
+      noDeslop: false,
+      approvedHint: {
+        ...approvedHint,
+        contextPackStatus: 'incomplete',
+        contextPackIssues: ['Pack omits required execution roles.'],
+        missingRequiredContextPackRoles: ['build', 'verify'],
+      },
+    });
+    assert.match(instructions, /incomplete context pack issues: Pack omits required execution roles/i);
+    assert.match(instructions, /missing required context roles: build, verify/i);
+    assert.match(instructions, /repair or recreate the canonical context pack with required role coverage/i);
   });
 
   it('seeds the changed-files artifact with bounded-scope guidance', () => {

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -766,24 +766,67 @@ describe('parseTeamStartArgs', () => {
     }
   });
 
-  it('attaches approved repository context summary only for matching team launches', async () => {
+  it('attaches approved repository context summary only for matching ready team launches', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-context-approved-'));
     const previousCwd = process.cwd();
     try {
       process.chdir(wd);
-      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-2039.md');
+      const testSpecPath = join(plansDir, 'test-spec-issue-2039.md');
       await writeFile(
-        join(wd, '.omx', 'plans', 'prd-issue-2039.md'),
-        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 2039 plan"\n',
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-2039')),
+          '',
+          'Launch via omx team 3:executor "Execute approved issue 2039 plan"',
+        ].join('\n'),
       );
-      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-2039.md'), '# Test spec\n');
-      await writeFile(join(wd, '.omx', 'plans', 'repo-context-issue-2039.md'), 'Key boundary: latest approved handoff only.\n');
+      await writeFile(testSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'issue-2039', prdPath, testSpecPath);
+      await writeFile(join(plansDir, 'repo-context-issue-2039.md'), 'Key boundary: latest approved handoff only.\n');
 
       const approved = parseTeamStartArgs(['3:executor', 'Execute', 'approved', 'issue', '2039', 'plan']);
       assert.equal(approved.parsed.approvedRepositoryContextSummary?.content, 'Key boundary: latest approved handoff only.');
 
       const unrelated = parseTeamStartArgs(['3:executor', 'fix', 'unrelated', 'bug']);
       assert.equal(unrelated.parsed.approvedRepositoryContextSummary, undefined);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps ready approved execution generic when staffing no longer matches the approved launch hint', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-context-ready-mismatch-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-2040.md');
+      const testSpecPath = join(plansDir, 'test-spec-issue-2040.md');
+      await writeFile(
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-2040')),
+          '',
+          'Launch via omx team 3:executor "Execute approved issue 2040 plan"',
+        ].join('\n'),
+      );
+      await writeFile(testSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'issue-2040', prdPath, testSpecPath);
+      await writeFile(join(plansDir, 'repo-context-issue-2040.md'), 'Keep approved context off generic mismatches.\n');
+
+      const result = parseTeamStartArgs(['2:debugger', 'Execute', 'approved', 'issue', '2040', 'plan']);
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, false);
+      assert.equal(result.parsed.approvedExecution, undefined);
+      assert.equal(result.parsed.approvedRepositoryContextSummary, undefined);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -801,10 +844,12 @@ describe('parseTeamStartArgs', () => {
         '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 2087 plan"\n',
       );
       await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-2087.md'), '# Test spec\n');
+      await writeFile(join(wd, '.omx', 'plans', 'repo-context-issue-2087.md'), 'Do not widen plan-only context.\n');
 
       const result = parseTeamStartArgs(['3:executor', 'Execute', 'approved', 'issue', '2087', 'plan']);
       assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
       assert.equal(result.parsed.approvedExecution, undefined);
+      assert.equal(result.parsed.approvedRepositoryContextSummary, undefined);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -59,11 +59,12 @@ function buildContextPackOutcome(relativePackPath: string): string {
   ].join('\n');
 }
 
-async function writeReadyContextPack(
+async function writeContextPack(
   cwd: string,
   slug: string,
   prdPath: string,
   testSpecPath: string,
+  roles: readonly string[],
 ): Promise<void> {
   const contextDir = join(cwd, '.omx', 'context');
   const packPath = join(cwd, canonicalContextPackRelativePath(slug));
@@ -82,11 +83,20 @@ async function writeReadyContextPack(
         sha1: computeGitBlobSha1(testSpecContent),
       }],
     },
-    entries: ['scope', 'build', 'verify'].map((role, index) => ({
+    entries: roles.map((role, index) => ({
       path: `src/${role}-${index}.ts`,
       roles: [role],
     })),
   }, null, 2));
+}
+
+async function writeReadyContextPack(
+  cwd: string,
+  slug: string,
+  prdPath: string,
+  testSpecPath: string,
+): Promise<void> {
+  await writeContextPack(cwd, slug, prdPath, testSpecPath, ['scope', 'build', 'verify']);
 }
 
 beforeEach(() => {
@@ -567,6 +577,60 @@ describe('parseTeamStartArgs', () => {
       assert.throws(
         () => parseTeamStartArgs(['team']),
         /approved_execution_hint_nonready:team:invalid/,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails short follow-up reuse when the latest approved handoff is missing its baseline', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-missing-baseline-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      await writeFile(
+        join(plansDir, 'prd-issue-2086-missing-baseline.md'),
+        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 2086 missing-baseline plan"\n',
+      );
+
+      assert.throws(
+        () => parseTeamStartArgs(['team']),
+        /approved_execution_hint_nonready:team:missing-baseline/,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails short follow-up reuse when the latest approved handoff is incomplete', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-incomplete-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-2086-incomplete.md');
+      const testSpecPath = join(plansDir, 'test-spec-issue-2086-incomplete.md');
+      await writeFile(
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-2086-incomplete')),
+          '',
+          'Launch via omx team 3:executor "Execute approved issue 2086 incomplete plan"',
+        ].join('\n'),
+      );
+      await writeFile(testSpecPath, '# Test spec\n');
+      await writeContextPack(wd, 'issue-2086-incomplete', prdPath, testSpecPath, ['scope']);
+
+      assert.throws(
+        () => parseTeamStartArgs(['team']),
+        /approved_execution_hint_nonready:team:incomplete/,
       );
     } finally {
       process.chdir(previousCwd);

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { startMode, updateModeState } from '../modes/base.js';
-import { readApprovedExecutionLaunchHint, type ApprovedExecutionLaunchHint } from '../planning/artifacts.js';
+import { readApprovedExecutionLaunchHintOutcome, type ApprovedExecutionLaunchHint } from '../planning/artifacts.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import { resolveCodexHomeForLaunch } from './codex-home.js';
 import {
@@ -152,12 +152,13 @@ export function readMatchedApprovedRalphExecutionHint(
   cwd: string,
   explicitTask: string,
 ): ApprovedExecutionLaunchHint | null {
+  const outcome = readApprovedExecutionLaunchHintOutcome(
+    cwd,
+    'ralph',
+    explicitTask === 'ralph-cli-launch' ? {} : { task: explicitTask },
+  );
   return resolveApprovedRalphExecutionHint(
-    readApprovedExecutionLaunchHint(
-      cwd,
-      'ralph',
-      explicitTask === 'ralph-cli-launch' ? {} : { task: explicitTask },
-    ),
+    outcome.status === 'resolved' ? outcome.hint : null,
     explicitTask,
   );
 }

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -874,7 +874,7 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     && (followupReadyApprovedHint.agentType == null || followupReadyApprovedHint.agentType === agentType);
   const allowRepoAwareDagHandoff = followupContext != null || matchesApprovedLaunchHint;
   const approvedRepositoryContextSummary = allowRepoAwareDagHandoff
-    ? followupReadyApprovedHint?.repositoryContextSummary
+    ? contextReadyApprovedHint?.repositoryContextSummary
     : undefined;
 
   const teamName = sanitizeTeamName(slugifyTask(effectiveTask));
@@ -888,7 +888,9 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     displayName: teamName,
     allowRepoAwareDagHandoff,
     ...(approvedRepositoryContextSummary ? { approvedRepositoryContextSummary } : {}),
-    ...(contextReadyApprovedHint ? { approvedExecution: buildApprovedTeamExecutionBinding(contextReadyApprovedHint) } : {}),
+    ...(allowRepoAwareDagHandoff && contextReadyApprovedHint
+      ? { approvedExecution: buildApprovedTeamExecutionBinding(contextReadyApprovedHint) }
+      : {}),
   };
 }
 

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -451,6 +451,7 @@ describe('Team Exec Stage', () => {
       '# Plan-only plan\n\nLaunch via omx team 5:debugger "Execute plan-only team handoff"\n',
     );
     await writeFile(join(plansDir, 'test-spec-plan-only.md'), '# Plan-only test spec\n');
+    await writeFile(join(plansDir, 'repo-context-plan-only.md'), 'Plan-only repo summary should not reach workers.\n');
 
     const previousCwd = process.cwd();
     try {
@@ -475,6 +476,10 @@ describe('Team Exec Stage', () => {
       assert.equal(descriptor.approvedExecution, null);
       assert.equal(runtimeCliInput.task, 'Execute plan-only team handoff');
       assert.equal(runtimeCliInput.approvedExecution, null);
+      assert.equal(
+        (runtimeCliInput.decompositionMetadata as Record<string, unknown> | undefined)?.approved_context_summary,
+        undefined,
+      );
     } finally {
       process.chdir(previousCwd);
     }

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -485,6 +485,39 @@ describe('Team Exec Stage', () => {
     }
   });
 
+  it('blocks team-exec when the selected approved handoff is missing its baseline', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-missing-baseline.md'),
+      '# Missing-baseline plan\n\nLaunch via omx team 5:debugger "Execute missing-baseline team handoff"\n',
+    );
+
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(tmpdir());
+      const stage = createTeamExecStage();
+      const result = await stage.run(makeCtx({
+        task: 'original request task',
+        artifacts: {
+          ralplan: {
+            task: 'original request task',
+            stage: 'ralplan',
+            latestPlanPath: join('.omx', 'plans', 'prd-issue-missing-baseline.md'),
+          },
+        },
+      }));
+      assert.equal(result.status, 'failed');
+      assert.match(
+        result.error ?? '',
+        /team_exec_approved_handoff_nonready:missing-baseline:.*prd-issue-missing-baseline\.md/,
+      );
+      assert.deepEqual(result.artifacts, {});
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
   it('blocks team-exec when the selected approved handoff is nonready', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -140,13 +140,22 @@ function resolveApprovedTeamPlanPath(
 ): string {
   const artifacts = readPlanningArtifacts(cwd);
   const resolvedLatestPlanPath = resolvePlanningPrdPath(artifacts, cwd, latestPlanPath);
+  const latestPlanTestSpecPaths = resolvedLatestPlanPath.matchedPath
+    ? matchingTestSpecPathsForPrd(artifacts, resolvedLatestPlanPath.matchedPath)
+    : [];
+  if (!resolvedLatestPlanPath.matchedPath) {
+    throw new Error(`team_exec_approved_handoff_missing:${resolvedLatestPlanPath.fallbackPath}`);
+  }
+  if (latestPlanTestSpecPaths.length === 0) {
+    return resolvedLatestPlanPath.matchedPath;
+  }
   const selection = readRuntimeLatestPlanningSelection(artifacts, cwd, ralplanArtifacts)
     ?? readLatestApprovedPlanningSelection(artifacts);
   const selectedPrdPath = selection.prdPath
     ? resolvePlanningPrdPath(artifacts, cwd, selection.prdPath).matchedPath
     : null;
 
-  if (!selectedPrdPath || selection.testSpecPaths.length === 0 || !resolvedLatestPlanPath.matchedPath) {
+  if (!selectedPrdPath) {
     throw new Error(`team_exec_approved_handoff_missing:${resolvedLatestPlanPath.fallbackPath}`);
   }
   if (selectedPrdPath !== resolvedLatestPlanPath.matchedPath) {

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -9,6 +9,7 @@ import {
   decodeApprovedExecutionQuotedValue,
   isPlanningComplete,
   readApprovedExecutionLaunchHint,
+  readApprovedExecutionLaunchHintOutcome,
   readLatestPlanningArtifacts,
   readPlanningArtifacts,
   readTeamDagArtifactResolution,
@@ -285,6 +286,15 @@ describe('planning artifacts', () => {
     assert.equal(selection.contextPackStatus, 'missing-baseline');
     assert.deepEqual(selection.missingRequiredContextPackRoles, []);
     assert.deepEqual(selection.contextPackIssues, ['Approved plan is missing a matching test spec.']);
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph');
+    assert.equal(outcome.status, 'resolved');
+    if (outcome.status !== 'resolved') {
+      throw new Error('expected missing-baseline approved hint outcome');
+    }
+    assert.equal(outcome.hint.contextPackStatus, 'missing-baseline');
+    assert.deepEqual(outcome.hint.testSpecPaths, []);
+    assert.deepEqual(outcome.hint.contextPackIssues, ['Approved plan is missing a matching test spec.']);
 
     assert.equal(readApprovedExecutionLaunchHint(tempDir, 'ralph'), null);
 

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -259,11 +259,14 @@ function readApprovedRepositoryContextSummary(
 function readApprovedPlanText(
   cwd: string,
   options: ApprovedExecutionLaunchHintReadOptions = {},
+  allowMissingBaseline = false,
 ): { content: string; context: ApprovedPlanContext } | null {
   const artifacts = readPlanningArtifacts(cwd);
   const selection = selectPlanningArtifacts(artifacts, options.prdPath);
   const latestPrdPath = selection.prdPath;
-  if (!latestPrdPath || selection.testSpecPaths.length === 0 || !existsSync(latestPrdPath)) return null;
+  if (!latestPrdPath || (!allowMissingBaseline && selection.testSpecPaths.length === 0) || !existsSync(latestPrdPath)) {
+    return null;
+  }
 
   try {
     const content = readFileSync(latestPrdPath, 'utf-8');
@@ -429,7 +432,7 @@ export function readApprovedExecutionLaunchHintOutcome(
   mode: 'team' | 'ralph',
   options: ApprovedExecutionLaunchHintReadOptions = {},
 ): ApprovedExecutionLaunchHintOutcome {
-  const approvedPlan = readApprovedPlanText(cwd, options);
+  const approvedPlan = readApprovedPlanText(cwd, options, true);
   if (!approvedPlan) return { status: 'absent' };
 
   const selected = selectLaunchHintMatch(
@@ -476,5 +479,8 @@ export function readApprovedExecutionLaunchHint(
   options: ApprovedExecutionLaunchHintReadOptions = {},
 ): ApprovedExecutionLaunchHint | null {
   const outcome = readApprovedExecutionLaunchHintOutcome(cwd, mode, options);
-  return outcome.status === 'resolved' ? outcome.hint : null;
+  if (outcome.status !== 'resolved' || outcome.hint.contextPackStatus === 'missing-baseline') {
+    return null;
+  }
+  return outcome.hint;
 }

--- a/src/team/__tests__/approved-execution.test.ts
+++ b/src/team/__tests__/approved-execution.test.ts
@@ -187,6 +187,41 @@ describe('approved execution binding', () => {
     });
   });
 
+  it('preserves missing-baseline continuity instead of collapsing it to stale', async () => {
+    await withUnboxedOmxRoot(async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-missing-baseline-'));
+      const stateRoot = join(cwd, '.omx', 'state');
+      try {
+        const plansDir = join(cwd, '.omx', 'plans');
+        await mkdir(plansDir, { recursive: true });
+        const prdPath = join(plansDir, 'prd-issue-1318.md');
+        await writeFile(
+          prdPath,
+          '# Approved plan\n\nLaunch via omx team 1:executor "Execute approved issue 1318 plan"\n',
+        );
+        await writePersistedApprovedTeamExecutionBinding('bound-team', cwd, {
+          prd_path: prdPath,
+          task: 'Execute approved issue 1318 plan',
+          command: 'omx team 1:executor "Execute approved issue 1318 plan"',
+        }, stateRoot);
+
+        const state = await resolvePersistedApprovedTeamExecutionContinuityState(
+          'bound-team',
+          cwd,
+          stateRoot,
+        );
+        assert.equal(state.status, 'valid');
+        if (state.status !== 'valid') {
+          throw new Error('expected missing-baseline continuity state');
+        }
+        assert.equal(state.approvedHint.contextPackStatus, 'missing-baseline');
+        assert.deepEqual(state.approvedHint.testSpecPaths, []);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  });
+
   it('reports malformed and stale binding states explicitly', async () => {
     await withUnboxedOmxRoot(async () => {
       const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-invalid-'));


### PR DESCRIPTION
## Summary

`#2169` merged the nonready approved-handoff fallback row, but two gaps
remained on current `dev`: ready approved Team hints could still leak
`approvedExecution` or approved repository context onto generic launches when
staffing drifted, and `missing-baseline` still collapsed to `absent` before
Team short follow-up, Ralph follow-up guidance, and `team-exec` could enforce
the repair-only path.

This follow-up keeps the row narrow and closes those remaining gaps.

## Changes

- gate Team `approvedExecution` and approved repository context summary on the
  ready plus matching approved launch path
- preserve `missing-baseline` through the outcome reader while keeping the
  older nullable helper conservative, and switch Ralph follow-up reuse to the
  outcome path
- let `team-exec` report
  `team_exec_approved_handoff_nonready:missing-baseline:<prd>` when
  `latestPlanPath` itself is missing its baseline, while still skipping newer
  unrelated drafts without matching test specs
- add focused planning, CLI, pipeline, and continuity tests for
  missing-baseline and incomplete branches

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Additional validation:

- `npx tsc --noEmit`
- `npm run check:no-unused`
- `node --test dist/cli/__tests__/ralph.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/approved-execution.test.js dist/team/__tests__/runtime.test.js dist/pipeline/__tests__/stages.test.js`
- `node dist/scripts/generate-catalog-docs.js --check`
- `node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__ dist/ralph/__tests__ dist/ralplan/__tests__ dist/runtime/__tests__`
- `npm run coverage:team-critical:compiled`
- `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`
  - still hits the existing local `dist/cli/__tests__/launch-fallback.test.js`
    `/private/var` vs `/var` path assertion outside this diff

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Follow-up to #2169.
