### PR TITLE
feat(team): deliver approved context file refs

### DIFF
--- a/src/planning/__tests__/approved-execution-lifecycle-matrix.test.ts
+++ b/src/planning/__tests__/approved-execution-lifecycle-matrix.test.ts
@@ -261,9 +261,13 @@ function assertRalphGuidance(status: LifecycleStatus, instructions: string): voi
     case 'ready':
       assert.match(instructions, /approved context pack: .*context-20260507T120000Z-ready\.json/i);
       assert.match(instructions, /build refs \(read first\): src\/build\.ts/i);
+      assert.match(instructions, /verify refs: src\/verify\.ts/i);
+      assert.match(instructions, /scope refs: src\/scope\.ts/i);
       assert.match(instructions, /Read the build refs above before broader repo exploration/i);
       assert.doesNotMatch(instructions, /Missing-baseline fallback/i);
       assert.doesNotMatch(instructions, /repair or recreate the canonical context pack/i);
+      assert.doesNotMatch(instructions, /=.*\[file\]/);
+      assert.doesNotMatch(instructions, /query the canonical pack|Context pack index/i);
       return;
     default:
       throw new Error(`unexpected lifecycle status ${status}`);
@@ -360,10 +364,11 @@ describe('approved execution lifecycle matrix', () => {
           task: fixture.teamTask,
           command: fixture.teamCommand,
         });
-        assert.match(
-          buildApprovedTeamHandoffSection(teamHint) ?? '',
-          /Build refs \(read first\): src\/build\.ts/,
-        );
+        const handoff = buildApprovedTeamHandoffSection(teamHint) ?? '';
+        assert.match(handoff, /Build refs \(read first\): build=src\/build\.ts \[file\]/);
+        assert.match(handoff, /Verify refs: verify=src\/verify\.ts \[file\]/);
+        assert.match(handoff, /Scope refs: scope=src\/scope\.ts \[file\]/);
+        assert.doesNotMatch(handoff, /query the canonical pack|Context pack index/i);
       } else {
         assert.equal(buildApprovedTeamHandoffSection(teamHint), undefined);
       }

--- a/src/planning/__tests__/context-pack-file-refs.test.ts
+++ b/src/planning/__tests__/context-pack-file-refs.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import {
+  readReadyContextPackFileRefs,
+} from '../context-pack-file-refs.js';
+import type { ContextPackRole } from '../context-pack-status.js';
+
+let tempDir: string;
+const DERIVED_LABEL_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}\p{M}-]*$/u;
+const CONTEXT_PACK_ROLES = ['scope', 'build', 'verify'] as const satisfies readonly ContextPackRole[];
+
+type TestContextPackEntry = {
+  path: string;
+  roles: readonly ContextPackRole[];
+  label?: unknown;
+  tags?: unknown;
+  selector?: unknown;
+  relationPath?: unknown;
+  [key: string]: unknown;
+};
+
+function computeGitBlobSha1(content: string): string {
+  const buffer = Buffer.from(content, 'utf-8');
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function relativeToRepo(path: string): string {
+  return relative(tempDir, path).replaceAll('\\', '/');
+}
+
+function canonicalContextPackRelativePath(slug: string): string {
+  return `.omx/context/context-20260507T120000Z-${slug}.json`;
+}
+
+function createDeterministicRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = Math.imul(state, 1_664_525) + 1_013_904_223;
+    state >>>= 0;
+    return state / 0x1_0000_0000;
+  };
+}
+
+function maybe(nextRandom: () => number, threshold = 0.5): boolean {
+  return nextRandom() < threshold;
+}
+
+function pickRandom<T>(nextRandom: () => number, values: readonly T[]): T {
+  const index = Math.floor(nextRandom() * values.length);
+  return values[index]!;
+}
+
+async function setup(): Promise<void> {
+  tempDir = await mkdtemp(join(tmpdir(), 'omx-context-pack-file-refs-'));
+}
+
+async function cleanup(): Promise<void> {
+  if (tempDir && existsSync(tempDir)) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function writeContextPackWithEntries(
+  slug: string,
+  prdPath: string,
+  testSpecPath: string,
+  entries: readonly TestContextPackEntry[],
+): Promise<string> {
+  const contextDir = join(tempDir, '.omx', 'context');
+  await mkdir(contextDir, { recursive: true });
+  const packPath = join(tempDir, canonicalContextPackRelativePath(slug));
+  const prdContent = await readFile(prdPath, 'utf-8');
+  const testSpecContent = await readFile(testSpecPath, 'utf-8');
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relativeToRepo(prdPath),
+        sha1: computeGitBlobSha1(prdContent),
+      },
+      testSpecs: [{
+        path: relativeToRepo(testSpecPath),
+        sha1: computeGitBlobSha1(testSpecContent),
+      }],
+    },
+    entries,
+  }, null, 2));
+  return packPath;
+}
+
+async function writeReadyPlanningBaseline(slug: string): Promise<{
+  prdPath: string;
+  testSpecPath: string;
+}> {
+  const plansDir = join(tempDir, '.omx', 'plans');
+  await mkdir(plansDir, { recursive: true });
+  const prdPath = join(plansDir, `prd-${slug}.md`);
+  const testSpecPath = join(plansDir, `test-spec-${slug}.md`);
+  await writeFile(prdPath, `# PRD ${slug}\n`);
+  await writeFile(testSpecPath, `# Test Spec ${slug}\n`);
+  return { prdPath, testSpecPath };
+}
+
+function generateValidEntry(
+  nextRandom: () => number,
+  index: number,
+): TestContextPackEntry {
+  const dirs = [
+    'src/runtime',
+    'src/build',
+    'src/verify',
+    'tests/runtime',
+    'docs/guide',
+  ];
+  const basenames = ['index.ts', 'main.ts', 'contract.ts', 'overview.ts'];
+  const roleCount = maybe(nextRandom, 0.2) ? 2 : 1;
+  const roles = new Set<ContextPackRole>();
+  while (roles.size < roleCount) {
+    roles.add(pickRandom(nextRandom, CONTEXT_PACK_ROLES));
+  }
+
+  const entry: TestContextPackEntry = {
+    path: `${pickRandom(nextRandom, dirs)}/${index % 3}-${pickRandom(nextRandom, basenames)}`,
+    roles: [...roles],
+  };
+
+  if (maybe(nextRandom, 0.45)) {
+    entry.label = `${pickRandom(nextRandom, ['Runtime', 'Build', 'Verify', 'Scope'])} Focus`;
+  }
+  if (maybe(nextRandom, 0.4)) {
+    entry.tags = ['runtime', pickRandom(nextRandom, ['build', 'verify', 'scope'])];
+  }
+  if (maybe(nextRandom, 0.35)) {
+    entry.selector = maybe(nextRandom, 0.5)
+      ? { type: 'heading', value: `## ${pickRandom(nextRandom, ['Runtime Contract', 'Build Focus', 'Verification Notes'])}`, maxWords: 120 }
+      : { type: 'lines', start: 2 + index, end: 4 + index };
+  }
+  if (maybe(nextRandom, 0.3)) {
+    entry.relationPath = [
+      { tag: 'Plan', target: `feature-${index}` },
+      { tag: 'Implements', target: entry.path },
+    ];
+  }
+  return entry;
+}
+
+describe('context pack file refs', () => {
+  beforeEach(async () => { await setup(); });
+  afterEach(async () => { await cleanup(); });
+
+  it('projects previous-version ready packs with normalized repo-relative paths into derived direct file refs', async () => {
+    const { prdPath, testSpecPath } = await writeReadyPlanningBaseline('file-refs-plain');
+    const packPath = await writeContextPackWithEntries(
+      'file-refs-plain',
+      prdPath,
+      testSpecPath,
+      [
+        { path: './docs\\scope-ready.md', roles: ['scope'] },
+        { path: 'src\\build-ready.ts', roles: ['build'] },
+        { path: './tests/verify-ready.ts', roles: ['verify'] },
+      ],
+    );
+
+    const resolution = readReadyContextPackFileRefs(packPath, tempDir);
+
+    assert.deepEqual(resolution, {
+      refs: [
+        {
+          roles: ['scope'],
+          label: 'scope-ready',
+          path: join(tempDir, 'docs/scope-ready.md'),
+          sourcePath: join(tempDir, 'docs/scope-ready.md'),
+          delivery: 'file',
+        },
+        {
+          roles: ['build'],
+          label: 'build-ready',
+          path: join(tempDir, 'src/build-ready.ts'),
+          sourcePath: join(tempDir, 'src/build-ready.ts'),
+          delivery: 'file',
+        },
+        {
+          roles: ['verify'],
+          label: 'verify-ready',
+          path: join(tempDir, 'tests/verify-ready.ts'),
+          sourcePath: join(tempDir, 'tests/verify-ready.ts'),
+          delivery: 'file',
+        },
+      ],
+      issues: [],
+    });
+  });
+
+  it('prefers private labels while keeping selectors file-only in the first Team row', async () => {
+    const { prdPath, testSpecPath } = await writeReadyPlanningBaseline('file-refs-private');
+    const packPath = await writeContextPackWithEntries(
+      'file-refs-private',
+      prdPath,
+      testSpecPath,
+      [
+        {
+          path: 'src/runtime/build-entry.ts',
+          roles: ['build'],
+          label: ' Build Focus ',
+          tags: ['runtime', 'build'],
+          selector: { type: 'heading', value: ' ## Runtime Contract ', maxWords: 120 },
+          relationPath: [
+            { tag: 'Plan', target: 'file-refs-private' },
+            { tag: 'Implements', target: 'src/runtime/build-entry.ts#runtime-contract' },
+          ],
+        },
+      ],
+    );
+
+    const resolution = readReadyContextPackFileRefs(packPath, tempDir);
+
+    assert.deepEqual(resolution, {
+      refs: [
+        {
+          roles: ['build'],
+          label: 'build-focus',
+          path: join(tempDir, 'src/runtime/build-entry.ts'),
+          sourcePath: join(tempDir, 'src/runtime/build-entry.ts'),
+          delivery: 'file',
+        },
+      ],
+      issues: [],
+    });
+  });
+
+  it('fails closed when private entry metadata is malformed', async () => {
+    const { prdPath, testSpecPath } = await writeReadyPlanningBaseline('file-refs-malformed');
+    const packPath = await writeContextPackWithEntries(
+      'file-refs-malformed',
+      prdPath,
+      testSpecPath,
+      [
+        { path: 'docs/scope-malformed.md', roles: ['scope'] },
+        {
+          path: 'src/build-malformed.ts',
+          roles: ['build'],
+          selector: { type: 'heading', value: 'Build Focus', maxWords: 20 },
+        },
+        { path: 'tests/verify-malformed.ts', roles: ['verify'] },
+      ],
+    );
+
+    const resolution = readReadyContextPackFileRefs(packPath, tempDir);
+
+    assert.deepEqual(resolution.refs, []);
+    assert.equal(resolution.issues.length, 1);
+    assert.match(resolution.issues[0] ?? '', /Could not read ready private context-pack entry metadata/);
+  });
+
+  it('fails closed when a raw entry path escapes the repo root', async () => {
+    const { prdPath, testSpecPath } = await writeReadyPlanningBaseline('file-refs-escaped-path');
+    const packPath = await writeContextPackWithEntries(
+      'file-refs-escaped-path',
+      prdPath,
+      testSpecPath,
+      [
+        { path: 'docs/scope-ready.md', roles: ['scope'] },
+        { path: '../outside-build.ts', roles: ['build'] },
+        { path: 'tests/verify-ready.ts', roles: ['verify'] },
+      ],
+    );
+
+    const resolution = readReadyContextPackFileRefs(packPath, tempDir);
+
+    assert.deepEqual(resolution.refs, []);
+    assert.equal(resolution.issues.length, 1);
+    assert.match(resolution.issues[0] ?? '', /Could not read ready private context-pack entry metadata/);
+  });
+
+  it('keeps derived labels unique across duplicate basename and label collisions', async () => {
+    const { prdPath, testSpecPath } = await writeReadyPlanningBaseline('file-refs-duplicates');
+    const packPath = await writeContextPackWithEntries(
+      'file-refs-duplicates',
+      prdPath,
+      testSpecPath,
+      [
+        {
+          path: 'src/runtime/index.ts',
+          roles: ['build'],
+          label: 'Shared Focus',
+        },
+        {
+          path: 'tests/runtime/index.ts',
+          roles: ['verify'],
+          label: 'Shared Focus',
+        },
+        {
+          path: 'docs/runtime/index.ts',
+          roles: ['scope'],
+          selector: { type: 'heading', value: '## Runtime Contract', maxWords: 120 },
+        },
+      ],
+    );
+
+    const resolution = readReadyContextPackFileRefs(packPath, tempDir);
+    const labels = resolution.refs.map((ref) => ref.label);
+
+    assert.deepEqual(resolution.issues, []);
+    assert.equal(labels.length, 3);
+    assert.equal(new Set(labels).size, labels.length);
+    assert.ok(labels.includes('shared-focus'));
+    assert.ok(labels.every((label) => DERIVED_LABEL_PATTERN.test(label)));
+  });
+
+  it('satisfies the file-ref invariants across deterministic valid metadata cases', async () => {
+    const nextRandom = createDeterministicRandom(0xC0D3_2214);
+    for (let caseIndex = 0; caseIndex < 18; caseIndex += 1) {
+      const slug = `generated-${caseIndex}`;
+      const { prdPath, testSpecPath } = await writeReadyPlanningBaseline(slug);
+      const entries = Array.from({ length: 6 }, (_, entryIndex) =>
+        generateValidEntry(nextRandom, caseIndex * 10 + entryIndex));
+      const packPath = await writeContextPackWithEntries(slug, prdPath, testSpecPath, entries);
+
+      const resolution = readReadyContextPackFileRefs(packPath, tempDir);
+
+      assert.deepEqual(resolution.issues, [], `expected valid file refs for ${slug}`);
+      assert.equal(resolution.refs.length, entries.length, `expected one file ref per entry for ${slug}`);
+      assert.equal(
+        new Set(resolution.refs.map((ref) => ref.label)).size,
+        resolution.refs.length,
+        `expected unique labels for ${slug}`,
+      );
+      for (const ref of resolution.refs) {
+        const repoRelativePath = relative(tempDir, ref.path).replaceAll('\\', '/');
+        assert.equal(ref.delivery, 'file');
+        assert.equal(ref.path, ref.sourcePath);
+        assert.notEqual(repoRelativePath, '');
+        assert.notEqual(repoRelativePath, '.');
+        assert.ok(!repoRelativePath.startsWith('..'), `expected repo-rooted path for ${slug}`);
+        assert.ok(!repoRelativePath.startsWith('../'), `expected repo-rooted path for ${slug}`);
+        assert.ok(ref.roles.length > 0, `expected at least one role for ${slug}`);
+        assert.match(ref.label, DERIVED_LABEL_PATTERN);
+      }
+    }
+  });
+});

--- a/src/planning/__tests__/context-pack-file-refs.test.ts
+++ b/src/planning/__tests__/context-pack-file-refs.test.ts
@@ -278,6 +278,26 @@ describe('context pack file refs', () => {
     assert.match(resolution.issues[0] ?? '', /Could not read ready private context-pack entry metadata/);
   });
 
+  it('fails closed when the caller does not provide an absolute repo root', async () => {
+    const { prdPath, testSpecPath } = await writeReadyPlanningBaseline('file-refs-relative-root');
+    const packPath = await writeContextPackWithEntries(
+      'file-refs-relative-root',
+      prdPath,
+      testSpecPath,
+      [
+        { path: 'docs/scope-ready.md', roles: ['scope'] },
+        { path: 'src/build-ready.ts', roles: ['build'] },
+        { path: 'tests/verify-ready.ts', roles: ['verify'] },
+      ],
+    );
+
+    const resolution = readReadyContextPackFileRefs(packPath, '.');
+
+    assert.deepEqual(resolution.refs, []);
+    assert.equal(resolution.issues.length, 1);
+    assert.match(resolution.issues[0] ?? '', /Could not resolve an absolute repo root/);
+  });
+
   it('keeps derived labels unique across duplicate basename and label collisions', async () => {
     const { prdPath, testSpecPath } = await writeReadyPlanningBaseline('file-refs-duplicates');
     const packPath = await writeContextPackWithEntries(

--- a/src/planning/__tests__/context-pack-file-refs.test.ts
+++ b/src/planning/__tests__/context-pack-file-refs.test.ts
@@ -333,6 +333,33 @@ describe('context pack file refs', () => {
     assert.ok(labels.every((label) => DERIVED_LABEL_PATTERN.test(label)));
   });
 
+  it('keeps numeric collision fallback terminating across many length-saturated label collisions', async () => {
+    const { prdPath, testSpecPath } = await writeReadyPlanningBaseline('file-refs-long-labels');
+    const longLabel = 'A'.repeat(80);
+    const entries = Array.from({ length: 12 }, (_, index) => ({
+      path: `dir-${index}/runtime/shared.ts`,
+      roles: [CONTEXT_PACK_ROLES[index % CONTEXT_PACK_ROLES.length]!],
+      label: longLabel,
+    }));
+    const packPath = await writeContextPackWithEntries(
+      'file-refs-long-labels',
+      prdPath,
+      testSpecPath,
+      entries,
+    );
+
+    const resolution = readReadyContextPackFileRefs(packPath, tempDir);
+    const labels = resolution.refs.map((ref) => ref.label);
+
+    assert.deepEqual(resolution.issues, []);
+    assert.equal(labels.length, entries.length);
+    assert.equal(new Set(labels).size, labels.length);
+    assert.ok(labels.some((label) => /-2$/.test(label)));
+    assert.ok(labels.some((label) => /-12$/.test(label)));
+    assert.ok(labels.every((label) => label.length <= 80));
+    assert.ok(labels.every((label) => DERIVED_LABEL_PATTERN.test(label)));
+  });
+
   it('satisfies the file-ref invariants across deterministic valid metadata cases', async () => {
     const nextRandom = createDeterministicRandom(0xC0D3_2214);
     for (let caseIndex = 0; caseIndex < 18; caseIndex += 1) {

--- a/src/planning/context-pack-file-refs.ts
+++ b/src/planning/context-pack-file-refs.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, extname, resolve } from 'node:path';
+import { basename, dirname, extname, isAbsolute, resolve } from 'node:path';
 import {
   readReadyContextPackPrivateEntryReadModel,
   type ContextPackPrivateSelector,
@@ -130,6 +130,13 @@ export function readReadyContextPackFileRefs(
   packPath: string,
   repoRoot: string,
 ): ContextPackFileRefResolution {
+  if (!isAbsolute(repoRoot)) {
+    return {
+      refs: [],
+      issues: [`Could not resolve an absolute repo root for ${basename(packPath)}.`],
+    };
+  }
+
   const privateEntries = readReadyContextPackPrivateEntryReadModel(packPath);
   if (!privateEntries) {
     return {

--- a/src/planning/context-pack-file-refs.ts
+++ b/src/planning/context-pack-file-refs.ts
@@ -1,0 +1,177 @@
+import { basename, dirname, extname, resolve } from 'node:path';
+import {
+  readReadyContextPackPrivateEntryReadModel,
+  type ContextPackPrivateSelector,
+  type ContextPackRole,
+} from './context-pack-status.js';
+
+const CONTEXT_PACK_LABEL_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}\p{M}-]*$/u;
+const MAX_CONTEXT_PACK_LABEL_LENGTH = 80;
+
+export interface ContextPackFileRef {
+  readonly roles: readonly ContextPackRole[];
+  readonly label: string;
+  readonly path: string;
+  readonly sourcePath: string;
+  readonly delivery: 'file';
+}
+
+export interface ContextPackFileRefResolution {
+  readonly refs: readonly ContextPackFileRef[];
+  readonly issues: readonly string[];
+}
+
+function normalizeLabelToken(raw: string): string | null {
+  const normalized = Array.from(
+    raw
+      .normalize('NFKC')
+      .trim()
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\p{M}]+/gu, '-')
+      .replace(/^-+|-+$/g, ''),
+  )
+    .slice(0, MAX_CONTEXT_PACK_LABEL_LENGTH)
+    .join('')
+    .replace(/-+$/g, '');
+  return CONTEXT_PACK_LABEL_PATTERN.test(normalized) ? normalized : null;
+}
+
+function deriveBaseLabel(path: string): string {
+  const stem = basename(path, extname(path)).trim();
+  const fallback = basename(path).trim();
+  return normalizeLabelToken(stem)
+    ?? normalizeLabelToken(fallback)
+    ?? 'context-file';
+}
+
+function deriveSelectorSuffix(selector: ContextPackPrivateSelector | null): string | null {
+  if (!selector) {
+    return null;
+  }
+  if (selector.type === 'lines') {
+    return normalizeLabelToken(`lines-${selector.start}-${selector.end}`);
+  }
+  return normalizeLabelToken(selector.value) ?? 'heading';
+}
+
+function derivePathSuffixes(path: string): string[] {
+  const parent = dirname(path).replaceAll('\\', '/');
+  if (parent === '' || parent === '.') {
+    return [];
+  }
+
+  const suffixes: string[] = [];
+  let current = '';
+  for (const segment of parent.split('/').filter(Boolean).reverse()) {
+    const normalizedSegment = normalizeLabelToken(segment);
+    if (!normalizedSegment) {
+      continue;
+    }
+    current = current === ''
+      ? normalizedSegment
+      : `${current}-${normalizedSegment}`;
+    suffixes.push(current);
+  }
+  return suffixes;
+}
+
+function deriveRoleSuffix(roles: readonly ContextPackRole[]): string | null {
+  return roles.length > 0
+    ? normalizeLabelToken([...roles].sort().join('-'))
+    : null;
+}
+
+function buildLabelCandidate(
+  base: string,
+  suffixes: readonly string[],
+): string {
+  return normalizeLabelToken([base, ...suffixes].join('-')) ?? 'context-file';
+}
+
+function resolveUniqueLabel(
+  base: string,
+  selectorSuffix: string | null,
+  pathSuffixes: readonly string[],
+  roleSuffix: string | null,
+  used: Set<string>,
+): string {
+  let candidate = buildLabelCandidate(base, []);
+  if (!used.has(candidate)) {
+    used.add(candidate);
+    return candidate;
+  }
+
+  const uniquenessSuffixes = [
+    ...(selectorSuffix ? [selectorSuffix] : []),
+    ...pathSuffixes,
+    ...(roleSuffix ? [roleSuffix] : []),
+  ].filter((suffix) => suffix !== base);
+
+  const accumulated: string[] = [];
+  for (const suffix of uniquenessSuffixes) {
+    accumulated.push(suffix);
+    candidate = buildLabelCandidate(base, accumulated);
+    if (!used.has(candidate)) {
+      used.add(candidate);
+      return candidate;
+    }
+  }
+
+  for (let counter = 2; ; counter += 1) {
+    candidate = buildLabelCandidate(base, [...accumulated, String(counter)]);
+    if (!used.has(candidate)) {
+      used.add(candidate);
+      return candidate;
+    }
+  }
+}
+
+export function readReadyContextPackFileRefs(
+  packPath: string,
+  repoRoot: string,
+): ContextPackFileRefResolution {
+  const privateEntries = readReadyContextPackPrivateEntryReadModel(packPath);
+  if (!privateEntries) {
+    return {
+      refs: [],
+      issues: [`Could not read ready private context-pack entry metadata from ${basename(packPath)}.`],
+    };
+  }
+
+  const usedLabels = new Set<string>();
+  const refs = privateEntries.map((entry) => {
+    const baseLabel = entry.label ?? deriveBaseLabel(entry.path);
+    const label = resolveUniqueLabel(
+      baseLabel,
+      deriveSelectorSuffix(entry.selector),
+      derivePathSuffixes(entry.path),
+      deriveRoleSuffix(entry.roles),
+      usedLabels,
+    );
+    const sourcePath = resolve(repoRoot, entry.path);
+    return {
+      roles: [...entry.roles],
+      label,
+      path: sourcePath,
+      sourcePath,
+      delivery: 'file' as const,
+    };
+  });
+
+  return { refs, issues: [] };
+}
+
+export function groupContextPackFileRefsByRole(
+  refs: readonly ContextPackFileRef[],
+): Partial<Record<ContextPackRole, ContextPackFileRef[]>> {
+  const grouped: Partial<Record<ContextPackRole, ContextPackFileRef[]>> = {};
+  for (const ref of refs) {
+    for (const role of ref.roles) {
+      if (!grouped[role]) {
+        grouped[role] = [];
+      }
+      grouped[role]!.push(ref);
+    }
+  }
+  return grouped;
+}

--- a/src/planning/context-pack-file-refs.ts
+++ b/src/planning/context-pack-file-refs.ts
@@ -88,6 +88,24 @@ function buildLabelCandidate(
   return normalizeLabelToken([base, ...suffixes].join('-')) ?? 'context-file';
 }
 
+function buildNumberedLabelCandidate(
+  base: string,
+  suffixes: readonly string[],
+  counter: number,
+): string {
+  const prefix = buildLabelCandidate(base, suffixes);
+  const counterToken = String(counter);
+  const maxPrefixLength = MAX_CONTEXT_PACK_LABEL_LENGTH - counterToken.length - 1;
+  const trimmedPrefix = maxPrefixLength > 0
+    ? Array.from(prefix)
+      .slice(0, maxPrefixLength)
+      .join('')
+      .replace(/-+$/g, '')
+    : '';
+  return normalizeLabelToken(`${trimmedPrefix || 'context-file'}-${counterToken}`)
+    ?? 'context-file';
+}
+
 function resolveUniqueLabel(
   base: string,
   selectorSuffix: string | null,
@@ -118,7 +136,7 @@ function resolveUniqueLabel(
   }
 
   for (let counter = 2; ; counter += 1) {
-    candidate = buildLabelCandidate(base, [...accumulated, String(counter)]);
+    candidate = buildNumberedLabelCandidate(base, accumulated, counter);
     if (!used.has(candidate)) {
       used.add(candidate);
       return candidate;

--- a/src/team/__tests__/approved-execution.test.ts
+++ b/src/team/__tests__/approved-execution.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import {
   buildApprovedTeamHandoffSection,
   readPersistedApprovedTeamExecutionBinding,
@@ -11,7 +12,17 @@ import {
   resolvePersistedApprovedTeamExecutionContinuityState,
   writePersistedApprovedTeamExecutionBinding,
 } from '../approved-execution.js';
-import type { ApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
+import { readApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
+
+type TestContextPackEntry = {
+  path: string;
+  roles: readonly ('scope' | 'build' | 'verify')[];
+  label?: unknown;
+  tags?: unknown;
+  selector?: unknown;
+  relationPath?: unknown;
+  [key: string]: unknown;
+};
 
 async function withUnboxedOmxRoot<T>(fn: () => Promise<T>): Promise<T> {
   const previousOmxRoot = process.env.OMX_ROOT;
@@ -28,62 +39,246 @@ async function withUnboxedOmxRoot<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-function buildReadyApprovedTeamHint(
-  overrides: Partial<ApprovedExecutionLaunchHint> = {},
-): ApprovedExecutionLaunchHint {
-  return {
-    sourcePath: '/repo/.omx/plans/prd-issue-1314.md',
-    testSpecPaths: ['/repo/.omx/plans/test-spec-issue-1314.md'],
-    deepInterviewSpecPaths: [],
-    contextPack: { path: '/repo/.omx/context/context-20260507T120000Z-issue-1314.json' },
-    contextPackStatus: 'ready',
-    contextPackRoleRefs: {
-      build: ['src/build-entry.ts'],
-      verify: ['tests/verify-entry.ts'],
-      scope: ['docs/scope-entry.md'],
+function computeGitBlobSha1(content: string): string {
+  const buffer = Buffer.from(content, 'utf-8');
+  const header = Buffer.from(`blob ${buffer.length}\0`, 'utf-8');
+  return createHash('sha1').update(header).update(buffer).digest('hex');
+}
+
+function canonicalContextPackRelativePath(slug: string): string {
+  return `.omx/context/context-20260507T120000Z-${slug}.json`;
+}
+
+function buildContextPackOutcome(relativePackPath: string): string {
+  return [
+    '## Context Pack Outcome',
+    '',
+    `- pack: created \`${relativePackPath}\``,
+  ].join('\n');
+}
+
+async function writeContextPackWithEntries(
+  cwd: string,
+  slug: string,
+  prdPath: string,
+  testSpecPath: string,
+  entries: readonly TestContextPackEntry[],
+): Promise<string> {
+  const contextDir = join(cwd, '.omx', 'context');
+  await mkdir(contextDir, { recursive: true });
+  const packPath = join(cwd, canonicalContextPackRelativePath(slug));
+  const prdContent = await readFile(prdPath, 'utf-8');
+  const testSpecContent = await readFile(testSpecPath, 'utf-8');
+  await writeFile(packPath, JSON.stringify({
+    slug,
+    basis: {
+      prd: {
+        path: relative(cwd, prdPath).replaceAll('\\', '/'),
+        sha1: computeGitBlobSha1(prdContent),
+      },
+      testSpecs: [{
+        path: relative(cwd, testSpecPath).replaceAll('\\', '/'),
+        sha1: computeGitBlobSha1(testSpecContent),
+      }],
     },
-    missingRequiredContextPackRoles: [],
-    contextPackIssues: [],
-    repositoryContextSummary: {
-      sourcePath: '/repo/.omx/plans/repo-context-issue-1314.md',
-      content: 'Read the approved repository slice before broader repo exploration.',
-      truncated: false,
-    },
-    mode: 'team',
-    command: 'omx team 1:executor "Execute approved issue 1314 plan"',
-    task: 'Execute approved issue 1314 plan',
-    workerCount: 1,
-    agentType: 'executor',
-    linkedRalph: false,
-    ...overrides,
-  };
+    entries,
+  }, null, 2));
+  return packPath;
+}
+
+async function createReadyApprovedTeamHint(
+  cwd: string,
+  slug: string,
+  entries: readonly TestContextPackEntry[],
+): Promise<{
+  hint: NonNullable<ReturnType<typeof readApprovedExecutionLaunchHint>>;
+  prdPath: string;
+  testSpecPath: string;
+  packPath: string;
+  repoContextPath: string;
+}> {
+  const plansDir = join(cwd, '.omx', 'plans');
+  await mkdir(plansDir, { recursive: true });
+  const prdPath = join(plansDir, `prd-${slug}.md`);
+  const testSpecPath = join(plansDir, `test-spec-${slug}.md`);
+  const repoContextPath = join(plansDir, `repo-context-${slug}.md`);
+  await writeFile(
+    prdPath,
+    [
+      '# Approved plan',
+      '',
+      buildContextPackOutcome(canonicalContextPackRelativePath(slug)),
+      '',
+      `Launch via omx team 1:executor "Execute approved ${slug} plan"`,
+    ].join('\n'),
+  );
+  await writeFile(testSpecPath, '# Test spec\n');
+  await writeFile(repoContextPath, 'Read the approved repository slice before broader repo exploration.\n');
+  const packPath = await writeContextPackWithEntries(cwd, slug, prdPath, testSpecPath, entries);
+  const hint = readApprovedExecutionLaunchHint(cwd, 'team');
+  assert.ok(hint, 'expected ready Team approved hint');
+  return { hint, prdPath, testSpecPath, packPath, repoContextPath };
 }
 
 describe('approved execution binding', () => {
-  it('buildApprovedTeamHandoffSection renders ready approved Team context with grouped refs', () => {
-    const handoff = buildApprovedTeamHandoffSection(buildReadyApprovedTeamHint());
+  it('buildApprovedTeamHandoffSection renders ready approved Team context with labeled file refs', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-handoff-'));
+    try {
+      const { hint, prdPath, testSpecPath, packPath, repoContextPath } = await createReadyApprovedTeamHint(
+        cwd,
+        'issue-1314',
+        [
+          { path: 'docs/scope-entry.md', roles: ['scope'] },
+          { path: 'src/build-entry.ts', roles: ['build'], label: 'Build Focus' },
+          { path: 'tests/verify-entry.ts', roles: ['verify'] },
+        ],
+      );
 
-    assert.match(handoff ?? '', /Approved plan: \/repo\/\.omx\/plans\/prd-issue-1314\.md/);
-    assert.match(handoff ?? '', /Test specs: \/repo\/\.omx\/plans\/test-spec-issue-1314\.md/);
-    assert.match(handoff ?? '', /Approved context pack: \/repo\/\.omx\/context\/context-20260507T120000Z-issue-1314\.json/);
-    assert.match(handoff ?? '', /Approved repository context summary source: \/repo\/\.omx\/plans\/repo-context-issue-1314\.md/);
-    assert.match(handoff ?? '', /Read the approved repository slice before broader repo exploration\./);
-    assert.match(handoff ?? '', /Build refs \(read first\): src\/build-entry\.ts/);
-    assert.match(handoff ?? '', /Verify refs: tests\/verify-entry\.ts/);
-    assert.match(handoff ?? '', /Scope refs: docs\/scope-entry\.md/);
-    assert.match(handoff ?? '', /Read the build refs above before broader repo exploration\./);
-    assert.doesNotMatch(handoff ?? '', /query the canonical pack|Context pack index/);
+      const handoff = buildApprovedTeamHandoffSection(hint);
+
+      assert.match(handoff ?? '', new RegExp(`Approved plan: ${prdPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(handoff ?? '', new RegExp(`Test specs: ${testSpecPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(handoff ?? '', new RegExp(`Approved context pack: ${packPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(handoff ?? '', new RegExp(`Approved repository context summary source: ${repoContextPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(handoff ?? '', /Read the approved repository slice before broader repo exploration\./);
+      assert.match(handoff ?? '', /Build refs \(read first\): build-focus=src\/build-entry\.ts \[file\]/);
+      assert.match(handoff ?? '', /Verify refs: verify-entry=tests\/verify-entry\.ts \[file\]/);
+      assert.match(handoff ?? '', /Scope refs: scope-entry=docs\/scope-entry\.md \[file\]/);
+      assert.match(handoff ?? '', /Read the build refs above before broader repo exploration\./);
+      assert.doesNotMatch(handoff ?? '', /query the canonical pack|Context pack index/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
-  it('buildApprovedTeamHandoffSection stays undefined outside ready Team handoffs', () => {
-    assert.equal(
-      buildApprovedTeamHandoffSection(buildReadyApprovedTeamHint({ mode: 'ralph' })),
-      undefined,
-    );
-    assert.equal(
-      buildApprovedTeamHandoffSection(buildReadyApprovedTeamHint({ contextPackStatus: 'plan-only' })),
-      undefined,
-    );
+  it('upgrades previous-version ready packs to derived file refs without changing ready status', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-handoff-legacy-'));
+    try {
+      const { hint } = await createReadyApprovedTeamHint(
+        cwd,
+        'issue-1314-legacy',
+        [
+          { path: './docs\\scope-entry.md', roles: ['scope'] },
+          { path: 'src\\build-entry.ts', roles: ['build'] },
+          { path: './tests/verify-entry.ts', roles: ['verify'] },
+        ],
+      );
+
+      assert.equal(hint.contextPackStatus, 'ready');
+      assert.deepEqual(hint.contextPackRoleRefs, {
+        build: ['src/build-entry.ts'],
+        verify: ['tests/verify-entry.ts'],
+        scope: ['docs/scope-entry.md'],
+      });
+
+      const handoff = buildApprovedTeamHandoffSection(hint);
+
+      assert.match(handoff ?? '', /Build refs \(read first\): build-entry=src\/build-entry\.ts \[file\]/);
+      assert.match(handoff ?? '', /Verify refs: verify-entry=tests\/verify-entry\.ts \[file\]/);
+      assert.match(handoff ?? '', /Scope refs: scope-entry=docs\/scope-entry\.md \[file\]/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to grouped role refs when private metadata is malformed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-handoff-fallback-'));
+    try {
+      const { hint } = await createReadyApprovedTeamHint(
+        cwd,
+        'issue-1314-counterfactual',
+        [
+          { path: 'docs/scope-entry.md', roles: ['scope'] },
+          {
+            path: 'src/build-entry.ts',
+            roles: ['build'],
+            selector: { type: 'heading', value: 'Build Focus', maxWords: 20 },
+          },
+          { path: 'tests/verify-entry.ts', roles: ['verify'] },
+        ],
+      );
+
+      assert.equal(hint.contextPackStatus, 'ready');
+      assert.deepEqual(hint.contextPackRoleRefs, {
+        build: ['src/build-entry.ts'],
+        verify: ['tests/verify-entry.ts'],
+        scope: ['docs/scope-entry.md'],
+      });
+
+      const handoff = buildApprovedTeamHandoffSection(hint);
+
+      assert.match(handoff ?? '', /Build refs \(read first\): src\/build-entry\.ts/);
+      assert.match(handoff ?? '', /Verify refs: tests\/verify-entry\.ts/);
+      assert.match(handoff ?? '', /Scope refs: docs\/scope-entry\.md/);
+      assert.doesNotMatch(handoff ?? '', /=.*\[file\]/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rebinds file refs only when the worker repo contains the target path', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-handoff-rebind-'));
+    try {
+      const { hint } = await createReadyApprovedTeamHint(
+        cwd,
+        'issue-1314-rebind',
+        [
+          { path: 'docs/scope-entry.md', roles: ['scope'] },
+          { path: 'src/build-entry.ts', roles: ['build'], label: 'Build Focus' },
+          { path: 'tests/verify-entry.ts', roles: ['verify'] },
+        ],
+      );
+      assert.equal(hint.contextPackStatus, 'ready');
+      await mkdir(join(cwd, 'src'), { recursive: true });
+      await mkdir(join(cwd, 'tests'), { recursive: true });
+      await mkdir(join(cwd, 'docs'), { recursive: true });
+      await writeFile(join(cwd, 'src', 'build-entry.ts'), 'export const buildEntry = true;\n');
+      await writeFile(join(cwd, 'tests', 'verify-entry.ts'), 'export const verifyEntry = true;\n');
+      await writeFile(join(cwd, 'docs', 'scope-entry.md'), '# Scope\n');
+
+      const workerRepoRoot = join(cwd, 'worker-repo');
+      await mkdir(join(workerRepoRoot, 'src'), { recursive: true });
+      await writeFile(join(workerRepoRoot, 'src', 'build-entry.ts'), 'export const buildEntry = true;\n');
+
+      const handoff = buildApprovedTeamHandoffSection(hint, { repoRoot: workerRepoRoot });
+
+      assert.match(handoff ?? '', /Build refs \(read first\): build-focus=src\/build-entry\.ts \[file\]/);
+      assert.match(
+        handoff ?? '',
+        new RegExp(`Verify refs: verify-entry=${join(cwd, 'tests', 'verify-entry.ts').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} \\[file\\]`),
+      );
+      assert.match(
+        handoff ?? '',
+        new RegExp(`Scope refs: scope-entry=${join(cwd, 'docs', 'scope-entry.md').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} \\[file\\]`),
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('buildApprovedTeamHandoffSection stays undefined outside ready Team handoffs', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-approved-execution-handoff-nonready-'));
+    try {
+      const { hint } = await createReadyApprovedTeamHint(
+        cwd,
+        'issue-1314-nonready',
+        [
+          { path: 'docs/scope-entry.md', roles: ['scope'] },
+          { path: 'src/build-entry.ts', roles: ['build'] },
+          { path: 'tests/verify-entry.ts', roles: ['verify'] },
+        ],
+      );
+      assert.equal(
+        buildApprovedTeamHandoffSection({ ...hint, mode: 'ralph' }),
+        undefined,
+      );
+      assert.equal(
+        buildApprovedTeamHandoffSection({ ...hint, contextPackStatus: 'plan-only' }),
+        undefined,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('writes and reads a normalized approved execution binding under the team state root', async () => {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -90,11 +90,26 @@ function buildContextPackOutcome(relativePackPath: string): string {
   ].join('\n');
 }
 
+type TestContextPackEntry = {
+  path: string;
+  roles: readonly ('scope' | 'build' | 'verify')[];
+  label?: unknown;
+  tags?: unknown;
+  selector?: unknown;
+  relationPath?: unknown;
+  [key: string]: unknown;
+};
+
 async function writeReadyContextPack(
   cwd: string,
   slug: string,
   prdPath: string,
   testSpecPath: string,
+  entries: readonly TestContextPackEntry[] = [
+    { path: 'src/scope-0.ts', roles: ['scope'] },
+    { path: 'src/build-1.ts', roles: ['build'] },
+    { path: 'src/verify-2.ts', roles: ['verify'] },
+  ],
 ): Promise<void> {
   const contextDir = join(cwd, '.omx', 'context');
   const packPath = join(cwd, canonicalContextPackRelativePath(slug));
@@ -113,10 +128,7 @@ async function writeReadyContextPack(
         sha1: computeGitBlobSha1(testSpecContent),
       }],
     },
-    entries: ['scope', 'build', 'verify'].map((role, index) => ({
-      path: `src/${role}-${index}.ts`,
-      roles: [role],
-    })),
+    entries,
   }, null, 2));
 }
 
@@ -6539,7 +6551,16 @@ esac
       ].join('\n'),
     );
     await writeFile(testSpecPath, '# Test spec\n');
-    await writeReadyContextPack(cwd, 'issue-1314-handoff', prdPath, testSpecPath);
+    await writeReadyContextPack(cwd, 'issue-1314-handoff', prdPath, testSpecPath, [
+      { path: 'src/scope-0.ts', roles: ['scope'] },
+      {
+        path: 'src/build-1.ts',
+        roles: ['build'],
+        label: 'Build Focus',
+        selector: { type: 'heading', value: '## Build Focus', maxWords: 120 },
+      },
+      { path: 'src/verify-2.ts', roles: ['verify'] },
+    ]);
     await writeFile(
       join(cwd, '.omx', 'plans', 'repo-context-issue-1314-handoff.md'),
       'Read the approved repository slice first.\n',
@@ -6581,9 +6602,9 @@ esac
       assert.match(inbox, new RegExp(`Approved context pack: ${contextPackPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
       assert.match(inbox, /Approved repository context summary source: .*repo-context-issue-1314-handoff\.md/);
       assert.match(inbox, /Read the approved repository slice first\./);
-      assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
-      assert.match(inbox, /Verify refs: src\/verify-2\.ts/);
-      assert.match(inbox, /Scope refs: src\/scope-0\.ts/);
+      assert.match(inbox, /Build refs \(read first\): build-focus=src\/build-1\.ts \[file\]/);
+      assert.match(inbox, /Verify refs: verify-2=src\/verify-2\.ts \[file\]/);
+      assert.match(inbox, /Scope refs: scope-0=src\/scope-0\.ts \[file\]/);
       assert.doesNotMatch(inbox, /query the canonical pack|Context pack index/);
     } finally {
       if (runtime) {
@@ -6961,7 +6982,16 @@ esac
         ].join('\n'),
       );
       await writeFile(testSpecPath, '# Test spec\n');
-      await writeReadyContextPack(cwd, 'issue-1320', prdPath, testSpecPath);
+      await writeReadyContextPack(cwd, 'issue-1320', prdPath, testSpecPath, [
+        { path: 'src/scope-0.ts', roles: ['scope'] },
+        {
+          path: 'src/build-1.ts',
+          roles: ['build'],
+          label: 'Build Focus',
+          selector: { type: 'heading', value: '## Build Focus', maxWords: 120 },
+        },
+        { path: 'src/verify-2.ts', roles: ['verify'] },
+      ]);
       await writeFile(
         join(plansDir, 'repo-context-issue-1320.md'),
         'Follow the approved repository slice before broader repo exploration.\n',
@@ -7004,9 +7034,9 @@ esac
       assert.match(inbox, new RegExp(`Approved plan: ${prdPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
       assert.match(inbox, new RegExp(`Test specs: ${testSpecPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
       assert.match(inbox, new RegExp(`Approved context pack: ${contextPackPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
-      assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
-      assert.match(inbox, /Verify refs: src\/verify-2\.ts/);
-      assert.match(inbox, /Scope refs: src\/scope-0\.ts/);
+      assert.match(inbox, /Build refs \(read first\): build-focus=src\/build-1\.ts \[file\]/);
+      assert.match(inbox, /Verify refs: verify-2=src\/verify-2\.ts \[file\]/);
+      assert.match(inbox, /Scope refs: scope-0=src\/scope-0\.ts \[file\]/);
       assert.match(inbox, /Follow the approved repository slice before broader repo exploration\./);
       assert.doesNotMatch(inbox, /query the canonical pack|Context pack index/);
     } finally {

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -62,8 +62,6 @@ function buildContextPackOutcome(relativePackPath: string): string {
   ].join('\n');
 }
 
-type ContextPackRole = 'scope' | 'build' | 'verify';
-
 type ScaleUpApprovedBindingState =
   | 'missing'
   | 'malformed'
@@ -78,6 +76,16 @@ type ScaleUpApprovedBindingState =
 type ScaleUpObservedOutcome = 'generic' | 'blocked' | 'approved';
 
 type ScaleUpCount = 1 | 2 | 3;
+
+type TestContextPackEntry = {
+  path: string;
+  roles: readonly ('scope' | 'build' | 'verify')[];
+  label?: unknown;
+  tags?: unknown;
+  selector?: unknown;
+  relationPath?: unknown;
+  [key: string]: unknown;
+};
 
 type BlockedScaleUpApprovedBindingState = Exclude<ScaleUpApprovedBindingState, 'missing' | 'plan-only' | 'ready'>;
 
@@ -162,12 +170,18 @@ async function writeContextPack(
   slug: string,
   prdPath: string,
   testSpecPath: string,
-  roles: readonly ContextPackRole[],
+  entriesOrRoles: readonly TestContextPackEntry[] | readonly string[],
 ): Promise<void> {
   const contextDir = join(cwd, '.omx', 'context');
   const packPath = join(cwd, canonicalContextPackRelativePath(slug));
   const prdContent = await readFile(prdPath, 'utf-8');
   const testSpecContent = await readFile(testSpecPath, 'utf-8');
+  const entries: TestContextPackEntry[] = typeof entriesOrRoles[0] === 'string'
+    ? (entriesOrRoles as readonly string[]).map((role, index) => ({
+      path: `src/${role}-${index}.ts`,
+      roles: [role as 'scope' | 'build' | 'verify'],
+    }))
+    : [...entriesOrRoles as readonly TestContextPackEntry[]];
   await mkdir(contextDir, { recursive: true });
   await writeFile(packPath, JSON.stringify({
     slug,
@@ -181,10 +195,7 @@ async function writeContextPack(
         sha1: computeGitBlobSha1(testSpecContent),
       }],
     },
-    entries: roles.map((role, index) => ({
-      path: `src/${role}-${index}.ts`,
-      roles: [role],
-    })),
+    entries,
   }, null, 2));
 }
 
@@ -193,8 +204,13 @@ async function writeReadyContextPack(
   slug: string,
   prdPath: string,
   testSpecPath: string,
+  entries: readonly TestContextPackEntry[] = [
+    { path: 'src/scope-0.ts', roles: ['scope'] },
+    { path: 'src/build-1.ts', roles: ['build'] },
+    { path: 'src/verify-2.ts', roles: ['verify'] },
+  ],
 ): Promise<void> {
-  await writeContextPack(cwd, slug, prdPath, testSpecPath, ['scope', 'build', 'verify']);
+  await writeContextPack(cwd, slug, prdPath, testSpecPath, entries);
 }
 
 async function writeSuccessfulScaleUpTmuxStub(
@@ -838,7 +854,16 @@ describe('scaleUp', () => {
         ].join('\n'),
       );
       await writeFile(testSpecPath, '# Test spec\n');
-      await writeReadyContextPack(cwd, 'issue-1410', prdPath, testSpecPath);
+      await writeReadyContextPack(cwd, 'issue-1410', prdPath, testSpecPath, [
+        { path: 'src/scope-0.ts', roles: ['scope'] },
+        {
+          path: 'src/build-1.ts',
+          roles: ['build'],
+          label: 'Build Focus',
+          selector: { type: 'heading', value: '## Build Focus', maxWords: 120 },
+        },
+        { path: 'src/verify-2.ts', roles: ['verify'] },
+      ]);
       await writeFile(
         join(plansDir, 'repo-context-issue-1410.md'),
         'Read the approved repository slice first.\n',
@@ -872,9 +897,9 @@ describe('scaleUp', () => {
       assert.ok(inbox.includes(`Test specs: ${testSpecPath}`));
       assert.match(inbox, /Approved repository context summary source: .*repo-context-issue-1410\.md/);
       assert.match(inbox, /Read the approved repository slice first\./);
-      assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
-      assert.match(inbox, /Verify refs: src\/verify-2\.ts/);
-      assert.match(inbox, /Scope refs: src\/scope-0\.ts/);
+      assert.match(inbox, /Build refs \(read first\): build-focus=src\/build-1\.ts \[file\]/);
+      assert.match(inbox, /Verify refs: verify-2=src\/verify-2\.ts \[file\]/);
+      assert.match(inbox, /Scope refs: scope-0=src\/scope-0\.ts \[file\]/);
       assert.doesNotMatch(inbox, /query the canonical pack|Context pack index/);
       assert.ok(tmuxCommands.some((command) => command.startsWith('split-window ')));
     } finally {

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -1081,7 +1081,7 @@ describe("worker bootstrap", () => {
           "- Approved plan: .omx/plans/prd-issue-2039.md",
           "- Test specs: .omx/plans/test-spec-issue-2039.md",
           "- Approved context pack: .omx/context/context-20260507T120000Z-issue-2039.json",
-          "- Build refs (read first): src/build-1.ts",
+          "- Build refs (read first): build-focus=src/build-1.ts [file]",
           "- Read the build refs above before broader repo exploration.",
         ].join("\n"),
         approvedContextSummary: {
@@ -1096,7 +1096,7 @@ describe("worker bootstrap", () => {
     assert.match(inbox, /Approved plan: \.omx\/plans\/prd-issue-2039\.md/);
     assert.match(inbox, /Test specs: \.omx\/plans\/test-spec-issue-2039\.md/);
     assert.match(inbox, /Approved context pack: \.omx\/context\/context-20260507T120000Z-issue-2039\.json/);
-    assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
+    assert.match(inbox, /Build refs \(read first\): build-focus=src\/build-1\.ts \[file\]/);
     assert.doesNotMatch(inbox, /## Approved Repository Context Summary/);
   });
 
@@ -1116,8 +1116,8 @@ describe("worker bootstrap", () => {
           "- Approved plan: .omx/plans/prd-issue-2040.md",
           "- Test specs: .omx/plans/test-spec-issue-2040.md",
           "- Approved context pack: .omx/context/context-20260507T120000Z-issue-2040.json",
-          "- Build refs (read first): src/build-1.ts",
-          "- Verify refs: src/verify-2.ts",
+          "- Build refs (read first): build-focus=src/build-1.ts [file]",
+          "- Verify refs: verify-2=src/verify-2.ts [file]",
         ].join("\n"),
       },
     );
@@ -1126,8 +1126,8 @@ describe("worker bootstrap", () => {
     assert.match(inbox, /Approved plan: \.omx\/plans\/prd-issue-2040\.md/);
     assert.match(inbox, /Test specs: \.omx\/plans\/test-spec-issue-2040\.md/);
     assert.match(inbox, /Approved context pack: \.omx\/context\/context-20260507T120000Z-issue-2040\.json/);
-    assert.match(inbox, /Build refs \(read first\): src\/build-1\.ts/);
-    assert.match(inbox, /Verify refs: src\/verify-2\.ts/);
+    assert.match(inbox, /Build refs \(read first\): build-focus=src\/build-1\.ts \[file\]/);
+    assert.match(inbox, /Verify refs: verify-2=src\/verify-2\.ts \[file\]/);
   });
 
 });

--- a/src/team/approved-execution.ts
+++ b/src/team/approved-execution.ts
@@ -1,12 +1,17 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import {
   readApprovedExecutionLaunchHintOutcome,
   readPlanningArtifacts,
   type ApprovedRepositoryContextSummary,
   type ApprovedExecutionLaunchHint,
 } from '../planning/artifacts.js';
+import {
+  groupContextPackFileRefsByRole,
+  readReadyContextPackFileRefs,
+  type ContextPackFileRef,
+} from '../planning/context-pack-file-refs.js';
 import { TEAM_NAME_SAFE_PATTERN } from './contracts.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import { sameFilePath } from '../utils/paths.js';
@@ -92,8 +97,85 @@ function renderRoleRefLine(label: string, refs: readonly string[]): string | nul
     : null;
 }
 
+function inferApprovedExecutionRepoRoot(
+  approvedHint: ApprovedExecutionLaunchHint,
+): string | null {
+  if (!isAbsolute(approvedHint.sourcePath)) {
+    return null;
+  }
+  return resolve(dirname(approvedHint.sourcePath), '..', '..');
+}
+
+function displayApprovedContextFilePath(
+  path: string,
+  repoRoot: string | null,
+): string {
+  if (!repoRoot || !isAbsolute(path)) {
+    return path;
+  }
+  const displayPath = relative(repoRoot, path).replaceAll('\\', '/');
+  if (
+    displayPath === ''
+    || displayPath === '.'
+    || displayPath.startsWith('..')
+    || displayPath.startsWith('../')
+    || isAbsolute(displayPath)
+  ) {
+    return path;
+  }
+  return displayPath;
+}
+
+function rebindApprovedContextFileRef(
+  ref: ContextPackFileRef,
+  sourceRepoRoot: string | null,
+  repoRoot: string | null,
+): ContextPackFileRef {
+  if (!repoRoot || !sourceRepoRoot || !isAbsolute(ref.path) || !isAbsolute(ref.sourcePath)) {
+    return ref;
+  }
+
+  const repoRelativePath = relative(sourceRepoRoot, ref.sourcePath).replaceAll('\\', '/');
+  if (
+    repoRelativePath === ''
+    || repoRelativePath === '.'
+    || repoRelativePath.startsWith('..')
+    || repoRelativePath.startsWith('../')
+    || isAbsolute(repoRelativePath)
+  ) {
+    return ref;
+  }
+
+  const reboundPath = join(repoRoot, repoRelativePath);
+  return existsSync(reboundPath)
+    ? { ...ref, path: reboundPath }
+    : ref;
+}
+
+function describeApprovedContextFileRef(
+  ref: ContextPackFileRef,
+  repoRoot: string | null,
+): string {
+  return `${ref.label}=${displayApprovedContextFilePath(ref.path, repoRoot)} [${ref.delivery}]`;
+}
+
+function renderContextFileRefLine(
+  label: string,
+  refs: readonly ContextPackFileRef[],
+  repoRoot: string | null,
+): string | null {
+  return refs.length > 0
+    ? `- ${label}: ${refs.map((ref) => describeApprovedContextFileRef(ref, repoRoot)).join(', ')}`
+    : null;
+}
+
+export interface ApprovedTeamHandoffSectionOptions {
+  repoRoot?: string | null;
+}
+
 export function buildApprovedTeamHandoffSection(
   approvedHint: ApprovedExecutionLaunchHint | null | undefined,
+  options: ApprovedTeamHandoffSectionOptions = {},
 ): string | undefined {
   if (
     !approvedHint
@@ -120,9 +202,34 @@ export function buildApprovedTeamHandoffSection(
     lines.push(...renderApprovedRepositoryContextSummary(approvedHint.repositoryContextSummary));
   }
 
-  const buildLine = renderRoleRefLine('Build refs (read first)', build);
-  const verifyLine = renderRoleRefLine('Verify refs', verify);
-  const scopeLine = renderRoleRefLine('Scope refs', scope);
+  const sourceRepoRoot = inferApprovedExecutionRepoRoot(approvedHint);
+  const displayRepoRoot = options.repoRoot ?? sourceRepoRoot;
+  // File refs are additive in this row. If private entry metadata is unavailable,
+  // keep the older grouped-path handoff without changing ready/nonready behavior.
+  const contextFileRefs =
+    approvedHint.contextPack && sourceRepoRoot
+      ? readReadyContextPackFileRefs(approvedHint.contextPack.path, sourceRepoRoot)
+      : { refs: [], issues: ['Approved Team handoff could not resolve the source repo root.'] };
+  const groupedContextFileRefs =
+    contextFileRefs.issues.length === 0
+      ? groupContextPackFileRefsByRole(
+        contextFileRefs.refs.map((ref) =>
+          rebindApprovedContextFileRef(ref, sourceRepoRoot, options.repoRoot ?? null)),
+      )
+      : null;
+
+  const buildLine =
+    groupedContextFileRefs
+      ? renderContextFileRefLine('Build refs (read first)', groupedContextFileRefs.build ?? [], displayRepoRoot)
+      : renderRoleRefLine('Build refs (read first)', build);
+  const verifyLine =
+    groupedContextFileRefs
+      ? renderContextFileRefLine('Verify refs', groupedContextFileRefs.verify ?? [], displayRepoRoot)
+      : renderRoleRefLine('Verify refs', verify);
+  const scopeLine =
+    groupedContextFileRefs
+      ? renderContextFileRefLine('Scope refs', groupedContextFileRefs.scope ?? [], displayRepoRoot)
+      : renderRoleRefLine('Scope refs', scope);
   if (buildLine) {
     lines.push(buildLine);
   }

--- a/src/team/approved-execution.ts
+++ b/src/team/approved-execution.ts
@@ -110,7 +110,7 @@ function displayApprovedContextFilePath(
   path: string,
   repoRoot: string | null,
 ): string {
-  if (!repoRoot || !isAbsolute(path)) {
+  if (!repoRoot || !isAbsolute(repoRoot) || !isAbsolute(path)) {
     return path;
   }
   const displayPath = relative(repoRoot, path).replaceAll('\\', '/');
@@ -131,7 +131,14 @@ function rebindApprovedContextFileRef(
   sourceRepoRoot: string | null,
   repoRoot: string | null,
 ): ContextPackFileRef {
-  if (!repoRoot || !sourceRepoRoot || !isAbsolute(ref.path) || !isAbsolute(ref.sourcePath)) {
+  if (
+    !repoRoot
+    || !sourceRepoRoot
+    || !isAbsolute(repoRoot)
+    || !isAbsolute(sourceRepoRoot)
+    || !isAbsolute(ref.path)
+    || !isAbsolute(ref.sourcePath)
+  ) {
     return ref;
   }
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2378,7 +2378,6 @@ export async function startTeam(
     && isApprovedExecutionContextReadyStatus(selectedApprovedExecutionHint.contextPackStatus)
     ? buildApprovedTeamExecutionBinding(selectedApprovedExecutionHint)
     : null;
-  const approvedContextSection = buildApprovedTeamHandoffSection(selectedApprovedExecutionHint);
   const activeWorktreeMode: 'detached' | 'named' | null =
     effectiveWorktreeMode.enabled
       ? (effectiveWorktreeMode.detached ? 'detached' : 'named')
@@ -2609,6 +2608,9 @@ export async function startTeam(
         : rolePromptContent
           ? await writeWorkerRoleInstructionsFile(sanitized, workerName, leaderCwd, fallbackInstructionsPath, runtimeRole, rolePromptContent)
           : fallbackInstructionsPath;
+      const approvedContextSection = buildApprovedTeamHandoffSection(selectedApprovedExecutionHint, {
+        repoRoot: workerWorkspace.worktreeRepoRoot ?? null,
+      });
       const inbox = generateInitialInbox(workerName, sanitized, agentType, workerTasks, {
         teamStateRoot,
         leaderCwd,
@@ -3396,7 +3398,9 @@ export async function assignTask(
     );
     const approvedContextSection = approvedExecutionState.status === 'valid'
       && isApprovedExecutionFollowupReadyStatus(approvedExecutionState.approvedHint.contextPackStatus)
-      ? buildApprovedTeamHandoffSection(approvedExecutionState.approvedHint)
+      ? buildApprovedTeamHandoffSection(approvedExecutionState.approvedHint, {
+        repoRoot: workerInfo.worktree_repo_root ?? null,
+      })
       : undefined;
     const taskForInbox = task.delegation
       ? task

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -76,7 +76,10 @@ import {
   type EnsureWorktreeResult,
   type WorktreeMode,
 } from './worktree.js';
-import { isApprovedExecutionFollowupReadyStatus } from '../planning/artifacts.js';
+import {
+  isApprovedExecutionFollowupReadyStatus,
+  type ApprovedExecutionLaunchHint,
+} from '../planning/artifacts.js';
 import {
   buildApprovedTeamHandoffSection,
   resolvePersistedApprovedTeamExecutionContinuityState,
@@ -129,7 +132,7 @@ function resolveInstructionStateRoot(worktreePath?: string | null): string | und
 
 interface ScaleUpApprovedExecutionGate {
   ok: true;
-  approvedContextSection?: string;
+  approvedHint?: ApprovedExecutionLaunchHint;
 }
 
 function assertUnreachableApprovedExecutionState(state: never): never {
@@ -164,7 +167,7 @@ function resolveScaleUpApprovedExecutionGate(
       }
       return {
         ok: true,
-        approvedContextSection: buildApprovedTeamHandoffSection(approvedExecutionState.approvedHint),
+        approvedHint: approvedExecutionState.approvedHint,
       };
     default:
       return assertUnreachableApprovedExecutionState(approvedExecutionState);
@@ -302,7 +305,7 @@ export async function scaleUp(
     if (!approvedExecutionGate.ok) {
       return approvedExecutionGate;
     }
-    const { approvedContextSection } = approvedExecutionGate;
+    const { approvedHint } = approvedExecutionGate;
     const effectiveWorktreeMode = config.worktree_mode ?? resolveScaleUpWorktreeMode(config);
     if (!config.worktree_mode && effectiveWorktreeMode.enabled) {
       config.worktree_mode = effectiveWorktreeMode;
@@ -533,6 +536,11 @@ export async function scaleUp(
 
       // Get assigned tasks for this worker
       const workerTasks = persistedTasks.filter(t => t.owner === workerName);
+      const approvedContextSection = approvedHint
+        ? buildApprovedTeamHandoffSection(approvedHint, {
+          repoRoot: workerWorkspace?.repoRoot ?? null,
+        })
+        : undefined;
 
       const inbox = generateInitialInbox(workerName, sanitized, agentType, workerTasks, {
         teamStateRoot,


### PR DESCRIPTION
## Summary

Ready approved Team handoffs currently surface grouped role paths from
context packs. That keeps the ready/nonready contract intact, but it drops
the private labels introduced by the private metadata read model and makes
worktree-aware file reopening less direct.

This patch keeps the Team approved-execution seam private and file-only by
projecting ready packs into labeled direct file refs when that metadata is
available, while preserving the existing grouped role-ref fallback when it is
not.

## Changes

- add a planning-local helper that reads ready pack private metadata, prefers
  private labels, derives stable unique fallbacks, and emits direct
  `delivery=file` refs only
- render those labeled file refs in ready Team startup, reassignment, and
  scale-up handoffs, rebinding them into worker worktrees only when the
  target path exists there
- fail closed on non-absolute repo roots for file-ref projection, keep
  selectors non-materializing, and preserve the existing grouped role-ref
  fallback when private metadata cannot be projected

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [x] `node --test dist/planning/__tests__/artifacts.test.js dist/team/__tests__/approved-execution.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/worker-bootstrap.test.js dist/team/__tests__/scaling.test.js`
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__ dist/agents/__tests__ dist/autoresearch/__tests__ dist/catalog/__tests__ dist/compat/__tests__ dist/config/__tests__ dist/modes/__tests__ dist/pipeline/__tests__ dist/planning/__tests__ dist/scripts/__tests__ dist/session-history/__tests__ dist/subagents/__tests__ dist/utils/__tests__ dist/visual/__tests__` (`# tests 1767`, `# pass 1767`, `# fail 0`)
- [x] `node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__ dist/ralph/__tests__ dist/ralplan/__tests__ dist/runtime/__tests__` (still reproduces the unrelated local `dist/runtime/__tests__/process-tree.test.js` `runProcessTreeWithTimeout` failure outside the changed boundary)
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Follow-up to #2245.
