### PR TITLE
fix: dedupe managed hook trust state

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -738,6 +738,7 @@ describe("omx setup install mode behavior", () => {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
 				await withTempCwd(wd, async () => {
 					await setup({ scope: "user", installMode: "plugin" });
+					await setup({ scope: "user", installMode: "plugin" });
 
 					const hooks = await readFile(
 						join(codexHomeDir, "hooks.json"),
@@ -747,13 +748,31 @@ describe("omx setup install mode behavior", () => {
 					const config = await readFile(
 						join(codexHomeDir, "config.toml"),
 						"utf-8",
-						);
-						assert.match(config, /^codex_hooks = true$/m);
-						assert.match(config, /^goals = true$/m);
-						assert.match(config, /^\[hooks\.state\.".*hooks\.json:pre_tool_use:0:0"\]$/m);
-						assert.match(config, /^trusted_hash = "sha256:[a-f0-9]{64}"$/m);
-						assert.doesNotMatch(
-							config,
+					);
+					const parsed = parseToml(config) as {
+						hooks?: { state?: Record<string, unknown> };
+					};
+					const managedHookStateKeys = Object.keys(
+						parsed.hooks?.state ?? {},
+					).filter((key) => key.includes(`${codexHomeDir}/hooks.json:`));
+					assert.equal(managedHookStateKeys.length, 7);
+					assert.match(config, /^codex_hooks = true$/m);
+					assert.match(config, /^goals = true$/m);
+					assert.match(
+						config,
+						/^\[hooks\.state\.".*hooks\.json:pre_tool_use:0:0"\]$/m,
+					);
+					assert.equal(
+						(
+							config.match(
+								/^\[hooks\.state\.".*hooks\.json:pre_tool_use:0:0"\]$/gm,
+							) ?? []
+						).length,
+						1,
+					);
+					assert.match(config, /^trusted_hash = "sha256:[a-f0-9]{64}"$/m);
+					assert.doesNotMatch(
+						config,
 							/developer_instructions|notify-hook|mcp_servers/,
 					);
 					assert.equal(

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -13,6 +13,7 @@ import {
   cleanCodexModelAvailabilityNuxIfNeeded,
   mergeConfig,
   repairConfigIfNeeded,
+  stripManagedCodexHookTrustState,
   upsertManagedCodexHookTrustState,
 } from "../generator.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../omx-first-party-mcp.js";
@@ -1022,6 +1023,33 @@ describe("config generator idempotency (#384)", () => {
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
+  });
+
+  it("preserves trailing user config after an unmatched managed hook trust-state start marker", () => {
+    const malformed = [
+      'model = "gpt-5.5"',
+      "",
+      "# OMX-owned Codex hook trust state",
+      "# Missing the end fence must not cause trailing user config deletion.",
+      "",
+      '[hooks.state."custom:/hooks.json:stop:0:0"]',
+      'trusted_hash = "sha256:user"',
+      "enabled = false",
+      "",
+      "[hooks.state.user_prompt_submit]",
+      'trusted_hash = "sha256:prompt"',
+      "enabled = true",
+      "",
+    ].join("\n");
+
+    const stripped = stripManagedCodexHookTrustState(malformed);
+
+    assert.match(stripped, /^# OMX-owned Codex hook trust state$/m);
+    assert.match(stripped, /^\[hooks\.state\."custom:\/hooks\.json:stop:0:0"\]$/m);
+    assert.match(stripped, /^enabled = false$/m);
+    assert.match(stripped, /^\[hooks\.state\.user_prompt_submit\]$/m);
+    assert.match(stripped, /^trusted_hash = "sha256:prompt"$/m);
+    assert.doesNotThrow(() => TOML.parse(stripped));
   });
 
   it("dedupes prior fenced managed hook trust-state blocks before writing a replacement", () => {

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -8,7 +8,13 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import TOML from "@iarna/toml";
-import { buildMergedConfig, cleanCodexModelAvailabilityNuxIfNeeded, mergeConfig, repairConfigIfNeeded } from "../generator.js";
+import {
+  buildMergedConfig,
+  cleanCodexModelAvailabilityNuxIfNeeded,
+  mergeConfig,
+  repairConfigIfNeeded,
+  upsertManagedCodexHookTrustState,
+} from "../generator.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../omx-first-party-mcp.js";
 
 /** Count occurrences of a pattern in text */
@@ -122,6 +128,43 @@ function assertSingleOmxBlock(toml: string): void {
       `[mcp_servers.${name}] command should be absolute`,
     );
   }
+}
+
+function assertSingleManagedHookTrustState(toml: string): void {
+  const parsed = TOML.parse(toml) as {
+    hooks?: { state?: Record<string, { trusted_hash?: unknown }> };
+  };
+  const managedKeys = Object.keys(parsed.hooks?.state ?? {}).filter((key) =>
+    key.startsWith("/tmp/codex/hooks.json:"),
+  );
+
+  assert.deepEqual(
+    managedKeys.sort(),
+    [
+      "/tmp/codex/hooks.json:post_compact:0:0",
+      "/tmp/codex/hooks.json:post_tool_use:0:0",
+      "/tmp/codex/hooks.json:pre_compact:0:0",
+      "/tmp/codex/hooks.json:pre_tool_use:0:0",
+      "/tmp/codex/hooks.json:session_start:0:0",
+      "/tmp/codex/hooks.json:stop:0:0",
+      "/tmp/codex/hooks.json:user_prompt_submit:0:0",
+    ],
+  );
+  assert.equal(
+    count(toml, /^# OMX-owned Codex hook trust state$/gm),
+    1,
+    "managed hook trust fence should appear once",
+  );
+  assert.equal(
+    count(toml, /^# End OMX-owned Codex hook trust state$/gm),
+    1,
+    "managed hook trust end fence should appear once",
+  );
+  assert.equal(
+    count(toml, /^\[hooks\.state\."\/tmp\/codex\/hooks\.json:/gm),
+    managedKeys.length,
+    "managed hook trust tables should not duplicate",
+  );
 }
 
 describe("Codex transient TUI NUX cleanup", () => {
@@ -979,6 +1022,52 @@ describe("config generator idempotency (#384)", () => {
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
+  });
+
+  it("dedupes prior fenced managed hook trust-state blocks before writing a replacement", () => {
+    const first = upsertManagedCodexHookTrustState(
+      [
+        'model = "gpt-5.5"',
+        "",
+        '[hooks.state."custom:/hooks.json:stop:0:0"]',
+        'trusted_hash = "sha256:user"',
+        "enabled = false",
+        "",
+      ].join("\n"),
+      "/tmp/omx",
+      "/tmp/codex/hooks.json",
+    );
+    const brokenWithDuplicatePriorBlock = `${first}\n${first.slice(
+      first.indexOf("# OMX-owned Codex hook trust state"),
+    )}`;
+    assert.equal(
+      count(
+        brokenWithDuplicatePriorBlock,
+        /^\[hooks\.state\."\/tmp\/codex\/hooks\.json:stop:0:0"\]$/gm,
+      ),
+      2,
+      "regression fixture should contain duplicate managed trust tables",
+    );
+
+    const repaired = upsertManagedCodexHookTrustState(
+      brokenWithDuplicatePriorBlock,
+      "/tmp/omx",
+      "/tmp/codex/hooks.json",
+    );
+    const repeated = upsertManagedCodexHookTrustState(
+      repaired,
+      "/tmp/omx",
+      "/tmp/codex/hooks.json",
+    );
+
+    assert.equal(repeated, repaired);
+    assert.match(
+      repaired,
+      /^\[hooks\.state\."custom:\/hooks\.json:stop:0:0"\]$/m,
+      "unrelated user hook state should be preserved",
+    );
+    assert.match(repaired, /^enabled = false$/m);
+    assertSingleManagedHookTrustState(repaired);
   });
 
   it("syncs shared MCP registry entries in a dedicated managed block", async () => {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -526,21 +526,29 @@ const OMX_HOOK_TRUST_END_MARKER = "# End OMX-owned Codex hook trust state";
 export function stripManagedCodexHookTrustState(config: string): string {
   const lines = config.split(/\r?\n/);
   const kept: string[] = [];
-  let insideManagedBlock = false;
 
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed === OMX_HOOK_TRUST_START_MARKER) {
-      insideManagedBlock = true;
+  for (let i = 0; i < lines.length;) {
+    const trimmed = lines[i].trim();
+    if (trimmed !== OMX_HOOK_TRUST_START_MARKER) {
+      kept.push(lines[i]);
+      i += 1;
       continue;
     }
-    if (insideManagedBlock) {
-      if (trimmed === OMX_HOOK_TRUST_END_MARKER) {
-        insideManagedBlock = false;
-      }
+
+    const nextEndIdx = lines.findIndex(
+      (line, index) => index > i && line.trim() === OMX_HOOK_TRUST_END_MARKER,
+    );
+    const nextStartIdx = lines.findIndex(
+      (line, index) => index > i && line.trim() === OMX_HOOK_TRUST_START_MARKER,
+    );
+
+    if (nextEndIdx === -1 || (nextStartIdx !== -1 && nextStartIdx < nextEndIdx)) {
+      kept.push(lines[i]);
+      i += 1;
       continue;
     }
-    kept.push(line);
+
+    i = nextEndIdx + 1;
   }
 
   return kept.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -524,11 +524,26 @@ const OMX_HOOK_TRUST_START_MARKER = "# OMX-owned Codex hook trust state";
 const OMX_HOOK_TRUST_END_MARKER = "# End OMX-owned Codex hook trust state";
 
 export function stripManagedCodexHookTrustState(config: string): string {
-  const blockPattern = new RegExp(
-    `\n?${OMX_HOOK_TRUST_START_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\n[\\s\\S]*?${OMX_HOOK_TRUST_END_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\n?`,
-    "g",
-  );
-  return config.replace(blockPattern, "\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+  const lines = config.split(/\r?\n/);
+  const kept: string[] = [];
+  let insideManagedBlock = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === OMX_HOOK_TRUST_START_MARKER) {
+      insideManagedBlock = true;
+      continue;
+    }
+    if (insideManagedBlock) {
+      if (trimmed === OMX_HOOK_TRUST_END_MARKER) {
+        insideManagedBlock = false;
+      }
+      continue;
+    }
+    kept.push(line);
+  }
+
+  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
 }
 
 export function upsertManagedCodexHookTrustState(
@@ -1536,6 +1551,7 @@ export function buildMergedConfig(
 
   existing = stripOmxTopLevelKeys(existing);
   existing = stripOrphanedManagedNotify(existing);
+  existing = stripManagedCodexHookTrustState(existing);
   if (options.modelOverride) {
     existing = stripRootLevelKeys(existing, ["model"]);
   }


### PR DESCRIPTION
## Summary
- Fixes #2197
- Replaces all existing OMX-owned hook trust-state fenced blocks before writing fresh managed `[hooks.state.*]` TOML.
- Preserves unrelated user config and user-owned hook state outside the OMX fence.
- Adds regression coverage for duplicate prior fenced trust blocks and repeated user-scope plugin setup parsing.

## Verification
- `git diff --check`
- `npm run build`
- `node --test dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/setup-install-mode.test.js`
- `npm run lint`