### PR TITLE
Defer startup self-updates on Windows/global installs

### DIFF
--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -9,6 +9,7 @@ import {
   maybeCheckAndPromptUpdate,
   readUserInstallStamp,
   resolveInstalledCliEntry,
+  runDeferredGlobalUpdate,
   runImmediateUpdate,
   shouldCheckForUpdates,
   spawnInstalledSetupRefresh,
@@ -166,13 +167,15 @@ describe('maybeCheckAndPromptUpdate', () => {
     }
   }
 
-  it('runs setup refresh after a successful auto-update', async () => {
+  it('schedules a deferred update after a successful startup prompt', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
     const originalLog = console.log;
-    const prompts: string[] = [];
-    const setupRefreshCalls: string[] = [];
+    const logs: string[] = [];
+    let inlineUpdateCalls = 0;
+    let setupRefreshCalls = 0;
+    const deferredCwds: string[] = [];
     console.log = (...args: unknown[]) => {
-      prompts.push(args.map((arg) => String(arg)).join(' '));
+      logs.push(args.map((arg) => String(arg)).join(' '));
     };
 
     try {
@@ -180,26 +183,41 @@ describe('maybeCheckAndPromptUpdate', () => {
         await maybeCheckAndPromptUpdate(cwd, {
           getCurrentVersion: async () => '0.8.9',
           fetchLatestVersion: async () => '0.9.0',
-          askYesNo: async () => true,
-          runGlobalUpdate: () => ({ ok: true, stderr: '' }),
-          runSetupRefresh: async (refreshCwd) => {
-            setupRefreshCalls.push(refreshCwd);
+          askYesNo: async (question) => {
+            assert.match(question, /Update after this session exits/);
+            return true;
+          },
+          runGlobalUpdate: () => {
+            inlineUpdateCalls += 1;
+            return { ok: true, stderr: '' };
+          },
+          runDeferredGlobalUpdate: (deferredCwd) => {
+            deferredCwds.push(deferredCwd);
+            return { ok: true, stderr: '', logPath: join(deferredCwd, '.omx', 'logs', 'update-test.log') };
+          },
+          runSetupRefresh: async () => {
+            setupRefreshCalls += 1;
             return { ok: true, stderr: '' };
           },
         });
       });
 
-      assert.deepEqual(setupRefreshCalls, [cwd]);
-      assert.match(prompts.join('\n'), /Updated to v0\.9\.0/);
+      assert.equal(inlineUpdateCalls, 0);
+      assert.equal(setupRefreshCalls, 0);
+      assert.deepEqual(deferredCwds, [cwd]);
+      assert.match(logs.join('\n'), /Update scheduled after this session exits/);
+      assert.match(logs.join('\n'), /Log: .*update-test\.log/);
     } finally {
       console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('preserves local config semantics by avoiding force setup during auto-update', async () => {
+  it('keeps startup update deferred so local setup is not refreshed inline', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
+    const originalLog = console.log;
     const receivedCwds: string[] = [];
+    console.log = () => undefined;
 
     try {
       await withInteractiveTty(async () => {
@@ -207,16 +225,19 @@ describe('maybeCheckAndPromptUpdate', () => {
           getCurrentVersion: async () => '0.13.0',
           fetchLatestVersion: async () => '0.13.1',
           askYesNo: async () => true,
-          runGlobalUpdate: () => ({ ok: true, stderr: '' }),
-          runSetupRefresh: async (refreshCwd) => {
-            receivedCwds.push(refreshCwd);
-            return { ok: true, stderr: '' };
+          runDeferredGlobalUpdate: (deferredCwd) => {
+            receivedCwds.push(deferredCwd);
+            return { ok: true, stderr: '', logPath: join(deferredCwd, '.omx', 'logs', 'update-test.log') };
+          },
+          runSetupRefresh: async () => {
+            throw new Error('startup setup refresh should be handled by the deferred updater');
           },
         });
       });
 
       assert.deepEqual(receivedCwds, [cwd]);
     } finally {
+      console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -250,7 +271,7 @@ describe('maybeCheckAndPromptUpdate', () => {
     }
   });
 
-  it('does not refresh setup when the global update fails', async () => {
+  it('reports scheduler diagnostics when startup deferral cannot be launched', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
     const originalLog = console.log;
     const logs: string[] = [];
@@ -266,7 +287,7 @@ describe('maybeCheckAndPromptUpdate', () => {
           getCurrentVersion: async () => '0.8.9',
           fetchLatestVersion: async () => '0.9.0',
           askYesNo: async () => true,
-          runGlobalUpdate: () => ({ ok: false, stderr: 'npm exited 1' }),
+          runDeferredGlobalUpdate: () => ({ ok: false, stderr: 'powershell not found', logPath: join(cwd, '.omx', 'logs', 'update-test.log') }),
           runSetupRefresh: async () => {
             setupRefreshCalls += 1;
             return { ok: true, stderr: '' };
@@ -275,7 +296,9 @@ describe('maybeCheckAndPromptUpdate', () => {
       });
 
       assert.equal(setupRefreshCalls, 0);
-      assert.match(logs.join('\n'), /Update failed\. Run manually: npm install -g oh-my-codex@latest/);
+      assert.match(logs.join('\n'), /Failed to schedule the deferred update/);
+      assert.match(logs.join('\n'), /powershell not found/);
+      assert.match(logs.join('\n'), /update-test\.log/);
     } finally {
       console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
@@ -593,6 +616,85 @@ describe('runImmediateUpdate', () => {
       } else {
         delete process.env.CODEX_HOME;
       }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runImmediateUpdate failure diagnostics', () => {
+  it('reports npm stderr when explicit update fails', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
+    const originalLog = console.log;
+    const logs: string[] = [];
+    let refreshCalls = 0;
+
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+
+    try {
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.14.0',
+        fetchLatestVersion: async () => '0.14.1',
+        runGlobalUpdate: () => ({ ok: false, stderr: 'EPERM: file is locked\nmore detail' }),
+        runSetupRefresh: async () => {
+          refreshCalls += 1;
+          return { ok: true, stderr: '' };
+        },
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.equal(refreshCalls, 0);
+      assert.match(logs.join('\n'), /Update failed while running npm install -g oh-my-codex@latest/);
+      assert.match(logs.join('\n'), /npm stderr: EPERM: file is locked/);
+      assert.match(logs.join('\n'), /npm install -g oh-my-codex@latest && omx setup/);
+    } finally {
+      console.log = originalLog;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+
+describe('runDeferredGlobalUpdate', () => {
+  it('launches a detached Windows PowerShell updater that waits for the parent and runs setup after npm', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deferred-update-'));
+    const calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+    const listeners: string[] = [];
+
+    try {
+      const result = runDeferredGlobalUpdate(
+        cwd,
+        ((command, args, options) => {
+          calls.push({ command, args: args as string[], options: (options ?? {}) as Record<string, unknown> });
+          return {
+            once(event: string) {
+              listeners.push(event);
+              return this;
+            },
+            unref() {},
+          } as unknown as ReturnType<typeof import('node:child_process').spawn>;
+        }) as typeof import('node:child_process').spawn,
+        'win32',
+        12345,
+      );
+
+      assert.equal(result.ok, true);
+      assert.match(result.logPath ?? '', /\.omx[\\/]logs[\\/]update-/);
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].command, 'powershell.exe');
+      assert.deepEqual(calls[0].args.slice(0, 4), ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command']);
+      assert.deepEqual(listeners, ['error']);
+      assert.equal(calls[0].options.detached, true);
+      assert.equal(calls[0].options.stdio, 'ignore');
+      assert.equal(calls[0].options.windowsHide, true);
+      assert.equal(calls[0].options.cwd, cwd);
+      assert.equal((calls[0].options.env as NodeJS.ProcessEnv | undefined)?.OMX_DEFERRED_UPDATE_PARENT_PID, '12345');
+      assert.equal((calls[0].options.env as NodeJS.ProcessEnv | undefined)?.OMX_DEFERRED_UPDATE_LOG, result.logPath);
+      assert.match(calls[0].args[4], /Get-Process -Id \$parentPid/);
+      assert.match(calls[0].args[4], /npm install -g oh-my-codex@latest/);
+      assert.match(calls[0].args[4], /omx setup/);
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -7,9 +7,9 @@
  */
 
 import { readFile, writeFile, mkdir } from 'fs/promises';
-import { existsSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import { createInterface } from 'readline/promises';
 import { getPackageRoot } from '../utils/package.js';
 import { omxUserInstallStampPath } from '../utils/paths.js';
@@ -35,14 +35,16 @@ interface PackageManifest {
 }
 
 export interface UpdateExecutionResult {
-  status: 'updated' | 'up-to-date' | 'declined' | 'failed' | 'unavailable';
+  status: 'updated' | 'scheduled' | 'up-to-date' | 'declined' | 'failed' | 'unavailable';
   currentVersion: string | null;
   latestVersion: string | null;
 }
 
 type RunGlobalUpdateResult = { ok: boolean; stderr: string };
 type RunSetupRefreshResult = { ok: boolean; stderr: string };
+type RunDeferredUpdateResult = { ok: boolean; stderr: string; logPath?: string };
 type SpawnSyncLike = typeof spawnSync;
+type SpawnLike = typeof spawn;
 
 const PACKAGE_NAME = 'oh-my-codex';
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12h
@@ -124,7 +126,7 @@ async function getCurrentVersion(): Promise<string | null> {
 function runGlobalUpdate(): RunGlobalUpdateResult {
   const result = spawnSync('npm', ['install', '-g', `${PACKAGE_NAME}@latest`], {
     encoding: 'utf-8',
-    stdio: ['ignore', 'ignore', 'pipe'],
+    stdio: ['ignore', 'pipe', 'pipe'],
     timeout: 120000,
     windowsHide: true,
   });
@@ -136,6 +138,100 @@ function runGlobalUpdate(): RunGlobalUpdateResult {
     return { ok: false, stderr: (result.stderr || '').trim() || `npm exited ${result.status}` };
   }
   return { ok: true, stderr: '' };
+}
+
+function formatUpdateLogPath(date = new Date()): string {
+  return `update-${date.toISOString().replace(/[:.]/g, '-')}.log`;
+}
+
+export function runDeferredGlobalUpdate(
+  cwd: string,
+  spawnProcess: SpawnLike = spawn,
+  platform: NodeJS.Platform = process.platform,
+  parentPid = process.pid,
+): RunDeferredUpdateResult {
+  const logPath = join(cwd, '.omx', 'logs', formatUpdateLogPath());
+
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+
+    const env = {
+      ...process.env,
+      OMX_DEFERRED_UPDATE_LOG: logPath,
+      OMX_DEFERRED_UPDATE_PARENT_PID: String(parentPid),
+    };
+
+    const command = platform === 'win32' ? 'powershell.exe' : 'sh';
+    const args = platform === 'win32'
+      ? [
+          '-NoProfile',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-Command',
+          [
+            '$ErrorActionPreference = "Continue"',
+            '$log = $env:OMX_DEFERRED_UPDATE_LOG',
+            '$parentPid = [int]$env:OMX_DEFERRED_UPDATE_PARENT_PID',
+            'while (Get-Process -Id $parentPid -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 1 }',
+            'npm install -g oh-my-codex@latest *>> $log',
+            'if ($LASTEXITCODE -eq 0) { omx setup *>> $log }',
+          ].join('; '),
+        ]
+      : [
+          '-c',
+          [
+            'while kill -0 "$OMX_DEFERRED_UPDATE_PARENT_PID" 2>/dev/null; do sleep 1; done',
+            'npm install -g oh-my-codex@latest >> "$OMX_DEFERRED_UPDATE_LOG" 2>&1',
+            'if [ "$?" -eq 0 ]; then omx setup >> "$OMX_DEFERRED_UPDATE_LOG" 2>&1; fi',
+          ].join('; '),
+        ];
+
+    const child = spawnProcess(command, args, {
+      cwd,
+      detached: true,
+      env,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    child.once('error', (error) => {
+      try {
+        appendFileSync(
+          logPath,
+          `[omx] Deferred update launcher failed: ${error.message}\n`,
+          'utf-8',
+        );
+      } catch {
+        // The startup path must remain non-fatal even when diagnostics cannot be persisted.
+      }
+    });
+    child.unref();
+    return { ok: true, stderr: '', logPath };
+  } catch (error) {
+    return {
+      ok: false,
+      stderr: error instanceof Error ? error.message : String(error),
+      logPath,
+    };
+  }
+}
+
+function formatDeferredUpdateFailure(stderr: string, logPath?: string): string {
+  return [
+    '[omx] Failed to schedule the deferred update.',
+    stderr.trim() ? `[omx] scheduler error: ${stderr.trim()}` : undefined,
+    logPath ? `[omx] Intended log: ${logPath}` : undefined,
+    '[omx] You can retry manually with: npm install -g oh-my-codex@latest && omx setup',
+  ].filter((line): line is string => typeof line === 'string').join('\n');
+}
+
+function summarizeUpdateFailure(stderr: string, logPath?: string): string {
+  const details = stderr.trim().split(/\r?\n/).filter(Boolean).slice(0, 3).join(' | ');
+  return [
+    '[omx] Update failed while running npm install -g oh-my-codex@latest.',
+    details ? `[omx] npm stderr: ${details}` : undefined,
+    logPath ? `[omx] Full log: ${logPath}` : undefined,
+    '[omx] You can retry manually with: npm install -g oh-my-codex@latest && omx setup',
+  ].filter((line): line is string => typeof line === 'string').join('\n');
 }
 
 async function askYesNo(question: string): Promise<boolean> {
@@ -155,6 +251,7 @@ interface UpdateDependencies {
   getCurrentVersion: typeof getCurrentVersion;
   readUserInstallStamp: typeof readUserInstallStamp;
   runGlobalUpdate: typeof runGlobalUpdate;
+  runDeferredGlobalUpdate: typeof runDeferredGlobalUpdate;
   runSetupRefresh: (cwd: string) => Promise<RunSetupRefreshResult>;
   writeUpdateState: typeof writeUpdateState;
 }
@@ -165,6 +262,7 @@ const defaultUpdateDependencies: UpdateDependencies = {
   getCurrentVersion,
   readUserInstallStamp,
   runGlobalUpdate,
+  runDeferredGlobalUpdate,
   runSetupRefresh,
   writeUpdateState,
 };
@@ -377,18 +475,33 @@ async function executeUpdate(
 
   if (prompt) {
     const approved = await dependencies.askYesNo(
-      `[omx] Update available: v${current} → v${latest}. Update now? [Y/n] `,
+      immediate
+        ? `[omx] Update available: v${current} → v${latest}. Update now? [Y/n] `
+        : `[omx] Update available: v${current} → v${latest}. Update after this session exits? [Y/n] `,
     );
     if (!approved) {
       return { status: 'declined', currentVersion: current, latestVersion: latest };
     }
   }
 
+  if (!immediate) {
+    const deferredResult = dependencies.runDeferredGlobalUpdate(cwd);
+    if (!deferredResult.ok) {
+      console.log(formatDeferredUpdateFailure(deferredResult.stderr, deferredResult.logPath));
+      return { status: 'failed', currentVersion: current, latestVersion: latest };
+    }
+    console.log('[omx] Update scheduled after this session exits.');
+    if (deferredResult.logPath) {
+      console.log(`[omx] Log: ${deferredResult.logPath}`);
+    }
+    return { status: 'scheduled', currentVersion: current, latestVersion: latest };
+  }
+
   console.log(`[omx] Running: npm install -g ${PACKAGE_NAME}@latest`);
   const result = dependencies.runGlobalUpdate();
 
   if (!result.ok) {
-    console.log('[omx] Update failed. Run manually: npm install -g oh-my-codex@latest');
+    console.log(summarizeUpdateFailure(result.stderr));
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
 


### PR DESCRIPTION
## Summary
- defer startup self-updates into a detached updater that waits for the active OMX process to exit
- write a scheduled-update log path and keep startup non-fatal instead of mutating the active global npm install inline
- keep explicit `omx update` inline, but surface npm stderr and the manual retry command on failure

Fixes #2211.

## Validation
- `npm run build`
- `node --test dist/cli/__tests__/update.test.js` (36/36 passed)
- `npx biome lint src/cli/update.ts src/cli/__tests__/update.test.ts`
- `npm run check:no-unused -- --pretty false`
- Architect verification: APPROVED

## Notes
- Native Windows PowerShell execution was not run in this Linux/tmux worktree; Windows behavior is covered by a command-shape regression that asserts detached PowerShell launch, parent-PID wait, npm install, setup handoff, log env, and scheduler error listener registration.
- A broader run including `dist/cli/__tests__/index.test.js` hit unrelated live tmux/session-state failures; the update and package-bin tests in that run passed.
