### PR TITLE
fix(planning): normalize wrapped launch hint commands

### DIFF
--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -923,6 +923,41 @@ describe('planning artifacts', () => {
     }
   });
 
+  it('does not normalize whitespace that changes the quoted task payload', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+
+    const task = 'Execute embedded\nnewline task';
+    const exactCommand = [
+      'omx ralph "Execute embedded',
+      'newline task"',
+    ].join('\n');
+    const collapsedCommand = 'omx ralph "Execute embedded newline task"';
+
+    await writeFile(
+      join(plansDir, 'prd-exact-command-embedded-newline-task.md'),
+      [
+        '# PRD',
+        '',
+        'Launch via omx ralph "Execute embedded',
+        'newline task"',
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-exact-command-embedded-newline-task.md'), '# Test Spec\n');
+
+    const exactOutcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph', { command: exactCommand });
+    assert.equal(exactOutcome.status, 'resolved');
+    if (exactOutcome.status !== 'resolved') {
+      return;
+    }
+    assert.equal(exactOutcome.hint.command, exactCommand);
+    assert.equal(exactOutcome.hint.task, task);
+    assert.equal(
+      readApprovedExecutionLaunchHintOutcome(tempDir, 'ralph', { command: collapsedCommand }).status,
+      'absent',
+    );
+  });
+
   it('ignores Team launch hints inside fenced code blocks', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     const task = 'Execute approved issue 1314 fenced team plan';

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -732,6 +732,7 @@ describe('planning artifacts', () => {
   it('resolves Ralph launch hints wrapped across visible markdown lines', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     const task = 'Execute wrapped visible ralph plan';
+    const command = `omx ralph ${JSON.stringify(task)}`;
     await mkdir(plansDir, { recursive: true });
     await writeFile(
       join(plansDir, 'prd-wrapped-visible-ralph.md'),
@@ -747,8 +748,12 @@ describe('planning artifacts', () => {
     const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph', { task });
     assert.ok(hint);
     assert.equal(hint?.task, task);
-    assert.equal(hint?.command, `omx ralph\n${JSON.stringify(task)}`);
+    assert.equal(hint?.command, command);
     assert.equal(hint?.contextPackStatus, 'plan-only');
+
+    const exactHint = readApprovedExecutionLaunchHint(tempDir, 'ralph', { command });
+    assert.ok(exactHint);
+    assert.equal(exactHint?.command, command);
   });
 
   it('does not let Ralph launch hints span hidden markdown gaps', async () => {
@@ -801,6 +806,7 @@ describe('planning artifacts', () => {
   it('resolves Team launch hints wrapped across visible markdown lines', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     const task = 'Execute wrapped visible team plan';
+    const command = `omx team 2:executor ${JSON.stringify(task)}`;
     await mkdir(plansDir, { recursive: true });
     await writeFile(
       join(plansDir, 'prd-wrapped-visible-team.md'),
@@ -819,8 +825,102 @@ describe('planning artifacts', () => {
     assert.equal(hint?.task, task);
     assert.equal(hint?.workerCount, 2);
     assert.equal(hint?.agentType, 'executor');
-    assert.equal(hint?.command, `omx team\n2:executor\n${JSON.stringify(task)}`);
+    assert.equal(hint?.command, command);
     assert.equal(hint?.contextPackStatus, 'plan-only');
+
+    const exactHint = readApprovedExecutionLaunchHint(tempDir, 'team', { command });
+    assert.ok(exactHint);
+    assert.equal(exactHint?.command, command);
+  });
+
+  it('normalizes wrapped linked-Ralph team launch hints for exact command matching', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const task = 'Execute wrapped linked ralph team plan';
+    const command = `$team ralph 5:debugger ${JSON.stringify(task)}`;
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-wrapped-visible-team-linked-ralph.md'),
+      [
+        '# PRD',
+        '',
+        'Launch via $team',
+        'ralph',
+        '5:debugger',
+        JSON.stringify(task),
+      ].join('\n'),
+    );
+    await writeFile(join(plansDir, 'test-spec-wrapped-visible-team-linked-ralph.md'), '# Test Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'team', { command });
+    assert.ok(hint);
+    assert.equal(hint?.command, command);
+    assert.equal(hint?.workerCount, 5);
+    assert.equal(hint?.agentType, 'debugger');
+    assert.equal(hint?.linkedRalph, true);
+  });
+
+  it('keeps exact-command normalization bounded to visible whitespace-only variants', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+
+    const task = 'Execute exact-command normalization state table plan';
+    const command = `omx team 2:executor ${JSON.stringify(task)}`;
+    const cases = [
+      {
+        name: 'visible-whitespace-only-variant',
+        prdPath: 'prd-exact-command-visible.md',
+        content: [
+          '# PRD',
+          '',
+          'Launch via omx team',
+          '2:executor',
+          JSON.stringify(task),
+        ].join('\n'),
+        expectedStatus: 'resolved',
+      },
+      {
+        name: 'hidden-gap-counterfactual',
+        prdPath: 'prd-exact-command-hidden-gap.md',
+        content: [
+          '# PRD',
+          '',
+          'Launch via omx team',
+          '```md',
+          'hidden',
+          '```',
+          '2:executor',
+          JSON.stringify(task),
+        ].join('\n'),
+        expectedStatus: 'absent',
+      },
+      {
+        name: 'formatting-only-duplicate',
+        prdPath: 'prd-exact-command-duplicate.md',
+        content: [
+          '# PRD',
+          '',
+          `Launch via ${command}`,
+          'Launch via omx team',
+          '2:executor',
+          JSON.stringify(task),
+        ].join('\n'),
+        expectedStatus: 'ambiguous',
+      },
+    ] as const;
+
+    for (const scenario of cases) {
+      await writeFile(join(plansDir, scenario.prdPath), scenario.content);
+      await writeFile(
+        join(plansDir, scenario.prdPath.replace(/^prd-/, 'test-spec-')),
+        '# Test Spec\n',
+      );
+
+      const outcome = readApprovedExecutionLaunchHintOutcome(tempDir, 'team', { command });
+      assert.equal(outcome.status, scenario.expectedStatus, scenario.name);
+
+      await rm(join(plansDir, scenario.prdPath), { force: true });
+      await rm(join(plansDir, scenario.prdPath.replace(/^prd-/, 'test-spec-')), { force: true });
+    }
   });
 
   it('ignores Team launch hints inside fenced code blocks', async () => {

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -458,10 +458,64 @@ type LaunchHintSelection =
 
 type LaunchHintMatchFilter = (match: RegExpMatchArray, task: string) => boolean;
 
+const TEAM_LAUNCH_HINT_PATTERN_SOURCE =
+  String.raw`(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))`;
+const RALPH_LAUNCH_HINT_PATTERN_SOURCE =
+  String.raw`(?<command>(?:omx\s+ralph|\$ralph)\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))`;
+
 function launchHintPattern(mode: 'team' | 'ralph'): RegExp {
   return mode === 'team'
-    ? /(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi
-    : /(?<command>(?:omx\s+ralph|\$ralph)\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
+    ? new RegExp(TEAM_LAUNCH_HINT_PATTERN_SOURCE, 'gi')
+    : new RegExp(RALPH_LAUNCH_HINT_PATTERN_SOURCE, 'gi');
+}
+
+function launchHintExactPattern(mode: 'team' | 'ralph'): RegExp {
+  return mode === 'team'
+    ? new RegExp(`^${TEAM_LAUNCH_HINT_PATTERN_SOURCE}$`, 'i')
+    : new RegExp(`^${RALPH_LAUNCH_HINT_PATTERN_SOURCE}$`, 'i');
+}
+
+function normalizeLaunchHintCommandFromMatch(
+  mode: 'team' | 'ralph',
+  match: RegExpMatchArray | null | undefined,
+): string | null {
+  const groups = match?.groups;
+  const rawCommand = groups?.command?.trim();
+  const taskToken = groups?.task?.trim();
+  if (!groups || !rawCommand || !taskToken) {
+    return null;
+  }
+
+  if (mode === 'team') {
+    const countToken = groups.count?.trim();
+    if (!countToken) {
+      return null;
+    }
+    const roleToken = groups.role?.trim();
+    const prefix = /^\$team\b/i.test(rawCommand) ? '$team' : 'omx team';
+    const countWithRole = roleToken ? `${countToken}:${roleToken}` : countToken;
+    const parts = [prefix];
+    if (groups.ralph?.trim()) {
+      parts.push('ralph');
+    }
+    parts.push(countWithRole, taskToken);
+    return parts.join(' ');
+  }
+
+  const prefix = /^\$ralph\b/i.test(rawCommand) ? '$ralph' : 'omx ralph';
+  return `${prefix} ${taskToken}`;
+}
+
+function normalizeLaunchHintCommand(
+  mode: 'team' | 'ralph',
+  command: string | undefined,
+): string | undefined {
+  const trimmed = command?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = trimmed.match(launchHintExactPattern(mode));
+  return normalizeLaunchHintCommandFromMatch(mode, parsed) ?? trimmed;
 }
 
 function collectLaunchHintMatches(
@@ -472,15 +526,17 @@ function collectLaunchHintMatches(
 }
 
 function selectLaunchHintMatch(
+  mode: 'team' | 'ralph',
   matches: RegExpMatchArray[],
   normalizedTask?: string,
   normalizedCommand?: string,
   matchFilter?: LaunchHintMatchFilter,
 ): LaunchHintSelection {
+  const exactCommand = normalizeLaunchHintCommand(mode, normalizedCommand);
   if (normalizedCommand) {
     const exactMatches = matches.flatMap((match) => {
-      const command = match.groups?.command?.trim();
-      if (!command || command !== normalizedCommand) {
+      const command = normalizeLaunchHintCommandFromMatch(mode, match);
+      if (!command || command !== exactCommand) {
         return [];
       }
       const task = match.groups?.task ? decodeApprovedExecutionQuotedValue(match.groups.task) : null;
@@ -615,6 +671,7 @@ function readApprovedExecutionLaunchHintOutcomeForPrdPath(
     return { status: 'absent' };
   }
   const selected = selectLaunchHintMatch(
+    mode,
     collectLaunchHintMatches(approvedPlan.content, mode),
     options.task?.trim(),
     options.command?.trim(),
@@ -636,7 +693,7 @@ function readApprovedExecutionLaunchHintOutcomeForPrdPath(
       status: 'resolved',
       hint: {
         mode,
-        command: selected.match.groups.command,
+        command: normalizeLaunchHintCommandFromMatch(mode, selected.match) ?? selected.match.groups.command,
         task: selected.task,
         workerCount,
         agentType: selected.match.groups.role || undefined,
@@ -650,7 +707,7 @@ function readApprovedExecutionLaunchHintOutcomeForPrdPath(
     status: 'resolved',
     hint: {
       mode,
-      command: selected.match.groups.command,
+      command: normalizeLaunchHintCommandFromMatch(mode, selected.match) ?? selected.match.groups.command,
       task: selected.task,
       ...approvedPlan.context,
     },

--- a/src/team/__tests__/approved-execution.test.ts
+++ b/src/team/__tests__/approved-execution.test.ts
@@ -246,6 +246,52 @@ describe('approved execution binding', () => {
     });
   });
 
+  it('keeps an exact-command binding valid when the approved team hint is wrapped across visible lines', async () => {
+    await withUnboxedOmxRoot(async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-wrapped-command-'));
+      const stateRoot = join(cwd, '.omx', 'state');
+      const approvedTask = 'Execute approved issue 1317 wrapped plan';
+      const exactCommand = `omx team 2:executor "${approvedTask}"`;
+      try {
+        const plansDir = join(cwd, '.omx', 'plans');
+        await mkdir(plansDir, { recursive: true });
+        const prdPath = join(plansDir, 'prd-issue-1317-wrapped.md');
+        await writeFile(
+          prdPath,
+          [
+            '# Approved plan',
+            '',
+            'Launch via omx team',
+            '2:executor',
+            JSON.stringify(approvedTask),
+            `Launch via omx team 5:debugger "${approvedTask}"`,
+          ].join('\n'),
+        );
+        await writeFile(join(plansDir, 'test-spec-issue-1317-wrapped.md'), '# Test spec\n');
+        await writePersistedApprovedTeamExecutionBinding('bound-team', cwd, {
+          prd_path: prdPath,
+          task: approvedTask,
+          command: exactCommand,
+        }, stateRoot);
+
+        const state = await resolvePersistedApprovedTeamExecutionContinuityState(
+          'bound-team',
+          cwd,
+          stateRoot,
+        );
+        assert.equal(state.status, 'valid');
+        if (state.status !== 'valid') {
+          throw new Error('expected valid continuity state');
+        }
+        assert.equal(state.approvedHint.command, exactCommand);
+        assert.equal(state.approvedHint.workerCount, 2);
+        assert.equal(state.approvedHint.agentType, 'executor');
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  });
+
   it('preserves missing-baseline continuity instead of collapsing it to stale', async () => {
     await withUnboxedOmxRoot(async () => {
       const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-missing-baseline-'));


### PR DESCRIPTION
## Summary

Merged `#2243` made approved launch-hint scans preserve multiline visible
Team/Ralph commands, but exact-command lookup still compared the wrapped raw
text. That can make persisted approved Team bindings and explicit command
lookups go stale when a visible launch hint only changes formatting across
lines.

This patch normalizes approved launch-hint commands after parsing so
formatting-only visible wraps still resolve to the same exact command while
hidden markdown gaps and duplicate canonical commands continue to fail closed.

## Changes

- normalize exact-command matching and returned `hint.command` from parsed Team
  and Ralph launch-hint groups instead of comparing wrapped raw markdown text
- preserve exact launcher/signature identity during normalization, including
  `$team`/`$ralph`, linked-Ralph Team launches, worker counts, agent roles, and
  the quoted task token
- add planning and approved-execution regressions for wrapped visible
  exact-command reuse, linked-Ralph Team commands, duplicate ambiguity,
  hidden-gap absence, and the quoted-task payload boundary

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] `node --test dist/planning/__tests__/markdown-structure.test.js dist/planning/__tests__/artifacts.test.js dist/planning/__tests__/context-pack-status.test.js dist/team/__tests__/approved-execution.test.js`
- [x] exact compiled `cli-core-rest`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [ ] `npm test`
- [ ] `omx doctor`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Follow-up to #2243
