### PR TITLE
Prevent stale Ralph sessions from auto-resuming

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -731,6 +731,40 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     assert.deepEqual(warnings, []);
   });
 
+  it("marks active Ralph state cancelled with interrupted metadata during postLaunch cleanup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-ralph-interrupted-"));
+    const sessionId = "sess-postlaunch-ralph-interrupted";
+    const sessionStateDir = join(wd, ".omx", "state", "sessions", sessionId);
+    await mkdir(sessionStateDir, { recursive: true });
+    await writeFile(
+      join(sessionStateDir, "ralph-state.json"),
+      JSON.stringify({
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        owner_omx_session_id: sessionId,
+      }, null, 2),
+      "utf-8",
+    );
+
+    try {
+      await cleanupPostLaunchModeStateFiles(wd, sessionId, {
+        now: () => new Date("2026-05-09T08:00:00.000Z"),
+      });
+
+      const ralph = JSON.parse(
+        await readFile(join(sessionStateDir, "ralph-state.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(ralph.active, false);
+      assert.equal(ralph.current_phase, "cancelled");
+      assert.equal(ralph.completed_at, "2026-05-09T08:00:00.000Z");
+      assert.equal(ralph.interrupted_at, "2026-05-09T08:00:00.000Z");
+      assert.equal(ralph.stop_reason, "session_exit");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("does not cancel root mode state during session-scoped postLaunch cleanup", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-root-preserve-"));
     const sessionId = "sess-postlaunch-root-preserve";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3061,6 +3061,10 @@ export async function cleanupPostLaunchModeStateFiles(
         result.state.active = false;
         result.state.current_phase = "cancelled";
         result.state.completed_at = completedAt;
+        if (mode === "ralph") {
+          result.state.interrupted_at = completedAt;
+          result.state.stop_reason = cleanPostLaunchString(result.state.stop_reason) || "session_exit";
+        }
         await writeFile(path, JSON.stringify(result.state, null, 2));
         if (isTrackedWorkflowMode(mode)) {
           await syncCanonicalSkillStateForMode({

--- a/src/hooks/__tests__/notify-hook-ralph-resume.test.ts
+++ b/src/hooks/__tests__/notify-hook-ralph-resume.test.ts
@@ -378,6 +378,47 @@ describe('notify-hook Ralph session resume', () => {
     }
   });
 
+  it('keeps active current-session Ralph state when fresh turn activity is newer than stale updated_at', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-ralph-fresh-current-turn-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const currentOmxSessionId = 'sess-current';
+      const currentSessionDir = join(stateDir, 'sessions', currentOmxSessionId);
+      const lastTurnAt = new Date().toISOString();
+      await writeJson(join(stateDir, 'session.json'), { session_id: currentOmxSessionId });
+      await writeJson(join(currentSessionDir, 'ralph-state.json'), {
+        active: true,
+        iteration: 0,
+        max_iterations: 50,
+        current_phase: 'executing',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        last_turn_at: lastTurnAt,
+        owner_omx_session_id: currentOmxSessionId,
+        owner_codex_session_id: 'codex-session-1',
+      });
+
+      const result = await reconcileRalphSessionResume({
+        stateDir,
+        payloadSessionId: 'codex-session-1',
+        payloadThreadId: 'thread-fresh-current',
+        env: { OMX_RALPH_ACTIVE_STATE_STALE_MS: '60000' },
+      });
+
+      assert.equal(result.resumed, false);
+      assert.equal(result.reason, 'current_ralph_active');
+      const currentState = JSON.parse(
+        await readFile(join(currentSessionDir, 'ralph-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(currentState.active, true);
+      assert.equal(currentState.current_phase, 'executing');
+      assert.equal(currentState.stop_reason, undefined);
+      assert.equal(currentState.abandoned_at, undefined);
+      assert.equal(currentState.last_turn_at, lastTurnAt);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('marks a stale matching prior Ralph abandoned instead of auto-resuming it', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-notify-ralph-stale-prior-'));
     try {

--- a/src/hooks/__tests__/notify-hook-ralph-resume.test.ts
+++ b/src/hooks/__tests__/notify-hook-ralph-resume.test.ts
@@ -336,6 +336,131 @@ describe('notify-hook Ralph session resume', () => {
     }
   });
 
+
+
+  it('marks a stale active current-session Ralph state abandoned instead of rebinding it', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-ralph-stale-current-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const currentOmxSessionId = 'sess-current';
+      const currentSessionDir = join(stateDir, 'sessions', currentOmxSessionId);
+      await writeJson(join(stateDir, 'session.json'), { session_id: currentOmxSessionId });
+      await writeJson(join(currentSessionDir, 'ralph-state.json'), {
+        active: true,
+        iteration: 0,
+        max_iterations: 50,
+        current_phase: 'starting',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        owner_omx_session_id: currentOmxSessionId,
+        owner_codex_session_id: 'codex-session-1',
+      });
+
+      const result = await reconcileRalphSessionResume({
+        stateDir,
+        payloadSessionId: 'codex-session-1',
+        payloadThreadId: 'thread-stale-current',
+        env: { OMX_RALPH_ACTIVE_STATE_STALE_MS: '1000' },
+      });
+
+      assert.equal(result.resumed, false);
+      assert.equal(result.reason, 'current_ralph_abandoned_stale');
+      const currentState = JSON.parse(
+        await readFile(join(currentSessionDir, 'ralph-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(currentState.active, false);
+      assert.equal(currentState.current_phase, 'cancelled');
+      assert.equal(currentState.stop_reason, 'stale_active_state');
+      assert.equal(typeof currentState.abandoned_at, 'string');
+      assert.equal(currentState.stale_resume_threshold_ms, 1000);
+      assert.equal(currentState.stale_resume_timestamp_source, 'updated_at');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('marks a stale matching prior Ralph abandoned instead of auto-resuming it', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-ralph-stale-prior-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const currentOmxSessionId = 'sess-current';
+      const priorOmxSessionId = 'sess-prior';
+      const currentSessionDir = join(stateDir, 'sessions', currentOmxSessionId);
+      const priorSessionDir = join(stateDir, 'sessions', priorOmxSessionId);
+      await writeJson(join(stateDir, 'session.json'), { session_id: currentOmxSessionId });
+      await mkdir(currentSessionDir, { recursive: true });
+      await writeJson(join(priorSessionDir, 'ralph-state.json'), {
+        active: true,
+        iteration: 0,
+        max_iterations: 50,
+        current_phase: 'starting',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        owner_omx_session_id: priorOmxSessionId,
+        owner_codex_session_id: 'codex-session-1',
+      });
+
+      const result = await reconcileRalphSessionResume({
+        stateDir,
+        payloadSessionId: 'codex-session-1',
+        payloadThreadId: 'thread-stale-prior',
+        env: { OMX_RALPH_ACTIVE_STATE_STALE_MS: '1000' },
+      });
+
+      assert.equal(result.resumed, false);
+      assert.equal(result.reason, 'matching_prior_ralph_abandoned_stale');
+      assert.equal(existsSync(join(currentSessionDir, 'ralph-state.json')), false);
+      const priorState = JSON.parse(
+        await readFile(join(priorSessionDir, 'ralph-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(priorState.active, false);
+      assert.equal(priorState.current_phase, 'cancelled');
+      assert.equal(priorState.stop_reason, 'stale_active_state');
+      assert.equal(typeof priorState.abandoned_at, 'string');
+      assert.equal(priorState.stale_resume_timestamp_source, 'updated_at');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats interrupted Ralph state as terminal and not resumable', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-ralph-interrupted-terminal-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const currentOmxSessionId = 'sess-current';
+      const priorOmxSessionId = 'sess-prior';
+      const currentSessionDir = join(stateDir, 'sessions', currentOmxSessionId);
+      const priorSessionDir = join(stateDir, 'sessions', priorOmxSessionId);
+      await writeJson(join(stateDir, 'session.json'), { session_id: currentOmxSessionId });
+      await mkdir(currentSessionDir, { recursive: true });
+      await writeJson(join(priorSessionDir, 'ralph-state.json'), {
+        active: true,
+        iteration: 1,
+        max_iterations: 50,
+        current_phase: 'interrupted',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        owner_omx_session_id: priorOmxSessionId,
+        owner_codex_session_id: 'codex-session-1',
+      });
+
+      const result = await reconcileRalphSessionResume({
+        stateDir,
+        payloadSessionId: 'codex-session-1',
+        payloadThreadId: 'thread-interrupted',
+        env: { OMX_RALPH_ACTIVE_STATE_STALE_MS: '1000' },
+      });
+
+      assert.equal(result.resumed, false);
+      assert.equal(result.reason, 'no_matching_prior_ralph');
+      assert.equal(existsSync(join(currentSessionDir, 'ralph-state.json')), false);
+      const priorState = JSON.parse(
+        await readFile(join(priorSessionDir, 'ralph-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(priorState.active, true);
+      assert.equal(priorState.current_phase, 'interrupted');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('does not auto-resume without a unique matching prior Ralph owner', async (t) => {
     const scenarios = [
       {

--- a/src/scripts/notify-hook/ralph-session-resume.ts
+++ b/src/scripts/notify-hook/ralph-session-resume.ts
@@ -7,7 +7,8 @@ import { resolveCodexPane } from '../tmux-hook-engine.js';
 import { safeString } from './utils.js';
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
-const RALPH_TERMINAL_PHASES = new Set(['blocked_on_user', 'complete', 'failed', 'cancelled']);
+const RALPH_TERMINAL_PHASES = new Set(['blocked_on_user', 'complete', 'failed', 'cancelled', 'interrupted']);
+const DEFAULT_RALPH_ACTIVE_STATE_STALE_MS = 24 * 60 * 60 * 1000;
 const RALPH_RESUME_LOCK_STALE_MS = 10_000;
 const RALPH_RESUME_LOCK_TIMEOUT_MS = 5_000;
 const RALPH_RESUME_LOCK_RETRY_MS = 25;
@@ -38,6 +39,14 @@ interface RalphStateCandidate {
   sessionId: string;
   path: string;
   state: Record<string, unknown>;
+}
+
+interface RalphStateFreshness {
+  stale: boolean;
+  ageMs: number;
+  checkedAtMs: number;
+  staleThresholdMs: number;
+  timestampSource: string;
 }
 
 function lockOwnerToken(): string {
@@ -128,6 +137,77 @@ function isActiveRalphCandidate(state: Record<string, unknown> | null): state is
   return state.active === true && !isTerminalRalphPhase(state.current_phase);
 }
 
+function parsePositiveInteger(value: unknown): number | null {
+  const parsed = Number.parseInt(safeString(value).trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function resolveActiveStateStaleThresholdMs(env: NodeJS.ProcessEnv = process.env): number {
+  return parsePositiveInteger(env.OMX_RALPH_ACTIVE_STATE_STALE_MS)
+    ?? parsePositiveInteger(env.OMX_RALPH_RESUME_STALE_MS)
+    ?? DEFAULT_RALPH_ACTIVE_STATE_STALE_MS;
+}
+
+function parseTimestampMs(value: unknown): number | null {
+  const raw = safeString(value).trim();
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function stateActivityTimestampMs(state: Record<string, unknown>): { ms: number; source: string } | null {
+  for (const key of ['updated_at', 'last_turn_at', 'tmux_pane_set_at']) {
+    const ms = parseTimestampMs(state[key]);
+    if (ms !== null) return { ms, source: key };
+  }
+  return null;
+}
+
+async function readRalphStateFreshness(
+  path: string,
+  state: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<RalphStateFreshness> {
+  const checkedAtMs = Date.now();
+  const threshold = resolveActiveStateStaleThresholdMs(env);
+  let timestamp = stateActivityTimestampMs(state);
+  if (!timestamp) {
+    try {
+      const info = await stat(path);
+      timestamp = { ms: info.mtimeMs, source: 'mtime' };
+    } catch {
+      timestamp = { ms: checkedAtMs, source: 'missing_mtime' };
+    }
+  }
+  const ageMs = Math.max(0, checkedAtMs - timestamp.ms);
+  return {
+    stale: ageMs > threshold,
+    ageMs,
+    checkedAtMs,
+    staleThresholdMs: threshold,
+    timestampSource: timestamp.source,
+  };
+}
+
+async function markRalphStateAbandoned(
+  path: string,
+  state: Record<string, unknown>,
+  freshness: RalphStateFreshness,
+): Promise<void> {
+  const nowIso = new Date(freshness.checkedAtMs).toISOString();
+  await writeJsonAtomic(path, {
+    ...state,
+    active: false,
+    current_phase: 'cancelled',
+    completed_at: nowIso,
+    abandoned_at: nowIso,
+    stop_reason: 'stale_active_state',
+    stale_resume_age_ms: freshness.ageMs,
+    stale_resume_threshold_ms: freshness.staleThresholdMs,
+    stale_resume_timestamp_source: freshness.timestampSource,
+  });
+}
+
 function readSessionIdFromEnvironment(env: NodeJS.ProcessEnv = process.env): string {
   const candidates = [env.OMX_SESSION_ID, env.CODEX_SESSION_ID, env.SESSION_ID];
   for (const candidate of candidates) {
@@ -174,12 +254,14 @@ async function scanMatchingRalphCandidates(
   currentOmxSessionId: string,
   payloadSessionId: string,
   payloadThreadId: string,
-): Promise<RalphStateCandidate[]> {
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ candidates: RalphStateCandidate[]; abandonedCount: number }> {
   const sessionsRoot = join(stateDir, 'sessions');
-  if (!existsSync(sessionsRoot)) return [];
+  if (!existsSync(sessionsRoot)) return { candidates: [], abandonedCount: 0 };
 
   const entries = await readdir(sessionsRoot, { withFileTypes: true }).catch(() => []);
   const matches: RalphStateCandidate[] = [];
+  let abandonedCount = 0;
   for (const entry of entries) {
     if (!entry.isDirectory() || !SESSION_ID_PATTERN.test(entry.name) || entry.name === currentOmxSessionId) continue;
     const path = join(sessionsRoot, entry.name, 'ralph-state.json');
@@ -193,13 +275,19 @@ async function scanMatchingRalphCandidates(
     } else if (!payloadThreadId || !ownerThreadId || ownerThreadId !== payloadThreadId) {
       continue;
     }
+    const freshness = await readRalphStateFreshness(path, state, env);
+    if (freshness.stale) {
+      await markRalphStateAbandoned(path, state, freshness);
+      abandonedCount += 1;
+      continue;
+    }
     matches.push({
       sessionId: entry.name,
       path,
       state,
     });
   }
-  return matches;
+  return { candidates: matches, abandonedCount };
 }
 
 export async function reconcileRalphSessionResume({
@@ -231,6 +319,18 @@ export async function reconcileRalphSessionResume({
     const nowIso = new Date().toISOString();
 
     if (currentRalphState && currentRalphState.active === true) {
+      const freshness = await readRalphStateFreshness(currentRalphPath, currentRalphState, env);
+      if (freshness.stale) {
+        await markRalphStateAbandoned(currentRalphPath, currentRalphState, freshness);
+        return {
+          currentOmxSessionId,
+          resumed: false,
+          updatedCurrentOwner: false,
+          reason: 'current_ralph_abandoned_stale',
+          targetPath: currentRalphPath,
+        };
+      }
+
       let changed = false;
       const updated: Record<string, unknown> = { ...currentRalphState };
       const normalizedPayloadThreadId = safeString(payloadThreadId).trim();
@@ -296,18 +396,21 @@ export async function reconcileRalphSessionResume({
       };
     }
 
-    const candidates = await scanMatchingRalphCandidates(
+    const { candidates, abandonedCount } = await scanMatchingRalphCandidates(
       stateDir,
       currentOmxSessionId,
       normalizedPayloadSessionId,
       normalizedPayloadThreadId,
+      env,
     );
     if (candidates.length !== 1) {
       return {
         currentOmxSessionId,
         resumed: false,
         updatedCurrentOwner: false,
-        reason: candidates.length === 0 ? 'no_matching_prior_ralph' : 'multiple_matching_prior_ralphs',
+        reason: candidates.length === 0
+          ? (abandonedCount > 0 ? 'matching_prior_ralph_abandoned_stale' : 'no_matching_prior_ralph')
+          : 'multiple_matching_prior_ralphs',
       };
     }
 

--- a/src/scripts/notify-hook/ralph-session-resume.ts
+++ b/src/scripts/notify-hook/ralph-session-resume.ts
@@ -156,11 +156,14 @@ function parseTimestampMs(value: unknown): number | null {
 }
 
 function stateActivityTimestampMs(state: Record<string, unknown>): { ms: number; source: string } | null {
+  let newest: { ms: number; source: string } | null = null;
   for (const key of ['updated_at', 'last_turn_at', 'tmux_pane_set_at']) {
     const ms = parseTimestampMs(state[key]);
-    if (ms !== null) return { ms, source: key };
+    if (ms !== null && (!newest || ms > newest.ms)) {
+      newest = { ms, source: key };
+    }
   }
-  return null;
+  return newest;
 }
 
 async function readRalphStateFreshness(


### PR DESCRIPTION
## Summary
- add a conservative stale-age guard for Ralph session auto-resume
- mark stale active current/prior Ralph state abandoned instead of reviving it
- record interrupted metadata when detached postLaunch cleanup directly owns active Ralph state

Closes #2219

## Tests
- npm run build
- env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/hooks/__tests__/notify-hook-ralph-resume.test.js
- env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/cli/__tests__/index.test.js
- npm run lint -- src/scripts/notify-hook/ralph-session-resume.ts src/hooks/__tests__/notify-hook-ralph-resume.test.ts src/cli/index.ts src/cli/__tests__/index.test.ts