### PR TITLE
Require ultragoal final cleanup and review gate

### DIFF
--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -20,7 +20,7 @@ All artifacts live under `.omx/ultragoal/`:
 
 - `brief.md` — original project/conversation brief.
 - `goals.json` — ordered durable plan with status, attempts, evidence, and the active goal id.
-- `ledger.jsonl` — append-only checkpoint events (`plan_created`, `goal_started`, `goal_resumed`, `goal_completed`, `goal_blocked`, `goal_failed`, `goal_retried`).
+- `ledger.jsonl` — append-only checkpoint events (`plan_created`, `goal_started`, `goal_resumed`, `goal_completed`, `goal_blocked`, `goal_failed`, `goal_retried`, `goal_added`, `final_review_failed`, `goal_review_blocked`).
 
 In aggregate mode, `goals.json` also stores:
 
@@ -52,7 +52,7 @@ For intermediate stories, do **not** call `update_goal`; checkpoint the OMX stor
 omx ultragoal checkpoint --goal-id G001-example --status complete --evidence "npm test passed; docs updated" --codex-goal-json ./get-goal.json
 ```
 
-For the final story, run the whole-run audit, call `update_goal({status: "complete"})`, call `get_goal` again, and checkpoint with the fresh complete aggregate snapshot.
+For the final story, run the whole-run audit plus the mandatory final `ai-slop-cleaner`, post-cleaner verification, and `$code-review` gate. If review is clean (`APPROVE` + `CLEAR`), call `update_goal({status: "complete"})`, call `get_goal` again, and checkpoint with the fresh complete aggregate snapshot plus `--quality-gate-json`. If review is non-clean, do not call `update_goal`; use `omx ultragoal record-review-blockers` to append a durable blocker-resolution story and continue.
 
 Failure handling:
 
@@ -77,13 +77,45 @@ omx ultragoal status --codex-goal-json ./get-goal.json
 omx ultragoal status --json
 ```
 
+## Mandatory final cleanup and review gate
+
+The final ultragoal story is not complete until the active agent has run the final quality gate:
+
+1. Run targeted verification for the story.
+2. Run `ai-slop-cleaner` on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
+3. Rerun verification after the cleaner pass.
+4. Run `$code-review`. Clean means `codeReview.recommendation: "APPROVE"` and `codeReview.architectStatus: "CLEAR"`; `COMMENT`, `WATCH`, `REQUEST CHANGES`, and `BLOCK` are non-clean.
+5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
+
+   ```sh
+   omx ultragoal record-review-blockers --goal-id <id> --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json <active-get-goal-json-or-path>
+   ```
+
+   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need a fresh/available Codex goal context because the old per-story Codex goal remains active/incomplete.
+
+6. If review is clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
+
+   ```sh
+   omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<tests/files/review evidence>" --codex-goal-json <fresh-complete-get-goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>
+   ```
+
+`--quality-gate-json` must include:
+
+```json
+{
+  "aiSlopCleaner": { "status": "passed", "evidence": "cleaner report" },
+  "verification": { "status": "passed", "commands": ["npm test"], "evidence": "post-cleaner verification" },
+  "codeReview": { "recommendation": "APPROVE", "architectStatus": "CLEAR", "evidence": "final review synthesis" }
+}
+```
+
 ## Integration constraints
 
 - One Codex thread can have at most one goal focus.
 - `create_goal` starts the active objective; it is not a general plan store.
 - `update_goal` is completion-only; pause/resume/budget state is controlled by Codex/user/system, not OMX.
 - Aggregate mode is the default: one Codex objective covers the whole ultragoal run, and G001/G002 are OMX ledger stories.
-- Intermediate aggregate story checkpoints require a matching `active` Codex snapshot. A `complete` snapshot before the final story is rejected to prevent premature `update_goal`.
+- Intermediate aggregate story checkpoints require a matching `active` Codex snapshot. A `complete` snapshot before the final story is rejected to prevent premature `update_goal`. A non-clean final review records the old story as `review_blocked` and appends a pending blocker story before any completion checkpoint.
 - Final aggregate story checkpoints require a matching `complete` Codex snapshot captured after `update_goal({status: "complete"})`.
 - There is currently no Codex goal-tool reset/new-goal surface for replacing a completed legacy thread goal. In per-story mode, if `get_goal` returns a different completed objective and `create_goal` rejects because the thread already has a goal, record `omx ultragoal checkpoint --status blocked` with that `get_goal` JSON, then continue in a fresh Codex thread on the same branch/worktree and call `create_goal` there for the ultragoal payload.
 - Ultragoal owns durable plan and ledger state; Codex goal mode owns active-thread focus and accounting.

--- a/plugins/oh-my-codex/skills/ultragoal/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultragoal/SKILL.md
@@ -34,14 +34,47 @@ Loop until `omx ultragoal status` reports all goals complete:
 4. If no active Codex goal exists, call `create_goal` with the printed payload. In aggregate mode, if the same aggregate Codex objective is already active, continue the current OMX story without creating a new Codex goal.
 5. Complete the current OMX story only.
 6. Run a completion audit against the story objective and real artifacts/tests.
-7. In aggregate mode, do **not** call `update_goal` for intermediate stories; checkpoint with a fresh `get_goal` snapshot whose aggregate objective is still `active`. On the final story only, call `update_goal({status: "complete"})`, then call `get_goal` again for a fresh `complete` snapshot.
-8. Checkpoint the durable ledger with that snapshot:
-   `omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --codex-goal-json <get_goal-json-or-path>`
+7. In aggregate mode, do **not** call `update_goal` for intermediate stories; checkpoint with a fresh `get_goal` snapshot whose aggregate objective is still `active`. On the final story only, first run the mandatory final cleanup/review gate below; call `update_goal({status: "complete"})` only after that gate is clean, then call `get_goal` again for a fresh `complete` snapshot.
+8. Checkpoint the durable ledger with that snapshot. Intermediate aggregate checkpoints use only `--codex-goal-json`; final clean checkpoints also require `--quality-gate-json`:
+   `omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --codex-goal-json <get_goal-json-or-path> [--quality-gate-json <quality-gate-json-or-path>]`
 9. If blocked or failed, checkpoint failure:
    `omx ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
 10. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
    `omx ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json <get_goal-json-or-path>`
 11. Resume failed goals with `omx ultragoal complete-goals --retry-failed`.
+
+
+## Mandatory final cleanup and review gate
+
+The final ultragoal story is not complete until the active agent has run the final quality gate:
+
+1. Run targeted verification for the story.
+2. Run `ai-slop-cleaner` on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
+3. Rerun verification after the cleaner pass.
+4. Run `$code-review`. Clean means `codeReview.recommendation: "APPROVE"` and `codeReview.architectStatus: "CLEAR"`; `COMMENT`, `WATCH`, `REQUEST CHANGES`, and `BLOCK` are non-clean.
+5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
+
+   ```sh
+   omx ultragoal record-review-blockers --goal-id <id> --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json <active-get-goal-json-or-path>
+   ```
+
+   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need a fresh/available Codex goal context because the old per-story Codex goal remains active/incomplete.
+
+6. If review is clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
+
+   ```sh
+   omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<tests/files/review evidence>" --codex-goal-json <fresh-complete-get-goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>
+   ```
+
+`--quality-gate-json` must include:
+
+```json
+{
+  "aiSlopCleaner": { "status": "passed", "evidence": "cleaner report" },
+  "verification": { "status": "passed", "commands": ["npm test"], "evidence": "post-cleaner verification" },
+  "codeReview": { "recommendation": "APPROVE", "architectStatus": "CLEAR", "evidence": "final review synthesis" }
+}
+```
 
 ## Constraints
 

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -34,14 +34,47 @@ Loop until `omx ultragoal status` reports all goals complete:
 4. If no active Codex goal exists, call `create_goal` with the printed payload. In aggregate mode, if the same aggregate Codex objective is already active, continue the current OMX story without creating a new Codex goal.
 5. Complete the current OMX story only.
 6. Run a completion audit against the story objective and real artifacts/tests.
-7. In aggregate mode, do **not** call `update_goal` for intermediate stories; checkpoint with a fresh `get_goal` snapshot whose aggregate objective is still `active`. On the final story only, call `update_goal({status: "complete"})`, then call `get_goal` again for a fresh `complete` snapshot.
-8. Checkpoint the durable ledger with that snapshot:
-   `omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --codex-goal-json <get_goal-json-or-path>`
+7. In aggregate mode, do **not** call `update_goal` for intermediate stories; checkpoint with a fresh `get_goal` snapshot whose aggregate objective is still `active`. On the final story only, first run the mandatory final cleanup/review gate below; call `update_goal({status: "complete"})` only after that gate is clean, then call `get_goal` again for a fresh `complete` snapshot.
+8. Checkpoint the durable ledger with that snapshot. Intermediate aggregate checkpoints use only `--codex-goal-json`; final clean checkpoints also require `--quality-gate-json`:
+   `omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --codex-goal-json <get_goal-json-or-path> [--quality-gate-json <quality-gate-json-or-path>]`
 9. If blocked or failed, checkpoint failure:
    `omx ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
 10. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
    `omx ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json <get_goal-json-or-path>`
 11. Resume failed goals with `omx ultragoal complete-goals --retry-failed`.
+
+
+## Mandatory final cleanup and review gate
+
+The final ultragoal story is not complete until the active agent has run the final quality gate:
+
+1. Run targeted verification for the story.
+2. Run `ai-slop-cleaner` on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
+3. Rerun verification after the cleaner pass.
+4. Run `$code-review`. Clean means `codeReview.recommendation: "APPROVE"` and `codeReview.architectStatus: "CLEAR"`; `COMMENT`, `WATCH`, `REQUEST CHANGES`, and `BLOCK` are non-clean.
+5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
+
+   ```sh
+   omx ultragoal record-review-blockers --goal-id <id> --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json <active-get-goal-json-or-path>
+   ```
+
+   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need a fresh/available Codex goal context because the old per-story Codex goal remains active/incomplete.
+
+6. If review is clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
+
+   ```sh
+   omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<tests/files/review evidence>" --codex-goal-json <fresh-complete-get-goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>
+   ```
+
+`--quality-gate-json` must include:
+
+```json
+{
+  "aiSlopCleaner": { "status": "passed", "evidence": "cleaner report" },
+  "verification": { "status": "passed", "commands": ["npm test"], "evidence": "post-cleaner verification" },
+  "codeReview": { "recommendation": "APPROVE", "architectStatus": "CLEAR", "evidence": "final review synthesis" }
+}
+```
 
 ## Constraints
 

--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -17,6 +17,14 @@ async function withCwd<T>(run: (cwd: string) => Promise<T>): Promise<T> {
   }
 }
 
+function cleanQualityGate(): string {
+  return JSON.stringify({
+    aiSlopCleaner: { status: 'passed', evidence: 'ai-slop-cleaner passed' },
+    verification: { status: 'passed', commands: ['npm test'], evidence: 'tests passed after cleaner' },
+    codeReview: { recommendation: 'APPROVE', architectStatus: 'CLEAR', evidence: '$code-review APPROVE + CLEAR' },
+  });
+}
+
 async function capture(run: () => Promise<void>): Promise<{ stdout: string[]; stderr: string[]; exitCode: string | number | undefined }> {
   const stdout: string[] = [];
   const stderr: string[] = [];
@@ -42,6 +50,11 @@ describe('cli/ultragoal', () => {
     assert.match(ULTRAGOAL_HELP, /blocked/);
     assert.match(ULTRAGOAL_HELP, /fresh Codex thread/);
     assert.match(ULTRAGOAL_HELP, /get_goal\/create_goal\/update_goal/);
+    assert.match(ULTRAGOAL_HELP, /add-goal/);
+    assert.match(ULTRAGOAL_HELP, /record-review-blockers/);
+    assert.match(ULTRAGOAL_HELP, /quality-gate-json/);
+    assert.match(ULTRAGOAL_HELP, /ai-slop-cleaner/);
+    assert.match(ULTRAGOAL_HELP, /code-review/);
   });
 
   it('creates and starts goals through the command surface', async () => {
@@ -76,11 +89,56 @@ describe('cli/ultragoal', () => {
         '--status', 'complete',
         '--evidence', 'tests passed',
         '--codex-goal-json', JSON.stringify({ goal: { objective: goals.codexObjective, status: 'complete' } }),
+        '--quality-gate-json', cleanQualityGate(),
         '--json',
       ]));
       assert.equal(checkpoint.exitCode, undefined);
       const parsed = JSON.parse(checkpoint.stdout.join('\n')) as { summary: { complete: number } };
       assert.equal(parsed.summary.complete, 1);
+    });
+  });
+
+  it('adds goals through the command surface', async () => {
+    await withCwd(async () => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));
+      const added = await capture(() => ultragoalCommand([
+        'add-goal',
+        '--title', 'Resolve final code-review blockers',
+        '--objective', 'Fix blockers and rerun gates.',
+        '--evidence', 'review findings',
+        '--json',
+      ]));
+
+      assert.equal(added.exitCode, undefined);
+      const parsed = JSON.parse(added.stdout.join('\n')) as { addedGoal: { id: string; status: string }; summary: { pending: number } };
+      assert.equal(parsed.addedGoal.id, 'G002-resolve-final-code-review-blockers');
+      assert.equal(parsed.addedGoal.status, 'pending');
+      assert.equal(parsed.summary.pending, 2);
+    });
+  });
+
+  it('records final review blockers through the command surface', async () => {
+    await withCwd(async (cwd) => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- Final milestone']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+      const goals = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { codexObjective: string };
+
+      const blocked = await capture(() => ultragoalCommand([
+        'record-review-blockers',
+        '--goal-id', 'G001-final-milestone',
+        '--title', 'Resolve final code-review blockers',
+        '--objective', 'Fix blockers and rerun final gates.',
+        '--evidence', 'code-review REQUEST CHANGES',
+        '--codex-goal-json', JSON.stringify({ goal: { objective: goals.codexObjective, status: 'active' } }),
+        '--json',
+      ]));
+
+      assert.equal(blocked.exitCode, undefined);
+      const parsed = JSON.parse(blocked.stdout.join('\n')) as { blockedGoal: { status: string }; addedGoal: { status: string }; summary: { reviewBlocked: number; pending: number } };
+      assert.equal(parsed.blockedGoal.status, 'review_blocked');
+      assert.equal(parsed.addedGoal.status, 'pending');
+      assert.equal(parsed.summary.reviewBlocked, 1);
+      assert.equal(parsed.summary.pending, 1);
     });
   });
 
@@ -118,6 +176,26 @@ describe('cli/ultragoal', () => {
       ]));
       assert.equal(mismatch.exitCode, 1);
       assert.match(mismatch.stderr.join('\n'), /objective mismatch/);
+    });
+  });
+
+  it('fails closed for malformed final quality-gate json', async () => {
+    await withCwd(async (cwd) => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+      const goals = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { codexObjective: string };
+
+      const malformed = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first-milestone',
+        '--status', 'complete',
+        '--evidence', 'tests passed',
+        '--codex-goal-json', JSON.stringify({ goal: { objective: goals.codexObjective, status: 'complete' } }),
+        '--quality-gate-json', '{bad json',
+      ]));
+
+      assert.equal(malformed.exitCode, 1);
+      assert.match(malformed.stderr.join('\n'), /Invalid --quality-gate-json/);
     });
   });
 

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -6,10 +6,12 @@ import {
   reconcileCodexGoalSnapshot,
 } from '../goal-workflows/codex-goal-snapshot.js';
 import {
+  addUltragoalGoal,
   buildCodexGoalInstruction,
   checkpointUltragoal,
   createUltragoalPlan,
   readUltragoalPlan,
+  recordFinalReviewBlockers,
   startNextUltragoal,
   summarizeUltragoalPlan,
   type UltragoalItem,
@@ -21,7 +23,9 @@ export const ULTRAGOAL_HELP = `omx ultragoal - Durable repo-native multi-goal wo
 Usage:
   omx ultragoal create-goals [--brief <text> | --brief-file <path> | --from-stdin] [--goal <title::objective>] [--codex-goal-mode <aggregate|per-story>] [--force] [--json]
   omx ultragoal complete-goals [--retry-failed] [--json]
-  omx ultragoal checkpoint --goal-id <id> --status <complete|failed|blocked> [--evidence <text>] [--codex-goal-json <json-or-path>] [--json]
+  omx ultragoal add-goal --title <title> --objective <text> [--evidence <text>] [--json]
+  omx ultragoal record-review-blockers --goal-id <id> --title <title> --objective <text> --evidence <review-findings> --codex-goal-json <active-json-or-path> [--json]
+  omx ultragoal checkpoint --goal-id <id> --status <complete|failed|blocked> [--evidence <text>] [--codex-goal-json <json-or-path>] [--quality-gate-json <json-or-path>] [--json]
   omx ultragoal status [--codex-goal-json <json-or-path>] [--json]
 
 Aliases:
@@ -40,6 +44,9 @@ Codex goal integration:
   run while OMX checkpoints G001/G002 stories in the durable ledger. Legacy
   per-story plans retain fresh Codex thread blocker handling when a completed thread
   goal prevents create_goal for the next story.
+  Final completion is mandatory-gated: run ai-slop-cleaner, rerun verification,
+  run $code-review, and pass --quality-gate-json with APPROVE + CLEAR evidence.
+  Non-clean final review must use record-review-blockers before update_goal.
 `;
 
 function hasFlag(args: readonly string[], flag: string): boolean {
@@ -81,7 +88,7 @@ async function readStdin(): Promise<string> {
 }
 
 function positionalText(args: readonly string[]): string {
-  const valueTaking = new Set(['--brief', '--brief-file', '--goal', '--goal-id', '--status', '--evidence', '--codex-goal-json', '--codex-goal-mode']);
+  const valueTaking = new Set(['--brief', '--brief-file', '--goal', '--goal-id', '--status', '--evidence', '--codex-goal-json', '--codex-goal-mode', '--title', '--objective', '--quality-gate-json']);
   const words: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -105,7 +112,7 @@ function normalizeCodexGoalMode(raw: string | undefined): 'aggregate' | 'per_sto
 
 function printStatus(plan: Awaited<ReturnType<typeof readUltragoalPlan>>): void {
   const summary = summarizeUltragoalPlan(plan);
-  console.log(`ultragoal: ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed`);
+  console.log(`ultragoal: ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked`);
   for (const goal of plan.goals) {
     const marker = goal.id === plan.activeGoalId ? '*' : '-';
     console.log(`${marker} ${goal.id} [${goal.status}] ${goal.title}`);
@@ -115,6 +122,18 @@ function printStatus(plan: Awaited<ReturnType<typeof readUltragoalPlan>>): void 
 async function parseCodexGoalJson(raw: string | undefined): Promise<unknown> {
   if (!raw) return undefined;
   return readCodexGoalSnapshotInput(raw, process.cwd());
+}
+
+async function readJsonInput(raw: string | undefined): Promise<unknown> {
+  if (!raw) return undefined;
+  try {
+    const trimmed = raw.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) return JSON.parse(trimmed);
+    return JSON.parse(await readFile(trimmed, 'utf-8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new UltragoalError(`Invalid --quality-gate-json: ${message}`);
+  }
 }
 
 export async function ultragoalCommand(args: string[]): Promise<void> {
@@ -176,6 +195,39 @@ export async function ultragoalCommand(args: string[]): Promise<void> {
       return;
     }
 
+    if (command === 'add-goal') {
+      const title = readValue(rest, '--title');
+      const objective = readValue(rest, '--objective');
+      if (!title?.trim()) throw new UltragoalError('Missing --title.');
+      if (!objective?.trim()) throw new UltragoalError('Missing --objective.');
+      const result = await addUltragoalGoal(cwd, { title, objective, evidence: readValue(rest, '--evidence') });
+      if (json) printJson({ ok: true, plan: result.plan, addedGoal: result.goal, summary: summarizeUltragoalPlan(result.plan) });
+      else {
+        console.log(`ultragoal added goal: ${result.goal.id}`);
+        printStatus(result.plan);
+      }
+      return;
+    }
+
+    if (command === 'record-review-blockers') {
+      const goalId = readValue(rest, '--goal-id');
+      const title = readValue(rest, '--title');
+      const objective = readValue(rest, '--objective');
+      const evidence = readValue(rest, '--evidence');
+      if (!goalId) throw new UltragoalError('Missing --goal-id.');
+      if (!title?.trim()) throw new UltragoalError('Missing --title.');
+      if (!objective?.trim()) throw new UltragoalError('Missing --objective.');
+      if (!evidence?.trim()) throw new UltragoalError('Missing --evidence.');
+      const codexGoal = await parseCodexGoalJson(readValue(rest, '--codex-goal-json'));
+      const result = await recordFinalReviewBlockers(cwd, { goalId, title, objective, evidence, codexGoal });
+      if (json) printJson({ ok: true, plan: result.plan, blockedGoal: result.blockedGoal, addedGoal: result.addedGoal, summary: summarizeUltragoalPlan(result.plan) });
+      else {
+        console.log(`ultragoal final review blockers recorded: ${result.blockedGoal.id} -> review_blocked; added ${result.addedGoal.id}`);
+        printStatus(result.plan);
+      }
+      return;
+    }
+
     if (command === 'complete' || command === 'complete-goals' || command === 'next' || command === 'start-next') {
       const result = await startNextUltragoal(cwd, { retryFailed: hasFlag(rest, '--retry-failed') });
       if (!result.goal) {
@@ -196,7 +248,8 @@ export async function ultragoalCommand(args: string[]): Promise<void> {
       if (status !== 'complete' && status !== 'failed' && status !== 'blocked') throw new UltragoalError('Missing or invalid --status; expected complete, failed, or blocked.');
       const evidence = readValue(rest, '--evidence');
       const codexGoal = await parseCodexGoalJson(readValue(rest, '--codex-goal-json'));
-      const plan = await checkpointUltragoal(cwd, { goalId, status, evidence, codexGoal });
+      const qualityGate = await readJsonInput(readValue(rest, '--quality-gate-json'));
+      const plan = await checkpointUltragoal(cwd, { goalId, status, evidence, codexGoal, qualityGate });
       if (json) printJson({ ok: true, plan, summary: summarizeUltragoalPlan(plan) });
       else {
         const goal = plan.goals.find((candidate: UltragoalItem) => candidate.id === goalId);

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -4,10 +4,13 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
+  addUltragoalGoal,
   buildCodexGoalInstruction,
   checkpointUltragoal,
   createUltragoalPlan,
+  isUltragoalDone,
   readUltragoalPlan,
+  recordFinalReviewBlockers,
   startNextUltragoal,
 } from '../artifacts.js';
 
@@ -18,6 +21,14 @@ async function withTempRepo<T>(run: (cwd: string) => Promise<T>): Promise<T> {
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }
+}
+
+function cleanQualityGate(): object {
+  return {
+    aiSlopCleaner: { status: 'passed', evidence: 'ai-slop-cleaner ran on changed files' },
+    verification: { status: 'passed', commands: ['npm test'], evidence: 'tests passed after cleaner' },
+    codeReview: { recommendation: 'APPROVE', architectStatus: 'CLEAR', evidence: '$code-review approved with CLEAR architecture' },
+  };
 }
 
 describe('ultragoal artifacts', () => {
@@ -160,6 +171,7 @@ describe('ultragoal artifacts', () => {
         status: 'complete',
         evidence: 'final audit passed',
         codexGoal: { goal: { objective: aggregateObjective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
       });
 
       const plan = await readUltragoalPlan(cwd);
@@ -191,10 +203,149 @@ describe('ultragoal artifacts', () => {
         status: 'complete',
         evidence: 'legacy per-story audit passed',
         codexGoal: { goal: { objective: first.goal!.objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
       });
 
       const plan = await readUltragoalPlan(cwd);
       assert.equal(plan.goals[0]?.status, 'complete');
+    });
+  });
+
+  it('appends goals without changing the stored aggregate objective', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'First', objective: 'Complete first milestone.' }],
+      });
+      const objective = plan.codexObjective;
+      const added = await addUltragoalGoal(cwd, {
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix review blockers and rerun final gates.',
+        evidence: 'review findings',
+      });
+
+      assert.equal(added.goal.id, 'G002-resolve-final-code-review-blockers');
+      assert.equal(added.goal.status, 'pending');
+      assert.equal(added.plan.codexObjective, objective);
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"goal_added"/);
+    });
+  });
+
+  it('records final aggregate review blockers atomically and starts the blocker next', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.codexObjective!;
+
+      const result = await recordFinalReviewBlockers(cwd, {
+        goalId: started.goal!.id,
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix final code-review blockers and rerun final gates.',
+        evidence: 'code-review REQUEST CHANGES',
+        codexGoal: { goal: { objective, status: 'active' } },
+      });
+
+      assert.equal(result.blockedGoal.status, 'review_blocked');
+      assert.equal(result.addedGoal.status, 'pending');
+      assert.equal(result.plan.activeGoalId, undefined);
+      assert.equal(result.plan.codexObjective, objective);
+
+      const next = await startNextUltragoal(cwd);
+      assert.equal(next.goal?.id, result.addedGoal.id);
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"final_review_failed"/);
+      assert.match(ledger, /"event":"goal_review_blocked"/);
+    });
+  });
+
+  it('records final per-story review blockers without claiming Codex completion', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        codexGoalMode: 'per_story',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const result = await recordFinalReviewBlockers(cwd, {
+        goalId: started.goal!.id,
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix final code-review blockers in a fresh goal context.',
+        evidence: 'architect BLOCK',
+        codexGoal: { goal: { objective: started.goal!.objective, status: 'active' } },
+      });
+
+      assert.equal(result.blockedGoal.status, 'review_blocked');
+      assert.equal(result.addedGoal.status, 'pending');
+      assert.equal(isUltragoalDone(result.plan), false);
+    });
+  });
+
+  it('requires structured final quality gate evidence for clean completion', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.codexObjective!;
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+        }),
+        /quality-gate-json|quality gate/i,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            codeReview: { recommendation: 'COMMENT', architectStatus: 'CLEAR', evidence: 'not clean' },
+          },
+        }),
+        /APPROVE/,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            aiSlopCleaner: { status: 'not_applicable', evidence: 'skipped cleaner' },
+          },
+        }),
+        /aiSlopCleaner\.status="passed"/,
+      );
+
+      await checkpointUltragoal(cwd, {
+        goalId: started.goal!.id,
+        status: 'complete',
+        evidence: 'final gates passed',
+        codexGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+      const plan = await readUltragoalPlan(cwd);
+      assert.equal(isUltragoalDone(plan), true);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"qualityGate"/);
+      assert.match(ledger, /"aiSlopCleaner"/);
+      assert.match(ledger, /"codeReview"/);
     });
   });
 

--- a/src/ultragoal/__tests__/docs-contract.test.ts
+++ b/src/ultragoal/__tests__/docs-contract.test.ts
@@ -33,4 +33,27 @@ describe('ultragoal docs contract', () => {
     assert.match(doc, /Active or incomplete wrong Codex goals remain strict mismatch errors/i);
     assert.match(doc, /must not be used to bypass active-goal mismatch protection/i);
   });
+
+  it('documents the mandatory final cleanup and review gate', () => {
+    const docs = [
+      loadDoc('docs/ultragoal.md'),
+      loadDoc('skills/ultragoal/SKILL.md'),
+      loadDoc('plugins/oh-my-codex/skills/ultragoal/SKILL.md'),
+    ];
+
+    for (const doc of docs) {
+      assert.match(doc, /Mandatory final cleanup and review gate/);
+      assert.match(doc, /ai-slop-cleaner/);
+      assert.match(doc, /passed\/no-op report/);
+      assert.match(doc, /post-cleaner verification/i);
+      assert.match(doc, /\$code-review/);
+      assert.match(doc, /record-review-blockers/);
+      assert.match(doc, /review_blocked/);
+      assert.match(doc, /quality-gate-json/);
+      assert.match(doc, /APPROVE/);
+      assert.match(doc, /CLEAR/);
+      assert.doesNotMatch(doc, /not_applicable/);
+      assert.doesNotMatch(doc, /On the final story only, call `update_goal/);
+    }
+  });
 });

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -12,7 +12,7 @@ export const ULTRAGOAL_BRIEF = 'brief.md';
 export const ULTRAGOAL_GOALS = 'goals.json';
 export const ULTRAGOAL_LEDGER = 'ledger.jsonl';
 
-export type UltragoalStatus = 'pending' | 'in_progress' | 'complete' | 'failed';
+export type UltragoalStatus = 'pending' | 'in_progress' | 'complete' | 'failed' | 'review_blocked';
 export type UltragoalCodexGoalMode = 'aggregate' | 'per_story';
 
 export interface UltragoalItem {
@@ -27,6 +27,7 @@ export interface UltragoalItem {
   startedAt?: string;
   completedAt?: string;
   failedAt?: string;
+  reviewBlockedAt?: string;
   evidence?: string;
   failureReason?: string;
 }
@@ -53,12 +54,16 @@ export interface UltragoalLedgerEntry {
     | 'goal_completed'
     | 'goal_blocked'
     | 'goal_failed'
-    | 'goal_retried';
+    | 'goal_retried'
+    | 'goal_added'
+    | 'final_review_failed'
+    | 'goal_review_blocked';
   goalId?: string;
   status?: UltragoalStatus;
   message?: string;
   codexGoal?: unknown;
   evidence?: string;
+  qualityGate?: UltragoalQualityGate;
 }
 
 export interface CreateUltragoalOptions {
@@ -79,7 +84,38 @@ export interface CheckpointOptions {
   status: Extract<UltragoalStatus, 'complete' | 'failed'> | 'blocked';
   evidence?: string;
   codexGoal?: unknown;
+  qualityGate?: unknown;
+  allowActiveFinalCodexGoal?: boolean;
   now?: Date;
+}
+
+export interface AddUltragoalGoalOptions {
+  title: string;
+  objective: string;
+  evidence?: string;
+  now?: Date;
+}
+
+export interface RecordFinalReviewBlockersOptions extends AddUltragoalGoalOptions {
+  goalId: string;
+  codexGoal?: unknown;
+}
+
+export interface UltragoalQualityGate {
+  aiSlopCleaner: {
+    status: 'passed';
+    evidence: string;
+  };
+  verification: {
+    status: 'passed';
+    commands: string[];
+    evidence: string;
+  };
+  codeReview: {
+    recommendation: 'APPROVE';
+    architectStatus: 'CLEAR';
+    evidence: string;
+  };
 }
 
 export class UltragoalError extends Error {}
@@ -120,6 +156,10 @@ function codexGoalMode(plan: UltragoalPlan): UltragoalCodexGoalMode {
   return plan.codexGoalMode ?? 'per_story';
 }
 
+function isResolvedStatus(status: UltragoalStatus): boolean {
+  return status === 'complete' || status === 'review_blocked';
+}
+
 function aggregateCodexObjective(goals: readonly UltragoalItem[]): string {
   const prefix = `Complete all ultragoal stories in ${ULTRAGOAL_DIR}/${ULTRAGOAL_GOALS}: `;
   const suffix = goals.map((goal) => `${goal.id} ${goal.title}`).join('; ');
@@ -136,8 +176,16 @@ function expectedCodexObjective(plan: UltragoalPlan, goal: UltragoalItem): strin
     : goal.objective;
 }
 
-function isFinalAggregateCheckpoint(plan: UltragoalPlan, goal: UltragoalItem): boolean {
-  return plan.goals.every((candidate) => candidate.id === goal.id || candidate.status === 'complete');
+export function isFinalRunCompletionCandidate(plan: UltragoalPlan, goal: UltragoalItem): boolean {
+  return plan.goals.every((candidate) => candidate.id === goal.id || isResolvedStatus(candidate.status));
+}
+
+export function isUltragoalDone(plan: UltragoalPlan): boolean {
+  if (plan.goals.length === 0) return true;
+  if (plan.goals.some((goal) => goal.status === 'pending' || goal.status === 'in_progress' || goal.status === 'failed')) return false;
+  if (!plan.goals.every((goal) => isResolvedStatus(goal.status))) return false;
+  const latestNonReviewBlocked = [...plan.goals].reverse().find((goal) => goal.status !== 'review_blocked');
+  return latestNonReviewBlocked?.status === 'complete';
 }
 
 function titleFromObjective(objective: string, fallback: string): string {
@@ -246,15 +294,86 @@ export async function createUltragoalPlan(cwd: string, options: CreateUltragoalO
   return plan;
 }
 
-export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; activeGoalId?: string } {
+export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; activeGoalId?: string } {
   return {
     total: plan.goals.length,
     pending: plan.goals.filter((goal) => goal.status === 'pending').length,
     inProgress: plan.goals.filter((goal) => goal.status === 'in_progress').length,
     complete: plan.goals.filter((goal) => goal.status === 'complete').length,
     failed: plan.goals.filter((goal) => goal.status === 'failed').length,
+    reviewBlocked: plan.goals.filter((goal) => goal.status === 'review_blocked').length,
     activeGoalId: plan.activeGoalId,
   };
+}
+
+function assertNonEmpty(value: string | undefined, label: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new UltragoalError(`Missing ${label}.`);
+  return trimmed;
+}
+
+function appendGoalToPlan(plan: UltragoalPlan, options: AddUltragoalGoalOptions, now: string): UltragoalItem {
+  const title = assertNonEmpty(options.title, '--title');
+  const objective = assertNonEmpty(options.objective, '--objective');
+  const goal: UltragoalItem = {
+    id: normalizeGoalId(title, plan.goals.length),
+    title,
+    objective,
+    status: 'pending',
+    attempt: 0,
+    createdAt: now,
+    updatedAt: now,
+    evidence: options.evidence,
+  };
+  plan.goals.push(goal);
+  plan.updatedAt = now;
+  return goal;
+}
+
+export async function addUltragoalGoal(cwd: string, options: AddUltragoalGoalOptions): Promise<{ plan: UltragoalPlan; goal: UltragoalItem }> {
+  const plan = await readUltragoalPlan(cwd);
+  const now = iso(options.now);
+  const goal = appendGoalToPlan(plan, options, now);
+  await writePlan(cwd, plan);
+  await appendLedger(cwd, {
+    ts: now,
+    event: 'goal_added',
+    goalId: goal.id,
+    status: goal.status,
+    evidence: options.evidence,
+    message: goal.title,
+  });
+  return { plan, goal };
+}
+
+function validateQualityGate(value: unknown): UltragoalQualityGate {
+  if (!value || typeof value !== 'object') {
+    throw new UltragoalError('Final ultragoal completion requires --quality-gate-json with ai-slop-cleaner, verification, and code-review evidence.');
+  }
+  const gate = value as Partial<UltragoalQualityGate>;
+  const cleaner = gate.aiSlopCleaner;
+  const verification = gate.verification;
+  const review = gate.codeReview;
+  if (!cleaner || typeof cleaner !== 'object') throw new UltragoalError('Final quality gate is missing aiSlopCleaner evidence.');
+  if (cleaner.status !== 'passed') {
+    throw new UltragoalError('Final quality gate requires aiSlopCleaner.status="passed"; run ai-slop-cleaner even when it is a no-op.');
+  }
+  assertNonEmpty(cleaner.evidence, 'aiSlopCleaner.evidence');
+  if (!verification || typeof verification !== 'object') throw new UltragoalError('Final quality gate is missing verification evidence.');
+  if (verification.status !== 'passed') throw new UltragoalError('Final quality gate requires verification.status="passed".');
+  if (!Array.isArray(verification.commands) || verification.commands.length === 0 || verification.commands.some((command) => typeof command !== 'string' || command.trim() === '')) {
+    throw new UltragoalError('Final quality gate requires non-empty verification.commands.');
+  }
+  assertNonEmpty(verification.evidence, 'verification.evidence');
+  if (!review || typeof review !== 'object') throw new UltragoalError('Final quality gate is missing codeReview evidence.');
+  if (review.recommendation !== 'APPROVE') {
+    throw new UltragoalError('Final code-review must be clean: codeReview.recommendation must be APPROVE; use record-review-blockers for COMMENT or REQUEST CHANGES.');
+  }
+  if (review.architectStatus !== 'CLEAR') {
+    throw new UltragoalError('Final code-review must be clean: codeReview.architectStatus must be CLEAR; use record-review-blockers for WATCH or BLOCK.');
+  }
+  assertNonEmpty(review.evidence, 'codeReview.evidence');
+  return gate as UltragoalQualityGate;
 }
 
 export async function startNextUltragoal(cwd: string, options: StartNextOptions = {}): Promise<{ plan: UltragoalPlan; goal: UltragoalItem | null; resumed: boolean; done: boolean }> {
@@ -271,7 +390,7 @@ export async function startNextUltragoal(cwd: string, options: StartNextOptions 
     next = plan.goals.find((goal) => goal.status === 'failed');
     if (next) await appendLedger(cwd, { ts: now, event: 'goal_retried', goalId: next.id, status: 'pending', message: next.failureReason });
   }
-  if (!next) return { plan, goal: null, resumed: false, done: plan.goals.every((goal) => goal.status === 'complete') };
+  if (!next) return { plan, goal: null, resumed: false, done: isUltragoalDone(plan) };
 
   next.status = 'in_progress';
   next.attempt += 1;
@@ -325,22 +444,26 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
   if (options.status === 'complete') {
     const expectedObjective = expectedCodexObjective(plan, goal);
     const aggregateMode = codexGoalMode(plan) === 'aggregate';
-    const finalAggregateCheckpoint = aggregateMode && isFinalAggregateCheckpoint(plan, goal);
+    const finalRunCheckpoint = isFinalRunCompletionCandidate(plan, goal);
     const reconciliation = reconcileCodexGoalSnapshot(
       options.codexGoal === undefined ? null : parseCodexGoalSnapshot(options.codexGoal),
       {
         expectedObjective,
         allowedStatuses: aggregateMode
-          ? (finalAggregateCheckpoint ? ['complete'] : ['active'])
+          ? (finalRunCheckpoint && !options.allowActiveFinalCodexGoal ? ['complete'] : ['active'])
           : ['complete'],
         requireSnapshot: true,
-        requireComplete: !aggregateMode || finalAggregateCheckpoint,
+        requireComplete: !aggregateMode || (finalRunCheckpoint && !options.allowActiveFinalCodexGoal),
       },
     );
     if (!reconciliation.ok) {
       throw new UltragoalError(formatCodexGoalReconciliation(reconciliation));
     }
+    if (finalRunCheckpoint && !options.allowActiveFinalCodexGoal) goal.evidence = options.evidence;
   }
+  const qualityGate = options.status === 'complete' && isFinalRunCompletionCandidate(plan, goal) && !options.allowActiveFinalCodexGoal
+    ? validateQualityGate(options.qualityGate)
+    : undefined;
   goal.status = options.status;
   goal.updatedAt = now;
   if (options.status === 'complete') {
@@ -363,8 +486,79 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     status: goal.status,
     evidence: options.evidence,
     codexGoal: options.codexGoal,
+    qualityGate,
   });
   return plan;
+}
+
+export async function recordFinalReviewBlockers(cwd: string, options: RecordFinalReviewBlockersOptions): Promise<{ plan: UltragoalPlan; blockedGoal: UltragoalItem; addedGoal: UltragoalItem }> {
+  const plan = await readUltragoalPlan(cwd);
+  const goal = plan.goals.find((candidate) => candidate.id === options.goalId);
+  if (!goal) throw new UltragoalError(`Unknown ultragoal id: ${options.goalId}`);
+  assertNonEmpty(options.evidence, '--evidence');
+  if (goal.status !== 'in_progress') {
+    throw new UltragoalError(`Cannot record final review blockers for ${goal.id} while it is ${goal.status}; start or resume the ultragoal first.`);
+  }
+  if (!isFinalRunCompletionCandidate(plan, goal)) {
+    throw new UltragoalError(`Cannot record final review blockers for ${goal.id}; it is not the only unresolved ultragoal story.`);
+  }
+
+  const now = iso(options.now);
+  const expectedObjective = expectedCodexObjective(plan, goal);
+  const aggregateMode = codexGoalMode(plan) === 'aggregate';
+  const reconciliation = reconcileCodexGoalSnapshot(
+    options.codexGoal === undefined ? null : parseCodexGoalSnapshot(options.codexGoal),
+    {
+      expectedObjective,
+      allowedStatuses: ['active'],
+      requireSnapshot: true,
+      requireComplete: false,
+    },
+  );
+  if (!reconciliation.ok) {
+    throw new UltragoalError(formatCodexGoalReconciliation(reconciliation));
+  }
+
+  const addedGoal = appendGoalToPlan(plan, options, now);
+  goal.status = 'review_blocked';
+  goal.reviewBlockedAt = now;
+  goal.updatedAt = now;
+  goal.completedAt = undefined;
+  goal.failedAt = undefined;
+  goal.failureReason = undefined;
+  goal.evidence = options.evidence;
+  if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
+  plan.updatedAt = now;
+
+  await writePlan(cwd, plan);
+  await appendLedger(cwd, {
+    ts: now,
+    event: 'final_review_failed',
+    goalId: goal.id,
+    status: goal.status,
+    evidence: options.evidence,
+    codexGoal: options.codexGoal,
+    message: aggregateMode
+      ? 'Final aggregate code-review was not clean; blocker story was appended while Codex goal remains active.'
+      : 'Final per-story code-review was not clean; blocker story was appended and may require a fresh/available Codex goal context.',
+  });
+  await appendLedger(cwd, {
+    ts: now,
+    event: 'goal_added',
+    goalId: addedGoal.id,
+    status: addedGoal.status,
+    evidence: options.evidence,
+    message: addedGoal.title,
+  });
+  await appendLedger(cwd, {
+    ts: now,
+    event: 'goal_review_blocked',
+    goalId: goal.id,
+    status: goal.status,
+    evidence: options.evidence,
+    codexGoal: options.codexGoal,
+  });
+  return { plan, blockedGoal: goal, addedGoal };
 }
 
 export function buildCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan): string {
@@ -377,6 +571,7 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
     objective: goal.objective,
     ...(goal.tokenBudget ? { token_budget: goal.tokenBudget } : {}),
   };
+  const finalStory = isFinalRunCompletionCandidate(plan, goal);
   return [
     'Ultragoal active-goal handoff',
     `Plan: ${plan.goalsPath}`,
@@ -389,8 +584,24 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
     '- If get_goal returns a different completed legacy/thread goal and create_goal rejects because this thread already has a completed goal, continue this ultragoal in a fresh Codex thread (same repo/worktree) and create the payload there.',
     `- To preserve the durable ledger before switching threads, record the non-terminal blocker without failing this goal: omx ultragoal checkpoint --goal-id ${goal.id} --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json "<get_goal JSON or path>"`,
     '- Work only this goal until its completion audit passes.',
-    '- After the goal is actually complete, call update_goal({status: "complete"}), call get_goal again for a fresh completion snapshot, then checkpoint the ledger with:',
-    `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh get_goal JSON or path>"`,
+    finalStory
+      ? '- Final mandatory quality gate: run ai-slop-cleaner on changed files even when it is a no-op, rerun verification, then run $code-review.'
+      : '- This is not the final ultragoal story; do not run the final ai-slop-cleaner/$code-review gate yet.',
+    finalStory
+      ? '- If final $code-review is not APPROVE with architect status CLEAR, do not call update_goal. Record blockers with:'
+      : '- After the goal is actually complete, call update_goal({status: "complete"}), call get_goal again for a fresh completion snapshot, then checkpoint the ledger with:',
+    finalStory
+      ? `  omx ultragoal record-review-blockers --goal-id ${goal.id} --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json "<active get_goal JSON or path>"`
+      : `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh get_goal JSON or path>"`,
+    finalStory
+      ? '- In legacy per-story mode, the blocker story may require a fresh/available Codex goal context because this story remains an active incomplete Codex goal; do not claim it is complete.'
+      : null,
+    finalStory
+      ? '- If final $code-review is clean (APPROVE + CLEAR), call update_goal({status: "complete"}), call get_goal again, then checkpoint with --quality-gate-json:'
+      : null,
+    finalStory
+      ? `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh complete get_goal JSON or path>" --quality-gate-json "<quality gate JSON or path>"`
+      : null,
     '- If blocked or failed, checkpoint with --status failed and the failure evidence; rerun complete-goals --retry-failed to resume.',
     '',
     'create_goal payload:',
@@ -398,12 +609,12 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
     '',
     'Objective:',
     goal.objective,
-  ].join('\n');
+  ].filter((line): line is string => line !== null).join('\n');
 }
 
 function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan): string {
   const objective = plan.codexObjective ?? aggregateCodexObjective(plan.goals);
-  const finalStory = isFinalAggregateCheckpoint(plan, goal);
+  const finalStory = isFinalRunCompletionCandidate(plan, goal);
   const createPayload = { objective };
   const checkpointStatus = finalStory ? 'complete' : 'active';
   return [
@@ -418,10 +629,21 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
     '- If get_goal reports the same aggregate objective as active, continue this OMX story without creating a new Codex goal.',
     '- If a different active or incomplete Codex goal exists, finish/checkpoint that goal before starting this ultragoal; do not replace hidden Codex state from the shell.',
     finalStory
-      ? '- This is the final pending story: after the story and whole-run audit pass, call update_goal({status: "complete"}), then call get_goal again for a fresh complete snapshot.'
+      ? '- This is the final pending story: run the mandatory final ai-slop-cleaner pass, rerun verification, and run $code-review before any update_goal call.'
       : '- This is not the final story: do not call update_goal yet; the aggregate Codex goal must remain active while later OMX stories remain.',
+    finalStory
+      ? '- If final $code-review is not APPROVE with architect status CLEAR, do not call update_goal. Record durable blocker work first:'
+      : null,
+    finalStory
+      ? `  omx ultragoal record-review-blockers --goal-id ${goal.id} --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json "<active get_goal JSON or path>"`
+      : null,
+    finalStory
+      ? '- If final $code-review is clean (APPROVE + CLEAR), call update_goal({status: "complete"}), call get_goal again for a fresh complete snapshot, then checkpoint with --quality-gate-json.'
+      : null,
     `- Checkpoint this OMX story with a fresh get_goal snapshot whose objective matches the aggregate payload and whose status is ${checkpointStatus}:`,
-    `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh get_goal JSON or path>"`,
+    finalStory
+      ? `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh complete get_goal JSON or path>" --quality-gate-json "<quality gate JSON or path>"`
+      : `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh get_goal JSON or path>"`,
     '- If blocked or failed, checkpoint with --status failed and the failure evidence; rerun complete-goals --retry-failed to resume.',
     '',
     'create_goal payload:',
@@ -432,5 +654,5 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
     '',
     'Current OMX story objective:',
     goal.objective,
-  ].join('\n');
+  ].filter((line): line is string => line !== null).join('\n');
 }


### PR DESCRIPTION
## Summary
- Require ultragoal final completion to include mandatory `ai-slop-cleaner`, post-clean verification, and `$code-review` evidence.
- Add `review_blocked`, blocker-story append, `add-goal`, and `record-review-blockers` flows so failed final review creates follow-up work instead of completing the goal.
- Update docs, installed skill, plugin mirror, and contract tests to make the final gate mandatory and auditable.

## Validation
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node --test dist/ultragoal/__tests__/artifacts.test.js dist/cli/__tests__/ultragoal.test.js dist/ultragoal/__tests__/docs-contract.test.js`
- `npm run verify:plugin-bundle`
- `git diff --check`
- `$code-review`: APPROVE / architect CLEAR after blocker fixes

## Notes
- Full `npm test` was attempted but is noisy in this attached runtime and showed unrelated runtime-coupled failures outside this diff, so targeted verification above is the clean signal for this change.
