### PR TITLE
Add context-pack status command

### DIFF
--- a/src/cli/__tests__/context-pack.test.ts
+++ b/src/cli/__tests__/context-pack.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { CONTEXT_PACK_HELP, contextPackCommand } from "../context-pack.js";
+
+let tempDir: string;
+
+function gitBlobSha1(content: string): string {
+	const buffer = Buffer.from(content, "utf-8");
+	return createHash("sha1")
+		.update(Buffer.from(`blob ${buffer.length}\0`, "utf-8"))
+		.update(buffer)
+		.digest("hex");
+}
+
+function rel(path: string): string {
+	return relative(tempDir, path).replaceAll("\\", "/");
+}
+
+async function writeReadyPack(slug: string): Promise<string> {
+	const plansDir = join(tempDir, ".omx", "plans");
+	const contextDir = join(tempDir, ".omx", "context");
+	await mkdir(plansDir, { recursive: true });
+	await mkdir(contextDir, { recursive: true });
+	const packRelativePath = `.omx/context/context-20260507T120000Z-${slug}.json`;
+	const prdPath = join(plansDir, `prd-${slug}.md`);
+	const testSpecPath = join(plansDir, `test-spec-${slug}.md`);
+	await writeFile(
+		prdPath,
+		[
+			"# PRD",
+			"",
+			"## Context Pack Outcome",
+			"",
+			`- pack: created \`${packRelativePath}\``,
+		].join("\n"),
+	);
+	await writeFile(testSpecPath, "# Test Spec\n");
+	const prdContent = await readFile(prdPath, "utf-8");
+	const testSpecContent = await readFile(testSpecPath, "utf-8");
+	await writeFile(
+		join(tempDir, packRelativePath),
+		JSON.stringify(
+			{
+				slug,
+				basis: {
+					prd: { path: rel(prdPath), sha1: gitBlobSha1(prdContent) },
+					testSpecs: [
+						{ path: rel(testSpecPath), sha1: gitBlobSha1(testSpecContent) },
+					],
+				},
+				entries: ["scope", "build", "verify"].map((role) => ({
+					path: `src/${role}.ts`,
+					roles: [role],
+				})),
+			},
+			null,
+			2,
+		),
+	);
+	return packRelativePath;
+}
+
+describe("contextPackCommand", () => {
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "omx-context-pack-cli-"));
+	});
+
+	afterEach(async () => {
+		if (tempDir && existsSync(tempDir)) {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("prints local help", async () => {
+		const out: string[] = [];
+		await contextPackCommand(["--help"], {
+			cwd: tempDir,
+			stdout: (line) => out.push(line),
+		});
+		assert.deepEqual(out, [CONTEXT_PACK_HELP]);
+	});
+
+	it("emits JSON status for a canonical pack", async () => {
+		const pack = await writeReadyPack("cli-ready");
+		const out: string[] = [];
+
+		await contextPackCommand(["status", pack, "--json"], {
+			cwd: tempDir,
+			stdout: (line) => out.push(line),
+		});
+
+		assert.equal(out.length, 1);
+		const parsed = JSON.parse(out[0]!);
+		assert.equal(parsed.contextPackStatus, "ready");
+		assert.equal(parsed.packRelativePath, pack);
+		assert.equal(parsed.declarationState, "declared");
+	});
+
+	it("keeps query and view out of the first status-only slice", async () => {
+		await assert.rejects(
+			contextPackCommand(
+				["query", ".omx/context/context-20260507T120000Z-cli-ready.json"],
+				{ cwd: tempDir },
+			),
+			/Unknown context-pack subcommand: query/,
+		);
+	});
+});

--- a/src/cli/context-pack.ts
+++ b/src/cli/context-pack.ts
@@ -1,0 +1,88 @@
+import { readDirectContextPackStatus } from "../planning/context-pack-status.js";
+
+export const CONTEXT_PACK_HELP = `Usage: omx context-pack status <pack> [--json]
+
+Read-only context-pack inspection:
+  omx context-pack status .omx/context/context-20260507T120000Z-example.json
+
+<pack> must be a canonical .omx/context/context-<timestamp>-<slug>.json path.
+Only status is implemented in this first slice; query/view are intentionally out of scope.`;
+
+export interface ContextPackCommandDependencies {
+	cwd?: string;
+	stdout?: (line: string) => void;
+}
+
+function renderHumanStatus(
+	status: ReturnType<typeof readDirectContextPackStatus>,
+): string {
+	const lines = [
+		`Context pack status: ${status.contextPackStatus}`,
+		`- pack: ${status.packRelativePath}`,
+		`- slug: ${status.slug}`,
+		`- declaration: ${status.declarationState}`,
+		`- declared pack: ${status.declaredPackPath ?? "(none)"}`,
+		`- pack state: ${status.packState}`,
+		`- basis: ${status.basisState}`,
+		`- role coverage: ${status.roleCoverage}`,
+	];
+	if (status.missingRequiredContextPackRoles.length > 0) {
+		lines.push(
+			`- missing roles: ${status.missingRequiredContextPackRoles.join(", ")}`,
+		);
+	}
+	if (status.contextPackIssues.length > 0) {
+		lines.push("- issues:");
+		for (const issue of status.contextPackIssues) {
+			lines.push(`  - ${issue}`);
+		}
+	}
+	return lines.join("\n");
+}
+
+export async function contextPackCommand(
+	args: string[],
+	deps: ContextPackCommandDependencies = {},
+): Promise<void> {
+	const stdout = deps.stdout ?? ((line: string) => console.log(line));
+	const cwd = deps.cwd ?? process.cwd();
+	const subcommand = args[0];
+
+	if (
+		!subcommand ||
+		subcommand === "--help" ||
+		subcommand === "-h" ||
+		subcommand === "help"
+	) {
+		stdout(CONTEXT_PACK_HELP);
+		return;
+	}
+
+	if (subcommand !== "status") {
+		throw new Error(
+			`Unknown context-pack subcommand: ${subcommand}\n${CONTEXT_PACK_HELP}`,
+		);
+	}
+
+	let json = false;
+	let pack: string | undefined;
+	for (let index = 1; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === "--json") {
+			json = true;
+			continue;
+		}
+		if (!pack) {
+			pack = arg;
+			continue;
+		}
+		throw new Error(`Unknown context-pack status argument: ${arg}`);
+	}
+
+	if (!pack) {
+		throw new Error(`Missing context-pack path.\n${CONTEXT_PACK_HELP}`);
+	}
+
+	const status = readDirectContextPackStatus(cwd, pack);
+	stdout(json ? JSON.stringify(status) : renderHumanStatus(status));
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ import { performanceGoalCommand } from "./performance-goal.js";
 import { askCommand } from "./ask.js";
 import { questionCommand } from "./question.js";
 import { stateCommand } from "./state.js";
+import { contextPackCommand } from "./context-pack.js";
 import {
   cleanupCommand,
   cleanupOmxMcpProcesses,
@@ -211,6 +212,8 @@ Usage:
   omx hud       Show HUD statusline (--watch, --json, --preset=NAME)
   omx sidecar   Show read-only team/multi-agent visualization (--watch, --json, --tmux)
   omx state     Read/write/list OMX mode state via CLI parity surface
+  omx context-pack status <pack>
+                Read-only status for a canonical context pack
   omx notepad   CLI parity for OMX notepad MCP tools
   omx project-memory
                 CLI parity for OMX project-memory MCP tools
@@ -347,6 +350,7 @@ type CliCommand =
   | "hud"
   | "sidecar"
   | "state"
+  | "context-pack"
   | "wiki"
   | "mcp-serve"
   | "status"
@@ -372,6 +376,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "hud",
   "sidecar",
   "state",
+  "context-pack",
   "wiki",
   "mcp-serve",
   "ralph",
@@ -1109,7 +1114,7 @@ export async function main(args: string[]): Promise<void> {
     "ask",
     "question",
     "autoresearch",
-  "autoresearch-goal",
+    "autoresearch-goal",
     "explore",
     "sparkshell",
     "team",
@@ -1124,6 +1129,7 @@ export async function main(args: string[]): Promise<void> {
     "hud",
     "sidecar",
     "state",
+    "context-pack",
     "mcp-serve",
     "status",
     "cancel",
@@ -1256,6 +1262,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "state":
         await stateCommand(args.slice(1));
+        break;
+      case "context-pack":
+        await contextPackCommand(args.slice(1));
         break;
       case "notepad":
         await mcpParityCommand("notepad", args.slice(1));

--- a/src/planning/__tests__/direct-context-pack-status.test.ts
+++ b/src/planning/__tests__/direct-context-pack-status.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { readDirectContextPackStatus } from "../context-pack-status.js";
+
+let tempDir: string;
+
+function computeGitBlobSha1(content: string): string {
+	const buffer = Buffer.from(content, "utf-8");
+	const header = Buffer.from(`blob ${buffer.length}\0`, "utf-8");
+	return createHash("sha1").update(header).update(buffer).digest("hex");
+}
+
+function relativeToRepo(path: string): string {
+	return relative(tempDir, path).replaceAll("\\", "/");
+}
+
+function canonicalContextPackRelativePath(slug: string): string {
+	return `.omx/context/context-20260507T120000Z-${slug}.json`;
+}
+
+function buildContextPackOutcome(relativePackPath: string): string {
+	return [
+		"## Context Pack Outcome",
+		"",
+		`- pack: created \`${relativePackPath}\``,
+	].join("\n");
+}
+
+async function writeApprovedPlan(
+	slug: string,
+	bodyLines: string[],
+): Promise<{
+	prdPath: string;
+	testSpecPath: string;
+	packRelativePath: string;
+}> {
+	const plansDir = join(tempDir, ".omx", "plans");
+	const contextDir = join(tempDir, ".omx", "context");
+	await mkdir(plansDir, { recursive: true });
+	await mkdir(contextDir, { recursive: true });
+
+	const prdPath = join(plansDir, `prd-${slug}.md`);
+	const testSpecPath = join(plansDir, `test-spec-${slug}.md`);
+	const packRelativePath = canonicalContextPackRelativePath(slug);
+
+	await writeFile(prdPath, bodyLines.join("\n"));
+	await writeFile(testSpecPath, "# Test Spec\n");
+
+	return { prdPath, testSpecPath, packRelativePath };
+}
+
+async function writeContextPack(
+	slug: string,
+	prdPath: string,
+	testSpecPath: string,
+	roles: string[],
+): Promise<void> {
+	const packPath = join(tempDir, canonicalContextPackRelativePath(slug));
+	const prdActual = await readFile(prdPath, "utf-8");
+	const testSpecActual = await readFile(testSpecPath, "utf-8");
+	await writeFile(
+		packPath,
+		JSON.stringify(
+			{
+				slug,
+				basis: {
+					prd: {
+						path: relativeToRepo(prdPath),
+						sha1: computeGitBlobSha1(prdActual),
+					},
+					testSpecs: [
+						{
+							path: relativeToRepo(testSpecPath),
+							sha1: computeGitBlobSha1(testSpecActual),
+						},
+					],
+				},
+				entries: roles.map((role, index) => ({
+					path: `src/${role}-${index}.ts`,
+					roles: [role],
+				})),
+			},
+			null,
+			2,
+		),
+	);
+}
+
+describe("direct context pack status", () => {
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "omx-direct-context-pack-status-"));
+	});
+
+	afterEach(async () => {
+		if (tempDir && existsSync(tempDir)) {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("reports ready for a canonical pack with fresh basis, declaration, and required roles", async () => {
+		const { prdPath, testSpecPath, packRelativePath } = await writeApprovedPlan(
+			"direct-ready",
+			[
+				"# PRD",
+				"",
+				buildContextPackOutcome(
+					canonicalContextPackRelativePath("direct-ready"),
+				),
+			],
+		);
+		await writeContextPack("direct-ready", prdPath, testSpecPath, [
+			"scope",
+			"build",
+			"verify",
+		]);
+
+		const status = readDirectContextPackStatus(tempDir, packRelativePath);
+
+		assert.equal(status.contextPackStatus, "ready");
+		assert.equal(status.packRelativePath, packRelativePath);
+		assert.equal(status.declarationState, "declared");
+		assert.equal(status.basisState, "fresh");
+		assert.equal(status.roleCoverage, "covered");
+		assert.deepEqual(status.contextPackIssues, []);
+	});
+
+	it("rejects non-canonical pack paths before reading", () => {
+		assert.throws(
+			() =>
+				readDirectContextPackStatus(tempDir, ".omx/context/not-a-pack.json"),
+			/context-<timestamp>-<slug>\.json/,
+		);
+	});
+
+	it("reports incomplete when a canonical pack is missing required roles", async () => {
+		const { prdPath, testSpecPath, packRelativePath } = await writeApprovedPlan(
+			"direct-roles",
+			[
+				"# PRD",
+				"",
+				buildContextPackOutcome(
+					canonicalContextPackRelativePath("direct-roles"),
+				),
+			],
+		);
+		await writeContextPack("direct-roles", prdPath, testSpecPath, ["scope"]);
+
+		const status = readDirectContextPackStatus(tempDir, packRelativePath);
+
+		assert.equal(status.contextPackStatus, "incomplete");
+		assert.deepEqual(status.missingRequiredContextPackRoles, [
+			"build",
+			"verify",
+		]);
+	});
+
+	it("reports invalid when the basis PRD declares a different canonical pack", async () => {
+		const { prdPath, testSpecPath, packRelativePath } = await writeApprovedPlan(
+			"direct-mismatch",
+			[
+				"# PRD",
+				"",
+				buildContextPackOutcome(canonicalContextPackRelativePath("other-pack")),
+			],
+		);
+		await writeContextPack("direct-mismatch", prdPath, testSpecPath, [
+			"scope",
+			"build",
+			"verify",
+		]);
+
+		const status = readDirectContextPackStatus(tempDir, packRelativePath);
+
+		assert.equal(status.contextPackStatus, "invalid");
+		assert.equal(status.declarationState, "mismatch");
+		assert.equal(
+			status.declaredPackPath,
+			canonicalContextPackRelativePath("other-pack"),
+		);
+		assert.ok(
+			status.contextPackIssues.some((issue) => issue.includes("instead of")),
+		);
+	});
+});

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -23,6 +23,9 @@ export type ContextPackPackState = 'missing' | 'unreadable' | 'invalid' | 'valid
 export type ContextPackRoleCoverageState =
   'unknown' | 'missing-required-roles' | 'covered';
 export type ContextPackBasisState = 'stale' | 'fresh';
+export type DirectContextPackStatus = 'ready' | 'incomplete' | 'invalid';
+export type DirectContextPackDeclarationState =
+  'unknown' | 'missing' | 'malformed' | 'ambiguous' | 'mismatch' | 'declared';
 
 export interface ContextPackRef {
   path: string;
@@ -44,6 +47,20 @@ export interface ContextPackHandoffStatusSnapshot {
 
 export interface ContextPackArtifactReadModel {
   plansDir: string;
+}
+
+export interface DirectContextPackStatusSnapshot {
+  packPath: string;
+  packRelativePath: string;
+  slug: string;
+  contextPackStatus: DirectContextPackStatus;
+  declarationState: DirectContextPackDeclarationState;
+  declaredPackPath: string | null;
+  packState: ContextPackPackState;
+  roleCoverage: ContextPackRoleCoverageState;
+  basisState: ContextPackBasisState;
+  missingRequiredContextPackRoles: ContextPackRole[];
+  contextPackIssues: string[];
 }
 
 export interface ContextPackBaselineSelection {
@@ -510,6 +527,165 @@ function validateContextPackBasis(
   }
 
   return issues;
+}
+
+
+function validateDirectContextPackBasis(
+  repoRoot: string,
+  document: ContextPackDocument,
+): string[] {
+  const issues: string[] = [];
+  const validateBasisObject = (basis: ContextPackBasisObject, label: string): void => {
+    const basisPath = resolve(repoRoot, basis.path);
+    const roundTripPath = normalizeRepoRelativePath(relative(repoRoot, basisPath));
+    if (!roundTripPath || roundTripPath !== basis.path) {
+      issues.push(
+        `Declared context pack ${label} basis path ${basis.path} escapes the repository.`,
+      );
+      return;
+    }
+    if (!existsSync(basisPath)) {
+      issues.push(`Declared context pack ${label} basis file is missing: ${basis.path}.`);
+      return;
+    }
+    if (basis.sha1 !== computeGitBlobSha1(basisPath)) {
+      issues.push(
+        `Declared context pack ${label} basis hash for ${basis.path} does not match the current file.`,
+      );
+    }
+  };
+
+  validateBasisObject(document.basis.prd, 'prd');
+  document.basis.testSpecs.forEach((testSpec, index) => {
+    validateBasisObject(testSpec, `test-spec[${index}]`);
+  });
+  return issues;
+}
+
+function resolveDirectContextPackState(input: {
+  packState: ContextPackPackState;
+  roleCoverage: ContextPackRoleCoverageState;
+  basisState: ContextPackBasisState;
+  declarationState: DirectContextPackDeclarationState;
+}): DirectContextPackStatus {
+  if (input.packState === 'invalid' || input.packState === 'unreadable') {
+    return input.packState === 'unreadable' ? 'incomplete' : 'invalid';
+  }
+  if (input.basisState !== 'fresh') {
+    return 'invalid';
+  }
+  if (
+    input.declarationState === 'malformed'
+    || input.declarationState === 'ambiguous'
+    || input.declarationState === 'mismatch'
+  ) {
+    return 'invalid';
+  }
+  if (
+    input.roleCoverage === 'missing-required-roles'
+    || input.declarationState !== 'declared'
+  ) {
+    return 'incomplete';
+  }
+  return 'ready';
+}
+
+export function readDirectContextPackStatus(
+  repoRoot: string,
+  packPath: string,
+): DirectContextPackStatusSnapshot {
+  const resolvedPack = resolveDeclaredContextPackPath(repoRoot, packPath);
+  if (!resolvedPack) {
+    throw new Error(
+      'Context pack path must be canonical: .omx/context/context-<timestamp>-<slug>.json',
+    );
+  }
+
+  let packState: ContextPackPackState = 'missing';
+  let roleCoverage: ContextPackRoleCoverageState = 'unknown';
+  let basisState: ContextPackBasisState = 'stale';
+  let declarationState: DirectContextPackDeclarationState = 'unknown';
+  let declaredPackPath: string | null = null;
+  let missingRequiredContextPackRoles: ContextPackRole[] = [];
+  const contextPackIssues: string[] = [];
+
+  if (!existsSync(resolvedPack.resolvedPath)) {
+    packState = 'unreadable';
+    contextPackIssues.push(`Context pack file is missing: ${resolvedPack.normalizedPath}.`);
+  } else {
+    const packDocument = readContextPackDocument(resolvedPack.resolvedPath);
+    packState = packDocument.packState;
+    contextPackIssues.push(...packDocument.issues);
+
+    if (packDocument.document) {
+      const document = packDocument.document;
+      if (document.slug !== resolvedPack.slug) {
+        contextPackIssues.push(
+          `Context pack slug ${document.slug} does not match canonical path slug ${resolvedPack.slug}.`,
+        );
+        packState = 'invalid';
+      }
+
+      missingRequiredContextPackRoles = findMissingRequiredContextPackRoles(document);
+      roleCoverage = missingRequiredContextPackRoles.length === 0
+        ? 'covered'
+        : 'missing-required-roles';
+
+      const basisIssues = validateDirectContextPackBasis(repoRoot, document);
+      if (basisIssues.length === 0) {
+        basisState = 'fresh';
+      } else {
+        contextPackIssues.push(...basisIssues);
+      }
+
+      const prdPath = resolve(repoRoot, document.basis.prd.path);
+      if (existsSync(prdPath)) {
+        try {
+          const outcome = inspectContextPackOutcome(repoRoot, readFileSync(prdPath, 'utf-8'));
+          declaredPackPath = outcome.declaredPackPath;
+          contextPackIssues.push(...outcome.issues);
+          if (outcome.outcomeState === 'absent') {
+            declarationState = 'missing';
+          } else if (outcome.outcomeState === 'malformed') {
+            declarationState = 'malformed';
+          } else if (outcome.outcomeState === 'ambiguous') {
+            declarationState = 'ambiguous';
+          } else if (outcome.declaredPackPath === resolvedPack.normalizedPath) {
+            declarationState = 'declared';
+          } else {
+            declarationState = 'mismatch';
+            contextPackIssues.push(
+              `Basis PRD declares ${outcome.declaredPackPath ?? '(none)'} instead of ${resolvedPack.normalizedPath}.`,
+            );
+          }
+        } catch {
+          declarationState = 'unknown';
+          contextPackIssues.push(
+            'Basis PRD could not be read while resolving context pack declaration.',
+          );
+        }
+      }
+    }
+  }
+
+  return {
+    packPath: resolvedPack.resolvedPath,
+    packRelativePath: resolvedPack.normalizedPath,
+    slug: resolvedPack.slug,
+    contextPackStatus: resolveDirectContextPackState({
+      packState,
+      roleCoverage,
+      basisState,
+      declarationState,
+    }),
+    declarationState,
+    declaredPackPath,
+    packState,
+    roleCoverage,
+    basisState,
+    missingRequiredContextPackRoles,
+    contextPackIssues,
+  };
 }
 
 export function resolveContextPackHandoffState(input: {


### PR DESCRIPTION
## Summary\n- Add read-only `omx context-pack status <pack>` for canonical `.omx/context/context-<timestamp>-<slug>.json` paths.\n- Report pack readiness, declaration state, basis freshness, role coverage, missing required roles, and issues.\n- Keep query/view and all mutation/authoring flows out of scope for this first slice.\n\nReferences #2175\n\n## Verification\n- `npm run build`\n- `env -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/planning/__tests__/context-pack-status.test.js dist/planning/__tests__/direct-context-pack-status.test.js dist/cli/__tests__/context-pack.test.js`\n- `npm run check:no-unused`