### PR TITLE
Fix ultragoal legacy completion loop

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -176,6 +176,8 @@ describe('cli/ultragoal', () => {
       ]));
       assert.equal(mismatch.exitCode, 1);
       assert.match(mismatch.stderr.join('\n'), /objective mismatch/);
+      assert.match(mismatch.stderr.join('\n'), /--status blocked/);
+      assert.match(mismatch.stderr.join('\n'), /fresh Codex thread/);
     });
   });
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   dispatchCodexNativeHook,
   isCodexNativeHookMainModule,
+  looksLikeGoalCompletionPrompt,
   mapCodexHookEventToOmxEvent,
   resolveSessionOwnerPidFromAncestry,
 } from "../codex-native-hook.js";
@@ -1409,6 +1410,32 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("classifies only actionable goal completion wording", () => {
+    const actionable = [
+      "complete this goal now",
+      "Performance goal complete; next call update_goal({status: \"complete\"}).",
+      "get_goal returned a completed legacy goal, so ultragoal complete failed; marking complete now.",
+      "omx ultragoal checkpoint --goal-id G001-demo --status complete --codex-goal-json goal.json",
+      "Call update_goal({status: \"complete\"}) after verification.",
+      "Goal complete.",
+      "The goal is complete.",
+    ];
+
+    const ordinary = [
+      "my goal is to complete the migration without regressions",
+      "Our goal is to finish this carefully after tests pass.",
+      "The goal of this patch is to close a review gap.",
+      "A goal can be complete only after a human review.",
+    ];
+
+    for (const text of actionable) {
+      assert.equal(looksLikeGoalCompletionPrompt(text), true, text);
+    }
+    for (const text of ordinary) {
+      assert.equal(looksLikeGoalCompletionPrompt(text), false, text);
+    }
+  });
+
   it("warns completion-like prompts when active goal workflows need Codex snapshot reconciliation", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-goal-warning-"));
     try {
@@ -1457,6 +1484,54 @@ describe("codex native hook dispatch", () => {
       assert.match(JSON.stringify(result.outputJson), /get_goal snapshot reconciliation/);
       assert.match(JSON.stringify(result.outputJson), /omx performance-goal complete --slug latency/);
       assert.match(JSON.stringify(result.outputJson), /Hooks must not mutate Codex goal state/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks ultragoal Stop for concise generic goal completion claims", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-generic-complete-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
+        version: 1,
+        activeGoalId: "G001-demo",
+        goals: [{ id: "G001-demo", status: "in_progress", objective: "Demo goal" }],
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-ultragoal-generic-complete-stop",
+        thread_id: "thread-ultragoal-generic-complete-stop",
+        last_assistant_message: "Goal complete.",
+      }, { cwd });
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /omx ultragoal checkpoint --goal-id G001-demo --status complete/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block ultragoal Stop for ordinary prose about a goal to complete work", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-ordinary-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
+        version: 1,
+        activeGoalId: "G001-demo",
+        goals: [{ id: "G001-demo", status: "in_progress", objective: "Demo goal" }],
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-ultragoal-ordinary-stop",
+        thread_id: "thread-ultragoal-ordinary-stop",
+        last_assistant_message: "My goal is to complete the migration without regressions, so I will keep testing.",
+      }, { cwd });
+
+      assert.notEqual(result.outputJson?.stopReason, "ultragoal_codex_goal_snapshot_required");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /omx ultragoal checkpoint --goal-id G001-demo --status complete/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1462,6 +1462,34 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("blocks ultragoal Stop with blocked checkpoint and fresh-thread remediation for completed legacy snapshots", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-legacy-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
+        version: 1,
+        activeGoalId: "G001-demo",
+        goals: [{ id: "G001-demo", status: "in_progress", objective: "Demo goal" }],
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-ultragoal-legacy-stop",
+        thread_id: "thread-ultragoal-legacy-stop",
+        last_assistant_message: "get_goal returned a completed legacy goal, so ultragoal complete failed; marking complete now.",
+      }, { cwd });
+
+      const output = JSON.stringify(result.outputJson);
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(output, /omx ultragoal checkpoint --goal-id G001-demo --status complete/);
+      assert.match(output, /--status blocked/);
+      assert.match(output, /fresh Codex thread/);
+      assert.match(output, /Hooks must not mutate Codex goal state/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block Stop for non-passing autoresearch-goal professor-critic verdicts", async () => {
     for (const verdict of ["blocked", "fail", "failed"]) {
       const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-autoresearch-${verdict}-stop-`));

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1419,6 +1419,10 @@ describe("codex native hook dispatch", () => {
       "Call update_goal({status: \"complete\"}) after verification.",
       "Goal complete.",
       "The goal is complete.",
+      "Goal complete: verified with tests.",
+      "Goal complete — verified with tests.",
+      "The goal is complete: verified.",
+      "The goal is complete — verified.",
     ];
 
     const ordinary = [

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1709,7 +1709,7 @@ export function looksLikeGoalCompletionPrompt(text: string): boolean {
     || /\bomx\s+(?:ultragoal|performance-goal|autoresearch-goal)\s+(?:checkpoint|complete)\b/i.test(text)
     || /\b(?:complete|checkpoint|finish|close|mark)\b.{0,80}\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b/i.test(text)
     || /\b(?:ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b.{0,80}\b(?:complete|checkpoint|finish|close|mark)\b/i.test(text)
-    || /(?:^|[.!?]\s+)(?:the\s+)?goal\s+(?:is\s+|now\s+|has\s+been\s+)?(?:complete|completed|finished|closed)\s*(?:[.!?]|$)/i.test(text);
+    || /(?:^|[.!?]\s+)(?:the\s+)?goal\s+(?:is\s+|now\s+|has\s+been\s+)?(?:complete|completed|finished|closed)(?:\s*(?:[.!?]|$)|\s*[:;]\s*\S|\s*[—–-]\s*\S)/i.test(text);
 }
 
 async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Promise<{ workflow: string; command: string; remediation?: string } | null> {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1706,18 +1706,25 @@ async function buildModeBasedStopOutput(
 
 function looksLikeGoalCompletionPrompt(text: string): boolean {
   return /\b(?:complete|checkpoint|finish|close|mark)\b.{0,80}\b(?:goal|ultragoal|performance-goal|autoresearch-goal)\b/i.test(text)
+    || /\b(?:goal|ultragoal|performance-goal|autoresearch-goal)\b.{0,80}\b(?:complete|checkpoint|finish|close|mark)\b/i.test(text)
     || /\bupdate_goal\s*\(/i.test(text)
     || /\bomx\s+(?:ultragoal|performance-goal|autoresearch-goal)\s+(?:checkpoint|complete)\b/i.test(text);
 }
 
-async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Promise<{ workflow: string; command: string } | null> {
+async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Promise<{ workflow: string; command: string; remediation?: string } | null> {
   const ultragoal = await readJsonIfExists(join(cwd, ".omx", "ultragoal", "goals.json"));
   const ultragoals = Array.isArray(ultragoal?.goals) ? ultragoal.goals.map(safeObject) : [];
   const activeUltragoal = ultragoals.find((goal) => safeString(goal.status) === "in_progress" || safeString(goal.id) === safeString(ultragoal?.activeGoalId));
   if (activeUltragoal) {
+    const goalId = safeString(activeUltragoal.id) || "<goal-id>";
     return {
       workflow: "ultragoal",
-      command: `omx ultragoal checkpoint --goal-id ${safeString(activeUltragoal.id) || "<goal-id>"} --status complete --codex-goal-json '<get_goal JSON or path>' --evidence '<evidence>'`,
+      command: `omx ultragoal checkpoint --goal-id ${goalId} --status complete --codex-goal-json '<get_goal JSON or path>' --evidence '<evidence>'`,
+      remediation: [
+        `If get_goal instead returns a different completed legacy objective and complete checkpointing fails, do not repeat --status complete in this thread.`,
+        `Record the non-terminal blocker with: omx ultragoal checkpoint --goal-id ${goalId} --status blocked --codex-goal-json '<different completed get_goal JSON or path>' --evidence '<completed legacy Codex goal blocks create_goal in this thread>'.`,
+        "Then continue this ultragoal from a fresh Codex thread in the same repo/worktree and create the intended goal there.",
+      ].join(" "),
     };
   }
 
@@ -1761,7 +1768,8 @@ async function buildGoalWorkflowReconciliationPromptWarning(cwd: string, prompt:
     `OMX ${requirement.workflow} goal workflow requires Codex goal snapshot reconciliation before completion.`,
     "Call get_goal, pass the resulting JSON or a path with --codex-goal-json, and do not rely on hooks or shell commands to mutate Codex-owned goal state.",
     `Required command shape: ${requirement.command}.`,
-  ].join(" ");
+    requirement.remediation,
+  ].filter(Boolean).join(" ");
 }
 
 async function buildGoalWorkflowReconciliationStopOutput(
@@ -1773,7 +1781,11 @@ async function buildGoalWorkflowReconciliationStopOutput(
   const requirement = await findActiveGoalWorkflowReconciliationRequirement(cwd);
   if (!requirement) return null;
   const systemMessage =
-    `OMX ${requirement.workflow} requires get_goal snapshot reconciliation before completion; call get_goal and pass --codex-goal-json to ${requirement.command}. Hooks must not mutate Codex goal state.`;
+    [
+      `OMX ${requirement.workflow} requires get_goal snapshot reconciliation before completion; call get_goal and pass --codex-goal-json to ${requirement.command}.`,
+      requirement.remediation,
+      "Hooks must not mutate Codex goal state.",
+    ].filter(Boolean).join(" ");
   return {
     decision: "block",
     reason: systemMessage,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1704,11 +1704,12 @@ async function buildModeBasedStopOutput(
   };
 }
 
-function looksLikeGoalCompletionPrompt(text: string): boolean {
-  return /\b(?:complete|checkpoint|finish|close|mark)\b.{0,80}\b(?:goal|ultragoal|performance-goal|autoresearch-goal)\b/i.test(text)
-    || /\b(?:goal|ultragoal|performance-goal|autoresearch-goal)\b.{0,80}\b(?:complete|checkpoint|finish|close|mark)\b/i.test(text)
-    || /\bupdate_goal\s*\(/i.test(text)
-    || /\bomx\s+(?:ultragoal|performance-goal|autoresearch-goal)\s+(?:checkpoint|complete)\b/i.test(text);
+export function looksLikeGoalCompletionPrompt(text: string): boolean {
+  return /\bupdate_goal\s*\(/i.test(text)
+    || /\bomx\s+(?:ultragoal|performance-goal|autoresearch-goal)\s+(?:checkpoint|complete)\b/i.test(text)
+    || /\b(?:complete|checkpoint|finish|close|mark)\b.{0,80}\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b/i.test(text)
+    || /\b(?:ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b.{0,80}\b(?:complete|checkpoint|finish|close|mark)\b/i.test(text)
+    || /(?:^|[.!?]\s+)(?:the\s+)?goal\s+(?:is\s+|now\s+|has\s+been\s+)?(?:complete|completed|finished|closed)\s*(?:[.!?]|$)/i.test(text);
 }
 
 async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Promise<{ workflow: string; command: string; remediation?: string } | null> {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -379,6 +379,34 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('guides different completed legacy snapshots to blocked checkpoints and fresh threads', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        codexGoalMode: 'per_story',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'complete',
+          evidence: 'audit passed but wrong Codex snapshot',
+          codexGoal: { goal: { objective: 'Completed legacy objective', status: 'complete' } },
+        }),
+        (error: unknown) => {
+          assert.match(String(error), /objective mismatch/);
+          assert.match(String(error), /--status blocked/);
+          assert.match(String(error), /fresh Codex thread/);
+          return true;
+        },
+      );
+    });
+  });
+
   it('rejects blocked checkpoints for active or same-objective Codex goals', async () => {
     await withTempRepo(async (cwd) => {
       await createUltragoalPlan(cwd, {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -152,6 +152,14 @@ function normalizeObjective(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
 }
 
+function buildCompletedLegacyGoalRemediation(goal: UltragoalItem): string {
+  return [
+    'If get_goal returns a different completed legacy/thread objective, do not repeat --status complete in this thread.',
+    `Record a non-terminal blocker with: omx ultragoal checkpoint --goal-id ${goal.id} --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json "<different completed get_goal JSON or path>".`,
+    'Then continue this ultragoal in a fresh Codex thread in the same repo/worktree and create the intended goal there.',
+  ].join(' ');
+}
+
 function codexGoalMode(plan: UltragoalPlan): UltragoalCodexGoalMode {
   return plan.codexGoalMode ?? 'per_story';
 }
@@ -457,7 +465,13 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       },
     );
     if (!reconciliation.ok) {
-      throw new UltragoalError(formatCodexGoalReconciliation(reconciliation));
+      const remediation = reconciliation.snapshot.available
+        && reconciliation.snapshot.status === 'complete'
+        && Boolean(reconciliation.snapshot.objective)
+        && normalizeObjective(reconciliation.snapshot.objective ?? '') !== normalizeObjective(expectedObjective)
+        ? ` ${buildCompletedLegacyGoalRemediation(goal)}`
+        : '';
+      throw new UltragoalError(`${formatCodexGoalReconciliation(reconciliation)}${remediation}`);
     }
     if (finalRunCheckpoint && !options.allowActiveFinalCodexGoal) goal.evidence = options.evidence;
   }


### PR DESCRIPTION
## Summary
- Fixes #2271
- Adds non-looping ultragoal remediation when a fresh get_goal snapshot is a different completed legacy objective
- Keeps strict protection for matching completion, and for different active/incomplete snapshots
- Preserves hook rule that hooks must not mutate Codex goal state

## Tests
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/ultragoal.test.js dist/ultragoal/__tests__/artifacts.test.js dist/goal-workflows/__tests__/codex-goal-snapshot.test.js
- npx biome lint src/scripts/codex-native-hook.ts src/ultragoal/artifacts.ts src/scripts/__tests__/codex-native-hook.test.ts src/cli/__tests__/ultragoal.test.ts src/ultragoal/__tests__/artifacts.test.ts
- npm run check:no-unused

Do not merge until reviewed.