### PR TITLE
Load project memory during SessionStart

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -25,7 +25,7 @@ import { resetTriageConfigCache } from "../../hooks/triage-config.js";
 import { executeStateOperation } from "../../state/operations.js";
 import { OMX_TMUX_HUD_OWNER_ENV } from "../../hud/reconcile.js";
 import { readAllState } from "../../hud/state.js";
-import { writePage } from "../../wiki/storage.js";
+import { getLegacyWikiDir, serializePage, writePage } from "../../wiki/storage.js";
 import { WIKI_SCHEMA_VERSION } from "../../wiki/types.js";
 
 function nativeHookScriptPath(): string {
@@ -1089,6 +1089,68 @@ describe("codex native hook dispatch", () => {
       assert.match(serialized, /small diffs, verify before claim/);
       assert.match(serialized, /Keep native Stop bounded to real continuation decisions\./);
       assert.match(serialized, /Requires LOCAL_API_BASE for smoke tests/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers repository project-memory.json during SessionStart while preserving legacy wiki guidance", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-root-memory-legacy-wiki-"));
+    try {
+      const now = new Date().toISOString();
+      const legacyWikiDir = getLegacyWikiDir(cwd);
+      await mkdir(legacyWikiDir, { recursive: true });
+      await writeFile(join(legacyWikiDir, "legacy.md"), serializePage({
+        filename: "legacy.md",
+        frontmatter: {
+          title: "Legacy",
+          tags: ["legacy"],
+          created: now,
+          updated: now,
+          sources: [],
+          links: [],
+          category: "reference",
+          confidence: "medium",
+          schemaVersion: WIKI_SCHEMA_VERSION,
+        },
+        content: "\n# Legacy\n\nLegacy wiki context must remain visible.\n",
+      }));
+      await writeJson(join(cwd, ".omx", "project-memory.json"), {
+        techStack: "Legacy runtime memory should not win",
+        notes: [{ category: "legacy", content: "stale legacy note", timestamp: now }],
+      });
+      await writeJson(join(cwd, "project-memory.json"), {
+        techStack: "Canonical root memory",
+        build: "npm run build && node --test dist/scripts/__tests__/codex-native-hook.test.js",
+        conventions: "prefer repository-visible project memory at startup",
+        directives: [
+          { directive: "Load root project-memory.json before legacy .omx memory.", priority: "high", timestamp: now },
+        ],
+        notes: [
+          { category: "issue", content: "Regression fixture for issue #2273.", timestamp: now },
+        ],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "sess-root-memory-legacy-wiki",
+        },
+        { cwd, sessionOwnerPid: 43210 },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /\[Project memory\]/);
+      assert.match(additionalContext, /source: project-memory\.json/);
+      assert.match(additionalContext, /Canonical root memory/);
+      assert.match(additionalContext, /Load root project-memory\.json before legacy \.omx memory\./);
+      assert.match(additionalContext, /Regression fixture for issue #2273\./);
+      assert.doesNotMatch(additionalContext, /Legacy runtime memory should not win/);
+      assert.match(additionalContext, /legacy pages at \.omx\/wiki\//);
+      assert.match(additionalContext, /Legacy wiki fallback is read-only/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -33,7 +33,7 @@ import {
   writeTeamLeaderAttention,
   writeTeamPhase,
 } from "../team/state.js";
-import { omxNotepadPath, omxProjectMemoryPath } from "../utils/paths.js";
+import { omxNotepadPath, resolveProjectMemoryPath } from "../utils/paths.js";
 import { findGitLayout } from "../utils/git-layout.js";
 import { getBaseStateDir, getStateFilePath, getStatePath } from "../mcp/state-paths.js";
 import {
@@ -155,6 +155,12 @@ function safeString(value: unknown): string {
 
 function safeObject(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" ? value as Record<string, unknown> : {};
+}
+
+function safeContextSnippet(value: unknown, maxLength = 300): string {
+  const text = safeString(value).replace(/\s+/g, " ").trim();
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 1).trimEnd()}…`;
 }
 
 interface NativeSubagentSessionStartMetadata {
@@ -1122,28 +1128,31 @@ async function buildSessionStartContext(
     sections.push(["[Active OMX modes]", ...modeSummaries].join("\n"));
   }
 
-  const projectMemory = await readJsonIfExists(omxProjectMemoryPath(cwd));
-  if (projectMemory) {
+  const projectMemoryPath = resolveProjectMemoryPath(cwd);
+  const projectMemory = projectMemoryPath ? await readJsonIfExists(projectMemoryPath) : null;
+  if (projectMemory && projectMemoryPath) {
     const directives = Array.isArray(projectMemory.directives) ? projectMemory.directives : [];
     const notes = Array.isArray(projectMemory.notes) ? projectMemory.notes : [];
-    const techStack = safeString(projectMemory.techStack).trim();
-    const conventions = safeString(projectMemory.conventions).trim();
-    const build = safeString(projectMemory.build).trim();
+    const techStack = safeContextSnippet(projectMemory.techStack);
+    const conventions = safeContextSnippet(projectMemory.conventions);
+    const build = safeContextSnippet(projectMemory.build);
     const summary: string[] = [];
+    const relativeMemoryPath = relative(cwd, projectMemoryPath).replace(/\\/g, "/");
+    summary.push(`- source: ${relativeMemoryPath === "project-memory.json" ? "project-memory.json" : ".omx/project-memory.json"}`);
     if (techStack) summary.push(`- stack: ${techStack}`);
     if (conventions) summary.push(`- conventions: ${conventions}`);
     if (build) summary.push(`- build: ${build}`);
     if (directives.length > 0) {
       const firstDirective = directives[0] as Record<string, unknown>;
-      const directive = safeString(firstDirective.directive).trim();
+      const directive = safeContextSnippet(firstDirective.directive);
       if (directive) summary.push(`- directive: ${directive}`);
     }
     if (notes.length > 0) {
       const firstNote = notes[0] as Record<string, unknown>;
-      const note = safeString(firstNote.content).trim();
+      const note = safeContextSnippet(firstNote.content);
       if (note) summary.push(`- note: ${note}`);
     }
-    if (summary.length > 0) {
+    if (summary.length > 1) {
       sections.push(["[Project memory]", ...summary].join("\n"));
     }
   }

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -16,6 +16,9 @@ import {
   omxStateDir,
   omxRoot,
   omxProjectMemoryPath,
+  canonicalProjectMemoryPath,
+  projectMemoryPathCandidates,
+  resolveProjectMemoryPath,
   omxNotepadPath,
   omxPlansDir,
   omxAdaptersDir,
@@ -400,6 +403,38 @@ describe("omxProjectMemoryPath", () => {
       omxProjectMemoryPath(),
       join(process.cwd(), ".omx", "project-memory.json"),
     );
+  });
+});
+
+describe("project memory startup path resolution", () => {
+  it("prefers repository project-memory.json over legacy .omx/project-memory.json", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-project-memory-paths-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(join(wd, "project-memory.json"), "{}");
+      await writeFile(join(wd, ".omx", "project-memory.json"), "{}");
+
+      assert.equal(canonicalProjectMemoryPath(wd), join(wd, "project-memory.json"));
+      assert.deepEqual(projectMemoryPathCandidates(wd), [
+        join(wd, "project-memory.json"),
+        join(wd, ".omx", "project-memory.json"),
+      ]);
+      assert.equal(resolveProjectMemoryPath(wd), join(wd, "project-memory.json"));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to legacy .omx/project-memory.json when canonical memory is absent", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-project-memory-legacy-path-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(join(wd, ".omx", "project-memory.json"), "{}");
+
+      assert.equal(resolveProjectMemoryPath(wd), join(wd, ".omx", "project-memory.json"));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -310,6 +310,26 @@ export function omxProjectMemoryPath(projectRoot?: string): string {
   return join(omxRoot(projectRoot), "project-memory.json");
 }
 
+/** Repository-visible project memory file used as canonical startup context. */
+export function canonicalProjectMemoryPath(projectRoot?: string): string {
+  return join(projectRoot || process.cwd(), "project-memory.json");
+}
+
+/** Project memory read order: repository-visible canonical file, then legacy OMX runtime memory. */
+export function projectMemoryPathCandidates(projectRoot?: string): string[] {
+  const canonical = canonicalProjectMemoryPath(projectRoot);
+  const legacy = omxProjectMemoryPath(projectRoot);
+  return canonical === legacy ? [canonical] : [canonical, legacy];
+}
+
+/** First readable project memory path, preferring repository-visible canonical memory. */
+export function resolveProjectMemoryPath(projectRoot?: string): string | null {
+  for (const path of projectMemoryPathCandidates(projectRoot)) {
+    if (existsSync(path)) return path;
+  }
+  return null;
+}
+
 /** oh-my-codex notepad file (.omx/notepad.md) */
 export function omxNotepadPath(projectRoot?: string): string {
   return join(omxRoot(projectRoot), "notepad.md");

--- a/src/wiki/lifecycle.ts
+++ b/src/wiki/lifecycle.ts
@@ -4,7 +4,7 @@
 
 import { existsSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
-import { codexHome, omxProjectMemoryPath } from '../utils/paths.js';
+import { codexHome, resolveProjectMemoryPath } from '../utils/paths.js';
 import {
   appendLogUnsafe,
   getWikiDir,
@@ -187,8 +187,8 @@ export function onPostCompact(data: { cwd?: string }): { additionalContext?: str
 
 function feedProjectMemory(root: string): void {
   try {
-    const projectMemoryPath = omxProjectMemoryPath(root);
-    if (!existsSync(projectMemoryPath)) return;
+    const projectMemoryPath = resolveProjectMemoryPath(root);
+    if (!projectMemoryPath || !existsSync(projectMemoryPath)) return;
 
     const parsed = JSON.parse(readFileSync(projectMemoryPath, 'utf8')) as Record<string, unknown>;
     const existing = readPage(root, 'environment.md');


### PR DESCRIPTION
## Summary\n- prefer repository-root `project-memory.json` as canonical native SessionStart startup memory\n- keep legacy `.omx/project-memory.json` fallback and existing `omx_wiki/` / legacy `.omx/wiki/` startup guidance\n- add regression coverage for root project memory plus legacy wiki fallback context\n\nFixes #2273.\n\n## Verification\n- `npm run build`\n- `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/wiki/__tests__/session-hooks.test.js`\n- `env -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/utils/__tests__/paths.test.js`\n- `npm run lint`\n- `npm run check:no-unused`\n\nDo not merge until reviewed.