### PR TITLE
Add reusable worktree cleanup skill

### DIFF
--- a/plugins/oh-my-codex/skills/worktree-cleaner/SKILL.md
+++ b/plugins/oh-my-codex/skills/worktree-cleaner/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: worktree-cleaner
+description: Safely inventory, triage, and clean local Git worktree clutter across Codex, OMX, and Claude. Use when the user asks in English or Korean to clean worktrees / cleanup worktrees / remove stale worktrees / 워크트리 정리 / 워크트리 청소 / worktree 정리, including *.omx-worktrees launch folders, .claude/worktrees, .codex/worktrees, stale Git worktree registry entries, local-only/upstream-gone branches, copied automation folders, and runtime artifacts.
+---
+
+# Worktree Cleaner
+
+## Safety contract
+
+Default to **dry-run inventory only**. Do not delete, overwrite, force-prune, remove worktrees, or delete branches until the user explicitly approves the concrete paths or branch names.
+
+Prefer reversible cleanup:
+1. move approved paths to a dated quarantine folder or OS Trash;
+2. run `git worktree prune --dry-run` before `git worktree prune`;
+3. delete local branches only as a separate, explicit step after their worktree paths are gone;
+4. verify only the cleanup state; builds/tests are not needed unless source files were edited.
+
+Never remove:
+- the current working directory or any parent of it;
+- active tmux/process cwd paths;
+- dirty worktrees unless explicitly requested for that exact path;
+- `main`, `master`, or `develop` working trees/branches without explicit approval;
+- credential/config roots such as `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config`, global `~/.codex`, or global `~/.claude`;
+- project source folders outside a clearly stale worktree/copy-folder classification.
+
+Project-local `.claude/worktrees/*` and `.codex/worktrees/*` children are cleanup candidates; the `.claude` / `.codex` config directories themselves are not.
+
+## Quick workflow
+
+1. Identify the scan root. Default to the current repo's parent/workspace; avoid scanning all of `$HOME` unless requested.
+2. Run the bundled inventory script:
+
+```bash
+python3 ~/.codex/skills/worktree-cleaner/scripts/inventory.py --root . --root .. --format markdown
+```
+
+For workspace-wide machine-readable output:
+
+```bash
+python3 ~/.codex/skills/worktree-cleaner/scripts/inventory.py --root ~/Documents/workspace --format json > /tmp/worktree-cleanup-inventory.json
+```
+
+3. Check Git registry from a real repo root:
+
+```bash
+git worktree list --porcelain
+git worktree prune --dry-run
+```
+
+4. Classify candidates:
+   - **Likely removable**: clean, stale generated worktrees such as `*.omx-worktrees/launch-*`, `.claude/worktrees/*`, `.codex/worktrees/*`, old task/team/worker dirs, with no active cwd/process references.
+   - **Prune only**: broken entries from `git worktree prune --dry-run`.
+   - **Branch cleanup**: local-only or upstream-gone branches associated with already-removed/quarantined clean worktrees. Use `branch_cleanup.py`; do not fold this into path cleanup.
+   - **Manual review**: dirty worktrees, protected branches, non-launch copies, copied automation folders, runtime state directories, recently modified items, or anything with unclear ownership.
+   - **Keep**: active cwd, parent dirs, global config/credential dirs, protected branches, and unknown source trees.
+5. Present a compact cleanup plan with exact paths, reason, branch/status, upstream state, age, and proposed action.
+6. Ask approval only for destructive/reversible actions, not for additional dry-run inspection.
+7. After cleanup, re-run inventory and `git worktree prune --dry-run`; report remaining candidates.
+
+## Useful commands
+
+Check whether a candidate has local work:
+
+```bash
+git -C /path/to/worktree status --short --branch
+git -C /path/to/worktree branch --show-current
+```
+
+Check active tmux cwd references before proposing removal:
+
+```bash
+tmux list-panes -a -F '#{pane_current_path}' | sort -u
+```
+
+Move approved paths to quarantine instead of deleting. First dry-run exact paths, then apply only after approval:
+
+```bash
+python3 ~/.codex/skills/worktree-cleaner/scripts/quarantine.py /approved/path
+python3 ~/.codex/skills/worktree-cleaner/scripts/quarantine.py --apply /approved/path
+```
+
+Delete approved local-only/upstream-gone branches only after their worktrees are gone:
+
+```bash
+python3 ~/.codex/skills/worktree-cleaner/scripts/branch_cleanup.py --repo /repo/root branch-a branch-b
+python3 ~/.codex/skills/worktree-cleaner/scripts/branch_cleanup.py --repo /repo/root --apply branch-a branch-b
+```
+
+Use `rm -rf` only when the user explicitly asks for permanent deletion and the exact paths were just shown.
+
+## Reading references
+
+Read `references/policy.md` when classification is uncertain, when deleting branches, or when a candidate path is outside generated worktree containers.

--- a/plugins/oh-my-codex/skills/worktree-cleaner/agents/openai.yaml
+++ b/plugins/oh-my-codex/skills/worktree-cleaner/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Worktree Cleaner"
+  short_description: "워크트리 정리: safely clean Git, Codex, OMX, and Claude worktrees"
+  default_prompt: "Use $worktree-cleaner when the user asks to clean worktrees, cleanup worktrees, 워크트리 정리, or 워크트리 청소. Inventory stale local Git/Codex/Claude worktrees and local-only branches with dry-run evidence first."

--- a/plugins/oh-my-codex/skills/worktree-cleaner/references/policy.md
+++ b/plugins/oh-my-codex/skills/worktree-cleaner/references/policy.md
@@ -1,0 +1,69 @@
+# Cleanup classification policy
+
+## Path patterns
+
+Generated worktree containers:
+- `*.omx-worktrees/`
+- `*.worktrees/`
+- project-local `.claude/worktrees/`
+- project-local `.codex/worktrees/`
+- children named `launch-*`, `run-*`, `task-*`, `team-*`, `worker-*`
+
+Likely automation copy folders:
+- `oh-my-codex*`
+- `omx-*` when clearly outside an active repo and containing prompt/skill/plugin scaffolding
+- folders containing `.codex/skills`, `.codex/agents`, or `omx_wiki` copied beside repos
+
+Runtime artifacts to review instead of delete automatically:
+- `.omx/state/`
+- `.omx/logs/`
+- `.omx/plans/`
+- `.omx/notepad.md`
+- project-local `.codex/` outside `.codex/worktrees/*`
+- project-local `.claude/` outside `.claude/worktrees/*`
+
+## Removable path criteria
+
+A path is safe to propose for quarantine when all are true:
+- it is not cwd and cwd is not inside it;
+- it is not a parent of cwd;
+- it is not under a protected global config path;
+- if under `.claude` or `.codex`, it is a child of project-local `worktrees/`;
+- it is older than the user's freshness threshold or visibly stale;
+- if it is a Git worktree, `git status --short` is empty;
+- if branch is known, branch is not `main`, `master`, or `develop` unless explicitly approved;
+- no running process/tmux pane has cwd under it when that can be checked cheaply.
+
+## Branch cleanup policy
+
+Branch deletion is separate from path quarantine because it rewrites local Git state.
+
+A local branch is safe to propose for `git branch -D` only when all are true:
+- the user approved that exact branch name;
+- the branch is not `main`, `master`, or `develop`;
+- it is not the current branch;
+- no worktree currently has the branch checked out;
+- its associated worktree path was already removed/quarantined or never existed;
+- it is local-only or its upstream is gone.
+
+Branches with live upstreams require a second explicit approval and `--allow-tracking`.
+Dirty worktrees, ahead-of-upstream branches, or branches involved in active PRs should be manual-review unless the user explicitly prioritizes local cleanup over preservation.
+
+## Escalation criteria
+
+Stop and ask a concrete question when:
+- a dirty worktree may contain unpushed or uncommitted work;
+- the path looks like a canonical repo rather than a generated worktree/copy;
+- deleting would affect global `~/.codex`, global `~/.claude`, credentials, caches shared by many projects, or package managers;
+- the user asks for permanent deletion of many paths at once without a dry-run list;
+- branch deletion would remove a live-upstream or ahead/diverged branch.
+
+## Final report checklist
+
+Report:
+- scan roots;
+- number of candidates by class;
+- paths moved/deleted, or that no destructive action was taken;
+- branch cleanup commands run or intentionally not run;
+- blocked/manual-review paths and why;
+- follow-up command if `git worktree prune` is still needed.

--- a/plugins/oh-my-codex/skills/worktree-cleaner/scripts/branch_cleanup.py
+++ b/plugins/oh-my-codex/skills/worktree-cleaner/scripts/branch_cleanup.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Dry-run or delete explicitly approved local Git branches after worktree cleanup.
+
+This is intentionally separate from path quarantine because branch deletion rewrites
+local Git state and is less reversible. It never discovers branches by itself; pass
+exact branch names and run without --apply first.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+PROTECTED_BRANCHES = {"main", "master", "develop"}
+
+
+def run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
+    proc = subprocess.run(cmd, cwd=str(cwd), text=True, capture_output=True, check=False)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def current_branch(repo: Path) -> str | None:
+    code, out, _ = run(["git", "branch", "--show-current"], repo)
+    return out if code == 0 and out else None
+
+
+def branch_exists(repo: Path, branch: str) -> bool:
+    code, _, _ = run(["git", "show-ref", "--verify", f"refs/heads/{branch}"], repo)
+    return code == 0
+
+
+def branch_in_worktree(repo: Path, branch: str) -> str | None:
+    code, out, _ = run(["git", "worktree", "list", "--porcelain"], repo)
+    if code != 0:
+        return None
+    current_path: str | None = None
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            current_path = line.removeprefix("worktree ")
+        elif line == f"branch refs/heads/{branch}" and current_path:
+            return current_path
+    return None
+
+
+def upstream_state(repo: Path, branch: str) -> str:
+    code, out, _ = run(["git", "for-each-ref", "--format=%(upstream:short)", f"refs/heads/{branch}"], repo)
+    if code != 0 or not out:
+        return "local-only"
+    code, _, _ = run(["git", "rev-parse", "--verify", "--quiet", out], repo)
+    return "tracking" if code == 0 else "upstream-gone"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("branches", nargs="+", help="Exact local branch names approved for deletion")
+    parser.add_argument("--repo", default=".", help="Repository root/main worktree to run git branch in")
+    parser.add_argument("--apply", action="store_true", help="Actually run git branch -D. Without this, dry-run only.")
+    parser.add_argument(
+        "--allow-tracking",
+        action="store_true",
+        help="Allow deleting branches that still have a live upstream. Default only allows local-only/upstream-gone branches.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo = Path(args.repo).expanduser().resolve()
+    current = current_branch(repo)
+
+    refused: list[tuple[str, str]] = []
+    allowed: list[tuple[str, str]] = []
+    for branch in args.branches:
+        if branch in PROTECTED_BRANCHES:
+            refused.append((branch, "protected branch"))
+            continue
+        if branch == current:
+            refused.append((branch, "is current branch"))
+            continue
+        if not branch_exists(repo, branch):
+            refused.append((branch, "local branch does not exist"))
+            continue
+        worktree_path = branch_in_worktree(repo, branch)
+        if worktree_path:
+            refused.append((branch, f"still checked out by worktree: {worktree_path}"))
+            continue
+        state = upstream_state(repo, branch)
+        if state == "tracking" and not args.allow_tracking:
+            refused.append((branch, "has live upstream; pass --allow-tracking only after explicit approval"))
+            continue
+        allowed.append((branch, state))
+
+    print(f"repo: {repo}")
+    print(f"mode: {'apply' if args.apply else 'dry-run'}")
+
+    if refused:
+        print("\nrefused:")
+        for branch, reason in refused:
+            print(f"- {branch} ({reason})")
+
+    if allowed:
+        print("\nallowed:")
+        for branch, state in allowed:
+            print(f"- git branch -D {branch}  # {state}")
+
+    if refused:
+        print("\nNo branches deleted because at least one branch was refused.")
+        return 2
+    if not args.apply:
+        print("\nDry-run only. Re-run with --apply after reviewing the exact branch names.")
+        return 0
+
+    for branch, _ in allowed:
+        code, out, err = run(["git", "branch", "-D", branch], repo)
+        if out:
+            print(out)
+        if err:
+            print(err, file=sys.stderr)
+        if code != 0:
+            return code
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/oh-my-codex/skills/worktree-cleaner/scripts/inventory.py
+++ b/plugins/oh-my-codex/skills/worktree-cleaner/scripts/inventory.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Inventory local Git/Codex/Claude/OMX worktree cleanup candidates.
+
+Read-only by design. It prints candidate paths and metadata so an agent can
+propose a safe cleanup plan without guessing or deleting Git state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+SKIP_DIR_NAMES = {
+    ".git",
+    "node_modules",
+    ".next",
+    ".nuxt",
+    "dist",
+    "build",
+    "coverage",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".turbo",
+    ".cache",
+    "Library",
+    "Applications",
+    "Movies",
+    "Music",
+    "Pictures",
+}
+
+PROTECTED_DIRS = {
+    ".ssh",
+    ".aws",
+    ".gnupg",
+    ".config",
+    ".codex",
+    ".claude",
+}
+
+WORKTREE_CONTAINER_SUFFIXES = (".omx-worktrees", ".worktrees")
+WORKTREE_CONTAINER_NAMES = {"worktrees"}
+CLAUDE_WORKTREES_MARKER = (".claude", "worktrees")
+CODEX_WORKTREES_MARKER = (".codex", "worktrees")
+LAUNCH_PREFIXES = ("launch-", "run-", "task-", "team-", "worker-")
+COPY_PATTERNS = ("oh-my-codex", "omx-copy", "omx_backup", "omx-backup", "codex-copy")
+PROTECTED_BRANCHES = {"main", "master", "develop"}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    classification: str
+    path: str
+    reason: str
+    action: str
+    age_days: float | None
+    branch: str | None = None
+    dirty: bool | None = None
+    upstream: str | None = None
+    upstream_state: str | None = None
+    ahead: int | None = None
+    behind: int | None = None
+    protected: bool = False
+    notes: str | None = None
+
+
+def run(cmd: list[str], cwd: Path | None = None, timeout: int = 5) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 1, "", str(exc)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def age_days(path: Path) -> float | None:
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return None
+    now = datetime.now(timezone.utc).timestamp()
+    return round(max(0.0, (now - mtime) / 86400), 2)
+
+
+def is_git_worktree(path: Path) -> bool:
+    return (path / ".git").exists()
+
+
+def git_branch(path: Path) -> str | None:
+    code, out, _ = run(["git", "branch", "--show-current"], cwd=path)
+    return out if code == 0 and out else None
+
+
+def git_dirty(path: Path) -> bool | None:
+    code, out, _ = run(["git", "status", "--short"], cwd=path)
+    if code != 0:
+        return None
+    return bool(out)
+
+
+def parse_ahead_behind(status_line: str) -> tuple[int | None, int | None]:
+    ahead: int | None = None
+    behind: int | None = None
+    if "[" not in status_line or "]" not in status_line:
+        return ahead, behind
+    bracket = status_line.split("[", 1)[1].split("]", 1)[0]
+    for part in [p.strip() for p in bracket.split(",")]:
+        if part.startswith("ahead "):
+            try:
+                ahead = int(part.split()[1])
+            except (IndexError, ValueError):
+                pass
+        elif part.startswith("behind "):
+            try:
+                behind = int(part.split()[1])
+            except (IndexError, ValueError):
+                pass
+    return ahead, behind
+
+
+def git_upstream_info(path: Path) -> tuple[str | None, str | None, int | None, int | None]:
+    code, out, _ = run(["git", "status", "--short", "--branch"], cwd=path)
+    if code != 0 or not out:
+        return None, None, None, None
+    first = out.splitlines()[0]
+    if not first.startswith("## "):
+        return None, None, None, None
+    text = first[3:]
+    ahead, behind = parse_ahead_behind(text)
+    if "..." not in text:
+        return None, "local-only", ahead, behind
+    upstream_part = text.split("...", 1)[1]
+    upstream = upstream_part.split(" ", 1)[0]
+    if "[gone]" in text:
+        state = "upstream-gone"
+    elif ahead and behind:
+        state = "diverged"
+    elif ahead:
+        state = "ahead"
+    elif behind:
+        state = "behind"
+    else:
+        state = "tracking"
+    return upstream, state, ahead, behind
+
+
+def cwd_relationship(path: Path, cwd: Path) -> str | None:
+    try:
+        resolved = path.resolve()
+        cwd_resolved = cwd.resolve()
+    except OSError:
+        return None
+    if resolved == cwd_resolved:
+        return "is current working directory"
+    if resolved in cwd_resolved.parents:
+        return "contains current working directory"
+    return None
+
+
+
+
+def related_path_note(path: Path, other: Path, label: str) -> str | None:
+    try:
+        resolved = path.resolve()
+        other_resolved = other.resolve()
+    except OSError:
+        return None
+    if resolved == other_resolved:
+        return f"is active {label}"
+    if resolved in other_resolved.parents:
+        return f"contains active {label}"
+    return None
+
+
+def active_tmux_cwds() -> list[Path]:
+    code, out, _ = run(["tmux", "list-panes", "-a", "-F", "#{pane_current_path}"], timeout=3)
+    if code != 0 or not out:
+        return []
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for line in out.splitlines():
+        if not line:
+            continue
+        path = Path(line).expanduser()
+        key = str(path)
+        if key not in seen:
+            paths.append(path)
+            seen.add(key)
+    return paths
+
+def has_marker(path: Path, marker: tuple[str, str]) -> bool:
+    parts = path.parts
+    for idx in range(len(parts) - 1):
+        if parts[idx] == marker[0] and parts[idx + 1] == marker[1]:
+            return True
+    return False
+
+
+def marker_child_depth(path: Path, marker: tuple[str, str]) -> int | None:
+    parts = path.parts
+    for idx in range(len(parts) - 1):
+        if parts[idx] == marker[0] and parts[idx + 1] == marker[1]:
+            return len(parts) - (idx + 2)
+    return None
+
+
+def is_allowed_nested_worktree_path(path: Path) -> bool:
+    """Allow project-local .claude/.codex/worktrees children without unprotecting global config roots."""
+    for marker in (CLAUDE_WORKTREES_MARKER, CODEX_WORKTREES_MARKER):
+        depth = marker_child_depth(path, marker)
+        if depth is not None and depth >= 1:
+            return True
+    return False
+
+
+def protected_path(path: Path, cwd: Path, active_cwds: list[Path]) -> tuple[bool, str | None]:
+    relationship = cwd_relationship(path, cwd)
+    if relationship:
+        return True, relationship
+    for active_cwd in active_cwds:
+        active_relationship = related_path_note(path, active_cwd, "tmux pane cwd")
+        if active_relationship:
+            return True, active_relationship
+    parts = set(path.parts)
+    protected_hits = sorted(parts & PROTECTED_DIRS)
+    if protected_hits:
+        if is_allowed_nested_worktree_path(path):
+            non_worktree_hits = [hit for hit in protected_hits if hit not in {".claude", ".codex"}]
+            if not non_worktree_hits:
+                return False, None
+            protected_hits = non_worktree_hits
+        return True, f"under protected config segment {', '.join(protected_hits)}"
+    return False, None
+
+
+def candidate_action(branch: str | None, dirty: bool | None, upstream_state: str | None) -> tuple[str, str, str | None]:
+    note: str | None = None
+    if branch in PROTECTED_BRANCHES:
+        return "manual-review", "review protected branch before quarantine", "branch is protected"
+    if dirty is True:
+        return "manual-review", "inspect uncommitted work before quarantine", None
+    if dirty is False:
+        if upstream_state in {"local-only", "upstream-gone"}:
+            note = "branch has no live upstream; branch deletion needs explicit approval"
+        return "likely-removable", "candidate for quarantine after approval", note
+    return "manual-review", "inspect before quarantine", None
+
+
+def make_worktree_candidate(path: Path, cwd: Path, active_cwds: list[Path], reason: str) -> Candidate:
+    branch = git_branch(path) if is_git_worktree(path) else None
+    dirty = git_dirty(path) if is_git_worktree(path) else None
+    upstream, upstream_state, ahead, behind = git_upstream_info(path) if is_git_worktree(path) else (None, None, None, None)
+    protected, note = protected_path(path, cwd, active_cwds)
+    action = "keep"
+    classification = "keep"
+
+    if protected:
+        action = "do not remove"
+    else:
+        classification, action, branch_note = candidate_action(branch, dirty, upstream_state)
+        if branch_note:
+            note = branch_note if not note else f"{note}; {branch_note}"
+
+    return Candidate(
+        classification=classification,
+        path=str(path),
+        reason=reason,
+        action=action,
+        age_days=age_days(path),
+        branch=branch,
+        dirty=dirty,
+        upstream=upstream,
+        upstream_state=upstream_state,
+        ahead=ahead,
+        behind=behind,
+        protected=protected,
+        notes=note,
+    )
+
+
+def iter_dirs(root: Path, max_depth: int) -> Iterable[tuple[Path, int]]:
+    root = root.expanduser()
+    if not root.exists():
+        return
+    stack: list[tuple[Path, int]] = [(root, 0)]
+    while stack:
+        current, depth = stack.pop()
+        yield current, depth
+        if depth >= max_depth:
+            continue
+        try:
+            children = sorted(current.iterdir(), key=lambda p: p.name)
+        except OSError:
+            continue
+        for child in reversed(children):
+            if not child.is_dir():
+                continue
+            if child.name in SKIP_DIR_NAMES:
+                continue
+            # Project-local .claude/.codex may contain worktrees; global config remains protected at action time.
+            stack.append((child, depth + 1))
+
+
+def add_children(path: Path, cwd: Path, active_cwds: list[Path], add) -> None:
+    try:
+        children = sorted(path.iterdir(), key=lambda p: p.name)
+    except OSError:
+        children = []
+    for child in children:
+        if child.is_dir() and (child.name.startswith(LAUNCH_PREFIXES) or is_git_worktree(child)):
+            add(make_worktree_candidate(child, cwd, active_cwds, f"child of {path.name} worktree container"))
+
+
+def scan_root(root: Path, max_depth: int, cwd: Path, active_cwds: list[Path]) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    seen: set[str] = set()
+
+    def add(candidate: Candidate) -> None:
+        key = candidate.path
+        if key not in seen:
+            candidates.append(candidate)
+            seen.add(key)
+
+    for path, depth in iter_dirs(root, max_depth):
+        name = path.name
+        lowered = name.lower()
+
+        if name.endswith(WORKTREE_CONTAINER_SUFFIXES):
+            protected, note = protected_path(path, cwd, active_cwds)
+            add(
+                Candidate(
+                    classification="manual-review" if not protected else "keep",
+                    path=str(path),
+                    reason="generic worktree container",
+                    action="review children; remove container only when empty",
+                    age_days=age_days(path),
+                    protected=protected,
+                    notes=note,
+                )
+            )
+            add_children(path, cwd, active_cwds, add)
+            continue
+
+        if name == "worktrees" and (has_marker(path, CLAUDE_WORKTREES_MARKER) or has_marker(path, CODEX_WORKTREES_MARKER)):
+            protected, note = protected_path(path, cwd, active_cwds)
+            add(
+                Candidate(
+                    classification="manual-review" if not protected else "keep",
+                    path=str(path),
+                    reason="Claude/Codex worktree container",
+                    action="review children; remove container only when empty",
+                    age_days=age_days(path),
+                    protected=protected,
+                    notes=note,
+                )
+            )
+            add_children(path, cwd, active_cwds, add)
+            continue
+
+        if depth > 0 and name.startswith(LAUNCH_PREFIXES) and is_git_worktree(path):
+            add(make_worktree_candidate(path, cwd, active_cwds, "launch-like Git worktree"))
+            continue
+
+        if any(lowered.startswith(pattern) for pattern in COPY_PATTERNS):
+            protected, note = protected_path(path, cwd, active_cwds)
+            add(
+                Candidate(
+                    classification="manual-review" if not protected else "keep",
+                    path=str(path),
+                    reason="possible copied Codex/OMX folder",
+                    action="inspect contents before quarantine",
+                    age_days=age_days(path),
+                    protected=protected,
+                    notes=note,
+                )
+            )
+            continue
+
+        if name in {".omx"}:
+            protected, note = protected_path(path, cwd, active_cwds)
+            add(
+                Candidate(
+                    classification="manual-review" if not protected else "keep",
+                    path=str(path),
+                    reason="OMX runtime state directory",
+                    action="prune logs/state only with repo-specific approval",
+                    age_days=age_days(path),
+                    protected=protected,
+                    notes=note,
+                )
+            )
+
+    return candidates
+
+
+def render_markdown(candidates: list[Candidate]) -> str:
+    if not candidates:
+        return "No worktree cleanup candidates found."
+
+    groups: dict[str, list[Candidate]] = {}
+    for item in candidates:
+        groups.setdefault(item.classification, []).append(item)
+
+    lines = ["# Worktree cleanup inventory", ""]
+    for classification in sorted(groups):
+        items = groups[classification]
+        lines.append(f"## {classification} ({len(items)})")
+        lines.append("")
+        for item in sorted(items, key=lambda c: c.path):
+            dirty = "unknown" if item.dirty is None else ("yes" if item.dirty else "no")
+            meta = []
+            if item.age_days is not None:
+                meta.append(f"age={item.age_days}d")
+            if item.branch:
+                meta.append(f"branch={item.branch}")
+            if item.dirty is not None:
+                meta.append(f"dirty={dirty}")
+            if item.upstream_state:
+                meta.append(f"upstream={item.upstream_state}")
+            if item.upstream:
+                meta.append(f"tracks={item.upstream}")
+            if item.ahead:
+                meta.append(f"ahead={item.ahead}")
+            if item.behind:
+                meta.append(f"behind={item.behind}")
+            if item.protected:
+                meta.append("protected=yes")
+            suffix = f" ({', '.join(meta)})" if meta else ""
+            lines.append(f"- `{item.path}`{suffix}")
+            lines.append(f"  - reason: {item.reason}")
+            lines.append(f"  - action: {item.action}")
+            if item.notes:
+                lines.append(f"  - notes: {item.notes}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        action="append",
+        default=[],
+        help="Root directory to scan. Repeatable. Defaults to current directory.",
+    )
+    parser.add_argument("--max-depth", type=int, default=5, help="Directory traversal depth per root.")
+    parser.add_argument("--format", choices={"markdown", "json"}, default="markdown")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cwd = Path.cwd()
+    active_cwds = active_tmux_cwds()
+    roots = [Path(r).expanduser() for r in (args.root or ["."])]
+    candidates: list[Candidate] = []
+    seen: set[str] = set()
+
+    for root in roots:
+        for candidate in scan_root(root, args.max_depth, cwd, active_cwds):
+            if candidate.path not in seen:
+                candidates.append(candidate)
+                seen.add(candidate.path)
+
+    if args.format == "json":
+        payload = {
+            "roots": [str(r) for r in roots],
+            "cwd": str(cwd),
+            "active_cwds": [str(path) for path in active_cwds],
+            "candidate_count": len(candidates),
+            "candidates": [asdict(candidate) for candidate in candidates],
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(render_markdown(candidates))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/oh-my-codex/skills/worktree-cleaner/scripts/quarantine.py
+++ b/plugins/oh-my-codex/skills/worktree-cleaner/scripts/quarantine.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Move explicitly approved cleanup paths into a dated quarantine folder.
+
+Dry-run by default. Requires --apply to move anything. Accept only explicit paths;
+this script performs no discovery and intentionally does not expand globs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+PROTECTED_SEGMENTS = {".ssh", ".aws", ".gnupg", ".config", ".codex", ".claude"}
+ALLOWED_NESTED_MARKERS = ((".claude", "worktrees"), (".codex", "worktrees"))
+
+
+def resolve(path: str) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def relation_to_cwd(path: Path, cwd: Path) -> str | None:
+    if path == cwd:
+        return "is current working directory"
+    if path in cwd.parents:
+        return "contains current working directory"
+    return None
+
+
+def marker_child_depth(path: Path, marker: tuple[str, str]) -> int | None:
+    parts = path.parts
+    for idx in range(len(parts) - 1):
+        if parts[idx] == marker[0] and parts[idx + 1] == marker[1]:
+            return len(parts) - (idx + 2)
+    return None
+
+
+def allowed_nested_worktree_child(path: Path) -> bool:
+    # Allow only children under project-local .claude/.codex/worktrees, not the config dir itself.
+    return any((depth := marker_child_depth(path, marker)) is not None and depth >= 1 for marker in ALLOWED_NESTED_MARKERS)
+
+
+def refusal_reason(path: Path, cwd: Path) -> str | None:
+    relation = relation_to_cwd(path, cwd)
+    if relation:
+        return relation
+    if not path.exists():
+        return "does not exist"
+    protected = sorted(set(path.parts) & PROTECTED_SEGMENTS)
+    if protected:
+        if allowed_nested_worktree_child(path):
+            non_worktree_hits = [hit for hit in protected if hit not in {".claude", ".codex"}]
+            if not non_worktree_hits:
+                return None
+            protected = non_worktree_hits
+        return f"contains protected path segment: {', '.join(protected)}"
+    return None
+
+
+def unique_destination(quarantine_dir: Path, source: Path) -> Path:
+    target = quarantine_dir / source.name
+    if not target.exists():
+        return target
+    index = 1
+    while True:
+        candidate = quarantine_dir / f"{source.name}.{index}"
+        if not candidate.exists():
+            return candidate
+        index += 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", help="Explicit paths approved for quarantine")
+    parser.add_argument("--apply", action="store_true", help="Actually move paths. Without this, dry-run only.")
+    parser.add_argument(
+        "--quarantine-dir",
+        default=f"~/.Trash/worktree-cleanup-{datetime.now().strftime('%Y%m%d-%H%M%S')}",
+        help="Destination directory. Defaults to a dated folder under ~/.Trash.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cwd = Path.cwd().resolve()
+    quarantine_dir = resolve(args.quarantine_dir)
+    sources = [resolve(path) for path in args.paths]
+
+    refused: list[tuple[Path, str]] = []
+    allowed: list[Path] = []
+    for source in sources:
+        reason = refusal_reason(source, cwd)
+        if reason:
+            refused.append((source, reason))
+        else:
+            allowed.append(source)
+
+    print(f"quarantine_dir: {quarantine_dir}")
+    print(f"mode: {'apply' if args.apply else 'dry-run'}")
+
+    if refused:
+        print("\nrefused:")
+        for path, reason in refused:
+            print(f"- {path} ({reason})")
+
+    if allowed:
+        print("\nallowed:")
+        for source in allowed:
+            print(f"- {source} -> {unique_destination(quarantine_dir, source)}")
+
+    if refused:
+        print("\nNo files moved because at least one path was refused.")
+        return 2
+
+    if not args.apply:
+        print("\nDry-run only. Re-run with --apply after reviewing the exact paths.")
+        return 0
+
+    quarantine_dir.mkdir(parents=True, exist_ok=True)
+    for source in allowed:
+        target = unique_destination(quarantine_dir, source)
+        shutil.move(str(source), str(target))
+    print("\nMoved approved paths to quarantine.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/worktree-cleaner/SKILL.md
+++ b/skills/worktree-cleaner/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: worktree-cleaner
+description: Safely inventory, triage, and clean local Git worktree clutter across Codex, OMX, and Claude. Use when the user asks in English or Korean to clean worktrees / cleanup worktrees / remove stale worktrees / 워크트리 정리 / 워크트리 청소 / worktree 정리, including *.omx-worktrees launch folders, .claude/worktrees, .codex/worktrees, stale Git worktree registry entries, local-only/upstream-gone branches, copied automation folders, and runtime artifacts.
+---
+
+# Worktree Cleaner
+
+## Safety contract
+
+Default to **dry-run inventory only**. Do not delete, overwrite, force-prune, remove worktrees, or delete branches until the user explicitly approves the concrete paths or branch names.
+
+Prefer reversible cleanup:
+1. move approved paths to a dated quarantine folder or OS Trash;
+2. run `git worktree prune --dry-run` before `git worktree prune`;
+3. delete local branches only as a separate, explicit step after their worktree paths are gone;
+4. verify only the cleanup state; builds/tests are not needed unless source files were edited.
+
+Never remove:
+- the current working directory or any parent of it;
+- active tmux/process cwd paths;
+- dirty worktrees unless explicitly requested for that exact path;
+- `main`, `master`, or `develop` working trees/branches without explicit approval;
+- credential/config roots such as `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config`, global `~/.codex`, or global `~/.claude`;
+- project source folders outside a clearly stale worktree/copy-folder classification.
+
+Project-local `.claude/worktrees/*` and `.codex/worktrees/*` children are cleanup candidates; the `.claude` / `.codex` config directories themselves are not.
+
+## Quick workflow
+
+1. Identify the scan root. Default to the current repo's parent/workspace; avoid scanning all of `$HOME` unless requested.
+2. Run the bundled inventory script:
+
+```bash
+python3 ~/.codex/skills/worktree-cleaner/scripts/inventory.py --root . --root .. --format markdown
+```
+
+For workspace-wide machine-readable output:
+
+```bash
+python3 ~/.codex/skills/worktree-cleaner/scripts/inventory.py --root ~/Documents/workspace --format json > /tmp/worktree-cleanup-inventory.json
+```
+
+3. Check Git registry from a real repo root:
+
+```bash
+git worktree list --porcelain
+git worktree prune --dry-run
+```
+
+4. Classify candidates:
+   - **Likely removable**: clean, stale generated worktrees such as `*.omx-worktrees/launch-*`, `.claude/worktrees/*`, `.codex/worktrees/*`, old task/team/worker dirs, with no active cwd/process references.
+   - **Prune only**: broken entries from `git worktree prune --dry-run`.
+   - **Branch cleanup**: local-only or upstream-gone branches associated with already-removed/quarantined clean worktrees. Use `branch_cleanup.py`; do not fold this into path cleanup.
+   - **Manual review**: dirty worktrees, protected branches, non-launch copies, copied automation folders, runtime state directories, recently modified items, or anything with unclear ownership.
+   - **Keep**: active cwd, parent dirs, global config/credential dirs, protected branches, and unknown source trees.
+5. Present a compact cleanup plan with exact paths, reason, branch/status, upstream state, age, and proposed action.
+6. Ask approval only for destructive/reversible actions, not for additional dry-run inspection.
+7. After cleanup, re-run inventory and `git worktree prune --dry-run`; report remaining candidates.
+
+## Useful commands
+
+Check whether a candidate has local work:
+
+```bash
+git -C /path/to/worktree status --short --branch
+git -C /path/to/worktree branch --show-current
+```
+
+Check active tmux cwd references before proposing removal:
+
+```bash
+tmux list-panes -a -F '#{pane_current_path}' | sort -u
+```
+
+Move approved paths to quarantine instead of deleting. First dry-run exact paths, then apply only after approval:
+
+```bash
+python3 ~/.codex/skills/worktree-cleaner/scripts/quarantine.py /approved/path
+python3 ~/.codex/skills/worktree-cleaner/scripts/quarantine.py --apply /approved/path
+```
+
+Delete approved local-only/upstream-gone branches only after their worktrees are gone:
+
+```bash
+python3 ~/.codex/skills/worktree-cleaner/scripts/branch_cleanup.py --repo /repo/root branch-a branch-b
+python3 ~/.codex/skills/worktree-cleaner/scripts/branch_cleanup.py --repo /repo/root --apply branch-a branch-b
+```
+
+Use `rm -rf` only when the user explicitly asks for permanent deletion and the exact paths were just shown.
+
+## Reading references
+
+Read `references/policy.md` when classification is uncertain, when deleting branches, or when a candidate path is outside generated worktree containers.

--- a/skills/worktree-cleaner/agents/openai.yaml
+++ b/skills/worktree-cleaner/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Worktree Cleaner"
+  short_description: "워크트리 정리: safely clean Git, Codex, OMX, and Claude worktrees"
+  default_prompt: "Use $worktree-cleaner when the user asks to clean worktrees, cleanup worktrees, 워크트리 정리, or 워크트리 청소. Inventory stale local Git/Codex/Claude worktrees and local-only branches with dry-run evidence first."

--- a/skills/worktree-cleaner/references/policy.md
+++ b/skills/worktree-cleaner/references/policy.md
@@ -1,0 +1,69 @@
+# Cleanup classification policy
+
+## Path patterns
+
+Generated worktree containers:
+- `*.omx-worktrees/`
+- `*.worktrees/`
+- project-local `.claude/worktrees/`
+- project-local `.codex/worktrees/`
+- children named `launch-*`, `run-*`, `task-*`, `team-*`, `worker-*`
+
+Likely automation copy folders:
+- `oh-my-codex*`
+- `omx-*` when clearly outside an active repo and containing prompt/skill/plugin scaffolding
+- folders containing `.codex/skills`, `.codex/agents`, or `omx_wiki` copied beside repos
+
+Runtime artifacts to review instead of delete automatically:
+- `.omx/state/`
+- `.omx/logs/`
+- `.omx/plans/`
+- `.omx/notepad.md`
+- project-local `.codex/` outside `.codex/worktrees/*`
+- project-local `.claude/` outside `.claude/worktrees/*`
+
+## Removable path criteria
+
+A path is safe to propose for quarantine when all are true:
+- it is not cwd and cwd is not inside it;
+- it is not a parent of cwd;
+- it is not under a protected global config path;
+- if under `.claude` or `.codex`, it is a child of project-local `worktrees/`;
+- it is older than the user's freshness threshold or visibly stale;
+- if it is a Git worktree, `git status --short` is empty;
+- if branch is known, branch is not `main`, `master`, or `develop` unless explicitly approved;
+- no running process/tmux pane has cwd under it when that can be checked cheaply.
+
+## Branch cleanup policy
+
+Branch deletion is separate from path quarantine because it rewrites local Git state.
+
+A local branch is safe to propose for `git branch -D` only when all are true:
+- the user approved that exact branch name;
+- the branch is not `main`, `master`, or `develop`;
+- it is not the current branch;
+- no worktree currently has the branch checked out;
+- its associated worktree path was already removed/quarantined or never existed;
+- it is local-only or its upstream is gone.
+
+Branches with live upstreams require a second explicit approval and `--allow-tracking`.
+Dirty worktrees, ahead-of-upstream branches, or branches involved in active PRs should be manual-review unless the user explicitly prioritizes local cleanup over preservation.
+
+## Escalation criteria
+
+Stop and ask a concrete question when:
+- a dirty worktree may contain unpushed or uncommitted work;
+- the path looks like a canonical repo rather than a generated worktree/copy;
+- deleting would affect global `~/.codex`, global `~/.claude`, credentials, caches shared by many projects, or package managers;
+- the user asks for permanent deletion of many paths at once without a dry-run list;
+- branch deletion would remove a live-upstream or ahead/diverged branch.
+
+## Final report checklist
+
+Report:
+- scan roots;
+- number of candidates by class;
+- paths moved/deleted, or that no destructive action was taken;
+- branch cleanup commands run or intentionally not run;
+- blocked/manual-review paths and why;
+- follow-up command if `git worktree prune` is still needed.

--- a/skills/worktree-cleaner/scripts/branch_cleanup.py
+++ b/skills/worktree-cleaner/scripts/branch_cleanup.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Dry-run or delete explicitly approved local Git branches after worktree cleanup.
+
+This is intentionally separate from path quarantine because branch deletion rewrites
+local Git state and is less reversible. It never discovers branches by itself; pass
+exact branch names and run without --apply first.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+PROTECTED_BRANCHES = {"main", "master", "develop"}
+
+
+def run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
+    proc = subprocess.run(cmd, cwd=str(cwd), text=True, capture_output=True, check=False)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def current_branch(repo: Path) -> str | None:
+    code, out, _ = run(["git", "branch", "--show-current"], repo)
+    return out if code == 0 and out else None
+
+
+def branch_exists(repo: Path, branch: str) -> bool:
+    code, _, _ = run(["git", "show-ref", "--verify", f"refs/heads/{branch}"], repo)
+    return code == 0
+
+
+def branch_in_worktree(repo: Path, branch: str) -> str | None:
+    code, out, _ = run(["git", "worktree", "list", "--porcelain"], repo)
+    if code != 0:
+        return None
+    current_path: str | None = None
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            current_path = line.removeprefix("worktree ")
+        elif line == f"branch refs/heads/{branch}" and current_path:
+            return current_path
+    return None
+
+
+def upstream_state(repo: Path, branch: str) -> str:
+    code, out, _ = run(["git", "for-each-ref", "--format=%(upstream:short)", f"refs/heads/{branch}"], repo)
+    if code != 0 or not out:
+        return "local-only"
+    code, _, _ = run(["git", "rev-parse", "--verify", "--quiet", out], repo)
+    return "tracking" if code == 0 else "upstream-gone"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("branches", nargs="+", help="Exact local branch names approved for deletion")
+    parser.add_argument("--repo", default=".", help="Repository root/main worktree to run git branch in")
+    parser.add_argument("--apply", action="store_true", help="Actually run git branch -D. Without this, dry-run only.")
+    parser.add_argument(
+        "--allow-tracking",
+        action="store_true",
+        help="Allow deleting branches that still have a live upstream. Default only allows local-only/upstream-gone branches.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo = Path(args.repo).expanduser().resolve()
+    current = current_branch(repo)
+
+    refused: list[tuple[str, str]] = []
+    allowed: list[tuple[str, str]] = []
+    for branch in args.branches:
+        if branch in PROTECTED_BRANCHES:
+            refused.append((branch, "protected branch"))
+            continue
+        if branch == current:
+            refused.append((branch, "is current branch"))
+            continue
+        if not branch_exists(repo, branch):
+            refused.append((branch, "local branch does not exist"))
+            continue
+        worktree_path = branch_in_worktree(repo, branch)
+        if worktree_path:
+            refused.append((branch, f"still checked out by worktree: {worktree_path}"))
+            continue
+        state = upstream_state(repo, branch)
+        if state == "tracking" and not args.allow_tracking:
+            refused.append((branch, "has live upstream; pass --allow-tracking only after explicit approval"))
+            continue
+        allowed.append((branch, state))
+
+    print(f"repo: {repo}")
+    print(f"mode: {'apply' if args.apply else 'dry-run'}")
+
+    if refused:
+        print("\nrefused:")
+        for branch, reason in refused:
+            print(f"- {branch} ({reason})")
+
+    if allowed:
+        print("\nallowed:")
+        for branch, state in allowed:
+            print(f"- git branch -D {branch}  # {state}")
+
+    if refused:
+        print("\nNo branches deleted because at least one branch was refused.")
+        return 2
+    if not args.apply:
+        print("\nDry-run only. Re-run with --apply after reviewing the exact branch names.")
+        return 0
+
+    for branch, _ in allowed:
+        code, out, err = run(["git", "branch", "-D", branch], repo)
+        if out:
+            print(out)
+        if err:
+            print(err, file=sys.stderr)
+        if code != 0:
+            return code
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/worktree-cleaner/scripts/inventory.py
+++ b/skills/worktree-cleaner/scripts/inventory.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Inventory local Git/Codex/Claude/OMX worktree cleanup candidates.
+
+Read-only by design. It prints candidate paths and metadata so an agent can
+propose a safe cleanup plan without guessing or deleting Git state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+SKIP_DIR_NAMES = {
+    ".git",
+    "node_modules",
+    ".next",
+    ".nuxt",
+    "dist",
+    "build",
+    "coverage",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".turbo",
+    ".cache",
+    "Library",
+    "Applications",
+    "Movies",
+    "Music",
+    "Pictures",
+}
+
+PROTECTED_DIRS = {
+    ".ssh",
+    ".aws",
+    ".gnupg",
+    ".config",
+    ".codex",
+    ".claude",
+}
+
+WORKTREE_CONTAINER_SUFFIXES = (".omx-worktrees", ".worktrees")
+WORKTREE_CONTAINER_NAMES = {"worktrees"}
+CLAUDE_WORKTREES_MARKER = (".claude", "worktrees")
+CODEX_WORKTREES_MARKER = (".codex", "worktrees")
+LAUNCH_PREFIXES = ("launch-", "run-", "task-", "team-", "worker-")
+COPY_PATTERNS = ("oh-my-codex", "omx-copy", "omx_backup", "omx-backup", "codex-copy")
+PROTECTED_BRANCHES = {"main", "master", "develop"}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    classification: str
+    path: str
+    reason: str
+    action: str
+    age_days: float | None
+    branch: str | None = None
+    dirty: bool | None = None
+    upstream: str | None = None
+    upstream_state: str | None = None
+    ahead: int | None = None
+    behind: int | None = None
+    protected: bool = False
+    notes: str | None = None
+
+
+def run(cmd: list[str], cwd: Path | None = None, timeout: int = 5) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 1, "", str(exc)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def age_days(path: Path) -> float | None:
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return None
+    now = datetime.now(timezone.utc).timestamp()
+    return round(max(0.0, (now - mtime) / 86400), 2)
+
+
+def is_git_worktree(path: Path) -> bool:
+    return (path / ".git").exists()
+
+
+def git_branch(path: Path) -> str | None:
+    code, out, _ = run(["git", "branch", "--show-current"], cwd=path)
+    return out if code == 0 and out else None
+
+
+def git_dirty(path: Path) -> bool | None:
+    code, out, _ = run(["git", "status", "--short"], cwd=path)
+    if code != 0:
+        return None
+    return bool(out)
+
+
+def parse_ahead_behind(status_line: str) -> tuple[int | None, int | None]:
+    ahead: int | None = None
+    behind: int | None = None
+    if "[" not in status_line or "]" not in status_line:
+        return ahead, behind
+    bracket = status_line.split("[", 1)[1].split("]", 1)[0]
+    for part in [p.strip() for p in bracket.split(",")]:
+        if part.startswith("ahead "):
+            try:
+                ahead = int(part.split()[1])
+            except (IndexError, ValueError):
+                pass
+        elif part.startswith("behind "):
+            try:
+                behind = int(part.split()[1])
+            except (IndexError, ValueError):
+                pass
+    return ahead, behind
+
+
+def git_upstream_info(path: Path) -> tuple[str | None, str | None, int | None, int | None]:
+    code, out, _ = run(["git", "status", "--short", "--branch"], cwd=path)
+    if code != 0 or not out:
+        return None, None, None, None
+    first = out.splitlines()[0]
+    if not first.startswith("## "):
+        return None, None, None, None
+    text = first[3:]
+    ahead, behind = parse_ahead_behind(text)
+    if "..." not in text:
+        return None, "local-only", ahead, behind
+    upstream_part = text.split("...", 1)[1]
+    upstream = upstream_part.split(" ", 1)[0]
+    if "[gone]" in text:
+        state = "upstream-gone"
+    elif ahead and behind:
+        state = "diverged"
+    elif ahead:
+        state = "ahead"
+    elif behind:
+        state = "behind"
+    else:
+        state = "tracking"
+    return upstream, state, ahead, behind
+
+
+def cwd_relationship(path: Path, cwd: Path) -> str | None:
+    try:
+        resolved = path.resolve()
+        cwd_resolved = cwd.resolve()
+    except OSError:
+        return None
+    if resolved == cwd_resolved:
+        return "is current working directory"
+    if resolved in cwd_resolved.parents:
+        return "contains current working directory"
+    return None
+
+
+
+
+def related_path_note(path: Path, other: Path, label: str) -> str | None:
+    try:
+        resolved = path.resolve()
+        other_resolved = other.resolve()
+    except OSError:
+        return None
+    if resolved == other_resolved:
+        return f"is active {label}"
+    if resolved in other_resolved.parents:
+        return f"contains active {label}"
+    return None
+
+
+def active_tmux_cwds() -> list[Path]:
+    code, out, _ = run(["tmux", "list-panes", "-a", "-F", "#{pane_current_path}"], timeout=3)
+    if code != 0 or not out:
+        return []
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for line in out.splitlines():
+        if not line:
+            continue
+        path = Path(line).expanduser()
+        key = str(path)
+        if key not in seen:
+            paths.append(path)
+            seen.add(key)
+    return paths
+
+def has_marker(path: Path, marker: tuple[str, str]) -> bool:
+    parts = path.parts
+    for idx in range(len(parts) - 1):
+        if parts[idx] == marker[0] and parts[idx + 1] == marker[1]:
+            return True
+    return False
+
+
+def marker_child_depth(path: Path, marker: tuple[str, str]) -> int | None:
+    parts = path.parts
+    for idx in range(len(parts) - 1):
+        if parts[idx] == marker[0] and parts[idx + 1] == marker[1]:
+            return len(parts) - (idx + 2)
+    return None
+
+
+def is_allowed_nested_worktree_path(path: Path) -> bool:
+    """Allow project-local .claude/.codex/worktrees children without unprotecting global config roots."""
+    for marker in (CLAUDE_WORKTREES_MARKER, CODEX_WORKTREES_MARKER):
+        depth = marker_child_depth(path, marker)
+        if depth is not None and depth >= 1:
+            return True
+    return False
+
+
+def protected_path(path: Path, cwd: Path, active_cwds: list[Path]) -> tuple[bool, str | None]:
+    relationship = cwd_relationship(path, cwd)
+    if relationship:
+        return True, relationship
+    for active_cwd in active_cwds:
+        active_relationship = related_path_note(path, active_cwd, "tmux pane cwd")
+        if active_relationship:
+            return True, active_relationship
+    parts = set(path.parts)
+    protected_hits = sorted(parts & PROTECTED_DIRS)
+    if protected_hits:
+        if is_allowed_nested_worktree_path(path):
+            non_worktree_hits = [hit for hit in protected_hits if hit not in {".claude", ".codex"}]
+            if not non_worktree_hits:
+                return False, None
+            protected_hits = non_worktree_hits
+        return True, f"under protected config segment {', '.join(protected_hits)}"
+    return False, None
+
+
+def candidate_action(branch: str | None, dirty: bool | None, upstream_state: str | None) -> tuple[str, str, str | None]:
+    note: str | None = None
+    if branch in PROTECTED_BRANCHES:
+        return "manual-review", "review protected branch before quarantine", "branch is protected"
+    if dirty is True:
+        return "manual-review", "inspect uncommitted work before quarantine", None
+    if dirty is False:
+        if upstream_state in {"local-only", "upstream-gone"}:
+            note = "branch has no live upstream; branch deletion needs explicit approval"
+        return "likely-removable", "candidate for quarantine after approval", note
+    return "manual-review", "inspect before quarantine", None
+
+
+def make_worktree_candidate(path: Path, cwd: Path, active_cwds: list[Path], reason: str) -> Candidate:
+    branch = git_branch(path) if is_git_worktree(path) else None
+    dirty = git_dirty(path) if is_git_worktree(path) else None
+    upstream, upstream_state, ahead, behind = git_upstream_info(path) if is_git_worktree(path) else (None, None, None, None)
+    protected, note = protected_path(path, cwd, active_cwds)
+    action = "keep"
+    classification = "keep"
+
+    if protected:
+        action = "do not remove"
+    else:
+        classification, action, branch_note = candidate_action(branch, dirty, upstream_state)
+        if branch_note:
+            note = branch_note if not note else f"{note}; {branch_note}"
+
+    return Candidate(
+        classification=classification,
+        path=str(path),
+        reason=reason,
+        action=action,
+        age_days=age_days(path),
+        branch=branch,
+        dirty=dirty,
+        upstream=upstream,
+        upstream_state=upstream_state,
+        ahead=ahead,
+        behind=behind,
+        protected=protected,
+        notes=note,
+    )
+
+
+def iter_dirs(root: Path, max_depth: int) -> Iterable[tuple[Path, int]]:
+    root = root.expanduser()
+    if not root.exists():
+        return
+    stack: list[tuple[Path, int]] = [(root, 0)]
+    while stack:
+        current, depth = stack.pop()
+        yield current, depth
+        if depth >= max_depth:
+            continue
+        try:
+            children = sorted(current.iterdir(), key=lambda p: p.name)
+        except OSError:
+            continue
+        for child in reversed(children):
+            if not child.is_dir():
+                continue
+            if child.name in SKIP_DIR_NAMES:
+                continue
+            # Project-local .claude/.codex may contain worktrees; global config remains protected at action time.
+            stack.append((child, depth + 1))
+
+
+def add_children(path: Path, cwd: Path, active_cwds: list[Path], add) -> None:
+    try:
+        children = sorted(path.iterdir(), key=lambda p: p.name)
+    except OSError:
+        children = []
+    for child in children:
+        if child.is_dir() and (child.name.startswith(LAUNCH_PREFIXES) or is_git_worktree(child)):
+            add(make_worktree_candidate(child, cwd, active_cwds, f"child of {path.name} worktree container"))
+
+
+def scan_root(root: Path, max_depth: int, cwd: Path, active_cwds: list[Path]) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    seen: set[str] = set()
+
+    def add(candidate: Candidate) -> None:
+        key = candidate.path
+        if key not in seen:
+            candidates.append(candidate)
+            seen.add(key)
+
+    for path, depth in iter_dirs(root, max_depth):
+        name = path.name
+        lowered = name.lower()
+
+        if name.endswith(WORKTREE_CONTAINER_SUFFIXES):
+            protected, note = protected_path(path, cwd, active_cwds)
+            add(
+                Candidate(
+                    classification="manual-review" if not protected else "keep",
+                    path=str(path),
+                    reason="generic worktree container",
+                    action="review children; remove container only when empty",
+                    age_days=age_days(path),
+                    protected=protected,
+                    notes=note,
+                )
+            )
+            add_children(path, cwd, active_cwds, add)
+            continue
+
+        if name == "worktrees" and (has_marker(path, CLAUDE_WORKTREES_MARKER) or has_marker(path, CODEX_WORKTREES_MARKER)):
+            protected, note = protected_path(path, cwd, active_cwds)
+            add(
+                Candidate(
+                    classification="manual-review" if not protected else "keep",
+                    path=str(path),
+                    reason="Claude/Codex worktree container",
+                    action="review children; remove container only when empty",
+                    age_days=age_days(path),
+                    protected=protected,
+                    notes=note,
+                )
+            )
+            add_children(path, cwd, active_cwds, add)
+            continue
+
+        if depth > 0 and name.startswith(LAUNCH_PREFIXES) and is_git_worktree(path):
+            add(make_worktree_candidate(path, cwd, active_cwds, "launch-like Git worktree"))
+            continue
+
+        if any(lowered.startswith(pattern) for pattern in COPY_PATTERNS):
+            protected, note = protected_path(path, cwd, active_cwds)
+            add(
+                Candidate(
+                    classification="manual-review" if not protected else "keep",
+                    path=str(path),
+                    reason="possible copied Codex/OMX folder",
+                    action="inspect contents before quarantine",
+                    age_days=age_days(path),
+                    protected=protected,
+                    notes=note,
+                )
+            )
+            continue
+
+        if name in {".omx"}:
+            protected, note = protected_path(path, cwd, active_cwds)
+            add(
+                Candidate(
+                    classification="manual-review" if not protected else "keep",
+                    path=str(path),
+                    reason="OMX runtime state directory",
+                    action="prune logs/state only with repo-specific approval",
+                    age_days=age_days(path),
+                    protected=protected,
+                    notes=note,
+                )
+            )
+
+    return candidates
+
+
+def render_markdown(candidates: list[Candidate]) -> str:
+    if not candidates:
+        return "No worktree cleanup candidates found."
+
+    groups: dict[str, list[Candidate]] = {}
+    for item in candidates:
+        groups.setdefault(item.classification, []).append(item)
+
+    lines = ["# Worktree cleanup inventory", ""]
+    for classification in sorted(groups):
+        items = groups[classification]
+        lines.append(f"## {classification} ({len(items)})")
+        lines.append("")
+        for item in sorted(items, key=lambda c: c.path):
+            dirty = "unknown" if item.dirty is None else ("yes" if item.dirty else "no")
+            meta = []
+            if item.age_days is not None:
+                meta.append(f"age={item.age_days}d")
+            if item.branch:
+                meta.append(f"branch={item.branch}")
+            if item.dirty is not None:
+                meta.append(f"dirty={dirty}")
+            if item.upstream_state:
+                meta.append(f"upstream={item.upstream_state}")
+            if item.upstream:
+                meta.append(f"tracks={item.upstream}")
+            if item.ahead:
+                meta.append(f"ahead={item.ahead}")
+            if item.behind:
+                meta.append(f"behind={item.behind}")
+            if item.protected:
+                meta.append("protected=yes")
+            suffix = f" ({', '.join(meta)})" if meta else ""
+            lines.append(f"- `{item.path}`{suffix}")
+            lines.append(f"  - reason: {item.reason}")
+            lines.append(f"  - action: {item.action}")
+            if item.notes:
+                lines.append(f"  - notes: {item.notes}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        action="append",
+        default=[],
+        help="Root directory to scan. Repeatable. Defaults to current directory.",
+    )
+    parser.add_argument("--max-depth", type=int, default=5, help="Directory traversal depth per root.")
+    parser.add_argument("--format", choices={"markdown", "json"}, default="markdown")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cwd = Path.cwd()
+    active_cwds = active_tmux_cwds()
+    roots = [Path(r).expanduser() for r in (args.root or ["."])]
+    candidates: list[Candidate] = []
+    seen: set[str] = set()
+
+    for root in roots:
+        for candidate in scan_root(root, args.max_depth, cwd, active_cwds):
+            if candidate.path not in seen:
+                candidates.append(candidate)
+                seen.add(candidate.path)
+
+    if args.format == "json":
+        payload = {
+            "roots": [str(r) for r in roots],
+            "cwd": str(cwd),
+            "active_cwds": [str(path) for path in active_cwds],
+            "candidate_count": len(candidates),
+            "candidates": [asdict(candidate) for candidate in candidates],
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(render_markdown(candidates))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/worktree-cleaner/scripts/quarantine.py
+++ b/skills/worktree-cleaner/scripts/quarantine.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Move explicitly approved cleanup paths into a dated quarantine folder.
+
+Dry-run by default. Requires --apply to move anything. Accept only explicit paths;
+this script performs no discovery and intentionally does not expand globs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+PROTECTED_SEGMENTS = {".ssh", ".aws", ".gnupg", ".config", ".codex", ".claude"}
+ALLOWED_NESTED_MARKERS = ((".claude", "worktrees"), (".codex", "worktrees"))
+
+
+def resolve(path: str) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def relation_to_cwd(path: Path, cwd: Path) -> str | None:
+    if path == cwd:
+        return "is current working directory"
+    if path in cwd.parents:
+        return "contains current working directory"
+    return None
+
+
+def marker_child_depth(path: Path, marker: tuple[str, str]) -> int | None:
+    parts = path.parts
+    for idx in range(len(parts) - 1):
+        if parts[idx] == marker[0] and parts[idx + 1] == marker[1]:
+            return len(parts) - (idx + 2)
+    return None
+
+
+def allowed_nested_worktree_child(path: Path) -> bool:
+    # Allow only children under project-local .claude/.codex/worktrees, not the config dir itself.
+    return any((depth := marker_child_depth(path, marker)) is not None and depth >= 1 for marker in ALLOWED_NESTED_MARKERS)
+
+
+def refusal_reason(path: Path, cwd: Path) -> str | None:
+    relation = relation_to_cwd(path, cwd)
+    if relation:
+        return relation
+    if not path.exists():
+        return "does not exist"
+    protected = sorted(set(path.parts) & PROTECTED_SEGMENTS)
+    if protected:
+        if allowed_nested_worktree_child(path):
+            non_worktree_hits = [hit for hit in protected if hit not in {".claude", ".codex"}]
+            if not non_worktree_hits:
+                return None
+            protected = non_worktree_hits
+        return f"contains protected path segment: {', '.join(protected)}"
+    return None
+
+
+def unique_destination(quarantine_dir: Path, source: Path) -> Path:
+    target = quarantine_dir / source.name
+    if not target.exists():
+        return target
+    index = 1
+    while True:
+        candidate = quarantine_dir / f"{source.name}.{index}"
+        if not candidate.exists():
+            return candidate
+        index += 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", help="Explicit paths approved for quarantine")
+    parser.add_argument("--apply", action="store_true", help="Actually move paths. Without this, dry-run only.")
+    parser.add_argument(
+        "--quarantine-dir",
+        default=f"~/.Trash/worktree-cleanup-{datetime.now().strftime('%Y%m%d-%H%M%S')}",
+        help="Destination directory. Defaults to a dated folder under ~/.Trash.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cwd = Path.cwd().resolve()
+    quarantine_dir = resolve(args.quarantine_dir)
+    sources = [resolve(path) for path in args.paths]
+
+    refused: list[tuple[Path, str]] = []
+    allowed: list[Path] = []
+    for source in sources:
+        reason = refusal_reason(source, cwd)
+        if reason:
+            refused.append((source, reason))
+        else:
+            allowed.append(source)
+
+    print(f"quarantine_dir: {quarantine_dir}")
+    print(f"mode: {'apply' if args.apply else 'dry-run'}")
+
+    if refused:
+        print("\nrefused:")
+        for path, reason in refused:
+            print(f"- {path} ({reason})")
+
+    if allowed:
+        print("\nallowed:")
+        for source in allowed:
+            print(f"- {source} -> {unique_destination(quarantine_dir, source)}")
+
+    if refused:
+        print("\nNo files moved because at least one path was refused.")
+        return 2
+
+    if not args.apply:
+        print("\nDry-run only. Re-run with --apply after reviewing the exact paths.")
+        return 0
+
+    quarantine_dir.mkdir(parents=True, exist_ok=True)
+    for source in allowed:
+        target = unique_destination(quarantine_dir, source)
+        shutil.move(str(source), str(target))
+    print("\nMoved approved paths to quarantine.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-05-06T00:56:25.752Z",
+  "generatedAt": "2026-05-12T04:11:07.561Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 46,
+    "skillCount": 47,
     "promptCount": 30,
-    "activeSkillCount": 24,
+    "activeSkillCount": 25,
     "activeAgentCount": 16
   },
   "coreSkills": [
@@ -275,6 +275,13 @@
     },
     {
       "name": "skill",
+      "category": "utility",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "worktree-cleaner",
       "category": "utility",
       "status": "active",
       "core": false,

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -216,6 +216,12 @@
       "status": "active"
     },
     {
+      "name": "worktree-cleaner",
+      "category": "utility",
+      "status": "active",
+      "core": false
+    },
+    {
       "name": "hud",
       "category": "utility",
       "status": "active"

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -267,6 +267,13 @@
       "internalRequired": false
     },
     {
+      "name": "worktree-cleaner",
+      "category": "utility",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "hud",
       "category": "utility",
       "status": "active",


### PR DESCRIPTION
## Summary
- add a packaged `worktree-cleaner` skill for stale Git/Codex/OMX/Claude worktree cleanup
- include dry-run inventory, quarantine, and explicit branch cleanup helper scripts
- register the skill in the catalog and sync the plugin mirror bundle

## Safety model
- defaults to dry-run inventory only
- protects cwd/parents, active tmux pane cwd paths, dirty worktrees, and protected branches
- treats project-local `.claude/worktrees/*` and `.codex/worktrees/*` as candidates while keeping global config roots protected
- keeps branch deletion as a separate exact-name approval flow for local-only/upstream-gone branches

## Validation
- `npm run build`
- `npm run sync:plugin`
- `npm run verify:plugin-bundle`
- `npm run verify:native-agents`
- `node --test dist/catalog/__tests__/schema.test.js dist/catalog/__tests__/generator.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js`
- script smoke tests for `inventory.py`, `quarantine.py`, and `branch_cleanup.py`

## Not tested
- Full `npm run test:ci:compiled` did not complete in my active OMX/tmux environment; unrelated env-sensitive runtime tests failed around adapter/team/autoresearch active state before I stopped the run.
