### PR TITLE
fix(planning): preserve team launch signatures

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -788,6 +788,58 @@ describe('parseTeamStartArgs', () => {
     }
   });
 
+  it('uses the persisted team launch signature to disambiguate a short approved follow-up', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-signature-'));
+    const previousCwd = process.cwd();
+    const approvedTask = 'Execute approved issue 2042 plan';
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-2042.md');
+      const testSpecPath = join(plansDir, 'test-spec-issue-2042.md');
+      await writeFile(
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-2042')),
+          '',
+          `Launch via omx team 2:executor "${approvedTask}"`,
+          `Launch via $team ralph 5:debugger "${approvedTask}"`,
+        ].join('\n'),
+      );
+      await writeFile(testSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'issue-2042', prdPath, testSpecPath);
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(stateDir, 'team-state.json'),
+        JSON.stringify({
+          active: true,
+          team_name: 'signature-followup-team',
+          task_description: approvedTask,
+          agent_count: 2,
+          agentType: 'executor',
+          linkedRalph: false,
+        }, null, 2),
+      );
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, approvedTask);
+      assert.equal(result.parsed.workerCount, 2);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
+      assert.equal(
+        result.parsed.approvedExecution?.command,
+        `omx team 2:executor "${approvedTask}"`,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 
   it('does not opt normal team startup into repo-aware DAG handoff even when a stale sidecar exists', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-dag-normal-'));
@@ -825,6 +877,79 @@ describe('parseTeamStartArgs', () => {
 
       const result = parseTeamStartArgs(['3:executor', 'Execute', 'approved', 'issue', '831', 'plan']);
       assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('matches the full approved team launch signature for same-task explicit launches', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-dag-signature-match-'));
+    const previousCwd = process.cwd();
+    const approvedTask = 'Execute approved issue 2043 plan';
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-2043.md');
+      const testSpecPath = join(plansDir, 'test-spec-issue-2043.md');
+      await writeFile(
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-2043')),
+          '',
+          `Launch via omx team 2:executor "${approvedTask}"`,
+          `Launch via $team ralph 5:debugger "${approvedTask}"`,
+        ].join('\n'),
+      );
+      await writeFile(testSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'issue-2043', prdPath, testSpecPath);
+
+      const result = parseTeamStartArgs(['2:executor', 'Execute', 'approved', 'issue', '2043', 'plan']);
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
+      assert.equal(result.parsed.approvedExecution?.task, approvedTask);
+      assert.equal(
+        result.parsed.approvedExecution?.command,
+        `omx team 2:executor "${approvedTask}"`,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers the exact omx team command when same-signature duplicates are present', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-dag-command-match-'));
+    const previousCwd = process.cwd();
+    const approvedTask = 'Execute approved issue 2044 plan';
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-2044.md');
+      const testSpecPath = join(plansDir, 'test-spec-issue-2044.md');
+      await writeFile(
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-2044')),
+          '',
+          `Launch via omx team 2:executor "${approvedTask}"`,
+          `Launch via $team 2:executor "${approvedTask}"`,
+        ].join('\n'),
+      );
+      await writeFile(testSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'issue-2044', prdPath, testSpecPath);
+
+      const result = parseTeamStartArgs(['2:executor', 'Execute', 'approved', 'issue', '2044', 'plan']);
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
+      assert.equal(
+        result.parsed.approvedExecution?.command,
+        `omx team 2:executor "${approvedTask}"`,
+      );
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -172,6 +172,23 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
     && existingTeamState.team_state_root.trim() !== ''
     ? existingTeamState.team_state_root.trim()
     : undefined;
+  const persistedTask = typeof existingTeamState?.task_description === 'string'
+    ? existingTeamState.task_description.trim()
+    : typeof existingTeamState?.task === 'string'
+      ? existingTeamState.task.trim()
+      : '';
+  const persistedWorkerCount = typeof existingTeamState?.agent_count === 'number'
+    ? existingTeamState.agent_count
+    : typeof existingTeamState?.workerCount === 'number'
+      ? existingTeamState.workerCount
+      : null;
+  const persistedAgentType = typeof existingTeamState?.agentType === 'string'
+    && existingTeamState.agentType.trim() !== ''
+    ? existingTeamState.agentType.trim()
+    : undefined;
+  const persistedLinkedRalph = typeof existingTeamState?.linkedRalph === 'boolean'
+    ? existingTeamState.linkedRalph
+    : undefined;
   let approvedHint: ApprovedExecutionLaunchHint | null = null;
 
   if (persistedTeamName !== '') {
@@ -202,7 +219,12 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
   }
 
   if (!approvedHint) {
-    const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team');
+    const approvedHintOutcome = readApprovedExecutionLaunchHintOutcome(cwd, 'team', {
+      ...(persistedTask !== '' ? { task: persistedTask } : {}),
+      ...(persistedWorkerCount != null ? { workerCount: persistedWorkerCount } : {}),
+      ...(persistedAgentType ? { agentType: persistedAgentType } : {}),
+      ...(persistedLinkedRalph != null ? { linkedRalph: persistedLinkedRalph } : {}),
+    });
     if (approvedHintOutcome.status === 'ambiguous') {
       throw new Error('approved_execution_hint_ambiguous:team');
     }
@@ -213,17 +235,7 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
     approvedHint = approvedHintOutcome.hint;
   }
 
-  const persistedTask = typeof existingTeamState?.task_description === 'string'
-    ? existingTeamState.task_description
-    : typeof existingTeamState?.task === 'string'
-      ? existingTeamState.task
-      : null;
-  const persistedWorkerCount = typeof existingTeamState?.agent_count === 'number'
-    ? existingTeamState.agent_count
-    : typeof existingTeamState?.workerCount === 'number'
-      ? existingTeamState.workerCount
-      : null;
-  if (persistedTask && persistedWorkerCount && persistedTask.trim() === approvedHint.task.trim()) {
+  if (persistedTask !== '' && persistedWorkerCount && persistedTask === approvedHint.task.trim()) {
     return {
       task: persistedTask,
       workerCount: persistedWorkerCount,
@@ -242,6 +254,23 @@ function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFoll
     explicitAgentType: approvedHint.agentType != null,
     approvedHint,
   };
+}
+
+function buildExplicitOmxTeamLaunchCommand(
+  task: string,
+  workerCount: number,
+  explicitWorkerCount: boolean,
+  agentType: string,
+  explicitAgentType: boolean,
+): string | null {
+  if (!explicitWorkerCount) {
+    return null;
+  }
+
+  const countToken = explicitAgentType
+    ? `${workerCount}:${agentType}`
+    : String(workerCount);
+  return `omx team ${countToken} ${JSON.stringify(task)}`;
 }
 
 const MIN_WORKER_COUNT = 1;
@@ -860,9 +889,31 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     }
   }
 
+  const explicitApprovedCommand = followupContext == null
+    ? buildExplicitOmxTeamLaunchCommand(
+      effectiveTask,
+      workerCount,
+      explicitWorkerCount,
+      agentType,
+      explicitAgentType,
+    )
+    : null;
+  const exactCommandHintOutcome = explicitApprovedCommand
+    ? readApprovedExecutionLaunchHintOutcome(cwd, 'team', {
+      task: effectiveTask,
+      command: explicitApprovedCommand,
+    })
+    : null;
   const approvedHintOutcome = followupContext
     ? null
-    : readApprovedExecutionLaunchHintOutcome(cwd, 'team', { task: effectiveTask });
+    : exactCommandHintOutcome && exactCommandHintOutcome.status !== 'absent'
+      ? exactCommandHintOutcome
+    : readApprovedExecutionLaunchHintOutcome(cwd, 'team', {
+      task: effectiveTask,
+      workerCount,
+      agentType,
+      linkedRalph: false,
+    });
   const approvedHint = followupContext?.approvedHint
     ?? (approvedHintOutcome?.status === 'resolved' && approvedHintOutcome.hint.contextPackStatus !== 'missing-baseline'
       ? approvedHintOutcome.hint
@@ -874,9 +925,11 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     && isApprovedExecutionContextReadyStatus(followupReadyApprovedHint.contextPackStatus)
     ? followupReadyApprovedHint
     : null;
-  const matchesApprovedLaunchHint = followupReadyApprovedHint?.task.trim() === effectiveTask.trim()
+  const matchesApprovedLaunchHint = followupContext == null
+    && followupReadyApprovedHint?.task.trim() === effectiveTask.trim()
     && (followupReadyApprovedHint.workerCount == null || followupReadyApprovedHint.workerCount === workerCount)
-    && (followupReadyApprovedHint.agentType == null || followupReadyApprovedHint.agentType === agentType);
+    && (followupReadyApprovedHint.agentType == null || followupReadyApprovedHint.agentType === agentType)
+    && Boolean(followupReadyApprovedHint.linkedRalph) === false;
   const allowRepoAwareDagHandoff = followupContext != null || matchesApprovedLaunchHint;
   const dagFallbackReason = followupContext == null
     && approvedHintOutcome?.status === 'resolved'

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -638,6 +638,63 @@ describe('planning artifacts', () => {
     assert.equal(hint, null);
   });
 
+  it('uses the requested team launch signature to disambiguate same-task launch hints', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const sharedTask = 'Execute shared team handoff';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-910-signature.md'),
+      [
+        '# PRD',
+        '',
+        `Launch via omx team 2:executor ${JSON.stringify(sharedTask)}`,
+        `Launch via $team ralph 5:debugger ${JSON.stringify(sharedTask)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-910-signature.md'), '# Test Spec\n');
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'team', {
+      task: sharedTask,
+      workerCount: 2,
+      agentType: 'executor',
+      linkedRalph: false,
+    });
+
+    assert.equal(outcome.status, 'resolved');
+    if (outcome.status !== 'resolved') {
+      throw new Error('expected a resolved team launch-hint outcome');
+    }
+    assert.equal(outcome.hint.command, `omx team 2:executor ${JSON.stringify(sharedTask)}`);
+    assert.equal(outcome.hint.workerCount, 2);
+    assert.equal(outcome.hint.agentType, 'executor');
+    assert.equal(outcome.hint.linkedRalph, false);
+  });
+
+  it('keeps same-task team launch-hint selection ambiguous when the full signature repeats', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const sharedTask = 'Execute shared duplicate team handoff';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-910-same-signature.md'),
+      [
+        '# PRD',
+        '',
+        `Launch via omx team 2:executor ${JSON.stringify(sharedTask)}`,
+        `Launch via $team 2:executor ${JSON.stringify(sharedTask)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-910-same-signature.md'), '# Test Spec\n');
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'team', {
+      task: sharedTask,
+      workerCount: 2,
+      agentType: 'executor',
+      linkedRalph: false,
+    });
+
+    assert.equal(outcome.status, 'ambiguous');
+  });
+
   it('rehydrates the exact team launch hint by command when one PRD repeats the same task', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     const sharedTask = 'Ship feature';

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -94,6 +94,9 @@ interface ApprovedExecutionLaunchHintReadOptions {
   prdPath?: string;
   task?: string;
   command?: string;
+  workerCount?: number;
+  agentType?: string;
+  linkedRalph?: boolean;
 }
 
 export type ApprovedExecutionLaunchHintOutcome =
@@ -376,6 +379,8 @@ type LaunchHintSelection =
   | { status: 'ambiguous' }
   | { status: 'unique'; match: RegExpMatchArray; task: string };
 
+type LaunchHintMatchFilter = (match: RegExpMatchArray, task: string) => boolean;
+
 function launchHintPattern(mode: 'team' | 'ralph'): RegExp {
   return mode === 'team'
     ? /(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi
@@ -393,6 +398,7 @@ function selectLaunchHintMatch(
   matches: RegExpMatchArray[],
   normalizedTask?: string,
   normalizedCommand?: string,
+  matchFilter?: LaunchHintMatchFilter,
 ): LaunchHintSelection {
   if (normalizedCommand) {
     const exactMatches = matches.flatMap((match) => {
@@ -401,7 +407,10 @@ function selectLaunchHintMatch(
         return [];
       }
       const task = match.groups?.task ? decodeApprovedExecutionQuotedValue(match.groups.task) : null;
-      return task ? [{ match, task }] : [];
+      if (!task) {
+        return [];
+      }
+      return [{ match, task }];
     });
     if (exactMatches.length === 0) return { status: 'no-match' };
     if (exactMatches.length > 1) return { status: 'ambiguous' };
@@ -411,7 +420,13 @@ function selectLaunchHintMatch(
   if (!normalizedTask) {
     const decodedMatches = matches.flatMap((match) => {
       const task = match.groups?.task ? decodeApprovedExecutionQuotedValue(match.groups.task) : null;
-      return task ? [{ match, task }] : [];
+      if (!task) {
+        return [];
+      }
+      if (matchFilter && !matchFilter(match, task)) {
+        return [];
+      }
+      return [{ match, task }];
     });
     if (decodedMatches.length === 0) return { status: 'no-match' };
     if (decodedMatches.length > 1) return { status: 'ambiguous' };
@@ -420,11 +435,58 @@ function selectLaunchHintMatch(
 
   const exactMatches = matches.flatMap((match) => {
     const task = match.groups?.task ? decodeApprovedExecutionQuotedValue(match.groups.task) : null;
-    return task && task.trim() === normalizedTask ? [{ match, task }] : [];
+    if (!task || task.trim() !== normalizedTask) {
+      return [];
+    }
+    if (matchFilter && !matchFilter(match, task)) {
+      return [];
+    }
+    return [{ match, task }];
   });
   if (exactMatches.length === 0) return { status: 'no-match' };
   if (exactMatches.length > 1) return { status: 'ambiguous' };
   return { status: 'unique', ...exactMatches[0]! };
+}
+
+function hasRequestedTeamLaunchSignature(
+  options: ApprovedExecutionLaunchHintReadOptions,
+): boolean {
+  return options.workerCount != null
+    || options.agentType != null
+    || options.linkedRalph != null;
+}
+
+function matchesRequestedTeamLaunchSignature(
+  match: RegExpMatchArray,
+  options: ApprovedExecutionLaunchHintReadOptions,
+): boolean {
+  const groups = match.groups;
+  if (!groups) {
+    return false;
+  }
+
+  if (options.workerCount != null) {
+    const workerCount = Number.parseInt(groups.count ?? '', 10);
+    if (!Number.isFinite(workerCount) || workerCount !== options.workerCount) {
+      return false;
+    }
+  }
+
+  if (options.agentType != null) {
+    const requestedAgentType = options.agentType.trim();
+    const actualAgentType = groups.role?.trim() || '';
+    if (actualAgentType !== requestedAgentType) {
+      return false;
+    }
+  }
+
+  if (options.linkedRalph != null) {
+    if (Boolean(groups.ralph?.trim()) !== options.linkedRalph) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 export function readApprovedExecutionLaunchHintOutcome(
@@ -435,10 +497,16 @@ export function readApprovedExecutionLaunchHintOutcome(
   const approvedPlan = readApprovedPlanText(cwd, options, true);
   if (!approvedPlan) return { status: 'absent' };
 
+  const teamMatchFilter = mode === 'team'
+    && !options.command
+    && hasRequestedTeamLaunchSignature(options)
+    ? (match: RegExpMatchArray, _task: string) => matchesRequestedTeamLaunchSignature(match, options)
+    : undefined;
   const selected = selectLaunchHintMatch(
     collectLaunchHintMatches(approvedPlan.content, mode),
     options.task?.trim(),
     options.command?.trim(),
+    teamMatchFilter,
   );
   if (selected.status === 'ambiguous') return { status: 'ambiguous' };
   if (selected.status !== 'unique' || !selected.match.groups) return { status: 'absent' };


### PR DESCRIPTION
## Summary

Same-task approved Team handoffs can still widen to the wrong launch when the
plan contains multiple Team launch lines with the same task text but different
staffing or Ralph linkage.

This change keeps Team approved-handoff reuse bound to the launch signature
that current `dev` already knows privately, without adding any new public
surface.

## Changes

- preserve task-only Team launch-hint selection with `workerCount`,
  `agentType`, and `linkedRalph`
- thread persisted Team follow-up state into short approved follow-up reuse
- prefer the exact `omx team ...` command for explicit Team launches before
  falling back to signature matching
- add planning and CLI regressions for mixed-signature and same-signature
  duplicate Team launch hints

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- `node --test dist/planning/__tests__/artifacts.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/approved-execution.test.js dist/pipeline/__tests__/stages.test.js`
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `node dist/scripts/generate-catalog-docs.js --check`
- `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`
  passed outside the sandbox on this machine after the sandboxed run hit known
  loopback/tmux `EPERM` restrictions
- `node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__ dist/ralph/__tests__ dist/ralplan/__tests__ dist/runtime/__tests__`
  passed outside the sandbox on this machine after the sandboxed run hit known
  tmux/process-permission restrictions
- `npm run coverage:team-critical:compiled`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- None
