### PR TITLE
test: normalize Darwin launch-fallback worktree root assertion

### DIFF
--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -173,7 +173,10 @@ printf 'fake-codex:%s\n' "$*"
 
       const worktreePath = join(dirname(repo), `${basename(repo)}.omx-worktrees`, 'launch-detached');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
-      assert.match(result.stdout, new RegExp(`fake-codex-omx-root:${escapeRegExp(repo)}`));
+      assert.match(
+        normalizeDarwinTmpPath(result.stdout),
+        new RegExp(`fake-codex-omx-root:${escapeRegExp(normalizeDarwinTmpPath(repo))}`),
+      );
       assert.equal(existsSync(join(repo, '.omx', 'state')), true);
       assert.equal(existsSync(join(worktreePath, '.omx')), false);
     } finally {


### PR DESCRIPTION
## Summary

Current `dev` still fails the Darwin/macOS `omx --worktree`
launch-fallback assertion because the default worktree-root subtest compares
raw spawned `OMX_ROOT` output under `/private/var/...` against an expected
repo path under `/var/...`. Runtime behavior is unchanged; the failure is only
in the Darwin test expectation.

## Changes

- normalize the captured `fake-codex-omx-root` stdout and expected repo path
  through the existing `normalizeDarwinTmpPath(...)` helper before matching
  the default Darwin worktree-state assertion
- keep the row test-only and leave runtime worktree root handling untouched

## Evidence

- before this patch, the standalone Darwin failure expected
  `fake-codex-omx-root:/var/.../repo` but captured
  `fake-codex-omx-root:/private/var/.../repo`
- after the patch, `node --test dist/cli/__tests__/launch-fallback.test.js`
  passes cleanly (`# pass 14`, `# fail 0`)
- the wider `npm run test:recent-bug-regressions:compiled` rerun keeps the
  touched Darwin `launch-fallback` boundary green and only reduces to the
  pre-existing unrelated `runtime.test` failure
  `shutdownTeam reaps detached prompt-worker descendants`

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/cli/__tests__/launch-fallback.test.js`
- [ ] `npm run test:recent-bug-regressions:compiled`
  - rerun on rebased `upstream/dev` reduces to the existing unrelated
    `dist/team/__tests__/runtime.test.js` failure
    `shutdownTeam reaps detached prompt-worker descendants`; the touched
    `launch-fallback` boundary passes cleanly inside the lane

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
