### PR TITLE
Fix stateful workflow session isolation

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -411,32 +411,17 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(result.initialized_mode, 'autopilot');
       assert.equal(result.initialized_state_path, '.omx/state/sessions/sess-1/autopilot-state.json');
 
-      const persisted = JSON.parse(await readFile(join(stateDir, SKILL_ACTIVE_STATE_FILE), 'utf-8')) as {
-        skill: string;
-        phase: string;
-        active: boolean;
-        active_skills?: Array<{ skill: string; session_id?: string }>;
-        initialized_mode?: string;
-      };
-      assert.equal(persisted.skill, 'autopilot');
-      assert.equal(persisted.phase, 'ralplan');
-      assert.equal(persisted.active, true);
-      assert.deepEqual(persisted.active_skills, [{
-        skill: 'autopilot',
-        phase: 'ralplan',
-        active: true,
-        activated_at: '2026-02-25T00:00:00.000Z',
-        updated_at: '2026-02-25T00:00:00.000Z',
-        session_id: 'sess-1',
-        thread_id: 'thread-1',
-        turn_id: 'turn-1',
-      }]);
-      assert.equal(persisted.initialized_mode, 'autopilot');
+      assert.equal(
+        existsSync(join(stateDir, SKILL_ACTIVE_STATE_FILE)),
+        false,
+        'session-scoped non-Ralph activation should not create root canonical state when no root state exists',
+      );
 
       const sessionScopedSkillState = JSON.parse(
         await readFile(join(stateDir, 'sessions', 'sess-1', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
-      ) as { active_skills?: Array<{ skill: string; session_id?: string }> };
-      assert.deepEqual(sessionScopedSkillState.active_skills, persisted.active_skills);
+      ) as { active_skills?: Array<{ skill: string; session_id?: string }>; initialized_mode?: string };
+      assert.deepEqual(sessionScopedSkillState.active_skills, result.active_skills);
+      assert.equal(sessionScopedSkillState.initialized_mode, 'autopilot');
 
       const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', 'sess-1', 'autopilot-state.json'), 'utf-8')) as {
         mode: string;
@@ -1091,16 +1076,10 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.ok(result);
       assert.equal(result.skill, 'ralph');
 
-      const rootCanonical = JSON.parse(
-        await readFile(join(stateDir, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
-      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
-      assert.deepEqual(
-        rootCanonical.active_skills?.map(({ skill, phase, session_id }) => ({
-          skill,
-          phase,
-          session_id,
-        })),
-        [{ skill: 'team', phase: 'planning', session_id: 'sess-team-ralph' }],
+      assert.equal(
+        existsSync(join(stateDir, SKILL_ACTIVE_STATE_FILE)),
+        false,
+        'session-scoped team and Ralph activations should stay out of root canonical state when no root state exists',
       );
 
       const sessionCanonical = JSON.parse(
@@ -1411,12 +1390,11 @@ describe('keyword detector skill-active-state lifecycle', () => {
   it('preserves seeded mode progress for same-skill continuation', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-seed-continuation-'));
     const stateDir = join(cwd, '.omx', 'state');
-    const statePath = join(stateDir, SKILL_ACTIVE_STATE_FILE);
     try {
       await mkdir(stateDir, { recursive: true });
       await mkdir(join(stateDir, 'sessions', 'sess-autopilot'), { recursive: true });
       await writeFile(
-        statePath,
+        join(stateDir, 'sessions', 'sess-autopilot', SKILL_ACTIVE_STATE_FILE),
         JSON.stringify({
           version: 1,
           active: true,
@@ -1790,6 +1768,44 @@ describe('keyword detector skill-active-state lifecycle', () => {
 
       assert.equal(result, null);
       assert.equal(existsSync(join(stateDir, 'sessions', 'sess-unknown-prefixed', 'ralph-state.json')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not continue a workflow from another session root canonical entry', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-cross-session-continue-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(stateDir, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: 'autopilot',
+          phase: 'ralplan',
+          session_id: 'sess-a',
+          active_skills: [{ skill: 'autopilot', phase: 'ralplan', active: true, session_id: 'sess-a' }],
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'continue',
+        sessionId: 'sess-b',
+        nowIso: '2026-05-08T00:00:00.000Z',
+      });
+
+      assert.equal(result, null);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-b', SKILL_ACTIVE_STATE_FILE)), false);
+      const rootCanonical = JSON.parse(await readFile(join(stateDir, SKILL_ACTIVE_STATE_FILE), 'utf-8')) as {
+        active_skills?: Array<{ skill: string; session_id?: string }>;
+      };
+      assert.deepEqual(rootCanonical.active_skills, [
+        { skill: 'autopilot', phase: 'ralplan', active: true, session_id: 'sess-a' },
+      ]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1069,7 +1069,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
-  it('preserves root team state when $ralph is activated for the current session', async () => {
+  it('keeps root team state out of the session-scoped Ralph canonical state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-ralph-'));
     const stateDir = join(cwd, '.omx', 'state');
     try {

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -1875,6 +1875,8 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(join(cwd, 'tmux.log')));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1885,15 +1887,17 @@ exit 0
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const skillStatePath = join(stateDir, 'skill-active-state.json');
-      assert.ok(existsSync(skillStatePath), 'skill-active-state.json should be created');
+      const rootSkillStatePath = join(stateDir, 'skill-active-state.json');
+      assert.equal(existsSync(rootSkillStatePath), false, 'session-scoped activation should not write root skill-active-state.json');
+      const skillStatePath = join(sessionStateDir, 'skill-active-state.json');
+      assert.ok(existsSync(skillStatePath), 'session skill-active-state.json should be created');
       const skillState = JSON.parse(await readFile(skillStatePath, 'utf-8')) as {
         skill: string;
         phase: string;
         active: boolean;
       };
       assert.equal(skillState.skill, 'autopilot');
-      assert.equal(skillState.phase, 'ralplan');
+      assert.equal(skillState.phase, 'planning');
       assert.equal(skillState.active, true);
     });
   });
@@ -2004,6 +2008,7 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
+      await writeManagedSessionState(stateDir, cwd);
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(join(cwd, 'tmux.log')));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -2014,7 +2019,12 @@ exit 0
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+      assert.equal(
+        existsSync(join(stateDir, 'skill-active-state.json')),
+        false,
+        'session-scoped deep-interview activation should not write root skill-active-state.json',
+      );
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
         skill: string;
         input_lock?: { active: boolean; blocked_inputs: string[]; message: string };
       };

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -735,8 +735,7 @@ function selectRootSkillStateCopy(
 ): SkillActiveState | null | undefined {
   if (!sessionId) return nextState;
   if (previousRoot) return previousRoot;
-  if (nextState.skill === 'ralph') return null;
-  return nextState;
+  return null;
 }
 
 export async function recordSkillActivation(input: RecordSkillActivationInput): Promise<SkillActiveState | null> {
@@ -746,7 +745,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     : null;
   const previousRoot = await readExistingSkillState(rootStatePath);
   const previousSession = sessionStatePath ? await readExistingSkillState(sessionStatePath) : null;
-  const previous = previousSession ?? previousRoot;
+  const previous = input.sessionId ? previousSession : previousRoot;
   const match = resolveContinuationKeywordMatch(
     input.text,
     previous,

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -832,7 +832,7 @@ describe('state-server directory initialization', () => {
     }
   });
 
-  it('propagates root clears into inherited session canonical copies', async () => {
+  it('does not propagate root clears into isolated session canonical copies', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
 
@@ -886,7 +886,7 @@ describe('state-server directory initialization', () => {
     }
   });
 
-  it('preserves root-scoped team state when session-scoped ralph is added via state_write', async () => {
+  it('keeps root-scoped team state out of session-scoped ralph canonical state', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
 
@@ -945,10 +945,7 @@ describe('state-server directory initialization', () => {
           phase,
           session_id,
         })),
-        [
-          { skill: 'team', phase: 'running', session_id: undefined },
-          { skill: 'ralph', phase: 'executing', session_id: 'sess-team-ralph' },
-        ],
+        [{ skill: 'ralph', phase: 'executing', session_id: 'sess-team-ralph' }],
       );
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -1179,4 +1176,182 @@ describe('state-server directory initialization', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('keeps session-scoped workflow states isolated across writes and clears', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-session-isolation-'));
+    try {
+      const writeA = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-a',
+            mode: 'deep-interview',
+            active: true,
+            current_phase: 'interview-a',
+          },
+        },
+      });
+      assert.equal(writeA.isError, undefined);
+
+      const writeB = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-b',
+            mode: 'ralph',
+            active: true,
+            iteration: 1,
+            max_iterations: 3,
+            current_phase: 'executing',
+          },
+        },
+      });
+      assert.equal(writeB.isError, undefined);
+
+      await handleStateToolCall({
+        params: {
+          name: 'state_clear',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-b',
+            mode: 'ralph',
+          },
+        },
+      });
+
+      const sessionAState = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-a', 'deep-interview-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(sessionAState.active, true);
+      assert.equal(sessionAState.current_phase, 'interview-a');
+
+      const sessionACanonical = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-a', 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; session_id?: string }> };
+      assert.deepEqual(
+        sessionACanonical.active_skills?.map(({ skill, session_id }) => ({ skill, session_id })),
+        [{ skill: 'deep-interview', session_id: 'sess-a' }],
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not auto-complete session workflows from root-scoped workflow writes', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-root-session-isolation-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-interview',
+            mode: 'deep-interview',
+            active: true,
+            current_phase: 'asking',
+          },
+        },
+      });
+
+      const rootWrite = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'ralplan',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+      assert.equal(rootWrite.isError, undefined);
+
+      const sessionState = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-interview', 'deep-interview-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(sessionState.active, true);
+      assert.equal(sessionState.current_phase, 'asking');
+      assert.equal(sessionState.auto_completed_reason, undefined);
+
+      const sessionCanonical = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-interview', 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; session_id?: string }> };
+      assert.deepEqual(
+        sessionCanonical.active_skills?.map(({ skill, session_id }) => ({ skill, session_id })),
+        [{ skill: 'deep-interview', session_id: 'sess-interview' }],
+      );
+
+      const rootState = JSON.parse(await readFile(join(wd, '.omx', 'state', 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(rootState.active, true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps session canonical state when clearing the root scope without all_sessions', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-root-clear-isolation-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-keep',
+            mode: 'deep-interview',
+            active: true,
+            current_phase: 'asking',
+          },
+        },
+      });
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'deep-interview',
+            active: true,
+            current_phase: 'root-asking',
+          },
+        },
+      });
+
+      await handleStateToolCall({
+        params: {
+          name: 'state_clear',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'deep-interview',
+          },
+        },
+      });
+
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'deep-interview-state.json')), false);
+      const sessionState = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-keep', 'deep-interview-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(sessionState.active, true);
+
+      const sessionCanonical = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-keep', 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; session_id?: string }> };
+      assert.deepEqual(
+        sessionCanonical.active_skills?.map(({ skill, session_id }) => ({ skill, session_id })),
+        [{ skill: 'deep-interview', session_id: 'sess-keep' }],
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1101,7 +1101,12 @@ describe("codex native hook dispatch", () => {
       assert.ok(result.outputJson, "UserPromptSubmit should emit developer context");
       assert.match(JSON.stringify(result.outputJson), /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
 
-      const statePath = join(cwd, ".omx", "state", "skill-active-state.json");
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "skill-active-state.json")),
+        false,
+        "session-scoped keyword activation should not write root skill-active-state.json",
+      );
+      const statePath = join(cwd, ".omx", "state", "sessions", "sess-1", "skill-active-state.json");
       assert.equal(existsSync(statePath), true);
       const state = JSON.parse(await readFile(statePath, "utf-8")) as {
         skill?: string;

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -300,6 +300,66 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('isolates same workflow state across explicit session ids when starting and clearing one session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-same-workflow-isolation-'));
+    try {
+      const writeA = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: 'sess-a',
+        mode: 'ralph',
+        active: true,
+        iteration: 1,
+        max_iterations: 5,
+        current_phase: 'executing',
+        state: { task_slug: 'session-a-task' },
+      });
+      assert.equal(writeA.isError, undefined);
+
+      const sessionAStatePath = join(wd, '.omx', 'state', 'sessions', 'sess-a', 'ralph-state.json');
+      const sessionACanonicalPath = join(wd, '.omx', 'state', 'sessions', 'sess-a', 'skill-active-state.json');
+      const sessionAStateBefore = JSON.parse(await readFile(sessionAStatePath, 'utf-8')) as Record<string, unknown>;
+      const sessionACanonicalBefore = JSON.parse(await readFile(sessionACanonicalPath, 'utf-8')) as Record<string, unknown>;
+
+      const writeB = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: 'sess-b',
+        mode: 'ralph',
+        active: true,
+        iteration: 1,
+        max_iterations: 5,
+        current_phase: 'executing',
+        state: { task_slug: 'session-b-task' },
+      });
+      assert.equal(writeB.isError, undefined);
+
+      assert.deepEqual(JSON.parse(await readFile(sessionAStatePath, 'utf-8')), sessionAStateBefore);
+      assert.deepEqual(JSON.parse(await readFile(sessionACanonicalPath, 'utf-8')), sessionACanonicalBefore);
+
+      await executeStateOperation('state_clear', {
+        workingDirectory: wd,
+        session_id: 'sess-b',
+        mode: 'ralph',
+      });
+
+      const activeA = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: 'sess-a',
+      });
+      assert.deepEqual(activeA.payload, { active_modes: ['ralph'] });
+
+      const activeB = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: 'sess-b',
+      });
+      assert.deepEqual(activeB.payload, { active_modes: [] });
+
+      assert.deepEqual(JSON.parse(await readFile(sessionAStatePath, 'utf-8')), sessionAStateBefore);
+      assert.deepEqual(JSON.parse(await readFile(sessionACanonicalPath, 'utf-8')), sessionACanonicalBefore);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('serializes concurrent state_write calls per mode file and preserves merged fields', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-concurrency-'));
     try {
@@ -379,6 +439,40 @@ describe('state operations directory initialization', () => {
       const readBody = readResponse.payload as Record<string, unknown>;
       assert.equal(readBody.active, false);
       assert.equal(readBody.current_phase, 'cleared');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('all_sessions clear removes session-only canonical workflow state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-all-sessions-session-only-'));
+    try {
+      const sessionDir = join(wd, '.omx', 'state', 'sessions', 'sess-only');
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(
+        join(sessionDir, 'ralph-state.json'),
+        JSON.stringify({ active: true, mode: 'ralph', current_phase: 'executing' }, null, 2),
+      );
+      await writeFile(
+        join(sessionDir, 'skill-active-state.json'),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'ralph',
+          session_id: 'sess-only',
+          active_skills: [{ skill: 'ralph', phase: 'executing', active: true, session_id: 'sess-only' }],
+        }, null, 2),
+      );
+
+      const cleared = await executeStateOperation('state_clear', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        all_sessions: true,
+      });
+      assert.equal(cleared.isError, undefined);
+
+      assert.equal(existsSync(join(sessionDir, 'ralph-state.json')), false);
+      assert.equal(existsSync(join(sessionDir, 'skill-active-state.json')), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -49,7 +49,7 @@ describe('skill-active state helpers', () => {
     });
   });
 
-  it('drops stale entries from other sessions when syncing canonical state for the current session', async () => {
+  it('keeps stale root entries from other sessions out of current session state', async () => {
     await withTempRepo('omx-skill-active-filter-', async (cwd) => {
       await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
       await writeSkillActiveStateCopies(cwd, {
@@ -84,17 +84,15 @@ describe('skill-active state helpers', () => {
         active_skills?: Array<{ skill: string; session_id?: string }>;
       };
       assert.deepEqual(rootState.active_skills, [{
-        skill: 'ralph',
-        phase: 'executing',
+        skill: 'deep-interview',
+        phase: 'intent-first',
         active: true,
-        activated_at: '2026-04-08T00:00:00.000Z',
-        updated_at: '2026-04-08T00:00:00.000Z',
-        session_id: 'new-session',
+        session_id: 'old-session',
       }]);
     });
   });
 
-  it('preserves root-scoped team state when a session-scoped ralph overlap is activated', async () => {
+  it('keeps root-scoped team state isolated when session-scoped ralph is activated', async () => {
     await withTempRepo('omx-skill-active-team-ralph-', async (cwd) => {
       await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
       await writeSkillActiveStateCopies(cwd, {
@@ -133,10 +131,7 @@ describe('skill-active state helpers', () => {
           phase,
           session_id,
         })),
-        [
-          { skill: 'team', phase: 'running', session_id: undefined },
-          { skill: 'ralph', phase: 'executing', session_id: 'sess-overlap' },
-        ],
+        [{ skill: 'ralph', phase: 'executing', session_id: 'sess-overlap' }],
       );
     });
   });
@@ -178,8 +173,8 @@ describe('skill-active state helpers', () => {
       );
 
       const rootState = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
-      assert.equal(rootState.initialized_mode, undefined);
-      assert.equal(rootState.initialized_state_path, undefined);
+      assert.equal(rootState.initialized_mode, 'ralph');
+      assert.equal(rootState.initialized_state_path, '.omx/state/sessions/old-session/ralph-state.json');
     });
   });
 
@@ -212,14 +207,8 @@ describe('skill-active state helpers', () => {
 
       const sessionState = await readVisibleSkillActiveState(cwd, 'sess-terminal');
       assert.ok(sessionState);
-      assert.deepEqual(
-        listActiveSkills(sessionState).map(({ skill, phase, session_id }) => ({
-          skill,
-          phase,
-          session_id,
-        })),
-        [{ skill: 'custom-skill', phase: 'running', session_id: undefined }],
-      );
+      assert.equal(sessionState.active, false);
+      assert.deepEqual(listActiveSkills(sessionState), []);
 
       const rootState = JSON.parse(
         await readFile(join(cwd, '.omx', 'state', 'skill-active-state.json'), 'utf-8'),

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -123,16 +123,6 @@ async function initializeStateEnvironment(cwd: string, effectiveSessionId?: stri
   await ensureTmuxHookInitialized(cwd);
 }
 
-async function listStateSessionIds(cwd: string): Promise<string[]> {
-  const sessionsDir = join(getStateDir(cwd), 'sessions');
-  if (!existsSync(sessionsDir)) return [];
-  const entries = await readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
-  return entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .filter((entry) => entry.trim().length > 0);
-}
-
 function hasExplicitStateField(
   fields: Record<string, unknown>,
   customState: unknown,
@@ -309,17 +299,6 @@ export async function executeStateOperation(
 
           if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
             try {
-              if (!effectiveSessionId) {
-                for (const sessionId of await listStateSessionIds(cwd)) {
-                  const sessionTransition = await reconcileWorkflowTransition(cwd, mode, {
-                    action: 'write',
-                    sessionId,
-                    source: 'state-operations',
-                  });
-                  transitionMessage ??= sessionTransition.transitionMessage;
-                }
-              }
-
               const transition = await reconcileWorkflowTransition(cwd, mode, {
                 action: 'write',
                 sessionId: effectiveSessionId,
@@ -417,6 +396,7 @@ export async function executeStateOperation(
             mode,
             active: false,
             source: 'state-operations',
+            allSessions: true,
           });
         }
 

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -64,6 +64,7 @@ export interface SyncCanonicalSkillStateOptions {
   turnId?: string;
   nowIso?: string;
   source?: string;
+  allSessions?: boolean;
 }
 
 function safeString(value: unknown): string {
@@ -172,13 +173,13 @@ export function listActiveSkills(raw: unknown): SkillActiveEntry[] {
     for (const candidate of state.active_skills) {
       const normalized = normalizeSkillActiveEntry(candidate);
       if (!normalized || normalized.active === false) continue;
-      deduped.set(normalized.skill, normalized);
+      deduped.set(entryKey(normalized), normalized);
     }
   }
 
   const topLevelSkill = safeString(state.skill).trim();
   if (deduped.size === 0 && state.active === true && topLevelSkill) {
-    deduped.set(topLevelSkill, {
+    const topLevelEntry = {
       skill: topLevelSkill,
       phase: safeString(state.phase).trim() || undefined,
       active: true,
@@ -187,7 +188,8 @@ export function listActiveSkills(raw: unknown): SkillActiveEntry[] {
       session_id: safeString(state.session_id).trim() || undefined,
       thread_id: safeString(state.thread_id).trim() || undefined,
       turn_id: safeString(state.turn_id).trim() || undefined,
-    });
+    };
+    deduped.set(entryKey(topLevelEntry), topLevelEntry);
   }
 
   return [...deduped.values()];
@@ -288,6 +290,7 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
     turnId,
     nowIso = new Date().toISOString(),
     source = 'state-server',
+    allSessions = false,
   } = options;
 
   if (!tracksCanonicalWorkflowSkill(mode)) return;
@@ -295,15 +298,13 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
   const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
   const existingRoot = await readSkillActiveState(rootPath);
   const existingSession = sessionPath ? await readSkillActiveState(sessionPath) : null;
-  if (!existingRoot && !existingSession && !active) return;
+  if (!existingRoot && !existingSession && !active && !options.allSessions) return;
 
   const normalizedSessionId = safeString(sessionId).trim();
+  const allRootEntries = listActiveSkills(existingRoot ?? {});
   const rootEntries = normalizedSessionId
-    ? listActiveSkills(existingRoot ?? {}).filter((entry) => {
-      const entrySessionId = safeString(entry.session_id).trim();
-      return entrySessionId.length === 0 || entrySessionId === normalizedSessionId;
-    })
-    : listActiveSkills(existingRoot ?? {});
+    ? allRootEntries.filter((entry) => safeString(entry.session_id).trim() === normalizedSessionId)
+    : allRootEntries;
   const sessionOnlyEntries = normalizedSessionId
     ? listActiveSkills(existingSession ?? {}).filter((entry) => (
       safeString(entry.session_id).trim() === normalizedSessionId
@@ -315,7 +316,7 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
     : [];
   const visibleEntries = normalizedSessionId
     ? [...rootEntries, ...sessionOnlyEntries]
-    : [...rootEntries];
+    : rootEntries.filter((entry) => safeString(entry.session_id).trim().length === 0);
 
   if (active && isTrackedWorkflowMode(mode)) {
     const currentWorkflowModes = visibleEntries
@@ -366,14 +367,18 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
       });
     }
 
-    const nextRootEntries = rootEntries.filter((entry) => !(
+    const nextSessionRootEntries = rootEntries.filter((entry) => !(
+      entry.skill === mode
+      && safeString(entry.session_id).trim() === normalizedSessionId
+    ));
+    const nextRootEntries = allRootEntries.filter((entry) => !(
       entry.skill === mode
       && safeString(entry.session_id).trim() === normalizedSessionId
     ));
 
     const nextSessionState = applyEntriesToState(
       existingSession ?? existingRoot,
-      [...nextRootEntries, ...nextSessionEntries],
+      [...nextSessionRootEntries, ...nextSessionEntries],
       mode,
       normalizedSessionId,
     );
@@ -389,19 +394,26 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
     return;
   }
 
-  const nextRootEntries = rootEntries.filter((entry) => entry.skill !== mode);
+  const rootScopedEntries = rootEntries.filter((entry) => safeString(entry.session_id).trim().length === 0);
+  const sessionScopedRootMirrorEntries = allSessions
+    ? []
+    : rootEntries.filter((entry) => safeString(entry.session_id).trim().length > 0);
+  const nextRootScopedEntries = rootScopedEntries.filter((entry) => entry.skill !== mode);
   if (active) {
-    nextRootEntries.push({
+    nextRootScopedEntries.push({
       skill: mode,
       phase: safeString(currentPhase).trim() || undefined,
       active: true,
-      activated_at: rootEntries.find((entry) => entry.skill === mode)?.activated_at || nowIso,
+      activated_at: rootScopedEntries.find((entry) => entry.skill === mode)?.activated_at || nowIso,
       updated_at: nowIso,
       session_id: undefined,
       thread_id: safeString(threadId).trim() || undefined,
       turn_id: safeString(turnId).trim() || undefined,
     });
   }
+  const nextRootEntries = allSessions
+    ? rootEntries.filter((entry) => entry.skill !== mode)
+    : [...sessionScopedRootMirrorEntries, ...nextRootScopedEntries];
 
   const nextRootState = applyEntriesToState(existingRoot, nextRootEntries, mode);
   await writeSkillActiveStateCopies(cwd, nextRootState, undefined, nextRootState);
@@ -418,8 +430,10 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
     if (!existsSync(sessionPath)) continue;
 
     const existingSessionState = await readSkillActiveState(sessionPath);
-    const sessionOnlyEntries = filterSessionOnlyEntries(existingSessionState, rootEntries, sessionId);
-    const nextVisibleRootEntries = filterRootEntriesForSession(nextRootEntries, sessionId);
+    const sessionOnlyEntries = filterSessionOnlyEntries(existingSessionState, rootEntries, sessionId)
+      .filter((entry) => !(allSessions && entry.skill === mode));
+    const nextVisibleRootEntries = nextRootEntries
+      .filter((entry) => safeString(entry.session_id).trim() === sessionId);
     const nextSessionEntries = [...nextVisibleRootEntries, ...sessionOnlyEntries];
 
     if (nextSessionEntries.length === 0) {

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -57,6 +57,7 @@ async function readJsonIfExists(
 async function visibleTrackedModes(cwd: string, sessionId?: string): Promise<TrackedWorkflowMode[]> {
   const canonical = await readVisibleSkillActiveState(cwd, sessionId);
   const canonicalModes = listActiveSkills(canonical ?? {})
+    .filter((entry) => sessionId || safeString(entry.session_id).trim().length === 0)
     .map((entry) => entry.skill)
     .filter(isTrackedWorkflowMode);
 


### PR DESCRIPTION
## Summary
- isolate canonical workflow state by OMX session instead of inheriting root/global workflow entries into session scopes
- stop root-scoped workflow writes from reconciling/autocompleting session workflow states
- keep explicit all_sessions clears as the global cleanup path, including session-only canonical state

## Tests
- env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT npm run build
- env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/state/__tests__/skill-active.test.js dist/state/__tests__/operations.test.js dist/mcp/__tests__/state-server.test.js dist/hooks/__tests__/keyword-detector.test.js
- env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT npm run lint
- env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT npm run check:no-unused

Note: full npm test was attempted with ambient OMX env unset but hit existing unrelated notify/team runtime flakes/timeouts in notify-fallback-watcher, notify-hook-auto-nudge, and team/runtime after 4645 passing tests.