### PR TITLE
Prevent recursive OMX notify dispatcher wrapping

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -165,6 +165,94 @@ describe("notify setup scope", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+
+	it("does not preserve stale OMX dispatcher metadata as previous notify", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-stale-dispatcher-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await mkdir(codexHomeDir, { recursive: true });
+				const metadataPath = join(
+					codexHomeDir,
+					".omx",
+					"notify-dispatch.json",
+				);
+				const stalePkgRoot = join(wd, "old-global", "oh-my-codex");
+				const staleDispatcher = join(
+					stalePkgRoot,
+					"dist",
+					"scripts",
+					"notify-dispatcher.js",
+				);
+				await mkdir(dirname(metadataPath), { recursive: true });
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					`notify = ["node", "${staleDispatcher}", "--metadata", "${metadataPath}"]\napproval_policy = "on-failure"\n`,
+				);
+				await writeFile(
+					metadataPath,
+					JSON.stringify({
+						managedBy: "oh-my-codex",
+						version: 1,
+						previousNotify: [
+							"node",
+							staleDispatcher,
+							"--metadata",
+							metadataPath,
+						],
+						omxNotify: [
+							"node",
+							join(stalePkgRoot, "dist", "scripts", "notify-hook.js"),
+						],
+						dispatcherNotify: ["node", staleDispatcher, "--metadata", metadataPath],
+					}),
+				);
+
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.match(config, /^notify = \["node", ".*notify-hook\.js"\]$/m);
+				assert.doesNotMatch(config, /notify-dispatcher\.js/);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not wrap stale global OMX notify hooks as user notify commands", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-stale-hook-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await mkdir(codexHomeDir, { recursive: true });
+				const staleHook = join(
+					"/opt",
+					"homebrew",
+					"lib",
+					"node_modules",
+					"oh-my-codex",
+					"dist",
+					"scripts",
+					"notify-hook.js",
+				);
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					`notify = ["node", "${staleHook}"]\napproval_policy = "on-failure"\n`,
+				);
+
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.match(config, /^notify = \["node", ".*notify-hook\.js"\]$/m);
+				assert.doesNotMatch(config, /notify-dispatcher\.js/);
+				assert.doesNotMatch(config, /opt\/homebrew/);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });
 
 async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -309,6 +309,58 @@ describe('omx uninstall', () => {
   });
 
 
+  it('does not restore stale OMX dispatcher metadata as notify', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-stale-notify-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const metadataPath = join(codexDir, '.omx', 'notify-dispatch.json');
+      const stalePkgRoot = join(wd, 'old-global', 'oh-my-codex');
+      const staleDispatcher = join(stalePkgRoot, 'dist', 'scripts', 'notify-dispatcher.js');
+      await mkdir(dirname(metadataPath), { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        [
+          '# User settings',
+          'approval_policy = "on-failure"',
+          `notify = ["node", "${staleDispatcher}", "--metadata", "${metadataPath}"]`,
+          '',
+          '# ============================================================',
+          '# oh-my-codex (OMX) Configuration',
+          '# Managed by omx setup - manual edits preserved on next setup',
+          '# ============================================================',
+          '[mcp_servers.omx_state]',
+          'command = "node"',
+          'args = ["/path/to/state-server.js"]',
+          'enabled = true',
+          '# ============================================================',
+          '# End oh-my-codex',
+          '',
+        ].join('\n'),
+      );
+      await writeFile(
+        metadataPath,
+        JSON.stringify({
+          managedBy: 'oh-my-codex',
+          version: 1,
+          previousNotify: ['node', staleDispatcher, '--metadata', metadataPath],
+        }),
+      );
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      assert.match(config, /^approval_policy = "on-failure"$/m);
+      assert.doesNotMatch(config, /^notify\s*=/m);
+      assert.doesNotMatch(config, /notify-dispatcher\.js/);
+      assert.doesNotMatch(config, /oh-my-codex \(OMX\) Configuration/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves user config entries when removing OMX', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
     try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -36,6 +36,7 @@ import {
 	getRootTomlArray,
 	hasLegacyOmxTeamRunTable,
 	isOmxManagedNotifyCommand,
+	sanitizePreviousNotifyCommand,
 	stripExistingOmxBlocks,
 	stripExistingSharedMcpRegistryBlock,
 	stripOmxEnvSettings,
@@ -3117,13 +3118,20 @@ async function buildNotifyMergePlan(
 				Array.isArray(previousNotify) &&
 				previousNotify.every((item) => typeof item === "string")
 			) {
+				const sanitizedPreviousNotify = sanitizePreviousNotifyCommand(
+					previousNotify,
+					pkgRoot,
+				);
+				if (!sanitizedPreviousNotify) {
+					return { notifyCommand: omxNotify };
+				}
 				return {
 					notifyCommand: dispatcherNotify,
 					metadataPath,
 					metadata: {
 						managedBy: "oh-my-codex",
 						version: 1,
-						previousNotify,
+						previousNotify: sanitizedPreviousNotify,
 						omxNotify,
 						dispatcherNotify,
 					},
@@ -3141,7 +3149,7 @@ async function buildNotifyMergePlan(
 		metadata: {
 			managedBy: "oh-my-codex",
 			version: 1,
-			previousNotify: existingNotify,
+			previousNotify: sanitizePreviousNotifyCommand(existingNotify, pkgRoot),
 			omxNotify,
 			dispatcherNotify,
 		},

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -9,6 +9,7 @@ import {
   formatTomlStringArray,
   getRootTomlArray,
   isOmxManagedNotifyCommand,
+  sanitizePreviousNotifyCommand,
   stripExistingOmxBlocks,
   stripOmxEnvSettings,
   stripOmxTopLevelKeys,
@@ -170,10 +171,16 @@ async function restorePreviousNotifyIfDispatcher(
       Array.isArray(previousNotify) &&
       previousNotify.every((item) => typeof item === "string")
     ) {
-      return insertRootTomlKey(
-        strippedConfig,
-        `notify = ${formatTomlStringArray(previousNotify)}`,
+      const sanitizedPreviousNotify = sanitizePreviousNotifyCommand(
+        previousNotify,
+        getPackageRoot(),
       );
+      if (sanitizedPreviousNotify) {
+        return insertRootTomlKey(
+          strippedConfig,
+          `notify = ${formatTomlStringArray(sanitizedPreviousNotify)}`,
+        );
+      }
     }
   } catch {
     // Missing or malformed metadata means uninstall falls back to removing OMX notify.

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -533,6 +533,21 @@ describe('config generator', () => {
     assert.match(merged, /^approval_policy = "never"$/m);
   });
 
+  it('does not preserve OMX notify commands invoked through node flags when notify is disabled', () => {
+    const pkgRoot = '/current/install/oh-my-codex';
+    const staleConfig = [
+      'notify = ["node", "--no-warnings", "/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/notify-hook.js"]',
+      'approval_policy = "never"',
+      '',
+    ].join('\n');
+
+    const merged = buildMergedConfig(staleConfig, pkgRoot, { notifyCommand: false });
+
+    assert.doesNotMatch(merged, /^notify\s*=/m);
+    assert.doesNotMatch(merged, /notify-hook\.js/);
+    assert.match(merged, /^approval_policy = "never"$/m);
+  });
+
   it('preserves real user notify commands that mention OMX paths as arguments', () => {
     const pkgRoot = '/current/install/oh-my-codex';
     const userNotify = [

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mergeConfig, OMX_DEVELOPER_INSTRUCTIONS, upsertPluginModeRuntimeFeatureFlags } from '../generator.js';
+import { buildMergedConfig, mergeConfig, OMX_DEVELOPER_INSTRUCTIONS, upsertPluginModeRuntimeFeatureFlags } from '../generator.js';
 
 describe('config generator', () => {
   it('places top-level keys before [features]', async () => {
@@ -501,5 +501,52 @@ describe('config generator', () => {
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
+  });
+
+  it('does not preserve cross-install OMX notify commands when notify is disabled', () => {
+    const pkgRoot = '/current/install/oh-my-codex';
+    const staleConfig = [
+      'notify = ["node", "/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/notify-dispatcher.js", "--metadata", "/tmp/notify-dispatch.json"]',
+      'approval_policy = "never"',
+      '',
+    ].join('\n');
+
+    const merged = buildMergedConfig(staleConfig, pkgRoot, { notifyCommand: false });
+
+    assert.doesNotMatch(merged, /^notify\s*=/m);
+    assert.doesNotMatch(merged, /notify-dispatcher\.js/);
+    assert.match(merged, /^approval_policy = "never"$/m);
+  });
+
+  it('does not preserve Windows-style OMX notify hooks when notify is disabled', () => {
+    const pkgRoot = 'C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\oh-my-codex';
+    const staleConfig = [
+      'notify = ["node", "C:\\\\Users\\\\alice\\\\AppData\\\\Roaming\\\\npm\\\\node_modules\\\\oh-my-codex\\\\dist\\\\scripts\\\\notify-hook.js"]',
+      'approval_policy = "never"',
+      '',
+    ].join('\n');
+
+    const merged = buildMergedConfig(staleConfig, pkgRoot, { notifyCommand: false });
+
+    assert.doesNotMatch(merged, /^notify\s*=/m);
+    assert.doesNotMatch(merged, /notify-hook\.js/);
+    assert.match(merged, /^approval_policy = "never"$/m);
+  });
+
+  it('preserves real user notify commands that mention OMX paths as arguments', () => {
+    const pkgRoot = '/current/install/oh-my-codex';
+    const userNotify = [
+      'notify = ["node", "/tmp/user-notify.js", "/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/notify-hook.js"]',
+      'approval_policy = "never"',
+      '',
+    ].join('\n');
+
+    const merged = buildMergedConfig(userNotify, pkgRoot, { notifyCommand: false });
+
+    assert.match(
+      merged,
+      /^notify = \["node", "\/tmp\/user-notify\.js", "\/opt\/homebrew\/lib\/node_modules\/oh-my-codex\/dist\/scripts\/notify-hook\.js"\]$/m,
+    );
+    assert.match(merged, /^approval_policy = "never"$/m);
   });
 });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -288,15 +288,19 @@ export function getRootTomlArray(config: string, key: string): string[] | null {
   }
 }
 
+function resolveNotifyEntrypoint(command: readonly string[]): string | undefined {
+  if (!/(?:^|[\\/])node(?:\.exe)?$/i.test(command[0] ?? "")) {
+    return command[0];
+  }
+  return command.slice(1).find((arg) => !arg.startsWith("-"));
+}
+
 export function isOmxManagedNotifyCommand(
   command: readonly string[] | null | undefined,
   pkgRoot?: string,
 ): boolean {
   if (!command) return false;
-  const entrypoint =
-    /(?:^|[\\/])node(?:\.exe)?$/i.test(command[0] ?? "")
-      ? command[1]
-      : command[0];
+  const entrypoint = resolveNotifyEntrypoint(command);
   if (!entrypoint) return false;
   if (!/(?:^|[\\/])notify-(?:hook|dispatcher)\.js$/.test(entrypoint)) {
     return false;

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -12,7 +12,7 @@
 
 import { readFile, writeFile } from "fs/promises";
 import { existsSync } from "fs";
-import { isAbsolute, join, resolve } from "path";
+import { join, resolve } from "path";
 import TOML from "@iarna/toml";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
@@ -293,19 +293,31 @@ export function isOmxManagedNotifyCommand(
   pkgRoot?: string,
 ): boolean {
   if (!command) return false;
+  const entrypoint =
+    /(?:^|[\\/])node(?:\.exe)?$/i.test(command[0] ?? "")
+      ? command[1]
+      : command[0];
+  if (!entrypoint) return false;
+  if (!/(?:^|[\\/])notify-(?:hook|dispatcher)\.js$/.test(entrypoint)) {
+    return false;
+  }
   const managedScripts = pkgRoot
     ? new Set([
         resolve(pkgRoot, "dist", "scripts", "notify-hook.js"),
         resolve(pkgRoot, "dist", "scripts", "notify-dispatcher.js"),
       ])
     : new Set<string>();
-  return command.some((part) => {
-    if (!/(?:^|[\\/])notify-(?:hook|dispatcher)\.js$/.test(part)) return false;
-    if (pkgRoot) {
-      return isAbsolute(part) && managedScripts.has(resolve(part));
-    }
-    return /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(part);
-  });
+  if (pkgRoot && managedScripts.has(resolve(entrypoint))) return true;
+  return /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(entrypoint);
+}
+
+export function sanitizePreviousNotifyCommand(
+  command: readonly string[] | null | undefined,
+  pkgRoot?: string,
+): string[] | null {
+  if (!command || command.length === 0) return null;
+  if (isOmxManagedNotifyCommand(command, pkgRoot)) return null;
+  return [...command];
 }
 
 function getOmxTopLevelLines(

--- a/src/scripts/__tests__/notify-dispatcher.test.ts
+++ b/src/scripts/__tests__/notify-dispatcher.test.ts
@@ -1,0 +1,116 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+function runDispatcher(metadataPath: string): void {
+	const dispatcherScript = join(process.cwd(), "dist", "scripts", "notify-dispatcher.js");
+	const result = spawnSync(
+		process.execPath,
+		[dispatcherScript, "--metadata", metadataPath, JSON.stringify({ type: "test" })],
+		{ encoding: "utf-8", windowsHide: true },
+	);
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+}
+
+describe("notify dispatcher previousNotify guard", () => {
+	it("skips stale OMX-managed previousNotify dispatcher entries", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-stale-"));
+		try {
+			const oldPkgScripts = join(wd, "global", "oh-my-codex", "dist", "scripts");
+			mkdirSync(oldPkgScripts, { recursive: true });
+			const stalePreviousMarker = join(wd, "stale-previous-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const staleDispatcher = join(oldPkgScripts, "notify-dispatcher.js");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(staleDispatcher, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(stalePreviousMarker)}, "ran");\n`);
+			writeFileSync(omxHook, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [process.execPath, staleDispatcher, "--metadata", metadataPath],
+					omxNotify: [process.execPath, omxHook],
+					dispatcherNotify: [
+						process.execPath,
+						join(process.cwd(), "dist", "scripts", "notify-dispatcher.js"),
+						"--metadata",
+						metadataPath,
+					],
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.equal(existsSync(stalePreviousMarker), false);
+			assert.equal(readFileSync(omxMarker, "utf-8"), "ran");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves and runs real user previousNotify entries", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-user-"));
+		try {
+			const userMarker = join(wd, "user-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const userScript = join(wd, "user-notify.js");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(userScript, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(userMarker)}, "ran");\n`);
+			writeFileSync(omxHook, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [process.execPath, userScript],
+					omxNotify: [process.execPath, omxHook],
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.equal(readFileSync(userMarker, "utf-8"), "ran");
+			assert.equal(readFileSync(omxMarker, "utf-8"), "ran");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not mistake real user notify arguments for managed entrypoints", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-user-arg-"));
+		try {
+			const userMarker = join(wd, "user-ran");
+			const userScript = join(wd, "user-notify.js");
+			writeFileSync(
+				userScript,
+				`import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(userMarker)}, process.argv.slice(2).join("\\n"));\n`,
+			);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [
+						process.execPath,
+						userScript,
+						"/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/notify-hook.js",
+					],
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.match(readFileSync(userMarker, "utf-8"), /notify-hook\.js/);
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/scripts/__tests__/notify-dispatcher.test.ts
+++ b/src/scripts/__tests__/notify-dispatcher.test.ts
@@ -54,6 +54,43 @@ describe("notify dispatcher previousNotify guard", () => {
 		}
 	});
 
+	it("skips stale OMX-managed previousNotify dispatcher entries behind node flags", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-flagged-stale-"));
+		try {
+			const oldPkgScripts = join(wd, "global", "oh-my-codex", "dist", "scripts");
+			mkdirSync(oldPkgScripts, { recursive: true });
+			const stalePreviousMarker = join(wd, "stale-previous-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const staleDispatcher = join(oldPkgScripts, "notify-dispatcher.js");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(staleDispatcher, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(stalePreviousMarker)}, "ran");\n`);
+			writeFileSync(omxHook, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [
+						process.execPath,
+						"--no-warnings",
+						staleDispatcher,
+						"--metadata",
+						metadataPath,
+					],
+					omxNotify: [process.execPath, omxHook],
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.equal(existsSync(stalePreviousMarker), false);
+			assert.equal(readFileSync(omxMarker, "utf-8"), "ran");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves and runs real user previousNotify entries", () => {
 		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-user-"));
 		try {

--- a/src/scripts/notify-dispatcher.ts
+++ b/src/scripts/notify-dispatcher.ts
@@ -45,12 +45,16 @@ function sameCommand(
 	return left.every((part, index) => part === right[index]);
 }
 
+function resolveNotifyEntrypoint(command: readonly string[]): string | undefined {
+	if (!/(?:^|[\\/])node(?:\.exe)?$/i.test(command[0] ?? "")) {
+		return command[0];
+	}
+	return command.slice(1).find((arg) => !arg.startsWith("-"));
+}
+
 function isOmxManagedNotifyCommand(command: readonly string[] | null | undefined): boolean {
 	if (!command) return false;
-	const entrypoint =
-		/(?:^|[\\/])node(?:\.exe)?$/i.test(command[0] ?? "")
-			? command[1]
-			: command[0];
+	const entrypoint = resolveNotifyEntrypoint(command);
 	if (!entrypoint) return false;
 	if (!/(?:^|[\\/])notify-(?:hook|dispatcher)\.js$/.test(entrypoint)) {
 		return false;

--- a/src/scripts/notify-dispatcher.ts
+++ b/src/scripts/notify-dispatcher.ts
@@ -13,6 +13,7 @@ interface NotifyDispatcherMetadata {
 	version?: number;
 	previousNotify?: string[] | null;
 	omxNotify?: string[];
+	dispatcherNotify?: string[];
 }
 
 function parseArgs(): { metadataPath: string; payloadArg: string } {
@@ -33,6 +34,38 @@ function parseArgs(): { metadataPath: string; payloadArg: string } {
 function isCommand(value: unknown): value is string[] {
 	return (
 		Array.isArray(value) && value.every((item) => typeof item === "string")
+	);
+}
+
+function sameCommand(
+	left: readonly string[] | null | undefined,
+	right: readonly string[] | null | undefined,
+): boolean {
+	if (!left || !right || left.length !== right.length) return false;
+	return left.every((part, index) => part === right[index]);
+}
+
+function isOmxManagedNotifyCommand(command: readonly string[] | null | undefined): boolean {
+	if (!command) return false;
+	const entrypoint =
+		/(?:^|[\\/])node(?:\.exe)?$/i.test(command[0] ?? "")
+			? command[1]
+			: command[0];
+	if (!entrypoint) return false;
+	if (!/(?:^|[\\/])notify-(?:hook|dispatcher)\.js$/.test(entrypoint)) {
+		return false;
+	}
+	return /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(entrypoint);
+}
+
+function isManagedPreviousNotify(
+	previousNotify: readonly string[] | null | undefined,
+	metadata: NotifyDispatcherMetadata | null,
+): boolean {
+	return (
+		isOmxManagedNotifyCommand(previousNotify) ||
+		sameCommand(previousNotify, metadata?.omxNotify) ||
+		sameCommand(previousNotify, metadata?.dispatcherNotify)
 	);
 }
 
@@ -67,7 +100,9 @@ async function main(): Promise<void> {
 	const { metadataPath, payloadArg } = parseArgs();
 	if (!payloadArg || payloadArg.startsWith("-")) return;
 	const metadata = await readMetadata(metadataPath);
-	runNotify(metadata?.previousNotify, payloadArg);
+	if (!isManagedPreviousNotify(metadata?.previousNotify, metadata)) {
+		runNotify(metadata?.previousNotify, payloadArg);
+	}
 	runNotify(metadata?.omxNotify, payloadArg);
 }
 


### PR DESCRIPTION
## Summary

- Prevent setup/generator flows from preserving OMX-managed notify dispatcher or notify hook commands as user `previousNotify`, including stale cross-install/global paths.
- Add a runtime notify-dispatcher guard that skips stale managed `previousNotify` entries before invoking the OMX hook.
- Preserve real user notify commands, including commands that merely pass OMX-looking paths as arguments.

Fixes #2254

## Validation

- `npm run build`
- `node --test dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/setup-install-mode.test.js dist/scripts/__tests__/notify-dispatcher.test.js` (66 passed)
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- Ralph architect verification: APPROVED

## Notes

Full `npm test` was not run; targeted notify/setup/generator dispatcher coverage plus build/lint/no-unused were run for this focused fix.
