### PR TITLE
feat: add readonly context-pack status inspect

### DIFF
--- a/src/planning/__tests__/context-tool.test.ts
+++ b/src/planning/__tests__/context-tool.test.ts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { contextToolMain } from '../context-tool.js';
+
+let tempDir: string;
+
+function computeGitBlobSha1(content: string): string {
+  const buffer = Buffer.from(content, 'utf-8');
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function relativeToRepo(path: string): string {
+  return relative(tempDir, path).replaceAll('\\', '/');
+}
+
+function packRelativePath(slug: string, timestamp = '20260507T120000Z'): string {
+  return `.omx/context/context-${timestamp}-${slug}.json`;
+}
+
+async function writePackFixture(slug: string, timestamp = '20260507T120000Z'): Promise<{
+  packPath: string;
+  relativePackPath: string;
+}> {
+  const plansDir = join(tempDir, '.omx', 'plans');
+  const contextDir = join(tempDir, '.omx', 'context');
+  await mkdir(plansDir, { recursive: true });
+  await mkdir(contextDir, { recursive: true });
+
+  const prdPath = join(plansDir, `prd-${slug}.md`);
+  const testSpecPath = join(plansDir, `test-spec-${slug}.md`);
+  const relativePackPath = packRelativePath(slug, timestamp);
+  const packPath = join(tempDir, relativePackPath);
+  const prdContent = [
+    '# PRD',
+    '',
+    '## Context Pack Outcome',
+    '',
+    `- pack: created \`${packRelativePath(slug)}\``,
+    '',
+    `Launch via omx ralph "Execute ${slug} handoff"`,
+  ].join('\n');
+  const testSpecContent = '# Test Spec\n';
+  await writeFile(prdPath, prdContent);
+  await writeFile(testSpecPath, testSpecContent);
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relativeToRepo(prdPath),
+        sha1: computeGitBlobSha1(prdContent),
+      },
+      testSpecs: [{
+        path: relativeToRepo(testSpecPath),
+        sha1: computeGitBlobSha1(testSpecContent),
+      }],
+    },
+    entries: [
+      { path: 'docs/scope.md', roles: ['scope'] },
+      { path: 'docs/build.md', roles: ['build'] },
+      { path: 'docs/verify.md', roles: ['verify'] },
+    ],
+  }, null, 2));
+
+  return { packPath, relativePackPath };
+}
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map((arg) => String(arg)).join(' '));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return lines.join('\n');
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'omx-context-tool-'));
+});
+
+afterEach(async () => {
+  if (tempDir && existsSync(tempDir)) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe('context-tool', () => {
+  it('prints status-only help text', async () => {
+    const stdout = await captureStdout(() => contextToolMain([], tempDir));
+    assert.match(stdout, /node dist\/planning\/context-tool\.js status/);
+    assert.doesNotMatch(stdout, /node dist\/planning\/context-tool\.js query/);
+    assert.doesNotMatch(stdout, /node dist\/planning\/context-tool\.js view/);
+  });
+
+  it('resolves ready status from a nested workspace cwd', async () => {
+    const slug = 'issue-status';
+    const { relativePackPath } = await writePackFixture(slug);
+    const nestedCwd = join(tempDir, 'packages', 'app');
+    await mkdir(nestedCwd, { recursive: true });
+
+    const stdout = await captureStdout(() =>
+      contextToolMain(['status', relativePackPath, '--json'], nestedCwd),
+    );
+    const parsed = JSON.parse(stdout) as {
+      handoffState: string;
+      declaredPackPath: string | null;
+      missingRequiredContextPackRoles: string[];
+    };
+
+    assert.equal(parsed.handoffState, 'ready');
+    assert.equal(parsed.declaredPackPath, relativePackPath);
+    assert.deepEqual(parsed.missingRequiredContextPackRoles, []);
+  });
+
+  it('rejects noncanonical pack paths fail-closed', async () => {
+    await assert.rejects(
+      () => contextToolMain(['status', '.omx/context/not-a-pack.json'], tempDir),
+      /Context pack path must be \.omx\/context\/context-<timestamp>-<slug>\.json\./,
+    );
+  });
+
+  it('resolves status against the pack repo root for absolute canonical paths', async () => {
+    const slug = 'absolute-status';
+    const { packPath } = await writePackFixture(slug);
+    const unrelatedCwd = await mkdtemp(join(tmpdir(), 'omx-context-tool-unrelated-'));
+
+    try {
+      const stdout = await captureStdout(() =>
+        contextToolMain(['status', packPath, '--json'], unrelatedCwd),
+      );
+      const parsed = JSON.parse(stdout) as { handoffState: string; slug: string | null };
+      assert.equal(parsed.handoffState, 'ready');
+      assert.equal(parsed.slug, slug);
+    } finally {
+      await rm(unrelatedCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when the approved plan declares a different pack for the same slug', async () => {
+    const slug = 'different-pack';
+    const { packPath } = await writePackFixture(slug, '20260507T130000Z');
+
+    const stdout = await captureStdout(() =>
+      contextToolMain(['status', packPath, '--json'], tempDir),
+    );
+    const parsed = JSON.parse(stdout) as {
+      handoffState: string;
+      outcomeState: string;
+      issues: string[];
+    };
+
+    assert.equal(parsed.handoffState, 'invalid');
+    assert.equal(parsed.outcomeState, 'other-pack');
+    assert.ok(parsed.issues.some((issue) => issue.includes('Approved plan declares different context pack')));
+  });
+});

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -1,15 +1,17 @@
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, relative, resolve } from 'node:path';
+import { dirname, relative } from 'node:path';
 import { planningArtifactSlug } from './artifact-names.js';
+import {
+  normalizePlanningRepoRelativePath,
+  resolveDeclaredContextPackPath,
+} from './path-utils.js';
 
 const CONTEXT_PACK_OUTCOME_HEADING_PATTERN =
   /^#{1,6}\s+Context Pack Outcome\s*$/i;
 const CONTEXT_PACK_OUTCOME_DECLARATION_PATTERN = /^[*-]\s*pack\s*:/i;
 const CONTEXT_PACK_OUTCOME_LINE_PATTERN =
   /^[*-]\s*pack\s*:\s*(?:(?:created|refreshed|revalidated)\s+)?(?:`(?<quotedPath>[^`]+\.json)`|(?<barePath>\S+\.json))\s*$/i;
-const CONTEXT_PACK_PATH_PATTERN =
-  /^\.omx\/context\/context-(?<timestamp>\d{8}T\d{6}Z)-(?<slug>[^/]+)\.json$/i;
 const SHA1_PATTERN = /^[0-9a-f]{40}$/i;
 
 export const REQUIRED_CONTEXT_PACK_ROLES = ['scope', 'build', 'verify'] as const;
@@ -56,7 +58,7 @@ interface ContextPackBasisObject {
   sha1: string;
 }
 
-interface ContextPackDocument {
+export interface ContextPackDocument {
   slug: string;
   basis: {
     prd: ContextPackBasisObject;
@@ -68,7 +70,7 @@ interface ContextPackDocument {
   }>;
 }
 
-interface ContextPackOutcomeInspection {
+export interface ContextPackOutcomeInspection {
   outcomeState: ContextPackOutcomeState;
   contextPack: ContextPackRef | null;
   declaredPackPath: string | null;
@@ -86,28 +88,6 @@ export function isApprovedExecutionContextReadyStatus(
   status: ContextPackStatus,
 ): boolean {
   return status === 'ready';
-}
-
-function normalizeRepoRelativePath(rawPath: string): string | null {
-  const trimmed = rawPath.trim().replace(/^`|`$/g, '').replaceAll('\\', '/');
-  if (!trimmed) {
-    return null;
-  }
-  const withoutLeadingDot = trimmed.startsWith('./') ? trimmed.slice(2) : trimmed;
-  if (
-    !withoutLeadingDot
-    || withoutLeadingDot.startsWith('/')
-    || /^[A-Za-z]:/.test(withoutLeadingDot)
-  ) {
-    return null;
-  }
-  const segments = withoutLeadingDot
-    .split('/')
-    .filter((segment) => segment.length > 0);
-  if (segments.length === 0 || segments.includes('..')) {
-    return null;
-  }
-  return segments.join('/');
 }
 
 function computeGitBlobSha1(filePath: string): string {
@@ -162,31 +142,7 @@ function extractContextPackOutcomeSections(content: string): string[][] {
   return sections;
 }
 
-function resolveDeclaredContextPackPath(
-  repoRoot: string,
-  rawPath: string,
-): { normalizedPath: string; resolvedPath: string; slug: string } | null {
-  const normalizedPath = normalizeRepoRelativePath(rawPath);
-  if (!normalizedPath) {
-    return null;
-  }
-  const pathMatch = normalizedPath.match(CONTEXT_PACK_PATH_PATTERN);
-  if (!pathMatch?.groups?.slug) {
-    return null;
-  }
-  const resolvedPath = resolve(repoRoot, normalizedPath);
-  const roundTripPath = normalizeRepoRelativePath(relative(repoRoot, resolvedPath));
-  if (!roundTripPath || roundTripPath !== normalizedPath) {
-    return null;
-  }
-  return {
-    normalizedPath,
-    resolvedPath,
-    slug: pathMatch.groups.slug,
-  };
-}
-
-function inspectContextPackOutcome(
+export function inspectContextPackOutcome(
   repoRoot: string,
   content: string,
 ): ContextPackOutcomeInspection {
@@ -284,7 +240,7 @@ function inspectContextPackOutcome(
   };
 }
 
-function readContextPackDocument(packPath: string): {
+export function readContextPackDocument(packPath: string): {
   packState: ContextPackPackState;
   document: ContextPackDocument | null;
   issues: string[];
@@ -350,7 +306,7 @@ function readContextPackDocument(packPath: string): {
     }
     const record = value as Record<string, unknown>;
     const path =
-      typeof record.path === 'string' ? normalizeRepoRelativePath(record.path) : null;
+      typeof record.path === 'string' ? normalizePlanningRepoRelativePath(record.path) : null;
     if (!path) {
       issues.push(`Declared context pack ${label} basis path must be repo-relative.`);
     }
@@ -388,7 +344,7 @@ function readContextPackDocument(packPath: string): {
       }
       const record = rawEntry as Record<string, unknown>;
       const path =
-        typeof record.path === 'string' ? normalizeRepoRelativePath(record.path) : null;
+        typeof record.path === 'string' ? normalizePlanningRepoRelativePath(record.path) : null;
       if (!path) {
         issues.push('Declared context pack entries must provide a repo-relative path.');
       }
@@ -445,14 +401,14 @@ function readContextPackDocument(packPath: string): {
   };
 }
 
-function findMissingRequiredContextPackRoles(
+export function findMissingRequiredContextPackRoles(
   document: ContextPackDocument,
 ): ContextPackRole[] {
   const presentRoles = new Set(document.entries.flatMap((entry) => entry.roles));
   return REQUIRED_CONTEXT_PACK_ROLES.filter((role) => !presentRoles.has(role));
 }
 
-function validateContextPackBasis(
+export function validateContextPackBasis(
   repoRoot: string,
   prdPath: string,
   testSpecPaths: readonly string[],
@@ -468,7 +424,8 @@ function validateContextPackBasis(
     );
   }
 
-  const expectedPrdRelativePath = normalizeRepoRelativePath(relative(repoRoot, prdPath));
+  const expectedPrdRelativePath =
+    normalizePlanningRepoRelativePath(relative(repoRoot, prdPath));
   if (!expectedPrdRelativePath) {
     issues.push('Approved plan path could not be normalized for context pack validation.');
   } else if (document.basis.prd.path !== expectedPrdRelativePath) {
@@ -482,7 +439,8 @@ function validateContextPackBasis(
   }
 
   const expectedTestSpecMap = new Map(testSpecPaths.flatMap((testSpecPath) => {
-    const normalizedPath = normalizeRepoRelativePath(relative(repoRoot, testSpecPath));
+    const normalizedPath =
+      normalizePlanningRepoRelativePath(relative(repoRoot, testSpecPath));
     return normalizedPath
       ? [[normalizedPath, computeGitBlobSha1(testSpecPath)]]
       : [];

--- a/src/planning/context-packs.ts
+++ b/src/planning/context-packs.ts
@@ -1,0 +1,236 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import {
+  comparePlanningArtifactPaths,
+  planningArtifactSlug,
+  selectLatestPlanningArtifactPath,
+  selectMatchingTestSpecsForPrd,
+} from './artifact-names.js';
+import {
+  findMissingRequiredContextPackRoles,
+  inspectContextPackOutcome,
+  readContextPackDocument,
+  resolveContextPackHandoffState,
+  validateContextPackBasis,
+  type ContextPackBaselineState,
+  type ContextPackBasisState,
+  type ContextPackOutcomeState,
+  type ContextPackPackState,
+  type ContextPackRole,
+  type ContextPackRoleCoverageState,
+  type ContextPackStatus,
+} from './context-pack-status.js';
+import {
+  isCanonicalContextPackPath,
+  normalizePlanningRepoRelativePath,
+} from './path-utils.js';
+import { omxPlansDir } from '../utils/paths.js';
+
+const PRD_PATTERN = /^prd-.*\.md$/i;
+const TEST_SPEC_PATTERN = /^test-?spec-.*\.md$/i;
+const CONTEXT_PACK_FILE_PATTERN = /^context-(?<timestamp>\d{8}T\d{6}Z)-(?<slug>[^/]+)\.json$/i;
+
+export type ContextPackInspectOutcomeState = ContextPackOutcomeState | 'other-pack';
+
+export interface ContextPackReadStatusSnapshot {
+  packPath: string;
+  slug: string | null;
+  prdPath: string | null;
+  declaredPackPath: string | null;
+  testSpecPaths: string[];
+  baselineState: ContextPackBaselineState;
+  outcomeState: ContextPackInspectOutcomeState;
+  packState: ContextPackPackState;
+  roleCoverage: ContextPackRoleCoverageState;
+  basisState: ContextPackBasisState;
+  handoffState: ContextPackStatus;
+  missingRequiredContextPackRoles: ContextPackRole[];
+  issues: string[];
+}
+
+interface ApprovedPlanBasisResolution {
+  prdPath: string | null;
+  testSpecPaths: string[];
+  baselineState: ContextPackBaselineState;
+  issues: string[];
+}
+
+function readMatchingPaths(dir: string, pattern: RegExp): string[] {
+  if (!existsSync(dir)) {
+    return [];
+  }
+  try {
+    return readdirSync(dir)
+      .filter((file) => pattern.test(file))
+      .sort(comparePlanningArtifactPaths)
+      .map((file) => join(dir, file));
+  } catch {
+    return [];
+  }
+}
+
+function parseContextPackSlug(packPath: string): string | null {
+  if (!isCanonicalContextPackPath(packPath)) {
+    return null;
+  }
+  const match = basename(packPath).match(CONTEXT_PACK_FILE_PATTERN);
+  if (!match?.groups?.slug) {
+    return null;
+  }
+  return match.groups.slug;
+}
+
+function resolveApprovedPlanBasisForSlug(
+  repoRoot: string,
+  slug: string,
+): ApprovedPlanBasisResolution {
+  const plansDir = omxPlansDir(repoRoot);
+  const prdPaths = readMatchingPaths(plansDir, PRD_PATTERN)
+    .filter((path) => planningArtifactSlug(path, 'prd') === slug);
+  const prdPath = selectLatestPlanningArtifactPath(prdPaths);
+  if (!prdPath) {
+    return {
+      prdPath: null,
+      testSpecPaths: [],
+      baselineState: 'missing-prd',
+      issues: [`Could not resolve approved plan for slug ${slug}.`],
+    };
+  }
+
+  const testSpecPaths = selectMatchingTestSpecsForPrd(
+    prdPath,
+    readMatchingPaths(plansDir, TEST_SPEC_PATTERN),
+  );
+  if (testSpecPaths.length === 0) {
+    return {
+      prdPath,
+      testSpecPaths,
+      baselineState: 'missing-test-spec',
+      issues: ['Approved plan is missing a matching test spec.'],
+    };
+  }
+
+  return {
+    prdPath,
+    testSpecPaths,
+    baselineState: 'present',
+    issues: [],
+  };
+}
+
+export function resolveContextPackRepoRoot(packPath: string, fallbackCwd: string): string {
+  const resolvedPackPath = isAbsolute(packPath) ? resolve(packPath) : resolve(fallbackCwd, packPath);
+  if (!parseContextPackSlug(resolvedPackPath)) {
+    return resolve(fallbackCwd);
+  }
+  const contextDir = dirname(resolvedPackPath);
+  const omxDir = dirname(contextDir);
+  if (basename(contextDir) !== 'context' || basename(omxDir) !== '.omx') {
+    return resolve(fallbackCwd);
+  }
+  return dirname(omxDir);
+}
+
+export function readContextPackHandoffStatus(
+  repoRoot: string,
+  packPath: string,
+): ContextPackReadStatusSnapshot {
+  const absolutePackPath = isAbsolute(packPath) ? resolve(packPath) : resolve(repoRoot, packPath);
+  const slug = parseContextPackSlug(absolutePackPath);
+  const basisResolution = slug
+    ? resolveApprovedPlanBasisForSlug(repoRoot, slug)
+    : {
+      prdPath: null,
+      testSpecPaths: [],
+      baselineState: 'missing-prd' as const,
+      issues: ['Context pack path must follow context-<timestamp>-<slug>.json naming.'],
+    };
+  const targetPackPath =
+    normalizePlanningRepoRelativePath(relative(repoRoot, absolutePackPath));
+
+  let outcomeState: ContextPackInspectOutcomeState = 'absent';
+  let declaredPackPath: string | null = null;
+  const issues = [...basisResolution.issues];
+
+  if (basisResolution.prdPath && existsSync(basisResolution.prdPath)) {
+    try {
+      const prdContent = readFileSync(basisResolution.prdPath, 'utf-8');
+      const outcome = inspectContextPackOutcome(repoRoot, prdContent);
+      declaredPackPath = outcome.declaredPackPath;
+      issues.push(...outcome.issues);
+      outcomeState = outcome.outcomeState;
+      if (
+        outcome.outcomeState === 'declared'
+        && declaredPackPath
+        && targetPackPath
+        && declaredPackPath !== targetPackPath
+      ) {
+        outcomeState = 'other-pack';
+        issues.push(`Approved plan declares different context pack: ${declaredPackPath}.`);
+      }
+    } catch {
+      outcomeState = 'malformed';
+      issues.push('Approved plan could not be read while resolving context pack status.');
+    }
+  }
+
+  let packState: ContextPackPackState = 'missing';
+  let roleCoverage: ContextPackRoleCoverageState = 'unknown';
+  let basisState: ContextPackBasisState = 'stale';
+  let missingRequiredContextPackRoles: ContextPackRole[] = [];
+
+  if (!existsSync(absolutePackPath)) {
+    packState = 'missing';
+    issues.push(`Declared context pack file is missing: ${targetPackPath ?? absolutePackPath}.`);
+  } else {
+    const loadedPack = readContextPackDocument(absolutePackPath);
+    packState = loadedPack.packState;
+    issues.push(...loadedPack.issues);
+    if (loadedPack.document) {
+      missingRequiredContextPackRoles =
+        findMissingRequiredContextPackRoles(loadedPack.document);
+      roleCoverage =
+        missingRequiredContextPackRoles.length === 0
+          ? 'covered'
+          : 'missing-required-roles';
+      if (basisResolution.baselineState === 'present' && basisResolution.prdPath) {
+        const basisIssues = validateContextPackBasis(
+          repoRoot,
+          basisResolution.prdPath,
+          basisResolution.testSpecPaths,
+          loadedPack.document,
+        );
+        if (basisIssues.length === 0) {
+          basisState = 'fresh';
+        } else {
+          issues.push(...basisIssues);
+        }
+      }
+    }
+  }
+
+  const normalizedOutcomeState: ContextPackOutcomeState =
+    outcomeState === 'other-pack' ? 'malformed' : outcomeState;
+
+  return {
+    packPath: absolutePackPath,
+    slug,
+    prdPath: basisResolution.prdPath,
+    declaredPackPath,
+    testSpecPaths: basisResolution.testSpecPaths,
+    baselineState: basisResolution.baselineState,
+    outcomeState,
+    packState,
+    roleCoverage,
+    basisState,
+    handoffState: resolveContextPackHandoffState({
+      baselineState: basisResolution.baselineState,
+      outcomeState: normalizedOutcomeState,
+      packState,
+      roleCoverage,
+      basisState,
+    }),
+    missingRequiredContextPackRoles,
+    issues,
+  };
+}

--- a/src/planning/context-tool.ts
+++ b/src/planning/context-tool.ts
@@ -1,0 +1,147 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import {
+  readContextPackHandoffStatus,
+  resolveContextPackRepoRoot,
+} from './context-packs.js';
+import {
+  isCanonicalContextPackPath,
+  normalizePlanningRepoRelativePath,
+} from './path-utils.js';
+
+const HELP = `
+Usage:
+  node dist/planning/context-tool.js status <pack.json> [--json]
+
+Notes:
+  The tool is internal to planning/execution workflows.
+  \`status\` is read-only: it reports the canonical handoff state for a pack path.
+`.trim();
+
+function findNearestOmxRoot(cwd: string): string | null {
+  let current = resolve(cwd);
+  while (true) {
+    if (existsSync(join(current, '.omx'))) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function resolveWorkspaceRootForPack(cwd: string): string {
+  const ancestorOmxRoot = findNearestOmxRoot(cwd);
+  return ancestorOmxRoot ? resolve(ancestorOmxRoot) : resolve(cwd);
+}
+
+function resolvePackPathFromWorkspaceRoot(workspaceRoot: string, rawPath: string): string {
+  if (isAbsolute(rawPath)) {
+    if (!isCanonicalContextPackPath(rawPath)) {
+      throw new Error('Context pack path must be .omx/context/context-<timestamp>-<slug>.json.');
+    }
+    return resolve(rawPath);
+  }
+
+  const normalizedPath = normalizePlanningRepoRelativePath(rawPath);
+  const slashNormalizedRawPath = rawPath.trim().replace(/^`|`$/g, '').replace(/\\/g, '/');
+  const canonicalRawPath = slashNormalizedRawPath.startsWith('./')
+    ? slashNormalizedRawPath.slice(2)
+    : slashNormalizedRawPath;
+  if (
+    normalizedPath !== canonicalRawPath
+    || normalizedPath === null
+    || !isCanonicalContextPackPath(normalizedPath)
+  ) {
+    throw new Error('Context pack path must be .omx/context/context-<timestamp>-<slug>.json.');
+  }
+  return join(workspaceRoot, normalizedPath);
+}
+
+function buildStatusText(status: ReturnType<typeof readContextPackHandoffStatus>): string {
+  const lines = [
+    'Context pack status:',
+    `- pack: ${status.packPath}`,
+    `- slug: ${status.slug ?? '(unknown)'}`,
+    `- handoff: ${status.handoffState}`,
+    `- baseline: ${status.baselineState}`,
+    `- outcome: ${status.outcomeState}`,
+    `- pack-state: ${status.packState}`,
+    `- roles: ${status.roleCoverage}`,
+    `- basis: ${status.basisState}`,
+  ];
+  if (status.prdPath) {
+    lines.push(`- prd: ${status.prdPath}`);
+  }
+  if (status.declaredPackPath) {
+    lines.push(`- declared-pack: ${status.declaredPackPath}`);
+  }
+  lines.push(`- test-specs: ${status.testSpecPaths.length}`);
+  if (status.missingRequiredContextPackRoles.length > 0) {
+    lines.push(`- missing roles: ${status.missingRequiredContextPackRoles.join(', ')}`);
+  }
+  if (status.issues.length > 0) {
+    lines.push('- issues:');
+    for (const issue of status.issues) {
+      lines.push(`  - ${issue}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function runStatus(cwd: string, args: readonly string[]): Promise<void> {
+  const [rawPackPath, ...rest] = args;
+  if (!rawPackPath) {
+    throw new Error('status requires <pack.json>.');
+  }
+  const json = rest.includes('--json');
+  const unknown = rest.find((token) => token !== '--json');
+  if (unknown) {
+    throw new Error(`Unknown status option: ${unknown}`);
+  }
+
+  const workspaceRoot = resolveWorkspaceRootForPack(cwd);
+  const packPath = resolvePackPathFromWorkspaceRoot(workspaceRoot, rawPackPath);
+  const repoRoot = resolveContextPackRepoRoot(packPath, workspaceRoot);
+  const status = readContextPackHandoffStatus(repoRoot, packPath);
+  if (json) {
+    console.log(JSON.stringify(status, null, 2));
+    return;
+  }
+  console.log(buildStatusText(status));
+}
+
+export async function contextToolMain(
+  args: readonly string[],
+  cwd: string = process.cwd(),
+): Promise<void> {
+  const [command, ...rest] = args;
+  if (!command || command === '--help' || command === '-h' || command === 'help') {
+    console.log(HELP);
+    return;
+  }
+
+  switch (command) {
+    case 'status':
+      await runStatus(cwd, rest);
+      return;
+    default:
+      throw new Error(`Unknown context-tool command: ${command}`);
+  }
+}
+
+const isEntrypoint = (() => {
+  const currentPath = fileURLToPath(import.meta.url);
+  const invokedPath = process.argv[1];
+  return typeof invokedPath === 'string' && currentPath === invokedPath;
+})();
+
+if (isEntrypoint) {
+  contextToolMain(process.argv.slice(2)).catch((error) => {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/planning/path-utils.ts
+++ b/src/planning/path-utils.ts
@@ -1,0 +1,70 @@
+import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
+
+const CONTEXT_PACK_BASENAME_PATTERN = /^context-\d{8}T\d{6}Z-(?<slug>[^/]+)\.json$/i;
+const CONTEXT_PACK_RELATIVE_PATH_PATTERN = /^\.omx\/context\/context-\d{8}T\d{6}Z-(?<slug>[^/]+)\.json$/i;
+
+export function normalizePlanningRepoRelativePath(rawPath: string): string | null {
+  const trimmed = rawPath.trim().replace(/^`|`$/g, '').replaceAll('\\', '/');
+  if (!trimmed) {
+    return null;
+  }
+  const withoutLeadingDot = trimmed.startsWith('./') ? trimmed.slice(2) : trimmed;
+  if (
+    !withoutLeadingDot
+    || withoutLeadingDot.startsWith('/')
+    || /^[A-Za-z]:/.test(withoutLeadingDot)
+  ) {
+    return null;
+  }
+  const segments = withoutLeadingDot
+    .split('/')
+    .filter((segment) => segment.length > 0);
+  if (segments.length === 0 || segments.includes('..')) {
+    return null;
+  }
+  return segments.join('/');
+}
+
+function isCanonicalContextPackRelativePath(normalizedPath: string): boolean {
+  return CONTEXT_PACK_RELATIVE_PATH_PATTERN.test(normalizedPath);
+}
+
+export function isCanonicalContextPackPath(packPath: string): boolean {
+  if (isAbsolute(packPath)) {
+    return CONTEXT_PACK_BASENAME_PATTERN.test(basename(packPath))
+      && basename(dirname(packPath)) === 'context'
+      && basename(dirname(dirname(packPath))) === '.omx';
+  }
+
+  const normalizedPath = normalizePlanningRepoRelativePath(packPath);
+  return normalizedPath !== null && isCanonicalContextPackRelativePath(normalizedPath);
+}
+
+export interface ResolvedDeclaredContextPackPath {
+  normalizedPath: string;
+  resolvedPath: string;
+  slug: string;
+}
+
+export function resolveDeclaredContextPackPath(
+  repoRoot: string,
+  rawPath: string,
+): ResolvedDeclaredContextPackPath | null {
+  const normalizedPath = normalizePlanningRepoRelativePath(rawPath);
+  const match = normalizedPath?.match(CONTEXT_PACK_RELATIVE_PATH_PATTERN);
+  if (!normalizedPath || !match?.groups?.slug) {
+    return null;
+  }
+
+  const resolvedPath = resolve(repoRoot, normalizedPath);
+  const roundTripPath = normalizePlanningRepoRelativePath(relative(repoRoot, resolvedPath));
+  if (roundTripPath !== normalizedPath) {
+    return null;
+  }
+
+  return {
+    normalizedPath,
+    resolvedPath,
+    slug: match.groups.slug,
+  };
+}


### PR DESCRIPTION
## Summary

Current context-pack status is only available indirectly through approved plan
selection. That leaves no planning-local way to inspect a canonical pack path
directly, and it makes status resolution depend on the caller cwd instead of
the pack repo root.

This adds a small read-only inspect surface for canonical pack status without
bringing in query/view behavior or runtime consumer wiring.

## Changes

- add strict planning path helpers for canonical `.omx/context/context-<timestamp>-<slug>.json` validation
- add a read-only pack-path status reader that resolves approved PRD/test-spec basis from the pack slug and fails closed when the approved plan declares a different pack
- add internal `context-tool status <pack>` text and JSON output
- add focused tests for nested cwd resolution, absolute pack-root resolution, noncanonical path rejection, and different-pack invalidation

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Additional checks run:

- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] `node --test dist/planning/__tests__/context-tool.test.js dist/planning/__tests__/context-pack-status.test.js`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`
  outside the sandbox; the remaining failure is the known local-only
  `dist/cli/__tests__/launch-fallback.test.js` `/private/var` vs `/var`
  assertion outside this diff

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Refs #2175

