### PR TITLE
Expose a bounded Hermes MCP bridge

### DIFF
--- a/docs/hermes-mcp-bridge.md
+++ b/docs/hermes-mcp-bridge.md
@@ -1,0 +1,42 @@
+# Hermes MCP bridge
+
+OMX exposes a small optional MCP server for Hermes-style coordinators that need to dispatch work, poll status, and fetch result artifacts without scraping tmux panes or terminal text.
+
+Launch target:
+
+```bash
+omx mcp-serve hermes
+```
+
+The plugin manifest registers it as `omx_hermes` and keeps it disabled by default, like the other first-party OMX MCP servers.
+
+## Boundary
+
+Hermes or another coordinator owns intake, operator Q&A, package shaping, and external approval policy. OMX owns planning, execution, review, and local artifact production inside a bounded worktree/session. The bridge only connects those product-facing responsibilities.
+
+The v1 bridge intentionally does **not** expose:
+
+- interactive `$deep-interview` turn routing
+- tmux scrollback scraping or terminal UI control
+- broad internal team/control-room operations
+- GitHub merge policy, approval gates, or repository mutation outside OMX launch/follow-up/report files
+
+Set `OMX_MCP_WORKDIR_ROOTS` when running this server for an external client to restrict `workingDirectory` values to known safe roots.
+
+## Tools
+
+Read tools:
+
+- `hermes_list_sessions` — list known OMX session-state directories and active mode names.
+- `hermes_read_status` — read selected session/mode JSON status.
+- `hermes_read_tail` — read `.omx/logs/session-history.jsonl` tail, not tmux scrollback.
+- `hermes_list_artifacts` — list safe result artifacts under `.omx/plans`, `.omx/specs`, `.omx/goals`, `.omx/context`, and `.omx/reports`.
+- `hermes_read_artifact` — read one safe relative `.omx/...` artifact with byte truncation.
+
+Mutating tools require `allow_mutation: true`:
+
+- `hermes_start_session` — starts `omx --tmux --worktree[=<name>] <prompt>` from the bounded working directory.
+- `hermes_send_prompt` — queues one prompt through the existing audited `exec-followups.json` contract for a selected exec session.
+- `hermes_report_status` — writes `.omx/state[/sessions/<session_id>]/hermes-coordination.json` with final/blocker/PR summary data.
+
+Failure responses are explicit JSON with `ok: false`, `code`, and `error`, including `no_session`, `prompt_not_accepted`, `artifact_missing`, `artifact_outside_safe_roots`, `mutation_not_allowed`, and `command_failed`.

--- a/plugins/oh-my-codex/.mcp.json
+++ b/plugins/oh-my-codex/.mcp.json
@@ -39,6 +39,14 @@
         "wiki"
       ],
       "enabled": false
+    },
+    "omx_hermes": {
+      "command": "omx",
+      "args": [
+        "mcp-serve",
+        "hermes"
+      ],
+      "enabled": false
     }
   }
 }

--- a/src/cli/__tests__/mcp-serve.test.ts
+++ b/src/cli/__tests__/mcp-serve.test.ts
@@ -27,6 +27,9 @@ describe("mcp-serve command", () => {
 				"wiki-server.js": async () => {
 					loaded.push("wiki-server.js");
 				},
+				"hermes-server.js": async () => {
+					loaded.push("hermes-server.js");
+				},
 			},
 		});
 
@@ -60,6 +63,7 @@ describe("mcp-serve command", () => {
 				"code-intel-server.js": async () => {},
 				"trace-server.js": async () => {},
 				"wiki-server.js": async () => {},
+				"hermes-server.js": async () => {},
 			},
 		});
 		void commandPromise.then(

--- a/src/cli/mcp-serve.ts
+++ b/src/cli/mcp-serve.ts
@@ -31,6 +31,7 @@ const MCP_SERVE_LOADERS: McpServeLoaderMap = {
   "code-intel-server.js": async () => await import("../mcp/code-intel-server.js"),
   "trace-server.js": async () => await import("../mcp/trace-server.js"),
   "wiki-server.js": async () => await import("../mcp/wiki-server.js"),
+  "hermes-server.js": async () => await import("../mcp/hermes-server.js"),
 };
 
 const MCP_SERVE_TARGET_ALIASES: Record<string, McpServeEntrypoint> = {
@@ -51,6 +52,9 @@ const MCP_SERVE_TARGET_ALIASES: Record<string, McpServeEntrypoint> = {
   wiki: "wiki-server.js",
   "wiki-server": "wiki-server.js",
   "wiki-server.js": "wiki-server.js",
+  hermes: "hermes-server.js",
+  "hermes-server": "hermes-server.js",
+  "hermes-server.js": "hermes-server.js",
 };
 
 export function normalizeOmxMcpServeTarget(

--- a/src/config/omx-first-party-mcp.ts
+++ b/src/config/omx-first-party-mcp.ts
@@ -48,6 +48,13 @@ const OMX_FIRST_PARTY_MCP_SPECS: readonly OmxFirstPartyMcpSpec[] = [
     pluginTarget: "wiki",
     startupTimeoutSec: 5,
   },
+  {
+    name: "omx_hermes",
+    title: "# OMX Hermes Coordination MCP Server (safe dispatch/status/artifacts)",
+    entrypoint: "hermes-server.js",
+    pluginTarget: "hermes",
+    startupTimeoutSec: 5,
+  },
 ] as const;
 
 export const OMX_FIRST_PARTY_MCP_SERVER_NAMES = OMX_FIRST_PARTY_MCP_SPECS.map(

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -28,6 +28,7 @@ const ALL_SERVERS: readonly McpServerName[] = [
   'code_intel',
   'trace',
   'wiki',
+  'hermes',
 ] as const;
 
 const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
@@ -36,6 +37,7 @@ const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
   code_intel: 'OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START',
   trace: 'OMX_TRACE_SERVER_DISABLE_AUTO_START',
   wiki: 'OMX_WIKI_SERVER_DISABLE_AUTO_START',
+  hermes: 'OMX_HERMES_SERVER_DISABLE_AUTO_START',
 };
 
 const SERVER_ENTRYPOINTS: Array<{ server: McpServerName; file: string }> = [
@@ -44,6 +46,7 @@ const SERVER_ENTRYPOINTS: Array<{ server: McpServerName; file: string }> = [
   { server: 'code_intel', file: 'src/mcp/code-intel-server.ts' },
   { server: 'trace', file: 'src/mcp/trace-server.ts' },
   { server: 'wiki', file: 'src/mcp/wiki-server.ts' },
+  { server: 'hermes', file: 'src/mcp/hermes-server.ts' },
 ];
 
 describe('mcp bootstrap auto-start guard', () => {

--- a/src/mcp/__tests__/hermes-bridge.test.ts
+++ b/src/mcp/__tests__/hermes-bridge.test.ts
@@ -256,6 +256,54 @@ describe("Hermes MCP bridge core", () => {
     }
   });
 
+
+  it("rejects workdir-root candidate symlinks that would expose outside artifacts", async () => {
+    const allowed = await tempWorkspace("omx-hermes-allowed-root-");
+    const outside = await tempWorkspace("omx-hermes-outside-root-");
+    try {
+      await mkdir(join(outside, ".omx", "plans"), { recursive: true });
+      await writeFile(join(outside, ".omx", "plans", "secret.md"), "outside via workdir symlink");
+      await symlink(outside, join(allowed, "link"));
+      process.env.OMX_MCP_WORKDIR_ROOTS = allowed;
+
+      const result = await hermesReadArtifact({
+        workingDirectory: join(allowed, "link"),
+        path: ".omx/plans/secret.md",
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.code, "invalid_input");
+      assert.match(result.error ?? "", /outside allowed roots/);
+    } finally {
+      await rm(allowed, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects symlinked OMX_MCP_WORKDIR_ROOTS entries before reading artifacts", async () => {
+    const intended = await tempWorkspace("omx-hermes-intended-root-");
+    const outside = await tempWorkspace("omx-hermes-outside-root-");
+    try {
+      await mkdir(join(outside, ".omx", "plans"), { recursive: true });
+      await writeFile(join(outside, ".omx", "plans", "secret.md"), "outside via symlinked root");
+      const symlinkedRoot = join(intended, "allowed-link");
+      await symlink(outside, symlinkedRoot);
+      process.env.OMX_MCP_WORKDIR_ROOTS = symlinkedRoot;
+
+      const result = await hermesReadArtifact({
+        workingDirectory: symlinkedRoot,
+        path: ".omx/plans/secret.md",
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.code, "invalid_input");
+      assert.match(result.error ?? "", /resolves through a symlink/);
+    } finally {
+      await rm(intended, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it("writes a bounded Hermes coordination report", async () => {
     const cwd = await tempWorkspace("omx-hermes-report-");
     try {

--- a/src/mcp/__tests__/hermes-bridge.test.ts
+++ b/src/mcp/__tests__/hermes-bridge.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+  hermesListArtifacts,
+  hermesListSessions,
+  hermesReadArtifact,
+  hermesReadStatus,
+  hermesReadTail,
+  hermesReportStatus,
+  hermesSendPrompt,
+  hermesStartSession,
+} from "../hermes-bridge.js";
+
+const originalRoots = process.env.OMX_MCP_WORKDIR_ROOTS;
+const originalOmxRoot = process.env.OMX_ROOT;
+const originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+const originalTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+
+afterEach(() => {
+  if (typeof originalRoots === "string") process.env.OMX_MCP_WORKDIR_ROOTS = originalRoots;
+  else delete process.env.OMX_MCP_WORKDIR_ROOTS;
+  if (typeof originalOmxRoot === "string") process.env.OMX_ROOT = originalOmxRoot;
+  else delete process.env.OMX_ROOT;
+  if (typeof originalOmxStateRoot === "string") process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+  else delete process.env.OMX_STATE_ROOT;
+  if (typeof originalTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = originalTeamStateRoot;
+  else delete process.env.OMX_TEAM_STATE_ROOT;
+});
+
+async function tempWorkspace(name: string): Promise<string> {
+  delete process.env.OMX_ROOT;
+  delete process.env.OMX_STATE_ROOT;
+  delete process.env.OMX_TEAM_STATE_ROOT;
+  return await mkdtemp(join(tmpdir(), name));
+}
+
+describe("Hermes MCP bridge core", () => {
+  it("lists session-scoped OMX state without exposing terminal internals", async () => {
+    const cwd = await tempWorkspace("omx-hermes-list-");
+    try {
+      await mkdir(join(cwd, ".omx", "state", "sessions", "sess-a"), { recursive: true });
+      await writeFile(
+        join(cwd, ".omx", "state", "sessions", "sess-a", "ralph-state.json"),
+        JSON.stringify({ active: true, current_phase: "executing" }),
+      );
+
+      const result = await hermesListSessions({ workingDirectory: cwd });
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.data?.sessions, [
+        { session_id: "sess-a", active: false, source: "session_state_dir", modes: ["ralph"] },
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("projects status without leaking raw internal mode state", async () => {
+    const cwd = await tempWorkspace("omx-hermes-status-");
+    try {
+      await mkdir(join(cwd, ".omx", "state", "sessions", "sess-a"), { recursive: true });
+      await writeFile(
+        join(cwd, ".omx", "state", "sessions", "sess-a", "ralph-state.json"),
+        JSON.stringify({
+          active: true,
+          current_phase: "verifying",
+          run_outcome: "continue",
+          lifecycle_outcome: "finished",
+          updated_at: "2026-05-11T00:00:00.000Z",
+          completed_at: "2026-05-11T00:01:00.000Z",
+          private_control_room: { token: "do-not-leak" },
+          state: { prompt_to_artifact_checklist: ["internal"] },
+        }),
+      );
+
+      const result = await hermesReadStatus({ workingDirectory: cwd, session_id: "sess-a" });
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.data?.modes, [
+        {
+          mode: "ralph",
+          scope: "session",
+          active: true,
+          phase: "verifying",
+          run_outcome: "continue",
+          lifecycle_outcome: "finished",
+          updated_at: "2026-05-11T00:00:00.000Z",
+          completed_at: "2026-05-11T00:01:00.000Z",
+        },
+      ]);
+      assert.equal(JSON.stringify(result).includes("do-not-leak"), false);
+      assert.equal(JSON.stringify(result).includes("prompt_to_artifact_checklist"), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("projects current session metadata without leaking process or tmux internals", async () => {
+    const cwd = await tempWorkspace("omx-hermes-current-status-");
+    try {
+      const result = await hermesReadStatus(
+        { workingDirectory: cwd },
+        {
+          readUsableSessionState: async () => ({
+            session_id: "sess-current",
+            native_session_id: "native-current",
+            cwd,
+            started_at: "2026-05-11T00:00:00.000Z",
+            pid: 12345,
+            pid_cmdline: "codex --secret",
+            pid_start_ticks: 67890,
+            tmux_session_name: "private-tmux",
+          }),
+        },
+      );
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.data?.session, {
+        session_id: "sess-current",
+        native_session_id: "native-current",
+        cwd,
+        started_at: "2026-05-11T00:00:00.000Z",
+      });
+      assert.equal(JSON.stringify(result).includes("12345"), false);
+      assert.equal(JSON.stringify(result).includes("codex --secret"), false);
+      assert.equal(JSON.stringify(result).includes("private-tmux"), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("reads a bounded session-history tail without tmux scrollback", async () => {
+    const cwd = await tempWorkspace("omx-hermes-tail-");
+    try {
+      await mkdir(join(cwd, ".omx", "logs"), { recursive: true });
+      await writeFile(
+        join(cwd, ".omx", "logs", "session-history.jsonl"),
+        ["one", "two", "three"].map((message) => JSON.stringify({ message })).join("\n") + "\n",
+      );
+
+      const result = await hermesReadTail({ workingDirectory: cwd, lines: 2 });
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.data?.tail, [JSON.stringify({ message: "two" }), JSON.stringify({ message: "three" })]);
+      assert.match(result.data?.path ?? "", /session-history\.jsonl$/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("requires explicit mutation opt-in before queuing prompts", async () => {
+    const result = await hermesSendPrompt({ session_id: "sess-a", prompt: "continue" });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "mutation_not_allowed");
+  });
+
+  it("queues selected prompts through the audited exec follow-up contract", async () => {
+    const result = await hermesSendPrompt(
+      { session_id: "sess-a", prompt: "continue", actor: "hermes-test", allow_mutation: true },
+      {
+        injectExecFollowup: async ({ sessionId, prompt, actor }) => ({
+          queued: {
+            id: "followup-1",
+            session_id: sessionId,
+            prompt,
+            actor: actor ?? "missing",
+            created_at: "2026-05-11T00:00:00.000Z",
+          },
+          queuePath: "/tmp/queue.json",
+        }),
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.data, {
+      followup_id: "followup-1",
+      session_id: "sess-a",
+      queue_path: "/tmp/queue.json",
+    });
+  });
+
+  it("starts sessions in tmux worktree mode and requires mutation opt-in", async () => {
+    const cwd = await tempWorkspace("omx-hermes-start-");
+    try {
+      let observed: { command: string; args: string[]; cwd?: string } | null = null;
+      const result = await hermesStartSession(
+        { workingDirectory: cwd, prompt: "$ralph fix it", worktreeName: "pkg/demo", allow_mutation: true },
+        {
+          resolveOmxCliEntryPath: () => "/opt/omx/dist/cli/omx.js",
+          spawnProcess: ((command: string, args: string[], options: { cwd?: string }) => {
+            observed = { command, args, cwd: options.cwd };
+            return { pid: 4242, unref() {} };
+          }) as never,
+        },
+      );
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(observed, {
+        command: "/opt/omx/dist/cli/omx.js",
+        args: ["--tmux", "--worktree=pkg/demo", "$ralph fix it"],
+        cwd,
+      });
+      assert.equal(result.data?.pid, 4242);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("lists and reads only safe result artifact paths", async () => {
+    const cwd = await tempWorkspace("omx-hermes-artifacts-");
+    try {
+      await mkdir(join(cwd, ".omx", "plans"), { recursive: true });
+      await writeFile(join(cwd, ".omx", "plans", "prd-demo.md"), "hello artifact");
+
+      const list = await hermesListArtifacts({ workingDirectory: cwd });
+      assert.equal(list.ok, true);
+      assert.deepEqual(list.data?.artifacts, [{ path: ".omx/plans/prd-demo.md", bytes: 14 }]);
+
+      const read = await hermesReadArtifact({ workingDirectory: cwd, path: ".omx/plans/prd-demo.md", max_bytes: 5 });
+      assert.equal(read.ok, true);
+      assert.deepEqual(read.data, { path: ".omx/plans/prd-demo.md", content: "hello", truncated: true });
+
+      const rejected = await hermesReadArtifact({ workingDirectory: cwd, path: "package.json" });
+      assert.equal(rejected.ok, false);
+      assert.equal(rejected.code, "artifact_outside_safe_roots");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a bounded Hermes coordination report", async () => {
+    const cwd = await tempWorkspace("omx-hermes-report-");
+    try {
+      const result = await hermesReportStatus(
+        {
+          workingDirectory: cwd,
+          session_id: "sess-a",
+          status: "complete",
+          summary: "PR opened",
+          pr_url: "https://github.com/Yeachan-Heo/oh-my-codex/pull/1",
+          allow_mutation: true,
+        },
+        { now: () => new Date("2026-05-11T00:00:00.000Z") },
+      );
+
+      assert.equal(result.ok, true);
+      assert.match(result.data?.path ?? "", /sessions[/\\]sess-a[/\\]hermes-coordination\.json$/);
+      assert.deepEqual(result.data?.report, {
+        status: "complete",
+        updated_at: "2026-05-11T00:00:00.000Z",
+        summary: "PR opened",
+        pr_url: "https://github.com/Yeachan-Heo/oh-my-codex/pull/1",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/mcp/__tests__/hermes-bridge.test.ts
+++ b/src/mcp/__tests__/hermes-bridge.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
@@ -229,8 +229,30 @@ describe("Hermes MCP bridge core", () => {
       const rejected = await hermesReadArtifact({ workingDirectory: cwd, path: "package.json" });
       assert.equal(rejected.ok, false);
       assert.equal(rejected.code, "artifact_outside_safe_roots");
+
+      const traversal = await hermesReadArtifact({ workingDirectory: cwd, path: ".omx/plans/../../package.json" });
+      assert.equal(traversal.ok, false);
+      assert.equal(traversal.code, "artifact_outside_safe_roots");
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects safe-root artifact symlinks that resolve outside the worktree", async () => {
+    const cwd = await tempWorkspace("omx-hermes-artifact-symlink-");
+    const outside = await mkdtemp(join(tmpdir(), "omx-hermes-artifact-outside-"));
+    try {
+      await mkdir(join(cwd, ".omx", "plans"), { recursive: true });
+      const outsideFile = join(outside, "host.md");
+      await writeFile(outsideFile, "outside artifact");
+      await symlink(outsideFile, join(cwd, ".omx", "plans", "host.md"));
+
+      const result = await hermesReadArtifact({ workingDirectory: cwd, path: ".omx/plans/host.md" });
+      assert.equal(result.ok, false);
+      assert.equal(result.code, "artifact_outside_safe_roots");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
     }
   });
 

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve as resolvePath } from 'path';
@@ -149,6 +149,66 @@ describe('state paths', () => {
       else delete process.env.OMX_MCP_WORKDIR_ROOTS;
       await rm(allowedRoot, { recursive: true, force: true });
       await rm(disallowedRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves symlinked workingDirectory spelling when no allowlist is configured', async () => {
+    const realRoot = await mkdtemp(join(tmpdir(), 'omx-real-root-'));
+    const linkParent = await mkdtemp(join(tmpdir(), 'omx-link-parent-'));
+    const link = join(linkParent, 'workspace-link');
+    const prev = process.env.OMX_MCP_WORKDIR_ROOTS;
+    delete process.env.OMX_MCP_WORKDIR_ROOTS;
+    try {
+      await symlink(realRoot, link);
+
+      assert.equal(resolveWorkingDirectoryForState(link), link);
+    } finally {
+      if (typeof prev === 'string') process.env.OMX_MCP_WORKDIR_ROOTS = prev;
+      else delete process.env.OMX_MCP_WORKDIR_ROOTS;
+      await rm(realRoot, { recursive: true, force: true });
+      await rm(linkParent, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlinked workingDirectory candidates that escape OMX_MCP_WORKDIR_ROOTS', async () => {
+    const allowedRoot = await mkdtemp(join(tmpdir(), 'omx-allowed-root-'));
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'omx-outside-root-'));
+    const prev = process.env.OMX_MCP_WORKDIR_ROOTS;
+    process.env.OMX_MCP_WORKDIR_ROOTS = allowedRoot;
+    try {
+      const link = join(allowedRoot, 'link');
+      await symlink(outsideRoot, link);
+
+      assert.throws(
+        () => resolveWorkingDirectoryForState(link),
+        /outside allowed roots \(OMX_MCP_WORKDIR_ROOTS\)/,
+      );
+    } finally {
+      if (typeof prev === 'string') process.env.OMX_MCP_WORKDIR_ROOTS = prev;
+      else delete process.env.OMX_MCP_WORKDIR_ROOTS;
+      await rm(allowedRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlinked OMX_MCP_WORKDIR_ROOTS entries instead of treating their targets as allowed roots', async () => {
+    const intendedRoot = await mkdtemp(join(tmpdir(), 'omx-intended-root-'));
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'omx-outside-root-'));
+    const prev = process.env.OMX_MCP_WORKDIR_ROOTS;
+    const symlinkedRoot = join(intendedRoot, 'allowed-link');
+    process.env.OMX_MCP_WORKDIR_ROOTS = symlinkedRoot;
+    try {
+      await symlink(outsideRoot, symlinkedRoot);
+
+      assert.throws(
+        () => resolveWorkingDirectoryForState(symlinkedRoot),
+        /OMX_MCP_WORKDIR_ROOTS root .* resolves through a symlink/,
+      );
+    } finally {
+      if (typeof prev === 'string') process.env.OMX_MCP_WORKDIR_ROOTS = prev;
+      else delete process.env.OMX_MCP_WORKDIR_ROOTS;
+      await rm(intendedRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { resolveOmxFirstPartyMcpEntrypointForPluginTarget } from '../config/omx-first-party-mcp.js';
 import { writeMcpLifecycleTelemetry } from './lifecycle-telemetry.js';
 
-export type McpServerName = 'state' | 'memory' | 'code_intel' | 'trace' | 'wiki';
+export type McpServerName = 'state' | 'memory' | 'code_intel' | 'trace' | 'wiki' | 'hermes';
 
 const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
   state: 'OMX_STATE_SERVER_DISABLE_AUTO_START',
@@ -11,6 +11,7 @@ const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
   code_intel: 'OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START',
   trace: 'OMX_TRACE_SERVER_DISABLE_AUTO_START',
   wiki: 'OMX_WIKI_SERVER_DISABLE_AUTO_START',
+  hermes: 'OMX_HERMES_SERVER_DISABLE_AUTO_START',
 };
 
 const GLOBAL_DISABLE_ENV = 'OMX_MCP_SERVER_DISABLE_AUTO_START';
@@ -66,6 +67,7 @@ const SERVER_ENTRYPOINT: Record<McpServerName, string> = {
   code_intel: 'code-intel-server.js',
   trace: 'trace-server.js',
   wiki: 'wiki-server.js',
+  hermes: 'hermes-server.js',
 };
 
 function normalizeCommand(command: string): string {

--- a/src/mcp/hermes-bridge.ts
+++ b/src/mcp/hermes-bridge.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, realpath, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { injectExecFollowup } from "../exec/followup.js";
 import { isSessionStateUsable, readUsableSessionState, type SessionState } from "../hooks/session.js";
@@ -308,6 +308,39 @@ function normalizeArtifactRelativePath(pathValue: unknown): string {
   return normalized;
 }
 
+function isInsideDirectory(parent: string, candidate: string): boolean {
+  const rel = relative(parent, candidate);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+async function resolveSafeArtifactPath(cwd: string, rel: string): Promise<string> {
+  const cwdRealPath = await realpath(cwd);
+  const full = resolve(cwd, rel);
+  const relativeToCwd = relative(resolve(cwd), full);
+  if (relativeToCwd.startsWith("..") || isAbsolute(relativeToCwd)) {
+    throw new Error("artifact resolved outside working directory");
+  }
+
+  let artifactRealPath: string;
+  try {
+    artifactRealPath = await realpath(full);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") throw new Error("artifact_missing");
+    throw error;
+  }
+
+  if (!isInsideDirectory(cwdRealPath, artifactRealPath)) {
+    throw new Error("artifact resolved outside working directory");
+  }
+
+  for (const prefix of SAFE_ARTIFACT_PREFIXES) {
+    const rootRealPath = await realpath(resolve(cwd, prefix)).catch(() => null);
+    if (rootRealPath && isInsideDirectory(rootRealPath, artifactRealPath)) return artifactRealPath;
+  }
+
+  throw new Error(`artifact path must be under ${SAFE_ARTIFACT_PREFIXES.join(", ")}`);
+}
+
 async function collectFiles(root: string, cwd: string, limit: number, out: Array<{ path: string; bytes: number }>): Promise<void> {
   if (out.length >= limit || !existsSync(root)) return;
   const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
@@ -350,22 +383,17 @@ export async function hermesReadArtifact(
   try {
     const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
     const rel = normalizeArtifactRelativePath(args.path);
-    const full = resolve(cwd, rel);
-    const relativeToCwd = relative(resolve(cwd), full);
-    if (relativeToCwd.startsWith("..") || isAbsolute(relativeToCwd)) {
-      return failure("artifact_outside_safe_roots", "artifact resolved outside working directory");
-    }
+    const full = await resolveSafeArtifactPath(cwd, rel);
     const maxBytes = normalizePositiveInteger(args.max_bytes, DEFAULT_ARTIFACT_MAX_BYTES, 1_000_000);
-    const raw = await readFile(full).catch((error) => {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") throw new Error("artifact_missing");
-      throw error;
-    });
+    const raw = await readFile(full);
     const truncated = raw.byteLength > maxBytes;
     return jsonResult({ path: rel, content: raw.subarray(0, maxBytes).toString("utf-8"), truncated });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (message === "artifact_missing") return failure("artifact_missing", message);
-    if (message.includes("artifact path")) return failure("artifact_outside_safe_roots", message);
+    if (message.includes("artifact path") || message.includes("outside working directory")) {
+      return failure("artifact_outside_safe_roots", message);
+    }
     return failure("invalid_input", message);
   }
 }

--- a/src/mcp/hermes-bridge.ts
+++ b/src/mcp/hermes-bridge.ts
@@ -1,0 +1,420 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { injectExecFollowup } from "../exec/followup.js";
+import { isSessionStateUsable, readUsableSessionState, type SessionState } from "../hooks/session.js";
+import {
+  getAllSessionScopedStateDirs,
+  getBaseStateDir,
+  listModeStateFilesWithScopePreference,
+  resolveWorkingDirectoryForState,
+  validateSessionId,
+} from "./state-paths.js";
+import { resolveOmxCliEntryPath } from "../utils/paths.js";
+import { safeJsonParse } from "../utils/safe-json.js";
+
+export type HermesBridgeFailureCode =
+  | "artifact_missing"
+  | "artifact_outside_safe_roots"
+  | "command_failed"
+  | "invalid_input"
+  | "mutation_not_allowed"
+  | "no_session"
+  | "prompt_not_accepted";
+
+export interface HermesBridgeResult<T extends Record<string, unknown> = Record<string, unknown>> {
+  ok: boolean;
+  code?: HermesBridgeFailureCode;
+  error?: string;
+  data?: T;
+}
+
+export interface HermesSessionSummary {
+  session_id: string;
+  cwd?: string;
+  started_at?: string;
+  active: boolean;
+  source: "current" | "session_state_dir";
+  modes: string[];
+}
+
+export interface HermesStatusSessionSummary {
+  session_id: string;
+  native_session_id?: string;
+  cwd?: string;
+  started_at?: string;
+}
+
+export interface HermesModeStatusSummary {
+  mode: string;
+  scope: string;
+  active?: boolean;
+  phase?: string;
+  run_outcome?: string;
+  lifecycle_outcome?: string;
+  updated_at?: string;
+  completed_at?: string;
+  error?: string;
+}
+
+export interface HermesBridgeDeps {
+  now?: () => Date;
+  spawnProcess?: typeof spawn;
+  resolveOmxCliEntryPath?: typeof resolveOmxCliEntryPath;
+  readUsableSessionState?: typeof readUsableSessionState;
+  injectExecFollowup?: typeof injectExecFollowup;
+}
+
+const SAFE_ARTIFACT_PREFIXES = [
+  ".omx/plans/",
+  ".omx/specs/",
+  ".omx/goals/",
+  ".omx/context/",
+  ".omx/reports/",
+];
+const DEFAULT_ARTIFACT_MAX_BYTES = 128_000;
+const DEFAULT_TAIL_LINES = 80;
+const MAX_TAIL_LINES = 500;
+
+function jsonResult<T extends Record<string, unknown>>(data: T): HermesBridgeResult<T> {
+  return { ok: true, data };
+}
+
+function failure<T extends Record<string, unknown> = Record<string, unknown>>(
+  code: HermesBridgeFailureCode,
+  error: string,
+): HermesBridgeResult<T> {
+  return { ok: false, code, error };
+}
+
+function normalizeString(value: unknown, name: string, options: { required?: boolean } = {}): string | undefined {
+  if (value == null) {
+    if (options.required) throw new Error(`${name} is required`);
+    return undefined;
+  }
+  if (typeof value !== "string") throw new Error(`${name} must be a string`);
+  const trimmed = value.trim();
+  if (!trimmed && options.required) throw new Error(`${name} must be non-empty`);
+  return trimmed || undefined;
+}
+
+function requireMutation(args: Record<string, unknown>): void {
+  if (args.allow_mutation !== true) {
+    throw new Error("mutating Hermes bridge tools require allow_mutation: true");
+  }
+}
+
+function normalizePositiveInteger(value: unknown, fallback: number, max: number): number {
+  if (value == null) return fallback;
+  const parsed = typeof value === "number" ? value : Number.parseInt(String(value), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
+  return Math.min(parsed, max);
+}
+
+async function readJsonFile<T>(path: string): Promise<T | null> {
+  try {
+    return safeJsonParse<T | null>(await readFile(path, "utf-8"), null);
+  } catch {
+    return null;
+  }
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function optionalString(value: unknown): string | undefined {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized || undefined;
+}
+
+function projectSessionStatus(session: SessionState | null): HermesStatusSessionSummary | null {
+  if (!session) return null;
+  return {
+    session_id: session.session_id,
+    ...(optionalString(session.native_session_id) ? { native_session_id: optionalString(session.native_session_id) } : {}),
+    ...(optionalString(session.cwd) ? { cwd: optionalString(session.cwd) } : {}),
+    ...(optionalString(session.started_at) ? { started_at: optionalString(session.started_at) } : {}),
+  };
+}
+
+function projectModeStatus(mode: string, scope: string, state: unknown): HermesModeStatusSummary {
+  const raw = state && typeof state === "object" && !Array.isArray(state)
+    ? state as Record<string, unknown>
+    : {};
+  return {
+    mode,
+    scope,
+    ...(optionalBoolean(raw.active) !== undefined ? { active: optionalBoolean(raw.active) } : {}),
+    ...(optionalString(raw.current_phase) ? { phase: optionalString(raw.current_phase) } : {}),
+    ...(optionalString(raw.phase) && !optionalString(raw.current_phase) ? { phase: optionalString(raw.phase) } : {}),
+    ...(optionalString(raw.run_outcome) ? { run_outcome: optionalString(raw.run_outcome) } : {}),
+    ...(optionalString(raw.lifecycle_outcome) ? { lifecycle_outcome: optionalString(raw.lifecycle_outcome) } : {}),
+    ...(optionalString(raw.updated_at) ? { updated_at: optionalString(raw.updated_at) } : {}),
+    ...(optionalString(raw.completed_at) ? { completed_at: optionalString(raw.completed_at) } : {}),
+    ...(optionalString(raw.error) ? { error: optionalString(raw.error) } : {}),
+  };
+}
+
+async function listModeNamesInStateDir(stateDir: string): Promise<string[]> {
+  if (!existsSync(stateDir)) return [];
+  const entries = await readdir(stateDir, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith("-state.json"))
+    .map((entry) => entry.name.slice(0, -"-state.json".length))
+    .sort();
+}
+
+function sessionIdFromSessionStateDir(path: string): string | null {
+  const name = basename(path);
+  try {
+    return validateSessionId(name) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function summarizeCurrentSession(cwd: string, deps: HermesBridgeDeps): Promise<HermesSessionSummary | null> {
+  const reader = deps.readUsableSessionState ?? readUsableSessionState;
+  const current = await reader(cwd);
+  if (!current || !isSessionStateUsable(current, cwd)) return null;
+  return {
+    session_id: current.session_id,
+    cwd: current.cwd,
+    started_at: current.started_at,
+    active: true,
+    source: "current",
+    modes: await listModeNamesInStateDir(join(getBaseStateDir(cwd), "sessions", current.session_id)),
+  };
+}
+
+export async function hermesListSessions(
+  args: Record<string, unknown>,
+  deps: HermesBridgeDeps = {},
+): Promise<HermesBridgeResult<{ sessions: HermesSessionSummary[] }>> {
+  try {
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
+    const sessions = new Map<string, HermesSessionSummary>();
+    const current = await summarizeCurrentSession(cwd, deps);
+    if (current) sessions.set(current.session_id, current);
+
+    for (const dir of await getAllSessionScopedStateDirs(cwd)) {
+      const sessionId = sessionIdFromSessionStateDir(dir);
+      if (!sessionId || sessions.has(sessionId)) continue;
+      sessions.set(sessionId, {
+        session_id: sessionId,
+        active: false,
+        source: "session_state_dir",
+        modes: await listModeNamesInStateDir(dir),
+      });
+    }
+
+    return jsonResult({ sessions: [...sessions.values()].sort((a, b) => a.session_id.localeCompare(b.session_id)) });
+  } catch (error) {
+    return failure("invalid_input", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function hermesReadStatus(
+  args: Record<string, unknown>,
+  deps: HermesBridgeDeps = {},
+): Promise<HermesBridgeResult<{ session: HermesStatusSessionSummary | null; modes: HermesModeStatusSummary[] }>> {
+  try {
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
+    const sessionId = validateSessionId(normalizeString(args.session_id, "session_id"));
+    const rawSession = sessionId ? null : await (deps.readUsableSessionState ?? readUsableSessionState)(cwd);
+    const session = projectSessionStatus(rawSession);
+    if (sessionId && !existsSync(join(getBaseStateDir(cwd), "sessions", sessionId))) {
+      return failure("no_session", `No OMX session state directory exists for ${sessionId}`);
+    }
+    const refs = await listModeStateFilesWithScopePreference(cwd, sessionId);
+    const modes: HermesModeStatusSummary[] = [];
+    for (const ref of refs) {
+      modes.push(projectModeStatus(ref.mode, ref.scope, await readJsonFile(ref.path)));
+    }
+    return jsonResult({ session, modes });
+  } catch (error) {
+    return failure("invalid_input", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function hermesSendPrompt(
+  args: Record<string, unknown>,
+  deps: HermesBridgeDeps = {},
+): Promise<HermesBridgeResult<{ followup_id: string; session_id: string; queue_path: string }>> {
+  try {
+    requireMutation(args);
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
+    const sessionId = normalizeString(args.session_id, "session_id", { required: true })!;
+    validateSessionId(sessionId);
+    const prompt = normalizeString(args.prompt, "prompt", { required: true })!;
+    const actor = normalizeString(args.actor, "actor") ?? "hermes-mcp";
+    const inject = deps.injectExecFollowup ?? injectExecFollowup;
+    const result = await inject({ cwd, sessionId, prompt, actor });
+    return jsonResult({
+      followup_id: result.queued.id,
+      session_id: result.queued.session_id,
+      queue_path: result.queuePath,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith("job_not_input_accepting")) return failure("prompt_not_accepted", message);
+    if (message.includes("allow_mutation")) return failure("mutation_not_allowed", message);
+    return failure("invalid_input", message);
+  }
+}
+
+export async function hermesStartSession(
+  args: Record<string, unknown>,
+  deps: HermesBridgeDeps = {},
+): Promise<HermesBridgeResult<{ pid: number; command: string; args: string[]; workingDirectory: string }>> {
+  try {
+    requireMutation(args);
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory", { required: true }));
+    const prompt = normalizeString(args.prompt, "prompt", { required: true })!;
+    const worktreeName = normalizeString(args.worktreeName, "worktreeName");
+    if (worktreeName && (!/^[A-Za-z0-9._/-]{1,128}$/.test(worktreeName) || worktreeName.includes("..") || worktreeName.startsWith("/"))) {
+      throw new Error("worktreeName must be a relative safe worktree name");
+    }
+    const command = (deps.resolveOmxCliEntryPath ?? resolveOmxCliEntryPath)({ cwd }) ?? "omx";
+    const launchArgs = ["--tmux", worktreeName ? `--worktree=${worktreeName}` : "--worktree", prompt];
+    const child = (deps.spawnProcess ?? spawn)(command, launchArgs, {
+      cwd,
+      detached: true,
+      stdio: "ignore",
+      env: { ...process.env, OMX_HERMES_MCP_BRIDGE: "1" },
+    }) as ChildProcess;
+    child.unref();
+    if (!child.pid) return failure("command_failed", "OMX session launcher did not report a pid");
+    return jsonResult({ pid: child.pid, command, args: launchArgs, workingDirectory: cwd });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("allow_mutation")) return failure("mutation_not_allowed", message);
+    return failure("invalid_input", message);
+  }
+}
+
+function normalizeArtifactRelativePath(pathValue: unknown): string {
+  const raw = normalizeString(pathValue, "path", { required: true })!;
+  if (isAbsolute(raw)) throw new Error("artifact path must be relative");
+  const normalized = raw.replace(/\\/g, "/").replace(/^\.\//, "");
+  if (normalized.includes("../") || normalized === ".." || normalized.includes("\0")) {
+    throw new Error("artifact path must not traverse directories");
+  }
+  if (!SAFE_ARTIFACT_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+    throw new Error(`artifact path must be under ${SAFE_ARTIFACT_PREFIXES.join(", ")}`);
+  }
+  return normalized;
+}
+
+async function collectFiles(root: string, cwd: string, limit: number, out: Array<{ path: string; bytes: number }>): Promise<void> {
+  if (out.length >= limit || !existsSync(root)) return;
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (out.length >= limit) return;
+    const full = join(root, entry.name);
+    if (entry.isDirectory()) {
+      await collectFiles(full, cwd, limit, out);
+    } else if (entry.isFile()) {
+      const rel = relative(cwd, full).replace(/\\/g, "/");
+      try {
+        const content = await readFile(full);
+        out.push({ path: rel, bytes: content.byteLength });
+      } catch {
+        // Ignore unreadable artifacts.
+      }
+    }
+  }
+}
+
+export async function hermesListArtifacts(
+  args: Record<string, unknown>,
+): Promise<HermesBridgeResult<{ artifacts: Array<{ path: string; bytes: number }> }>> {
+  try {
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
+    const limit = normalizePositiveInteger(args.limit, 100, 500);
+    const artifacts: Array<{ path: string; bytes: number }> = [];
+    for (const prefix of [".omx/plans", ".omx/specs", ".omx/goals", ".omx/context", ".omx/reports"]) {
+      await collectFiles(join(cwd, prefix), cwd, limit, artifacts);
+    }
+    return jsonResult({ artifacts: artifacts.sort((a, b) => a.path.localeCompare(b.path)) });
+  } catch (error) {
+    return failure("invalid_input", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function hermesReadArtifact(
+  args: Record<string, unknown>,
+): Promise<HermesBridgeResult<{ path: string; content: string; truncated: boolean }>> {
+  try {
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
+    const rel = normalizeArtifactRelativePath(args.path);
+    const full = resolve(cwd, rel);
+    const relativeToCwd = relative(resolve(cwd), full);
+    if (relativeToCwd.startsWith("..") || isAbsolute(relativeToCwd)) {
+      return failure("artifact_outside_safe_roots", "artifact resolved outside working directory");
+    }
+    const maxBytes = normalizePositiveInteger(args.max_bytes, DEFAULT_ARTIFACT_MAX_BYTES, 1_000_000);
+    const raw = await readFile(full).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") throw new Error("artifact_missing");
+      throw error;
+    });
+    const truncated = raw.byteLength > maxBytes;
+    return jsonResult({ path: rel, content: raw.subarray(0, maxBytes).toString("utf-8"), truncated });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message === "artifact_missing") return failure("artifact_missing", message);
+    if (message.includes("artifact path")) return failure("artifact_outside_safe_roots", message);
+    return failure("invalid_input", message);
+  }
+}
+
+export async function hermesReadTail(
+  args: Record<string, unknown>,
+): Promise<HermesBridgeResult<{ tail: string[]; path: string }>> {
+  try {
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
+    const lines = normalizePositiveInteger(args.lines, DEFAULT_TAIL_LINES, MAX_TAIL_LINES);
+    const path = join(cwd, ".omx", "logs", "session-history.jsonl");
+    if (!existsSync(path)) return jsonResult({ tail: [], path });
+    const content = await readFile(path, "utf-8");
+    return jsonResult({ tail: content.split(/\r?\n/).filter(Boolean).slice(-lines), path });
+  } catch (error) {
+    return failure("invalid_input", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function hermesReportStatus(
+  args: Record<string, unknown>,
+  deps: HermesBridgeDeps = {},
+): Promise<HermesBridgeResult<{ path: string; report: Record<string, unknown> }>> {
+  try {
+    requireMutation(args);
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
+    const sessionId = validateSessionId(normalizeString(args.session_id, "session_id"));
+    const status = normalizeString(args.status, "status", { required: true })!;
+    if (!["running", "blocked", "failed", "complete"].includes(status)) {
+      throw new Error("status must be one of running, blocked, failed, complete");
+    }
+    const summary = normalizeString(args.summary, "summary");
+    const prUrl = normalizeString(args.pr_url, "pr_url");
+    const blocker = normalizeString(args.blocker, "blocker");
+    const report = {
+      status,
+      updated_at: (deps.now ?? (() => new Date()))().toISOString(),
+      ...(summary ? { summary } : {}),
+      ...(prUrl ? { pr_url: prUrl } : {}),
+      ...(blocker ? { blocker } : {}),
+    };
+    const stateDir = sessionId ? join(getBaseStateDir(cwd), "sessions", sessionId) : getBaseStateDir(cwd);
+    const path = join(stateDir, "hermes-coordination.json");
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(report, null, 2) + "\n");
+    return jsonResult({ path, report });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("allow_mutation")) return failure("mutation_not_allowed", message);
+    return failure("invalid_input", message);
+  }
+}

--- a/src/mcp/hermes-server.ts
+++ b/src/mcp/hermes-server.ts
@@ -1,0 +1,144 @@
+/**
+ * OMX Hermes Coordination MCP Server
+ * Small product-facing bridge for dispatch/status/artifact coordination.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { autoStartStdioMcpServer } from "./bootstrap.js";
+import {
+  hermesListArtifacts,
+  hermesListSessions,
+  hermesReadArtifact,
+  hermesReadStatus,
+  hermesReadTail,
+  hermesReportStatus,
+  hermesSendPrompt,
+  hermesStartSession,
+} from "./hermes-bridge.js";
+
+const server = new Server(
+  { name: "omx-hermes", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+export function buildHermesServerTools() {
+  const workingDirectory = { type: "string", description: "Bounded OMX project/worktree directory" };
+  const sessionId = { type: "string", description: "OMX session_id (A-Z, a-z, 0-9, _, -)" };
+  const allowMutation = {
+    type: "boolean",
+    description: "Must be true for mutating operations; read tools ignore it.",
+  };
+  return [
+    {
+      name: "hermes_list_sessions",
+      description: "List known OMX session state for a bounded worktree without reading terminal UI.",
+      inputSchema: { type: "object", properties: { workingDirectory } },
+    },
+    {
+      name: "hermes_start_session",
+      description: "Start a new isolated OMX tmux session in disposable worktree mode for one bounded prompt.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          workingDirectory,
+          prompt: { type: "string" },
+          worktreeName: { type: "string" },
+          allow_mutation: allowMutation,
+        },
+        required: ["workingDirectory", "prompt", "allow_mutation"],
+      },
+    },
+    {
+      name: "hermes_send_prompt",
+      description: "Queue one explicit prompt for a selected OMX exec session via the audited follow-up queue.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          workingDirectory,
+          session_id: sessionId,
+          prompt: { type: "string" },
+          actor: { type: "string" },
+          allow_mutation: allowMutation,
+        },
+        required: ["session_id", "prompt", "allow_mutation"],
+      },
+    },
+    {
+      name: "hermes_read_status",
+      description: "Read selected session/mode status JSON from OMX state files.",
+      inputSchema: { type: "object", properties: { workingDirectory, session_id: sessionId } },
+    },
+    {
+      name: "hermes_read_tail",
+      description: "Read the bounded OMX session history log tail, not tmux scrollback.",
+      inputSchema: { type: "object", properties: { workingDirectory, lines: { type: "number" } } },
+    },
+    {
+      name: "hermes_list_artifacts",
+      description: "List known safe result artifact files under .omx plans/specs/goals/context/reports.",
+      inputSchema: { type: "object", properties: { workingDirectory, limit: { type: "number" } } },
+    },
+    {
+      name: "hermes_read_artifact",
+      description: "Read one safe .omx result artifact by relative path with byte truncation.",
+      inputSchema: {
+        type: "object",
+        properties: { workingDirectory, path: { type: "string" }, max_bytes: { type: "number" } },
+        required: ["path"],
+      },
+    },
+    {
+      name: "hermes_report_status",
+      description: "Write a small final/blocker status report for Hermes without owning merge policy.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          workingDirectory,
+          session_id: sessionId,
+          status: { type: "string", enum: ["running", "blocked", "failed", "complete"] },
+          summary: { type: "string" },
+          pr_url: { type: "string" },
+          blocker: { type: "string" },
+          allow_mutation: allowMutation,
+        },
+        required: ["status", "allow_mutation"],
+      },
+    },
+  ];
+}
+
+const TOOL_HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {
+  hermes_list_sessions: hermesListSessions,
+  hermes_start_session: hermesStartSession,
+  hermes_send_prompt: hermesSendPrompt,
+  hermes_read_status: hermesReadStatus,
+  hermes_read_tail: hermesReadTail,
+  hermes_list_artifacts: hermesListArtifacts,
+  hermes_read_artifact: hermesReadArtifact,
+  hermes_report_status: hermesReportStatus,
+};
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: buildHermesServerTools() }));
+
+export async function handleHermesToolCall(request: {
+  params: { name: string; arguments?: Record<string, unknown> };
+}) {
+  const { name, arguments: args = {} } = request.params;
+  const handler = TOOL_HANDLERS[name];
+  if (!handler) {
+    return { content: [{ type: "text", text: `Unknown tool: ${name}` }], isError: true };
+  }
+  const result = await handler(args);
+  const isError = typeof result === "object" && result !== null && (result as { ok?: unknown }).ok === false;
+  return {
+    content: [{ type: "text", text: JSON.stringify(result) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+server.setRequestHandler(CallToolRequestSchema, handleHermesToolCall);
+autoStartStdioMcpServer("hermes", server);

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -1,5 +1,5 @@
 import { delimiter, isAbsolute, join, relative, resolve as resolvePath } from 'path';
-import { existsSync } from 'fs';
+import { existsSync, realpathSync } from 'fs';
 import { readFile, readdir } from 'fs/promises';
 import {
   isSessionStateUsable,
@@ -103,8 +103,7 @@ export function resolveWorkingDirectoryForState(workingDirectory?: string): stri
   }
   if (!raw) {
     const cwd = resolvePath(process.cwd());
-    enforceWorkingDirectoryPolicy(cwd);
-    return cwd;
+    return enforceWorkingDirectoryPolicy(cwd);
   }
 
   let normalized = raw;
@@ -126,8 +125,32 @@ export function resolveWorkingDirectoryForState(workingDirectory?: string): stri
   }
 
   const resolved = resolvePath(normalized);
-  enforceWorkingDirectoryPolicy(resolved);
-  return resolved;
+  return enforceWorkingDirectoryPolicy(resolved);
+}
+
+function canonicalizeExistingPath(path: string): string {
+  try {
+    return realpathSync.native(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+
+  let current = path;
+  const suffixes: string[] = [];
+  while (true) {
+    const parent = resolvePath(current, '..');
+    if (parent === current) break;
+    suffixes.unshift(current.substring(parent.length).replace(/^[\\/]+/, ''));
+    current = parent;
+    try {
+      const realParent = realpathSync.native(current);
+      return suffixes.reduce((acc, segment) => resolvePath(acc, segment), realParent);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+
+  return path;
 }
 
 function parseAllowedWorkingDirectoryRoots(): string[] {
@@ -142,7 +165,12 @@ function parseAllowedWorkingDirectoryRoots(): string[] {
       if (part.includes('\0')) {
         throw new Error(`${WORKDIR_ALLOWLIST_ENV} contains an invalid root with a NUL byte`);
       }
-      return resolvePath(part);
+      const resolvedRoot = resolvePath(part);
+      const realRoot = canonicalizeExistingPath(resolvedRoot);
+      if (realRoot !== resolvedRoot) {
+        throw new Error(`${WORKDIR_ALLOWLIST_ENV} root "${resolvedRoot}" resolves through a symlink to "${realRoot}"`);
+      }
+      return realRoot;
     });
 
   return [...new Set(roots)];
@@ -153,16 +181,18 @@ function isWithinRoot(path: string, root: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
-function enforceWorkingDirectoryPolicy(resolvedWorkingDirectory: string): void {
+function enforceWorkingDirectoryPolicy(resolvedWorkingDirectory: string): string {
   const roots = parseAllowedWorkingDirectoryRoots();
-  if (roots.length === 0) return;
+  if (roots.length === 0) return resolvedWorkingDirectory;
 
-  const allowed = roots.some((root) => isWithinRoot(resolvedWorkingDirectory, root));
+  const canonicalWorkingDirectory = canonicalizeExistingPath(resolvedWorkingDirectory);
+  const allowed = roots.some((root) => isWithinRoot(canonicalWorkingDirectory, root));
   if (!allowed) {
     throw new Error(
-      `workingDirectory "${resolvedWorkingDirectory}" is outside allowed roots (${WORKDIR_ALLOWLIST_ENV})`,
+      `workingDirectory "${canonicalWorkingDirectory}" is outside allowed roots (${WORKDIR_ALLOWLIST_ENV})`,
     );
   }
+  return canonicalWorkingDirectory;
 }
 
 export function getBaseStateDir(workingDirectory?: string): string {


### PR DESCRIPTION
## Summary
- Add a disabled-by-default `omx_hermes` first-party MCP target (`omx mcp-serve hermes`) for Hermes/OMX coordination.
- Expose bounded session listing/start/prompt/status/tail/artifact/report tools with explicit `allow_mutation` gates for writes.
- Project session/status metadata and restrict artifact roots so Hermes gets product-facing coordination data without raw runtime/control-room leakage.
- Document the safe coordinator boundary and non-goals in `docs/hermes-mcp-bridge.md`.

## Validation
- `npm run build`
- `node --test dist/mcp/__tests__/hermes-bridge.test.js`
- `node --test dist/cli/__tests__/mcp-serve.test.js dist/mcp/__tests__/bootstrap.test.js dist/config/__tests__/generator-idempotent.test.js`
- `npm run verify:plugin-bundle`
- `npm run check:no-unused`
- `npm run lint`
- `node --test dist/cli/__tests__/package-bin-contract.test.js dist/mcp/__tests__/path-traversal.test.js`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_SESSION_ID node --test dist/mcp/__tests__/state-paths.test.js`

## Notes
- Full `npm run test:ci:compiled` was not used as completion evidence in this live Ralph/tmux runtime because session-scoped `OMX_ROOT`/tmux state contaminates unrelated runtime tests; impacted MCP/bootstrap/config/package/state lanes pass.
- Document-refresh: not-needed | The CLI change only registers the new `mcp-serve hermes` target; the feature-specific product/operator documentation is added in `docs/hermes-mcp-bridge.md`.

Closes #2278

🤖 Generated with [Oh My Codex](https://github.com/Yeachan-Heo/oh-my-codex)

Co-authored-by: OmX <omx@oh-my-codex.dev>
