### PR TITLE
Require passing Ralph completion audit examples

### DIFF
--- a/plugins/oh-my-codex/skills/ralph/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralph/SKILL.md
@@ -125,8 +125,8 @@ Use the CLI-first state surface for Ralph lifecycle state (`omx state write/read
   `omx state write --input '{"mode":"ralph","iteration":<current>,"current_phase":"executing"}' --json`
 - **On verification/fix transition**:
   `omx state write --input '{"mode":"ralph","current_phase":"verifying"}' --json` or `omx state write --input '{"mode":"ralph","current_phase":"fixing"}' --json`
-- **On completion**:
-  `omx state write --input '{"mode":"ralph","active":false,"current_phase":"complete","completed_at":"<now>"}' --json`
+- **On completion** (only after the completion audit passes with real evidence):
+  `omx state write --input '{"mode":"ralph","active":false,"current_phase":"complete","completed_at":"<now>","completion_audit":{"passed":true,"prompt_to_artifact_checklist":["<requirement mapped to artifact/evidence>"],"verification_evidence":["<fresh test/build/lint command and result>"]}}' --json`
 - **On cancellation/cleanup**:
   run `$cancel` (which should call `omx state clear --input '{"mode":"ralph"}' --json`)
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -125,8 +125,8 @@ Use the CLI-first state surface for Ralph lifecycle state (`omx state write/read
   `omx state write --input '{"mode":"ralph","iteration":<current>,"current_phase":"executing"}' --json`
 - **On verification/fix transition**:
   `omx state write --input '{"mode":"ralph","current_phase":"verifying"}' --json` or `omx state write --input '{"mode":"ralph","current_phase":"fixing"}' --json`
-- **On completion**:
-  `omx state write --input '{"mode":"ralph","active":false,"current_phase":"complete","completed_at":"<now>"}' --json`
+- **On completion** (only after the completion audit passes with real evidence):
+  `omx state write --input '{"mode":"ralph","active":false,"current_phase":"complete","completed_at":"<now>","completion_audit":{"passed":true,"prompt_to_artifact_checklist":["<requirement mapped to artifact/evidence>"],"verification_evidence":["<fresh test/build/lint command and result>"]}}' --json`
 - **On cancellation/cleanup**:
   run `$cancel` (which should call `omx state clear --input '{"mode":"ralph"}' --json`)
 

--- a/src/cli/__tests__/ralph-goal-mode-contract.test.ts
+++ b/src/cli/__tests__/ralph-goal-mode-contract.test.ts
@@ -16,6 +16,9 @@ describe('ralph goal mode integration contract', () => {
     assert.match(ralphSkill, /update_goal\(\{status: "complete"\}\)/i);
     assert.match(ralphSkill, /prompt-to-artifact checklist/i);
     assert.match(ralphSkill, /Do not use passing tests, Ralph state, or architect approval as proxy proof/i);
+    assert.match(ralphSkill, /"completion_audit":\{"passed":true/i);
+    assert.match(ralphSkill, /"prompt_to_artifact_checklist":\["<requirement mapped to artifact\/evidence>"\]/i);
+    assert.match(ralphSkill, /"verification_evidence":\["<fresh test\/build\/lint command and result>"\]/i);
   });
 
   it('injects goal-mode guidance into launched Ralph sessions', () => {

--- a/src/ralph/__tests__/completion-audit.test.ts
+++ b/src/ralph/__tests__/completion-audit.test.ts
@@ -129,6 +129,51 @@ test('requires explicit passed=true in completion-audit evidence', async () => {
   }
 });
 
+test('requires explicit passed=true in inline completion-audit state', () => {
+  for (const completion_audit of [
+    {
+      passed: false,
+      prompt_to_artifact_checklist: ['mapped'],
+      verification_evidence: ['tested'],
+    },
+    {
+      status: 'passed',
+      prompt_to_artifact_checklist: ['mapped'],
+      verification_evidence: ['tested'],
+    },
+  ]) {
+    const result = evaluateRalphCompletionAuditEvidence({ completion_audit }, process.cwd());
+
+    assert.equal(result.complete, false);
+    assert.equal(result.reason, 'completion_audit_not_passing');
+    assert.equal(result.source, 'state');
+  }
+});
+
+test('requires checklist and verification evidence in inline completion-audit state', () => {
+  const missingChecklist = evaluateRalphCompletionAuditEvidence({
+    completion_audit: {
+      passed: true,
+      verification_evidence: ['tested'],
+    },
+  }, process.cwd());
+
+  assert.equal(missingChecklist.complete, false);
+  assert.equal(missingChecklist.reason, 'missing_completion_checklist');
+  assert.equal(missingChecklist.source, 'state');
+
+  const missingEvidence = evaluateRalphCompletionAuditEvidence({
+    completion_audit: {
+      passed: true,
+      prompt_to_artifact_checklist: ['mapped'],
+    },
+  }, process.cwd());
+
+  assert.equal(missingEvidence.complete, false);
+  assert.equal(missingEvidence.reason, 'missing_verification_evidence');
+  assert.equal(missingEvidence.source, 'state');
+});
+
 test('accepts structured relative JSON completion-audit artifacts with evidence', async () => {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-audit-valid-json-'));
   try {


### PR DESCRIPTION
## Summary
- Fixes the Ralph skill completion-state example so it records `completion_audit.passed: true` plus required checklist and verification evidence.
- Updates the Stop-hook recovery guidance to explicitly require `completion_audit.passed=true` before reporting completion.
- Adds regressions for rejected inline audit state (`passed: false` or only `status: "passed"`) and missing checklist/evidence, plus a guidance contract assertion.

Closes #2289.

## Verification
- `npm run build`
- `node --test dist/ralph/__tests__/completion-audit.test.js dist/cli/__tests__/ralph-goal-mode-contract.test.js dist/scripts/__tests__/codex-native-hook.test.js` (298 passing)
- `npm run lint`
- `npm run check:no-unused`
- `npm run verify:plugin-bundle`

## Notes
- Full `npm test` was not run; targeted Stop-hook/Ralph audit suites and relevant static/plugin checks passed.
