### PR TITLE
Keep OMX hooks active after clear resets

### DIFF
--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -28,6 +28,23 @@ describe("codex hooks helpers", () => {
     );
   });
 
+  it("registers SessionStart for startup, resume, and clear reset sources", () => {
+    const config = buildManagedCodexHooksConfig("/repo");
+    const sessionStart = config.hooks.SessionStart[0];
+
+    assert.equal(sessionStart?.matcher, "startup|resume|clear");
+    assert.match(
+      sessionStart?.matcher ?? "",
+      /(?:^|\|)clear(?:\||$)/,
+      "Codex emits SessionStart source=clear after /clear replacement threads; OMX must keep beginning-of-session hooks active",
+    );
+    assert.match(
+      sessionStart?.matcher ?? "",
+      /(?:^|\|)startup(?:\||$)/,
+      "fresh /new thread starts remain covered by Codex's startup SessionStart source",
+    );
+  });
+
   it("uses portable node invocation for Windows managed hook commands", () => {
     const config = buildManagedCodexHooksConfig(
       "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -137,7 +137,7 @@ export function buildManagedCodexHooksConfig(
     hooks: {
       SessionStart: [
         buildCommandHook(command, {
-          matcher: "startup|resume",
+          matcher: "startup|resume|clear",
         }),
       ],
       PreToolUse: [

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -236,7 +236,7 @@ describe("codex native hook config", () => {
       matcher?: string;
       hooks?: Array<Record<string, unknown>>;
     };
-    assert.equal(sessionStart.matcher, "startup|resume");
+    assert.equal(sessionStart.matcher, "startup|resume|clear");
     assert.equal(sessionStart.hooks?.[0]?.statusMessage, undefined);
 
     const preToolUse = config.hooks.PreToolUse[0] as {


### PR DESCRIPTION
Fixes #2247

## Summary
- Add Codex `SessionStart` source `clear` to the OMX-managed hook matcher so `/clear` replacement conversations still run beginning-of-session hooks.
- Keep `startup` coverage for fresh `/new`/new-thread starts and `resume` coverage unchanged.
- Add a focused config regression documenting the `/clear` reset path and fresh startup path.

## Validation
- `npm run build`
- `node --test dist/config/__tests__/codex-hooks.test.js`
- `node --test --test-name-pattern='SessionStart|fresh native session|canonical OMX session scope' dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`
- `npm run check:no-unused`

## Notes
- Full `npm test` was not run; targeted hook/config suites plus build/typecheck/lint passed.
