### PR TITLE
Restore hook visibility in the HUD

### DIFF
--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -240,6 +240,79 @@ describe('renderHud – team', () => {
   });
 });
 
+// ── Hooks dashboard ──────────────────────────────────────────────────────────
+
+describe('renderHud – hooks dashboard', () => {
+  it('renders hook count and covered event count', () => {
+    const ctx: HudRenderContext = {
+      ...emptyCtx(),
+      hooks: {
+        status: 'ok',
+        enabled: true,
+        total_hooks: 10,
+        managed_hooks: 5,
+        custom_hooks: 5,
+        event_count: 5,
+        managed_event_count: 5,
+        expected_managed_event_count: 5,
+        missing_managed_events: [],
+        hooks_path: '/tmp/hooks.json',
+      },
+    };
+
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${GREEN}hooks:10/5ev${RESET}`));
+  });
+
+  it('highlights partial hook coverage', () => {
+    const ctx: HudRenderContext = {
+      ...emptyCtx(),
+      hooks: {
+        status: 'partial',
+        enabled: true,
+        total_hooks: 4,
+        managed_hooks: 4,
+        custom_hooks: 0,
+        event_count: 4,
+        managed_event_count: 4,
+        expected_managed_event_count: 5,
+        missing_managed_events: ['Stop'],
+        hooks_path: '/tmp/hooks.json',
+      },
+    };
+
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${YELLOW}hooks:4/4ev${RESET}`));
+  });
+
+  it('shows disabled, missing, and invalid hook states as dashboard warnings', () => {
+    const baseHooks = {
+      enabled: true,
+      total_hooks: 0,
+      managed_hooks: 0,
+      custom_hooks: 0,
+      event_count: 0,
+      managed_event_count: 0,
+      expected_managed_event_count: 5,
+      missing_managed_events: [],
+      hooks_path: '/tmp/hooks.json',
+    };
+
+    assert.ok(renderHud({
+      ...emptyCtx(),
+      hooks: { ...baseHooks, status: 'disabled', enabled: false },
+    }, 'focused').includes('hooks:off'));
+    assert.ok(renderHud({
+      ...emptyCtx(),
+      hooks: { ...baseHooks, status: 'missing' },
+    }, 'focused').includes('hooks:missing'));
+    assert.ok(renderHud({
+      ...emptyCtx(),
+      hooks: { ...baseHooks, status: 'invalid' },
+    }, 'focused').includes('hooks:invalid'));
+  });
+});
+
 // ── Metrics – turns ───────────────────────────────────────────────────────────
 
 describe('renderHud – metrics (turns)', () => {

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -10,6 +10,7 @@ import {
   readGitBranch,
   readAllState,
   readHudNotifyState,
+  readHookDashboardState,
   readRalphState,
   readRalplanState,
   readDeepInterviewState,
@@ -45,6 +46,23 @@ async function withTempRepo(prefix: string, run: (cwd: string) => Promise<void>)
     await run(cwd);
   } finally {
     await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function withTempCodexHome(prefix: string, run: (home: string) => Promise<void>): Promise<void> {
+  const home = await mkdtemp(join(tmpdir(), prefix));
+  const previous = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = home;
+
+  try {
+    await run(home);
+  } finally {
+    if (typeof previous === 'string') {
+      process.env.CODEX_HOME = previous;
+    } else {
+      delete process.env.CODEX_HOME;
+    }
+    await rm(home, { recursive: true, force: true });
   }
 }
 
@@ -431,6 +449,63 @@ describe('additional HUD mode state readers', () => {
         if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
         else delete process.env.OMX_SESSION_ID;
       }
+    });
+  });
+});
+
+describe('readHookDashboardState', () => {
+  it('counts Codex native hooks across events for the HUD dashboard', async () => {
+    await withTempCodexHome('omx-hud-hooks-home-', async (home) => {
+      await writeFile(join(home, 'config.toml'), 'codex_hooks = true\n');
+      await writeFile(join(home, 'hooks.json'), JSON.stringify({
+        hooks: {
+          SessionStart: [{ hooks: [{ type: 'command', command: 'node "/pkg/dist/scripts/codex-native-hook.js"' }] }],
+          PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'node "/pkg/dist/scripts/codex-native-hook.js"' }] }],
+          PostToolUse: [{ hooks: [{ type: 'command', command: 'node "/pkg/dist/scripts/codex-native-hook.js"' }] }],
+          UserPromptSubmit: [
+            { hooks: [{ type: 'command', command: 'node "/pkg/dist/scripts/codex-native-hook.js"' }] },
+            { hooks: [{ type: 'command', command: 'node "/custom/hook.js"' }] },
+          ],
+          Stop: [{ hooks: [{ type: 'command', command: 'node "/pkg/dist/scripts/codex-native-hook.js"', timeout: 30 }] }],
+        },
+      }));
+
+      const state = await readHookDashboardState();
+      assert.equal(state.status, 'ok');
+      assert.equal(state.enabled, true);
+      assert.equal(state.total_hooks, 6);
+      assert.equal(state.managed_hooks, 5);
+      assert.equal(state.custom_hooks, 1);
+      assert.equal(state.event_count, 5);
+      assert.equal(state.managed_event_count, 5);
+      assert.deepEqual(state.missing_managed_events, []);
+    });
+  });
+
+  it('reports partial coverage when a managed event wrapper is missing', async () => {
+    await withTempCodexHome('omx-hud-hooks-partial-', async (home) => {
+      await writeFile(join(home, 'config.toml'), 'codex_hooks = true\n');
+      await writeFile(join(home, 'hooks.json'), JSON.stringify({
+        hooks: {
+          SessionStart: [{ hooks: [{ type: 'command', command: 'node "/pkg/dist/scripts/codex-native-hook.js"' }] }],
+        },
+      }));
+
+      const state = await readHookDashboardState();
+      assert.equal(state.status, 'partial');
+      assert.equal(state.total_hooks, 1);
+      assert.deepEqual(state.missing_managed_events, ['PreToolUse', 'PostToolUse', 'UserPromptSubmit', 'Stop']);
+    });
+  });
+
+  it('reports missing hooks when codex_hooks is enabled but hooks.json is absent', async () => {
+    await withTempCodexHome('omx-hud-hooks-missing-', async (home) => {
+      await writeFile(join(home, 'config.toml'), 'codex_hooks = true\n');
+
+      const state = await readHookDashboardState();
+      assert.equal(state.status, 'missing');
+      assert.equal(state.enabled, true);
+      assert.equal(state.total_hooks, 0);
     });
   });
 });

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -124,6 +124,20 @@ function renderTeam(ctx: HudRenderContext): string | null {
   return green('team');
 }
 
+function renderHooks(ctx: HudRenderContext): string | null {
+  if (!ctx.hooks) return null;
+
+  const status = ctx.hooks.status;
+  if (status === 'disabled') return dim('hooks:off');
+  if (status === 'missing') return yellow('hooks:missing');
+  if (status === 'invalid') return yellow('hooks:invalid');
+
+  const totalHooks = Number.isFinite(ctx.hooks.total_hooks) ? ctx.hooks.total_hooks : 0;
+  const eventCount = Number.isFinite(ctx.hooks.event_count) ? ctx.hooks.event_count : 0;
+  const label = `hooks:${totalHooks}/${eventCount}ev`;
+  return status === 'partial' ? yellow(label) : green(label);
+}
+
 function renderTurns(ctx: HudRenderContext): string | null {
   if (!ctx.metrics || !isCurrentSessionMetrics(ctx)) return null;
   return dim(`turns:${ctx.metrics.session_turns}`);
@@ -211,6 +225,7 @@ const FOCUSED_ELEMENTS: ElementRenderer[] = [
   renderAutoresearch,
   renderUltraqa,
   renderTeam,
+  renderHooks,
   renderTurns,
   renderTokens,
   renderQuota,
@@ -228,6 +243,7 @@ const FULL_ELEMENTS: ElementRenderer[] = [
   renderAutoresearch,
   renderUltraqa,
   renderTeam,
+  renderHooks,
   renderTurns,
   renderTokens,
   renderQuota,

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -9,7 +9,7 @@ import { readFileSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
-import { omxStateDir } from '../utils/paths.js';
+import { codexConfigPath, codexHome, omxStateDir } from '../utils/paths.js';
 import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
@@ -17,6 +17,7 @@ import { getReadScopedStateFilePaths, getReadScopedStatePaths, readCurrentSessio
 import { teamReadPhase as readTeamPhase } from '../team/team-ops.js';
 import { readUsableSessionState } from '../hooks/session.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
+import { MANAGED_HOOK_EVENTS, getMissingManagedCodexHookEvents, parseCodexHooksConfig } from '../config/codex-hooks.js';
 import type {
   RalphStateForHud,
   UltraworkStateForHud,
@@ -31,6 +32,7 @@ import type {
   HudConfig,
   HudRenderContext,
   SessionStateForHud,
+  HookDashboardStateForHud,
   ResolvedHudConfig,
   HudGitDisplay,
 } from './types.js';
@@ -179,6 +181,130 @@ export async function readHudNotifyState(cwd: string): Promise<HudNotifyState | 
 export async function readSessionState(cwd: string): Promise<SessionStateForHud | null> {
   const state = await readUsableSessionState(cwd);
   return state?.session_id ? state : null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isOmxManagedHookCommand(command: string): boolean {
+  return /(?:^|[\\/])codex-native-hook\.js(?:["'\s]|$)/.test(command);
+}
+
+function readCodexHooksFeatureEnabled(configText: string): boolean | null {
+  const matches = [...configText.matchAll(/^\s*codex_hooks\s*=\s*(true|false)\s*(?:#.*)?$/gmi)];
+  const last = matches.at(-1)?.[1];
+  if (last === 'true') return true;
+  if (last === 'false') return false;
+  return null;
+}
+
+function summarizeHookEntries(hooksRoot: unknown): {
+  totalHooks: number;
+  managedHooks: number;
+  customHooks: number;
+  eventCount: number;
+  managedEventCount: number;
+} {
+  let totalHooks = 0;
+  let managedHooks = 0;
+  let customHooks = 0;
+  let eventCount = 0;
+  let managedEventCount = 0;
+
+  if (!isPlainObject(hooksRoot)) {
+    return { totalHooks, managedHooks, customHooks, eventCount, managedEventCount };
+  }
+
+  for (const entries of Object.values(hooksRoot)) {
+    if (!Array.isArray(entries)) continue;
+
+    let hooksForEvent = 0;
+    let managedForEvent = 0;
+
+    for (const entry of entries) {
+      if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) continue;
+
+      for (const hook of entry.hooks) {
+        if (!isPlainObject(hook)) continue;
+
+        totalHooks += 1;
+        hooksForEvent += 1;
+
+        const command = typeof hook.command === 'string' ? hook.command : '';
+        if (hook.type === 'command' && isOmxManagedHookCommand(command)) {
+          managedHooks += 1;
+          managedForEvent += 1;
+        } else {
+          customHooks += 1;
+        }
+      }
+    }
+
+    if (hooksForEvent > 0) eventCount += 1;
+    if (managedForEvent > 0) managedEventCount += 1;
+  }
+
+  return { totalHooks, managedHooks, customHooks, eventCount, managedEventCount };
+}
+
+export async function readHookDashboardState(): Promise<HookDashboardStateForHud> {
+  const hooksPath = join(codexHome(), 'hooks.json');
+  const configPath = codexConfigPath();
+  const configText = await readFile(configPath, 'utf-8').catch(() => '');
+  const nativeEnabled = configText ? readCodexHooksFeatureEnabled(configText) : null;
+  const hooksContent = await readFile(hooksPath, 'utf-8').catch(() => null);
+
+  if (hooksContent === null) {
+    return {
+      status: nativeEnabled === false ? 'disabled' : 'missing',
+      enabled: nativeEnabled === true,
+      total_hooks: 0,
+      managed_hooks: 0,
+      custom_hooks: 0,
+      event_count: 0,
+      managed_event_count: 0,
+      expected_managed_event_count: MANAGED_HOOK_EVENTS.length,
+      missing_managed_events: [...MANAGED_HOOK_EVENTS],
+      hooks_path: hooksPath,
+    };
+  }
+
+  const parsed = parseCodexHooksConfig(hooksContent);
+  if (!parsed) {
+    return {
+      status: 'invalid',
+      enabled: nativeEnabled !== false,
+      total_hooks: 0,
+      managed_hooks: 0,
+      custom_hooks: 0,
+      event_count: 0,
+      managed_event_count: 0,
+      expected_managed_event_count: MANAGED_HOOK_EVENTS.length,
+      missing_managed_events: [...MANAGED_HOOK_EVENTS],
+      hooks_path: hooksPath,
+    };
+  }
+
+  const summary = summarizeHookEntries(parsed.hooks);
+  const missingManagedEvents = getMissingManagedCodexHookEvents(hooksContent) ?? [...MANAGED_HOOK_EVENTS];
+  const enabled = nativeEnabled !== false;
+  const status = enabled
+    ? (missingManagedEvents.length > 0 ? 'partial' : 'ok')
+    : 'disabled';
+
+  return {
+    status,
+    enabled,
+    total_hooks: summary.totalHooks,
+    managed_hooks: summary.managedHooks,
+    custom_hooks: summary.customHooks,
+    event_count: summary.eventCount,
+    managed_event_count: summary.managedEventCount,
+    expected_managed_event_count: MANAGED_HOOK_EVENTS.length,
+    missing_managed_events: missingManagedEvents,
+    hooks_path: hooksPath,
+  };
 }
 
 export async function readHudConfig(cwd: string): Promise<ResolvedHudConfig> {
@@ -403,11 +529,12 @@ function mergeTeamPhase(
 export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFAULT_HUD_CONFIG): Promise<HudRenderContext> {
   const version = readVersion();
   const gitBranch = buildGitBranchLabel(cwd, config);
-  const [metrics, hudNotify, session, currentSessionId] = await Promise.all([
+  const [metrics, hudNotify, session, currentSessionId, hooks] = await Promise.all([
     readMetrics(cwd),
     readHudNotifyState(cwd),
     readSessionState(cwd),
     readCurrentSessionId(cwd),
+    readHookDashboardState(),
   ]);
   const canonicalSkillState = await readVisibleSkillActiveState(cwd, currentSessionId);
   const canonicalSkills = new Map(
@@ -500,6 +627,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     metrics,
     hudNotify,
     session,
+    hooks,
     runtimeSnapshot,
   };
 }

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -81,6 +81,22 @@ export interface SessionStateForHud {
   started_at: string;
 }
 
+export type HookDashboardStatus = 'ok' | 'partial' | 'missing' | 'invalid' | 'disabled';
+
+/** Native Codex hook coverage summary for HUD display */
+export interface HookDashboardStateForHud {
+  status: HookDashboardStatus;
+  enabled: boolean;
+  total_hooks: number;
+  managed_hooks: number;
+  custom_hooks: number;
+  event_count: number;
+  managed_event_count: number;
+  expected_managed_event_count: number;
+  missing_managed_events: string[];
+  hooks_path: string;
+}
+
 /** All data needed to render one HUD frame */
 export interface HudRenderContext {
   version: string | null;
@@ -96,6 +112,7 @@ export interface HudRenderContext {
   metrics: HudMetrics | null;
   hudNotify: HudNotifyState | null;
   session: SessionStateForHud | null;
+  hooks?: HookDashboardStateForHud | null;
   /** Rust-authored runtime snapshot (present when bridge is enabled and snapshot.json exists). */
   runtimeSnapshot?: import('../runtime/bridge.js').RuntimeSnapshot | null;
 }


### PR DESCRIPTION
## Summary
- Restore hook automation visibility in the HUD/statusline.
- Read native Codex hook coverage from `~/.codex/hooks.json` plus `codex_hooks` config state.
- Render `hooks:<total>/<event-count>ev` in focused/full HUD presets, with warning states for missing/partial/invalid/disabled coverage.

## Scope
- HUD state reader and render context types.
- HUD statusline renderer.
- HUD render/state tests.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `env -u OMX_SESSION_ID -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js`
- [x] Manual smoke: `node dist/cli/omx.js hud --json` shows `hooks.status = ok`; `node dist/cli/omx.js hud --preset=full` shows `hooks:10/5ev` locally.

## Rollout note
- Read-only HUD/statusline change; no hook installation or setup behavior changes.
- `npm run test:ci:compiled` was attempted locally but interrupted after unrelated environment-sensitive failures caused by active OMX state/tmux sessions in this machine. Targeted HUD tests pass in a clean env override.
