### PR TITLE
Fix OMX HUD state-root visualization

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -71,7 +71,7 @@ export {
 import {
   SKILL_ACTIVE_STATE_MODE,
   extractSessionIdFromInitializedStatePath,
-  getSkillActiveStatePaths,
+  getSkillActiveStatePathsForStateDir,
   listActiveSkills,
   readSkillActiveState,
   syncCanonicalSkillStateForMode,
@@ -2931,7 +2931,7 @@ function postLaunchUniqueStrings(values: string[]): string[] {
 }
 
 async function scrubPostLaunchRootSkillActiveForSession(
-  cwd: string,
+  stateDir: string,
   sessionId: string,
   nowIso: string,
   writeFileFn: typeof import("fs/promises").writeFile,
@@ -2940,7 +2940,7 @@ async function scrubPostLaunchRootSkillActiveForSession(
   const normalizedSessionId = cleanPostLaunchString(sessionId);
   if (!normalizedSessionId) return;
 
-  const { rootPath } = getSkillActiveStatePaths(cwd);
+  const { rootPath } = getSkillActiveStatePathsForStateDir(stateDir);
   const rootState = rootStateBeforeCleanup ?? await readSkillActiveState(rootPath);
   if (!rootState) return;
 
@@ -3012,8 +3012,9 @@ export async function cleanupPostLaunchModeStateFiles(
   const scopedDirs = sessionId
     ? [getStateDir(cwd, sessionId)]
     : [getBaseStateDir(cwd)];
+  const rootStateDir = getBaseStateDir(cwd);
   const rootSkillActiveStateBeforeCleanup = sessionId
-    ? await readSkillActiveState(getSkillActiveStatePaths(cwd).rootPath)
+    ? await readSkillActiveState(getSkillActiveStatePathsForStateDir(rootStateDir).rootPath)
     : null;
 
   for (const stateDir of scopedDirs) {
@@ -3040,6 +3041,7 @@ export async function cleanupPostLaunchModeStateFiles(
             if (isTrackedWorkflowMode(mode)) {
               await syncCanonicalSkillStateForMode({
                 cwd,
+                baseStateDir: rootStateDir,
                 mode,
                 active: false,
                 currentPhase: "cancelled",
@@ -3086,6 +3088,7 @@ export async function cleanupPostLaunchModeStateFiles(
         if (isTrackedWorkflowMode(mode)) {
           await syncCanonicalSkillStateForMode({
             cwd,
+            baseStateDir: rootStateDir,
             mode,
             active: false,
             currentPhase: "cancelled",
@@ -3105,7 +3108,7 @@ export async function cleanupPostLaunchModeStateFiles(
   if (sessionId) {
     try {
       await scrubPostLaunchRootSkillActiveForSession(
-        cwd,
+        rootStateDir,
         sessionId,
         now().toISOString(),
         writeFile,

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -380,6 +380,112 @@ describe('keyword registry coverage', () => {
 });
 
 describe('keyword detector skill-active-state lifecycle', () => {
+  it('co-locates direct boxed activation mode detail and canonical skill state for OMX_ROOT', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-keyword-boxed-root-'));
+    const sourceCwd = join(root, 'source');
+    const omxRoot = join(root, 'box');
+    const stateDir = join(omxRoot, '.omx', 'state');
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      await mkdir(sourceCwd, { recursive: true });
+      process.env.OMX_ROOT = omxRoot;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+
+      const result = await recordSkillActivation({
+        stateDir,
+        sourceCwd,
+        text: '$ralplan implement issue #1307',
+        sessionId: 'sess-boxed-ralplan',
+        threadId: 'thread-boxed',
+        turnId: 'turn-boxed',
+        nowIso: '2026-05-10T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'ralplan');
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-boxed-ralplan', SKILL_ACTIVE_STATE_FILE)),
+        true,
+      );
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-boxed-ralplan', 'ralplan-state.json')),
+        true,
+      );
+      assert.equal(
+        existsSync(join(sourceCwd, '.omx', 'state', 'sessions', 'sess-boxed-ralplan', SKILL_ACTIVE_STATE_FILE)),
+        false,
+      );
+      assert.equal(
+        existsSync(join(sourceCwd, '.omx', 'state', 'sessions', 'sess-boxed-ralplan', 'ralplan-state.json')),
+        false,
+      );
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('co-locates direct boxed activation mode detail and canonical skill state for OMX_STATE_ROOT', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-keyword-boxed-state-root-'));
+    const sourceCwd = join(root, 'source');
+    const stateRoot = join(root, 'state-root');
+    const stateDir = join(stateRoot, '.omx', 'state');
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      await mkdir(sourceCwd, { recursive: true });
+      delete process.env.OMX_ROOT;
+      process.env.OMX_STATE_ROOT = stateRoot;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+
+      const result = await recordSkillActivation({
+        stateDir,
+        sourceCwd,
+        text: '$ralplan implement issue #1307',
+        sessionId: 'sess-state-root-ralplan',
+        threadId: 'thread-state-root',
+        turnId: 'turn-state-root',
+        nowIso: '2026-05-10T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'ralplan');
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-state-root-ralplan', SKILL_ACTIVE_STATE_FILE)),
+        true,
+      );
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-state-root-ralplan', 'ralplan-state.json')),
+        true,
+      );
+      assert.equal(
+        existsSync(join(sourceCwd, '.omx', 'state', 'sessions', 'sess-state-root-ralplan', SKILL_ACTIVE_STATE_FILE)),
+        false,
+      );
+      assert.equal(
+        existsSync(join(sourceCwd, '.omx', 'state', 'sessions', 'sess-state-root-ralplan', 'ralplan-state.json')),
+        false,
+      );
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('writes skill-active-state.json with ralplan phase when autopilot keyword activates', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/notify-hook-non-omx-guard.test.ts
+++ b/src/hooks/__tests__/notify-hook-non-omx-guard.test.ts
@@ -1,12 +1,152 @@
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { describe, it } from "node:test";
 
 describe("notify-hook non-OMX project guard", () => {
+	it("co-locates boxed prompt skill mode detail and canonical skill state under OMX_ROOT", async () => {
+		const root = await mkdtemp(join(tmpdir(), "omx-notify-boxed-skill-"));
+		const wd = join(root, "source");
+		const omxRoot = join(root, "box");
+		const sessionId = "sess-notify-ralplan";
+		try {
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await writeFile(join(wd, ".omx", "managed"), "");
+			const payload = JSON.stringify({
+				cwd: wd,
+				type: "agent-turn-complete",
+				session_id: sessionId,
+				thread_id: "thread-notify",
+				turn_id: "turn-notify",
+				"input-messages": ["$ralplan implement issue #1307"],
+				"last-assistant-message": "working",
+			});
+			const result = spawnSync(
+				process.execPath,
+				["dist/scripts/notify-hook.js", payload],
+				{
+					cwd: process.cwd(),
+					encoding: "utf-8",
+					env: {
+						...process.env,
+						OMX_ROOT: omxRoot,
+						OMX_STATE_ROOT: "",
+						OMX_TEAM_STATE_ROOT: "",
+					},
+				},
+			);
+			assert.equal(result.status, 0);
+			const boxedSessionDir = join(omxRoot, ".omx", "state", "sessions", sessionId);
+			assert.equal(existsSync(join(boxedSessionDir, "skill-active-state.json")), true);
+			assert.equal(existsSync(join(boxedSessionDir, "ralplan-state.json")), true);
+			assert.equal(existsSync(join(wd, ".omx", "state", "sessions", sessionId, "skill-active-state.json")), false);
+			assert.equal(existsSync(join(wd, ".omx", "state", "sessions", sessionId, "ralplan-state.json")), false);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("co-locates team-worker prompt skill state under the resolved team state root", async () => {
+		const root = await mkdtemp(join(tmpdir(), "omx-notify-team-worker-skill-"));
+		const wd = join(root, "worker-worktree");
+		const teamStateRoot = join(root, "team-state");
+		const teamName = "fixhud";
+		const workerName = "worker-1";
+		const sessionId = "sess-worker-ralplan";
+		try {
+			await mkdir(join(teamStateRoot, "team", teamName, "workers", workerName), { recursive: true });
+			await writeFile(
+				join(teamStateRoot, "team", teamName, "workers", workerName, "identity.json"),
+				JSON.stringify({
+					name: workerName,
+					worktree_path: wd,
+					team_state_root: teamStateRoot,
+				}),
+			);
+			await mkdir(wd, { recursive: true });
+
+			const payload = JSON.stringify({
+				cwd: wd,
+				type: "agent-turn-complete",
+				session_id: sessionId,
+				thread_id: "thread-worker",
+				turn_id: "turn-worker",
+				"input-messages": ["$ralplan implement issue #1307"],
+				"last-assistant-message": "working",
+			});
+			const result = spawnSync(
+				process.execPath,
+				["dist/scripts/notify-hook.js", payload],
+				{
+					cwd: process.cwd(),
+					encoding: "utf-8",
+					env: {
+						...process.env,
+						OMX_TEAM_INTERNAL_WORKER: `${teamName}/${workerName}`,
+						OMX_TEAM_STATE_ROOT: teamStateRoot,
+						OMX_ROOT: "",
+						OMX_STATE_ROOT: "",
+					},
+				},
+			);
+			assert.equal(result.status, 0);
+			const teamSessionDir = join(teamStateRoot, "sessions", sessionId);
+			assert.equal(existsSync(join(teamSessionDir, "skill-active-state.json")), true);
+			assert.equal(existsSync(join(teamSessionDir, "ralplan-state.json")), true);
+			assert.equal(existsSync(join(wd, ".omx", "state", "sessions", sessionId, "skill-active-state.json")), false);
+			assert.equal(existsSync(join(wd, ".omx", "state", "sessions", sessionId, "ralplan-state.json")), false);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("co-locates non-worker prompt skill state under OMX_TEAM_STATE_ROOT", async () => {
+		const root = await mkdtemp(join(tmpdir(), "omx-notify-team-root-skill-"));
+		const wd = join(root, "source");
+		const teamStateRoot = join(root, "team-state");
+		const sessionId = "sess-notify-team-root";
+		try {
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await writeFile(join(wd, ".omx", "managed"), "");
+			const payload = JSON.stringify({
+				cwd: wd,
+				type: "agent-turn-complete",
+				session_id: sessionId,
+				thread_id: "thread-notify-team-root",
+				turn_id: "turn-notify-team-root",
+				"input-messages": ["$ralplan implement issue #1307"],
+				"last-assistant-message": "working",
+			});
+			const result = spawnSync(
+				process.execPath,
+				["dist/scripts/notify-hook.js", payload],
+				{
+					cwd: process.cwd(),
+					encoding: "utf-8",
+					env: {
+						...process.env,
+						OMX_TEAM_STATE_ROOT: teamStateRoot,
+						OMX_ROOT: "",
+						OMX_STATE_ROOT: "",
+						OMX_TEAM_INTERNAL_WORKER: "",
+						OMX_TEAM_WORKER: "",
+					},
+				},
+			);
+			assert.equal(result.status, 0);
+			const teamSessionDir = join(teamStateRoot, "sessions", sessionId);
+			assert.equal(existsSync(join(teamSessionDir, "skill-active-state.json")), true);
+			assert.equal(existsSync(join(teamSessionDir, "ralplan-state.json")), true);
+			assert.equal(existsSync(join(wd, ".omx", "state", "sessions", sessionId, "skill-active-state.json")), false);
+			assert.equal(existsSync(join(wd, ".omx", "state", "sessions", sessionId, "ralplan-state.json")), false);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
 	it("exits without creating .omx artifacts for unmanaged cwd", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-notify-unmanaged-"));
 		try {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -20,7 +20,7 @@ import { KEYWORD_TRIGGER_DEFINITIONS, compareKeywordMatches } from './keyword-re
 import {
   SKILL_ACTIVE_STATE_FILE,
   listActiveSkills,
-  writeSkillActiveStateCopies,
+  writeSkillActiveStateCopiesForStateDir,
   type SkillActiveEntry,
 } from '../state/skill-active.js';
 import {
@@ -89,6 +89,7 @@ export interface SkillActiveState {
 
 export interface RecordSkillActivationInput {
   stateDir: string;
+  sourceCwd?: string;
   text: string;
   sessionId?: string;
   threadId?: string;
@@ -739,6 +740,7 @@ function selectRootSkillStateCopy(
 }
 
 export async function recordSkillActivation(input: RecordSkillActivationInput): Promise<SkillActiveState | null> {
+  const sourceCwd = input.sourceCwd ?? dirname(dirname(input.stateDir));
   const rootStatePath = join(input.stateDir, SKILL_ACTIVE_STATE_FILE);
   const sessionStatePath = input.sessionId
     ? join(input.stateDir, 'sessions', input.sessionId, SKILL_ACTIVE_STATE_FILE)
@@ -776,8 +778,8 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     };
 
     try {
-      await writeSkillActiveStateCopies(
-        dirname(dirname(input.stateDir)),
+      await writeSkillActiveStateCopiesForStateDir(
+        input.stateDir,
         state,
         input.sessionId,
         selectRootSkillStateCopy(previousRoot, state, input.sessionId),
@@ -850,12 +852,13 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 
       if (decision.autoCompleteModes.length > 0) {
         const transition = await reconcileWorkflowTransition(
-          dirname(dirname(input.stateDir)),
+          sourceCwd,
           requestedMode,
           {
             action: 'activate',
             sessionId: input.sessionId,
             source: 'keyword-detector',
+            baseStateDir: input.stateDir,
             currentModes: nextWorkflowEntries.map((entry) => entry.skill),
           },
         );
@@ -949,8 +952,8 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         }
       }
       nextState.active_skills = buildActiveSkills(nextState);
-      await writeSkillActiveStateCopies(
-        dirname(dirname(input.stateDir)),
+      await writeSkillActiveStateCopiesForStateDir(
+        input.stateDir,
         nextState,
         input.sessionId,
         selectRootSkillStateCopy(previousRoot, nextState, input.sessionId),
@@ -992,8 +995,8 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   try {
     const nextState = await persistStatefulSkillSeedState(input.stateDir, state, nowIso, previous);
     nextState.active_skills = buildActiveSkills(nextState);
-    await writeSkillActiveStateCopies(
-      dirname(dirname(input.stateDir)),
+    await writeSkillActiveStateCopiesForStateDir(
+      input.stateDir,
       nextState,
       input.sessionId,
       selectRootSkillStateCopy(previousRoot, nextState, input.sessionId),

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -667,6 +667,152 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('uses OMX_TEAM_STATE_ROOT canonical skill state to suppress stale team-root mode detail', async () => {
+    await withTempRepo('omx-hud-canonical-team-root-', async (cwd) => {
+      const teamStateRoot = join(cwd, 'team-state-root');
+      const sessionId = 'sess-team-root-canonical';
+      const sessionDir = join(teamStateRoot, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(teamStateRoot, 'session.json'), JSON.stringify({ session_id: sessionId, cwd }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: false,
+        skill: 'ralplan',
+        phase: 'completed',
+        session_id: sessionId,
+        active_skills: [],
+      }));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'stale-planning',
+      }));
+
+      const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+      const previousOmxRoot = process.env.OMX_ROOT;
+      const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+      const previousSessionId = process.env.OMX_SESSION_ID;
+      try {
+        process.env.OMX_TEAM_STATE_ROOT = teamStateRoot;
+        delete process.env.OMX_ROOT;
+        delete process.env.OMX_STATE_ROOT;
+        process.env.OMX_SESSION_ID = sessionId;
+
+        const state = await readAllState(cwd);
+        assert.equal(state.ralplan, null);
+      } finally {
+        if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+        else delete process.env.OMX_TEAM_STATE_ROOT;
+        if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+        else delete process.env.OMX_ROOT;
+        if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+        else delete process.env.OMX_STATE_ROOT;
+        if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+        else delete process.env.OMX_SESSION_ID;
+      }
+    });
+  });
+
+  it('uses OMX_TEAM_STATE_ROOT session.json for session-scoped canonical HUD state without OMX_SESSION_ID', async () => {
+    await withTempRepo('omx-hud-canonical-team-root-session-json-', async (cwd) => {
+      const teamStateRoot = join(cwd, 'team-state-root');
+      const sessionId = 'sess-team-root-session-json';
+      const sessionDir = join(teamStateRoot, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(teamStateRoot, 'session.json'), JSON.stringify({ session_id: sessionId, cwd }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [{ skill: 'ralplan', phase: 'planning', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'planning',
+      }));
+      const sourceStateDir = join(cwd, '.omx', 'state');
+      await mkdir(sourceStateDir, { recursive: true });
+      await writeFile(join(sourceStateDir, 'session.json'), JSON.stringify({
+        session_id: 'sess-stale-source-root',
+        cwd: join(cwd, '..', 'other-worktree'),
+      }));
+
+      const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+      const previousOmxRoot = process.env.OMX_ROOT;
+      const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+      const previousSessionId = process.env.OMX_SESSION_ID;
+      try {
+        process.env.OMX_TEAM_STATE_ROOT = teamStateRoot;
+        delete process.env.OMX_ROOT;
+        delete process.env.OMX_STATE_ROOT;
+        delete process.env.OMX_SESSION_ID;
+
+        const state = await readAllState(cwd);
+        assert.deepEqual(state.ralplan, {
+          active: true,
+          current_phase: 'planning',
+        });
+      } finally {
+        if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+        else delete process.env.OMX_TEAM_STATE_ROOT;
+        if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+        else delete process.env.OMX_ROOT;
+        if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+        else delete process.env.OMX_STATE_ROOT;
+        if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+        else delete process.env.OMX_SESSION_ID;
+      }
+    });
+  });
+
+  it('does not let source-root session.json suppress authoritative team-root HUD fallback', async () => {
+    await withTempRepo('omx-hud-canonical-team-root-ignore-source-session-', async (cwd) => {
+      const teamStateRoot = join(cwd, 'team-state-root');
+      await mkdir(teamStateRoot, { recursive: true });
+      await writeFile(join(teamStateRoot, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        active_skills: [{ skill: 'ralplan', phase: 'planning', active: true }],
+      }));
+      await writeFile(join(teamStateRoot, 'ralplan-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'planning',
+      }));
+      const sourceStateDir = join(cwd, '.omx', 'state');
+      await mkdir(join(sourceStateDir, 'sessions', 'sess-source-current'), { recursive: true });
+      await writeFile(join(sourceStateDir, 'session.json'), JSON.stringify({
+        session_id: 'sess-source-current',
+        cwd,
+      }));
+
+      const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+      const previousOmxRoot = process.env.OMX_ROOT;
+      const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+      const previousSessionId = process.env.OMX_SESSION_ID;
+      try {
+        process.env.OMX_TEAM_STATE_ROOT = teamStateRoot;
+        delete process.env.OMX_ROOT;
+        delete process.env.OMX_STATE_ROOT;
+        delete process.env.OMX_SESSION_ID;
+
+        const state = await readAllState(cwd);
+        assert.deepEqual(state.ralplan, {
+          active: true,
+          current_phase: 'planning',
+        });
+      } finally {
+        if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+        else delete process.env.OMX_TEAM_STATE_ROOT;
+        if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+        else delete process.env.OMX_ROOT;
+        if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+        else delete process.env.OMX_STATE_ROOT;
+        if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+        else delete process.env.OMX_SESSION_ID;
+      }
+    });
+  });
+
   it('preserves root fallback when no usable session or OMX_SESSION_ID exists', async () => {
     await withTempRepo('omx-hud-canonical-root-fallback-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -9,14 +9,13 @@ import { readFileSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
-import { omxStateDir } from '../utils/paths.js';
 import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
-import { getReadScopedStateFilePaths, getReadScopedStatePaths, readCurrentSessionId } from '../mcp/state-paths.js';
+import { getBaseStateDir, getReadScopedStateFilePaths, getReadScopedStatePaths, readCurrentSessionId } from '../mcp/state-paths.js';
 import { teamReadPhase as readTeamPhase } from '../team/team-ops.js';
 import { readUsableSessionState } from '../hooks/session.js';
-import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
+import { listActiveSkills, readVisibleSkillActiveStateForStateDir } from '../state/skill-active.js';
 import type {
   RalphStateForHud,
   UltraworkStateForHud,
@@ -409,7 +408,8 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     readSessionState(cwd),
     readCurrentSessionId(cwd),
   ]);
-  const canonicalSkillState = await readVisibleSkillActiveState(cwd, currentSessionId);
+  const stateDir = getBaseStateDir(cwd);
+  const canonicalSkillState = await readVisibleSkillActiveStateForStateDir(stateDir, currentSessionId);
   const canonicalSkills = new Map(
     listActiveSkills(canonicalSkillState).map((entry) => [entry.skill, entry] as const),
   );
@@ -481,7 +481,6 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
   // for authority/backlog/readiness display over JS-inferred state.
   let runtimeSnapshot: RuntimeSnapshot | null = null;
   if (isBridgeEnabled()) {
-    const stateDir = omxStateDir(cwd);
     const bridge = getDefaultBridge(stateDir);
     runtimeSnapshot = bridge.readCompatFile<RuntimeSnapshot>('snapshot.json');
   }

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -289,4 +289,59 @@ describe('state paths', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('resolves current session from authoritative team state root without OMX_SESSION_ID', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-paths-team-root-session-'));
+    const teamStateRoot = join(wd, 'team-state-root');
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    try {
+      process.env.OMX_TEAM_STATE_ROOT = teamStateRoot;
+      delete process.env.OMX_SESSION_ID;
+      await mkdir(join(teamStateRoot, 'sessions', 'sess-team-current'), { recursive: true });
+      await writeFile(join(teamStateRoot, 'session.json'), JSON.stringify({
+        session_id: 'sess-team-current',
+        cwd: wd,
+      }));
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({
+        session_id: 'sess-stale-source-root',
+        cwd: join(wd, '..', 'other-worktree'),
+      }));
+
+      assert.equal(await readCurrentSessionId(wd), 'sess-team-current');
+    } finally {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not resolve current session from source root when a team state root is authoritative', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-paths-ignore-source-session-'));
+    const teamStateRoot = join(wd, 'team-state-root');
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    try {
+      process.env.OMX_TEAM_STATE_ROOT = teamStateRoot;
+      delete process.env.OMX_SESSION_ID;
+      await mkdir(teamStateRoot, { recursive: true });
+      const sourceStateDir = join(wd, '.omx', 'state');
+      await mkdir(join(sourceStateDir, 'sessions', 'sess-source-current'), { recursive: true });
+      await writeFile(join(sourceStateDir, 'session.json'), JSON.stringify({
+        session_id: 'sess-source-current',
+        cwd: wd,
+      }));
+
+      assert.equal(await readCurrentSessionId(wd), undefined);
+    } finally {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -144,6 +144,166 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('co-locates boxed tracked mode and canonical skill state under OMX_ROOT', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const root = await mkdtemp(join(tmpdir(), 'omx-state-server-boxed-skill-'));
+    const box = join(root, 'box');
+    const wd = join(root, 'source');
+    const sessionId = 'sess-boxed-ralplan';
+    try {
+      await mkdir(wd, { recursive: true });
+      process.env.OMX_ROOT = box;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'ralplan',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const boxedSessionDir = join(box, '.omx', 'state', 'sessions', sessionId);
+      assert.equal(existsSync(join(boxedSessionDir, 'ralplan-state.json')), true);
+      assert.equal(existsSync(join(boxedSessionDir, 'skill-active-state.json')), true);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', sessionId, 'ralplan-state.json')), false);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', sessionId, 'skill-active-state.json')), false);
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('co-locates tracked mode and canonical skill state under OMX_TEAM_STATE_ROOT', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const root = await mkdtemp(join(tmpdir(), 'omx-state-server-team-skill-'));
+    const teamStateRoot = join(root, 'team-state');
+    const wd = join(root, 'source');
+    const sessionId = 'sess-team-ralplan';
+    try {
+      await mkdir(wd, { recursive: true });
+      delete process.env.OMX_ROOT;
+      delete process.env.OMX_STATE_ROOT;
+      process.env.OMX_TEAM_STATE_ROOT = teamStateRoot;
+
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'ralplan',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const teamSessionDir = join(teamStateRoot, 'sessions', sessionId);
+      assert.equal(existsSync(join(teamSessionDir, 'ralplan-state.json')), true);
+      assert.equal(existsSync(join(teamSessionDir, 'skill-active-state.json')), true);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', sessionId, 'ralplan-state.json')), false);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', sessionId, 'skill-active-state.json')), false);
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps auto-completed transition canonical state under OMX_TEAM_STATE_ROOT', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const root = await mkdtemp(join(tmpdir(), 'omx-state-server-team-transition-'));
+    const teamStateRoot = join(root, 'team-state');
+    const wd = join(root, 'source');
+    const sessionId = 'sess-team-transition';
+    try {
+      await mkdir(wd, { recursive: true });
+      delete process.env.OMX_ROOT;
+      delete process.env.OMX_STATE_ROOT;
+      process.env.OMX_TEAM_STATE_ROOT = teamStateRoot;
+
+      const deepInterview = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'deep-interview',
+            active: true,
+            current_phase: 'interviewing',
+          },
+        },
+      });
+      assert.equal(deepInterview.isError, undefined);
+
+      const ralplan = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'ralplan',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(ralplan.isError, undefined);
+      const teamSessionDir = join(teamStateRoot, 'sessions', sessionId);
+      const completedDeepInterview = JSON.parse(
+        await readFile(join(teamSessionDir, 'deep-interview-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string };
+      assert.equal(completedDeepInterview.active, false);
+      assert.equal(completedDeepInterview.current_phase, 'completed');
+      assert.equal(existsSync(join(teamSessionDir, 'ralplan-state.json')), true);
+      assert.equal(existsSync(join(teamSessionDir, 'skill-active-state.json')), true);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', sessionId, 'deep-interview-state.json')), false);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', sessionId, 'skill-active-state.json')), false);
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps missing state_read side-effect-free without setup', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -1,7 +1,11 @@
 import { delimiter, isAbsolute, join, relative, resolve as resolvePath } from 'path';
 import { existsSync } from 'fs';
-import { readdir } from 'fs/promises';
-import { readUsableSessionState } from '../hooks/session.js';
+import { readFile, readdir } from 'fs/promises';
+import {
+  isSessionStateUsable,
+  readUsableSessionState,
+  type SessionState,
+} from '../hooks/session.js';
 
 export const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 export const STATE_MODE_SEGMENT_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -211,12 +215,37 @@ function readSessionIdFromEnvironment(env: NodeJS.ProcessEnv = process.env): str
   return undefined;
 }
 
+async function readUsableSessionStateFromBaseStateDir(
+  cwd: string,
+  baseStateDir = getBaseStateDir(cwd),
+): Promise<SessionState | null> {
+  const sessionPath = join(baseStateDir, 'session.json');
+  if (!existsSync(sessionPath)) return null;
+
+  try {
+    const content = await readFile(sessionPath, 'utf-8');
+    const state = JSON.parse(content) as SessionState;
+    return isSessionStateUsable(state, cwd) ? state : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function readCurrentSessionId(workingDirectory?: string): Promise<string | undefined> {
   const cwd = resolveWorkingDirectoryForState(workingDirectory);
+  const baseStateDir = getBaseStateDir(cwd);
   const envSessionId = readSessionIdFromEnvironment();
   if (envSessionId) {
     const envScopedDir = getStateDir(cwd, envSessionId);
     if (existsSync(envScopedDir)) return envSessionId;
+  }
+
+  const baseSession = await readUsableSessionStateFromBaseStateDir(cwd, baseStateDir);
+  if (baseSession) return baseSession.session_id;
+
+  const localStateDir = join(cwd, '.omx', 'state');
+  if (resolvePath(baseStateDir) !== resolvePath(localStateDir)) {
+    return undefined;
   }
 
   return (await readUsableSessionState(cwd))?.session_id;

--- a/src/modes/__tests__/base-session-scope.test.ts
+++ b/src/modes/__tests__/base-session-scope.test.ts
@@ -27,6 +27,30 @@ describe('modes/base session-scoped persistence', () => {
     }
   });
 
+  it('writes session canonical skill state under the base state dir without nesting sessions twice', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-session-canonical-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-base-canonical';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+
+      await startMode('ralplan', 'write canonical in session scope', 5, wd);
+      await updateModeState('ralplan', { current_phase: 'planning', iteration: 1 }, wd);
+
+      const canonicalPath = join(sessionDir, 'skill-active-state.json');
+      const nestedCanonicalPath = join(sessionDir, 'sessions', sessionId, 'skill-active-state.json');
+      assert.equal(existsSync(canonicalPath), true);
+      assert.equal(existsSync(nestedCanonicalPath), false);
+      const canonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(canonical.skill, 'ralplan');
+      assert.equal(canonical.phase, 'planning');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('persists owner_omx_session_id for Ralph when session scope is active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-session-ralph-owner-'));
     try {

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -120,12 +120,14 @@ export async function startMode(
   await mkdir(dir, { recursive: true });
 
   const scope = await resolveStateScope(projectRoot);
+  const baseStateDir = getBaseStateDir(projectRoot);
   let transitionMessage: string | undefined;
   if (isTrackedWorkflowMode(mode)) {
     const transition = await reconcileWorkflowTransition(projectRoot ?? process.cwd(), mode, {
       action: 'start',
       sessionId: scope.sessionId,
       source: 'startMode',
+      baseStateDir,
     });
     transitionMessage = transition.transitionMessage;
   }
@@ -150,6 +152,7 @@ export async function startMode(
   if (isTrackedWorkflowMode(mode)) {
     await syncCanonicalSkillStateForMode({
       cwd: projectRoot ?? process.cwd(),
+      baseStateDir,
       mode,
       active: true,
       currentPhase: typeof state.current_phase === 'string' ? state.current_phase : undefined,
@@ -235,6 +238,7 @@ export async function updateModeState(
   explicitSessionId?: string,
 ): Promise<ModeState> {
   const scope = await resolveStateScope(projectRoot, explicitSessionId);
+  const baseStateDir = getBaseStateDir(projectRoot);
   const current = mode === 'ralph' && scope.sessionId
     ? await readModeStateForActiveDecision(mode, scope.sessionId, projectRoot)
     : explicitSessionId
@@ -261,6 +265,7 @@ export async function updateModeState(
   if (isTrackedWorkflowMode(mode)) {
     await syncCanonicalSkillStateForMode({
       cwd: projectRoot ?? process.cwd(),
+      baseStateDir,
       mode,
       active: updated.active === true,
       currentPhase: typeof updated.current_phase === 'string' ? updated.current_phase : undefined,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -24,6 +24,7 @@ import { writeSessionStart } from "../../hooks/session.js";
 import { resetTriageConfigCache } from "../../hooks/triage-config.js";
 import { executeStateOperation } from "../../state/operations.js";
 import { OMX_TMUX_HUD_OWNER_ENV } from "../../hud/reconcile.js";
+import { readAllState } from "../../hud/state.js";
 import { writePage } from "../../wiki/storage.js";
 import { WIKI_SCHEMA_VERSION } from "../../wiki/types.js";
 
@@ -1237,6 +1238,112 @@ describe("codex native hook dispatch", () => {
       assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-1", "ralplan-state.json")), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("records boxed keyword activation mode detail and skill state under OMX_ROOT", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-hook-boxed-"));
+    const cwd = join(root, "source");
+    const omxRoot = join(root, "box");
+    const sessionId = "sess-boxed-ralplan";
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const previousOmxSessionId = process.env.OMX_SESSION_ID;
+    try {
+      await mkdir(cwd, { recursive: true });
+      process.env.OMX_ROOT = omxRoot;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      process.env.OMX_SESSION_ID = sessionId;
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-boxed",
+          turn_id: "turn-boxed",
+          prompt: "$ralplan implement issue #1307",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "ralplan");
+
+      const boxedSessionDir = join(omxRoot, ".omx", "state", "sessions", sessionId);
+      assert.equal(existsSync(join(boxedSessionDir, "skill-active-state.json")), true);
+      assert.equal(existsSync(join(boxedSessionDir, "ralplan-state.json")), true);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", sessionId, "skill-active-state.json")), false);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", sessionId, "ralplan-state.json")), false);
+
+      const hudState = await readAllState(cwd);
+      assert.equal(hudState.ralplan?.active, true);
+      assert.equal(hudState.ralplan?.current_phase, "planning");
+    } finally {
+      if (typeof previousOmxRoot === "string") process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === "string") process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof previousOmxSessionId === "string") process.env.OMX_SESSION_ID = previousOmxSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("records native keyword activation mode detail and skill state under OMX_TEAM_STATE_ROOT", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-hook-team-root-"));
+    const cwd = join(root, "source");
+    const teamStateRoot = join(root, "team-state");
+    const sessionId = "sess-team-root-ralplan";
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const previousOmxSessionId = process.env.OMX_SESSION_ID;
+    try {
+      await mkdir(cwd, { recursive: true });
+      delete process.env.OMX_ROOT;
+      delete process.env.OMX_STATE_ROOT;
+      process.env.OMX_TEAM_STATE_ROOT = teamStateRoot;
+      process.env.OMX_SESSION_ID = sessionId;
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-team-root",
+          turn_id: "turn-team-root",
+          prompt: "$ralplan implement issue #1307",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "ralplan");
+
+      const teamSessionDir = join(teamStateRoot, "sessions", sessionId);
+      assert.equal(existsSync(join(teamSessionDir, "skill-active-state.json")), true);
+      assert.equal(existsSync(join(teamSessionDir, "ralplan-state.json")), true);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", sessionId, "skill-active-state.json")), false);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", sessionId, "ralplan-state.json")), false);
+
+      const hudState = await readAllState(cwd);
+      assert.equal(hudState.ralplan?.active, true);
+      assert.equal(hudState.ralplan?.current_phase, "planning");
+    } finally {
+      if (typeof previousOmxRoot === "string") process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === "string") process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof previousOmxSessionId === "string") process.env.OMX_SESSION_ID = previousOmxSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(root, { recursive: true, force: true });
     }
   });
 
@@ -6246,6 +6353,41 @@ exit 0
         systemMessage: "OMX team pipeline is still active at phase team-exec.",
       });
       assert.equal(existsSync(join(sharedRoot, "team", "canonical-root-team", "phase.json")), true);
+    } finally {
+      if (typeof priorTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = priorTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores stale source-root team Stop fallback when OMX_TEAM_STATE_ROOT is authoritative", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-stale-source-root-"));
+    const teamStateRoot = join(cwd, "shared-team-state");
+    const priorTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_TEAM_STATE_ROOT = teamStateRoot;
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await mkdir(join(teamStateRoot, "team", "stale-source-team"), { recursive: true });
+      await writeJson(join(cwd, ".omx", "state", "team-state.json"), {
+        active: true,
+        team_name: "stale-source-team",
+        current_phase: "team-exec",
+      });
+      await writeJson(join(teamStateRoot, "team", "stale-source-team", "phase.json"), {
+        current_phase: "team-exec",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stale-source-team",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
     } finally {
       if (typeof priorTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = priorTeamStateRoot;
       else delete process.env.OMX_TEAM_STATE_ROOT;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6,10 +6,10 @@ import { pathToFileURL } from "url";
 import { readModeState, readModeStateForActiveDecision, readModeStateForSession, updateModeState } from "../modes/base.js";
 import {
   extractSessionIdFromInitializedStatePath,
-  getSkillActiveStatePaths,
+  getSkillActiveStatePathsForStateDir,
   listActiveSkills,
   readSkillActiveState,
-  readVisibleSkillActiveState,
+  readVisibleSkillActiveStateForStateDir,
   type SkillActiveStateLike,
 } from "../state/skill-active.js";
 import {
@@ -35,7 +35,7 @@ import {
 } from "../team/state.js";
 import { omxNotepadPath, omxProjectMemoryPath } from "../utils/paths.js";
 import { findGitLayout } from "../utils/git-layout.js";
-import { getStateFilePath, getStatePath } from "../mcp/state-paths.js";
+import { getBaseStateDir, getStateFilePath, getStatePath } from "../mcp/state-paths.js";
 import {
   detectKeywords,
   detectPrimaryKeyword,
@@ -559,8 +559,8 @@ async function readCanonicalTerminalRunStateForStop(
   return shouldHonorCanonicalTerminalRunState(runRecord, mode) ? runRecord : null;
 }
 
-async function isVisibleRalphActiveForSession(cwd: string, sessionId: string): Promise<boolean> {
-  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+async function isVisibleRalphActiveForSession(stateDir: string, sessionId: string): Promise<boolean> {
+  const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   if (!canonicalState) return false;
   return listActiveSkills(canonicalState).some((entry) => (
     entry.skill === "ralph"
@@ -568,8 +568,8 @@ async function isVisibleRalphActiveForSession(cwd: string, sessionId: string): P
   ));
 }
 
-async function hasConsistentRalphSkillActivation(cwd: string, sessionId: string): Promise<boolean> {
-  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+async function hasConsistentRalphSkillActivation(stateDir: string, sessionId: string): Promise<boolean> {
+  const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   if (!canonicalState) return true;
 
   const initializedMode = safeString(canonicalState.initialized_mode).trim();
@@ -582,6 +582,7 @@ async function hasConsistentRalphSkillActivation(cwd: string, sessionId: string)
 }
 
 async function readActiveRalphState(
+  cwd: string,
   stateDir: string,
   preferredSessionId?: string,
   ownerContext?: {
@@ -590,7 +591,6 @@ async function readActiveRalphState(
     tmuxPaneId?: string;
   },
 ): Promise<ActiveRalphStopState | null> {
-  const cwd = resolve(stateDir, "..", "..");
   const [rawSessionInfo, usableSessionInfo] = await Promise.all([
     readSessionState(cwd),
     readUsableSessionState(cwd),
@@ -620,7 +620,7 @@ async function readActiveRalphState(
     if (
       sessionScoped?.active === true
       && isRalphStartingPhase(sessionScoped)
-      && !(await isVisibleRalphActiveForSession(cwd, sessionId))
+      && !(await isVisibleRalphActiveForSession(stateDir, sessionId))
     ) {
       continue;
     }
@@ -634,7 +634,7 @@ async function readActiveRalphState(
         currentNativeSessionId,
         tmuxPaneId: safeString(ownerContext?.tmuxPaneId).trim(),
       })
-      && await hasConsistentRalphSkillActivation(cwd, sessionId)
+      && await hasConsistentRalphSkillActivation(stateDir, sessionId)
     ) {
       return { state: sessionScoped, path: sessionScopedPath };
     }
@@ -1480,7 +1480,7 @@ async function resolveTeamWorkerStopDecision(
   const blockWorkerStop = (
     reasonCode: string,
     detail: string,
-    stateDirForDecision = join(cwd, ".omx", "state"),
+    stateDirForDecision = getBaseStateDir(cwd),
   ): TeamWorkerStopDecision => ({
     kind: "blocked",
     stateDir: stateDirForDecision,
@@ -1698,6 +1698,7 @@ async function buildGoalWorkflowReconciliationStopOutput(
 
 async function readTeamModeStateForStop(
   cwd: string,
+  stateDir: string,
   sessionId?: string,
 ): Promise<Record<string, unknown> | null> {
   const normalizedSessionId = safeString(sessionId).trim();
@@ -1705,10 +1706,10 @@ async function readTeamModeStateForStop(
     return await readModeState("team", cwd);
   }
 
-  const scopedState = await readStopSessionPinnedState("team-state.json", cwd, normalizedSessionId);
+  const scopedState = await readStopSessionPinnedState("team-state.json", cwd, normalizedSessionId, stateDir);
   if (scopedState) return scopedState;
 
-  const rootState = await readJsonIfExists(join(cwd, ".omx", "state", "team-state.json"));
+  const rootState = await readJsonIfExists(join(stateDir, "team-state.json"));
   if (rootState?.active !== true) return null;
 
   const ownerSessionId = safeString(rootState.session_id).trim();
@@ -1723,7 +1724,7 @@ async function buildTeamStopOutput(cwd: string, sessionId?: string): Promise<Rec
   if (await readCanonicalTerminalRunStateForStop(cwd, sessionId, "team")) {
     return null;
   }
-  const teamState = await readTeamModeStateForStop(cwd, sessionId);
+  const teamState = await readTeamModeStateForStop(cwd, getBaseStateDir(cwd), sessionId);
   if (teamState?.active !== true) return null;
   const teamName = safeString(teamState.team_name).trim();
   if (teamName) {
@@ -1781,12 +1782,13 @@ function hasReleaseReadinessMode(payload: CodexHookPayload): boolean {
 
 async function hasReleaseReadinessStopMarker(
   cwd: string,
+  stateDir: string,
   sessionId: string,
   teamName: string,
 ): Promise<boolean> {
   if (!sessionId) return false;
 
-  const markerState = await readStopSessionPinnedState("release-readiness-state.json", cwd, sessionId);
+  const markerState = await readStopSessionPinnedState("release-readiness-state.json", cwd, sessionId, stateDir);
   if (markerState?.active !== true || markerState.stable_final_recommendation_emitted !== true) {
     return false;
   }
@@ -1831,8 +1833,11 @@ async function readStopSessionPinnedState(
   fileName: string,
   cwd: string,
   sessionId: string,
+  stateDir?: string,
 ): Promise<Record<string, unknown> | null> {
-  const statePath = getStateFilePath(fileName, cwd, sessionId || undefined);
+  const statePath = stateDir && sessionId
+    ? join(stateDir, "sessions", sessionId, fileName)
+    : getStateFilePath(fileName, cwd, sessionId || undefined);
   return readJsonIfExists(statePath);
 }
 
@@ -1883,11 +1888,12 @@ function modeStateMatchesSkillStopContext(
 
 async function readBlockingSkillForStop(
   cwd: string,
+  stateDir: string,
   sessionId: string,
   threadId: string,
   requiredSkill?: string,
 ): Promise<{ skill: string; phase: string; latestPlanPath?: string; planningComplete?: boolean; runOutcome?: string } | null> {
-  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+  const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   const visibleEntries = canonicalState ? listActiveSkills(canonicalState) : [];
   const candidateSkills = requiredSkill
     ? [requiredSkill]
@@ -1897,7 +1903,7 @@ async function readBlockingSkillForStop(
     const terminalRunState = await readCanonicalTerminalRunStateForStop(cwd, sessionId, skill);
     if (terminalRunState) continue;
 
-    const modeState = await readStopSessionPinnedState(`${skill}-state.json`, cwd, sessionId);
+    const modeState = await readStopSessionPinnedState(`${skill}-state.json`, cwd, sessionId, stateDir);
     if (!modeState || modeState.active !== true) continue;
     if (!modeStateMatchesSkillStopContext(modeState, cwd, sessionId)) continue;
 
@@ -1957,11 +1963,12 @@ function isTerminalOrInactiveModeState(state: Record<string, unknown> | null): b
 
 async function readSessionScopedModeStateForRootSkill(
   cwd: string,
+  stateDir: string,
   skill: string,
   sessionIds: string[],
 ): Promise<Record<string, unknown> | null> {
   for (const sessionId of sessionIds) {
-    const state = await readJsonIfExists(getStateFilePath(`${skill}-state.json`, cwd, sessionId));
+    const state = await readStopSessionPinnedState(`${skill}-state.json`, cwd, sessionId, stateDir);
     if (state) return state;
   }
   return null;
@@ -1969,9 +1976,10 @@ async function readSessionScopedModeStateForRootSkill(
 
 async function reconcileStaleRootSkillActiveStateForStop(
   cwd: string,
+  stateDir: string,
   sessionId: string,
 ): Promise<void> {
-  const { rootPath } = getSkillActiveStatePaths(cwd);
+  const { rootPath } = getSkillActiveStatePathsForStateDir(stateDir);
   const rootState = await readSkillActiveState(rootPath);
   if (!rootState?.active) return;
 
@@ -1997,7 +2005,7 @@ async function reconcileStaleRootSkillActiveStateForStop(
       initializedSessionId,
       safeString(rootState.session_id),
     ]);
-    const modeState = await readSessionScopedModeStateForRootSkill(cwd, skill, candidateSessionIds);
+    const modeState = await readSessionScopedModeStateForRootSkill(cwd, stateDir, skill, candidateSessionIds);
     if (isTerminalOrInactiveModeState(modeState)) {
       changed = true;
       continue;
@@ -2076,12 +2084,13 @@ function buildRalplanContinuationStatus(
 
 async function readStopAutoNudgePhase(
   cwd: string,
+  stateDir: string,
   sessionId: string,
   threadId: string,
 ): Promise<string> {
   const normalizedSessionId = sessionId.trim();
   if (normalizedSessionId) {
-    const scopedModeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, normalizedSessionId);
+    const scopedModeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, normalizedSessionId, stateDir);
     if (
       scopedModeState?.active === true
       && safeString(scopedModeState.current_phase).trim().toLowerCase() === "intent-first"
@@ -2089,7 +2098,7 @@ async function readStopAutoNudgePhase(
       return "planning";
     }
   } else {
-    const rootModeState = await readJsonIfExists(join(cwd, ".omx", "state", "deep-interview-state.json"));
+    const rootModeState = await readJsonIfExists(join(stateDir, "deep-interview-state.json"));
     if (
       rootModeState?.active === true
       && safeString(rootModeState.current_phase).trim().toLowerCase() === "intent-first"
@@ -2100,7 +2109,7 @@ async function readStopAutoNudgePhase(
 
   if (!normalizedSessionId) return "";
 
-  const canonicalState = await readVisibleSkillActiveState(cwd, normalizedSessionId);
+  const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, normalizedSessionId);
   const visibleEntries = canonicalState ? listActiveSkills(canonicalState) : [];
   const deepInterview = visibleEntries.find((entry) => (
     entry.skill === "deep-interview"
@@ -2108,7 +2117,7 @@ async function readStopAutoNudgePhase(
   ));
   if (!deepInterview) return "";
 
-  const modeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, normalizedSessionId);
+  const modeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, normalizedSessionId, stateDir);
   if (!modeState || modeState.active !== true) return "";
 
   const modePhase = safeString(modeState.current_phase).trim().toLowerCase();
@@ -2117,11 +2126,12 @@ async function readStopAutoNudgePhase(
 
 async function buildDeepInterviewQuestionStopOutput(
   cwd: string,
+  stateDir: string,
   sessionId: string,
   threadId: string,
 ): Promise<{ output: Record<string, unknown>; obligationId: string } | null> {
   await reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords(cwd, sessionId);
-  const modeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId);
+  const modeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId, stateDir);
   if (!modeState) return null;
 
   const questionEnforcement = safeObject(modeState.question_enforcement);
@@ -2133,7 +2143,7 @@ async function buildDeepInterviewQuestionStopOutput(
     return null;
   }
 
-  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+  const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   if (canonicalState) {
     const blocker = listActiveSkills(canonicalState).find((entry) => (
       entry.skill === "deep-interview"
@@ -2336,9 +2346,10 @@ async function findCanonicalActiveTeamForSession(
 
 async function resolveActiveTeamNameForStop(
   cwd: string,
+  stateDir: string,
   sessionId: string,
 ): Promise<string> {
-  const directState = await readTeamModeStateForStop(cwd, sessionId);
+  const directState = await readTeamModeStateForStop(cwd, stateDir, sessionId);
   const directTeamName = safeString(directState?.team_name).trim();
   if (directState?.active === true && directTeamName) return directTeamName;
 
@@ -2354,12 +2365,12 @@ async function maybeBuildReleaseReadinessFinalizeStopOutput(
 ): Promise<{ matched: boolean; output: Record<string, unknown> | null }> {
   if (!sessionId) return { matched: false, output: null };
 
-  const teamName = await resolveActiveTeamNameForStop(cwd, sessionId);
+  const teamName = await resolveActiveTeamNameForStop(cwd, stateDir, sessionId);
   if (!teamName) return { matched: false, output: null };
 
   const explicitReleaseReadinessContext =
     hasReleaseReadinessMode(payload)
-    || await hasReleaseReadinessStopMarker(cwd, sessionId, teamName);
+    || await hasReleaseReadinessStopMarker(cwd, stateDir, sessionId, teamName);
   if (!explicitReleaseReadinessContext) {
     return { matched: false, output: null };
   }
@@ -2397,10 +2408,11 @@ async function maybeBuildReleaseReadinessFinalizeStopOutput(
 
 async function buildSkillStopOutput(
   cwd: string,
+  stateDir: string,
   sessionId: string,
   threadId: string,
 ): Promise<Record<string, unknown> | null> {
-  const blocker = await readBlockingSkillForStop(cwd, sessionId, threadId);
+  const blocker = await readBlockingSkillForStop(cwd, stateDir, sessionId, threadId);
   if (!blocker) return null;
 
   const subagentSummary = await readSubagentSessionSummary(cwd, sessionId).catch(() => null);
@@ -2547,13 +2559,13 @@ async function buildStopHookOutput(
   const canonicalSessionId = await resolveInternalSessionIdForPayload(cwd, sessionId);
   const threadId = readPayloadThreadId(payload);
   if (canonicalSessionId) {
-    await reconcileStaleRootSkillActiveStateForStop(cwd, canonicalSessionId);
+    await reconcileStaleRootSkillActiveStateForStop(cwd, stateDir, canonicalSessionId);
   }
   const execFollowupOutput = await buildExecFollowupStopOutput(cwd, canonicalSessionId);
   if (execFollowupOutput) return execFollowupOutput;
   const ralphState = options.skipRalphStopBlock === true
     ? null
-    : await readActiveRalphState(stateDir, canonicalSessionId, {
+    : await readActiveRalphState(cwd, stateDir, canonicalSessionId, {
       payloadSessionId: sessionId,
       threadId,
       tmuxPaneId: safeString(process.env.TMUX_PANE).trim(),
@@ -2667,6 +2679,7 @@ async function buildStopHookOutput(
     if (canonicalSessionId) {
       const deepInterviewQuestionOutput = await buildDeepInterviewQuestionStopOutput(
         cwd,
+        stateDir,
         canonicalSessionId,
         threadId,
       );
@@ -2700,7 +2713,7 @@ async function buildStopHookOutput(
         if (repeatedCanonicalTeamOutput) return repeatedCanonicalTeamOutput;
       }
 
-      const skillOutput = await buildSkillStopOutput(cwd, canonicalSessionId, threadId);
+      const skillOutput = await buildSkillStopOutput(cwd, stateDir, canonicalSessionId, threadId);
       if (skillOutput) {
         return await returnPersistentStopBlock(
           payload,
@@ -2730,7 +2743,7 @@ async function buildStopHookOutput(
       );
     }
     const autoNudgeConfig = await loadAutoNudgeConfig();
-    const autoNudgePhase = await readStopAutoNudgePhase(cwd, canonicalSessionId, threadId);
+    const autoNudgePhase = await readStopAutoNudgePhase(cwd, stateDir, canonicalSessionId, threadId);
 
     if (
       autoNudgeConfig.enabled
@@ -2816,7 +2829,9 @@ export async function dispatchCodexNativeHook(
 ): Promise<NativeHookDispatchResult> {
   const hookEventName = readHookEventName(payload);
   const cwd = options.cwd ?? (safeString(payload.cwd).trim() || process.cwd());
-  const stateDir = join(cwd, ".omx", "state");
+  // Native hooks must use the same authoritative runtime state root as HUD/MCP
+  // when boxed/team roots are active; do not bypass it with cwd/.omx/state.
+  const stateDir = getBaseStateDir(cwd);
   await mkdir(stateDir, { recursive: true });
 
   const omxEventName = mapCodexHookEventToOmxEvent(hookEventName);
@@ -2918,6 +2933,7 @@ export async function dispatchCodexNativeHook(
         turnId || undefined,
       ) ?? await recordSkillActivation({
         stateDir,
+        sourceCwd: cwd,
         text: prompt,
         sessionId: sessionIdForState,
         threadId,

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -29,6 +29,7 @@ import {
   getQuotaUsage,
   normalizeInputMessages,
 } from './notify-hook/payload-parser.js';
+import { getBaseStateDir } from '../mcp/state-paths.js';
 import {
   getScopedStatePath,
   readCurrentSessionId,
@@ -303,7 +304,7 @@ async function main() {
     ? await resolveTeamStateDirForWorker(cwd, parsedTeamWorker)
     : null;
   const workerStateRootResolved = !isTeamWorker || !!resolvedWorkerStateDir;
-  const stateDir = resolvedWorkerStateDir || join(cwd, '.omx', 'state');
+  const stateDir = resolvedWorkerStateDir || getBaseStateDir(cwd);
   const logsDir = join(cwd, '.omx', 'logs');
   const omxDir = join(cwd, '.omx');
   let currentOmxSessionId = '';
@@ -621,6 +622,7 @@ async function main() {
     if (latestUserInput) {
         await recordSkillActivation({
           stateDir,
+          sourceCwd: cwd,
           text: latestUserInput,
           sessionId: getEffectiveSessionId(),
           threadId: payloadThreadId,

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -157,4 +157,61 @@ describe('workflow transition rules', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('co-locates auto-completed mode detail and canonical skill state under an explicit base state dir', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-workflow-reconcile-base-dir-'));
+    try {
+      const wd = join(root, 'source');
+      const baseStateDir = join(root, 'boxed-state');
+      const sessionId = 'sess-transition-base-dir';
+      const sessionDir = join(baseStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(
+        join(sessionDir, 'deep-interview-state.json'),
+        JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'interviewing' }, null, 2),
+        'utf-8',
+      );
+      await writeFile(
+        join(sessionDir, 'skill-active-state.json'),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'deep-interview',
+          phase: 'interviewing',
+          active_skills: [
+            {
+              skill: 'deep-interview',
+              phase: 'interviewing',
+              active: true,
+              session_id: sessionId,
+            },
+          ],
+        }, null, 2),
+        'utf-8',
+      );
+
+      const transition = await reconcileWorkflowTransition(wd, 'ralplan', {
+        action: 'start',
+        sessionId,
+        source: 'test',
+        baseStateDir,
+      });
+
+      const boxedModePath = join(sessionDir, 'deep-interview-state.json');
+      assert.equal(transition.decision.allowed, true);
+      assert.deepEqual(transition.completedPaths, [boxedModePath]);
+
+      const boxedMode = JSON.parse(await readFile(boxedModePath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(boxedMode.active, false);
+      assert.equal(boxedMode.current_phase, 'completed');
+
+      const boxedSkill = JSON.parse(await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(boxedSkill.active, false);
+
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', sessionId, 'deep-interview-state.json')), false);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', sessionId, 'skill-active-state.json')), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -6,6 +6,7 @@ import { withModeRuntimeContext } from './mode-state-context.js';
 import {
   getAllScopedStatePaths,
   getAuthoritativeActiveStateDirs,
+  getBaseStateDir,
   getReadScopedStateDirs,
   getReadScopedStatePaths,
   getStateDir,
@@ -22,7 +23,7 @@ import {
   SKILL_ACTIVE_STATE_MODE,
   readSkillActiveState,
   syncCanonicalSkillStateForMode,
-  writeSkillActiveStateCopies,
+  writeSkillActiveStateCopiesForStateDir,
 } from './skill-active.js';
 import { isTrackedWorkflowMode } from './workflow-transition.js';
 import { reconcileWorkflowTransition } from './workflow-transition-reconcile.js';
@@ -225,6 +226,7 @@ export async function executeStateOperation(
         await initializeStateEnvironment(cwd, effectiveSessionId);
 
         const mode = validateStateModeSegment(rawArgs.mode);
+        const baseStateDir = getBaseStateDir(cwd);
         const path = getStatePath(mode, cwd, effectiveSessionId);
         const {
           mode: _mode,
@@ -303,6 +305,7 @@ export async function executeStateOperation(
                 action: 'write',
                 sessionId: effectiveSessionId,
                 source: 'state-operations',
+                baseStateDir,
               });
               transitionMessage ??= transition.transitionMessage;
             } catch (error) {
@@ -325,7 +328,7 @@ export async function executeStateOperation(
         if (mode === SKILL_ACTIVE_STATE_MODE) {
           const state = await readSkillActiveState(path);
           if (state) {
-            await writeSkillActiveStateCopies(cwd, state, effectiveSessionId);
+            await writeSkillActiveStateCopiesForStateDir(baseStateDir, state, effectiveSessionId);
           }
         } else {
           if (mode === 'ralph' && ensureRalphArtifacts) {
@@ -334,6 +337,7 @@ export async function executeStateOperation(
           const data = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
           await syncCanonicalSkillStateForMode({
             cwd,
+            baseStateDir,
             mode,
             active: data.active === true,
             currentPhase: typeof data.current_phase === 'string' ? data.current_phase : undefined,
@@ -358,6 +362,7 @@ export async function executeStateOperation(
         await initializeStateEnvironment(cwd, effectiveSessionId);
 
         const mode = validateStateModeSegment(rawArgs.mode);
+        const baseStateDir = getBaseStateDir(cwd);
         const allSessions = rawArgs.all_sessions === true;
 
         if (!allSessions) {
@@ -374,6 +379,7 @@ export async function executeStateOperation(
           if (mode !== SKILL_ACTIVE_STATE_MODE) {
             await syncCanonicalSkillStateForMode({
               cwd,
+              baseStateDir,
               mode,
               active: false,
               sessionId: effectiveSessionId,
@@ -393,6 +399,7 @@ export async function executeStateOperation(
         if (mode !== SKILL_ACTIVE_STATE_MODE) {
           await syncCanonicalSkillStateForMode({
             cwd,
+            baseStateDir,
             mode,
             active: false,
             source: 'state-operations',

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -56,6 +56,7 @@ export interface SkillActiveStateLike {
 
 export interface SyncCanonicalSkillStateOptions {
   cwd: string;
+  baseStateDir?: string;
   mode: string;
   active: boolean;
   currentPhase?: string;
@@ -224,12 +225,19 @@ export function getSkillActiveStatePaths(cwd: string, sessionId?: string): {
   rootPath: string;
   sessionPath?: string;
 } {
-  const rootPath = join(omxStateDir(cwd), SKILL_ACTIVE_STATE_FILE);
+  return getSkillActiveStatePathsForStateDir(omxStateDir(cwd), sessionId);
+}
+
+export function getSkillActiveStatePathsForStateDir(stateDir: string, sessionId?: string): {
+  rootPath: string;
+  sessionPath?: string;
+} {
+  const rootPath = join(stateDir, SKILL_ACTIVE_STATE_FILE);
   const normalizedSession = safeString(sessionId).trim();
   if (!normalizedSession) return { rootPath };
   return {
     rootPath,
-    sessionPath: join(omxStateDir(cwd), 'sessions', normalizedSession, SKILL_ACTIVE_STATE_FILE),
+    sessionPath: join(stateDir, 'sessions', normalizedSession, SKILL_ACTIVE_STATE_FILE),
   };
 }
 
@@ -248,6 +256,25 @@ export async function writeSkillActiveStateCopies(
   rootState?: SkillActiveStateLike | null,
 ): Promise<void> {
   const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
+  await writeSkillActiveStateCopiesToPaths(rootPath, sessionPath, state, rootState);
+}
+
+export async function writeSkillActiveStateCopiesForStateDir(
+  stateDir: string,
+  state: SkillActiveStateLike,
+  sessionId?: string,
+  rootState?: SkillActiveStateLike | null,
+): Promise<void> {
+  const { rootPath, sessionPath } = getSkillActiveStatePathsForStateDir(stateDir, sessionId);
+  await writeSkillActiveStateCopiesToPaths(rootPath, sessionPath, state, rootState);
+}
+
+async function writeSkillActiveStateCopiesToPaths(
+  rootPath: string,
+  sessionPath: string | undefined,
+  state: SkillActiveStateLike,
+  rootState?: SkillActiveStateLike | null,
+): Promise<void> {
   const normalized = { version: 1, ...state };
   const normalizedRoot = rootState === null
     ? null
@@ -267,6 +294,21 @@ export async function writeSkillActiveStateCopies(
 
 export async function readVisibleSkillActiveState(cwd: string, sessionId?: string): Promise<SkillActiveStateLike | null> {
   const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
+  return readVisibleSkillActiveStateFromPaths(rootPath, sessionPath);
+}
+
+export async function readVisibleSkillActiveStateForStateDir(
+  stateDir: string,
+  sessionId?: string,
+): Promise<SkillActiveStateLike | null> {
+  const { rootPath, sessionPath } = getSkillActiveStatePathsForStateDir(stateDir, sessionId);
+  return readVisibleSkillActiveStateFromPaths(rootPath, sessionPath);
+}
+
+async function readVisibleSkillActiveStateFromPaths(
+  rootPath: string,
+  sessionPath?: string,
+): Promise<SkillActiveStateLike | null> {
   if (sessionPath && existsSync(sessionPath)) {
     return readSkillActiveState(sessionPath);
   }
@@ -282,6 +324,7 @@ export function tracksCanonicalWorkflowSkill(mode: string): mode is CanonicalWor
 export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkillStateOptions): Promise<void> {
   const {
     cwd,
+    baseStateDir = omxStateDir(cwd),
     mode,
     active,
     currentPhase,
@@ -295,7 +338,7 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
 
   if (!tracksCanonicalWorkflowSkill(mode)) return;
 
-  const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
+  const { rootPath, sessionPath } = getSkillActiveStatePathsForStateDir(baseStateDir, sessionId);
   const existingRoot = await readSkillActiveState(rootPath);
   const existingSession = sessionPath ? await readSkillActiveState(sessionPath) : null;
   if (!existingRoot && !existingSession && !active && !options.allSessions) return;
@@ -390,7 +433,7 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
         mode,
         normalizedSessionId,
       );
-    await writeSkillActiveStateCopies(cwd, nextSessionState, sessionId, nextRootState);
+    await writeSkillActiveStateCopiesForStateDir(baseStateDir, nextSessionState, sessionId, nextRootState);
     return;
   }
 
@@ -416,9 +459,9 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
     : [...sessionScopedRootMirrorEntries, ...nextRootScopedEntries];
 
   const nextRootState = applyEntriesToState(existingRoot, nextRootEntries, mode);
-  await writeSkillActiveStateCopies(cwd, nextRootState, undefined, nextRootState);
+  await writeSkillActiveStateCopiesForStateDir(baseStateDir, nextRootState, undefined, nextRootState);
 
-  const sessionsDir = join(omxStateDir(cwd), 'sessions');
+  const sessionsDir = join(baseStateDir, 'sessions');
   if (!existsSync(sessionsDir)) return;
 
   const sessionIds = await readdir(sessionsDir).catch(() => []);
@@ -447,6 +490,6 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
       nextSessionEntries[0]?.skill || mode,
       sessionId,
     );
-    await writeSkillActiveStateCopies(cwd, nextSessionState, sessionId, nextRootState);
+    await writeSkillActiveStateCopiesForStateDir(baseStateDir, nextSessionState, sessionId, nextRootState);
   }
 }

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import { getStatePath } from '../mcp/state-paths.js';
 import {
   buildWorkflowTransitionError,
@@ -14,6 +14,7 @@ import {
 import {
   listActiveSkills,
   readVisibleSkillActiveState,
+  readVisibleSkillActiveStateForStateDir,
   syncCanonicalSkillStateForMode,
 } from './skill-active.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
@@ -54,8 +55,28 @@ async function readJsonIfExists(
   }
 }
 
-async function visibleTrackedModes(cwd: string, sessionId?: string): Promise<TrackedWorkflowMode[]> {
-  const canonical = await readVisibleSkillActiveState(cwd, sessionId);
+function modeStatePathForRoot(
+  mode: TrackedWorkflowMode,
+  cwd: string,
+  sessionId?: string,
+  baseStateDir?: string,
+): string {
+  if (baseStateDir) {
+    return sessionId
+      ? join(baseStateDir, 'sessions', sessionId, `${mode}-state.json`)
+      : join(baseStateDir, `${mode}-state.json`);
+  }
+  return getStatePath(mode, cwd, sessionId);
+}
+
+async function visibleTrackedModes(
+  cwd: string,
+  sessionId?: string,
+  baseStateDir?: string,
+): Promise<TrackedWorkflowMode[]> {
+  const canonical = baseStateDir
+    ? await readVisibleSkillActiveStateForStateDir(baseStateDir, sessionId)
+    : await readVisibleSkillActiveState(cwd, sessionId);
   const canonicalModes = listActiveSkills(canonical ?? {})
     .filter((entry) => sessionId || safeString(entry.session_id).trim().length === 0)
     .map((entry) => entry.skill)
@@ -63,9 +84,7 @@ async function visibleTrackedModes(cwd: string, sessionId?: string): Promise<Tra
 
   const visibleModes = new Set<TrackedWorkflowMode>(canonicalModes);
   for (const mode of TRACKED_WORKFLOW_MODES) {
-    const candidatePaths = sessionId
-      ? [getStatePath(mode, cwd, sessionId)]
-      : [getStatePath(mode, cwd)];
+    const candidatePaths = [modeStatePathForRoot(mode, cwd, sessionId, baseStateDir)];
     for (const candidatePath of candidatePaths) {
       const state = await readJsonIfExists(candidatePath, {
         mode,
@@ -82,6 +101,7 @@ async function visibleTrackedModes(cwd: string, sessionId?: string): Promise<Tra
 
 async function completeSourceModeState(
   cwd: string,
+  baseStateDir: string | undefined,
   sourceMode: TrackedWorkflowMode,
   destinationMode: TrackedWorkflowMode,
   sessionId: string | undefined,
@@ -89,9 +109,7 @@ async function completeSourceModeState(
   source: string,
 ): Promise<string[]> {
   const transitionMessage = `mode transiting: ${sourceMode} -> ${destinationMode}`;
-  const candidatePaths = sessionId
-    ? [getStatePath(sourceMode, cwd, sessionId)]
-    : [getStatePath(sourceMode, cwd)];
+  const candidatePaths = [modeStatePathForRoot(sourceMode, cwd, sessionId, baseStateDir)];
   const completedPaths: string[] = [];
 
   for (const candidatePath of candidatePaths) {
@@ -130,6 +148,7 @@ async function completeSourceModeState(
 
   await syncCanonicalSkillStateForMode({
     cwd,
+    ...(baseStateDir ? { baseStateDir } : {}),
     mode: sourceMode,
     active: false,
     currentPhase: 'completed',
@@ -149,6 +168,7 @@ export async function reconcileWorkflowTransition(
     sessionId?: string;
     nowIso?: string;
     source?: string;
+    baseStateDir?: string;
     currentModes?: Iterable<string>;
   } = {},
 ): Promise<ReconciledWorkflowTransition> {
@@ -157,10 +177,11 @@ export async function reconcileWorkflowTransition(
     sessionId,
     nowIso = new Date().toISOString(),
     source = 'workflow-transition',
+    baseStateDir,
   } = options;
   const currentModes = options.currentModes
     ? [...options.currentModes].filter(isTrackedWorkflowMode)
-    : await visibleTrackedModes(cwd, sessionId);
+    : await visibleTrackedModes(cwd, sessionId, baseStateDir);
   const decision = evaluateWorkflowTransition(currentModes, requestedMode);
 
   if (!decision.allowed) {
@@ -171,6 +192,7 @@ export async function reconcileWorkflowTransition(
   for (const sourceMode of decision.autoCompleteModes) {
     completedPaths.push(...await completeSourceModeState(
       cwd,
+      baseStateDir,
       sourceMode,
       requestedMode,
       sessionId,


### PR DESCRIPTION
## Summary
- Co-locate HUD/native hook/state writer reads and writes under the authoritative OMX base state root.
- Make `OMX_TEAM_STATE_ROOT` / boxed roots authoritative for session discovery, canonical `skill-active-state.json`, and mode detail state.
- Add regressions proving boxed/team-root HUD visibility and source-root stale state suppression.

## Verification
- `npm run build`
- `npm run check:no-unused`
- `npm run lint`
- `git diff --check`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/hud/__tests__/state.test.js dist/mcp/__tests__/state-paths.test.js` — 62 pass
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/hooks/__tests__/notify-hook-non-omx-guard.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/state/__tests__/workflow-transition.test.js dist/state/__tests__/skill-active.test.js dist/hooks/__tests__/keyword-detector.test.js dist/mcp/__tests__/state-server.test.js dist/modes/__tests__/base-session-scope.test.js` — 462 pass
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT npm run test:ralph-persistence:compiled` — 57 pass
- Final code-review: APPROVE, 0 issues
- Final architecture review: CLEAR

Document-refresh: not-needed | Existing plan `.omx/plans/ralplan-hud-state-root-colocation.md` captures this behavior contract; no public operator/spec doc changed, and regression tests lock the updated behavior.
