### PR TITLE
Fix plugin-mode skill discovery

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -764,6 +764,7 @@ describe("omx setup install mode behavior", () => {
 							string,
 							{ source_type?: string; source?: string }
 						>;
+						plugins?: Record<string, { enabled?: boolean }>;
 					};
 					assert.equal(
 						parsed.marketplaces?.["oh-my-codex-local"]?.source_type,
@@ -780,6 +781,15 @@ describe("omx setup install mode behavior", () => {
 							.length,
 						1,
 					);
+					assert.equal(
+						(config.match(/^\[plugins\."oh-my-codex@oh-my-codex-local"\]$/gm) ?? [])
+							.length,
+						1,
+					);
+					assert.equal(
+						parsed.plugins?.["oh-my-codex@oh-my-codex-local"]?.enabled,
+						true,
+					);
 					assert.match(config, /^codex_hooks = true$/m);
 					assert.doesNotMatch(config, /\[mcp_servers\./);
 					assert.equal(
@@ -792,6 +802,59 @@ describe("omx setup install mode behavior", () => {
 					);
 					assert.equal(
 						existsSync(join(codexHomeDir, "prompts", "executor.md")),
+						false,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("enables the local Codex plugin while preserving plugin subtable policy", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					await writeFile(
+						configPath,
+						[
+							"[plugins.\"oh-my-codex@oh-my-codex-local\"]",
+							"enabled = false",
+							"",
+							"[plugins.\"oh-my-codex@oh-my-codex-local\".mcp_servers.omx_state]",
+							"enabled = false",
+							"",
+						].join("\n"),
+					);
+
+					await setup({ scope: "user", installMode: "plugin", force: true });
+					await setup({ scope: "user", installMode: "plugin", force: true });
+
+					const config = await readFile(configPath, "utf-8");
+					const parsed = parseToml(config) as {
+						plugins?: Record<
+							string,
+							{
+								enabled?: boolean;
+								mcp_servers?: Record<string, { enabled?: boolean }>;
+							}
+						>;
+					};
+
+					assert.equal(
+						(config.match(/^\[plugins\."oh-my-codex@oh-my-codex-local"\]$/gm) ?? [])
+							.length,
+						1,
+					);
+					assert.equal(
+						parsed.plugins?.["oh-my-codex@oh-my-codex-local"]?.enabled,
+						true,
+					);
+					assert.equal(
+						parsed.plugins?.["oh-my-codex@oh-my-codex-local"]?.mcp_servers
+							?.omx_state?.enabled,
 						false,
 					);
 				});

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "path";
 
 export const OMX_LOCAL_MARKETPLACE_NAME = "oh-my-codex-local";
 export const OMX_PLUGIN_NAME = "oh-my-codex";
+export const OMX_LOCAL_PLUGIN_CONFIG_KEY = `${OMX_PLUGIN_NAME}@${OMX_LOCAL_MARKETPLACE_NAME}`;
 
 export interface PackagedOmxMarketplace {
 	marketplacePath: string;
@@ -123,4 +124,49 @@ export function upsertLocalOmxMarketplaceRegistration(
 	const stripped = stripLocalOmxMarketplaceRegistration(config).trimEnd();
 	const registration = buildLocalOmxMarketplaceRegistration(packageRoot);
 	return `${stripped ? `${stripped}\n\n` : ""}${registration}\n`;
+}
+
+function localPluginTableHeaderPattern(): RegExp {
+	return new RegExp(
+		`^\\s*\\[plugins\\.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\]\\s*$`,
+	);
+}
+
+export function upsertLocalOmxPluginEnablement(config: string): string {
+	const lines = config.split(/\r?\n/);
+	const headerPattern = localPluginTableHeaderPattern();
+	const start = lines.findIndex((line) => headerPattern.test(line));
+
+	if (start < 0) {
+		const base = config.trimEnd();
+		return `${base ? `${base}\n\n` : ""}[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}]\nenabled = true\n`;
+	}
+
+	let end = lines.length;
+	for (let index = start + 1; index < lines.length; index += 1) {
+		if (isTomlTableHeader(lines[index])) {
+			end = index;
+			break;
+		}
+	}
+
+	let enabledIndex = -1;
+	for (let index = start + 1; index < end; index += 1) {
+		if (/^\s*enabled\s*=/.test(lines[index])) {
+			if (enabledIndex < 0) {
+				enabledIndex = index;
+				lines[index] = "enabled = true";
+			} else {
+				lines.splice(index, 1);
+				index -= 1;
+				end -= 1;
+			}
+		}
+	}
+
+	if (enabledIndex < 0) {
+		lines.splice(start + 1, 0, "enabled = true");
+	}
+
+	return lines.join("\n").replace(/\n*$/, "\n");
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -87,6 +87,7 @@ import {
 	OMX_LOCAL_MARKETPLACE_NAME,
 	resolvePackagedOmxMarketplace,
 	upsertLocalOmxMarketplaceRegistration,
+	upsertLocalOmxPluginEnablement,
 } from "./plugin-marketplace.js";
 
 async function resolveStatusLinePresetForSetup(
@@ -1373,7 +1374,7 @@ async function ensurePluginMarketplaceRegistration(
 		? await readFile(configPath, "utf-8")
 		: "";
 	const nextConfig = upsertLocalOmxMarketplaceRegistration(
-		existingConfig,
+		upsertLocalOmxPluginEnablement(existingConfig),
 		pkgRoot,
 	);
 	const destinationExists = existsSync(configPath);


### PR DESCRIPTION
## Summary
- enable the locally registered Codex plugin in plugin-mode setup by writing `[plugins."oh-my-codex@oh-my-codex-local"] enabled = true`
- preserve existing plugin subtable policy such as per-MCP enablement while normalizing the top-level plugin enablement
- add setup regression coverage for plugin enablement and idempotence

Fixes #2233

## Root cause
Codex 0.130.0 does not load plugin skills from marketplace registration alone. It loads plugin skill roots from installed/enabled plugin entries, so `omx setup --plugin/--force` could register `[marketplaces.oh-my-codex-local]` and refresh caches while still leaving `oh-my-codex@oh-my-codex-local` absent or disabled. That made the mirrored `plugins/oh-my-codex/skills/**/SKILL.md` bundle invisible to `/skills`.

This is separate from #2229, which handles the deprecated hook feature flag and duplicate `hooks.state` cleanup.

## Validation
- `npm run build`
- `node --test dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/codex-plugin-layout.test.js dist/cli/__tests__/package-bin-contract.test.js`
- `npm run check:no-unused`
- `git diff --check`
- `node --test --test-name-pattern "enables the local Codex plugin" dist/cli/__tests__/setup-install-mode.test.js`

## Notes
- Did not copy plugin-mode skills back into `~/.codex/skills`; plugin mode should rely on Codex plugin discovery rather than reintroducing legacy setup-installed skill copies.
