### PR TITLE
feat(planning): expose ready context-pack role refs

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -184,6 +184,7 @@ const approvedHint: ApprovedExecutionLaunchHint = {
   deepInterviewSpecPaths: ['.omx/specs/deep-interview-issue-1072.md'],
   contextPack: null,
   contextPackStatus: 'plan-only',
+  contextPackRoleRefs: null,
   missingRequiredContextPackRoles: [],
   contextPackIssues: [],
   repositoryContextSummary: {

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -284,6 +284,7 @@ describe('planning artifacts', () => {
     assert.equal(selection.prdPath, join(plansDir, 'prd-20260427T153100Z-alpha.md'));
     assert.deepEqual(selection.testSpecPaths, []);
     assert.equal(selection.contextPackStatus, 'missing-baseline');
+    assert.equal(selection.contextPackRoleRefs, null);
     assert.deepEqual(selection.missingRequiredContextPackRoles, []);
     assert.deepEqual(selection.contextPackIssues, ['Approved plan is missing a matching test spec.']);
 
@@ -293,6 +294,7 @@ describe('planning artifacts', () => {
       throw new Error('expected missing-baseline approved hint outcome');
     }
     assert.equal(outcome.hint.contextPackStatus, 'missing-baseline');
+    assert.equal(outcome.hint.contextPackRoleRefs, null);
     assert.deepEqual(outcome.hint.testSpecPaths, []);
     assert.deepEqual(outcome.hint.contextPackIssues, ['Approved plan is missing a matching test spec.']);
 
@@ -319,11 +321,13 @@ describe('planning artifacts', () => {
 
     assert.equal(selection.contextPack, null);
     assert.equal(selection.contextPackStatus, 'plan-only');
+    assert.equal(selection.contextPackRoleRefs, null);
     assert.deepEqual(selection.missingRequiredContextPackRoles, []);
     assert.deepEqual(selection.contextPackIssues, []);
     assert.ok(hint);
     assert.equal(hint?.contextPack, null);
     assert.equal(hint?.contextPackStatus, 'plan-only');
+    assert.equal(hint?.contextPackRoleRefs, null);
     assert.deepEqual(hint?.missingRequiredContextPackRoles, []);
     assert.deepEqual(hint?.contextPackIssues, []);
   });
@@ -346,11 +350,24 @@ describe('planning artifacts', () => {
     await writeFile(testSpecPath, '# Test Spec\n');
     const packPath = await writeContextPack('context-ready', prdPath, testSpecPath, ['scope', 'build', 'verify']);
 
+    const selection = readLatestPlanningArtifacts(tempDir);
     const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
 
+    assert.deepEqual(selection.contextPack, { path: packPath });
+    assert.equal(selection.contextPackStatus, 'ready');
+    assert.deepEqual(selection.contextPackRoleRefs, {
+      scope: ['src/scope-0.ts'],
+      build: ['src/build-1.ts'],
+      verify: ['src/verify-2.ts'],
+    });
     assert.ok(hint);
     assert.deepEqual(hint?.contextPack, { path: packPath });
     assert.equal(hint?.contextPackStatus, 'ready');
+    assert.deepEqual(hint?.contextPackRoleRefs, {
+      scope: ['src/scope-0.ts'],
+      build: ['src/build-1.ts'],
+      verify: ['src/verify-2.ts'],
+    });
     assert.deepEqual(hint?.missingRequiredContextPackRoles, []);
     assert.deepEqual(hint?.contextPackIssues, []);
   });
@@ -378,6 +395,7 @@ describe('planning artifacts', () => {
 
     assert.ok(hint);
     assert.equal(hint?.contextPackStatus, 'invalid');
+    assert.equal(hint?.contextPackRoleRefs, null);
     assert.deepEqual(hint?.missingRequiredContextPackRoles, []);
     assert.ok(hint?.contextPackIssues.some((issue) => issue.includes('basis test-spec hash')));
   });
@@ -405,6 +423,7 @@ describe('planning artifacts', () => {
 
     assert.ok(hint);
     assert.equal(hint?.contextPackStatus, 'invalid');
+    assert.equal(hint?.contextPackRoleRefs, null);
     assert.deepEqual(hint?.missingRequiredContextPackRoles, ['build', 'verify']);
     assert.ok(hint?.contextPackIssues.some((issue) => issue.includes('basis test-spec hash')));
   });

--- a/src/planning/__tests__/ready-context-pack-role-refs.test.ts
+++ b/src/planning/__tests__/ready-context-pack-role-refs.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { readReadyContextPackRoleRefs } from '../context-pack-status.js';
+
+let tempDir: string;
+
+function computeGitBlobSha1(content: string): string {
+  const buffer = Buffer.from(content, 'utf-8');
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function relativeToRepo(path: string): string {
+  return relative(tempDir, path).replaceAll('\\', '/');
+}
+
+function canonicalContextPackRelativePath(slug: string): string {
+  return `.omx/context/context-20260507T120000Z-${slug}.json`;
+}
+
+async function setup(): Promise<void> {
+  tempDir = await mkdtemp(join(tmpdir(), 'omx-context-pack-role-refs-'));
+}
+
+async function cleanup(): Promise<void> {
+  if (tempDir && existsSync(tempDir)) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function writeContextPack(
+  slug: string,
+  entries: Array<{ path: string; roles: string[] }>,
+): Promise<string> {
+  const plansDir = join(tempDir, '.omx', 'plans');
+  const contextDir = join(tempDir, '.omx', 'context');
+  await mkdir(plansDir, { recursive: true });
+  await mkdir(contextDir, { recursive: true });
+
+  const prdPath = join(plansDir, `prd-${slug}.md`);
+  const testSpecPath = join(plansDir, `test-spec-${slug}.md`);
+  const packPath = join(tempDir, canonicalContextPackRelativePath(slug));
+
+  await writeFile(prdPath, '# PRD\n');
+  await writeFile(testSpecPath, '# Test Spec\n');
+
+  const prdContent = await readFile(prdPath, 'utf-8');
+  const testSpecContent = await readFile(testSpecPath, 'utf-8');
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relativeToRepo(prdPath),
+        sha1: computeGitBlobSha1(prdContent),
+      },
+      testSpecs: [{
+        path: relativeToRepo(testSpecPath),
+        sha1: computeGitBlobSha1(testSpecContent),
+      }],
+    },
+    entries,
+  }, null, 2));
+
+  return packPath;
+}
+
+describe('ready context pack role refs', () => {
+  beforeEach(async () => { await setup(); });
+  afterEach(async () => { await cleanup(); });
+
+  it('normalizes, groups, and dedupes repo-relative refs by role', async () => {
+    const packPath = await writeContextPack('alpha', [
+      { path: './src/scope.ts', roles: ['scope'] },
+      { path: 'src\\build.ts', roles: ['build', 'verify'] },
+      { path: 'src/build.ts', roles: ['build'] },
+      { path: 'src/shared.ts', roles: ['scope', 'build'] },
+      { path: 'src/shared.ts', roles: ['scope'] },
+      { path: 'src/verify.ts', roles: ['verify'] },
+    ]);
+
+    assert.deepEqual(readReadyContextPackRoleRefs(packPath), {
+      scope: ['src/scope.ts', 'src/shared.ts'],
+      build: ['src/build.ts', 'src/shared.ts'],
+      verify: ['src/build.ts', 'src/verify.ts'],
+    });
+  });
+
+  it('fails closed when the pack contains malformed entry paths or unsupported roles', async () => {
+    const invalidPathPack = await writeContextPack('invalid-path', [
+      { path: '../outside.ts', roles: ['build'] },
+    ]);
+    const invalidRolePack = await writeContextPack('invalid-role', [
+      { path: 'src/build.ts', roles: ['deploy'] },
+    ]);
+
+    assert.equal(readReadyContextPackRoleRefs(invalidPathPack), null);
+    assert.equal(readReadyContextPackRoleRefs(invalidRolePack), null);
+  });
+
+  it('fails closed when the pack file cannot be read', () => {
+    const missingPackPath = join(tempDir, canonicalContextPackRelativePath('missing'));
+    assert.equal(readReadyContextPackRoleRefs(missingPackPath), null);
+  });
+});

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -8,10 +8,12 @@ import {
   selectMatchingTestSpecsForPrd,
 } from './artifact-names.js';
 import {
+  readReadyContextPackRoleRefs,
   resolveContextPackHandoffStatus,
   type ContextPackHandoffStatusSnapshot,
   type ContextPackRef,
   type ContextPackRole,
+  type ContextPackRoleRefs,
   type ContextPackStatus,
 } from './context-pack-status.js';
 import { omxPlansDir } from '../utils/paths.js';
@@ -36,6 +38,7 @@ export type {
   ContextPackPackState,
   ContextPackRef,
   ContextPackRole,
+  ContextPackRoleRefs,
   ContextPackRoleCoverageState,
   ContextPackStatus,
 } from './context-pack-status.js';
@@ -66,6 +69,7 @@ export interface ApprovedPlanContext {
   deepInterviewSpecPaths: string[];
   contextPack: ContextPackRef | null;
   contextPackStatus: ContextPackStatus;
+  contextPackRoleRefs: ContextPackRoleRefs | null;
   missingRequiredContextPackRoles: ContextPackRole[];
   contextPackIssues: string[];
   repositoryContextSummary?: ApprovedRepositoryContextSummary;
@@ -86,6 +90,7 @@ export interface LatestPlanningArtifactSelection {
   deepInterviewSpecPaths: string[];
   contextPack: ContextPackRef | null;
   contextPackStatus: ContextPackStatus;
+  contextPackRoleRefs: ContextPackRoleRefs | null;
   missingRequiredContextPackRoles: ContextPackRole[];
   contextPackIssues: string[];
 }
@@ -198,10 +203,15 @@ function selectPlanningArtifacts(
 ): LatestPlanningArtifactSelection {
   const selection = selectPlanningArtifactsBase(artifacts, prdPath);
   const handoffStatus = resolveContextPackHandoffStatus(artifacts, selection);
+  const contextPackRoleRefs =
+    handoffStatus.contextPackStatus === 'ready' && handoffStatus.contextPack
+      ? readReadyContextPackRoleRefs(handoffStatus.contextPack.path)
+      : null;
   return {
     ...selection,
     contextPack: handoffStatus.contextPack,
     contextPackStatus: handoffStatus.contextPackStatus,
+    contextPackRoleRefs,
     missingRequiredContextPackRoles: handoffStatus.missingRequiredContextPackRoles,
     contextPackIssues: handoffStatus.contextPackIssues,
   };
@@ -283,6 +293,7 @@ function readApprovedPlanText(
         deepInterviewSpecPaths: selection.deepInterviewSpecPaths,
         contextPack: selection.contextPack,
         contextPackStatus: selection.contextPackStatus,
+        contextPackRoleRefs: selection.contextPackRoleRefs,
         missingRequiredContextPackRoles: selection.missingRequiredContextPackRoles,
         contextPackIssues: selection.contextPackIssues,
         ...(repositoryContextSummary ? { repositoryContextSummary } : {}),

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -28,6 +28,12 @@ export interface ContextPackRef {
   path: string;
 }
 
+export interface ContextPackRoleRefs {
+  scope: string[];
+  build: string[];
+  verify: string[];
+}
+
 export interface ContextPackHandoffStatusSnapshot {
   prdPath: string | null;
   testSpecPaths: string[];
@@ -450,6 +456,38 @@ function findMissingRequiredContextPackRoles(
 ): ContextPackRole[] {
   const presentRoles = new Set(document.entries.flatMap((entry) => entry.roles));
   return REQUIRED_CONTEXT_PACK_ROLES.filter((role) => !presentRoles.has(role));
+}
+
+function emptyContextPackRoleRefs(): ContextPackRoleRefs {
+  return { scope: [], build: [], verify: [] };
+}
+
+export function readReadyContextPackRoleRefs(
+  packPath: string,
+): ContextPackRoleRefs | null {
+  const packDocument = readContextPackDocument(packPath);
+  if (!packDocument.document) {
+    return null;
+  }
+
+  const grouped = emptyContextPackRoleRefs();
+  const seen: Record<ContextPackRole, Set<string>> = {
+    scope: new Set<string>(),
+    build: new Set<string>(),
+    verify: new Set<string>(),
+  };
+
+  for (const entry of packDocument.document.entries) {
+    for (const role of entry.roles) {
+      if (seen[role].has(entry.path)) {
+        continue;
+      }
+      seen[role].add(entry.path);
+      grouped[role].push(entry.path);
+    }
+  }
+
+  return grouped;
 }
 
 function validateContextPackBasis(


### PR DESCRIPTION
## Summary
- add readReadyContextPackRoleRefs() in the existing context-pack status seam to group scope, build, and verify repo-relative file refs from entries[].path and entries[].roles
- thread nullable contextPackRoleRefs through approved planning selections and launch hints only when the handoff is already ready
- keep nonready or malformed packs fail-closed with null refs; this row does not deliver the refs into Team or Ralph yet and does not add any public CLI surface

## Testing
- npm run build
- node --test dist/planning/__tests__/context-pack-status.test.js dist/planning/__tests__/artifacts.test.js dist/planning/__tests__/ready-context-pack-role-refs.test.js
- npx tsc --noEmit
- npm run check:no-unused
- node dist/scripts/generate-catalog-docs.js --check
- node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__ outside sandbox after the known local listen EPERM and cache-lock restrictions in the sandboxed lane; outside-sandbox rerun finished with # fail 0
- node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__ dist/ralph/__tests__ dist/ralplan/__tests__ dist/runtime/__tests__ outside sandbox; rerun finished with # fail 0
- npm run coverage:team-critical:compiled outside sandbox; rerun finished with # fail 0
