### PR TITLE
Expose plugin-mode skills in Codex local marketplace

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -74,6 +74,21 @@ function currentNativeHookCommand(): string {
 	return `${quoteCommandPart(process.execPath)} ${quoteCommandPart(join(repoRoot, "dist", "scripts", "codex-native-hook.js"))}`;
 }
 
+async function packagedPluginVersion(): Promise<string> {
+	const testDir = dirname(fileURLToPath(import.meta.url));
+	const repoRoot = join(testDir, "..", "..", "..");
+	const manifest = JSON.parse(
+		await readFile(
+			join(repoRoot, "plugins", "oh-my-codex", ".codex-plugin", "plugin.json"),
+			"utf-8",
+		),
+	) as { version?: unknown };
+	if (typeof manifest.version !== "string") {
+		assert.fail("packaged plugin manifest version must be a string");
+	}
+	return manifest.version;
+}
+
 function buildHooksJsonWithPostCompactCommand(postCompactCommand: string): string {
 	const expectedCommand = currentNativeHookCommand();
 	return `${JSON.stringify({
@@ -182,6 +197,63 @@ command = "node"
 			assert.doesNotMatch(res.stdout, /Skills: skills directory not found/);
 			assert.doesNotMatch(res.stdout, /Skills: \d+ skills \(expected >=/);
 			assert.doesNotMatch(res.stdout, /MCP Servers: no MCP servers configured/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("warns when plugin cache manifest version is stale even when skills match", async () => {
+		const wd = await mkdtemp(
+			join(tmpdir(), "omx-doctor-plugin-cache-stale-version-"),
+		);
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+
+			const setupRes = runOmx(
+				wd,
+				["setup", "--scope", "user", "--plugin", "--force"],
+				{
+					HOME: home,
+					CODEX_HOME: codexDir,
+				},
+			);
+			if (shouldSkipForSpawnPermissions(setupRes.error)) return;
+			assert.equal(setupRes.status, 0, setupRes.stderr || setupRes.stdout);
+
+			const version = await packagedPluginVersion();
+			const cacheManifestPath = join(
+				codexDir,
+				"plugins",
+				"cache",
+				"oh-my-codex-local",
+				"oh-my-codex",
+				version,
+				".codex-plugin",
+				"plugin.json",
+			);
+			const staleManifest = JSON.parse(
+				await readFile(cacheManifestPath, "utf-8"),
+			) as Record<string, unknown>;
+			staleManifest.version = "0.0.0-stale";
+			await writeFile(
+				cacheManifestPath,
+				`${JSON.stringify(staleManifest, null, 2)}\n`,
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				new RegExp(
+					`Skills: plugin marketplace oh-my-codex-local is registered, but installed Codex plugin cache manifest version 0\\.0\\.0-stale does not match packaged version ${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}; run "omx setup --plugin --force" so /skills can discover OMX plugin skills`,
+				),
+			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -187,6 +187,43 @@ command = "node"
 		}
 	});
 
+	it("warns when plugin mode is configured but the Codex plugin cache is missing", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-cache-missing-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+
+			const setupRes = runOmx(
+				wd,
+				["setup", "--scope", "user", "--plugin", "--force"],
+				{
+					HOME: home,
+					CODEX_HOME: codexDir,
+				},
+			);
+			if (shouldSkipForSpawnPermissions(setupRes.error)) return;
+			assert.equal(setupRes.status, 0, setupRes.stderr || setupRes.stdout);
+			await rm(join(codexDir, "plugins", "cache"), {
+				recursive: true,
+				force: true,
+			});
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Skills: plugin marketplace oh-my-codex-local is registered, but no installed Codex plugin cache was found; run "omx setup --plugin --force" so \/skills can discover OMX plugin skills/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("uses project-scoped plugin marketplace registration without legacy omission warnings", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-project-plugin-mode-"));
 		try {

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -366,6 +366,23 @@ async function seedStalePluginDiscoveryCache(codexHomeDir: string): Promise<stri
 	return artifactPath;
 }
 
+async function packagedPluginCacheDir(codexHomeDir: string): Promise<string> {
+	const manifest = JSON.parse(
+		await readFile(
+			join(packageRoot, "plugins", "oh-my-codex", ".codex-plugin", "plugin.json"),
+			"utf-8",
+		),
+	) as { version: string };
+	return join(
+		codexHomeDir,
+		"plugins",
+		"cache",
+		"oh-my-codex-local",
+		"oh-my-codex",
+		manifest.version,
+	);
+}
+
 describe("omx setup install mode behavior", () => {
 	it("summarizes and keeps persisted setup preferences when review chooses keep", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
@@ -747,7 +764,11 @@ describe("omx setup install mode behavior", () => {
 						await setup({ scope: "user", installMode: "plugin" });
 					});
 
-					assert.equal(existsSync(cacheDir), false);
+					assert.equal(existsSync(join(cacheDir, "skills", "old-only", "SKILL.md")), false);
+					assert.equal(
+						existsSync(join(await packagedPluginCacheDir(codexHomeDir), "skills", "ask", "SKILL.md")),
+						true,
+					);
 					assert.match(
 						output,
 						/Invalidated 1 stale Codex plugin discovery cache entry/,
@@ -779,6 +800,25 @@ describe("omx setup install mode behavior", () => {
 						output,
 						/Would invalidate 1 stale Codex plugin discovery cache entry/,
 					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reports plugin cache materialization during dry-run without writing cache", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin", dryRun: true });
+					});
+
+					const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+					assert.equal(existsSync(cacheDir), false);
+					assert.match(output, /Would install local Codex plugin cache/);
 				});
 			});
 		} finally {
@@ -940,6 +980,15 @@ describe("omx setup install mode behavior", () => {
 					);
 					assert.equal(
 						parsed.plugins?.["oh-my-codex@oh-my-codex-local"]?.enabled,
+						true,
+					);
+					const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+					assert.equal(
+						existsSync(join(cacheDir, ".codex-plugin", "plugin.json")),
+						true,
+					);
+					assert.equal(
+						existsSync(join(cacheDir, "skills", "ask", "SKILL.md")),
 						true,
 					);
 					assert.match(config, /^hooks = true$/m);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -59,6 +59,9 @@ import {
 import {
 	OMX_LOCAL_MARKETPLACE_NAME,
 	OMX_LOCAL_PLUGIN_CONFIG_KEY,
+	discoverOmxPluginCacheDirs,
+	expectedPackagedOmxSkillNames,
+	readOmxPluginCacheState,
 	resolvePackagedOmxMarketplace,
 } from "./plugin-marketplace.js";
 
@@ -1274,17 +1277,23 @@ async function checkLegacySkillRootOverlap(): Promise<Check> {
 	};
 }
 
-function getParsedMarketplaceRegistration(
-	content: string,
-): { source_type?: unknown; source?: unknown } | null {
+function getParsedPluginMarketplaceConfig(content: string): {
+	marketplace: { source_type?: unknown; source?: unknown } | null;
+	plugin: { enabled?: unknown } | null;
+} {
 	const parsed = parseToml(content) as {
 		marketplaces?: Record<string, { source_type?: unknown; source?: unknown }>;
+		plugins?: Record<string, { enabled?: unknown }>;
 	};
-	return parsed.marketplaces?.[OMX_LOCAL_MARKETPLACE_NAME] ?? null;
+	return {
+		marketplace: parsed.marketplaces?.[OMX_LOCAL_MARKETPLACE_NAME] ?? null,
+		plugin: parsed.plugins?.[OMX_LOCAL_PLUGIN_CONFIG_KEY] ?? null,
+	};
 }
 
 async function checkPluginMarketplaceRegistration(
 	configPath: string,
+	codexHomeDir: string,
 ): Promise<Check> {
 	const packagedMarketplace = await resolvePackagedOmxMarketplace(
 		getPackageRoot(),
@@ -1307,7 +1316,8 @@ async function checkPluginMarketplaceRegistration(
 
 	try {
 		const content = await readFile(configPath, "utf-8");
-		const registration = getParsedMarketplaceRegistration(content);
+		const { marketplace: registration, plugin } =
+			getParsedPluginMarketplaceConfig(content);
 		if (!registration) {
 			return {
 				name: "Skills",
@@ -1329,10 +1339,49 @@ async function checkPluginMarketplaceRegistration(
 				message: `Codex marketplace ${OMX_LOCAL_MARKETPLACE_NAME} points to ${String(registration.source)} (expected ${getPackageRoot()}); run "omx setup --plugin --force"`,
 			};
 		}
+		if (plugin?.enabled !== true) {
+			return {
+				name: "Skills",
+				status: "warn",
+				message: `Codex plugin ${OMX_LOCAL_PLUGIN_CONFIG_KEY} is not enabled; run "omx setup --plugin --force"`,
+			};
+		}
+
+		const [expectedSkillNames, cacheDirs] = await Promise.all([
+			expectedPackagedOmxSkillNames(packagedMarketplace),
+			discoverOmxPluginCacheDirs(codexHomeDir),
+		]);
+		if (!expectedSkillNames || expectedSkillNames.length === 0) {
+			return {
+				name: "Skills",
+				status: "warn",
+				message: `packaged ${OMX_LOCAL_MARKETPLACE_NAME} plugin has no skills mirror; reinstall oh-my-codex`,
+			};
+		}
+		const cacheStates = (
+			await Promise.all(cacheDirs.map((dir) => readOmxPluginCacheState(dir)))
+		).filter((state) => state !== null);
+		const readyCache = cacheStates.find(
+			(state) =>
+				state.skillsPointer === "./skills/" &&
+				JSON.stringify(state.skillNames) === JSON.stringify(expectedSkillNames),
+		);
+		if (!readyCache) {
+			const detail =
+				cacheStates.length === 0
+					? "no installed Codex plugin cache was found"
+					: "installed Codex plugin cache is missing the packaged skills mirror";
+			return {
+				name: "Skills",
+				status: "warn",
+				message: `plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} is registered, but ${detail}; run "omx setup --plugin --force" so /skills can discover OMX plugin skills`,
+			};
+		}
+
 		return {
 			name: "Skills",
 			status: "pass",
-			message: `plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} registered; OMX skills are supplied by ${packagedMarketplace.pluginRoot}`,
+			message: `plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} registered; OMX skills are supplied by ${readyCache.cacheDir}`,
 		};
 	} catch {
 		return {
@@ -1349,7 +1398,10 @@ async function checkSkills(
 	installMode?: SetupInstallMode,
 ): Promise<Check> {
 	if (installMode === "plugin") {
-		return checkPluginMarketplaceRegistration(paths.configPath);
+		return checkPluginMarketplaceRegistration(
+			paths.configPath,
+			paths.codexHomeDir,
+		);
 	}
 
 	const expectations = getCatalogExpectations();

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -61,6 +61,7 @@ import {
 	OMX_LOCAL_PLUGIN_CONFIG_KEY,
 	discoverOmxPluginCacheDirs,
 	expectedPackagedOmxSkillNames,
+	packagedOmxPluginVersion,
 	readOmxPluginCacheState,
 	resolvePackagedOmxMarketplace,
 } from "./plugin-marketplace.js";
@@ -1347,10 +1348,19 @@ async function checkPluginMarketplaceRegistration(
 			};
 		}
 
-		const [expectedSkillNames, cacheDirs] = await Promise.all([
-			expectedPackagedOmxSkillNames(packagedMarketplace),
-			discoverOmxPluginCacheDirs(codexHomeDir),
-		]);
+		const [packagedManifestVersion, expectedSkillNames, cacheDirs] =
+			await Promise.all([
+				packagedOmxPluginVersion(packagedMarketplace),
+				expectedPackagedOmxSkillNames(packagedMarketplace),
+				discoverOmxPluginCacheDirs(codexHomeDir),
+			]);
+		if (!packagedManifestVersion) {
+			return {
+				name: "Skills",
+				status: "warn",
+				message: `packaged ${OMX_LOCAL_MARKETPLACE_NAME} plugin has no manifest version; reinstall oh-my-codex`,
+			};
+		}
 		if (!expectedSkillNames || expectedSkillNames.length === 0) {
 			return {
 				name: "Skills",
@@ -1361,14 +1371,28 @@ async function checkPluginMarketplaceRegistration(
 		const cacheStates = (
 			await Promise.all(cacheDirs.map((dir) => readOmxPluginCacheState(dir)))
 		).filter((state) => state !== null);
+		const packagedManifestSummary = {
+			manifestVersion: packagedManifestVersion,
+			skillNames: expectedSkillNames,
+		};
 		const readyCache = cacheStates.find(
 			(state) =>
+				state.manifestVersion === packagedManifestSummary.manifestVersion &&
 				state.skillsPointer === "./skills/" &&
-				JSON.stringify(state.skillNames) === JSON.stringify(expectedSkillNames),
+				JSON.stringify(state.skillNames) ===
+					JSON.stringify(packagedManifestSummary.skillNames),
 		);
 		if (!readyCache) {
-			const detail =
-				cacheStates.length === 0
+			const staleManifestCache = cacheStates.find(
+				(state) =>
+					state.skillsPointer === "./skills/" &&
+					JSON.stringify(state.skillNames) ===
+						JSON.stringify(packagedManifestSummary.skillNames) &&
+					state.manifestVersion !== packagedManifestSummary.manifestVersion,
+			);
+			const detail = staleManifestCache
+				? `installed Codex plugin cache manifest version ${String(staleManifestCache.manifestVersion)} does not match packaged version ${packagedManifestSummary.manifestVersion}`
+				: cacheStates.length === 0
 					? "no installed Codex plugin cache was found"
 					: "installed Codex plugin cache is missing the packaged skills mirror";
 			return {

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "fs";
-import { readFile } from "fs/promises";
+import { cp, readdir, readFile, rm } from "fs/promises";
 import { join, resolve } from "path";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 
@@ -24,6 +24,7 @@ interface MarketplaceManifest {
 
 interface PluginManifest {
 	name?: unknown;
+	version?: unknown;
 	skills?: unknown;
 }
 
@@ -75,6 +76,167 @@ export async function resolvePackagedOmxMarketplace(
 	}
 
 	return { marketplacePath, packageRoot, pluginRoot, pluginManifestPath };
+}
+
+async function readPluginManifest(
+	manifestPath: string,
+): Promise<PluginManifest | null> {
+	try {
+		return JSON.parse(await readFile(manifestPath, "utf-8")) as PluginManifest;
+	} catch {
+		return null;
+	}
+}
+
+async function listChildDirectoryNames(dir: string): Promise<string[] | null> {
+	try {
+		const entries = await readdir(dir, { withFileTypes: true });
+		return entries
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name)
+			.sort();
+	} catch {
+		return null;
+	}
+}
+
+export async function packagedOmxPluginVersion(
+	packagedMarketplace: PackagedOmxMarketplace,
+): Promise<string | null> {
+	const manifest = await readPluginManifest(packagedMarketplace.pluginManifestPath);
+	return typeof manifest?.version === "string" && manifest.version.trim()
+		? manifest.version.trim()
+		: null;
+}
+
+export async function expectedPackagedOmxSkillNames(
+	packagedMarketplace: PackagedOmxMarketplace,
+): Promise<string[] | null> {
+	return listChildDirectoryNames(join(packagedMarketplace.pluginRoot, "skills"));
+}
+
+export function omxPluginCacheBase(codexHomeDir: string): string {
+	return join(
+		codexHomeDir,
+		"plugins",
+		"cache",
+		OMX_LOCAL_MARKETPLACE_NAME,
+		OMX_PLUGIN_NAME,
+	);
+}
+
+export async function discoverOmxPluginCacheDirs(
+	codexHomeDir: string,
+): Promise<string[]> {
+	const cacheRoot = join(codexHomeDir, "plugins", "cache");
+	if (!existsSync(cacheRoot)) return [];
+
+	const queue: Array<{ path: string; depth: number }> = [
+		{ path: cacheRoot, depth: 0 },
+	];
+	const maxDepth = 5;
+	const matches: string[] = [];
+
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (!current) break;
+
+		const manifestPath = join(current.path, ".codex-plugin", "plugin.json");
+		if (existsSync(manifestPath)) {
+			const manifest = await readPluginManifest(manifestPath);
+			if (manifest?.name === OMX_PLUGIN_NAME) {
+				matches.push(current.path);
+				continue;
+			}
+		}
+
+		if (current.depth >= maxDepth) continue;
+
+		let entries;
+		try {
+			entries = await readdir(current.path, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			if (entry.name === ".git" || entry.name === "node_modules") continue;
+			queue.push({
+				path: join(current.path, entry.name),
+				depth: current.depth + 1,
+			});
+		}
+	}
+
+	return matches.sort();
+}
+
+export interface OmxPluginCacheState {
+	cacheDir: string;
+	manifestVersion: string | null;
+	skillsPointer: string | null;
+	skillNames: string[] | null;
+}
+
+export async function readOmxPluginCacheState(
+	cacheDir: string,
+): Promise<OmxPluginCacheState | null> {
+	const manifest = await readPluginManifest(
+		join(cacheDir, ".codex-plugin", "plugin.json"),
+	);
+	if (manifest?.name !== OMX_PLUGIN_NAME) return null;
+	return {
+		cacheDir,
+		manifestVersion:
+			typeof manifest.version === "string" ? manifest.version : null,
+		skillsPointer: typeof manifest.skills === "string" ? manifest.skills : null,
+		skillNames: await listChildDirectoryNames(join(cacheDir, "skills")),
+	};
+}
+
+export async function hasExpectedOmxPluginCache(
+	codexHomeDir: string,
+	packagedMarketplace: PackagedOmxMarketplace,
+): Promise<boolean> {
+	const [version, expectedSkillNames] = await Promise.all([
+		packagedOmxPluginVersion(packagedMarketplace),
+		expectedPackagedOmxSkillNames(packagedMarketplace),
+	]);
+	if (!version || !expectedSkillNames) return false;
+	const state = await readOmxPluginCacheState(
+		join(omxPluginCacheBase(codexHomeDir), version),
+	);
+	return (
+		state?.manifestVersion === version &&
+		state.skillsPointer === "./skills/" &&
+		JSON.stringify(state.skillNames) === JSON.stringify(expectedSkillNames)
+	);
+}
+
+export interface OmxPluginCacheMaterializeResult {
+	status: "unavailable" | "unchanged" | "materialized";
+	cacheDir?: string;
+	version?: string;
+}
+
+export async function materializePackagedOmxPluginCache(
+	codexHomeDir: string,
+	packagedMarketplace: PackagedOmxMarketplace | null,
+	options: { dryRun?: boolean } = {},
+): Promise<OmxPluginCacheMaterializeResult> {
+	if (!packagedMarketplace) return { status: "unavailable" };
+	const version = await packagedOmxPluginVersion(packagedMarketplace);
+	if (!version) return { status: "unavailable" };
+	const cacheDir = join(omxPluginCacheBase(codexHomeDir), version);
+	if (await hasExpectedOmxPluginCache(codexHomeDir, packagedMarketplace)) {
+		return { status: "unchanged", cacheDir, version };
+	}
+	if (!options.dryRun) {
+		await rm(cacheDir, { recursive: true, force: true });
+		await cp(packagedMarketplace.pluginRoot, cacheDir, { recursive: true });
+	}
+	return { status: "materialized", cacheDir, version };
 }
 
 function marketplaceTableHeaderPattern(): RegExp {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -90,6 +90,8 @@ import {
 } from "./setup-preferences.js";
 import {
 	OMX_LOCAL_MARKETPLACE_NAME,
+	OMX_PLUGIN_NAME,
+	materializePackagedOmxPluginCache,
 	resolvePackagedOmxMarketplace,
 	upsertLocalOmxMarketplaceRegistration,
 	upsertLocalOmxPluginEnablement,
@@ -948,6 +950,7 @@ interface PluginDiscoveryCacheRefreshResult {
 async function refreshOmxPluginDiscoveryCache(
 	pkgRoot: string,
 	options: Pick<SetupOptions, "dryRun" | "verbose">,
+	codexHomeDir = codexHome(),
 ): Promise<PluginDiscoveryCacheRefreshResult> {
 	const packagedMarketplace = await resolvePackagedOmxMarketplace(pkgRoot);
 	if (!packagedMarketplace) {
@@ -959,7 +962,7 @@ async function refreshOmxPluginDiscoveryCache(
 			JSON.parse(raw) as { version?: unknown },
 		),
 		listChildDirectoryNames(join(packagedMarketplace.pluginRoot, "skills")),
-		discoverOmxPluginCacheDirs(),
+		discoverOmxPluginCacheDirs(join(codexHomeDir, "plugins", "cache")),
 	]);
 	const expectedVersion = typeof pkg.version === "string" ? pkg.version : null;
 	const staleDirs: string[] = [];
@@ -2014,16 +2017,33 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				`  Local Codex plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} already registered (${pkgRoot}).`,
 			);
 		}
-		const pluginCacheRefresh = await refreshOmxPluginDiscoveryCache(pkgRoot, {
-			dryRun,
-			verbose,
-		});
+		const packagedMarketplace = await resolvePackagedOmxMarketplace(pkgRoot);
+		const pluginCacheRefresh = await refreshOmxPluginDiscoveryCache(
+			pkgRoot,
+			{
+				dryRun,
+				verbose,
+			},
+			scopeDirs.codexHomeDir,
+		);
 		if (pluginCacheRefresh.status === "refreshed") {
 			console.log(
 				`  ${dryRun ? "Would invalidate" : "Invalidated"} ${pluginCacheRefresh.staleDirs.length} stale Codex plugin discovery cache entr${pluginCacheRefresh.staleDirs.length === 1 ? "y" : "ies"} so plugin skills refresh from the packaged manifest.`,
 			);
 		} else if (pluginCacheRefresh.status === "unchanged") {
 			console.log("  Codex plugin discovery cache already matches packaged plugin metadata.");
+		}
+		const pluginCacheMaterialize = await materializePackagedOmxPluginCache(
+			scopeDirs.codexHomeDir,
+			packagedMarketplace,
+			{ dryRun },
+		);
+		if (pluginCacheMaterialize.status === "materialized") {
+			console.log(
+				`  ${dryRun ? "Would install" : "Installed"} local Codex plugin cache for ${OMX_LOCAL_MARKETPLACE_NAME}/${OMX_PLUGIN_NAME} at ${pluginCacheMaterialize.cacheDir}.`,
+			);
+		} else if (pluginCacheMaterialize.status === "unchanged") {
+			console.log("  Local Codex plugin cache already exposes packaged OMX skills.");
 		}
 		if (shouldSyncSharedMcpRegistry) {
 			resolvedConfig = await syncSharedMcpRegistryIntoConfig(
@@ -2042,12 +2062,12 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				);
 			}
 		}
-			resolvedConfig = existsSync(scopeDirs.codexConfigFile)
-				? await readFile(scopeDirs.codexConfigFile, "utf-8")
-				: "";
-			console.log(
-				`  Native Codex hooks and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; hooks, goals).\n`,
-			);
+		resolvedConfig = existsSync(scopeDirs.codexConfigFile)
+			? await readFile(scopeDirs.codexConfigFile, "utf-8")
+			: "";
+		console.log(
+			`  Native Codex hooks and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; hooks, goals).\n`,
+		);
 
 		if (usePluginDeveloperInstructionsDefault) {
 			const developerInstructionsResult =


### PR DESCRIPTION
## Summary
- Materialize the packaged `oh-my-codex-local/oh-my-codex` plugin into Codex's installed plugin cache during `omx setup --plugin`, so `/skills` can discover plugin-provided OMX skills without legacy skill installation.
- Keep plugin-mode setup scoped to plugin delivery: legacy prompts/skills/native-agent TOMLs stay uninstalled/cleaned up.
- Extend `omx doctor` to detect registered/enabled plugin mode with a missing or stale Codex plugin cache and point users to `omx setup --plugin --force`.

Fixes #2266.

## Diagnosis
Codex 0.130-style plugin discovery expects an enabled plugin to be present under `CODEX_HOME/plugins/cache/<marketplace>/<plugin>/<version>`. OMX already had a valid marketplace/plugin mirror, but plugin-mode setup only registered/enabled the local marketplace entry; it did not populate Codex's installed plugin cache. That made Codex discovery miss the plugin skills even though the packaged layout itself was valid.

## Tests
- `npm run build`
- `node --test dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/doctor-warning-copy.test.js dist/cli/__tests__/codex-plugin-layout.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js`
- `npm run verify:native-agents`
- `npm run verify:plugin-bundle`
- `npm run check:no-unused`
- `npm run lint`
- `git diff --check`

## Notes
- I also attempted `npm run test:ci:compiled`; it did not complete cleanly in this attached OMX/tmux runtime because unrelated state/tmux-sensitive suites failed before plugin-related coverage had already passed.
