### PR TITLE
Fix Windows native hook launch with PowerShell shim

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -21,6 +21,7 @@ import {
 	checkExploreHarness,
 	classifyPostCompactHookStdout,
 } from "../doctor.js";
+import { buildManagedCodexNativeHookCommand } from "../../config/codex-hooks.js";
 
 const MANAGED_HOOK_EVENTS = [
 	"SessionStart",
@@ -68,10 +69,12 @@ function quoteCommandPart(value: string): string {
 	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function currentNativeHookCommand(): string {
+function currentNativeHookCommand(codexHomeDir: string): string {
 	const testDir = dirname(fileURLToPath(import.meta.url));
 	const repoRoot = join(testDir, "..", "..", "..");
-	return `${quoteCommandPart(process.execPath)} ${quoteCommandPart(join(repoRoot, "dist", "scripts", "codex-native-hook.js"))}`;
+	return buildManagedCodexNativeHookCommand(repoRoot, {
+		codexHomeDir,
+	});
 }
 
 async function packagedPluginVersion(): Promise<string> {
@@ -89,8 +92,11 @@ async function packagedPluginVersion(): Promise<string> {
 	return manifest.version;
 }
 
-function buildHooksJsonWithPostCompactCommand(postCompactCommand: string): string {
-	const expectedCommand = currentNativeHookCommand();
+function buildHooksJsonWithPostCompactCommand(
+	postCompactCommand: string,
+	codexHomeDir: string,
+): string {
+	const expectedCommand = currentNativeHookCommand(codexHomeDir);
 	return `${JSON.stringify({
 		hooks: Object.fromEntries(
 			MANAGED_HOOK_EVENTS.map((eventName) => [
@@ -785,6 +791,7 @@ command = "node"
 				join(codexDir, "hooks.json"),
 				buildHooksJsonWithPostCompactCommand(
 					`${quoteCommandPart(process.execPath)} ${quoteCommandPart(join(wd, "old", "dist", "scripts", "codex-native-hook.js"))}`,
+					codexDir,
 				),
 			);
 
@@ -833,7 +840,10 @@ command = "node"
 			await writeFile(join(codexDir, "config.toml"), "omx_enabled = true\n");
 			await writeFile(
 				join(codexDir, "hooks.json"),
-				buildHooksJsonWithPostCompactCommand(currentNativeHookCommand()),
+				buildHooksJsonWithPostCompactCommand(
+					currentNativeHookCommand(codexDir),
+					codexDir,
+				),
 			);
 
 			const res = runOmx(wd, ["doctor", "--verbose"], {

--- a/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
+++ b/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
@@ -87,7 +87,15 @@ function hookCommands(entries: HookRegistration[] | undefined): string[] {
 }
 
 function countManagedHooks(entries: HookRegistration[] | undefined): number {
-  return hookCommands(entries).filter((command) => command.includes("codex-native-hook.js")).length;
+  return hookCommands(entries).filter((command) =>
+    command.includes("codex-native-hook.js")
+    || command.includes("omx-native-hook-windows-shim.ps1")
+  ).length;
+}
+
+function hasManagedHookCommand(command: string): boolean {
+  return command.includes("codex-native-hook.js")
+    || command.includes("omx-native-hook-windows-shim.ps1");
 }
 
 function cloneRegistration(entry: HookRegistration): HookRegistration {
@@ -221,7 +229,7 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
         "setup should keep the managed PostToolUse wrapper alongside user hooks",
       );
       assert.ok(
-        hookCommands(refreshed.hooks?.UserPromptSubmit).some((command) => command.includes("codex-native-hook.js")),
+        hookCommands(refreshed.hooks?.UserPromptSubmit).some(hasManagedHookCommand),
         "setup should still register managed UserPromptSubmit hooks",
       );
     } finally {
@@ -268,7 +276,7 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
       assert.ok(allCommands.includes('node "/custom/session-start.js"'));
       assert.ok(allCommands.includes('node "/custom/post-tool.js"'));
       assert.equal(
-        allCommands.some((command) => command.includes("codex-native-hook.js")),
+        allCommands.some(hasManagedHookCommand),
         false,
         "uninstall should strip only OMX-managed wrappers",
       );

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -194,6 +194,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 		const postCompactRuntimeCheck = await checkNativePostCompactHookRuntime(
 			paths.hooksPath,
 			cwd,
+			paths.codexHomeDir,
 		);
 		if (postCompactRuntimeCheck) checks.push(postCompactRuntimeCheck);
 	}
@@ -1098,6 +1099,7 @@ export function classifyPostCompactHookStdout(stdout: string): Check | null {
 async function checkNativePostCompactHookRuntime(
 	hooksPath: string,
 	cwd: string,
+	codexHomeDir: string,
 ): Promise<Check | null> {
 	if (!existsSync(hooksPath)) return null;
 
@@ -1116,7 +1118,9 @@ async function checkNativePostCompactHookRuntime(
 		return null;
 	}
 
-	const expectedCommand = buildManagedCodexNativeHookCommand(getPackageRoot());
+	const expectedCommand = buildManagedCodexNativeHookCommand(getPackageRoot(), {
+		codexHomeDir,
+	});
 	const uniqueCommands = [...new Set(postCompactCommands)];
 	if (uniqueCommands.length !== 1 || uniqueCommands[0] !== expectedCommand) {
 		return {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -49,7 +49,11 @@ import {
 	OMX_PLUGIN_DEVELOPER_INSTRUCTIONS,
 } from "../config/generator.js";
 import type { CodexHookFeatureFlag } from "../config/codex-feature-flags.js";
-import { mergeManagedCodexHooksConfig } from "../config/codex-hooks.js";
+import {
+	buildManagedCodexNativeHookWindowsShimContent,
+	buildManagedCodexNativeHookWindowsShimPath,
+	mergeManagedCodexHooksConfig,
+} from "../config/codex-hooks.js";
 import {
 	getLegacyUnifiedMcpRegistryCandidate,
 	getUnifiedMcpRegistryCandidates,
@@ -1449,6 +1453,7 @@ async function applyPluginModeHooksConfig(
 	configPath: string,
 	hooksPath: string,
 	pkgRoot: string,
+	codexHomeDir: string,
 	backupContext: SetupBackupContext,
 	summary: SetupCategorySummary,
 	options: Pick<SetupOptions, "dryRun" | "verbose"> & {
@@ -1465,6 +1470,7 @@ async function applyPluginModeHooksConfig(
 		),
 		pkgRoot,
 		hooksPath,
+		{ platform: process.platform, codexHomeDir },
 	);
 	if (nextConfig !== existingConfig) {
 		if (
@@ -1493,6 +1499,7 @@ async function applyPluginModeHooksConfig(
 		existingHooksContent,
 		pkgRoot,
 		hooksPath,
+		{ platform: process.platform, codexHomeDir },
 	);
 	await syncManagedContent(
 		hooksConfig,
@@ -1501,6 +1508,13 @@ async function applyPluginModeHooksConfig(
 		backupContext,
 		options,
 		`native hooks ${hooksPath}`,
+	);
+	await syncManagedWindowsNativeHookShim(
+		codexHomeDir,
+		pkgRoot,
+		summary,
+		backupContext,
+		options,
 	);
 
 		if (options.verbose) {
@@ -1992,6 +2006,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			scopeDirs.codexConfigFile,
 			scopeDirs.codexHooksFile,
 			pkgRoot,
+			scopeDirs.codexHomeDir,
 			backupContext,
 			summary.config,
 			{ dryRun, verbose, codexHookFeatureFlag },
@@ -2145,6 +2160,8 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		const hooksConfig = mergeManagedCodexHooksConfig(
 			existingHooksContent,
 			pkgRoot,
+			scopeDirs.codexHooksFile,
+			{ platform: process.platform, codexHomeDir: scopeDirs.codexHomeDir },
 		);
 		await syncManagedContent(
 			hooksConfig,
@@ -2153,6 +2170,13 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			backupContext,
 			{ dryRun, verbose },
 			`native hooks ${scopeDirs.codexHooksFile}`,
+		);
+		await syncManagedWindowsNativeHookShim(
+			scopeDirs.codexHomeDir,
+			pkgRoot,
+			summary.config,
+			backupContext,
+			{ dryRun, verbose },
 		);
 		console.log(
 			`  Native Codex hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
@@ -2596,6 +2620,27 @@ async function syncManagedContent(
 			`  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
 		);
 	}
+}
+
+async function syncManagedWindowsNativeHookShim(
+	codexHomeDir: string,
+	pkgRoot: string,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<void> {
+	if (process.platform !== "win32") return;
+
+	const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+	const shimContent = buildManagedCodexNativeHookWindowsShimContent(pkgRoot);
+	await syncManagedContent(
+		shimContent,
+		shimPath,
+		summary,
+		backupContext,
+		options,
+		`native hook Windows shim ${shimPath}`,
+	);
 }
 
 async function syncManagedAgentsContent(
@@ -3317,6 +3362,8 @@ async function updateManagedConfig(
 	const finalConfig = buildMergedConfig(existing, pkgRoot, {
 		includeTui: omxManagesTui,
 		codexHooksFile: hooksPath,
+		codexHomeDir,
+		hookCommandPlatform: process.platform,
 		codexHookFeatureFlag: options.codexHookFeatureFlag,
 		modelOverride,
 		sharedMcpServers: sharedMcpRegistry.servers,

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -94,7 +94,7 @@ describe("codex hooks helpers", () => {
     ));
   });
 
-  it("builds deterministic Windows shim paths and ProcessStartInfo content", () => {
+  it("builds deterministic Windows shim paths and PowerShell 5.1-compatible ProcessStartInfo content", () => {
     assert.equal(
       buildManagedCodexNativeHookWindowsShimPath("C:\\Users\\Ada Lovelace\\.codex"),
       "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1",
@@ -107,6 +107,7 @@ describe("codex hooks helpers", () => {
 
     assert.match(content, /\$stdinPayload = \[Console\]::In\.ReadToEnd\(\)/);
     assert.match(content, /\[System\.Diagnostics\.ProcessStartInfo\]::new\(\)/);
+    assert.doesNotMatch(content, /ArgumentList/);
     assert.match(content, /\$startInfo\.UseShellExecute = \$false/);
     assert.match(content, /\$startInfo\.RedirectStandardInput = \$true/);
     assert.match(content, /\$startInfo\.RedirectStandardOutput = \$true/);
@@ -117,7 +118,7 @@ describe("codex hooks helpers", () => {
     assert.match(content, /\$startInfo\.FileName = 'C:\\Program Files\\nodejs\\node\.exe'/);
     assert.match(
       content,
-      /\$startInfo\.ArgumentList\.Add\('D:\\Program Files\\O''Malley\\oh-my-codex\\dist\\scripts\\codex-native-hook\.js'\)/,
+      /\$startInfo\.Arguments = '"D:\\Program Files\\O''Malley\\oh-my-codex\\dist\\scripts\\codex-native-hook\.js"'/,
     );
   });
 

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -3,7 +3,11 @@ import assert from "node:assert/strict";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import {
+  buildManagedCodexNativeHookCommand,
+  buildManagedCodexNativeHookWindowsShimContent,
+  buildManagedCodexNativeHookWindowsShimPath,
   buildManagedCodexHookTrustState,
   buildManagedCodexHookTrustToml,
   buildManagedCodexHooksConfig,
@@ -45,10 +49,10 @@ describe("codex hooks helpers", () => {
     );
   });
 
-  it("uses portable node invocation for Windows managed hook commands", () => {
+  it("uses a PowerShell ProcessStartInfo shim for Windows managed hook commands", () => {
     const config = buildManagedCodexHooksConfig(
       "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",
-      { platform: "win32" },
+      { platform: "win32", codexHomeDir: "C:\\Users\\Ada Lovelace\\.codex" },
     );
     const command = (config.hooks.SessionStart[0] as {
       hooks?: Array<{ command?: string }>;
@@ -56,13 +60,12 @@ describe("codex hooks helpers", () => {
 
     assert.equal(
       command,
-      'node "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex\\dist\\scripts\\codex-native-hook.js"',
+      'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
     );
-    assert.doesNotMatch(command ?? "", /^"/, "the node launcher must not be a quoted absolute node.exe path");
-    assert.match(command ?? "", /^node "[^"]*Program Files[^"]*codex-native-hook\.js"$/);
+    assert.doesNotMatch(command ?? "", /codex-native-hook\.js/);
   });
 
-  it("keeps Windows hook script paths quoted when they contain spaces", () => {
+  it("keeps Windows shim paths quoted when they contain spaces", () => {
     const merged = JSON.parse(
       mergeManagedCodexHooksConfig(
         JSON.stringify({
@@ -76,7 +79,8 @@ describe("codex hooks helpers", () => {
           },
         }),
         "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",
-        { platform: "win32" },
+        "C:\\Users\\Ada Lovelace\\.codex\\hooks.json",
+        { platform: "win32", codexHomeDir: "C:\\Users\\Ada Lovelace\\.codex" },
       ),
     ) as { hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>> };
 
@@ -86,8 +90,85 @@ describe("codex hooks helpers", () => {
 
     assert.ok(commands.includes("echo keep-me"));
     assert.ok(commands.includes(
-      'node "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex\\dist\\scripts\\codex-native-hook.js"',
+      'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
     ));
+  });
+
+  it("builds deterministic Windows shim paths and ProcessStartInfo content", () => {
+    assert.equal(
+      buildManagedCodexNativeHookWindowsShimPath("C:\\Users\\Ada Lovelace\\.codex"),
+      "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1",
+    );
+
+    const content = buildManagedCodexNativeHookWindowsShimContent(
+      "D:\\Program Files\\O'Malley\\oh-my-codex",
+      { nodePath: "C:\\Program Files\\nodejs\\node.exe" },
+    );
+
+    assert.match(content, /\$stdinPayload = \[Console\]::In\.ReadToEnd\(\)/);
+    assert.match(content, /\[System\.Diagnostics\.ProcessStartInfo\]::new\(\)/);
+    assert.match(content, /\$startInfo\.UseShellExecute = \$false/);
+    assert.match(content, /\$startInfo\.RedirectStandardInput = \$true/);
+    assert.match(content, /\$startInfo\.RedirectStandardOutput = \$true/);
+    assert.match(content, /\$startInfo\.RedirectStandardError = \$true/);
+    assert.match(content, /\[Console\]::Out\.Write\(\$stdoutTask\.Result\)/);
+    assert.match(content, /\[Console\]::Error\.Write\(\$stderrTask\.Result\)/);
+    assert.match(content, /exit \$process\.ExitCode/);
+    assert.match(content, /\$startInfo\.FileName = 'C:\\Program Files\\nodejs\\node\.exe'/);
+    assert.match(
+      content,
+      /\$startInfo\.ArgumentList\.Add\('D:\\Program Files\\O''Malley\\oh-my-codex\\dist\\scripts\\codex-native-hook\.js'\)/,
+    );
+  });
+
+  it("forwards payload, stdout, stderr, and non-zero exit through the Windows shim when PowerShell is available", async () => {
+    const shell = ["pwsh", "powershell.exe", "powershell"].find((candidate) => {
+      const probe = spawnSync(candidate, ["-NoProfile", "-Command", "$PSVersionTable.PSVersion.ToString()"], {
+        encoding: "utf-8",
+      });
+      return !probe.error && probe.status === 0;
+    });
+    if (!shell) return;
+
+    const wd = await mkdtemp(join(tmpdir(), "omx-windows-hook-shim-"));
+    try {
+      const pkgRoot = join(wd, "pkg root");
+      const hookPath = join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
+      await mkdir(join(pkgRoot, "dist", "scripts"), { recursive: true });
+      await writeFile(
+        hookPath,
+        [
+          "const chunks = [];",
+          "process.stdin.on('data', (chunk) => chunks.push(chunk));",
+          "process.stdin.on('end', () => {",
+          "  const input = Buffer.concat(chunks).toString('utf8');",
+          "  process.stdout.write(`stdout:${input}`);",
+          "  process.stderr.write(`stderr:${input}`);",
+          "  process.exit(17);",
+          "});",
+          "",
+        ].join("\n"),
+      );
+      const shimPath = join(wd, "shim.ps1");
+      await writeFile(
+        shimPath,
+        buildManagedCodexNativeHookWindowsShimContent(pkgRoot, {
+          nodePath: process.execPath,
+        }),
+      );
+
+      const result = spawnSync(
+        shell,
+        ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", shimPath],
+        { input: "payload with spaces", encoding: "utf-8" },
+      );
+
+      assert.equal(result.status, 17);
+      assert.equal(result.stdout, "stdout:payload with spaces");
+      assert.equal(result.stderr, "stderr:payload with spaces");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
   });
 
   it("merges managed wrappers without dropping user hooks", () => {
@@ -172,6 +253,45 @@ describe("codex hooks helpers", () => {
     const expectedHash = `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
 
     assert.equal(state["/hooks.json:pre_tool_use:0:0"]?.trusted_hash, expectedHash);
+  });
+
+  it("matches Codex's normalized command hook hash identity for Windows shim commands", async () => {
+    const hooksPath = "C:\\Users\\Ada Lovelace\\.codex\\hooks.json";
+    const pkgRoot = "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex";
+    const state = buildManagedCodexHookTrustState(hooksPath, pkgRoot, {
+      platform: "win32",
+      codexHomeDir: "C:\\Users\\Ada Lovelace\\.codex",
+    });
+    const command = buildManagedCodexNativeHookCommand(pkgRoot, {
+      platform: "win32",
+      codexHomeDir: "C:\\Users\\Ada Lovelace\\.codex",
+    });
+    const expectedIdentity = {
+      event_name: "pre_tool_use",
+      hooks: [
+        {
+          async: false,
+          command,
+          timeout: 600,
+          type: "command",
+        },
+      ],
+      matcher: "Bash",
+    };
+    const canonical = JSON.stringify({
+      event_name: expectedIdentity.event_name,
+      hooks: expectedIdentity.hooks.map((hook) => ({
+        async: hook.async,
+        command: hook.command,
+        timeout: hook.timeout,
+        type: hook.type,
+      })),
+      matcher: expectedIdentity.matcher,
+    });
+    const { createHash } = await import("node:crypto");
+    const expectedHash = `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+
+    assert.equal(state[`${hooksPath}:pre_tool_use:0:0`]?.trusted_hash, expectedHash);
   });
 
   it("serializes managed hook trust state as TOML tables for config.toml", () => {
@@ -307,6 +427,55 @@ describe("codex hooks helpers", () => {
     const second = mergeManagedCodexHooksConfig(first, "/repo", "/hooks.json");
 
     assert.equal(second, first);
+  });
+
+  it("keeps Windows shim hook merge idempotent while replacing stale direct-node wrappers", () => {
+    const stale = JSON.stringify({
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              { type: "command", command: 'node "D:\\old\\dist\\scripts\\codex-native-hook.js"' },
+              { type: "command", command: "echo keep-me" },
+            ],
+          },
+          {
+            hooks: [
+              {
+                type: "command",
+                command: 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const options = {
+      platform: "win32" as const,
+      codexHomeDir: "C:\\Users\\Ada Lovelace\\.codex",
+    };
+    const first = mergeManagedCodexHooksConfig(
+      stale,
+      "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",
+      "C:\\Users\\Ada Lovelace\\.codex\\hooks.json",
+      options,
+    );
+    const second = mergeManagedCodexHooksConfig(
+      first,
+      "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",
+      "C:\\Users\\Ada Lovelace\\.codex\\hooks.json",
+      options,
+    );
+
+    assert.equal(second, first);
+    const merged = JSON.parse(first) as {
+      hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
+    };
+    const commands = merged.hooks.SessionStart.flatMap((entry) => entry.hooks ?? [])
+      .map((hook) => hook.command ?? "");
+    assert.equal(commands.filter((command) => /omx-native-hook-windows-shim\.ps1/.test(command)).length, 1);
+    assert.equal(commands.filter((command) => /codex-native-hook\.js/.test(command)).length, 0);
+    assert.ok(commands.includes("echo keep-me"));
   });
 
   it("removes only OMX-managed wrappers during uninstall cleanup", () => {

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -153,6 +153,7 @@ describe("codex hooks helpers", () => {
       await writeFile(
         shimPath,
         buildManagedCodexNativeHookWindowsShimContent(pkgRoot, {
+          hookScriptPath: hookPath,
           nodePath: process.execPath,
         }),
       );

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -95,6 +95,33 @@ function quotePowerShellLiteral(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
+function quoteWindowsProcessArgument(value: string): string {
+  let quoted = '"';
+  let backslashes = 0;
+
+  for (const char of value) {
+    if (char === '\\') {
+      backslashes += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      quoted += '\\'.repeat(backslashes * 2 + 1);
+      quoted += '"';
+      backslashes = 0;
+      continue;
+    }
+
+    quoted += '\\'.repeat(backslashes);
+    quoted += char;
+    backslashes = 0;
+  }
+
+  quoted += '\\'.repeat(backslashes * 2);
+  quoted += '"';
+  return quoted;
+}
+
 export const WINDOWS_NATIVE_HOOK_SHIM_RELATIVE_PATH = [
   "hooks",
   "omx-native-hook-windows-shim.ps1",
@@ -131,7 +158,7 @@ export function buildManagedCodexNativeHookWindowsShimContent(
     "$startInfo.RedirectStandardInput = $true",
     "$startInfo.RedirectStandardOutput = $true",
     "$startInfo.RedirectStandardError = $true",
-    `$startInfo.ArgumentList.Add(${quotePowerShellLiteral(hookScript)})`,
+    `$startInfo.Arguments = ${quotePowerShellLiteral(quoteWindowsProcessArgument(hookScript))}`,
     "$process = [System.Diagnostics.Process]::new()",
     "$process.StartInfo = $startInfo",
     "$null = $process.Start()",

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -104,6 +104,7 @@ export interface ManagedCodexHookOptions {
   platform?: HookCommandPlatform;
   codexHomeDir?: string;
   nodePath?: string;
+  hookScriptPath?: string;
 }
 
 export function buildManagedCodexNativeHookWindowsShimPath(
@@ -114,9 +115,11 @@ export function buildManagedCodexNativeHookWindowsShimPath(
 
 export function buildManagedCodexNativeHookWindowsShimContent(
   pkgRoot: string,
-  options: Pick<ManagedCodexHookOptions, "nodePath"> = {},
+  options: Pick<ManagedCodexHookOptions, "hookScriptPath" | "nodePath"> = {},
 ): string {
-  const hookScript = win32.join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
+  const hookScript =
+    options.hookScriptPath ??
+    win32.join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
   const nodePath = options.nodePath ?? process.execPath;
 
   return [

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
 import { readdir, realpath } from "fs/promises";
-import { basename, join, relative, resolve, win32 } from "path";
+import { basename, dirname, join, relative, resolve, win32 } from "path";
 
 export const MANAGED_HOOK_EVENTS = [
   "SessionStart",
@@ -91,16 +91,75 @@ function quoteWindowsCommandPart(value: string): string {
   return `"${value.replace(/"/g, '\\"')}"`;
 }
 
+function quotePowerShellLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export const WINDOWS_NATIVE_HOOK_SHIM_RELATIVE_PATH = [
+  "hooks",
+  "omx-native-hook-windows-shim.ps1",
+] as const;
+
+export interface ManagedCodexHookOptions {
+  platform?: HookCommandPlatform;
+  codexHomeDir?: string;
+  nodePath?: string;
+}
+
+export function buildManagedCodexNativeHookWindowsShimPath(
+  codexHomeDir: string,
+): string {
+  return win32.join(codexHomeDir, ...WINDOWS_NATIVE_HOOK_SHIM_RELATIVE_PATH);
+}
+
+export function buildManagedCodexNativeHookWindowsShimContent(
+  pkgRoot: string,
+  options: Pick<ManagedCodexHookOptions, "nodePath"> = {},
+): string {
+  const hookScript = win32.join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
+  const nodePath = options.nodePath ?? process.execPath;
+
+  return [
+    "$ErrorActionPreference = 'Stop'",
+    "$stdinPayload = [Console]::In.ReadToEnd()",
+    "$startInfo = [System.Diagnostics.ProcessStartInfo]::new()",
+    `$startInfo.FileName = ${quotePowerShellLiteral(nodePath)}`,
+    "$startInfo.UseShellExecute = $false",
+    "$startInfo.RedirectStandardInput = $true",
+    "$startInfo.RedirectStandardOutput = $true",
+    "$startInfo.RedirectStandardError = $true",
+    `$startInfo.ArgumentList.Add(${quotePowerShellLiteral(hookScript)})`,
+    "$process = [System.Diagnostics.Process]::new()",
+    "$process.StartInfo = $startInfo",
+    "$null = $process.Start()",
+    "$stdoutTask = $process.StandardOutput.ReadToEndAsync()",
+    "$stderrTask = $process.StandardError.ReadToEndAsync()",
+    "$process.StandardInput.Write($stdinPayload)",
+    "$process.StandardInput.Close()",
+    "$process.WaitForExit()",
+    "[Console]::Out.Write($stdoutTask.Result)",
+    "[Console]::Error.Write($stderrTask.Result)",
+    "exit $process.ExitCode",
+    "",
+  ].join("\n");
+}
+
 export function buildManagedCodexNativeHookCommand(
   pkgRoot: string,
-  platform: HookCommandPlatform = process.platform,
+  optionsOrPlatform: HookCommandPlatform | ManagedCodexHookOptions = process.platform,
 ): string {
+  const options = typeof optionsOrPlatform === "string"
+    ? { platform: optionsOrPlatform }
+    : optionsOrPlatform;
+  const platform = options.platform ?? process.platform;
   const hookScript = platform === "win32"
     ? win32.join(pkgRoot, "dist", "scripts", "codex-native-hook.js")
     : join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
 
   if (platform === "win32") {
-    return `node ${quoteWindowsCommandPart(hookScript)}`;
+    const codexHomeDir = options.codexHomeDir ?? dirname(pkgRoot);
+    const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+    return `powershell.exe -NoProfile -ExecutionPolicy Bypass -File ${quoteWindowsCommandPart(shimPath)}`;
   }
 
   return `${quoteCommandPart(process.execPath)} ${quoteCommandPart(hookScript)}`;
@@ -129,9 +188,9 @@ function buildCommandHook(
 
 export function buildManagedCodexHooksConfig(
   pkgRoot: string,
-  options: { platform?: HookCommandPlatform } = {},
+  options: ManagedCodexHookOptions = {},
 ): ManagedCodexHooksConfig {
-  const command = buildManagedCodexNativeHookCommand(pkgRoot, options.platform);
+  const command = buildManagedCodexNativeHookCommand(pkgRoot, options);
 
   return {
     hooks: {
@@ -183,7 +242,8 @@ export function parseCodexHooksConfig(
 }
 
 function isOmxManagedHookCommand(command: string): boolean {
-  return /(?:^|[\\/])codex-native-hook\.js(?:["'\s]|$)/.test(command);
+  return /(?:^|[\\/])codex-native-hook\.js(?:["'\s]|$)/.test(command)
+    || /(?:^|[\\/])omx-native-hook-windows-shim\.ps1(?:["'\s]|$)/i.test(command);
 }
 
 function countManagedHooksInEntry(entry: unknown): number {
@@ -333,9 +393,14 @@ function managedHookStateKey(
 export function buildManagedCodexHookTrustState(
   hooksPath: string,
   pkgRoot: string,
-  options: { platform?: HookCommandPlatform } = {},
+  options: ManagedCodexHookOptions = {},
 ): Record<string, ManagedCodexHookTrustState> {
-  const managedConfig = buildManagedCodexHooksConfig(pkgRoot, options);
+  const managedConfig = buildManagedCodexHooksConfig(pkgRoot, {
+    ...options,
+    ...(options.platform === "win32" && !options.codexHomeDir
+      ? { codexHomeDir: dirname(hooksPath) }
+      : {}),
+  });
   const state: Record<string, ManagedCodexHookTrustState> = {};
 
   for (const eventName of MANAGED_HOOK_EVENTS) {
@@ -366,7 +431,7 @@ export function buildManagedCodexHookTrustState(
 export function buildManagedCodexHookTrustToml(
   hooksPath: string | undefined,
   pkgRoot: string,
-  options: { platform?: HookCommandPlatform } = {},
+  options: ManagedCodexHookOptions = {},
 ): string {
   if (!hooksPath) return "";
   const state = buildManagedCodexHookTrustState(hooksPath, pkgRoot, options);
@@ -499,13 +564,19 @@ export async function discoverCodexHookConfigPaths(
 export function mergeManagedCodexHooksConfig(
   existingContent: string | null | undefined,
   pkgRoot: string,
-  hooksPathOrOptions?: string | { platform?: HookCommandPlatform },
-  options: { platform?: HookCommandPlatform } = {},
+  hooksPathOrOptions?: string | ManagedCodexHookOptions,
+  options: ManagedCodexHookOptions = {},
 ): string {
   const hooksPath = typeof hooksPathOrOptions === "string" ? hooksPathOrOptions : undefined;
-  const resolvedOptions = typeof hooksPathOrOptions === "object" && hooksPathOrOptions !== null
+  const providedOptions = typeof hooksPathOrOptions === "object" && hooksPathOrOptions !== null
     ? hooksPathOrOptions
     : options;
+  const resolvedOptions = {
+    ...providedOptions,
+    ...(hooksPath && providedOptions.platform === "win32" && !providedOptions.codexHomeDir
+      ? { codexHomeDir: dirname(hooksPath) }
+      : {}),
+  };
   const managedConfig = buildManagedCodexHooksConfig(pkgRoot, resolvedOptions);
   const parsed =
     typeof existingContent === "string"

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -28,12 +28,17 @@ import {
   OMX_FIRST_PARTY_MCP_SERVER_NAMES,
   getOmxFirstPartySetupMcpServers,
 } from "./omx-first-party-mcp.js";
-import { buildManagedCodexHookTrustToml } from "./codex-hooks.js";
+import {
+  buildManagedCodexHookTrustToml,
+  type ManagedCodexHookOptions,
+} from "./codex-hooks.js";
 import type { HudPreset } from "../hud/types.js";
 
 interface MergeOptions {
   includeTui?: boolean;
   codexHooksFile?: string;
+  codexHomeDir?: string;
+  hookCommandPlatform?: ManagedCodexHookOptions["platform"];
   codexHookFeatureFlag?: CodexHookFeatureFlag;
   modelOverride?: string;
   sharedMcpServers?: UnifiedMcpRegistryServer[];
@@ -738,8 +743,9 @@ export function upsertManagedCodexHookTrustState(
   config: string,
   pkgRoot: string,
   codexHooksFile: string | undefined,
+  options: ManagedCodexHookOptions = {},
 ): string {
-  const hookTrustToml = buildManagedCodexHookTrustToml(codexHooksFile, pkgRoot);
+  const hookTrustToml = buildManagedCodexHookTrustToml(codexHooksFile, pkgRoot, options);
   const stripped = stripUnfencedManagedCodexHookTrustState(
     stripManagedCodexHookTrustState(config),
     hookTrustToml,
@@ -749,7 +755,7 @@ export function upsertManagedCodexHookTrustState(
     stripped,
     "",
     OMX_HOOK_TRUST_START_MARKER,
-    "# Trusts only setup-managed codex-native-hook.js wrappers.",
+    "# Trusts only setup-managed native hook wrappers.",
     hookTrustToml,
     OMX_HOOK_TRUST_END_MARKER,
     "",
@@ -1798,6 +1804,7 @@ function getOmxTablesBlock(
   includeTui = true,
   statusLinePreset: HudPreset = DEFAULT_STATUS_LINE_PRESET,
   codexHooksFile?: string,
+  hookOptions: ManagedCodexHookOptions = {},
   includeFirstPartyMcp = false,
 ): string {
   const lines = [
@@ -1826,11 +1833,15 @@ function getOmxTablesBlock(
     }
   }
 
-  const hookTrustToml = buildManagedCodexHookTrustToml(codexHooksFile, pkgRoot);
+  const hookTrustToml = buildManagedCodexHookTrustToml(
+    codexHooksFile,
+    pkgRoot,
+    hookOptions,
+  );
   if (hookTrustToml) {
     lines.push("");
     lines.push("# OMX-owned Codex hook trust state");
-    lines.push("# Trusts only setup-managed codex-native-hook.js wrappers.");
+    lines.push("# Trusts only setup-managed native hook wrappers.");
     lines.push(hookTrustToml);
     lines.push("# End OMX-owned Codex hook trust state");
   }
@@ -1905,7 +1916,10 @@ export function buildMergedConfig(
   existing = stripManagedCodexHookTrustState(existing);
   existing = stripUnfencedManagedCodexHookTrustState(
     existing,
-    buildManagedCodexHookTrustToml(options.codexHooksFile, pkgRoot),
+    buildManagedCodexHookTrustToml(options.codexHooksFile, pkgRoot, {
+      codexHomeDir: options.codexHomeDir,
+      platform: options.hookCommandPlatform,
+    }),
   );
   if (options.modelOverride) {
     existing = stripRootLevelKeys(existing, ["model"]);
@@ -1934,6 +1948,10 @@ export function buildMergedConfig(
     includeTui && !tuiUpsert.hadExistingTui,
     statusLinePreset,
     options.codexHooksFile,
+    {
+      codexHomeDir: options.codexHomeDir,
+      platform: options.hookCommandPlatform,
+    },
     options.includeFirstPartyMcp === true,
   );
   const sharedRegistryBlock = getSharedMcpRegistryBlock(


### PR DESCRIPTION
## Summary\n- Fixes #2269 by generating a Windows-only Codex-home PowerShell shim for managed native hooks.\n- Registers Windows hooks as `powershell.exe -NoProfile -ExecutionPolicy Bypass -File <shim>` while preserving POSIX direct Node hook commands.\n- Keeps managed hook trust/dedupe/uninstall behavior aware of both legacy direct-node commands and the new shim command.\n\n## Validation\n- `npm run build`\n- `npm run lint`\n- `node --test dist/config/__tests__/codex-hooks.test.js`\n- `node --test dist/cli/__tests__/setup-hooks-shared-ownership.test.js dist/scripts/__tests__/codex-native-hook.test.js`\n- `npm run test:plugin-boundaries:compiled`\n- `node dist/scripts/generate-catalog-docs.js --check`\n- `node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/launch-fallback.test.js`\n\n## Notes\nFull `npm run test:ci:compiled` and full `npm run test:recent-bug-regressions:compiled` were attempted but hit unrelated existing tmux/team/path environment failures in this OMX runtime; affected hook/config/setup/plugin-boundary lanes pass.