### PR TITLE
fix: harden approved launch-hint markdown scanning

### DIFF
--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -666,6 +666,183 @@ describe('planning artifacts', () => {
     assert.equal(hint, null);
   });
 
+  it('ignores Ralph launch hints that appear only inside indented code blocks', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute hidden indented ralph plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-hidden-indented-ralph.md'),
+      [
+        '# PRD',
+        '',
+        `    omx ralph ${JSON.stringify(task)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-hidden-indented-ralph.md'), '# Test Spec\n');
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph', { task });
+    assert.equal(outcome.status, 'absent');
+  });
+
+  it('ignores Team launch hints inside fenced code blocks', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute approved issue 1314 fenced team plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-1314-fenced-team.md'),
+      [
+        '# PRD',
+        '',
+        '```sh',
+        `omx team 5:reviewer ${JSON.stringify(task)}`,
+        '```',
+        '',
+        `Launch via omx team 2:executor ${JSON.stringify(task)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-1314-fenced-team.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team');
+    assert.ok(hint);
+    assert.equal(hint?.task, task);
+    assert.equal(hint?.workerCount, 2);
+    assert.equal(hint?.agentType, 'executor');
+    assert.equal(hint?.command, `omx team 2:executor ${JSON.stringify(task)}`);
+    assert.equal(hint?.contextPackStatus, 'plan-only');
+  });
+
+  it('ignores Team launch hints that appear only inside fenced code blocks', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute hidden fenced team plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-hidden-fenced-team.md'),
+      [
+        '# PRD',
+        '',
+        '```sh',
+        `omx team 2:executor ${JSON.stringify(task)}`,
+        '```',
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-hidden-fenced-team.md'), '# Test Spec\n');
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'team', { task });
+    assert.equal(outcome.status, 'absent');
+  });
+
+  it('ignores adversarial hidden Team launch hints that try to break out with deceptive fence lines', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute adversarial fenced team plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-adversarial-fenced-team.md'),
+      [
+        '# PRD',
+        '',
+        '```md',
+        `omx team 9:reviewer ${JSON.stringify(task)}`,
+        '    ```',
+        '```still-open',
+        '~~~',
+        `omx team 7:critic ${JSON.stringify(task)}`,
+        '```',
+        '',
+        `Launch via omx team 2:executor ${JSON.stringify(task)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-adversarial-fenced-team.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team');
+    assert.ok(hint);
+    assert.equal(hint?.task, task);
+    assert.equal(hint?.workerCount, 2);
+    assert.equal(hint?.agentType, 'executor');
+    assert.equal(hint?.command, `omx team 2:executor ${JSON.stringify(task)}`);
+    assert.equal(hint?.contextPackStatus, 'plan-only');
+  });
+
+  it('ignores Team launch hints inside nested commented blocks with inner fence lookalikes', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute commented nested team plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-commented-nested-team.md'),
+      [
+        '# PRD',
+        '',
+        '<!--',
+        `Launch via omx team 9:reviewer ${JSON.stringify(task)}`,
+        '<!--',
+        `omx team 7:critic ${JSON.stringify(task)}`,
+        '```md',
+        `Launch via omx team 6:debugger ${JSON.stringify(task)}`,
+        '-->',
+        '~~~',
+        '-->',
+        '',
+        `Launch via omx team 2:executor ${JSON.stringify(task)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-commented-nested-team.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team');
+    assert.ok(hint);
+    assert.equal(hint?.task, task);
+    assert.equal(hint?.workerCount, 2);
+    assert.equal(hint?.agentType, 'executor');
+    assert.equal(hint?.command, `omx team 2:executor ${JSON.stringify(task)}`);
+    assert.equal(hint?.contextPackStatus, 'plan-only');
+  });
+
+  it('ignores Ralph launch hints inside indented code blocks', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute approved issue 1314 indented ralph plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-1314-indented-ralph.md'),
+      [
+        '# PRD',
+        '',
+        `    omx ralph ${JSON.stringify(task)}`,
+        '',
+        `Launch via omx ralph ${JSON.stringify(task)}`,
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-1314-indented-ralph.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    assert.equal(hint?.task, task);
+    assert.equal(hint?.command, `omx ralph ${JSON.stringify(task)}`);
+    assert.equal(hint?.contextPackStatus, 'plan-only');
+  });
+
+  it('ignores Ralph launch hints that appear only inside nested commented blocks', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute hidden commented ralph plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-hidden-commented-ralph.md'),
+      [
+        '# PRD',
+        '',
+        '<!--',
+        `Launch via omx ralph ${JSON.stringify(task)}`,
+        '<!--',
+        `omx ralph ${JSON.stringify(task)}`,
+        '```md',
+        `Launch via omx ralph ${JSON.stringify(task)}`,
+        '-->',
+        '-->',
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-hidden-commented-ralph.md'), '# Test Spec\n');
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph', { task });
+    assert.equal(outcome.status, 'absent');
+  });
+
   it('honors the requested team task when a single plan lists multiple team launch hints', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/planning/__tests__/context-pack-status.test.ts
+++ b/src/planning/__tests__/context-pack-status.test.ts
@@ -288,6 +288,109 @@ describe('context pack handoff status', () => {
     assert.equal(status.outcomeState, 'absent');
   });
 
+  it('ignores indented outcome declarations and keeps the plan in plan-only status', async () => {
+    await writeApprovedPlan('epsilon-indented', [
+      '# PRD',
+      '',
+      '    ## Context Pack Outcome',
+      '',
+      `    - pack: created \`${canonicalContextPackRelativePath('epsilon-indented')}\``,
+      '',
+      'Launch via omx ralph "Execute epsilon indented plan"',
+    ]);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'plan-only');
+    assert.equal(status.outcomeState, 'absent');
+  });
+
+  it('ignores commented outcome declarations and keeps the plan in plan-only status', async () => {
+    await writeApprovedPlan('epsilon-commented', [
+      '# PRD',
+      '',
+      '<!--',
+      '## Context Pack Outcome',
+      '',
+      `- pack: created \`${canonicalContextPackRelativePath('epsilon-commented-hidden')}\``,
+      '<!--',
+      `- pack: created \`${canonicalContextPackRelativePath('epsilon-commented-hidden-deeper')}\``,
+      '-->',
+      '-->',
+      '',
+      'Launch via omx ralph "Execute epsilon commented plan"',
+    ]);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'plan-only');
+    assert.equal(status.outcomeState, 'absent');
+  });
+
+  it('ignores adversarial hidden outcome declarations and still reads the visible declaration', async () => {
+    const { prdPath, testSpecPath } = await writeApprovedPlan('epsilon-adversarial', [
+      '# PRD',
+      '',
+      '```md',
+      '## Context Pack Outcome',
+      '',
+      `- pack: created \`${canonicalContextPackRelativePath('sample-hidden')}\``,
+      '    ```',
+      '```still-open',
+      '~~~',
+      '## Context Pack Outcome',
+      '',
+      `- pack: created \`${canonicalContextPackRelativePath('other-hidden')}\``,
+      '```',
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath('epsilon-adversarial')),
+      '',
+      'Launch via omx ralph "Execute epsilon adversarial plan"',
+    ]);
+    await writeContextPack('epsilon-adversarial', prdPath, testSpecPath, ['scope', 'build', 'verify']);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'ready');
+    assert.equal(status.outcomeState, 'declared');
+    assert.deepEqual(status.contextPack, {
+      path: join(tempDir, canonicalContextPackRelativePath('epsilon-adversarial')),
+    });
+    assert.deepEqual(status.contextPackIssues, []);
+  });
+
+  it('keeps the visible outcome section valid when nested hidden blocks appear inside it', async () => {
+    const { prdPath, testSpecPath } = await writeApprovedPlan('epsilon-inner-hidden', [
+      '# PRD',
+      '',
+      '## Context Pack Outcome',
+      '',
+      '<!--',
+      `- pack: created \`${canonicalContextPackRelativePath('epsilon-inner-hidden-comment')}\``,
+      '<!--',
+      `- pack: created \`${canonicalContextPackRelativePath('epsilon-inner-hidden-comment-deeper')}\``,
+      '-->',
+      '-->',
+      '```md',
+      `- pack: created \`${canonicalContextPackRelativePath('epsilon-inner-hidden-fenced')}\``,
+      '```',
+      `    - pack: created \`${canonicalContextPackRelativePath('epsilon-inner-hidden-indented')}\``,
+      `- pack: created \`${canonicalContextPackRelativePath('epsilon-inner-hidden')}\``,
+      '',
+      'Launch via omx ralph "Execute epsilon inner hidden plan"',
+    ]);
+    await writeContextPack('epsilon-inner-hidden', prdPath, testSpecPath, ['scope', 'build', 'verify']);
+
+    const status = readContextPackHandoffStatus(tempDir);
+
+    assert.equal(status.contextPackStatus, 'ready');
+    assert.equal(status.outcomeState, 'declared');
+    assert.deepEqual(status.contextPack, {
+      path: join(tempDir, canonicalContextPackRelativePath('epsilon-inner-hidden')),
+    });
+    assert.deepEqual(status.contextPackIssues, []);
+  });
+
   it('rejects nested outcome paths that are not canonical context-pack files', async () => {
     await writeApprovedPlan('eta', [
       '# PRD',

--- a/src/planning/__tests__/markdown-structure.test.ts
+++ b/src/planning/__tests__/markdown-structure.test.ts
@@ -1,0 +1,548 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { collectMarkdownVisibleMatches } from '../markdown-structure.js';
+
+type ModelFenceChar = '`' | '~';
+
+interface ModelFenceState {
+  readonly char: ModelFenceChar;
+  readonly length: number;
+}
+
+interface ModelFenceMarker extends ModelFenceState {
+  readonly suffix: string;
+}
+
+interface ModelVisibilityState {
+  readonly fence: ModelFenceState | null;
+  readonly commentDepth: number;
+}
+
+const MATCH_TOKEN_PATTERN = /match-[a-z]+/g;
+const MODEL_COMMENT_LINE_PATTERN = /^(?: {0,3})<!--/;
+const MODEL_COMMENT_OPEN = '<!--';
+const MODEL_COMMENT_CLOSE = '-->';
+const INITIAL_MODEL_VISIBILITY_STATE: ModelVisibilityState = {
+  fence: null,
+  commentDepth: 0,
+};
+
+function isModelIndentedCodeLine(line: string): boolean {
+  return line.startsWith('    ') || line.startsWith('\t');
+}
+
+function readModelFenceMarker(line: string): ModelFenceMarker | null {
+  let index = 0;
+  while (index < line.length && line[index] === ' ' && index < 4) {
+    index += 1;
+  }
+  if (index >= 4 || line[index] === '\t') {
+    return null;
+  }
+  const char = line[index];
+  if (char !== '`' && char !== '~') {
+    return null;
+  }
+  let markerEnd = index;
+  while (line[markerEnd] === char) {
+    markerEnd += 1;
+  }
+  const length = markerEnd - index;
+  if (length < 3) {
+    return null;
+  }
+  return {
+    char,
+    length,
+    suffix: line.slice(markerEnd),
+  };
+}
+
+function advanceModelCommentDepth(activeDepth: number, line: string): number {
+  if (activeDepth === 0 && !MODEL_COMMENT_LINE_PATTERN.test(line)) {
+    return 0;
+  }
+
+  let depth = activeDepth;
+  let index = 0;
+
+  while (index < line.length) {
+    const nextOpen = line.indexOf(MODEL_COMMENT_OPEN, index);
+    const nextClose = line.indexOf(MODEL_COMMENT_CLOSE, index);
+
+    if (nextOpen === -1 && nextClose === -1) {
+      break;
+    }
+    if (nextOpen !== -1 && (nextClose === -1 || nextOpen < nextClose)) {
+      depth += 1;
+      index = nextOpen + MODEL_COMMENT_OPEN.length;
+      continue;
+    }
+    if (depth > 0) {
+      depth -= 1;
+    }
+    index = nextClose + MODEL_COMMENT_CLOSE.length;
+  }
+
+  return depth;
+}
+
+function advanceModelFenceState(
+  activeFence: ModelFenceState | null,
+  line: string,
+): ModelFenceState | null {
+  const fenceMarker = readModelFenceMarker(line);
+  if (!fenceMarker) {
+    return activeFence;
+  }
+  if (activeFence) {
+    if (
+      fenceMarker.char === activeFence.char
+      && fenceMarker.length >= activeFence.length
+      && /^[ \t]*$/.test(fenceMarker.suffix)
+    ) {
+      return null;
+    }
+    return activeFence;
+  }
+  return { char: fenceMarker.char, length: fenceMarker.length };
+}
+
+function collectMatchesFromMarkdownModel(content: string): string[] {
+  const lines = content.split(/\r?\n/);
+  const matches: string[] = [];
+  let state = INITIAL_MODEL_VISIBILITY_STATE;
+
+  for (const line of lines) {
+    if (state.fence) {
+      state = {
+        fence: advanceModelFenceState(state.fence, line),
+        commentDepth: state.commentDepth,
+      };
+      continue;
+    }
+    if (state.commentDepth > 0 || MODEL_COMMENT_LINE_PATTERN.test(line)) {
+      state = {
+        fence: null,
+        commentDepth: advanceModelCommentDepth(state.commentDepth, line),
+      };
+      continue;
+    }
+    if (isModelIndentedCodeLine(line)) {
+      continue;
+    }
+
+    const fenceMarker = readModelFenceMarker(line);
+    if (fenceMarker) {
+      state = {
+        fence: { char: fenceMarker.char, length: fenceMarker.length },
+        commentDepth: 0,
+      };
+      continue;
+    }
+
+    matches.push(...Array.from(line.matchAll(MATCH_TOKEN_PATTERN), (match) => match[0]));
+  }
+
+  return matches;
+}
+
+describe('collectMarkdownVisibleMatches', () => {
+  it('collects matches from normal markdown lines', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        'match-alpha',
+        '',
+        'match-beta',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-alpha', 'match-beta']);
+  });
+
+  it('ignores matches inside backtick fenced code blocks with info strings', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '```sh',
+        'match-hidden',
+        '```',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('treats fences with up to three leading spaces as real fenced blocks', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '   ```sh',
+        'match-hidden',
+        '   ```',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('treats block comments with up to three leading spaces as hidden blocks', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '   <!--',
+        'match-hidden',
+        '   -->',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('keeps nested block comments opaque across arbitrary nesting depths', () => {
+    for (let depth = 1; depth <= 6; depth += 1) {
+      const matches = collectMarkdownVisibleMatches(
+        [
+          '# PRD',
+          '',
+          ...Array.from({ length: depth }, () => '<!--'),
+          '```md',
+          'match-hidden-a',
+          '~~~',
+          'match-hidden-b',
+          ...Array.from({ length: depth }, () => '-->'),
+          '',
+          'match-visible',
+        ].join('\n'),
+        MATCH_TOKEN_PATTERN,
+      );
+
+      assert.deepEqual(
+        matches.map((match) => match[0]),
+        ['match-visible'],
+        `depth: ${depth}`,
+      );
+    }
+  });
+
+  it('ignores matches inside four-space indented code blocks', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '    match-hidden',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('ignores matches inside tab-indented code blocks', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '\tmatch-hidden',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('does not let tab-indented fence lookalikes open a fenced block', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '\t```',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('handles CRLF markdown without leaking hidden matches', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '```sh',
+        'match-hidden',
+        '```',
+        '',
+        'match-visible',
+      ].join('\r\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('keeps three-space fences distinct from four-space indented fence lookalikes', () => {
+    const fencedMatches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '   ```md',
+        'match-hidden',
+        '   ```',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+    const indentedMatches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '    ```',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(fencedMatches.map((match) => match[0]), ['match-visible']);
+    assert.deepEqual(indentedMatches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('does not treat short fence markers as fenced blocks', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '``',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('does not let four-space-indented fence markers close an active fenced block', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '```md',
+        'match-hidden-a',
+        '    ```',
+        'match-hidden-b',
+        '```',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('does not let four-space-indented fence markers open a fenced block', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '    ```',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('keeps exact closing fences distinct from trailing-text fence lookalikes', () => {
+    const closedMatches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '```md',
+        'match-hidden-a',
+        '```',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+    const stillOpenMatches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '```md',
+        'match-hidden-a',
+        '```still-open',
+        'match-hidden-b',
+        '```',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(closedMatches.map((match) => match[0]), ['match-visible']);
+    assert.deepEqual(stillOpenMatches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('allows closing fences with trailing spaces', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '```md',
+        'match-hidden',
+        '```   ',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('does not treat trailing info text as a fenced-block close marker', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '```md',
+        'match-hidden-a',
+        '```still-open',
+        'match-hidden-b',
+        '```',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('keeps matching close characters distinct from different-character fence lookalikes', () => {
+    const closedMatches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '~~~md',
+        'match-hidden-a',
+        '~~~',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+    const mismatchedMatches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '~~~md',
+        'match-hidden-a',
+        '```',
+        'match-hidden-b',
+        '~~~',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(closedMatches.map((match) => match[0]), ['match-visible']);
+    assert.deepEqual(mismatchedMatches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('keeps a longer tilde fence active until an equal-or-longer matching close', () => {
+    const matches = collectMarkdownVisibleMatches(
+      [
+        '# PRD',
+        '',
+        '~~~~md',
+        'match-hidden-a',
+        '```',
+        'match-hidden-b',
+        '~~~',
+        'match-hidden-c',
+        '~~~~',
+        '',
+        'match-visible',
+      ].join('\n'),
+      MATCH_TOKEN_PATTERN,
+    );
+
+    assert.deepEqual(matches.map((match) => match[0]), ['match-visible']);
+  });
+
+  it('matches a reference markdown-visibility model across generated line sequences', () => {
+    const generatedLinePatterns = [
+      { name: 'blank', line: '' },
+      { name: 'visible-alpha', line: 'match-alpha' },
+      { name: 'visible-beta', line: 'match-beta' },
+      { name: 'indented-visible', line: '    match-alpha' },
+      { name: 'tab-indented-fence-like', line: '\t```' },
+      { name: 'short-backtick', line: '``' },
+      { name: 'open-backtick', line: '```md' },
+      { name: 'open-long-backtick', line: '````md' },
+      { name: 'open-three-space-backtick', line: '   ```md' },
+      { name: 'close-backtick', line: '```' },
+      { name: 'close-backtick-spaces', line: '```   ' },
+      { name: 'indented-fence-like', line: '    ```' },
+      { name: 'close-like-with-text', line: '```still-open' },
+      { name: 'open-tilde', line: '~~~md' },
+      { name: 'close-tilde', line: '~~~' },
+      { name: 'single-line-comment', line: '<!-- match-hidden -->' },
+      { name: 'comment-open', line: '<!--' },
+      { name: 'comment-open-with-match', line: '<!-- match-hidden' },
+      { name: 'comment-open-with-nested-open', line: '<!-- nested <!--' },
+      { name: 'comment-close', line: '-->' },
+      { name: 'comment-close-with-match', line: '--> match-alpha' },
+      { name: 'commented-fence-like', line: '<!-- ``` -->' },
+    ] as const;
+
+    let checkedSequenceCount = 0;
+
+    for (const first of generatedLinePatterns) {
+      for (const second of generatedLinePatterns) {
+        for (const third of generatedLinePatterns) {
+          for (const fourth of generatedLinePatterns) {
+            const sequence = [first, second, third, fourth];
+            const content = sequence.map((entry) => entry.line).join('\n');
+            const expectedMatches = collectMatchesFromMarkdownModel(content);
+            const actualMatches = collectMarkdownVisibleMatches(content, MATCH_TOKEN_PATTERN)
+              .map((match) => match[0]);
+            assert.deepEqual(
+              actualMatches,
+              expectedMatches,
+              `sequence: ${sequence.map((entry) => entry.name).join(' -> ')}`,
+            );
+            checkedSequenceCount += 1;
+          }
+        }
+      }
+    }
+
+    assert.equal(checkedSequenceCount, generatedLinePatterns.length ** 4);
+  });
+});

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -15,6 +15,7 @@ import {
   type ContextPackRoleRefs,
   type ContextPackStatus,
 } from './context-pack-status.js';
+import { collectMarkdownVisibleMatches } from './markdown-structure.js';
 
 const PRD_PATTERN = /^prd-.*\.md$/i;
 const TEST_SPEC_PATTERN = /^test-?spec-.*\.md$/i;
@@ -466,7 +467,7 @@ function collectLaunchHintMatches(
   content: string,
   mode: 'team' | 'ralph',
 ): RegExpMatchArray[] {
-  return [...content.matchAll(launchHintPattern(mode))];
+  return collectMarkdownVisibleMatches(content, launchHintPattern(mode));
 }
 
 function selectLaunchHintMatch(

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -2,6 +2,11 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { planningArtifactSlug } from './artifact-names.js';
+import {
+  INITIAL_MARKDOWN_VISIBILITY_STATE,
+  inspectMarkdownLine,
+  type MarkdownVisibilityState,
+} from './markdown-structure.js';
 
 const CONTEXT_PACK_OUTCOME_HEADING_PATTERN =
   /^#{1,6}\s+Context Pack Outcome\s*$/i;
@@ -125,45 +130,39 @@ function computeGitBlobSha1(filePath: string): string {
   return createHash('sha1').update(header).update(buffer).digest('hex');
 }
 
-function isMarkdownFenceLine(line: string): boolean {
-  return /^(```|~~~)/.test(line.trimStart());
-}
-
-function isIndentedMarkdownCodeLine(line: string): boolean {
-  return /^(?: {4,}|\t)/.test(line);
-}
-
 function extractContextPackOutcomeSections(content: string): string[][] {
   const lines = content.replace(/\r\n/g, '\n').split('\n');
   const sections: string[][] = [];
-  let inFence = false;
+  let state = INITIAL_MARKDOWN_VISIBILITY_STATE;
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index]!;
-    if (isMarkdownFenceLine(line)) {
-      inFence = !inFence;
+    const inspection = inspectMarkdownLine(state, line);
+    state = inspection.nextState;
+    if (inspection.scanState !== 'normal') {
       continue;
     }
-    if (inFence || isIndentedMarkdownCodeLine(line)) {
-      continue;
-    }
-    if (!CONTEXT_PACK_OUTCOME_HEADING_PATTERN.test(line.trim())) {
+    if (!CONTEXT_PACK_OUTCOME_HEADING_PATTERN.test(inspection.visibleText.trim())) {
       continue;
     }
 
     const section: string[] = [];
+    let sectionState: MarkdownVisibilityState = INITIAL_MARKDOWN_VISIBILITY_STATE;
     for (let sectionIndex = index + 1; sectionIndex < lines.length; sectionIndex += 1) {
       const sectionLine = lines[sectionIndex]!;
-      const trimmed = sectionLine.trim();
+      const sectionInspection = inspectMarkdownLine(sectionState, sectionLine);
+      sectionState = sectionInspection.nextState;
+      if (sectionInspection.scanState !== 'normal') {
+        continue;
+      }
+      const trimmed = sectionInspection.visibleText.trim();
       if (
-        isMarkdownFenceLine(sectionLine)
-        || isIndentedMarkdownCodeLine(sectionLine)
-        || /^#{1,6}\s+\S/.test(trimmed)
+        /^#{1,6}\s+\S/.test(trimmed)
         || (trimmed !== '' && !/^[*-]\s+/.test(trimmed))
       ) {
         break;
       }
-      section.push(sectionLine);
+      section.push(sectionInspection.visibleText);
     }
     sections.push(section);
   }

--- a/src/planning/markdown-structure.ts
+++ b/src/planning/markdown-structure.ts
@@ -1,0 +1,183 @@
+export type MarkdownFenceChar = '`' | '~';
+
+export interface MarkdownFenceState {
+  readonly char: MarkdownFenceChar;
+  readonly length: number;
+}
+
+export interface MarkdownVisibilityState {
+  readonly fence: MarkdownFenceState | null;
+  readonly commentDepth: number;
+}
+
+export type MarkdownScanState = 'normal' | 'fenced' | 'indented-code' | 'comment';
+
+interface MarkdownFenceMarker {
+  readonly char: MarkdownFenceChar;
+  readonly length: number;
+  readonly suffix: string;
+}
+
+export interface MarkdownLineInspection {
+  readonly scanState: MarkdownScanState;
+  readonly visibleText: string;
+  readonly nextState: MarkdownVisibilityState;
+}
+
+const MARKDOWN_FENCE_PATTERN =
+  /^(?: {0,3})(?<marker>`{3,}|~{3,})(?<suffix>[^\r\n]*)$/;
+const MARKDOWN_FENCE_CLOSE_SUFFIX_PATTERN = /^[ \t]*$/;
+const MARKDOWN_COMMENT_LINE_PATTERN = /^(?: {0,3})<!--/;
+const MARKDOWN_COMMENT_OPEN = '<!--';
+const MARKDOWN_COMMENT_CLOSE = '-->';
+
+export const INITIAL_MARKDOWN_VISIBILITY_STATE: MarkdownVisibilityState = {
+  fence: null,
+  commentDepth: 0,
+};
+
+function readMarkdownFenceMarker(line: string): MarkdownFenceMarker | null {
+  const markerMatch = line.match(MARKDOWN_FENCE_PATTERN);
+  const marker = markerMatch?.groups?.marker ?? null;
+  if (!marker) {
+    return null;
+  }
+  const char = marker[0];
+  if (char !== '`' && char !== '~') {
+    return null;
+  }
+  return {
+    char,
+    length: marker.length,
+    suffix: markerMatch?.groups?.suffix ?? '',
+  };
+}
+
+export function isIndentedMarkdownCodeLine(line: string): boolean {
+  return /^(?: {4,}|\t)/.test(line);
+}
+
+function advanceMarkdownCommentDepth(
+  activeDepth: number,
+  line: string,
+): number {
+  if (activeDepth === 0 && !MARKDOWN_COMMENT_LINE_PATTERN.test(line)) {
+    return 0;
+  }
+
+  let depth = activeDepth;
+  let index = 0;
+
+  while (index < line.length) {
+    const nextOpen = line.indexOf(MARKDOWN_COMMENT_OPEN, index);
+    const nextClose = line.indexOf(MARKDOWN_COMMENT_CLOSE, index);
+
+    if (nextOpen === -1 && nextClose === -1) {
+      break;
+    }
+    if (nextOpen !== -1 && (nextClose === -1 || nextOpen < nextClose)) {
+      depth += 1;
+      index = nextOpen + MARKDOWN_COMMENT_OPEN.length;
+      continue;
+    }
+    if (depth > 0) {
+      depth -= 1;
+    }
+    index = nextClose + MARKDOWN_COMMENT_CLOSE.length;
+  }
+
+  return depth;
+}
+
+function advanceMarkdownFenceState(
+  activeFence: MarkdownFenceState | null,
+  line: string,
+): MarkdownFenceState | null {
+  const marker = readMarkdownFenceMarker(line);
+  if (!marker) {
+    return activeFence;
+  }
+  if (activeFence) {
+    if (
+      marker.char === activeFence.char
+      && marker.length >= activeFence.length
+      && MARKDOWN_FENCE_CLOSE_SUFFIX_PATTERN.test(marker.suffix)
+    ) {
+      return null;
+    }
+    return activeFence;
+  }
+  return { char: marker.char, length: marker.length };
+}
+
+function isMarkdownCommentLine(
+  state: MarkdownVisibilityState,
+  line: string,
+): boolean {
+  return state.commentDepth > 0 || MARKDOWN_COMMENT_LINE_PATTERN.test(line);
+}
+
+export function inspectMarkdownLine(
+  state: MarkdownVisibilityState,
+  line: string,
+): MarkdownLineInspection {
+  if (state.fence) {
+    return {
+      scanState: 'fenced',
+      visibleText: '',
+      nextState: {
+        fence: advanceMarkdownFenceState(state.fence, line),
+        commentDepth: state.commentDepth,
+      },
+    };
+  }
+
+  if (isMarkdownCommentLine(state, line)) {
+    return {
+      scanState: 'comment',
+      visibleText: '',
+      nextState: {
+        fence: null,
+        commentDepth: advanceMarkdownCommentDepth(state.commentDepth, line),
+      },
+    };
+  }
+
+  if (isIndentedMarkdownCodeLine(line)) {
+    return {
+      scanState: 'indented-code',
+      visibleText: '',
+      nextState: state,
+    };
+  }
+
+  const nextFence = advanceMarkdownFenceState(null, line);
+  return {
+    scanState: nextFence ? 'fenced' : 'normal',
+    visibleText: nextFence ? '' : line,
+    nextState: {
+      fence: nextFence,
+      commentDepth: 0,
+    },
+  };
+}
+
+export function collectMarkdownVisibleMatches(
+  content: string,
+  pattern: RegExp,
+): RegExpMatchArray[] {
+  const lines = content.split(/\r?\n/);
+  const globalFlags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+  let state = INITIAL_MARKDOWN_VISIBILITY_STATE;
+  const matches: RegExpMatchArray[] = [];
+
+  for (const line of lines) {
+    const inspection = inspectMarkdownLine(state, line);
+    if (inspection.scanState === 'normal') {
+      matches.push(...inspection.visibleText.matchAll(new RegExp(pattern.source, globalFlags)));
+    }
+    state = inspection.nextState;
+  }
+
+  return matches;
+}


### PR DESCRIPTION
## Summary

Approved launch-hint selection already ignores fenced and indented examples
in straightforward cases, but the scanner still let indented fence
lookalikes advance fence state. That left room for hidden command examples
and hidden Context Pack Outcome content to survive deceptive close lines and
affect visible planning reads. This patch hardens the shared planning
markdown visibility scan so those readers stay bound to visible markdown
structure.

## Changes

- add a planning-local markdown visibility helper that tracks fenced blocks,
  block comments, and indented code with stricter backtick and tilde fence
  close rules
- use that helper for approved Team/Ralph launch-hint matching and Context
  Pack Outcome scanning so hidden content is ignored while visible outcome
  sections can continue past hidden inner blocks
- add direct model-based coverage plus integration tests for adversarial
  fence lines, nested commented blocks, hidden-only launch hints, and
  visible outcome declarations surrounded by hidden content

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] `node --test dist/planning/__tests__/markdown-structure.test.js dist/planning/__tests__/artifacts.test.js dist/planning/__tests__/context-pack-status.test.js`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Supersedes #2235.
