### PR TITLE
feat: emit question bridge events

### DIFF
--- a/docs/hermes-mcp-bridge.md
+++ b/docs/hermes-mcp-bridge.md
@@ -14,6 +14,9 @@ The plugin manifest registers it as `omx_hermes` and keeps it disabled by defaul
 
 Hermes or another coordinator owns intake, operator Q&A, package shaping, and external approval policy. OMX owns planning, execution, review, and local artifact production inside a bounded worktree/session. The bridge only connects those product-facing responsibilities.
 
+For operator Q&A, Hermes should use the structured question bridge rather than
+terminal relay. See [Question coordinator bridge](./question-coordinator-bridge.md).
+
 The v1 bridge intentionally does **not** expose:
 
 - interactive `$deep-interview` turn routing
@@ -30,6 +33,8 @@ Read tools:
 - `hermes_list_sessions` — list known OMX session-state directories and active mode names.
 - `hermes_read_status` — read selected session/mode JSON status.
 - `hermes_read_tail` — read `.omx/logs/session-history.jsonl` tail, not tmux scrollback.
+- `hermes_list_question_events` — read structured question lifecycle events for coordinator correlation.
+- `hermes_list_questions` — list pending or terminal structured question records without terminal scraping.
 - `hermes_list_artifacts` — list safe result artifacts under `.omx/plans`, `.omx/specs`, `.omx/goals`, `.omx/context`, and `.omx/reports`.
 - `hermes_read_artifact` — read one safe relative `.omx/...` artifact with byte truncation.
 
@@ -37,6 +42,7 @@ Mutating tools require `allow_mutation: true`:
 
 - `hermes_start_session` — starts `omx --tmux --worktree[=<name>] <prompt>` from the bounded working directory.
 - `hermes_send_prompt` — queues one prompt through the existing audited `exec-followups.json` contract for a selected exec session.
+- `hermes_submit_question_answer` — submits one bounded structured answer by question id; stale, duplicate, unknown, and malformed submissions fail closed.
 - `hermes_report_status` — writes `.omx/state[/sessions/<session_id>]/hermes-coordination.json` with final/blocker/PR summary data.
 
-Failure responses are explicit JSON with `ok: false`, `code`, and `error`, including `no_session`, `prompt_not_accepted`, `artifact_missing`, `artifact_outside_safe_roots`, `mutation_not_allowed`, and `command_failed`.
+Failure responses are explicit JSON with `ok: false`, `code`, and `error`, including `no_session`, `prompt_not_accepted`, `artifact_missing`, `artifact_outside_safe_roots`, `mutation_not_allowed`, `question_unknown`, `question_not_open`, `question_invalid_answer`, and `command_failed`.

--- a/docs/question-coordinator-bridge.md
+++ b/docs/question-coordinator-bridge.md
@@ -1,0 +1,42 @@
+# Question coordinator bridge
+
+OMX structured questions are an OMX-owned blocking workflow surface. Coordinator
+bridges such as Hermes may render those questions in an operator UI, then submit
+a bounded structured answer by `question_id`.
+
+## Event flow
+
+1. A workflow creates a question record under `.omx/state/.../questions/`.
+2. OMX appends a `question-created` JSONL event to
+   `.omx/state/question-events.jsonl`.
+3. A coordinator reads the event or uses the Hermes MCP question tools to render
+   the prompt, options, source, session/run correlation, and timeout/state
+   metadata.
+4. The operator answers in the coordinator UI.
+5. The coordinator calls the bounded answer submission tool with:
+   - `question_id`
+   - `session_id` when the question is session-scoped
+   - one structured `answer` or an `answers[]` batch
+   - explicit mutation opt-in
+6. OMX validates that the id exists and is still `pending` or `prompting`,
+   persists the answer, emits `question-answered`, and the waiting workflow
+   resumes from the record state.
+
+Terminal state or runtime failures emit `question-error` with a clear code and
+message.
+
+## Safety contract
+
+- Unknown ids fail with `question_unknown`.
+- Already answered, aborted, or errored records fail with `question_not_open`.
+- Malformed answer payloads fail with `question_invalid_answer`.
+- Coordinators receive structured prompt and option schema, not terminal
+  scrollback.
+- Coordinators submit structured answers to the question record, not arbitrary
+  terminal stdin.
+
+## Non-goal
+
+This bridge is not a remote terminal editor, shell relay, or tmux scraping
+surface. It exists only for structured operator Q&A correlation while preserving
+OMX context isolation.

--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -1,5 +1,5 @@
 import { evaluateQuestionPolicy } from '../question/policy.js';
-import { appendQuestionEvent } from '../question/events.js';
+import { appendQuestionAnsweredEventOnce, appendQuestionEvent } from '../question/events.js';
 import {
   createQuestionRecord,
   markQuestionTerminalError,
@@ -319,7 +319,7 @@ export async function questionCommand(args: string[]): Promise<void> {
     return;
   }
 
-  await appendQuestionEvent(cwd, 'question-answered', finalRecord, {
+  await appendQuestionAnsweredEventOnce(cwd, finalRecord, {
     recordPath,
     timeoutMs: waitTimeoutMs,
   });

--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -1,8 +1,11 @@
 import { evaluateQuestionPolicy } from '../question/policy.js';
+import { appendQuestionEvent } from '../question/events.js';
 import {
   createQuestionRecord,
   markQuestionTerminalError,
   markQuestionPrompting,
+  QuestionSubmitError,
+  submitQuestionAnswerById,
   waitForQuestionTerminalState,
 } from '../question/state.js';
 import { isQuestionRendererAlive, launchQuestionRenderer } from '../question/renderer.js';
@@ -28,6 +31,9 @@ Options:
   --help, -h           Show this help message
   --input <json>       JSON object with question/options schema; blocks until answered
   --input=<json>       Same as --input
+  --answer-question-id <id>  Submit a bounded answer payload for a known question id
+  --answer <json>      JSON answer object or {"answers":[...]} payload for --answer-question-id
+  --session-id <id>    Optional session scope for answer submission
   --json               Emit compact JSON on stdout for machine callers
   --ui                 Internal renderer mode; renders the OMX question UI for an existing state record
   --state-path <path>  Question record path used by --ui mode
@@ -66,6 +72,9 @@ interface ParsedQuestionArgs {
   ui: boolean;
   input?: string;
   statePath?: string;
+  answerQuestionId?: string;
+  answer?: string;
+  sessionId?: string;
 }
 
 function parseQuestionArgs(args: string[]): ParsedQuestionArgs {
@@ -93,6 +102,39 @@ function parseQuestionArgs(args: string[]): ParsedQuestionArgs {
     }
     if (arg.startsWith('--input=')) {
       parsed.input = arg.slice('--input='.length);
+      continue;
+    }
+    if (arg === '--answer-question-id') {
+      const next = args[index + 1];
+      if (!next) throw new Error('Missing question id after --answer-question-id');
+      parsed.answerQuestionId = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--answer-question-id=')) {
+      parsed.answerQuestionId = arg.slice('--answer-question-id='.length);
+      continue;
+    }
+    if (arg === '--answer') {
+      const next = args[index + 1];
+      if (!next) throw new Error('Missing JSON value after --answer');
+      parsed.answer = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--answer=')) {
+      parsed.answer = arg.slice('--answer='.length);
+      continue;
+    }
+    if (arg === '--session-id') {
+      const next = args[index + 1];
+      if (!next) throw new Error('Missing session id after --session-id');
+      parsed.sessionId = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--session-id=')) {
+      parsed.sessionId = arg.slice('--session-id='.length);
       continue;
     }
     if (arg === '--state-path') {
@@ -143,6 +185,45 @@ export async function questionCommand(args: string[]): Promise<void> {
     return;
   }
 
+  if (parsed.answerQuestionId) {
+    if (!parsed.answer) throw new Error('--answer-question-id requires --answer');
+    let answerPayload: unknown;
+    try {
+      answerPayload = JSON.parse(parsed.answer);
+    } catch (error) {
+      throw new Error(`--answer must be valid JSON: ${(error as Error).message}`);
+    }
+    try {
+      const { record, recordPath } = await submitQuestionAnswerById(
+        process.cwd(),
+        parsed.answerQuestionId,
+        answerPayload,
+        { sessionId: parsed.sessionId },
+      );
+      printJson({
+        ok: true,
+        question_id: record.question_id,
+        session_id: record.session_id,
+        status: record.status,
+        answers: record.answers ?? [],
+        record_path: recordPath,
+      }, parsed.json);
+    } catch (error) {
+      const code = error instanceof QuestionSubmitError ? error.code : 'question_submit_failed';
+      printJson({
+        ok: false,
+        question_id: parsed.answerQuestionId,
+        session_id: parsed.sessionId,
+        error: {
+          code,
+          message: extractErrorMessage(error),
+        },
+      }, parsed.json);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   if (!parsed.input) throw new Error('omx question requires --input in normal mode');
 
   let rawInput: unknown;
@@ -167,7 +248,11 @@ export async function questionCommand(args: string[]): Promise<void> {
     return;
   }
 
-  const { record, recordPath } = await createQuestionRecord(cwd, input, policy.sessionId);
+  const waitTimeoutMs = parseQuestionWaitTimeoutMs();
+  const { record, recordPath } = await createQuestionRecord(cwd, input, policy.sessionId, new Date(), {
+    emitEvent: true,
+    timeoutMs: waitTimeoutMs,
+  });
 
   let finalRecord;
   try {
@@ -184,7 +269,7 @@ export async function questionCommand(args: string[]): Promise<void> {
       );
     }
     finalRecord = await waitForQuestionTerminalState(recordPath, {
-      timeoutMs: parseQuestionWaitTimeoutMs(),
+      timeoutMs: waitTimeoutMs,
       rendererAlive: (currentRecord) => isQuestionRendererAlive(currentRecord.renderer),
       rendererDeathMessage: (currentRecord) => (
         `Question renderer ${currentRecord.renderer?.renderer ?? renderer.renderer} ${currentRecord.renderer?.target ?? renderer.target} exited before answering.`
@@ -192,12 +277,16 @@ export async function questionCommand(args: string[]): Promise<void> {
     });
   } catch (error) {
     const message = extractErrorMessage(error);
-    await markQuestionTerminalError(
+    const errorRecord = await markQuestionTerminalError(
       recordPath,
       'error',
       'question_runtime_failed',
       message,
     );
+    await appendQuestionEvent(cwd, 'question-error', errorRecord, {
+      recordPath,
+      timeoutMs: waitTimeoutMs,
+    });
     printJson({
       ok: false,
       question_id: record.question_id,
@@ -212,6 +301,12 @@ export async function questionCommand(args: string[]): Promise<void> {
   }
 
   if (finalRecord.status !== 'answered' || !finalRecord.answer) {
+    if (finalRecord.status === 'aborted' || finalRecord.status === 'error') {
+      await appendQuestionEvent(cwd, 'question-error', finalRecord, {
+        recordPath,
+        timeoutMs: waitTimeoutMs,
+      });
+    }
     printJson({
       ok: false,
       question_id: finalRecord.question_id,
@@ -223,6 +318,11 @@ export async function questionCommand(args: string[]): Promise<void> {
     process.exitCode = 1;
     return;
   }
+
+  await appendQuestionEvent(cwd, 'question-answered', finalRecord, {
+    recordPath,
+    timeoutMs: waitTimeoutMs,
+  });
 
   const isSingleQuestion = (finalRecord.questions?.length ?? 0) === 1;
   printJson({

--- a/src/mcp/__tests__/hermes-bridge.test.ts
+++ b/src/mcp/__tests__/hermes-bridge.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import {
+  hermesListQuestionEvents,
+  hermesListQuestions,
   hermesListArtifacts,
   hermesListSessions,
   hermesReadArtifact,
@@ -11,8 +13,10 @@ import {
   hermesReadTail,
   hermesReportStatus,
   hermesSendPrompt,
+  hermesSubmitQuestionAnswer,
   hermesStartSession,
 } from "../hermes-bridge.js";
+import { createQuestionRecord } from "../../question/state.js";
 
 const originalRoots = process.env.OMX_MCP_WORKDIR_ROOTS;
 const originalOmxRoot = process.env.OMX_ROOT;
@@ -158,6 +162,76 @@ describe("Hermes MCP bridge core", () => {
 
     assert.equal(result.ok, false);
     assert.equal(result.code, "mutation_not_allowed");
+  });
+
+  it("lists question events and submits bounded answers without terminal input proxying", async () => {
+    const cwd = await tempWorkspace("omx-hermes-questions-");
+    try {
+      const { record } = await createQuestionRecord(cwd, {
+        question: "Pick one",
+        options: [{ label: "A", value: "a" }],
+        allow_other: false,
+        other_label: "Other",
+        multi_select: false,
+        source: "hermes-test",
+      }, "sess-q", new Date("2026-05-11T00:00:00.000Z"), {
+        emitEvent: true,
+        runId: "run-q",
+      });
+
+      const listed = await hermesListQuestions({ workingDirectory: cwd, session_id: "sess-q" });
+      assert.equal(listed.ok, true);
+      assert.equal(listed.data?.questions[0]?.question_id, record.question_id);
+      assert.equal(listed.data?.questions[0]?.source, "hermes-test");
+      assert.equal(JSON.stringify(listed).includes("tmux scrollback"), false);
+
+      const events = await hermesListQuestionEvents({ workingDirectory: cwd });
+      assert.equal(events.ok, true);
+      assert.equal(events.data?.events[0]?.type, "question-created");
+      assert.equal(events.data?.events[0]?.run_id, "run-q");
+
+      const missingMutation = await hermesSubmitQuestionAnswer({
+        workingDirectory: cwd,
+        session_id: "sess-q",
+        question_id: record.question_id,
+        answer: { kind: "option", value: "a", selected_labels: ["A"], selected_values: ["a"] },
+      });
+      assert.equal(missingMutation.ok, false);
+      assert.equal(missingMutation.code, "mutation_not_allowed");
+
+      const submitted = await hermesSubmitQuestionAnswer({
+        workingDirectory: cwd,
+        session_id: "sess-q",
+        question_id: record.question_id,
+        answer: { kind: "option", value: "a", selected_labels: ["A"], selected_values: ["a"] },
+        allow_mutation: true,
+      });
+      assert.equal(submitted.ok, true);
+      assert.equal(submitted.data?.question.status, "answered");
+      assert.equal(submitted.data?.answers[0]?.answer.value, "a");
+
+      const duplicate = await hermesSubmitQuestionAnswer({
+        workingDirectory: cwd,
+        session_id: "sess-q",
+        question_id: record.question_id,
+        answer: { kind: "option", value: "a", selected_labels: ["A"], selected_values: ["a"] },
+        allow_mutation: true,
+      });
+      assert.equal(duplicate.ok, false);
+      assert.equal(duplicate.code, "question_not_open");
+
+      const unknown = await hermesSubmitQuestionAnswer({
+        workingDirectory: cwd,
+        session_id: "sess-q",
+        question_id: "question-unknown",
+        answer: { kind: "option", value: "a", selected_labels: ["A"], selected_values: ["a"] },
+        allow_mutation: true,
+      });
+      assert.equal(unknown.ok, false);
+      assert.equal(unknown.code, "question_unknown");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it("queues selected prompts through the audited exec follow-up contract", async () => {

--- a/src/mcp/__tests__/hermes-bridge.test.ts
+++ b/src/mcp/__tests__/hermes-bridge.test.ts
@@ -209,6 +209,8 @@ describe("Hermes MCP bridge core", () => {
       assert.equal(submitted.ok, true);
       assert.equal(submitted.data?.question.status, "answered");
       assert.equal(submitted.data?.answers[0]?.answer.value, "a");
+      const answeredEvents = await hermesListQuestionEvents({ workingDirectory: cwd });
+      assert.equal(answeredEvents.data?.events.find((event) => event.type === "question-answered")?.run_id, "run-q");
 
       const duplicate = await hermesSubmitQuestionAnswer({
         workingDirectory: cwd,

--- a/src/mcp/hermes-bridge.ts
+++ b/src/mcp/hermes-bridge.ts
@@ -4,6 +4,9 @@ import { mkdir, readdir, readFile, realpath, writeFile } from "node:fs/promises"
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { injectExecFollowup } from "../exec/followup.js";
 import { isSessionStateUsable, readUsableSessionState, type SessionState } from "../hooks/session.js";
+import { readQuestionEvents } from "../question/events.js";
+import { listQuestionRecords, QuestionSubmitError, submitQuestionAnswerById } from "../question/state.js";
+import type { QuestionAnswerEntry, QuestionRecord } from "../question/types.js";
 import {
   getAllSessionScopedStateDirs,
   getBaseStateDir,
@@ -21,7 +24,10 @@ export type HermesBridgeFailureCode =
   | "invalid_input"
   | "mutation_not_allowed"
   | "no_session"
-  | "prompt_not_accepted";
+  | "prompt_not_accepted"
+  | "question_invalid_answer"
+  | "question_not_open"
+  | "question_unknown";
 
 export interface HermesBridgeResult<T extends Record<string, unknown> = Record<string, unknown>> {
   ok: boolean;
@@ -56,6 +62,25 @@ export interface HermesModeStatusSummary {
   updated_at?: string;
   completed_at?: string;
   error?: string;
+}
+
+export interface HermesQuestionSummary {
+  question_id: string;
+  session_id?: string;
+  created_at: string;
+  updated_at: string;
+  status: QuestionRecord["status"];
+  source?: string;
+  header?: string;
+  question: string;
+  questions?: QuestionRecord["questions"];
+  options?: QuestionRecord["options"];
+  allow_other?: boolean;
+  other_label?: string;
+  type?: QuestionRecord["type"];
+  multi_select?: boolean;
+  renderer?: QuestionRecord["renderer"];
+  error?: QuestionRecord["error"];
 }
 
 export interface HermesBridgeDeps {
@@ -127,6 +152,27 @@ function optionalBoolean(value: unknown): boolean | undefined {
 function optionalString(value: unknown): string | undefined {
   const normalized = typeof value === "string" ? value.trim() : "";
   return normalized || undefined;
+}
+
+function projectQuestion(record: QuestionRecord): HermesQuestionSummary {
+  return {
+    question_id: record.question_id,
+    ...(record.session_id ? { session_id: record.session_id } : {}),
+    created_at: record.created_at,
+    updated_at: record.updated_at,
+    status: record.status,
+    ...(record.source ? { source: record.source } : {}),
+    ...(record.header ? { header: record.header } : {}),
+    question: record.question,
+    ...(record.questions ? { questions: record.questions } : {}),
+    options: record.options,
+    allow_other: record.allow_other,
+    other_label: record.other_label,
+    type: record.type,
+    multi_select: record.multi_select,
+    ...(record.renderer ? { renderer: record.renderer } : {}),
+    ...(record.error ? { error: record.error } : {}),
+  };
 }
 
 function projectSessionStatus(session: SessionState | null): HermesStatusSessionSummary | null {
@@ -236,6 +282,62 @@ export async function hermesReadStatus(
     return jsonResult({ session, modes });
   } catch (error) {
     return failure("invalid_input", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function hermesListQuestionEvents(
+  args: Record<string, unknown>,
+): Promise<HermesBridgeResult<{ events: Awaited<ReturnType<typeof readQuestionEvents>> }>> {
+  try {
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
+    const limit = normalizePositiveInteger(args.limit, 100, 1000);
+    return jsonResult({ events: await readQuestionEvents(cwd, { limit }) });
+  } catch (error) {
+    return failure("invalid_input", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function hermesListQuestions(
+  args: Record<string, unknown>,
+): Promise<HermesBridgeResult<{ questions: HermesQuestionSummary[] }>> {
+  try {
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
+    const sessionId = validateSessionId(normalizeString(args.session_id, "session_id"));
+    const status = normalizeString(args.status, "status") ?? "open";
+    if (!["open", "pending", "prompting", "answered", "aborted", "error"].includes(status)) {
+      throw new Error("status must be one of open, pending, prompting, answered, aborted, error");
+    }
+    const limit = normalizePositiveInteger(args.limit, 100, 1000);
+    const questionStatus = status as "open" | QuestionRecord["status"];
+    const records = await listQuestionRecords(cwd, {
+      ...(sessionId ? { sessionId } : {}),
+      status: questionStatus,
+      limit,
+    });
+    return jsonResult({ questions: records.map(({ record }) => projectQuestion(record)) });
+  } catch (error) {
+    return failure("invalid_input", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function hermesSubmitQuestionAnswer(
+  args: Record<string, unknown>,
+): Promise<HermesBridgeResult<{ question: HermesQuestionSummary; answers: QuestionAnswerEntry[] }>> {
+  try {
+    requireMutation(args);
+    const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
+    const sessionId = validateSessionId(normalizeString(args.session_id, "session_id"));
+    const questionId = normalizeString(args.question_id, "question_id", { required: true })!;
+    const payload = args.answers !== undefined ? { answers: args.answers } : { answer: args.answer };
+    const { record } = await submitQuestionAnswerById(cwd, questionId, payload, {
+      ...(sessionId ? { sessionId } : {}),
+    });
+    return jsonResult({ question: projectQuestion(record), answers: record.answers ?? [] });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("allow_mutation")) return failure("mutation_not_allowed", message);
+    if (error instanceof QuestionSubmitError) return failure(error.code, message);
+    return failure("invalid_input", message);
   }
 }
 

--- a/src/mcp/hermes-server.ts
+++ b/src/mcp/hermes-server.ts
@@ -11,12 +11,15 @@ import {
 import { autoStartStdioMcpServer } from "./bootstrap.js";
 import {
   hermesListArtifacts,
+  hermesListQuestionEvents,
+  hermesListQuestions,
   hermesListSessions,
   hermesReadArtifact,
   hermesReadStatus,
   hermesReadTail,
   hermesReportStatus,
   hermesSendPrompt,
+  hermesSubmitQuestionAnswer,
   hermesStartSession,
 } from "./hermes-bridge.js";
 
@@ -78,6 +81,40 @@ export function buildHermesServerTools() {
       inputSchema: { type: "object", properties: { workingDirectory, lines: { type: "number" } } },
     },
     {
+      name: "hermes_list_question_events",
+      description: "Read structured question lifecycle events for coordinator bridge correlation.",
+      inputSchema: { type: "object", properties: { workingDirectory, limit: { type: "number" } } },
+    },
+    {
+      name: "hermes_list_questions",
+      description: "List bounded structured question records without reading terminal UI.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          workingDirectory,
+          session_id: sessionId,
+          status: { type: "string", enum: ["open", "pending", "prompting", "answered", "aborted", "error"] },
+          limit: { type: "number" },
+        },
+      },
+    },
+    {
+      name: "hermes_submit_question_answer",
+      description: "Submit a bounded structured answer by question id; never proxies arbitrary terminal input.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          workingDirectory,
+          session_id: sessionId,
+          question_id: { type: "string" },
+          answer: { type: "object" },
+          answers: { type: "array", items: { type: "object" } },
+          allow_mutation: allowMutation,
+        },
+        required: ["question_id", "allow_mutation"],
+      },
+    },
+    {
       name: "hermes_list_artifacts",
       description: "List known safe result artifact files under .omx plans/specs/goals/context/reports.",
       inputSchema: { type: "object", properties: { workingDirectory, limit: { type: "number" } } },
@@ -115,6 +152,9 @@ const TOOL_HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<u
   hermes_list_sessions: hermesListSessions,
   hermes_start_session: hermesStartSession,
   hermes_send_prompt: hermesSendPrompt,
+  hermes_list_question_events: hermesListQuestionEvents,
+  hermes_list_questions: hermesListQuestions,
+  hermes_submit_question_answer: hermesSubmitQuestionAnswer,
   hermes_read_status: hermesReadStatus,
   hermes_read_tail: hermesReadTail,
   hermes_list_artifacts: hermesListArtifacts,

--- a/src/question/__tests__/state.test.ts
+++ b/src/question/__tests__/state.test.ts
@@ -14,7 +14,7 @@ import {
   submitQuestionAnswerById,
   waitForQuestionTerminalState,
 } from '../state.js';
-import { appendQuestionEvent, readQuestionEvents } from '../events.js';
+import { appendQuestionAnsweredEventOnce, appendQuestionEvent, readQuestionEvents } from '../events.js';
 
 const tempDirs: string[] = [];
 
@@ -200,6 +200,42 @@ describe('question state', () => {
 
     const loaded = await readQuestionRecord(getQuestionRecordPath(cwd, record.question_id, 'sess-invalid'));
     assert.equal(loaded?.status, 'pending');
+  });
+
+  it('dedupes answered lifecycle events when a waiting command observes an externally submitted answer', async () => {
+    const cwd = await makeRepo();
+    const { record, recordPath } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-external', new Date('2026-05-11T00:00:00.000Z'), {
+      emitEvent: true,
+      runId: 'run-external-answer',
+    });
+
+    const submitted = await submitQuestionAnswerById(cwd, record.question_id, {
+      answer: {
+        kind: 'option',
+        value: 'a',
+        selected_labels: ['A'],
+        selected_values: ['a'],
+      },
+    }, { sessionId: 'sess-external' });
+
+    const duplicateAppend = await appendQuestionAnsweredEventOnce(cwd, submitted.record, {
+      recordPath,
+      timeoutMs: 5000,
+    });
+
+    assert.equal(duplicateAppend.appended, false);
+    const answeredEvents = (await readQuestionEvents(cwd)).filter((event) => (
+      event.type === 'question-answered' && event.question_id === record.question_id
+    ));
+    assert.equal(answeredEvents.length, 1);
+    assert.equal(answeredEvents[0]?.run_id, 'run-external-answer');
+    assert.equal(answeredEvents[0]?.state?.answer_count, 1);
   });
 
   it('serializes concurrent duplicate submissions so only one answer is accepted', async () => {

--- a/src/question/__tests__/state.test.ts
+++ b/src/question/__tests__/state.test.ts
@@ -14,7 +14,7 @@ import {
   submitQuestionAnswerById,
   waitForQuestionTerminalState,
 } from '../state.js';
-import { readQuestionEvents } from '../events.js';
+import { appendQuestionEvent, readQuestionEvents } from '../events.js';
 
 const tempDirs: string[] = [];
 
@@ -118,6 +118,166 @@ describe('question state', () => {
       }, { sessionId: 'sess-submit' }),
       (error) => error instanceof QuestionSubmitError && error.code === 'question_unknown',
     );
+  });
+
+  it('rejects submitted answers that do not match the prompt option schema', async () => {
+    const cwd = await makeRepo();
+    const { record } = await createQuestionRecord(cwd, {
+      questions: [
+        {
+          id: 'single',
+          question: 'Pick one',
+          options: [{ label: 'A', value: 'a' }],
+          allow_other: false,
+          other_label: 'Other',
+          multi_select: false,
+          type: 'single-answerable',
+        },
+        {
+          id: 'multi',
+          question: 'Pick many',
+          options: [{ label: 'B', value: 'b' }, { label: 'C', value: 'c' }],
+          allow_other: false,
+          other_label: 'Other',
+          multi_select: true,
+          type: 'multi-answerable',
+        },
+      ],
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-invalid');
+
+    await assert.rejects(
+      () => submitQuestionAnswerById(cwd, record.question_id, {
+        answers: [
+          {
+            question_id: 'single',
+            answer: { kind: 'option', value: 'missing', selected_labels: ['Missing'], selected_values: ['missing'] },
+          },
+          {
+            question_id: 'multi',
+            answer: { kind: 'multi', value: ['b'], selected_labels: ['B'], selected_values: ['b'] },
+          },
+        ],
+      }, { sessionId: 'sess-invalid' }),
+      (error) => error instanceof QuestionSubmitError && error.code === 'question_invalid_answer',
+    );
+
+    await assert.rejects(
+      () => submitQuestionAnswerById(cwd, record.question_id, {
+        answers: [
+          {
+            question_id: 'single',
+            answer: { kind: 'other', value: 'custom', selected_labels: ['Other'], selected_values: ['custom'], other_text: 'custom' },
+          },
+          {
+            question_id: 'multi',
+            answer: { kind: 'multi', value: ['b'], selected_labels: ['B'], selected_values: ['b'] },
+          },
+        ],
+      }, { sessionId: 'sess-invalid' }),
+      (error) => error instanceof QuestionSubmitError && error.code === 'question_invalid_answer',
+    );
+
+    await assert.rejects(
+      () => submitQuestionAnswerById(cwd, record.question_id, {
+        answers: [
+          {
+            question_id: 'single',
+            answer: { kind: 'multi', value: ['a'], selected_labels: ['A'], selected_values: ['a'] },
+          },
+          {
+            question_id: 'multi',
+            answer: { kind: 'multi', value: ['b'], selected_labels: ['B'], selected_values: ['b'] },
+          },
+        ],
+      }, { sessionId: 'sess-invalid' }),
+      (error) => error instanceof QuestionSubmitError && error.code === 'question_invalid_answer',
+    );
+
+    const loaded = await readQuestionRecord(getQuestionRecordPath(cwd, record.question_id, 'sess-invalid'));
+    assert.equal(loaded?.status, 'pending');
+  });
+
+  it('serializes concurrent duplicate submissions so only one answer is accepted', async () => {
+    const cwd = await makeRepo();
+    const { record } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-race');
+
+    const payload = {
+      answer: {
+        kind: 'option',
+        value: 'a',
+        selected_labels: ['A'],
+        selected_values: ['a'],
+      },
+    };
+    const results = await Promise.allSettled([
+      submitQuestionAnswerById(cwd, record.question_id, payload, { sessionId: 'sess-race' }),
+      submitQuestionAnswerById(cwd, record.question_id, payload, { sessionId: 'sess-race' }),
+    ]);
+
+    assert.equal(results.filter((result) => result.status === 'fulfilled').length, 1);
+    const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+    assert.equal(rejected?.reason instanceof QuestionSubmitError, true);
+    assert.equal((rejected?.reason as QuestionSubmitError).code, 'question_not_open');
+    const answeredEvents = (await readQuestionEvents(cwd)).filter((event) => (
+      event.type === 'question-answered' && event.question_id === record.question_id
+    ));
+    assert.equal(answeredEvents.length, 1);
+  });
+
+  it('preserves original run_id correlation on later answered and error events', async () => {
+    const cwd = await makeRepo();
+    const { record, recordPath } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-run', new Date('2026-05-11T00:00:00.000Z'), {
+      emitEvent: true,
+      runId: 'run-original',
+    });
+
+    await submitQuestionAnswerById(cwd, record.question_id, {
+      answer: {
+        kind: 'option',
+        value: 'a',
+        selected_labels: ['A'],
+        selected_values: ['a'],
+      },
+    }, { sessionId: 'sess-run' });
+
+    const answerEvent = (await readQuestionEvents(cwd)).find((event) => (
+      event.type === 'question-answered' && event.question_id === record.question_id
+    ));
+    assert.equal(answerEvent?.run_id, 'run-original');
+
+    const { recordPath: errorPath } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-run', new Date('2026-05-11T00:01:00.000Z'), {
+      emitEvent: true,
+      runId: 'run-error-original',
+    });
+    const errorRecord = await markQuestionTerminalError(errorPath, 'error', 'question_runtime_failed', 'boom');
+    await appendQuestionEvent(cwd, 'question-error', errorRecord, { recordPath: errorPath });
+    const errorEvent = (await readQuestionEvents(cwd)).find((event) => (
+      event.type === 'question-error' && event.question_id === errorRecord.question_id
+    ));
+    assert.equal(errorEvent?.run_id, 'run-error-original');
   });
 
   it('waits for terminal answered state and returns free-text other values exactly', async () => {

--- a/src/question/__tests__/state.test.ts
+++ b/src/question/__tests__/state.test.ts
@@ -9,9 +9,12 @@ import {
   markQuestionAnswered,
   markQuestionPrompting,
   markQuestionTerminalError,
+  QuestionSubmitError,
   readQuestionRecord,
+  submitQuestionAnswerById,
   waitForQuestionTerminalState,
 } from '../state.js';
+import { readQuestionEvents } from '../events.js';
 
 const tempDirs: string[] = [];
 
@@ -40,6 +43,81 @@ describe('question state', () => {
     const loaded = await readQuestionRecord(recordPath);
     assert.equal(loaded?.question, 'Pick one');
     assert.equal(loaded?.type, 'single-answerable');
+  });
+
+  it('emits a structured creation event with correlation metadata', async () => {
+    const cwd = await makeRepo();
+    const { record } = await createQuestionRecord(cwd, {
+      header: 'Decision',
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a', description: 'Alpha lane' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+      source: 'test-source',
+    }, 'sess-events', new Date('2026-05-11T00:00:00.000Z'), {
+      emitEvent: true,
+      timeoutMs: 1234,
+      runId: 'run-1',
+    });
+
+    const event = (await readQuestionEvents(cwd)).find((item) => item.question_id === record.question_id);
+    assert.equal(event?.type, 'question-created');
+    assert.equal(event?.session_id, 'sess-events');
+    assert.equal(event?.run_id, 'run-1');
+    assert.equal(event?.context_summary, 'Decision — Pick one');
+    assert.equal(event?.option_schema?.[0]?.options[0]?.description, 'Alpha lane');
+    assert.equal(event?.state?.timeout_ms, 1234);
+  });
+
+  it('submits bounded answers by id and rejects duplicate stale or unknown submissions', async () => {
+    const cwd = await makeRepo();
+    const { record } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-submit');
+
+    const submitted = await submitQuestionAnswerById(cwd, record.question_id, {
+      answer: {
+        kind: 'option',
+        value: 'a',
+        selected_labels: ['A'],
+        selected_values: ['a'],
+      },
+    }, { sessionId: 'sess-submit' });
+
+    assert.equal(submitted.record.status, 'answered');
+    assert.equal(submitted.record.answer?.value, 'a');
+    const events = await readQuestionEvents(cwd);
+    assert.equal(events.at(-1)?.type, 'question-answered');
+    assert.equal(events.at(-1)?.state?.answer_count, 1);
+
+    await assert.rejects(
+      () => submitQuestionAnswerById(cwd, record.question_id, {
+        answer: {
+          kind: 'option',
+          value: 'a',
+          selected_labels: ['A'],
+          selected_values: ['a'],
+        },
+      }, { sessionId: 'sess-submit' }),
+      (error) => error instanceof QuestionSubmitError && error.code === 'question_not_open',
+    );
+
+    await assert.rejects(
+      () => submitQuestionAnswerById(cwd, 'question-missing', {
+        answer: {
+          kind: 'option',
+          value: 'a',
+          selected_labels: ['A'],
+          selected_values: ['a'],
+        },
+      }, { sessionId: 'sess-submit' }),
+      (error) => error instanceof QuestionSubmitError && error.code === 'question_unknown',
+    );
   });
 
   it('waits for terminal answered state and returns free-text other values exactly', async () => {

--- a/src/question/__tests__/state.test.ts
+++ b/src/question/__tests__/state.test.ts
@@ -202,6 +202,86 @@ describe('question state', () => {
     assert.equal(loaded?.status, 'pending');
   });
 
+  it('rejects other answers whose selected labels do not exactly match the other label', async () => {
+    const cwd = await makeRepo();
+    const { record } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      other_label: 'Something else',
+      multi_select: false,
+    }, 'sess-other-labels');
+
+    await assert.rejects(
+      () => submitQuestionAnswerById(cwd, record.question_id, {
+        answer: {
+          kind: 'other',
+          value: 'custom',
+          selected_labels: ['Something else', 'custom'],
+          selected_values: ['custom'],
+          other_text: 'custom',
+        },
+      }, { sessionId: 'sess-other-labels' }),
+      (error) => error instanceof QuestionSubmitError && error.code === 'question_invalid_answer',
+    );
+
+    await assert.rejects(
+      () => submitQuestionAnswerById(cwd, record.question_id, {
+        answer: {
+          kind: 'other',
+          value: 'custom',
+          selected_labels: ['Other'],
+          selected_values: ['custom'],
+          other_text: 'custom',
+        },
+      }, { sessionId: 'sess-other-labels' }),
+      (error) => error instanceof QuestionSubmitError && error.code === 'question_invalid_answer',
+    );
+
+    const loaded = await readQuestionRecord(getQuestionRecordPath(cwd, record.question_id, 'sess-other-labels'));
+    assert.equal(loaded?.status, 'pending');
+  });
+
+  it('rejects multi answers whose selected labels do not match selected values', async () => {
+    const cwd = await makeRepo();
+    const { record } = await createQuestionRecord(cwd, {
+      question: 'Pick many',
+      options: [{ label: 'B', value: 'b' }, { label: 'C', value: 'c' }],
+      allow_other: true,
+      other_label: 'Other value',
+      multi_select: true,
+      type: 'multi-answerable',
+    }, 'sess-multi-labels');
+
+    await assert.rejects(
+      () => submitQuestionAnswerById(cwd, record.question_id, {
+        answer: {
+          kind: 'multi',
+          value: ['b', 'c'],
+          selected_labels: ['C', 'B'],
+          selected_values: ['b', 'c'],
+        },
+      }, { sessionId: 'sess-multi-labels' }),
+      (error) => error instanceof QuestionSubmitError && error.code === 'question_invalid_answer',
+    );
+
+    await assert.rejects(
+      () => submitQuestionAnswerById(cwd, record.question_id, {
+        answer: {
+          kind: 'multi',
+          value: ['b', 'custom'],
+          selected_labels: ['B', 'custom'],
+          selected_values: ['b', 'custom'],
+          other_text: 'custom',
+        },
+      }, { sessionId: 'sess-multi-labels' }),
+      (error) => error instanceof QuestionSubmitError && error.code === 'question_invalid_answer',
+    );
+
+    const loaded = await readQuestionRecord(getQuestionRecordPath(cwd, record.question_id, 'sess-multi-labels'));
+    assert.equal(loaded?.status, 'pending');
+  });
+
   it('dedupes answered lifecycle events when a waiting command observes an externally submitted answer', async () => {
     const cwd = await makeRepo();
     const { record, recordPath } = await createQuestionRecord(cwd, {

--- a/src/question/__tests__/ui.test.ts
+++ b/src/question/__tests__/ui.test.ts
@@ -275,7 +275,7 @@ describe('question ui arrow navigation', () => {
     }
   });
 
-  it('injects using fresh renderer metadata when the UI read a pre-prompting record', async () => {
+  it('answers by writing record state only when renderer metadata races the UI answer', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-stale-record-'));
     try {
       const { recordPath } = await createQuestionRecord(
@@ -321,7 +321,7 @@ describe('question ui arrow navigation', () => {
       }, 25);
 
       await runPromise;
-      assert.deepEqual(injected, [{ paneId: '%11', value: 'b' }]);
+      assert.deepEqual(injected, []);
       const loaded = await readQuestionRecord(recordPath);
       assert.equal(loaded?.status, 'answered');
       assert.equal(loaded?.renderer?.return_target, '%11');
@@ -330,7 +330,7 @@ describe('question ui arrow navigation', () => {
     }
   });
 
-  it('falls back to launcher-provided return-target env when prompting metadata races the UI answer', async () => {
+  it('does not use launcher return-target env as an answer transport', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-env-return-'));
     try {
       const { recordPath } = await createQuestionRecord(
@@ -367,13 +367,13 @@ describe('question ui arrow navigation', () => {
       }, 25);
 
       await runPromise;
-      assert.deepEqual(injected, [{ paneId: '%11', value: 'a' }]);
+      assert.deepEqual(injected, []);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('submits multi-answerable checkbox selections through the env return-target fallback', async () => {
+  it('persists multi-answerable checkbox selections without return-pane injection', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-multi-env-return-'));
     try {
       const { recordPath } = await createQuestionRecord(
@@ -416,7 +416,7 @@ describe('question ui arrow navigation', () => {
       }, 25);
 
       await runPromise;
-      assert.deepEqual(injected, [{ paneId: '%11', value: ['a', 'b'] }]);
+      assert.deepEqual(injected, []);
       const loaded = await readQuestionRecord(recordPath);
       assert.equal(loaded?.status, 'answered');
       assert.deepEqual(loaded?.answer?.selected_values, ['a', 'b']);
@@ -492,7 +492,7 @@ describe('question ui batch wizard', () => {
     }
   });
 
-  it('injects every batch answer into the return pane', async () => {
+  it('persists every batch answer without return-pane injection', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-batch-inject-'));
     try {
       const { recordPath } = await createQuestionRecord(
@@ -534,7 +534,7 @@ describe('question ui batch wizard', () => {
       }, 25);
 
       await runPromise;
-      assert.deepEqual(injected, [{ paneId: '%11', values: ['a', 'd'] }]);
+      assert.deepEqual(injected, []);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/question/events.ts
+++ b/src/question/events.ts
@@ -61,7 +61,7 @@ export function buildQuestionEvent(
 ): QuestionEventRecord {
   const now = options.now ?? new Date();
   const answerCount = record.answers?.length ?? (record.answer ? 1 : 0);
-  const runId = options.runId ?? resolveQuestionRunId();
+  const runId = options.runId ?? record.run_id ?? resolveQuestionRunId();
   return {
     kind: 'omx.question-event/v1',
     event_id: `${type}-${record.question_id}-${now.toISOString().replace(/[:.]/g, '-')}`,

--- a/src/question/events.ts
+++ b/src/question/events.ts
@@ -1,10 +1,14 @@
 import { existsSync } from 'node:fs';
-import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { sleep } from '../utils/sleep.js';
 import { getBaseStateDir } from '../mcp/state-paths.js';
 import type { QuestionAnswerEntry, QuestionRecord } from './types.js';
 
 export type QuestionEventType = 'question-created' | 'question-answered' | 'question-error';
+
+const QUESTION_EVENT_LOCK_STALE_MS = 30_000;
+const QUESTION_EVENT_LOCK_TIMEOUT_MS = 10_000;
 
 export interface QuestionEventRecord {
   kind: 'omx.question-event/v1';
@@ -30,6 +34,80 @@ export interface QuestionEventRecord {
 
 export function getQuestionEventsPath(cwd: string): string {
   return join(getBaseStateDir(cwd), 'question-events.jsonl');
+}
+
+function questionEventLockOwnerToken(): string {
+  return `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+}
+
+async function maybeRecoverStaleQuestionEventLock(lockDir: string): Promise<boolean> {
+  try {
+    const info = await stat(lockDir);
+    if (Date.now() - info.mtimeMs > QUESTION_EVENT_LOCK_STALE_MS) {
+      await rm(lockDir, { recursive: true, force: true });
+      return true;
+    }
+  } catch {
+  }
+  return false;
+}
+
+async function withQuestionEventLock<T>(eventsPath: string, lockName: string, fn: () => Promise<T>): Promise<T> {
+  const lockDir = `${eventsPath}.${lockName}.lock`;
+  const ownerPath = join(lockDir, 'owner');
+  const ownerToken = questionEventLockOwnerToken();
+  const deadline = Date.now() + QUESTION_EVENT_LOCK_TIMEOUT_MS;
+  await mkdir(dirname(lockDir), { recursive: true });
+  while (true) {
+    try {
+      await mkdir(lockDir);
+      try {
+        await writeFile(ownerPath, ownerToken, 'utf8');
+      } catch (error) {
+        await rm(lockDir, { recursive: true, force: true });
+        throw error;
+      }
+      break;
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code !== 'EEXIST') throw error;
+      if (await maybeRecoverStaleQuestionEventLock(lockDir)) continue;
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out acquiring question event lock for ${eventsPath}`);
+      }
+      await sleep(25);
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    try {
+      const currentOwner = await readFile(ownerPath, 'utf8');
+      if (currentOwner.trim() === ownerToken) {
+        await rm(lockDir, { recursive: true, force: true });
+      }
+    } catch {
+    }
+  }
+}
+
+function parseQuestionEventLines(contents: string, options: { type?: QuestionEventType } = {}): QuestionEventRecord[] {
+  const lines = contents.split(/\r?\n/).filter(Boolean);
+  return lines.flatMap((line) => {
+    try {
+      const parsed = JSON.parse(line) as QuestionEventRecord;
+      if (options.type && parsed.type !== options.type) return [];
+      return [parsed];
+    } catch {
+      return [];
+    }
+  });
+}
+
+async function readAllQuestionEventsFromPath(path: string, options: { type?: QuestionEventType } = {}): Promise<QuestionEventRecord[]> {
+  if (!existsSync(path)) return [];
+  return parseQuestionEventLines(await readFile(path, 'utf-8'), options);
 }
 
 function safeString(value: unknown): string {
@@ -98,20 +176,25 @@ export async function appendQuestionEvent(
   return event;
 }
 
+export async function appendQuestionAnsweredEventOnce(
+  cwd: string,
+  record: QuestionRecord,
+  options: { recordPath?: string; timeoutMs?: number; runId?: string; now?: Date } = {},
+): Promise<{ event: QuestionEventRecord; appended: boolean }> {
+  const path = getQuestionEventsPath(cwd);
+  return await withQuestionEventLock(path, `answered-${record.question_id}`, async () => {
+    const existing = (await readAllQuestionEventsFromPath(path, { type: 'question-answered' }))
+      .find((event) => event.question_id === record.question_id);
+    if (existing) return { event: existing, appended: false };
+    const event = await appendQuestionEvent(cwd, 'question-answered', record, options);
+    return { event, appended: true };
+  });
+}
+
 export async function readQuestionEvents(cwd: string, options: { limit?: number; type?: QuestionEventType } = {}): Promise<QuestionEventRecord[]> {
   const path = getQuestionEventsPath(cwd);
-  if (!existsSync(path)) return [];
   const limit = Math.max(1, Math.min(options.limit ?? 100, 1000));
-  const lines = (await readFile(path, 'utf-8')).split(/\r?\n/).filter(Boolean);
-  const events = lines.flatMap((line) => {
-    try {
-      const parsed = JSON.parse(line) as QuestionEventRecord;
-      if (options.type && parsed.type !== options.type) return [];
-      return [parsed];
-    } catch {
-      return [];
-    }
-  });
+  const events = await readAllQuestionEventsFromPath(path, { type: options.type });
   return events.slice(-limit);
 }
 

--- a/src/question/events.ts
+++ b/src/question/events.ts
@@ -1,0 +1,153 @@
+import { existsSync } from 'node:fs';
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { getBaseStateDir } from '../mcp/state-paths.js';
+import type { QuestionAnswerEntry, QuestionRecord } from './types.js';
+
+export type QuestionEventType = 'question-created' | 'question-answered' | 'question-error';
+
+export interface QuestionEventRecord {
+  kind: 'omx.question-event/v1';
+  event_id: string;
+  type: QuestionEventType;
+  question_id: string;
+  session_id?: string;
+  run_id?: string;
+  created_at: string;
+  question_created_at?: string;
+  status: QuestionRecord['status'];
+  source?: string;
+  context_summary?: string;
+  option_schema?: QuestionRecord['questions'];
+  state?: {
+    record_path?: string;
+    renderer?: QuestionRecord['renderer'];
+    timeout_ms?: number;
+    error?: QuestionRecord['error'];
+    answer_count?: number;
+  };
+}
+
+export function getQuestionEventsPath(cwd: string): string {
+  return join(getBaseStateDir(cwd), 'question-events.jsonl');
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function resolveQuestionRunId(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return safeString(env.OMX_RUN_ID) || safeString(env.OMX_RUN_ID_OVERRIDE) || safeString(env.OMX_CURRENT_RUN_ID) || undefined;
+}
+
+function truncateSummary(value: string, max = 600): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized.length > max ? `${normalized.slice(0, max - 1)}…` : normalized;
+}
+
+export function summarizeQuestionContext(record: QuestionRecord): string {
+  const parts: string[] = [];
+  if (record.header) parts.push(record.header);
+  if (record.question) parts.push(record.question);
+  const questions = record.questions ?? [];
+  if (questions.length > 1) parts.push(`${questions.length} structured questions`);
+  return truncateSummary(parts.join(' — ') || record.question_id);
+}
+
+export function buildQuestionEvent(
+  type: QuestionEventType,
+  record: QuestionRecord,
+  options: { recordPath?: string; timeoutMs?: number; runId?: string; now?: Date } = {},
+): QuestionEventRecord {
+  const now = options.now ?? new Date();
+  const answerCount = record.answers?.length ?? (record.answer ? 1 : 0);
+  const runId = options.runId ?? resolveQuestionRunId();
+  return {
+    kind: 'omx.question-event/v1',
+    event_id: `${type}-${record.question_id}-${now.toISOString().replace(/[:.]/g, '-')}`,
+    type,
+    question_id: record.question_id,
+    ...(record.session_id ? { session_id: record.session_id } : {}),
+    ...(runId ? { run_id: runId } : {}),
+    created_at: now.toISOString(),
+    question_created_at: record.created_at,
+    status: record.status,
+    ...(record.source ? { source: record.source } : {}),
+    context_summary: summarizeQuestionContext(record),
+    option_schema: record.questions,
+    state: {
+      ...(options.recordPath ? { record_path: options.recordPath } : {}),
+      ...(record.renderer ? { renderer: record.renderer } : {}),
+      ...(typeof options.timeoutMs === 'number' ? { timeout_ms: options.timeoutMs } : {}),
+      ...(record.error ? { error: record.error } : {}),
+      ...(answerCount ? { answer_count: answerCount } : {}),
+    },
+  };
+}
+
+export async function appendQuestionEvent(
+  cwd: string,
+  type: QuestionEventType,
+  record: QuestionRecord,
+  options: { recordPath?: string; timeoutMs?: number; runId?: string; now?: Date } = {},
+): Promise<QuestionEventRecord> {
+  const event = buildQuestionEvent(type, record, options);
+  const path = getQuestionEventsPath(cwd);
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, `${JSON.stringify(event)}\n`);
+  return event;
+}
+
+export async function readQuestionEvents(cwd: string, options: { limit?: number; type?: QuestionEventType } = {}): Promise<QuestionEventRecord[]> {
+  const path = getQuestionEventsPath(cwd);
+  if (!existsSync(path)) return [];
+  const limit = Math.max(1, Math.min(options.limit ?? 100, 1000));
+  const lines = (await readFile(path, 'utf-8')).split(/\r?\n/).filter(Boolean);
+  const events = lines.flatMap((line) => {
+    try {
+      const parsed = JSON.parse(line) as QuestionEventRecord;
+      if (options.type && parsed.type !== options.type) return [];
+      return [parsed];
+    } catch {
+      return [];
+    }
+  });
+  return events.slice(-limit);
+}
+
+export function normalizeSubmittedAnswers(record: QuestionRecord, raw: unknown): QuestionAnswerEntry[] {
+  const rawAnswers = Array.isArray(raw)
+    ? raw
+    : raw && typeof raw === 'object' && Array.isArray((raw as { answers?: unknown }).answers)
+      ? (raw as { answers: unknown[] }).answers
+      : raw && typeof raw === 'object' && (raw as { answer?: unknown }).answer
+        ? [{ question_id: record.questions?.[0]?.id ?? 'q-1', index: 0, answer: (raw as { answer: unknown }).answer }]
+        : [];
+
+  if (rawAnswers.length === 0) throw new Error('answer payload must include answer or answers[]');
+  const validQuestionIds = new Set((record.questions ?? []).map((question) => question.id));
+  if (validQuestionIds.size === 0) validQuestionIds.add('q-1');
+  const seen = new Set<string>();
+
+  return rawAnswers.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) throw new Error(`answers[${index}] must be an object`);
+    const object = entry as Record<string, unknown>;
+    const questionId = safeString(object.question_id) || (record.questions?.[index]?.id ?? (index === 0 ? 'q-1' : ''));
+    if (!questionId || !validQuestionIds.has(questionId)) throw new Error(`answers[${index}].question_id is unknown for this question: ${questionId || '<missing>'}`);
+    if (seen.has(questionId)) throw new Error(`answers question_id must be unique: ${questionId}`);
+    seen.add(questionId);
+    const answer = object.answer;
+    if (!answer || typeof answer !== 'object' || Array.isArray(answer)) throw new Error(`answers[${index}].answer must be an object`);
+    const answerObject = answer as Record<string, unknown>;
+    const kind = safeString(answerObject.kind);
+    if (!['option', 'other', 'multi'].includes(kind)) throw new Error(`answers[${index}].answer.kind must be option, other, or multi`);
+    if (!Array.isArray(answerObject.selected_labels) || !Array.isArray(answerObject.selected_values)) {
+      throw new Error(`answers[${index}].answer must include selected_labels[] and selected_values[]`);
+    }
+    return {
+      question_id: questionId,
+      index: Number.isInteger(object.index) ? object.index as number : index,
+      answer: answerObject as unknown as QuestionAnswerEntry['answer'],
+    };
+  });
+}

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -1,9 +1,10 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { getStateDir } from '../mcp/state-paths.js';
 import { writeAtomic } from '../team/state.js';
 import { sleep } from '../utils/sleep.js';
+import { appendQuestionEvent, normalizeSubmittedAnswers } from './events.js';
 import { getNormalizedQuestionType, normalizeQuestionInput } from './types.js';
 import type {
   QuestionAnswer,
@@ -16,6 +17,21 @@ import type {
 
 const QUESTION_NAMESPACE = 'questions';
 const DEFAULT_POLL_INTERVAL_MS = 100;
+
+export type QuestionSubmitFailureCode =
+  | 'question_unknown'
+  | 'question_not_open'
+  | 'question_invalid_answer';
+
+export class QuestionSubmitError extends Error {
+  readonly code: QuestionSubmitFailureCode;
+
+  constructor(code: QuestionSubmitFailureCode, message: string) {
+    super(message);
+    this.name = 'QuestionSubmitError';
+    this.code = code;
+  }
+}
 
 function buildQuestionId(now = new Date()): string {
   return `question-${now.toISOString().replace(/[:.]/g, '-')}-$${Math.random().toString(16).slice(2, 10)}`.replace('$', '');
@@ -45,6 +61,7 @@ export async function createQuestionRecord(
   input: QuestionInput,
   sessionId?: string,
   now = new Date(),
+  options: { emitEvent?: boolean; timeoutMs?: number; runId?: string } = {},
 ): Promise<{ recordPath: string; record: QuestionRecord }> {
   const normalizedInput = normalizeQuestionInput(input);
   const questionId = buildQuestionId(now);
@@ -68,6 +85,14 @@ export async function createQuestionRecord(
   };
   const recordPath = getQuestionRecordPath(cwd, questionId, sessionId);
   await writeQuestionRecord(recordPath, record);
+  if (options.emitEvent) {
+    await appendQuestionEvent(cwd, 'question-created', record, {
+      recordPath,
+      timeoutMs: options.timeoutMs,
+      runId: options.runId,
+      now,
+    });
+  }
   return { recordPath, record };
 }
 
@@ -112,6 +137,72 @@ export async function markQuestionAnswered(
       error: undefined,
     };
   });
+}
+
+function isValidQuestionId(questionId: string): boolean {
+  return /^question-[A-Za-z0-9_.-]+$/.test(questionId) && !questionId.includes('..');
+}
+
+async function listQuestionRecordsInDir(dir: string): Promise<Array<{ recordPath: string; record: QuestionRecord }>> {
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  const records: Array<{ recordPath: string; record: QuestionRecord }> = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const recordPath = join(dir, entry.name);
+    const record = await readQuestionRecord(recordPath).catch(() => null);
+    if (record?.kind === 'omx.question/v1') records.push({ recordPath, record });
+  }
+  return records;
+}
+
+export async function listQuestionRecords(
+  cwd: string,
+  options: { sessionId?: string; status?: QuestionStatus | 'open'; limit?: number } = {},
+): Promise<Array<{ recordPath: string; record: QuestionRecord }>> {
+  const dirs = [getQuestionStateDir(cwd, options.sessionId)];
+  const records = (await Promise.all(dirs.map((dir) => listQuestionRecordsInDir(dir)))).flat();
+  const filtered = records.filter(({ record }) => {
+    if (!options.status) return true;
+    if (options.status === 'open') return record.status === 'pending' || record.status === 'prompting';
+    return record.status === options.status;
+  });
+  const limit = Math.max(1, Math.min(options.limit ?? 100, 1000));
+  return filtered
+    .sort((left, right) => left.record.created_at.localeCompare(right.record.created_at))
+    .slice(-limit);
+}
+
+export async function submitQuestionAnswerById(
+  cwd: string,
+  questionId: string,
+  answerPayload: unknown,
+  options: { sessionId?: string; runId?: string } = {},
+): Promise<{ recordPath: string; record: QuestionRecord }> {
+  const normalizedQuestionId = questionId.trim();
+  if (!isValidQuestionId(normalizedQuestionId)) {
+    throw new QuestionSubmitError('question_unknown', `Unknown question id: ${questionId}`);
+  }
+
+  const recordPath = getQuestionRecordPath(cwd, normalizedQuestionId, options.sessionId);
+  const current = await readQuestionRecord(recordPath);
+  if (!current) throw new QuestionSubmitError('question_unknown', `Unknown question id: ${normalizedQuestionId}`);
+  if (current.status !== 'pending' && current.status !== 'prompting') {
+    throw new QuestionSubmitError(
+      'question_not_open',
+      `Question ${normalizedQuestionId} is ${current.status}; only pending or prompting questions can be answered.`,
+    );
+  }
+
+  let answers: QuestionAnswerEntry[];
+  try {
+    answers = normalizeSubmittedAnswers(current, answerPayload);
+  } catch (error) {
+    throw new QuestionSubmitError('question_invalid_answer', error instanceof Error ? error.message : String(error));
+  }
+  const record = await markQuestionAnswered(recordPath, answers);
+  await appendQuestionEvent(cwd, 'question-answered', record, { recordPath, runId: options.runId });
+  return { recordPath, record };
 }
 
 export async function markQuestionTerminalError(

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -1,12 +1,13 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, readdir } from 'node:fs/promises';
+import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { getStateDir } from '../mcp/state-paths.js';
 import { writeAtomic } from '../team/state.js';
 import { sleep } from '../utils/sleep.js';
-import { appendQuestionEvent, normalizeSubmittedAnswers } from './events.js';
-import { getNormalizedQuestionType, normalizeQuestionInput } from './types.js';
+import { appendQuestionEvent, normalizeSubmittedAnswers, resolveQuestionRunId } from './events.js';
+import { getNormalizedQuestionType, isMultiAnswerableQuestion, normalizeQuestionInput } from './types.js';
 import type {
+  NormalizedQuestionItem,
   QuestionAnswer,
   QuestionAnswerEntry,
   QuestionInput,
@@ -17,6 +18,8 @@ import type {
 
 const QUESTION_NAMESPACE = 'questions';
 const DEFAULT_POLL_INTERVAL_MS = 100;
+const QUESTION_SUBMIT_LOCK_STALE_MS = 30_000;
+const QUESTION_SUBMIT_LOCK_TIMEOUT_MS = 10_000;
 
 export type QuestionSubmitFailureCode =
   | 'question_unknown'
@@ -66,6 +69,7 @@ export async function createQuestionRecord(
   const normalizedInput = normalizeQuestionInput(input);
   const questionId = buildQuestionId(now);
   const nowIso = now.toISOString();
+  const runId = options.runId ?? resolveQuestionRunId();
   const record: QuestionRecord = {
     kind: 'omx.question/v1',
     question_id: questionId,
@@ -73,6 +77,7 @@ export async function createQuestionRecord(
     created_at: nowIso,
     updated_at: nowIso,
     status: 'pending',
+    ...(runId ? { run_id: runId } : {}),
     ...(normalizedInput.header ? { header: normalizedInput.header } : {}),
     question: normalizedInput.question,
     options: normalizedInput.options,
@@ -156,6 +161,165 @@ async function listQuestionRecordsInDir(dir: string): Promise<Array<{ recordPath
   return records;
 }
 
+function lockOwnerToken(): string {
+  return `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+}
+
+async function maybeRecoverStaleQuestionLock(lockDir: string): Promise<boolean> {
+  try {
+    const info = await stat(lockDir);
+    if (Date.now() - info.mtimeMs > QUESTION_SUBMIT_LOCK_STALE_MS) {
+      await rm(lockDir, { recursive: true, force: true });
+      return true;
+    }
+  } catch {
+  }
+  return false;
+}
+
+async function withQuestionSubmitLock<T>(recordPath: string, fn: () => Promise<T>): Promise<T> {
+  const lockDir = `${recordPath}.submit.lock`;
+  const ownerPath = join(lockDir, 'owner');
+  const ownerToken = lockOwnerToken();
+  const deadline = Date.now() + QUESTION_SUBMIT_LOCK_TIMEOUT_MS;
+  await mkdir(dirname(lockDir), { recursive: true });
+  while (true) {
+    try {
+      await mkdir(lockDir);
+      try {
+        await writeFile(ownerPath, ownerToken, 'utf8');
+      } catch (error) {
+        await rm(lockDir, { recursive: true, force: true });
+        throw error;
+      }
+      break;
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code !== 'EEXIST') throw error;
+      if (await maybeRecoverStaleQuestionLock(lockDir)) continue;
+      if (Date.now() > deadline) {
+        throw new QuestionSubmitError('question_not_open', `Timed out acquiring submit lock for ${recordPath}`);
+      }
+      await sleep(25);
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    try {
+      const currentOwner = await readFile(ownerPath, 'utf8');
+      if (currentOwner.trim() === ownerToken) {
+        await rm(lockDir, { recursive: true, force: true });
+      }
+    } catch {
+    }
+  }
+}
+
+function validateStringArray(value: unknown, path: string): string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string' && item.trim().length > 0)) {
+    throw new Error(`${path} must be a non-empty string array`);
+  }
+  return value;
+}
+
+function assertNoDuplicateValues(values: string[], path: string): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) throw new Error(`${path} must not contain duplicate values: ${value}`);
+    seen.add(value);
+  }
+}
+
+function questionForAnswer(record: QuestionRecord, entry: QuestionAnswerEntry): NormalizedQuestionItem {
+  const question = (record.questions ?? []).find((item) => item.id === entry.question_id);
+  if (question) return question;
+  if (entry.question_id === 'q-1') {
+    return {
+      id: 'q-1',
+      ...(record.header ? { header: record.header } : {}),
+      question: record.question,
+      options: record.options,
+      allow_other: record.allow_other,
+      other_label: record.other_label,
+      multi_select: record.multi_select,
+      type: getNormalizedQuestionType(record),
+    };
+  }
+  throw new Error(`answers[${entry.index}].question_id is unknown for this question: ${entry.question_id}`);
+}
+
+function validateAnswerAgainstQuestion(question: NormalizedQuestionItem, entry: QuestionAnswerEntry): void {
+  const { answer } = entry;
+  const selectedValues = validateStringArray(answer.selected_values, `answers[${entry.index}].answer.selected_values`);
+  const selectedLabels = validateStringArray(answer.selected_labels, `answers[${entry.index}].answer.selected_labels`);
+  assertNoDuplicateValues(selectedValues, `answers[${entry.index}].answer.selected_values`);
+
+  const optionValues = new Set(question.options.map((option) => option.value));
+  const optionLabelsByValue = new Map(question.options.map((option) => [option.value, option.label]));
+  const multi = isMultiAnswerableQuestion(question);
+  const hasOtherText = typeof answer.other_text === 'string' && answer.other_text.trim().length > 0;
+  const otherText = hasOtherText ? answer.other_text!.trim() : undefined;
+  const outOfSchemaValues = selectedValues.filter((value) => !optionValues.has(value));
+
+  if (answer.kind === 'other') {
+    if (!question.allow_other) throw new Error(`answers[${entry.index}].answer.kind=other is not allowed for this question`);
+    if (multi) throw new Error(`answers[${entry.index}].answer.kind=other is only valid for single-answerable questions`);
+    if (!otherText) throw new Error(`answers[${entry.index}].answer.other_text must be a non-empty string`);
+    if (selectedValues.length !== 1 || selectedValues[0] !== otherText || answer.value !== otherText) {
+      throw new Error(`answers[${entry.index}].answer other value must match selected_values[0] and other_text`);
+    }
+    return;
+  }
+
+  if (answer.kind === 'option') {
+    if (multi) throw new Error(`answers[${entry.index}].answer.kind=option is only valid for single-answerable questions`);
+    if (selectedValues.length !== 1 || selectedLabels.length !== 1) {
+      throw new Error(`answers[${entry.index}].answer must select exactly one option`);
+    }
+    const selectedValue = selectedValues[0]!;
+    if (!optionValues.has(selectedValue)) {
+      throw new Error(`answers[${entry.index}].answer selected value is not in the option schema: ${selectedValue}`);
+    }
+    if (answer.value !== selectedValue) {
+      throw new Error(`answers[${entry.index}].answer.value must match selected_values[0]`);
+    }
+    if (selectedLabels[0] !== optionLabelsByValue.get(selectedValue)) {
+      throw new Error(`answers[${entry.index}].answer.selected_labels[0] must match the selected option label`);
+    }
+    return;
+  }
+
+  if (!multi) throw new Error(`answers[${entry.index}].answer.kind=multi is only valid for multi-answerable questions`);
+  if (!Array.isArray(answer.value)) throw new Error(`answers[${entry.index}].answer.value must be an array for multi answers`);
+  if (answer.value.length !== selectedValues.length || answer.value.some((value, index) => value !== selectedValues[index])) {
+    throw new Error(`answers[${entry.index}].answer.value must match selected_values`);
+  }
+  if (outOfSchemaValues.length > 0) {
+    if (!question.allow_other) {
+      throw new Error(`answers[${entry.index}].answer selected value is not in the option schema: ${outOfSchemaValues[0]}`);
+    }
+    if (!otherText || outOfSchemaValues.length !== 1 || outOfSchemaValues[0] !== otherText) {
+      throw new Error(`answers[${entry.index}].answer out-of-schema selection must match a single other_text value`);
+    }
+  }
+  const expectedLabelCount = selectedValues.filter((value) => optionValues.has(value)).length + (otherText ? 1 : 0);
+  if (selectedLabels.length !== expectedLabelCount) {
+    throw new Error(`answers[${entry.index}].answer.selected_labels cardinality must match selected values`);
+  }
+}
+
+function validateSubmittedAnswersAgainstSchema(record: QuestionRecord, answers: QuestionAnswerEntry[]): void {
+  const expectedQuestionIds = new Set((record.questions ?? []).map((question) => question.id));
+  if (expectedQuestionIds.size > 0 && answers.length !== expectedQuestionIds.size) {
+    throw new Error(`answer payload must include exactly one answer for each question (${expectedQuestionIds.size})`);
+  }
+  for (const entry of answers) {
+    validateAnswerAgainstQuestion(questionForAnswer(record, entry), entry);
+  }
+}
+
 export async function listQuestionRecords(
   cwd: string,
   options: { sessionId?: string; status?: QuestionStatus | 'open'; limit?: number } = {},
@@ -185,24 +349,27 @@ export async function submitQuestionAnswerById(
   }
 
   const recordPath = getQuestionRecordPath(cwd, normalizedQuestionId, options.sessionId);
-  const current = await readQuestionRecord(recordPath);
-  if (!current) throw new QuestionSubmitError('question_unknown', `Unknown question id: ${normalizedQuestionId}`);
-  if (current.status !== 'pending' && current.status !== 'prompting') {
-    throw new QuestionSubmitError(
-      'question_not_open',
-      `Question ${normalizedQuestionId} is ${current.status}; only pending or prompting questions can be answered.`,
-    );
-  }
+  return await withQuestionSubmitLock(recordPath, async () => {
+    const current = await readQuestionRecord(recordPath);
+    if (!current) throw new QuestionSubmitError('question_unknown', `Unknown question id: ${normalizedQuestionId}`);
+    if (current.status !== 'pending' && current.status !== 'prompting') {
+      throw new QuestionSubmitError(
+        'question_not_open',
+        `Question ${normalizedQuestionId} is ${current.status}; only pending or prompting questions can be answered.`,
+      );
+    }
 
-  let answers: QuestionAnswerEntry[];
-  try {
-    answers = normalizeSubmittedAnswers(current, answerPayload);
-  } catch (error) {
-    throw new QuestionSubmitError('question_invalid_answer', error instanceof Error ? error.message : String(error));
-  }
-  const record = await markQuestionAnswered(recordPath, answers);
-  await appendQuestionEvent(cwd, 'question-answered', record, { recordPath, runId: options.runId });
-  return { recordPath, record };
+    let answers: QuestionAnswerEntry[];
+    try {
+      answers = normalizeSubmittedAnswers(current, answerPayload);
+      validateSubmittedAnswersAgainstSchema(current, answers);
+    } catch (error) {
+      throw new QuestionSubmitError('question_invalid_answer', error instanceof Error ? error.message : String(error));
+    }
+    const record = await markQuestionAnswered(recordPath, answers);
+    await appendQuestionEvent(cwd, 'question-answered', record, { recordPath, runId: options.runId });
+    return { recordPath, record };
+  });
 }
 
 export async function markQuestionTerminalError(

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -232,6 +232,34 @@ function assertNoDuplicateValues(values: string[], path: string): void {
   }
 }
 
+function expectedSelectedLabelsForValues(
+  question: NormalizedQuestionItem,
+  selectedValues: string[],
+  otherText: string | undefined,
+): string[] {
+  const optionLabelsByValue = new Map(question.options.map((option) => [option.value, option.label]));
+  return selectedValues.map((value) => {
+    const optionLabel = optionLabelsByValue.get(value);
+    if (optionLabel) return optionLabel;
+    if (question.allow_other && otherText && value === otherText) return question.other_label;
+    throw new Error(`selected value is not in the option schema: ${value}`);
+  });
+}
+
+function assertSelectedLabelsMatch(
+  selectedLabels: string[],
+  expectedLabels: string[],
+  path: string,
+): void {
+  if (selectedLabels.length !== expectedLabels.length) {
+    throw new Error(`${path} cardinality must match selected values`);
+  }
+  const mismatchIndex = selectedLabels.findIndex((label, index) => label !== expectedLabels[index]);
+  if (mismatchIndex !== -1) {
+    throw new Error(`${path}[${mismatchIndex}] must match the selected value label`);
+  }
+}
+
 function questionForAnswer(record: QuestionRecord, entry: QuestionAnswerEntry): NormalizedQuestionItem {
   const question = (record.questions ?? []).find((item) => item.id === entry.question_id);
   if (question) return question;
@@ -257,7 +285,6 @@ function validateAnswerAgainstQuestion(question: NormalizedQuestionItem, entry: 
   assertNoDuplicateValues(selectedValues, `answers[${entry.index}].answer.selected_values`);
 
   const optionValues = new Set(question.options.map((option) => option.value));
-  const optionLabelsByValue = new Map(question.options.map((option) => [option.value, option.label]));
   const multi = isMultiAnswerableQuestion(question);
   const hasOtherText = typeof answer.other_text === 'string' && answer.other_text.trim().length > 0;
   const otherText = hasOtherText ? answer.other_text!.trim() : undefined;
@@ -270,6 +297,11 @@ function validateAnswerAgainstQuestion(question: NormalizedQuestionItem, entry: 
     if (selectedValues.length !== 1 || selectedValues[0] !== otherText || answer.value !== otherText) {
       throw new Error(`answers[${entry.index}].answer other value must match selected_values[0] and other_text`);
     }
+    assertSelectedLabelsMatch(
+      selectedLabels,
+      [question.other_label],
+      `answers[${entry.index}].answer.selected_labels`,
+    );
     return;
   }
 
@@ -285,9 +317,11 @@ function validateAnswerAgainstQuestion(question: NormalizedQuestionItem, entry: 
     if (answer.value !== selectedValue) {
       throw new Error(`answers[${entry.index}].answer.value must match selected_values[0]`);
     }
-    if (selectedLabels[0] !== optionLabelsByValue.get(selectedValue)) {
-      throw new Error(`answers[${entry.index}].answer.selected_labels[0] must match the selected option label`);
-    }
+    assertSelectedLabelsMatch(
+      selectedLabels,
+      expectedSelectedLabelsForValues(question, selectedValues, undefined),
+      `answers[${entry.index}].answer.selected_labels`,
+    );
     return;
   }
 
@@ -304,10 +338,11 @@ function validateAnswerAgainstQuestion(question: NormalizedQuestionItem, entry: 
       throw new Error(`answers[${entry.index}].answer out-of-schema selection must match a single other_text value`);
     }
   }
-  const expectedLabelCount = selectedValues.filter((value) => optionValues.has(value)).length + (otherText ? 1 : 0);
-  if (selectedLabels.length !== expectedLabelCount) {
-    throw new Error(`answers[${entry.index}].answer.selected_labels cardinality must match selected values`);
-  }
+  assertSelectedLabelsMatch(
+    selectedLabels,
+    expectedSelectedLabelsForValues(question, selectedValues, otherText),
+    `answers[${entry.index}].answer.selected_labels`,
+  );
 }
 
 function validateSubmittedAnswersAgainstSchema(record: QuestionRecord, answers: QuestionAnswerEntry[]): void {

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { getStateDir } from '../mcp/state-paths.js';
 import { writeAtomic } from '../team/state.js';
 import { sleep } from '../utils/sleep.js';
-import { appendQuestionEvent, normalizeSubmittedAnswers, resolveQuestionRunId } from './events.js';
+import { appendQuestionAnsweredEventOnce, appendQuestionEvent, normalizeSubmittedAnswers, resolveQuestionRunId } from './events.js';
 import { getNormalizedQuestionType, isMultiAnswerableQuestion, normalizeQuestionInput } from './types.js';
 import type {
   NormalizedQuestionItem,
@@ -367,7 +367,7 @@ export async function submitQuestionAnswerById(
       throw new QuestionSubmitError('question_invalid_answer', error instanceof Error ? error.message : String(error));
     }
     const record = await markQuestionAnswered(recordPath, answers);
-    await appendQuestionEvent(cwd, 'question-answered', record, { recordPath, runId: options.runId });
+    await appendQuestionAnsweredEventOnce(cwd, record, { recordPath, runId: options.runId });
     return { recordPath, record };
   });
 }

--- a/src/question/types.ts
+++ b/src/question/types.ts
@@ -71,6 +71,7 @@ export interface QuestionRecord {
   created_at: string;
   updated_at: string;
   status: QuestionStatus;
+  run_id?: string;
   header?: string;
   question: string;
   options: QuestionOption[];

--- a/src/question/ui.ts
+++ b/src/question/ui.ts
@@ -1,7 +1,6 @@
 import { emitKeypressEvents } from 'node:readline';
 import { createInterface as createPromptInterface } from 'node:readline/promises';
 import { stdin as defaultInput, stdout as defaultOutput } from 'node:process';
-import { injectQuestionAnswersToPane } from './renderer.js';
 import { markQuestionAnswered, markQuestionTerminalError, readQuestionRecord } from './state.js';
 import { isMultiAnswerableQuestion } from './types.js';
 import type { NormalizedQuestionItem, QuestionAnswer, QuestionAnswerEntry, QuestionRecord } from './types.js';
@@ -142,21 +141,6 @@ function buildAnswer(question: NormalizedQuestionItem, selections: number[], oth
   const selected = selectedOptions[0];
   if (!selected) throw new Error('No option selected.');
   return { kind: 'option', value: selected.value, selected_labels: [selected.label], selected_values: [selected.value] };
-}
-
-function safeString(value: unknown): string {
-  return typeof value === 'string' ? value : '';
-}
-
-function maybeInjectAnswers(record: QuestionRecord, answers: QuestionAnswerEntry[], deps: Pick<QuestionUiDeps, 'env' | 'injectAnswersToPane'> = {}): void {
-  const env = deps.env ?? process.env;
-  const envTransport = safeString(env.OMX_QUESTION_RETURN_TRANSPORT).trim();
-  const target = record.renderer?.return_target ?? safeString(env.OMX_QUESTION_RETURN_TARGET).trim();
-  const transport = record.renderer?.return_transport ?? (envTransport === 'tmux-send-keys' ? envTransport : undefined);
-  if (!target || transport !== 'tmux-send-keys') return;
-  try {
-    (deps.injectAnswersToPane ?? injectQuestionAnswersToPane)(target, answers);
-  } catch {}
 }
 
 function supportsInteractiveArrowUi(input: QuestionUiInput, output: QuestionUiOutput): boolean {
@@ -474,8 +458,7 @@ export async function runQuestionUi(recordPath: string, deps: QuestionUiDeps = {
         ? await promptForAnswersWithArrows(record, { input, output })
         : await promptForAnswersWithNumbers(record, { input, output });
     }
-    const answeredRecord = await markQuestionAnswered(recordPath, answers);
-    maybeInjectAnswers(answeredRecord, answers, { env: deps.env, injectAnswersToPane: deps.injectAnswersToPane });
+    await markQuestionAnswered(recordPath, answers);
   } catch (error) {
     await markQuestionTerminalError(recordPath, 'error', 'question_ui_failed', error instanceof Error ? error.message : String(error));
     throw error;


### PR DESCRIPTION
## Summary
- emit structured question lifecycle events with question/session/run correlation and prompt schema metadata
- add bounded answer submission by question id through the question command and Hermes MCP bridge tools
- stop using return-pane input injection as the UI answer transport and document the coordinator bridge non-goal

## Tests
- npm run build
- node --test dist/question/__tests__/state.test.js dist/question/__tests__/ui.test.js dist/mcp/__tests__/hermes-bridge.test.js
- npm run lint
- npm run check:no-unused
- Hermes tool registry smoke via dist import

Closes #2286