### PR TITLE
fix(team): preserve role-agnostic approved hints

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -920,6 +920,80 @@ describe('parseTeamStartArgs', () => {
     }
   });
 
+  it('matches role-agnostic approved team hints for default executor launches', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-dag-role-agnostic-default-'));
+    const previousCwd = process.cwd();
+    const approvedTask = 'Execute approved issue 2045 plan';
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-2045.md');
+      const testSpecPath = join(plansDir, 'test-spec-issue-2045.md');
+      await writeFile(
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-2045')),
+          '',
+          `Launch via omx team 3 "${approvedTask}"`,
+        ].join('\n'),
+      );
+      await writeFile(testSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'issue-2045', prdPath, testSpecPath);
+
+      const result = parseTeamStartArgs(['Execute', 'approved', 'issue', '2045', 'plan']);
+      assert.equal(result.parsed.workerCount, 3);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
+      assert.equal(
+        result.parsed.approvedExecution?.command,
+        `omx team 3 "${approvedTask}"`,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('matches role-agnostic approved team hints when fallback must ignore the default executor role', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-dag-role-agnostic-fallback-'));
+    const previousCwd = process.cwd();
+    const approvedTask = 'Execute approved issue 2046 plan';
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-2046.md');
+      const testSpecPath = join(plansDir, 'test-spec-issue-2046.md');
+      await writeFile(
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-2046')),
+          '',
+          `Launch via $team 3 "${approvedTask}"`,
+        ].join('\n'),
+      );
+      await writeFile(testSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'issue-2046', prdPath, testSpecPath);
+
+      const result = parseTeamStartArgs(['3', 'Execute', 'approved', 'issue', '2046', 'plan']);
+      assert.equal(result.parsed.workerCount, 3);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
+      assert.equal(
+        result.parsed.approvedExecution?.command,
+        `$team 3 "${approvedTask}"`,
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('prefers the exact omx team command when same-signature duplicates are present', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-dag-command-match-'));
     const previousCwd = process.cwd();

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -911,7 +911,7 @@ export function parseTeamArgs(args: string[], cwd: string = process.cwd()): Pars
     : readApprovedExecutionLaunchHintOutcome(cwd, 'team', {
       task: effectiveTask,
       workerCount,
-      agentType,
+      ...(explicitAgentType ? { agentType } : {}),
       linkedRalph: false,
     });
   const approvedHint = followupContext?.approvedHint


### PR DESCRIPTION
## Summary

Merged PR #2202 tightened same-task approved Team reuse to the launch signature, but the Team CLI fallback still treated the implicit default `executor` role as if it were an explicit approved signature.

That breaks role-agnostic approved hints such as `Launch via omx team 3 "..."` and `Launch via $team 3 "..."` for equivalent default Team launches, which silently disables repo-aware approved handoff even though the task and worker count still match.

## Changes

- only constrain fallback approved Team hint lookup by `agentType` when the launch explicitly requested a role
- keep exact-command matching authoritative before falling back to signature matching
- preserve role-agnostic approved hints for bare and count-only default Team launches
- add focused CLI regressions for both role-agnostic launch forms

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- `npx tsc --noEmit`
- `npm run check:no-unused`
- focused node test reruns skipped at requester instruction for this follow-up PR

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- Follow-up to `#2202`
- Merged baseline on `dev`: `6ee2903f`
- Document-refresh: not-needed | private approved Team launch-hint repair only