### PR TITLE
Prevent tmux shell rc fan-out before Codex launch

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeCodexLaunchArgs,
   buildTmuxShellCommand,
   buildTmuxPaneCommand,
+  shouldSourceTmuxPaneShellRc,
   buildWindowsPromptCommand,
   buildTmuxSessionName,
   resolveCliInvocation,
@@ -3770,18 +3771,19 @@ describe("buildTmuxShellCommand", () => {
 });
 
 describe("buildTmuxPaneCommand", () => {
-  it("wraps command with zsh profile sourcing while preserving tmux cwd", () => {
+  it("wraps command with zsh without sourcing rc files by default", () => {
     const result = buildTmuxPaneCommand(
       "codex",
       ["--model", "gpt-5"],
       "/usr/bin/zsh",
+      {},
     );
     assert.ok(
       result.startsWith("'/usr/bin/zsh' -c "),
       "should start with zsh non-login shell to preserve tmux cwd",
     );
     assert.ok(!result.includes(" -lc "), "should not use a login shell");
-    assert.ok(result.includes("source ~/.zshrc"), "should source .zshrc");
+    assert.ok(!result.includes("source ~/.zshrc"), "should not source .zshrc by default");
     assert.ok(result.includes("exec "), "should exec the command");
   });
 
@@ -3790,6 +3792,7 @@ describe("buildTmuxPaneCommand", () => {
       "codex",
       ["--model", "gpt-5"],
       "/opt/homebrew/bin/zsh",
+      {},
     );
     assert.ok(
       result.startsWith("'/opt/homebrew/bin/zsh' -c "),
@@ -3799,7 +3802,7 @@ describe("buildTmuxPaneCommand", () => {
       !result.startsWith("'/bin/sh' -c "),
       "should not fall back to /bin/sh for supported Homebrew zsh",
     );
-    assert.ok(result.includes("source ~/.zshrc"), "should source .zshrc");
+    assert.ok(!result.includes("source ~/.zshrc"), "should not source .zshrc by default");
   });
 
   it("keeps MacPorts zsh instead of downgrading to /bin/sh", () => {
@@ -3807,6 +3810,7 @@ describe("buildTmuxPaneCommand", () => {
       "codex",
       ["--model", "gpt-5"],
       "/opt/local/bin/zsh",
+      {},
     );
     assert.ok(
       result.startsWith("'/opt/local/bin/zsh' -c "),
@@ -3816,18 +3820,31 @@ describe("buildTmuxPaneCommand", () => {
       !result.startsWith("'/bin/sh' -c "),
       "should not fall back to /bin/sh for supported MacPorts zsh",
     );
-    assert.ok(result.includes("source ~/.zshrc"), "should source .zshrc");
+    assert.ok(!result.includes("source ~/.zshrc"), "should not source .zshrc by default");
   });
 
-  it("wraps command with bash profile sourcing while preserving tmux cwd", () => {
-    const result = buildTmuxPaneCommand("codex", [], "/bin/bash");
+  it("prevents issue #2282 bash rc fan-out by default", () => {
+    const result = buildTmuxPaneCommand("codex", [], "/bin/bash", {});
     assert.ok(
       result.startsWith("'/bin/bash' -c "),
       "should start with bash non-login shell to preserve tmux cwd",
     );
     assert.ok(!result.includes(" -lc "), "should not use a login shell");
-    assert.ok(result.includes("source ~/.bashrc"), "should source .bashrc");
+    assert.ok(!result.includes("source ~/.bashrc"), "should not source .bashrc by default");
     assert.ok(result.includes("exec "), "should exec the command");
+  });
+
+  it("sources zsh and bash rc files only when explicitly opted in", () => {
+    assert.equal(shouldSourceTmuxPaneShellRc({}), false);
+    assert.equal(shouldSourceTmuxPaneShellRc({ OMX_TMUX_SOURCE_SHELL_RC: "1" }), true);
+    assert.ok(
+      buildTmuxPaneCommand("codex", [], "/usr/bin/zsh", { OMX_TMUX_SOURCE_SHELL_RC: "1" }).includes("source ~/.zshrc"),
+      "opt-in zsh launches may source .zshrc",
+    );
+    assert.ok(
+      buildTmuxPaneCommand("codex", [], "/bin/bash", { OMX_TMUX_SOURCE_SHELL_RC: "1" }).includes("source ~/.bashrc"),
+      "opt-in bash launches may source .bashrc",
+    );
   });
 
   it("skips rc sourcing for unknown shells without using a login shell", () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3760,19 +3760,33 @@ export function buildWindowsPromptCommand(
  * Wrap a command for tmux pane execution while preserving the tmux pane cwd.
  * tmux already starts the pane at `-c <cwd>`; using a login shell here can
  * reset that cwd back to the shell's startup directory on some setups.
- * Source zsh/bash rc files explicitly when needed, then exec the target.
+ *
+ * Do not source user shell rc files by default. In issue #2282 the surviving
+ * OOM signature was thousands of bash processes, not MCP node children;
+ * non-interactive tmux panes sourcing ~/.bashrc can recursively trigger user
+ * automation and fan out before Codex starts. Users who need legacy PATH setup
+ * can opt in with OMX_TMUX_SOURCE_SHELL_RC=1.
  */
+export function shouldSourceTmuxPaneShellRc(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return String(env.OMX_TMUX_SOURCE_SHELL_RC ?? "").trim() === "1";
+}
+
 export function buildTmuxPaneCommand(
   command: string,
   args: string[],
   shellPath: string | undefined = process.env.SHELL,
+  env: NodeJS.ProcessEnv = process.env,
 ): string {
   const bareCmd = buildTmuxShellCommand(command, args);
   let rcSource = "";
-  if (shellPath && /\/zsh$/i.test(shellPath)) {
-    rcSource = "if [ -f ~/.zshrc ]; then source ~/.zshrc; fi; ";
-  } else if (shellPath && /\/bash$/i.test(shellPath)) {
-    rcSource = "if [ -f ~/.bashrc ]; then source ~/.bashrc; fi; ";
+  if (shouldSourceTmuxPaneShellRc(env)) {
+    if (shellPath && /\/zsh$/i.test(shellPath)) {
+      rcSource = "if [ -f ~/.zshrc ]; then source ~/.zshrc; fi; ";
+    } else if (shellPath && /\/bash$/i.test(shellPath)) {
+      rcSource = "if [ -f ~/.bashrc ]; then source ~/.bashrc; fi; ";
+    }
   }
   const rawShell =
     shellPath && shellPath.trim() !== "" ? shellPath.trim() : "/bin/sh";


### PR DESCRIPTION
## Summary
- Stop tmux pane launches from sourcing user shell rc files by default before `exec codex`.
- Keep the cwd-preserving non-login shell wrapper, but require explicit `OMX_TMUX_SOURCE_SHELL_RC=1` for legacy `.bashrc` / `.zshrc` sourcing.
- Add regression coverage named for #2282 so bash rc fan-out is blocked by default while opt-in behavior remains available.

## Focused diagnosis
Issue #2282 reproduced after #2240 with the same ~1.4TB total-vm signature, but the attached v0.16.4 journal/OOM dump is dominated by thousands of `bash` processes and only two `node` entries near the OOM event. That points away from the #2240 plugin MCP orphan path and toward the tmux pane shell bootstrap path.

The surviving leak path was `buildTmuxPaneCommand()` sourcing `~/.bashrc` / `~/.zshrc` in non-interactive tmux panes before `exec codex`. User shell rc automation can recursively fan out `bash`/OMX/Codex work before Codex starts, matching the issue logs.

## Tests
- `npm ci`
- `npm run lint -- src/cli/index.ts src/cli/__tests__/index.test.ts`
- `npm run check:no-unused`
- `npm run build`
- `node --test --test-name-pattern 'buildTmuxPaneCommand|cleanupOmxMcpProcesses|findCleanupCandidates' dist/cli/__tests__/index.test.js dist/cli/__tests__/cleanup.test.js`
- `npm run test:plugin-boundaries:compiled`

## Notes
- Full `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/cleanup.test.js` was also attempted; the changed `buildTmuxPaneCommand` and cleanup suites passed, but existing unrelated `cleanupPostLaunchModeStateFiles` and tmux extended-keys lease tests failed in this environment.

Fixes #2282

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
