### PR TITLE
team: include approved context pack path in ready handoffs

### DIFF
--- a/src/team/__tests__/approved-execution.test.ts
+++ b/src/team/__tests__/approved-execution.test.ts
@@ -65,6 +65,7 @@ describe('approved execution binding', () => {
 
     assert.match(handoff ?? '', /Approved plan: \/repo\/\.omx\/plans\/prd-issue-1314\.md/);
     assert.match(handoff ?? '', /Test specs: \/repo\/\.omx\/plans\/test-spec-issue-1314\.md/);
+    assert.match(handoff ?? '', /Approved context pack: \/repo\/\.omx\/context\/context-20260507T120000Z-issue-1314\.json/);
     assert.match(handoff ?? '', /Approved repository context summary source: \/repo\/\.omx\/plans\/repo-context-issue-1314\.md/);
     assert.match(handoff ?? '', /Read the approved repository slice before broader repo exploration\./);
     assert.match(handoff ?? '', /Build refs \(read first\): src\/build-entry\.ts/);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6527,6 +6527,7 @@ esac
     await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
     const prdPath = join(cwd, '.omx', 'plans', 'prd-issue-1314-handoff.md');
     const testSpecPath = join(cwd, '.omx', 'plans', 'test-spec-issue-1314-handoff.md');
+    const contextPackPath = join(cwd, canonicalContextPackRelativePath('issue-1314-handoff'));
     await writeFile(
       prdPath,
       [
@@ -6577,6 +6578,7 @@ esac
       assert.match(inbox, /## Approved Handoff Context/);
       assert.match(inbox, new RegExp(`Approved plan: ${prdPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
       assert.match(inbox, new RegExp(`Test specs: ${testSpecPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(inbox, new RegExp(`Approved context pack: ${contextPackPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
       assert.match(inbox, /Approved repository context summary source: .*repo-context-issue-1314-handoff\.md/);
       assert.match(inbox, /Read the approved repository slice first\./);
       assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
@@ -6947,6 +6949,7 @@ esac
       await mkdir(plansDir, { recursive: true });
       const prdPath = join(plansDir, 'prd-issue-1320.md');
       const testSpecPath = join(plansDir, 'test-spec-issue-1320.md');
+      const contextPackPath = join(cwd, canonicalContextPackRelativePath('issue-1320'));
       await writeFile(
         prdPath,
         [
@@ -6999,6 +7002,8 @@ esac
       );
       assert.match(inbox, /## Approved Handoff Context/);
       assert.match(inbox, new RegExp(`Approved plan: ${prdPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(inbox, new RegExp(`Test specs: ${testSpecPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(inbox, new RegExp(`Approved context pack: ${contextPackPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
       assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
       assert.match(inbox, /Verify refs: src\/verify-2\.ts/);
       assert.match(inbox, /Scope refs: src\/scope-0\.ts/);

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -1079,6 +1079,8 @@ describe("worker bootstrap", () => {
       {
         approvedContextSection: [
           "- Approved plan: .omx/plans/prd-issue-2039.md",
+          "- Test specs: .omx/plans/test-spec-issue-2039.md",
+          "- Approved context pack: .omx/context/context-20260507T120000Z-issue-2039.json",
           "- Build refs (read first): src/build-1.ts",
           "- Read the build refs above before broader repo exploration.",
         ].join("\n"),
@@ -1092,6 +1094,8 @@ describe("worker bootstrap", () => {
 
     assert.match(inbox, /## Approved Handoff Context/);
     assert.match(inbox, /Approved plan: \.omx\/plans\/prd-issue-2039\.md/);
+    assert.match(inbox, /Test specs: \.omx\/plans\/test-spec-issue-2039\.md/);
+    assert.match(inbox, /Approved context pack: \.omx\/context\/context-20260507T120000Z-issue-2039\.json/);
     assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
     assert.doesNotMatch(inbox, /## Approved Repository Context Summary/);
   });
@@ -1110,6 +1114,8 @@ describe("worker bootstrap", () => {
       {
         approvedContextSection: [
           "- Approved plan: .omx/plans/prd-issue-2040.md",
+          "- Test specs: .omx/plans/test-spec-issue-2040.md",
+          "- Approved context pack: .omx/context/context-20260507T120000Z-issue-2040.json",
           "- Build refs (read first): src/build-1.ts",
           "- Verify refs: src/verify-2.ts",
         ].join("\n"),
@@ -1118,6 +1124,8 @@ describe("worker bootstrap", () => {
 
     assert.match(inbox, /## Approved Handoff Context/);
     assert.match(inbox, /Approved plan: \.omx\/plans\/prd-issue-2040\.md/);
+    assert.match(inbox, /Test specs: \.omx\/plans\/test-spec-issue-2040\.md/);
+    assert.match(inbox, /Approved context pack: \.omx\/context\/context-20260507T120000Z-issue-2040\.json/);
     assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
     assert.match(inbox, /Verify refs: src\/verify-2\.ts/);
   });

--- a/src/team/approved-execution.ts
+++ b/src/team/approved-execution.ts
@@ -113,6 +113,9 @@ export function buildApprovedTeamHandoffSection(
   if (approvedHint.testSpecPaths.length > 0) {
     lines.push(`- Test specs: ${approvedHint.testSpecPaths.join(', ')}`);
   }
+  if (approvedHint.contextPack) {
+    lines.push(`- Approved context pack: ${approvedHint.contextPack.path}`);
+  }
   if (approvedHint.repositoryContextSummary) {
     lines.push(...renderApprovedRepositoryContextSummary(approvedHint.repositoryContextSummary));
   }


### PR DESCRIPTION
## Summary

Ready approved Team handoffs already tell workers which plan, tests, and repo
slice to read first, but they do not show the approved pack file that produced
that handoff. That makes it harder to reopen the exact approved pack when a
worker needs to inspect or cross-check the source of the ready context. This
change adds the approved context-pack path to the existing private Team
handoff section so workers can open the same approved pack directly without
adding any new public Team or CLI surface.

## Changes

- append `Approved context pack: <path>` in
  `buildApprovedTeamHandoffSection()` for ready Team hints so the handoff
  points back to the exact approved pack
- extend Team runtime inbox assertions so both initial worker bootstraps and
  follow-up assignments keep the pack path alongside the existing approved
  handoff lines
- keep nonready Team behavior unchanged

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- `node --test dist/team/__tests__/approved-execution.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/worker-bootstrap.test.js`
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `node dist/scripts/generate-catalog-docs.js --check`
- `node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__ dist/ralph/__tests__ dist/ralplan/__tests__ dist/runtime/__tests__`
  still showed an unrelated failure in
  `dist/runtime/__tests__/process-tree.test.js`
  (`runProcessTreeWithTimeout`) on this machine
- `npm run coverage:team-critical:compiled` still showed unrelated
  environment-sensitive failures outside the approved handoff files on this
  machine, including `dist/runtime/__tests__/process-tree.test.js` and the
  descendant-reaping runtime case in `dist/team/__tests__/runtime.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- Related: #2222
