### PR TITLE
Prefer CLI-first OMX setup over MCP defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ omx --madmax --high
 
 On a real `oh-my-codex` version bump, the global npm install now prints an explicit reminder instead of launching `omx setup` automatically. When you're ready, run `omx setup` manually or use `omx update` to check npm and then run the same setup refresh path.
 
-**Codex plugin install note:** this repo also ships an official Codex plugin layout at `plugins/oh-my-codex` with marketplace metadata in `.agents/plugins/marketplace.json`. That plugin bundles the mirrored skill surface plus plugin-scoped companion metadata for MCP servers and apps. Native/runtime hooks still stay on the setup/runtime side rather than the installable plugin manifest. It is still **not** a replacement for `npm install -g oh-my-codex` plus `omx setup`: legacy setup mode installs native agents and prompts, while plugin setup mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompts/native-agent TOMLs so stale role files cannot shadow plugin behavior.
+**Codex plugin install note:** this repo also ships an official Codex plugin layout at `plugins/oh-my-codex` with marketplace metadata in `.agents/plugins/marketplace.json`. That plugin bundles the mirrored skill surface plus plugin-scoped companion metadata for optional MCP compatibility servers and apps, disabled by default. Native/runtime hooks still stay on the setup/runtime side rather than the installable plugin manifest. It is still **not** a replacement for `npm install -g oh-my-codex` plus `omx setup`: legacy setup mode installs native agents and prompts, while plugin setup mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompts/native-agent TOMLs so stale role files cannot shadow plugin behavior.
 
 Then work normally inside Codex:
 
@@ -223,7 +223,7 @@ omx team shutdown <team-name>
 ### Setup, doctor, and HUD
 
 These are operator/support surfaces:
-- Codex plugin marketplace install/discovery can cache the plugin under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (local installs may use `local` as the version identifier); that packaged plugin now includes plugin-scoped companion metadata for MCP servers and apps, while native/runtime hooks remain setup-owned, so it is still not the full OMX runtime setup
+- Codex plugin marketplace install/discovery can cache the plugin under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (local installs may use `local` as the version identifier); that packaged plugin includes plugin-scoped companion metadata for optional MCP compatibility servers and apps (disabled by default), while native/runtime hooks remain setup-owned, so it is still not the full OMX runtime setup
 - `omx setup` installs prompts, skills, AGENTS scaffolding, `.codex/config.toml`, and OMX-managed native Codex hooks in `.codex/hooks.json`
   - setup refresh preserves non-OMX hook entries in `.codex/hooks.json` and only rewrites OMX-managed wrappers
   - `omx setup --merge-agents` preserves existing `AGENTS.md` guidance while inserting or refreshing generated OMX sections between `<!-- OMX:AGENTS:START -->` / `<!-- OMX:AGENTS:END -->`; without `--merge-agents` or `--force`, non-interactive setup keeps skipping existing `AGENTS.md` files
@@ -278,7 +278,7 @@ omx sparkshell --tmux-pane %12 --tail-lines 400
 
 ### Wiki
 
-- `omx wiki` is the CLI parity surface for the OMX wiki MCP server
+- `omx wiki` is the CLI-first JSON surface for wiki operations; `omx_wiki` MCP is explicit compatibility only
 - wiki data lives as repository project knowledge under `omx_wiki/`
 - the wiki is markdown-first and search-first, not vector-first
 

--- a/docs/reference/project-wiki.md
+++ b/docs/reference/project-wiki.md
@@ -6,26 +6,23 @@ It is intentionally **not** a literal OMC port.
 ## Core shape
 
 - Keep the reusable wiki domain under `src/wiki/*`.
-- Expose wiki operations from a dedicated MCP server at `src/mcp/wiki-server.ts`.
-- Register the server as `omx_wiki`.
+- Expose wiki operations through the CLI-first JSON parity surface (`omx wiki <tool> --input <json> --json`). Keep `src/mcp/wiki-server.ts` as explicit compatibility implementation code.
+- Register the optional compatibility server as `omx_wiki` only when MCP compat mode is explicitly enabled.
 - Keep wiki storage under repository-root `omx_wiki/` so project knowledge can be committed and shared.
 - Do **not** add vector embeddings; query stays keyword/tag based.
 
 ## Config + generator contract
 
-`omx setup` / the config generator should own the dedicated wiki MCP block:
+`omx setup` / the config generator should keep wiki access CLI-first by default and emit the dedicated wiki MCP block only in explicit compat mode:
 
 ```toml
 [mcp_servers.omx_wiki]
 command = "<absolute Node executable used by omx setup>"
 args = ["<repo>/dist/mcp/wiki-server.js"]
-enabled = true
+enabled = true  # compat mode only
 ```
 
-The bootstrap/config path should treat `omx_wiki` as a first-party OMX server
-alongside the existing built-ins, while keeping the diff small and idempotent.
-Setup-managed first-party MCP blocks must use the stable absolute Node
-executable that ran `omx setup` rather than a PATH-dependent bare `node`.
+The bootstrap/config path should treat `omx_wiki` as a first-party OMX compatibility server alongside the existing built-ins, while keeping the diff small and idempotent. Setup-managed first-party MCP blocks must not appear in default CLI-first setup; when compat mode is explicit, they must use the stable absolute Node executable that ran `omx setup` rather than a PATH-dependent bare `node`.
 
 ## Storage contract
 
@@ -66,9 +63,9 @@ Wiki access should be explicit:
 
 This keeps the routing surface specific enough to avoid false positives from ordinary prose.
 
-## MCP tool surface
+## CLI-first tool surface
 
-The dedicated `omx_wiki` server should expose the eight stabilized wiki tools:
+The CLI-first `omx wiki <tool> --input <json> --json` surface should expose the eight stabilized wiki tools; the optional `omx_wiki` MCP compatibility server mirrors the same tools when explicitly enabled:
 
 - `wiki_ingest`
 - `wiki_query`
@@ -79,4 +76,4 @@ The dedicated `omx_wiki` server should expose the eight stabilized wiki tools:
 - `wiki_delete`
 - `wiki_refresh`
 
-These tools should write to `omx_wiki/`, may read legacy `.omx/wiki/` only as conservative compatibility fallback when `omx_wiki/` is absent, and keep lifecycle behavior bounded.
+These CLI operations should write to `omx_wiki/`, may read legacy `.omx/wiki/` only as conservative compatibility fallback when `omx_wiki/` is absent, and keep lifecycle behavior bounded.

--- a/plugins/oh-my-codex/.mcp.json
+++ b/plugins/oh-my-codex/.mcp.json
@@ -6,7 +6,7 @@
         "mcp-serve",
         "state"
       ],
-      "enabled": true
+      "enabled": false
     },
     "omx_memory": {
       "command": "omx",
@@ -14,7 +14,7 @@
         "mcp-serve",
         "memory"
       ],
-      "enabled": true
+      "enabled": false
     },
     "omx_code_intel": {
       "command": "omx",
@@ -22,7 +22,7 @@
         "mcp-serve",
         "code-intel"
       ],
-      "enabled": true
+      "enabled": false
     },
     "omx_trace": {
       "command": "omx",
@@ -30,7 +30,7 @@
         "mcp-serve",
         "trace"
       ],
-      "enabled": true
+      "enabled": false
     },
     "omx_wiki": {
       "command": "omx",
@@ -38,7 +38,7 @@
         "mcp-serve",
         "wiki"
       ],
-      "enabled": true
+      "enabled": false
     }
   }
 }

--- a/plugins/oh-my-codex/skills/autopilot/SKILL.md
+++ b/plugins/oh-my-codex/skills/autopilot/SKILL.md
@@ -75,7 +75,7 @@ Before Phase `ralplan` starts or resumes:
 </Execution_Policy>
 
 <State_Management>
-Use `omx_state` MCP tools (or `omx state ... --json` fallback if MCP transport is unavailable) for Autopilot lifecycle state. State must be session-aware when a session id exists.
+Use the CLI-first state surface (`omx state ... --json`) for Autopilot lifecycle state. State must be session-aware when a session id exists. If the explicit MCP compatibility surface is already available, equivalent `omx_state` tool calls remain acceptable but are not required.
 
 Required fields:
 
@@ -99,7 +99,7 @@ Required fields:
 }
 ```
 
-- **On start**: `state_write({mode:"autopilot", active:true, current_phase:"ralplan", iteration:1, review_cycle:0, state:{phase_cycle:["ralplan","ralph","code-review"], handoff_artifacts:{context_snapshot_path, ralplan:null, ralph:null, code_review:null}, review_verdict:null, return_to_ralplan_reason:null}})`
+- **On start**: `omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan","iteration":1,"review_cycle":0,"state":{"phase_cycle":["ralplan","ralph","code-review"],"handoff_artifacts":{"context_snapshot_path":"<snapshot-path>","ralplan":null,"ralph":null,"code_review":null},"review_verdict":null,"return_to_ralplan_reason":null}}' --json`
 - **On ralplan -> ralph**: set `current_phase:"ralph"`, persist the plan/test-spec paths under `handoff_artifacts.ralplan`.
 - **On ralph -> code-review**: set `current_phase:"code-review"`, persist implementation/test evidence under `handoff_artifacts.ralph`.
 - **On clean review**: set `active:false`, `current_phase:"complete"`, persist `review_verdict:{recommendation:"APPROVE", architectural_status:"CLEAR", clean:true}` and `completed_at`.

--- a/plugins/oh-my-codex/skills/code-review/SKILL.md
+++ b/plugins/oh-my-codex/skills/code-review/SKILL.md
@@ -141,9 +141,7 @@ The code-reviewer agent SHOULD consult Codex for cross-validation.
 - Small, isolated changes
 
 ### Tool Usage
-Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
-Use `mcp__x__ask_codex` with `agent_role: "code-reviewer"`.
-If ToolSearch finds no MCP tools, fall back to the `code-reviewer` agent.
+Prefer native `code-reviewer` agent consultation or CLI-backed `ask_codex` surfaces when available. Optional MCP compatibility ask tools may be used only when already enabled. If consultation tools are unavailable, fall back to the `code-reviewer` agent.
 
 **Note:** Codex calls can take up to 1 hour. Consider the review timeline before consulting.
 

--- a/plugins/oh-my-codex/skills/deep-interview/SKILL.md
+++ b/plugins/oh-my-codex/skills/deep-interview/SKILL.md
@@ -72,7 +72,7 @@ If no flag is provided, use **Standard**.
 - Do not hand off to execution while ambiguity remains above threshold unless user explicitly opts to proceed with warning
 - Do not crystallize or hand off while `Non-goals` or `Decision Boundaries` remain unresolved, even if the weighted ambiguity threshold is met
 - Treat early exit as a safety valve, not the default success path
-- Persist mode state for resume safety (`state_write` / `state_read`)
+- Persist mode state for resume safety with CLI-first state commands (`omx state write/read --input '<json>' --json`); use `state_write` / `state_read` only when explicit MCP compatibility is enabled
 </Execution_Policy>
 
 <Steps>
@@ -101,7 +101,7 @@ If no flag is provided, use **Standard**.
 2. Detect project context:
    - Run `explore` to classify **brownfield** (existing codebase target) vs **greenfield**.
    - For brownfield, collect relevant codebase context before questioning.
-3. Initialize state via `state_write(mode="deep-interview")`:
+3. Initialize state via `omx state write --input '{"mode":"deep-interview","active":true}' --json`:
 
 ```json
 {
@@ -286,7 +286,7 @@ Readiness gate:
 Show weighted breakdown table, readiness-gate status (`Non-goals`, `Decision Boundaries`), and the next focus dimension.
 
 ### 2e) Persist state
-Append round result and updated scores via `state_write`.
+Append round result and updated scores via `omx state write --input '<json>' --json`; use `state_write` only when explicit MCP compatibility is enabled.
 
 ### 2f) Round controls
 - Do not offer early exit before the first explicit assumption probe and one persistent follow-up have happened
@@ -428,7 +428,7 @@ Preserve `$ralph` for persistent single-owner execution/verification and `$team`
 - From attached-tmux Bash/tool paths, call it as `OMX_QUESTION_RETURN_PANE=$TMUX_PANE omx question ...` unless an explicit `%pane` return target is already known
 - If the current runtime is outside tmux and cannot render `omx question`, use native structured input when available; otherwise ask exactly one concise plain-text question and wait for the answer
 - After `omx question` returns JSON, prefer `answers[0].answer` / `answers[]`; use legacy `answer` only as a fallback for older records
-- Use `state_write` / `state_read` for resumable mode state
+- Use `omx state write/read --input '<json>' --json` for resumable mode state; `state_write` / `state_read` are explicit MCP compatibility fallbacks only
 - If the interview cannot ask a required `omx question` round, persist the blocker as terminal state with `active: false` and `current_phase: "blocked"`; do not write a terminal blocked phase with `active: true`
 - Read/write context snapshots under `.omx/context/`
 - Record whether the oversized-context summary gate is not needed, pending, or satisfied before any scoring or handoff step

--- a/plugins/oh-my-codex/skills/deep-interview/SKILL.md
+++ b/plugins/oh-my-codex/skills/deep-interview/SKILL.md
@@ -475,7 +475,7 @@ enableChallengeModes = true
 
 ## Resume
 
-If interrupted, rerun `$deep-interview`. Resume from persisted mode state via `state_read(mode="deep-interview")`.
+If interrupted, rerun `$deep-interview`. Resume from persisted mode state via `omx state read --input '{"mode":"deep-interview"}' --json`.
 
 ## Recommended 3-Stage Pipeline
 

--- a/plugins/oh-my-codex/skills/doctor/SKILL.md
+++ b/plugins/oh-my-codex/skills/doctor/SKILL.md
@@ -51,7 +51,7 @@ echo "Latest npm: $LATEST"
 - If no cache entry exists: INFO - plugin marketplace artifact not cached; this may be normal when OMX was installed only through npm/setup
 - Compare each printed `PLUGIN_VERSION` with `LATEST`; if it differs and is not `local`: WARN - outdated plugin cache
 - If one marketplace has multiple version directories: WARN - stale cache for that marketplace/plugin pair
-- Remember: plugin install/discovery is not a replacement for `npm install -g oh-my-codex` plus `omx setup`; the packaged plugin now carries plugin-scoped companion metadata for MCP servers and apps, while native/runtime hooks and the rest of OMX runtime wiring stay setup-owned
+- Remember: plugin install/discovery is not a replacement for `npm install -g oh-my-codex` plus `omx setup`; the packaged plugin carries plugin-scoped companion metadata for optional MCP compatibility servers and apps, with first-party MCP disabled by default, while native/runtime hooks and the rest of OMX runtime wiring stay setup-owned
 
 ### Step 2: Check Hook Configuration (config.toml + legacy settings.json)
 
@@ -123,7 +123,7 @@ ls -la ~/.agents/skills/ 2>/dev/null
 ```
 
 **Diagnosis**:
-- If `~/.codex/agents/` exists with oh-my-codex-related files: WARN - legacy generated agents or hand-installed role files. The Codex plugin can package reusable workflows plus plugin-scoped companion metadata for MCP/apps; legacy setup installs native agents, while plugin setup archives stale legacy native-agent files and keeps config/hooks current.
+- If `~/.codex/agents/` exists with oh-my-codex-related files: WARN - legacy generated agents or hand-installed role files. The Codex plugin can package reusable workflows plus plugin-scoped companion metadata for optional MCP/apps; legacy setup installs native agents, while plugin setup archives stale legacy native-agent files and keeps config/hooks current.
 - If `~/.codex/commands/` exists with oh-my-codex-related files: WARN - legacy command files from older installs. Current OMX uses skills/workflows plus setup-managed native surfaces.
 - If `${CODEX_HOME:-~/.codex}/skills/` exists with OMX skills: OK - canonical current user skill root
 - If `~/.agents/skills/` exists: WARN - historical legacy skill root that can overlap with `${CODEX_HOME:-~/.codex}/skills/` and cause duplicate Enable/Disable Skills entries

--- a/plugins/oh-my-codex/skills/omx-setup/SKILL.md
+++ b/plugins/oh-my-codex/skills/omx-setup/SKILL.md
@@ -114,7 +114,7 @@ From `omx doctor`, expect:
 - Skills installed (scope-dependent: user or project)
 - AGENTS.md found in project root
 - `.omx/state` exists
-- OMX MCP servers configured in scope target `config.toml` (`~/.codex/config.toml` or `./.codex/config.toml`)
+- CLI-first config present in the scope target `config.toml`; first-party OMX MCP servers and shared MCP registry sync are omitted by default unless setup was run with `--mcp compat`
 
 ## Troubleshooting
 

--- a/plugins/oh-my-codex/skills/pipeline/SKILL.md
+++ b/plugins/oh-my-codex/skills/pipeline/SKILL.md
@@ -52,9 +52,9 @@ return a `StageResult` with status, artifacts, and duration.
 Pipeline state persists via the ModeState system at `.omx/state/pipeline-state.json`.
 The HUD renders pipeline phase automatically. Resume is supported from the last incomplete stage.
 
-- **On start**: `state_write({mode: "pipeline", active: true, current_phase: "stage:ralplan"})`
-- **On stage transitions**: `state_write({mode: "pipeline", current_phase: "stage:<name>"})`
-- **On completion**: `state_write({mode: "pipeline", active: false, current_phase: "complete"})`
+- **On start**: `omx state write --input '{"mode":"pipeline","active":true,"current_phase":"stage:ralplan"}' --json`
+- **On stage transitions**: `omx state write --input '{"mode":"pipeline","current_phase":"stage:<name>"}' --json`
+- **On completion**: `omx state write --input '{"mode":"pipeline","active":false,"current_phase":"complete"}' --json`
 
 ## API
 

--- a/plugins/oh-my-codex/skills/plan/SKILL.md
+++ b/plugins/oh-my-codex/skills/plan/SKILL.md
@@ -143,7 +143,7 @@ Plans are saved to `.omx/plans/`. Drafts go to `.omx/drafts/`.
 - Use `ask_codex` with `agent_role: "planner"` for planning validation on large-scope plans
 - Use `ask_codex` with `agent_role: "analyst"` for requirements analysis
 - Use `ask_codex` with `agent_role: "critic"` for plan review in consensus and review modes
-- If ToolSearch finds no MCP tools or Codex is unavailable, fall back to equivalent OMX prompt agents -- never block on external tools
+- If optional MCP compatibility tools or Codex consultation are unavailable, fall back to equivalent OMX prompt/native agents -- never block on external tools
 - **CRITICAL — Consensus mode agent calls MUST be sequential, never parallel.** Always await the Architect result before issuing the Critic call.
 - In consensus mode, default to RALPLAN-DR short mode; enable deliberate mode on `--deliberate` or explicit high-risk signals (auth/security, migrations, destructive changes, production incidents, compliance/PII, public API breakage)
 - In consensus mode with `--interactive`: use `AskUserQuestion` / the structured question UI for the user feedback step (step 2) and the final approval step (step 7) -- never ask for approval in plain text when a structured surface is available. Without `--interactive`, auto-proceed through planning steps without pausing. Output the final plan without execution.

--- a/plugins/oh-my-codex/skills/ralph/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralph/SKILL.md
@@ -91,14 +91,13 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 </Steps>
 
 <Tool_Usage>
-- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
 - Use `ask_codex` with `agent_role: "architect"` for verification cross-checks when changes are security-sensitive, architectural, or involve complex multi-system integration
 - Skip Codex consultation for simple feature additions, well-tested changes, or time-critical verification
-- If ToolSearch finds no MCP tools or Codex is unavailable, proceed with architect agent verification alone -- never block on external tools
-- Use `state_write` / `state_read` for ralph mode state persistence between iterations
+- If MCP compatibility tools are unavailable, proceed with CLI/agent verification alone -- never block on external tools
+- Use `omx state write/read --input '<json>' --json` for ralph mode state persistence between iterations
 - Use Codex goal tools when present: `get_goal` to discover or re-check the active objective, `create_goal` only when the user/system explicitly requested a new goal and no active goal exists, and `update_goal` only after the audited objective is fully achieved.
 - Persist context snapshot path in Ralph mode state so later phases and agents share the same grounding context
-- If an `omx_state` MCP tool call reports that its stdio transport is unavailable/closed, do **not** retry the same MCP call. Retry once through the supported CLI parity surface with the same payload, preserving `workingDirectory` and `session_id`: `omx state write --input '<json>' --json`, `omx state read --input '<json>' --json`, or `omx state clear --input '<json>' --json`. If the CLI path also fails, continue with `.omx/context` / `.omx/plans` file-backed artifacts and report the state persistence blocker.
+- Prefer CLI state commands. If an explicit MCP compatibility `omx_state` call reports that its stdio transport is unavailable/closed, do **not** retry the same MCP call. Retry once through the supported CLI parity surface with the same payload, preserving `workingDirectory` and `session_id`: `omx state write --input '<json>' --json`, `omx state read --input '<json>' --json`, or `omx state clear --input '<json>' --json`. If the CLI path also fails, continue with `.omx/context` / `.omx/plans` file-backed artifacts and report the state persistence blocker.
 </Tool_Usage>
 
 ## Goal Mode Integration
@@ -118,18 +117,18 @@ Codex goal mode is the thread-level completion contract for long-running Ralph w
 
 ## State Management
 
-Use the `omx_state` MCP server tools (`state_write`, `state_read`, `state_clear`) for Ralph lifecycle state.
+Use the CLI-first state surface for Ralph lifecycle state (`omx state write/read/clear --input '<json>' --json`). Explicit MCP compatibility tools (`state_write`, `state_read`, `state_clear`) remain acceptable only when already enabled.
 
 - **On start**:
-  `state_write({mode: "ralph", active: true, iteration: 1, max_iterations: 10, current_phase: "executing", started_at: "<now>", state: {context_snapshot_path: "<snapshot-path>"}})`
+  `omx state write --input '{"mode":"ralph","active":true,"iteration":1,"max_iterations":10,"current_phase":"executing","started_at":"<now>","state":{"context_snapshot_path":"<snapshot-path>"}}' --json`
 - **On each iteration**:
-  `state_write({mode: "ralph", iteration: <current>, current_phase: "executing"})`
+  `omx state write --input '{"mode":"ralph","iteration":<current>,"current_phase":"executing"}' --json`
 - **On verification/fix transition**:
-  `state_write({mode: "ralph", current_phase: "verifying"})` or `state_write({mode: "ralph", current_phase: "fixing"})`
+  `omx state write --input '{"mode":"ralph","current_phase":"verifying"}' --json` or `omx state write --input '{"mode":"ralph","current_phase":"fixing"}' --json`
 - **On completion**:
-  `state_write({mode: "ralph", active: false, current_phase: "complete", completed_at: "<now>"})`
+  `omx state write --input '{"mode":"ralph","active":false,"current_phase":"complete","completed_at":"<now>"}' --json`
 - **On cancellation/cleanup**:
-  run `$cancel` (which should call `state_clear(mode="ralph")`)
+  run `$cancel` (which should call `omx state clear --input '{"mode":"ralph"}' --json`)
 
 
 ## Scenario Examples

--- a/plugins/oh-my-codex/skills/ultraqa/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultraqa/SKILL.md
@@ -93,19 +93,19 @@ Output progress each cycle:
 
 ## State Tracking
 
-Use `omx_state` MCP tools for UltraQA lifecycle state.
+Use the CLI-first state surface (`omx state ... --json`) for UltraQA lifecycle state. If explicit MCP compatibility tools are already available, equivalent `omx_state` calls are optional compatibility, not the default.
 
 - **On start**:
-  `state_write({mode: "ultraqa", active: true, current_phase: "qa", iteration: 1, started_at: "<now>"})`
+  `omx state write --input '{"mode":"ultraqa","active":true,"current_phase":"qa","iteration":1,"started_at":"<now>"}' --json`
 - **On each cycle**:
-  `state_write({mode: "ultraqa", current_phase: "qa", iteration: <cycle>})`
+  `omx state write --input '{"mode":"ultraqa","current_phase":"qa","iteration":<cycle>}' --json`
 - **On diagnose/fix transitions**:
-  `state_write({mode: "ultraqa", current_phase: "diagnose"})`
-  `state_write({mode: "ultraqa", current_phase: "fix"})`
+  `omx state write --input '{"mode":"ultraqa","current_phase":"diagnose"}' --json`
+  `omx state write --input '{"mode":"ultraqa","current_phase":"fix"}' --json`
 - **On completion**:
-  `state_write({mode: "ultraqa", active: false, current_phase: "complete", completed_at: "<now>"})`
+  `omx state write --input '{"mode":"ultraqa","active":false,"current_phase":"complete","completed_at":"<now>"}' --json`
 - **For resume detection**:
-  `state_read({mode: "ultraqa"})`
+  `omx state read --input '{"mode":"ultraqa"}' --json`
 
 ## Scenario Examples
 
@@ -131,9 +131,9 @@ User can cancel with `/cancel` which clears the state file.
 
 When goal is met OR max cycles reached OR exiting early, run `$cancel` or call:
 
-`state_clear({mode: "ultraqa"})`
+`omx state clear --input '{"mode":"ultraqa"}' --json`
 
-Use MCP state cleanup rather than deleting files directly.
+Use CLI state cleanup rather than deleting files directly.
 
 ---
 

--- a/plugins/oh-my-codex/skills/ultrawork/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultrawork/SKILL.md
@@ -81,16 +81,16 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 
 ## State Management
 
-Use `omx_state` MCP tools for ultrawork lifecycle state.
+Use the CLI-first state surface (`omx state ... --json`) for ultrawork lifecycle state. If explicit MCP compatibility tools are already available, equivalent `omx_state` calls are optional compatibility, not the default.
 
 - **On start**:
-  `state_write({mode: "ultrawork", active: true, reinforcement_count: 1, started_at: "<now>"})`
+  `omx state write --input '{"mode":"ultrawork","active":true,"reinforcement_count":1,"started_at":"<now>"}' --json`
 - **On each reinforcement/loop step**:
-  `state_write({mode: "ultrawork", reinforcement_count: <current>})`
+  `omx state write --input '{"mode":"ultrawork","reinforcement_count":<current>}' --json`
 - **On completion**:
-  `state_write({mode: "ultrawork", active: false})`
+  `omx state write --input '{"mode":"ultrawork","active":false}' --json`
 - **On cancellation/cleanup**:
-  run `$cancel` (which should call `state_clear(mode="ultrawork")`)
+  run `$cancel` (which should call `omx state clear --input '{"mode":"ultrawork"}' --json`)
 
 <Examples>
 <Good>

--- a/plugins/oh-my-codex/skills/wiki/SKILL.md
+++ b/plugins/oh-my-codex/skills/wiki/SKILL.md
@@ -11,31 +11,31 @@ Persistent, self-maintained markdown knowledge base for project and session know
 ## Operations
 
 ### Ingest
-```text
-wiki_ingest({ title: "Auth Architecture", content: "...", tags: ["auth", "architecture"], category: "architecture" })
+```bash
+omx wiki wiki_ingest --input '{"title":"Auth Architecture","content":"...","tags":["auth","architecture"],"category":"architecture"}' --json
 ```
 
 ### Query
-```text
-wiki_query({ query: "authentication", tags: ["auth"], category: "architecture" })
+```bash
+omx wiki wiki_query --input '{"query":"authentication","tags":["auth"],"category":"architecture"}' --json
 ```
 
 ### Lint
-```text
-wiki_lint()
+```bash
+omx wiki wiki_lint --json
 ```
 
 ### Quick Add
-```text
-wiki_add({ title: "Page Title", content: "...", tags: ["tag1"], category: "decision" })
+```bash
+omx wiki wiki_add --input '{"title":"Page Title","content":"...","tags":["tag1"],"category":"decision"}' --json
 ```
 
 ### List / Read / Delete
-```text
-wiki_list()
-wiki_read({ page: "auth-architecture" })
-wiki_delete({ page: "outdated-page" })
-wiki_refresh()
+```bash
+omx wiki wiki_list --json
+omx wiki wiki_read --input '{"page":"auth-architecture"}' --json
+omx wiki wiki_delete --input '{"page":"outdated-page"}' --json
+omx wiki wiki_refresh --json
 ```
 
 ## Categories

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -75,7 +75,7 @@ Before Phase `ralplan` starts or resumes:
 </Execution_Policy>
 
 <State_Management>
-Use `omx_state` MCP tools (or `omx state ... --json` fallback if MCP transport is unavailable) for Autopilot lifecycle state. State must be session-aware when a session id exists.
+Use the CLI-first state surface (`omx state ... --json`) for Autopilot lifecycle state. State must be session-aware when a session id exists. If the explicit MCP compatibility surface is already available, equivalent `omx_state` tool calls remain acceptable but are not required.
 
 Required fields:
 
@@ -99,7 +99,7 @@ Required fields:
 }
 ```
 
-- **On start**: `state_write({mode:"autopilot", active:true, current_phase:"ralplan", iteration:1, review_cycle:0, state:{phase_cycle:["ralplan","ralph","code-review"], handoff_artifacts:{context_snapshot_path, ralplan:null, ralph:null, code_review:null}, review_verdict:null, return_to_ralplan_reason:null}})`
+- **On start**: `omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan","iteration":1,"review_cycle":0,"state":{"phase_cycle":["ralplan","ralph","code-review"],"handoff_artifacts":{"context_snapshot_path":"<snapshot-path>","ralplan":null,"ralph":null,"code_review":null},"review_verdict":null,"return_to_ralplan_reason":null}}' --json`
 - **On ralplan -> ralph**: set `current_phase:"ralph"`, persist the plan/test-spec paths under `handoff_artifacts.ralplan`.
 - **On ralph -> code-review**: set `current_phase:"code-review"`, persist implementation/test evidence under `handoff_artifacts.ralph`.
 - **On clean review**: set `active:false`, `current_phase:"complete"`, persist `review_verdict:{recommendation:"APPROVE", architectural_status:"CLEAR", clean:true}` and `completed_at`.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -141,9 +141,7 @@ The code-reviewer agent SHOULD consult Codex for cross-validation.
 - Small, isolated changes
 
 ### Tool Usage
-Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
-Use `mcp__x__ask_codex` with `agent_role: "code-reviewer"`.
-If ToolSearch finds no MCP tools, fall back to the `code-reviewer` agent.
+Prefer native `code-reviewer` agent consultation or CLI-backed `ask_codex` surfaces when available. Optional MCP compatibility ask tools may be used only when already enabled. If consultation tools are unavailable, fall back to the `code-reviewer` agent.
 
 **Note:** Codex calls can take up to 1 hour. Consider the review timeline before consulting.
 

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -72,7 +72,7 @@ If no flag is provided, use **Standard**.
 - Do not hand off to execution while ambiguity remains above threshold unless user explicitly opts to proceed with warning
 - Do not crystallize or hand off while `Non-goals` or `Decision Boundaries` remain unresolved, even if the weighted ambiguity threshold is met
 - Treat early exit as a safety valve, not the default success path
-- Persist mode state for resume safety (`state_write` / `state_read`)
+- Persist mode state for resume safety with CLI-first state commands (`omx state write/read --input '<json>' --json`); use `state_write` / `state_read` only when explicit MCP compatibility is enabled
 </Execution_Policy>
 
 <Steps>
@@ -101,7 +101,7 @@ If no flag is provided, use **Standard**.
 2. Detect project context:
    - Run `explore` to classify **brownfield** (existing codebase target) vs **greenfield**.
    - For brownfield, collect relevant codebase context before questioning.
-3. Initialize state via `state_write(mode="deep-interview")`:
+3. Initialize state via `omx state write --input '{"mode":"deep-interview","active":true}' --json`:
 
 ```json
 {
@@ -286,7 +286,7 @@ Readiness gate:
 Show weighted breakdown table, readiness-gate status (`Non-goals`, `Decision Boundaries`), and the next focus dimension.
 
 ### 2e) Persist state
-Append round result and updated scores via `state_write`.
+Append round result and updated scores via `omx state write --input '<json>' --json`; use `state_write` only when explicit MCP compatibility is enabled.
 
 ### 2f) Round controls
 - Do not offer early exit before the first explicit assumption probe and one persistent follow-up have happened
@@ -428,7 +428,7 @@ Preserve `$ralph` for persistent single-owner execution/verification and `$team`
 - From attached-tmux Bash/tool paths, call it as `OMX_QUESTION_RETURN_PANE=$TMUX_PANE omx question ...` unless an explicit `%pane` return target is already known
 - If the current runtime is outside tmux and cannot render `omx question`, use native structured input when available; otherwise ask exactly one concise plain-text question and wait for the answer
 - After `omx question` returns JSON, prefer `answers[0].answer` / `answers[]`; use legacy `answer` only as a fallback for older records
-- Use `state_write` / `state_read` for resumable mode state
+- Use `omx state write/read --input '<json>' --json` for resumable mode state; `state_write` / `state_read` are explicit MCP compatibility fallbacks only
 - If the interview cannot ask a required `omx question` round, persist the blocker as terminal state with `active: false` and `current_phase: "blocked"`; do not write a terminal blocked phase with `active: true`
 - Read/write context snapshots under `.omx/context/`
 - Record whether the oversized-context summary gate is not needed, pending, or satisfied before any scoring or handoff step

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -475,7 +475,7 @@ enableChallengeModes = true
 
 ## Resume
 
-If interrupted, rerun `$deep-interview`. Resume from persisted mode state via `state_read(mode="deep-interview")`.
+If interrupted, rerun `$deep-interview`. Resume from persisted mode state via `omx state read --input '{"mode":"deep-interview"}' --json`.
 
 ## Recommended 3-Stage Pipeline
 

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -51,7 +51,7 @@ echo "Latest npm: $LATEST"
 - If no cache entry exists: INFO - plugin marketplace artifact not cached; this may be normal when OMX was installed only through npm/setup
 - Compare each printed `PLUGIN_VERSION` with `LATEST`; if it differs and is not `local`: WARN - outdated plugin cache
 - If one marketplace has multiple version directories: WARN - stale cache for that marketplace/plugin pair
-- Remember: plugin install/discovery is not a replacement for `npm install -g oh-my-codex` plus `omx setup`; the packaged plugin now carries plugin-scoped companion metadata for MCP servers and apps, while native/runtime hooks and the rest of OMX runtime wiring stay setup-owned
+- Remember: plugin install/discovery is not a replacement for `npm install -g oh-my-codex` plus `omx setup`; the packaged plugin carries plugin-scoped companion metadata for optional MCP compatibility servers and apps, with first-party MCP disabled by default, while native/runtime hooks and the rest of OMX runtime wiring stay setup-owned
 
 ### Step 2: Check Hook Configuration (config.toml + legacy settings.json)
 
@@ -123,7 +123,7 @@ ls -la ~/.agents/skills/ 2>/dev/null
 ```
 
 **Diagnosis**:
-- If `~/.codex/agents/` exists with oh-my-codex-related files: WARN - legacy generated agents or hand-installed role files. The Codex plugin can package reusable workflows plus plugin-scoped companion metadata for MCP/apps; legacy setup installs native agents, while plugin setup archives stale legacy native-agent files and keeps config/hooks current.
+- If `~/.codex/agents/` exists with oh-my-codex-related files: WARN - legacy generated agents or hand-installed role files. The Codex plugin can package reusable workflows plus plugin-scoped companion metadata for optional MCP/apps; legacy setup installs native agents, while plugin setup archives stale legacy native-agent files and keeps config/hooks current.
 - If `~/.codex/commands/` exists with oh-my-codex-related files: WARN - legacy command files from older installs. Current OMX uses skills/workflows plus setup-managed native surfaces.
 - If `${CODEX_HOME:-~/.codex}/skills/` exists with OMX skills: OK - canonical current user skill root
 - If `~/.agents/skills/` exists: WARN - historical legacy skill root that can overlap with `${CODEX_HOME:-~/.codex}/skills/` and cause duplicate Enable/Disable Skills entries

--- a/skills/ecomode/SKILL.md
+++ b/skills/ecomode/SKILL.md
@@ -104,11 +104,11 @@ Set in `~/.codex/.omx-config.json`:
 
 ## State Management
 
-Use `omx_state` MCP tools for ecomode lifecycle state.
+Use the CLI-first state surface (`omx state ... --json`) for ecomode lifecycle state. If explicit MCP compatibility tools are already available, equivalent `omx_state` calls are optional compatibility, not the default.
 
 - **On activation**:
-  `state_write({mode: "ecomode", active: true})`
+  `omx state write --input '{"mode":"ecomode","active":true}' --json`
 - **On deactivation/completion**:
-  `state_write({mode: "ecomode", active: false})`
+  `omx state write --input '{"mode":"ecomode","active":false}' --json`
 - **On cancellation/cleanup**:
-  run `$cancel` (which should call `state_clear(mode="ecomode")`)
+  run `$cancel` (which should call `omx state clear --input '{"mode":"ecomode"}' --json`)

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -114,7 +114,7 @@ From `omx doctor`, expect:
 - Skills installed (scope-dependent: user or project)
 - AGENTS.md found in project root
 - `.omx/state` exists
-- OMX MCP servers configured in scope target `config.toml` (`~/.codex/config.toml` or `./.codex/config.toml`)
+- CLI-first config present in the scope target `config.toml`; first-party OMX MCP servers and shared MCP registry sync are omitted by default unless setup was run with `--mcp compat`
 
 ## Troubleshooting
 

--- a/skills/pipeline/SKILL.md
+++ b/skills/pipeline/SKILL.md
@@ -52,9 +52,9 @@ return a `StageResult` with status, artifacts, and duration.
 Pipeline state persists via the ModeState system at `.omx/state/pipeline-state.json`.
 The HUD renders pipeline phase automatically. Resume is supported from the last incomplete stage.
 
-- **On start**: `state_write({mode: "pipeline", active: true, current_phase: "stage:ralplan"})`
-- **On stage transitions**: `state_write({mode: "pipeline", current_phase: "stage:<name>"})`
-- **On completion**: `state_write({mode: "pipeline", active: false, current_phase: "complete"})`
+- **On start**: `omx state write --input '{"mode":"pipeline","active":true,"current_phase":"stage:ralplan"}' --json`
+- **On stage transitions**: `omx state write --input '{"mode":"pipeline","current_phase":"stage:<name>"}' --json`
+- **On completion**: `omx state write --input '{"mode":"pipeline","active":false,"current_phase":"complete"}' --json`
 
 ## API
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -143,7 +143,7 @@ Plans are saved to `.omx/plans/`. Drafts go to `.omx/drafts/`.
 - Use `ask_codex` with `agent_role: "planner"` for planning validation on large-scope plans
 - Use `ask_codex` with `agent_role: "analyst"` for requirements analysis
 - Use `ask_codex` with `agent_role: "critic"` for plan review in consensus and review modes
-- If ToolSearch finds no MCP tools or Codex is unavailable, fall back to equivalent OMX prompt agents -- never block on external tools
+- If optional MCP compatibility tools or Codex consultation are unavailable, fall back to equivalent OMX prompt/native agents -- never block on external tools
 - **CRITICAL — Consensus mode agent calls MUST be sequential, never parallel.** Always await the Architect result before issuing the Critic call.
 - In consensus mode, default to RALPLAN-DR short mode; enable deliberate mode on `--deliberate` or explicit high-risk signals (auth/security, migrations, destructive changes, production incidents, compliance/PII, public API breakage)
 - In consensus mode with `--interactive`: use `AskUserQuestion` / the structured question UI for the user feedback step (step 2) and the final approval step (step 7) -- never ask for approval in plain text when a structured surface is available. Without `--interactive`, auto-proceed through planning steps without pausing. Output the final plan without execution.

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -91,14 +91,13 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 </Steps>
 
 <Tool_Usage>
-- Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
 - Use `ask_codex` with `agent_role: "architect"` for verification cross-checks when changes are security-sensitive, architectural, or involve complex multi-system integration
 - Skip Codex consultation for simple feature additions, well-tested changes, or time-critical verification
-- If ToolSearch finds no MCP tools or Codex is unavailable, proceed with architect agent verification alone -- never block on external tools
-- Use `state_write` / `state_read` for ralph mode state persistence between iterations
+- If MCP compatibility tools are unavailable, proceed with CLI/agent verification alone -- never block on external tools
+- Use `omx state write/read --input '<json>' --json` for ralph mode state persistence between iterations
 - Use Codex goal tools when present: `get_goal` to discover or re-check the active objective, `create_goal` only when the user/system explicitly requested a new goal and no active goal exists, and `update_goal` only after the audited objective is fully achieved.
 - Persist context snapshot path in Ralph mode state so later phases and agents share the same grounding context
-- If an `omx_state` MCP tool call reports that its stdio transport is unavailable/closed, do **not** retry the same MCP call. Retry once through the supported CLI parity surface with the same payload, preserving `workingDirectory` and `session_id`: `omx state write --input '<json>' --json`, `omx state read --input '<json>' --json`, or `omx state clear --input '<json>' --json`. If the CLI path also fails, continue with `.omx/context` / `.omx/plans` file-backed artifacts and report the state persistence blocker.
+- Prefer CLI state commands. If an explicit MCP compatibility `omx_state` call reports that its stdio transport is unavailable/closed, do **not** retry the same MCP call. Retry once through the supported CLI parity surface with the same payload, preserving `workingDirectory` and `session_id`: `omx state write --input '<json>' --json`, `omx state read --input '<json>' --json`, or `omx state clear --input '<json>' --json`. If the CLI path also fails, continue with `.omx/context` / `.omx/plans` file-backed artifacts and report the state persistence blocker.
 </Tool_Usage>
 
 ## Goal Mode Integration
@@ -118,18 +117,18 @@ Codex goal mode is the thread-level completion contract for long-running Ralph w
 
 ## State Management
 
-Use the `omx_state` MCP server tools (`state_write`, `state_read`, `state_clear`) for Ralph lifecycle state.
+Use the CLI-first state surface for Ralph lifecycle state (`omx state write/read/clear --input '<json>' --json`). Explicit MCP compatibility tools (`state_write`, `state_read`, `state_clear`) remain acceptable only when already enabled.
 
 - **On start**:
-  `state_write({mode: "ralph", active: true, iteration: 1, max_iterations: 10, current_phase: "executing", started_at: "<now>", state: {context_snapshot_path: "<snapshot-path>"}})`
+  `omx state write --input '{"mode":"ralph","active":true,"iteration":1,"max_iterations":10,"current_phase":"executing","started_at":"<now>","state":{"context_snapshot_path":"<snapshot-path>"}}' --json`
 - **On each iteration**:
-  `state_write({mode: "ralph", iteration: <current>, current_phase: "executing"})`
+  `omx state write --input '{"mode":"ralph","iteration":<current>,"current_phase":"executing"}' --json`
 - **On verification/fix transition**:
-  `state_write({mode: "ralph", current_phase: "verifying"})` or `state_write({mode: "ralph", current_phase: "fixing"})`
+  `omx state write --input '{"mode":"ralph","current_phase":"verifying"}' --json` or `omx state write --input '{"mode":"ralph","current_phase":"fixing"}' --json`
 - **On completion**:
-  `state_write({mode: "ralph", active: false, current_phase: "complete", completed_at: "<now>"})`
+  `omx state write --input '{"mode":"ralph","active":false,"current_phase":"complete","completed_at":"<now>"}' --json`
 - **On cancellation/cleanup**:
-  run `$cancel` (which should call `state_clear(mode="ralph")`)
+  run `$cancel` (which should call `omx state clear --input '{"mode":"ralph"}' --json`)
 
 
 ## Scenario Examples

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -99,6 +99,6 @@ The tdd-guide agent SHOULD consult Codex for test strategy validation.
 - Small, isolated functionality
 
 ### Tool Usage
-If ToolSearch finds no MCP tools, fall back to the `test-engineer` agent.
+Prefer native `test-engineer` consultation or CLI-backed ask surfaces when available. Optional MCP compatibility ask tools may be used only when already enabled. If consultation tools are unavailable, fall back to the `test-engineer` agent.
 
 **Remember:** The discipline IS the value. Shortcuts destroy the benefit.

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -93,19 +93,19 @@ Output progress each cycle:
 
 ## State Tracking
 
-Use `omx_state` MCP tools for UltraQA lifecycle state.
+Use the CLI-first state surface (`omx state ... --json`) for UltraQA lifecycle state. If explicit MCP compatibility tools are already available, equivalent `omx_state` calls are optional compatibility, not the default.
 
 - **On start**:
-  `state_write({mode: "ultraqa", active: true, current_phase: "qa", iteration: 1, started_at: "<now>"})`
+  `omx state write --input '{"mode":"ultraqa","active":true,"current_phase":"qa","iteration":1,"started_at":"<now>"}' --json`
 - **On each cycle**:
-  `state_write({mode: "ultraqa", current_phase: "qa", iteration: <cycle>})`
+  `omx state write --input '{"mode":"ultraqa","current_phase":"qa","iteration":<cycle>}' --json`
 - **On diagnose/fix transitions**:
-  `state_write({mode: "ultraqa", current_phase: "diagnose"})`
-  `state_write({mode: "ultraqa", current_phase: "fix"})`
+  `omx state write --input '{"mode":"ultraqa","current_phase":"diagnose"}' --json`
+  `omx state write --input '{"mode":"ultraqa","current_phase":"fix"}' --json`
 - **On completion**:
-  `state_write({mode: "ultraqa", active: false, current_phase: "complete", completed_at: "<now>"})`
+  `omx state write --input '{"mode":"ultraqa","active":false,"current_phase":"complete","completed_at":"<now>"}' --json`
 - **For resume detection**:
-  `state_read({mode: "ultraqa"})`
+  `omx state read --input '{"mode":"ultraqa"}' --json`
 
 ## Scenario Examples
 
@@ -131,9 +131,9 @@ User can cancel with `/cancel` which clears the state file.
 
 When goal is met OR max cycles reached OR exiting early, run `$cancel` or call:
 
-`state_clear({mode: "ultraqa"})`
+`omx state clear --input '{"mode":"ultraqa"}' --json`
 
-Use MCP state cleanup rather than deleting files directly.
+Use CLI state cleanup rather than deleting files directly.
 
 ---
 

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -81,16 +81,16 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 
 ## State Management
 
-Use `omx_state` MCP tools for ultrawork lifecycle state.
+Use the CLI-first state surface (`omx state ... --json`) for ultrawork lifecycle state. If explicit MCP compatibility tools are already available, equivalent `omx_state` calls are optional compatibility, not the default.
 
 - **On start**:
-  `state_write({mode: "ultrawork", active: true, reinforcement_count: 1, started_at: "<now>"})`
+  `omx state write --input '{"mode":"ultrawork","active":true,"reinforcement_count":1,"started_at":"<now>"}' --json`
 - **On each reinforcement/loop step**:
-  `state_write({mode: "ultrawork", reinforcement_count: <current>})`
+  `omx state write --input '{"mode":"ultrawork","reinforcement_count":<current>}' --json`
 - **On completion**:
-  `state_write({mode: "ultrawork", active: false})`
+  `omx state write --input '{"mode":"ultrawork","active":false}' --json`
 - **On cancellation/cleanup**:
-  run `$cancel` (which should call `state_clear(mode="ultrawork")`)
+  run `$cancel` (which should call `omx state clear --input '{"mode":"ultrawork"}' --json`)
 
 <Examples>
 <Good>

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -11,31 +11,31 @@ Persistent, self-maintained markdown knowledge base for project and session know
 ## Operations
 
 ### Ingest
-```text
-wiki_ingest({ title: "Auth Architecture", content: "...", tags: ["auth", "architecture"], category: "architecture" })
+```bash
+omx wiki wiki_ingest --input '{"title":"Auth Architecture","content":"...","tags":["auth","architecture"],"category":"architecture"}' --json
 ```
 
 ### Query
-```text
-wiki_query({ query: "authentication", tags: ["auth"], category: "architecture" })
+```bash
+omx wiki wiki_query --input '{"query":"authentication","tags":["auth"],"category":"architecture"}' --json
 ```
 
 ### Lint
-```text
-wiki_lint()
+```bash
+omx wiki wiki_lint --json
 ```
 
 ### Quick Add
-```text
-wiki_add({ title: "Page Title", content: "...", tags: ["tag1"], category: "decision" })
+```bash
+omx wiki wiki_add --input '{"title":"Page Title","content":"...","tags":["tag1"],"category":"decision"}' --json
 ```
 
 ### List / Read / Delete
-```text
-wiki_list()
-wiki_read({ page: "auth-architecture" })
-wiki_delete({ page: "outdated-page" })
-wiki_refresh()
+```bash
+omx wiki wiki_list --json
+omx wiki wiki_read --input '{"page":"auth-architecture"}' --json
+omx wiki wiki_delete --input '{"page":"outdated-page"}' --json
+omx wiki wiki_refresh --json
 ```
 
 ## Categories

--- a/src/catalog/__tests__/plugin-bundle-ssot.test.ts
+++ b/src/catalog/__tests__/plugin-bundle-ssot.test.ts
@@ -10,6 +10,7 @@ import {
 	isDirectCliInvocation,
 	syncPluginMirror,
 } from "../../scripts/sync-plugin-mirror.js";
+import { buildOmxPluginMcpManifest } from "../../config/omx-first-party-mcp.js";
 
 const root = process.cwd();
 
@@ -61,6 +62,28 @@ describe("plugin bundle SSOT contract", () => {
 		assert.equal(result.changed, false);
 		assert.deepEqual(result.mirroredSkillNames, expectedSkillNames);
 		assert.equal(result.mirroredSkillNames.includes("pipeline"), true);
+		const pluginMcp = JSON.parse(
+			await readFile(join(root, "plugins", "oh-my-codex", ".mcp.json"), "utf-8"),
+		) as { mcpServers?: Record<string, { enabled?: boolean }> };
+		assert.deepEqual(
+			Object.values(pluginMcp.mcpServers ?? {}).map((server) => server.enabled),
+			Object.values(pluginMcp.mcpServers ?? {}).map(() => false),
+			"checked-in plugin MCP metadata must be disabled by default",
+		);
+	});
+
+	it("builds disabled plugin MCP metadata by default with explicit compat opt-in", () => {
+		const defaultManifest = buildOmxPluginMcpManifest();
+		assert.deepEqual(
+			Object.values(defaultManifest.mcpServers).map((server) => server.enabled),
+			Object.values(defaultManifest.mcpServers).map(() => false),
+		);
+
+		const compatManifest = buildOmxPluginMcpManifest({ enabled: true });
+		assert.deepEqual(
+			Object.values(compatManifest.mcpServers).map((server) => server.enabled),
+			Object.values(compatManifest.mcpServers).map(() => true),
+		);
 	});
 
 	it("fails check mode when plugin MCP metadata drifts from canonical first-party specs", async () => {

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -159,7 +159,7 @@ describe('official Codex plugin layout', () => {
     assert.ok(manifest.interface?.developerName, 'expected developerName');
   });
 
-  it('ships plugin-scoped companion metadata for MCP servers and apps while hooks stay setup-owned', async () => {
+  it('ships disabled-by-default plugin-scoped MCP compatibility metadata while hooks stay setup-owned', async () => {
     const [mcpManifest, appsManifest] = await Promise.all([
       readJson<PluginMcpManifest>(pluginMcpPath),
       readJson<PluginAppsManifest>(pluginAppsPath),
@@ -176,7 +176,7 @@ describe('official Codex plugin layout', () => {
     for (const [serverName, server] of Object.entries(mcpManifest.mcpServers ?? {})) {
       assert.equal(server.command, OMX_PLUGIN_MCP_COMMAND, `${serverName} should run via omx`);
       assert.notEqual(server.command, 'node', `${serverName} should not depend on a bare node command`);
-      assert.equal(server.enabled, true, `${serverName} should be enabled`);
+      assert.equal(server.enabled, false, `${serverName} should be disabled by default`);
       assert.equal(server.args?.length, 2, `${serverName} should have serve subcommand + public target args`);
       assert.equal(server.args?.[0], OMX_PLUGIN_MCP_SERVE_SUBCOMMAND, `${serverName} should launch through omx mcp-serve`);
       const target = server.args?.[1];
@@ -187,9 +187,15 @@ describe('official Codex plugin layout', () => {
     }
   });
 
-  it('keeps plugin MCP metadata aligned with the setup-managed MCP roster', async () => {
+  it('keeps plugin MCP metadata aligned with the explicit compat setup-managed MCP roster', async () => {
     const mcpManifest = await readJson<PluginMcpManifest>(pluginMcpPath);
-    const mergedConfig = buildMergedConfig('', root, { includeTui: false });
+    const defaultConfig = buildMergedConfig('', root, { includeTui: false });
+    assert.doesNotMatch(
+      defaultConfig,
+      /^\[mcp_servers\.omx_state\]$/m,
+      'default setup config should stay CLI-first without first-party MCP tables',
+    );
+    const mergedConfig = buildMergedConfig('', root, { includeTui: false, includeFirstPartyMcp: true });
     const setupManagedServers = [...mergedConfig.matchAll(/^\[mcp_servers\.(omx_[^\]]+)\]$/gm)]
       .map((match) => match[1])
       .sort();
@@ -309,7 +315,7 @@ describe('official Codex plugin layout', () => {
     assert.match(combined, /plugins\/cache\/\$MARKETPLACE_NAME\/oh-my-codex\/\$VERSION\//);
     assert.match(combined, /not a replacement for `npm install -g oh-my-codex` plus `omx setup`/);
     assert.match(combined, /legacy setup mode installs native agents(?:\/| and )prompts|plugin setup mode archives stale legacy prompt\/native-agent files/);
-    assert.match(combined, /plugin-scoped companion metadata for MCP servers and apps/i);
+    assert.match(combined, /plugin-scoped companion metadata for optional MCP compatibility servers and apps/i);
     assert.match(combined, /hooks stay setup-owned|hooks remain setup-owned|native \.codex\/hooks\.json coverage/i);
   });
 });

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -107,7 +107,7 @@ describe("omx doctor onboarding warning copy", () => {
 		assert.match(check.message, /OMX_EXPLORE_BIN/);
 	});
 
-	it("explains first-setup expectation for config and MCP onboarding warnings", async () => {
+	it("treats user-managed MCP servers as preserved under CLI-first defaults", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-copy-"));
 		try {
 			const home = join(wd, "home");
@@ -133,7 +133,7 @@ command = "node"
 			);
 			assert.match(
 				res.stdout,
-				/MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
+				/MCP Servers: 1 user-managed MCP server\(s\) preserved; first-party OMX MCP omitted by default/,
 			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
@@ -165,6 +165,7 @@ command = "node"
 			if (shouldSkipForSpawnPermissions(res.error)) return;
 			assert.equal(res.status, 0, res.stderr || res.stdout);
 			assert.match(res.stdout, /Resolved setup install mode: plugin/);
+			assert.match(res.stdout, /Resolved setup MCP mode: none/);
 			assert.match(
 				res.stdout,
 				/Prompts: plugin mode intentionally omits setup-owned prompts; Codex plugin discovery supplies workflow surfaces/,
@@ -175,7 +176,7 @@ command = "node"
 			);
 			assert.match(
 				res.stdout,
-				/MCP Servers: plugin mode uses plugin-scoped MCP metadata; setup-owned OMX MCP tables are intentionally omitted/,
+				/MCP Servers: CLI-first plugin mode: first-party MCP compatibility explicitly disabled/,
 			);
 			assert.doesNotMatch(res.stdout, /Prompts: prompts directory not found/);
 			assert.doesNotMatch(res.stdout, /Skills: skills directory not found/);
@@ -220,6 +221,10 @@ command = "node"
 			);
 			assert.match(
 				res.stdout,
+				/Resolved setup MCP mode: none \(from \.omx\/setup-scope\.json\)/,
+			);
+			assert.match(
+				res.stdout,
 				/Skills: plugin marketplace oh-my-codex-local registered; OMX skills are supplied by/,
 			);
 			assert.match(
@@ -228,7 +233,7 @@ command = "node"
 			);
 			assert.match(
 				res.stdout,
-				/MCP Servers: plugin mode uses plugin-scoped MCP metadata; setup-owned OMX MCP tables are intentionally omitted/,
+				/MCP Servers: CLI-first plugin mode: first-party MCP compatibility explicitly disabled/,
 			);
 			assert.doesNotMatch(res.stdout, /Prompts: prompts directory not found/);
 			assert.doesNotMatch(res.stdout, /Skills: skills directory not found/);
@@ -303,7 +308,7 @@ enabled = true
 			assert.doesNotMatch(res.stdout, /Config: config\.toml has OMX entries/);
 			assert.doesNotMatch(
 				res.stdout,
-				/MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
+				/MCP Servers: 1 user-managed MCP server\(s\) preserved; first-party OMX MCP omitted by default/,
 			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -33,6 +33,7 @@ import {
   resolveSetupInstallModeArg,
   resolveSetupMcpModeArg,
   resolveSetupScopeArg,
+  resolveLaunchConfigRepairOptions,
   readPersistedSetupPreferences,
   readPersistedSetupScope,
   resolveCodexConfigPathForLaunch,
@@ -69,6 +70,7 @@ import {
   withTmuxExtendedKeys,
   CODEX_SQLITE_HOME_ENV,
 } from "../index.js";
+import { mergeConfig, repairConfigIfNeeded } from "../../config/generator.js";
 import { ensureReusableNodeModules } from "../../utils/repo-deps.js";
 import { readAllState } from "../../hud/state.js";
 import { generateOverlay } from "../../hooks/agents-overlay.js";
@@ -1729,6 +1731,78 @@ describe("project launch scope helpers", () => {
         resolveCodexConfigPathForLaunch(wd, {}),
         join(wd, ".codex", "config.toml"),
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves explicit compat MCP during launch config repair", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await mkdir(join(wd, ".codex"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project", mcpMode: "compat" }),
+      );
+      const configPath = join(wd, ".codex", "config.toml");
+      await mergeConfig(configPath, wd, {
+        includeFirstPartyMcp: true,
+        sharedMcpServers: [
+          {
+            name: "eslint",
+            command: "npx",
+            args: ["@eslint/mcp@latest"],
+            enabled: true,
+            startupTimeoutSec: 12,
+          },
+        ],
+        sharedMcpRegistrySource: join(wd, ".omx", "mcp-registry.json"),
+      });
+      const clean = await readFile(configPath, "utf-8");
+      assert.match(clean, /^\[mcp_servers\.omx_state\]$/m);
+      assert.match(clean, /oh-my-codex \(OMX\) Shared MCP Registry Sync/);
+      assert.match(clean, /^\[mcp_servers\.eslint\]$/m);
+
+      await writeFile(configPath, `${clean}\n[tui]\nstatus_line = ["git-branch"]\n`);
+      const repaired = await repairConfigIfNeeded(
+        configPath,
+        wd,
+        await resolveLaunchConfigRepairOptions(wd, configPath),
+      );
+      const repairedToml = await readFile(configPath, "utf-8");
+
+      assert.equal(repaired, true);
+      assert.match(repairedToml, /^\[mcp_servers\.omx_state\]$/m);
+      assert.match(repairedToml, /oh-my-codex \(OMX\) Shared MCP Registry Sync/);
+      assert.match(repairedToml, /^\[mcp_servers\.eslint\]$/m);
+      assert.equal((repairedToml.match(/^\[tui\]$/gm) ?? []).length, 1);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves existing compat MCP during launch repair without cwd-local preferences", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      const configPath = join(wd, "global-codex", "config.toml");
+      await mkdir(dirname(configPath), { recursive: true });
+      await mergeConfig(configPath, wd, { includeFirstPartyMcp: true });
+      const clean = await readFile(configPath, "utf-8");
+      assert.equal(existsSync(join(wd, ".omx", "setup-scope.json")), false);
+      assert.match(clean, /^\[mcp_servers\.omx_state\]$/m);
+
+      await writeFile(configPath, `${clean}\n[tui]\nstatus_line = ["git-branch"]\n`);
+      const repaired = await repairConfigIfNeeded(
+        configPath,
+        wd,
+        await resolveLaunchConfigRepairOptions(wd, configPath),
+      );
+      const repairedToml = await readFile(configPath, "utf-8");
+
+      assert.equal(repaired, true);
+      assert.match(repairedToml, /^\[mcp_servers\.omx_state\]$/m);
+      assert.equal((repairedToml.match(/^\[tui\]$/gm) ?? []).length, 1);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -31,6 +31,7 @@ import {
   injectModelInstructionsBypassArgs,
   resolveWorkerSparkModel,
   resolveSetupInstallModeArg,
+  resolveSetupMcpModeArg,
   resolveSetupScopeArg,
   readPersistedSetupPreferences,
   readPersistedSetupScope,
@@ -1574,6 +1575,37 @@ describe("resolveSetupInstallModeArg", () => {
     assert.throws(
       () => resolveSetupInstallModeArg(["--legacy", "--install-mode=plugin"]),
       /Conflicting setup install mode flags/,
+    );
+  });
+});
+
+
+describe("resolveSetupMcpModeArg", () => {
+  it("maps explicit setup MCP mode flags", () => {
+    assert.equal(resolveSetupMcpModeArg(["--dry-run"]), undefined);
+    assert.equal(resolveSetupMcpModeArg(["--no-mcp"]), "none");
+    assert.equal(resolveSetupMcpModeArg(["--with-mcp"]), "compat");
+    assert.equal(resolveSetupMcpModeArg(["--mcp", "none"]), "none");
+    assert.equal(resolveSetupMcpModeArg(["--mcp=compat"]), "compat");
+    assert.equal(resolveSetupMcpModeArg(["--scope", "project", "--mcp", "compat"]), "compat");
+  });
+
+  it("rejects invalid or conflicting setup MCP mode flags", () => {
+    assert.throws(
+      () => resolveSetupMcpModeArg(["--mcp"]),
+      /Missing setup MCP mode value after --mcp/,
+    );
+    assert.throws(
+      () => resolveSetupMcpModeArg(["--mcp", "full"]),
+      /Invalid setup MCP mode: full/,
+    );
+    assert.throws(
+      () => resolveSetupMcpModeArg(["--no-mcp", "--with-mcp"]),
+      /Conflicting setup MCP mode flags/,
+    );
+    assert.throws(
+      () => resolveSetupMcpModeArg(["--no-mcp", "--mcp=compat"]),
+      /Conflicting setup MCP mode flags/,
     );
   });
 });

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -15,6 +15,7 @@ import { dirname, join } from "node:path";
 import { parse as parseToml } from "@iarna/toml";
 import { setup } from "../setup.js";
 import { uninstall } from "../uninstall.js";
+import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../../config/omx-first-party-mcp.js";
 
 const packageRoot = process.cwd();
 
@@ -261,7 +262,7 @@ async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {
 	const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
 	assert.match(config, /^hooks = true$/m);
 	assert.match(config, /^goals = true$/m);
-	assert.doesNotMatch(config, /developer_instructions|notify-hook|mcp_servers/);
+	assert.doesNotMatch(config, /developer_instructions|notify-hook/g);
 	assert.equal(
 		existsSync(join(wd, ".codex", "skills", "ask", "SKILL.md")),
 		false,
@@ -276,6 +277,7 @@ async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {
 	assert.deepEqual(persisted, {
 		scope: "project",
 		installMode: "plugin",
+		mcpMode: "none",
 	});
 }
 
@@ -390,7 +392,7 @@ describe("omx setup install mode behavior", () => {
 
 					assert.match(
 						output,
-						/Setup preference review: keep \(scope=user, installMode=legacy\)/,
+						/Setup preference review: keep \(scope=user, installMode=legacy, mcpMode=not recorded\)/,
 					);
 					assert.match(
 						output,
@@ -433,7 +435,11 @@ describe("omx setup install mode behavior", () => {
 					const persisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+					assert.deepEqual(persisted, {
+						scope: "user",
+						installMode: "plugin",
+						mcpMode: "none",
+					});
 				});
 			});
 		} finally {
@@ -463,7 +469,7 @@ describe("omx setup install mode behavior", () => {
 					const persisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(persisted, { scope: "project" });
+					assert.deepEqual(persisted, { scope: "project", mcpMode: "none" });
 				});
 			});
 		} finally {
@@ -499,7 +505,11 @@ describe("omx setup install mode behavior", () => {
 					const persisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+					assert.deepEqual(persisted, {
+						scope: "user",
+						installMode: "plugin",
+						mcpMode: "none",
+					});
 				});
 			});
 		} finally {
@@ -535,7 +545,11 @@ describe("omx setup install mode behavior", () => {
 					const persisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+					assert.deepEqual(persisted, {
+						scope: "user",
+						installMode: "plugin",
+						mcpMode: "none",
+					});
 				});
 			});
 		} finally {
@@ -569,7 +583,11 @@ describe("omx setup install mode behavior", () => {
 					const persisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(persisted, { scope: "user", installMode: "legacy" });
+					assert.deepEqual(persisted, {
+						scope: "user",
+						installMode: "legacy",
+						mcpMode: "none",
+					});
 				});
 			});
 		} finally {
@@ -629,8 +647,46 @@ describe("omx setup install mode behavior", () => {
 
 			const persisted = JSON.parse(
 				await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
-			) as { scope: string; installMode?: string };
-			assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+			) as { scope: string; installMode?: string; mcpMode?: string };
+			assert.deepEqual(persisted, {
+				scope: "user",
+				installMode: "plugin",
+				mcpMode: "none",
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("defaults setup to no first-party MCP blocks", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-mcp-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy" });
+				});
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.doesNotMatch(config, /^\[mcp_servers\.omx_state\]$/m);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("emits first-party MCP blocks when compat MCP mode is requested", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-mcp-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy", mcpMode: "compat" });
+				});
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.match(config, /^\[mcp_servers\.omx_state\]$/m);
+				const persisted = JSON.parse(
+					await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+				) as { mcpMode?: string };
+				assert.equal(persisted.mcpMode, "compat");
+			});
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}
@@ -659,7 +715,11 @@ describe("omx setup install mode behavior", () => {
 					const persisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(persisted, { scope: "user", installMode: "plugin" });
+					assert.deepEqual(persisted, {
+						scope: "user",
+						installMode: "plugin",
+						mcpMode: "none",
+					});
 					assert.equal(
 						existsSync(join(codexHomeDir, "skills", "ask", "SKILL.md")),
 						false,
@@ -744,7 +804,7 @@ describe("omx setup install mode behavior", () => {
 			const persisted = JSON.parse(
 				await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 			) as { scope: string; installMode?: string };
-			assert.deepEqual(persisted, { scope: "project" });
+			assert.deepEqual(persisted, { scope: "project", mcpMode: "none" });
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}
@@ -762,7 +822,7 @@ describe("omx setup install mode behavior", () => {
 					const persisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(persisted, { scope: "project" });
+					assert.deepEqual(persisted, { scope: "project", mcpMode: "none" });
 					assert.equal(
 						existsSync(join(wd, ".codex", "skills", "ask", "SKILL.md")),
 						true,
@@ -773,7 +833,7 @@ describe("omx setup install mode behavior", () => {
 					const repeatedPersisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(repeatedPersisted, { scope: "project" });
+					assert.deepEqual(repeatedPersisted, { scope: "project", mcpMode: "none" });
 					assert.equal(
 						existsSync(join(wd, ".codex", "agents", "planner.toml")),
 						true,
@@ -801,7 +861,11 @@ describe("omx setup install mode behavior", () => {
 					const persisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(persisted, { scope: "user", installMode: "legacy" });
+					assert.deepEqual(persisted, {
+						scope: "user",
+						installMode: "legacy",
+						mcpMode: "none",
+					});
 					assert.equal(
 						existsSync(join(codexHomeDir, "skills", "ask", "SKILL.md")),
 						true,
@@ -953,6 +1017,55 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("enables plugin MCP subtables only when compat MCP mode is requested", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						mcpMode: "compat",
+						force: true,
+					});
+					let parsed = parseToml(await readFile(configPath, "utf-8")) as {
+						plugins?: Record<
+							string,
+							{ mcp_servers?: Record<string, { enabled?: boolean }> }
+						>;
+					};
+					assert.equal(
+						parsed.plugins?.["oh-my-codex@oh-my-codex-local"]?.mcp_servers
+							?.omx_state?.enabled,
+						true,
+					);
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						mcpMode: "none",
+						force: true,
+					});
+					parsed = parseToml(await readFile(configPath, "utf-8")) as {
+						plugins?: Record<
+							string,
+							{ mcp_servers?: Record<string, { enabled?: boolean }> }
+						>;
+					};
+					assert.equal(
+						parsed.plugins?.["oh-my-codex@oh-my-codex-local"]?.mcp_servers
+							?.omx_state?.enabled,
+						false,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("reports plugin marketplace registration during dry-run without mutating config", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
@@ -1022,7 +1135,7 @@ describe("omx setup install mode behavior", () => {
 					assert.match(config, /^trusted_hash = "sha256:[a-f0-9]{64}"$/m);
 					assert.doesNotMatch(
 						config,
-						/developer_instructions|notify-hook|mcp_servers/,
+						/developer_instructions|notify-hook/g,
 					);
 					assert.equal(
 						existsSync(join(codexHomeDir, "skills", "ask", "SKILL.md")),
@@ -1091,7 +1204,9 @@ describe("omx setup install mode behavior", () => {
 					assert.doesNotMatch(config, /Native subagents live in \.codex\/agents/);
 					assert.doesNotMatch(config, /Treat installed prompts as narrower execution surfaces/);
 					assert.match(config, /^hooks = true$/m);
-					assert.doesNotMatch(config, /notify-hook|mcp_servers/);
+					assert.doesNotMatch(config, /notify-hook/);
+					assert.doesNotMatch(config, /^\s*\[mcp_servers[.\]]/m);
+					assert.match(config, /mcp_servers\.omx_state]\nenabled = false/);
 
 					const agentsMd = await readFile(
 						join(codexHomeDir, "AGENTS.md"),
@@ -1284,6 +1399,7 @@ describe("omx setup install mode behavior", () => {
 				assert.deepEqual(persisted, {
 					scope: "project",
 					installMode: "plugin",
+					mcpMode: "none",
 				});
 
 				await setup({ scope: "project" });
@@ -1323,7 +1439,7 @@ describe("omx setup install mode behavior", () => {
 				const persisted = JSON.parse(
 					await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 				) as { scope: string; installMode?: string };
-				assert.deepEqual(persisted, { scope: "project" });
+				assert.deepEqual(persisted, { scope: "project", mcpMode: "none" });
 				assert.equal(
 					existsSync(join(wd, ".codex", "skills", "ask", "SKILL.md")),
 					true,
@@ -1361,6 +1477,7 @@ describe("omx setup install mode behavior", () => {
 					assert.deepEqual(persisted, {
 						scope: "user",
 						installMode: "legacy",
+						mcpMode: "none",
 					});
 					assert.equal(
 						existsSync(join(codexHomeDir, "skills", "ask", "SKILL.md")),
@@ -1428,6 +1545,7 @@ describe("omx setup install mode behavior", () => {
 					assert.deepEqual(persisted, {
 						scope: "user",
 						installMode: "legacy",
+						mcpMode: "none",
 					});
 				});
 			});

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -550,6 +550,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
 
       await runSetupInTempDir(wd, {
         scope: "project",
+        mcpMode: "compat",
         mcpRegistryCandidates: [registryPath],
       });
 
@@ -558,6 +559,65 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       assert.match(config, /^\[mcp_servers\.eslint\]$/m);
       assert.match(config, /^command = "npx"$/m);
       assert.match(config, /^startup_timeout_sec = 9$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("syncs shared MCP registry entries during plugin-mode compat setup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      const registryPath = join(wd, "mcp-registry.json");
+      await writeFile(
+        registryPath,
+        JSON.stringify({
+          eslint: { command: "npx", args: ["@eslint/mcp@latest"], timeout: 9 },
+        }),
+      );
+
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        installMode: "plugin",
+        mcpMode: "compat",
+        mcpRegistryCandidates: [registryPath],
+      });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.match(config, /oh-my-codex \(OMX\) Shared MCP Registry Sync/);
+      assert.match(config, /^\[mcp_servers\.eslint\]$/m);
+      assert.match(config, /^command = "npx"$/m);
+      assert.match(config, /^startup_timeout_sec = 9$/m);
+      assert.match(
+        config,
+        /^\[plugins\."oh-my-codex@oh-my-codex-local"\.mcp_servers\.omx_state\]$/m,
+      );
+      assert.match(config, /^enabled = true$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not sync shared MCP registry entries without compat MCP mode", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      const registryPath = join(wd, "mcp-registry.json");
+      await writeFile(
+        registryPath,
+        JSON.stringify({
+          eslint: { command: "npx", args: ["@eslint/mcp@latest"], timeout: 9 },
+        }),
+      );
+
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        mcpRegistryCandidates: [registryPath],
+      });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.doesNotMatch(config, /oh-my-codex \(OMX\) Shared MCP Registry Sync/);
+      assert.doesNotMatch(config, /^\[mcp_servers\.eslint\]$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -659,10 +719,12 @@ describe("omx setup refresh summary and dry-run behavior", () => {
 
       await runSetupInTempDir(wd, {
         scope: "user",
+        mcpMode: "compat",
         mcpRegistryCandidates: [registryPath],
       });
       await runSetupInTempDir(wd, {
         scope: "user",
+        mcpMode: "compat",
         mcpRegistryCandidates: [registryPath],
       });
 
@@ -701,6 +763,44 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("does not sync shared MCP registry entries into Claude settings without compat MCP mode", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    const previousHome = process.env.HOME;
+    const previousCodexHome = process.env.CODEX_HOME;
+    try {
+      process.env.HOME = wd;
+      delete process.env.CODEX_HOME;
+
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      await mkdir(join(wd, ".claude"), { recursive: true });
+      const existingSettings = JSON.stringify({ uiTheme: "dark" }, null, 2) + "\n";
+      await writeFile(join(wd, ".claude", "settings.json"), existingSettings);
+      const registryPath = join(wd, "mcp-registry.json");
+      await writeFile(
+        registryPath,
+        JSON.stringify({
+          eslint: { command: "npx", args: ["@eslint/mcp@latest"] },
+        }),
+      );
+
+      await runSetupInTempDir(wd, {
+        scope: "user",
+        mcpRegistryCandidates: [registryPath],
+      });
+
+      assert.equal(
+        await readFile(join(wd, ".claude", "settings.json"), "utf-8"),
+        existingSettings,
+      );
+    } finally {
+      if (typeof previousHome === "string") process.env.HOME = previousHome;
+      else delete process.env.HOME;
+      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("does not write ~/.claude/settings.json during project-scoped setup", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     const previousHome = process.env.HOME;
@@ -720,6 +820,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
 
       await runSetupInTempDir(wd, {
         scope: "project",
+        mcpMode: "compat",
         mcpRegistryCandidates: [registryPath],
       });
 
@@ -733,7 +834,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
-  it("ignores legacy ~/.omc/mcp-registry.json during setup unless candidates are passed explicitly", async () => {
+  it("ignores legacy ~/.omc/mcp-registry.json during setup by default", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     const previousHome = process.env.HOME;
     const previousCodexHome = process.env.CODEX_HOME;
@@ -757,8 +858,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       assert.doesNotMatch(config, /Shared MCP Server: legacy_helper/);
 
       const output = await runSetupWithCapturedLogs(wd, { scope: "project" });
-      assert.match(output, /legacy shared MCP registry detected at .*\.omc\/mcp-registry\.json but ignored by default/i);
-      assert.match(output, /move it to .*\.omx\/mcp-registry\.json/i);
+      assert.doesNotMatch(output, /legacy shared MCP registry detected/i);
     } finally {
       if (typeof previousHome === "string") process.env.HOME = previousHome;
       else delete process.env.HOME;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -54,9 +54,11 @@ import { readTriageConfig } from "../hooks/triage-config.js";
 import {
 	readPersistedSetupPreferences,
 	type SetupInstallMode,
+	type SetupMcpMode,
 } from "./setup-preferences.js";
 import {
 	OMX_LOCAL_MARKETPLACE_NAME,
+	OMX_LOCAL_PLUGIN_CONFIG_KEY,
 	resolvePackagedOmxMarketplace,
 } from "./plugin-marketplace.js";
 
@@ -79,6 +81,7 @@ interface DoctorScopeResolution {
 	scope: DoctorSetupScope;
 	source: "persisted" | "default";
 	installMode?: SetupInstallMode;
+	mcpMode?: SetupMcpMode;
 }
 
 interface DoctorPaths {
@@ -97,6 +100,7 @@ async function resolveDoctorScope(cwd: string): Promise<DoctorScopeResolution> {
 			scope: persisted.scope,
 			source: "persisted",
 			installMode: persisted.installMode,
+			mcpMode: persisted.mcpMode ?? "none",
 		};
 	}
 
@@ -148,6 +152,11 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	if (scopeResolution.installMode) {
 		console.log(
 			`Resolved setup install mode: ${scopeResolution.installMode}${scopeSourceMessage}`,
+		);
+	}
+	if (scopeResolution.mcpMode) {
+		console.log(
+			`Resolved setup MCP mode: ${scopeResolution.mcpMode}${scopeSourceMessage}`,
 		);
 	}
 	console.log();
@@ -220,7 +229,11 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
 	// Check 9: MCP servers configured
 	checks.push(
-		await checkMcpServers(paths.configPath, scopeResolution.installMode),
+		await checkMcpServers(
+			paths.configPath,
+			scopeResolution.installMode,
+			scopeResolution.mcpMode,
+		),
 	);
 
 	// Check 10: Prompt triage
@@ -1475,9 +1488,56 @@ function checkPromptTriage(): Check {
 	}
 }
 
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function pluginMcpServerEnabled(content: string, serverName: string): boolean | null {
+	const headerPattern = new RegExp(
+		`^\\s*\\[plugins\\.${escapeRegExp(JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY))}\\.mcp_servers\\.${escapeRegExp(serverName)}\\]\\s*$`,
+	);
+	const lines = content.split(/\r?\n/);
+	const start = lines.findIndex((line) => headerPattern.test(line));
+	if (start < 0) return null;
+	for (let index = start + 1; index < lines.length; index += 1) {
+		const line = lines[index];
+		if (/^\s*\[/.test(line)) break;
+		const enabledMatch = line.match(/^\s*enabled\s*=\s*(true|false)\s*$/);
+		if (enabledMatch) return enabledMatch[1] === "true";
+	}
+	return null;
+}
+
+function describePluginMcpState(content: string, mcpMode?: SetupMcpMode): Check {
+	const states = OMX_FIRST_PARTY_MCP_SERVER_NAMES.map((serverName) =>
+		pluginMcpServerEnabled(content, serverName),
+	);
+	const enabledCount = states.filter((state) => state === true).length;
+	const disabledCount = states.filter((state) => state === false).length;
+	const missingCount = states.filter((state) => state === null).length;
+	const expectedEnabled = mcpMode === "compat";
+
+	if (missingCount === 0 && enabledCount === (expectedEnabled ? states.length : 0)) {
+		return {
+			name: "MCP Servers",
+			status: "pass",
+			message: expectedEnabled
+				? `plugin MCP compatibility enabled by setup MCP mode compat (${enabledCount}/${states.length} first-party servers enabled)`
+				: `CLI-first plugin mode: first-party MCP compatibility explicitly disabled (${disabledCount}/${states.length} first-party servers disabled)`,
+		};
+	}
+
+	return {
+		name: "MCP Servers",
+		status: "warn",
+		message: `plugin MCP compatibility overrides are incomplete or mixed (enabled=${enabledCount}, disabled=${disabledCount}, missing=${missingCount}); run "omx setup --plugin --force --mcp ${mcpMode ?? "none"}" to repair`,
+	};
+}
+
 async function checkMcpServers(
 	configPath: string,
 	installMode?: SetupInstallMode,
+	mcpMode?: SetupMcpMode,
 ): Promise<Check> {
 	if (!existsSync(configPath)) {
 		if (installMode === "plugin") {
@@ -1505,34 +1565,29 @@ async function checkMcpServers(
 			};
 		}
 		if (installMode === "plugin") {
-			return {
-				name: "MCP Servers",
-				status: "pass",
-				message:
-					"plugin mode uses plugin-scoped MCP metadata; setup-owned OMX MCP tables are intentionally omitted",
-			};
+			return describePluginMcpState(content, mcpMode);
 		}
 		if (mcpCount > 0) {
 			const hasOmx = OMX_FIRST_PARTY_MCP_SERVER_NAMES.some((name) =>
-				content.includes(name),
+				content.includes(`[mcp_servers.${name}]`),
 			);
 			if (hasOmx) {
 				return {
 					name: "MCP Servers",
 					status: "pass",
-					message: `${mcpCount} servers configured (OMX present)`,
+					message: `${mcpCount} servers configured; first-party OMX MCP compatibility is explicitly present`,
 				};
 			}
 			return {
 				name: "MCP Servers",
-				status: "warn",
-				message: `${mcpCount} servers but no OMX servers yet (expected before first setup; run "omx setup --force" once)`,
+				status: "pass",
+				message: `${mcpCount} user-managed MCP server(s) preserved; first-party OMX MCP omitted by default`,
 			};
 		}
 		return {
 			name: "MCP Servers",
-			status: "warn",
-			message: "no MCP servers configured",
+			status: "pass",
+			message: "CLI-first default: no first-party OMX MCP servers configured",
 		};
 	} catch {
 		return {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -463,7 +463,7 @@ export function resolveSetupMcpModeArg(args: string[]): SetupMcpMode | undefined
     }
     value = next;
   };
-  const parseValue = (next: string, source: string): SetupMcpMode => {
+  const parseValue = (next: string, _source: string): SetupMcpMode => {
     if (!SETUP_MCP_MODES.includes(next as SetupMcpMode)) {
       throw new Error(
         `Invalid setup MCP mode: ${next}. Expected one of: none, compat`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -64,6 +64,7 @@ import {
 } from "../mcp/state-paths.js";
 import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
 import {
+  readPersistedSetupPreferences,
   resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
   resolveProjectLocalCodexHomeForLaunch,
@@ -119,7 +120,9 @@ import {
 } from "../team/tmux-session.js";
 import { getPackageRoot } from "../utils/package.js";
 import { codexConfigPath, omxRoot, rememberOmxLaunchContext, resolveOmxEntryPath } from "../utils/paths.js";
-import { cleanCodexModelAvailabilityNuxIfNeeded, repairConfigIfNeeded, upsertManagedCodexHookTrustState } from "../config/generator.js";
+import { cleanCodexModelAvailabilityNuxIfNeeded, extractSharedMcpRegistryServersFromConfig, repairConfigIfNeeded, upsertManagedCodexHookTrustState } from "../config/generator.js";
+import type { UnifiedMcpRegistryServer } from "../config/mcp-registry.js";
+import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
 import { OMX_TMUX_HUD_OWNER_ENV } from "../hud/reconcile.js";
 import {
@@ -463,7 +466,7 @@ export function resolveSetupMcpModeArg(args: string[]): SetupMcpMode | undefined
     }
     value = next;
   };
-  const parseValue = (next: string, _source: string): SetupMcpMode => {
+  const parseValue = (next: string): SetupMcpMode => {
     if (!SETUP_MCP_MODES.includes(next as SetupMcpMode)) {
       throw new Error(
         `Invalid setup MCP mode: ${next}. Expected one of: none, compat`,
@@ -489,12 +492,12 @@ export function resolveSetupMcpModeArg(args: string[]): SetupMcpMode | undefined
           `Missing setup MCP mode value after --mcp. Expected one of: none, compat`,
         );
       }
-      setValue(parseValue(next, arg), arg);
+      setValue(parseValue(next), arg);
       index += 1;
       continue;
     }
     if (arg.startsWith("--mcp=")) {
-      setValue(parseValue(arg.slice("--mcp=".length), "--mcp"), "--mcp");
+      setValue(parseValue(arg.slice("--mcp=".length)), "--mcp");
     }
   }
 
@@ -1011,6 +1014,52 @@ export function classifyCodexExecFailure(
     kind: "launch-error",
     code,
     message,
+  };
+}
+
+export async function resolveLaunchConfigRepairOptions(
+  cwd: string,
+  configPath: string,
+): Promise<{
+  includeFirstPartyMcp: boolean;
+  sharedMcpServers?: UnifiedMcpRegistryServer[];
+  sharedMcpRegistrySource?: string;
+}> {
+  let content: string | undefined;
+  const readConfig = async (): Promise<string | undefined> => {
+    if (content !== undefined) return content;
+    if (!existsSync(configPath)) return undefined;
+    content = await readFile(configPath, "utf-8");
+    return content;
+  };
+
+  const existingContent = await readConfig();
+  const sharedMcpRegistry = existingContent
+    ? extractSharedMcpRegistryServersFromConfig(existingContent)
+    : { servers: [] };
+  const sharedMcpOptions =
+    sharedMcpRegistry.servers.length > 0
+      ? {
+          sharedMcpServers: sharedMcpRegistry.servers,
+          sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
+        }
+      : {};
+
+  if (readPersistedSetupPreferences(cwd)?.mcpMode === "compat") {
+    return { includeFirstPartyMcp: true, ...sharedMcpOptions };
+  }
+
+  if (existingContent) {
+    const hasExistingFirstPartyMcp = OMX_FIRST_PARTY_MCP_SERVER_NAMES.some((name) =>
+      new RegExp(`^\\s*\\[mcp_servers\\.${name}\\]\\s*$`, "m").test(existingContent),
+    );
+    if (hasExistingFirstPartyMcp || sharedMcpRegistry.servers.length > 0) {
+      return { includeFirstPartyMcp: hasExistingFirstPartyMcp, ...sharedMcpOptions };
+    }
+  }
+
+  return {
+    includeFirstPartyMcp: false,
   };
 }
 
@@ -1569,9 +1618,11 @@ export async function launchWithHud(args: string[]): Promise<void> {
   // have written a config.toml with duplicate [tui] sections.  Codex CLI's
   // TOML parser rejects duplicates, so we repair before spawning the CLI.
   try {
+    const configPath = resolveCodexConfigPathForLaunch(launchCwd, process.env);
     const repaired = await repairConfigIfNeeded(
-      resolveCodexConfigPathForLaunch(launchCwd, process.env),
+      configPath,
       getPackageRoot(),
+      await resolveLaunchConfigRepairOptions(launchCwd, configPath),
     );
     if (repaired) {
       console.log("[omx] Repaired managed config.toml compatibility issue.");
@@ -1680,9 +1731,11 @@ export async function execWithOverlay(args: string[]): Promise<void> {
   }
 
   try {
+    const configPath = resolveCodexConfigPathForLaunch(launchCwd, process.env);
     const repaired = await repairConfigIfNeeded(
-      resolveCodexConfigPathForLaunch(launchCwd, process.env),
+      configPath,
       getPackageRoot(),
+      await resolveLaunchConfigRepairOptions(launchCwd, configPath),
     );
     if (repaired) {
       console.log("[omx] Repaired managed config.toml compatibility issue.");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,7 +8,14 @@ import { basename, dirname, join, posix, win32 } from "path";
 import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, symlink, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
-import { setup, SETUP_SCOPES, type SetupInstallMode, type SetupScope } from "./setup.js";
+import {
+  setup,
+  SETUP_MCP_MODES,
+  SETUP_SCOPES,
+  type SetupInstallMode,
+  type SetupMcpMode,
+  type SetupScope,
+} from "./setup.js";
 import { uninstall } from "./uninstall.js";
 import { version } from "./version.js";
 import { tmuxHookCommand } from "./tmux-hook.js";
@@ -179,7 +186,7 @@ Usage:
                 Queue audited follow-up instructions for a running non-interactive exec job
   omx imagegen continuation <session-id> --artifact <name>
                 Queue a Stop-hook continuation for built-in image generation turns
-  omx setup     Install skills, prompts, MCP servers, and scope-specific AGENTS.md
+  omx setup     Install skills, prompts, CLI-first config, and scope-specific AGENTS.md
                 (user scope prompts for legacy vs plugin skill delivery when needed)
   omx update    Check npm now, update the global install immediately, then refresh setup
   omx uninstall Remove OMX configuration and clean up installed artifacts
@@ -212,13 +219,13 @@ Usage:
   omx hud       Show HUD statusline (--watch, --json, --preset=NAME)
   omx sidecar   Show read-only team/multi-agent visualization (--watch, --json, --tmux)
   omx state     Read/write/list OMX mode state via CLI parity surface
-  omx notepad   CLI parity for OMX notepad MCP tools
+  omx notepad   JSON CLI surface for OMX notepad operations
   omx project-memory
-                CLI parity for OMX project-memory MCP tools
-  omx trace     CLI parity for OMX trace MCP tools
+                JSON CLI surface for OMX project-memory operations
+  omx trace     JSON CLI surface for OMX trace operations
   omx code-intel
-                CLI parity for OMX code-intel MCP tools
-  omx wiki      CLI parity for OMX wiki MCP tools
+                JSON CLI surface for OMX code-intel operations
+  omx wiki      JSON CLI surface for OMX wiki operations
   omx mcp-serve Launch an OMX stdio MCP server target (plugin/runtime use)
   omx sparkshell <command> [args...]
   omx sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]
@@ -260,6 +267,10 @@ Options:
   --legacy      Use legacy setup delivery for omx setup, overriding persisted plugin mode
   --install-mode <legacy|plugin>
                 Explicit setup install mode (canonical form; --legacy/--plugin are aliases)
+  --mcp <none|compat>
+                Explicit setup MCP mode (default: none; compat enables first-party MCP compatibility and shared registry sync)
+  --no-mcp      Alias for --mcp=none
+  --with-mcp    Alias for --mcp=compat
   --keep-config Skip config.toml cleanup during uninstall
   --purge       Remove .omx/ cache directory during uninstall
   --verbose     Show detailed output
@@ -435,6 +446,55 @@ export function resolveSetupInstallModeArg(args: string[]): SetupInstallMode | u
         );
       }
       setValue(next, "--install-mode");
+    }
+  }
+
+  return value;
+}
+
+
+export function resolveSetupMcpModeArg(args: string[]): SetupMcpMode | undefined {
+  let value: SetupMcpMode | undefined;
+  const setValue = (next: SetupMcpMode, source: string): void => {
+    if (value && value !== next) {
+      throw new Error(
+        `Conflicting setup MCP mode flags: ${source} selects ${next}, but another flag already selected ${value}`,
+      );
+    }
+    value = next;
+  };
+  const parseValue = (next: string, source: string): SetupMcpMode => {
+    if (!SETUP_MCP_MODES.includes(next as SetupMcpMode)) {
+      throw new Error(
+        `Invalid setup MCP mode: ${next}. Expected one of: none, compat`,
+      );
+    }
+    return next as SetupMcpMode;
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--no-mcp") {
+      setValue("none", arg);
+      continue;
+    }
+    if (arg === "--with-mcp") {
+      setValue("compat", arg);
+      continue;
+    }
+    if (arg === "--mcp") {
+      const next = args[index + 1];
+      if (!next || next.startsWith("-")) {
+        throw new Error(
+          `Missing setup MCP mode value after --mcp. Expected one of: none, compat`,
+        );
+      }
+      setValue(parseValue(next, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--mcp=")) {
+      setValue(parseValue(arg.slice("--mcp=".length), "--mcp"), "--mcp");
     }
   }
 
@@ -1185,6 +1245,7 @@ export async function main(args: string[]): Promise<void> {
           verbose: options.verbose,
           scope: resolveSetupScopeArg(args.slice(1)),
           installMode: resolveSetupInstallModeArg(args.slice(1)),
+          mcpMode: resolveSetupMcpModeArg(args.slice(1)),
         });
         break;
       case "update":

--- a/src/cli/mcp-parity.ts
+++ b/src/cli/mcp-parity.ts
@@ -188,7 +188,7 @@ async function loadStateDescriptor(): Promise<McpCliDescriptor> {
   );
   return {
     commandName: "state",
-    title: "CLI parity surface for OMX state MCP tools.",
+    title: "JSON CLI surface for OMX state operations.",
     tools: buildStateServerTools().map(({ name, description }) => ({ name, description })),
     aliases: {
       read: "state_read",
@@ -242,7 +242,7 @@ async function loadTraceDescriptor(): Promise<McpCliDescriptor> {
   );
   return {
     commandName: "trace",
-    title: "CLI parity surface for OMX trace MCP tools.",
+    title: "JSON CLI surface for OMX trace operations.",
     tools: buildTraceServerTools().map(({ name, description }) => ({ name, description })),
     aliases: {
       timeline: "trace_timeline",
@@ -259,7 +259,7 @@ async function loadCodeIntelDescriptor(): Promise<McpCliDescriptor> {
   );
   return {
     commandName: "code-intel",
-    title: "CLI parity surface for OMX code-intel MCP tools.",
+    title: "JSON CLI surface for OMX code-intel operations.",
     tools: buildCodeIntelServerTools().map(({ name, description }) => ({ name, description })),
     handle: handleCodeIntelToolCall,
   };
@@ -272,7 +272,7 @@ async function loadWikiDescriptor(): Promise<McpCliDescriptor> {
   );
   return {
     commandName: "wiki",
-    title: "CLI parity surface for OMX wiki MCP tools.",
+    title: "JSON CLI surface for OMX wiki operations.",
     tools: buildWikiServerTools().map(({ name, description }) => ({ name, description })),
     aliases: {
       ingest: "wiki_ingest",
@@ -299,7 +299,7 @@ export async function mcpParityCommand(
     case "notepad":
       await runDescriptorCommand(
         args,
-        async () => await loadMemoryDescriptor("notepad", "notepad_", "CLI parity surface for OMX notepad MCP tools."),
+        async () => await loadMemoryDescriptor("notepad", "notepad_", "JSON CLI surface for OMX notepad operations."),
       );
       return;
     case "project-memory":
@@ -308,7 +308,7 @@ export async function mcpParityCommand(
         async () => await loadMemoryDescriptor(
           "project-memory",
           "project_memory_",
-          "CLI parity surface for OMX project-memory MCP tools.",
+          "JSON CLI surface for OMX project-memory operations.",
         ),
       );
       return;
@@ -334,7 +334,7 @@ export async function executeMcpParityCommand(
     case "notepad":
       return await executeDescriptorCommand(
         args,
-        async () => await loadMemoryDescriptor("notepad", "notepad_", "CLI parity surface for OMX notepad MCP tools."),
+        async () => await loadMemoryDescriptor("notepad", "notepad_", "JSON CLI surface for OMX notepad operations."),
       );
     case "project-memory":
       return await executeDescriptorCommand(
@@ -342,7 +342,7 @@ export async function executeMcpParityCommand(
         async () => await loadMemoryDescriptor(
           "project-memory",
           "project_memory_",
-          "CLI parity surface for OMX project-memory MCP tools.",
+          "JSON CLI surface for OMX project-memory operations.",
         ),
       );
     case "trace":

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { join, resolve } from "path";
+import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 
 export const OMX_LOCAL_MARKETPLACE_NAME = "oh-my-codex-local";
 export const OMX_PLUGIN_NAME = "oh-my-codex";
@@ -132,6 +133,58 @@ function localPluginTableHeaderPattern(): RegExp {
 	);
 }
 
+function localPluginMcpServerTableHeaderPattern(serverName: string): RegExp {
+	return new RegExp(
+		`^\\s*\\[plugins\\.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.mcp_servers\\.${serverName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\]\\s*$`,
+	);
+}
+
+function upsertTomlTableBooleanKey(
+	config: string,
+	header: string,
+	headerPattern: RegExp,
+	key: string,
+	value: boolean,
+	options: { create: boolean },
+): string {
+	const lines = config.split(/\r?\n/);
+	const start = lines.findIndex((line) => headerPattern.test(line));
+
+	if (start < 0) {
+		if (!options.create) return config;
+		const base = config.trimEnd();
+		return `${base ? `${base}\n\n` : ""}${header}\n${key} = ${value ? "true" : "false"}\n`;
+	}
+
+	let end = lines.length;
+	for (let index = start + 1; index < lines.length; index += 1) {
+		if (isTomlTableHeader(lines[index])) {
+			end = index;
+			break;
+		}
+	}
+
+	let keyIndex = -1;
+	for (let index = start + 1; index < end; index += 1) {
+		if (new RegExp(`^\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=`).test(lines[index])) {
+			if (keyIndex < 0) {
+				keyIndex = index;
+				lines[index] = `${key} = ${value ? "true" : "false"}`;
+			} else {
+				lines.splice(index, 1);
+				index -= 1;
+				end -= 1;
+			}
+		}
+	}
+
+	if (keyIndex < 0) {
+		lines.splice(start + 1, 0, `${key} = ${value ? "true" : "false"}`);
+	}
+
+	return lines.join("\n").replace(/\n*$/, "\n");
+}
+
 export function upsertLocalOmxPluginEnablement(config: string): string {
 	const lines = config.split(/\r?\n/);
 	const headerPattern = localPluginTableHeaderPattern();
@@ -169,4 +222,19 @@ export function upsertLocalOmxPluginEnablement(config: string): string {
 	}
 
 	return lines.join("\n").replace(/\n*$/, "\n");
+}
+
+export function upsertLocalOmxPluginMcpServerEnablement(
+	config: string,
+	enabled: boolean,
+): string {
+	let next = config;
+	for (const serverName of OMX_FIRST_PARTY_MCP_SERVER_NAMES) {
+		const header = `[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}.mcp_servers.${serverName}]`;
+		const headerPattern = localPluginMcpServerTableHeaderPattern(serverName);
+		next = upsertTomlTableBooleanKey(next, header, headerPattern, "enabled", enabled, {
+			create: true,
+		});
+	}
+	return next;
 }

--- a/src/cli/setup-preferences.ts
+++ b/src/cli/setup-preferences.ts
@@ -8,9 +8,13 @@ export type SetupScope = (typeof SETUP_SCOPES)[number];
 export const SETUP_INSTALL_MODES = ["legacy", "plugin"] as const;
 export type SetupInstallMode = (typeof SETUP_INSTALL_MODES)[number];
 
+export const SETUP_MCP_MODES = ["none", "compat"] as const;
+export type SetupMcpMode = (typeof SETUP_MCP_MODES)[number];
+
 export interface PersistedSetupScope {
 	scope: SetupScope;
 	installMode?: SetupInstallMode;
+	mcpMode?: SetupMcpMode;
 }
 
 export type PartialPersistedSetupScope = Partial<PersistedSetupScope>;
@@ -27,6 +31,10 @@ export function isSetupInstallMode(value: string): value is SetupInstallMode {
 	return SETUP_INSTALL_MODES.includes(value as SetupInstallMode);
 }
 
+export function isSetupMcpMode(value: string): value is SetupMcpMode {
+	return SETUP_MCP_MODES.includes(value as SetupMcpMode);
+}
+
 export function getSetupScopeFilePath(projectRoot: string): string {
 	return join(projectRoot, ".omx", "setup-scope.json");
 }
@@ -38,6 +46,7 @@ function parsePersistedSetupPreferences(
 	const parsed = JSON.parse(raw) as Partial<{
 		scope: unknown;
 		installMode: unknown;
+		mcpMode: unknown;
 	}>;
 	const persisted: PartialPersistedSetupScope = {};
 
@@ -57,6 +66,10 @@ function parsePersistedSetupPreferences(
 		isSetupInstallMode(parsed.installMode)
 	) {
 		persisted.installMode = parsed.installMode;
+	}
+
+	if (typeof parsed.mcpMode === "string" && isSetupMcpMode(parsed.mcpMode)) {
+		persisted.mcpMode = parsed.mcpMode;
 	}
 
 	return Object.keys(persisted).length > 0 ? persisted : undefined;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -39,6 +39,7 @@ import {
 	sanitizePreviousNotifyCommand,
 	stripExistingOmxBlocks,
 	stripExistingSharedMcpRegistryBlock,
+	mergeSharedMcpRegistryBlock,
 	stripOmxEnvSettings,
 	stripOmxFeatureFlags,
 	stripOmxSeededBehavioralDefaults,
@@ -78,11 +79,13 @@ import {
 import { DEFAULT_HUD_CONFIG, type HudPreset } from "../hud/types.js";
 import {
 	SETUP_INSTALL_MODES,
+	SETUP_MCP_MODES,
 	SETUP_SCOPES,
 	getSetupScopeFilePath,
 	readPersistedSetupPreferences,
 	type PersistedSetupScope,
 	type SetupInstallMode,
+	type SetupMcpMode,
 	type SetupScope,
 } from "./setup-preferences.js";
 import {
@@ -90,6 +93,7 @@ import {
 	resolvePackagedOmxMarketplace,
 	upsertLocalOmxMarketplaceRegistration,
 	upsertLocalOmxPluginEnablement,
+	upsertLocalOmxPluginMcpServerEnablement,
 } from "./plugin-marketplace.js";
 import { resolveCodexHookFeatureFlagForCli } from "./codex-feature-probe.js";
 
@@ -127,6 +131,7 @@ interface SetupOptions {
 	mergeAgents?: boolean;
 	dryRun?: boolean;
 	installMode?: SetupInstallMode;
+	mcpMode?: SetupMcpMode;
 	scope?: SetupScope;
 	verbose?: boolean;
 	agentsOverwritePrompt?: (destinationPath: string) => Promise<boolean>;
@@ -149,8 +154,8 @@ interface SetupOptions {
 	mcpRegistryCandidates?: string[];
 }
 
-export { SETUP_INSTALL_MODES, SETUP_SCOPES };
-export type { SetupInstallMode, SetupScope };
+export { SETUP_INSTALL_MODES, SETUP_MCP_MODES, SETUP_SCOPES };
+export type { SetupInstallMode, SetupMcpMode, SetupScope };
 
 export interface ScopeDirectories {
 	codexConfigFile: string;
@@ -211,6 +216,7 @@ const PROJECT_GITIGNORE_ENTRIES = [
 ] as const;
 const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".codex/"] as const;
 const SETUP_ONLY_INSTALLABLE_SKILLS = new Set(["wiki"]);
+const DEFAULT_SETUP_MCP_MODE: SetupMcpMode = "none";
 const HARD_DEPRECATED_SKILL_NAMES = new Set(["web-clone"]);
 
 function isCatalogInstallableStatus(status: string | undefined): boolean {
@@ -263,6 +269,11 @@ interface ResolvedSetupScope {
 interface ResolvedSetupInstallMode {
 	installMode: SetupInstallMode;
 	source: "cli" | "persisted" | "prompt" | "default";
+}
+
+interface ResolvedSetupMcpMode {
+	mcpMode: SetupMcpMode;
+	source: "cli" | "persisted" | "default";
 }
 
 type PersistedSetupReviewDecision = "keep" | "review" | "reset";
@@ -631,6 +642,7 @@ function formatPersistedSetupPreferenceSummary(
 	return [
 		`scope=${preferences.scope ?? "not recorded"}`,
 		`installMode=${preferences.installMode ?? "not recorded"}`,
+		`mcpMode=${preferences.mcpMode ?? "not recorded"}`,
 	].join(", ");
 }
 
@@ -993,6 +1005,26 @@ async function refreshOmxPluginDiscoveryCache(
 		status: staleDirs.length > 0 ? "refreshed" : "unchanged",
 		staleDirs,
 	};
+}
+
+
+function resolveSetupMcpMode(
+	scope: SetupScope,
+	requestedMcpMode: SetupMcpMode | undefined,
+	persistedReviewDecision: PersistedSetupReviewDecision,
+	persistedPreferences?: Partial<PersistedSetupScope>,
+): ResolvedSetupMcpMode {
+	if (requestedMcpMode) {
+		return { mcpMode: requestedMcpMode, source: "cli" };
+	}
+	if (
+		persistedPreferences?.mcpMode &&
+		persistedReviewDecision === "keep" &&
+		persistedPreferences.scope === scope
+	) {
+		return { mcpMode: persistedPreferences.mcpMode, source: "persisted" };
+	}
+	return { mcpMode: DEFAULT_SETUP_MCP_MODE, source: "default" };
 }
 
 async function resolveSetupInstallMode(
@@ -1364,6 +1396,7 @@ function insertRootTomlKey(config: string, line: string): string {
 async function ensurePluginMarketplaceRegistration(
 	configPath: string,
 	pkgRoot: string,
+	mcpMode: SetupMcpMode,
 	backupContext: SetupBackupContext,
 	summary: SetupCategorySummary,
 	options: Pick<SetupOptions, "dryRun" | "verbose">,
@@ -1378,7 +1411,10 @@ async function ensurePluginMarketplaceRegistration(
 		? await readFile(configPath, "utf-8")
 		: "";
 	const nextConfig = upsertLocalOmxMarketplaceRegistration(
-		upsertLocalOmxPluginEnablement(existingConfig),
+		upsertLocalOmxPluginMcpServerEnablement(
+			upsertLocalOmxPluginEnablement(existingConfig),
+			mcpMode === "compat",
+		),
 		pkgRoot,
 	);
 	const destinationExists = existsSync(configPath);
@@ -1593,6 +1629,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		force = false,
 		dryRun = false,
 		installMode: requestedInstallMode,
+		mcpMode: requestedMcpMode,
 		scope: requestedScope,
 		verbose = false,
 		setupScopePrompt,
@@ -1619,9 +1656,14 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		Boolean(persistedPreferences?.installMode) &&
 		(!persistedPreferences?.scope ||
 			persistedPreferences.scope === effectiveScopeForInstallMode);
+	const wouldUsePersistedMcpMode =
+		!requestedMcpMode &&
+		Boolean(persistedPreferences?.mcpMode) &&
+		(!persistedPreferences?.scope ||
+			persistedPreferences.scope === effectiveScopeForInstallMode);
 	const shouldReviewPersistedSetup =
 		hasPersistedSetupPreferences(persistedPreferences) &&
-		(wouldUsePersistedScope || wouldUsePersistedInstallMode) &&
+		(wouldUsePersistedScope || wouldUsePersistedInstallMode || wouldUsePersistedMcpMode) &&
 		(typeof persistedSetupReviewPrompt === "function" ||
 			(process.stdin.isTTY && process.stdout.isTTY));
 	if (shouldReviewPersistedSetup) {
@@ -1644,6 +1686,12 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		resolvedScope.scope,
 		requestedInstallMode,
 		installModePrompt,
+		persistedReviewDecision,
+		persistedPreferences,
+	);
+	const resolvedMcpMode = resolveSetupMcpMode(
+		resolvedScope.scope,
+		requestedMcpMode,
 		persistedReviewDecision,
 		persistedPreferences,
 	);
@@ -1683,6 +1731,13 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			`Using setup install mode: ${resolvedInstallMode.installMode}${installModeSourceMessage}\n`,
 		);
 	}
+	const mcpModeSourceMessage =
+		resolvedMcpMode.source === "persisted"
+			? " (from .omx/setup-scope.json)"
+			: "";
+	console.log(
+		`Using setup MCP mode: ${resolvedMcpMode.mcpMode}${mcpModeSourceMessage}\n`,
+	);
 
 	// Step 1: Ensure directories exist
 	console.log("[1/8] Creating directories...");
@@ -1708,17 +1763,15 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		}
 		if (verbose) console.log(`  mkdir ${dir}`);
 	}
-	const setupPreferencesToPersist: PersistedSetupScope =
-		resolvedInstallMode &&
+	const setupPreferencesToPersist: PersistedSetupScope = {
+		scope: resolvedScope.scope,
+		mcpMode: resolvedMcpMode.mcpMode,
+		...(resolvedInstallMode &&
 		(resolvedScope.scope === "user" ||
 			resolvedInstallMode.installMode === "plugin")
-			? {
-					scope: resolvedScope.scope,
-					installMode: resolvedInstallMode.installMode,
-				}
-			: {
-					scope: resolvedScope.scope,
-				};
+			? { installMode: resolvedInstallMode.installMode }
+			: {}),
+	};
 	await persistSetupPreferences(projectRoot, setupPreferencesToPersist, {
 		dryRun,
 		verbose,
@@ -1891,6 +1944,34 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			`  Native Codex hook feature flag: [features].${codexHookFeatureFlag}`,
 		);
 	}
+	const shouldSyncSharedMcpRegistry = resolvedMcpMode.mcpMode === "compat";
+	const registryCandidates = getUnifiedMcpRegistryCandidates();
+	const defaultRegistryCandidates = registryCandidates.slice(0, 1);
+	const sharedMcpRegistry: UnifiedMcpRegistryLoadResult = shouldSyncSharedMcpRegistry
+		? await loadUnifiedMcpRegistry({
+				candidates: options.mcpRegistryCandidates ?? defaultRegistryCandidates,
+			})
+		: { servers: [], warnings: [] };
+	const legacyRegistryCandidate = getLegacyUnifiedMcpRegistryCandidate();
+	if (
+		shouldSyncSharedMcpRegistry &&
+		!options.mcpRegistryCandidates &&
+		!sharedMcpRegistry.sourcePath &&
+		existsSync(legacyRegistryCandidate) &&
+		!existsSync(defaultRegistryCandidates[0])
+	) {
+		console.log(
+			`  warning: legacy shared MCP registry detected at ${legacyRegistryCandidate} but ignored by default; move or copy it to ${defaultRegistryCandidates[0]} and rerun setup with --mcp compat if you still want setup to sync those servers`,
+		);
+	}
+	if (verbose && sharedMcpRegistry.sourcePath) {
+		console.log(
+			`  shared MCP registry: ${sharedMcpRegistry.sourcePath} (${sharedMcpRegistry.servers.length} servers)`,
+		);
+	}
+	for (const warning of sharedMcpRegistry.warnings) {
+		console.log(`  warning: ${warning}`);
+	}
 	if (isPluginInstallMode) {
 		const configCleaned = await cleanupPluginModeLegacyConfig(
 			scopeDirs.codexConfigFile,
@@ -1915,6 +1996,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		const pluginMarketplaceResult = await ensurePluginMarketplaceRegistration(
 			scopeDirs.codexConfigFile,
 			pkgRoot,
+			resolvedMcpMode.mcpMode,
 			backupContext,
 			summary.config,
 			{ dryRun, verbose },
@@ -1942,6 +2024,23 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			);
 		} else if (pluginCacheRefresh.status === "unchanged") {
 			console.log("  Codex plugin discovery cache already matches packaged plugin metadata.");
+		}
+		if (shouldSyncSharedMcpRegistry) {
+			resolvedConfig = await syncSharedMcpRegistryIntoConfig(
+				scopeDirs.codexConfigFile,
+				sharedMcpRegistry,
+				summary.config,
+				backupContext,
+				{ dryRun, verbose },
+			);
+			if (resolvedScope.scope === "user") {
+				await syncClaudeCodeMcpSettings(
+					sharedMcpRegistry,
+					summary.config,
+					backupContext,
+					{ dryRun, verbose },
+				);
+			}
 		}
 			resolvedConfig = existsSync(scopeDirs.codexConfigFile)
 				? await readFile(scopeDirs.codexConfigFile, "utf-8")
@@ -1980,30 +2079,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			);
 		}
 	} else {
-		const registryCandidates = getUnifiedMcpRegistryCandidates();
-		const defaultRegistryCandidates = registryCandidates.slice(0, 1);
-		const legacyRegistryCandidate = getLegacyUnifiedMcpRegistryCandidate();
-		const sharedMcpRegistry = await loadUnifiedMcpRegistry({
-			candidates: options.mcpRegistryCandidates ?? defaultRegistryCandidates,
-		});
-		if (
-			!options.mcpRegistryCandidates &&
-			!sharedMcpRegistry.sourcePath &&
-			existsSync(legacyRegistryCandidate) &&
-			!existsSync(defaultRegistryCandidates[0])
-		) {
-			console.log(
-				`  warning: legacy shared MCP registry detected at ${legacyRegistryCandidate} but ignored by default; move it to ${defaultRegistryCandidates[0]} if you still want setup to sync those servers`,
-			);
-		}
-		if (verbose && sharedMcpRegistry.sourcePath) {
-			console.log(
-				`  shared MCP registry: ${sharedMcpRegistry.sourcePath} (${sharedMcpRegistry.servers.length} servers)`,
-			);
-		}
-		for (const warning of sharedMcpRegistry.warnings) {
-			console.log(`  warning: ${warning}`);
-		}
 		const statusLinePreset = await resolveStatusLinePresetForSetup(
 			projectRoot,
 			{ force },
@@ -2013,6 +2088,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			scopeDirs.codexHooksFile,
 			pkgRoot,
 			sharedMcpRegistry,
+			resolvedMcpMode.mcpMode,
 			resolvedScope.scope,
 			scopeDirs.codexHomeDir,
 			summary.config,
@@ -2033,7 +2109,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				"  Removed retired [mcp_servers.omx_team_run] config during refresh.",
 			);
 		}
-		if (resolvedScope.scope === "user") {
+		if (shouldSyncSharedMcpRegistry && resolvedScope.scope === "user") {
 			await syncClaudeCodeMcpSettings(
 				sharedMcpRegistry,
 				summary.config,
@@ -3179,6 +3255,7 @@ async function updateManagedConfig(
 	hooksPath: string,
 	pkgRoot: string,
 	sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
+	mcpMode: SetupMcpMode,
 	scope: SetupScope,
 	codexHomeDir: string,
 	summary: SetupCategorySummary,
@@ -3228,6 +3305,7 @@ async function updateManagedConfig(
 		statusLinePreset: options.statusLinePreset,
 		forceStatusLinePreset: options.forceStatusLinePreset,
 		notifyCommand: notifyPlan.notifyCommand,
+		includeFirstPartyMcp: mcpMode === "compat",
 	});
 	const changed = existing !== finalConfig;
 
@@ -3285,6 +3363,51 @@ async function updateManagedConfig(
 		repairedLegacyTeamRunTable:
 			hadLegacyTeamRunTable && !hasLegacyOmxTeamRunTable(finalConfig),
 	};
+}
+
+async function syncSharedMcpRegistryIntoConfig(
+	configPath: string,
+	sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<string> {
+	if (sharedMcpRegistry.servers.length === 0) {
+		return existsSync(configPath) ? await readFile(configPath, "utf-8") : "";
+	}
+
+	const existing = existsSync(configPath)
+		? await readFile(configPath, "utf-8")
+		: "";
+	const finalConfig = mergeSharedMcpRegistryBlock(
+		existing,
+		sharedMcpRegistry.servers,
+		sharedMcpRegistry.sourcePath,
+	);
+	if (existing === finalConfig) {
+		summary.unchanged += 1;
+		return finalConfig;
+	}
+	if (
+		await ensureBackup(
+			configPath,
+			existsSync(configPath),
+			backupContext,
+			options,
+		)
+	) {
+		summary.backedUp += 1;
+	}
+	if (!options.dryRun) {
+		await writeFile(configPath, finalConfig);
+	}
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would sync" : "synced"} shared MCP registry servers into ${configPath}`,
+		);
+	}
+	return finalConfig;
 }
 
 function getClaudeCodeSettingsPath(homeDir = homedir()): string {

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -16,7 +16,7 @@ Resolved setup scope: user
   [OK] Legacy skill roots: no ~/.agents/skills overlap detected
   [!!] AGENTS.md: not found in <CODEX_HOME>/AGENTS.md (run omx setup --scope user)
   [!!] State dir: <REPO_STATE_DIR> (not created yet)
-  [!!] MCP Servers: 1 servers but no OMX servers yet (expected before first setup; run "omx setup --force" once)
+  [OK] MCP Servers: 1 user-managed MCP server(s) preserved; first-party OMX MCP omitted by default
   [OK] Prompt triage: config: enabled (default)
 
 Results: <RESULTS>

--- a/src/compat/fixtures/help.stdout.txt
+++ b/src/compat/fixtures/help.stdout.txt
@@ -4,7 +4,7 @@ oh-my-codex (omx) - Multi-agent orchestration for Codex CLI
 Usage:
   omx           Launch Codex CLI (HUD auto-attaches only when already inside tmux)
   omx exec      Run codex exec non-interactively with OMX AGENTS/overlay injection
-  omx setup     Install skills, prompts, MCP servers, and scope-specific AGENTS.md
+  omx setup     Install skills, prompts, CLI-first config, and scope-specific AGENTS.md
                 (user scope prompts for legacy vs plugin skill delivery when needed)
   omx uninstall Remove OMX configuration and clean up installed artifacts
   omx doctor    Check installation health

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -24,7 +24,10 @@ function count(text: string, pattern: RegExp): number {
 }
 
 /** Assert the current OMX block appears exactly once */
-function assertSingleOmxBlock(toml: string): void {
+function assertSingleOmxBlock(
+  toml: string,
+  options: { includeFirstPartyMcp?: boolean } = {},
+): void {
   assert.equal(
     count(toml, /# oh-my-codex \(OMX\) Configuration/g),
     1,
@@ -35,31 +38,17 @@ function assertSingleOmxBlock(toml: string): void {
     1,
     "End marker should appear once",
   );
-  assert.equal(
-    count(toml, /^\[mcp_servers\.omx_state\]$/gm),
-    1,
-    "[mcp_servers.omx_state] should appear once",
-  );
-  assert.equal(
-    count(toml, /^\[mcp_servers\.omx_memory\]$/gm),
-    1,
-    "[mcp_servers.omx_memory] should appear once",
-  );
-  assert.equal(
-    count(toml, /^\[mcp_servers\.omx_code_intel\]$/gm),
-    1,
-    "[mcp_servers.omx_code_intel] should appear once",
-  );
-  assert.equal(
-    count(toml, /^\[mcp_servers\.omx_trace\]$/gm),
-    1,
-    "[mcp_servers.omx_trace] should appear once",
-  );
-  assert.equal(
-    count(toml, /^\[mcp_servers\.omx_wiki\]$/gm),
-    1,
-    "[mcp_servers.omx_wiki] should appear once",
-  );
+  if (options.includeFirstPartyMcp) {
+    assertFirstPartyMcpBlocks(toml);
+  } else {
+    for (const name of OMX_FIRST_PARTY_MCP_SERVER_NAMES) {
+      assert.equal(
+        count(toml, new RegExp(`^\\[mcp_servers\\.${name}\\]$`, "gm")),
+        0,
+        `[mcp_servers.${name}] should not be emitted by default`,
+      );
+    }
+  }
   assert.equal(
     count(toml, /^\[mcp_servers\.omx_team_run\]$/gm),
     0,
@@ -113,10 +102,18 @@ function assertSingleOmxBlock(toml: string): void {
     "USE_OMX_EXPLORE_CMD should appear once",
   );
 
+}
+
+function assertFirstPartyMcpBlocks(toml: string): void {
   const parsed = TOML.parse(toml) as {
     mcp_servers?: Record<string, { command?: unknown }>;
   };
   for (const name of OMX_FIRST_PARTY_MCP_SERVER_NAMES) {
+    assert.equal(
+      count(toml, new RegExp(`^\\[mcp_servers\\.${name}\\]$`, "gm")),
+      1,
+      `[mcp_servers.${name}] should appear once when first-party MCP is enabled`,
+    );
     const command = parsed.mcp_servers?.[name]?.command;
     assert.equal(
       command,
@@ -253,6 +250,14 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
+  it("emits first-party MCP blocks only when explicitly enabled", () => {
+    const toml = buildMergedConfig("", "/tmp/omx", {
+      includeFirstPartyMcp: true,
+    });
+
+    assertSingleOmxBlock(toml, { includeFirstPartyMcp: true });
+  });
+
   it("second run updates without duplicating any section", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
@@ -376,6 +381,34 @@ describe("config generator idempotency (#384)", () => {
       assert.match(toml, /^model = "o3"$/m, "user model preserved");
       assert.match(toml, /^\[user\.settings\]$/m, "user section preserved");
       assert.match(toml, /^name = "kept"$/m, "user key preserved");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves user-owned omx-prefixed MCP servers that are not first-party", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      const userMcp = [
+        "[mcp_servers.omx_custom]",
+        'command = "node"',
+        'args = ["/user/custom-server.js"]',
+        "enabled = true",
+        "",
+      ].join("\n");
+      await writeFile(configPath, userMcp);
+
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, "utf-8");
+
+      assertSingleOmxBlock(toml);
+      assert.match(
+        toml,
+        /^\[mcp_servers\.omx_custom\]$/m,
+        "user-owned omx-prefixed MCP server preserved",
+      );
+      assert.match(toml, /^args = \["\/user\/custom-server\.js"\]$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -613,7 +646,7 @@ describe("config generator idempotency (#384)", () => {
     });
 
     assert.doesNotMatch(toml, /^\[tui\]$/m);
-    assert.match(toml, /^\[mcp_servers\.omx_state\]$/m);
+    assert.doesNotMatch(toml, /^\[mcp_servers\.omx_state\]$/m);
     assert.match(toml, /^\[shell_environment_policy\.set\]$/m);
     assert.match(toml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
   });

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -520,7 +520,7 @@ describe('config generator', () => {
     try {
       const configPath = join(wd, 'config.toml');
       const windowsPkgRoot = 'C:\\Users\\alice\\oh-my-codex';
-      await mergeConfig(configPath, windowsPkgRoot);
+      await mergeConfig(configPath, windowsPkgRoot, { includeFirstPartyMcp: true });
       const toml = await readFile(configPath, 'utf-8');
 
       assert.match(

--- a/src/config/__tests__/wiki-config-contract.test.ts
+++ b/src/config/__tests__/wiki-config-contract.test.ts
@@ -3,12 +3,15 @@ import assert from "node:assert/strict";
 import { loadSurface } from "../../hooks/__tests__/prompt-guidance-test-helpers.js";
 
 describe("project wiki config/generator documentation contract", () => {
-  it("documents the dedicated omx_wiki MCP server block", () => {
+  it("documents CLI-first wiki access with explicit MCP compatibility", () => {
     const doc = loadSurface("docs/reference/project-wiki.md");
+    assert.match(doc, /CLI-first JSON parity surface/i);
+    assert.match(doc, /`omx wiki <tool> --input <json> --json`/);
     assert.match(doc, /\[mcp_servers\.omx_wiki\]/);
     assert.match(doc, /dist\/mcp\/wiki-server\.js/);
-    assert.match(doc, /`omx setup` \/ the config generator/i);
-    assert.match(doc, /bootstrap\/config path should treat `omx_wiki` as a first-party OMX server/i);
+    assert.match(doc, /explicit compat mode/i);
+    assert.match(doc, /must not appear in default CLI-first setup/i);
+    assert.match(doc, /bootstrap\/config path should treat `omx_wiki` as a first-party OMX compatibility server/i);
   });
 
   it("documents the OMX-native storage path instead of legacy OMC storage", () => {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -49,6 +49,10 @@ function escapeTomlString(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 // ---------------------------------------------------------------------------
 // Top-level OMX keys (must live before any [table] header)
 // ---------------------------------------------------------------------------
@@ -1506,6 +1510,88 @@ export function stripExistingSharedMcpRegistryBlock(config: string): {
   }
 
   return { cleaned, removed };
+}
+
+function getExistingSharedMcpRegistryBlocks(config: string): string[] {
+  const blocks: string[] = [];
+  let cursor = 0;
+
+  while (cursor < config.length) {
+    const markerIdx = config.indexOf(SHARED_MCP_REGISTRY_MARKER, cursor);
+    if (markerIdx < 0) break;
+
+    let blockStart = config.lastIndexOf("\n", markerIdx);
+    blockStart = blockStart >= 0 ? blockStart + 1 : 0;
+
+    const previousLineEnd = blockStart - 1;
+    if (previousLineEnd >= 0) {
+      const previousLineStart = config.lastIndexOf("\n", previousLineEnd - 1);
+      const previousLine = config.slice(previousLineStart + 1, previousLineEnd);
+      if (/^# =+$/.test(previousLine.trim())) {
+        blockStart = previousLineStart >= 0 ? previousLineStart + 1 : 0;
+      }
+    }
+
+    let blockEnd = config.length;
+    const endIdx = config.indexOf(SHARED_MCP_REGISTRY_END_MARKER, markerIdx);
+    if (endIdx >= 0) {
+      const endLineBreak = config.indexOf("\n", endIdx);
+      blockEnd = endLineBreak >= 0 ? endLineBreak + 1 : config.length;
+    }
+
+    blocks.push(config.slice(blockStart, blockEnd));
+    cursor = blockEnd;
+  }
+
+  return blocks;
+}
+
+export function extractSharedMcpRegistryServersFromConfig(config: string): {
+  servers: UnifiedMcpRegistryServer[];
+  sourcePath?: string;
+} {
+  const servers: UnifiedMcpRegistryServer[] = [];
+  let sourcePath: string | undefined;
+
+  for (const block of getExistingSharedMcpRegistryBlocks(config)) {
+    sourcePath ??= block.match(/^# Source:\s*(.+?)\s*$/m)?.[1];
+
+    let parsed: unknown;
+    try {
+      parsed = TOML.parse(block);
+    } catch {
+      continue;
+    }
+
+    if (!isRecord(parsed) || !isRecord(parsed.mcp_servers)) continue;
+
+    for (const [name, value] of Object.entries(parsed.mcp_servers)) {
+      if (!isRecord(value) || typeof value.command !== "string") continue;
+      const args = Array.isArray(value.args)
+        ? value.args.filter((arg): arg is string => typeof arg === "string")
+        : [];
+      const enabled =
+        typeof value.enabled === "boolean" ? value.enabled : true;
+      const timeoutCandidate =
+        typeof value.startup_timeout_sec === "number"
+          ? value.startup_timeout_sec
+          : value.startupTimeoutSec;
+      const startupTimeoutSec =
+        typeof timeoutCandidate === "number" && Number.isFinite(timeoutCandidate)
+          ? timeoutCandidate
+          : undefined;
+
+      servers.push({
+        name,
+        command: value.command,
+        args,
+        enabled,
+        ...(startupTimeoutSec !== undefined ? { startupTimeoutSec } : {}),
+      });
+    }
+  }
+
+  return { servers, sourcePath };
 }
 
 function toMcpServerTableKey(name: string): string {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -24,7 +24,10 @@ import {
   normalizeCodexHookFeatureFlag,
   type CodexHookFeatureFlag,
 } from "./codex-feature-flags.js";
-import { getOmxFirstPartySetupMcpServers } from "./omx-first-party-mcp.js";
+import {
+  OMX_FIRST_PARTY_MCP_SERVER_NAMES,
+  getOmxFirstPartySetupMcpServers,
+} from "./omx-first-party-mcp.js";
 import { buildManagedCodexHookTrustToml } from "./codex-hooks.js";
 import type { HudPreset } from "../hud/types.js";
 
@@ -39,6 +42,7 @@ interface MergeOptions {
   statusLinePreset?: HudPreset;
   forceStatusLinePreset?: boolean;
   notifyCommand?: string[] | false;
+  includeFirstPartyMcp?: boolean;
 }
 
 function escapeTomlString(value: string): string {
@@ -1159,6 +1163,17 @@ export function stripOmxEnvSettings(config: string): string {
  * Check whether a TOML table name belongs to a legacy OMX-managed agent entry.
  * Handles both `agents.name` and `agents."name"` forms.
  */
+
+function isOmxFirstPartyMcpSection(tableName: string): boolean {
+  const match = tableName.match(/^mcp_servers\.(?:"([^"]+)"|([A-Za-z0-9_-]+))$/);
+  const name = match?.[1] ?? match?.[2];
+  return Boolean(
+    name &&
+      ((OMX_FIRST_PARTY_MCP_SERVER_NAMES as readonly string[]).includes(name) ||
+        name === "omx_team_run"),
+  );
+}
+
 function isLegacyOmxAgentSection(tableName: string): boolean {
   const m = tableName.match(/^agents\.(?:"([^"]+)"|(\w[\w-]*))$/);
   if (!m) return false;
@@ -1171,7 +1186,8 @@ function isLegacyOmxAgentSection(tableName: string): boolean {
  * This covers legacy configs that were written before markers were added,
  * or configs where the marker was accidentally removed.
  *
- * Targets: [mcp_servers.omx_*], legacy [agents.<name>] entries, [tui]
+ * Targets: exact first-party [mcp_servers.<name>] entries, retired
+ * [mcp_servers.omx_team_run], and legacy [agents.<name>] entries.
  */
 function stripOrphanedOmxSections(config: string): string {
   const lines = config.split(/\r?\n/);
@@ -1188,7 +1204,7 @@ function stripOrphanedOmxSections(config: string): string {
       // The marker-based stripExistingOmxBlocks already handles [tui]
       // when it lives inside the OMX marker block.
       const isOmxSection =
-        /^mcp_servers\.omx_/.test(tableName) ||
+        isOmxFirstPartyMcpSection(tableName) ||
         isLegacyOmxAgentSection(tableName);
 
       if (isOmxSection) {
@@ -1664,6 +1680,29 @@ function getSharedMcpRegistryBlock(
   return lines.join("\n");
 }
 
+export function mergeSharedMcpRegistryBlock(
+  config: string,
+  servers: UnifiedMcpRegistryServer[],
+  sourcePath?: string,
+): string {
+  const stripped = stripExistingSharedMcpRegistryBlock(config);
+  const existing = stripped.cleaned;
+  const sharedRegistryBlock = getSharedMcpRegistryBlock(
+    servers,
+    sourcePath,
+    existing,
+  );
+  const body = existing.trimEnd();
+  const merged = sharedRegistryBlock
+    ? body
+      ? `${body}\n\n${sharedRegistryBlock}\n`
+      : `${sharedRegistryBlock}\n`
+    : body
+      ? `${body}\n`
+      : "";
+  return addDefaultLauncherMcpStartupTimeouts(merged);
+}
+
 /**
  * OMX table-section block (MCP servers, TUI).
  * Contains ONLY [table] sections — no bare keys.
@@ -1673,6 +1712,7 @@ function getOmxTablesBlock(
   includeTui = true,
   statusLinePreset: HudPreset = DEFAULT_STATUS_LINE_PRESET,
   codexHooksFile?: string,
+  includeFirstPartyMcp = false,
 ): string {
   const lines = [
     "",
@@ -1682,19 +1722,21 @@ function getOmxTablesBlock(
     "# ============================================================",
   ];
 
-  for (const server of getOmxFirstPartySetupMcpServers(pkgRoot)) {
-    lines.push("");
-    lines.push(server.title);
-    lines.push(`[mcp_servers.${server.name}]`);
-    lines.push(`command = "${escapeTomlString(server.command)}"`);
-    lines.push(
-      `args = [${server.args
-        .map((arg) => `"${escapeTomlString(arg)}"`)
-        .join(", ")}]`,
-    );
-    lines.push(`enabled = ${server.enabled ? "true" : "false"}`);
-    if (typeof server.startupTimeoutSec === "number") {
-      lines.push(`startup_timeout_sec = ${server.startupTimeoutSec}`);
+  if (includeFirstPartyMcp) {
+    for (const server of getOmxFirstPartySetupMcpServers(pkgRoot)) {
+      lines.push("");
+      lines.push(server.title);
+      lines.push(`[mcp_servers.${server.name}]`);
+      lines.push(`command = "${escapeTomlString(server.command)}"`);
+      lines.push(
+        `args = [${server.args
+          .map((arg) => `"${escapeTomlString(arg)}"`)
+          .join(", ")}]`,
+      );
+      lines.push(`enabled = ${server.enabled ? "true" : "false"}`);
+      if (typeof server.startupTimeoutSec === "number") {
+        lines.push(`startup_timeout_sec = ${server.startupTimeoutSec}`);
+      }
     }
   }
 
@@ -1806,6 +1848,7 @@ export function buildMergedConfig(
     includeTui && !tuiUpsert.hadExistingTui,
     statusLinePreset,
     options.codexHooksFile,
+    options.includeFirstPartyMcp === true,
   );
   const sharedRegistryBlock = getSharedMcpRegistryBlock(
     options.sharedMcpServers ?? [],

--- a/src/config/omx-first-party-mcp.ts
+++ b/src/config/omx-first-party-mcp.ts
@@ -93,7 +93,9 @@ export function getOmxFirstPartySetupMcpServers(
   }));
 }
 
-export function buildOmxPluginMcpManifest(): {
+export function buildOmxPluginMcpManifest(
+  options: { enabled?: boolean } = {},
+): {
   mcpServers: Record<
     string,
     {
@@ -110,7 +112,7 @@ export function buildOmxPluginMcpManifest(): {
         {
           command: OMX_PLUGIN_MCP_COMMAND,
           args: [OMX_PLUGIN_MCP_SERVE_SUBCOMMAND, spec.pluginTarget],
-          enabled: true,
+          enabled: options.enabled === true,
         },
       ]),
     ),

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -668,8 +668,8 @@ describe('keyword detector skill-active-state lifecycle', () => {
 
       assert.ok(denied?.transition_error);
       assert.match(String(denied?.transition_error), /Unsupported workflow overlap: team \+ autopilot\./);
-      assert.match(String(denied?.transition_error), /`omx state clear --mode <mode>`/);
-      assert.match(String(denied?.transition_error), /`omx_state\.\*` MCP tools/);
+      assert.match(String(denied?.transition_error), /`omx state clear --input '{"mode":"<mode>"}' --json`/);
+      assert.match(String(denied?.transition_error), /explicit MCP compatibility is enabled/);
 
       const persisted = JSON.parse(
         await readFile(join(stateDir, 'sessions', 'sess-deny', SKILL_ACTIVE_STATE_FILE), 'utf-8'),

--- a/src/hooks/__tests__/skill-catalog-hygiene.test.ts
+++ b/src/hooks/__tests__/skill-catalog-hygiene.test.ts
@@ -68,4 +68,38 @@ describe('skill catalog hygiene', () => {
 
     assert.deepEqual(offenders, []);
   });
+
+  it('keeps primary workflow guidance CLI-first instead of MCP-first', () => {
+    const primaryWorkflows = [
+      'autopilot',
+      'code-review',
+      'ecomode',
+      'plan',
+      'ralph',
+      'tdd',
+      'ultraqa',
+      'ultrawork',
+      'wiki',
+    ];
+    const mcpFirstPatterns = [
+      /Use `omx_state` MCP tools/i,
+      /Use the `omx_state` MCP server tools/i,
+      /Before first MCP tool use, call `ToolSearch\("mcp"\)`/i,
+      /If ToolSearch finds no MCP tools/i,
+      /state_write MCP tool/i,
+			/write subsequent updates via omx_state MCP/i,
+			/omx state clear --mode/i,
+			/omx state state_write/i,
+      /wiki_(?:ingest|query|lint|add|list|read|delete|refresh)\([^)]*\)/,
+    ];
+
+    const offenders = primaryWorkflows.flatMap((name) => {
+      const content = skillContent(name);
+      return mcpFirstPatterns
+        .filter((pattern) => pattern.test(content))
+        .map((pattern) => `${name}: ${pattern}`);
+    });
+
+    assert.deepEqual(offenders, []);
+  });
 });

--- a/src/hooks/__tests__/skill-catalog-hygiene.test.ts
+++ b/src/hooks/__tests__/skill-catalog-hygiene.test.ts
@@ -87,9 +87,10 @@ describe('skill catalog hygiene', () => {
       /Before first MCP tool use, call `ToolSearch\("mcp"\)`/i,
       /If ToolSearch finds no MCP tools/i,
       /state_write MCP tool/i,
-			/write subsequent updates via omx_state MCP/i,
-			/omx state clear --mode/i,
-			/omx state state_write/i,
+      /write subsequent updates via omx_state MCP/i,
+      /omx state clear --mode/i,
+      /omx state state_write/i,
+      /state_(?:read|write)\(mode=/i,
       /wiki_(?:ingest|query|lint|add|list|read|delete|refresh)\([^)]*\)/,
     ];
 

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -316,8 +316,8 @@ async function readProjectMemorySummary(cwd: string): Promise<string> {
 function getCompactionInstructions(): string {
   return [
     "Before context compaction, preserve critical state:",
-    "1. Write progress checkpoint via state_write MCP tool",
-    "2. Save key decisions to notepad via notepad_write_working",
+    "1. Write progress checkpoint via `omx state write --input '<json>' --json`",
+    "2. Save key decisions via `omx notepad write-working --input '<json>' --json`",
     "3. If context is >80% full, proactively checkpoint state",
   ].join("\n");
 }

--- a/src/modes/__tests__/base-tmux-pane.test.ts
+++ b/src/modes/__tests__/base-tmux-pane.test.ts
@@ -5,36 +5,66 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { startMode } from '../base.js';
 
+const STATE_ENV_KEYS = [
+  'OMX_ROOT',
+  'OMX_STATE_ROOT',
+  'OMX_TEAM_STATE_ROOT',
+  'OMX_SESSION_ID',
+  'CODEX_SESSION_ID',
+  'SESSION_ID',
+] as const;
+
+async function withIsolatedStateEnv(fn: () => Promise<void>): Promise<void> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of STATE_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  try {
+    await fn();
+  } finally {
+    for (const key of STATE_ENV_KEYS) {
+      const value = previous.get(key);
+      if (typeof value === 'string') process.env[key] = value;
+      else delete process.env[key];
+    }
+  }
+}
+
 describe('modes/base tmux pane capture', () => {
   it('captures tmux_pane_id in mode state on startMode()', async () => {
-    const prev = process.env.TMUX_PANE;
-    process.env.TMUX_PANE = '%123';
-    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-pane-'));
-    try {
-      await startMode('ralph', 'test', 1, wd);
-      const raw = JSON.parse(await readFile(join(wd, '.omx', 'state', 'ralph-state.json'), 'utf-8'));
-      assert.equal(raw.tmux_pane_id, '%123');
-      assert.ok(typeof raw.tmux_pane_set_at === 'string' && raw.tmux_pane_set_at.length > 0);
-    } finally {
-      if (typeof prev === 'string') process.env.TMUX_PANE = prev;
-      else delete process.env.TMUX_PANE;
-      await rm(wd, { recursive: true, force: true });
-    }
+    await withIsolatedStateEnv(async () => {
+      const prev = process.env.TMUX_PANE;
+      process.env.TMUX_PANE = '%123';
+      const wd = await mkdtemp(join(tmpdir(), 'omx-mode-pane-'));
+      try {
+        await startMode('ralph', 'test', 1, wd);
+        const raw = JSON.parse(await readFile(join(wd, '.omx', 'state', 'ralph-state.json'), 'utf-8'));
+        assert.equal(raw.tmux_pane_id, '%123');
+        assert.ok(typeof raw.tmux_pane_set_at === 'string' && raw.tmux_pane_set_at.length > 0);
+      } finally {
+        if (typeof prev === 'string') process.env.TMUX_PANE = prev;
+        else delete process.env.TMUX_PANE;
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
   });
 
   it('blocks exclusive mode startup when another exclusive state file is malformed', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-malformed-'));
-    try {
-      const stateDir = join(wd, '.omx', 'state');
-      await mkdir(stateDir, { recursive: true });
-      await writeFile(join(stateDir, 'ralph-state.json'), '{ "active": true');
+    await withIsolatedStateEnv(async () => {
+      const wd = await mkdtemp(join(tmpdir(), 'omx-mode-malformed-'));
+      try {
+        const stateDir = join(wd, '.omx', 'state');
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(join(stateDir, 'ralph-state.json'), '{ "active": true');
 
-      await assert.rejects(
-        () => startMode('autopilot', 'test', 1, wd),
-        /repair or clear that workflow state yourself via `omx state clear --mode ralph` or the `omx_state\.\*` MCP tools/i,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
+        await assert.rejects(
+          () => startMode('autopilot', 'test', 1, wd),
+          /repair or clear that workflow state yourself via `omx state clear --input '\{"mode":"ralph"\}' --json`/i,
+        );
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1218,7 +1218,7 @@ describe("codex native hook dispatch", () => {
       assert.equal(result.omxEventName, "keyword-detector");
       assert.equal(result.skillState?.skill, "ralplan");
       assert.ok(result.outputJson, "UserPromptSubmit should emit developer context");
-      assert.match(JSON.stringify(result.outputJson), /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.match(JSON.stringify(result.outputJson), /use CLI-first state updates via `omx state write\/read\/clear --input '<json>' --json`/);
 
       assert.equal(
         existsSync(join(cwd, ".omx", "state", "skill-active-state.json")),
@@ -1581,7 +1581,7 @@ describe("codex native hook dispatch", () => {
         (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
       );
       assert.match(message, /\$oh-my-codex:ralplan" -> ralplan/);
-      assert.match(message, /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-plugin-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.match(message, /use CLI-first state updates via `omx state write\/read\/clear --input '<json>' --json`/);
       assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-plugin-1", "ralplan-state.json")), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -1798,7 +1798,7 @@ describe("codex native hook dispatch", () => {
         (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
       );
       assert.match(message, /\$ralph" -> ralph/);
-      assert.match(message, /skill: ralph activated and initial state initialized at \.omx\/state\/sessions\/sess-ralph-msg\/ralph-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.match(message, /use CLI-first state updates via `omx state write\/read\/clear --input '<json>' --json`/);
       assert.match(message, /Prompt-side `\$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`\./);
       assert.match(message, /Use `omx ralph --prd \.\.\.` only when you explicitly want the PRD-gated CLI startup path\./);
     } finally {
@@ -1828,7 +1828,7 @@ describe("codex native hook dispatch", () => {
         (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
       );
       assert.match(message, /\$oh-my-codex:ralph" -> ralph/);
-      assert.match(message, /skill: ralph activated and initial state initialized at \.omx\/state\/sessions\/sess-plugin-ralph-msg\/ralph-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.match(message, /use CLI-first state updates via `omx state write\/read\/clear --input '<json>' --json`/);
       assert.match(message, /Prompt-side `\$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`\./);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -1910,7 +1910,7 @@ describe("codex native hook dispatch", () => {
         (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
       );
       assert.match(message, /\$deep-interview" -> deep-interview/);
-      assert.match(message, /skill: deep-interview activated and initial state initialized at \.omx\/state\/sessions\/sess-deep-interview-msg\/deep-interview-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.match(message, /use CLI-first state updates via `omx state write\/read\/clear --input '<json>' --json`/);
       assert.match(message, /Deep-interview is active, but this session is not attached to tmux/);
       assert.match(message, /Do not invoke `omx question`, `omx hud`, or `omx team`/);
       assert.match(message, /native structured question tool when available/);
@@ -2386,8 +2386,11 @@ export async function onHookEvent(event) {
 
       assert.match(JSON.stringify(denied.outputJson), /denied workflow keyword/i);
       assert.match(JSON.stringify(denied.outputJson), /Unsupported workflow overlap: team \+ autopilot\./);
-      assert.match(JSON.stringify(denied.outputJson), /`omx state clear --mode <mode>`/);
-      assert.match(JSON.stringify(denied.outputJson), /`omx_state\.\*` MCP tools/);
+      assert.match(JSON.stringify(denied.outputJson), /omx state clear --input/);
+      assert.match(JSON.stringify(denied.outputJson), /mode\\":\\"<mode>/);
+      assert.match(JSON.stringify(denied.outputJson), /--json/);
+      assert.match(JSON.stringify(denied.outputJson), /explicit MCP compatibility is enabled/);
+      assert.match(JSON.stringify(denied.outputJson), /`omx_state\.\*` tools/);
       assert.equal(
         existsSync(join(cwd, ".omx", "state", "sessions", "sess-deny-1", "autopilot-state.json")),
         false,
@@ -2464,7 +2467,7 @@ export async function onHookEvent(event) {
       assert.match(message, /\$ralph" -> ralph/);
       assert.doesNotMatch(message, /mode transiting:/);
       assert.match(message, /planning preserved over simultaneous execution follow-up; deferred skills: team, ralph\./);
-      assert.match(message, /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-multi-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.match(message, /use CLI-first state updates via `omx state write\/read\/clear --input '<json>' --json`/);
       assert.doesNotMatch(message, /Use the durable OMX team runtime via `omx team \.\.\.`/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -2496,7 +2499,7 @@ export async function onHookEvent(event) {
       assert.match(message, /\$oh-my-codex:ralph" -> ralph/);
       assert.doesNotMatch(message, /mode transiting:/);
       assert.match(message, /planning preserved over simultaneous execution follow-up; deferred skills: team, ralph\./);
-      assert.match(message, /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-plugin-multi-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.match(message, /use CLI-first state updates via `omx state write\/read\/clear --input '<json>' --json`/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -4606,7 +4609,7 @@ exit 0
       );
       assert.match(
         additionalContext,
-        /omx state state_write --input/,
+        /omx state write --input/,
       );
       assert.match(
         additionalContext,
@@ -4854,7 +4857,7 @@ exit 0
       assert.equal(hookSpecificOutput?.hookEventName, "PostToolUse");
       assert.match(
         String(hookSpecificOutput?.additionalContext || ""),
-        /Retry via CLI parity with `omx state state_write --input '\{\}' --json`\./,
+        /Retry via CLI parity with `omx state write --input '\{\}' --json`\./,
       );
       assert.match(
         String(hookSpecificOutput?.additionalContext || ""),
@@ -4940,7 +4943,7 @@ exit 0
         hookSpecificOutput: {
           hookEventName: "PostToolUse",
           additionalContext:
-            "Clear MCP transport-death signal detected. Preserve current team/runtime state. Retry via CLI parity with `omx state state_write --input '{\"mode\":\"team\",\"active\":true}' --json`. OMX MCP servers are plain Node stdio processes, so they still shut down when stdin/transport closes. If this happened during team runtime, inspect first with `omx team status <team>` or `omx team api read-stall-state --input '{\"team_name\":\"<team>\"}' --json`, and only force cleanup after capturing needed state. For root-cause debugging, rerun with `OMX_MCP_TRANSPORT_DEBUG=1` to log why the stdio transport closed.",
+            "Clear MCP transport-death signal detected. Preserve current team/runtime state. Retry via CLI parity with `omx state write --input '{\"mode\":\"team\",\"active\":true}' --json`. OMX MCP servers are plain Node stdio processes, so they still shut down when stdin/transport closes. If this happened during team runtime, inspect first with `omx team status <team>` or `omx team api read-stall-state --input '{\"team_name\":\"<team>\"}' --json`, and only force cleanup after capturing needed state. For root-cause debugging, rerun with `OMX_MCP_TRANSPORT_DEBUG=1` to log why the stdio transport closed.",
         },
       });
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1386,6 +1386,10 @@ function buildNativeOutsideTmuxTeamPromptBlockState(
   };
 }
 
+function buildSkillStateCliInstruction(mode: string, statePath: string): string {
+  return `skill: ${mode} activated and initial state initialized at ${statePath}; use CLI-first state updates via \`omx state write/read/clear --input '<json>' --json\`; use omx_state MCP only when explicit MCP compatibility is enabled.`;
+}
+
 function buildAdditionalContextMessage(
   prompt: string,
   skillState?: SkillActiveState | null,
@@ -1447,7 +1451,7 @@ function buildAdditionalContextMessage(
       promptPriorityMessage,
       ultragoalPromptActivationNote,
       skillState.initialized_mode && skillState.initialized_state_path
-        ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
+        ? buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path)
         : null,
       teamDetected
         ? buildTeamRuntimeInstruction(cwd, payload)
@@ -1459,7 +1463,7 @@ function buildAdditionalContextMessage(
 
   if (teamDetected) {
     const initializedStateMessage = skillState?.initialized_mode && skillState.initialized_state_path
-      ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
+      ? buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path)
       : null;
     return [
       detectedKeywordMessage,
@@ -1486,7 +1490,7 @@ function buildAdditionalContextMessage(
         ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
         : null,
       promptPriorityMessage,
-      `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
+      buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path),
       deepInterviewPromptActivationNote,
       ultraworkPromptActivationNote,
       ultragoalPromptActivationNote,

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -185,7 +185,10 @@ function resolveOmxParityTarget(toolName: string): { command: OmxParityCommand; 
   if (!match) return null;
 
   const [, server, tool] = match;
-  if (server === "state") return { command: "state", tool };
+  if (server === "state") {
+    const stateTool = tool.replace(/^state_/, "").replace(/_/g, "-");
+    return { command: "state", tool: stateTool };
+  }
   if (server === "trace") return { command: "trace", tool };
   if (server === "code_intel") return { command: "code-intel", tool };
   if (server === "memory" && tool.startsWith("notepad_")) {

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -12,6 +12,32 @@ import {
 } from '../workflow-transition.js';
 import { reconcileWorkflowTransition } from '../workflow-transition-reconcile.js';
 
+const STATE_ENV_KEYS = [
+  'OMX_ROOT',
+  'OMX_STATE_ROOT',
+  'OMX_TEAM_STATE_ROOT',
+  'OMX_SESSION_ID',
+  'CODEX_SESSION_ID',
+  'SESSION_ID',
+] as const;
+
+async function withIsolatedStateEnv(fn: () => Promise<void>): Promise<void> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of STATE_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  try {
+    await fn();
+  } finally {
+    for (const key of STATE_ENV_KEYS) {
+      const value = previous.get(key);
+      if (typeof value === 'string') process.env[key] = value;
+      else delete process.env[key];
+    }
+  }
+}
+
 describe('workflow transition rules', () => {
   it('allows the approved overlap matrix and denies unsupported combinations', () => {
     const cases: Array<{
@@ -47,8 +73,8 @@ describe('workflow transition rules', () => {
     assert.match(error, /Unsupported workflow overlap: team \+ autopilot\./);
     assert.match(error, /Current state is unchanged\./);
     assert.match(error, /Clear incompatible workflow state yourself via/);
-    assert.match(error, /`omx state clear --mode <mode>`/);
-    assert.match(error, /`omx_state\.\*` MCP tools/);
+    assert.match(error, /`omx state clear --input '{"mode":"<mode>"}' --json`/);
+    assert.match(error, /explicit MCP compatibility is enabled/);
   });
 
   it('returns auto-complete decisions for allowlisted forward transitions', () => {
@@ -104,58 +130,62 @@ describe('workflow transition rules', () => {
   });
 
   it('ignores stale root workflow state for session-scoped active decisions', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-workflow-active-scope-'));
-    try {
-      const stateDir = join(wd, '.omx', 'state');
-      const sessionDir = join(stateDir, 'sessions', 'sess-current');
-      await mkdir(sessionDir, { recursive: true });
-      await writeFile(
-        join(stateDir, 'ralph-state.json'),
-        JSON.stringify({ active: true, mode: 'ralph', current_phase: 'executing' }, null, 2),
-        'utf-8',
-      );
-      await writeFile(
-        join(stateDir, 'session.json'),
-        JSON.stringify({ session_id: 'sess-current', cwd: wd }, null, 2),
-        'utf-8',
-      );
+    await withIsolatedStateEnv(async () => {
+      const wd = await mkdtemp(join(tmpdir(), 'omx-workflow-active-scope-'));
+      try {
+        const stateDir = join(wd, '.omx', 'state');
+        const sessionDir = join(stateDir, 'sessions', 'sess-current');
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(stateDir, 'ralph-state.json'),
+          JSON.stringify({ active: true, mode: 'ralph', current_phase: 'executing' }, null, 2),
+          'utf-8',
+        );
+        await writeFile(
+          join(stateDir, 'session.json'),
+          JSON.stringify({ session_id: 'sess-current', cwd: wd }, null, 2),
+          'utf-8',
+        );
 
-      assert.deepEqual(await readActiveWorkflowModes(wd, 'sess-current'), []);
-      assert.deepEqual(await readActiveWorkflowModes(wd), []);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
+        assert.deepEqual(await readActiveWorkflowModes(wd, 'sess-current'), []);
+        assert.deepEqual(await readActiveWorkflowModes(wd), []);
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
   });
 
   it('does not auto-complete stale root workflow state during a session transition', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-workflow-reconcile-scope-'));
-    try {
-      const stateDir = join(wd, '.omx', 'state');
-      const sessionDir = join(stateDir, 'sessions', 'sess-current');
-      const rootRalphPath = join(stateDir, 'ralph-state.json');
-      await mkdir(sessionDir, { recursive: true });
-      await writeFile(
-        rootRalphPath,
-        JSON.stringify({ active: true, mode: 'ralph', current_phase: 'executing' }, null, 2),
-        'utf-8',
-      );
+    await withIsolatedStateEnv(async () => {
+      const wd = await mkdtemp(join(tmpdir(), 'omx-workflow-reconcile-scope-'));
+      try {
+        const stateDir = join(wd, '.omx', 'state');
+        const sessionDir = join(stateDir, 'sessions', 'sess-current');
+        const rootRalphPath = join(stateDir, 'ralph-state.json');
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          rootRalphPath,
+          JSON.stringify({ active: true, mode: 'ralph', current_phase: 'executing' }, null, 2),
+          'utf-8',
+        );
 
-      const transition = await reconcileWorkflowTransition(wd, 'ralplan', {
-        action: 'start',
-        sessionId: 'sess-current',
-        source: 'test',
-      });
+        const transition = await reconcileWorkflowTransition(wd, 'ralplan', {
+          action: 'start',
+          sessionId: 'sess-current',
+          source: 'test',
+        });
 
-      assert.equal(transition.decision.allowed, true);
-      assert.deepEqual(transition.decision.currentModes, []);
-      assert.deepEqual(transition.completedPaths, []);
+        assert.equal(transition.decision.allowed, true);
+        assert.deepEqual(transition.decision.currentModes, []);
+        assert.deepEqual(transition.completedPaths, []);
 
-      const rootRalph = JSON.parse(await readFile(rootRalphPath, 'utf-8')) as { active?: unknown };
-      assert.equal(rootRalph.active, true);
-      assert.equal(existsSync(join(sessionDir, 'ralph-state.json')), false);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
+        const rootRalph = JSON.parse(await readFile(rootRalphPath, 'utf-8')) as { active?: unknown };
+        assert.equal(rootRalph.active, true);
+        assert.equal(existsSync(join(sessionDir, 'ralph-state.json')), false);
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
   });
 
   it('co-locates auto-completed mode detail and canonical skill state under an explicit base state dir', async () => {

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -48,7 +48,7 @@ async function readJsonIfExists(
   } catch {
     if (options?.throwOnParseError && options.mode) {
       throw new Error(
-        `Cannot read ${options.mode} workflow state at ${path}. Repair or clear that workflow state yourself via \`omx state clear --mode ${options.mode}\` or the \`omx_state.*\` MCP tools.`,
+        `Cannot read ${options.mode} workflow state at ${path}. Repair or clear that workflow state yourself via \`omx state clear --input '{"mode":"${options.mode}"}' --json\`; if explicit MCP compatibility is enabled, \`omx_state.*\` tools are also acceptable.`,
       );
     }
     return null;

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -191,14 +191,14 @@ export function buildWorkflowTransitionError(
       `Cannot ${action} ${requestedMode}: ${activeModesMessage}.`,
       'Execution-to-planning rollback auto-complete is not allowed.',
       'First clear current state first and retry if this action is intended.',
-      `Clear incompatible workflow state yourself via \`omx state clear --mode <mode>\` or the \`omx_state.*\` MCP tools, then retry.`,
+      `Clear incompatible workflow state yourself via \`omx state clear --input '{"mode":"<mode>"}' --json\`; if explicit MCP compatibility is enabled, \`omx_state.*\` tools are also acceptable.`,
     ].join(' ');
   }
   return [
     `Cannot ${action} ${requestedMode}: ${activeModesMessage}.`,
     `Unsupported workflow overlap: ${overlap}.`,
     'Current state is unchanged.',
-    `Clear incompatible workflow state yourself via \`omx state clear --mode <mode>\` or the \`omx_state.*\` MCP tools, then retry.`,
+    `Clear incompatible workflow state yourself via \`omx state clear --input '{"mode":"<mode>"}' --json\`; if explicit MCP compatibility is enabled, \`omx_state.*\` tools are also acceptable.`,
   ].join(' ');
 }
 
@@ -230,7 +230,7 @@ export async function readActiveWorkflowModes(
         break;
       } catch {
         throw new Error(
-          `Cannot read ${mode} workflow state at ${candidatePath}. Repair or clear that workflow state yourself via \`omx state clear --mode ${mode}\` or the \`omx_state.*\` MCP tools.`,
+          `Cannot read ${mode} workflow state at ${candidatePath}. Repair or clear that workflow state yourself via \`omx state clear --input '{"mode":"${mode}"}' --json\`; if explicit MCP compatibility is enabled, \`omx_state.*\` tools are also acceptable.`,
         );
       }
     }

--- a/src/wiki/lifecycle.ts
+++ b/src/wiki/lifecycle.ts
@@ -177,7 +177,7 @@ export function onPostCompact(data: { cwd?: string }): { additionalContext?: str
       additionalContext: [
         '[OMX Wiki PostCompact Nudge]',
         'Review the compaction artifacts and write durable findings to repository `omx_wiki/` when they would help future agents.',
-        'Use wiki_ingest or omx wiki add for decisions, architecture notes, debugging findings, environment facts, and session-log summaries worth committing.',
+        'Use `omx wiki wiki_ingest --input <json> --json` or `omx wiki wiki_add --input <json> --json` for decisions, architecture notes, debugging findings, environment facts, and session-log summaries worth committing.',
       ].join('\n'),
     };
   } catch {


### PR DESCRIPTION
## Summary
- make OMX setup CLI-first with MCP disabled by default while preserving explicit `--mcp compat` opt-in
- harden plugin MCP overrides, shared registry sync policy, doctor reporting, and generated guidance around no-MCP defaults
- refresh skill/plugin mirror guidance and tests so workflow/state recovery points to `omx` CLI bindings instead of MCP-first paths

## Context
Closes #2214.

## Validation
- `npm run build`
- `node --test dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/doctor-warning-copy.test.js`
- `node --test dist/state/__tests__/workflow-transition.test.js dist/modes/__tests__/base-tmux-pane.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/skill-catalog-hygiene.test.js`
- `npm run verify:plugin-bundle`
- `git diff --check`
- stale MCP-first guidance grep excluding hygiene test sentinels

## Review status
- code-reviewer: APPROVE, 0 issues
- architect: prior BLOCK resolved; remaining WATCH copy item cleaned before final checkpoint
