### PR TITLE
Prevent tmux continuation injection crossing session ownership

### DIFF
--- a/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
@@ -10,11 +10,28 @@ import { handleTmuxInjection, resolvePaneTarget } from '../../scripts/notify-hoo
 
 const NOTIFY_HOOK_SCRIPT = new URL('../../../dist/scripts/notify-hook.js', import.meta.url);
 
+const STATE_ENV_KEYS = [
+  'OMX_ROOT',
+  'OMX_STATE_ROOT',
+  'OMX_SESSION_ID',
+  'CODEX_SESSION_ID',
+  'SESSION_ID',
+] as const;
+
 async function withTempWorkingDir(run: (cwd: string) => Promise<void>): Promise<void> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-notify-tmux-heal-'));
+  const previous = new Map<string, string | undefined>();
+  for (const key of STATE_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+    delete process.env[key];
+  }
   try {
     await run(cwd);
   } finally {
+    for (const [key, value] of previous) {
+      if (typeof value === 'string') process.env[key] = value;
+      else delete process.env[key];
+    }
     await rm(cwd, { recursive: true, force: true });
   }
 }
@@ -1284,6 +1301,274 @@ exit 1
       const healedConfig = await readJson<{ target: { type: string; value: string } }>(configPath);
       assert.equal(healedConfig.target.type, 'pane');
       assert.equal(healedConfig.target.value, '%99');
+    });
+  });
+
+  it('fails closed when stale mode pane conflicts with the current managed prompt pane', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const sessionId = 'omx-current-pane-wins';
+      const sessionStateDir = join(stateDir, 'sessions', sessionId);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const managedSessionName = buildTmuxSessionName(cwd, sessionId);
+      const configPath = join(omxDir, 'tmux-hook.json');
+      const hookStatePath = join(stateDir, 'tmux-hook-state.json');
+
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeManagedSessionState(stateDir, cwd, sessionId);
+      await writeJson(join(sessionStateDir, 'ralph-state.json'), {
+        active: true,
+        iteration: 0,
+        tmux_pane_id: '%99',
+      });
+      await writeJson(configPath, {
+        enabled: true,
+        target: { type: 'pane', value: '%99' },
+        allowed_modes: ['ralph'],
+        cooldown_ms: 0,
+        max_injections_per_session: 10,
+        prompt_template: 'Continue from current mode state. [OMX_TMUX_INJECT]',
+        marker: '[OMX_TMUX_INJECT]',
+        dry_run: false,
+        log_level: 'debug',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_id}" && ( "$target" == "%42" || "$target" == "%99" ) ]]; then echo "$target"; exit 0; fi
+  if [[ "$format" == "#{pane_current_path}" && ( "$target" == "%42" || "$target" == "%99" ) ]]; then echo "${cwd}"; exit 0; fi
+  if [[ "$format" == "#{pane_current_command}" && ( "$target" == "%42" || "$target" == "%99" ) ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#{pane_start_command}" && ( "$target" == "%42" || "$target" == "%99" ) ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#S" && ( "$target" == "%42" || "$target" == "%99" ) ]]; then echo "${managedSessionName}"; exit 0; fi
+  echo "bad display target: $target / $format" >&2
+  exit 1
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  echo "unexpected send-keys to stale mode pane" >&2
+  exit 1
+fi
+echo "unsupported cmd: $cmd" >&2
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        session_id: sessionId,
+        'thread-id': 'thread-current-pane-mismatch',
+        'turn-id': 'turn-current-pane-mismatch',
+        'input-messages': ['no marker here'],
+        'last-assistant-message': 'output',
+      };
+
+      await withPatchedEnv({
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+        OMX_TEAM_WORKER: '',
+        TMUX_PANE: '%42',
+      }, async () => {
+        await handleTmuxInjection({ payload, cwd, stateDir, logsDir });
+      });
+
+      const hookState = await readJson<Record<string, unknown>>(hookStatePath);
+      assert.equal(hookState.last_reason, 'mode_pane_current_pane_mismatch');
+      assert.equal(hookState.total_injections ?? 0, 0);
+    });
+  });
+
+  it('fails closed when a continuation hook has mode state but no current OMX session owner', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const configPath = join(omxDir, 'tmux-hook.json');
+      const hookStatePath = join(stateDir, 'tmux-hook-state.json');
+
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'ralph-state.json'), {
+        active: true,
+        iteration: 0,
+        tmux_pane_id: '%42',
+      });
+      await writeJson(configPath, {
+        enabled: true,
+        target: { type: 'pane', value: '%42' },
+        allowed_modes: ['ralph'],
+        cooldown_ms: 0,
+        max_injections_per_session: 10,
+        prompt_template: 'Continue from current mode state. [OMX_TMUX_INJECT]',
+        marker: '[OMX_TMUX_INJECT]',
+        dry_run: false,
+        log_level: 'debug',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_id}" && "$target" == "%42" ]]; then echo "%42"; exit 0; fi
+  if [[ "$format" == "#{pane_current_path}" && "$target" == "%42" ]]; then echo "${cwd}"; exit 0; fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%42" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%42" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#S" && "$target" == "%42" ]]; then echo "unowned-session"; exit 0; fi
+  echo "bad display target: $target / $format" >&2
+  exit 1
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  echo "unexpected send-keys without OMX owner" >&2
+  exit 1
+fi
+echo "unsupported cmd: $cmd" >&2
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        'thread-id': 'thread-missing-session-owner',
+        'turn-id': 'turn-missing-session-owner',
+        'input-messages': ['no marker here'],
+        'last-assistant-message': 'output',
+      };
+
+      await withPatchedEnv({
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+        OMX_TEAM_WORKER: '',
+      }, async () => {
+        await handleTmuxInjection({ payload, cwd, stateDir, logsDir });
+      });
+
+      const hookState = await readJson<Record<string, unknown>>(hookStatePath);
+      assert.equal(hookState.last_reason, 'missing_session_id');
+      assert.equal(hookState.total_injections ?? 0, 0);
+    });
+  });
+
+  it('fails closed when the resolved pane is in a different tmux window than the mode owner recorded', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const sessionId = 'omx-window-owner';
+      const sessionStateDir = join(stateDir, 'sessions', sessionId);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const managedSessionName = buildTmuxSessionName(cwd, sessionId);
+      const configPath = join(omxDir, 'tmux-hook.json');
+      const hookStatePath = join(stateDir, 'tmux-hook-state.json');
+
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeManagedSessionState(stateDir, cwd, sessionId);
+      await writeJson(join(sessionStateDir, 'ralph-state.json'), {
+        active: true,
+        iteration: 0,
+        tmux_pane_id: '%42',
+        tmux_window_id: '@expected',
+      });
+      await writeJson(configPath, {
+        enabled: true,
+        target: { type: 'pane', value: '%42' },
+        allowed_modes: ['ralph'],
+        cooldown_ms: 0,
+        max_injections_per_session: 10,
+        prompt_template: 'Continue from current mode state. [OMX_TMUX_INJECT]',
+        marker: '[OMX_TMUX_INJECT]',
+        dry_run: false,
+        log_level: 'debug',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_id}" && "$target" == "%42" ]]; then echo "%42"; exit 0; fi
+  if [[ "$format" == "#{pane_current_path}" && "$target" == "%42" ]]; then echo "${cwd}"; exit 0; fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%42" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%42" ]]; then echo "codex"; exit 0; fi
+  if [[ "$format" == "#S" && "$target" == "%42" ]]; then echo "${managedSessionName}"; exit 0; fi
+  if [[ "$format" == "#{window_id}" && "$target" == "%42" ]]; then echo "@wrong"; exit 0; fi
+  echo "bad display target: $target / $format" >&2
+  exit 1
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  echo "unexpected send-keys to wrong window" >&2
+  exit 1
+fi
+echo "unsupported cmd: $cmd" >&2
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        session_id: sessionId,
+        'thread-id': 'thread-window-mismatch',
+        'turn-id': 'turn-window-mismatch',
+        'input-messages': ['no marker here'],
+        'last-assistant-message': 'output',
+      };
+
+      await withPatchedEnv({
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+        OMX_TEAM_WORKER: '',
+      }, async () => {
+        await handleTmuxInjection({ payload, cwd, stateDir, logsDir });
+      });
+
+      const hookState = await readJson<Record<string, unknown>>(hookStatePath);
+      assert.equal(hookState.last_reason, 'pane_window_mismatch');
+      assert.equal(hookState.total_injections ?? 0, 0);
     });
   });
 

--- a/src/modes/__tests__/base-tmux-pane.test.ts
+++ b/src/modes/__tests__/base-tmux-pane.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, readFile, mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, mkdir, writeFile, chmod } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { startMode } from '../base.js';
@@ -35,16 +35,41 @@ describe('modes/base tmux pane capture', () => {
   it('captures tmux_pane_id in mode state on startMode()', async () => {
     await withIsolatedStateEnv(async () => {
       const prev = process.env.TMUX_PANE;
+      const prevTmux = process.env.TMUX;
+      const prevPath = process.env.PATH;
+      const prevHudOwner = process.env.OMX_TMUX_HUD_OWNER;
       process.env.TMUX_PANE = '%123';
       const wd = await mkdtemp(join(tmpdir(), 'omx-mode-pane-'));
       try {
+        const fakeBin = join(wd, 'fake-bin');
+        await mkdir(fakeBin, { recursive: true });
+        const fakeTmux = join(fakeBin, 'tmux');
+        await writeFile(fakeTmux, `#!/usr/bin/env bash
+if [[ "$1" == "display-message" && "$*" == *"#{window_id}"* ]]; then
+  echo "@7"
+  exit 0
+fi
+exit 1
+`);
+        await chmod(fakeTmux, 0o755);
+        process.env.PATH = `${fakeBin}:${process.env.PATH || ''}`;
+        process.env.TMUX = '/tmp/tmux-test';
+        process.env.OMX_TMUX_HUD_OWNER = '1';
+
         await startMode('ralph', 'test', 1, wd);
         const raw = JSON.parse(await readFile(join(wd, '.omx', 'state', 'ralph-state.json'), 'utf-8'));
         assert.equal(raw.tmux_pane_id, '%123');
+        assert.equal(raw.tmux_window_id, '@7');
         assert.ok(typeof raw.tmux_pane_set_at === 'string' && raw.tmux_pane_set_at.length > 0);
       } finally {
         if (typeof prev === 'string') process.env.TMUX_PANE = prev;
         else delete process.env.TMUX_PANE;
+        if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+        else delete process.env.TMUX;
+        if (typeof prevPath === 'string') process.env.PATH = prevPath;
+        else delete process.env.PATH;
+        if (typeof prevHudOwner === 'string') process.env.OMX_TMUX_HUD_OWNER = prevHudOwner;
+        else delete process.env.OMX_TMUX_HUD_OWNER;
         await rm(wd, { recursive: true, force: true });
       }
     });

--- a/src/scripts/notify-hook/tmux-injection.ts
+++ b/src/scripts/notify-hook/tmux-injection.ts
@@ -99,7 +99,7 @@ async function resolveCanonicalPaneFromPaneTarget(paneTarget: any, expectedCwd: 
   return finalizeResolvedPane(healedPaneId, 'healed_hud_pane_target', expectedCwd);
 }
 
-async function resolvePreferredModePane(stateDir: string, allowedModes: string[]): Promise<{ mode: string; state: any; pane: string } | null> {
+async function resolvePreferredModePane(stateDir: string, allowedModes: string[]): Promise<{ mode: string; state: any; pane: string; stateDir: string } | null> {
   const scopedDirs = await getScopedStateDirsForCurrentSession(stateDir).catch(() => [stateDir]);
   const dirs = [...scopedDirs];
   if (!dirs.map((dir) => resolvePath(dir)).includes(resolvePath(stateDir))) {
@@ -111,11 +111,82 @@ async function resolvePreferredModePane(stateDir: string, allowedModes: string[]
       const parsed = await readJsonIfExists(path, null);
       const pane = safeString(parsed?.tmux_pane_id || '').trim();
       if (parsed?.active && pane) {
-        return { mode, state: parsed, pane };
+        return { mode, state: parsed, pane, stateDir: dir };
       }
     }
   }
   return null;
+}
+
+function modeStateMatchesInvocationOwner(modeState: any, payload: any, managedContext: any): { ok: true } | { ok: false; reason: string } {
+  const invocationSessionId = resolveInvocationSessionId(payload);
+  const canonicalSessionId = safeString(managedContext?.canonicalSessionId || managedContext?.sessionState?.session_id).trim();
+  const nativeSessionId = safeString(managedContext?.nativeSessionId || managedContext?.sessionState?.native_session_id || managedContext?.sessionState?.codex_session_id).trim();
+  const allowedSessionIds = new Set([
+    invocationSessionId,
+    canonicalSessionId,
+    nativeSessionId,
+  ].filter(Boolean));
+
+  const ownerOmxSessionId = safeString(modeState?.owner_omx_session_id).trim();
+  if (ownerOmxSessionId && !allowedSessionIds.has(ownerOmxSessionId)) {
+    return { ok: false, reason: 'mode_owner_session_mismatch' };
+  }
+
+  const stateSessionId = safeString(modeState?.session_id).trim();
+  if (!ownerOmxSessionId && stateSessionId && !allowedSessionIds.has(stateSessionId)) {
+    return { ok: false, reason: 'mode_session_mismatch' };
+  }
+
+  const ownerCodexSessionId = safeString(modeState?.owner_codex_session_id || modeState?.codex_session_id).trim();
+  if (ownerCodexSessionId && !allowedSessionIds.has(ownerCodexSessionId)) {
+    return { ok: false, reason: 'mode_codex_session_mismatch' };
+  }
+
+  return { ok: true };
+}
+
+async function validateResolvedInjectionOwnership({
+  paneTarget,
+  cwd,
+  payload,
+  modeState,
+  modePane,
+  managedCurrentPane,
+}: any): Promise<{ ok: true } | { ok: false; reason: string; managedContext?: any }> {
+  const ownership = await verifyManagedPaneTarget(paneTarget, cwd, payload, { allowTeamWorker: false });
+  if (!ownership.ok) {
+    return { ok: false, reason: ownership.reason || 'pane_not_managed_session', managedContext: ownership.managedContext };
+  }
+
+  const modeOwner = modeStateMatchesInvocationOwner(modeState, payload, ownership.managedContext);
+  if (!modeOwner.ok) return { ...modeOwner, managedContext: ownership.managedContext };
+
+  const statePane = safeString(modePane || modeState?.tmux_pane_id).trim();
+  const currentPane = safeString(managedCurrentPane).trim();
+  if (statePane && currentPane && statePane !== currentPane) {
+    return { ok: false, reason: 'mode_pane_current_pane_mismatch', managedContext: ownership.managedContext };
+  }
+
+  const expectedWindowId = safeString(modeState?.tmux_window_id || modeState?.tmuxWindowId).trim();
+  if (!expectedWindowId) {
+    return { ok: true };
+  }
+
+  try {
+    const windowResult = await runProcess('tmux', ['display-message', '-p', '-t', paneTarget, '#{window_id}'], 2000);
+    const paneWindowId = safeString(windowResult.stdout).trim();
+    if (!paneWindowId) {
+      return { ok: false, reason: 'pane_window_unverified', managedContext: ownership.managedContext };
+    }
+    if (paneWindowId !== expectedWindowId) {
+      return { ok: false, reason: 'pane_window_mismatch', managedContext: ownership.managedContext };
+    }
+  } catch {
+    return { ok: false, reason: 'pane_window_unverified', managedContext: ownership.managedContext };
+  }
+
+  return { ok: true };
 }
 
 async function readVisibleAllowedModes(
@@ -460,7 +531,22 @@ export async function handleTmuxInjection({
     turnId,
     timestamp: nowIso,
   }), sourceText);
-  const preferredPaneTarget = modePane || await resolveManagedCurrentPane(cwd, payload, { allowTeamWorker: false });
+  const managedCurrentPane = await resolveManagedCurrentPane(cwd, payload, { allowTeamWorker: false });
+  if (modePane && managedCurrentPane && modePane !== managedCurrentPane) {
+    state.last_reason = 'mode_pane_current_pane_mismatch';
+    state.last_event_at = nowIso;
+    await writeFile(hookStatePath, JSON.stringify(state, null, 2)).catch(() => {});
+    await logTmuxHookEvent(logsDir, {
+      ...baseLog,
+      event: 'injection_skipped',
+      reason: 'mode_pane_current_pane_mismatch',
+      mode_pane: modePane,
+      current_pane: managedCurrentPane,
+    });
+    return;
+  }
+
+  const preferredPaneTarget = modePane || managedCurrentPane;
   let resolution = preferredModePane
     ? await resolvePaneTarget({ type: 'pane', value: preferredModePane.pane }, cwd, preferredModePane.pane, cwd, payload)
     : preferredPaneTarget
@@ -483,6 +569,27 @@ export async function handleTmuxInjection({
     return;
   }
   const paneTarget = resolution.paneTarget;
+
+  const ownership = await validateResolvedInjectionOwnership({
+    paneTarget,
+    cwd,
+    payload,
+    modeState,
+    modePane,
+    managedCurrentPane,
+  });
+  if (!ownership.ok) {
+    state.last_reason = ownership.reason;
+    state.last_event_at = nowIso;
+    await writeFile(hookStatePath, JSON.stringify(state, null, 2)).catch(() => {});
+    await logTmuxHookEvent(logsDir, {
+      ...baseLog,
+      event: 'injection_skipped',
+      reason: ownership.reason,
+      pane_target: paneTarget,
+    });
+    return;
+  }
 
   // Final guard phase: pane is canonical identity for quota/cooldown.
   const guard = evaluateInjectionGuards({

--- a/src/state/mode-state-context.ts
+++ b/src/state/mode-state-context.ts
@@ -1,7 +1,10 @@
+import { execFileSync } from 'child_process';
+
 export interface ModeStateContextLike {
   active?: unknown;
   tmux_pane_id?: unknown;
   tmux_pane_set_at?: unknown;
+  tmux_window_id?: unknown;
   [key: string]: unknown;
 }
 
@@ -10,6 +13,22 @@ export function captureTmuxPaneFromEnv(env: NodeJS.ProcessEnv = process.env): st
   if (typeof value !== 'string') return null;
   const pane = value.trim();
   return pane.length > 0 ? pane : null;
+}
+
+export function captureTmuxWindowForPane(pane: string, env: NodeJS.ProcessEnv = process.env): string | null {
+  if (!pane || !env.TMUX || env.OMX_TMUX_HUD_OWNER !== '1') return null;
+  try {
+    const tmux = env.TMUX_BINARY || 'tmux';
+    const windowId = execFileSync(tmux, ['display-message', '-p', '-t', pane, '#{window_id}'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+      windowsHide: true,
+    }).trim();
+    return windowId.length > 0 ? windowId : null;
+  } catch {
+    return null;
+  }
 }
 
 function hasNonEmptyString(value: unknown): boolean {
@@ -31,6 +50,8 @@ export function withModeRuntimeContext<T extends ModeStateContextLike>(
     const pane = captureTmuxPaneFromEnv(env);
     if (pane) {
       next.tmux_pane_id = pane;
+      const windowId = captureTmuxWindowForPane(pane, env);
+      if (windowId) next.tmux_window_id = windowId;
       if (!hasNonEmptyString(next.tmux_pane_set_at)) {
         next.tmux_pane_set_at = nowIso;
       }


### PR DESCRIPTION
## Summary
- Fixes #2265 by adding final fail-closed ownership validation immediately before tmux prompt injection.
- Verifies the target pane is managed by the current OMX session, belongs to the expected tmux session/window when recorded, and matches the current mode/prompt pane ownership.
- Persists window ownership for OMX-owned tmux mode starts and covers stale-pane, missing-session-owner, and wrong-window regressions.

## Validation
- npm run build
- env -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/hooks/__tests__/notify-hook-tmux-heal.test.js
- env -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/modes/__tests__/base-tmux-pane.test.js
- env -u OMX_ROOT -u OMX_STATE_ROOT npm run check:no-unused
- env -u OMX_ROOT -u OMX_STATE_ROOT npm run test:ci:compiled

Do not merge yet.