### PR TITLE
fix: surface Codex startup exits

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2388,9 +2388,12 @@ describe("detached tmux new-session sequencing", () => {
     assert.match(leaderCmd!, /wait "\$omx_codex_pid";/);
     assert.match(leaderCmd!, /kill -TERM "\$omx_codex_pid"/);
     assert.match(leaderCmd!, /releaseTmuxExtendedKeysLease/);
-    assert.match(leaderCmd!, /if \[ "\$status" -lt 128 \]; then/);
+    assert.match(leaderCmd!, /if \[ "\$status" -eq 0 \]; then/);
     assert.match(leaderCmd!, /tmux kill-session -t/);
     assert.match(leaderCmd!, /"omx-demo"/);
+    assert.match(leaderCmd!, /codex exited immediately with code 0/);
+    assert.match(leaderCmd!, /codex exited with code/);
+    assert.match(leaderCmd!, /detached tmux session is being kept open/);
     assert.match(leaderCmd!, /exit \$status/);
   });
 
@@ -2416,7 +2419,7 @@ describe("detached tmux new-session sequencing", () => {
     assert.match(leaderCmd!, /\/tmp\/project\/\.codex-project/);
     assert.match(leaderCmd!, /\/tmp\/project\/\.omx\/runtime\/codex-home\/omx-session-123/);
     const helperIndex = leaderCmd!.indexOf("runDetachedSessionPostLaunch");
-    const signalGateIndex = leaderCmd!.indexOf('if [ "$status" -lt 128 ]');
+    const signalGateIndex = leaderCmd!.indexOf('if [ "$status" -eq 0 ]');
     assert.ok(helperIndex >= 0);
     assert.ok(signalGateIndex >= 0);
     assert.ok(
@@ -2644,6 +2647,146 @@ exit 0
       assert.match(log, /tmux:set-option -sq extended-keys always/);
       assert.match(log, /tmux:set-option -sq extended-keys off/);
       assert.doesNotMatch(log, /tmux:kill-session -t omx-demo/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("detached leader command keeps child startup errors visible instead of killing the session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-error-"));
+    const fakeBin = join(cwd, "bin");
+    const logPath = join(cwd, "leader.log");
+
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        join(fakeBin, "codex"),
+        `#!/bin/sh
+printf 'codex-stderr: unsupported startup flag\\n' >&2
+exit 42
+`,
+      );
+      await chmod(join(fakeBin, "codex"), 0o755);
+      await writeFile(
+        join(fakeBin, "tmux"),
+        `#!/bin/sh
+printf 'tmux:%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message)
+    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\\n'
+    else
+      printf '0\\n'
+    fi
+    ;;
+  show-options)
+    printf 'off\\n'
+    ;;
+  set-option|kill-session)
+    ;;
+esac
+exit 0
+`,
+      );
+      await chmod(join(fakeBin, "tmux"), 0o755);
+
+      const steps = buildDetachedSessionBootstrapSteps(
+        "omx-demo",
+        cwd,
+        buildTmuxPaneCommand("codex", ["--bad-startup-flag"], "/bin/sh"),
+        "'node' '/tmp/omx.js' 'hud' '--watch'",
+        null,
+      );
+      const leaderCmd = steps[0]?.args.at(-1);
+      assert.equal(typeof leaderCmd, "string");
+
+      const result = (await import("node:child_process")).spawnSync("/bin/sh", ["-c", leaderCmd!], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          HOME: cwd,
+        },
+        input: "\n",
+        encoding: "utf-8",
+      });
+
+      assert.equal(result.status, 42);
+      assert.match(result.stderr, /codex-stderr: unsupported startup flag/);
+      assert.match(result.stderr, /codex exited with code 42 during startup/);
+      assert.match(result.stderr, /detached tmux session is being kept open/);
+      const log = await readFile(logPath, "utf-8");
+      assert.doesNotMatch(log, /tmux:kill-session -t omx-demo/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("detached leader command keeps immediate zero-code exits visible instead of silently closing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-zero-"));
+    const fakeBin = join(cwd, "bin");
+    const logPath = join(cwd, "leader.log");
+
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        join(fakeBin, "codex"),
+        `#!/bin/sh
+printf 'codex-started-then-quit\\n' >&2
+exit 0
+`,
+      );
+      await chmod(join(fakeBin, "codex"), 0o755);
+      await writeFile(
+        join(fakeBin, "tmux"),
+        `#!/bin/sh
+printf 'tmux:%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message)
+    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\\n'
+    else
+      printf '0\\n'
+    fi
+    ;;
+  show-options)
+    printf 'off\\n'
+    ;;
+  set-option|kill-session)
+    ;;
+esac
+exit 0
+`,
+      );
+      await chmod(join(fakeBin, "tmux"), 0o755);
+
+      const steps = buildDetachedSessionBootstrapSteps(
+        "omx-demo",
+        cwd,
+        buildTmuxPaneCommand("codex", [], "/bin/sh"),
+        "'node' '/tmp/omx.js' 'hud' '--watch'",
+        null,
+      );
+      const leaderCmd = steps[0]?.args.at(-1);
+      assert.equal(typeof leaderCmd, "string");
+
+      const result = (await import("node:child_process")).spawnSync("/bin/sh", ["-c", leaderCmd!], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          HOME: cwd,
+        },
+        input: "\n",
+        encoding: "utf-8",
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /codex-started-then-quit/);
+      assert.match(result.stderr, /codex exited immediately with code 0 during startup/);
+      assert.match(result.stderr, /detached tmux session is being kept open/);
+      const log = await readFile(logPath, "utf-8");
+      assert.match(log, /tmux:kill-session -t omx-demo/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -97,6 +97,73 @@ async function createLaunchFixture(
 }
 
 describe('omx launch fallback when tmux is unavailable', () => {
+  it('surfaces direct Codex startup stderr and preserves the child exit code', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-child-error-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeExecutable(
+        join(fakeBin, 'codex'),
+        `#!/bin/sh
+printf 'codex-startup-boom\\n' >&2
+exit 42
+`,
+      );
+      await writeExecutable(join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n');
+
+      const result = runOmx(wd, ['--direct', '--version'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        TMUX: '',
+        TMUX_PANE: '',
+      });
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 42, result.error || result.stderr || result.stdout);
+      assert.match(result.stderr, /codex-startup-boom/);
+      assert.match(result.stderr, /\[omx\] codex exited with code 42/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a missing Codex executable instead of exiting silently', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-missing-codex-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeExecutable(join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n');
+
+      const result = runOmx(wd, ['--direct', '--version'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        TMUX: '',
+        TMUX_PANE: '',
+      });
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /failed to launch codex: executable not found in PATH/);
+      assert.notEqual(result.stderr.trim(), '');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('launches codex directly without tmux ENOENT noise', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-fallback-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -972,6 +972,8 @@ function runCodexBlocking(
         : resolveSignalExitCode(result.signal);
     if (result.signal) {
       console.error(`[omx] codex exited due to signal ${result.signal}`);
+    } else if (typeof result.status === "number") {
+      console.error(`[omx] codex exited with code ${result.status}`);
     }
   }
 }
@@ -2332,15 +2334,30 @@ function buildDetachedSessionLeaderCommand(
     'exec 3<&- 2>/dev/null || true;',
     buildTmuxExtendedKeysReleaseShellSnippet(cwd),
     detachedPostLaunchHelper,
-    'if [ "$status" -lt 128 ]; then',
+    'if [ "$status" -eq 0 ]; then',
     `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
     "fi;",
     "exit $status;",
     "};",
     "trap omx_detached_session_cleanup 0 INT TERM HUP;",
+    "omx_codex_started_at=$(date +%s 2>/dev/null || printf 0);",
     `${codexCmd} <&3 &`,
     "omx_codex_pid=$!;",
     'wait "$omx_codex_pid";',
+    "omx_codex_status=$?;",
+    "omx_codex_finished_at=$(date +%s 2>/dev/null || printf 0);",
+    'omx_codex_elapsed=$((omx_codex_finished_at - omx_codex_started_at));',
+    'if [ "$omx_codex_status" -eq 0 ] && [ "$omx_codex_elapsed" -le 2 ]; then',
+    'printf "\\n[omx] codex exited immediately with code 0 during startup. The detached tmux session is being kept open so any output above remains visible. Press Enter to close this OMX session.\\n" >&2;',
+    'IFS= read -r _omx_close || true;',
+    'elif [ "$omx_codex_status" -gt 0 ] && [ "$omx_codex_status" -lt 128 ] && [ "$omx_codex_elapsed" -le 2 ]; then',
+    'printf "\\n[omx] codex exited with code %s during startup. The detached tmux session is being kept open so the error above remains visible. Press Enter to close this OMX session.\\n" "$omx_codex_status" >&2;',
+    'IFS= read -r _omx_close || true;',
+    'elif [ "$omx_codex_status" -gt 0 ] && [ "$omx_codex_status" -lt 128 ]; then',
+    'printf "\\n[omx] codex exited with code %s. The detached tmux session is being kept open so the error above remains visible. Press Enter to close this OMX session.\\n" "$omx_codex_status" >&2;',
+    'IFS= read -r _omx_close || true;',
+    "fi;",
+    'exit "$omx_codex_status";',
   ].join(" ");
   return `/bin/sh -c ${quoteShellArg(wrapped)}`;
 }


### PR DESCRIPTION
## Summary
- surface non-zero direct Codex child exits with an explicit `[omx] codex exited with code ...` diagnostic while preserving inherited stderr and exit code
- keep detached tmux leader sessions open on immediate Codex exits so startup stderr / zero-code early quits are visible instead of collapsing to `[exited]`
- add Linux regression coverage with fake `codex`/`tmux` for direct startup errors, missing Codex, detached non-zero startup exits, and immediate zero-code exits

Closes #2185

## Validation
- `npm run build`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMXBOX_ACTIVE -u OMX_SOURCE_CWD -u OMX_TEAM_WORKER_LAUNCH_ARGS -u OMX_SESSION_ID -u OMX_TMUX_HUD_OWNER node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js`
- `npm run lint`

## Notes
- Linux coverage forces the generic wrapper paths with fake child binaries; no macOS-specific assumptions are required for the error-surfacing fix.
