### PR TITLE
Bound native Stop hook diff audit runtime

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -55,6 +55,18 @@ Setup-owned trust state is limited to those generated wrapper identities; user h
 | wiki session capture | none | `session-end` | runtime-fallback | Wiki session-log capture runs from the existing runtime session-end cleanup path, not from a native Codex hook |
 | `session-idle` | none | `session-idle` | runtime-fallback | Still emitted from runtime/notify path, not native Codex hooks |
 
+## Stop diff audit budget
+
+The native `Stop` adapter also runs a bounded sloppy-fallback diff audit after
+active workflow continuation and auto-nudge checks. Because `Stop` runs inside
+Codex's foreground hook timeout, this audit must stay best-effort: git diff
+commands share `OMX_STOP_DIFF_AUDIT_BUDGET_MS` (default `2500` ms), untracked
+source scanning is capped by `OMX_STOP_DIFF_AUDIT_MAX_UNTRACKED_FILES` (default
+`200`), and oversized untracked files are skipped above
+`OMX_STOP_DIFF_AUDIT_MAX_FILE_BYTES` (default `524288`). If those limits are
+exhausted, the audit returns no findings instead of risking a native Stop hook
+timeout.
+
 
 ## Document-refresh warning MVP
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -195,6 +195,9 @@ const TEAM_ENV_KEYS = [
   "SESSION_ID",
   "OMX_QUESTION_RETURN_PANE",
   "OMX_LEADER_PANE_ID",
+  "OMX_STOP_DIFF_AUDIT_BUDGET_MS",
+  "OMX_STOP_DIFF_AUDIT_MAX_UNTRACKED_FILES",
+  "OMX_STOP_DIFF_AUDIT_MAX_FILE_BYTES",
   "TMUX",
   "TMUX_PANE",
   "OMX_TMUX_HUD_OWNER",
@@ -3127,6 +3130,51 @@ exit 0
       assert.equal((repeated.outputJson as { decision?: string } | null)?.decision, "block");
       assert.equal((repeated.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let a slow sloppy fallback diff audit consume the Stop hook timeout", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-budget-");
+    const originalPath = process.env.PATH;
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const binDir = join(cwd, "bin");
+      await mkdir(binDir, { recursive: true });
+      await writeFile(
+        join(binDir, "git"),
+        [
+          "#!/usr/bin/env bash",
+          "sleep 1",
+          "exit 0",
+        ].join("\n"),
+      );
+      await chmod(join(binDir, "git"), 0o755);
+
+      process.env.PATH = `${binDir}:${originalPath}`;
+      process.env.OMX_STOP_DIFF_AUDIT_BUDGET_MS = "50";
+
+      const startedAt = Date.now();
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-budget" },
+        { cwd },
+      );
+      const elapsedMs = Date.now() - startedAt;
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+      assert.ok(elapsedMs < 1000, `Stop hook should return within the audit budget path, got ${elapsedMs}ms`);
+    } finally {
+      process.env.PATH = originalPath;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { closeSync, existsSync, openSync, readFileSync, readSync } from "fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "fs";
 import { appendFile, mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { extname, join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
@@ -771,6 +771,19 @@ interface SloppyFallbackDiffFinding {
   source: "staged" | "unstaged" | "untracked";
 }
 
+const STOP_DIFF_AUDIT_BUDGET_ENV = "OMX_STOP_DIFF_AUDIT_BUDGET_MS";
+const STOP_DIFF_AUDIT_MAX_UNTRACKED_FILES_ENV = "OMX_STOP_DIFF_AUDIT_MAX_UNTRACKED_FILES";
+const STOP_DIFF_AUDIT_MAX_FILE_BYTES_ENV = "OMX_STOP_DIFF_AUDIT_MAX_FILE_BYTES";
+const DEFAULT_STOP_DIFF_AUDIT_BUDGET_MS = 2500;
+const DEFAULT_STOP_DIFF_AUDIT_MAX_UNTRACKED_FILES = 200;
+const DEFAULT_STOP_DIFF_AUDIT_MAX_FILE_BYTES = 512 * 1024;
+
+interface SloppyFallbackAuditBudget {
+  deadlineMs: number;
+  maxUntrackedFiles: number;
+  maxFileBytes: number;
+}
+
 const SOURCE_DIFF_EXTENSIONS = new Set([
   ".c",
   ".cc",
@@ -797,7 +810,33 @@ const SOURCE_DIFF_EXTENSIONS = new Set([
   ".tsx",
 ]);
 
-function gitOutput(cwd: string, args: string[]): string {
+function parsePositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function createSloppyFallbackAuditBudget(): SloppyFallbackAuditBudget {
+  return {
+    deadlineMs: Date.now() + parsePositiveIntegerEnv(STOP_DIFF_AUDIT_BUDGET_ENV, DEFAULT_STOP_DIFF_AUDIT_BUDGET_MS),
+    maxUntrackedFiles: parsePositiveIntegerEnv(
+      STOP_DIFF_AUDIT_MAX_UNTRACKED_FILES_ENV,
+      DEFAULT_STOP_DIFF_AUDIT_MAX_UNTRACKED_FILES,
+    ),
+    maxFileBytes: parsePositiveIntegerEnv(STOP_DIFF_AUDIT_MAX_FILE_BYTES_ENV, DEFAULT_STOP_DIFF_AUDIT_MAX_FILE_BYTES),
+  };
+}
+
+function remainingAuditBudgetMs(budget: SloppyFallbackAuditBudget): number {
+  return Math.max(0, budget.deadlineMs - Date.now());
+}
+
+function isAuditBudgetExhausted(budget: SloppyFallbackAuditBudget): boolean {
+  return remainingAuditBudgetMs(budget) <= 0;
+}
+
+function gitOutput(cwd: string, args: string[], timeoutMs?: number): string {
   try {
     return execFileSync("git", args, {
       cwd,
@@ -805,10 +844,17 @@ function gitOutput(cwd: string, args: string[]): string {
       stdio: ["ignore", "pipe", "ignore"],
       windowsHide: true,
       maxBuffer: 10 * 1024 * 1024,
+      ...(timeoutMs ? { timeout: Math.max(1, timeoutMs) } : {}),
     });
   } catch {
     return "";
   }
+}
+
+function gitOutputWithinBudget(cwd: string, args: string[], budget: SloppyFallbackAuditBudget): string {
+  const timeoutMs = remainingAuditBudgetMs(budget);
+  if (timeoutMs <= 0) return "";
+  return gitOutput(cwd, args, timeoutMs);
 }
 
 function normalizeGitPath(path: string): string {
@@ -906,16 +952,24 @@ function collectSloppyFallbackFindingsFromPatch(
   return findings;
 }
 
-function collectSloppyFallbackFindingsFromUntracked(cwd: string): SloppyFallbackDiffFinding[] {
-  const output = gitOutput(cwd, ["ls-files", "--others", "--exclude-standard", "-z"]);
+function collectSloppyFallbackFindingsFromUntracked(
+  cwd: string,
+  budget: SloppyFallbackAuditBudget,
+): SloppyFallbackDiffFinding[] {
+  const output = gitOutputWithinBudget(cwd, ["ls-files", "--others", "--exclude-standard", "-z"], budget);
   if (!output) return [];
   const findings: SloppyFallbackDiffFinding[] = [];
+  let inspectedFiles = 0;
   for (const rawPath of output.split("\0")) {
+    if (isAuditBudgetExhausted(budget) || inspectedFiles >= budget.maxUntrackedFiles) break;
     const path = normalizeGitPath(rawPath.trim());
     if (!path || !isDiffAuditableSourcePath(path)) continue;
+    const absolutePath = join(cwd, path);
     let content = "";
     try {
-      content = readFileSync(join(cwd, path), "utf-8");
+      if (statSync(absolutePath).size > budget.maxFileBytes) continue;
+      inspectedFiles += 1;
+      content = readFileSync(absolutePath, "utf-8");
     } catch {
       continue;
     }
@@ -928,10 +982,17 @@ function findSloppyFallbackDiffFindings(cwd: string): SloppyFallbackDiffFinding[
   const layout = findGitLayout(cwd);
   if (!layout) return [];
   const auditRoot = layout.worktreeRoot;
+  const budget = createSloppyFallbackAuditBudget();
   return [
-    ...collectSloppyFallbackFindingsFromPatch(gitOutput(auditRoot, ["diff", "--cached", "--no-ext-diff", "--unified=3"]), "staged"),
-    ...collectSloppyFallbackFindingsFromPatch(gitOutput(auditRoot, ["diff", "--no-ext-diff", "--unified=3"]), "unstaged"),
-    ...collectSloppyFallbackFindingsFromUntracked(auditRoot),
+    ...collectSloppyFallbackFindingsFromPatch(
+      gitOutputWithinBudget(auditRoot, ["diff", "--cached", "--no-ext-diff", "--unified=3"], budget),
+      "staged",
+    ),
+    ...collectSloppyFallbackFindingsFromPatch(
+      gitOutputWithinBudget(auditRoot, ["diff", "--no-ext-diff", "--unified=3"], budget),
+      "unstaged",
+    ),
+    ...collectSloppyFallbackFindingsFromUntracked(auditRoot, budget),
   ];
 }
 


### PR DESCRIPTION
## Summary
- bound the Stop-only sloppy fallback diff audit with a shared time budget
- add per-git-command timeout, untracked file count cap, and max untracked file size cap
- document the new Stop diff audit budget knobs

## Why
A Codex App/native session repeatedly showed:

```
Stop hook (failed)
  error: hook timed out after 30s
```

Local diagnosis on oh-my-codex 0.16.3 showed the non-OMX cc-notch Stop hook completed in about 0.04s, while the OMX `codex-native-hook.js` Stop path took about 25.86s for a no-op Stop payload and then timed out in real foreground Stop handling. The affected workspace also resolved git to a very large parent worktree, so the Stop-only diff audit should be best-effort rather than unbounded.

## Testing
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js` (278 tests passed)
- `npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts`

## Notes
The audit still blocks ordinary staged, unstaged, and untracked sloppy fallback edits when git responds within budget. If the budget is exhausted, it returns no findings instead of risking Codex's native Stop hook timeout.