### PR TITLE
fix: keep team DAG fallbacks aligned with handoff status

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../team.js';
 import { readModeState } from '../../modes/base.js';
 import { readApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
+import { buildRepoAwareTeamExecutionPlan } from '../../team/repo-aware-decomposition.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
 import { shutdownTeam } from '../../team/runtime.js';
 import { sameFilePath } from '../../utils/paths.js';
@@ -917,6 +918,99 @@ describe('parseTeamStartArgs', () => {
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves lifecycle-specific DAG fallback reasons for explicit nonready approved launches', async () => {
+    const previousCwd = process.cwd();
+    const cases = [
+      {
+        name: 'missing-baseline',
+        slug: 'issue-2090-missing-baseline',
+        includeOutcome: false,
+        writeTestSpec: false,
+        packSetup: async (_wd: string, _prdPath: string, _testSpecPath: string) => {},
+        expected: 'context_pack_not_followup_ready:missing-baseline',
+      },
+      {
+        name: 'incomplete',
+        slug: 'issue-2090-incomplete',
+        includeOutcome: true,
+        writeTestSpec: true,
+        packSetup: async (wd: string, prdPath: string, testSpecPath: string) => {
+          await writeContextPack(wd, 'issue-2090-incomplete', prdPath, testSpecPath, ['scope']);
+        },
+        expected: 'context_pack_not_followup_ready:incomplete',
+      },
+      {
+        name: 'invalid',
+        slug: 'issue-2090-invalid',
+        includeOutcome: true,
+        writeTestSpec: true,
+        packSetup: async (_wd: string, _prdPath: string, _testSpecPath: string) => {},
+        expected: 'context_pack_not_followup_ready:invalid',
+      },
+    ] as const;
+
+    try {
+      for (const scenario of cases) {
+        const wd = await mkdtemp(join(tmpdir(), `omx-team-dag-fallback-${scenario.name}-`));
+        try {
+          process.chdir(wd);
+          const plansDir = join(wd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, `prd-${scenario.slug}.md`);
+          const testSpecPath = join(plansDir, `test-spec-${scenario.slug}.md`);
+          const outcomePath = scenario.name === 'invalid'
+            ? canonicalContextPackRelativePath('other')
+            : canonicalContextPackRelativePath(scenario.slug);
+          const prdSections = ['# Approved plan', ''];
+          if (scenario.includeOutcome) {
+            prdSections.push(buildContextPackOutcome(outcomePath), '');
+          }
+          prdSections.push(`Launch via omx team 3:executor "Execute approved ${scenario.name} DAG plan"`);
+          await writeFile(
+            prdPath,
+            prdSections.join('\n'),
+          );
+          if (scenario.writeTestSpec) {
+            await writeFile(testSpecPath, '# Test spec\n');
+          }
+          await writeFile(
+            join(plansDir, `team-dag-${scenario.slug}.json`),
+            '{"schema_version":1,"nodes":[{"id":"impl","subject":"Impl","description":"Impl"}]}\n',
+          );
+          await scenario.packSetup(wd, prdPath, testSpecPath);
+
+          const parsed = parseTeamStartArgs(['3:executor', 'Execute', 'approved', scenario.name, 'DAG', 'plan']);
+          const executionPlan = buildRepoAwareTeamExecutionPlan({
+            task: parsed.parsed.task,
+            workerCount: parsed.parsed.workerCount,
+            agentType: parsed.parsed.agentType,
+            explicitAgentType: parsed.parsed.explicitAgentType,
+            explicitWorkerCount: parsed.parsed.explicitWorkerCount,
+            cwd: wd,
+            buildLegacyPlan: (task, workerCount, agentType) => ({
+              workerCount,
+              tasks: [{ subject: task, description: task, owner: 'worker-1', role: agentType }],
+            }),
+            allowDagHandoff: parsed.parsed.allowRepoAwareDagHandoff,
+            dagFallbackReason: parsed.parsed.dagFallbackReason,
+            approvedRepositoryContextSummary: parsed.parsed.approvedRepositoryContextSummary,
+          });
+
+          assert.equal(parsed.parsed.allowRepoAwareDagHandoff, false);
+          assert.equal(parsed.parsed.dagFallbackReason, scenario.expected);
+          assert.equal(parsed.parsed.approvedExecution, undefined);
+          assert.equal(executionPlan.metadata?.decomposition_source, 'legacy_text');
+          assert.equal(executionPlan.metadata?.fallback_reason, scenario.expected);
+        } finally {
+          process.chdir(previousCwd);
+          await rm(wd, { recursive: true, force: true });
+        }
+      }
+    } finally {
+      process.chdir(previousCwd);
     }
   });
 

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -13,7 +13,6 @@ import { classifyTaskSize } from '../hooks/task-size-detector.js';
 import {
   isApprovedExecutionContextReadyStatus,
   isApprovedExecutionFollowupReadyStatus,
-  readApprovedExecutionLaunchHint,
   readApprovedExecutionLaunchHintOutcome,
   type ApprovedExecutionLaunchHint,
   type ApprovedRepositoryContextSummary,
@@ -55,6 +54,7 @@ interface ParsedTeamArgs {
   teamName: string;
   displayName?: string;
   allowRepoAwareDagHandoff: boolean;
+  dagFallbackReason?: string;
   approvedRepositoryContextSummary?: ApprovedRepositoryContextSummary;
   approvedExecution?: ApprovedTeamExecutionBinding;
 }
@@ -860,8 +860,13 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     }
   }
 
+  const approvedHintOutcome = followupContext
+    ? null
+    : readApprovedExecutionLaunchHintOutcome(cwd, 'team', { task: effectiveTask });
   const approvedHint = followupContext?.approvedHint
-    ?? readApprovedExecutionLaunchHint(cwd, 'team', { task: effectiveTask });
+    ?? (approvedHintOutcome?.status === 'resolved' && approvedHintOutcome.hint.contextPackStatus !== 'missing-baseline'
+      ? approvedHintOutcome.hint
+      : null);
   const followupReadyApprovedHint = approvedHint && isApprovedExecutionFollowupReadyStatus(approvedHint.contextPackStatus)
     ? approvedHint
     : null;
@@ -873,6 +878,11 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     && (followupReadyApprovedHint.workerCount == null || followupReadyApprovedHint.workerCount === workerCount)
     && (followupReadyApprovedHint.agentType == null || followupReadyApprovedHint.agentType === agentType);
   const allowRepoAwareDagHandoff = followupContext != null || matchesApprovedLaunchHint;
+  const dagFallbackReason = followupContext == null
+    && approvedHintOutcome?.status === 'resolved'
+    && !isApprovedExecutionFollowupReadyStatus(approvedHintOutcome.hint.contextPackStatus)
+    ? `context_pack_not_followup_ready:${approvedHintOutcome.hint.contextPackStatus}`
+    : undefined;
   const approvedRepositoryContextSummary = allowRepoAwareDagHandoff
     ? contextReadyApprovedHint?.repositoryContextSummary
     : undefined;
@@ -887,6 +897,7 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     teamName,
     displayName: teamName,
     allowRepoAwareDagHandoff,
+    ...(dagFallbackReason ? { dagFallbackReason } : {}),
     ...(approvedRepositoryContextSummary ? { approvedRepositoryContextSummary } : {}),
     ...(allowRepoAwareDagHandoff && contextReadyApprovedHint
       ? { approvedExecution: buildApprovedTeamExecutionBinding(contextReadyApprovedHint) }
@@ -1633,6 +1644,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     cwd,
     buildLegacyPlan: buildTeamExecutionPlan,
     allowDagHandoff: parsed.allowRepoAwareDagHandoff,
+    dagFallbackReason: parsed.dagFallbackReason,
     approvedRepositoryContextSummary: parsed.approvedRepositoryContextSummary,
   });
   const tasks = executionPlan.tasks;

--- a/src/team/__tests__/repo-aware-decomposition.test.ts
+++ b/src/team/__tests__/repo-aware-decomposition.test.ts
@@ -69,6 +69,27 @@ describe('buildRepoAwareTeamExecutionPlan', () => {
     assert.equal(plan.tasks[0].subject, 'legacy');
   });
 
+  it('preserves explicit lifecycle fallback reasons when DAG handoff is disabled upstream', () => {
+    const cwd = repo();
+    writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({
+      schema_version: 1,
+      nodes: [{ id: 'stale', subject: 'Stale sidecar', description: 'Must not override lifecycle-rejected startup' }],
+    }));
+    const plan = buildRepoAwareTeamExecutionPlan({
+      task: 'fix unrelated tests',
+      workerCount: 3,
+      agentType: 'executor',
+      explicitAgentType: false,
+      explicitWorkerCount: false,
+      cwd,
+      buildLegacyPlan: legacy,
+      dagFallbackReason: 'context_pack_not_followup_ready:invalid',
+    });
+    assert.equal(plan.metadata?.decomposition_source, 'legacy_text');
+    assert.equal(plan.metadata?.fallback_reason, 'context_pack_not_followup_ready:invalid');
+    assert.equal(plan.tasks[0].subject, 'legacy');
+  });
+
   it('requires a matching approved test spec before importing an opted-in DAG sidecar', () => {
     const cwd = repo();
     writeFileSync(join(cwd, '.omx', 'plans', 'test-spec-demo.md'), '');

--- a/src/team/repo-aware-decomposition.ts
+++ b/src/team/repo-aware-decomposition.ts
@@ -13,6 +13,7 @@ export interface LegacyTeamExecutionPlanInput {
   cwd: string;
   buildLegacyPlan: (task: string, workerCount: number, agentType: string, explicitAgentType: boolean, explicitWorkerCount: boolean) => RepoAwareTeamExecutionPlan;
   allowDagHandoff?: boolean;
+  dagFallbackReason?: string;
   approvedRepositoryContextSummary?: ApprovedRepositoryContextSummary;
 }
 
@@ -284,7 +285,11 @@ export function remapRepoAwareDecompositionMetadataToCreatedTasks(
 export function buildRepoAwareTeamExecutionPlan(input: LegacyTeamExecutionPlanInput): RepoAwareTeamExecutionPlan {
   const resolution = input.allowDagHandoff === true
     ? readTeamDagHandoffForLatestPlan(input.cwd)
-    : ({ dag: null, source: 'none', error: 'dag_handoff_not_approved_for_invocation' } satisfies TeamDagResolution);
+    : ({
+      dag: null,
+      source: 'none',
+      error: input.dagFallbackReason ?? 'dag_handoff_not_approved_for_invocation',
+    } satisfies TeamDagResolution);
   if (resolution.dag) return buildFromDag(input, resolution as TeamDagResolution & { dag: TeamDagHandoff });
 
   const legacy = input.buildLegacyPlan(input.task, input.workerCount, input.agentType, input.explicitAgentType, input.explicitWorkerCount);


### PR DESCRIPTION
## Summary

Explicit Team launches already stayed off repo-aware DAG handoff when the
selected approved handoff was not follow-up reusable, but the fallback
metadata still collapsed those launches to the generic
`dag_handoff_not_approved_for_invocation` reason. That dropped the more
specific approved handoff status that planning selection had already derived,
including `missing-baseline`, `incomplete`, and `invalid`.

## Changes

- Keep explicit nonreusable approved Team launches on the generic path, but
  preserve a status-specific DAG fallback reason in `parseTeamArgs()`.
- Thread that fallback reason into `buildRepoAwareTeamExecutionPlan()` only
  when DAG handoff is already disabled, leaving the existing DAG selection and
  authority rules unchanged.
- Add focused coverage in `src/cli/__tests__/team.test.ts` and
  `src/team/__tests__/repo-aware-decomposition.test.ts` to prove that
  explicit nonready launches keep their handoff status through CLI parsing and
  legacy decomposition fallback.

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Focused validation run for this change:

- `npx tsc --noEmit`
- `npm run check:no-unused`
- `npm run build`
- `node --test dist/cli/__tests__/team.test.js dist/team/__tests__/repo-aware-decomposition.test.js dist/pipeline/__tests__/stages.test.js`
- `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`
  - exact outside-sandbox rerun reduced to the existing
    `dist/cli/__tests__/launch-fallback.test.js` `/private/var` vs `/var`
    assertion outside this diff

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
