### PR TITLE
Trust setup-owned Codex hooks during setup

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -10,6 +10,7 @@ This page is the canonical answer to:
 
 - `.codex/config.toml` → enables setup-owned runtime feature flags including `[features].hooks = true` and `[features].goals = true`
 - `.codex/hooks.json` → registers the OMX-managed native hook command while preserving non-OMX hook entries already in the file
+- `.codex/config.toml` → also records `hooks.state."<hooks.json>:<event>:<group>:<handler>".trusted_hash` for the OMX-owned wrappers so recent Codex releases do not require a manual `/hooks` review for setup-managed hooks
 
 For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of source control.
 `omx uninstall` removes only the OMX-managed wrapper entries from `.codex/hooks.json`; if user hooks remain, the file stays in place.
@@ -23,6 +24,7 @@ For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of sourc
 - **tmux/runtime fallbacks**: `omx tmux-hook`, notify-hook, derived watcher, idle/session-end reporters
 
 OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js`. User-managed hook entries in the same `.codex/hooks.json` file are preserved across `omx setup` refreshes and `omx uninstall`.
+Setup-owned trust state is limited to those generated wrapper identities; user hooks and user-owned `hooks.state` entries are preserved and remain subject to Codex's normal review flow.
 
 ## Mapping matrix
 

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -229,6 +229,11 @@ describe("omx setup scope behavior", () => {
       assert.match(configToml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
       assert.match(configToml, /^hooks = true$/m);
       assert.match(configToml, /^goals = true$/m);
+      assert.match(
+        configToml,
+        /^\[hooks\.state\.".*\/\.codex\/hooks\.json:session_start:0:0"\]$/m,
+      );
+      assert.match(configToml, /^trusted_hash = "sha256:[a-f0-9]{64}"$/m);
       const hooksJson = JSON.parse(await readFile(localHooks, "utf-8")) as {
         hooks?: Record<string, unknown>;
       };
@@ -287,6 +292,15 @@ describe("omx setup scope behavior", () => {
           2,
         ) + "\n",
       );
+      await writeFile(
+        join(codexDir, "config.toml"),
+        [
+          "[hooks.state.\"custom:/hooks.json:stop:0:0\"]",
+          "trusted_hash = \"sha256:user\"",
+          "enabled = false",
+          "",
+        ].join("\n"),
+      );
 
       const res = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
       if (shouldSkipForSpawnPermissions(res.error)) return;
@@ -318,6 +332,16 @@ describe("omx setup scope behavior", () => {
       assert.doesNotMatch(
         JSON.stringify(hooksJson),
         /\/old\/dist\/scripts\/codex-native-hook\.js/,
+      );
+      const configToml = await readFile(join(codexDir, "config.toml"), "utf-8");
+      assert.match(
+        configToml,
+        /^\[hooks\.state\."custom:\/hooks\.json:stop:0:0"\]$/m,
+      );
+      assert.match(configToml, /^enabled = false$/m);
+      assert.match(
+        configToml,
+        /^\[hooks\.state\.".*\/\.codex\/hooks\.json:stop:0:0"\]$/m,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1982,6 +1982,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		);
 		const managedConfig = await updateManagedConfig(
 			scopeDirs.codexConfigFile,
+			scopeDirs.codexHooksFile,
 			pkgRoot,
 			sharedMcpRegistry,
 			summary.config,
@@ -3055,6 +3056,7 @@ async function cleanupLegacyManagedSkills(
 
 async function updateManagedConfig(
 	configPath: string,
+	hooksPath: string,
 	pkgRoot: string,
 	sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
 	summary: SetupCategorySummary,
@@ -3088,6 +3090,7 @@ async function updateManagedConfig(
 
 	const finalConfig = buildMergedConfig(existing, pkgRoot, {
 		includeTui: omxManagesTui,
+		codexHooksFile: hooksPath,
 		modelOverride,
 		sharedMcpServers: sharedMcpRegistry.servers,
 		sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildManagedCodexHookTrustState,
+  buildManagedCodexHookTrustToml,
   buildManagedCodexHooksConfig,
   getMissingManagedCodexHookEvents,
   mergeManagedCodexHooksConfig,
@@ -50,6 +52,112 @@ describe("codex hooks helpers", () => {
     assert.match(JSON.stringify(sessionStart), /echo keep-me/);
     assert.match(JSON.stringify(sessionStart), /echo standalone-user/);
     assert.doesNotMatch(JSON.stringify(sessionStart), /Loading OMX session context/);
+  });
+
+  it("builds trust state only for generated OMX hook handlers", () => {
+    const state = buildManagedCodexHookTrustState("/home/me/.codex/hooks.json", "/repo");
+    const keys = Object.keys(state).sort();
+
+    assert.deepEqual(keys, [
+      "/home/me/.codex/hooks.json:post_compact:0:0",
+      "/home/me/.codex/hooks.json:post_tool_use:0:0",
+      "/home/me/.codex/hooks.json:pre_compact:0:0",
+      "/home/me/.codex/hooks.json:pre_tool_use:0:0",
+      "/home/me/.codex/hooks.json:session_start:0:0",
+      "/home/me/.codex/hooks.json:stop:0:0",
+      "/home/me/.codex/hooks.json:user_prompt_submit:0:0",
+    ]);
+    for (const hookState of Object.values(state)) {
+      assert.match(hookState.trusted_hash, /^sha256:[a-f0-9]{64}$/);
+    }
+  });
+
+  it("matches Codex's normalized command hook hash identity", async () => {
+    const state = buildManagedCodexHookTrustState("/hooks.json", "/repo");
+    const command =
+      `"${process.execPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}" "/repo/dist/scripts/codex-native-hook.js"`;
+    const expectedIdentity = {
+      event_name: "pre_tool_use",
+      hooks: [
+        {
+          async: false,
+          command,
+          timeout: 600,
+          type: "command",
+        },
+      ],
+      matcher: "Bash",
+    };
+    const canonical = JSON.stringify({
+      event_name: expectedIdentity.event_name,
+      hooks: expectedIdentity.hooks.map((hook) => ({
+        async: hook.async,
+        command: hook.command,
+        timeout: hook.timeout,
+        type: hook.type,
+      })),
+      matcher: expectedIdentity.matcher,
+    });
+    const { createHash } = await import("node:crypto");
+    const expectedHash = `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+
+    assert.equal(state["/hooks.json:pre_tool_use:0:0"]?.trusted_hash, expectedHash);
+  });
+
+  it("serializes managed hook trust state as TOML tables for config.toml", () => {
+    const toml = buildManagedCodexHookTrustToml("/hooks.json", "/repo");
+
+    assert.ok(
+      toml.includes('[hooks.state."/hooks.json:pre_tool_use:0:0"]'),
+    );
+    assert.match(toml, /^trusted_hash = "sha256:[a-f0-9]{64}"$/m);
+    assert.doesNotMatch(toml, /echo keep-me/);
+  });
+
+  it("can preserve existing hook state when explicitly merging trust into hooks.json", () => {
+    const merged = JSON.parse(
+      mergeManagedCodexHooksConfig(
+        JSON.stringify({
+          hooks: {
+            state: {
+              "custom:/hooks.json:stop:0:0": {
+                trusted_hash: "sha256:user",
+                enabled: false,
+              },
+            },
+            Stop: [
+              {
+                hooks: [{ type: "command", command: "echo user-stop" }],
+              },
+            ],
+          },
+        }),
+        "/repo",
+        "/hooks.json",
+      ),
+    ) as {
+      hooks: {
+        state: Record<string, { trusted_hash?: string; enabled?: boolean }>;
+        Stop: Array<{ hooks?: Array<{ command?: string }> }>;
+      };
+    };
+
+    assert.deepEqual(merged.hooks.state["custom:/hooks.json:stop:0:0"], {
+      trusted_hash: "sha256:user",
+      enabled: false,
+    });
+    assert.match(
+      merged.hooks.state["/hooks.json:stop:0:0"]?.trusted_hash ?? "",
+      /^sha256:[a-f0-9]{64}$/,
+    );
+    assert.match(JSON.stringify(merged.hooks.Stop), /echo user-stop/);
+  });
+
+  it("keeps managed hook merge idempotent", () => {
+    const first = mergeManagedCodexHooksConfig(null, "/repo", "/hooks.json");
+    const second = mergeManagedCodexHooksConfig(first, "/repo", "/hooks.json");
+
+    assert.equal(second, first);
   });
 
   it("removes only OMX-managed wrappers during uninstall cleanup", () => {

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { join } from "path";
 
 export const MANAGED_HOOK_EVENTS = [
@@ -14,8 +15,18 @@ type ManagedHookEventName = (typeof MANAGED_HOOK_EVENTS)[number];
 
 type JsonObject = Record<string, unknown>;
 
+export interface ManagedHookEntry {
+  matcher?: string;
+  hooks: Array<{
+    type: "command";
+    command: string;
+    statusMessage?: string;
+    timeout?: number;
+  }>;
+}
+
 export interface ManagedCodexHooksConfig {
-  hooks: Record<ManagedHookEventName, Array<Record<string, unknown>>>;
+  hooks: Record<ManagedHookEventName, ManagedHookEntry[]>;
 }
 
 interface ParsedCodexHooksConfig {
@@ -27,6 +38,20 @@ export interface RemoveManagedCodexHooksResult {
   nextContent: string | null;
   removedCount: number;
 }
+
+export interface ManagedCodexHookTrustState {
+  trusted_hash: string;
+}
+
+const CODEX_HOOK_EVENT_LABELS: Record<ManagedHookEventName, string> = {
+  SessionStart: "session_start",
+  PreToolUse: "pre_tool_use",
+  PostToolUse: "post_tool_use",
+  UserPromptSubmit: "user_prompt_submit",
+  PreCompact: "pre_compact",
+  PostCompact: "post_compact",
+  Stop: "stop",
+};
 
 function isPlainObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -40,6 +65,10 @@ function quoteCommandPart(value: string): string {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
+function escapeTomlBasicString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 function buildCommandHook(
   command: string,
   options: {
@@ -47,13 +76,13 @@ function buildCommandHook(
     statusMessage?: string;
     timeout?: number;
   } = {},
-): Record<string, unknown> {
+): ManagedHookEntry {
   const hook = {
     type: "command",
     command,
     ...(options.statusMessage ? { statusMessage: options.statusMessage } : {}),
     ...(typeof options.timeout === "number" ? { timeout: options.timeout } : {}),
-  };
+  } satisfies ManagedHookEntry["hooks"][number];
 
   return {
     ...(options.matcher ? { matcher: options.matcher } : {}),
@@ -186,9 +215,108 @@ function serializeCodexHooksConfig(root: JsonObject): string {
   return JSON.stringify(root, null, 2) + "\n";
 }
 
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalJson(item));
+  }
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalJson(value[key])]),
+    );
+  }
+  return value;
+}
+
+function versionForCodexTomlIdentity(value: JsonObject): string {
+  const canonical = canonicalJson(value);
+  const serialized = JSON.stringify(canonical);
+  return `sha256:${createHash("sha256").update(serialized).digest("hex")}`;
+}
+
+function normalizedCommandHookIdentity(
+  eventName: ManagedHookEventName,
+  entry: ManagedHookEntry,
+  hook: ManagedHookEntry["hooks"][number],
+): JsonObject {
+  return {
+    event_name: CODEX_HOOK_EVENT_LABELS[eventName],
+    ...(entry.matcher ? { matcher: entry.matcher } : {}),
+    hooks: [
+      {
+        type: "command",
+        command: hook.command,
+        timeout: Math.max(1, hook.timeout ?? 600),
+        async: false,
+        ...(hook.statusMessage ? { statusMessage: hook.statusMessage } : {}),
+      },
+    ],
+  };
+}
+
+function managedHookStateKey(
+  hooksPath: string,
+  eventName: ManagedHookEventName,
+  groupIndex: number,
+  handlerIndex: number,
+): string {
+  return `${hooksPath}:${CODEX_HOOK_EVENT_LABELS[eventName]}:${groupIndex}:${handlerIndex}`;
+}
+
+export function buildManagedCodexHookTrustState(
+  hooksPath: string,
+  pkgRoot: string,
+): Record<string, ManagedCodexHookTrustState> {
+  const managedConfig = buildManagedCodexHooksConfig(pkgRoot);
+  const state: Record<string, ManagedCodexHookTrustState> = {};
+
+  for (const eventName of MANAGED_HOOK_EVENTS) {
+    const entries = managedConfig.hooks[eventName] as ManagedHookEntry[];
+    entries.forEach((entry, groupIndex) => {
+      entry.hooks.forEach((hook, handlerIndex) => {
+        if (hook.type !== "command" || !isOmxManagedHookCommand(hook.command)) {
+          return;
+        }
+        const key = managedHookStateKey(
+          hooksPath,
+          eventName,
+          groupIndex,
+          handlerIndex,
+        );
+        state[key] = {
+          trusted_hash: versionForCodexTomlIdentity(
+            normalizedCommandHookIdentity(eventName, entry, hook),
+          ),
+        };
+      });
+    });
+  }
+
+  return state;
+}
+
+export function buildManagedCodexHookTrustToml(
+  hooksPath: string | undefined,
+  pkgRoot: string,
+): string {
+  if (!hooksPath) return "";
+  const state = buildManagedCodexHookTrustState(hooksPath, pkgRoot);
+  return Object.entries(state)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .flatMap(([key, hookState]) => [
+      `[hooks.state."${escapeTomlBasicString(key)}"]`,
+      `trusted_hash = "${escapeTomlBasicString(hookState.trusted_hash)}"`,
+      "",
+    ])
+    .join("\n")
+    .trimEnd();
+}
+
 export function mergeManagedCodexHooksConfig(
   existingContent: string | null | undefined,
   pkgRoot: string,
+  hooksPath?: string,
 ): string {
   const managedConfig = buildManagedCodexHooksConfig(pkgRoot);
   const parsed =
@@ -216,6 +344,16 @@ export function mergeManagedCodexHooksConfig(
       ...preservedEntries,
       ...managedConfig.hooks[eventName].map((entry) => cloneJson(entry)),
     ];
+  }
+
+  if (hooksPath) {
+    const existingState = isPlainObject(nextHooks.state)
+      ? cloneJson(nextHooks.state)
+      : {};
+    nextHooks.state = {
+      ...existingState,
+      ...buildManagedCodexHookTrustState(hooksPath, pkgRoot),
+    };
   }
 
   if (Object.keys(nextHooks).length > 0) {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -18,10 +18,12 @@ import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 import { getOmxFirstPartySetupMcpServers } from "./omx-first-party-mcp.js";
+import { buildManagedCodexHookTrustToml } from "./codex-hooks.js";
 import type { HudPreset } from "../hud/types.js";
 
 interface MergeOptions {
   includeTui?: boolean;
+  codexHooksFile?: string;
   modelOverride?: string;
   sharedMcpServers?: UnifiedMcpRegistryServer[];
   sharedMcpRegistrySource?: string;
@@ -1410,6 +1412,7 @@ function getOmxTablesBlock(
   pkgRoot: string,
   includeTui = true,
   statusLinePreset: HudPreset = DEFAULT_STATUS_LINE_PRESET,
+  codexHooksFile?: string,
 ): string {
   const lines = [
     "",
@@ -1433,6 +1436,14 @@ function getOmxTablesBlock(
     if (typeof server.startupTimeoutSec === "number") {
       lines.push(`startup_timeout_sec = ${server.startupTimeoutSec}`);
     }
+  }
+
+  const hookTrustToml = buildManagedCodexHookTrustToml(codexHooksFile, pkgRoot);
+  if (hookTrustToml) {
+    lines.push("");
+    lines.push("# OMX-owned Codex hook trust state");
+    lines.push("# Trusts only setup-managed codex-native-hook.js wrappers.");
+    lines.push(hookTrustToml);
   }
 
   lines.push(
@@ -1517,6 +1528,7 @@ export function buildMergedConfig(
     pkgRoot,
     includeTui && !tuiUpsert.hadExistingTui,
     statusLinePreset,
+    options.codexHooksFile,
   );
   const sharedRegistryBlock = getSharedMcpRegistryBlock(
     options.sharedMcpServers ?? [],


### PR DESCRIPTION
## Summary
- add Codex-compatible trusted_hash generation for OMX-owned codex-native-hook.js wrappers
- write setup-owned hook trust state into config.toml for the generated hooks.json path
- preserve user hook entries and user hook state while documenting the review boundary

## Verification
- npm run build
- node --test dist/config/__tests__/codex-hooks.test.js dist/cli/__tests__/setup-scope.test.js
- npx tsc --noEmit --pretty false

## Not tested
- Live Codex TUI /hooks screen after installing the package