### PR TITLE
hud: register client-resized hook to re-enforce pane height on terminal resize

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -161,4 +161,50 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(resized[0]?.paneId, '%2');
     assert.equal(resized[0]?.heightLines, 3);
   });
+
+  it('registers client-resized hook after resizing an existing HUD pane', async () => {
+    const written: Array<{ path: string; lines: number }> = [];
+    const registered: string[] = [];
+
+    await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%2', currentCommand: 'node', startCommand: 'node omx hud --watch' },
+      ],
+      resizeTmuxPane: () => true,
+      writeHudResizeScript: (path, lines) => { written.push({ path, lines }); },
+      registerHudResizeHook: (path) => { registered.push(path); return true; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(written.length, 1);
+    assert.match(written[0]?.path ?? '', /\.omx[/\\]state[/\\]hud-resize\.sh$/);
+    assert.equal(written[0]?.lines, 3);
+    assert.equal(registered.length, 1);
+    assert.equal(registered[0], written[0]?.path);
+  });
+
+  it('registers client-resized hook after creating a new HUD pane', async () => {
+    const written: Array<{ path: string; lines: number }> = [];
+    const registered: string[] = [];
+
+    await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      createHudWatchPane: () => '%9',
+      resizeTmuxPane: () => true,
+      writeHudResizeScript: (path, lines) => { written.push({ path, lines }); },
+      registerHudResizeHook: (path) => { registered.push(path); return true; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(written.length, 1);
+    assert.match(written[0]?.path ?? '', /\.omx[/\\]state[/\\]hud-resize\.sh$/);
+    assert.equal(written[0]?.lines, 3);
+    assert.equal(registered.length, 1);
+    assert.equal(registered[0], written[0]?.path);
+  });
 });

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import { readHudConfig } from './state.js';
 import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import {
@@ -7,7 +8,9 @@ import {
   isHudWatchPane,
   killTmuxPane,
   listCurrentWindowPanes,
+  registerHudResizeHook,
   resizeTmuxPane,
+  writeHudResizeScript,
   type TmuxPaneSnapshot,
 } from './tmux.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
@@ -45,6 +48,22 @@ export interface ReconcileHudForPromptSubmitDeps {
   resizeTmuxPane?: (paneId: string, heightLines: number) => boolean;
   readHudConfig?: typeof readHudConfig;
   resolveOmxCliEntryPath?: typeof resolveOmxCliEntryPath;
+  writeHudResizeScript?: (scriptPath: string, heightLines: number) => void;
+  registerHudResizeHook?: (scriptPath: string) => boolean;
+}
+
+function ensureHudResizeHook(
+  cwd: string,
+  desiredHeight: number,
+  deps: ReconcileHudForPromptSubmitDeps,
+): void {
+  const scriptPath = join(cwd, '.omx', 'state', 'hud-resize.sh');
+  try {
+    (deps.writeHudResizeScript ?? writeHudResizeScript)(scriptPath, desiredHeight);
+    (deps.registerHudResizeHook ?? ((p) => registerHudResizeHook(p)))(scriptPath);
+  } catch {
+    // Non-critical — hook registration failure does not break HUD lifecycle.
+  }
 }
 
 export async function reconcileHudForPromptSubmit(
@@ -101,6 +120,7 @@ export async function reconcileHudForPromptSubmit(
 
   if (hudPaneIds.length === 1) {
     const resized = resizePane(hudPaneIds[0], desiredHeight);
+    if (resized) ensureHudResizeHook(cwd, desiredHeight, deps);
     return {
       status: resized ? 'resized' : 'failed',
       paneId: hudPaneIds[0],
@@ -128,6 +148,7 @@ export async function reconcileHudForPromptSubmit(
   }
 
   resizePane(paneId, desiredHeight);
+  ensureHudResizeHook(cwd, desiredHeight, deps);
 
   return {
     status: hudPaneIds.length > 1 ? 'replaced_duplicates' : 'recreated',

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from 'child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 
@@ -177,6 +179,28 @@ export function resizeTmuxPane(
     : HUD_TMUX_HEIGHT_LINES;
   try {
     execTmuxSync(['resize-pane', '-t', paneId, '-y', String(height)]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function buildHudResizeScript(heightLines: number): string {
+  const h = String(Math.max(1, Math.floor(heightLines)));
+  return `#!/bin/sh\ntmux list-panes -F "#{pane_id} #{pane_start_command}" 2>/dev/null | grep "hud.*--watch" | awk '{print $1}' | while read -r id; do tmux resize-pane -t "$id" -y ${h} 2>/dev/null; done\n`;
+}
+
+export function writeHudResizeScript(scriptPath: string, heightLines: number): void {
+  mkdirSync(dirname(scriptPath), { recursive: true });
+  writeFileSync(scriptPath, buildHudResizeScript(heightLines), { mode: 0o755 });
+}
+
+export function registerHudResizeHook(
+  scriptPath: string,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): boolean {
+  try {
+    execTmuxSync(['set-hook', '-g', 'client-resized[99]', `run-shell -b ${shellEscapeSingle(scriptPath)}`]);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Problem

When the user resizes their terminal, tmux proportionally scales all panes — including the HUD watch pane. The reconciler only enforces the canonical 3-line height on the *next prompt submit*, leaving the HUD oversized until then.

## Root cause

`reconcileHudForPromptSubmit` calls `resizeTmuxPane` on every prompt submit, but there is no equivalent enforcement on `client-resized`. tmux naturally redistributes space among all panes when the terminal dimensions change.

## Fix

After each successful resize or create in `reconcileHudForPromptSubmit`:

1. Write a small POSIX sh script to `.omx/state/hud-resize.sh` — it enumerates panes in the current window, filters for HUD watch panes (`grep "hud.*--watch"`), and calls `tmux resize-pane -y <height>` on each match.
2. Register it as a global tmux hook via `set-hook -g 'client-resized[99]' "run-shell -b '<script>'"`.

Using an indexed slot (`[99]`) ensures we never clobber existing user or plugin hooks at other indices. The index is stable so repeated calls on every prompt submit are idempotent. Hook registration and script write failures are caught and treated as non-critical so they cannot break the HUD lifecycle.

## New exports (`src/hud/tmux.ts`)

- `buildHudResizeScript(heightLines)` — returns the POSIX sh script content
- `writeHudResizeScript(scriptPath, heightLines)` — writes + chmods the script
- `registerHudResizeHook(scriptPath, execTmuxSync?)` — calls `set-hook -g 'client-resized[99]'`

Both `writeHudResizeScript` and `registerHudResizeHook` are injectable via `ReconcileHudForPromptSubmitDeps` for unit testing.

## Tests

Two new test cases in `reconcile.test.ts`:
- Verifies hook is registered after resizing an existing HUD pane
- Verifies hook is registered after creating a new HUD pane

Existing tests pass unchanged — the `try/catch` in `ensureHudResizeHook` silently absorbs the `mkdirSync`/tmux failures that occur in test environments without a real filesystem or tmux session.

## Addressing #2284 review feedback

Previous PR used bare `set-hook -g client-resized` which clears all existing hooks at that hook point. This version uses `client-resized[99]` (stable indexed slot) so only the OMX-owned slot is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)