### PR TITLE
fix(planning): ignore hidden approved launch hints

### DIFF
--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -666,6 +666,94 @@ describe('planning artifacts', () => {
     assert.equal(hint, null);
   });
 
+  it('ignores Ralph launch hints that appear only inside indented code blocks', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute hidden indented ralph plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-hidden-indented-ralph.md'),
+      [
+        '# PRD',
+        '',
+        `    omx ralph ${JSON.stringify(task)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-hidden-indented-ralph.md'), '# Test Spec\n');
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph', { task });
+    assert.equal(outcome.status, 'absent');
+  });
+
+  it('ignores Team launch hints inside fenced code blocks', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute approved issue 1314 fenced team plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-1314-fenced-team.md'),
+      [
+        '# PRD',
+        '',
+        '```sh',
+        `omx team 5:reviewer ${JSON.stringify(task)}`,
+        '```',
+        '',
+        `Launch via omx team 2:executor ${JSON.stringify(task)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-1314-fenced-team.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team');
+    assert.ok(hint);
+    assert.equal(hint?.task, task);
+    assert.equal(hint?.workerCount, 2);
+    assert.equal(hint?.agentType, 'executor');
+    assert.equal(hint?.command, `omx team 2:executor ${JSON.stringify(task)}`);
+    assert.equal(hint?.contextPackStatus, 'plan-only');
+  });
+
+  it('ignores Team launch hints that appear only inside fenced code blocks', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute hidden fenced team plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-hidden-fenced-team.md'),
+      [
+        '# PRD',
+        '',
+        '```sh',
+        `omx team 2:executor ${JSON.stringify(task)}`,
+        '```',
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-hidden-fenced-team.md'), '# Test Spec\n');
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'team', { task });
+    assert.equal(outcome.status, 'absent');
+  });
+
+  it('ignores Ralph launch hints inside indented code blocks', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute approved issue 1314 indented ralph plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-1314-indented-ralph.md'),
+      [
+        '# PRD',
+        '',
+        `    omx ralph ${JSON.stringify(task)}`,
+        '',
+        `Launch via omx ralph ${JSON.stringify(task)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-1314-indented-ralph.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    assert.equal(hint?.task, task);
+    assert.equal(hint?.command, `omx ralph ${JSON.stringify(task)}`);
+    assert.equal(hint?.contextPackStatus, 'plan-only');
+  });
+
   it('honors the requested team task when a single plan lists multiple team launch hints', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/planning/__tests__/context-pack-status.test.ts
+++ b/src/planning/__tests__/context-pack-status.test.ts
@@ -288,6 +288,23 @@ describe('context pack handoff status', () => {
     assert.equal(status.outcomeState, 'absent');
   });
 
+  it('ignores indented outcome declarations and keeps the plan in plan-only status', async () => {
+    await writeApprovedPlan('epsilon-indented', [
+      '# PRD',
+      '',
+      '    ## Context Pack Outcome',
+      '',
+      `    - pack: created \`${canonicalContextPackRelativePath('epsilon-indented')}\``,
+      '',
+      'Launch via omx ralph "Execute epsilon indented plan"',
+    ]);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'plan-only');
+    assert.equal(status.outcomeState, 'absent');
+  });
+
   it('rejects nested outcome paths that are not canonical context-pack files', async () => {
     await writeApprovedPlan('eta', [
       '# PRD',

--- a/src/planning/__tests__/markdown-structure.test.ts
+++ b/src/planning/__tests__/markdown-structure.test.ts
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { collectMarkdownVisibleMatches } from '../markdown-structure.js';
+
+describe('collectMarkdownVisibleMatches', () => {
+  it('collects matches from normal markdown lines', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        'match-alpha',
+        '',
+        'match-beta',
+      ].join('\n'),
+      /match-[a-z]+/g,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-alpha', 'match-beta']);
+  });
+
+  it('ignores matches inside backtick fenced code blocks with info strings', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '```sh',
+        'match-hidden',
+        '```',
+        '',
+        'match-visible',
+      ].join('\n'),
+      /match-[a-z]+/g,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('ignores matches inside tilde fenced code blocks', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '~~~md',
+        'match-hidden',
+        '~~~',
+        '',
+        'match-visible',
+      ].join('\n'),
+      /match-[a-z]+/g,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('ignores matches inside four-space indented code blocks', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '    match-hidden',
+        '',
+        'match-visible',
+      ].join('\n'),
+      /match-[a-z]+/g,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('ignores matches inside tab-indented code blocks', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '\tmatch-hidden',
+        '',
+        'match-visible',
+      ].join('\n'),
+      /match-[a-z]+/g,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('keeps a longer tilde fence active until an equal-or-longer matching close', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '~~~~md',
+        'match-hidden-a',
+        '```',
+        'match-hidden-b',
+        '~~~',
+        'match-hidden-c',
+        '~~~~',
+        '',
+        'match-visible',
+      ].join('\n'),
+      /match-[a-z-]+/g,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+});

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -15,6 +15,7 @@ import {
   type ContextPackRoleRefs,
   type ContextPackStatus,
 } from './context-pack-status.js';
+import { collectMarkdownVisibleMatches } from './markdown-structure.js';
 
 const PRD_PATTERN = /^prd-.*\.md$/i;
 const TEST_SPEC_PATTERN = /^test-?spec-.*\.md$/i;
@@ -466,7 +467,7 @@ function collectLaunchHintMatches(
   content: string,
   mode: 'team' | 'ralph',
 ): RegExpMatchArray[] {
-  return [...content.matchAll(launchHintPattern(mode))];
+  return collectMarkdownVisibleMatches(content, launchHintPattern(mode));
 }
 
 function selectLaunchHintMatch(

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -2,6 +2,11 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { planningArtifactSlug } from './artifact-names.js';
+import {
+  advanceMarkdownFenceState,
+  getMarkdownScanState,
+  type MarkdownFenceState,
+} from './markdown-structure.js';
 
 const CONTEXT_PACK_OUTCOME_HEADING_PATTERN =
   /^#{1,6}\s+Context Pack Outcome\s*$/i;
@@ -125,26 +130,16 @@ function computeGitBlobSha1(filePath: string): string {
   return createHash('sha1').update(header).update(buffer).digest('hex');
 }
 
-function isMarkdownFenceLine(line: string): boolean {
-  return /^(```|~~~)/.test(line.trimStart());
-}
-
-function isIndentedMarkdownCodeLine(line: string): boolean {
-  return /^(?: {4,}|\t)/.test(line);
-}
-
 function extractContextPackOutcomeSections(content: string): string[][] {
   const lines = content.replace(/\r\n/g, '\n').split('\n');
   const sections: string[][] = [];
-  let inFence = false;
+  let activeFence: MarkdownFenceState | null = null;
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index]!;
-    if (isMarkdownFenceLine(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence || isIndentedMarkdownCodeLine(line)) {
+    const scanState = getMarkdownScanState(activeFence, line);
+    activeFence = advanceMarkdownFenceState(activeFence, line);
+    if (scanState !== 'normal') {
       continue;
     }
     if (!CONTEXT_PACK_OUTCOME_HEADING_PATTERN.test(line.trim())) {
@@ -152,12 +147,14 @@ function extractContextPackOutcomeSections(content: string): string[][] {
     }
 
     const section: string[] = [];
+    let sectionFence: MarkdownFenceState | null = null;
     for (let sectionIndex = index + 1; sectionIndex < lines.length; sectionIndex += 1) {
       const sectionLine = lines[sectionIndex]!;
       const trimmed = sectionLine.trim();
+      const sectionScanState = getMarkdownScanState(sectionFence, sectionLine);
+      sectionFence = advanceMarkdownFenceState(sectionFence, sectionLine);
       if (
-        isMarkdownFenceLine(sectionLine)
-        || isIndentedMarkdownCodeLine(sectionLine)
+        sectionScanState !== 'normal'
         || /^#{1,6}\s+\S/.test(trimmed)
         || (trimmed !== '' && !/^[*-]\s+/.test(trimmed))
       ) {

--- a/src/planning/markdown-structure.ts
+++ b/src/planning/markdown-structure.ts
@@ -1,0 +1,66 @@
+export interface MarkdownFenceState {
+  char: string;
+  length: number;
+}
+
+export type MarkdownScanState = 'normal' | 'fenced' | 'indented-code';
+
+const MARKDOWN_FENCE_PATTERN = /^(?<marker>`{3,}|~{3,})/;
+
+export function isIndentedMarkdownCodeLine(line: string): boolean {
+  return /^(?: {4,}|\t)/.test(line);
+}
+
+export function getMarkdownScanState(
+  activeFence: MarkdownFenceState | null,
+  line: string,
+): MarkdownScanState {
+  if (activeFence) {
+    return 'fenced';
+  }
+  const trimmed = line.trim();
+  if (MARKDOWN_FENCE_PATTERN.test(trimmed)) {
+    return 'fenced';
+  }
+  if (isIndentedMarkdownCodeLine(line)) {
+    return 'indented-code';
+  }
+  return 'normal';
+}
+
+export function advanceMarkdownFenceState(
+  activeFence: MarkdownFenceState | null,
+  line: string,
+): MarkdownFenceState | null {
+  const trimmed = line.trim();
+  const marker = trimmed.match(MARKDOWN_FENCE_PATTERN)?.groups?.marker ?? null;
+  if (!marker) {
+    return activeFence;
+  }
+  if (activeFence) {
+    if (marker[0] === activeFence.char && marker.length >= activeFence.length) {
+      return null;
+    }
+    return activeFence;
+  }
+  return { char: marker[0]!, length: marker.length };
+}
+
+export function collectMarkdownVisibleMatches(
+  content: string,
+  pattern: RegExp,
+): RegExpMatchArray[] {
+  const lines = content.split(/\r?\n/);
+  const globalFlags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+  let activeFence: MarkdownFenceState | null = null;
+  const matches: RegExpMatchArray[] = [];
+
+  for (const line of lines) {
+    if (getMarkdownScanState(activeFence, line) === 'normal') {
+      matches.push(...line.matchAll(new RegExp(pattern.source, globalFlags)));
+    }
+    activeFence = advanceMarkdownFenceState(activeFence, line);
+  }
+
+  return matches;
+}


### PR DESCRIPTION
## Summary

Approved handoff selection currently scans the full approved PRD markdown body. When a plan includes fenced shell examples or indented command snippets, those hidden commands can participate in Team or Ralph launch-hint selection, which makes same-task lookups ambiguous and can make hidden-only hints look valid. This keeps launch-hint selection limited to visible markdown prose while preserving the existing approved handoff contracts.

## Changes

- add a planning-local markdown visibility helper for normal, fenced, and indented scan states
- make approved Team and Ralph launch-hint collection read only visible markdown lines
- reuse the same hidden-markdown rule for Context Pack Outcome parsing and expand the planning proof for hidden-only hints, hidden duplicate hints, indented outcome declarations, and fence/tab edge cases

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- `node --test dist/planning/__tests__/markdown-structure.test.js dist/planning/__tests__/artifacts.test.js dist/planning/__tests__/context-pack-status.test.js dist/cli/__tests__/ralph.test.js dist/cli/__tests__/team.test.js`
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`
- `node dist/scripts/generate-catalog-docs.js --check`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- None
