### PR TITLE
fix: preserve multiline approved launch-hint matching

### DIFF
--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -684,6 +684,100 @@ describe('planning artifacts', () => {
     assert.equal(outcome.status, 'absent');
   });
 
+  it('resolves Ralph launch hints wrapped across visible markdown lines', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute wrapped visible ralph plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-wrapped-visible-ralph.md'),
+      [
+        '# PRD',
+        '',
+        'Launch via omx ralph',
+        JSON.stringify(task),
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-wrapped-visible-ralph.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph', { task });
+    assert.ok(hint);
+    assert.equal(hint?.task, task);
+    assert.equal(hint?.command, `omx ralph\n${JSON.stringify(task)}`);
+    assert.equal(hint?.contextPackStatus, 'plan-only');
+  });
+
+  it('does not let Ralph launch hints span hidden markdown gaps', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+
+    const scenarios = [
+      {
+        name: 'fenced',
+        buildHiddenLines: (task: string) => [
+          '```md',
+          JSON.stringify(task),
+          '```',
+        ],
+      },
+      {
+        name: 'commented',
+        buildHiddenLines: (task: string) => [
+          '<!--',
+          JSON.stringify(task),
+          '-->',
+        ],
+      },
+      {
+        name: 'indented',
+        buildHiddenLines: (task: string) => [
+          `    ${JSON.stringify(task)}`,
+        ],
+      },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const task = `Execute hidden-gap ${scenario.name} ralph plan`;
+      await writeFile(
+        join(plansDir, `prd-hidden-gap-${scenario.name}-ralph.md`),
+        [
+          '# PRD',
+          '',
+          'Launch via omx ralph',
+          ...scenario.buildHiddenLines(task),
+        ].join('\n'),
+      );
+      await writeFile(join(plansDir, `test-spec-hidden-gap-${scenario.name}-ralph.md`), '# Test Spec\n');
+
+      const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph', { task });
+      assert.equal(outcome.status, 'absent', scenario.name);
+    }
+  });
+
+  it('resolves Team launch hints wrapped across visible markdown lines', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute wrapped visible team plan';
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-wrapped-visible-team.md'),
+      [
+        '# PRD',
+        '',
+        'Launch via omx team',
+        '2:executor',
+        JSON.stringify(task),
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-wrapped-visible-team.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team', { task });
+    assert.ok(hint);
+    assert.equal(hint?.task, task);
+    assert.equal(hint?.workerCount, 2);
+    assert.equal(hint?.agentType, 'executor');
+    assert.equal(hint?.command, `omx team\n2:executor\n${JSON.stringify(task)}`);
+    assert.equal(hint?.contextPackStatus, 'plan-only');
+  });
+
   it('ignores Team launch hints inside fenced code blocks', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     const task = 'Execute approved issue 1314 fenced team plan';

--- a/src/planning/__tests__/markdown-structure.test.ts
+++ b/src/planning/__tests__/markdown-structure.test.ts
@@ -19,6 +19,7 @@ interface ModelVisibilityState {
 }
 
 const MATCH_TOKEN_PATTERN = /match-[a-z]+/g;
+const MULTILINE_MATCH_PATTERN = /match-alpha\s+match-beta/g;
 const MODEL_COMMENT_LINE_PATTERN = /^(?: {0,3})<!--/;
 const MODEL_COMMENT_OPEN = '<!--';
 const MODEL_COMMENT_CLOSE = '-->';
@@ -161,6 +162,67 @@ describe('collectMarkdownVisibleMatches', () => {
     );
 
     assert.deepEqual(matches.map((match) => match[0]), ['match-alpha', 'match-beta']);
+  });
+
+  it('preserves multiline matches across contiguous visible markdown while blocking hidden-gap counterfactuals', () => {
+    const cases = [
+      {
+        name: 'visible-adjacent-lines',
+        content: [
+          'match-alpha',
+          'match-beta',
+        ].join('\n'),
+        expected: ['match-alpha\nmatch-beta'],
+      },
+      {
+        name: 'visible-blank-line',
+        content: [
+          'match-alpha',
+          '',
+          'match-beta',
+        ].join('\n'),
+        expected: ['match-alpha\n\nmatch-beta'],
+      },
+      {
+        name: 'fenced-gap',
+        content: [
+          'match-alpha',
+          '```md',
+          'match-hidden',
+          '```',
+          'match-beta',
+        ].join('\n'),
+        expected: [],
+      },
+      {
+        name: 'comment-gap',
+        content: [
+          'match-alpha',
+          '<!--',
+          'match-hidden',
+          '-->',
+          'match-beta',
+        ].join('\n'),
+        expected: [],
+      },
+      {
+        name: 'indented-gap',
+        content: [
+          'match-alpha',
+          '    match-hidden',
+          'match-beta',
+        ].join('\n'),
+        expected: [],
+      },
+    ] as const;
+
+    for (const { name, content, expected } of cases) {
+      assert.deepEqual(
+        collectMarkdownVisibleMatches(content, MULTILINE_MATCH_PATTERN).map((match) => match[0]),
+        expected,
+        name,
+      );
+    }
   });
 
   it('ignores matches inside backtick fenced code blocks with info strings', () => {

--- a/src/planning/markdown-structure.ts
+++ b/src/planning/markdown-structure.ts
@@ -170,14 +170,30 @@ export function collectMarkdownVisibleMatches(
   const globalFlags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
   let state = INITIAL_MARKDOWN_VISIBILITY_STATE;
   const matches: RegExpMatchArray[] = [];
+  const visibleChunkLines: string[] = [];
+
+  const flushVisibleChunk = (): void => {
+    if (visibleChunkLines.length === 0) {
+      return;
+    }
+    matches.push(
+      ...visibleChunkLines
+        .join('\n')
+        .matchAll(new RegExp(pattern.source, globalFlags)),
+    );
+    visibleChunkLines.length = 0;
+  };
 
   for (const line of lines) {
     const inspection = inspectMarkdownLine(state, line);
     if (inspection.scanState === 'normal') {
-      matches.push(...inspection.visibleText.matchAll(new RegExp(pattern.source, globalFlags)));
+      visibleChunkLines.push(inspection.visibleText);
+    } else {
+      flushVisibleChunk();
     }
     state = inspection.nextState;
   }
 
+  flushVisibleChunk();
   return matches;
 }


### PR DESCRIPTION
## Summary

Merged `#2238` made approved launch-hint scans respect visible markdown structure, but the helper now scans one visible line at a time. That regressed wrapped visible Team/Ralph commands such as `Launch via omx ralph` followed by the quoted task on the next line. This patch restores multiline matching within contiguous visible markdown while keeping fenced, commented, and indented hidden blocks as hard boundaries.

## Changes

- scan contiguous visible markdown chunks instead of isolated lines in `collectMarkdownVisibleMatches`
- add markdown-structure coverage for visible multiline matches and hidden-gap counterfactuals
- add planning artifact regressions for wrapped visible Ralph/Team hints and hidden-gap Ralph cases

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] `node --test dist/planning/__tests__/markdown-structure.test.js dist/planning/__tests__/artifacts.test.js dist/planning/__tests__/context-pack-status.test.js`
- [x] exact compiled `cli-core-rest`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [ ] `npm test`
- [ ] `omx doctor`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Follow-up to #2238
