### PR TITLE
fix: accept canonical approved PRD aliases

### DIFF
--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
-import { join, relative } from 'node:path';
+import { basename, join, relative } from 'node:path';
 import {
   decodeApprovedExecutionQuotedValue,
   isPlanningComplete,
@@ -615,6 +615,7 @@ describe('planning artifacts', () => {
     const rejectedAliases = [
       '.omx/plans/prd-missing.md',
       '../prd-alpha.md',
+      join('..', basename(tempDir), '.omx', 'plans', 'prd-alpha.md'),
       join(tempDir, '.omx', 'prd-alpha.md'),
       relative(process.cwd(), join(plansDir, 'prd-alpha.md')),
     ];

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -575,6 +575,58 @@ describe('planning artifacts', () => {
     assert.deepEqual(hint?.testSpecPaths, [join(plansDir, 'test-spec-alpha.md')]);
   });
 
+  it('binds approved launch hints through canonical-equivalent requested PRD aliases', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const alphaPrdPath = join(plansDir, 'prd-alpha.md');
+    await writeFile(alphaPrdPath, '# Alpha\n\nLaunch via omx ralph "Execute alpha"\n');
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha Test Spec\n');
+    await writeFile(join(plansDir, 'prd-zeta.md'), '# Zeta\n\nLaunch via omx ralph "Execute zeta"\n');
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta Test Spec\n');
+
+    const aliases = [
+      '.omx/plans/prd-alpha.md',
+      'prd-alpha.md',
+      alphaPrdPath,
+      '.omx/plans/../plans/prd-alpha.md',
+      '../plans/prd-alpha.md',
+      join(tempDir, '.omx', 'plans', '..', 'plans', 'prd-alpha.md'),
+    ];
+
+    for (const prdPath of aliases) {
+      const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph', { prdPath });
+
+      assert.equal(outcome.status, 'resolved');
+      if (outcome.status !== 'resolved') {
+        throw new Error(`expected resolved hint for alias ${prdPath}`);
+      }
+      assert.equal(outcome.hint.task, 'Execute alpha');
+      assert.equal(outcome.hint.sourcePath, alphaPrdPath);
+      assert.deepEqual(outcome.hint.testSpecPaths, [join(plansDir, 'test-spec-alpha.md')]);
+    }
+  });
+
+  it('does not bind requested PRD aliases that do not resolve to a discovered canonical PRD', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-alpha.md'), '# Alpha\n\nLaunch via omx ralph "Execute alpha"\n');
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha Test Spec\n');
+
+    const rejectedAliases = [
+      '.omx/plans/prd-missing.md',
+      '../prd-alpha.md',
+      join(tempDir, '.omx', 'prd-alpha.md'),
+      relative(process.cwd(), join(plansDir, 'prd-alpha.md')),
+    ];
+
+    for (const prdPath of rejectedAliases) {
+      assert.equal(
+        readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph', { prdPath }).status,
+        'absent',
+      );
+    }
+  });
+
   it('honors the requested Ralph task when a single plan lists multiple Ralph launch hints', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -210,23 +210,55 @@ function resolveRequestedPrdPath(
   }
 
   const repoRoot = dirname(dirname(artifacts.plansDir));
-  const candidatePaths = isAbsolute(requested)
-    ? [resolve(requested)]
-    : [
-      resolve(repoRoot, requested),
-      resolve(artifacts.plansDir, requested),
-    ];
   const canonicalByResolvedPath = new Map(
     artifacts.prdPaths.map((artifactPath) => [resolve(artifactPath), artifactPath]),
   );
+  const candidatePaths = isAbsolute(requested)
+    ? [resolve(requested)]
+    : [
+      resolveRelativePathWithinRoot(repoRoot, requested, repoRoot),
+      resolveRelativePathWithinRoot(artifacts.plansDir, requested, repoRoot),
+    ];
 
   for (const candidatePath of candidatePaths) {
+    if (!candidatePath) {
+      continue;
+    }
     const canonical = canonicalByResolvedPath.get(candidatePath);
     if (canonical) {
       return canonical;
     }
   }
   return null;
+}
+
+function resolveRelativePathWithinRoot(
+  baseDir: string,
+  rawPath: string,
+  rootDir: string,
+): string | null {
+  const resolvedRootDir = resolve(rootDir);
+  let currentDir = resolve(baseDir);
+
+  for (const segment of rawPath.split(/[\\/]+/)) {
+    if (!segment || segment === '.') {
+      continue;
+    }
+    if (segment === '..') {
+      if (currentDir === resolvedRootDir) {
+        return null;
+      }
+      const parentDir = dirname(currentDir);
+      if (parentDir === currentDir) {
+        return null;
+      }
+      currentDir = parentDir;
+      continue;
+    }
+    currentDir = join(currentDir, segment);
+  }
+
+  return resolve(currentDir);
 }
 
 function selectPlanningArtifacts(

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import {
   comparePlanningArtifactPaths,
   parsePlanningArtifactFileName,
@@ -180,11 +180,12 @@ function selectPlanningArtifactsBase(
   artifacts: PlanningArtifacts,
   prdPath?: string,
 ): PlanningArtifactSelectionBase {
+  const requestedPrdPath = prdPath == null
+    ? null
+    : resolveRequestedPrdPath(artifacts, prdPath);
   const selectedPrdPath = prdPath == null
     ? selectLatestPlanningArtifactPath(artifacts.prdPaths)
-    : artifacts.prdPaths.includes(prdPath)
-      ? prdPath
-      : null;
+    : requestedPrdPath;
   const slug = selectedPrdPath
     ? planningArtifactSlug(selectedPrdPath, 'prd')
     : null;
@@ -194,6 +195,38 @@ function selectPlanningArtifactsBase(
     testSpecPaths: selectMatchingTestSpecsForPrd(selectedPrdPath, artifacts.testSpecPaths),
     deepInterviewSpecPaths: selectDeepInterviewSpecPathsForSlug(artifacts.deepInterviewSpecPaths, slug),
   };
+}
+
+function resolveRequestedPrdPath(
+  artifacts: PlanningArtifacts,
+  rawPrdPath: string,
+): string | null {
+  const requested = rawPrdPath.trim();
+  if (!requested) {
+    return null;
+  }
+  if (artifacts.prdPaths.includes(requested)) {
+    return requested;
+  }
+
+  const repoRoot = dirname(dirname(artifacts.plansDir));
+  const candidatePaths = isAbsolute(requested)
+    ? [resolve(requested)]
+    : [
+      resolve(repoRoot, requested),
+      resolve(artifacts.plansDir, requested),
+    ];
+  const canonicalByResolvedPath = new Map(
+    artifacts.prdPaths.map((artifactPath) => [resolve(artifactPath), artifactPath]),
+  );
+
+  for (const candidatePath of candidatePaths) {
+    const canonical = canonicalByResolvedPath.get(candidatePath);
+    if (canonical) {
+      return canonical;
+    }
+  }
+  return null;
 }
 
 function selectPlanningArtifacts(


### PR DESCRIPTION
## Summary

Approved execution rehydration already accepts an explicit `prdPath`, but the planning artifact reader only matched the discovered artifact path string exactly. If a caller persisted the same approved PRD through a repo-relative, plans-relative, absolute, or normalized alias, the reader treated the hint as missing even though the canonical plan was still present.

This change resolves requested `prdPath` aliases against the current repo root and plans directory before selecting the approved launch hint. The selected hint still reports the discovered canonical PRD path as `sourcePath`, so the persisted binding stays stable once it rehydrates.

## Changes

- accept canonical-equivalent approved `prdPath` aliases when they resolve to a discovered PRD under `.omx/plans`
- keep returning the discovered canonical PRD path instead of echoing the caller alias
- add focused planning artifact coverage for accepted aliases and rejected non-canonical inputs, including a process-cwd-relative path that stays out of scope

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `node --test dist/planning/__tests__/artifacts.test.js dist/pipeline/__tests__/stages.test.js dist/team/__tests__/approved-execution.test.js`
- [x] `node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__ dist/ralph/__tests__ dist/ralplan/__tests__ dist/runtime/__tests__`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- None.
