### PR TITLE
Fix runtime hook mirror dedupe and hooks feature flag

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -14,6 +14,7 @@ This page is the canonical answer to:
 
 For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of source control.
 `omx uninstall` removes only the OMX-managed wrapper entries from `.codex/hooks.json`; if user hooks remain, the file stays in place.
+Project launches use a session-scoped `.omx/runtime/codex-home/<session>/` mirror for Codex runtime writes; hook review/discovery tools should treat that directory as runtime mirror state and ignore its `hooks.json` surfaces rather than loading them alongside the canonical `.codex/hooks.json`.
 
 `omx doctor` can confirm that these files exist and are shaped correctly. It does not prove that the same shell/profile can complete an authenticated Codex request; use `codex login status` plus a real `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"` smoke test for that boundary.
 

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -512,6 +512,55 @@ OMX_LORE_COMMIT_GUARD = "off"
 		}
 	});
 
+	it("warns when runtime codex-home hooks.json symlinks back to project hooks", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-runtime-mirror-"));
+		try {
+			const codexDir = join(wd, ".codex");
+			const runtimeSessionDir = join(wd, ".omx", "runtime", "codex-home", "session-1");
+			await mkdir(codexDir, { recursive: true });
+			await mkdir(runtimeSessionDir, { recursive: true });
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				JSON.stringify({ scope: "project" }),
+			);
+			const managedEntry = {
+				hooks: [
+					{
+						type: "command",
+						command: 'node "/repo/dist/scripts/codex-native-hook.js"',
+					},
+				],
+			};
+			await writeFile(
+				join(codexDir, "hooks.json"),
+				JSON.stringify(
+					{
+						hooks: {
+							SessionStart: [managedEntry],
+							PreToolUse: [managedEntry],
+							PostToolUse: [managedEntry],
+							UserPromptSubmit: [managedEntry],
+							Stop: [managedEntry],
+						},
+					},
+					null,
+					2,
+				) + "\n",
+			);
+			await symlink(join(codexDir, "hooks.json"), join(runtimeSessionDir, "hooks.json"));
+
+			const res = runOmx(wd, ["doctor"]);
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Native hook runtime mirrors: \.omx\/runtime\/codex-home contains 1 hooks\.json runtime mirror skipped by hook discovery/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("warns when hooks.json is missing after OMX config was already installed", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-missing-"));
 		try {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, utimesSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -1650,6 +1650,7 @@ describe("project launch scope helpers", () => {
       ].join("\n");
       await writeFile(configPath, originalConfig);
       await writeFile(join(projectCodexHome, "agents", "planner.toml"), 'name = "planner"\n');
+      await writeFile(join(projectCodexHome, "hooks.json"), '{"hooks":{}}\n');
       await writeFile(join(projectCodexHome, "state_5.sqlite"), "state db placeholder");
       await writeFile(join(projectCodexHome, "state_5.sqlite-wal"), "state db wal placeholder");
       await writeFile(join(projectCodexHome, "logs_2.sqlite-shm"), "logs db shm placeholder");
@@ -1667,6 +1668,8 @@ describe("project launch scope helpers", () => {
         await readFile(join(runtimeCodexHome, "agents", "planner.toml"), "utf-8"),
         'name = "planner"\n',
       );
+      assert.equal(await readFile(join(runtimeCodexHome, "hooks.json"), "utf-8"), '{"hooks":{}}\n');
+      assert.equal((await lstat(join(runtimeCodexHome, "hooks.json"))).isSymbolicLink(), false);
       assert.equal(existsSync(join(runtimeCodexHome, "state_5.sqlite")), false);
       assert.equal(existsSync(join(runtimeCodexHome, "state_5.sqlite-wal")), false);
       assert.equal(existsSync(join(runtimeCodexHome, "logs_2.sqlite-shm")), false);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -31,6 +31,7 @@ import {
 	getModelContextRecommendation,
 } from "../config/generator.js";
 import { getMissingManagedCodexHookEvents } from "../config/codex-hooks.js";
+import { discoverCodexHookConfigPaths } from "../config/codex-hooks.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { getDefaultBridge, isBridgeEnabled } from "../runtime/bridge.js";
 import {
@@ -170,6 +171,8 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
 	// Check 4.25: Native hooks coverage
 	checks.push(await checkNativeHooks(paths.hooksPath, paths.configPath));
+	const runtimeMirrorCheck = await checkNativeHookRuntimeMirrors(cwd, paths.hooksPath);
+	if (runtimeMirrorCheck) checks.push(runtimeMirrorCheck);
 
 	// Check 4.5: Explore routing default
 	checks.push(await checkExploreRouting(paths.configPath));
@@ -1039,6 +1042,26 @@ async function checkNativeHooks(
 			message: "cannot read hooks.json",
 		};
 	}
+}
+
+async function checkNativeHookRuntimeMirrors(
+	cwd: string,
+	hooksPath: string,
+): Promise<Check | null> {
+	if (!existsSync(hooksPath)) return null;
+
+	const discovery = await discoverCodexHookConfigPaths(cwd);
+	const runtimeMirrorCount = discovery.skipped.filter(
+		(entry) => entry.reason === "runtime_codex_home_mirror",
+	).length;
+	if (runtimeMirrorCount === 0) return null;
+
+	return {
+		name: "Native hook runtime mirrors",
+		status: "warn",
+		message:
+			`.omx/runtime/codex-home contains ${runtimeMirrorCount} hooks.json runtime mirror${runtimeMirrorCount === 1 ? "" : "s"} skipped by hook discovery; cleanup or relaunch so external hook review tools do not see duplicate native hook surfaces`,
+	};
 }
 
 async function checkPrompts(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -661,7 +661,7 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
     if (isCodexSqliteArtifact(entry.name)) continue;
     const source = join(projectCodexHome, entry.name);
     const destination = join(runtimeCodexHome, entry.name);
-    if (entry.name === "config.toml") {
+    if (entry.name === "config.toml" || entry.name === "hooks.json") {
       await copyFile(source, destination);
       continue;
     }

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -1,10 +1,16 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildManagedCodexHookTrustState,
   buildManagedCodexHookTrustToml,
   buildManagedCodexHooksConfig,
+  discoverCodexHookConfigPaths,
+  dedupeCodexHookConfigPaths,
   getMissingManagedCodexHookEvents,
+  isRuntimeCodexHomeMirrorPath,
   mergeManagedCodexHooksConfig,
   removeManagedCodexHooks,
 } from "../codex-hooks.js";
@@ -275,5 +281,62 @@ describe("codex hooks helpers", () => {
 
   it("returns null for invalid hooks.json content", () => {
     assert.equal(getMissingManagedCodexHookEvents("{ invalid json"), null);
+  });
+
+  it("ignores runtime codex-home hook mirrors before hook loading", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-hook-dedupe-"));
+    try {
+      const canonicalPath = join(cwd, ".codex", "hooks.json");
+      const mirrorPath = join(cwd, ".omx", "runtime", "codex-home", "session-1", "hooks.json");
+      await mkdir(join(cwd, ".codex"), { recursive: true });
+      await mkdir(join(cwd, ".omx", "runtime", "codex-home", "session-1"), { recursive: true });
+      await writeFile(canonicalPath, JSON.stringify(buildManagedCodexHooksConfig("/repo")));
+      await symlink(canonicalPath, mirrorPath);
+
+      assert.equal(isRuntimeCodexHomeMirrorPath(mirrorPath, cwd), true);
+
+      const result = await dedupeCodexHookConfigPaths([canonicalPath, mirrorPath], cwd);
+      assert.deepEqual(result.paths.map((entry) => entry.path), [canonicalPath]);
+      assert.deepEqual(result.skipped.map((entry) => entry.reason), ["runtime_codex_home_mirror"]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("de-dupes hook config paths by realpath outside runtime mirrors", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-hook-realpath-dedupe-"));
+    try {
+      const canonicalPath = join(cwd, ".codex", "hooks.json");
+      const aliasPath = join(cwd, "alias-hooks.json");
+      await mkdir(join(cwd, ".codex"), { recursive: true });
+      await writeFile(canonicalPath, JSON.stringify(buildManagedCodexHooksConfig("/repo")));
+      await symlink(canonicalPath, aliasPath);
+
+      const result = await dedupeCodexHookConfigPaths([canonicalPath, aliasPath], cwd);
+      assert.deepEqual(result.paths.map((entry) => entry.path), [canonicalPath]);
+      assert.deepEqual(result.skipped.map((entry) => entry.reason), ["duplicate_realpath"]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers canonical hook configs while skipping runtime codex-home mirrors", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-hook-discover-"));
+    try {
+      const canonicalPath = join(cwd, ".codex", "hooks.json");
+      const mirrorPath = join(cwd, ".omx", "runtime", "codex-home", "session-1", "hooks.json");
+      await mkdir(join(cwd, ".codex"), { recursive: true });
+      await mkdir(join(cwd, ".omx", "runtime", "codex-home", "session-1"), { recursive: true });
+      await writeFile(canonicalPath, JSON.stringify(buildManagedCodexHooksConfig("/repo")));
+      await writeFile(mirrorPath, JSON.stringify(buildManagedCodexHooksConfig("/repo")));
+
+      const result = await discoverCodexHookConfigPaths(cwd);
+
+      assert.deepEqual(result.paths.map((entry) => entry.path), [canonicalPath]);
+      assert.deepEqual(result.skipped.map((entry) => entry.path), [mirrorPath]);
+      assert.deepEqual(result.skipped.map((entry) => entry.reason), ["runtime_codex_home_mirror"]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mergeConfig, OMX_DEVELOPER_INSTRUCTIONS } from '../generator.js';
+import { mergeConfig, OMX_DEVELOPER_INSTRUCTIONS, upsertPluginModeRuntimeFeatureFlags } from '../generator.js';
 
 describe('config generator', () => {
   it('places top-level keys before [features]', async () => {
@@ -407,6 +407,47 @@ describe('config generator', () => {
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
+  });
+
+  it('keeps existing codex_hooks flag idempotent without adding hooks alias', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      const original = [
+        '[features]',
+        'codex_hooks = true',
+        'custom_user_flag = false',
+        '',
+      ].join('\n');
+      await writeFile(configPath, original);
+
+      await mergeConfig(configPath, wd);
+      const merged = await readFile(configPath, 'utf-8');
+
+      assert.equal((merged.match(/^codex_hooks = true$/gm) ?? []).length, 1);
+      assert.doesNotMatch(merged, /^hooks\s*=/m);
+      assert.match(merged, /^custom_user_flag = false$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes plugin-mode runtime flags from hooks alias to codex_hooks', () => {
+    const original = [
+      '[features]',
+      'custom_user_flag = false',
+      'hooks = true',
+      'goal = true',
+      '',
+    ].join('\n');
+
+    const merged = upsertPluginModeRuntimeFeatureFlags(original);
+
+    assert.match(merged, /^codex_hooks = true$/m);
+    assert.match(merged, /^goals = true$/m);
+    assert.doesNotMatch(merged, /^hooks\s*=/m);
+    assert.doesNotMatch(merged, /^goal\s*=/m);
+    assert.match(merged, /^custom_user_flag = false$/m);
   });
 
   it('escapes Windows-style backslashes for MCP server args', async () => {

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -1,5 +1,6 @@
 import { createHash } from "crypto";
-import { join, win32 } from "path";
+import { readdir, realpath } from "fs/promises";
+import { basename, join, relative, resolve, win32 } from "path";
 
 export const MANAGED_HOOK_EVENTS = [
   "SessionStart",
@@ -41,6 +42,21 @@ export interface RemoveManagedCodexHooksResult {
 
 export interface ManagedCodexHookTrustState {
   trusted_hash: string;
+}
+
+export interface DedupedCodexHookConfigPath {
+  path: string;
+  reason: "unique";
+}
+
+export interface SkippedCodexHookConfigPath {
+  path: string;
+  reason: "runtime_codex_home_mirror" | "duplicate_realpath";
+  canonicalPath?: string;
+}
+
+export interface DiscoverCodexHookConfigPathsOptions {
+  maxFiles?: number;
 }
 
 const CODEX_HOOK_EVENT_LABELS: Record<ManagedHookEventName, string> = {
@@ -334,6 +350,121 @@ export function buildManagedCodexHookTrustToml(
     ])
     .join("\n")
     .trimEnd();
+}
+
+function pathSegments(filePath: string): string[] {
+  return filePath.split(/[\\/]+/).filter(Boolean);
+}
+
+export function isRuntimeCodexHomeMirrorPath(
+  hookConfigPath: string,
+  cwd: string = process.cwd(),
+): boolean {
+  if (basename(hookConfigPath) !== "hooks.json") return false;
+
+  const absolutePath = resolve(cwd, hookConfigPath);
+  const relativePath = relative(resolve(cwd), absolutePath);
+  const segments = pathSegments(relativePath);
+  if (relativePath === "" || segments[0] === "..") {
+    return false;
+  }
+
+  const omxIndex = segments.indexOf(".omx");
+  if (omxIndex < 0) return false;
+
+  return (
+    segments[omxIndex + 1] === "runtime" &&
+    segments[omxIndex + 2] === "codex-home" &&
+    segments.length > omxIndex + 4 &&
+    segments[segments.length - 1] === "hooks.json"
+  );
+}
+
+export async function dedupeCodexHookConfigPaths(
+  hookConfigPaths: readonly string[],
+  cwd: string = process.cwd(),
+): Promise<{
+  paths: DedupedCodexHookConfigPath[];
+  skipped: SkippedCodexHookConfigPath[];
+}> {
+  const seenRealpaths = new Set<string>();
+  const paths: DedupedCodexHookConfigPath[] = [];
+  const skipped: SkippedCodexHookConfigPath[] = [];
+
+  for (const hookConfigPath of hookConfigPaths) {
+    if (isRuntimeCodexHomeMirrorPath(hookConfigPath, cwd)) {
+      skipped.push({
+        path: hookConfigPath,
+        reason: "runtime_codex_home_mirror",
+      });
+      continue;
+    }
+
+    let canonicalPath: string;
+    try {
+      canonicalPath = await realpath(hookConfigPath);
+    } catch {
+      canonicalPath = resolve(cwd, hookConfigPath);
+    }
+
+    if (seenRealpaths.has(canonicalPath)) {
+      skipped.push({
+        path: hookConfigPath,
+        reason: "duplicate_realpath",
+        canonicalPath,
+      });
+      continue;
+    }
+
+    seenRealpaths.add(canonicalPath);
+    paths.push({ path: hookConfigPath, reason: "unique" });
+  }
+
+  return { paths, skipped };
+}
+
+const DEFAULT_DISCOVER_HOOK_CONFIG_MAX_FILES = 5_000;
+const DISCOVER_HOOK_CONFIG_EXCLUDED_DIRS = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "target",
+]);
+
+export async function discoverCodexHookConfigPaths(
+  cwd: string = process.cwd(),
+  options: DiscoverCodexHookConfigPathsOptions = {},
+): Promise<{
+  paths: DedupedCodexHookConfigPath[];
+  skipped: SkippedCodexHookConfigPath[];
+}> {
+  const root = resolve(cwd);
+  const maxFiles = options.maxFiles ?? DEFAULT_DISCOVER_HOOK_CONFIG_MAX_FILES;
+  const pending = [root];
+  const candidates: string[] = [];
+  let visitedFiles = 0;
+
+  while (pending.length > 0 && visitedFiles < maxFiles) {
+    const dir = pending.pop()!;
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!DISCOVER_HOOK_CONFIG_EXCLUDED_DIRS.has(entry.name)) {
+          pending.push(fullPath);
+        }
+        continue;
+      }
+
+      if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+      visitedFiles += 1;
+      if (entry.name === "hooks.json") candidates.push(fullPath);
+      if (visitedFiles >= maxFiles) break;
+    }
+  }
+
+  return dedupeCodexHookConfigPaths(candidates, root);
 }
 
 export function mergeManagedCodexHooksConfig(


### PR DESCRIPTION
## Summary
- add Codex hooks.json discovery that skips `.omx/runtime/codex-home/**` mirrors and realpath-dedupes aliases before review/loading
- copy project `hooks.json` into session runtime CODEX_HOME instead of symlinking it, avoiding dirty symlink aliases for new launches
- keep config generation on `[features].hooks = true` with compatibility migration from legacy `codex_hooks`, plus focused idempotency coverage
- add doctor warning/docs for runtime hook mirror surfaces

## Verification
- npm run build
- npm run lint
- npm run check:no-unused
- node --test dist/config/__tests__/codex-hooks.test.js dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/doctor-warning-copy.test.js
- node --test --test-name-pattern "uses a session-scoped CODEX_HOME mirror" dist/cli/__tests__/index.test.js

Closes #2187
