### PR TITLE
fix(planning): keep lineage fallback on visible hints

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -127,6 +127,38 @@ describe('readMatchedApprovedRalphExecutionHint', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('reuses the older approved Ralph hint when the latest same-task handoff is missing its baseline', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-lineage-fallback-'));
+    const approvedTask = 'Repair approved Ralph lineage handoff';
+    try {
+      await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'plans', 'prd-alpha-lineage.md'),
+        `# PRD\n\nLaunch via omx ralph ${JSON.stringify(approvedTask)}\n`,
+      );
+      await writeFile(join(cwd, '.omx', 'plans', 'test-spec-alpha-lineage.md'), '# Test Spec\n');
+      await writeFile(
+        join(cwd, '.omx', 'plans', 'prd-zeta-lineage.md'),
+        `# PRD\n\nLaunch via omx ralph ${JSON.stringify(approvedTask)}\n`,
+      );
+
+      const hint = readMatchedApprovedRalphExecutionHint(cwd, 'ralph-cli-launch');
+      assert.ok(hint);
+      assert.equal(hint?.sourcePath, join(cwd, '.omx', 'plans', 'prd-alpha-lineage.md'));
+      assert.equal(hint?.contextPackStatus, 'plan-only');
+
+      const instructions = buildRalphAppendInstructions(approvedTask, {
+        changedFilesPath: '.omx/ralph/changed-files.txt',
+        noDeslop: false,
+        approvedHint: hint,
+      });
+      assert.match(instructions, /Approved planning handoff context/i);
+      assert.doesNotMatch(instructions, /Missing-baseline fallback/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('isRalphPrdMode', () => {

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -318,6 +318,135 @@ describe('parseTeamStartArgs', () => {
     }
   });
 
+  it('reuses the older same-signature approved team hint when the latest matching handoff is missing its baseline', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-lineage-missing-baseline-'));
+    const previousCwd = process.cwd();
+    const approvedTask = 'Execute approved Team lineage follow-up';
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      await writeFile(
+        join(plansDir, 'prd-alpha-team-lineage.md'),
+        `# Approved plan\n\nLaunch via omx team 3:executor ${JSON.stringify(approvedTask)}\n`,
+      );
+      await writeFile(join(plansDir, 'test-spec-alpha-team-lineage.md'), '# Test spec\n');
+      await writeFile(
+        join(plansDir, 'prd-zeta-team-lineage.md'),
+        `# Approved plan\n\nLaunch via omx team 3:executor ${JSON.stringify(approvedTask)}\n`,
+      );
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, approvedTask);
+      assert.equal(result.parsed.workerCount, 3);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
+      assert.equal(result.parsed.approvedExecution, undefined);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses the older ready Team handoff when the latest same-signature handoff is invalid', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-lineage-invalid-'));
+    const previousCwd = process.cwd();
+    const approvedTask = 'Execute approved Team invalid lineage follow-up';
+    const approvedCommand = `omx team 3:executor ${JSON.stringify(approvedTask)}`;
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const alphaPrdPath = join(plansDir, 'prd-alpha-team-lineage-ready.md');
+      const alphaTestSpecPath = join(plansDir, 'test-spec-alpha-team-lineage-ready.md');
+      await writeFile(
+        alphaPrdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('alpha-team-lineage-ready')),
+          '',
+          `Launch via ${approvedCommand}`,
+        ].join('\n'),
+      );
+      await writeFile(alphaTestSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'alpha-team-lineage-ready', alphaPrdPath, alphaTestSpecPath);
+      await writeFile(
+        join(plansDir, 'prd-zeta-team-lineage-invalid.md'),
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('zeta-team-lineage-invalid')),
+          '',
+          `Launch via ${approvedCommand}`,
+        ].join('\n'),
+      );
+      await writeFile(join(plansDir, 'test-spec-zeta-team-lineage-invalid.md'), '# Test spec\n');
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, approvedTask);
+      assert.equal(result.parsed.workerCount, 3);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
+      assert.equal(result.parsed.approvedExecution?.command, approvedCommand);
+      assert.equal(sameFilePath(result.parsed.approvedExecution?.prd_path ?? '', alphaPrdPath), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses the older ready Team handoff when the latest same-signature handoff is incomplete', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-lineage-incomplete-'));
+    const previousCwd = process.cwd();
+    const approvedTask = 'Execute approved Team incomplete lineage follow-up';
+    const approvedCommand = `omx team 3:executor ${JSON.stringify(approvedTask)}`;
+    try {
+      process.chdir(wd);
+      const plansDir = join(wd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      const alphaPrdPath = join(plansDir, 'prd-alpha-team-lineage-complete.md');
+      const alphaTestSpecPath = join(plansDir, 'test-spec-alpha-team-lineage-complete.md');
+      await writeFile(
+        alphaPrdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('alpha-team-lineage-complete')),
+          '',
+          `Launch via ${approvedCommand}`,
+        ].join('\n'),
+      );
+      await writeFile(alphaTestSpecPath, '# Test spec\n');
+      await writeReadyContextPack(wd, 'alpha-team-lineage-complete', alphaPrdPath, alphaTestSpecPath);
+      const zetaPrdPath = join(plansDir, 'prd-zeta-team-lineage-incomplete.md');
+      const zetaTestSpecPath = join(plansDir, 'test-spec-zeta-team-lineage-incomplete.md');
+      await writeFile(
+        zetaPrdPath,
+        [
+          '# Approved plan',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath('zeta-team-lineage-incomplete')),
+          '',
+          `Launch via ${approvedCommand}`,
+        ].join('\n'),
+      );
+      await writeFile(zetaTestSpecPath, '# Test spec\n');
+      await writeContextPack(wd, 'zeta-team-lineage-incomplete', zetaPrdPath, zetaTestSpecPath, ['scope']);
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, approvedTask);
+      assert.equal(result.parsed.workerCount, 3);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.allowRepoAwareDagHandoff, true);
+      assert.equal(result.parsed.approvedExecution?.command, approvedCommand);
+      assert.equal(sameFilePath(result.parsed.approvedExecution?.prd_path ?? '', alphaPrdPath), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('prefers the persisted approved binding over a newer latest approved hint for a short follow-up', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-bound-'));
     const previousCwd = process.cwd();

--- a/src/planning/__tests__/approved-launch-hint-lineage-matrix.test.ts
+++ b/src/planning/__tests__/approved-launch-hint-lineage-matrix.test.ts
@@ -1,0 +1,701 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  readApprovedExecutionLaunchHint,
+  readApprovedExecutionLaunchHintOutcome,
+} from '../artifacts.js';
+
+type RalphPlanState = 'none' | 'hidden' | 'ready' | 'nonready' | 'ambiguous';
+type RalphQueryKind = 'bare' | 'task' | 'command';
+type TeamSignature = 'A' | 'B';
+type TeamQueryKind =
+  | 'bare'
+  | 'task'
+  | 'bareSignatureA'
+  | 'bareSignatureB'
+  | 'taskSignatureA'
+  | 'taskSignatureB'
+  | 'commandA'
+  | 'commandB';
+type TeamPlanState =
+  | 'none'
+  | 'hiddenA'
+  | 'readyA'
+  | 'nonreadyA'
+  | 'readyB'
+  | 'nonreadyB'
+  | 'readyAB'
+  | 'nonreadyAB'
+  | 'readyAA'
+  | 'nonreadyAA';
+
+interface HintModel {
+  command: string;
+  task: string;
+  ready: boolean;
+  signature?: TeamSignature;
+}
+
+interface QueryModel {
+  task?: string;
+  command?: string;
+  signature?: TeamSignature;
+}
+
+interface ExpectedSelection {
+  status: 'absent' | 'ambiguous' | 'resolved';
+  stem?: string;
+  hint?: HintModel;
+}
+
+type HintSelection =
+  | { status: 'no-match' }
+  | { status: 'ambiguous' }
+  | { status: 'unique'; hint: HintModel };
+
+const STEMS = ['alpha', 'beta', 'gamma', 'zeta'] as const;
+const RALPH_SHARED_TASK = 'Execute shared Ralph lineage matrix handoff';
+const RALPH_COMMAND = `omx ralph ${JSON.stringify(RALPH_SHARED_TASK)}`;
+const RALPH_DUPLICATE_COMMAND = `$ralph ${JSON.stringify(RALPH_SHARED_TASK)}`;
+const TEAM_SHARED_TASK = 'Execute shared Team lineage matrix handoff';
+const TEAM_COMMANDS = {
+  A: `omx team 3:executor ${JSON.stringify(TEAM_SHARED_TASK)}`,
+  ADuplicate: `$team 3:executor ${JSON.stringify(TEAM_SHARED_TASK)}`,
+  B: `$team ralph 5:debugger ${JSON.stringify(TEAM_SHARED_TASK)}`,
+} as const;
+const RALPH_PLAN_STATES: readonly RalphPlanState[] = [
+  'none',
+  'hidden',
+  'ready',
+  'nonready',
+  'ambiguous',
+] as const;
+const TEAM_PLAN_STATES: readonly TeamPlanState[] = [
+  'none',
+  'hiddenA',
+  'readyA',
+  'nonreadyA',
+  'readyB',
+  'nonreadyB',
+  'readyAB',
+  'nonreadyAB',
+  'readyAA',
+  'nonreadyAA',
+] as const;
+const RALPH_QUERY_KINDS: readonly RalphQueryKind[] = ['bare', 'task', 'command'] as const;
+const TEAM_QUERY_KINDS: readonly TeamQueryKind[] = [
+  'bare',
+  'task',
+  'bareSignatureA',
+  'bareSignatureB',
+  'taskSignatureA',
+  'taskSignatureB',
+  'commandA',
+  'commandB',
+] as const;
+
+let tempDir = '';
+
+function planPath(cwd: string, stem: string): string {
+  return join(cwd, '.omx', 'plans', `prd-${stem}.md`);
+}
+
+function createDeterministicRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = Math.imul(state, 1_664_525) + 1_013_904_223;
+    state >>>= 0;
+    return state / 0x1_0000_0000;
+  };
+}
+
+function pickRandom<T>(nextRandom: () => number, values: readonly T[]): T {
+  const index = Math.floor(nextRandom() * values.length);
+  return values[index]!;
+}
+
+function ralphVisibleHints(state: RalphPlanState): HintModel[] {
+  switch (state) {
+    case 'none':
+    case 'hidden':
+      return [];
+    case 'ready':
+      return [{ command: RALPH_COMMAND, task: RALPH_SHARED_TASK, ready: true }];
+    case 'nonready':
+      return [{ command: RALPH_COMMAND, task: RALPH_SHARED_TASK, ready: false }];
+    case 'ambiguous':
+      return [
+        { command: RALPH_COMMAND, task: RALPH_SHARED_TASK, ready: true },
+        { command: RALPH_DUPLICATE_COMMAND, task: RALPH_SHARED_TASK, ready: true },
+      ];
+  }
+}
+
+function teamVisibleHints(state: TeamPlanState): HintModel[] {
+  switch (state) {
+    case 'none':
+    case 'hiddenA':
+      return [];
+    case 'readyA':
+      return [{ command: TEAM_COMMANDS.A, task: TEAM_SHARED_TASK, ready: true, signature: 'A' }];
+    case 'nonreadyA':
+      return [{ command: TEAM_COMMANDS.A, task: TEAM_SHARED_TASK, ready: false, signature: 'A' }];
+    case 'readyB':
+      return [{ command: TEAM_COMMANDS.B, task: TEAM_SHARED_TASK, ready: true, signature: 'B' }];
+    case 'nonreadyB':
+      return [{ command: TEAM_COMMANDS.B, task: TEAM_SHARED_TASK, ready: false, signature: 'B' }];
+    case 'readyAB':
+      return [
+        { command: TEAM_COMMANDS.A, task: TEAM_SHARED_TASK, ready: true, signature: 'A' },
+        { command: TEAM_COMMANDS.B, task: TEAM_SHARED_TASK, ready: true, signature: 'B' },
+      ];
+    case 'nonreadyAB':
+      return [
+        { command: TEAM_COMMANDS.A, task: TEAM_SHARED_TASK, ready: false, signature: 'A' },
+        { command: TEAM_COMMANDS.B, task: TEAM_SHARED_TASK, ready: false, signature: 'B' },
+      ];
+    case 'readyAA':
+      return [
+        { command: TEAM_COMMANDS.A, task: TEAM_SHARED_TASK, ready: true, signature: 'A' },
+        { command: TEAM_COMMANDS.ADuplicate, task: TEAM_SHARED_TASK, ready: true, signature: 'A' },
+      ];
+    case 'nonreadyAA':
+      return [
+        { command: TEAM_COMMANDS.A, task: TEAM_SHARED_TASK, ready: false, signature: 'A' },
+        { command: TEAM_COMMANDS.ADuplicate, task: TEAM_SHARED_TASK, ready: false, signature: 'A' },
+      ];
+  }
+}
+
+function selectUniqueHint(
+  visibleHints: readonly HintModel[],
+  query: QueryModel,
+  signatureFilter?: TeamSignature,
+): HintSelection {
+  const matches = visibleHints.filter((hint) => {
+    if (query.command) {
+      return hint.command === query.command;
+    }
+    if (query.task && hint.task.trim() !== query.task.trim()) {
+      return false;
+    }
+    if (signatureFilter && hint.signature !== signatureFilter) {
+      return false;
+    }
+    return true;
+  });
+  if (matches.length === 0) {
+    return { status: 'no-match' };
+  }
+  if (matches.length > 1) {
+    return { status: 'ambiguous' };
+  }
+  return { status: 'unique', hint: matches[0]! };
+}
+
+function resolveExpectedRalphSelection(
+  stems: readonly string[],
+  states: readonly RalphPlanState[],
+  query: QueryModel,
+): ExpectedSelection {
+  const newestNonready: { stem: string; hint: HintModel }[] = [];
+
+  if (!query.task && !query.command) {
+    const latestIndex = states.length - 1;
+    const latestSelection = selectUniqueHint(ralphVisibleHints(states[latestIndex]!), query);
+    if (latestSelection.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    if (latestSelection.status !== 'unique') {
+      return { status: 'absent' };
+    }
+    if (latestSelection.hint.ready) {
+      return { status: 'resolved', stem: stems[latestIndex]!, hint: latestSelection.hint };
+    }
+    for (let index = latestIndex - 1; index >= 0; index -= 1) {
+      const selection = selectUniqueHint(ralphVisibleHints(states[index]!), { task: latestSelection.hint.task });
+      if (selection.status === 'ambiguous') {
+        return { status: 'ambiguous' };
+      }
+      if (selection.status === 'unique' && selection.hint.ready) {
+        return { status: 'resolved', stem: stems[index]!, hint: selection.hint };
+      }
+    }
+    return { status: 'resolved', stem: stems[latestIndex]!, hint: latestSelection.hint };
+  }
+
+  for (let index = states.length - 1; index >= 0; index -= 1) {
+    const selection = selectUniqueHint(ralphVisibleHints(states[index]!), query);
+    if (selection.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    if (selection.status !== 'unique') {
+      continue;
+    }
+    if (selection.hint.ready) {
+      return { status: 'resolved', stem: stems[index]!, hint: selection.hint };
+    }
+    newestNonready.push({ stem: stems[index]!, hint: selection.hint });
+  }
+
+  return newestNonready.length > 0
+    ? { status: 'resolved', stem: newestNonready[0]!.stem, hint: newestNonready[0]!.hint }
+    : { status: 'absent' };
+}
+
+function resolveExpectedTeamSelection(
+  stems: readonly string[],
+  states: readonly TeamPlanState[],
+  query: QueryModel,
+): ExpectedSelection {
+  const requestedSignature = query.command ? undefined : query.signature;
+
+  if (!query.task && !query.command) {
+    const latestIndex = states.length - 1;
+    const latestSelection = selectUniqueHint(
+      teamVisibleHints(states[latestIndex]!),
+      query,
+      requestedSignature,
+    );
+    if (latestSelection.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    if (latestSelection.status !== 'unique') {
+      return { status: 'absent' };
+    }
+    if (latestSelection.hint.ready) {
+      return { status: 'resolved', stem: stems[latestIndex]!, hint: latestSelection.hint };
+    }
+    for (let index = latestIndex - 1; index >= 0; index -= 1) {
+      const selection = selectUniqueHint(
+        teamVisibleHints(states[index]!),
+        { task: latestSelection.hint.task },
+        latestSelection.hint.signature,
+      );
+      if (selection.status === 'ambiguous') {
+        return { status: 'ambiguous' };
+      }
+      if (selection.status === 'unique' && selection.hint.ready) {
+        return { status: 'resolved', stem: stems[index]!, hint: selection.hint };
+      }
+    }
+    return { status: 'resolved', stem: stems[latestIndex]!, hint: latestSelection.hint };
+  }
+
+  let newestNonready: { stem: string; hint: HintModel } | null = null;
+  let lineageSignature: TeamSignature | null = null;
+  for (let index = states.length - 1; index >= 0; index -= 1) {
+    const selection = selectUniqueHint(
+      teamVisibleHints(states[index]!),
+      query,
+      requestedSignature ?? (
+        query.task && !query.command
+          ? lineageSignature ?? undefined
+          : undefined
+      ),
+    );
+    if (selection.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    if (selection.status !== 'unique') {
+      continue;
+    }
+    if (query.task && !query.command) {
+      lineageSignature ??= selection.hint.signature ?? null;
+    }
+    if (selection.hint.ready) {
+      return { status: 'resolved', stem: stems[index]!, hint: selection.hint };
+    }
+    newestNonready ??= { stem: stems[index]!, hint: selection.hint };
+  }
+
+  return newestNonready
+    ? { status: 'resolved', stem: newestNonready.stem, hint: newestNonready.hint }
+    : { status: 'absent' };
+}
+
+function ralphQueryModel(kind: RalphQueryKind): QueryModel {
+  switch (kind) {
+    case 'bare':
+      return {};
+    case 'task':
+      return { task: RALPH_SHARED_TASK };
+    case 'command':
+      return { task: RALPH_SHARED_TASK, command: RALPH_COMMAND };
+  }
+}
+
+function teamQueryModel(kind: TeamQueryKind): QueryModel {
+  switch (kind) {
+    case 'bare':
+      return {};
+    case 'task':
+      return { task: TEAM_SHARED_TASK };
+    case 'bareSignatureA':
+      return { signature: 'A' };
+    case 'bareSignatureB':
+      return { signature: 'B' };
+    case 'taskSignatureA':
+      return { task: TEAM_SHARED_TASK, signature: 'A' };
+    case 'taskSignatureB':
+      return { task: TEAM_SHARED_TASK, signature: 'B' };
+    case 'commandA':
+      return { task: TEAM_SHARED_TASK, command: TEAM_COMMANDS.A };
+    case 'commandB':
+      return { task: TEAM_SHARED_TASK, command: TEAM_COMMANDS.B };
+  }
+}
+
+function ralphQueryOptions(
+  kind: RalphQueryKind,
+): Parameters<typeof readApprovedExecutionLaunchHintOutcome>[2] {
+  switch (kind) {
+    case 'bare':
+      return {};
+    case 'task':
+      return { task: RALPH_SHARED_TASK };
+    case 'command':
+      return { task: RALPH_SHARED_TASK, command: RALPH_COMMAND };
+  }
+}
+
+function teamQueryOptions(
+  kind: TeamQueryKind,
+): Parameters<typeof readApprovedExecutionLaunchHintOutcome>[2] {
+  switch (kind) {
+    case 'bare':
+      return {};
+    case 'task':
+      return { task: TEAM_SHARED_TASK };
+    case 'bareSignatureA':
+      return { workerCount: 3, agentType: 'executor', linkedRalph: false };
+    case 'bareSignatureB':
+      return { workerCount: 5, agentType: 'debugger', linkedRalph: true };
+    case 'taskSignatureA':
+      return { task: TEAM_SHARED_TASK, workerCount: 3, agentType: 'executor', linkedRalph: false };
+    case 'taskSignatureB':
+      return { task: TEAM_SHARED_TASK, workerCount: 5, agentType: 'debugger', linkedRalph: true };
+    case 'commandA':
+      return { task: TEAM_SHARED_TASK, command: TEAM_COMMANDS.A };
+    case 'commandB':
+      return { task: TEAM_SHARED_TASK, command: TEAM_COMMANDS.B };
+  }
+}
+
+async function setup(): Promise<void> {
+  tempDir = await mkdtemp(join(tmpdir(), 'omx-approved-lineage-matrix-'));
+}
+
+async function cleanup(): Promise<void> {
+  if (tempDir && existsSync(tempDir)) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function writePlanFiles(
+  cwd: string,
+  stem: string,
+  lines: readonly string[],
+  withTestSpec: boolean,
+): Promise<void> {
+  const plansDir = join(cwd, '.omx', 'plans');
+  await mkdir(plansDir, { recursive: true });
+  await writeFile(planPath(cwd, stem), `${lines.join('\n')}\n`);
+  if (withTestSpec) {
+    await writeFile(join(plansDir, `test-spec-${stem}.md`), '# Test Spec\n');
+  }
+}
+
+async function writeRalphPlanState(
+  cwd: string,
+  stem: string,
+  state: RalphPlanState,
+): Promise<void> {
+  const lines = ['# PRD', ''];
+  switch (state) {
+    case 'none':
+      lines.push('No matching Ralph launch hint here.');
+      break;
+    case 'hidden':
+      lines.push(`    ${RALPH_COMMAND}`);
+      break;
+    case 'ready':
+      lines.push(`Launch via ${RALPH_COMMAND}`);
+      break;
+    case 'nonready':
+      lines.push(`Launch via ${RALPH_COMMAND}`);
+      break;
+    case 'ambiguous':
+      lines.push(`Launch via ${RALPH_COMMAND}`);
+      lines.push(`Launch via ${RALPH_DUPLICATE_COMMAND}`);
+      break;
+  }
+  await writePlanFiles(cwd, stem, lines, state === 'hidden' || state === 'ready' || state === 'ambiguous');
+}
+
+async function writeTeamPlanState(
+  cwd: string,
+  stem: string,
+  state: TeamPlanState,
+): Promise<void> {
+  const lines = ['# PRD', ''];
+  switch (state) {
+    case 'none':
+      lines.push('No matching Team launch hint here.');
+      break;
+    case 'hiddenA':
+      lines.push('```sh');
+      lines.push(TEAM_COMMANDS.A);
+      lines.push('```');
+      break;
+    case 'readyA':
+    case 'nonreadyA':
+      lines.push(`Launch via ${TEAM_COMMANDS.A}`);
+      break;
+    case 'readyB':
+    case 'nonreadyB':
+      lines.push(`Launch via ${TEAM_COMMANDS.B}`);
+      break;
+    case 'readyAB':
+    case 'nonreadyAB':
+      lines.push(`Launch via ${TEAM_COMMANDS.A}`);
+      lines.push(`Launch via ${TEAM_COMMANDS.B}`);
+      break;
+    case 'readyAA':
+    case 'nonreadyAA':
+      lines.push(`Launch via ${TEAM_COMMANDS.A}`);
+      lines.push(`Launch via ${TEAM_COMMANDS.ADuplicate}`);
+      break;
+  }
+  const withTestSpec = state.startsWith('ready') || state === 'hiddenA';
+  await writePlanFiles(cwd, stem, lines, withTestSpec);
+}
+
+async function writeRalphScenario(
+  cwd: string,
+  states: readonly RalphPlanState[],
+): Promise<void> {
+  await Promise.all(states.map((state, index) => writeRalphPlanState(cwd, STEMS[index]!, state)));
+}
+
+async function writeTeamScenario(
+  cwd: string,
+  states: readonly TeamPlanState[],
+): Promise<void> {
+  await Promise.all(states.map((state, index) => writeTeamPlanState(cwd, STEMS[index]!, state)));
+}
+
+function assertExpectedSelection(
+  cwd: string,
+  label: string,
+  mode: 'team' | 'ralph',
+  options: Parameters<typeof readApprovedExecutionLaunchHintOutcome>[2],
+  expected: ExpectedSelection,
+): void {
+  const outcome = readApprovedExecutionLaunchHintOutcome(cwd, mode, options);
+  const hint = readApprovedExecutionLaunchHint(cwd, mode, options);
+
+  assert.equal(outcome.status, expected.status, `${label}: unexpected outcome status`);
+  if (expected.status !== 'resolved') {
+    assert.equal(hint, null, `${label}: reusable hint must fail closed`);
+    return;
+  }
+  if (outcome.status !== 'resolved') {
+    throw new Error(`${label}: expected a resolved outcome`);
+  }
+
+  assert.equal(
+    outcome.hint.sourcePath,
+    planPath(cwd, expected.stem!),
+    `${label}: unexpected selected PRD`,
+  );
+  assert.equal(
+    outcome.hint.command,
+    expected.hint?.command,
+    `${label}: unexpected selected command`,
+  );
+  assert.equal(
+    outcome.hint.contextPackStatus,
+    expected.hint?.ready ? 'plan-only' : 'missing-baseline',
+    `${label}: unexpected readiness state`,
+  );
+  if (mode === 'team') {
+    assert.equal(
+      outcome.hint.workerCount,
+      expected.hint?.signature === 'A' ? 3 : 5,
+      `${label}: unexpected worker count`,
+    );
+    assert.equal(
+      outcome.hint.agentType,
+      expected.hint?.signature === 'A' ? 'executor' : 'debugger',
+      `${label}: unexpected agent type`,
+    );
+    assert.equal(
+      outcome.hint.linkedRalph,
+      expected.hint?.signature === 'B',
+      `${label}: unexpected linked Ralph flag`,
+    );
+  }
+
+  if (expected.hint?.ready) {
+    assert.ok(hint, `${label}: expected reusable follow-up hint`);
+    assert.equal(
+      hint?.sourcePath,
+      planPath(cwd, expected.stem!),
+      `${label}: unexpected reusable hint source`,
+    );
+  } else {
+    assert.equal(hint, null, `${label}: nonready result must stay repair-only`);
+  }
+}
+
+describe('approved launch hint lineage matrix', () => {
+  beforeEach(async () => { await setup(); });
+  afterEach(async () => { await cleanup(); });
+
+  it('matches the Ralph oracle across exhaustive two-plan state-machine checks', async () => {
+    const stems = STEMS.slice(0, 2);
+    for (const queryKind of RALPH_QUERY_KINDS) {
+      for (const olderState of RALPH_PLAN_STATES) {
+        for (const latestState of RALPH_PLAN_STATES) {
+          const cwd = join(tempDir, `ralph-${queryKind}-${olderState}-${latestState}`);
+          const states = [olderState, latestState] as const;
+          await writeRalphScenario(cwd, states);
+          const expected = resolveExpectedRalphSelection(stems, states, ralphQueryModel(queryKind));
+          assertExpectedSelection(
+            cwd,
+            `ralph query=${queryKind} older=${olderState} latest=${latestState}`,
+            'ralph',
+            ralphQueryOptions(queryKind),
+            expected,
+          );
+        }
+      }
+    }
+  });
+
+  it('matches the Team oracle across exhaustive two-plan state-machine checks', async () => {
+    const stems = STEMS.slice(0, 2);
+    for (const queryKind of TEAM_QUERY_KINDS) {
+      for (const olderState of TEAM_PLAN_STATES) {
+        for (const latestState of TEAM_PLAN_STATES) {
+          const cwd = join(tempDir, `team-${queryKind}-${olderState}-${latestState}`);
+          const states = [olderState, latestState] as const;
+          await writeTeamScenario(cwd, states);
+          const expected = resolveExpectedTeamSelection(stems, states, teamQueryModel(queryKind));
+          assertExpectedSelection(
+            cwd,
+            `team query=${queryKind} older=${olderState} latest=${latestState}`,
+            'team',
+            teamQueryOptions(queryKind),
+            expected,
+          );
+        }
+      }
+    }
+  });
+
+  it('matches deterministic multi-plan property checks against the Ralph oracle', async () => {
+    const nextRandom = createDeterministicRandom(0x2236);
+    for (let index = 0; index < 48; index += 1) {
+      const states = STEMS.map(() => pickRandom(nextRandom, RALPH_PLAN_STATES));
+      const cwd = join(tempDir, `ralph-random-${index}`);
+      await writeRalphScenario(cwd, states);
+      for (const queryKind of RALPH_QUERY_KINDS) {
+        const expected = resolveExpectedRalphSelection(STEMS, states, ralphQueryModel(queryKind));
+        assertExpectedSelection(
+          cwd,
+          `ralph random=${index} query=${queryKind} states=${states.join(',')}`,
+          'ralph',
+          ralphQueryOptions(queryKind),
+          expected,
+        );
+      }
+    }
+  });
+
+  it('matches deterministic multi-plan property checks against the Team oracle', async () => {
+    const nextRandom = createDeterministicRandom(0x2241);
+    for (let index = 0; index < 48; index += 1) {
+      const states = STEMS.map(() => pickRandom(nextRandom, TEAM_PLAN_STATES));
+      const cwd = join(tempDir, `team-random-${index}`);
+      await writeTeamScenario(cwd, states);
+      for (const queryKind of TEAM_QUERY_KINDS) {
+        const expected = resolveExpectedTeamSelection(STEMS, states, teamQueryModel(queryKind));
+        assertExpectedSelection(
+          cwd,
+          `team random=${index} query=${queryKind} states=${states.join(',')}`,
+          'team',
+          teamQueryOptions(queryKind),
+          expected,
+        );
+      }
+    }
+  });
+
+  it('skips newer nonready siblings until the last reusable visible Ralph lineage handoff', async () => {
+    const cwd = join(tempDir, 'ralph-three-plan-skip');
+    await writeRalphScenario(cwd, ['ready', 'nonready', 'nonready']);
+    assertExpectedSelection(
+      cwd,
+      'ralph three-plan skip',
+      'ralph',
+      {},
+      {
+        status: 'resolved',
+        stem: 'alpha',
+        hint: { command: RALPH_COMMAND, task: RALPH_SHARED_TASK, ready: true },
+      },
+    );
+  });
+
+  it('stops on same-lineage ambiguity before reviving an older Team handoff', async () => {
+    const cwd = join(tempDir, 'team-three-plan-ambiguous');
+    await writeTeamScenario(cwd, ['readyA', 'nonreadyAA', 'nonreadyA']);
+    assertExpectedSelection(
+      cwd,
+      'team three-plan ambiguity',
+      'team',
+      { task: TEAM_SHARED_TASK },
+      { status: 'ambiguous' },
+    );
+  });
+
+  it('keeps hidden lineage candidates invisible even for exact-command lookups', async () => {
+    {
+      const cwd = join(tempDir, 'ralph-hidden-command');
+      await writeRalphScenario(cwd, ['hidden', 'nonready']);
+      assertExpectedSelection(
+        cwd,
+        'ralph hidden exact command',
+        'ralph',
+        ralphQueryOptions('command'),
+        {
+          status: 'resolved',
+          stem: 'beta',
+          hint: { command: RALPH_COMMAND, task: RALPH_SHARED_TASK, ready: false },
+        },
+      );
+    }
+
+    {
+      const cwd = join(tempDir, 'team-hidden-command');
+      await writeTeamScenario(cwd, ['hiddenA', 'nonreadyA']);
+      assertExpectedSelection(
+        cwd,
+        'team hidden exact command',
+        'team',
+        teamQueryOptions('commandA'),
+        {
+          status: 'resolved',
+          stem: 'beta',
+          hint: { command: TEAM_COMMANDS.A, task: TEAM_SHARED_TASK, ready: false, signature: 'A' },
+        },
+      );
+    }
+  });
+});

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import fs, { existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
+import { syncBuiltinESMExports } from 'node:module';
 import { tmpdir } from 'node:os';
 import { basename, join, relative } from 'node:path';
 import {
@@ -89,7 +90,11 @@ async function cleanup(): Promise<void> {
 
 describe('planning artifacts', () => {
   beforeEach(async () => { await setup(); });
-  afterEach(async () => { await cleanup(); });
+  afterEach(async () => {
+    mock.restoreAll();
+    syncBuiltinESMExports();
+    await cleanup();
+  });
 
   it('round-trips single-quoted approved execution tasks with only escaped apostrophes normalized', () => {
     const task = String.raw`Fix Bob's regression in C:\\tmp`;
@@ -646,6 +651,46 @@ describe('planning artifacts', () => {
     assert.ok(hint);
     assert.equal(hint?.task, 'Execute alpha');
     assert.equal(hint?.command, 'omx ralph "Execute alpha"');
+  });
+
+  it('reuses one planning artifact scan while task lookup checks older same-lineage PRDs', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute cached planning artifact lineage lookup';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-alpha.md'),
+      `# Alpha\n\nLaunch via omx ralph ${JSON.stringify(task)}\n`,
+    );
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha Test Spec\n');
+    await writeFile(
+      join(plansDir, 'prd-beta.md'),
+      `# Beta\n\nLaunch via omx ralph ${JSON.stringify(task)}\n`,
+    );
+    await writeFile(
+      join(plansDir, 'prd-gamma.md'),
+      `# Gamma\n\nLaunch via omx ralph ${JSON.stringify(task)}\n`,
+    );
+    await writeFile(
+      join(plansDir, 'prd-zeta.md'),
+      `# Zeta\n\nLaunch via omx ralph ${JSON.stringify(task)}\n`,
+    );
+
+    let readdirCount = 0;
+    const originalReaddirSync = fs.readdirSync;
+    mock.method(fs, 'readdirSync', ((...args: unknown[]) => {
+      readdirCount += 1;
+      return Reflect.apply(originalReaddirSync, fs, args);
+    }) as typeof fs.readdirSync);
+    syncBuiltinESMExports();
+
+    const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph', { task });
+
+    assert.equal(outcome.status, 'resolved');
+    if (outcome.status !== 'resolved') {
+      return;
+    }
+    assert.equal(outcome.hint.sourcePath, join(plansDir, 'prd-alpha.md'));
+    assert.equal(readdirCount, 2);
   });
 
   it('fails closed for bare Ralph lookups when a single plan lists multiple Ralph launch hints', async () => {

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -339,8 +339,8 @@ function readApprovedPlanText(
   cwd: string,
   options: ApprovedExecutionLaunchHintReadOptions = {},
   allowMissingBaseline = false,
+  artifacts: PlanningArtifacts = readPlanningArtifacts(cwd),
 ): { content: string; context: ApprovedPlanContext } | null {
-  const artifacts = readPlanningArtifacts(cwd);
   const selection = selectPlanningArtifacts(artifacts, options.prdPath);
   const latestPrdPath = selection.prdPath;
   if (!latestPrdPath || (!allowMissingBaseline && selection.testSpecPaths.length === 0) || !existsSync(latestPrdPath)) {
@@ -608,8 +608,9 @@ function readApprovedExecutionLaunchHintOutcomeForPrdPath(
   prdPath: string,
   options: ApprovedExecutionLaunchHintReadOptions = {},
   matchFilter?: LaunchHintMatchFilter,
+  artifacts: PlanningArtifacts = readPlanningArtifacts(cwd),
 ): ApprovedExecutionLaunchHintOutcome {
-  const approvedPlan = readApprovedPlanText(cwd, { ...options, prdPath }, true);
+  const approvedPlan = readApprovedPlanText(cwd, { ...options, prdPath }, true, artifacts);
   if (!approvedPlan) {
     return { status: 'absent' };
   }
@@ -684,6 +685,7 @@ function resolveOlderReusableSameLineageHint(
       mode === 'team'
         ? (match: RegExpMatchArray, _task: string) => sameTeamLaunchSignatureMatch(anchorHint, match)
         : undefined,
+      artifacts,
     );
     if (outcome.status === 'ambiguous') {
       return { status: 'ambiguous' };
@@ -704,6 +706,7 @@ export function readApprovedExecutionLaunchHintOutcome(
   mode: 'team' | 'ralph',
   options: ApprovedExecutionLaunchHintReadOptions = {},
 ): ApprovedExecutionLaunchHintOutcome {
+  const artifacts = readPlanningArtifacts(cwd);
   if (options.prdPath) {
     return readApprovedExecutionLaunchHintOutcomeForPrdPath(
       cwd,
@@ -711,13 +714,13 @@ export function readApprovedExecutionLaunchHintOutcome(
       options.prdPath,
       options,
       mode === 'team' ? buildRequestedTeamLaunchSignatureMatchFilter(options) : undefined,
+      artifacts,
     );
   }
 
   const normalizedTask = options.task?.trim();
   const normalizedCommand = options.command?.trim();
   if (!normalizedTask && !normalizedCommand) {
-    const artifacts = readPlanningArtifacts(cwd);
     const latestPrdPath = selectLatestPlanningArtifactPath(artifacts.prdPaths);
     if (!latestPrdPath) {
       return { status: 'absent' };
@@ -729,6 +732,7 @@ export function readApprovedExecutionLaunchHintOutcome(
       latestPrdPath,
       options,
       mode === 'team' ? buildRequestedTeamLaunchSignatureMatchFilter(options) : undefined,
+      artifacts,
     );
     if (latestOutcome.status === 'ambiguous') {
       return { status: 'ambiguous' };
@@ -755,7 +759,6 @@ export function readApprovedExecutionLaunchHintOutcome(
       : latestOutcome;
   }
 
-  const artifacts = readPlanningArtifacts(cwd);
   let newestNonreadyHint: ApprovedExecutionLaunchHint | null = null;
   let teamLineageAnchorHint: ApprovedExecutionLaunchHint | null = null;
   for (const prdPath of orderedPrdPathsNewestFirst(artifacts.prdPaths)) {
@@ -777,6 +780,7 @@ export function readApprovedExecutionLaunchHintOutcome(
       prdPath,
       options,
       teamLineageMatchFilter,
+      artifacts,
     );
     if (outcome.status === 'ambiguous') {
       return { status: 'ambiguous' };

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -8,6 +8,7 @@ import {
   selectMatchingTestSpecsForPrd,
 } from './artifact-names.js';
 import {
+  isApprovedExecutionFollowupReadyStatus,
   resolveContextPackHandoffStatus,
   type ContextPackHandoffStatusSnapshot,
   type ContextPackRef,
@@ -565,27 +566,65 @@ function matchesRequestedTeamLaunchSignature(
   return true;
 }
 
-export function readApprovedExecutionLaunchHintOutcome(
+function buildRequestedTeamLaunchSignatureMatchFilter(
+  options: ApprovedExecutionLaunchHintReadOptions,
+): LaunchHintMatchFilter | undefined {
+  if (options.command || !hasRequestedTeamLaunchSignature(options)) {
+    return undefined;
+  }
+  return (match: RegExpMatchArray, _task: string) => matchesRequestedTeamLaunchSignature(match, options);
+}
+
+function sameTeamLaunchSignatureMatch(
+  anchorHint: ApprovedExecutionLaunchHint,
+  match: RegExpMatchArray,
+): boolean {
+  const groups = match.groups;
+  if (!groups) {
+    return false;
+  }
+
+  const workerCount = Number.parseInt(groups.count ?? '', 10);
+  if (!Number.isFinite(workerCount) || workerCount !== anchorHint.workerCount) {
+    return false;
+  }
+
+  const actualAgentType = groups.role?.trim();
+  const expectedAgentType = anchorHint.agentType?.trim();
+  if ((actualAgentType || undefined) !== (expectedAgentType || undefined)) {
+    return false;
+  }
+
+  return Boolean(groups.ralph?.trim()) === Boolean(anchorHint.linkedRalph);
+}
+
+function orderedPrdPathsNewestFirst(prdPaths: readonly string[]): string[] {
+  return [...prdPaths].sort(comparePlanningArtifactPaths).reverse();
+}
+
+function readApprovedExecutionLaunchHintOutcomeForPrdPath(
   cwd: string,
   mode: 'team' | 'ralph',
+  prdPath: string,
   options: ApprovedExecutionLaunchHintReadOptions = {},
+  matchFilter?: LaunchHintMatchFilter,
 ): ApprovedExecutionLaunchHintOutcome {
-  const approvedPlan = readApprovedPlanText(cwd, options, true);
-  if (!approvedPlan) return { status: 'absent' };
-
-  const teamMatchFilter = mode === 'team'
-    && !options.command
-    && hasRequestedTeamLaunchSignature(options)
-    ? (match: RegExpMatchArray, _task: string) => matchesRequestedTeamLaunchSignature(match, options)
-    : undefined;
+  const approvedPlan = readApprovedPlanText(cwd, { ...options, prdPath }, true);
+  if (!approvedPlan) {
+    return { status: 'absent' };
+  }
   const selected = selectLaunchHintMatch(
     collectLaunchHintMatches(approvedPlan.content, mode),
     options.task?.trim(),
     options.command?.trim(),
-    teamMatchFilter,
+    matchFilter,
   );
-  if (selected.status === 'ambiguous') return { status: 'ambiguous' };
-  if (selected.status !== 'unique' || !selected.match.groups) return { status: 'absent' };
+  if (selected.status === 'ambiguous') {
+    return { status: 'ambiguous' };
+  }
+  if (selected.status !== 'unique' || !selected.match.groups) {
+    return { status: 'absent' };
+  }
 
   if (mode === 'team') {
     const workerCount = Number.parseInt(selected.match.groups.count, 10);
@@ -615,6 +654,148 @@ export function readApprovedExecutionLaunchHintOutcome(
       ...approvedPlan.context,
     },
   };
+}
+
+type SameLineageFallback =
+  | { status: 'none' }
+  | { status: 'ambiguous' }
+  | { status: 'resolved'; hint: ApprovedExecutionLaunchHint };
+
+function resolveOlderReusableSameLineageHint(
+  cwd: string,
+  mode: 'team' | 'ralph',
+  artifacts: PlanningArtifacts,
+  latestPrdPath: string,
+  anchorHint: ApprovedExecutionLaunchHint,
+): SameLineageFallback {
+  const orderedPrdPaths = [...artifacts.prdPaths].sort(comparePlanningArtifactPaths);
+  const latestIndex = orderedPrdPaths.lastIndexOf(latestPrdPath);
+  if (latestIndex <= 0) {
+    return { status: 'none' };
+  }
+
+  for (let index = latestIndex - 1; index >= 0; index -= 1) {
+    const prdPath = orderedPrdPaths[index]!;
+    const outcome = readApprovedExecutionLaunchHintOutcomeForPrdPath(
+      cwd,
+      mode,
+      prdPath,
+      { task: anchorHint.task },
+      mode === 'team'
+        ? (match: RegExpMatchArray, _task: string) => sameTeamLaunchSignatureMatch(anchorHint, match)
+        : undefined,
+    );
+    if (outcome.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    if (outcome.status !== 'resolved') {
+      continue;
+    }
+    if (isApprovedExecutionFollowupReadyStatus(outcome.hint.contextPackStatus)) {
+      return { status: 'resolved', hint: outcome.hint };
+    }
+  }
+
+  return { status: 'none' };
+}
+
+export function readApprovedExecutionLaunchHintOutcome(
+  cwd: string,
+  mode: 'team' | 'ralph',
+  options: ApprovedExecutionLaunchHintReadOptions = {},
+): ApprovedExecutionLaunchHintOutcome {
+  if (options.prdPath) {
+    return readApprovedExecutionLaunchHintOutcomeForPrdPath(
+      cwd,
+      mode,
+      options.prdPath,
+      options,
+      mode === 'team' ? buildRequestedTeamLaunchSignatureMatchFilter(options) : undefined,
+    );
+  }
+
+  const normalizedTask = options.task?.trim();
+  const normalizedCommand = options.command?.trim();
+  if (!normalizedTask && !normalizedCommand) {
+    const artifacts = readPlanningArtifacts(cwd);
+    const latestPrdPath = selectLatestPlanningArtifactPath(artifacts.prdPaths);
+    if (!latestPrdPath) {
+      return { status: 'absent' };
+    }
+
+    const latestOutcome = readApprovedExecutionLaunchHintOutcomeForPrdPath(
+      cwd,
+      mode,
+      latestPrdPath,
+      options,
+      mode === 'team' ? buildRequestedTeamLaunchSignatureMatchFilter(options) : undefined,
+    );
+    if (latestOutcome.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    if (latestOutcome.status !== 'resolved') {
+      return { status: 'absent' };
+    }
+    if (isApprovedExecutionFollowupReadyStatus(latestOutcome.hint.contextPackStatus)) {
+      return latestOutcome;
+    }
+
+    const fallback = resolveOlderReusableSameLineageHint(
+      cwd,
+      mode,
+      artifacts,
+      latestPrdPath,
+      latestOutcome.hint,
+    );
+    if (fallback.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    return fallback.status === 'resolved'
+      ? { status: 'resolved', hint: fallback.hint }
+      : latestOutcome;
+  }
+
+  const artifacts = readPlanningArtifacts(cwd);
+  let newestNonreadyHint: ApprovedExecutionLaunchHint | null = null;
+  let teamLineageAnchorHint: ApprovedExecutionLaunchHint | null = null;
+  for (const prdPath of orderedPrdPathsNewestFirst(artifacts.prdPaths)) {
+    const teamLineageAnchor = teamLineageAnchorHint;
+    const requestedTeamMatchFilter = mode === 'team'
+      ? buildRequestedTeamLaunchSignatureMatchFilter(options)
+      : undefined;
+    const teamLineageMatchFilter = requestedTeamMatchFilter ?? (
+      mode === 'team'
+      && normalizedTask
+      && !normalizedCommand
+      && teamLineageAnchor
+        ? (match: RegExpMatchArray, _task: string) => sameTeamLaunchSignatureMatch(teamLineageAnchor, match)
+        : undefined
+    );
+    const outcome = readApprovedExecutionLaunchHintOutcomeForPrdPath(
+      cwd,
+      mode,
+      prdPath,
+      options,
+      teamLineageMatchFilter,
+    );
+    if (outcome.status === 'ambiguous') {
+      return { status: 'ambiguous' };
+    }
+    if (outcome.status !== 'resolved') {
+      continue;
+    }
+    if (mode === 'team' && normalizedTask && !normalizedCommand) {
+      teamLineageAnchorHint ??= outcome.hint;
+    }
+    if (isApprovedExecutionFollowupReadyStatus(outcome.hint.contextPackStatus)) {
+      return outcome;
+    }
+    newestNonreadyHint ??= outcome.hint;
+  }
+
+  return newestNonreadyHint
+    ? { status: 'resolved', hint: newestNonreadyHint }
+    : { status: 'absent' };
 }
 
 export function readApprovedExecutionLaunchHint(


### PR DESCRIPTION
## Summary

Approved follow-up lookup can stop at the newest same-lineage handoff even
when that handoff is nonready and an older visible handoff in the same
lineage is still reusable. This change keeps reuse inside the same lineage
while continuing to respect the current visible-markdown scan, so hidden
hints stay out of selection, nonready results stay repair-only, and
multi-PRD lineage scans do not rediscover planning artifacts for every
candidate plan.

## Changes

- keep pinned `prdPath` lookups exact and let unpinned follow-up lookup
  recover the last reusable older hint only within the same lineage
- preserve the existing lineage rules: Ralph follows task text, Team follows
  the full launch signature, exact command lookups still win, and
  same-lineage ambiguity still fails closed
- thread one cached `PlanningArtifacts` snapshot through task, command, and
  same-lineage fallback scans so multi-PRD lookup does not rescan planning
  directories per candidate PRD
- add a dedicated Team/Ralph lineage matrix with exhaustive two-plan state
  checks, deterministic multi-plan oracle checks, and counterfactual cases
  for hidden hints and same-lineage ambiguity
- add CLI regressions that cover short follow-up reuse across
  missing-baseline, invalid, and incomplete newer handoffs, plus a focused
  scan-count regression for the cached lookup path

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- `node --test dist/planning/__tests__/approved-launch-hint-lineage-matrix.test.js dist/planning/__tests__/artifacts.test.js dist/cli/__tests__/ralph.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/approved-execution.test.js` (`# pass 178`, `# fail 0`)
- `npx tsc --noEmit`
- `npm run check:no-unused`
- outside sandbox: `/bin/zsh -lc "node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__ >/private/tmp/fix-approved-launch-hint-markdown-scan-state-cli-core-rest.log 2>&1"` (`# pass 1684`, `# fail 0`)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

None.
