### PR TITLE
feat(ralph): add approved context refs

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -337,6 +337,31 @@ describe('ralph deslop launch wiring', () => {
     assert.match(instructions, /do not treat this as approved context-bearing execution/i);
   });
 
+  it('includes ready approved context pack refs as read-first Ralph guidance', () => {
+    const instructions = buildRalphAppendInstructions('Execute approved issue 1072 plan', {
+      changedFilesPath: '.omx/ralph/changed-files.txt',
+      noDeslop: false,
+      approvedHint: {
+        ...approvedHint,
+        contextPack: { path: '.omx/context/context-20260507T120000Z-issue-1072.json' },
+        contextPackStatus: 'ready',
+        contextPackRoleRefs: {
+          build: ['src/cli/ralph.ts', 'src/planning/artifacts.ts'],
+          verify: ['src/cli/__tests__/ralph.test.ts'],
+          scope: ['docs/ralph.md'],
+        },
+      },
+    });
+
+    assert.match(instructions, /approved context pack: \.omx\/context\/context-20260507T120000Z-issue-1072\.json/i);
+    assert.match(instructions, /build refs \(read first\): src\/cli\/ralph\.ts, src\/planning\/artifacts\.ts/i);
+    assert.match(instructions, /verify refs: src\/cli\/__tests__\/ralph\.test\.ts/i);
+    assert.match(instructions, /scope refs: docs\/ralph\.md/i);
+    assert.match(instructions, /Read the build refs above before broader repo exploration/i);
+    assert.doesNotMatch(instructions, /Plan-only fallback/i);
+    assert.doesNotMatch(instructions, /repair or recreate the canonical context pack/i);
+  });
+
   it('surfaces repair-only guidance for invalid approved handoff context', () => {
     const instructions = buildRalphAppendInstructions('Repair approved issue 1072 plan', {
       changedFilesPath: '.omx/ralph/changed-files.txt',

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -182,6 +182,28 @@ function buildRalphApprovedContextLines(approvedHint: ApprovedExecutionLaunchHin
     lines.push(approvedHint.repositoryContextSummary.content);
   }
   if (approvedHint.contextPackStatus === 'ready') {
+    if (approvedHint.contextPack) {
+      lines.push(`- approved context pack: ${approvedHint.contextPack.path}`);
+    }
+    if (approvedHint.contextPackRoleRefs) {
+      const { build, verify, scope } = approvedHint.contextPackRoleRefs;
+      if (build.length > 0) {
+        lines.push(`- build refs (read first): ${build.join(', ')}`);
+      }
+      if (verify.length > 0) {
+        lines.push(`- verify refs: ${verify.join(', ')}`);
+      }
+      if (scope.length > 0) {
+        lines.push(`- scope refs: ${scope.join(', ')}`);
+      }
+      if (build.length > 0 || verify.length > 0 || scope.length > 0) {
+        lines.push(
+          build.length > 0
+            ? '- Read the build refs above before broader repo exploration.'
+            : '- Read the approved refs above before broader repo exploration.',
+        );
+      }
+    }
     return lines;
   }
   if (approvedHint.contextPackStatus === 'plan-only') {


### PR DESCRIPTION
## Summary

Ralph already receives approved plan, test-spec, deep-interview, and
repository-summary guidance when it launches from an approved execution hint.
Ready context-pack hints also carry grouped role refs, but Ralph was not
rendering those refs into the session instructions, so the launched run did
not get the bounded read-first context that the approved handoff had already
validated.

This change adds that ready-only guidance to the existing Ralph append
instructions. Nonready context-pack states keep their current fallback and
repair-only behavior.

## Changes

- Render the approved context-pack path for ready approved Ralph handoffs.
- Render grouped `build`, `verify`, and `scope` refs, with build refs marked
  as read-first guidance before broader repository exploration.
- Keep `plan-only`, `incomplete`, `invalid`, and `missing-baseline` behavior
  on the existing fallback or repair-only paths.
- Add focused Ralph instruction coverage for the ready approved context refs.

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/cli/__tests__/ralph.test.js dist/planning/__tests__/artifacts.test.js`
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__` (outside sandbox, 1629 passing)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Follows #2208.
