### PR TITLE
Avoid stale Codex hook flags across CLI releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Codex hook feature flag compatibility** — setup now probes `codex features list` and writes the current `[features].hooks = true` flag when supported, while retaining legacy `[features].codex_hooks = true` fallback for older Codex releases and deduping stale aliases during refresh.
+
 ## [0.16.3] - 2026-05-09
 
 Patch release focused on post-`0.16.2` native-hook/setup/runtime hardening: supported Codex hook feature flags, safer notify ownership, runtime hook-trust mirroring, Team startup-evidence state isolation, approved handoff context, planning context-pack references, stale Ralph resume prevention, and native compact-hook JSON validity.

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -8,7 +8,7 @@ This page is the canonical answer to:
 
 `omx setup` now owns both of these native Codex artifacts:
 
-- `.codex/config.toml` → enables setup-owned runtime feature flags including `[features].codex_hooks = true` and `[features].goals = true`
+- `.codex/config.toml` → enables setup-owned runtime feature flags including the installed-Codex hook flag (`[features].hooks = true`, or legacy `[features].codex_hooks = true` when that is the only reported feature) and `[features].goals = true`
 - `.codex/hooks.json` → registers the OMX-managed native hook command while preserving non-OMX hook entries already in the file
 - `.codex/config.toml` → also records `hooks.state."<hooks.json>:<event>:<group>:<handler>".trusted_hash` for the OMX-owned wrappers so recent Codex releases do not require a manual `/hooks` review for setup-managed hooks
 

--- a/plugins/oh-my-codex/skills/omx-setup/SKILL.md
+++ b/plugins/oh-my-codex/skills/omx-setup/SKILL.md
@@ -60,7 +60,7 @@ Supported setup flags (current implementation):
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
 - User-scope skill delivery targets:
   - `legacy`: keep installing/updating OMX skills in the resolved user skill root
-  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and setup-owned runtime feature flags (`codex_hooks = true`, `goals = true`) because plugins do not carry hooks or enable Codex goal mode by themselves.
+  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and setup-owned runtime feature flags (`hooks = true` on current Codex, legacy `codex_hooks = true` when that is the only reported hook feature, plus `goals = true`) because plugins do not carry hooks or enable Codex goal mode by themselves.
 - Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
@@ -74,7 +74,7 @@ Use this map when reconciling setup behavior or debugging a confusing install:
 | Surface | Owner | Notes |
 | --- | --- | --- |
 | `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
-| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, `codex_hooks`, and `goals`. |
+| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, the Codex hook feature flag (`hooks` or legacy `codex_hooks`), and `goals`. |
 | `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
 | prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompt/native-agent copies. |
 | `AGENTS.md` | `omx setup` with overwrite safety | Generated defaults or managed refreshes are guarded by force/session checks. |

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -60,7 +60,7 @@ Supported setup flags (current implementation):
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
 - User-scope skill delivery targets:
   - `legacy`: keep installing/updating OMX skills in the resolved user skill root
-  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and setup-owned runtime feature flags (`codex_hooks = true`, `goals = true`) because plugins do not carry hooks or enable Codex goal mode by themselves.
+  - `plugin`: rely on Codex plugin discovery for bundled skills and archive/remove legacy OMX-managed prompts/skills/native agents; setup still installs native Codex hooks and setup-owned runtime feature flags (`hooks = true` on current Codex, legacy `codex_hooks = true` when that is the only reported hook feature, plus `goals = true`) because plugins do not carry hooks or enable Codex goal mode by themselves.
 - Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - Plugin mode prompts separately for optional AGENTS.md defaults and optional `developer_instructions` defaults. If `developer_instructions` already exists, setup asks before overwriting it; non-interactive runs preserve it.
@@ -74,7 +74,7 @@ Use this map when reconciling setup behavior or debugging a confusing install:
 | Surface | Owner | Notes |
 | --- | --- | --- |
 | `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
-| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, `codex_hooks`, and `goals`. |
+| `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, the Codex hook feature flag (`hooks` or legacy `codex_hooks`), and `goals`. |
 | `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
 | prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompt/native-agent copies. |
 | `AGENTS.md` | `omx setup` with overwrite safety | Generated defaults or managed refreshes are guarded by force/session checks. |

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1740,7 +1740,7 @@ describe("project launch scope helpers", () => {
         join(projectCodexHome, "config.toml"),
         [
           "[features]",
-          "codex_hooks = true",
+          "hooks = true",
           "",
           "# OMX-owned Codex hook trust state",
           "# Trusts only setup-managed codex-native-hook.js wrappers.",

--- a/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
+++ b/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
@@ -276,10 +276,10 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
       assert.match(
         config,
-        /^codex_hooks = true$/m,
+        /^hooks = true$/m,
         "uninstall should keep native Codex hooks enabled for preserved user hooks",
       );
-      assert.doesNotMatch(config, /^hooks = true$/m);
+      assert.doesNotMatch(config, /^codex_hooks = true$/m);
       assert.doesNotMatch(config, /^multi_agent\s*=/m);
       assert.doesNotMatch(config, /^child_agents_md\s*=/m);
       assert.doesNotMatch(config, /^goals\s*=/m);

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -171,7 +171,7 @@ async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {
 	const hooks = await readFile(join(wd, ".codex", "hooks.json"), "utf-8");
 	assert.match(hooks, /codex-native-hook\.js/);
 	const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-	assert.match(config, /^codex_hooks = true$/m);
+	assert.match(config, /^hooks = true$/m);
 	assert.match(config, /^goals = true$/m);
 	assert.doesNotMatch(config, /developer_instructions|notify-hook|mcp_servers/);
 	assert.equal(
@@ -780,7 +780,7 @@ describe("omx setup install mode behavior", () => {
 							.length,
 						1,
 					);
-					assert.match(config, /^codex_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 					assert.doesNotMatch(config, /\[mcp_servers\./);
 					assert.equal(
 						existsSync(join(codexHomeDir, "skills", "ask", "SKILL.md")),
@@ -852,8 +852,8 @@ describe("omx setup install mode behavior", () => {
 						parsed.hooks?.state ?? {},
 					).filter((key) => key.includes(`${codexHomeDir}/hooks.json:`));
 					assert.equal(managedHookStateKeys.length, 7);
-					assert.match(config, /^codex_hooks = true$/m);
-					assert.doesNotMatch(config, /^hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
+					assert.doesNotMatch(config, /^codex_hooks = true$/m);
 					assert.match(config, /^goals = true$/m);
 					assert.match(
 						config,
@@ -938,7 +938,7 @@ describe("omx setup install mode behavior", () => {
 					);
 					assert.doesNotMatch(config, /Native subagents live in \.codex\/agents/);
 					assert.doesNotMatch(config, /Treat installed prompts as narrower execution surfaces/);
-					assert.match(config, /^codex_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 					assert.doesNotMatch(config, /notify-hook|mcp_servers/);
 
 					const agentsMd = await readFile(
@@ -1024,7 +1024,7 @@ describe("omx setup install mode behavior", () => {
 
 					const config = await readFile(configPath, "utf-8");
 					assert.match(config, /^developer_instructions = "custom"$/m);
-					assert.match(config, /^codex_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 					assert.equal(
 						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
 						1,
@@ -1058,8 +1058,34 @@ describe("omx setup install mode behavior", () => {
 						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
 						1,
 					);
-					assert.match(config, /^codex_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 					assert.match(config, /^\[hooks\.state\.".*hooks\.json:pre_tool_use:0:0"\]$/m);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("uses legacy codex_hooks only when the installed Codex reports that hook feature", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						codexFeaturesProbe: () =>
+							"codex_hooks                             experimental       true\n",
+						codexVersionProbe: () => "codex-cli 0.129.0",
+					});
+
+					const config = await readFile(
+						join(codexHomeDir, "config.toml"),
+						"utf-8",
+					);
+					assert.match(config, /^codex_hooks = true$/m);
+					assert.doesNotMatch(config, /^hooks = true$/m);
 				});
 			});
 		} finally {
@@ -1086,7 +1112,7 @@ describe("omx setup install mode behavior", () => {
 						join(codexHomeDir, "config.toml"),
 						"utf-8",
 					);
-					assert.match(config, /^codex_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 				});
 			});
 		} finally {
@@ -1338,7 +1364,7 @@ describe("omx setup install mode behavior", () => {
 					const hooks = await readFile(hooksPath, "utf-8");
 					assert.match(hooks, /codex-native-hook\.js/);
 					const config = await readFile(configPath, "utf-8");
-					assert.match(config, /^codex_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 					assert.doesNotMatch(
 						config,
 						/^\s*(?:notify|developer_instructions)\s*=|^\s*\[mcp_servers[.\]]/m,

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -227,7 +227,7 @@ describe("omx setup scope behavior", () => {
       assert.doesNotMatch(configToml, /^\[env\]$/m);
       assert.match(configToml, /^\[shell_environment_policy\.set\]$/m);
       assert.match(configToml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
-      assert.match(configToml, /^codex_hooks = true$/m);
+      assert.match(configToml, /^hooks = true$/m);
       assert.match(configToml, /^goals = true$/m);
       assert.match(
         configToml,

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -49,7 +49,7 @@ function buildOmxConfig(): string {
     '[features]',
     'multi_agent = true',
     'child_agents_md = true',
-    'codex_hooks = true',
+    'hooks = true',
     'goals = true',
     '',
     '# ============================================================',
@@ -123,7 +123,7 @@ function buildConfigWithSeededModelContext(): string {
     '[features]',
     'multi_agent = true',
     'child_agents_md = true',
-    'codex_hooks = true',
+    'hooks = true',
     'goals = true',
     '',
     '# ============================================================',
@@ -157,7 +157,7 @@ function buildConfigWithEditedSeededModelContext(): string {
     '[features]',
     'multi_agent = true',
     'child_agents_md = true',
-    'codex_hooks = true',
+    'hooks = true',
     'goals = true',
     '',
     '# ============================================================',
@@ -189,7 +189,7 @@ function buildMixedConfig(): string {
     '[features]',
     'multi_agent = true',
     'child_agents_md = true',
-    'codex_hooks = true',
+    'hooks = true',
     'goals = true',
     'web_search = true',
     '',
@@ -377,7 +377,7 @@ describe('omx uninstall', () => {
       assert.doesNotMatch(hooks, /codex-native-hook\.js/);
 
       const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
-      assert.match(config, /^codex_hooks = true$/m);
+      assert.match(config, /^hooks = true$/m);
       assert.doesNotMatch(config, /^multi_agent\s*=/m);
       assert.doesNotMatch(config, /^child_agents_md\s*=/m);
       assert.doesNotMatch(config, /^goals\s*=/m);
@@ -394,7 +394,7 @@ describe('omx uninstall', () => {
       await mkdir(codexDir, { recursive: true });
       await writeFile(
         join(codexDir, 'config.toml'),
-        `${buildOmxConfig().replace('codex_hooks = true\n', '')}\n[user.settings]\nhooks = true\n`,
+        `${buildOmxConfig().replace('hooks = true\n', '')}\n[user.settings]\nhooks = true\n`,
       );
       await writeFile(
         join(codexDir, 'hooks.json'),

--- a/src/cli/codex-feature-probe.ts
+++ b/src/cli/codex-feature-probe.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from "child_process";
+import {
+  DEFAULT_CODEX_HOOK_FEATURE_FLAG,
+  resolveCodexHookFeatureFlag,
+  type CodexHookFeatureFlag,
+} from "../config/codex-feature-flags.js";
+
+export interface CodexFeatureProbeOptions {
+  codexFeaturesProbe?: () => string | null;
+  codexVersionProbe?: () => string | null;
+}
+
+export function probeInstalledCodexFeatureList(): string | null {
+  const result = spawnSync("codex", ["features", "list"], {
+    encoding: "utf-8",
+  });
+  if (result.error || result.status !== 0) return null;
+  return [result.stdout, result.stderr].filter(Boolean).join("\n") || null;
+}
+
+export function probeInstalledCodexVersion(): string | null {
+  const result = spawnSync("codex", ["--version"], {
+    encoding: "utf-8",
+  });
+  if (result.error || result.status !== 0) return null;
+  return [result.stdout, result.stderr].filter(Boolean).join("\n") || null;
+}
+
+export function resolveCodexHookFeatureFlagForCli(
+  options: CodexFeatureProbeOptions = {},
+): CodexHookFeatureFlag {
+  const featuresListOutput =
+    options.codexFeaturesProbe?.() ?? probeInstalledCodexFeatureList();
+  const versionOutput = options.codexVersionProbe?.() ?? probeInstalledCodexVersion();
+  return resolveCodexHookFeatureFlag({
+    featuresListOutput,
+    versionOutput,
+    fallback: DEFAULT_CODEX_HOOK_FEATURE_FLAG,
+  });
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -46,6 +46,7 @@ import {
 	stripManagedCodexHookTrustState,
 	OMX_PLUGIN_DEVELOPER_INSTRUCTIONS,
 } from "../config/generator.js";
+import type { CodexHookFeatureFlag } from "../config/codex-feature-flags.js";
 import { mergeManagedCodexHooksConfig } from "../config/codex-hooks.js";
 import {
 	getLegacyUnifiedMcpRegistryCandidate,
@@ -88,6 +89,7 @@ import {
 	resolvePackagedOmxMarketplace,
 	upsertLocalOmxMarketplaceRegistration,
 } from "./plugin-marketplace.js";
+import { resolveCodexHookFeatureFlagForCli } from "./codex-feature-probe.js";
 
 async function resolveStatusLinePresetForSetup(
 	projectRoot: string,
@@ -117,6 +119,7 @@ import {
 } from "../utils/agents-model-table.js";
 
 interface SetupOptions {
+	codexFeaturesProbe?: () => string | null;
 	codexVersionProbe?: () => string | null;
 	force?: boolean;
 	mergeAgents?: boolean;
@@ -1407,13 +1410,18 @@ async function applyPluginModeHooksConfig(
 	pkgRoot: string,
 	backupContext: SetupBackupContext,
 	summary: SetupCategorySummary,
-	options: Pick<SetupOptions, "dryRun" | "verbose">,
+	options: Pick<SetupOptions, "dryRun" | "verbose"> & {
+		codexHookFeatureFlag: CodexHookFeatureFlag;
+	},
 ): Promise<void> {
 	const existingConfig = existsSync(configPath)
 		? await readFile(configPath, "utf-8")
 		: "";
 	const nextConfig = upsertManagedCodexHookTrustState(
-		upsertPluginModeRuntimeFeatureFlags(stripManagedCodexHookTrustState(existingConfig)),
+		upsertPluginModeRuntimeFeatureFlags(
+			stripManagedCodexHookTrustState(existingConfig),
+			options.codexHookFeatureFlag,
+		),
 		pkgRoot,
 		hooksPath,
 	);
@@ -1872,6 +1880,15 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	console.log("[5/8] Updating config.toml...");
 	let resolvedConfig = "";
 	let omxManagesTui = false;
+	const codexHookFeatureFlag = resolveCodexHookFeatureFlagForCli({
+		codexFeaturesProbe: options.codexFeaturesProbe,
+		codexVersionProbe: options.codexVersionProbe,
+	});
+	if (verbose) {
+		console.log(
+			`  Native Codex hook feature flag: [features].${codexHookFeatureFlag}`,
+		);
+	}
 	if (isPluginInstallMode) {
 		const configCleaned = await cleanupPluginModeLegacyConfig(
 			scopeDirs.codexConfigFile,
@@ -1891,7 +1908,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			pkgRoot,
 			backupContext,
 			summary.config,
-			{ dryRun, verbose },
+			{ dryRun, verbose, codexHookFeatureFlag },
 		);
 		const pluginMarketplaceResult = await ensurePluginMarketplaceRegistration(
 			scopeDirs.codexConfigFile,
@@ -2004,6 +2021,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				verbose,
 				statusLinePreset,
 				forceStatusLinePreset: force,
+				codexHookFeatureFlag,
 			},
 		);
 		resolvedConfig = managedConfig.finalConfig;
@@ -3159,6 +3177,7 @@ async function updateManagedConfig(
 	options: Pick<SetupOptions, "dryRun" | "verbose" | "modelUpgradePrompt"> & {
 		statusLinePreset?: HudPreset;
 		forceStatusLinePreset?: boolean;
+		codexHookFeatureFlag: CodexHookFeatureFlag;
 	},
 ): Promise<ManagedConfigResult> {
 	const existing = existsSync(configPath)
@@ -3192,6 +3211,7 @@ async function updateManagedConfig(
 	const finalConfig = buildMergedConfig(existing, pkgRoot, {
 		includeTui: omxManagesTui,
 		codexHooksFile: hooksPath,
+		codexHookFeatureFlag: options.codexHookFeatureFlag,
 		modelOverride,
 		sharedMcpServers: sharedMcpRegistry.servers,
 		sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -25,11 +25,14 @@ import { getPackageRoot } from "../utils/package.js";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { detectLegacySkillRootOverlap } from "../utils/paths.js";
 import { resolveScopeDirectories, type SetupScope } from "./setup.js";
+import { resolveCodexHookFeatureFlagForCli } from "./codex-feature-probe.js";
 import { readPersistedSetupScope } from "./index.js";
 import { isOmxGeneratedAgentsMd } from "../utils/agents-md.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 
 export interface UninstallOptions {
+  codexFeaturesProbe?: () => string | null;
+  codexVersionProbe?: () => string | null;
   dryRun?: boolean;
   keepConfig?: boolean;
   verbose?: boolean;
@@ -183,7 +186,10 @@ async function restorePreviousNotifyIfDispatcher(
 
 async function cleanConfig(
   configPath: string,
-  options: Pick<UninstallOptions, "dryRun" | "verbose"> & {
+  options: Pick<
+    UninstallOptions,
+    "dryRun" | "verbose" | "codexFeaturesProbe" | "codexVersionProbe"
+  > & {
     preserveHooksFeatureFlag?: boolean;
   },
 ): Promise<
@@ -238,7 +244,13 @@ async function cleanConfig(
   // Strip feature flags
   config = stripOmxFeatureFlags(config);
   if (shouldRestoreHooksFeatureFlag) {
-    config = upsertCodexHooksFeatureFlag(config);
+    config = upsertCodexHooksFeatureFlag(
+      config,
+      resolveCodexHookFeatureFlagForCli({
+        codexFeaturesProbe: options.codexFeaturesProbe,
+        codexVersionProbe: options.codexVersionProbe,
+      }),
+    );
   }
 
   // Strip OMX-managed env defaults
@@ -585,6 +597,8 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
       dryRun,
       verbose,
       preserveHooksFeatureFlag,
+      codexFeaturesProbe: options.codexFeaturesProbe,
+      codexVersionProbe: options.codexVersionProbe,
     });
     Object.assign(summary, configResult);
   }

--- a/src/config/__tests__/codex-feature-flags.test.ts
+++ b/src/config/__tests__/codex-feature-flags.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  parseCodexFeatureNames,
+  resolveCodexHookFeatureFlag,
+} from "../codex-feature-flags.js";
+
+describe("Codex feature flag resolution", () => {
+  it("prefers the current hooks feature when Codex reports it", () => {
+    const output = [
+      "goals                                   experimental       true",
+      "hooks                                   stable             true",
+      "multi_agent                             stable             true",
+      "",
+    ].join("\n");
+
+    assert.equal(resolveCodexHookFeatureFlag({ featuresListOutput: output }), "hooks");
+  });
+
+  it("falls back to legacy codex_hooks when it is the only reported hook flag", () => {
+    const output = [
+      "codex_hooks                             experimental       true",
+      "multi_agent                             stable             true",
+      "",
+    ].join("\n");
+
+    assert.equal(
+      resolveCodexHookFeatureFlag({ featuresListOutput: output }),
+      "codex_hooks",
+    );
+  });
+
+  it("uses version fallback for current Codex releases when feature listing is unavailable", () => {
+    assert.equal(
+      resolveCodexHookFeatureFlag({ versionOutput: "codex-cli 0.130.0" }),
+      "hooks",
+    );
+  });
+
+  it("parses feature names without treating table headings as features", () => {
+    const names = parseCodexFeatureNames(
+      [
+        "hooks                                   stable             true",
+        "Under-development features enabled: hooks",
+        "",
+      ].join("\n"),
+    );
+
+    assert.equal(names.has("hooks"), true);
+    assert.equal(names.has("Under-development"), false);
+  });
+});

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -77,7 +77,7 @@ function assertSingleOmxBlock(toml: string): void {
     "[features] should appear once",
   );
   assert.equal(
-    count(toml, /^codex_hooks = true$/gm),
+    count(toml, /^hooks = true$/gm),
     1,
     "hooks should appear once",
   );
@@ -241,7 +241,7 @@ describe("config generator idempotency (#384)", () => {
       assertSingleOmxBlock(toml);
       assert.match(toml, /^multi_agent = true$/m);
       assert.match(toml, /^child_agents_md = true$/m);
-      assert.match(toml, /^codex_hooks = true$/m);
+      assert.match(toml, /^hooks = true$/m);
       assert.match(toml, /^goals = true$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -63,7 +63,7 @@ describe('config generator', () => {
       const toml = await readFile(configPath, 'utf-8');
 
       assert.match(toml, /^notify = \["node", ".*notify-hook\.js"\]$/m);
-      assert.match(toml, /^codex_hooks = true$/m);
+      assert.match(toml, /^hooks = true$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -183,7 +183,7 @@ describe('config generator', () => {
 
       // Top-level keys present and before [features]
       assert.match(rerun, /^notify = \["node", ".*notify-hook\.js"\]$/m);
-      assert.match(rerun, /^codex_hooks = true$/m);
+      assert.match(rerun, /^hooks = true$/m);
       assert.match(rerun, /^model_reasoning_effort = "medium"$/m);
       const notifyIdx = rerun.indexOf('notify =');
       const featuresIdx = rerun.indexOf('[features]');
@@ -376,7 +376,7 @@ describe('config generator', () => {
       assert.match(merged, /^custom_user_flag = false$/m);
       assert.match(merged, /^multi_agent = true$/m);
       assert.match(merged, /^child_agents_md = true$/m);
-      assert.match(merged, /^codex_hooks = true$/m);
+      assert.match(merged, /^hooks = true$/m);
       assert.match(merged, /^goals = true$/m);
       assert.doesNotMatch(merged, /^goal\s*=/m);
       assert.match(merged, /^\[user.settings\]$/m);
@@ -386,7 +386,7 @@ describe('config generator', () => {
     }
   });
 
-  it('preserves existing codex_hooks flag without adding unsupported hooks', async () => {
+  it('migrates legacy codex_hooks flag to current hooks by default', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
     try {
       const configPath = join(wd, 'config.toml');
@@ -401,15 +401,15 @@ describe('config generator', () => {
       await mergeConfig(configPath, wd);
       const merged = await readFile(configPath, 'utf-8');
 
-      assert.equal((merged.match(/^codex_hooks = true$/gm) ?? []).length, 1);
-      assert.doesNotMatch(merged, /^hooks\s*=/m);
+      assert.equal((merged.match(/^hooks = true$/gm) ?? []).length, 1);
+      assert.doesNotMatch(merged, /^codex_hooks\s*=/m);
       assert.match(merged, /^custom_user_flag = false$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it('migrates unsupported hooks flag to codex_hooks and removes hooks', async () => {
+  it('can target the legacy codex_hooks flag when requested', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
     try {
       const configPath = join(wd, 'config.toml');
@@ -421,7 +421,7 @@ describe('config generator', () => {
       ].join('\n');
       await writeFile(configPath, original);
 
-      await mergeConfig(configPath, wd);
+      await mergeConfig(configPath, wd, { codexHookFeatureFlag: 'codex_hooks' });
       const merged = await readFile(configPath, 'utf-8');
 
       assert.equal((merged.match(/^codex_hooks = true$/gm) ?? []).length, 1);
@@ -432,7 +432,25 @@ describe('config generator', () => {
     }
   });
 
-  it('normalizes plugin-mode runtime flags from unsupported hooks flag to codex_hooks', () => {
+  it('normalizes plugin-mode runtime flags to the current hooks flag by default', () => {
+    const original = [
+      '[features]',
+      'custom_user_flag = false',
+      'codex_hooks = true',
+      'goal = true',
+      '',
+    ].join('\n');
+
+    const merged = upsertPluginModeRuntimeFeatureFlags(original);
+
+    assert.match(merged, /^hooks = true$/m);
+    assert.match(merged, /^goals = true$/m);
+    assert.doesNotMatch(merged, /^codex_hooks\s*=/m);
+    assert.doesNotMatch(merged, /^goal\s*=/m);
+    assert.match(merged, /^custom_user_flag = false$/m);
+  });
+
+  it('normalizes plugin-mode runtime flags to legacy codex_hooks when requested', () => {
     const original = [
       '[features]',
       'custom_user_flag = false',
@@ -441,7 +459,7 @@ describe('config generator', () => {
       '',
     ].join('\n');
 
-    const merged = upsertPluginModeRuntimeFeatureFlags(original);
+    const merged = upsertPluginModeRuntimeFeatureFlags(original, 'codex_hooks');
 
     assert.match(merged, /^codex_hooks = true$/m);
     assert.match(merged, /^goals = true$/m);

--- a/src/config/codex-feature-flags.ts
+++ b/src/config/codex-feature-flags.ts
@@ -1,0 +1,78 @@
+export const CODEX_HOOK_FEATURE_FLAGS = ["hooks", "codex_hooks"] as const;
+
+export type CodexHookFeatureFlag = (typeof CODEX_HOOK_FEATURE_FLAGS)[number];
+
+/**
+ * Current Codex CLI releases expose lifecycle hooks as `[features].hooks`.
+ * Older releases used `[features].codex_hooks`. Keep the default on the
+ * current canonical name while allowing setup to probe and select the legacy
+ * spelling when it is the only feature reported by the installed Codex.
+ */
+export const DEFAULT_CODEX_HOOK_FEATURE_FLAG: CodexHookFeatureFlag = "hooks";
+
+export function isCodexHookFeatureFlagName(
+  name: string,
+): name is CodexHookFeatureFlag {
+  return (CODEX_HOOK_FEATURE_FLAGS as readonly string[]).includes(name);
+}
+
+export function normalizeCodexHookFeatureFlag(
+  value: string | null | undefined,
+): CodexHookFeatureFlag {
+  return value === "codex_hooks" ? "codex_hooks" : DEFAULT_CODEX_HOOK_FEATURE_FLAG;
+}
+
+export function parseCodexFeatureNames(
+  featuresListOutput: string | null | undefined,
+): Set<string> {
+  const names = new Set<string>();
+  for (const rawLine of (featuresListOutput ?? "").split(/\r?\n/)) {
+    const match = rawLine.trim().match(/^([A-Za-z0-9_]+)\s+/);
+    if (match) names.add(match[1]);
+  }
+  return names;
+}
+
+export function parseCodexCliVersion(
+  versionOutput: string | null | undefined,
+): [number, number, number] | null {
+  const match = (versionOutput ?? "").match(/\b(\d+)\.(\d+)\.(\d+)\b/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function isCodexCliVersionAtLeast(
+  versionOutput: string | null | undefined,
+  minimum: [number, number, number],
+): boolean {
+  const parsed = parseCodexCliVersion(versionOutput);
+  if (!parsed) return false;
+  for (let i = 0; i < minimum.length; i++) {
+    if (parsed[i] > minimum[i]) return true;
+    if (parsed[i] < minimum[i]) return false;
+  }
+  return true;
+}
+
+export function resolveCodexHookFeatureFlag(options: {
+  featuresListOutput?: string | null;
+  versionOutput?: string | null;
+  fallback?: CodexHookFeatureFlag;
+} = {}): CodexHookFeatureFlag {
+  const featureNames = parseCodexFeatureNames(options.featuresListOutput);
+
+  if (featureNames.has("hooks")) return "hooks";
+  if (featureNames.has("codex_hooks")) return "codex_hooks";
+
+  if (isCodexCliVersionAtLeast(options.versionOutput, [0, 130, 0])) {
+    return "hooks";
+  }
+
+  return options.fallback ?? DEFAULT_CODEX_HOOK_FEATURE_FLAG;
+}
+
+export function formatCodexHookFeatureFlagLine(
+  featureFlag: CodexHookFeatureFlag,
+): string {
+  return `${normalizeCodexHookFeatureFlag(featureFlag)} = true`;
+}

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -17,6 +17,13 @@ import TOML from "@iarna/toml";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
+import {
+  DEFAULT_CODEX_HOOK_FEATURE_FLAG,
+  CODEX_HOOK_FEATURE_FLAGS,
+  formatCodexHookFeatureFlagLine,
+  normalizeCodexHookFeatureFlag,
+  type CodexHookFeatureFlag,
+} from "./codex-feature-flags.js";
 import { getOmxFirstPartySetupMcpServers } from "./omx-first-party-mcp.js";
 import { buildManagedCodexHookTrustToml } from "./codex-hooks.js";
 import type { HudPreset } from "../hud/types.js";
@@ -24,6 +31,7 @@ import type { HudPreset } from "../hud/types.js";
 interface MergeOptions {
   includeTui?: boolean;
   codexHooksFile?: string;
+  codexHookFeatureFlag?: CodexHookFeatureFlag;
   modelOverride?: string;
   sharedMcpServers?: UnifiedMcpRegistryServer[];
   sharedMcpRegistrySource?: string;
@@ -489,10 +497,65 @@ export function stripOmxTopLevelKeys(config: string): string {
 // [features] upsert
 // ---------------------------------------------------------------------------
 
-function upsertFeatureFlags(config: string): string {
+function isFeatureFlagLine(line: string, featureFlag: string): boolean {
+  return new RegExp(`^\\s*${featureFlag}\\s*=`).test(line);
+}
+
+function isAnyCodexHookFeatureFlagLine(line: string): boolean {
+  return CODEX_HOOK_FEATURE_FLAGS.some((flag) => isFeatureFlagLine(line, flag));
+}
+
+function upsertCodexHookFeatureFlagInSection(
+  lines: string[],
+  featuresStart: number,
+  sectionEnd: number,
+  codexHookFeatureFlag: CodexHookFeatureFlag,
+): { sectionEnd: number; featureFlagIndex: number } {
+  const featureFlag = normalizeCodexHookFeatureFlag(codexHookFeatureFlag);
+  let featureFlagIdx = -1;
+  let fallbackAliasIdx = -1;
+
+  for (let i = featuresStart + 1; i < sectionEnd; i++) {
+    if (isFeatureFlagLine(lines[i], featureFlag)) {
+      featureFlagIdx = i;
+    } else if (isAnyCodexHookFeatureFlagLine(lines[i]) && fallbackAliasIdx < 0) {
+      fallbackAliasIdx = i;
+    }
+  }
+
+  if (featureFlagIdx < 0 && fallbackAliasIdx >= 0) {
+    featureFlagIdx = fallbackAliasIdx;
+  }
+
+  if (featureFlagIdx >= 0) {
+    lines[featureFlagIdx] = formatCodexHookFeatureFlagLine(featureFlag);
+  } else {
+    lines.splice(sectionEnd, 0, formatCodexHookFeatureFlagLine(featureFlag));
+    featureFlagIdx = sectionEnd;
+    sectionEnd += 1;
+  }
+
+  for (let i = sectionEnd - 1; i > featuresStart; i--) {
+    if (i !== featureFlagIdx && isAnyCodexHookFeatureFlagLine(lines[i])) {
+      lines.splice(i, 1);
+      sectionEnd -= 1;
+      if (featureFlagIdx > i) featureFlagIdx -= 1;
+    }
+  }
+
+  return { sectionEnd, featureFlagIndex: featureFlagIdx };
+}
+
+function upsertFeatureFlags(
+  config: string,
+  codexHookFeatureFlag: CodexHookFeatureFlag = DEFAULT_CODEX_HOOK_FEATURE_FLAG,
+): string {
   const lines = config.split(/\r?\n/);
   const featuresStart = lines.findIndex((line) =>
     /^\s*\[features\]\s*$/.test(line),
+  );
+  const hookFeatureFlagLine = formatCodexHookFeatureFlagLine(
+    codexHookFeatureFlag,
   );
 
   if (featuresStart < 0) {
@@ -501,7 +564,7 @@ function upsertFeatureFlags(config: string): string {
       "[features]",
       "multi_agent = true",
       "child_agents_md = true",
-      "codex_hooks = true",
+      hookFeatureFlagLine,
       "goals = true",
       "",
     ].join("\n");
@@ -530,20 +593,11 @@ function upsertFeatureFlags(config: string): string {
 
   let multiAgentIdx = -1;
   let childAgentsIdx = -1;
-  let codexHooksIdx = -1;
-  let unsupportedHooksIdx = -1;
-  let goalsIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {
     if (/^\s*multi_agent\s*=/.test(lines[i])) {
       multiAgentIdx = i;
     } else if (/^\s*child_agents_md\s*=/.test(lines[i])) {
       childAgentsIdx = i;
-    } else if (/^\s*hooks\s*=/.test(lines[i])) {
-      unsupportedHooksIdx = i;
-    } else if (/^\s*codex_hooks\s*=/.test(lines[i])) {
-      codexHooksIdx = i;
-    } else if (/^\s*goals\s*=/.test(lines[i])) {
-      goalsIdx = i;
     }
   }
 
@@ -561,27 +615,19 @@ function upsertFeatureFlags(config: string): string {
     sectionEnd += 1;
   }
 
-  if (codexHooksIdx >= 0) {
-    lines[codexHooksIdx] = "codex_hooks = true";
-  } else if (unsupportedHooksIdx >= 0) {
-    lines[unsupportedHooksIdx] = "codex_hooks = true";
-    codexHooksIdx = unsupportedHooksIdx;
-    unsupportedHooksIdx = -1;
-  } else {
-    lines.splice(sectionEnd, 0, "codex_hooks = true");
-    codexHooksIdx = sectionEnd;
-    sectionEnd += 1;
-  }
+  ({ sectionEnd } = upsertCodexHookFeatureFlagInSection(
+    lines,
+    featuresStart,
+    sectionEnd,
+    codexHookFeatureFlag,
+  ));
 
-  for (let i = sectionEnd - 1; i > featuresStart; i--) {
-    if (i !== codexHooksIdx && /^\s*hooks\s*=/.test(lines[i])) {
-      lines.splice(i, 1);
-      sectionEnd -= 1;
-      if (codexHooksIdx > i) codexHooksIdx -= 1;
-      if (goalsIdx > i) goalsIdx -= 1;
+  let goalsIdx = -1;
+  for (let i = featuresStart + 1; i < sectionEnd; i++) {
+    if (/^\s*goals\s*=/.test(lines[i])) {
+      goalsIdx = i;
     }
   }
-
   if (goalsIdx >= 0) {
     lines[goalsIdx] = "goals = true";
   } else {
@@ -644,17 +690,23 @@ export function upsertManagedCodexHookTrustState(
   ].filter((line, index) => index !== 0 || line.length > 0).join("\n");
 }
 
-export function upsertPluginModeRuntimeFeatureFlags(config: string): string {
+export function upsertPluginModeRuntimeFeatureFlags(
+  config: string,
+  codexHookFeatureFlag: CodexHookFeatureFlag = DEFAULT_CODEX_HOOK_FEATURE_FLAG,
+): string {
   const lines = config.split(/\r?\n/);
   const featuresStart = lines.findIndex((line) =>
     /^\s*\[features\]\s*$/.test(line),
+  );
+  const hookFeatureFlagLine = formatCodexHookFeatureFlagLine(
+    codexHookFeatureFlag,
   );
 
   if (featuresStart < 0) {
     const base = config.trimEnd();
     const featureBlock = [
       "[features]",
-      "codex_hooks = true",
+      hookFeatureFlagLine,
       "goals = true",
       "",
     ].join("\n");
@@ -681,40 +733,19 @@ export function upsertPluginModeRuntimeFeatureFlags(config: string): string {
     }
   }
 
-  let codexHooksIdx = -1;
-  let unsupportedHooksIdx = -1;
+  ({ sectionEnd } = upsertCodexHookFeatureFlagInSection(
+    lines,
+    featuresStart,
+    sectionEnd,
+    codexHookFeatureFlag,
+  ));
+
   let goalsIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {
-    if (/^\s*hooks\s*=/.test(lines[i])) {
-      unsupportedHooksIdx = i;
-    } else if (/^\s*codex_hooks\s*=/.test(lines[i])) {
-      codexHooksIdx = i;
-    } else if (/^\s*goals\s*=/.test(lines[i])) {
+    if (/^\s*goals\s*=/.test(lines[i])) {
       goalsIdx = i;
     }
   }
-
-  if (codexHooksIdx >= 0) {
-    lines[codexHooksIdx] = "codex_hooks = true";
-  } else if (unsupportedHooksIdx >= 0) {
-    lines[unsupportedHooksIdx] = "codex_hooks = true";
-    codexHooksIdx = unsupportedHooksIdx;
-    unsupportedHooksIdx = -1;
-  } else {
-    lines.splice(sectionEnd, 0, "codex_hooks = true");
-    codexHooksIdx = sectionEnd;
-    sectionEnd++;
-  }
-
-  for (let i = sectionEnd - 1; i > featuresStart; i--) {
-    if (i !== codexHooksIdx && /^\s*hooks\s*=/.test(lines[i])) {
-      lines.splice(i, 1);
-      sectionEnd--;
-      if (codexHooksIdx > i) codexHooksIdx--;
-      if (goalsIdx > i) goalsIdx--;
-    }
-  }
-
   if (goalsIdx >= 0) {
     lines[goalsIdx] = "goals = true";
   } else {
@@ -1015,15 +1046,21 @@ export function stripOmxFeatureFlags(config: string): string {
  * Preserve native Codex hook enablement without re-adding other OMX feature
  * flags. Used by uninstall when user-owned hooks remain in hooks.json.
  */
-export function upsertCodexHooksFeatureFlag(config: string): string {
+export function upsertCodexHooksFeatureFlag(
+  config: string,
+  codexHookFeatureFlag: CodexHookFeatureFlag = DEFAULT_CODEX_HOOK_FEATURE_FLAG,
+): string {
   const lines = config.split(/\r?\n/);
   const featuresStart = lines.findIndex((line) =>
     /^\s*\[features\]\s*$/.test(line),
   );
+  const hookFeatureFlagLine = formatCodexHookFeatureFlagLine(
+    codexHookFeatureFlag,
+  );
 
   if (featuresStart < 0) {
     const base = config.trimEnd();
-    const featureBlock = ["[features]", "codex_hooks = true", ""].join("\n");
+    const featureBlock = ["[features]", hookFeatureFlagLine, ""].join("\n");
     return base.length === 0 ? featureBlock : `${base}\n${featureBlock}`;
   }
 
@@ -1035,32 +1072,12 @@ export function upsertCodexHooksFeatureFlag(config: string): string {
     }
   }
 
-  let codexHooksIdx = -1;
-  for (let i = featuresStart + 1; i < sectionEnd; i++) {
-    if (/^\s*codex_hooks\s*=/.test(lines[i])) {
-      codexHooksIdx = i;
-      lines[i] = "codex_hooks = true";
-      break;
-    }
-    if (codexHooksIdx < 0 && /^\s*hooks\s*=/.test(lines[i])) {
-      codexHooksIdx = i;
-      lines[i] = "codex_hooks = true";
-    }
-  }
-
-  if (codexHooksIdx < 0) {
-    lines.splice(sectionEnd, 0, "codex_hooks = true");
-    codexHooksIdx = sectionEnd;
-    sectionEnd += 1;
-  }
-
-  for (let i = sectionEnd - 1; i > featuresStart; i--) {
-    if (i !== codexHooksIdx && /^\s*hooks\s*=/.test(lines[i])) {
-      lines.splice(i, 1);
-      sectionEnd -= 1;
-      if (codexHooksIdx > i) codexHooksIdx -= 1;
-    }
-  }
+  upsertCodexHookFeatureFlagInSection(
+    lines,
+    featuresStart,
+    sectionEnd,
+    codexHookFeatureFlag,
+  );
 
   return lines.join("\n");
 }
@@ -1704,7 +1721,7 @@ export function buildMergedConfig(
     existing = stripRootLevelKeys(existing, ["model"]);
   }
   existing = stripOrphanedOmxSections(existing);
-  existing = upsertFeatureFlags(existing);
+  existing = upsertFeatureFlags(existing, options.codexHookFeatureFlag);
   existing = upsertEnvSettings(existing);
   existing = upsertAgentsSettings(existing);
   const tuiUpsert = includeTui


### PR DESCRIPTION
## Summary
- Detect the installed Codex hook feature flag from `codex features list`, preferring current `[features].hooks` and falling back to legacy `[features].codex_hooks` only when that is the only reported spelling.
- Normalize existing config aliases during setup/plugin-mode refresh/uninstall so OMX does not reintroduce deprecated `codex_hooks` on current Codex CLI releases.
- Add focused tests plus setup docs/changelog updates covering current and legacy feature flag behavior.

## Validation
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node dist/scripts/generate-catalog-docs.js --check`
- `node --test dist/config/__tests__/codex-feature-flags.test.js dist/config/__tests__/generator-idempotent.test.js dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js dist/cli/__tests__/uninstall.test.js`

## Note
- Full `npm test` was attempted locally but the active OMX runtime had unrelated pre-existing environment contamination (stale run state / locks / local harness differences), so the PR relies on build, lint, static checks, catalog check, and the targeted suites above.
