### PR TITLE
Fix boxed team state root precedence

### DIFF
--- a/src/team/__tests__/state-root.test.ts
+++ b/src/team/__tests__/state-root.test.ts
@@ -45,7 +45,7 @@ describe('state-root', () => {
     try {
       process.env.OMX_ROOT = '/tmp/omx-box';
       assert.equal(
-        resolveCanonicalTeamStateRoot('/tmp/demo/project', {}),
+        resolveCanonicalTeamStateRoot('/tmp/demo/project'),
         '/tmp/omx-box/.omx/state',
       );
     } finally {

--- a/src/team/state-root.ts
+++ b/src/team/state-root.ts
@@ -14,6 +14,12 @@ export function resolveCanonicalTeamStateRoot(
   if (typeof explicit === 'string' && explicit.trim() !== '') {
     return resolve(leaderCwd, explicit.trim());
   }
+
+  const boxedRoot = env.OMX_ROOT || env.OMX_STATE_ROOT;
+  if (typeof boxedRoot === 'string' && boxedRoot.trim() !== '') {
+    return resolve(leaderCwd, boxedRoot.trim(), '.omx', 'state');
+  }
+
   return omxStateDir(leaderCwd);
 }
 

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -66,7 +66,7 @@ import {
 } from './contracts.js';
 import type { TeamReminderIntent } from './reminder-intents.js';
 import type { WorktreeMode } from './worktree.js';
-import { omxStateDir } from '../utils/paths.js';
+import { resolveCanonicalTeamStateRoot } from './state-root.js';
 
 export type { TeamDispatchRequestStatus, TeamWorkerIntegrationStatus } from './contracts.js';
 
@@ -583,11 +583,7 @@ function normalizeTask(task: TeamTask): TeamTaskV2 {
 
 // Team state directory: .omx/state/team/{teamName}/
 function resolveTeamStateRoot(cwd: string, env: NodeJS.ProcessEnv = process.env): string {
-  const explicit = env.OMX_TEAM_STATE_ROOT;
-  if (typeof explicit === 'string' && explicit.trim() !== '') {
-    return resolve(cwd, explicit.trim());
-  }
-  return omxStateDir(cwd);
+  return resolveCanonicalTeamStateRoot(cwd, env);
 }
 
 function assertSafeTeamName(teamName: string): void {


### PR DESCRIPTION
## Summary
- restore boxed `OMX_ROOT` / `OMX_STATE_ROOT` precedence for canonical team state roots
- route runtime team state directory resolution through the shared canonical resolver
- cover ambient boxed-root behavior while keeping explicit empty env maps deterministic

## CI failure addressed
Dev push run `25597606207` on commit `67e2bfa` failed in:
- `dist/team/__tests__/runtime-boxed-state.test.js` expecting `/tmp/box/.omx/state/team`
- `dist/team/__tests__/state-root.test.js` expecting `/tmp/omx-box/.omx/state`

## Verification
- `npm run build`
- `node --test dist/team/__tests__/state-root.test.js dist/team/__tests__/runtime-boxed-state.test.js`