### PR TITLE
fix: preserve user hook enablement on uninstall

### DIFF
--- a/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
+++ b/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
@@ -262,6 +262,17 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
         false,
         "uninstall should strip only OMX-managed wrappers",
       );
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.match(
+        config,
+        /^codex_hooks = true$/m,
+        "uninstall should keep native Codex hooks enabled for preserved user hooks",
+      );
+      assert.doesNotMatch(config, /^hooks = true$/m);
+      assert.doesNotMatch(config, /^multi_agent\s*=/m);
+      assert.doesNotMatch(config, /^child_agents_md\s*=/m);
+      assert.doesNotMatch(config, /^goals\s*=/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -375,6 +375,53 @@ describe('omx uninstall', () => {
       assert.match(hooks, /echo keep-me/);
       assert.match(hooks, /"version": 1/);
       assert.doesNotMatch(hooks, /codex-native-hook\.js/);
+
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      assert.match(config, /^codex_hooks = true$/m);
+      assert.doesNotMatch(config, /^hooks = true$/m);
+      assert.doesNotMatch(config, /^multi_agent\s*=/m);
+      assert.doesNotMatch(config, /^child_agents_md\s*=/m);
+      assert.doesNotMatch(config, /^goals\s*=/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not preserve hooks feature flag from non-features tables', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        `${buildOmxConfig().replace('codex_hooks = true\n', '')}\n[user.settings]\nhooks = true\n`,
+      );
+      await writeFile(
+        join(codexDir, 'hooks.json'),
+        JSON.stringify({
+          hooks: {
+            SessionStart: [
+              {
+                hooks: [
+                  { type: 'command', command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
+                  { type: 'command', command: 'echo keep-me' },
+                ],
+              },
+            ],
+          },
+        }) + '\n',
+      );
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      const featuresBlock = config.match(/^\[features\]\n(?:(?!^\[).*\n?)*/m)?.[0] ?? '';
+      assert.doesNotMatch(featuresBlock, /^hooks = true$/m);
+      assert.doesNotMatch(featuresBlock, /^codex_hooks = true$/m);
+      assert.match(config, /^\[user\.settings\]\nhooks = true$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -10,9 +10,11 @@ import {
   stripOmxEnvSettings,
   stripOmxTopLevelKeys,
   stripOmxFeatureFlags,
+  upsertCodexHooksFeatureFlag,
   stripOmxSeededBehavioralDefaults,
 } from "../config/generator.js";
 import {
+  hasUserCodexHooksAfterManagedRemoval,
   parseCodexHooksConfig,
   removeManagedCodexHooks,
 } from "../config/codex-hooks.js";
@@ -97,9 +99,44 @@ function detectOmxConfigArtifacts(config: string): {
   };
 }
 
+function hasNativeHooksFeatureFlag(config: string): boolean {
+  const lines = config.split(/\r?\n/);
+  const featuresStart = lines.findIndex((line) =>
+    /^\s*\[features\]\s*$/.test(line),
+  );
+  if (featuresStart < 0) return false;
+
+  let sectionEnd = lines.length;
+  for (let i = featuresStart + 1; i < lines.length; i++) {
+    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
+      sectionEnd = i;
+      break;
+    }
+  }
+
+  return lines
+    .slice(featuresStart + 1, sectionEnd)
+    .some((line) => /^\s*(?:hooks|codex_hooks)\s*=\s*true/.test(line));
+}
+
+async function shouldPreserveHooksFeatureFlag(
+  hooksFilePath: string,
+): Promise<boolean> {
+  if (!existsSync(hooksFilePath)) return false;
+
+  try {
+    const existing = await readFile(hooksFilePath, "utf-8");
+    return hasUserCodexHooksAfterManagedRemoval(existing);
+  } catch {
+    return false;
+  }
+}
+
 async function cleanConfig(
   configPath: string,
-  options: Pick<UninstallOptions, "dryRun" | "verbose">,
+  options: Pick<UninstallOptions, "dryRun" | "verbose"> & {
+    preserveHooksFeatureFlag?: boolean;
+  },
 ): Promise<
   Pick<
     UninstallSummary,
@@ -127,6 +164,8 @@ async function cleanConfig(
 
   const original = await readFile(configPath, "utf-8");
   const detected = detectOmxConfigArtifacts(original);
+  const shouldRestoreHooksFeatureFlag =
+    options.preserveHooksFeatureFlag && hasNativeHooksFeatureFlag(original);
 
   result.mcpServersRemoved = detected.hasMcpServers;
   result.agentEntriesRemoved = detected.hasAgentEntries;
@@ -147,6 +186,9 @@ async function cleanConfig(
 
   // Strip feature flags
   config = stripOmxFeatureFlags(config);
+  if (shouldRestoreHooksFeatureFlag) {
+    config = upsertCodexHooksFeatureFlag(config);
+  }
 
   // Strip OMX-managed env defaults
   config = stripOmxEnvSettings(config);
@@ -391,7 +433,9 @@ function printSummary(summary: UninstallSummary, dryRun: boolean): void {
       );
     }
     if (summary.featureFlagsRemoved) {
-      console.log("    Feature flags (multi_agent, child_agents_md, hooks, goals)");
+      console.log(
+        "    Feature flags (multi_agent, child_agents_md, goals; hooks preserved when user hooks remain)",
+      );
     }
   } else if (!summary.configCleaned && summary.mcpServersRemoved.length === 0) {
     console.log("  config.toml: no OMX entries found (or --keep-config used)");
@@ -477,6 +521,9 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
   };
 
   summary.legacySkillRootWarning = await detectLegacySkillRootWarning(scope);
+  const preserveHooksFeatureFlag = await shouldPreserveHooksFeatureFlag(
+    scopeDirs.codexHooksFile,
+  );
 
   // Step 1: Clean config.toml
   if (keepConfig) {
@@ -486,6 +533,7 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
     const configResult = await cleanConfig(scopeDirs.codexConfigFile, {
       dryRun,
       verbose,
+      preserveHooksFeatureFlag,
     });
     Object.assign(summary, configResult);
   }

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -5,6 +5,7 @@ import {
   buildManagedCodexHookTrustToml,
   buildManagedCodexHooksConfig,
   getMissingManagedCodexHookEvents,
+  hasUserCodexHooksAfterManagedRemoval,
   mergeManagedCodexHooksConfig,
   removeManagedCodexHooks,
 } from "../codex-hooks.js";
@@ -188,7 +189,39 @@ describe("codex hooks helpers", () => {
     assert.match(removedMixed.nextContent, /"version": 1/);
   });
 
+  it("detects user hooks that remain after managed wrapper removal", () => {
+    const managedOnly = JSON.stringify(buildManagedCodexHooksConfig("/repo"));
+    const mixed = JSON.stringify({
+      hooks: {
+        state: {
+          "custom:/hooks.json:stop:0:0": {
+            trusted_hash: "sha256:user",
+          },
+        },
+        SessionStart: [
+          {
+            hooks: [
+              { type: "command", command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
+              { type: "command", command: "echo keep-me" },
+            ],
+          },
+        ],
+      },
+    });
+    const stateOnly = JSON.stringify({
+      hooks: {
+        state: {
+          "custom:/hooks.json:stop:0:0": {
+            trusted_hash: "sha256:user",
+          },
+        },
+      },
+    });
 
+    assert.equal(hasUserCodexHooksAfterManagedRemoval(managedOnly), false);
+    assert.equal(hasUserCodexHooksAfterManagedRemoval(mixed), true);
+    assert.equal(hasUserCodexHooksAfterManagedRemoval(stateOnly), false);
+  });
 
   it("registers managed compact hook wrappers", () => {
     const config = buildManagedCodexHooksConfig("/repo");

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -415,3 +415,24 @@ export function removeManagedCodexHooks(
     removedCount,
   };
 }
+
+export function hasCodexHookEntries(content: string): boolean {
+  const parsed = parseCodexHooksConfig(content);
+  if (!parsed) return false;
+
+  return Object.entries(parsed.hooks).some(([eventName, rawEntries]) => {
+    if (eventName === "state" || !Array.isArray(rawEntries)) return false;
+    return rawEntries.some((entry) => {
+      return isPlainObject(entry) &&
+        Array.isArray(entry.hooks) &&
+        entry.hooks.length > 0;
+    });
+  });
+}
+
+export function hasUserCodexHooksAfterManagedRemoval(
+  existingContent: string,
+): boolean {
+  const { nextContent } = removeManagedCodexHooks(existingContent);
+  return nextContent !== null && hasCodexHookEntries(nextContent);
+}

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -910,6 +910,41 @@ export function stripOmxFeatureFlags(config: string): string {
   return filtered.join("\n");
 }
 
+/**
+ * Preserve native Codex hook enablement without re-adding other OMX feature
+ * flags. Used by uninstall when user-owned hooks remain in hooks.json.
+ */
+export function upsertCodexHooksFeatureFlag(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const featuresStart = lines.findIndex((line) =>
+    /^\s*\[features\]\s*$/.test(line),
+  );
+
+  if (featuresStart < 0) {
+    const base = config.trimEnd();
+    const featureBlock = ["[features]", "codex_hooks = true", ""].join("\n");
+    return base.length === 0 ? featureBlock : `${base}\n${featureBlock}`;
+  }
+
+  let sectionEnd = lines.length;
+  for (let i = featuresStart + 1; i < lines.length; i++) {
+    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
+      sectionEnd = i;
+      break;
+    }
+  }
+
+  for (let i = featuresStart + 1; i < sectionEnd; i++) {
+    if (/^\s*(?:hooks|codex_hooks)\s*=/.test(lines[i])) {
+      lines[i] = "codex_hooks = true";
+      return lines.join("\n");
+    }
+  }
+
+  lines.splice(sectionEnd, 0, "codex_hooks = true");
+  return lines.join("\n");
+}
+
 export function stripOmxEnvSettings(config: string): string {
   let lines = config.split(/\r?\n/);
   lines = stripTomlTableKey(lines, /^\s*\[env\]\s*$/, OMX_EXPLORE_CMD_ENV);


### PR DESCRIPTION
## Summary
- resolves the maintainer-side rebase of #2198 against current `dev`
- preserves native Codex hook enablement on `omx uninstall` only when the original `[features]` enabled `hooks`/`codex_hooks` and user-owned hook commands remain after managed wrapper removal
- keeps current `dev` hook behavior: runtime hook mirror dedupe, Windows managed hook command behavior, hook trust-state handling, and `codex_hooks` normalization

## Notes
- `hooks.state` trust metadata alone is not treated as a user hook entry
- unrelated `hooks = true` keys outside `[features]` do not re-enable native hooks
- replacement for conflicted external PR #2198; do not merge #2198 separately

## Verification
- `npm run build`
- `node --test dist/config/__tests__/codex-hooks.test.js dist/cli/__tests__/uninstall.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js`
- `npm run lint`
- `git diff --check`
- `git diff --cached --check`
