### PR TITLE
Make OMX wiki commit-shared and add compact hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ If `Shift+Enter` still submits instead of inserting a newline inside an OMX-mana
 
 - `omx explore --prompt "..."` is for read-only repository lookup
 - `omx sparkshell <command>` is for shell-native inspection and bounded verification
-- when `.omx/wiki/` exists, `omx explore` can inject wiki-first context before falling back to broader repository search
+- when `omx_wiki/` exists, `omx explore` can inject wiki-first context before falling back to broader repository search
 - fallback boundaries are explicit: sparkshell-backend fallback is reported on stderr, and spark-model fallback emits stderr metadata plus an `## OMX Explore fallback` notice in stdout so users can see when cost/behavior may differ from the low-cost path
 
 Examples:
@@ -279,7 +279,7 @@ omx sparkshell --tmux-pane %12 --tail-lines 400
 ### Wiki
 
 - `omx wiki` is the CLI parity surface for the OMX wiki MCP server
-- wiki data lives locally under `.omx/wiki/`
+- wiki data lives as repository project knowledge under `omx_wiki/`
 - the wiki is markdown-first and search-first, not vector-first
 
 Examples:

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -29,7 +29,7 @@ OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js
 | OMC / OMX surface | Native Codex source | OMX runtime target | Status | Notes |
 | --- | --- | --- | --- | --- |
 | `session-start` | `SessionStart` | `session-start` | native | Native adapter refreshes leader session bookkeeping, preserves the canonical leader scope when a native subagent `SessionStart` is detected from rollout `session_meta`, restores startup developer context, and ensures `.omx/` is gitignored at the repo root |
-| wiki startup context | `SessionStart` | `session-start` | native | Wiki session-start context can append a compact `.omx/wiki/` summary when wiki pages exist; startup writes stay config-gated |
+| wiki startup context | `SessionStart` | `session-start` | native | Wiki session-start context can append a compact `omx_wiki/` summary when wiki pages exist; startup writes stay config-gated |
 | `keyword-detector` | `UserPromptSubmit` | `keyword-detector` | native | Persists skill activation state and can add prompt-side developer context for top-level prompts; native subagent prompt text is treated as delegated task text, so literal workflow keywords inside a child prompt do not activate nested workflow state; `$ralph` prompt routing seeds workflow state only and does not launch `omx ralph --prd ...` |
 | `pre-tool-use` | `PreToolUse` (`Bash`) | `pre-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior cautions on `rm -rf dist`, blocks inspectable inline `git commit` commands until Lore-format structure + the required `Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer are present unless explicitly opted out with `OMX_LORE_COMMIT_GUARD=0`, and emits non-blocking document-refresh warnings for mapped staged commit changes that lack rule-scoped docs/spec refresh evidence |
 | `post-tool-use` | `PostToolUse` (`Bash`) | `post-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior covers command-not-found / permission-denied / missing-path guidance only from stderr or non-zero Bash results, ignores failure-looking strings from successful source/log reads, and keeps MCP transport-death guidance scoped to MCP-like tool calls; document-refresh commit warnings use PreToolUse advisory output, with PostToolUse reserved as a future fallback if Codex advisory semantics change |
@@ -119,10 +119,10 @@ instead of using an unrelated docs edit as a blanket suppression.
 
 The approved OMX-native wiki backport keeps lifecycle ownership intentionally narrow:
 
-- **Storage** lives under `.omx/wiki/`, not `.omc/wiki/`.
-- **SessionStart** may surface bounded wiki context from `.omx/wiki/` when the wiki already exists, but it should stay read-mostly and must not block the native hook path on expensive writes or index rebuilds.
-- **SessionEnd** remains a runtime/notify-path responsibility for best-effort, non-blocking session capture into `.omx/wiki/`.
-- **PreCompact parity is intentionally deferred** in v1 unless a clearly OMX-native compaction seam exists.
+- **Storage** lives under repository `omx_wiki/`, not ignored `.omx/wiki/` runtime state and not `.omc/wiki/`.
+- **SessionStart** may surface bounded wiki context from `omx_wiki/` when the wiki already exists, but it should stay read-mostly and must not block the native hook path on expensive writes or index rebuilds.
+- **SessionEnd** remains a runtime/notify-path responsibility for best-effort, non-blocking session capture into `omx_wiki/`.
+- **PreCompact** is native and bounded: it can surface compact wiki context before compaction. **PostCompact** is native and advisory: it nudges agents to write/update `omx_wiki/` entries about compaction artifacts.
 - **Routing should stay explicit**: prefer `$wiki` or task verbs like `wiki query` / `wiki add`, and avoid implicit bare `wiki` noun activation.
 
 ## Explicit terminal stop model note

--- a/docs/reference/project-wiki.md
+++ b/docs/reference/project-wiki.md
@@ -8,7 +8,7 @@ It is intentionally **not** a literal OMC port.
 - Keep the reusable wiki domain under `src/wiki/*`.
 - Expose wiki operations from a dedicated MCP server at `src/mcp/wiki-server.ts`.
 - Register the server as `omx_wiki`.
-- Keep wiki storage under `.omx/wiki/`.
+- Keep wiki storage under repository-root `omx_wiki/` so project knowledge can be committed and shared.
 - Do **not** add vector embeddings; query stays keyword/tag based.
 
 ## Config + generator contract
@@ -31,9 +31,9 @@ executable that ran `omx setup` rather than a PATH-dependent bare `node`.
 
 Wiki state is project-local and should live under:
 
-- `.omx/wiki/*.md` — content pages
-- `.omx/wiki/index.md` — generated catalog
-- `.omx/wiki/log.md` — append-only operation log
+- `omx_wiki/*.md` — content pages
+- `omx_wiki/index.md` — generated catalog
+- `omx_wiki/log.md` — append-only operation log
 
 Guardrails that must stay true:
 
@@ -49,12 +49,12 @@ The docs and code should never regress back to `.omc/wiki/`.
 ## Lifecycle + hook contract
 
 - `SessionStart` stays **native** and **bounded**.
-  - It may read `.omx/wiki/` and surface brief context when the wiki already exists.
+  - It may read `omx_wiki/` and surface brief context when the wiki already exists.
   - It should stay read-mostly and must not block startup on heavy writes.
 - `SessionEnd` stays **runtime-fallback** and **non-blocking**.
   - Best-effort capture is okay.
   - Missing wiki state should degrade to a no-op.
-- Literal `PreCompact` parity is **deferred in v1** unless an OMX-native seam is proven clean.
+- `PreCompact` and `PostCompact` are native lifecycle seams: `PreCompact` surfaces bounded wiki context, and `PostCompact` nudges durable wiki capture about compaction artifacts.
 
 ## Routing contract
 
@@ -68,7 +68,7 @@ This keeps the routing surface specific enough to avoid false positives from ord
 
 ## MCP tool surface
 
-The dedicated `omx_wiki` server should expose the seven stabilized wiki tools:
+The dedicated `omx_wiki` server should expose the eight stabilized wiki tools:
 
 - `wiki_ingest`
 - `wiki_query`
@@ -77,5 +77,6 @@ The dedicated `omx_wiki` server should expose the seven stabilized wiki tools:
 - `wiki_list`
 - `wiki_read`
 - `wiki_delete`
+- `wiki_refresh`
 
-These tools should operate only on `.omx/wiki/` and keep lifecycle behavior bounded.
+These tools should write to `omx_wiki/`, may read legacy `.omx/wiki/` only as conservative compatibility fallback when `omx_wiki/` is absent, and keep lifecycle behavior bounded.

--- a/docs/wiki-feature.md
+++ b/docs/wiki-feature.md
@@ -4,7 +4,7 @@ OMX Wiki is a compiled markdown knowledge layer for agents.
 
 ## What it is
 
-- local project knowledge stored under `.omx/wiki/`
+- commit-friendly project knowledge stored under repository `omx_wiki/`
 - markdown-first and search-first
 - designed for agentic retrieval workflows, not vector-first RAG
 
@@ -32,4 +32,4 @@ OMX Wiki is a compiled markdown knowledge layer for agents.
 ## Constraints
 
 - no vector embeddings required
-- wiki is local project state, not source-controlled product code
+- wiki is source-visible project knowledge intended for review/commit when useful

--- a/plugins/oh-my-codex/skills/wiki/SKILL.md
+++ b/plugins/oh-my-codex/skills/wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiki
-description: Persistent markdown project wiki stored under .omx/wiki with keyword search and lifecycle capture
+description: Persistent markdown project wiki stored under repository omx_wiki with keyword search and lifecycle capture
 triggers: ["wiki add", "wiki lint", "wiki query", "wiki read", "wiki delete"]
 ---
 
@@ -42,9 +42,9 @@ wiki_refresh()
 `architecture`, `decision`, `pattern`, `debugging`, `environment`, `session-log`, `reference`, `convention`
 
 ## Storage
-- Pages: `.omx/wiki/*.md`
-- Index: `.omx/wiki/index.md`
-- Log: `.omx/wiki/log.md`
+- Pages: `omx_wiki/*.md`
+- Index: `omx_wiki/index.md`
+- Log: `omx_wiki/log.md`
 
 ## Cross-References
 Use `[[page-name]]` wiki-link syntax to create cross-references between pages.
@@ -54,4 +54,4 @@ At session end, discoveries can be captured as `session-log-*` pages. Configure 
 
 ## Hard Constraints
 - No vector embeddings — query uses keyword + tag matching only
-- Wiki files remain local project state under `.omx/wiki/`
+- Wiki files are repository project knowledge under `omx_wiki/`; legacy `.omx/wiki/` is read-only compatibility input when no canonical wiki exists

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiki
-description: Persistent markdown project wiki stored under .omx/wiki with keyword search and lifecycle capture
+description: Persistent markdown project wiki stored under repository omx_wiki with keyword search and lifecycle capture
 triggers: ["wiki add", "wiki lint", "wiki query", "wiki read", "wiki delete"]
 ---
 
@@ -42,9 +42,9 @@ wiki_refresh()
 `architecture`, `decision`, `pattern`, `debugging`, `environment`, `session-log`, `reference`, `convention`
 
 ## Storage
-- Pages: `.omx/wiki/*.md`
-- Index: `.omx/wiki/index.md`
-- Log: `.omx/wiki/log.md`
+- Pages: `omx_wiki/*.md`
+- Index: `omx_wiki/index.md`
+- Log: `omx_wiki/log.md`
 
 ## Cross-References
 Use `[[page-name]]` wiki-link syntax to create cross-references between pages.
@@ -54,4 +54,4 @@ At session end, discoveries can be captured as `session-log-*` pages. Configure 
 
 ## Hard Constraints
 - No vector embeddings — query uses keyword + tag matching only
-- Wiki files remain local project state under `.omx/wiki/`
+- Wiki files are repository project knowledge under `omx_wiki/`; legacy `.omx/wiki/` is read-only compatibility input when no canonical wiki exists

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -505,7 +505,7 @@ OMX_LORE_COMMIT_GUARD = "off"
 			assert.equal(res.status, 0, res.stderr || res.stdout);
 			assert.match(
 				res.stdout,
-				/Native hooks: hooks\.json is missing OMX-managed coverage for PreToolUse, PostToolUse, UserPromptSubmit, Stop; run "omx setup --force" to restore native hooks/,
+				/Native hooks: hooks\.json is missing OMX-managed coverage for PreToolUse, PostToolUse, UserPromptSubmit, PreCompact, PostCompact, Stop; run "omx setup --force" to restore native hooks/,
 			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -348,7 +348,7 @@ describe('buildExplorePromptWithWikiContext', () => {
       assert.match(prompt, /prefer repository-backed facts/i);
       assert.match(prompt, /Wiki mismatch/);
       assert.match(prompt, /Original Explore Prompt/);
-      assert.equal(existsSync(join(wd, '.omx', 'wiki', 'log.md')), false);
+      assert.equal(existsSync(join(wd, 'omx_wiki', 'log.md')), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -374,7 +374,7 @@ describe('buildExplorePromptWithWikiContext', () => {
       });
 
       buildExplorePromptWithWikiContext('session-start lifecycle', wd);
-      const logPath = join(wd, '.omx', 'wiki', 'log.md');
+      const logPath = join(wd, 'omx_wiki', 'log.md');
       assert.equal(existsSync(logPath), false);
 
       // sanity: direct query callers still log by default

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -24,7 +24,7 @@ import {
   getPackageVersion,
   resolveNativeCacheRoot,
 } from './native-assets.js';
-import { getWikiDir, queryWiki } from '../wiki/index.js';
+import { hasReadableWiki, queryWiki } from '../wiki/index.js';
 import { resolveCodexHomeForLaunch } from './codex-home.js';
 import { runProcessTreeWithTimeout } from '../runtime/process-tree.js';
 
@@ -106,11 +106,10 @@ export interface ExploreSparkShellRoute {
 
 const MAX_WIKI_CONTEXT_RESULTS = 5;
 const WEAK_WIKI_NOTE =
-  'Wiki evidence is weak or missing. Fall back to broader repository search and recommend that the user build an initial project wiki under .omx/wiki/ if this repo benefits from persistent project knowledge.';
+  'Wiki evidence is weak or missing. Fall back to broader repository search and recommend that the user build an initial project wiki under omx_wiki/ if this repo benefits from persistent project knowledge.';
 
 function formatWikiContextBlock(prompt: string, cwd: string): string | null {
-  const wikiDir = getWikiDir(cwd);
-  if (!existsSync(wikiDir)) {
+  if (!hasReadableWiki(cwd)) {
     return [
       '[OMX Wiki Status]',
       WEAK_WIKI_NOTE,

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -80,6 +80,20 @@ describe("codex hooks helpers", () => {
     assert.match(removedMixed.nextContent, /"version": 1/);
   });
 
+
+
+  it("registers managed compact hook wrappers", () => {
+    const config = buildManagedCodexHooksConfig("/repo");
+    assert.ok(config.hooks.PreCompact?.length);
+    assert.ok(config.hooks.PostCompact?.length);
+    const preCompact = config.hooks.PreCompact as Array<{ hooks?: Array<{ command?: string }> }>;
+    const postCompact = config.hooks.PostCompact as Array<{ hooks?: Array<{ command?: string }> }>;
+    const preCommand = preCompact[0]?.hooks?.[0]?.command;
+    const postCommand = postCompact[0]?.hooks?.[0]?.command;
+    assert.match(String(preCommand), /codex-native-hook\.js/);
+    assert.match(String(postCommand), /codex-native-hook\.js/);
+  });
+
   it("reports missing managed hook coverage by event", () => {
     const missing = getMissingManagedCodexHookEvents(
       JSON.stringify({
@@ -102,7 +116,7 @@ describe("codex hooks helpers", () => {
       }),
     );
 
-    assert.deepEqual(missing, ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop"]);
+    assert.deepEqual(missing, ["PreToolUse", "PostToolUse", "UserPromptSubmit", "PreCompact", "PostCompact", "Stop"]);
   });
 
   it("returns null for invalid hooks.json content", () => {

--- a/src/config/__tests__/wiki-config-contract.test.ts
+++ b/src/config/__tests__/wiki-config-contract.test.ts
@@ -14,7 +14,8 @@ describe("project wiki config/generator documentation contract", () => {
   it("documents the OMX-native storage path instead of legacy OMC storage", () => {
     const doc = loadSurface("docs/reference/project-wiki.md");
     assert.match(doc, /Wiki state is project-local and should live under/i);
-    assert.match(doc, /`\.omx\/wiki\/\*\.md`/);
+    assert.match(doc, /`omx_wiki\/\*\.md`/);
+    assert.match(doc, /legacy `\.omx\/wiki\/`/i);
     assert.match(doc, /The docs and code should never regress back to `\.omc\/wiki\/`/);
   });
 });

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -5,6 +5,8 @@ export const MANAGED_HOOK_EVENTS = [
   "PreToolUse",
   "PostToolUse",
   "UserPromptSubmit",
+  "PreCompact",
+  "PostCompact",
   "Stop",
 ] as const;
 
@@ -81,6 +83,12 @@ export function buildManagedCodexHooksConfig(
         buildCommandHook(command),
       ],
       UserPromptSubmit: [
+        buildCommandHook(command),
+      ],
+      PreCompact: [
+        buildCommandHook(command),
+      ],
+      PostCompact: [
         buildCommandHook(command),
       ],
       Stop: [

--- a/src/hooks/__tests__/wiki-docs-contract.test.ts
+++ b/src/hooks/__tests__/wiki-docs-contract.test.ts
@@ -6,13 +6,14 @@ describe("project wiki documentation contract", () => {
   it("documents the OMX-native storage, routing, and tool surface", () => {
     const doc = loadSurface("docs/reference/project-wiki.md");
     assert.match(doc, /`omx_wiki`/);
-    assert.match(doc, /`\.omx\/wiki\/`/);
+    assert.match(doc, /`omx_wiki\/`/);
+    assert.match(doc, /legacy `\.omx\/wiki\/`/i);
     assert.match(doc, /prefer `\$wiki`/i);
     assert.match(doc, /avoid implicit bare `wiki` noun activation/i);
     assert.match(doc, /wiki_ingest/);
     assert.match(doc, /wiki_query/);
     assert.match(doc, /Do \*\*not\*\* add vector embeddings/i);
-    assert.match(doc, /These tools should operate only on `\.omx\/wiki\/`/i);
+    assert.match(doc, /write to `omx_wiki\/`/i);
   });
 
   it("locks the approved source-fix regression list into docs", () => {
@@ -27,10 +28,11 @@ describe("project wiki documentation contract", () => {
 
   it("keeps native hooks documentation aligned with the wiki lifecycle split", () => {
     const hooksDoc = loadSurface("docs/codex-native-hooks.md");
-    assert.match(hooksDoc, /Storage.*`\.omx\/wiki\/`/i);
+    assert.match(hooksDoc, /Storage.*`omx_wiki\/`/i);
     assert.match(hooksDoc, /SessionStart.*bounded wiki context/i);
     assert.match(hooksDoc, /SessionEnd.*runtime\/notify-path.*non-blocking/i);
-    assert.match(hooksDoc, /PreCompact parity is intentionally deferred/i);
+    assert.match(hooksDoc, /PreCompact.*native.*bounded/i);
+    assert.match(hooksDoc, /PostCompact.*native.*advisory/i);
     assert.match(hooksDoc, /prefer `\$wiki`.*avoid implicit bare `wiki` noun activation/i);
   });
 });

--- a/src/mcp/__tests__/wiki-server.test.ts
+++ b/src/mcp/__tests__/wiki-server.test.ts
@@ -1,7 +1,15 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  getLegacyWikiDir,
+  getWikiDir,
+  serializePage,
+} from '../../wiki/storage.js';
+import { WIKI_SCHEMA_VERSION } from '../../wiki/types.js';
 
 const REQUIRED_TOOLS = [
   'wiki_ingest',
@@ -31,4 +39,80 @@ describe('mcp/wiki-server module contract', () => {
     assert.doesNotMatch(src, /new StdioServerTransport\(\)/);
     assert.doesNotMatch(src, /server\.connect\(transport\)\.catch\(console\.error\);/);
   });
+
+  it('wiki_add writes canonical pages even when the same legacy slug exists', async () => {
+    process.env.OMX_WIKI_SERVER_DISABLE_AUTO_START = '1';
+    const { handleWikiToolCall } = await import('../wiki-server.js');
+    const root = await mkdtemp(join(tmpdir(), 'wiki-mcp-legacy-add-'));
+    try {
+      writeLegacyPage(root, 'Same Title', 'private legacy content');
+
+      const response = await handleWikiToolCall({
+        params: {
+          name: 'wiki_add',
+          arguments: {
+            title: 'Same Title',
+            content: 'canonical public content',
+            workingDirectory: root,
+          },
+        },
+      });
+
+      assert.equal('isError' in response ? response.isError : false, false);
+      assert.equal(existsSync(join(getWikiDir(root), 'same-title.md')), true);
+      assert.match(await readFile(join(getWikiDir(root), 'same-title.md'), 'utf8'), /canonical public content/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('wiki_refresh leaves legacy-only fallback read-only and does not create canonical storage', async () => {
+    process.env.OMX_WIKI_SERVER_DISABLE_AUTO_START = '1';
+    const { handleWikiToolCall } = await import('../wiki-server.js');
+    const root = await mkdtemp(join(tmpdir(), 'wiki-mcp-legacy-refresh-'));
+    try {
+      writeLegacyPage(root, 'Legacy Only', 'legacy content');
+
+      const response = await handleWikiToolCall({
+        params: {
+          name: 'wiki_refresh',
+          arguments: { workingDirectory: root },
+        },
+      });
+      const payload = JSON.parse(response.content[0].text) as {
+        refreshed: boolean;
+        legacyFallback: boolean;
+        pages: string[];
+      };
+
+      assert.equal(payload.refreshed, false);
+      assert.equal(payload.legacyFallback, true);
+      assert.deepEqual(payload.pages, ['legacy-only.md']);
+      assert.equal(existsSync(getWikiDir(root)), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
+
+function writeLegacyPage(root: string, title: string, content: string): void {
+  const now = new Date().toISOString();
+  const filename = `${title.toLowerCase().replace(/\s+/g, '-')}.md`;
+  const legacyDir = getLegacyWikiDir(root);
+  mkdirSync(legacyDir, { recursive: true });
+  writeFileSync(join(legacyDir, filename), serializePage({
+    filename,
+    frontmatter: {
+      title,
+      tags: ['legacy'],
+      created: now,
+      updated: now,
+      sources: [],
+      links: [],
+      category: 'reference',
+      confidence: 'medium',
+      schemaVersion: WIKI_SCHEMA_VERSION,
+    },
+    content: `\n# ${title}\n\n${content}\n`,
+  }));
+}

--- a/src/mcp/__tests__/wiki-server.test.ts
+++ b/src/mcp/__tests__/wiki-server.test.ts
@@ -7,6 +7,8 @@ import { tmpdir } from 'node:os';
 import {
   getLegacyWikiDir,
   getWikiDir,
+  isLegacyWikiFallbackActive,
+  listPages,
   serializePage,
 } from '../../wiki/storage.js';
 import { WIKI_SCHEMA_VERSION } from '../../wiki/types.js';
@@ -61,6 +63,33 @@ describe('mcp/wiki-server module contract', () => {
       assert.equal('isError' in response ? response.isError : false, false);
       assert.equal(existsSync(join(getWikiDir(root), 'same-title.md')), true);
       assert.match(await readFile(join(getWikiDir(root), 'same-title.md'), 'utf8'), /canonical public content/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('wiki_delete does not create canonical storage when deleting from legacy-only fallback', async () => {
+    process.env.OMX_WIKI_SERVER_DISABLE_AUTO_START = '1';
+    const { handleWikiToolCall } = await import('../wiki-server.js');
+    const root = await mkdtemp(join(tmpdir(), 'wiki-mcp-legacy-delete-'));
+    try {
+      writeLegacyPage(root, 'Legacy', 'legacy content');
+
+      const response = await handleWikiToolCall({
+        params: {
+          name: 'wiki_delete',
+          arguments: {
+            page: 'legacy.md',
+            workingDirectory: root,
+          },
+        },
+      });
+
+      assert.equal('isError' in response ? response.isError : false, true);
+      assert.match(JSON.parse(response.content[0].text).error, /Wiki page not found or reserved: legacy\.md/);
+      assert.equal(existsSync(getWikiDir(root)), false);
+      assert.equal(isLegacyWikiFallbackActive(root), true);
+      assert.deepEqual(listPages(root), ['legacy.md']);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/src/mcp/wiki-server.ts
+++ b/src/mcp/wiki-server.ts
@@ -10,10 +10,12 @@ import {
   appendLog,
   deletePage,
   ingestKnowledge,
+  isLegacyWikiFallbackActive,
   lintWiki,
   listPages,
   normalizeWikiPageName,
   queryWiki,
+  readCanonicalPage,
   readIndex,
   readPage,
   titleToSlug,
@@ -203,7 +205,7 @@ export async function handleWikiToolCall(request: {
       case 'wiki_add': {
         const title = String(args.title || '');
         const slug = titleToSlug(title);
-        if (readPage(root, slug)) {
+        if (readCanonicalPage(root, slug)) {
           return errorText(`Page "${slug}" already exists. Use wiki_ingest to merge into it.`);
         }
         const result = ingestKnowledge(root, {
@@ -248,6 +250,15 @@ export async function handleWikiToolCall(request: {
       }
 
       case 'wiki_refresh': {
+        if (isLegacyWikiFallbackActive(root)) {
+          return text({
+            refreshed: false,
+            legacyFallback: true,
+            pages: listPages(root),
+            index: readIndex(root),
+            message: 'Legacy .omx/wiki fallback is read-only; copy selected pages into omx_wiki/ before refreshing canonical metadata.',
+          });
+        }
         withWikiLock(root, () => {
           updateIndexUnsafe(root);
         });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -24,6 +24,8 @@ import { writeSessionStart } from "../../hooks/session.js";
 import { resetTriageConfigCache } from "../../hooks/triage-config.js";
 import { executeStateOperation } from "../../state/operations.js";
 import { OMX_TMUX_HUD_OWNER_ENV } from "../../hud/reconcile.js";
+import { writePage } from "../../wiki/storage.js";
+import { WIKI_SCHEMA_VERSION } from "../../wiki/types.js";
 
 function nativeHookScriptPath(): string {
   return join(process.cwd(), "dist", "scripts", "codex-native-hook.js");
@@ -225,6 +227,8 @@ describe("codex native hook config", () => {
       "PreToolUse",
       "PostToolUse",
       "UserPromptSubmit",
+      "PreCompact",
+      "PostCompact",
       "Stop",
     ]);
 
@@ -511,7 +515,68 @@ describe("codex native hook dispatch", () => {
     assert.equal(mapCodexHookEventToOmxEvent("UserPromptSubmit"), "keyword-detector");
     assert.equal(mapCodexHookEventToOmxEvent("PreToolUse"), "pre-tool-use");
     assert.equal(mapCodexHookEventToOmxEvent("PostToolUse"), "post-tool-use");
+    assert.equal(mapCodexHookEventToOmxEvent("PreCompact"), "pre-compact");
+    assert.equal(mapCodexHookEventToOmxEvent("PostCompact"), "post-compact");
     assert.equal(mapCodexHookEventToOmxEvent("Stop"), "stop");
+  });
+
+
+
+  it("returns bounded wiki context for PreCompact", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-precompact-"));
+    try {
+      writePage(cwd, {
+        filename: "architecture.md",
+        frontmatter: {
+          title: "Architecture",
+          tags: ["architecture"],
+          created: "2026-05-08T00:00:00.000Z",
+          updated: "2026-05-08T00:00:00.000Z",
+          sources: [],
+          links: [],
+          category: "architecture",
+          confidence: "high",
+          schemaVersion: WIKI_SCHEMA_VERSION,
+        },
+        content: "\n# Architecture\n\nCompaction-relevant architecture note.\n",
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "PreCompact",
+        cwd,
+        session_id: "sess-precompact",
+      });
+
+      assert.equal(result.hookEventName, "PreCompact");
+      assert.equal(result.omxEventName, "pre-compact");
+      const additionalContext = (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } } | null)
+        ?.hookSpecificOutput?.additionalContext ?? "";
+      assert.match(additionalContext, /Wiki: 1 pages/);
+      assert.match(additionalContext, /architecture/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a PostCompact nudge to write compaction artifacts to omx_wiki", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-postcompact-"));
+    try {
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "PostCompact",
+        cwd,
+        session_id: "sess-postcompact",
+      });
+
+      assert.equal(result.hookEventName, "PostCompact");
+      assert.equal(result.omxEventName, "post-compact");
+      const additionalContext = (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } } | null)
+        ?.hookSpecificOutput?.additionalContext ?? "";
+      assert.match(additionalContext, /PostCompact Nudge/);
+      assert.match(additionalContext, /omx_wiki/);
+      assert.match(additionalContext, /compaction artifacts/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it("writes SessionStart state against the long-lived session owner pid and injects environment context", async () => {

--- a/src/scripts/codex-execution-surface.ts
+++ b/src/scripts/codex-execution-surface.ts
@@ -6,6 +6,8 @@ type CodexHookEventName =
   | "PreToolUse"
   | "PostToolUse"
   | "UserPromptSubmit"
+  | "PreCompact"
+  | "PostCompact"
   | "Stop";
 
 type CodexHookPayload = Record<string, unknown>;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -70,7 +70,11 @@ import {
 import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
 import { dispatchHookEventRuntime } from "../hooks/extensibility/runtime.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
-import { onSessionStart as buildWikiSessionStartContext } from "../wiki/lifecycle.js";
+import {
+  onPostCompact as buildWikiPostCompactContext,
+  onPreCompact as buildWikiPreCompactContext,
+  onSessionStart as buildWikiSessionStartContext,
+} from "../wiki/lifecycle.js";
 import { readAutoresearchCompletionStatus, readAutoresearchModeStateForActiveDecision } from "../autoresearch/skill-validation.js";
 import { readRunState } from "../runtime/run-state.js";
 import { getRunContinuationSnapshot, shouldContinueRun } from "../runtime/run-loop.js";
@@ -99,6 +103,8 @@ type CodexHookEventName =
   | "PreToolUse"
   | "PostToolUse"
   | "UserPromptSubmit"
+  | "PreCompact"
+  | "PostCompact"
   | "Stop";
 
 type CodexHookPayload = Record<string, unknown>;
@@ -358,6 +364,8 @@ function readHookEventName(payload: CodexHookPayload): CodexHookEventName | null
     || raw === "PreToolUse"
     || raw === "PostToolUse"
     || raw === "UserPromptSubmit"
+    || raw === "PreCompact"
+    || raw === "PostCompact"
     || raw === "Stop"
   ) {
     return raw;
@@ -377,6 +385,10 @@ export function mapCodexHookEventToOmxEvent(
       return "post-tool-use";
     case "UserPromptSubmit":
       return "keyword-detector";
+    case "PreCompact":
+      return "pre-compact";
+    case "PostCompact":
+      return "post-compact";
     case "Stop":
       return "stop";
     default:
@@ -3010,7 +3022,27 @@ export async function dispatchCodexNativeHook(
     });
   }
 
-  if ((hookEventName === "SessionStart" && !skipCanonicalSessionStartContext) || hookEventName === "UserPromptSubmit") {
+  if (hookEventName === "PreCompact") {
+    const compactContext = buildWikiPreCompactContext({ cwd });
+    if (compactContext.additionalContext) {
+      outputJson = {
+        hookSpecificOutput: {
+          hookEventName,
+          additionalContext: compactContext.additionalContext,
+        },
+      };
+    }
+  } else if (hookEventName === "PostCompact") {
+    const compactContext = buildWikiPostCompactContext({ cwd });
+    if (compactContext.additionalContext) {
+      outputJson = {
+        hookSpecificOutput: {
+          hookEventName,
+          additionalContext: compactContext.additionalContext,
+        },
+      };
+    }
+  } else if ((hookEventName === "SessionStart" && !skipCanonicalSessionStartContext) || hookEventName === "UserPromptSubmit") {
     const additionalContext = hookEventName === "SessionStart"
       ? await buildSessionStartContext(cwd, canonicalSessionId || nativeSessionId, {
         hookEventName,

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -315,9 +315,14 @@ export function omxNotepadPath(projectRoot?: string): string {
   return join(omxRoot(projectRoot), "notepad.md");
 }
 
-/** oh-my-codex wiki directory (.omx/wiki/) */
+/** oh-my-codex wiki directory (repository-root omx_wiki/) */
 export function omxWikiDir(projectRoot?: string): string {
-  return join(omxRoot(projectRoot), "wiki");
+  return join(projectRoot || process.cwd(), "omx_wiki");
+}
+
+/** Legacy project-local wiki directory used before wiki pages became repository-tracked. */
+export function omxLegacyWikiDir(projectRoot?: string): string {
+  return join(projectRoot || process.cwd(), ".omx", "wiki");
 }
 
 /** oh-my-codex plans directory (.omx/plans/) */

--- a/src/wiki/__tests__/ingest.test.ts
+++ b/src/wiki/__tests__/ingest.test.ts
@@ -8,7 +8,9 @@ import fsp from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { ingestKnowledge } from '../ingest.js';
-import { readPage, readLog } from '../storage.js';
+import { getLegacyWikiDir, getWikiDir, readPage, readLog, serializePage } from '../storage.js';
+import { WIKI_SCHEMA_VERSION } from '../types.js';
+import fs from 'fs';
 
 describe('Wiki Ingest', () => {
   let tempDir: string;
@@ -67,6 +69,43 @@ describe('Wiki Ingest', () => {
       const page = readPage(tempDir, 'linking-page.md');
       expect(page!.frontmatter.links).toContain('auth-architecture.md');
       expect(page!.frontmatter.links).toContain('database-schema.md');
+    });
+
+
+
+    it('does not merge legacy fallback content into canonical pages', () => {
+      const legacyDir = getLegacyWikiDir(tempDir);
+      fs.mkdirSync(legacyDir, { recursive: true });
+      fs.writeFileSync(path.join(legacyDir, 'legacy-title.md'), serializePage({
+        filename: 'legacy-title.md',
+        frontmatter: {
+          title: 'Legacy Title',
+          tags: ['private'],
+          created: '2025-01-01T00:00:00.000Z',
+          updated: '2025-01-01T00:00:00.000Z',
+          sources: [],
+          links: [],
+          category: 'reference',
+          confidence: 'medium',
+          schemaVersion: WIKI_SCHEMA_VERSION,
+        },
+        content: '\n# Legacy Title\n\nprivate legacy content\n',
+      }));
+
+      const result = ingestKnowledge(tempDir, {
+        title: 'Legacy Title',
+        content: 'new canonical content',
+        tags: ['public'],
+        category: 'reference',
+      });
+
+      expect(result.created).toEqual(['legacy-title.md']);
+      expect(result.updated).toEqual([]);
+      const canonicalPath = path.join(getWikiDir(tempDir), 'legacy-title.md');
+      expect(fs.existsSync(canonicalPath)).toBe(true);
+      const canonical = fs.readFileSync(canonicalPath, 'utf8');
+      expect(canonical).toContain('new canonical content');
+      expect(canonical).not.toContain('private legacy content');
     });
 
     it('should log the ingest operation', () => {

--- a/src/wiki/__tests__/lint.test.ts
+++ b/src/wiki/__tests__/lint.test.ts
@@ -6,9 +6,10 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import { expect } from './test-helpers.js';
 import fsp from 'fs/promises';
 import path from 'path';
+import fs from 'fs';
 import os from 'os';
 import { lintWiki } from '../lint.js';
-import { writePage, ensureWikiDir } from '../storage.js';
+import { writePage, ensureWikiDir, getLegacyWikiDir, getWikiDir, serializePage } from '../storage.js';
 import { WIKI_SCHEMA_VERSION } from '../types.js';
 import type { WikiPage } from '../types.js';
 
@@ -54,6 +55,23 @@ describe('Wiki Lint', () => {
     const report = lintWiki(tempDir);
     expect(report.issues).toEqual([]);
     expect(report.stats.totalPages).toBe(0);
+  });
+
+
+
+  it('does not create canonical omx_wiki while linting legacy fallback', async () => {
+    await fsp.rm(getWikiDir(tempDir), { recursive: true, force: true });
+    const legacyDir = getLegacyWikiDir(tempDir);
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, 'legacy.md'), serializePage(makePage('legacy.md', {
+      title: 'Legacy',
+      content: '\n# Legacy\n\nlegacy lint content\n',
+    })));
+
+    const report = lintWiki(tempDir);
+
+    expect(report.stats.totalPages).toBe(1);
+    expect(fs.existsSync(getWikiDir(tempDir))).toBe(false);
   });
 
   describe('orphan detection', () => {

--- a/src/wiki/__tests__/query.test.ts
+++ b/src/wiki/__tests__/query.test.ts
@@ -9,7 +9,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { queryWiki } from '../query.js';
-import { writePage, ensureWikiDir } from '../storage.js';
+import { writePage, ensureWikiDir, getLegacyWikiDir, getWikiDir } from '../storage.js';
 import { WIKI_SCHEMA_VERSION } from '../types.js';
 import type { WikiPage } from '../types.js';
 
@@ -155,10 +155,40 @@ describe('Wiki Query', () => {
 
     queryWiki(tempDir, 'authentication');
 
-    const logPath = path.join(tempDir, '.omx', 'wiki', 'log.md');
+    const logPath = path.join(getWikiDir(tempDir), 'log.md');
     expect(fs.existsSync(logPath)).toBe(true);
     const logContent = await fsp.readFile(logPath, 'utf8');
     expect(logContent).toContain('Query "authentication"');
+  });
+
+
+
+  it('does not create canonical omx_wiki while querying legacy fallback', async () => {
+    await fsp.rm(getWikiDir(tempDir), { recursive: true, force: true });
+    const legacyDir = getLegacyWikiDir(tempDir);
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, 'legacy.md'), `---
+title: "Legacy Auth"
+tags: ["auth"]
+created: 2025-01-01T00:00:00.000Z
+updated: 2025-01-01T00:00:00.000Z
+sources: []
+links: []
+category: reference
+confidence: medium
+schemaVersion: 1
+---
+
+# Legacy Auth
+
+legacy authentication note
+`);
+
+    const results = queryWiki(tempDir, 'authentication');
+
+    expect(results.length).toBe(1);
+    expect(results[0].page.filename).toBe('legacy.md');
+    expect(fs.existsSync(getWikiDir(tempDir))).toBe(false);
   });
 
   it('can skip query logging for read-only callers', () => {
@@ -169,6 +199,6 @@ describe('Wiki Query', () => {
 
     const results = queryWiki(tempDir, 'sessionstart', { logQuery: false });
     expect(results.length).toBe(1);
-    expect(fs.existsSync(path.join(tempDir, '.omx', 'wiki', 'log.md'))).toBe(false);
+    expect(fs.existsSync(path.join(getWikiDir(tempDir), 'log.md'))).toBe(false);
   });
 });

--- a/src/wiki/__tests__/session-hooks.test.ts
+++ b/src/wiki/__tests__/session-hooks.test.ts
@@ -8,8 +8,14 @@ import fs from 'fs';
 import fsp from 'fs/promises';
 import path from 'path';
 import os from 'os';
-import { ensureWikiDir } from '../storage.js';
-import { onSessionEnd } from '../lifecycle.js';
+import {
+  ensureWikiDir,
+  getLegacyWikiDir,
+  getWikiDir,
+  serializePage,
+} from '../storage.js';
+import { onSessionEnd, onSessionStart } from '../lifecycle.js';
+import { WIKI_SCHEMA_VERSION } from '../types.js';
 
 describe('Wiki lifecycle hooks', () => {
   let tempDir: string;
@@ -45,5 +51,35 @@ describe('Wiki lifecycle hooks', () => {
     const indexPath = path.join(wikiDir, 'index.md');
     expect(fs.existsSync(indexPath)).toBe(true);
     expect(fs.readFileSync(indexPath, 'utf-8')).toContain('session-log');
+  });
+
+  it('summarizes legacy fallback on session start without creating canonical wiki files', () => {
+    const now = new Date().toISOString();
+    const legacyDir = getLegacyWikiDir(tempDir);
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.mkdirSync(path.join(tempDir, '.omx'), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, '.omx', 'project-memory.json'), JSON.stringify({
+      techStack: 'Do not sync this into canonical storage during legacy fallback.',
+    }));
+    fs.writeFileSync(path.join(legacyDir, 'legacy.md'), serializePage({
+      filename: 'legacy.md',
+      frontmatter: {
+        title: 'Legacy',
+        tags: ['legacy'],
+        created: now,
+        updated: now,
+        sources: [],
+        links: [],
+        category: 'reference',
+        confidence: 'medium',
+        schemaVersion: WIKI_SCHEMA_VERSION,
+      },
+      content: '\n# Legacy\n',
+    }));
+
+    const result = onSessionStart({ cwd: tempDir });
+
+    expect(result.additionalContext).toContain('legacy pages at .omx/wiki/');
+    expect(fs.existsSync(getWikiDir(tempDir))).toBe(false);
   });
 });

--- a/src/wiki/__tests__/storage.test.ts
+++ b/src/wiki/__tests__/storage.test.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import os from 'os';
 import {
   getWikiDir,
+  getLegacyWikiDir,
   ensureWikiDir,
   parseFrontmatter,
   serializePage,
@@ -59,9 +60,71 @@ describe('Wiki Storage', () => {
   });
 
   describe('getWikiDir', () => {
-    it('should return .omx/wiki path', () => {
+    it('should return repository omx_wiki path', () => {
       const dir = getWikiDir(tempDir);
-      expect(dir).toBe(path.join(tempDir, '.omx', 'wiki'));
+      expect(dir).toBe(path.join(tempDir, 'omx_wiki'));
+    });
+  });
+
+
+  describe('legacy .omx/wiki fallback', () => {
+    it('should expose legacy pages only when canonical wiki is absent', () => {
+      const legacyDir = getLegacyWikiDir(tempDir);
+      fs.mkdirSync(legacyDir, { recursive: true });
+      fs.writeFileSync(path.join(legacyDir, 'legacy.md'), serializePage(makePage({
+        filename: 'legacy.md',
+        frontmatter: {
+          ...makePage().frontmatter,
+          title: 'Legacy',
+        },
+      })));
+
+      expect(listPages(tempDir)).toEqual(['legacy.md']);
+      expect(readPage(tempDir, 'legacy.md')?.frontmatter.title).toBe('Legacy');
+    });
+
+    it('should prefer canonical omx_wiki when both directories exist', () => {
+      const legacyDir = getLegacyWikiDir(tempDir);
+      fs.mkdirSync(legacyDir, { recursive: true });
+      fs.writeFileSync(path.join(legacyDir, 'legacy.md'), serializePage(makePage({ filename: 'legacy.md' })));
+
+      ensureWikiDir(tempDir);
+      const canonicalDir = getWikiDir(tempDir);
+      fs.writeFileSync(path.join(canonicalDir, 'canonical.md'), serializePage(makePage({ filename: 'canonical.md' })));
+
+      expect(listPages(tempDir)).toEqual(['canonical.md']);
+      expect(readPage(tempDir, 'legacy.md')).toBeNull();
+    });
+
+    it('should write to canonical omx_wiki even when legacy exists', () => {
+      const legacyDir = getLegacyWikiDir(tempDir);
+      fs.mkdirSync(legacyDir, { recursive: true });
+
+      writePage(tempDir, makePage());
+
+      expect(fs.existsSync(path.join(getWikiDir(tempDir), 'test-page.md'))).toBe(true);
+      expect(fs.existsSync(path.join(legacyDir, 'test-page.md'))).toBe(false);
+    });
+
+    it('should not index legacy fallback pages into canonical metadata', () => {
+      const legacyDir = getLegacyWikiDir(tempDir);
+      fs.mkdirSync(legacyDir, { recursive: true });
+      fs.writeFileSync(path.join(legacyDir, 'legacy.md'), serializePage(makePage({
+        filename: 'legacy.md',
+        frontmatter: {
+          ...makePage().frontmatter,
+          title: 'Legacy Private',
+        },
+        content: '\n# Legacy Private\n',
+      })));
+
+      withWikiLock(tempDir, () => {
+        updateIndexUnsafe(tempDir);
+      });
+
+      const index = fs.readFileSync(path.join(getWikiDir(tempDir), 'index.md'), 'utf-8');
+      expect(index).toContain('> 0 pages | Last updated:');
+      expect(index).not.toContain('Legacy Private');
     });
   });
 
@@ -71,33 +134,21 @@ describe('Wiki Storage', () => {
       expect(fs.existsSync(dir)).toBe(true);
     });
 
-    it('should create .gitignore with wiki/ entry', () => {
+    it('should not create .omx/.gitignore for wiki ignores', () => {
       ensureWikiDir(tempDir);
       const gitignorePath = path.join(tempDir, '.omx', '.gitignore');
-      expect(fs.existsSync(gitignorePath)).toBe(true);
-      expect(fs.readFileSync(gitignorePath, 'utf-8')).toContain('wiki/');
+      expect(fs.existsSync(gitignorePath)).toBe(false);
     });
 
-    it('should append to existing .gitignore', () => {
-      const omcDir = path.join(tempDir, '.omx');
-      fs.mkdirSync(omcDir, { recursive: true });
-      fs.writeFileSync(path.join(omcDir, '.gitignore'), 'state/\n');
+    it('should not mutate an existing .omx/.gitignore', () => {
+      const omxDir = path.join(tempDir, '.omx');
+      fs.mkdirSync(omxDir, { recursive: true });
+      const gitignorePath = path.join(omxDir, '.gitignore');
+      fs.writeFileSync(gitignorePath, 'state/\n');
 
       ensureWikiDir(tempDir);
-      const content = fs.readFileSync(path.join(omcDir, '.gitignore'), 'utf-8');
-      expect(content).toContain('state/');
-      expect(content).toContain('wiki/');
-    });
-
-    it('should not duplicate wiki/ in .gitignore', () => {
-      const omcDir = path.join(tempDir, '.omx');
-      fs.mkdirSync(omcDir, { recursive: true });
-      fs.writeFileSync(path.join(omcDir, '.gitignore'), 'wiki/\n');
-
-      ensureWikiDir(tempDir);
-      const content = fs.readFileSync(path.join(omcDir, '.gitignore'), 'utf-8');
-      const matches = content.match(/wiki\//g);
-      expect(matches?.length).toBe(1);
+      const content = fs.readFileSync(gitignorePath, 'utf-8');
+      expect(content).toBe('state/\n');
     });
   });
 

--- a/src/wiki/index.ts
+++ b/src/wiki/index.ts
@@ -25,6 +25,10 @@ export { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG } from './types.js';
 // Storage
 export {
   getWikiDir,
+  getLegacyWikiDir,
+  hasReadableWiki,
+  isLegacyWikiFallbackActive,
+  readCanonicalPage,
   ensureWikiDir,
   withWikiLock,
   readPage,
@@ -50,4 +54,4 @@ export {
 export { ingestKnowledge } from './ingest.js';
 export { queryWiki, tokenize } from './query.js';
 export { lintWiki } from './lint.js';
-export { onSessionStart, onSessionEnd, onPreCompact } from './lifecycle.js';
+export { onSessionStart, onSessionEnd, onPreCompact, onPostCompact } from './lifecycle.js';

--- a/src/wiki/ingest.ts
+++ b/src/wiki/ingest.ts
@@ -14,7 +14,7 @@ import {
 } from './types.js';
 import {
   withWikiLock,
-  readPage,
+  readCanonicalPage,
   writePageUnsafe,
   updateIndexUnsafe,
   appendLogUnsafe,
@@ -38,7 +38,7 @@ export function ingestKnowledge(root: string, input: WikiIngestInput): WikiInges
   const result: WikiIngestResult = { created: [], updated: [], totalAffected: 0 };
 
   withWikiLock(root, () => {
-    const existing = readPage(root, slug);
+    const existing = readCanonicalPage(root, slug);
 
     if (existing) {
       // Merge into existing page

--- a/src/wiki/lifecycle.ts
+++ b/src/wiki/lifecycle.ts
@@ -8,6 +8,7 @@ import { codexHome, omxProjectMemoryPath } from '../utils/paths.js';
 import {
   appendLogUnsafe,
   getWikiDir,
+  isLegacyWikiFallbackActive,
   listPages,
   readAllPages,
   readIndex,
@@ -42,13 +43,23 @@ export function onSessionStart(data: { cwd?: string }): { additionalContext?: st
     const config = loadWikiConfig(root);
     if (!config.enabled) return {};
 
+    const legacyFallbackActive = isLegacyWikiFallbackActive(root);
     const wikiDir = getWikiDir(root);
-    if (!existsSync(wikiDir)) return {};
+    if (!existsSync(wikiDir) && !legacyFallbackActive) return {};
 
     const pages = listPages(root);
     if (pages.length === 0) return {};
 
-    if (!readIndex(root)) {
+    if (legacyFallbackActive) {
+      const summary = [
+        `[OMX Wiki: ${pages.length} legacy pages at .omx/wiki/; canonical storage is omx_wiki/]`,
+        '',
+        'Legacy wiki fallback is read-only. Review and copy selected pages into omx_wiki/ before committing.',
+      ].join('\n');
+      return { additionalContext: summary };
+    }
+
+    if (!legacyFallbackActive && !readIndex(root)) {
       withWikiLock(root, () => {
         updateIndexUnsafe(root);
       });
@@ -62,7 +73,7 @@ export function onSessionStart(data: { cwd?: string }): { additionalContext?: st
     if (!index) return {};
 
     const summary = [
-      `[OMX Wiki: ${pages.length} pages at .omx/wiki/]`,
+      `[OMX Wiki: ${pages.length} pages at omx_wiki/]`,
       '',
       'Use wiki_query to search, wiki_list to browse, wiki_read to inspect pages.',
       '',
@@ -149,6 +160,25 @@ export function onPreCompact(data: { cwd?: string }): { additionalContext?: stri
 
     return {
       additionalContext: `[Wiki: ${pages.length} pages | categories: ${categories.join(', ')} | last updated: ${latestUpdate}]`,
+    };
+  } catch {
+    return {};
+  }
+}
+
+
+export function onPostCompact(data: { cwd?: string }): { additionalContext?: string } {
+  try {
+    const root = data.cwd || process.cwd();
+    const config = loadWikiConfig(root);
+    if (!config.enabled) return {};
+
+    return {
+      additionalContext: [
+        '[OMX Wiki PostCompact Nudge]',
+        'Review the compaction artifacts and write durable findings to repository `omx_wiki/` when they would help future agents.',
+        'Use wiki_ingest or omx wiki add for decisions, architecture notes, debugging findings, environment facts, and session-log summaries worth committing.',
+      ].join('\n'),
     };
   } catch {
     return {};

--- a/src/wiki/lint.ts
+++ b/src/wiki/lint.ts
@@ -16,6 +16,7 @@ import {
 import {
   readAllPages,
   appendLog,
+  isLegacyWikiFallbackActive,
 } from './storage.js';
 
 /**
@@ -34,6 +35,7 @@ import {
  * @returns Lint report with issues and stats
  */
 export function lintWiki(root: string, config: WikiConfig = DEFAULT_WIKI_CONFIG): WikiLintReport {
+  const legacyFallbackActive = isLegacyWikiFallbackActive(root);
   const pages = readAllPages(root);
   const issues: WikiLintIssue[] = [];
   const pageFilenames = new Set(pages.map(p => p.filename));
@@ -122,13 +124,16 @@ export function lintWiki(root: string, config: WikiConfig = DEFAULT_WIKI_CONFIG)
     contradictionCount: issues.filter(i => i.type === 'structural-contradiction').length,
   };
 
-  // Log the lint operation
-  appendLog(root, {
-    timestamp: new Date().toISOString(),
-    operation: 'lint',
-    pagesAffected: [...new Set(issues.map(i => i.page))],
-    summary: `Lint: ${issues.length} issues (${stats.orphanCount} orphan, ${stats.staleCount} stale, ${stats.brokenRefCount} broken, ${stats.contradictionCount} contradictions)`,
-  });
+  // Log the lint operation. Suppress logging while serving legacy fallback so
+  // read-only lint does not create source-visible canonical wiki files.
+  if (!legacyFallbackActive) {
+    appendLog(root, {
+      timestamp: new Date().toISOString(),
+      operation: 'lint',
+      pagesAffected: [...new Set(issues.map(i => i.page))],
+      summary: `Lint: ${issues.length} issues (${stats.orphanCount} orphan, ${stats.staleCount} stale, ${stats.brokenRefCount} broken, ${stats.contradictionCount} contradictions)`,
+    });
+  }
 
   return { issues, stats };
 }

--- a/src/wiki/query.ts
+++ b/src/wiki/query.ts
@@ -15,6 +15,7 @@ import {
 import {
   readAllPages,
   appendLog,
+  isLegacyWikiFallbackActive,
 } from './storage.js';
 
 /**
@@ -81,6 +82,7 @@ export function queryWiki(
   options: WikiQueryOptions = {},
 ): WikiQueryMatch[] {
   const { tags: filterTags, category, limit = 20, logQuery = true } = options;
+  const legacyFallbackActive = isLegacyWikiFallbackActive(root);
   const pages = readAllPages(root);
   const queryLower = queryText.toLowerCase();
   const queryTerms = tokenize(queryText);
@@ -150,7 +152,7 @@ export function queryWiki(
   matches.sort((a, b) => b.score - a.score);
   const limited = matches.slice(0, limit);
 
-  if (logQuery) {
+  if (logQuery && !legacyFallbackActive) {
     appendLog(root, {
       timestamp: new Date().toISOString(),
       operation: 'query',

--- a/src/wiki/storage.ts
+++ b/src/wiki/storage.ts
@@ -364,6 +364,8 @@ export function writePage(root: string, page: WikiPage, options: { allowReserved
 }
 
 export function deletePage(root: string, filename: string): boolean {
+  if (!existsSync(getWikiDir(root))) return false;
+
   return withWikiLock(root, () => {
     const deleted = deletePageUnsafe(root, filename);
     if (deleted) updateIndexUnsafe(root);

--- a/src/wiki/storage.ts
+++ b/src/wiki/storage.ts
@@ -15,7 +15,7 @@ import {
   writeFileSync,
 } from 'fs';
 import { dirname, join, resolve, sep } from 'path';
-import { omxWikiDir } from '../utils/paths.js';
+import { omxLegacyWikiDir, omxWikiDir } from '../utils/paths.js';
 import {
   type WikiLogEntry,
   type WikiPage,
@@ -77,20 +77,27 @@ export function getWikiDir(root: string): string {
   return omxWikiDir(root);
 }
 
+export function getLegacyWikiDir(root: string): string {
+  return omxLegacyWikiDir(root);
+}
+
+export function isLegacyWikiFallbackActive(root: string): boolean {
+  return !existsSync(getWikiDir(root)) && existsSync(getLegacyWikiDir(root));
+}
+
+
+export function hasReadableWiki(root: string): boolean {
+  return existsSync(getWikiDir(root)) || existsSync(getLegacyWikiDir(root));
+}
+
+function getReadableWikiDir(root: string): string {
+  if (isLegacyWikiFallbackActive(root)) return getLegacyWikiDir(root);
+  return getWikiDir(root);
+}
+
 export function ensureWikiDir(root: string): string {
   const wikiDir = getWikiDir(root);
   mkdirSync(wikiDir, { recursive: true });
-  const omxRoot = join(root, '.omx');
-  mkdirSync(omxRoot, { recursive: true });
-  const gitignorePath = join(omxRoot, '.gitignore');
-  if (existsSync(gitignorePath)) {
-    const content = readFileSync(gitignorePath, 'utf8');
-    if (!content.includes('wiki/')) {
-      atomicWriteFileSync(gitignorePath, `${content.trimEnd()}\nwiki/\n`);
-    }
-  } else {
-    atomicWriteFileSync(gitignorePath, 'wiki/\n');
-  }
   return wikiDir;
 }
 
@@ -212,7 +219,8 @@ function safeWikiPath(wikiDir: string, filename: string): string | null {
   return filePath;
 }
 
-export function readPage(root: string, filename: string): WikiPage | null {
+
+export function readCanonicalPage(root: string, filename: string): WikiPage | null {
   const wikiDir = getWikiDir(root);
   const filePath = safeWikiPath(wikiDir, filename);
   if (!filePath || !existsSync(filePath)) return null;
@@ -230,8 +238,26 @@ export function readPage(root: string, filename: string): WikiPage | null {
   }
 }
 
+export function readPage(root: string, filename: string): WikiPage | null {
+  const wikiDir = getReadableWikiDir(root);
+  const filePath = safeWikiPath(wikiDir, filename);
+  if (!filePath || !existsSync(filePath)) return null;
+
+  try {
+    const parsed = parseFrontmatter(readFileSync(filePath, 'utf8'));
+    if (!parsed) return null;
+    return {
+      filename,
+      frontmatter: parsed.frontmatter,
+      content: parsed.content,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export function listPages(root: string): string[] {
-  const wikiDir = getWikiDir(root);
+  const wikiDir = getReadableWikiDir(root);
   if (!existsSync(wikiDir)) return [];
   return readdirSync(wikiDir)
     .filter((entry) => entry.endsWith('.md') && !RESERVED_FILES.has(entry))
@@ -244,13 +270,27 @@ export function readAllPages(root: string): WikiPage[] {
     .filter((page): page is WikiPage => page !== null);
 }
 
+function listCanonicalPages(root: string): string[] {
+  const wikiDir = getWikiDir(root);
+  if (!existsSync(wikiDir)) return [];
+  return readdirSync(wikiDir)
+    .filter((entry) => entry.endsWith('.md') && !RESERVED_FILES.has(entry))
+    .sort();
+}
+
+function readAllCanonicalPages(root: string): WikiPage[] {
+  return listCanonicalPages(root)
+    .map((filename) => readCanonicalPage(root, filename))
+    .filter((page): page is WikiPage => page !== null);
+}
+
 export function readIndex(root: string): string | null {
-  const indexPath = join(getWikiDir(root), INDEX_FILE);
+  const indexPath = join(getReadableWikiDir(root), INDEX_FILE);
   return existsSync(indexPath) ? readFileSync(indexPath, 'utf8') : null;
 }
 
 export function readLog(root: string): string | null {
-  const logPath = join(getWikiDir(root), LOG_FILE);
+  const logPath = join(getReadableWikiDir(root), LOG_FILE);
   return existsSync(logPath) ? readFileSync(logPath, 'utf8') : null;
 }
 
@@ -276,7 +316,7 @@ export function deletePageUnsafe(root: string, filename: string): boolean {
 }
 
 export function updateIndexUnsafe(root: string): void {
-  const pages = readAllPages(root);
+  const pages = readAllCanonicalPages(root);
   const byCategory = new Map<string, WikiPage[]>();
 
   for (const page of pages) {


### PR DESCRIPTION
## Summary
- Move canonical OMX wiki storage to repository-root `omx_wiki/` so shared wiki pages can be committed.
- Preserve legacy `.omx/wiki/` as read-only compatibility fallback only when canonical `omx_wiki/` is absent.
- Wire native `PreCompact` and `PostCompact` hooks; `PostCompact` nudges agents to promote durable compaction findings into `omx_wiki/`.
- Update docs, skill/plugin mirror, MCP edge cases, and regressions around legacy privacy boundaries.

## Validation
- `npm run verify:plugin-bundle`
- `npm run build && node --test dist/mcp/__tests__/wiki-server.test.js dist/wiki/__tests__/storage.test.js dist/wiki/__tests__/query.test.js dist/wiki/__tests__/ingest.test.js dist/wiki/__tests__/lint.test.js dist/wiki/__tests__/session-hooks.test.js dist/hooks/__tests__/wiki-docs-contract.test.js dist/config/__tests__/wiki-config-contract.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/config/__tests__/codex-hooks.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `$code-review`: code-reviewer APPROVE; architect CLEAR

## Notes
- Full `npm test` was attempted after plugin mirror sync; it hit unrelated pre-existing active-runtime failures in adapt/autoresearch/agents-init tests, so focused verification above was used for this PR.
