### PR TITLE
doctor: validate PostCompact hook output

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -52,6 +52,66 @@ function shouldSkipForSpawnPermissions(err?: string): boolean {
 }
 
 describe("omx doctor onboarding warning copy", () => {
+	it("fails native hooks when registered PostCompact command writes invalid stdout", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-postcompact-invalid-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			const staleDir = join(wd, "stale-dist", "scripts");
+			const staleHook = join(staleDir, "codex-native-hook.js");
+			await mkdir(codexDir, { recursive: true });
+			await mkdir(staleDir, { recursive: true });
+			await writeFile(join(codexDir, "config.toml"), "hooks = true\n");
+			await writeFile(
+				staleHook,
+				"process.stdout.write('PostCompact Nudge: stale hook output\\n');\n",
+			);
+			const command = `${JSON.stringify(process.execPath)} ${JSON.stringify(staleHook)}`;
+			const hooks = Object.fromEntries(
+				[
+					"SessionStart",
+					"PreToolUse",
+					"PostToolUse",
+					"UserPromptSubmit",
+					"PreCompact",
+					"PostCompact",
+					"Stop",
+				].map((eventName) => [
+					eventName,
+					[
+						{
+							hooks: [{ type: "command", command }],
+						},
+					],
+				]),
+			);
+			await writeFile(
+				join(codexDir, "hooks.json"),
+				JSON.stringify({ hooks }, null, 2),
+			);
+
+			const res = runOmx(wd, ["doctor", "--verbose"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/\[XX\] Native hooks: hooks\.json includes OMX-managed coverage, but the effective PostCompact command wrote stdout/,
+			);
+			assert.match(res.stdout, /no-stdout PostCompact contract from #2207/);
+			assert.match(res.stdout, /codex-native-hook\.js/);
+			assert.match(res.stdout, /PostCompact Nudge: stale hook output/);
+			assert.doesNotMatch(
+				res.stdout,
+				/Native hooks: hooks\.json includes OMX-managed coverage for all native hook events/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("warns that the built-in explore harness is not ready on Windows", () => {
 		const check = checkExploreHarness("win32", {} as NodeJS.ProcessEnv);
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3,8 +3,10 @@
  */
 
 import { existsSync } from "fs";
-import { readdir, readFile } from "fs/promises";
+import { mkdtemp, readdir, readFile, rm } from "fs/promises";
 import { join } from "path";
+import { tmpdir } from "os";
+import { spawnSync } from "child_process";
 import {
 	codexHome,
 	codexConfigPath,
@@ -30,7 +32,10 @@ import {
 	hasLegacyOmxTeamRunTable,
 	getModelContextRecommendation,
 } from "../config/generator.js";
-import { getMissingManagedCodexHookEvents } from "../config/codex-hooks.js";
+import {
+	getManagedCodexHookCommands,
+	getMissingManagedCodexHookEvents,
+} from "../config/codex-hooks.js";
 import { discoverCodexHookConfigPaths } from "../config/codex-hooks.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { getDefaultBridge, isBridgeEnabled } from "../runtime/bridge.js";
@@ -1029,6 +1034,12 @@ async function checkNativeHooks(
 			};
 		}
 
+		const postCompactSmokeCheck = await checkPostCompactHookContract(
+			content,
+			hooksPath,
+		);
+		if (postCompactSmokeCheck) return postCompactSmokeCheck;
+
 		return {
 			name: "Native hooks",
 			status: "pass",
@@ -1042,6 +1053,85 @@ async function checkNativeHooks(
 			message: "cannot read hooks.json",
 		};
 	}
+}
+
+function extractNativeHookScriptPath(command: string): string | null {
+	const match = command.match(
+		/"([^"]*[\\/]codex-native-hook\.js)"|'([^']*[\\/]codex-native-hook\.js)'|(\S*[\\/]codex-native-hook\.js)/,
+	);
+	return match?.[1] ?? match?.[2] ?? match?.[3] ?? null;
+}
+
+function oneLine(value: string, maxLength = 240): string {
+	const normalized = value.replace(/\s+/g, " ").trim();
+	if (normalized.length <= maxLength) return normalized;
+	return `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+async function checkPostCompactHookContract(
+	hooksContent: string,
+	hooksPath: string,
+): Promise<Check | null> {
+	const commands = getManagedCodexHookCommands(hooksContent, "PostCompact");
+	if (commands === null || commands.length === 0) return null;
+
+	for (const command of commands) {
+		const scriptPath = extractNativeHookScriptPath(command);
+		if (scriptPath && !existsSync(scriptPath)) {
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message: `hooks.json includes OMX-managed coverage, but PostCompact command points to a missing native hook path; inspect ${hooksPath} command=${JSON.stringify(command)} path=${scriptPath}`,
+			};
+		}
+
+		const smokeCwd = await mkdtemp(join(tmpdir(), "omx-doctor-postcompact-"));
+		try {
+			const payload = JSON.stringify({
+				hook_event_name: "PostCompact",
+				cwd: smokeCwd,
+				session_id: "omx-doctor-postcompact-smoke",
+			});
+			const result = spawnSync(command, {
+				cwd: smokeCwd,
+				encoding: "utf-8",
+				env: {
+					...process.env,
+					OMX_DOCTOR_POSTCOMPACT_SMOKE: "1",
+				},
+				input: payload,
+				shell: true,
+				timeout: 3_000,
+				windowsHide: true,
+			});
+			const stdout = result.stdout || "";
+			const stderr = result.stderr || "";
+			if (result.error) {
+				return {
+					name: "Native hooks",
+					status: "fail",
+					message: `hooks.json includes OMX-managed coverage, but the effective PostCompact command could not run; inspect ${hooksPath} command=${JSON.stringify(command)}${scriptPath ? ` path=${scriptPath}` : ""} error=${oneLine(result.error.message)}`,
+				};
+			}
+			if (result.status !== 0) {
+				return {
+					name: "Native hooks",
+					status: "fail",
+					message: `hooks.json includes OMX-managed coverage, but the effective PostCompact command exited ${result.status}; inspect ${hooksPath} command=${JSON.stringify(command)}${scriptPath ? ` path=${scriptPath}` : ""}${stderr ? ` stderr=${JSON.stringify(oneLine(stderr))}` : ""}`,
+				};
+			}
+			if (stdout.trim() !== "") {
+				return {
+					name: "Native hooks",
+					status: "fail",
+					message: `hooks.json includes OMX-managed coverage, but the effective PostCompact command wrote stdout that violates the no-stdout PostCompact contract from #2207; inspect ${hooksPath} command=${JSON.stringify(command)}${scriptPath ? ` path=${scriptPath}` : ""} stdout=${JSON.stringify(oneLine(stdout))}`,
+				};
+			}
+		} finally {
+			await rm(smokeCwd, { recursive: true, force: true }).catch(() => {});
+		}
+	}
+	return null;
 }
 
 async function checkNativeHookRuntimeMirrors(

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -213,6 +213,34 @@ export function getMissingManagedCodexHookEvents(
   });
 }
 
+export function getManagedCodexHookCommands(
+  content: string,
+  eventName: ManagedHookEventName,
+): string[] | null {
+  const parsed = parseCodexHooksConfig(content);
+  if (!parsed) return null;
+
+  const entries = Array.isArray(parsed.hooks[eventName])
+    ? parsed.hooks[eventName]
+    : [];
+  const commands: string[] = [];
+  for (const entry of entries) {
+    if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) continue;
+    for (const hook of entry.hooks) {
+      if (
+        !isPlainObject(hook) ||
+        hook.type !== "command" ||
+        typeof hook.command !== "string" ||
+        !isOmxManagedHookCommand(hook.command)
+      ) {
+        continue;
+      }
+      commands.push(hook.command);
+    }
+  }
+  return commands;
+}
+
 function stripManagedHooksFromEntry(entry: unknown): {
   entry: unknown | null;
   removedCount: number;


### PR DESCRIPTION
Fixes #2249

## Summary
- Smoke-check the effective PostCompact hook command from doctor when native hooks are registered.
- Fail doctor when a stale PostCompact command writes stdout or otherwise violates the no-stdout contract from #2207, including command/path details for inspection.
- Add regression coverage for invalid PostCompact stdout while registered native hook coverage is present.

## Validation
- npm run build
- node --test dist/cli/__tests__/doctor-warning-copy.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/config/__tests__/codex-hooks.test.js
- npm run lint
- npm run check:no-unused
