### PR TITLE
feat(team): add approved handoff context section

### DIFF
--- a/src/team/__tests__/approved-execution.test.ts
+++ b/src/team/__tests__/approved-execution.test.ts
@@ -5,11 +5,13 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  buildApprovedTeamHandoffSection,
   readPersistedApprovedTeamExecutionBinding,
   readPersistedApprovedTeamExecutionBindingStateSync,
   resolvePersistedApprovedTeamExecutionContinuityState,
   writePersistedApprovedTeamExecutionBinding,
 } from '../approved-execution.js';
+import type { ApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
 
 async function withUnboxedOmxRoot<T>(fn: () => Promise<T>): Promise<T> {
   const previousOmxRoot = process.env.OMX_ROOT;
@@ -26,7 +28,63 @@ async function withUnboxedOmxRoot<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+function buildReadyApprovedTeamHint(
+  overrides: Partial<ApprovedExecutionLaunchHint> = {},
+): ApprovedExecutionLaunchHint {
+  return {
+    sourcePath: '/repo/.omx/plans/prd-issue-1314.md',
+    testSpecPaths: ['/repo/.omx/plans/test-spec-issue-1314.md'],
+    deepInterviewSpecPaths: [],
+    contextPack: { path: '/repo/.omx/context/context-20260507T120000Z-issue-1314.json' },
+    contextPackStatus: 'ready',
+    contextPackRoleRefs: {
+      build: ['src/build-entry.ts'],
+      verify: ['tests/verify-entry.ts'],
+      scope: ['docs/scope-entry.md'],
+    },
+    missingRequiredContextPackRoles: [],
+    contextPackIssues: [],
+    repositoryContextSummary: {
+      sourcePath: '/repo/.omx/plans/repo-context-issue-1314.md',
+      content: 'Read the approved repository slice before broader repo exploration.',
+      truncated: false,
+    },
+    mode: 'team',
+    command: 'omx team 1:executor "Execute approved issue 1314 plan"',
+    task: 'Execute approved issue 1314 plan',
+    workerCount: 1,
+    agentType: 'executor',
+    linkedRalph: false,
+    ...overrides,
+  };
+}
+
 describe('approved execution binding', () => {
+  it('buildApprovedTeamHandoffSection renders ready approved Team context with grouped refs', () => {
+    const handoff = buildApprovedTeamHandoffSection(buildReadyApprovedTeamHint());
+
+    assert.match(handoff ?? '', /Approved plan: \/repo\/\.omx\/plans\/prd-issue-1314\.md/);
+    assert.match(handoff ?? '', /Test specs: \/repo\/\.omx\/plans\/test-spec-issue-1314\.md/);
+    assert.match(handoff ?? '', /Approved repository context summary source: \/repo\/\.omx\/plans\/repo-context-issue-1314\.md/);
+    assert.match(handoff ?? '', /Read the approved repository slice before broader repo exploration\./);
+    assert.match(handoff ?? '', /Build refs \(read first\): src\/build-entry\.ts/);
+    assert.match(handoff ?? '', /Verify refs: tests\/verify-entry\.ts/);
+    assert.match(handoff ?? '', /Scope refs: docs\/scope-entry\.md/);
+    assert.match(handoff ?? '', /Read the build refs above before broader repo exploration\./);
+    assert.doesNotMatch(handoff ?? '', /query the canonical pack|Context pack index/);
+  });
+
+  it('buildApprovedTeamHandoffSection stays undefined outside ready Team handoffs', () => {
+    assert.equal(
+      buildApprovedTeamHandoffSection(buildReadyApprovedTeamHint({ mode: 'ralph' })),
+      undefined,
+    );
+    assert.equal(
+      buildApprovedTeamHandoffSection(buildReadyApprovedTeamHint({ contextPackStatus: 'plan-only' })),
+      undefined,
+    );
+  });
+
   it('writes and reads a normalized approved execution binding under the team state root', async () => {
     await withUnboxedOmxRoot(async () => {
       const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-write-'));

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6470,6 +6470,79 @@ esac
     }
   });
 
+  it('startTeam injects approved handoff context into ready approved worker inboxes', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-handoff-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const approvedTask = 'Execute approved issue 1314 handoff plan';
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+    const prdPath = join(cwd, '.omx', 'plans', 'prd-issue-1314-handoff.md');
+    const testSpecPath = join(cwd, '.omx', 'plans', 'test-spec-issue-1314-handoff.md');
+    await writeFile(
+      prdPath,
+      [
+        '# Approved plan',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath('issue-1314-handoff')),
+        '',
+        `Launch via omx team 1:executor "${approvedTask}"`,
+      ].join('\n'),
+    );
+    await writeFile(testSpecPath, '# Test spec\n');
+    await writeReadyContextPack(cwd, 'issue-1314-handoff', prdPath, testSpecPath);
+    await writeFile(
+      join(cwd, '.omx', 'plans', 'repo-context-issue-1314-handoff.md'),
+      'Read the approved repository slice first.\n',
+    );
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withPromptModeCodexEnv(binDir, {}, () =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-approved-handoff',
+            'approved handoff context test',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            cwd,
+            {
+              approvedExecution: {
+                prd_path: prdPath,
+                task: approvedTask,
+                command: `omx team 1:executor "${approvedTask}"`,
+              },
+            },
+          ),
+        ),
+      );
+
+      const inbox = await readFile(
+        join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'inbox.md'),
+        'utf-8',
+      );
+      assert.match(inbox, /## Approved Handoff Context/);
+      assert.match(inbox, new RegExp(`Approved plan: ${prdPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(inbox, new RegExp(`Test specs: ${testSpecPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(inbox, /Approved repository context summary source: .*repo-context-issue-1314-handoff\.md/);
+      assert.match(inbox, /Read the approved repository slice first\./);
+      assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
+      assert.match(inbox, /Verify refs: src\/verify-2\.ts/);
+      assert.match(inbox, /Scope refs: src\/scope-0\.ts/);
+      assert.doesNotMatch(inbox, /query the canonical pack|Context pack index/);
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam keeps explicit plan-only approved bindings on the generic path', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-binding-plan-only-'));
     const binDir = join(cwd, 'bin');
@@ -6515,6 +6588,11 @@ esac
         'approved-execution.json',
       );
       assert.equal(existsSync(bindingPath), false);
+      const inbox = await readFile(
+        join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'inbox.md'),
+        'utf-8',
+      );
+      assert.doesNotMatch(inbox, /## Approved Handoff Context/);
     } finally {
       if (runtime) {
         await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
@@ -6803,6 +6881,81 @@ esac
       const inbox = await readFile(join(cwd, '.omx', 'state', 'team', 'team-assign-delegation', 'workers', 'worker-1', 'inbox.md'), 'utf-8');
       assert.match(inbox, /Assignment Cancelled/);
       assert.match(inbox, /worker_notify_failed/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('assignTask injects approved handoff context when the persisted approved binding remains ready', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-followup-'));
+    const approvedTask = 'Execute approved issue 1320 plan';
+    try {
+      await initTeamState('team-approved-followup', 'assignment test', 'executor', 1, cwd);
+      const manifestPath = teamStateTestPath(cwd, 'team', 'team-approved-followup', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+      manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 250 };
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+      const plansDir = join(cwd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const prdPath = join(plansDir, 'prd-issue-1320.md');
+      const testSpecPath = join(plansDir, 'test-spec-issue-1320.md');
+      await writeFile(
+        prdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('issue-1320')),
+          '',
+          `Launch via omx team 1:executor "${approvedTask}"`,
+        ].join('\n'),
+      );
+      await writeFile(testSpecPath, '# Test spec\n');
+      await writeReadyContextPack(cwd, 'issue-1320', prdPath, testSpecPath);
+      await writeFile(
+        join(plansDir, 'repo-context-issue-1320.md'),
+        'Follow the approved repository slice before broader repo exploration.\n',
+      );
+      await writePersistedApprovedTeamExecutionBinding('team-approved-followup', cwd, {
+        prd_path: prdPath,
+        task: approvedTask,
+        command: `omx team 1:executor "${approvedTask}"`,
+      });
+      const task = await createTask(
+        'team-approved-followup',
+        { subject: 'Implement approved follow-up', description: 'Implement approved follow-up', status: 'pending' },
+        cwd,
+      );
+
+      const assignPromise = assignTask('team-approved-followup', 'worker-1', task.id, cwd);
+      const deadline = Date.now() + 2_000;
+      let delivered = false;
+      while (Date.now() < deadline && !delivered) {
+        const requests = await listDispatchRequests('team-approved-followup', cwd, { kind: 'inbox', to_worker: 'worker-1' });
+        if (!requests.some((request) => request.status === 'pending')) {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          continue;
+        }
+        await markPendingInboxDispatchesDelivered('team-approved-followup', cwd, {
+          toWorker: 'worker-1',
+          lastReason: 'test_delivered_receipt',
+        });
+        delivered = true;
+      }
+      assert.ok(delivered, 'expected follow-up inbox dispatch request to be queued');
+
+      await assignPromise;
+
+      const inbox = await readFile(
+        join(cwd, '.omx', 'state', 'team', 'team-approved-followup', 'workers', 'worker-1', 'inbox.md'),
+        'utf-8',
+      );
+      assert.match(inbox, /## Approved Handoff Context/);
+      assert.match(inbox, new RegExp(`Approved plan: ${prdPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
+      assert.match(inbox, /Verify refs: src\/verify-2\.ts/);
+      assert.match(inbox, /Scope refs: src\/scope-0\.ts/);
+      assert.match(inbox, /Follow the approved repository slice before broader repo exploration\./);
+      assert.doesNotMatch(inbox, /query the canonical pack|Context pack index/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -1070,4 +1070,56 @@ describe("worker bootstrap", () => {
     assert.match(inbox, /preserve approved context only for matching launches/);
   });
 
+  it("generateInitialInbox prefers approved handoff context when provided", () => {
+    const inbox = generateInitialInbox(
+      "worker-1",
+      "context-team",
+      "executor",
+      [{ id: "1", subject: "Implement", description: "Do task", status: "pending", owner: "worker-1", created_at: "2026-04-30T00:00:00.000Z" }],
+      {
+        approvedContextSection: [
+          "- Approved plan: .omx/plans/prd-issue-2039.md",
+          "- Build refs (read first): src/build-1.ts",
+          "- Read the build refs above before broader repo exploration.",
+        ].join("\n"),
+        approvedContextSummary: {
+          sourcePath: ".omx/plans/repo-context-issue-2039.md",
+          content: "This legacy summary should be suppressed when the handoff section is present.",
+          truncated: false,
+        },
+      },
+    );
+
+    assert.match(inbox, /## Approved Handoff Context/);
+    assert.match(inbox, /Approved plan: \.omx\/plans\/prd-issue-2039\.md/);
+    assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
+    assert.doesNotMatch(inbox, /## Approved Repository Context Summary/);
+  });
+
+  it("generateTaskAssignmentInbox includes approved handoff context when provided", () => {
+    const inbox = generateTaskAssignmentInbox(
+      "worker-1",
+      "team-followup",
+      {
+        id: "42",
+        subject: "Implement parser update",
+        description: "Implement parser update",
+        status: "pending",
+        created_at: "2026-04-30T00:00:00.000Z",
+      },
+      {
+        approvedContextSection: [
+          "- Approved plan: .omx/plans/prd-issue-2040.md",
+          "- Build refs (read first): src/build-1.ts",
+          "- Verify refs: src/verify-2.ts",
+        ].join("\n"),
+      },
+    );
+
+    assert.match(inbox, /## Approved Handoff Context/);
+    assert.match(inbox, /Approved plan: \.omx\/plans\/prd-issue-2040\.md/);
+    assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
+    assert.match(inbox, /Verify refs: src\/verify-2\.ts/);
+  });
+
 });

--- a/src/team/approved-execution.ts
+++ b/src/team/approved-execution.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from 'node:path';
 import {
   readApprovedExecutionLaunchHintOutcome,
   readPlanningArtifacts,
+  type ApprovedRepositoryContextSummary,
   type ApprovedExecutionLaunchHint,
 } from '../planning/artifacts.js';
 import { TEAM_NAME_SAFE_PATTERN } from './contracts.js';
@@ -70,6 +71,71 @@ export function buildApprovedTeamExecutionBinding(
     task: approvedHint.task,
     ...(approvedHint.command ? { command: approvedHint.command } : {}),
   };
+}
+
+function renderApprovedRepositoryContextSummary(
+  summary: ApprovedRepositoryContextSummary,
+): string[] {
+  const lines = [
+    `- Approved repository context summary source: ${summary.sourcePath}${summary.truncated ? ' (bounded/truncated)' : ''}`,
+  ];
+  const content = summary.content.trim();
+  if (content !== '') {
+    lines.push('', content);
+  }
+  return lines;
+}
+
+function renderRoleRefLine(label: string, refs: readonly string[]): string | null {
+  return refs.length > 0
+    ? `- ${label}: ${refs.join(', ')}`
+    : null;
+}
+
+export function buildApprovedTeamHandoffSection(
+  approvedHint: ApprovedExecutionLaunchHint | null | undefined,
+): string | undefined {
+  if (
+    !approvedHint
+    || approvedHint.mode !== 'team'
+    || approvedHint.contextPackStatus !== 'ready'
+    || !approvedHint.contextPackRoleRefs
+  ) {
+    return undefined;
+  }
+
+  const { build, verify, scope } = approvedHint.contextPackRoleRefs;
+  if (build.length === 0 && verify.length === 0 && scope.length === 0) {
+    return undefined;
+  }
+
+  const lines = [`- Approved plan: ${approvedHint.sourcePath}`];
+  if (approvedHint.testSpecPaths.length > 0) {
+    lines.push(`- Test specs: ${approvedHint.testSpecPaths.join(', ')}`);
+  }
+  if (approvedHint.repositoryContextSummary) {
+    lines.push(...renderApprovedRepositoryContextSummary(approvedHint.repositoryContextSummary));
+  }
+
+  const buildLine = renderRoleRefLine('Build refs (read first)', build);
+  const verifyLine = renderRoleRefLine('Verify refs', verify);
+  const scopeLine = renderRoleRefLine('Scope refs', scope);
+  if (buildLine) {
+    lines.push(buildLine);
+  }
+  if (verifyLine) {
+    lines.push(verifyLine);
+  }
+  if (scopeLine) {
+    lines.push(scopeLine);
+  }
+
+  lines.push(
+    build.length > 0
+      ? '- Read the build refs above before broader repo exploration.'
+      : '- Read the approved refs above before broader repo exploration.',
+  );
+  return lines.join('\n');
 }
 
 function assertSafeTeamName(teamName: string): void {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -137,6 +137,7 @@ import {
   isApprovedExecutionFollowupReadyStatus,
 } from '../planning/artifacts.js';
 import {
+  buildApprovedTeamHandoffSection,
   buildApprovedTeamExecutionBinding,
   normalizeApprovedTeamExecutionBinding,
   readApprovedTeamExecutionHintOutcomeFromBinding,
@@ -2290,6 +2291,7 @@ export async function startTeam(
     && isApprovedExecutionContextReadyStatus(selectedApprovedExecutionHint.contextPackStatus)
     ? buildApprovedTeamExecutionBinding(selectedApprovedExecutionHint)
     : null;
+  const approvedContextSection = buildApprovedTeamHandoffSection(selectedApprovedExecutionHint);
   const activeWorktreeMode: 'detached' | 'named' | null =
     effectiveWorktreeMode.enabled
       ? (effectiveWorktreeMode.detached ? 'detached' : 'named')
@@ -2527,7 +2529,10 @@ export async function startTeam(
         rolePromptContent: rawRolePromptContent ?? undefined,
         worktreeRootAgentsCanonical: Boolean(workerWorkspace.worktreePath),
         taskHints: effectiveDecompositionMetadata?.task_hints,
-        approvedContextSummary: effectiveDecompositionMetadata?.approved_context_summary,
+        approvedContextSection,
+        approvedContextSummary: approvedContextSection
+          ? undefined
+          : effectiveDecompositionMetadata?.approved_context_summary,
         workerGoalInstruction: buildTeamWorkerGoalInstruction(sanitized, workerName, workerTasks, { teamStateRoot }),
       });
       const triggerDirective = buildTriggerDirective(
@@ -3297,10 +3302,19 @@ export async function assignTask(
 
   try {
     // Retry dispatch up to 2 times to handle trust prompts during assignment (fixes #393).
+    const approvedExecutionState = await resolvePersistedApprovedTeamExecutionContinuityState(
+      sanitized,
+      config.leader_cwd ?? cwd,
+      config.team_state_root ?? resolveCanonicalTeamStateRoot(config.leader_cwd ?? cwd),
+    );
+    const approvedContextSection = approvedExecutionState.status === 'valid'
+      && isApprovedExecutionFollowupReadyStatus(approvedExecutionState.approvedHint.contextPackStatus)
+      ? buildApprovedTeamHandoffSection(approvedExecutionState.approvedHint)
+      : undefined;
     const taskForInbox = task.delegation
       ? task
       : (await updateTask(sanitized, taskId, { delegation: synthesizeDelegationPlan(task) }, cwd)) ?? task;
-    const inbox = generateTaskAssignmentInbox(workerName, sanitized, taskForInbox);
+    const inbox = generateTaskAssignmentInbox(workerName, sanitized, taskForInbox, { approvedContextSection });
     const maxAssignRetries = 2;
     const assignRetryDelayS = 2;
     let outcome: DispatchOutcome = { ok: false, transport: 'none', reason: 'not_attempted' };

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -705,6 +705,7 @@ export function generateInitialInbox(
     worktreeRootAgentsCanonical?: boolean;
     taskHints?: Record<string, TaskHintSummary>;
     approvedContextSummary?: ApprovedRepositoryContextSummary;
+    approvedContextSection?: string;
     workerGoalInstruction?: TeamWorkerGoalInstruction;
   } = {},
 ): string {
@@ -747,15 +748,21 @@ export function generateInitialInbox(
   const delegationSection = renderDelegationContracts(tasks);
   const workerGoalSection = renderTeamWorkerGoalInstruction(options.workerGoalInstruction);
 
-  const approvedContextSection = options.approvedContextSummary
+  const approvedContextSection = options.approvedContextSection
     ? `
+## Approved Handoff Context
+
+${options.approvedContextSection}
+`
+    : options.approvedContextSummary
+      ? `
 ## Approved Repository Context Summary
 
 Source: ${options.approvedContextSummary.sourcePath}${options.approvedContextSummary.truncated ? ' (bounded/truncated)' : ''}
 
 ${options.approvedContextSummary.content}
 `
-    : "";
+      : "";
 
   const specializationSection = options.worktreeRootAgentsCanonical === true
     ? ""
@@ -836,21 +843,35 @@ export function generateTaskAssignmentInbox(
   workerName: string,
   teamName: string,
   task: TeamTask,
+  options?: {
+    approvedContextSection?: string;
+  },
 ): string;
 export function generateTaskAssignmentInbox(
   workerName: string,
   teamName: string,
   taskId: string,
   taskDescription: string,
+  options?: {
+    approvedContextSection?: string;
+  },
 ): string;
 export function generateTaskAssignmentInbox(
   workerName: string,
   teamName: string,
   taskOrId: TeamTask | string,
-  taskDescriptionArg?: string,
+  taskDescriptionArg?: string | {
+    approvedContextSection?: string;
+  },
+  optionsArg: {
+    approvedContextSection?: string;
+  } = {},
 ): string {
+  const options = typeof taskDescriptionArg === "string"
+    ? optionsArg
+    : taskDescriptionArg ?? optionsArg;
   const task = typeof taskOrId === "string"
-    ? { id: taskOrId, description: taskDescriptionArg ?? "" }
+    ? { id: taskOrId, description: typeof taskDescriptionArg === "string" ? taskDescriptionArg : "" }
     : taskOrId;
   const taskId = task.id;
   const taskDescription = task.description;
@@ -870,6 +891,9 @@ export function generateTaskAssignmentInbox(
         }],
       });
   const delegationSection = renderDelegationContracts([task as TeamTask]);
+  const approvedContextSection = options.approvedContextSection
+    ? `\n## Approved Handoff Context\n\n${options.approvedContextSection}\n`
+    : "";
 
   return `# New Task Assignment
 
@@ -879,6 +903,7 @@ export function generateTaskAssignmentInbox(
 ## Task Description
 
 ${taskDescription}
+${approvedContextSection}
 ${workerGoalSection}
 ## Instructions
 


### PR DESCRIPTION
## Summary
Team already resolves approved launches through the private `approvedExecution`
path, but workers still mostly have to rediscover the approved repo slice on
their own. Once `#2204` made ready-pack role refs available on approved
hints, the next useful step was to turn that existing ready state into better
worker context.

This patch adds a private `Approved Handoff Context` block to Team worker
inboxes for ready approved launches and ready approved follow-up assignments.
The block is built from data the handoff already carries: the approved plan
path, matching test specs, the existing approved repository context summary,
and grouped `build` / `verify` / `scope` refs. The goal is to point workers at
the reviewed repo slice first, without changing the public Team surface.

## Changes

- build a single bounded `Approved Handoff Context` section in the existing
  Team approved-execution path
- render that section in worker inboxes for ready approved Team starts and
  ready approved follow-up assignments
- include approved plan path, matching test specs, the existing repository
  context summary, grouped role refs, and a small read-build-first cue
- leave generic launches and nonready states (`plan-only`, `incomplete`,
  `invalid`, `missing-baseline`) unchanged
- add no new CLI command, Team API, or inspect surface

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (not run; no setup/config behavior changed)

Also ran:

- `node --test dist/cli/__tests__/team.test.js dist/team/__tests__/approved-execution.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/worker-bootstrap.test.js dist/pipeline/__tests__/stages.test.js`
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `node dist/scripts/generate-catalog-docs.js --check`
- compiled `cli-core-rest` lane on the rebased branch: `# fail 0`
- compiled `team-state-runtime` lane on the rebased branch: `# fail 0`
- `npm run coverage:team-critical:compiled` on the rebased branch: `# fail 0`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed (not needed for private Team runtime behavior)
- [x] Backward-compatibility impact considered

## Related

Follow-up to `#2204`
