### PR TITLE
Fix setup legacy hook-state dedupe

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1203,6 +1203,61 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("dedupes plugin-mode hook trust state when switching user setup back to legacy", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+
+					await setup({ scope: "user", installMode: "plugin", force: true });
+					const pluginConfig = await readFile(configPath, "utf-8");
+					const staleUnfencedPluginConfig = pluginConfig
+						.split(/\r?\n/)
+						.filter(
+							(line) =>
+								line.trim() !== "# OMX-owned Codex hook trust state" &&
+								line.trim() !==
+									"# Trusts only setup-managed codex-native-hook.js wrappers." &&
+								line.trim() !== "# End OMX-owned Codex hook trust state",
+						)
+						.join("\n");
+					await writeFile(configPath, staleUnfencedPluginConfig);
+					assert.doesNotThrow(() => parseToml(staleUnfencedPluginConfig));
+
+					await setup({ scope: "user", installMode: "legacy", force: true });
+
+					const legacyConfig = await readFile(configPath, "utf-8");
+					assert.doesNotThrow(() => parseToml(legacyConfig));
+					assert.equal(
+						legacyConfig
+							.split(/\r?\n/)
+							.filter(
+								(line) =>
+									line.trim() ===
+									`[hooks.state."${join(codexHomeDir, "hooks.json")}:post_compact:0:0"]`,
+							).length,
+						1,
+						"legacy setup should replace stale plugin-mode hook trust state instead of duplicating it",
+					);
+					assert.match(
+						legacyConfig,
+						/# OMX-owned Codex hook trust state[\s\S]*# End OMX-owned Codex hook trust state/,
+					);
+					const persisted = JSON.parse(
+						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+					) as { scope: string; installMode?: string };
+					assert.deepEqual(persisted, {
+						scope: "user",
+						installMode: "legacy",
+					});
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("installs project-scoped native hooks when plugin mode is explicitly requested", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -1098,6 +1098,46 @@ describe("config generator idempotency (#384)", () => {
     assertSingleManagedHookTrustState(repaired);
   });
 
+  it("dedupes stale unfenced managed hook trust-state tables during legacy setup refresh", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const stalePluginModeConfig = [
+      "[features]",
+      "codex_hooks = true",
+      "goals = true",
+      "",
+      '[hooks.state."custom:/hooks.json:stop:0:0"]',
+      'trusted_hash = "sha256:user"',
+      "enabled = false",
+      "",
+      // Regression fixture for #2225: plugin-mode state could be left outside
+      // the managed fence, then legacy setup appended the same table again.
+      '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
+      'trusted_hash = "sha256:stale-plugin-mode"',
+      "",
+    ].join("\n");
+
+    const refreshed = buildMergedConfig(stalePluginModeConfig, "/tmp/omx", {
+      codexHooksFile: hooksPath,
+    });
+
+    assert.doesNotThrow(() => TOML.parse(refreshed));
+    assert.equal(
+      count(
+        refreshed,
+        /^\[hooks\.state\."\/tmp\/codex\/hooks\.json:post_compact:0:0"\]$/gm,
+      ),
+      1,
+      "legacy refresh should replace the stale plugin-mode managed hook state",
+    );
+    assert.match(
+      refreshed,
+      /^\[hooks\.state\."custom:\/hooks\.json:stop:0:0"\]$/m,
+      "unrelated user hook state should be preserved",
+    );
+    assert.match(refreshed, /^enabled = false$/m);
+    assertSingleManagedHookTrustState(refreshed);
+  });
+
   it("syncs shared MCP registry entries in a dedicated managed block", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -625,13 +625,55 @@ export function stripManagedCodexHookTrustState(config: string): string {
   return kept.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
 }
 
+function managedCodexHookTrustStateHeaders(
+  hookTrustToml: string,
+): ReadonlySet<string> {
+  const headers = new Set<string>();
+  for (const line of hookTrustToml.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (/^\[hooks\.state\./.test(trimmed)) {
+      headers.add(trimmed);
+    }
+  }
+  return headers;
+}
+
+function stripUnfencedManagedCodexHookTrustState(
+  config: string,
+  hookTrustToml: string,
+): string {
+  const managedHeaders = managedCodexHookTrustStateHeaders(hookTrustToml);
+  if (managedHeaders.size === 0) return config;
+
+  const lines = config.split(/\r?\n/);
+  const kept: string[] = [];
+
+  for (let i = 0; i < lines.length;) {
+    if (!managedHeaders.has(lines[i].trim())) {
+      kept.push(lines[i]);
+      i += 1;
+      continue;
+    }
+
+    i += 1;
+    while (i < lines.length && !TOML_TABLE_HEADER_PATTERN.test(lines[i])) {
+      i += 1;
+    }
+  }
+
+  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+}
+
 export function upsertManagedCodexHookTrustState(
   config: string,
   pkgRoot: string,
   codexHooksFile: string | undefined,
 ): string {
-  const stripped = stripManagedCodexHookTrustState(config);
   const hookTrustToml = buildManagedCodexHookTrustToml(codexHooksFile, pkgRoot);
+  const stripped = stripUnfencedManagedCodexHookTrustState(
+    stripManagedCodexHookTrustState(config),
+    hookTrustToml,
+  );
   if (!hookTrustToml) return `${stripped}\n`;
   return [
     stripped,
@@ -1700,6 +1742,10 @@ export function buildMergedConfig(
   }
   existing = stripOrphanedManagedNotify(existing, pkgRoot);
   existing = stripManagedCodexHookTrustState(existing);
+  existing = stripUnfencedManagedCodexHookTrustState(
+    existing,
+    buildManagedCodexHookTrustToml(options.codexHooksFile, pkgRoot),
+  );
   if (options.modelOverride) {
     existing = stripRootLevelKeys(existing, ["model"]);
   }


### PR DESCRIPTION
## Summary\n- Fixes #2225.\n- Strip stale unfenced OMX-managed `hooks.state` trust tables before writing the fresh managed block.\n- Preserve unrelated user-owned hook trust state while covering plugin-mode to legacy-mode setup transitions.\n\n## Validation\n- `npm run build`\n- `node --test dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/setup-install-mode.test.js`\n- `npm run check:no-unused`\n- `npm run lint -- src/config/generator.ts src/config/__tests__/generator-idempotent.test.ts src/cli/__tests__/setup-install-mode.test.ts`\n\n## Notes\n- Full `npm test` was attempted in the attached OMX runtime, but existing environment/session-sensitive suites failed unrelated to this change (tmux/session/path state expectations).