### PR TITLE
Make tmux submit delay configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,14 +263,27 @@ If `Shift+Enter` still submits instead of inserting a newline inside an OMX-mana
 
 ### Tmux submit timing
 
-If a terminal emulator needs more time between literal `tmux send-keys` text injection and the first `C-m` submit, persist the delay in `${CODEX_HOME:-~/.codex}/config.toml`:
+OMX uses tmux to type short prompts into worker panes and then presses Enter
+for you. On some terminal setups, especially slower iTerm/tmux combinations,
+tmux can press Enter before the typed text is fully visible to the Codex TUI.
+The usual symptom is that a worker pane shows the prompt text, but the prompt
+was not submitted until you manually press Enter.
+
+You can give the terminal a little more time between "type the prompt" and
+"press Enter" by saving a persistent delay in
+`${CODEX_HOME:-~/.codex}/config.toml`:
 
 ```toml
 [omx]
 tmux_submit_settle_ms = 275
 ```
 
-The default remains 120ms.
+Increase this value if worker startup prompts or notification replies are left
+typed but unsubmitted. The setting is in milliseconds; for example, `275` means
+OMX waits 0.275 seconds before sending Enter.
+
+The general default remains 120ms; team worker prompt submission preserves its
+legacy 150ms first-submit fallback unless this value is configured.
 
 ### Explore and sparkshell
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,17 @@ Only use the forced team shutdown for a team you have confirmed is dead or inten
 
 If `Shift+Enter` still submits instead of inserting a newline inside an OMX-managed tmux session, see [Troubleshooting execution readiness](./docs/troubleshooting.md#shiftenter-submits-instead-of-inserting-a-newline-in-tmux-backed-omx-sessions). Current OMX already enables tmux extended-key forwarding around its own Codex launch paths, so a persistent failure is usually a tmux terminal-capability/discoverability problem rather than a net-new OMX feature gap.
 
+### Tmux submit timing
+
+If a terminal emulator needs more time between literal `tmux send-keys` text injection and the first `C-m` submit, persist the delay in `${CODEX_HOME:-~/.codex}/config.toml`:
+
+```toml
+[omx]
+tmux_submit_settle_ms = 275
+```
+
+The default remains 120ms.
+
 ### Explore and sparkshell
 
 - `omx explore --prompt "..."` is for read-only repository lookup

--- a/src/hooks/extensibility/sdk/tmux.ts
+++ b/src/hooks/extensibility/sdk/tmux.ts
@@ -6,6 +6,10 @@ import { spawnSync } from 'child_process';
 import { sleepSync } from '../../../utils/sleep.js';
 import { resolveCodexPane } from '../../../scripts/tmux-hook-engine.js';
 import { resolveTmuxBinaryForPlatform } from '../../../utils/platform-command.js';
+import {
+  resolveTmuxSubmitRepeatDelayMs,
+  resolveTmuxSubmitSettleMs,
+} from '../../../utils/tmux-submit-delay.js';
 import type {
   HookEventEnvelope,
   HookPluginSdk,
@@ -50,9 +54,9 @@ function hashDedupeKey(target: string, text: string): string {
   return createHash('sha256').update(`${target}|${text}`).digest('hex');
 }
 
-function sleepFractionalSeconds(seconds: number): void {
-  if (!Number.isFinite(seconds) || seconds <= 0) return;
-  sleepSync(Math.round(seconds * 1000));
+function sleepMilliseconds(ms: number): void {
+  if (!Number.isFinite(ms) || ms <= 0) return;
+  sleepSync(Math.round(ms));
 }
 
 function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; stderr: string } {
@@ -185,9 +189,9 @@ async function sendTmuxKeys(
   }
 
   if (options.submit !== false) {
-    sleepFractionalSeconds(0.12);
+    sleepMilliseconds(resolveTmuxSubmitSettleMs());
     const submitA = runTmux(['send-keys', '-t', targetResolution.target, 'C-m']);
-    sleepFractionalSeconds(0.1);
+    sleepMilliseconds(resolveTmuxSubmitRepeatDelayMs());
     const submitB = runTmux(['send-keys', '-t', targetResolution.target, 'C-m']);
     if (!submitA.ok && !submitB.ok) {
       return {

--- a/src/notifications/__tests__/tmux-detector.test.ts
+++ b/src/notifications/__tests__/tmux-detector.test.ts
@@ -177,7 +177,9 @@ describe('buildSendPaneArgvs', () => {
     ]);
   });
 
-  it('delays the first C-m submit so tmux send-keys text is visible to the alternate-screen TUI', () => {
+  it('delays the first C-m submit so tmux send-keys text is visible to the alternate-screen TUI', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-tmux-delay-'));
+    const originalCodexHome = process.env.CODEX_HOME;
     const calls: string[][] = [];
     const sleeps: number[] = [];
     const fakeSpawnSync = (command: string, argv: readonly string[]) => {
@@ -186,18 +188,25 @@ describe('buildSendPaneArgvs', () => {
       return { status: 0 };
     };
 
-    const ok = sendToPane('%5', 'continue', true, {
-      spawnSyncImpl: fakeSpawnSync,
-      sleepImpl: (ms) => sleeps.push(ms),
-    });
+    try {
+      process.env.CODEX_HOME = codexHome;
+      const ok = sendToPane('%5', 'continue', true, {
+        spawnSyncImpl: fakeSpawnSync,
+        sleepImpl: (ms) => sleeps.push(ms),
+      });
 
-    assert.equal(ok, true);
-    assert.deepEqual(calls, [
-      ['send-keys', '-t', '%5', '-l', '--', 'continue'],
-      ['send-keys', '-t', '%5', 'C-m'],
-      ['send-keys', '-t', '%5', 'C-m'],
-    ]);
-    assert.deepEqual(sleeps, [120, 100]);
+      assert.equal(ok, true);
+      assert.deepEqual(calls, [
+        ['send-keys', '-t', '%5', '-l', '--', 'continue'],
+        ['send-keys', '-t', '%5', 'C-m'],
+        ['send-keys', '-t', '%5', 'C-m'],
+      ]);
+      assert.deepEqual(sleeps, [120, 100]);
+    } finally {
+      if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = originalCodexHome;
+      await rm(codexHome, { recursive: true, force: true });
+    }
   });
 
   it('honors persistent config.toml tmux submit settle delay for slower terminal emulators', async () => {

--- a/src/notifications/__tests__/tmux-detector.test.ts
+++ b/src/notifications/__tests__/tmux-detector.test.ts
@@ -1,6 +1,14 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { analyzePaneContent, buildSendPaneArgvs, buildCapturePaneArgv, sendToPane } from '../tmux-detector.js';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  analyzePaneContent,
+  buildSendPaneArgvs,
+  buildCapturePaneArgv,
+  sendToPane,
+} from '../tmux-detector.js';
 import type { PaneAnalysis } from '../tmux-detector.js';
 
 describe('analyzePaneContent', () => {
@@ -190,6 +198,28 @@ describe('buildSendPaneArgvs', () => {
       ['send-keys', '-t', '%5', 'C-m'],
     ]);
     assert.deepEqual(sleeps, [120, 100]);
+  });
+
+  it('honors persistent config.toml tmux submit settle delay for slower terminal emulators', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-tmux-delay-'));
+    const originalCodexHome = process.env.CODEX_HOME;
+    const sleeps: number[] = [];
+
+    try {
+      process.env.CODEX_HOME = codexHome;
+      await writeFile(join(codexHome, 'config.toml'), '[omx]\ntmux_submit_settle_ms = 275\n');
+      const ok = sendToPane('%5', 'continue', true, {
+        spawnSyncImpl: () => ({ status: 0 }),
+        sleepImpl: (ms) => sleeps.push(ms),
+      });
+
+      assert.equal(ok, true);
+      assert.deepEqual(sleeps, [275, 100]);
+    } finally {
+      if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = originalCodexHome;
+      await rm(codexHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/notifications/tmux-detector.ts
+++ b/src/notifications/tmux-detector.ts
@@ -9,6 +9,10 @@ import { execFileSync, spawnSync } from 'child_process';
 import { sleepSync } from '../utils/sleep.js';
 import { resolveCommandPathForPlatform, resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 import { buildCapturePaneArgv as sharedBuildCapturePaneArgv } from '../scripts/tmux-hook-engine.js';
+import {
+  resolveTmuxSubmitRepeatDelayMs,
+  resolveTmuxSubmitSettleMs,
+} from '../utils/tmux-submit-delay.js';
 
 export function isTmuxAvailable(): boolean {
   return resolveCommandPathForPlatform('tmux') !== null;
@@ -112,9 +116,6 @@ export function buildSendPaneArgvs(
   return argvs;
 }
 
-const TMUX_TEXT_SETTLE_MS = 120;
-const TMUX_SUBMIT_REPEAT_DELAY_MS = 100;
-
 /**
  * Returns the number of C-m (submit) key presses needed for a given worker CLI.
  * Source of truth: Rust runtime's submit_presses_for_worker_cli (Claude=1, Codex/Other=2).
@@ -152,6 +153,8 @@ export function sendToPane(
 ): boolean {
   const spawnSyncImpl = deps.spawnSyncImpl ?? spawnSync;
   const sleepImpl = deps.sleepImpl ?? sleepSync;
+  const submitSettleMs = resolveTmuxSubmitSettleMs();
+  const submitRepeatDelayMs = resolveTmuxSubmitRepeatDelayMs();
   const argvs = buildSendPaneArgvs(paneId, text, pressEnter);
   const tmuxCommand = resolveTmuxBinaryForPlatform() || 'tmux';
 
@@ -167,7 +170,7 @@ export function sendToPane(
     const hasNextArgv = index < argvs.length - 1;
     if (!hasNextArgv) continue;
 
-    sleepImpl(index === 0 ? TMUX_TEXT_SETTLE_MS : TMUX_SUBMIT_REPEAT_DELAY_MS);
+    sleepImpl(index === 0 ? submitSettleMs : submitRepeatDelayMs);
   }
   return true;
 }

--- a/src/scripts/notify-hook/team-tmux-guard.ts
+++ b/src/scripts/notify-hook/team-tmux-guard.ts
@@ -9,6 +9,10 @@ import {
   paneHasActiveTask,
   paneLooksReady,
 } from '../tmux-hook-engine.js';
+import {
+  resolveTmuxSubmitRepeatDelayMs,
+  resolveTmuxSubmitSettleMs,
+} from '../../utils/tmux-submit-delay.js';
 
 export const PANE_READINESS_UNVERIFIED_REASON = 'pane_readiness_unverified';
 
@@ -132,7 +136,7 @@ export async function sendPaneInput({
   paneTarget,
   prompt,
   submitKeyPresses = 2,
-  submitDelayMs = 0,
+  submitDelayMs,
   typePrompt = true,
 }: any): Promise<any> {
   const target = safeString(paneTarget).trim();
@@ -163,9 +167,16 @@ export async function sendPaneInput({
     if (typePrompt) {
       await runProcess('tmux', argv.typeArgv, 3000);
     }
-    for (const submit of argv.submitArgv) {
-      if (submitDelayMs > 0) {
-        await new Promise((resolve) => setTimeout(resolve, submitDelayMs));
+    const explicitDelayMs = Number.isFinite(submitDelayMs)
+      ? Math.max(0, Math.floor(submitDelayMs))
+      : undefined;
+    const settleDelayMs = explicitDelayMs ?? resolveTmuxSubmitSettleMs();
+    const repeatDelayMs = explicitDelayMs ?? resolveTmuxSubmitRepeatDelayMs();
+    for (let i = 0; i < argv.submitArgv.length; i++) {
+      const submit = argv.submitArgv[i]!;
+      const delayMs = typePrompt && i === 0 ? settleDelayMs : repeatDelayMs;
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
       await runProcess('tmux', submit, 3000);
     }

--- a/src/team/__tests__/tmux-session-submit-delay.test.ts
+++ b/src/team/__tests__/tmux-session-submit-delay.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { sendToWorker } from '../tmux-session.js';
+
+const READY_CODEX_CAPTURE = `OpenAI Codex
+model: test
+directory: /tmp/demo
+
+› Write tests for @filename`;
+
+async function withFakeTmux(
+  run: (ctx: { logPath: string }) => Promise<void>,
+): Promise<void> {
+  const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-tmux-submit-delay-'));
+  const previousPath = process.env.PATH;
+  const logPath = join(fakeBinDir, 'tmux.log');
+
+  try {
+    await writeFile(join(fakeBinDir, 'tmux'), `#!/bin/sh
+set -eu
+text_sent_file="${fakeBinDir}/text-sent"
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    if [ -f "$text_sent_file" ]; then
+      printf 'initialized in .\\n\\n◦ Waiting for background terminal (1s…)\\n'
+    else
+      cat <<'EOF'
+${READY_CODEX_CAPTURE}
+EOF
+    fi
+    ;;
+  send-keys)
+    if [ "\${4:-}" = "-l" ] && [ "\${6:-}" = "check inbox" ]; then
+      : > "$text_sent_file"
+    fi
+    ;;
+esac
+`);
+    await chmod(join(fakeBinDir, 'tmux'), 0o755);
+    process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+    await run({ logPath });
+  } finally {
+    if (typeof previousPath === 'string') process.env.PATH = previousPath;
+    else delete process.env.PATH;
+    await rm(fakeBinDir, { recursive: true, force: true });
+  }
+}
+
+describe('sendToWorker tmux submit timing', () => {
+  it('preserves the legacy 150ms first-submit settle fallback when config is absent', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-tmux-submit-delay-home-'));
+    const previousCodexHome = process.env.CODEX_HOME;
+    const sleeps: number[] = [];
+
+    try {
+      process.env.CODEX_HOME = codexHome;
+
+      await withFakeTmux(async () => {
+        await sendToWorker('omx-team-x', 1, 'check inbox', undefined, undefined, {
+          sleepImpl: async (ms) => { sleeps.push(ms); },
+        });
+
+        assert.deepEqual(sleeps.slice(0, 3), [150, 100, 100]);
+      });
+    } finally {
+      if (typeof previousCodexHome === 'string') process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  it('uses configured settle and repeat delays without waiting on wall-clock time', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-tmux-submit-delay-home-'));
+    const previousCodexHome = process.env.CODEX_HOME;
+    const sleeps: number[] = [];
+
+    try {
+      await writeFile(
+        join(codexHome, 'config.toml'),
+        '[omx]\ntmux_submit_settle_ms = 600\ntmux_submit_repeat_delay_ms = 10\n',
+      );
+      process.env.CODEX_HOME = codexHome;
+
+      await withFakeTmux(async ({ logPath }) => {
+        await sendToWorker('omx-team-x', 1, 'check inbox', undefined, undefined, {
+          sleepImpl: async (ms) => { sleeps.push(ms); },
+        });
+
+        const log = await readFile(logPath, 'utf-8');
+        assert.deepEqual(sleeps.slice(0, 3), [600, 10, 10]);
+        assert.match(log, /send-keys -t omx-team-x:1 -l -- check inbox/);
+        assert.match(log, /send-keys -t omx-team-x:1 C-m/);
+      });
+    } finally {
+      if (typeof previousCodexHome === 'string') process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -24,6 +24,10 @@ import { readActiveProviderEnvOverrides } from '../config/models.js';
 import { extractModelProviderOverrideValue } from './model-contract.js';
 import { sleep, sleepSync } from '../utils/sleep.js';
 import {
+  resolveTmuxSubmitRepeatDelayMs,
+  resolveTmuxSubmitSettleMs,
+} from '../utils/tmux-submit-delay.js';
+import {
   buildPlatformCommandSpec,
   classifySpawnError,
   resolveCommandPathForPlatform,
@@ -82,6 +86,7 @@ const TMUX_NO_UNDERLINE_STYLE_FLAGS = [
   'nodotted-underscore',
   'nodashed-underscore',
 ] as const;
+const SEND_TO_WORKER_DEFAULT_TMUX_SUBMIT_SETTLE_MS = 150;
 const TMUX_COPY_MODE_STYLE_OPTIONS = [
   'mode-style',
   'copy-mode-selection-style',
@@ -100,6 +105,16 @@ export interface WorkerSubmitPlan {
   rounds: number;
   submitKeyPressesPerRound: number;
   allowAdaptiveRetry: boolean;
+}
+
+export interface SendToWorkerOptions {
+  sleepImpl?: (ms: number) => Promise<void>;
+}
+
+interface SendToWorkerTiming {
+  sleepImpl: (ms: number) => Promise<void>;
+  settleDelayMs: number;
+  repeatDelayMs: number;
 }
 
 interface WorkerLaunchSpec {
@@ -1411,7 +1426,7 @@ export async function evaluateStartupDirectTriggerSafety(
 
 function acceptClaudeBypassPermissionsPrompt(target: string): void {
   runTmux(['send-keys', '-t', target, '-l', '--', '2']);
-  sleepFractionalSeconds(0.12);
+  sleepFractionalSeconds(resolveTmuxSubmitSettleMs() / 1000);
   runTmux(['send-keys', '-t', target, 'C-m']);
 }
 
@@ -1568,23 +1583,24 @@ async function attemptSubmitRounds(
   rounds: number,
   queueFirstRound: boolean,
   submitKeyPressesPerRound: number,
+  timing: SendToWorkerTiming,
 ): Promise<boolean> {
   const presses = Math.max(1, Math.floor(submitKeyPressesPerRound));
   for (let round = 0; round < rounds; round++) {
-    await sleep(100);
+    await timing.sleepImpl(timing.repeatDelayMs);
     if (round === 0 && queueFirstRound) {
       await sendKeyAsync(target, 'Tab');
-      await sleep(80);
+      await timing.sleepImpl(timing.repeatDelayMs);
       await sendKeyAsync(target, 'C-m');
     } else {
       for (let press = 0; press < presses; press++) {
         await sendKeyAsync(target, 'C-m');
         if (press < presses - 1) {
-          await sleep(200);
+          await timing.sleepImpl(timing.repeatDelayMs);
         }
       }
     }
-    await sleep(140);
+    await timing.sleepImpl(140);
     const [captured, visibleCapture] = await Promise.all([
       capturePaneAsync(target),
       captureVisiblePaneAsync(target),
@@ -1596,7 +1612,7 @@ async function attemptSubmitRounds(
     ) {
       return true;
     }
-    await sleep(140);
+    await timing.sleepImpl(140);
   }
   return false;
 }
@@ -1618,7 +1634,7 @@ export function waitForWorkerReady(
     // Trust + follow-up splash can require two submits in Codex TUI.
     // Use C-m (carriage return) for raw-mode compatibility.
     runTmux(['send-keys', '-t', target, 'C-m']);
-    sleepFractionalSeconds(0.12);
+    sleepFractionalSeconds(resolveTmuxSubmitRepeatDelayMs() / 1000);
     runTmux(['send-keys', '-t', target, 'C-m']);
   };
 
@@ -1694,7 +1710,7 @@ export async function waitForWorkerReadyAsync(
     // Trust + follow-up splash can require two submits in Codex TUI.
     // Use C-m (carriage return) for raw-mode compatibility.
     await runTmuxAsync(['send-keys', '-t', target, 'C-m']);
-    await sleep(120);
+    await sleep(resolveTmuxSubmitRepeatDelayMs());
     await runTmuxAsync(['send-keys', '-t', target, 'C-m']);
   };
 
@@ -1768,7 +1784,7 @@ export function dismissTrustPromptIfPresent(
   if (!paneHasTrustPrompt(result.stdout)) return false;
   // Trust prompt detected; send C-m twice to dismiss (trust + follow-up splash)
   runTmux(['send-keys', '-t', target, 'C-m']);
-  sleepFractionalSeconds(0.12);
+  sleepFractionalSeconds(resolveTmuxSubmitRepeatDelayMs() / 1000);
   runTmux(['send-keys', '-t', target, 'C-m']);
   return true;
 }
@@ -1807,38 +1823,48 @@ export async function sendToWorker(
   text: string,
   workerPaneId?: string,
   workerCli?: TeamWorkerCli,
+  options: SendToWorkerOptions = {},
 ): Promise<void> {
   assertWorkerTriggerText(text);
 
   const target = paneTarget(sessionName, workerIndex, workerPaneId);
   const strategy = resolveSendStrategyFromEnv();
   const resolvedWorkerCli = resolveWorkerCliForSend(workerIndex, workerCli);
+  const timing: SendToWorkerTiming = {
+    sleepImpl: options.sleepImpl ?? sleep,
+    settleDelayMs: resolveTmuxSubmitSettleMs(
+      undefined,
+      SEND_TO_WORKER_DEFAULT_TMUX_SUBMIT_SETTLE_MS,
+    ),
+    repeatDelayMs: resolveTmuxSubmitRepeatDelayMs(),
+  };
 
   // Guard: if the trust prompt is still present, advance it first so our trigger text
   // doesn't get typed into the trust screen and ignored.
   const capturedStr = await capturePaneAsync(target);
   const paneBusy = paneHasActiveTask(capturedStr);
   if (dismissClaudeBypassPermissionsPromptIfPresent(target, capturedStr)) {
-    await sleep(200);
+    await timing.sleepImpl(200);
   }
   if (paneHasTrustPrompt(capturedStr)) {
     await sendKeyAsync(target, 'C-m');
-    await sleep(120);
+    await timing.sleepImpl(timing.repeatDelayMs);
     await sendKeyAsync(target, 'C-m');
-    await sleep(200);
+    await timing.sleepImpl(200);
   }
 
   sendLiteralTextOrThrow(target, text);
 
-  // Allow the input buffer to settle before sending C-m
-  await sleep(150);
+  // Allow the terminal input buffer to settle before sending C-m. Slow
+  // terminal emulators can need more time after literal typing before Enter.
+  await timing.sleepImpl(timing.settleDelayMs);
 
   const allowAutoInterruptRetry = process.env[OMX_TEAM_AUTO_INTERRUPT_RETRY_ENV] !== '0';
   const submitPlan = buildWorkerSubmitPlan(strategy, resolvedWorkerCli, paneBusy, allowAutoInterruptRetry);
   if (submitPlan.shouldInterrupt) {
     // Explicit interrupt mode: abort current turn first, then submit the new command.
     await sendKeyAsync(target, 'C-c');
-    await sleep(100);
+    await timing.sleepImpl(100);
   }
 
   // Submit deterministically using CLI-specific plan:
@@ -1850,6 +1876,7 @@ export async function sendToWorker(
     submitPlan.rounds,
     submitPlan.queueFirstRound,
     submitPlan.submitKeyPressesPerRound,
+    timing,
   )) return;
 
   // Adaptive escalation for "likely unsent trigger text at ready prompt" cases:
@@ -1858,10 +1885,10 @@ export async function sendToWorker(
   if (shouldAttemptAdaptiveRetry(strategy, paneBusy, submitPlan.allowAdaptiveRetry, latestCapture || null, text)) {
     // Keep this branch non-interrupting to avoid canceling active turns on false positives.
     await sendKeyAsync(target, 'C-u');
-    await sleep(80);
+    await timing.sleepImpl(80);
     sendLiteralTextOrThrow(target, text);
-    await sleep(120);
-    if (await attemptSubmitRounds(target, text, 4, false, submitPlan.submitKeyPressesPerRound)) return;
+    await timing.sleepImpl(timing.settleDelayMs);
+    if (await attemptSubmitRounds(target, text, 4, false, submitPlan.submitKeyPressesPerRound, timing)) return;
   }
 
   // Fail-open by default: Codex may keep the last submitted line visible even after executing it.
@@ -1873,12 +1900,12 @@ export async function sendToWorker(
 
   // One last best-effort double C-m nudge, then verify.
   await sendKeyAsync(target, 'C-m');
-  await sleep(120);
+  await timing.sleepImpl(timing.repeatDelayMs);
   await sendKeyAsync(target, 'C-m');
 
   // Post-submit verification: wait briefly and confirm the worker consumed the
   // trigger (draft disappeared or active-task indicator appeared). Fixes #391.
-  await sleep(300);
+  await timing.sleepImpl(300);
   const [verifyCapture, verifyVisibleCapture] = await Promise.all([
     capturePaneAsync(target),
     captureVisiblePaneAsync(target),
@@ -1893,7 +1920,7 @@ export async function sendToWorker(
     }
     // Draft still visible and no active task — one more C-m attempt.
     await sendKeyAsync(target, 'C-m');
-    await sleep(150);
+    await timing.sleepImpl(timing.repeatDelayMs);
     await sendKeyAsync(target, 'C-m');
     const finalVisibleCapture = await captureVisiblePaneAsync(target);
     if (paneHasQueuedCodexSubmission(finalVisibleCapture)) {

--- a/src/utils/__tests__/tmux-submit-delay.test.ts
+++ b/src/utils/__tests__/tmux-submit-delay.test.ts
@@ -9,8 +9,13 @@ import {
 } from '../tmux-submit-delay.js';
 
 describe('resolveTmuxSubmitSettleMs', () => {
-  it('uses the compatibility default when no override is provided', () => {
-    assert.equal(resolveTmuxSubmitSettleMs(), DEFAULT_TMUX_SUBMIT_SETTLE_MS);
+  it('uses the compatibility default when no override is provided', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-tmux-delay-empty-'));
+    try {
+      assert.equal(resolveTmuxSubmitSettleMs(codexHome), DEFAULT_TMUX_SUBMIT_SETTLE_MS);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
   });
 
   it('uses persistent [omx] tmux_submit_settle_ms from config.toml', async () => {

--- a/src/utils/__tests__/tmux-submit-delay.test.ts
+++ b/src/utils/__tests__/tmux-submit-delay.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  DEFAULT_TMUX_SUBMIT_SETTLE_MS,
+  resolveTmuxSubmitSettleMs,
+} from '../tmux-submit-delay.js';
+
+describe('resolveTmuxSubmitSettleMs', () => {
+  it('uses the compatibility default when no override is provided', () => {
+    assert.equal(resolveTmuxSubmitSettleMs(), DEFAULT_TMUX_SUBMIT_SETTLE_MS);
+  });
+
+  it('uses persistent [omx] tmux_submit_settle_ms from config.toml', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-tmux-delay-'));
+    try {
+      await writeFile(join(codexHome, 'config.toml'), '[omx]\ntmux_submit_settle_ms = 275\n');
+      assert.equal(resolveTmuxSubmitSettleMs(codexHome), 275);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores invalid config.toml delay values', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-tmux-delay-'));
+    try {
+      await writeFile(join(codexHome, 'config.toml'), '[omx]\ntmux_submit_settle_ms = -1\n');
+      assert.equal(resolveTmuxSubmitSettleMs(codexHome), DEFAULT_TMUX_SUBMIT_SETTLE_MS);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/utils/tmux-submit-delay.ts
+++ b/src/utils/tmux-submit-delay.ts
@@ -1,0 +1,75 @@
+import { parse as parseToml } from '@iarna/toml';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { codexConfigPath } from './paths.js';
+
+export const DEFAULT_TMUX_SUBMIT_SETTLE_MS = 120;
+export const DEFAULT_TMUX_SUBMIT_REPEAT_DELAY_MS = 100;
+
+const MAX_TMUX_SUBMIT_DELAY_MS = 60_000;
+
+export function parseTmuxSubmitDelayMs(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return undefined;
+    const rounded = Math.floor(value);
+    if (rounded < 0 || rounded > MAX_TMUX_SUBMIT_DELAY_MS) return undefined;
+    return rounded;
+  }
+
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return undefined;
+  const rounded = Math.floor(parsed);
+  if (rounded < 0 || rounded > MAX_TMUX_SUBMIT_DELAY_MS) return undefined;
+  return rounded;
+}
+
+interface TmuxSubmitDelayTomlConfig {
+  tmux_submit_repeat_delay_ms?: unknown;
+  tmux_submit_settle_ms?: unknown;
+}
+
+interface CodexTomlConfig {
+  omx?: TmuxSubmitDelayTomlConfig;
+}
+
+function readCodexTomlConfig(codexHomeOverride?: string): CodexTomlConfig | null {
+  const configPath = codexHomeOverride
+    ? join(codexHomeOverride, 'config.toml')
+    : codexConfigPath();
+  if (!existsSync(configPath)) return null;
+
+  try {
+    const parsed = parseToml(readFileSync(configPath, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as CodexTomlConfig;
+  } catch {
+    return null;
+  }
+}
+
+function readTomlOmxDelayValue(
+  key: keyof TmuxSubmitDelayTomlConfig,
+  codexHomeOverride?: string,
+): number | undefined {
+  const omx = readCodexTomlConfig(codexHomeOverride)?.omx;
+  if (!omx || typeof omx !== 'object' || Array.isArray(omx)) return undefined;
+  return parseTmuxSubmitDelayMs(omx[key]);
+}
+
+export function resolveTmuxSubmitSettleMs(codexHomeOverride?: string): number {
+  return (
+    readTomlOmxDelayValue('tmux_submit_settle_ms', codexHomeOverride)
+    ?? DEFAULT_TMUX_SUBMIT_SETTLE_MS
+  );
+}
+
+export function resolveTmuxSubmitRepeatDelayMs(codexHomeOverride?: string): number {
+  return (
+    readTomlOmxDelayValue('tmux_submit_repeat_delay_ms', codexHomeOverride)
+    ?? DEFAULT_TMUX_SUBMIT_REPEAT_DELAY_MS
+  );
+}

--- a/src/utils/tmux-submit-delay.ts
+++ b/src/utils/tmux-submit-delay.ts
@@ -60,10 +60,13 @@ function readTomlOmxDelayValue(
   return parseTmuxSubmitDelayMs(omx[key]);
 }
 
-export function resolveTmuxSubmitSettleMs(codexHomeOverride?: string): number {
+export function resolveTmuxSubmitSettleMs(
+  codexHomeOverride?: string,
+  fallbackMs = DEFAULT_TMUX_SUBMIT_SETTLE_MS,
+): number {
   return (
     readTomlOmxDelayValue('tmux_submit_settle_ms', codexHomeOverride)
-    ?? DEFAULT_TMUX_SUBMIT_SETTLE_MS
+    ?? fallbackMs
   );
 }
 


### PR DESCRIPTION
## Summary

- Add persistent TOML configuration for tmux submit timing.
- Use the configured delay in tmux notification sending, SDK tmux injection, the shared team tmux guard, and team startup worker submit paths.
- Preserve the legacy `sendToWorker` first-submit compatibility fallback at 150ms when no TOML override is set.
- Document the setting for slower terminal emulators such as iTerm/tmux setups.
- Add regression coverage and guard against introducing a command-line flag for this persistent preference.

Fixes #2209.

## Context

PR #649 fixed the tmux `C-m` submission path, but the delay before submit remained hardcoded. Some terminal emulators need a longer settle delay between literal text injection and the first Enter keypress. This keeps the general default behavior unchanged while allowing users to tune the delay once in `${CODEX_HOME:-~/.codex}/config.toml`:

```toml
[omx]
tmux_submit_settle_ms = 275
```

The follow-up commit also wires the same persistent delay into the direct team startup path (`sendToWorker`). That path is used when `omx team` injects the initial worker inbox prompt, and local smoke testing showed it could still leave one worker prompt typed but unsubmitted until Enter was pressed manually. The direct startup path now keeps its previous 150ms fallback unless TOML config overrides it.

The direct startup regression lives in a focused `src/team/__tests__/tmux-session-submit-delay.test.ts` file instead of adding more fixture weight to the large `tmux-session.test.ts` suite.

## Validation

- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- Targeted regression tests after preserving the `sendToWorker` 150ms fallback:
  - `node --test --test-name-pattern "delays the first C-m submit|sendToWorker tmux submit timing|resolveTmuxSubmitSettleMs|persistent config.toml tmux submit settle delay|types then submits when typePrompt=true|submits without typing when typePrompt=false" dist/team/__tests__/tmux-session-submit-delay.test.js dist/hooks/__tests__/notify-hook-team-tmux-guard.test.js dist/utils/__tests__/tmux-submit-delay.test.js dist/notifications/__tests__/tmux-detector.test.js` — 9 passed, 0 failed
- Full `npm test` status after latest patch:
  - First rerun exposed a real test-isolation bug in `tmux-detector` because the test read the user `CODEX_HOME`; fixed by isolating `CODEX_HOME`.
  - Latest rerun reached `4737` passed / `1` skipped, then failed only in unrelated `notify-fallback-watcher` temp-dir cleanup with `ENOTEMPTY`; targeted rerun of `node --test dist/hooks/__tests__/notify-fallback-watcher.test.js` passed `62`/`62`.
- Live local smoke with `tmux_submit_settle_ms = 600`: `node dist/cli/omx.js team 4:executor "Startup smoke test only..."` — all 4 workers submitted initial prompts and ACKed without manual Enter; final team state `completed=4`, `failed=0`.
