### PR TITLE
fix: keep ready role refs inside handoff status

### DIFF
--- a/src/planning/__tests__/context-pack-status.test.ts
+++ b/src/planning/__tests__/context-pack-status.test.ts
@@ -155,6 +155,7 @@ describe('context pack handoff status', () => {
     assert.equal(status.baselineState, 'present');
     assert.equal(status.outcomeState, 'absent');
     assert.equal(status.declarationState, 'unknown');
+    assert.equal(status.contextPackRoleRefs, null);
     assert.equal(status.roleCoverage, 'unknown');
     assert.deepEqual(status.missingRequiredContextPackRoles, []);
     assert.deepEqual(status.contextPackIssues, []);
@@ -178,6 +179,11 @@ describe('context pack handoff status', () => {
     assert.equal(status.declarationState, 'matching');
     assert.equal(status.roleCoverage, 'covered');
     assert.equal(status.basisState, 'fresh');
+    assert.deepEqual(status.contextPackRoleRefs, {
+      scope: ['src/scope-0.ts'],
+      build: ['src/build-1.ts'],
+      verify: ['src/verify-2.ts'],
+    });
     assert.deepEqual(status.missingRequiredContextPackRoles, []);
     assert.deepEqual(status.contextPackIssues, []);
   });
@@ -195,6 +201,8 @@ describe('context pack handoff status', () => {
     const status = readContextPackHandoffStatus(tempDir);
 
     assert.equal(status.contextPackStatus, 'incomplete');
+    assert.equal(status.roleCoverage, 'missing-required-roles');
+    assert.equal(status.contextPackRoleRefs, null);
     assert.equal(status.roleCoverage, 'missing-required-roles');
     assert.deepEqual(status.missingRequiredContextPackRoles, ['build', 'verify']);
   });
@@ -215,6 +223,8 @@ describe('context pack handoff status', () => {
     assert.equal(status.contextPackStatus, 'invalid');
     assert.equal(status.roleCoverage, 'covered');
     assert.equal(status.basisState, 'stale');
+    assert.equal(status.contextPackRoleRefs, null);
+    assert.equal(status.basisState, 'stale');
     assert.deepEqual(status.missingRequiredContextPackRoles, []);
     assert.ok(status.contextPackIssues.some((issue) => issue.includes('basis test-spec hash')));
   });
@@ -234,6 +244,7 @@ describe('context pack handoff status', () => {
 
     assert.equal(status.contextPackStatus, 'invalid');
     assert.equal(status.roleCoverage, 'missing-required-roles');
+    assert.equal(status.contextPackRoleRefs, null);
     assert.deepEqual(status.missingRequiredContextPackRoles, ['build', 'verify']);
     assert.ok(status.contextPackIssues.some((issue) => issue.includes('basis test-spec hash')));
   });
@@ -252,6 +263,7 @@ describe('context pack handoff status', () => {
 
     assert.equal(status.contextPackStatus, 'invalid');
     assert.equal(status.packState, 'invalid');
+    assert.equal(status.contextPackRoleRefs, null);
     assert.equal(status.roleCoverage, 'unknown');
     assert.deepEqual(status.missingRequiredContextPackRoles, []);
     assert.ok(status.contextPackIssues.some((issue) => issue.includes('invalid JSON')));

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -8,7 +8,6 @@ import {
   selectMatchingTestSpecsForPrd,
 } from './artifact-names.js';
 import {
-  readReadyContextPackRoleRefs,
   resolveContextPackHandoffStatus,
   type ContextPackHandoffStatusSnapshot,
   type ContextPackRef,
@@ -204,8 +203,8 @@ function selectPlanningArtifacts(
   const selection = selectPlanningArtifactsBase(artifacts, prdPath);
   const handoffStatus = resolveContextPackHandoffStatus(artifacts, selection);
   const contextPackRoleRefs =
-    handoffStatus.contextPackStatus === 'ready' && handoffStatus.contextPack
-      ? readReadyContextPackRoleRefs(handoffStatus.contextPack.path)
+    handoffStatus.contextPackStatus === 'ready'
+      ? handoffStatus.contextPackRoleRefs
       : null;
   return {
     ...selection,

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -46,6 +46,7 @@ export interface ContextPackHandoffStatusSnapshot {
   packState: ContextPackPackState;
   roleCoverage: ContextPackRoleCoverageState;
   basisState: ContextPackBasisState;
+  contextPackRoleRefs: ContextPackRoleRefs | null;
   missingRequiredContextPackRoles: ContextPackRole[];
   contextPackIssues: string[];
 }
@@ -464,14 +465,9 @@ function emptyContextPackRoleRefs(): ContextPackRoleRefs {
   return { scope: [], build: [], verify: [] };
 }
 
-export function readReadyContextPackRoleRefs(
-  packPath: string,
-): ContextPackRoleRefs | null {
-  const packDocument = readContextPackDocument(packPath);
-  if (!packDocument.document) {
-    return null;
-  }
-
+function groupContextPackRoleRefs(
+  document: ContextPackDocument,
+): ContextPackRoleRefs {
   const grouped = emptyContextPackRoleRefs();
   const seen: Record<ContextPackRole, Set<string>> = {
     scope: new Set<string>(),
@@ -479,7 +475,7 @@ export function readReadyContextPackRoleRefs(
     verify: new Set<string>(),
   };
 
-  for (const entry of packDocument.document.entries) {
+  for (const entry of document.entries) {
     for (const role of entry.roles) {
       if (seen[role].has(entry.path)) {
         continue;
@@ -490,6 +486,16 @@ export function readReadyContextPackRoleRefs(
   }
 
   return grouped;
+}
+
+export function readReadyContextPackRoleRefs(
+  packPath: string,
+): ContextPackRoleRefs | null {
+  const packDocument = readContextPackDocument(packPath);
+  if (!packDocument.document) {
+    return null;
+  }
+  return groupContextPackRoleRefs(packDocument.document);
 }
 
 function validateContextPackBasis(
@@ -606,6 +612,7 @@ export function resolveContextPackHandoffStatus(
   let roleCoverage: ContextPackRoleCoverageState = 'unknown';
   let basisState: ContextPackBasisState = 'stale';
   let declarationState: ContextPackDeclarationState = 'unknown';
+  let contextPackRoleRefs: ContextPackRoleRefs | null = null;
   let missingRequiredContextPackRoles: ContextPackRole[] = [];
   let declarationMismatch = false;
 
@@ -649,6 +656,9 @@ export function resolveContextPackHandoffStatus(
               missingRequiredContextPackRoles.length === 0
                 ? 'covered'
                 : 'missing-required-roles';
+            if (missingRequiredContextPackRoles.length === 0) {
+              contextPackRoleRefs = groupContextPackRoleRefs(packDocument.document);
+            }
             if (baselineState === 'present') {
               const basisIssues = validateContextPackBasis(
                 repoRoot,
@@ -677,23 +687,26 @@ export function resolveContextPackHandoffStatus(
     packState = 'invalid';
   }
 
+  const contextPackStatus = resolveContextPackHandoffState({
+    baselineState,
+    outcomeState,
+    packState,
+    roleCoverage,
+    basisState,
+  });
+
   return {
     prdPath,
     testSpecPaths: selection.testSpecPaths,
     contextPack,
-    contextPackStatus: resolveContextPackHandoffState({
-      baselineState,
-      outcomeState,
-      packState,
-      roleCoverage,
-      basisState,
-    }),
+    contextPackStatus,
     baselineState,
     outcomeState,
     declarationState,
     packState,
     roleCoverage,
     basisState,
+    contextPackRoleRefs: contextPackStatus === 'ready' ? contextPackRoleRefs : null,
     missingRequiredContextPackRoles,
     contextPackIssues,
   };


### PR DESCRIPTION
## Summary

Ready approved context currently depends on one read to resolve handoff readiness and a later second read to project grouped role refs. That means a handoff can be treated as ready without the delivered refs being bound to the same validated pack read.

This change moves grouped role refs into the private handoff status snapshot and makes planning artifact selection reuse those refs only when the resolved handoff status remains `ready`. Nonready and invalid handoffs still fail closed with `null` grouped refs.

## Changes

- compute grouped role refs from the same parsed pack document used for role coverage and basis validation
- carry those grouped refs through `ContextPackHandoffStatusSnapshot`
- reuse snapshot role refs for ready planning artifacts instead of re-reading the pack later
- strengthen context-pack handoff tests to prove ready packs expose grouped refs and nonready packs keep them `null`

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/planning/__tests__/context-pack-status.test.js dist/planning/__tests__/ready-context-pack-role-refs.test.js dist/cli/__tests__/ralph.test.js dist/team/__tests__/approved-execution.test.js`
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__ dist/ralph/__tests__ dist/ralplan/__tests__ dist/runtime/__tests__`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- None.
