### PR TITLE
feat(planning): read private context-pack entry metadata

### DIFF
--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -78,6 +78,41 @@ async function writeContextPack(
   return packPath;
 }
 
+async function writeContextPackWithEntries(
+  slug: string,
+  prdPath: string,
+  testSpecPath: string,
+  entries: Array<{
+    path: string;
+    roles: string[];
+    label?: unknown;
+    tags?: unknown;
+    selector?: unknown;
+    relationPath?: unknown;
+  }>,
+): Promise<string> {
+  const contextDir = join(tempDir, '.omx', 'context');
+  await mkdir(contextDir, { recursive: true });
+  const packPath = join(tempDir, canonicalContextPackRelativePath(slug));
+  const prdContent = await readFile(prdPath, 'utf-8');
+  const testSpecContent = await readFile(testSpecPath, 'utf-8');
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relativeToRepo(prdPath),
+        sha1: computeGitBlobSha1(prdContent),
+      },
+      testSpecs: [{
+        path: relativeToRepo(testSpecPath),
+        sha1: computeGitBlobSha1(testSpecContent),
+      }],
+    },
+    entries,
+  }, null, 2));
+  return packPath;
+}
+
 async function setup(): Promise<void> {
   tempDir = await mkdtemp(join(tmpdir(), 'omx-planning-artifacts-'));
 }
@@ -372,6 +407,134 @@ describe('planning artifacts', () => {
       scope: ['src/scope-0.ts'],
       build: ['src/build-1.ts'],
       verify: ['src/verify-2.ts'],
+    });
+    assert.deepEqual(hint?.missingRequiredContextPackRoles, []);
+    assert.deepEqual(hint?.contextPackIssues, []);
+  });
+
+  it('keeps approved hint role refs unchanged when ready packs carry private entry metadata', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-context-ready-private.md');
+    const testSpecPath = join(plansDir, 'test-spec-context-ready-private.md');
+    await writeFile(
+      prdPath,
+      [
+        '# PRD',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath('context-ready-private')),
+        '',
+        'Launch via omx ralph "Execute context-ready private handoff"',
+      ].join('\n'),
+    );
+    await writeFile(testSpecPath, '# Test Spec\n');
+    const packPath = await writeContextPackWithEntries(
+      'context-ready-private',
+      prdPath,
+      testSpecPath,
+      [
+        {
+          path: 'src/scope-ready.ts',
+          roles: ['scope'],
+        },
+        {
+          path: 'src/build-ready.ts',
+          roles: ['build'],
+          label: 'Build Focus',
+          tags: ['runtime', 'build'],
+          selector: { type: 'heading', value: ' ## Build Focus ', maxWords: 120 },
+          relationPath: [
+            { tag: 'Plan', target: ' context-ready-private ' },
+            { tag: 'Implements', target: ' src/build-ready.ts#build-focus ' },
+          ],
+        },
+        {
+          path: 'src/verify-ready.ts',
+          roles: ['verify'],
+          relationPath: [
+            { tag: 'Plan', target: ' context-ready-private ' },
+            { tag: 'Verifies', target: ' src/verify-ready.ts ' },
+          ],
+        },
+      ],
+    );
+
+    const selection = readLatestPlanningArtifacts(tempDir);
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+
+    assert.deepEqual(selection.contextPack, { path: packPath });
+    assert.equal(selection.contextPackStatus, 'ready');
+    assert.deepEqual(selection.contextPackRoleRefs, {
+      scope: ['src/scope-ready.ts'],
+      build: ['src/build-ready.ts'],
+      verify: ['src/verify-ready.ts'],
+    });
+    assert.ok(hint);
+    assert.deepEqual(hint?.contextPack, { path: packPath });
+    assert.equal(hint?.contextPackStatus, 'ready');
+    assert.deepEqual(hint?.contextPackRoleRefs, {
+      scope: ['src/scope-ready.ts'],
+      build: ['src/build-ready.ts'],
+      verify: ['src/verify-ready.ts'],
+    });
+    assert.deepEqual(hint?.missingRequiredContextPackRoles, []);
+    assert.deepEqual(hint?.contextPackIssues, []);
+  });
+
+  it('keeps approved hint role refs unchanged when ready packs carry malformed private metadata', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    const prdPath = join(plansDir, 'prd-context-ready-private-counterfactual.md');
+    const testSpecPath = join(plansDir, 'test-spec-context-ready-private-counterfactual.md');
+    await writeFile(
+      prdPath,
+      [
+        '# PRD',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath('context-ready-private-counterfactual')),
+        '',
+        'Launch via omx ralph "Execute context-ready private counterfactual handoff"',
+      ].join('\n'),
+    );
+    await writeFile(testSpecPath, '# Test Spec\n');
+    const packPath = await writeContextPackWithEntries(
+      'context-ready-private-counterfactual',
+      prdPath,
+      testSpecPath,
+      [
+        {
+          path: 'src/scope-counterfactual.ts',
+          roles: ['scope'],
+        },
+        {
+          path: 'src/build-counterfactual.ts',
+          roles: ['build'],
+          selector: { type: 'heading', value: 'Build Focus', maxWords: 20 },
+        },
+        {
+          path: 'src/verify-counterfactual.ts',
+          roles: ['verify'],
+        },
+      ],
+    );
+
+    const selection = readLatestPlanningArtifacts(tempDir);
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+
+    assert.deepEqual(selection.contextPack, { path: packPath });
+    assert.equal(selection.contextPackStatus, 'ready');
+    assert.deepEqual(selection.contextPackRoleRefs, {
+      scope: ['src/scope-counterfactual.ts'],
+      build: ['src/build-counterfactual.ts'],
+      verify: ['src/verify-counterfactual.ts'],
+    });
+    assert.ok(hint);
+    assert.deepEqual(hint?.contextPack, { path: packPath });
+    assert.equal(hint?.contextPackStatus, 'ready');
+    assert.deepEqual(hint?.contextPackRoleRefs, {
+      scope: ['src/scope-counterfactual.ts'],
+      build: ['src/build-counterfactual.ts'],
+      verify: ['src/verify-counterfactual.ts'],
     });
     assert.deepEqual(hint?.missingRequiredContextPackRoles, []);
     assert.deepEqual(hint?.contextPackIssues, []);

--- a/src/planning/__tests__/context-pack-status.test.ts
+++ b/src/planning/__tests__/context-pack-status.test.ts
@@ -12,6 +12,16 @@ import {
 
 let tempDir: string;
 
+type TestContextPackEntry = {
+  path: string;
+  roles: string[];
+  label?: unknown;
+  tags?: unknown;
+  selector?: unknown;
+  relationPath?: unknown;
+  [key: string]: unknown;
+};
+
 function computeGitBlobSha1(content: string): string {
   const buffer = Buffer.from(content, 'utf-8');
   const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
@@ -89,6 +99,31 @@ async function writeContextPack(
       path: `src/${role}-${index}.ts`,
       roles: [role],
     })),
+  }, null, 2));
+}
+
+async function writeContextPackWithEntries(
+  slug: string,
+  prdPath: string,
+  testSpecPath: string,
+  entries: TestContextPackEntry[],
+): Promise<void> {
+  const packPath = join(tempDir, canonicalContextPackRelativePath(slug));
+  const prdActual = await readFile(prdPath, 'utf-8');
+  const testSpecActual = await readFile(testSpecPath, 'utf-8');
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relativeToRepo(prdPath),
+        sha1: computeGitBlobSha1(prdActual),
+      },
+      testSpecs: [{
+        path: relativeToRepo(testSpecPath),
+        sha1: computeGitBlobSha1(testSpecActual),
+      }],
+    },
+    entries,
   }, null, 2));
 }
 
@@ -186,6 +221,387 @@ describe('context pack handoff status', () => {
     });
     assert.deepEqual(status.missingRequiredContextPackRoles, []);
     assert.deepEqual(status.contextPackIssues, []);
+  });
+
+  it('keeps the handoff state machine invariant under private metadata variations and counterfactuals', async () => {
+    const cases: Array<{
+      slug: string;
+      entries: TestContextPackEntry[];
+      mutate?: (fixture: Awaited<ReturnType<typeof writeApprovedPlan>>) => Promise<void>;
+      expected: {
+        status: string;
+        packState: string;
+        declarationState: string;
+        basisState: string;
+        roleCoverage: string;
+        roleRefs: { scope: string[]; build: string[]; verify: string[] } | null;
+        missingRoles?: string[];
+        issue?: string;
+      };
+    }> = [
+      {
+        slug: 'ready-valid-private-metadata',
+        entries: [
+          { path: 'src/scope.ts', roles: ['scope'] },
+          {
+            path: 'src/build.ts',
+            roles: ['build'],
+            label: 'Runtime Contract',
+            tags: ['runtime', 'build'],
+            selector: { type: 'heading', value: '## Runtime Contract', maxWords: 120 },
+            relationPath: [
+              { tag: 'plan', target: 'ready-valid-private-metadata' },
+              { tag: 'implements', target: 'src/build.ts#runtime-contract' },
+            ],
+          },
+          {
+            path: 'src/verify.ts',
+            roles: ['verify'],
+            selector: { type: 'lines', start: 2, end: 4 },
+          },
+        ],
+        expected: {
+          status: 'ready',
+          packState: 'valid',
+          declarationState: 'matching',
+          basisState: 'fresh',
+          roleCoverage: 'covered',
+          roleRefs: {
+            scope: ['src/scope.ts'],
+            build: ['src/build.ts'],
+            verify: ['src/verify.ts'],
+          },
+        },
+      },
+      {
+        slug: 'ready-invalid-private-metadata',
+        entries: [
+          { path: 'src/scope.ts', roles: ['scope'] },
+          {
+            path: 'src/build.ts',
+            roles: ['build'],
+            selector: { type: 'heading', value: 'Runtime Contract', maxWords: 20 },
+          },
+          { path: 'src/verify.ts', roles: ['verify'] },
+        ],
+        expected: {
+          status: 'ready',
+          packState: 'valid',
+          declarationState: 'matching',
+          basisState: 'fresh',
+          roleCoverage: 'covered',
+          roleRefs: {
+            scope: ['src/scope.ts'],
+            build: ['src/build.ts'],
+            verify: ['src/verify.ts'],
+          },
+        },
+      },
+      {
+        slug: 'incomplete-invalid-private-metadata',
+        entries: [
+          { path: 'src/scope.ts', roles: ['scope'] },
+          {
+            path: 'src/build.ts',
+            roles: ['build'],
+            relationPath: [
+              { tag: 'plan', target: 'alpha' },
+              { tag: 'evidence', target: 'beta' },
+              { tag: 'implements', target: 'gamma' },
+              { tag: 'dependency', target: 'delta' },
+              { tag: 'bounds', target: 'epsilon' },
+              { tag: 'verifies', target: 'zeta' },
+            ],
+          },
+        ],
+        expected: {
+          status: 'incomplete',
+          packState: 'valid',
+          declarationState: 'matching',
+          basisState: 'fresh',
+          roleCoverage: 'missing-required-roles',
+          roleRefs: null,
+          missingRoles: ['verify'],
+        },
+      },
+      {
+        slug: 'invalid-stale-private-metadata',
+        entries: [
+          { path: 'src/scope.ts', roles: ['scope'] },
+          {
+            path: 'src/build.ts',
+            roles: ['build'],
+            tags: ['runtime', '', 'verify'],
+          },
+          { path: 'src/verify.ts', roles: ['verify'] },
+        ],
+        mutate: async ({ testSpecPath }) => {
+          await writeFile(testSpecPath, '# Drifted Test Spec\n');
+        },
+        expected: {
+          status: 'invalid',
+          packState: 'valid',
+          declarationState: 'matching',
+          basisState: 'stale',
+          roleCoverage: 'covered',
+          roleRefs: null,
+          issue: 'basis test-spec hash',
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const fixture = await writeApprovedPlan(testCase.slug, [
+        '# PRD',
+        '',
+        buildContextPackOutcome(canonicalContextPackRelativePath(testCase.slug)),
+        '',
+        `Launch via omx ralph ${JSON.stringify(`Execute ${testCase.slug} plan`)}`,
+      ]);
+      await writeContextPackWithEntries(
+        testCase.slug,
+        fixture.prdPath,
+        fixture.testSpecPath,
+        testCase.entries,
+      );
+      if (testCase.mutate) {
+        await testCase.mutate(fixture);
+      }
+
+      const status = readContextPackHandoffStatus(tempDir, fixture.prdPath);
+
+      assert.equal(status.contextPackStatus, testCase.expected.status, `status mismatch for ${testCase.slug}`);
+      assert.equal(status.packState, testCase.expected.packState, `packState mismatch for ${testCase.slug}`);
+      assert.equal(status.declarationState, testCase.expected.declarationState, `declarationState mismatch for ${testCase.slug}`);
+      assert.equal(status.basisState, testCase.expected.basisState, `basisState mismatch for ${testCase.slug}`);
+      assert.equal(status.roleCoverage, testCase.expected.roleCoverage, `roleCoverage mismatch for ${testCase.slug}`);
+      assert.deepEqual(status.contextPackRoleRefs, testCase.expected.roleRefs, `role refs mismatch for ${testCase.slug}`);
+      assert.deepEqual(
+        status.missingRequiredContextPackRoles,
+        testCase.expected.missingRoles ?? [],
+        `missing roles mismatch for ${testCase.slug}`,
+      );
+      if (testCase.expected.issue) {
+        assert.ok(
+          status.contextPackIssues.some((issue) => issue.includes(testCase.expected.issue ?? '')),
+          `expected issue containing ${testCase.expected.issue} for ${testCase.slug}`,
+        );
+      } else {
+        assert.deepEqual(status.contextPackIssues, [], `issues should stay empty for ${testCase.slug}`);
+      }
+    }
+  });
+
+  it('keeps the public handoff state machine invariant across exhaustive private metadata modes', async () => {
+    const metadataVariants: Array<{
+      name: string;
+      buildMetadata: (slug: string) => Record<string, unknown>;
+    }> = [
+      {
+        name: 'none',
+        buildMetadata: () => ({}),
+      },
+      {
+        name: 'valid-heading',
+        buildMetadata: (slug) => ({
+          label: 'Runtime Contract',
+          tags: ['runtime', 'build'],
+          selector: { type: 'heading', value: ' ## Runtime Contract ', maxWords: 120 },
+          relationPath: [
+            { tag: 'Plan', target: ` ${slug} ` },
+            { tag: 'Implements', target: ' src/build.ts#runtime-contract ' },
+          ],
+        }),
+      },
+      {
+        name: 'valid-lines',
+        buildMetadata: (slug) => ({
+          label: 'Verify Slice',
+          selector: { type: 'lines', start: 2, end: 5 },
+          relationPath: [
+            { tag: 'Plan', target: ` ${slug} ` },
+            { tag: 'Verifies', target: ' src/build.ts:2-5 ' },
+          ],
+        }),
+      },
+      {
+        name: 'invalid-label',
+        buildMetadata: () => ({ label: '---' }),
+      },
+      {
+        name: 'invalid-tags',
+        buildMetadata: () => ({ tags: ['runtime', '', 'verify'] }),
+      },
+      {
+        name: 'invalid-selector-extra-key',
+        buildMetadata: () => ({
+          selector: { type: 'heading', value: 'Runtime Contract', extra: true },
+        }),
+      },
+      {
+        name: 'invalid-relation-too-many-steps',
+        buildMetadata: () => ({
+          relationPath: [
+            { tag: 'plan', target: 'alpha' },
+            { tag: 'evidence', target: 'beta' },
+            { tag: 'dependency', target: 'gamma' },
+            { tag: 'links-to', target: 'delta' },
+            { tag: 'bounds', target: 'epsilon' },
+            { tag: 'verifies', target: 'zeta' },
+          ],
+        }),
+      },
+      {
+        name: 'invalid-relation-step-extra-key',
+        buildMetadata: () => ({
+          relationPath: [{ tag: 'plan', target: 'alpha', extra: true }],
+        }),
+      },
+      {
+        name: 'invalid-entry-extra-key',
+        buildMetadata: () => ({ unexpected: true }),
+      },
+    ];
+    const scenarios: Array<{
+      name: string;
+      buildEntries: (metadata: Record<string, unknown>) => TestContextPackEntry[];
+      mutate?: (fixture: Awaited<ReturnType<typeof writeApprovedPlan>>) => Promise<void>;
+      expected: {
+        status: string;
+        packState: string;
+        declarationState: string;
+        basisState: string;
+        roleCoverage: string;
+        roleRefs: { scope: string[]; build: string[]; verify: string[] } | null;
+        missingRoles?: string[];
+        issue?: string;
+      };
+    }> = [
+      {
+        name: 'ready',
+        buildEntries: (metadata) => [
+          { path: 'src/scope.ts', roles: ['scope'] },
+          { path: 'src/build.ts', roles: ['build'], ...metadata },
+          { path: 'src/verify.ts', roles: ['verify'] },
+        ],
+        expected: {
+          status: 'ready',
+          packState: 'valid',
+          declarationState: 'matching',
+          basisState: 'fresh',
+          roleCoverage: 'covered',
+          roleRefs: {
+            scope: ['src/scope.ts'],
+            build: ['src/build.ts'],
+            verify: ['src/verify.ts'],
+          },
+        },
+      },
+      {
+        name: 'incomplete',
+        buildEntries: (metadata) => [
+          { path: 'src/scope.ts', roles: ['scope'] },
+          { path: 'src/build.ts', roles: ['build'], ...metadata },
+        ],
+        expected: {
+          status: 'incomplete',
+          packState: 'valid',
+          declarationState: 'matching',
+          basisState: 'fresh',
+          roleCoverage: 'missing-required-roles',
+          roleRefs: null,
+          missingRoles: ['verify'],
+        },
+      },
+      {
+        name: 'stale',
+        buildEntries: (metadata) => [
+          { path: 'src/scope.ts', roles: ['scope'] },
+          { path: 'src/build.ts', roles: ['build'], ...metadata },
+          { path: 'src/verify.ts', roles: ['verify'] },
+        ],
+        mutate: async ({ testSpecPath }) => {
+          await writeFile(testSpecPath, '# Drifted Test Spec\n');
+        },
+        expected: {
+          status: 'invalid',
+          packState: 'valid',
+          declarationState: 'matching',
+          basisState: 'stale',
+          roleCoverage: 'covered',
+          roleRefs: null,
+          issue: 'basis test-spec hash',
+        },
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      for (const metadataVariant of metadataVariants) {
+        const slug = `${scenario.name}-${metadataVariant.name}`;
+        const fixture = await writeApprovedPlan(slug, [
+          '# PRD',
+          '',
+          buildContextPackOutcome(canonicalContextPackRelativePath(slug)),
+          '',
+          `Launch via omx ralph ${JSON.stringify(`Execute ${slug} plan`)}`,
+        ]);
+        await writeContextPackWithEntries(
+          slug,
+          fixture.prdPath,
+          fixture.testSpecPath,
+          scenario.buildEntries(metadataVariant.buildMetadata(slug)),
+        );
+        if (scenario.mutate) {
+          await scenario.mutate(fixture);
+        }
+
+        const status = readContextPackHandoffStatus(tempDir, fixture.prdPath);
+
+        assert.equal(
+          status.contextPackStatus,
+          scenario.expected.status,
+          `status mismatch for ${slug}`,
+        );
+        assert.equal(
+          status.packState,
+          scenario.expected.packState,
+          `packState mismatch for ${slug}`,
+        );
+        assert.equal(
+          status.declarationState,
+          scenario.expected.declarationState,
+          `declarationState mismatch for ${slug}`,
+        );
+        assert.equal(
+          status.basisState,
+          scenario.expected.basisState,
+          `basisState mismatch for ${slug}`,
+        );
+        assert.equal(
+          status.roleCoverage,
+          scenario.expected.roleCoverage,
+          `roleCoverage mismatch for ${slug}`,
+        );
+        assert.deepEqual(
+          status.contextPackRoleRefs,
+          scenario.expected.roleRefs,
+          `role refs mismatch for ${slug}`,
+        );
+        assert.deepEqual(
+          status.missingRequiredContextPackRoles,
+          scenario.expected.missingRoles ?? [],
+          `missing roles mismatch for ${slug}`,
+        );
+        if (scenario.expected.issue) {
+          assert.ok(
+            status.contextPackIssues.some((issue) => issue.includes(scenario.expected.issue ?? '')),
+            `expected issue containing ${scenario.expected.issue} for ${slug}`,
+          );
+        } else {
+          assert.deepEqual(status.contextPackIssues, [], `issues should stay empty for ${slug}`);
+        }
+      }
+    }
   });
 
   it('reports incomplete when the declared pack omits required execution roles', async () => {

--- a/src/planning/__tests__/ready-context-pack-role-refs.test.ts
+++ b/src/planning/__tests__/ready-context-pack-role-refs.test.ts
@@ -5,9 +5,40 @@ import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
-import { readReadyContextPackRoleRefs } from '../context-pack-status.js';
+import {
+  type ContextPackPrivateEntryReadModel,
+  type ContextPackPrivateRelationStep,
+  type ContextPackPrivateSelector,
+  readReadyContextPackPrivateEntryReadModel,
+  readReadyContextPackRoleRefs,
+} from '../context-pack-status.js';
 
 let tempDir: string;
+const PRIVATE_LABEL_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}\p{M}-]*$/u;
+const PRIVATE_COMPACT_TOKEN_PATTERN = /^[a-z][a-z0-9-]*$/;
+const MAX_PRIVATE_LABEL_LENGTH = 80;
+const MAX_PRIVATE_TAG_COUNT = 8;
+const MIN_PRIVATE_SELECTOR_MAX_WORDS = 40;
+const MAX_PRIVATE_SELECTOR_MAX_WORDS = 240;
+const MAX_PRIVATE_RELATION_PATH_STEPS = 5;
+const MAX_PRIVATE_RELATION_TARGET_LENGTH = 180;
+const SUPPORTED_ROLES = ['scope', 'build', 'verify'] as const;
+const PRIVATE_ENTRY_KEYS = ['path', 'roles', 'label', 'tags', 'selector', 'relationPath'];
+const PRIVATE_HEADING_SELECTOR_KEYS = ['type', 'value', 'maxWords'];
+const PRIVATE_LINES_SELECTOR_KEYS = ['type', 'start', 'end'];
+const PRIVATE_RELATION_STEP_KEYS = ['tag', 'target'];
+
+type SupportedRole = (typeof SUPPORTED_ROLES)[number];
+
+type TestContextPackEntry = {
+  path: string;
+  roles: string[];
+  label?: unknown;
+  tags?: unknown;
+  selector?: unknown;
+  relationPath?: unknown;
+  [key: string]: unknown;
+};
 
 function computeGitBlobSha1(content: string): string {
   const buffer = Buffer.from(content, 'utf-8');
@@ -33,9 +64,372 @@ async function cleanup(): Promise<void> {
   }
 }
 
+function createDeterministicRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = Math.imul(state, 1_664_525) + 1_013_904_223;
+    state >>>= 0;
+    return state / 0x1_0000_0000;
+  };
+}
+
+function pickRandom<T>(nextRandom: () => number, values: readonly T[]): T {
+  const index = Math.floor(nextRandom() * values.length);
+  return values[index]!;
+}
+
+function maybe(nextRandom: () => number, threshold = 0.5): boolean {
+  return nextRandom() < threshold;
+}
+
+function normalizeRepoRelativePathModel(rawPath: string): string | null {
+  const trimmed = rawPath.trim().replace(/^`|`$/g, '').replaceAll('\\', '/');
+  if (!trimmed) {
+    return null;
+  }
+  const withoutLeadingDot = trimmed.startsWith('./') ? trimmed.slice(2) : trimmed;
+  if (
+    !withoutLeadingDot
+    || withoutLeadingDot.startsWith('/')
+    || /^[A-Za-z]:/.test(withoutLeadingDot)
+  ) {
+    return null;
+  }
+  const segments = withoutLeadingDot
+    .split('/')
+    .filter((segment) => segment.length > 0);
+  if (segments.length === 0 || segments.includes('..')) {
+    return null;
+  }
+  return segments.join('/');
+}
+
+function hasOnlyAllowedKeysModel(
+  record: Record<string, unknown>,
+  allowedKeys: readonly string[],
+): boolean {
+  return Object.keys(record).every((key) => allowedKeys.includes(key));
+}
+
+function normalizeCompactTokenModel(raw: string): string | null {
+  const normalized = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_PRIVATE_LABEL_LENGTH)
+    .replace(/-+$/g, '');
+  return PRIVATE_COMPACT_TOKEN_PATTERN.test(normalized) ? normalized : null;
+}
+
+function normalizeLabelModel(raw: unknown): string | null {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const normalized = Array.from(
+    raw
+      .normalize('NFKC')
+      .trim()
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\p{M}]+/gu, '-')
+      .replace(/^-+|-+$/g, ''),
+  )
+    .slice(0, MAX_PRIVATE_LABEL_LENGTH)
+    .join('')
+    .replace(/-+$/g, '');
+  return PRIVATE_LABEL_PATTERN.test(normalized) ? normalized : null;
+}
+
+function normalizeTagsModel(raw: unknown): string[] | null {
+  if (!Array.isArray(raw) || raw.length > MAX_PRIVATE_TAG_COUNT) {
+    return null;
+  }
+  const normalized = new Set<string>();
+  for (const tag of raw) {
+    if (typeof tag !== 'string') {
+      return null;
+    }
+    const normalizedTag = normalizeCompactTokenModel(tag);
+    if (!normalizedTag) {
+      return null;
+    }
+    normalized.add(normalizedTag);
+  }
+  return [...normalized].sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeSelectorModel(raw: unknown): ContextPackPrivateSelector | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+  const record = raw as Record<string, unknown>;
+  if (record.type === 'heading') {
+    if (!hasOnlyAllowedKeysModel(record, PRIVATE_HEADING_SELECTOR_KEYS)) {
+      return null;
+    }
+    const value = typeof record.value === 'string' ? record.value.trim() : '';
+    const rawMaxWords = record.maxWords;
+    if (!value) {
+      return null;
+    }
+    if (rawMaxWords != null) {
+      if (typeof rawMaxWords !== 'number' || !Number.isInteger(rawMaxWords)) {
+        return null;
+      }
+      if (
+        rawMaxWords < MIN_PRIVATE_SELECTOR_MAX_WORDS
+        || rawMaxWords > MAX_PRIVATE_SELECTOR_MAX_WORDS
+      ) {
+        return null;
+      }
+    }
+    return {
+      type: 'heading',
+      value,
+      maxWords: typeof rawMaxWords === 'number' ? rawMaxWords : undefined,
+    };
+  }
+  if (record.type === 'lines') {
+    if (!hasOnlyAllowedKeysModel(record, PRIVATE_LINES_SELECTOR_KEYS)) {
+      return null;
+    }
+    const start = record.start;
+    const end = record.end;
+    if (typeof start !== 'number' || typeof end !== 'number') {
+      return null;
+    }
+    if (!Number.isInteger(start) || !Number.isInteger(end)) {
+      return null;
+    }
+    if (start < 1 || end < start) {
+      return null;
+    }
+    return { type: 'lines', start, end };
+  }
+  return null;
+}
+
+function normalizeRelationPathModel(
+  raw: unknown,
+): ContextPackPrivateRelationStep[] | null {
+  if (
+    !Array.isArray(raw)
+    || raw.length === 0
+    || raw.length > MAX_PRIVATE_RELATION_PATH_STEPS
+  ) {
+    return null;
+  }
+  const steps: ContextPackPrivateRelationStep[] = [];
+  for (const step of raw) {
+    if (!step || typeof step !== 'object' || Array.isArray(step)) {
+      return null;
+    }
+    const record = step as Record<string, unknown>;
+    if (!hasOnlyAllowedKeysModel(record, PRIVATE_RELATION_STEP_KEYS)) {
+      return null;
+    }
+    const tag = typeof record.tag === 'string' ? normalizeCompactTokenModel(record.tag) : null;
+    const target = typeof record.target === 'string' ? record.target.trim() : '';
+    if (!tag || !target || target.length > MAX_PRIVATE_RELATION_TARGET_LENGTH) {
+      return null;
+    }
+    steps.push({ tag, target });
+  }
+  return steps;
+}
+
+function expectedRoleRefsModel(
+  entries: readonly TestContextPackEntry[],
+): { scope: string[]; build: string[]; verify: string[] } | null {
+  const grouped = { scope: [] as string[], build: [] as string[], verify: [] as string[] };
+  const seen = {
+    scope: new Set<string>(),
+    build: new Set<string>(),
+    verify: new Set<string>(),
+  };
+
+  for (const entry of entries) {
+    const path = normalizeRepoRelativePathModel(entry.path);
+    if (!path) {
+      return null;
+    }
+    for (const role of entry.roles) {
+      if (!SUPPORTED_ROLES.includes(role as SupportedRole)) {
+        return null;
+      }
+      const typedRole = role as SupportedRole;
+      if (seen[typedRole].has(path)) {
+        continue;
+      }
+      seen[typedRole].add(path);
+      grouped[typedRole].push(path);
+    }
+  }
+
+  return grouped;
+}
+
+function expectedPrivateEntryReadModel(
+  entries: readonly TestContextPackEntry[],
+): ContextPackPrivateEntryReadModel[] | null {
+  const normalizedEntries: ContextPackPrivateEntryReadModel[] = [];
+  for (const entry of entries) {
+    const path = normalizeRepoRelativePathModel(entry.path);
+    if (!path) {
+      return null;
+    }
+    if (!hasOnlyAllowedKeysModel(entry, PRIVATE_ENTRY_KEYS)) {
+      return null;
+    }
+    const roles: SupportedRole[] = [];
+    for (const role of entry.roles) {
+      if (!SUPPORTED_ROLES.includes(role as SupportedRole)) {
+        return null;
+      }
+      if (!roles.includes(role as SupportedRole)) {
+        roles.push(role as SupportedRole);
+      }
+    }
+    if (roles.length === 0) {
+      return null;
+    }
+
+    const label = entry.label == null ? null : normalizeLabelModel(entry.label);
+    if (entry.label != null && !label) {
+      return null;
+    }
+    const tags = entry.tags == null ? [] : normalizeTagsModel(entry.tags);
+    if (entry.tags != null && !tags) {
+      return null;
+    }
+    const selector = entry.selector == null ? null : normalizeSelectorModel(entry.selector);
+    if (entry.selector != null && !selector) {
+      return null;
+    }
+    const relationPath =
+      entry.relationPath == null ? null : normalizeRelationPathModel(entry.relationPath);
+    if (entry.relationPath != null && !relationPath) {
+      return null;
+    }
+
+    normalizedEntries.push({
+      path,
+      roles,
+      label,
+      tags: tags ?? [],
+      selector,
+      relationPath,
+    });
+  }
+  return normalizedEntries;
+}
+
+function buildValidPrivateMetadata(
+  role: SupportedRole,
+  slug: string,
+  normalizedPath: string,
+  index: number,
+  nextRandom: () => number,
+): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {};
+  if (maybe(nextRandom, 0.8)) {
+    metadata.label = pickRandom(nextRandom, [
+      ` ${role} focus ${index} `,
+      `${role.toUpperCase()} contract ${index}`,
+      `Seção ${role} ${index}`,
+    ]);
+  }
+  if (maybe(nextRandom, 0.7)) {
+    const rawTags = [
+      role,
+      `lane ${index % 4}`,
+      pickRandom(nextRandom, ['runtime', 'api', 'smoke-test', 'handoff']),
+    ];
+    if (maybe(nextRandom, 0.5)) {
+      rawTags.push(role.toUpperCase());
+    }
+    metadata.tags = rawTags;
+  }
+  if (maybe(nextRandom, 0.7)) {
+    if (maybe(nextRandom)) {
+      metadata.selector = {
+        type: 'heading',
+        value: ` ## ${role.toUpperCase()} Focus ${index} `,
+        ...(maybe(nextRandom, 0.8)
+          ? { maxWords: pickRandom(nextRandom, [40, 80, 120, 240]) }
+          : {}),
+      };
+    } else {
+      const start = 1 + Math.floor(nextRandom() * 6);
+      metadata.selector = {
+        type: 'lines',
+        start,
+        end: start + Math.floor(nextRandom() * 4),
+      };
+    }
+  }
+  if (maybe(nextRandom, 0.8)) {
+    const relationPath: Array<{ tag: string; target: string }> = [
+      { tag: 'Plan', target: ` ${slug} ` },
+    ];
+    const middleStepCount = Math.floor(nextRandom() * 3);
+    for (let stepIndex = 0; stepIndex < middleStepCount; stepIndex += 1) {
+      relationPath.push({
+        tag: pickRandom(nextRandom, ['Evidence', 'Dependency', 'Links To']),
+        target: ` ${normalizedPath}#step-${index}-${stepIndex} `,
+      });
+    }
+    relationPath.push({
+      tag: pickRandom(nextRandom, ['Bounds', 'Implements', 'Verifies']),
+      target: ` ${normalizedPath} `,
+    });
+    metadata.relationPath = relationPath;
+  }
+  return metadata;
+}
+
+function buildValidPropertyEntries(
+  slug: string,
+  index: number,
+  nextRandom: () => number,
+): TestContextPackEntry[] {
+  const scopePath = pickRandom(nextRandom, [
+    `./docs/scope-${index}.md`,
+    `docs\\scope-${index}.md`,
+    `docs/scope-${index}.md`,
+  ]);
+  const buildPath = pickRandom(nextRandom, [
+    `./docs/build-${index}.md`,
+    `docs\\build-${index}.md`,
+    `docs/build-${index}.md`,
+  ]);
+  const verifyPath = pickRandom(nextRandom, [
+    `./docs/verify-${index}.md`,
+    `docs\\verify-${index}.md`,
+    `docs/verify-${index}.md`,
+  ]);
+  const entries: Array<{ role: SupportedRole; path: string }> = [
+    { role: 'scope', path: scopePath },
+    { role: 'build', path: buildPath },
+    { role: 'verify', path: verifyPath },
+  ];
+
+  return entries.map(({ role, path }) => ({
+    path,
+    roles: [role],
+    ...buildValidPrivateMetadata(
+      role,
+      slug,
+      normalizeRepoRelativePathModel(path) ?? path,
+      index,
+      nextRandom,
+    ),
+  }));
+}
+
 async function writeContextPack(
   slug: string,
-  entries: Array<{ path: string; roles: string[] }>,
+  entries: TestContextPackEntry[],
 ): Promise<string> {
   const plansDir = join(tempDir, '.omx', 'plans');
   const contextDir = join(tempDir, '.omx', 'context');
@@ -90,6 +484,243 @@ describe('ready context pack role refs', () => {
     });
   });
 
+  it('reads optional private entry metadata without changing grouped role refs', async () => {
+    const packPath = await writeContextPack('private-metadata', [
+      {
+        path: './docs/runtime.md',
+        roles: ['build', 'verify'],
+        label: 'Runtime Contract',
+        tags: ['runtime', 'api', 'runtime'],
+        selector: { type: 'heading', value: ' ## Runtime Contract ', maxWords: 120 },
+        relationPath: [
+          { tag: 'Plan', target: ' private-metadata ' },
+          { tag: 'Implements', target: ' docs/runtime.md#runtime-contract ' },
+        ],
+      },
+      {
+        path: 'docs/scope.md',
+        roles: ['scope'],
+        label: 'Scope Lines',
+        selector: { type: 'lines', start: 3, end: 7 },
+        relationPath: [
+          { tag: 'Plan', target: ' private-metadata ' },
+          { tag: 'Bounds', target: ' docs/scope.md:3-7 ' },
+        ],
+      },
+    ]);
+
+    assert.deepEqual(readReadyContextPackRoleRefs(packPath), {
+      scope: ['docs/scope.md'],
+      build: ['docs/runtime.md'],
+      verify: ['docs/runtime.md'],
+    });
+    assert.deepEqual(readReadyContextPackPrivateEntryReadModel(packPath), [
+      {
+        path: 'docs/runtime.md',
+        roles: ['build', 'verify'],
+        label: 'runtime-contract',
+        tags: ['api', 'runtime'],
+        selector: { type: 'heading', value: '## Runtime Contract', maxWords: 120 },
+        relationPath: [
+          { tag: 'plan', target: 'private-metadata' },
+          { tag: 'implements', target: 'docs/runtime.md#runtime-contract' },
+        ],
+      },
+      {
+        path: 'docs/scope.md',
+        roles: ['scope'],
+        label: 'scope-lines',
+        tags: [],
+        selector: { type: 'lines', start: 3, end: 7 },
+        relationPath: [
+          { tag: 'plan', target: 'private-metadata' },
+          { tag: 'bounds', target: 'docs/scope.md:3-7' },
+        ],
+      },
+    ]);
+  });
+
+  it('fails closed for malformed private metadata counterfactuals while grouped role refs stay usable', async () => {
+    const cases: Array<{ slug: string; metadata: Record<string, unknown> }> = [
+      { slug: 'invalid-label-type', metadata: { label: 42 } },
+      { slug: 'invalid-label-empty', metadata: { label: '---' } },
+      { slug: 'invalid-tags-shape', metadata: { tags: ['runtime', '', 'verify'] } },
+      {
+        slug: 'invalid-selector-heading',
+        metadata: { selector: { type: 'heading', value: 'Runtime Contract', maxWords: 20 } },
+      },
+      {
+        slug: 'invalid-selector-lines',
+        metadata: { selector: { type: 'lines', start: 0, end: 3 } },
+      },
+      {
+        slug: 'invalid-relation-path',
+        metadata: {
+          relationPath: [
+            { tag: 'plan', target: 'alpha' },
+            { tag: 'evidence', target: 'beta' },
+            { tag: 'implements', target: 'gamma' },
+            { tag: 'dependency', target: 'delta' },
+            { tag: 'bounds', target: 'epsilon' },
+            { tag: 'verifies', target: 'zeta' },
+          ],
+        },
+      },
+      { slug: 'invalid-entry-extra-key', metadata: { unexpected: true } },
+      {
+        slug: 'invalid-selector-extra-key',
+        metadata: { selector: { type: 'heading', value: 'Runtime Contract', extra: true } },
+      },
+      {
+        slug: 'invalid-relation-step-extra-key',
+        metadata: { relationPath: [{ tag: 'plan', target: 'alpha', extra: true }] },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const packPath = await writeContextPack(testCase.slug, [
+        { path: 'docs/scope.md', roles: ['scope'] },
+        {
+          path: 'docs/build.md',
+          roles: ['build'],
+          ...testCase.metadata,
+        },
+        { path: 'docs/verify.md', roles: ['verify'] },
+      ]);
+
+      assert.deepEqual(readReadyContextPackRoleRefs(packPath), {
+        scope: ['docs/scope.md'],
+        build: ['docs/build.md'],
+        verify: ['docs/verify.md'],
+      }, `grouped refs should stay usable for ${testCase.slug}`);
+      assert.equal(
+        readReadyContextPackPrivateEntryReadModel(packPath),
+        null,
+        `private entry read model should fail closed for ${testCase.slug}`,
+      );
+    }
+  });
+
+  it('matches deterministic property checks for valid private metadata while keeping grouped role refs stable', async () => {
+    const nextRandom = createDeterministicRandom(0x2244);
+    for (let index = 0; index < 48; index += 1) {
+      const slug = `property-valid-${index}`;
+      const entries = buildValidPropertyEntries(slug, index, nextRandom);
+      const expectedRoleRefs = expectedRoleRefsModel(entries);
+      const expectedReadModel = expectedPrivateEntryReadModel(entries);
+
+      const packPath = await writeContextPack(slug, entries);
+
+      assert.deepEqual(
+        readReadyContextPackRoleRefs(packPath),
+        expectedRoleRefs,
+        `role refs mismatch for ${slug}`,
+      );
+      assert.ok(expectedReadModel, `expected model should stay valid for ${slug}`);
+      assert.deepEqual(
+        readReadyContextPackPrivateEntryReadModel(packPath),
+        expectedReadModel,
+        `private read model mismatch for ${slug}`,
+      );
+    }
+  });
+
+  it('fails closed across deterministic adversarial private metadata property cases while keeping grouped role refs stable', async () => {
+    const nextRandom = createDeterministicRandom(0x2245);
+    const longTarget = `docs/build.md#${'x'.repeat(MAX_PRIVATE_RELATION_TARGET_LENGTH)}`;
+    const counterfactuals: Array<{
+      name: string;
+      mutate: (entry: TestContextPackEntry) => TestContextPackEntry;
+    }> = [
+      { name: 'label-type', mutate: (entry) => ({ ...entry, label: 42 }) },
+      { name: 'label-empty', mutate: (entry) => ({ ...entry, label: '---' }) },
+      {
+        name: 'too-many-tags',
+        mutate: (entry) => ({
+          ...entry,
+          tags: Array.from({ length: MAX_PRIVATE_TAG_COUNT + 1 }, (_, index) => `tag-${index}`),
+        }),
+      },
+      {
+        name: 'invalid-tag-token',
+        mutate: (entry) => ({ ...entry, tags: ['runtime', '', 'verify'] }),
+      },
+      {
+        name: 'selector-low-maxWords',
+        mutate: (entry) => ({
+          ...entry,
+          selector: { type: 'heading', value: 'Runtime Contract', maxWords: 20 },
+        }),
+      },
+      {
+        name: 'selector-extra-key',
+        mutate: (entry) => ({
+          ...entry,
+          selector: { type: 'lines', start: 2, end: 4, extra: true },
+        }),
+      },
+      {
+        name: 'relation-too-many-steps',
+        mutate: (entry) => ({
+          ...entry,
+          relationPath: [
+            { tag: 'plan', target: 'alpha' },
+            { tag: 'evidence', target: 'beta' },
+            { tag: 'dependency', target: 'gamma' },
+            { tag: 'links-to', target: 'delta' },
+            { tag: 'bounds', target: 'epsilon' },
+            { tag: 'verifies', target: 'zeta' },
+          ],
+        }),
+      },
+      {
+        name: 'relation-target-too-long',
+        mutate: (entry) => ({
+          ...entry,
+          relationPath: [{ tag: 'plan', target: longTarget }],
+        }),
+      },
+      {
+        name: 'relation-step-extra-key',
+        mutate: (entry) => ({
+          ...entry,
+          relationPath: [{ tag: 'plan', target: 'alpha', extra: true }],
+        }),
+      },
+      {
+        name: 'entry-extra-key',
+        mutate: (entry) => ({ ...entry, unexpected: true }),
+      },
+    ];
+
+    for (const counterfactual of counterfactuals) {
+      for (let index = 0; index < 8; index += 1) {
+        const slug = `property-invalid-${counterfactual.name}-${index}`;
+        const entries = buildValidPropertyEntries(slug, index, nextRandom);
+        const mutatedEntries = entries.map((entry, entryIndex) =>
+          entryIndex === 1 ? counterfactual.mutate(entry) : entry
+        );
+        const packPath = await writeContextPack(slug, mutatedEntries);
+
+        assert.deepEqual(
+          readReadyContextPackRoleRefs(packPath),
+          expectedRoleRefsModel(mutatedEntries),
+          `role refs should stay stable for ${slug}`,
+        );
+        assert.equal(
+          expectedPrivateEntryReadModel(mutatedEntries),
+          null,
+          `model should reject ${slug}`,
+        );
+        assert.equal(
+          readReadyContextPackPrivateEntryReadModel(packPath),
+          null,
+          `private read model should fail closed for ${slug}`,
+        );
+      }
+    }
+  });
+
   it('fails closed when the pack contains malformed entry paths or unsupported roles', async () => {
     const invalidPathPack = await writeContextPack('invalid-path', [
       { path: '../outside.ts', roles: ['build'] },
@@ -105,5 +736,6 @@ describe('ready context pack role refs', () => {
   it('fails closed when the pack file cannot be read', () => {
     const missingPackPath = join(tempDir, canonicalContextPackRelativePath('missing'));
     assert.equal(readReadyContextPackRoleRefs(missingPackPath), null);
+    assert.equal(readReadyContextPackPrivateEntryReadModel(missingPackPath), null);
   });
 });

--- a/src/planning/context-pack-status.ts
+++ b/src/planning/context-pack-status.ts
@@ -16,6 +16,36 @@ const CONTEXT_PACK_OUTCOME_LINE_PATTERN =
 const CONTEXT_PACK_PATH_PATTERN =
   /^\.omx\/context\/context-(?<timestamp>\d{8}T\d{6}Z)-(?<slug>[^/]+)\.json$/i;
 const SHA1_PATTERN = /^[0-9a-f]{40}$/i;
+const CONTEXT_PACK_COMPACT_TOKEN_PATTERN = /^[a-z][a-z0-9-]*$/;
+const CONTEXT_PACK_LABEL_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}\p{M}-]*$/u;
+const MAX_CONTEXT_PACK_LABEL_LENGTH = 80;
+const MAX_CONTEXT_PACK_TAG_COUNT = 8;
+const MIN_CONTEXT_PACK_SELECTOR_MAX_WORDS = 40;
+const MAX_CONTEXT_PACK_SELECTOR_MAX_WORDS = 240;
+const MAX_CONTEXT_PACK_RELATION_PATH_STEPS = 5;
+const MAX_CONTEXT_PACK_RELATION_TARGET_LENGTH = 180;
+const CONTEXT_PACK_PRIVATE_ENTRY_KEYS = new Set<string>([
+  'path',
+  'roles',
+  'label',
+  'tags',
+  'selector',
+  'relationPath',
+]);
+const CONTEXT_PACK_PRIVATE_HEADING_SELECTOR_KEYS = new Set<string>([
+  'type',
+  'value',
+  'maxWords',
+]);
+const CONTEXT_PACK_PRIVATE_LINES_SELECTOR_KEYS = new Set<string>([
+  'type',
+  'start',
+  'end',
+]);
+const CONTEXT_PACK_PRIVATE_RELATION_STEP_KEYS = new Set<string>([
+  'tag',
+  'target',
+]);
 
 export const REQUIRED_CONTEXT_PACK_ROLES = ['scope', 'build', 'verify'] as const;
 
@@ -38,6 +68,32 @@ export interface ContextPackRoleRefs {
   scope: string[];
   build: string[];
   verify: string[];
+}
+
+export interface ContextPackPrivateRelationStep {
+  tag: string;
+  target: string;
+}
+
+export type ContextPackPrivateSelector =
+  | {
+    type: 'heading';
+    value: string;
+    maxWords?: number;
+  }
+  | {
+    type: 'lines';
+    start: number;
+    end: number;
+  };
+
+export interface ContextPackPrivateEntryReadModel {
+  path: string;
+  roles: ContextPackRole[];
+  label: string | null;
+  tags: string[];
+  selector: ContextPackPrivateSelector | null;
+  relationPath: ContextPackPrivateRelationStep[] | null;
 }
 
 export interface ContextPackHandoffStatusSnapshot {
@@ -122,6 +178,160 @@ function normalizeRepoRelativePath(rawPath: string): string | null {
     return null;
   }
   return segments.join('/');
+}
+
+function hasOnlyAllowedKeys(
+  record: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+): boolean {
+  return Object.keys(record).every((key) => allowedKeys.has(key));
+}
+
+function normalizeContextPackCompactToken(raw: string): string | null {
+  const normalized = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_CONTEXT_PACK_LABEL_LENGTH)
+    .replace(/-+$/g, '');
+  return CONTEXT_PACK_COMPACT_TOKEN_PATTERN.test(normalized) ? normalized : null;
+}
+
+function normalizeContextPackLabel(raw: unknown): string | null {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const normalized = Array.from(
+    raw
+      .normalize('NFKC')
+      .trim()
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\p{M}]+/gu, '-')
+      .replace(/^-+|-+$/g, ''),
+  )
+    .slice(0, MAX_CONTEXT_PACK_LABEL_LENGTH)
+    .join('')
+    .replace(/-+$/g, '');
+  return CONTEXT_PACK_LABEL_PATTERN.test(normalized) ? normalized : null;
+}
+
+function normalizeContextPackPrivateTags(raw: unknown): string[] | null {
+  if (!Array.isArray(raw) || raw.length > MAX_CONTEXT_PACK_TAG_COUNT) {
+    return null;
+  }
+
+  const normalized = new Set<string>();
+  for (const tag of raw) {
+    if (typeof tag !== 'string') {
+      return null;
+    }
+    const normalizedTag = normalizeContextPackCompactToken(tag);
+    if (!normalizedTag) {
+      return null;
+    }
+    normalized.add(normalizedTag);
+  }
+
+  return [...normalized].sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeContextPackPrivateSelector(
+  raw: unknown,
+): ContextPackPrivateSelector | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+
+  const record = raw as Record<string, unknown>;
+  if (record.type === 'heading') {
+    if (!hasOnlyAllowedKeys(record, CONTEXT_PACK_PRIVATE_HEADING_SELECTOR_KEYS)) {
+      return null;
+    }
+    const value = typeof record.value === 'string' ? record.value.trim() : '';
+    const rawMaxWords = record.maxWords;
+    if (!value) {
+      return null;
+    }
+    if (rawMaxWords != null) {
+      if (typeof rawMaxWords !== 'number' || !Number.isInteger(rawMaxWords)) {
+        return null;
+      }
+      if (
+        rawMaxWords < MIN_CONTEXT_PACK_SELECTOR_MAX_WORDS
+        || rawMaxWords > MAX_CONTEXT_PACK_SELECTOR_MAX_WORDS
+      ) {
+        return null;
+      }
+    }
+    return {
+      type: 'heading',
+      value,
+      maxWords: typeof rawMaxWords === 'number' ? rawMaxWords : undefined,
+    };
+  }
+
+  if (record.type === 'lines') {
+    if (!hasOnlyAllowedKeys(record, CONTEXT_PACK_PRIVATE_LINES_SELECTOR_KEYS)) {
+      return null;
+    }
+    const start = record.start;
+    const end = record.end;
+    if (typeof start !== 'number' || typeof end !== 'number') {
+      return null;
+    }
+    if (!Number.isInteger(start) || !Number.isInteger(end)) {
+      return null;
+    }
+    if (start < 1 || end < start) {
+      return null;
+    }
+    return {
+      type: 'lines',
+      start,
+      end,
+    };
+  }
+
+  return null;
+}
+
+function normalizeContextPackPrivateRelationPath(
+  raw: unknown,
+): ContextPackPrivateRelationStep[] | null {
+  if (
+    !Array.isArray(raw)
+    || raw.length === 0
+    || raw.length > MAX_CONTEXT_PACK_RELATION_PATH_STEPS
+  ) {
+    return null;
+  }
+
+  const steps: ContextPackPrivateRelationStep[] = [];
+  for (const step of raw) {
+    if (!step || typeof step !== 'object' || Array.isArray(step)) {
+      return null;
+    }
+    const record = step as Record<string, unknown>;
+    if (!hasOnlyAllowedKeys(record, CONTEXT_PACK_PRIVATE_RELATION_STEP_KEYS)) {
+      return null;
+    }
+    const tag =
+      typeof record.tag === 'string'
+        ? normalizeContextPackCompactToken(record.tag)
+        : null;
+    const target = typeof record.target === 'string' ? record.target.trim() : '';
+    if (
+      !tag
+      || !target
+      || target.length > MAX_CONTEXT_PACK_RELATION_TARGET_LENGTH
+    ) {
+      return null;
+    }
+    steps.push({ tag, target });
+  }
+
+  return steps;
 }
 
 function computeGitBlobSha1(filePath: string): string {
@@ -290,6 +500,19 @@ function inspectContextPackOutcome(
     declaredSlug: resolvedSlug,
     issues: [],
   };
+}
+
+function readRawContextPackRecord(packPath: string): Record<string, unknown> | null {
+  try {
+    const rawContent = readFileSync(packPath, 'utf-8');
+    const rawDocument = JSON.parse(rawContent);
+    if (!rawDocument || typeof rawDocument !== 'object' || Array.isArray(rawDocument)) {
+      return null;
+    }
+    return rawDocument as Record<string, unknown>;
+  } catch {
+    return null;
+  }
 }
 
 function readContextPackDocument(packPath: string): {
@@ -495,6 +718,83 @@ export function readReadyContextPackRoleRefs(
     return null;
   }
   return groupContextPackRoleRefs(packDocument.document);
+}
+
+export function readReadyContextPackPrivateEntryReadModel(
+  packPath: string,
+): ContextPackPrivateEntryReadModel[] | null {
+  const packDocument = readContextPackDocument(packPath);
+  const rawDocument = readRawContextPackRecord(packPath);
+  if (!packDocument.document || !rawDocument) {
+    return null;
+  }
+
+  const rawEntries = rawDocument.entries;
+  if (
+    !Array.isArray(rawEntries)
+    || rawEntries.length !== packDocument.document.entries.length
+  ) {
+    return null;
+  }
+
+  const entries: ContextPackPrivateEntryReadModel[] = [];
+  for (const [index, rawEntry] of rawEntries.entries()) {
+    if (!rawEntry || typeof rawEntry !== 'object' || Array.isArray(rawEntry)) {
+      return null;
+    }
+    const baseEntry = packDocument.document.entries[index];
+    if (!baseEntry) {
+      return null;
+    }
+
+    const record = rawEntry as Record<string, unknown>;
+    if (!hasOnlyAllowedKeys(record, CONTEXT_PACK_PRIVATE_ENTRY_KEYS)) {
+      return null;
+    }
+    const label =
+      record.label == null
+        ? null
+        : normalizeContextPackLabel(record.label);
+    if (record.label != null && !label) {
+      return null;
+    }
+
+    let tags: string[] = [];
+    if (record.tags != null) {
+      const normalizedTags = normalizeContextPackPrivateTags(record.tags);
+      if (!normalizedTags) {
+        return null;
+      }
+      tags = normalizedTags;
+    }
+
+    const selector =
+      record.selector == null
+        ? null
+        : normalizeContextPackPrivateSelector(record.selector);
+    if (record.selector != null && !selector) {
+      return null;
+    }
+
+    const relationPath =
+      record.relationPath == null
+        ? null
+        : normalizeContextPackPrivateRelationPath(record.relationPath);
+    if (record.relationPath != null && !relationPath) {
+      return null;
+    }
+
+    entries.push({
+      path: baseEntry.path,
+      roles: [...baseEntry.roles],
+      label,
+      tags,
+      selector,
+      relationPath,
+    });
+  }
+
+  return entries;
 }
 
 function validateContextPackBasis(


### PR DESCRIPTION
## Summary

Ready context packs can now carry private entry metadata without changing the
existing readiness contract. This keeps the public planning and execution flow
anchored to the declared pack path plus `entries[].path` and `entries[].roles`,
while letting planning-local readers retain labels, tags, selectors, and
relation paths for later internal use. Malformed optional metadata still fails
closed, so it cannot silently change approved launch behavior or handoff state
selection.

## Changes

- add a planning-local private entry read model in `context-pack-status` for
  `label`, `tags`, `selector`, and `relationPath`
- normalize those private fields with the same compact-token, label, selector,
  and relation-path bounds used by context-pack manifests, and reject
  unsupported extra keys
- keep the public handoff status, grouped role refs, and approved launch hints
  driven by the existing `path` + `roles` authority
- add deterministic model/property tests, counterfactuals, and artifact-level
  proofs that malformed private metadata cannot change ready, incomplete, or
  invalid outcomes or the approved role refs

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] `node --test dist/planning/__tests__/context-pack-status.test.js dist/planning/__tests__/ready-context-pack-role-refs.test.js dist/planning/__tests__/artifacts.test.js`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- None
