### PR TITLE
Detect stale PostCompact hook wiring

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -17,7 +17,20 @@ import {
 	withPackagedExploreHarnessHidden,
 	withPackagedExploreHarnessLock,
 } from "./packaged-explore-harness-lock.js";
-import { checkExploreHarness } from "../doctor.js";
+import {
+	checkExploreHarness,
+	classifyPostCompactHookStdout,
+} from "../doctor.js";
+
+const MANAGED_HOOK_EVENTS = [
+	"SessionStart",
+	"PreToolUse",
+	"PostToolUse",
+	"UserPromptSubmit",
+	"PreCompact",
+	"PostCompact",
+	"Stop",
+] as const;
 
 function runOmx(
 	cwd: string,
@@ -49,6 +62,39 @@ function runOmx(
 
 function shouldSkipForSpawnPermissions(err?: string): boolean {
 	return typeof err === "string" && /(EPERM|EACCES)/i.test(err);
+}
+
+function quoteCommandPart(value: string): string {
+	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function currentNativeHookCommand(): string {
+	const testDir = dirname(fileURLToPath(import.meta.url));
+	const repoRoot = join(testDir, "..", "..", "..");
+	return `${quoteCommandPart(process.execPath)} ${quoteCommandPart(join(repoRoot, "dist", "scripts", "codex-native-hook.js"))}`;
+}
+
+function buildHooksJsonWithPostCompactCommand(postCompactCommand: string): string {
+	const expectedCommand = currentNativeHookCommand();
+	return `${JSON.stringify({
+		hooks: Object.fromEntries(
+			MANAGED_HOOK_EVENTS.map((eventName) => [
+				eventName,
+				[
+					{
+						hooks: [
+							{
+								type: "command",
+								command: eventName === "PostCompact"
+									? postCompactCommand
+									: expectedCommand,
+							},
+						],
+					},
+				],
+			]),
+		),
+	}, null, 2)}\n`;
 }
 
 describe("omx doctor onboarding warning copy", () => {
@@ -608,6 +654,83 @@ command = "node"
 			assert.match(
 				res.stdout,
 				/\[XX\] Native hooks: invalid hooks\.json; Codex may skip OMX hook coverage until "omx setup --force" repairs it/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("verbose doctor warns instead of executing when the effective PostCompact command is stale", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-postcompact-stale-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(join(codexDir, "config.toml"), "omx_enabled = true\n");
+			await writeFile(
+				join(codexDir, "hooks.json"),
+				buildHooksJsonWithPostCompactCommand(
+					`${quoteCommandPart(process.execPath)} ${quoteCommandPart(join(wd, "old", "dist", "scripts", "codex-native-hook.js"))}`,
+				),
+			);
+
+			const res = runOmx(wd, ["doctor", "--verbose"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Native hooks: hooks\.json includes OMX-managed coverage for all native hook events/,
+			);
+			assert.match(
+				res.stdout,
+				/\[!!\] Native PostCompact hook: effective PostCompact OMX command does not match this installation's managed hook command; doctor skipped execution for safety/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("classifies invalid or unsupported PostCompact stdout as a verbose doctor failure", () => {
+		const invalidJson = classifyPostCompactHookStdout("{not json");
+		assert.equal(invalidJson?.status, "fail");
+		assert.match(invalidJson?.message ?? "", /invalid JSON stdout/);
+
+		const unsupportedJson = classifyPostCompactHookStdout(
+			JSON.stringify({
+				hookSpecificOutput: {
+					hookEventName: "PostCompact",
+					additionalContext: "stale nudge",
+				},
+			}),
+		);
+		assert.equal(unsupportedJson?.status, "fail");
+		assert.match(unsupportedJson?.message ?? "", /must emit no stdout/);
+	});
+
+	it("verbose doctor smoke-validates the current PostCompact command with no stdout", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-postcompact-current-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(join(codexDir, "config.toml"), "omx_enabled = true\n");
+			await writeFile(
+				join(codexDir, "hooks.json"),
+				buildHooksJsonWithPostCompactCommand(currentNativeHookCommand()),
+			);
+
+			const res = runOmx(wd, ["doctor", "--verbose"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/\[OK\] Native PostCompact hook: verbose smoke validation confirmed the effective PostCompact hook exits successfully with no stdout/,
 			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3,8 +3,10 @@
  */
 
 import { existsSync } from "fs";
-import { readdir, readFile } from "fs/promises";
+import { mkdtemp, readdir, readFile, rm } from "fs/promises";
+import { spawnSync } from "child_process";
 import { join } from "path";
+import { tmpdir } from "os";
 import {
 	codexHome,
 	codexConfigPath,
@@ -30,8 +32,12 @@ import {
 	hasLegacyOmxTeamRunTable,
 	getModelContextRecommendation,
 } from "../config/generator.js";
-import { getMissingManagedCodexHookEvents } from "../config/codex-hooks.js";
-import { discoverCodexHookConfigPaths } from "../config/codex-hooks.js";
+import {
+	buildManagedCodexNativeHookCommand,
+	discoverCodexHookConfigPaths,
+	getManagedCodexHookCommandsForEvent,
+	getMissingManagedCodexHookEvents,
+} from "../config/codex-hooks.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { getDefaultBridge, isBridgeEnabled } from "../runtime/bridge.js";
 import {
@@ -171,6 +177,13 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
 	// Check 4.25: Native hooks coverage
 	checks.push(await checkNativeHooks(paths.hooksPath, paths.configPath));
+	if (options.verbose) {
+		const postCompactRuntimeCheck = await checkNativePostCompactHookRuntime(
+			paths.hooksPath,
+			cwd,
+		);
+		if (postCompactRuntimeCheck) checks.push(postCompactRuntimeCheck);
+	}
 	const runtimeMirrorCheck = await checkNativeHookRuntimeMirrors(cwd, paths.hooksPath);
 	if (runtimeMirrorCheck) checks.push(runtimeMirrorCheck);
 
@@ -1041,6 +1054,108 @@ async function checkNativeHooks(
 			status: "fail",
 			message: "cannot read hooks.json",
 		};
+	}
+}
+
+export function classifyPostCompactHookStdout(stdout: string): Check | null {
+	const trimmed = stdout.trim();
+	if (trimmed === "") return null;
+
+	try {
+		JSON.parse(trimmed);
+		return {
+			name: "Native PostCompact hook",
+			status: "fail",
+			message:
+				"PostCompact hook emitted JSON stdout, but OMX PostCompact must emit no stdout until Codex defines a supported PostCompact output contract; run \"omx setup --force\" after upgrading",
+		};
+	} catch (error) {
+		return {
+			name: "Native PostCompact hook",
+			status: "fail",
+			message: `PostCompact hook emitted invalid JSON stdout (${error instanceof Error ? error.message : String(error)}); run "omx setup --force" after upgrading`,
+		};
+	}
+}
+
+async function checkNativePostCompactHookRuntime(
+	hooksPath: string,
+	cwd: string,
+): Promise<Check | null> {
+	if (!existsSync(hooksPath)) return null;
+
+	let content: string;
+	try {
+		content = await readFile(hooksPath, "utf-8");
+	} catch {
+		return null;
+	}
+
+	const postCompactCommands = getManagedCodexHookCommandsForEvent(
+		content,
+		"PostCompact",
+	);
+	if (postCompactCommands === null || postCompactCommands.length === 0) {
+		return null;
+	}
+
+	const expectedCommand = buildManagedCodexNativeHookCommand(getPackageRoot());
+	const uniqueCommands = [...new Set(postCompactCommands)];
+	if (uniqueCommands.length !== 1 || uniqueCommands[0] !== expectedCommand) {
+		return {
+			name: "Native PostCompact hook",
+			status: "warn",
+			message:
+				"effective PostCompact OMX command does not match this installation's managed hook command; doctor skipped execution for safety, and \"omx setup --force\" should refresh stale hooks.json entries",
+		};
+	}
+
+	const smokeCwd = await mkdtemp(join(tmpdir(), "omx-doctor-postcompact-"));
+	try {
+		const payload = JSON.stringify({
+			hook_event_name: "PostCompact",
+			cwd: smokeCwd,
+			session_id: "omx-doctor-postcompact-smoke",
+		});
+		const result = spawnSync(expectedCommand, {
+			cwd,
+			encoding: "utf-8",
+			env: {
+				...process.env,
+				OMX_NATIVE_HOOK_DOCTOR_SMOKE: "1",
+			},
+			input: payload,
+			shell: true,
+			timeout: 5_000,
+		});
+
+		if (result.error) {
+			return {
+				name: "Native PostCompact hook",
+				status: "fail",
+				message: `PostCompact hook smoke validation failed to run (${result.error.message})`,
+			};
+		}
+		if (result.status !== 0) {
+			const stderr = (result.stderr || "").trim();
+			return {
+				name: "Native PostCompact hook",
+				status: "fail",
+				message: `PostCompact hook smoke validation exited ${result.status}${stderr ? `: ${stderr}` : ""}`,
+			};
+		}
+
+		const stdoutCheck = classifyPostCompactHookStdout(result.stdout || "");
+		if (stdoutCheck) return stdoutCheck;
+
+		return {
+			name: "Native PostCompact hook",
+			status: "pass",
+			message:
+				"verbose smoke validation confirmed the effective PostCompact hook exits successfully with no stdout",
+		};
+	} finally {
+		await rm(smokeCwd, { recursive: true, force: true });
 	}
 }
 

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -91,7 +91,7 @@ function quoteWindowsCommandPart(value: string): string {
   return `"${value.replace(/"/g, '\\"')}"`;
 }
 
-function buildNativeHookCommand(
+export function buildManagedCodexNativeHookCommand(
   pkgRoot: string,
   platform: HookCommandPlatform = process.platform,
 ): string {
@@ -131,7 +131,7 @@ export function buildManagedCodexHooksConfig(
   pkgRoot: string,
   options: { platform?: HookCommandPlatform } = {},
 ): ManagedCodexHooksConfig {
-  const command = buildNativeHookCommand(pkgRoot, options.platform);
+  const command = buildManagedCodexNativeHookCommand(pkgRoot, options.platform);
 
   return {
     hooks: {
@@ -211,6 +211,35 @@ export function getMissingManagedCodexHookEvents(
       : [];
     return !entries.some((entry) => countManagedHooksInEntry(entry) > 0);
   });
+}
+
+export function getManagedCodexHookCommandsForEvent(
+  content: string,
+  eventName: ManagedHookEventName,
+): string[] | null {
+  const parsed = parseCodexHooksConfig(content);
+  if (!parsed) return null;
+
+  const entries = Array.isArray(parsed.hooks[eventName])
+    ? parsed.hooks[eventName]
+    : [];
+  const commands: string[] = [];
+
+  for (const entry of entries) {
+    if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) continue;
+    for (const hook of entry.hooks) {
+      if (
+        isPlainObject(hook) &&
+        hook.type === "command" &&
+        typeof hook.command === "string" &&
+        isOmxManagedHookCommand(hook.command)
+      ) {
+        commands.push(hook.command);
+      }
+    }
+  }
+
+  return commands;
 }
 
 function stripManagedHooksFromEntry(entry: unknown): {


### PR DESCRIPTION
## Summary
- add a verbose-only doctor PostCompact validation check
- refuse to execute stale/mismatched OMX PostCompact commands and recommend setup refresh
- smoke-run only the current managed PostCompact command in a temporary cwd and fail on invalid/unsupported stdout

## Tests
- npm run build
- node --test dist/cli/__tests__/doctor-warning-copy.test.js dist/config/__tests__/codex-hooks.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npx biome lint src/cli/doctor.ts src/config/codex-hooks.ts src/cli/__tests__/doctor-warning-copy.test.ts

Fixes #2249