### PR TITLE
Guard Ralph completion on audit evidence

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -731,6 +731,77 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     assert.deepEqual(warnings, []);
   });
 
+  it("does not preserve complete Ralph cleanup state without completion-audit evidence", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-ralph-complete-audit-missing-"));
+    const sessionId = "sess-postlaunch-ralph-complete-audit-missing";
+    const sessionStateDir = join(wd, ".omx", "state", "sessions", sessionId);
+    await mkdir(sessionStateDir, { recursive: true });
+    await writeFile(
+      join(sessionStateDir, "ralph-state.json"),
+      JSON.stringify({
+        active: false,
+        mode: "ralph",
+        current_phase: "complete",
+        completed_at: "2026-05-09T07:00:00.000Z",
+      }, null, 2),
+      "utf-8",
+    );
+
+    try {
+      await cleanupPostLaunchModeStateFiles(wd, sessionId, {
+        now: () => new Date("2026-05-09T08:00:00.000Z"),
+      });
+
+      const ralph = JSON.parse(
+        await readFile(join(sessionStateDir, "ralph-state.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(ralph.active, false);
+      assert.equal(ralph.current_phase, "cancelled");
+      assert.equal(ralph.stop_reason, "missing_completion_audit:missing_completion_audit");
+      assert.equal(ralph.completion_audit_gate, "blocked");
+      assert.equal(ralph.completion_audit_missing_reason, "missing_completion_audit");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves complete Ralph cleanup state when completion-audit evidence is present", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-ralph-complete-audit-present-"));
+    const sessionId = "sess-postlaunch-ralph-complete-audit-present";
+    const sessionStateDir = join(wd, ".omx", "state", "sessions", sessionId);
+    await mkdir(sessionStateDir, { recursive: true });
+    await writeFile(
+      join(sessionStateDir, "ralph-state.json"),
+      JSON.stringify({
+        active: false,
+        mode: "ralph",
+        current_phase: "complete",
+        completed_at: "2026-05-09T07:00:00.000Z",
+        completion_audit: {
+          passed: true,
+          prompt_to_artifact_checklist: ["all prompt requirements mapped"],
+          verification_evidence: ["npm test"],
+        },
+      }, null, 2),
+      "utf-8",
+    );
+
+    try {
+      await cleanupPostLaunchModeStateFiles(wd, sessionId, {
+        now: () => new Date("2026-05-09T08:00:00.000Z"),
+      });
+
+      const ralph = JSON.parse(
+        await readFile(join(sessionStateDir, "ralph-state.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(ralph.active, false);
+      assert.equal(ralph.current_phase, "complete");
+      assert.equal(ralph.stop_reason, undefined);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("marks active Ralph state cancelled with interrupted metadata during postLaunch cleanup", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-ralph-interrupted-"));
     const sessionId = "sess-postlaunch-ralph-interrupted";

--- a/src/cli/__tests__/ralph-goal-mode-contract.test.ts
+++ b/src/cli/__tests__/ralph-goal-mode-contract.test.ts
@@ -30,5 +30,7 @@ describe('ralph goal mode integration contract', () => {
     assert.match(instructions, /update_goal\(\{status: "complete"\}\)/i);
     assert.match(instructions, /top-level completion contract/i);
     assert.match(instructions, /prompt-to-artifact checklist/i);
+    assert.match(instructions, /completion_audit\.passed=true/i);
+    assert.match(instructions, /completion_audit\.verification_evidence/i);
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -55,6 +55,7 @@ import {
   getStateDir,
   listModeStateFilesWithScopePreference,
 } from "../mcp/state-paths.js";
+import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
 import {
   resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
@@ -2998,6 +2999,26 @@ function buildRecoveredPostLaunchSkillActiveState(
   };
 }
 
+function markRalphCompletionAuditBlockedForPostLaunch(
+  state: Record<string, unknown>,
+  cwd: string,
+  nowIso: string,
+): boolean {
+  if (!isRalphCompletePhase(state.current_phase ?? state.currentPhase)) return false;
+  const audit = evaluateRalphCompletionAuditEvidence(state, cwd);
+  if (audit.complete) return false;
+  state.active = false;
+  state.current_phase = "cancelled";
+  state.completed_at = nowIso;
+  state.last_turn_at = nowIso;
+  state.interrupted_at = nowIso;
+  state.stop_reason = `missing_completion_audit:${audit.reason}`;
+  state.completion_audit_gate = "blocked";
+  state.completion_audit_missing_reason = audit.reason;
+  state.completion_audit_blocked_at = nowIso;
+  return true;
+}
+
 export async function cleanupPostLaunchModeStateFiles(
   cwd: string,
   sessionId: string,
@@ -3065,7 +3086,25 @@ export async function cleanupPostLaunchModeStateFiles(
       const skillStateStillVisible = mode === SKILL_ACTIVE_STATE_MODE
         && Array.isArray(result.state.active_skills)
         && result.state.active_skills.length > 0;
-      if (result.state.active !== true && !skillStateStillVisible) continue;
+      if (result.state.active !== true && !skillStateStillVisible) {
+        if (mode === "ralph") {
+          const completedAt = now().toISOString();
+          if (markRalphCompletionAuditBlockedForPostLaunch(result.state, cwd, completedAt)) {
+            await writeFile(path, JSON.stringify(result.state, null, 2));
+            await syncCanonicalSkillStateForMode({
+              cwd,
+              baseStateDir: rootStateDir,
+              mode,
+              active: false,
+              currentPhase: "cancelled",
+              sessionId: stateDir === getStateDir(cwd, sessionId) ? sessionId : undefined,
+              nowIso: completedAt,
+              source: "postLaunchCleanup",
+            });
+          }
+        }
+        continue;
+      }
 
       try {
         const completedAt = now().toISOString();

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -303,6 +303,7 @@ export function buildRalphAppendInstructions(
     '- Treat any active goal objective as the top-level completion contract for this Ralph run; Ralph mode state is not proof of goal completion by itself.',
     '- Call `create_goal` only when the user/system explicitly requested a new goal and `get_goal` reports no active goal; otherwise do not invent a goal.',
     '- Before completion, build a prompt-to-artifact checklist, inspect real evidence for every requirement, and continue working if any item is missing, incomplete, weakly verified, or uncovered.',
+    '- Record Ralph completion evidence in state before final Stop/cleanup: `completion_audit.passed=true`, a non-empty `completion_audit.prompt_to_artifact_checklist`, and non-empty `completion_audit.verification_evidence` (or point `completion_audit_path`/`completion_audit_evidence_path` at an artifact with those fields).',
     '- Call `update_goal({status: "complete"})` only after that audit proves the active objective is fully achieved; then report final elapsed time and token-budget usage when provided.',
     'Final deslop guidance:',
     options.noDeslop

--- a/src/ralph/completion-audit.ts
+++ b/src/ralph/completion-audit.ts
@@ -1,0 +1,106 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+
+const PASSING_VALUES = new Set(['pass', 'passed', 'approve', 'approved', 'complete', 'completed', 'ok', 'success', 'succeeded']);
+
+export interface RalphCompletionAuditResult {
+  complete: boolean;
+  reason: string;
+  source: 'state' | 'artifact' | 'missing';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function hasPassingVerdict(value: Record<string, unknown>): boolean {
+  if (value.passed === true || value.approved === true || value.complete === true) return true;
+  for (const key of ['status', 'verdict', 'result', 'outcome']) {
+    const candidate = safeString(value[key]).toLowerCase();
+    if (PASSING_VALUES.has(candidate)) return true;
+  }
+  return false;
+}
+
+function hasSubstantiveValue(value: unknown): boolean {
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (isRecord(value)) return Object.keys(value).length > 0;
+  return value === true;
+}
+
+function readAuditArtifact(cwd: string, rawPath: unknown): Record<string, unknown> | null {
+  const auditPath = safeString(rawPath);
+  if (!auditPath) return null;
+  const resolvedPath = isAbsolute(auditPath) ? auditPath : join(cwd, auditPath);
+  if (!existsSync(resolvedPath)) return null;
+  try {
+    const content = readFileSync(resolvedPath, 'utf-8').trim();
+    if (!content) return null;
+    if (!resolvedPath.endsWith('.json')) {
+      return { passed: true, checklist: content, verification_evidence: content };
+    }
+    const parsed = JSON.parse(content) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function selectAuditCandidate(state: Record<string, unknown>, cwd: string): { audit: Record<string, unknown> | null; source: 'state' | 'artifact' | 'missing' } {
+  for (const key of ['completion_audit', 'completionAudit', 'completion_audit_evidence', 'completionAuditEvidence']) {
+    if (isRecord(state[key])) return { audit: state[key], source: 'state' };
+  }
+
+  for (const key of ['completion_audit_path', 'completionAuditPath', 'completion_audit_evidence_path', 'completionAuditEvidencePath']) {
+    const artifact = readAuditArtifact(cwd, state[key]);
+    if (artifact) return { audit: artifact, source: 'artifact' };
+  }
+
+  return { audit: null, source: 'missing' };
+}
+
+export function evaluateRalphCompletionAuditEvidence(
+  state: Record<string, unknown>,
+  cwd: string,
+): RalphCompletionAuditResult {
+  const { audit, source } = selectAuditCandidate(state, cwd);
+  if (!audit) {
+    return { complete: false, reason: 'missing_completion_audit', source };
+  }
+
+  if (!hasPassingVerdict(audit)) {
+    return { complete: false, reason: 'completion_audit_not_passing', source };
+  }
+
+  const checklist = audit.prompt_to_artifact_checklist
+    ?? audit.promptToArtifactChecklist
+    ?? audit.checklist
+    ?? audit.requirements_checklist
+    ?? audit.requirementsChecklist;
+  if (!hasSubstantiveValue(checklist)) {
+    return { complete: false, reason: 'missing_completion_checklist', source };
+  }
+
+  const evidence = audit.verification_evidence
+    ?? audit.verificationEvidence
+    ?? audit.evidence
+    ?? audit.validation_evidence
+    ?? audit.validationEvidence
+    ?? audit.commands
+    ?? audit.tests;
+  if (!hasSubstantiveValue(evidence)) {
+    return { complete: false, reason: 'missing_verification_evidence', source };
+  }
+
+  return { complete: true, reason: 'completion_audit_passed', source };
+}
+
+export function isRalphCompletePhase(value: unknown): boolean {
+  const phase = safeString(value).toLowerCase();
+  return phase === 'complete' || phase === 'completed';
+}

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7430,6 +7430,79 @@ exit 0
     }
   });
 
+  it("blocks Codex App Stop when Ralph is marked complete without completion-audit evidence", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-complete-audit-missing-"));
+    try {
+      const sessionId = "sess-ralph-complete-missing";
+      const statePath = join(cwd, ".omx", "state", "sessions", sessionId, "ralph-state.json");
+      await writeJson(join(cwd, ".omx", "state", "session.json"), { session_id: sessionId, native_session_id: sessionId, cwd });
+      await writeJson(statePath, {
+        active: false,
+        mode: "ralph",
+        current_phase: "complete",
+        session_id: sessionId,
+        completed_at: "2026-05-10T12:00:00.000Z",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          last_assistant_message: "Done. Ralph complete.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.match(String(result.outputJson?.reason), /Ralph completion audit is missing required evidence/);
+      assert.equal(result.outputJson?.stopReason, "ralph_completion_audit_missing_completion_audit");
+      const reopened = JSON.parse(await readFile(statePath, "utf-8")) as Record<string, unknown>;
+      assert.equal(reopened.active, true);
+      assert.equal(reopened.current_phase, "verifying");
+      assert.equal(reopened.completion_audit_gate, "blocked");
+      assert.equal(reopened.completion_audit_missing_reason, "missing_completion_audit");
+      assert.equal(typeof reopened.completed_at, "undefined");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows Codex App Stop when complete Ralph state carries checklist and verification evidence", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-complete-audit-present-"));
+    try {
+      const sessionId = "sess-ralph-complete-present";
+      await writeJson(join(cwd, ".omx", "state", "session.json"), { session_id: sessionId, native_session_id: sessionId, cwd });
+      await writeJson(join(cwd, ".omx", "state", "sessions", sessionId, "ralph-state.json"), {
+        active: false,
+        mode: "ralph",
+        current_phase: "complete",
+        session_id: sessionId,
+        completed_at: "2026-05-10T12:00:00.000Z",
+        completion_audit: {
+          passed: true,
+          prompt_to_artifact_checklist: ["issue #2260 fixed", "tests added"],
+          verification_evidence: ["node --test dist/scripts/__tests__/codex-native-hook.test.js"],
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          last_assistant_message: "Done with completion audit evidence recorded.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns Stop continuation output while Ralph is active without an explicit session pin", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -76,6 +76,7 @@ import {
 } from "../wiki/lifecycle.js";
 import { readAutoresearchCompletionStatus, readAutoresearchModeStateForActiveDecision } from "../autoresearch/skill-validation.js";
 import { readRunState } from "../runtime/run-state.js";
+import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
 import { getRunContinuationSnapshot, shouldContinueRun } from "../runtime/run-loop.js";
 import { triagePrompt } from "../hooks/triage-heuristic.js";
 import { readTriageConfig } from "../hooks/triage-config.js";
@@ -485,6 +486,12 @@ interface ActiveRalphStopState {
   path: string;
 }
 
+interface RalphCompletionAuditBlockState {
+  state: Record<string, unknown>;
+  path: string;
+  reason: string;
+}
+
 interface RalphStopOwnershipContext {
   sessionId: string;
   payloadSessionId: string;
@@ -579,6 +586,72 @@ async function hasConsistentRalphSkillActivation(stateDir: string, sessionId: st
   if (initializedPathSessionId && initializedPathSessionId !== sessionId) return false;
 
   return true;
+}
+
+
+async function readRalphCompletionAuditBlockState(
+  cwd: string,
+  stateDir: string,
+  preferredSessionId?: string,
+  ownerContext?: {
+    payloadSessionId?: string;
+    threadId?: string;
+    tmuxPaneId?: string;
+  },
+): Promise<RalphCompletionAuditBlockState | null> {
+  const [rawSessionInfo, usableSessionInfo] = await Promise.all([
+    readSessionState(cwd),
+    readUsableSessionState(cwd),
+  ]);
+  const currentOmxSessionId = safeString(usableSessionInfo?.session_id).trim();
+  const currentNativeSessionId = safeString(usableSessionInfo?.native_session_id).trim();
+  const staleCurrentSessionId = rawSessionInfo && !isSessionStateUsable(rawSessionInfo, cwd)
+    ? safeString(rawSessionInfo.session_id).trim()
+    : "";
+  const sessionCandidates = [...new Set([
+    safeString(preferredSessionId).trim(),
+    currentOmxSessionId,
+  ].filter(Boolean))];
+
+  const evaluateCandidate = (state: Record<string, unknown> | null, path: string, sessionId: string): RalphCompletionAuditBlockState | null => {
+    if (!state || state.mode && safeString(state.mode) !== "ralph") return null;
+    if (!isRalphCompletePhase(state.current_phase ?? state.currentPhase)) return null;
+    if (activeRalphStateMatchesStopOwner(state, {
+      sessionId,
+      payloadSessionId: safeString(ownerContext?.payloadSessionId).trim(),
+      threadId: safeString(ownerContext?.threadId).trim(),
+      currentNativeSessionId,
+      tmuxPaneId: safeString(ownerContext?.tmuxPaneId).trim(),
+    }) !== true) return null;
+    const audit = evaluateRalphCompletionAuditEvidence(state, cwd);
+    return audit.complete ? null : { state, path, reason: audit.reason };
+  };
+
+  for (const sessionId of sessionCandidates) {
+    if (staleCurrentSessionId && sessionId === staleCurrentSessionId) continue;
+    const sessionScopedPath = getStateFilePath("ralph-state.json", cwd, sessionId);
+    const result = evaluateCandidate(await readJsonIfExists(sessionScopedPath), sessionScopedPath, sessionId);
+    if (result) return result;
+  }
+
+  if (sessionCandidates.length > 0) return null;
+
+  const directPath = join(stateDir, "ralph-state.json");
+  return evaluateCandidate(await readJsonIfExists(directPath), directPath, "");
+}
+
+async function reopenRalphCompletionAuditBlock(block: RalphCompletionAuditBlockState): Promise<void> {
+  const nowIso = new Date().toISOString();
+  const next: Record<string, unknown> = {
+    ...block.state,
+    active: true,
+    current_phase: "verifying",
+    completion_audit_gate: "blocked",
+    completion_audit_missing_reason: block.reason,
+    completion_audit_blocked_at: nowIso,
+  };
+  delete next.completed_at;
+  await writeFile(block.path, JSON.stringify(next, null, 2));
 }
 
 async function readActiveRalphState(
@@ -2563,13 +2636,37 @@ async function buildStopHookOutput(
   }
   const execFollowupOutput = await buildExecFollowupStopOutput(cwd, canonicalSessionId);
   if (execFollowupOutput) return execFollowupOutput;
+  const ralphOwnerContext = {
+    payloadSessionId: sessionId,
+    threadId,
+    tmuxPaneId: safeString(process.env.TMUX_PANE).trim(),
+  };
+  const ralphCompletionAuditBlock = options.skipRalphStopBlock === true
+    ? null
+    : await readRalphCompletionAuditBlockState(cwd, stateDir, canonicalSessionId, ralphOwnerContext);
+  if (ralphCompletionAuditBlock) {
+    await reopenRalphCompletionAuditBlock(ralphCompletionAuditBlock);
+    const blockingPath = formatStopStatePath(cwd, ralphCompletionAuditBlock.path);
+    const systemMessage =
+      `OMX Ralph completion audit is missing required evidence (${ralphCompletionAuditBlock.reason}; state: ${blockingPath}); continue verification, record a prompt-to-artifact checklist plus verification evidence, and do not report complete yet.`;
+    return await returnPersistentStopBlock(
+      payload,
+      stateDir,
+      "ralph-completion-audit-stop",
+      `${blockingPath}|${ralphCompletionAuditBlock.reason}`,
+      {
+        decision: "block",
+        reason: systemMessage,
+        stopReason: `ralph_completion_audit_${ralphCompletionAuditBlock.reason}`,
+        systemMessage,
+      },
+      canonicalSessionId,
+      { allowRepeatDuringStopHook: true },
+    );
+  }
   const ralphState = options.skipRalphStopBlock === true
     ? null
-    : await readActiveRalphState(cwd, stateDir, canonicalSessionId, {
-      payloadSessionId: sessionId,
-      threadId,
-      tmuxPaneId: safeString(process.env.TMUX_PANE).trim(),
-    });
+    : await readActiveRalphState(cwd, stateDir, canonicalSessionId, ralphOwnerContext);
   if (!ralphState) {
     const autoresearchState = await readActiveAutoresearchState(cwd, canonicalSessionId);
     if (autoresearchState) {


### PR DESCRIPTION
## Summary

Fixes #2260.

Codex App `$ralph` runs could mark Ralph state complete and then pass Stop/post-launch cleanup without a structured completion audit. This adds a runtime completion-audit gate so terminal Ralph state is not trusted unless it carries a passing audit with both prompt-to-artifact checklist coverage and verification evidence.

## Changes

- Adds shared Ralph completion-audit evidence evaluation for state fields and audit artifact paths.
- Blocks Codex App Stop when Ralph is marked complete without audit evidence, reopens the state into verification, and reports the missing gate reason.
- Hardens post-launch cleanup so incomplete Ralph terminal state is cancelled as missing audit evidence instead of being preserved as successful completion.
- Extends Ralph launch guidance to require `completion_audit` checklist and verification evidence before final Stop/cleanup.
- Adds regression coverage for the Codex App Stop path, post-launch cleanup path, and Ralph guidance contract.

## Validation

- [x] `npm run build`
- [x] `npm run check:no-unused`
- [x] `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/ralph-goal-mode-contract.test.js`
- [x] `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/cli/__tests__/index.test.js --test-name-pattern 'cleanupPostLaunchModeStateFiles|ralph goal mode integration contract'`
- [x] `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT npm run test:ci:compiled` — 4866/4866 pass
- [ ] `omx doctor` (not run; no setup/config behavior changed)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — not needed; this is internal runtime/hook behavior with plan/spec artifacts generated under ignored `.omx/`
- [x] Backward-compatibility impact considered — existing complete states remain accepted when they carry the new audit evidence; missing evidence now fails closed for Ralph completion

## Related

Fixes #2260

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
