### PR TITLE
Fix hooks.json trust state placement

### DIFF
--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -167,10 +167,16 @@ describe("codex hooks helpers", () => {
     assert.doesNotMatch(toml, /echo keep-me/);
   });
 
-  it("can preserve existing hook state when explicitly merging trust into hooks.json", () => {
+  it("keeps hooks.json trust state outside the hook event map", () => {
     const merged = JSON.parse(
       mergeManagedCodexHooksConfig(
         JSON.stringify({
+          state: {
+            "custom:/hooks.json:prompt:0:0": {
+              trusted_hash: "sha256:top-level-user",
+              enabled: true,
+            },
+          },
           hooks: {
             state: {
               "custom:/hooks.json:stop:0:0": {
@@ -189,18 +195,25 @@ describe("codex hooks helpers", () => {
         "/hooks.json",
       ),
     ) as {
-      hooks: {
-        state: Record<string, { trusted_hash?: string; enabled?: boolean }>;
-        Stop: Array<{ hooks?: Array<{ command?: string }> }>;
-      };
+      state: Record<string, { trusted_hash?: string; enabled?: boolean }>;
+      hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
     };
 
-    assert.deepEqual(merged.hooks.state["custom:/hooks.json:stop:0:0"], {
+    assert.equal(Object.hasOwn(merged.hooks, "state"), false);
+    assert.ok(
+      Object.values(merged.hooks).every(Array.isArray),
+      "Codex Rust hook discovery expects hooks.hooks values to be event arrays",
+    );
+    assert.deepEqual(merged.state["custom:/hooks.json:stop:0:0"], {
       trusted_hash: "sha256:user",
       enabled: false,
     });
+    assert.deepEqual(merged.state["custom:/hooks.json:prompt:0:0"], {
+      trusted_hash: "sha256:top-level-user",
+      enabled: true,
+    });
     assert.match(
-      merged.hooks.state["/hooks.json:stop:0:0"]?.trusted_hash ?? "",
+      merged.state["/hooks.json:stop:0:0"]?.trusted_hash ?? "",
       /^sha256:[a-f0-9]{64}$/,
     );
     assert.match(JSON.stringify(merged.hooks.Stop), /echo user-stop/);
@@ -217,6 +230,11 @@ describe("codex hooks helpers", () => {
     const managedOnly = JSON.stringify(buildManagedCodexHooksConfig("/repo"));
     const preserved = JSON.stringify({
       hooks: {
+        state: {
+          "custom:/hooks.json:session_start:0:0": {
+            trusted_hash: "sha256:user",
+          },
+        },
         SessionStart: [
           {
             hooks: [
@@ -233,12 +251,32 @@ describe("codex hooks helpers", () => {
     assert.equal(removedManagedOnly.removedCount > 0, true);
     assert.equal(removedManagedOnly.nextContent, null);
 
+    const generatedWithTrustState = mergeManagedCodexHooksConfig(
+      null,
+      "/repo",
+      "/hooks.json",
+    );
+    const removedGeneratedWithTrustState = removeManagedCodexHooks(
+      generatedWithTrustState,
+    );
+    assert.equal(removedGeneratedWithTrustState.removedCount > 0, true);
+    assert.equal(removedGeneratedWithTrustState.nextContent, null);
+
     const removedMixed = removeManagedCodexHooks(preserved);
     assert.equal(removedMixed.removedCount, 1);
     assert.ok(removedMixed.nextContent);
     assert.match(removedMixed.nextContent, /echo keep-me/);
     assert.doesNotMatch(removedMixed.nextContent, /codex-native-hook\.js/);
     assert.match(removedMixed.nextContent, /"version": 1/);
+
+    const cleaned = JSON.parse(removedMixed.nextContent) as {
+      state?: Record<string, { trusted_hash?: string }>;
+      hooks?: Record<string, unknown>;
+    };
+    assert.equal(Object.hasOwn(cleaned.hooks ?? {}, "state"), false);
+    assert.deepEqual(cleaned.state?.["custom:/hooks.json:session_start:0:0"], {
+      trusted_hash: "sha256:user",
+    });
   });
 
   it("detects user hooks that remain after managed wrapper removal", () => {

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -219,6 +219,72 @@ describe("codex hooks helpers", () => {
     assert.match(JSON.stringify(merged.hooks.Stop), /echo user-stop/);
   });
 
+  it("preserves top-level managed hook state metadata while updating trusted_hash", () => {
+    const managedState = buildManagedCodexHookTrustState("/hooks.json", "/repo");
+    const managedKey = Object.keys(managedState).find((key) =>
+      key.includes(":stop:"),
+    ) ?? Object.keys(managedState)[0];
+    assert.ok(managedKey);
+
+    const merged = JSON.parse(
+      mergeManagedCodexHooksConfig(
+        JSON.stringify({
+          state: {
+            [managedKey]: {
+              trusted_hash: "sha256:old",
+              enabled: false,
+            },
+          },
+        }),
+        "/repo",
+        "/hooks.json",
+      ),
+    ) as {
+      state: Record<string, { trusted_hash?: string; enabled?: boolean }>;
+      hooks: Record<string, unknown>;
+    };
+
+    assert.equal(Object.hasOwn(merged.hooks, "state"), false);
+    assert.deepEqual(merged.state[managedKey], {
+      trusted_hash: managedState[managedKey]?.trusted_hash,
+      enabled: false,
+    });
+  });
+
+  it("migrates misplaced managed hook state metadata while updating trusted_hash", () => {
+    const managedState = buildManagedCodexHookTrustState("/hooks.json", "/repo");
+    const managedKey = Object.keys(managedState).find((key) =>
+      key.includes(":stop:"),
+    ) ?? Object.keys(managedState)[0];
+    assert.ok(managedKey);
+
+    const merged = JSON.parse(
+      mergeManagedCodexHooksConfig(
+        JSON.stringify({
+          hooks: {
+            state: {
+              [managedKey]: {
+                trusted_hash: "sha256:old",
+                enabled: false,
+              },
+            },
+          },
+        }),
+        "/repo",
+        "/hooks.json",
+      ),
+    ) as {
+      state: Record<string, { trusted_hash?: string; enabled?: boolean }>;
+      hooks: Record<string, unknown>;
+    };
+
+    assert.equal(Object.hasOwn(merged.hooks, "state"), false);
+    assert.deepEqual(merged.state[managedKey], {
+      trusted_hash: managedState[managedKey]?.trusted_hash,
+      enabled: false,
+    });
+  });
+
   it("keeps managed hook merge idempotent", () => {
     const first = mergeManagedCodexHooksConfig(null, "/repo", "/hooks.json");
     const second = mergeManagedCodexHooksConfig(first, "/repo", "/hooks.json");

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -515,10 +515,20 @@ export function mergeManagedCodexHooksConfig(
   const nextState = {
     ...misplacedHookState,
     ...existingRootState,
-    ...(hooksPath
-      ? buildManagedCodexHookTrustState(hooksPath, pkgRoot, resolvedOptions)
-      : {}),
   };
+
+  const managedTrustState = hooksPath
+    ? buildManagedCodexHookTrustState(hooksPath, pkgRoot, resolvedOptions)
+    : {};
+  for (const [key, hookState] of Object.entries(managedTrustState)) {
+    const existingHookState = isPlainObject(nextState[key])
+      ? nextState[key]
+      : {};
+    nextState[key] = {
+      ...existingHookState,
+      trusted_hash: hookState.trusted_hash,
+    };
+  }
   if (Object.keys(nextState).length > 0) {
     nextRoot.state = nextState;
   } else if (isPlainObject(nextRoot.state)) {

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -485,6 +485,10 @@ export function mergeManagedCodexHooksConfig(
 
   const nextRoot = parsed ? cloneJson(parsed.root) : {};
   const nextHooks = parsed ? cloneJson(parsed.hooks) : {};
+  const misplacedHookState = isPlainObject(nextHooks.state)
+    ? cloneJson(nextHooks.state)
+    : {};
+  delete nextHooks.state;
 
   for (const eventName of MANAGED_HOOK_EVENTS) {
     const existingEntries = Array.isArray(nextHooks[eventName])
@@ -505,14 +509,20 @@ export function mergeManagedCodexHooksConfig(
     ];
   }
 
-  if (hooksPath) {
-    const existingState = isPlainObject(nextHooks.state)
-      ? cloneJson(nextHooks.state)
-      : {};
-    nextHooks.state = {
-      ...existingState,
-      ...buildManagedCodexHookTrustState(hooksPath, pkgRoot, resolvedOptions),
-    };
+  const existingRootState = isPlainObject(nextRoot.state)
+    ? cloneJson(nextRoot.state)
+    : {};
+  const nextState = {
+    ...misplacedHookState,
+    ...existingRootState,
+    ...(hooksPath
+      ? buildManagedCodexHookTrustState(hooksPath, pkgRoot, resolvedOptions)
+      : {}),
+  };
+  if (Object.keys(nextState).length > 0) {
+    nextRoot.state = nextState;
+  } else if (isPlainObject(nextRoot.state)) {
+    delete nextRoot.state;
   }
 
   if (Object.keys(nextHooks).length > 0) {
@@ -534,6 +544,10 @@ export function removeManagedCodexHooks(
 
   const nextRoot = cloneJson(parsed.root);
   const nextHooks = cloneJson(parsed.hooks);
+  const misplacedHookState = isPlainObject(nextHooks.state)
+    ? cloneJson(nextHooks.state)
+    : {};
+  delete nextHooks.state;
   let removedCount = 0;
 
   for (const [eventName, rawEntries] of Object.entries(nextHooks)) {
@@ -559,7 +573,25 @@ export function removeManagedCodexHooks(
     return { nextContent: existingContent, removedCount: 0 };
   }
 
-  if (Object.keys(nextHooks).length > 0) {
+  const hasRemainingHookEntries = Object.keys(nextHooks).length > 0;
+  if (hasRemainingHookEntries) {
+    const existingRootState = isPlainObject(nextRoot.state)
+      ? cloneJson(nextRoot.state)
+      : {};
+    const nextState = {
+      ...misplacedHookState,
+      ...existingRootState,
+    };
+    if (Object.keys(nextState).length > 0) {
+      nextRoot.state = nextState;
+    } else if (isPlainObject(nextRoot.state)) {
+      delete nextRoot.state;
+    }
+  } else {
+    delete nextRoot.state;
+  }
+
+  if (hasRemainingHookEntries) {
     nextRoot.hooks = nextHooks;
   } else {
     delete nextRoot.hooks;


### PR DESCRIPTION
## Summary
- keep managed `hooks.json` trust metadata out of the `hooks` event map
- migrate/repair existing bad `hooks.state` into top-level `state` during managed merges
- preserve user-owned hook entries/state and keep managed-only uninstall cleanup deleting the file

Fixes #2197.

## Validation
- `npm run build`
- `node --test dist/config/__tests__/codex-hooks.test.js dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js dist/cli/__tests__/uninstall.test.js`
- `npm run lint`
- `git diff --check`
- LSP diagnostics: 0 errors on touched files
- Ralph architect verification: APPROVED

## Notes
Full `npm test` was attempted after installing dependencies, but this attached tmux session still reports unrelated environment-sensitive failures in adapt/autoresearch/tmux/MCP suites. The targeted hook/setup/uninstall regression coverage for this root-cause track is green.

This is separate from #2199, which remains scoped to TOML fenced `[hooks.state.*]` trust-state dedupe.
