### PR TITLE
fix: tighten context pack handoff diagnostics

### DIFF
--- a/src/planning/__tests__/context-pack-status.test.ts
+++ b/src/planning/__tests__/context-pack-status.test.ts
@@ -154,6 +154,7 @@ describe('context pack handoff status', () => {
     assert.equal(status.contextPackStatus, 'plan-only');
     assert.equal(status.baselineState, 'present');
     assert.equal(status.outcomeState, 'absent');
+    assert.equal(status.declarationState, 'unknown');
     assert.equal(status.roleCoverage, 'unknown');
     assert.deepEqual(status.missingRequiredContextPackRoles, []);
     assert.deepEqual(status.contextPackIssues, []);
@@ -174,6 +175,7 @@ describe('context pack handoff status', () => {
     assert.deepEqual(status.contextPack, { path: packPath });
     assert.equal(status.contextPackStatus, 'ready');
     assert.equal(status.packState, 'valid');
+    assert.equal(status.declarationState, 'matching');
     assert.equal(status.roleCoverage, 'covered');
     assert.equal(status.basisState, 'fresh');
     assert.deepEqual(status.missingRequiredContextPackRoles, []);
@@ -193,6 +195,7 @@ describe('context pack handoff status', () => {
     const status = readContextPackHandoffStatus(tempDir);
 
     assert.equal(status.contextPackStatus, 'incomplete');
+    assert.equal(status.roleCoverage, 'missing-required-roles');
     assert.deepEqual(status.missingRequiredContextPackRoles, ['build', 'verify']);
   });
 
@@ -211,6 +214,7 @@ describe('context pack handoff status', () => {
 
     assert.equal(status.contextPackStatus, 'invalid');
     assert.equal(status.roleCoverage, 'covered');
+    assert.equal(status.basisState, 'stale');
     assert.deepEqual(status.missingRequiredContextPackRoles, []);
     assert.ok(status.contextPackIssues.some((issue) => issue.includes('basis test-spec hash')));
   });
@@ -303,6 +307,7 @@ describe('context pack handoff status', () => {
 
     assert.equal(status.contextPackStatus, 'invalid');
     assert.equal(status.outcomeState, 'declared');
+    assert.equal(status.declarationState, 'mismatched');
     assert.equal(status.packState, 'invalid');
     assert.ok(status.contextPackIssues.some((issue) => issue.includes(
       'does not match approved plan slug theta',
@@ -325,5 +330,129 @@ describe('context pack handoff status', () => {
     assert.equal(status.contextPackStatus, 'invalid');
     assert.equal(status.outcomeState, 'ambiguous');
     assert.ok(status.contextPackIssues.some((issue) => issue.includes('multiple Context Pack Outcome sections')));
+  });
+
+  it('distinguishes missing, unreadable, invalid, stale, mismatched, and missing-role handoffs', async () => {
+    const cases: Array<{
+      slug: string;
+      mutate: (fixture: Awaited<ReturnType<typeof writeApprovedPlan>>) => Promise<void>;
+      expected: {
+        status: string;
+        packState: string;
+        declarationState: string;
+        basisState: string;
+        roleCoverage: string;
+        issue?: string;
+        missingRoles?: string[];
+      };
+    }> = [
+      {
+        slug: 'missing-pack',
+        mutate: async () => {},
+        expected: {
+          status: 'incomplete',
+          packState: 'missing',
+          declarationState: 'matching',
+          basisState: 'stale',
+          roleCoverage: 'unknown',
+          issue: 'file is missing',
+        },
+      },
+      {
+        slug: 'unreadable-pack',
+        mutate: async ({ packPath }) => { await mkdir(packPath, { recursive: true }); },
+        expected: {
+          status: 'invalid',
+          packState: 'unreadable',
+          declarationState: 'matching',
+          basisState: 'stale',
+          roleCoverage: 'unknown',
+          issue: 'could not be read',
+        },
+      },
+      {
+        slug: 'invalid-pack',
+        mutate: async ({ packPath }) => { await writeFile(packPath, '{bad json'); },
+        expected: {
+          status: 'invalid',
+          packState: 'invalid',
+          declarationState: 'matching',
+          basisState: 'stale',
+          roleCoverage: 'unknown',
+          issue: 'invalid JSON',
+        },
+      },
+      {
+        slug: 'stale-basis',
+        mutate: async ({ prdPath, testSpecPath }) => {
+          await writeContextPack('stale-basis', prdPath, testSpecPath, ['scope', 'build', 'verify']);
+          await writeFile(testSpecPath, '# Drifted Test Spec\n');
+        },
+        expected: {
+          status: 'invalid',
+          packState: 'valid',
+          declarationState: 'matching',
+          basisState: 'stale',
+          roleCoverage: 'covered',
+          issue: 'basis test-spec hash',
+        },
+      },
+      {
+        slug: 'missing-role',
+        mutate: async ({ prdPath, testSpecPath }) => {
+          await writeContextPack('missing-role', prdPath, testSpecPath, ['scope']);
+        },
+        expected: {
+          status: 'incomplete',
+          packState: 'valid',
+          declarationState: 'matching',
+          basisState: 'fresh',
+          roleCoverage: 'missing-required-roles',
+          missingRoles: ['build', 'verify'],
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const fixture = await writeApprovedPlan(testCase.slug, [
+        '# PRD',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath(testCase.slug)),
+        '',
+        `Launch via omx ralph "Execute ${testCase.slug} plan"`,
+      ]);
+      await testCase.mutate(fixture);
+
+      const status = readContextPackHandoffStatus(tempDir, fixture.prdPath);
+
+      assert.equal(status.contextPackStatus, testCase.expected.status);
+      assert.equal(status.packState, testCase.expected.packState);
+      assert.equal(status.declarationState, testCase.expected.declarationState);
+      assert.equal(status.basisState, testCase.expected.basisState);
+      assert.equal(status.roleCoverage, testCase.expected.roleCoverage);
+      assert.deepEqual(
+        status.missingRequiredContextPackRoles,
+        testCase.expected.missingRoles ?? [],
+      );
+      if (testCase.expected.issue) {
+        assert.ok(
+          status.contextPackIssues.some((issue) => issue.includes(testCase.expected.issue ?? '')),
+          `expected issue containing ${testCase.expected.issue}`,
+        );
+      }
+    }
+
+    const mismatch = await writeApprovedPlan('declared-mismatch', [
+      '# PRD',
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath('other')),
+      '',
+      'Launch via omx ralph "Execute mismatch plan"',
+    ]);
+    const mismatchStatus = readContextPackHandoffStatus(tempDir, mismatch.prdPath);
+    assert.equal(mismatchStatus.contextPackStatus, 'invalid');
+    assert.equal(mismatchStatus.declarationState, 'mismatched');
+    assert.equal(mismatchStatus.packState, 'invalid');
+    assert.ok(mismatchStatus.contextPackIssues.some((issue) => issue.includes('does not match approved plan slug')));
   });
 });

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -33,6 +33,7 @@ export type {
   ContextPackHandoffStatusSnapshot,
   ContextPackBaselineState,
   ContextPackBasisState,
+  ContextPackDeclarationState,
   ContextPackOutcomeState,
   ContextPackPackState,
   ContextPackRef,

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -23,6 +23,7 @@ export type ContextPackPackState = 'missing' | 'unreadable' | 'invalid' | 'valid
 export type ContextPackRoleCoverageState =
   'unknown' | 'missing-required-roles' | 'covered';
 export type ContextPackBasisState = 'stale' | 'fresh';
+export type ContextPackDeclarationState = 'unknown' | 'matching' | 'mismatched';
 
 export interface ContextPackRef {
   path: string;
@@ -41,6 +42,7 @@ export interface ContextPackHandoffStatusSnapshot {
   contextPackStatus: ContextPackStatus;
   baselineState: ContextPackBaselineState;
   outcomeState: ContextPackOutcomeState;
+  declarationState: ContextPackDeclarationState;
   packState: ContextPackPackState;
   roleCoverage: ContextPackRoleCoverageState;
   basisState: ContextPackBasisState;
@@ -603,6 +605,7 @@ export function resolveContextPackHandoffStatus(
   let packState: ContextPackPackState = 'missing';
   let roleCoverage: ContextPackRoleCoverageState = 'unknown';
   let basisState: ContextPackBasisState = 'stale';
+  let declarationState: ContextPackDeclarationState = 'unknown';
   let missingRequiredContextPackRoles: ContextPackRole[] = [];
   let declarationMismatch = false;
 
@@ -621,9 +624,12 @@ export function resolveContextPackHandoffStatus(
         && outcome.declaredSlug !== expectedSlug
       ) {
         declarationMismatch = true;
+        declarationState = 'mismatched';
         contextPackIssues.push(
           `Declared context pack slug ${outcome.declaredSlug} does not match approved plan slug ${expectedSlug}.`,
         );
+      } else if (outcome.outcomeState === 'declared' && outcome.declaredSlug && expectedSlug) {
+        declarationState = 'matching';
       }
 
       if (outcome.outcomeState === 'declared' && contextPack) {
@@ -684,6 +690,7 @@ export function resolveContextPackHandoffStatus(
     }),
     baselineState,
     outcomeState,
+    declarationState,
     packState,
     roleCoverage,
     basisState,


### PR DESCRIPTION
## Summary

The context-pack handoff snapshot already preserved the existing `missing-baseline | plan-only | ready | incomplete | invalid` vocabulary, but it did not expose an explicit declaration-match state. That made declaration mismatch distinguishable only through issue text and left the private diagnostics matrix under-specified in tests.

This change adds a private `declarationState` axis to the handoff snapshot and tightens the planning diagnostics coverage around missing, unreadable, invalid, stale, mismatched, and missing-role pack states. The public status vocabulary stays unchanged.

## Changes

- add `declarationState` to `ContextPackHandoffStatusSnapshot` so declared packs can report `unknown`, `matching`, or `mismatched`
- keep the existing public handoff statuses unchanged while preserving the current missing-role fields
- strengthen planning diagnostics tests with a compact matrix that covers missing, unreadable, invalid, stale, mismatched, and missing-role cases

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/planning/__tests__/context-pack-status.test.js dist/planning/__tests__/artifacts.test.js dist/planning/__tests__/ready-context-pack-role-refs.test.js`
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- None.
