### PR TITLE
Fix ultragoal task-scoped goal reconciliation

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -98,6 +98,29 @@ describe('cli/ultragoal', () => {
     });
   });
 
+  it('labels aggregate product completion separately from microgoal bookkeeping status', async () => {
+    await withCwd(async () => {
+      const taskObjective = 'Fix ultragoal task-scoped goal reconciliation.';
+      await capture(() => ultragoalCommand(['create-goals', '--brief', taskObjective, '--goal', 'First::Synthetic slice 1.', '--goal', 'Second::Synthetic slice 2.']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+
+      const checkpoint = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first',
+        '--status', 'complete',
+        '--evidence', 'Actual planned work done for .omx/ultragoal/goals.json G001-first; validation complete; reviews clean.',
+        '--codex-goal-json', JSON.stringify({ goal: { objective: taskObjective, status: 'complete' } }),
+        '--quality-gate-json', cleanQualityGate(),
+      ]));
+      assert.equal(checkpoint.exitCode, undefined);
+
+      const status = await capture(() => ultragoalCommand(['status']));
+      const output = status.stdout.join('\n');
+      assert.match(output, /ultragoal aggregate product: complete/);
+      assert.match(output, /microgoal ledger bookkeeping \(progress-only\): 0\/2 complete, 1 pending, 1 in progress/);
+    });
+  });
+
   it('adds goals through the command surface', async () => {
     await withCwd(async () => {
       await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -112,7 +112,12 @@ function normalizeCodexGoalMode(raw: string | undefined): 'aggregate' | 'per_sto
 
 function printStatus(plan: Awaited<ReturnType<typeof readUltragoalPlan>>): void {
   const summary = summarizeUltragoalPlan(plan);
-  console.log(`ultragoal: ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked`);
+  if (summary.aggregateComplete) {
+    console.log('ultragoal aggregate product: complete');
+    console.log(`microgoal ledger bookkeeping (progress-only): ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked`);
+  } else {
+    console.log(`ultragoal: ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked`);
+  }
   for (const goal of plan.goals) {
     const marker = goal.id === plan.activeGoalId ? '*' : '-';
     console.log(`${marker} ${goal.id} [${goal.status}] ${goal.title}`);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1569,6 +1569,42 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+
+  it("does not block ultragoal Stop after task-scoped reconciliation finishes exploded bookkeeping", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-reconciled-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
+        version: 1,
+        codexGoalMode: "aggregate",
+        codexObjective: "Complete all ultragoal stories in .omx/ultragoal/goals.json: many micro goals",
+        activeGoalId: "G001-micro",
+        aggregateCompletion: {
+          status: "complete",
+          completedAt: "2026-05-04T10:04:00.000Z",
+          evidence: "planned work done; validation complete; reviews clean",
+        },
+        goals: Array.from({ length: 136 }, (_, index) => ({
+          id: `G${String(index + 1).padStart(3, "0")}-micro`,
+          status: index === 0 ? "in_progress" : "pending",
+          objective: `Synthetic slice ${index + 1}.`,
+        })),
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-ultragoal-reconciled-stop",
+        thread_id: "thread-ultragoal-reconciled-stop",
+        last_assistant_message: "Yes — planned implementation work is done; ultragoal bookkeeping reconciled complete.",
+      }, { cwd });
+
+      assert.notEqual(result.outputJson?.stopReason, "ultragoal_codex_goal_snapshot_required");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /omx ultragoal checkpoint --goal-id/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block Stop for non-passing autoresearch-goal professor-critic verdicts", async () => {
     for (const verdict of ["blocked", "fail", "failed"]) {
       const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-autoresearch-${verdict}-stop-`));

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1714,14 +1714,19 @@ export function looksLikeGoalCompletionPrompt(text: string): boolean {
 
 async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Promise<{ workflow: string; command: string; remediation?: string } | null> {
   const ultragoal = await readJsonIfExists(join(cwd, ".omx", "ultragoal", "goals.json"));
+  const aggregateCompletion = safeObject(ultragoal?.aggregateCompletion);
+  const aggregateProductComplete = safeString(aggregateCompletion.status) === "complete";
   const ultragoals = Array.isArray(ultragoal?.goals) ? ultragoal.goals.map(safeObject) : [];
-  const activeUltragoal = ultragoals.find((goal) => safeString(goal.status) === "in_progress" || safeString(goal.id) === safeString(ultragoal?.activeGoalId));
+  const activeUltragoal = aggregateProductComplete
+    ? undefined
+    : ultragoals.find((goal) => safeString(goal.status) === "in_progress" || safeString(goal.id) === safeString(ultragoal?.activeGoalId));
   if (activeUltragoal) {
     const goalId = safeString(activeUltragoal.id) || "<goal-id>";
     return {
       workflow: "ultragoal",
       command: `omx ultragoal checkpoint --goal-id ${goalId} --status complete --codex-goal-json '<get_goal JSON or path>' --evidence '<evidence>'`,
       remediation: [
+        `If get_goal returns a completed task-scoped objective for the same aggregate ultragoal plan, checkpoint ${goalId} with evidence naming ${goalId} plus .omx/ultragoal/goals.json or ledger.jsonl and pass final quality-gate JSON; OMX will reconcile the completed planned scope without mutating Codex goal state.`,
         `If get_goal instead returns a different completed legacy objective and complete checkpointing fails, do not repeat --status complete in this thread.`,
         `Record the non-terminal blocker with: omx ultragoal checkpoint --goal-id ${goalId} --status blocked --codex-goal-json '<different completed get_goal JSON or path>' --evidence '<completed legacy Codex goal blocks create_goal in this thread>'.`,
         "Then continue this ultragoal from a fresh Codex thread in the same repo/worktree and create the intended goal there.",

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -146,6 +146,95 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+
+  it('reconciles completed task-scoped Codex proof to finish exploded aggregate ultragoal bookkeeping', async () => {
+    await withTempRepo(async (cwd) => {
+      const taskObjective = 'Fix the mismatch between Codex immutable completed goal snapshots and OMX ultragoal checkpoint reconciliation.';
+      await createUltragoalPlan(cwd, {
+        brief: taskObjective,
+        goals: Array.from({ length: 136 }, (_, index) => ({
+          title: `Micro goal ${index + 1}`,
+          objective: `Synthetic bookkeeping slice ${index + 1}.`,
+        })),
+      });
+
+      const first = await startNextUltragoal(cwd);
+      assert.equal(first.goal?.id, 'G001-micro-goal-1');
+
+      const reconciled = await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'complete',
+        evidence: 'Actual planned work done for .omx/ultragoal/goals.json G001-micro-goal-1; validation complete; reviews clean.',
+        codexGoal: { goal: { objective: taskObjective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+        now: new Date('2026-05-04T10:04:00Z'),
+      });
+
+      assert.equal(reconciled.goals.length, 136);
+      assert.equal(reconciled.goals.filter((goal) => goal.status === 'complete').length, 0);
+      assert.equal(reconciled.goals[0]?.status, 'in_progress');
+      assert.equal(reconciled.activeGoalId, undefined);
+      assert.equal(reconciled.aggregateCompletion?.status, 'complete');
+      assert.match(reconciled.aggregateCompletion?.evidence ?? '', /planned work done/);
+      assert.equal(isUltragoalDone(reconciled), true);
+
+      const next = await startNextUltragoal(cwd);
+      assert.equal(next.goal, null);
+      assert.equal(next.done, true);
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /microgoal ledger progress remains independent/);
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 1);
+      assert.equal((ledger.match(/"event":"goal_completed"/g) ?? []).length, 0);
+    });
+  });
+
+  it('fails closed for task-scoped aggregate completion without plan mapping or evidence', async () => {
+    await withTempRepo(async (cwd) => {
+      const taskObjective = 'Implement the reconciler fix described in the approved ultragoal brief.';
+      await createUltragoalPlan(cwd, {
+        brief: taskObjective,
+        goals: [
+          { title: 'First', objective: 'Synthetic slice 1.' },
+          { title: 'Second', objective: 'Synthetic slice 2.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'complete',
+          evidence: 'Actual planned work done for .omx/ultragoal/goals.json G001-first; validation complete; reviews clean.',
+          codexGoal: { goal: { objective: 'Unrelated completed task', status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+        /objective mismatch/,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'complete',
+          evidence: 'done',
+          codexGoal: { goal: { objective: taskObjective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+        /Completed task-scoped aggregate reconciliation requires evidence/,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'complete',
+          evidence: 'Actual planned work done for .omx/ultragoal/goals.json G001-first; validation complete; reviews clean.',
+          codexGoal: { goal: { objective: taskObjective, status: 'complete' } },
+        }),
+        /quality-gate-json|quality gate/i,
+      );
+    });
+  });
+
   it('requires aggregate Codex goal completion only for the final story', async () => {
     await withTempRepo(async (cwd) => {
       await createUltragoalPlan(cwd, {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -220,7 +220,7 @@ describe('ultragoal artifacts', () => {
           codexGoal: { goal: { objective: taskObjective, status: 'complete' } },
           qualityGate: cleanQualityGate(),
         }),
-        /Completed task-scoped aggregate reconciliation requires evidence/,
+        /Completed task-scoped aggregate reconciliation requires .*active in-progress/,
       );
 
       await assert.rejects(
@@ -232,6 +232,43 @@ describe('ultragoal artifacts', () => {
         }),
         /quality-gate-json|quality gate/i,
       );
+    });
+  });
+
+  it('fails closed for task-scoped aggregate completion on a non-active microgoal id', async () => {
+    await withTempRepo(async (cwd) => {
+      const taskObjective = 'Fix the mismatch between Codex immutable completed goal snapshots and OMX ultragoal checkpoint reconciliation.';
+      await createUltragoalPlan(cwd, {
+        brief: taskObjective,
+        goals: [
+          { title: 'First', objective: 'Synthetic slice 1.' },
+          { title: 'Second', objective: 'Synthetic slice 2.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      assert.equal(first.goal?.id, 'G001-first');
+      assert.equal(first.plan.activeGoalId, 'G001-first');
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: 'G002-second',
+          status: 'complete',
+          evidence: 'Actual planned work done for .omx/ultragoal/goals.json G002-second; validation complete; reviews clean.',
+          codexGoal: { goal: { objective: taskObjective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+        /Completed task-scoped aggregate reconciliation requires .*active in-progress/,
+      );
+
+      const plan = await readUltragoalPlan(cwd);
+      assert.equal(plan.activeGoalId, 'G001-first');
+      assert.equal(plan.aggregateCompletion, undefined);
+      assert.equal(plan.goals.find((goal) => goal.id === 'G001-first')?.status, 'in_progress');
+      assert.equal(plan.goals.find((goal) => goal.id === 'G002-second')?.status, 'pending');
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
     });
   });
 

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -203,6 +203,7 @@ async function canReconcileCompletedTaskScopedAggregateSnapshot(
   evidence: string | undefined,
 ): Promise<boolean> {
   if (codexGoalMode(plan) !== 'aggregate') return false;
+  if (goal.status !== 'in_progress' || plan.activeGoalId !== goal.id) return false;
   if (!textMentionsUltragoalPlanArtifact(evidence)) return false;
   if (!textMentionsGoalId(evidence, goal.id)) return false;
   if (!textHasCompletionValidationEvidence(evidence)) return false;
@@ -542,7 +543,7 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
         };
       } else {
         const taskScopedRequirement = aggregateMode && snapshot?.status === 'complete' && Boolean(snapshot.objective)
-          ? ' Completed task-scoped aggregate reconciliation requires evidence that names the active OMX goal id, names .omx/ultragoal/goals.json or ledger.jsonl, includes completed implementation plus validation/review evidence, and a get_goal objective that maps to the ultragoal brief/artifact.'
+          ? ' Completed task-scoped aggregate reconciliation requires the checkpoint goal to be the active in-progress OMX goal, evidence that names that active OMX goal id, names .omx/ultragoal/goals.json or ledger.jsonl, includes completed implementation plus validation/review evidence, and a get_goal objective that maps to the ultragoal brief/artifact.'
           : '';
         const remediation = reconciliation.snapshot.available
           && reconciliation.snapshot.status === 'complete'

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -32,6 +32,13 @@ export interface UltragoalItem {
   failureReason?: string;
 }
 
+export interface UltragoalAggregateCompletion {
+  status: 'complete';
+  completedAt: string;
+  evidence: string;
+  codexGoal?: unknown;
+}
+
 export interface UltragoalPlan {
   version: 1;
   createdAt: string;
@@ -41,6 +48,7 @@ export interface UltragoalPlan {
   ledgerPath: string;
   codexGoalMode?: UltragoalCodexGoalMode;
   codexObjective?: string;
+  aggregateCompletion?: UltragoalAggregateCompletion;
   activeGoalId?: string;
   goals: UltragoalItem[];
 }
@@ -55,6 +63,7 @@ export interface UltragoalLedgerEntry {
     | 'goal_blocked'
     | 'goal_failed'
     | 'goal_retried'
+    | 'aggregate_completed'
     | 'goal_added'
     | 'final_review_failed'
     | 'goal_review_blocked';
@@ -152,6 +161,55 @@ function normalizeObjective(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
 }
 
+
+function textMentionsUltragoalPlanArtifact(value: string | undefined): boolean {
+  const normalized = (value ?? '').toLowerCase();
+  return normalized.includes(ULTRAGOAL_DIR.toLowerCase())
+    || normalized.includes(ULTRAGOAL_GOALS.toLowerCase())
+    || normalized.includes(ULTRAGOAL_LEDGER.toLowerCase());
+}
+
+function textMentionsGoalId(value: string | undefined, goalId: string): boolean {
+  return (value ?? '').toLowerCase().includes(goalId.toLowerCase());
+}
+
+function textHasCompletionValidationEvidence(value: string | undefined): boolean {
+  const normalized = (value ?? '').toLowerCase();
+  const hasImplementationCompletion = /\b(?:planned work|implementation|deliverables?|scope|task|work)\b/.test(normalized)
+    && /\b(?:done|complete|completed|finished|shipped)\b/.test(normalized);
+  const hasValidation = /\b(?:validation|verification|tests?|build|lint|review|quality gate|code-review)\b/.test(normalized)
+    && /\b(?:passed|complete|completed|clean|green|approve|approved|clear)\b/.test(normalized);
+  return hasImplementationCompletion && hasValidation;
+}
+
+async function snapshotObjectiveMapsToUltragoalPlan(cwd: string, snapshotObjective: string): Promise<boolean> {
+  const actual = normalizeObjective(snapshotObjective).toLowerCase();
+  if (textMentionsUltragoalPlanArtifact(actual)) return true;
+  if (actual.length < 24) return false;
+  try {
+    const brief = normalizeObjective(await readFile(ultragoalBriefPath(cwd), 'utf-8')).toLowerCase();
+    if (!brief || brief.length < 24) return false;
+    return brief.includes(actual) || actual.includes(brief);
+  } catch {
+    return false;
+  }
+}
+
+async function canReconcileCompletedTaskScopedAggregateSnapshot(
+  cwd: string,
+  plan: UltragoalPlan,
+  goal: UltragoalItem,
+  snapshotObjective: string,
+  evidence: string | undefined,
+): Promise<boolean> {
+  if (codexGoalMode(plan) !== 'aggregate') return false;
+  if (!textMentionsUltragoalPlanArtifact(evidence)) return false;
+  if (!textMentionsGoalId(evidence, goal.id)) return false;
+  if (!textHasCompletionValidationEvidence(evidence)) return false;
+  return snapshotObjectiveMapsToUltragoalPlan(cwd, snapshotObjective);
+}
+
+
 function buildCompletedLegacyGoalRemediation(goal: UltragoalItem): string {
   return [
     'If get_goal returns a different completed legacy/thread objective, do not repeat --status complete in this thread.',
@@ -189,6 +247,7 @@ export function isFinalRunCompletionCandidate(plan: UltragoalPlan, goal: Ultrago
 }
 
 export function isUltragoalDone(plan: UltragoalPlan): boolean {
+  if (plan.aggregateCompletion?.status === 'complete') return true;
   if (plan.goals.length === 0) return true;
   if (plan.goals.some((goal) => goal.status === 'pending' || goal.status === 'in_progress' || goal.status === 'failed')) return false;
   if (!plan.goals.every((goal) => isResolvedStatus(goal.status))) return false;
@@ -302,7 +361,7 @@ export async function createUltragoalPlan(cwd: string, options: CreateUltragoalO
   return plan;
 }
 
-export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; activeGoalId?: string } {
+export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; aggregateComplete: boolean; activeGoalId?: string } {
   return {
     total: plan.goals.length,
     pending: plan.goals.filter((goal) => goal.status === 'pending').length,
@@ -310,6 +369,7 @@ export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pe
     complete: plan.goals.filter((goal) => goal.status === 'complete').length,
     failed: plan.goals.filter((goal) => goal.status === 'failed').length,
     reviewBlocked: plan.goals.filter((goal) => goal.status === 'review_blocked').length,
+    aggregateComplete: plan.aggregateCompletion?.status === 'complete',
     activeGoalId: plan.activeGoalId,
   };
 }
@@ -387,6 +447,7 @@ function validateQualityGate(value: unknown): UltragoalQualityGate {
 export async function startNextUltragoal(cwd: string, options: StartNextOptions = {}): Promise<{ plan: UltragoalPlan; goal: UltragoalItem | null; resumed: boolean; done: boolean }> {
   const plan = await readUltragoalPlan(cwd);
   const now = iso(options.now);
+  if (plan.aggregateCompletion?.status === 'complete') return { plan, goal: null, resumed: false, done: true };
   const existing = plan.goals.find((goal) => goal.status === 'in_progress');
   if (existing) {
     await appendLedger(cwd, { ts: now, event: 'goal_resumed', goalId: existing.id, status: existing.status, message: 'Resuming active ultragoal' });
@@ -449,12 +510,14 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     });
     return plan;
   }
+  let aggregateCompletion: UltragoalAggregateCompletion | undefined;
   if (options.status === 'complete') {
     const expectedObjective = expectedCodexObjective(plan, goal);
     const aggregateMode = codexGoalMode(plan) === 'aggregate';
     const finalRunCheckpoint = isFinalRunCompletionCandidate(plan, goal);
+    const snapshot = options.codexGoal === undefined ? null : parseCodexGoalSnapshot(options.codexGoal);
     const reconciliation = reconcileCodexGoalSnapshot(
-      options.codexGoal === undefined ? null : parseCodexGoalSnapshot(options.codexGoal),
+      snapshot,
       {
         expectedObjective,
         allowedStatuses: aggregateMode
@@ -465,19 +528,53 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       },
     );
     if (!reconciliation.ok) {
-      const remediation = reconciliation.snapshot.available
-        && reconciliation.snapshot.status === 'complete'
-        && Boolean(reconciliation.snapshot.objective)
-        && normalizeObjective(reconciliation.snapshot.objective ?? '') !== normalizeObjective(expectedObjective)
-        ? ` ${buildCompletedLegacyGoalRemediation(goal)}`
-        : '';
-      throw new UltragoalError(`${formatCodexGoalReconciliation(reconciliation)}${remediation}`);
+      const completedTaskScopedAggregateSnapshot = snapshot?.available
+        && snapshot.status === 'complete'
+        && Boolean(snapshot.objective)
+        && normalizeObjective(snapshot.objective ?? '') !== normalizeObjective(expectedObjective)
+        && await canReconcileCompletedTaskScopedAggregateSnapshot(cwd, plan, goal, snapshot.objective ?? '', options.evidence);
+      if (completedTaskScopedAggregateSnapshot) {
+        aggregateCompletion = {
+          status: 'complete',
+          completedAt: now,
+          evidence: assertNonEmpty(options.evidence, '--evidence'),
+          codexGoal: options.codexGoal,
+        };
+      } else {
+        const taskScopedRequirement = aggregateMode && snapshot?.status === 'complete' && Boolean(snapshot.objective)
+          ? ' Completed task-scoped aggregate reconciliation requires evidence that names the active OMX goal id, names .omx/ultragoal/goals.json or ledger.jsonl, includes completed implementation plus validation/review evidence, and a get_goal objective that maps to the ultragoal brief/artifact.'
+          : '';
+        const remediation = reconciliation.snapshot.available
+          && reconciliation.snapshot.status === 'complete'
+          && Boolean(reconciliation.snapshot.objective)
+          && normalizeObjective(reconciliation.snapshot.objective ?? '') !== normalizeObjective(expectedObjective)
+          ? ` ${buildCompletedLegacyGoalRemediation(goal)}`
+          : '';
+        throw new UltragoalError(`${formatCodexGoalReconciliation(reconciliation)}${taskScopedRequirement}${remediation}`);
+      }
     }
     if (finalRunCheckpoint && !options.allowActiveFinalCodexGoal) goal.evidence = options.evidence;
   }
-  const qualityGate = options.status === 'complete' && isFinalRunCompletionCandidate(plan, goal) && !options.allowActiveFinalCodexGoal
+  const qualityGate = options.status === 'complete' && (aggregateCompletion !== undefined || (isFinalRunCompletionCandidate(plan, goal) && !options.allowActiveFinalCodexGoal))
     ? validateQualityGate(options.qualityGate)
     : undefined;
+  if (aggregateCompletion) {
+    plan.aggregateCompletion = aggregateCompletion;
+    if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
+    plan.updatedAt = now;
+    await writePlan(cwd, plan);
+    await appendLedger(cwd, {
+      ts: now,
+      event: 'aggregate_completed',
+      goalId: goal.id,
+      status: goal.status,
+      evidence: options.evidence,
+      codexGoal: options.codexGoal,
+      qualityGate,
+      message: 'Aggregate ultragoal plan completed via task-scoped Codex goal snapshot; microgoal ledger progress remains independent.',
+    });
+    return plan;
+  }
   goal.status = options.status;
   goal.updatedAt = now;
   if (options.status === 'complete') {


### PR DESCRIPTION
## Summary
- add aggregate ultragoal completion evidence separate from microgoal ledger status
- reconcile completed task-scoped Codex snapshots only when evidence names the active goal, ultragoal artifacts, and validation/review proof
- stop-hook reconciliation now stops blocking completed planned work when aggregate completion is already recorded, even if synthetic microgoals remain progress-only

## Verification
- npm run build
- node --test dist/ultragoal/__tests__/artifacts.test.js dist/cli/__tests__/ultragoal.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npm run lint
- npm run check:no-unused
- git diff --check

## Notes
- Codex goal state remains immutable/Codex-owned; implementation records OMX ledger/plan evidence only.
- Microgoals are not collapsed or mass-marked complete by aggregate reconciliation.
