### PR TITLE
Fix PostCompact native hook JSON output

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -125,7 +125,7 @@ The approved OMX-native wiki backport keeps lifecycle ownership intentionally na
 - **Storage** lives under repository `omx_wiki/`, not ignored `.omx/wiki/` runtime state and not `.omc/wiki/`.
 - **SessionStart** may surface bounded wiki context from `omx_wiki/` when the wiki already exists, but it should stay read-mostly and must not block the native hook path on expensive writes or index rebuilds.
 - **SessionEnd** remains a runtime/notify-path responsibility for best-effort, non-blocking session capture into `omx_wiki/`.
-- **PreCompact** is native and bounded: it can surface compact wiki context before compaction. **PostCompact** is native and advisory: it nudges agents to write/update `omx_wiki/` entries about compaction artifacts.
+- **PreCompact** is native and bounded: it can surface compact wiki context before compaction. **PostCompact** is native and no-stdout by default: it records the lifecycle seam without emitting advisory `additionalContext` that Codex rejects for PostCompact.
 - **Routing should stay explicit**: prefer `$wiki` or task verbs like `wiki query` / `wiki add`, and avoid implicit bare `wiki` noun activation.
 
 ## Explicit terminal stop model note

--- a/docs/reference/project-wiki.md
+++ b/docs/reference/project-wiki.md
@@ -54,7 +54,7 @@ The docs and code should never regress back to `.omc/wiki/`.
 - `SessionEnd` stays **runtime-fallback** and **non-blocking**.
   - Best-effort capture is okay.
   - Missing wiki state should degrade to a no-op.
-- `PreCompact` and `PostCompact` are native lifecycle seams: `PreCompact` surfaces bounded wiki context, and `PostCompact` nudges durable wiki capture about compaction artifacts.
+- `PreCompact` and `PostCompact` are native lifecycle seams: `PreCompact` surfaces bounded wiki context, and `PostCompact` stays a no-stdout lifecycle notification unless a future Codex PostCompact output contract explicitly supports more.
 
 ## Routing contract
 

--- a/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
+++ b/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
@@ -142,6 +142,16 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
         1,
         "setup should append the managed PostToolUse wrapper into user-owned hooks.json",
       );
+      assert.equal(
+        countManagedHooks(refreshed.hooks?.PostCompact),
+        1,
+        "setup should append a single managed PostCompact wrapper that runs the JSON-safe native hook",
+      );
+      assert.doesNotMatch(
+        hookCommands(refreshed.hooks?.PostCompact).join("\n"),
+        /PostCompact Nudge|additionalContext|printf/,
+        "generated PostCompact hooks should not embed advisory text or shell printf workarounds",
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -285,6 +285,8 @@ describe("codex hooks helpers", () => {
     const postCommand = postCompact[0]?.hooks?.[0]?.command;
     assert.match(String(preCommand), /codex-native-hook\.js/);
     assert.match(String(postCommand), /codex-native-hook\.js/);
+    assert.equal(postCommand, preCommand);
+    assert.doesNotMatch(String(postCommand), /PostCompact Nudge|additionalContext|printf/);
   });
 
   it("reports missing managed hook coverage by event", () => {

--- a/src/hooks/__tests__/wiki-docs-contract.test.ts
+++ b/src/hooks/__tests__/wiki-docs-contract.test.ts
@@ -32,7 +32,7 @@ describe("project wiki documentation contract", () => {
     assert.match(hooksDoc, /SessionStart.*bounded wiki context/i);
     assert.match(hooksDoc, /SessionEnd.*runtime\/notify-path.*non-blocking/i);
     assert.match(hooksDoc, /PreCompact.*native.*bounded/i);
-    assert.match(hooksDoc, /PostCompact.*native.*advisory/i);
+    assert.match(hooksDoc, /PostCompact.*native.*no-stdout/i);
     assert.match(hooksDoc, /prefer `\$wiki`.*avoid implicit bare `wiki` noun activation/i);
   });
 });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -276,6 +276,20 @@ describe("codex native hook config", () => {
       hooks?: Array<Record<string, unknown>>;
     };
     assert.equal(stop.hooks?.[0]?.timeout, 30);
+
+    const postCompact = config.hooks.PostCompact[0] as {
+      matcher?: string;
+      hooks?: Array<Record<string, unknown>>;
+    };
+    assert.equal(postCompact.matcher, undefined);
+    assert.match(
+      String(postCompact.hooks?.[0]?.command || ""),
+      /codex-native-hook\.js"?$/,
+    );
+    assert.doesNotMatch(
+      String(postCompact.hooks?.[0]?.command || ""),
+      /PostCompact Nudge|additionalContext|printf/,
+    );
   });
 });
 
@@ -558,7 +572,7 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("returns a PostCompact nudge to write compaction artifacts to omx_wiki", async () => {
+  it("does not write PostCompact stdout that Codex rejects as hook JSON", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-postcompact-"));
     try {
       const result = await dispatchCodexNativeHook({
@@ -569,11 +583,22 @@ describe("codex native hook dispatch", () => {
 
       assert.equal(result.hookEventName, "PostCompact");
       assert.equal(result.omxEventName, "post-compact");
-      const additionalContext = (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } } | null)
-        ?.hookSpecificOutput?.additionalContext ?? "";
-      assert.match(additionalContext, /PostCompact Nudge/);
-      assert.match(additionalContext, /omx_wiki/);
-      assert.match(additionalContext, /compaction artifacts/);
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("emits no CLI stdout for PostCompact when no Codex action is needed", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-postcompact-cli-"));
+    try {
+      const stdout = runNativeHookCli({
+        hook_event_name: "PostCompact",
+        cwd,
+        session_id: "sess-postcompact-cli",
+      });
+
+      assert.equal(stdout, "");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -71,7 +71,6 @@ import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
 import { dispatchHookEventRuntime } from "../hooks/extensibility/runtime.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
 import {
-  onPostCompact as buildWikiPostCompactContext,
   onPreCompact as buildWikiPreCompactContext,
   onSessionStart as buildWikiSessionStartContext,
 } from "../wiki/lifecycle.js";
@@ -3024,16 +3023,6 @@ export async function dispatchCodexNativeHook(
 
   if (hookEventName === "PreCompact") {
     const compactContext = buildWikiPreCompactContext({ cwd });
-    if (compactContext.additionalContext) {
-      outputJson = {
-        hookSpecificOutput: {
-          hookEventName,
-          additionalContext: compactContext.additionalContext,
-        },
-      };
-    }
-  } else if (hookEventName === "PostCompact") {
-    const compactContext = buildWikiPostCompactContext({ cwd });
     if (compactContext.additionalContext) {
       outputJson = {
         hookSpecificOutput: {


### PR DESCRIPTION
## Summary
- stop emitting `hookSpecificOutput.additionalContext` for native `PostCompact`, leaving it no-stdout when no Codex action is needed
- add regressions for native dispatch, CLI stdout, generated hook commands, and setup-owned `hooks.json`
- update wiki/native-hook docs to describe PostCompact as no-stdout by default

Fixes #2205.

## Validation
- `npm run build`
- `npm run check:no-unused`
- `npm run lint`
- `node --test dist/config/__tests__/codex-hooks.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js dist/hooks/__tests__/wiki-docs-contract.test.js` (296/296)
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_OPENCLAW -u OMX_OPENCLAW_COMMAND -u OMX_OPENCLAW_DEBUG -u OMX_TMUX_HUD_OWNER -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD -u TMUX -u CODEX_HOME npm test` (4734/4734)

## Notes
- The first unsanitized `npm test` attempt inherited this active OMX runtime environment (`OMX_ROOT`, `TMUX`, etc.) and failed unrelated environment-sensitive tests; the sanitized rerun passed fully.
- Not live-tested against Codex 0.129.0 on WSL2.
