### PR TITLE
Fix Windows Codex hook command generation

### DIFF
--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -20,6 +20,52 @@ describe("codex hooks helpers", () => {
       `"${process.execPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}" "/repo/dist/scripts/codex-native-hook.js"`,
     );
   });
+
+  it("uses portable node invocation for Windows managed hook commands", () => {
+    const config = buildManagedCodexHooksConfig(
+      "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",
+      { platform: "win32" },
+    );
+    const command = (config.hooks.SessionStart[0] as {
+      hooks?: Array<{ command?: string }>;
+    } | undefined)?.hooks?.[0]?.command;
+
+    assert.equal(
+      command,
+      'node "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex\\dist\\scripts\\codex-native-hook.js"',
+    );
+    assert.doesNotMatch(command ?? "", /^"/, "the node launcher must not be a quoted absolute node.exe path");
+    assert.match(command ?? "", /^node "[^"]*Program Files[^"]*codex-native-hook\.js"$/);
+  });
+
+  it("keeps Windows hook script paths quoted when they contain spaces", () => {
+    const merged = JSON.parse(
+      mergeManagedCodexHooksConfig(
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: "Bash",
+                hooks: [{ type: "command", command: "echo keep-me" }],
+              },
+            ],
+          },
+        }),
+        "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",
+        { platform: "win32" },
+      ),
+    ) as { hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>> };
+
+    const commands = merged.hooks.PreToolUse
+      .flatMap((entry) => entry.hooks ?? [])
+      .map((hook) => hook.command);
+
+    assert.ok(commands.includes("echo keep-me"));
+    assert.ok(commands.includes(
+      'node "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex\\dist\\scripts\\codex-native-hook.js"',
+    ));
+  });
+
   it("merges managed wrappers without dropping user hooks", () => {
     const merged = JSON.parse(
       mergeManagedCodexHooksConfig(

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { join } from "path";
+import { join, win32 } from "path";
 
 export const MANAGED_HOOK_EVENTS = [
   "SessionStart",
@@ -61,12 +61,33 @@ function cloneJson<T>(value: T): T {
   return structuredClone(value);
 }
 
+type HookCommandPlatform = NodeJS.Platform;
+
 function quoteCommandPart(value: string): string {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
 function escapeTomlBasicString(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function quoteWindowsCommandPart(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+function buildNativeHookCommand(
+  pkgRoot: string,
+  platform: HookCommandPlatform = process.platform,
+): string {
+  const hookScript = platform === "win32"
+    ? win32.join(pkgRoot, "dist", "scripts", "codex-native-hook.js")
+    : join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
+
+  if (platform === "win32") {
+    return `node ${quoteWindowsCommandPart(hookScript)}`;
+  }
+
+  return `${quoteCommandPart(process.execPath)} ${quoteCommandPart(hookScript)}`;
 }
 
 function buildCommandHook(
@@ -92,9 +113,9 @@ function buildCommandHook(
 
 export function buildManagedCodexHooksConfig(
   pkgRoot: string,
+  options: { platform?: HookCommandPlatform } = {},
 ): ManagedCodexHooksConfig {
-  const hookScript = join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
-  const command = `${quoteCommandPart(process.execPath)} ${quoteCommandPart(hookScript)}`;
+  const command = buildNativeHookCommand(pkgRoot, options.platform);
 
   return {
     hooks: {
@@ -267,8 +288,9 @@ function managedHookStateKey(
 export function buildManagedCodexHookTrustState(
   hooksPath: string,
   pkgRoot: string,
+  options: { platform?: HookCommandPlatform } = {},
 ): Record<string, ManagedCodexHookTrustState> {
-  const managedConfig = buildManagedCodexHooksConfig(pkgRoot);
+  const managedConfig = buildManagedCodexHooksConfig(pkgRoot, options);
   const state: Record<string, ManagedCodexHookTrustState> = {};
 
   for (const eventName of MANAGED_HOOK_EVENTS) {
@@ -299,9 +321,10 @@ export function buildManagedCodexHookTrustState(
 export function buildManagedCodexHookTrustToml(
   hooksPath: string | undefined,
   pkgRoot: string,
+  options: { platform?: HookCommandPlatform } = {},
 ): string {
   if (!hooksPath) return "";
-  const state = buildManagedCodexHookTrustState(hooksPath, pkgRoot);
+  const state = buildManagedCodexHookTrustState(hooksPath, pkgRoot, options);
   return Object.entries(state)
     .sort(([left], [right]) => left.localeCompare(right))
     .flatMap(([key, hookState]) => [
@@ -316,9 +339,14 @@ export function buildManagedCodexHookTrustToml(
 export function mergeManagedCodexHooksConfig(
   existingContent: string | null | undefined,
   pkgRoot: string,
-  hooksPath?: string,
+  hooksPathOrOptions?: string | { platform?: HookCommandPlatform },
+  options: { platform?: HookCommandPlatform } = {},
 ): string {
-  const managedConfig = buildManagedCodexHooksConfig(pkgRoot);
+  const hooksPath = typeof hooksPathOrOptions === "string" ? hooksPathOrOptions : undefined;
+  const resolvedOptions = typeof hooksPathOrOptions === "object" && hooksPathOrOptions !== null
+    ? hooksPathOrOptions
+    : options;
+  const managedConfig = buildManagedCodexHooksConfig(pkgRoot, resolvedOptions);
   const parsed =
     typeof existingContent === "string"
       ? parseCodexHooksConfig(existingContent)
@@ -352,7 +380,7 @@ export function mergeManagedCodexHooksConfig(
       : {};
     nextHooks.state = {
       ...existingState,
-      ...buildManagedCodexHookTrustState(hooksPath, pkgRoot),
+      ...buildManagedCodexHookTrustState(hooksPath, pkgRoot, resolvedOptions),
     };
   }
 


### PR DESCRIPTION
## Summary
- Generate Windows native hook commands as `node "<hook-script>"` instead of quoting an absolute `node.exe` path.
- Preserve existing POSIX command generation using the current JS runtime path.
- Add Windows-path regression coverage for paths with spaces and merge-generated hooks.json entries.

Fixes #2189.

## Verification
- `npm run build`
- `node --test dist/config/__tests__/codex-hooks.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

## Notes
- Not tested on a native Windows Codex 0.129 runtime in this Linux worktree; regression tests simulate Windows path generation.
