### PR TITLE
fix(setup): prevent recursive notify dispatcher wrapping

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -165,6 +165,93 @@ describe("notify setup scope", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+
+	it("does not preserve a managed dispatcher as previous notify across global installs", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-recursive-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const metadataPath = join(
+					codexHomeDir,
+					".omx",
+					"notify-dispatch.json",
+				);
+				const oldDispatcher =
+					"/tmp/old-global/lib/node_modules/oh-my-codex/dist/scripts/notify-dispatcher.js";
+				const olderDispatcher =
+					"/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/notify-dispatcher.js";
+				await mkdir(dirname(metadataPath), { recursive: true });
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					`notify = ["node", "${oldDispatcher}", "--metadata", "${metadataPath}"]\napproval_policy = "on-failure"\n`,
+				);
+				await writeFile(
+					metadataPath,
+					JSON.stringify(
+						{
+							managedBy: "oh-my-codex",
+							version: 1,
+							previousNotify: ["node", olderDispatcher, "--metadata", metadataPath],
+						},
+						null,
+						2,
+					),
+				);
+
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.match(config, /^notify = \["node", ".*notify-hook\.js"\]$/m);
+				assert.doesNotMatch(config, /notify-dispatcher\.js/);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves a real user notify from legacy dispatcher metadata", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-legacy-user-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const metadataPath = join(
+					codexHomeDir,
+					".omx",
+					"notify-dispatch.json",
+				);
+				const oldDispatcher =
+					"/tmp/old-global/lib/node_modules/oh-my-codex/dist/scripts/notify-dispatcher.js";
+				await mkdir(dirname(metadataPath), { recursive: true });
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					`notify = ["node", "${oldDispatcher}", "--metadata", "${metadataPath}"]\n`,
+				);
+				await writeFile(
+					metadataPath,
+					JSON.stringify(
+						{
+							managedBy: "oh-my-codex",
+							version: 1,
+							previousNotify: ["node", "/tmp/user-notify.js"],
+						},
+						null,
+						2,
+					),
+				);
+
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.match(config, /notify-dispatcher\.js/);
+				const metadata = JSON.parse(await readFile(metadataPath, "utf-8"));
+				assert.deepEqual(metadata.previousNotify, ["node", "/tmp/user-notify.js"]);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });
 
 async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -18,6 +18,14 @@ import { uninstall } from "../uninstall.js";
 
 const packageRoot = process.cwd();
 
+function formatTomlStringArray(values: string[]): string {
+	return `[${values.map((value) => JSON.stringify(value)).join(", ")}]`;
+}
+
+function configTomlWithNotify(notify: string[], extra = ""): string {
+	return `notify = ${formatTomlStringArray(notify)}\n${extra}`;
+}
+
 async function withTempCwd(wd: string, fn: () => Promise<void>): Promise<void> {
 	const previousCwd = process.cwd();
 	process.chdir(wd);
@@ -73,6 +81,19 @@ async function withIsolatedUserHome<T>(
 }
 
 describe("notify setup scope", () => {
+	it("escapes seeded notify commands with Windows-style paths", () => {
+		const notify = [
+			"node",
+			String.raw`C:\Users\agent\AppData\Local\Temp\notify-dispatcher.js`,
+			"--metadata",
+			String.raw`C:\Users\agent\AppData\Local\Temp\notify-dispatch.json`,
+		];
+		const parsed = parseToml(configTomlWithNotify(notify)) as {
+			notify?: unknown;
+		};
+		assert.deepEqual(parsed.notify, notify);
+	});
+
 	it("does not write unsupported project-scope notify", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-project-no-notify-"));
 		try {
@@ -182,7 +203,10 @@ describe("notify setup scope", () => {
 				await mkdir(dirname(metadataPath), { recursive: true });
 				await writeFile(
 					join(codexHomeDir, "config.toml"),
-					`notify = ["node", "${oldDispatcher}", "--metadata", "${metadataPath}"]\napproval_policy = "on-failure"\n`,
+					configTomlWithNotify(
+						["node", oldDispatcher, "--metadata", metadataPath],
+						'approval_policy = "on-failure"\n',
+					),
 				);
 				await writeFile(
 					metadataPath,
@@ -224,7 +248,7 @@ describe("notify setup scope", () => {
 				await mkdir(dirname(metadataPath), { recursive: true });
 				await writeFile(
 					join(codexHomeDir, "config.toml"),
-					`notify = ["node", "${oldDispatcher}", "--metadata", "${metadataPath}"]\n`,
+					configTomlWithNotify(["node", oldDispatcher, "--metadata", metadataPath]),
 				);
 				await writeFile(
 					metadataPath,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -3117,6 +3117,13 @@ async function buildNotifyMergePlan(
 				Array.isArray(previousNotify) &&
 				previousNotify.every((item) => typeof item === "string")
 			) {
+				if (
+					previousNotify.length === 0 ||
+					isOmxManagedNotifyCommand(previousNotify, pkgRoot) ||
+					isOmxManagedNotifyCommand(previousNotify)
+				) {
+					return { notifyCommand: omxNotify };
+				}
 				return {
 					notifyCommand: dispatcherNotify,
 					metadataPath,

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -3,9 +3,34 @@ import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mergeConfig, OMX_DEVELOPER_INSTRUCTIONS, upsertPluginModeRuntimeFeatureFlags } from '../generator.js';
+import {
+  isOmxManagedNotifyCommand,
+  mergeConfig,
+  OMX_DEVELOPER_INSTRUCTIONS,
+  upsertPluginModeRuntimeFeatureFlags,
+} from '../generator.js';
 
 describe('config generator', () => {
+  it('recognizes managed notify commands from another global install', () => {
+    assert.equal(
+      isOmxManagedNotifyCommand(
+        [
+          'node',
+          '/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/notify-dispatcher.js',
+        ],
+        '/tmp/current-package-root',
+      ),
+      true,
+    );
+    assert.equal(
+      isOmxManagedNotifyCommand(
+        ['node', '/tmp/user-notify-dispatcher.js'],
+        '/tmp/current-package-root',
+      ),
+      false,
+    );
+  });
+
   it('places top-level keys before [features]', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
     try {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -302,7 +302,7 @@ export function isOmxManagedNotifyCommand(
   return command.some((part) => {
     if (!/(?:^|[\\/])notify-(?:hook|dispatcher)\.js$/.test(part)) return false;
     if (pkgRoot) {
-      return isAbsolute(part) && managedScripts.has(resolve(part));
+      if (isAbsolute(part) && managedScripts.has(resolve(part))) return true;
     }
     return /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(part);
   });

--- a/src/scripts/__tests__/notify-dispatcher.test.ts
+++ b/src/scripts/__tests__/notify-dispatcher.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+describe("notify dispatcher", () => {
+	it("skips managed OMX notify commands stored as previous notify", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-notify-dispatcher-"));
+		try {
+			const dispatcher = join(
+				process.cwd(),
+				"dist",
+				"scripts",
+				"notify-dispatcher.js",
+			);
+			const managedPrevious = join(
+				wd,
+				"old",
+				"node_modules",
+				"oh-my-codex",
+				"dist",
+				"scripts",
+				"notify-dispatcher.js",
+			);
+			const omxNotify = join(wd, "omx-notify.js");
+			const previousMarker = join(wd, "previous-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const metadataPath = join(wd, "notify-dispatch.json");
+
+			await mkdir(join(managedPrevious, ".."), { recursive: true });
+			await writeFile(
+				managedPrevious,
+				`require("node:fs").writeFileSync(${JSON.stringify(previousMarker)}, "ran");\n`,
+			);
+			await writeFile(
+				omxNotify,
+				`require("node:fs").writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`,
+			);
+			await writeFile(
+				metadataPath,
+				JSON.stringify({
+					previousNotify: ["node", managedPrevious],
+					omxNotify: ["node", omxNotify],
+				}),
+			);
+
+			const result = spawnSync(
+				process.execPath,
+				[dispatcher, "--metadata", metadataPath, "{}"],
+				{ encoding: "utf-8" },
+			);
+
+			assert.equal(result.status, 0);
+			await assert.rejects(readFile(previousMarker, "utf-8"));
+			assert.equal(await readFile(omxMarker, "utf-8"), "ran");
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/scripts/notify-dispatcher.ts
+++ b/src/scripts/notify-dispatcher.ts
@@ -7,6 +7,7 @@
 
 import { readFile } from "fs/promises";
 import { spawnSync } from "child_process";
+import { isAbsolute, resolve } from "path";
 
 interface NotifyDispatcherMetadata {
 	managedBy?: string;
@@ -33,6 +34,18 @@ function parseArgs(): { metadataPath: string; payloadArg: string } {
 function isCommand(value: unknown): value is string[] {
 	return (
 		Array.isArray(value) && value.every((item) => typeof item === "string")
+	);
+}
+
+function isOmxNotifyEntrypointCommand(command: string[]): boolean {
+	const currentDispatcher = isAbsolute(process.argv[1] || "")
+		? resolve(process.argv[1])
+		: "";
+	return command.some(
+		(part) =>
+			/(?:^|[\\/])notify-(?:hook|dispatcher)\.js$/.test(part) &&
+			((currentDispatcher && isAbsolute(part) && resolve(part) === currentDispatcher) ||
+				/(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(part)),
 	);
 }
 
@@ -67,7 +80,12 @@ async function main(): Promise<void> {
 	const { metadataPath, payloadArg } = parseArgs();
 	if (!payloadArg || payloadArg.startsWith("-")) return;
 	const metadata = await readMetadata(metadataPath);
-	runNotify(metadata?.previousNotify, payloadArg);
+	if (
+		isCommand(metadata?.previousNotify) &&
+		!isOmxNotifyEntrypointCommand(metadata.previousNotify)
+	) {
+		runNotify(metadata.previousNotify, payloadArg);
+	}
 	runNotify(metadata?.omxNotify, payloadArg);
 }
 


### PR DESCRIPTION
## Summary

- Prevent `omx setup` from preserving an OMX-managed notify dispatcher/hook as `previousNotify` across global installs
- Add a runtime dispatcher guard so managed OMX notify entrypoints are skipped if stale metadata already exists
- Add regression tests for cross-install notify recursion, preserving real user notify commands, and Windows-safe TOML seeding in setup tests

## Root cause

A legacy `notify-dispatch.json` could preserve another OMX dispatcher as `previousNotify` after reinstalling/upgrading from a different global package path. That allowed the dispatcher to invoke itself/another managed dispatcher recursively, causing runaway `node` processes.

## Base branch

This PR targets `dev` as requested after the earlier `main`-targeted PR was closed.

## Validation

- `npm run build`
- `node --test dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/setup-install-mode.test.js dist/scripts/__tests__/notify-dispatcher.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

## Notes

A full `npm test` was attempted previously against the main-based branch, but unrelated existing environment/tmux-sensitive tests failed in the active OMX/tmux session. The changed notify/setup test targets above pass on this `dev`-based branch.
