### PR TITLE
Fix PreCompact native hook JSON output

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -125,7 +125,7 @@ The approved OMX-native wiki backport keeps lifecycle ownership intentionally na
 - **Storage** lives under repository `omx_wiki/`, not ignored `.omx/wiki/` runtime state and not `.omc/wiki/`.
 - **SessionStart** may surface bounded wiki context from `omx_wiki/` when the wiki already exists, but it should stay read-mostly and must not block the native hook path on expensive writes or index rebuilds.
 - **SessionEnd** remains a runtime/notify-path responsibility for best-effort, non-blocking session capture into `omx_wiki/`.
-- **PreCompact** is native and bounded: it can surface compact wiki context before compaction. **PostCompact** is native and no-stdout by default: it records the lifecycle seam without emitting advisory `additionalContext` that Codex rejects for PostCompact.
+- **PreCompact** and **PostCompact** are native and no-stdout by default: they record the lifecycle seams without emitting advisory `additionalContext` that Codex rejects for compact hook events.
 - **Routing should stay explicit**: prefer `$wiki` or task verbs like `wiki query` / `wiki add`, and avoid implicit bare `wiki` noun activation.
 
 ## Explicit terminal stop model note

--- a/docs/reference/project-wiki.md
+++ b/docs/reference/project-wiki.md
@@ -54,7 +54,7 @@ The docs and code should never regress back to `.omc/wiki/`.
 - `SessionEnd` stays **runtime-fallback** and **non-blocking**.
   - Best-effort capture is okay.
   - Missing wiki state should degrade to a no-op.
-- `PreCompact` and `PostCompact` are native lifecycle seams: `PreCompact` surfaces bounded wiki context, and `PostCompact` stays a no-stdout lifecycle notification unless a future Codex PostCompact output contract explicitly supports more.
+- `PreCompact` and `PostCompact` are native lifecycle seams that stay no-stdout by default unless a future Codex compact-hook output contract explicitly supports more.
 
 ## Routing contract
 

--- a/src/hooks/__tests__/wiki-docs-contract.test.ts
+++ b/src/hooks/__tests__/wiki-docs-contract.test.ts
@@ -31,8 +31,7 @@ describe("project wiki documentation contract", () => {
     assert.match(hooksDoc, /Storage.*`omx_wiki\/`/i);
     assert.match(hooksDoc, /SessionStart.*bounded wiki context/i);
     assert.match(hooksDoc, /SessionEnd.*runtime\/notify-path.*non-blocking/i);
-    assert.match(hooksDoc, /PreCompact.*native.*bounded/i);
-    assert.match(hooksDoc, /PostCompact.*native.*no-stdout/i);
+    assert.match(hooksDoc, /PreCompact.*PostCompact.*native.*no-stdout/i);
     assert.match(hooksDoc, /prefer `\$wiki`.*avoid implicit bare `wiki` noun activation/i);
   });
 });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -536,7 +536,7 @@ describe("codex native hook dispatch", () => {
 
 
 
-  it("returns bounded wiki context for PreCompact", async () => {
+  it("does not write PreCompact stdout that Codex rejects as hook JSON", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-precompact-"));
     try {
       writePage(cwd, {
@@ -563,10 +563,38 @@ describe("codex native hook dispatch", () => {
 
       assert.equal(result.hookEventName, "PreCompact");
       assert.equal(result.omxEventName, "pre-compact");
-      const additionalContext = (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } } | null)
-        ?.hookSpecificOutput?.additionalContext ?? "";
-      assert.match(additionalContext, /Wiki: 1 pages/);
-      assert.match(additionalContext, /architecture/);
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("emits no CLI stdout for PreCompact when no Codex action is needed", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-precompact-cli-"));
+    try {
+      writePage(cwd, {
+        filename: "architecture.md",
+        frontmatter: {
+          title: "Architecture",
+          tags: ["architecture"],
+          created: "2026-05-08T00:00:00.000Z",
+          updated: "2026-05-08T00:00:00.000Z",
+          sources: [],
+          links: [],
+          category: "architecture",
+          confidence: "high",
+          schemaVersion: WIKI_SCHEMA_VERSION,
+        },
+        content: "\n# Architecture\n\nCompaction-relevant architecture note.\n",
+      });
+
+      const stdout = runNativeHookCli({
+        hook_event_name: "PreCompact",
+        cwd,
+        session_id: "sess-precompact-cli",
+      });
+
+      assert.equal(stdout, "");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3025,15 +3025,10 @@ export async function dispatchCodexNativeHook(
   }
 
   if (hookEventName === "PreCompact") {
-    const compactContext = buildWikiPreCompactContext({ cwd });
-    if (compactContext.additionalContext) {
-      outputJson = {
-        hookSpecificOutput: {
-          hookEventName,
-          additionalContext: compactContext.additionalContext,
-        },
-      };
-    }
+    // Codex native PreCompact currently accepts only the common continuation fields.
+    // Keep the OMX lifecycle dispatch above, but do not emit `hookSpecificOutput`
+    // unless Codex defines a supported PreCompact output contract.
+    buildWikiPreCompactContext({ cwd });
   } else if ((hookEventName === "SessionStart" && !skipCanonicalSessionStartContext) || hookEventName === "UserPromptSubmit") {
     const additionalContext = hookEventName === "SessionStart"
       ? await buildSessionStartContext(cwd, canonicalSessionId || nativeSessionId, {


### PR DESCRIPTION
## Summary

- stop emitting `hookSpecificOutput.additionalContext` for native `PreCompact`, leaving it no-stdout when no Codex action is needed
- add dispatch and CLI stdout regressions for `PreCompact`, mirroring the PostCompact contract from #2207
- update wiki/native-hook docs to describe both compact lifecycle hooks as no-stdout by default

## Rationale

Follow-up to #2205 / #2207.

Codex compact hook output schemas currently allow only the common continuation fields for `PreCompact`/`PostCompact`. `hookSpecificOutput.additionalContext` is accepted by surfaces like `SessionStart`, but Codex rejects it for compact hook events with `invalid PreCompact hook JSON output`.

#2207 fixed the same failure mode for `PostCompact`; this applies the same contract to `PreCompact`.

## Validation

- `npm run build`
- `npm run check:no-unused`
- `npm run lint`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/wiki-docs-contract.test.js dist/config/__tests__/codex-hooks.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js` (302/302)

## Notes

Not live-tested against a full Codex compaction session after this branch, but locally reproduced the schema issue with oh-my-codex 0.16.2 + Codex CLI 0.130.0 and confirmed that no stdout avoids the invalid hook JSON output path.