### PR TITLE
Establish DESIGN.md as the canonical design workflow

### DIFF
--- a/docs/skills.html
+++ b/docs/skills.html
@@ -57,8 +57,9 @@
         <li><code>$build-fix</code></li>
         <li><code>$code-review</code></li>
         <li><code>$security-review</code></li>
-        <li><code>$visual-ralph</code></li>
-        <li><code>$frontend-ui-ux</code></li>
+        <li><code>$design</code> - maintain repo-local <code>DESIGN.md</code></li>
+        <li><code>$visual-ralph</code> - measured visual-reference implementation loop</li>
+        <li><code>$frontend-ui-ux</code> (deprecated; use <code>$design</code> or <code>$visual-ralph</code>)</li>
         <li><code>$git-master</code></li>
         <li><code>$review</code></li>
       </ul>

--- a/plugins/oh-my-codex/skills/design/SKILL.md
+++ b/plugins/oh-my-codex/skills/design/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: design
+description: Canonical repo-local DESIGN.md workflow for product, UI/UX, and frontend decision source of truth
+---
+
+# Design Skill
+
+Use `$design` when product, UI/UX, frontend, or design-system decisions need a durable source of truth in the repository. This skill discovers existing design context, interviews for missing product/design information, and creates or refreshes repo-local `DESIGN.md` so future UI/UX/frontend work is grounded instead of improvised.
+
+## Purpose
+
+Make repo-local `DESIGN.md` source of truth and canonical design contract for the current repository:
+
+`existing repo evidence -> missing-context interview -> create/refresh DESIGN.md -> use DESIGN.md for UI/UX/frontend decisions`.
+
+The output is not a pixel-matching loop and not a one-off visual critique. It is the maintained design brief/checklist that implementation, review, and future visual work should cite.
+
+## Use when
+
+- The user asks for design direction, UX guidance, frontend planning, or design-system alignment.
+- A repo needs a design brief before UI/frontend implementation begins.
+- Existing UI/components/assets/screenshots need to be summarized into a reusable design source of truth.
+- UI/UX/frontend decisions are ambiguous and should be resolved through product context, constraints, and documented principles.
+- A feature needs `DESIGN.md` created or refreshed before `$ralph`, a designer lane, or implementation work proceeds.
+
+## Do not use when
+
+- The user provides or requests a visual reference/image/live URL and wants measured implementation until screenshots match. Use `$visual-ralph` for that visual-reference implementation loop.
+- The task is pure backend/API/infrastructure work with no user-facing design consequence.
+- The user only asks to compare screenshots or score visual fidelity. Use `$visual-ralph` and its built-in visual verdict flow.
+
+## Relationship to `$visual-ralph`
+
+`$design` owns the durable repo design source of truth: product goals, users, IA, visual language, components, accessibility, constraints, and open questions in `DESIGN.md`.
+
+`$visual-ralph` owns implementation against an approved generated/static/live-URL visual reference, with screenshot capture, Visual Ralph verdict scoring, and pixel-diff evidence. `$visual-ralph` may read `DESIGN.md`, and it may leave design-system artifacts behind, but it does not replace the `DESIGN.md` discovery/interview/refresh workflow.
+
+If both are needed, run `$design` first to establish the design contract, then run `$visual-ralph` only after the visual reference/baseline is approved.
+
+## Workflow
+
+### 1. Discover local design evidence
+
+Inspect the repository before writing guidance. Look for:
+
+- `DESIGN.md`, `docs/design*`, `docs/ux*`, `docs/frontend*`, `README.md`, product specs, PRDs, and issue notes.
+- Existing UI source: routes, pages, layouts, components, stories, examples, demos, theme files, CSS variables, Tailwind/theme config, tokens, icons, and assets.
+- Screenshots, mockups, brand files, logos, Figma/export notes, Storybook snapshots, Playwright screenshots, visual-regression baselines, or `.omx/artifacts/visual-ralph/*` references.
+- Accessibility, responsive, i18n, content, and platform constraints already encoded in code or docs.
+
+Record evidence with file paths. Distinguish observed facts from design inferences.
+
+### 2. Interview only for missing context
+
+Ask concise questions only when repo evidence cannot answer design-critical context. Prefer one focused round that closes the biggest gaps, such as:
+
+- target users/personas and jobs to be done,
+- product/business goals and non-goals,
+- brand personality or forbidden aesthetics,
+- primary flows and information architecture,
+- accessibility level, device/browser support, and implementation constraints,
+- existing design assets or references the repo does not contain.
+
+If the user wants autonomous progress or cannot answer, create `DESIGN.md` with explicit assumptions and open questions instead of blocking.
+
+### 3. Create or refresh `DESIGN.md`
+
+Use the structure below. Preserve useful existing content, remove contradictions, and mark unknowns as open questions. Keep it actionable for implementers and reviewers.
+
+#### Required `DESIGN.md` structure/checklist
+
+```markdown
+# Design
+
+## Source of truth
+- Status: Draft | Active | Needs refresh
+- Last refreshed: YYYY-MM-DD
+- Primary product surfaces:
+- Evidence reviewed:
+
+## Brand
+- Personality:
+- Trust signals:
+- Avoid:
+
+## Product goals
+- Goals:
+- Non-goals:
+- Success signals:
+
+## Personas and jobs
+- Primary personas:
+- User jobs:
+- Key contexts of use:
+
+## Information architecture
+- Primary navigation:
+- Core routes/screens:
+- Content hierarchy:
+
+## Design principles
+- Principle 1:
+- Principle 2:
+- Tradeoffs:
+
+## Visual language
+- Color:
+- Typography:
+- Spacing/layout rhythm:
+- Shape/radius/elevation:
+- Motion:
+- Imagery/iconography:
+
+## Components
+- Existing components to reuse:
+- New/changed components:
+- Variants and states:
+- Token/component ownership:
+
+## Accessibility
+- Target standard:
+- Keyboard/focus behavior:
+- Contrast/readability:
+- Screen-reader semantics:
+- Reduced motion and sensory considerations:
+
+## Responsive behavior
+- Supported breakpoints/devices:
+- Layout adaptations:
+- Touch/hover differences:
+
+## Interaction states
+- Loading:
+- Empty:
+- Error:
+- Success:
+- Disabled:
+- Offline/slow network, if applicable:
+
+## Content voice
+- Tone:
+- Terminology:
+- Microcopy rules:
+
+## Implementation constraints
+- Framework/styling system:
+- Design-token constraints:
+- Performance constraints:
+- Compatibility constraints:
+- Test/screenshot expectations:
+
+## Open questions
+- [ ] Question / owner / impact
+```
+
+### 4. Use `DESIGN.md` as the decision contract
+
+For UI/UX/frontend work after the refresh:
+
+- Cite the relevant `DESIGN.md` sections before making design choices.
+- Prefer existing components, tokens, and documented constraints.
+- If implementation reveals a design contradiction, update `DESIGN.md` or add an open question before proceeding.
+- Do not introduce a new design-system layer when existing repo-native patterns can be extended.
+
+### 5. Handoff to implementation or Visual Ralph when appropriate
+
+- For normal frontend implementation, hand off with the relevant `DESIGN.md` sections, repo evidence, and acceptance criteria.
+- For visual-reference/image/live-URL matching, hand off to `$visual-ralph` with the approved reference/baseline and note that `DESIGN.md` is supporting context, not the visual verdict target.
+
+## Completion checklist
+
+Do not declare the design workflow complete until:
+
+- Existing design docs/assets/components/screenshots have been inspected or explicitly noted as absent.
+- Missing product/design context has been answered, assumed, or listed in `DESIGN.md` open questions.
+- `DESIGN.md` exists at the repo root and contains all required checklist sections.
+- UI/UX/frontend recommendations cite `DESIGN.md` rather than relying on unstated preferences.
+- Any `$visual-ralph` handoff is clearly separated as visual implementation matching, not DESIGN.md governance.
+
+Task: {{ARGUMENTS}}

--- a/plugins/oh-my-codex/skills/skill/SKILL.md
+++ b/plugins/oh-my-codex/skills/skill/SKILL.md
@@ -313,7 +313,8 @@ Project-only skills (2):
   - backend-scaffold
 
 Common skills (3):
-  - frontend-ui-ux
+  - design
+  - frontend-ui-ux (deprecated; use design or visual-ralph)
   - git-master
   - planner
 

--- a/plugins/oh-my-codex/skills/visual-ralph/SKILL.md
+++ b/plugins/oh-my-codex/skills/visual-ralph/SKILL.md
@@ -27,7 +27,7 @@ This is an orchestration skill. It composes existing skills and must not add run
 
 ## Do not use when
 
-- The user only wants design critique or general frontend advice; use `$frontend-ui-ux` or a designer lane.
+- The user only wants repo-wide design guidance, product/design context, or a DESIGN.md source of truth; use `$design` or a designer lane.
 - The task is a non-visual backend/API implementation with no UI reference target.
 - The user already supplied a final static reference image and only needs comparison/fixes; hand directly to `$ralph` with Visual Ralph verdict guidance.
 - The requested output is a deterministic SVG/vector/code-native asset rather than a raster reference.
@@ -117,7 +117,7 @@ Record final diff evidence with the reference/screenshot artifacts so the result
 
 ### 7. Build a reproducible design system
 
-The implementation is incomplete unless the visual match is encoded in repo-native reusable artifacts. Depending on the project, this may mean CSS variables, theme tokens, Tailwind config, component variants, Storybook stories, design docs, or existing equivalents.
+The implementation is incomplete unless the visual match is encoded in repo-native reusable artifacts. Depending on the project, this may mean CSS variables, theme tokens, Tailwind config, component variants, Storybook stories, updates that align with DESIGN.md, or existing equivalents.
 
 Capture at least the applicable:
 - colors,

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: design
+description: Canonical repo-local DESIGN.md workflow for product, UI/UX, and frontend decision source of truth
+---
+
+# Design Skill
+
+Use `$design` when product, UI/UX, frontend, or design-system decisions need a durable source of truth in the repository. This skill discovers existing design context, interviews for missing product/design information, and creates or refreshes repo-local `DESIGN.md` so future UI/UX/frontend work is grounded instead of improvised.
+
+## Purpose
+
+Make repo-local `DESIGN.md` source of truth and canonical design contract for the current repository:
+
+`existing repo evidence -> missing-context interview -> create/refresh DESIGN.md -> use DESIGN.md for UI/UX/frontend decisions`.
+
+The output is not a pixel-matching loop and not a one-off visual critique. It is the maintained design brief/checklist that implementation, review, and future visual work should cite.
+
+## Use when
+
+- The user asks for design direction, UX guidance, frontend planning, or design-system alignment.
+- A repo needs a design brief before UI/frontend implementation begins.
+- Existing UI/components/assets/screenshots need to be summarized into a reusable design source of truth.
+- UI/UX/frontend decisions are ambiguous and should be resolved through product context, constraints, and documented principles.
+- A feature needs `DESIGN.md` created or refreshed before `$ralph`, a designer lane, or implementation work proceeds.
+
+## Do not use when
+
+- The user provides or requests a visual reference/image/live URL and wants measured implementation until screenshots match. Use `$visual-ralph` for that visual-reference implementation loop.
+- The task is pure backend/API/infrastructure work with no user-facing design consequence.
+- The user only asks to compare screenshots or score visual fidelity. Use `$visual-ralph` and its built-in visual verdict flow.
+
+## Relationship to `$visual-ralph`
+
+`$design` owns the durable repo design source of truth: product goals, users, IA, visual language, components, accessibility, constraints, and open questions in `DESIGN.md`.
+
+`$visual-ralph` owns implementation against an approved generated/static/live-URL visual reference, with screenshot capture, Visual Ralph verdict scoring, and pixel-diff evidence. `$visual-ralph` may read `DESIGN.md`, and it may leave design-system artifacts behind, but it does not replace the `DESIGN.md` discovery/interview/refresh workflow.
+
+If both are needed, run `$design` first to establish the design contract, then run `$visual-ralph` only after the visual reference/baseline is approved.
+
+## Workflow
+
+### 1. Discover local design evidence
+
+Inspect the repository before writing guidance. Look for:
+
+- `DESIGN.md`, `docs/design*`, `docs/ux*`, `docs/frontend*`, `README.md`, product specs, PRDs, and issue notes.
+- Existing UI source: routes, pages, layouts, components, stories, examples, demos, theme files, CSS variables, Tailwind/theme config, tokens, icons, and assets.
+- Screenshots, mockups, brand files, logos, Figma/export notes, Storybook snapshots, Playwright screenshots, visual-regression baselines, or `.omx/artifacts/visual-ralph/*` references.
+- Accessibility, responsive, i18n, content, and platform constraints already encoded in code or docs.
+
+Record evidence with file paths. Distinguish observed facts from design inferences.
+
+### 2. Interview only for missing context
+
+Ask concise questions only when repo evidence cannot answer design-critical context. Prefer one focused round that closes the biggest gaps, such as:
+
+- target users/personas and jobs to be done,
+- product/business goals and non-goals,
+- brand personality or forbidden aesthetics,
+- primary flows and information architecture,
+- accessibility level, device/browser support, and implementation constraints,
+- existing design assets or references the repo does not contain.
+
+If the user wants autonomous progress or cannot answer, create `DESIGN.md` with explicit assumptions and open questions instead of blocking.
+
+### 3. Create or refresh `DESIGN.md`
+
+Use the structure below. Preserve useful existing content, remove contradictions, and mark unknowns as open questions. Keep it actionable for implementers and reviewers.
+
+#### Required `DESIGN.md` structure/checklist
+
+```markdown
+# Design
+
+## Source of truth
+- Status: Draft | Active | Needs refresh
+- Last refreshed: YYYY-MM-DD
+- Primary product surfaces:
+- Evidence reviewed:
+
+## Brand
+- Personality:
+- Trust signals:
+- Avoid:
+
+## Product goals
+- Goals:
+- Non-goals:
+- Success signals:
+
+## Personas and jobs
+- Primary personas:
+- User jobs:
+- Key contexts of use:
+
+## Information architecture
+- Primary navigation:
+- Core routes/screens:
+- Content hierarchy:
+
+## Design principles
+- Principle 1:
+- Principle 2:
+- Tradeoffs:
+
+## Visual language
+- Color:
+- Typography:
+- Spacing/layout rhythm:
+- Shape/radius/elevation:
+- Motion:
+- Imagery/iconography:
+
+## Components
+- Existing components to reuse:
+- New/changed components:
+- Variants and states:
+- Token/component ownership:
+
+## Accessibility
+- Target standard:
+- Keyboard/focus behavior:
+- Contrast/readability:
+- Screen-reader semantics:
+- Reduced motion and sensory considerations:
+
+## Responsive behavior
+- Supported breakpoints/devices:
+- Layout adaptations:
+- Touch/hover differences:
+
+## Interaction states
+- Loading:
+- Empty:
+- Error:
+- Success:
+- Disabled:
+- Offline/slow network, if applicable:
+
+## Content voice
+- Tone:
+- Terminology:
+- Microcopy rules:
+
+## Implementation constraints
+- Framework/styling system:
+- Design-token constraints:
+- Performance constraints:
+- Compatibility constraints:
+- Test/screenshot expectations:
+
+## Open questions
+- [ ] Question / owner / impact
+```
+
+### 4. Use `DESIGN.md` as the decision contract
+
+For UI/UX/frontend work after the refresh:
+
+- Cite the relevant `DESIGN.md` sections before making design choices.
+- Prefer existing components, tokens, and documented constraints.
+- If implementation reveals a design contradiction, update `DESIGN.md` or add an open question before proceeding.
+- Do not introduce a new design-system layer when existing repo-native patterns can be extended.
+
+### 5. Handoff to implementation or Visual Ralph when appropriate
+
+- For normal frontend implementation, hand off with the relevant `DESIGN.md` sections, repo evidence, and acceptance criteria.
+- For visual-reference/image/live-URL matching, hand off to `$visual-ralph` with the approved reference/baseline and note that `DESIGN.md` is supporting context, not the visual verdict target.
+
+## Completion checklist
+
+Do not declare the design workflow complete until:
+
+- Existing design docs/assets/components/screenshots have been inspected or explicitly noted as absent.
+- Missing product/design context has been answered, assumed, or listed in `DESIGN.md` open questions.
+- `DESIGN.md` exists at the repo root and contains all required checklist sections.
+- UI/UX/frontend recommendations cite `DESIGN.md` rather than relying on unstated preferences.
+- Any `$visual-ralph` handoff is clearly separated as visual implementation matching, not DESIGN.md governance.
+
+Task: {{ARGUMENTS}}

--- a/skills/frontend-ui-ux/SKILL.md
+++ b/skills/frontend-ui-ux/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: frontend-ui-ux
-description: Deprecated compatibility shim for designer-led frontend UI/UX work
+description: Deprecated compatibility shim for frontend UI/UX work; use $design or $visual-ralph
 ---
 
 # Frontend UI/UX compatibility shim
 
 Hard-deprecated. Do not invoke or route this skill for new work.
 
-Use the `designer` agent/lane directly, or use `$visual-ralph` when the task needs visual iteration and screenshot-based verification. This file exists only to preserve the public/catalog-visible `frontend-ui-ux` alias contract while designer-led frontend guidance is handled by the canonical designer surfaces.
+Use `$design` when the task needs product/design context, UX guidance, frontend planning, design-system alignment, or a repo-local `DESIGN.md` source of truth.
+
+Use `$visual-ralph` when the task needs implementation against an approved generated/static/live-URL visual reference with screenshot capture, Visual Ralph verdict scoring, and pixel-diff evidence.
+
+This file exists only to preserve the public/catalog-visible `frontend-ui-ux` compatibility contract while canonical design guidance is handled by `$design` and measured visual implementation is handled by `$visual-ralph`.
 
 Task: {{ARGUMENTS}}

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -313,7 +313,8 @@ Project-only skills (2):
   - backend-scaffold
 
 Common skills (3):
-  - frontend-ui-ux
+  - design
+  - frontend-ui-ux (deprecated; use design or visual-ralph)
   - git-master
   - planner
 

--- a/skills/visual-ralph/SKILL.md
+++ b/skills/visual-ralph/SKILL.md
@@ -27,7 +27,7 @@ This is an orchestration skill. It composes existing skills and must not add run
 
 ## Do not use when
 
-- The user only wants design critique or general frontend advice; use `$frontend-ui-ux` or a designer lane.
+- The user only wants repo-wide design guidance, product/design context, or a DESIGN.md source of truth; use `$design` or a designer lane.
 - The task is a non-visual backend/API implementation with no UI reference target.
 - The user already supplied a final static reference image and only needs comparison/fixes; hand directly to `$ralph` with Visual Ralph verdict guidance.
 - The requested output is a deterministic SVG/vector/code-native asset rather than a raster reference.
@@ -117,7 +117,7 @@ Record final diff evidence with the reference/screenshot artifacts so the result
 
 ### 7. Build a reproducible design system
 
-The implementation is incomplete unless the visual match is encoded in repo-native reusable artifacts. Depending on the project, this may mean CSS variables, theme tokens, Tailwind config, component variants, Storybook stories, design docs, or existing equivalents.
+The implementation is incomplete unless the visual match is encoded in repo-native reusable artifacts. Depending on the project, this may mean CSS variables, theme tokens, Tailwind config, component variants, Storybook stories, updates that align with DESIGN.md, or existing equivalents.
 
 Capture at least the applicable:
 - colors,

--- a/src/catalog/__tests__/generator.test.ts
+++ b/src/catalog/__tests__/generator.test.ts
@@ -51,6 +51,8 @@ describe('catalog reader/contract', () => {
     assert.ok(contract.skills.some((s) => s.name === 'ask-gemini' && s.status === 'deprecated' && !s.canonical));
     assert.ok(contract.skills.some((s) => s.name === 'ai-slop-cleaner' && s.status === 'active'));
     assert.ok(contract.skills.some((s) => s.name === 'visual-ralph' && s.status === 'active'));
+    assert.ok(contract.skills.some((s) => s.name === 'design' && s.status === 'active' && s.canonical === 'designer'));
+    assert.ok(contract.skills.some((s) => s.name === 'frontend-ui-ux' && s.status === 'deprecated' && !s.canonical));
     assert.ok(
       contract.skills.some(
         (s) => s.name === 'web-clone' && s.status === 'deprecated' && !s.canonical,

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-05-06T00:56:25.752Z",
+  "generatedAt": "2026-05-11T07:38:27.080Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 46,
+    "skillCount": 47,
     "promptCount": 30,
-    "activeSkillCount": 24,
+    "activeSkillCount": 25,
     "activeAgentCount": 16
   },
   "coreSkills": [
@@ -195,10 +195,17 @@
       "internalRequired": false
     },
     {
+      "name": "design",
+      "category": "shortcut",
+      "status": "active",
+      "canonical": "designer",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "frontend-ui-ux",
       "category": "shortcut",
-      "status": "alias",
-      "canonical": "designer",
+      "status": "deprecated",
       "core": false,
       "internalRequired": false
     },
@@ -511,10 +518,6 @@
     }
   ],
   "aliases": [
-    {
-      "name": "frontend-ui-ux",
-      "canonical": "designer"
-    },
     {
       "name": "git-master",
       "canonical": "git-master"

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -148,10 +148,15 @@
       "canonical": "designer"
     },
     {
+      "name": "design",
+      "category": "shortcut",
+      "status": "active",
+      "canonical": "designer"
+    },
+    {
       "name": "frontend-ui-ux",
       "category": "shortcut",
-      "status": "alias",
-      "canonical": "designer"
+      "status": "deprecated"
     },
     {
       "name": "git-master",

--- a/src/hooks/__tests__/design-skill.test.ts
+++ b/src/hooks/__tests__/design-skill.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { detectPrimaryKeyword } from '../keyword-detector.js';
+
+const repoRoot = new URL('../../..', import.meta.url).pathname;
+const designSkill = readFileSync(join(repoRoot, 'skills', 'design', 'SKILL.md'), 'utf-8');
+const frontendShim = readFileSync(join(repoRoot, 'skills', 'frontend-ui-ux', 'SKILL.md'), 'utf-8');
+const visualRalphSkill = readFileSync(join(repoRoot, 'skills', 'visual-ralph', 'SKILL.md'), 'utf-8');
+
+describe('design skill contract', () => {
+  it('defines canonical DESIGN.md source-of-truth workflow', () => {
+    assert.match(designSkill, /^---\nname: design/m);
+    assert.match(designSkill, /repo-local `DESIGN\.md` source of truth/i);
+    assert.match(designSkill, /Discover local design evidence/i);
+    assert.match(designSkill, /Interview only for missing context/i);
+    assert.match(designSkill, /Create or refresh `DESIGN\.md`/i);
+  });
+
+  it('requires the DESIGN.md checklist sections from issue 2277', () => {
+    for (const section of [
+      'Brand',
+      'Product goals',
+      'Personas and jobs',
+      'Information architecture',
+      'Design principles',
+      'Visual language',
+      'Components',
+      'Accessibility',
+      'Responsive behavior',
+      'Interaction states',
+      'Content voice',
+      'Implementation constraints',
+      'Open questions',
+    ]) {
+      assert.match(designSkill, new RegExp(`## ${section.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i'));
+    }
+  });
+
+  it('separates design governance from Visual Ralph matching', () => {
+    assert.match(designSkill, /`\$visual-ralph` owns implementation against an approved generated\/static\/live-URL visual reference/i);
+    assert.match(designSkill, /does not replace the `DESIGN\.md` discovery\/interview\/refresh workflow/i);
+    assert.doesNotMatch(visualRalphSkill, /use `\$frontend-ui-ux`/i);
+    assert.match(visualRalphSkill, /use `\$design`/i);
+  });
+
+  it('routes explicit $design while keeping frontend-ui-ux as deprecated compatibility guidance', () => {
+    const design = detectPrimaryKeyword('$design refresh our design docs');
+    assert.ok(design);
+    assert.equal(design.skill, 'design');
+
+    const deprecated = detectPrimaryKeyword('$frontend-ui-ux improve this page');
+    assert.ok(deprecated);
+    assert.equal(deprecated.skill, 'design');
+    assert.match(frontendShim, /Hard-deprecated/i);
+    assert.match(frontendShim, /Use `\$design`/i);
+    assert.match(frontendShim, /Use `\$visual-ralph`/i);
+  });
+});

--- a/src/hooks/__tests__/skill-catalog-hygiene.test.ts
+++ b/src/hooks/__tests__/skill-catalog-hygiene.test.ts
@@ -23,7 +23,7 @@ describe('skill catalog hygiene', () => {
       { name: 'swarm', canonical: /\$team|omx team/i },
       { name: 'ask-claude', canonical: /\$ask claude|omx ask claude/i },
       { name: 'ask-gemini', canonical: /\$ask gemini|omx ask gemini/i },
-      { name: 'frontend-ui-ux', canonical: /designer/i },
+      { name: 'frontend-ui-ux', canonical: /\$design|\$visual-ralph/i },
       { name: 'review', canonical: /\$code-review|code review/i },
       { name: 'ralph-init', canonical: /\$ralph|PRD\/test-spec/i },
     ];

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -544,7 +544,9 @@ interface ExplicitSkillParseResult {
 }
 
 function normalizeExplicitSkillToken(token: string): string {
-  return token === 'ulw' ? 'ultrawork' : token;
+  if (token === 'ulw') return 'ultrawork';
+  if (token === 'frontend-ui-ux') return 'design';
+  return token;
 }
 
 function parseExplicitSkillInvocations(text: string): ExplicitSkillParseResult {

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -42,6 +42,9 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
 
   { keyword: '$autoresearch', skill: 'autoresearch', priority: 10, guidance: 'Activate autoresearch validator-gated research loop' },
 
+  { keyword: '$design', skill: 'design', priority: 6, guidance: 'Activate canonical DESIGN.md design-source-of-truth workflow' },
+  { keyword: '$frontend-ui-ux', skill: 'design', priority: 5, guidance: 'Deprecated: route to $design for DESIGN.md guidance; use $visual-ralph for visual-reference implementation' },
+
   { keyword: '$team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
   { keyword: 'coordinated team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
 

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -181,10 +181,17 @@
       "internalRequired": false
     },
     {
+      "name": "design",
+      "category": "shortcut",
+      "status": "active",
+      "canonical": "designer",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "frontend-ui-ux",
       "category": "shortcut",
-      "status": "alias",
-      "canonical": "designer",
+      "status": "deprecated",
       "core": false,
       "internalRequired": false
     },


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Closes #2277.

Adds `$design` as the canonical repo-local `DESIGN.md` workflow for product/design context, UX guidance, frontend planning, and design-system decision governance. Deprecates `$frontend-ui-ux` toward `$design` or `$visual-ralph` depending on whether the user needs design-source-of-truth work or measured visual-reference implementation.

## Changes

- Added `skills/design/SKILL.md` with DESIGN.md discovery, missing-context interview, refresh/create workflow, and required checklist structure.
- Mirrored `$design` into the first-party plugin bundle and catalog/generated catalog outputs.
- Updated `$frontend-ui-ux` compatibility shim and explicit keyword routing so legacy invocations route to `$design`.
- Updated `$visual-ralph` guidance to keep visual reference/image/live-URL matching distinct from DESIGN.md governance.
- Added regression coverage for `$design` skill presence, checklist content, visual-ralph separation, catalog presence, and frontend-ui-ux deprecation/routing.
- Updated docs/catalog skill listings.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `node --test dist/hooks/__tests__/design-skill.test.js dist/hooks/__tests__/skill-catalog-hygiene.test.js dist/catalog/__tests__/generator.test.js dist/catalog/__tests__/schema.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js dist/hooks/__tests__/keyword-detector.test.js`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `node dist/scripts/sync-plugin-mirror.js --check`
- [x] Deslop scan found no masking fallback/TODO/vendoring issues in changed files
- [ ] `npm test` (not run; targeted catalog/plugin/keyword/design gates were run)
- [ ] `omx doctor` (not setup/config behavior)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #2277

🤖 Generated with [Oh My Codex](https://github.com/Yeachan-Heo/oh-my-codex)

Co-authored-by: OmX <omx@oh-my-codex.dev>
