### PR TITLE
fix(planning): reuse same-lineage approved hints

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -127,6 +127,38 @@ describe('readMatchedApprovedRalphExecutionHint', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('reuses the older approved Ralph hint when the latest same-task handoff is missing its baseline', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-lineage-fallback-'));
+    const approvedTask = 'Repair approved Ralph lineage handoff';
+    try {
+      await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'plans', 'prd-alpha-lineage.md'),
+        `# PRD\n\nLaunch via omx ralph ${JSON.stringify(approvedTask)}\n`,
+      );
+      await writeFile(join(cwd, '.omx', 'plans', 'test-spec-alpha-lineage.md'), '# Test Spec\n');
+      await writeFile(
+        join(cwd, '.omx', 'plans', 'prd-zeta-lineage.md'),
+        `# PRD\n\nLaunch via omx ralph ${JSON.stringify(approvedTask)}\n`,
+      );
+
+      const hint = readMatchedApprovedRalphExecutionHint(cwd, 'ralph-cli-launch');
+      assert.ok(hint);
+      assert.equal(hint?.sourcePath, join(cwd, '.omx', 'plans', 'prd-alpha-lineage.md'));
+      assert.equal(hint?.contextPackStatus, 'plan-only');
+
+      const instructions = buildRalphAppendInstructions(approvedTask, {
+        changedFilesPath: '.omx/ralph/changed-files.txt',
+        noDeslop: false,
+        approvedHint: hint,
+      });
+      assert.match(instructions, /Approved planning handoff context/i);
+      assert.doesNotMatch(instructions, /Missing-baseline fallback/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('isRalphPrdMode', () => {

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -318,6 +318,35 @@ describe('parseTeamStartArgs', () => {
     }
   });
 
+  it('reuses the older same-signature approved team hint when the latest matching handoff is missing its baseline', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-lineage-'));
+    const previousCwd = process.cwd();
+    const approvedTask = 'Execute approved Team lineage follow-up';
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      await writeFile(
+        join(plansDir, 'prd-alpha-team-lineage.md'),
+        `# Approved plan\n\nLaunch via omx team 3:executor ${JSON.stringify(approvedTask)}\n`,
+      );
+      await writeFile(join(plansDir, 'test-spec-alpha-team-lineage.md'), '# Test spec\n');
+      await writeFile(
+        join(plansDir, 'prd-zeta-team-lineage.md'),
+        `# Approved plan\n\nLaunch via omx team 3:executor ${JSON.stringify(approvedTask)}\n`,
+      );
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, approvedTask);
+      assert.equal(result.parsed.workerCount, 3);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.approvedExecution, undefined);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('prefers the persisted approved binding over a newer latest approved hint for a short follow-up', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-bound-'));
     const previousCwd = process.cwd();

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -666,6 +666,31 @@ describe('planning artifacts', () => {
     assert.equal(hint, null);
   });
 
+  it('reuses the older bare Ralph handoff when the latest same-task handoff is missing its baseline', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const sharedTask = 'Execute shared Ralph lineage handoff';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-alpha-ralph-lineage.md'),
+      `# Alpha\n\nLaunch via omx ralph ${JSON.stringify(sharedTask)}\n`,
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha-ralph-lineage.md'), '# Alpha Test Spec\n');
+    await writeFile(
+      join(plansDir, 'prd-zeta-ralph-lineage.md'),
+      `# Zeta\n\nLaunch via omx ralph ${JSON.stringify(sharedTask)}\n`,
+    );
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph');
+
+    assert.equal(outcome.status, 'resolved');
+    if (outcome.status !== 'resolved') {
+      throw new Error('expected a resolved Ralph lineage outcome');
+    }
+    assert.equal(outcome.hint.sourcePath, join(plansDir, 'prd-alpha-ralph-lineage.md'));
+    assert.equal(outcome.hint.contextPackStatus, 'plan-only');
+    assert.equal(readApprovedExecutionLaunchHint(tempDir, 'ralph')?.sourcePath, join(plansDir, 'prd-alpha-ralph-lineage.md'));
+  });
+
   it('honors the requested team task when a single plan lists multiple team launch hints', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });
@@ -795,6 +820,121 @@ describe('planning artifacts', () => {
     assert.equal(hint?.workerCount, 2);
     assert.equal(hint?.agentType, 'executor');
     assert.equal(hint?.linkedRalph, false);
+  });
+
+  it('reuses the older bare Team handoff when the latest same-signature handoff is missing its baseline', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const sharedTask = 'Execute shared Team lineage handoff';
+    const sharedCommand = `omx team 3:executor ${JSON.stringify(sharedTask)}`;
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-alpha-team-lineage.md'),
+      `# Alpha\n\nLaunch via ${sharedCommand}\n`,
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha-team-lineage.md'), '# Alpha Test Spec\n');
+    await writeFile(
+      join(plansDir, 'prd-zeta-team-lineage.md'),
+      `# Zeta\n\nLaunch via ${sharedCommand}\n`,
+    );
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'team');
+
+    assert.equal(outcome.status, 'resolved');
+    if (outcome.status !== 'resolved') {
+      throw new Error('expected a resolved Team lineage outcome');
+    }
+    assert.equal(outcome.hint.sourcePath, join(plansDir, 'prd-alpha-team-lineage.md'));
+    assert.equal(outcome.hint.contextPackStatus, 'plan-only');
+    assert.equal(outcome.hint.workerCount, 3);
+    assert.equal(outcome.hint.agentType, 'executor');
+    assert.equal(readApprovedExecutionLaunchHint(tempDir, 'team')?.sourcePath, join(plansDir, 'prd-alpha-team-lineage.md'));
+  });
+
+  it('keeps the latest nonready Team handoff when older same-task PRDs change the launch signature', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const sharedTask = 'Execute shared Team signature split';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-alpha-team-signature-split.md'),
+      `# Alpha\n\nLaunch via omx team 2:executor ${JSON.stringify(sharedTask)}\n`,
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha-team-signature-split.md'), '# Alpha Test Spec\n');
+    await writeFile(
+      join(plansDir, 'prd-zeta-team-signature-split.md'),
+      `# Zeta\n\nLaunch via omx team 5:debugger ${JSON.stringify(sharedTask)}\n`,
+    );
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'team', { task: sharedTask });
+
+    assert.equal(outcome.status, 'resolved');
+    if (outcome.status !== 'resolved') {
+      throw new Error('expected the latest nonready Team lineage outcome');
+    }
+    assert.equal(outcome.hint.sourcePath, join(plansDir, 'prd-zeta-team-signature-split.md'));
+    assert.equal(outcome.hint.contextPackStatus, 'missing-baseline');
+    assert.equal(outcome.hint.workerCount, 5);
+    assert.equal(outcome.hint.agentType, 'debugger');
+    assert.equal(readApprovedExecutionLaunchHint(tempDir, 'team', { task: sharedTask }), null);
+  });
+
+  it('rehydrates the exact older Team command across newer same-task nonready PRDs', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const sharedTask = 'Execute exact Team lineage command';
+    const olderCommand = `omx team 2:executor ${JSON.stringify(sharedTask)}`;
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-alpha-team-command-lineage.md'),
+      `# Alpha\n\nLaunch via ${olderCommand}\n`,
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha-team-command-lineage.md'), '# Alpha Test Spec\n');
+    await writeFile(
+      join(plansDir, 'prd-zeta-team-command-lineage.md'),
+      `# Zeta\n\nLaunch via omx team 5:debugger ${JSON.stringify(sharedTask)}\n`,
+    );
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'team', {
+      task: sharedTask,
+      command: olderCommand,
+    });
+
+    assert.equal(outcome.status, 'resolved');
+    if (outcome.status !== 'resolved') {
+      throw new Error('expected a resolved exact Team command outcome');
+    }
+    assert.equal(outcome.hint.sourcePath, join(plansDir, 'prd-alpha-team-command-lineage.md'));
+    assert.equal(outcome.hint.command, olderCommand);
+    assert.equal(outcome.hint.contextPackStatus, 'plan-only');
+  });
+
+  it('fails closed when an older same-lineage Team handoff becomes ambiguous', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const sharedTask = 'Execute ambiguous Team lineage handoff';
+    const sharedCommand = `omx team 3:executor ${JSON.stringify(sharedTask)}`;
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-alpha-team-lineage-ready.md'),
+      `# Alpha\n\nLaunch via ${sharedCommand}\n`,
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha-team-lineage-ready.md'), '# Alpha Test Spec\n');
+    await writeFile(
+      join(plansDir, 'prd-beta-team-lineage-ambiguous.md'),
+      [
+        '# Beta',
+        '',
+        `Launch via ${sharedCommand}`,
+        `Launch via $team 3:executor ${JSON.stringify(sharedTask)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-beta-team-lineage-ambiguous.md'), '# Beta Test Spec\n');
+    await writeFile(
+      join(plansDir, 'prd-zeta-team-lineage-nonready.md'),
+      `# Zeta\n\nLaunch via ${sharedCommand}\n`,
+    );
+
+    assert.equal(
+      readApprovedExecutionLaunchHintOutcome(tempDir, 'team', { task: sharedTask }).status,
+      'ambiguous',
+    );
   });
 
   it('fails closed for bare team lookups when a single plan lists multiple team launch hints', async () => {

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -8,6 +8,7 @@ import {
   selectMatchingTestSpecsForPrd,
 } from './artifact-names.js';
 import {
+  isApprovedExecutionFollowupReadyStatus,
   resolveContextPackHandoffStatus,
   type ContextPackHandoffStatusSnapshot,
   type ContextPackRef,
@@ -564,27 +565,66 @@ function matchesRequestedTeamLaunchSignature(
   return true;
 }
 
-export function readApprovedExecutionLaunchHintOutcome(
+function buildRequestedTeamLaunchSignatureMatchFilter(
+  options: ApprovedExecutionLaunchHintReadOptions,
+): LaunchHintMatchFilter | undefined {
+  if (options.command || !hasRequestedTeamLaunchSignature(options)) {
+    return undefined;
+  }
+  return (match: RegExpMatchArray, _task: string) => matchesRequestedTeamLaunchSignature(match, options);
+}
+
+function sameTeamLaunchSignatureMatch(
+  anchorHint: ApprovedExecutionLaunchHint,
+  match: RegExpMatchArray,
+): boolean {
+  const groups = match.groups;
+  if (!groups) {
+    return false;
+  }
+
+  const workerCount = Number.parseInt(groups.count ?? '', 10);
+  if (!Number.isFinite(workerCount) || workerCount !== anchorHint.workerCount) {
+    return false;
+  }
+
+  const actualAgentType = groups.role?.trim();
+  const expectedAgentType = anchorHint.agentType?.trim();
+  if ((actualAgentType || undefined) !== (expectedAgentType || undefined)) {
+    return false;
+  }
+
+  return Boolean(groups.ralph?.trim()) === Boolean(anchorHint.linkedRalph);
+}
+
+function orderedPrdPathsNewestFirst(prdPaths: readonly string[]): string[] {
+  return [...prdPaths].sort(comparePlanningArtifactPaths).reverse();
+}
+
+function readApprovedExecutionLaunchHintOutcomeForPrdPath(
   cwd: string,
   mode: 'team' | 'ralph',
+  prdPath: string,
   options: ApprovedExecutionLaunchHintReadOptions = {},
+  matchFilter?: LaunchHintMatchFilter,
 ): ApprovedExecutionLaunchHintOutcome {
-  const approvedPlan = readApprovedPlanText(cwd, options, true);
-  if (!approvedPlan) return { status: 'absent' };
+  const approvedPlan = readApprovedPlanText(cwd, { ...options, prdPath }, true);
+  if (!approvedPlan) {
+    return { status: 'absent' };
+  }
 
-  const teamMatchFilter = mode === 'team'
-    && !options.command
-    && hasRequestedTeamLaunchSignature(options)
-    ? (match: RegExpMatchArray, _task: string) => matchesRequestedTeamLaunchSignature(match, options)
-    : undefined;
   const selected = selectLaunchHintMatch(
     collectLaunchHintMatches(approvedPlan.content, mode),
     options.task?.trim(),
     options.command?.trim(),
-    teamMatchFilter,
+    matchFilter,
   );
-  if (selected.status === 'ambiguous') return { status: 'ambiguous' };
-  if (selected.status !== 'unique' || !selected.match.groups) return { status: 'absent' };
+  if (selected.status === 'ambiguous') {
+    return { status: 'ambiguous' };
+  }
+  if (selected.status !== 'unique' || !selected.match.groups) {
+    return { status: 'absent' };
+  }
 
   if (mode === 'team') {
     const workerCount = Number.parseInt(selected.match.groups.count, 10);
@@ -614,6 +654,148 @@ export function readApprovedExecutionLaunchHintOutcome(
       ...approvedPlan.context,
     },
   };
+}
+
+type SameLineageFallback =
+  | { status: 'none' }
+  | { status: 'ambiguous' }
+  | { status: 'resolved'; hint: ApprovedExecutionLaunchHint };
+
+function resolveOlderReusableSameLineageHint(
+  cwd: string,
+  mode: 'team' | 'ralph',
+  artifacts: PlanningArtifacts,
+  latestPrdPath: string,
+  anchorHint: ApprovedExecutionLaunchHint,
+): SameLineageFallback {
+  const orderedPrdPaths = [...artifacts.prdPaths].sort(comparePlanningArtifactPaths);
+  const latestIndex = orderedPrdPaths.lastIndexOf(latestPrdPath);
+  if (latestIndex <= 0) {
+    return { status: 'none' };
+  }
+
+  for (let index = latestIndex - 1; index >= 0; index -= 1) {
+    const prdPath = orderedPrdPaths[index]!;
+    const outcome = readApprovedExecutionLaunchHintOutcomeForPrdPath(
+      cwd,
+      mode,
+      prdPath,
+      { task: anchorHint.task },
+      mode === 'team'
+        ? (match: RegExpMatchArray, _task: string) => sameTeamLaunchSignatureMatch(anchorHint, match)
+        : undefined,
+    );
+    if (outcome.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    if (outcome.status !== 'resolved') {
+      continue;
+    }
+    if (isApprovedExecutionFollowupReadyStatus(outcome.hint.contextPackStatus)) {
+      return { status: 'resolved', hint: outcome.hint };
+    }
+  }
+
+  return { status: 'none' };
+}
+
+export function readApprovedExecutionLaunchHintOutcome(
+  cwd: string,
+  mode: 'team' | 'ralph',
+  options: ApprovedExecutionLaunchHintReadOptions = {},
+): ApprovedExecutionLaunchHintOutcome {
+  if (options.prdPath) {
+    return readApprovedExecutionLaunchHintOutcomeForPrdPath(
+      cwd,
+      mode,
+      options.prdPath,
+      options,
+      mode === 'team' ? buildRequestedTeamLaunchSignatureMatchFilter(options) : undefined,
+    );
+  }
+
+  const normalizedTask = options.task?.trim();
+  const normalizedCommand = options.command?.trim();
+  if (!normalizedTask && !normalizedCommand) {
+    const artifacts = readPlanningArtifacts(cwd);
+    const latestPrdPath = selectLatestPlanningArtifactPath(artifacts.prdPaths);
+    if (!latestPrdPath) {
+      return { status: 'absent' };
+    }
+
+    const latestOutcome = readApprovedExecutionLaunchHintOutcomeForPrdPath(
+      cwd,
+      mode,
+      latestPrdPath,
+      options,
+      mode === 'team' ? buildRequestedTeamLaunchSignatureMatchFilter(options) : undefined,
+    );
+    if (latestOutcome.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    if (latestOutcome.status !== 'resolved') {
+      return { status: 'absent' };
+    }
+    if (isApprovedExecutionFollowupReadyStatus(latestOutcome.hint.contextPackStatus)) {
+      return latestOutcome;
+    }
+
+    const fallback = resolveOlderReusableSameLineageHint(
+      cwd,
+      mode,
+      artifacts,
+      latestPrdPath,
+      latestOutcome.hint,
+    );
+    if (fallback.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    return fallback.status === 'resolved'
+      ? { status: 'resolved', hint: fallback.hint }
+      : latestOutcome;
+  }
+
+  const artifacts = readPlanningArtifacts(cwd);
+  let newestNonreadyHint: ApprovedExecutionLaunchHint | null = null;
+  let teamLineageAnchorHint: ApprovedExecutionLaunchHint | null = null;
+  for (const prdPath of orderedPrdPathsNewestFirst(artifacts.prdPaths)) {
+    const teamLineageAnchor = teamLineageAnchorHint;
+    const requestedTeamMatchFilter = mode === 'team'
+      ? buildRequestedTeamLaunchSignatureMatchFilter(options)
+      : undefined;
+    const teamLineageMatchFilter = requestedTeamMatchFilter ?? (
+      mode === 'team'
+      && normalizedTask
+      && !normalizedCommand
+      && teamLineageAnchor
+        ? (match: RegExpMatchArray, _task: string) => sameTeamLaunchSignatureMatch(teamLineageAnchor, match)
+        : undefined
+    );
+    const outcome = readApprovedExecutionLaunchHintOutcomeForPrdPath(
+      cwd,
+      mode,
+      prdPath,
+      options,
+      teamLineageMatchFilter,
+    );
+    if (outcome.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    if (outcome.status !== 'resolved') {
+      continue;
+    }
+    if (mode === 'team' && normalizedTask && !normalizedCommand) {
+      teamLineageAnchorHint ??= outcome.hint;
+    }
+    if (isApprovedExecutionFollowupReadyStatus(outcome.hint.contextPackStatus)) {
+      return outcome;
+    }
+    newestNonreadyHint ??= outcome.hint;
+  }
+
+  return newestNonreadyHint
+    ? { status: 'resolved', hint: newestNonreadyHint }
+    : { status: 'absent' };
 }
 
 export function readApprovedExecutionLaunchHint(


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Approved launch-hint selection currently stops at the newest matching PRD. When that newest Team or Ralph handoff is nonready, short follow-ups stay pinned to the nonready handoff even when an older reusable handoff in the same lineage still exists. This change keeps the selector fail-closed while allowing it to reuse older same-lineage handoffs instead of dropping usable approved context.

## Changes

- backscan approved Team and Ralph launch hints across older PRDs only when the newest matching handoff is nonready
- keep Team fallback constrained to the full launch signature and preserve exact-command selection
- add planning and CLI regression coverage for same-lineage reuse, signature-mismatch non-fallback, and ambiguous same-lineage fail-closed behavior

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- Focused rerun: `node --test dist/planning/__tests__/artifacts.test.js dist/cli/__tests__/ralph.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/approved-execution.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #