### PR TITLE
Prevent plugin MCP orphans from escaping cleanup

### DIFF
--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -73,6 +73,14 @@ describe('findCleanupCandidates', () => {
       'code-intel-server.cjs',
     );
     assert.equal(extractOmxMcpEntrypoint('node /tmp/worktree/dist/mcp/team-server.js'), null);
+    assert.equal(
+      extractOmxMcpEntrypoint('node /repo/dist/cli/omx.js mcp-serve state'),
+      'state-server.js',
+    );
+    assert.equal(
+      extractOmxMcpEntrypoint('omx mcp-serve code-intel'),
+      'code-intel-server.js',
+    );
   });
 
   it('selects orphaned OMX MCP processes while preserving the current session tree', () => {
@@ -176,9 +184,36 @@ describe('findCleanupCandidates', () => {
       { pid: 720, ppid: 700, command: 'node /repo/dist/mcp/wiki-server.js' },
       { pid: 900, ppid: 800, command: 'codex --model gpt-5' },
       { pid: 901, ppid: 900, command: 'node /repo/dist/mcp/trace-server.js' },
+      { pid: 910, ppid: 900, command: 'node /repo/dist/cli/omx.js mcp-serve state' },
+      { pid: 911, ppid: 900, command: 'node /repo/dist/cli/omx.js mcp-serve state' },
     ];
 
     assert.deepEqual(findLaunchSafeCleanupCandidates(processes, 701), []);
+  });
+
+  it('reaps plugin-launched omx mcp-serve orphans during launch-safe cleanup', () => {
+    const processes: ProcessEntry[] = [
+      { pid: 700, ppid: 500, command: 'codex app-server' },
+      { pid: 701, ppid: 700, command: 'node /repo/bin/omx.js cleanup --launch-safe' },
+      { pid: 820, ppid: 1, command: 'node /repo/dist/cli/omx.js mcp-serve state' },
+      { pid: 821, ppid: 42, command: 'omx mcp-serve code-intel' },
+      { pid: 830, ppid: 700, command: 'node /repo/dist/cli/omx.js mcp-serve memory' },
+    ];
+
+    assert.deepEqual(findLaunchSafeCleanupCandidates(processes, 701), [
+      {
+        pid: 820,
+        ppid: 1,
+        command: 'node /repo/dist/cli/omx.js mcp-serve state',
+        reason: 'ppid=1',
+      },
+      {
+        pid: 821,
+        ppid: 42,
+        command: 'omx mcp-serve code-intel',
+        reason: 'outside-current-session',
+      },
+    ]);
   });
 
   it('preserves same-parent first-party MCP siblings under live Codex and OMX ancestors during launch-safe cleanup', () => {

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -17,7 +17,6 @@ const HELP = [
 const PROCESS_EXIT_POLL_MS = 100;
 const SIGTERM_GRACE_MS = 5_000;
 const STALE_TMP_MAX_AGE_MS = 60 * 60 * 1000;
-const OMX_MCP_SERVER_PATTERN = /(?:^|[\\/])dist[\\/]mcp[\\/](?:state|memory|code-intel|trace|wiki)-server\.(?:[cm]?js|ts)\b/i;
 const OMX_MCP_ENTRYPOINT_PATTERN = /(?:^|[\\/])dist[\\/]mcp[\\/]((?:state|memory|code-intel|trace|wiki)-server\.(?:[cm]?js|ts))\b/i;
 const OMX_MCP_SERVE_TARGET_PATTERN = /(?:^|\s)mcp-serve\s+([^\s]+)/i;
 const CODEX_PROCESS_PATTERN = /(?:^|[\\/\s])codex(?:\.js)?(?:\s|$)|@openai[\\/]codex/i;

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -2,6 +2,7 @@ import { execFileSync, type ExecFileSyncOptionsWithStringEncoding } from 'child_
 import { readdir, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { resolveOmxFirstPartyMcpEntrypointForPluginTarget } from '../config/omx-first-party-mcp.js';
 
 const HELP = [
   'Usage: omx cleanup [--dry-run]',
@@ -18,6 +19,7 @@ const SIGTERM_GRACE_MS = 5_000;
 const STALE_TMP_MAX_AGE_MS = 60 * 60 * 1000;
 const OMX_MCP_SERVER_PATTERN = /(?:^|[\\/])dist[\\/]mcp[\\/](?:state|memory|code-intel|trace|wiki)-server\.(?:[cm]?js|ts)\b/i;
 const OMX_MCP_ENTRYPOINT_PATTERN = /(?:^|[\\/])dist[\\/]mcp[\\/]((?:state|memory|code-intel|trace|wiki)-server\.(?:[cm]?js|ts))\b/i;
+const OMX_MCP_SERVE_TARGET_PATTERN = /(?:^|\s)mcp-serve\s+([^\s]+)/i;
 const CODEX_PROCESS_PATTERN = /(?:^|[\\/\s])codex(?:\.js)?(?:\s|$)|@openai[\\/]codex/i;
 const OMX_LAUNCH_PROCESS_PATTERN = /(?:^|[\\/\s])omx(?:\.js)?(?:\s|$)|(?:^|[\\/])(?:bin|dist[\\/]cli)[\\/]omx\.js(?:\s|$)|oh-my-codex[\\/]dist[\\/]cli[\\/]omx\.js/i;
 const OMX_TMP_DIRECTORY_PATTERN = /^(omc|omx|oh-my-codex)-/;
@@ -101,13 +103,16 @@ function formatPlural(count: number, singular: string, plural = `${singular}s`):
 }
 
 export function isOmxMcpProcess(command: string): boolean {
-  const normalized = normalizeCommand(command);
-  return OMX_MCP_SERVER_PATTERN.test(normalized);
+  return extractOmxMcpEntrypoint(command) !== null;
 }
 
 export function extractOmxMcpEntrypoint(command: string): string | null {
   const normalized = normalizeCommand(command);
-  return normalized.match(OMX_MCP_ENTRYPOINT_PATTERN)?.[1]?.toLowerCase() ?? null;
+  const directEntrypoint = normalized.match(OMX_MCP_ENTRYPOINT_PATTERN)?.[1]?.toLowerCase();
+  if (directEntrypoint) return directEntrypoint;
+
+  const mcpServeTarget = normalized.match(OMX_MCP_SERVE_TARGET_PATTERN)?.[1];
+  return resolveOmxFirstPartyMcpEntrypointForPluginTarget(mcpServeTarget);
 }
 
 export function parsePsOutput(output: string): ProcessEntry[] {


### PR DESCRIPTION
## Summary
- Treat plugin-launched first-party MCP servers (`omx mcp-serve <target>`) as OMX MCP cleanup candidates, not just direct `dist/mcp/*-server.js` commands.
- This closes the #900-style blind spot where Codex/plugin mode could leave orphaned `omx` MCP processes outside the current live session tree, allowing repeated launches to accumulate processes on Linux.
- Add regression coverage for plugin-launched `mcp-serve` extraction, live-session preservation, and launch-safe orphan cleanup.

## Root cause hypothesis
Issue #2239 looks like a recurrence of #900 through the plugin launch path: direct first-party MCP server processes were cleanup-visible, but `omx mcp-serve state|memory|code-intel|trace|wiki` processes were not recognized by cleanup/pre-launch guardrails. Existing duplicate sibling guards could reduce same-parent duplication, but automatic cleanup missed orphaned plugin MCPs, so repeated sessions could fan out `omx`/`node` children until Linux memory pressure escalated.

## Tests
- `npm run lint -- src/cli/cleanup.ts src/cli/__tests__/cleanup.test.ts`
- `npm run build`
- `node --test dist/cli/__tests__/cleanup.test.js dist/mcp/__tests__/bootstrap.test.js`

## Notes
- I also tried adding `dist/cli/__tests__/index.test.js` to the focused run; cleanup/bootstrap still passed, but that file has unrelated failures in this environment around `cleanupPostLaunchModeStateFiles` and tmux extended-keys lease cases.

Refs #2239
