### PR TITLE
Add bounded best-practice research workflow

### DIFF
--- a/docs/skills.html
+++ b/docs/skills.html
@@ -47,6 +47,7 @@
         <li><code>$deep-interview</code> - requirements clarification before planning or execution</li>
         <li><code>$ralplan</code> - planner/architect/critic consensus planning</li>
         <li><code>$plan</code> - supporting strategic planning when you are not using the canonical path</li>
+        <li><code>$best-practice-research</code> - bounded official/upstream best-practice evidence wrapper when current external guidance affects correctness</li>
       </ul>
 
       <h2>Agent Shortcuts</h2>
@@ -79,6 +80,7 @@ $ralplan "approve the auth plan and review tradeoffs"
 $ralph "carry the approved plan to completion"
 $team 3:executor "execute the approved plan in parallel"
 $ultragoal "split this launch into durable Codex goals"
+$best-practice-research "find current official best practices for this API"
 $code-review "review current branch"
 $doctor</code></pre>
 

--- a/plugins/oh-my-codex/skills/best-practice-research/SKILL.md
+++ b/plugins/oh-my-codex/skills/best-practice-research/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: best-practice-research
+description: "[OMX] Bounded best-practice research wrapper using official/upstream evidence first"
+argument-hint: "<technology|decision|practice question>"
+---
+
+# Best-Practice Research
+
+Use this skill when a task depends on current external best practices, version-aware guidance, standards, official recommendations, or upstream behavior. This is a workflow wrapper: it routes evidence gathering and synthesis; it is not a new research authority and it does not replace `researcher`.
+
+## Purpose
+
+Produce a cited, reusable best-practice answer or handoff that separates current external evidence from repo-local facts and dependency-selection decisions.
+
+## Activate When
+
+- The user asks for best practices, recommended approach, current guidance, official recommendations, standards, or version-aware external behavior.
+- `$ralplan`, `$deep-interview`, `$team`, or another workflow needs current external evidence before planning or execution can be correct.
+- The task involves an already chosen technology and needs authoritative usage guidance, migration notes, API behavior, lifecycle rules, or current safety guidance.
+
+## Do Not Activate When
+
+- The answer is fully repo-local; use `explore` for codebase facts.
+- The main question is whether to adopt, replace, upgrade, or compare dependencies; use `dependency-expert`.
+- The user only needs implementation against already-grounded requirements; use `executor`, `$ralph`, or `$team` as appropriate.
+- The task can be answered from stable local project conventions without current external lookup.
+
+## Specialist Routing
+
+1. Use `explore` first for brownfield facts: current code usage, local constraints, versions, config, and integration points.
+2. Use `researcher` for official/upstream docs, release notes, standards, migration guides, source-backed examples, and current best-practice evidence for an already chosen technology.
+3. Use `dependency-expert` only for adoption/upgrade/replacement/comparison decisions.
+4. Return to the caller with explicit evidence, uncertainty, and any implementation handoff constraints.
+
+## Source-Quality Rules
+
+- Prefer official documentation, upstream source, release notes, changelogs, standards, and maintainer guidance.
+- Include source URLs for material claims.
+- State date/version context for current best-practice claims.
+- Label third-party summaries as supplemental; do not use them before official/upstream sources.
+- Flag stale, conflicting, undocumented, or version-mismatched evidence.
+- Do not over-fetch: gather the smallest evidence set that can support the decision.
+
+## Workflow
+
+1. Classify the question: conceptual best practice, implementation guidance, migration/version guidance, standards/compliance guidance, or mixed local + external guidance.
+2. Gather repo-local facts with `explore` when local usage or constraints affect the answer.
+3. Gather external evidence with `researcher` when current or version-aware practice affects correctness.
+4. Synthesize a concise answer with source quality, version/date context, caveats, and an implementation or planning handoff.
+5. Stop when the answer is grounded enough for the caller; otherwise report the exact blocker or specialist handoff needed.
+
+## Output Contract
+
+```md
+## Best-Practice Research: <question>
+
+### Direct Recommendation
+<actionable guidance or decision support>
+
+### Evidence Used
+- Official/upstream: <source URL> — <what it establishes>
+- Supplemental, if any: <source URL> — <why it is secondary>
+
+### Version / Date Context
+<versions, dates, release channels, or unknowns>
+
+### Repo-Local Context
+<facts from explore, or "not needed">
+
+### Boundaries / Non-goals
+<what this research does not decide>
+
+### Handoff
+<planning/execution/test implications>
+```
+
+## Stop Rules
+
+- Stop after a source-backed recommendation is reusable by the caller.
+- Stop and route upward if the task becomes dependency comparison, broad architecture, or implementation.
+- Do not continue researching when remaining work would only polish wording rather than change the recommendation.
+
+Task: {{ARGUMENTS}}

--- a/plugins/oh-my-codex/skills/deep-interview/SKILL.md
+++ b/plugins/oh-my-codex/skills/deep-interview/SKILL.md
@@ -56,6 +56,7 @@ If no flag is provided, use **Standard**.
 - Reduce user effort: ask only the highest-leverage unresolved question, and never ask the user for codebase facts that can be discovered directly
 - For brownfield work, prefer evidence-backed confirmation questions such as "I found X in Y. Should this change follow that pattern?"
 - Route facts before judgment in the Ouroboros style: before presenting a user-facing interview round, classify whether the needed information is a discoverable fact, a fact needing confirmation, or a human decision. The interview is with the human for judgment, not for facts the agent can inspect.
+- When unresolved ambiguity depends on current external best practices, official/upstream guidance, standards, or version-aware behavior, use `$best-practice-research` as the bounded evidence wrapper before crystallizing requirements or handing off to planning/execution.
 - Use these transcript/spec labels only; never use them as `omx question` `source` values, and never replace the runtime `source: "deep-interview"` contract for user-facing deep-interview questions:
   - `[from-code][auto-confirmed]` — exact, high-confidence codebase facts from manifests/configs or direct source evidence, with no prescription attached.
   - `[from-code]` — codebase findings that are useful but inferred, pattern-based, or low/medium confidence and therefore need a confirmation-style user-facing round before being treated as settled.

--- a/plugins/oh-my-codex/skills/ralplan/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralplan/SKILL.md
@@ -86,7 +86,7 @@ Before consensus planning or execution handoff, ensure a grounded context snapsh
    - unknowns/open questions
    - likely codebase touchpoints
 4. If ambiguity remains high, gather brownfield facts first. When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups with narrow, concrete prompts; otherwise use the richer normal explore path. Then run `$deep-interview --quick <task>` before continuing.
-5. If the plan depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, auto-delegate `researcher` before finalizing the planning handoff so execution does not start from repo-local recall alone.
+5. If the plan depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, use `$best-practice-research` as the bounded evidence wrapper and auto-delegate `researcher` for the official/upstream lookup before finalizing the planning handoff so execution does not start from repo-local recall alone.
 
 Do not hand off to execution modes until this intake is complete; if urgency forces progress, explicitly document the risk tradeoffs.
 

--- a/prompts/researcher.md
+++ b/prompts/researcher.md
@@ -7,15 +7,16 @@ You are Researcher (Librarian). Produce docs-first, version-aware external techn
 </identity>
 
 <goal>
-Identify the authoritative documentation set, establish version/date context, gather the smallest reliable evidence set, and return guidance the caller can reuse. You own external truth for an already chosen technology; you do not inspect repo usage, implement code, decide architecture, or compare dependencies.
+Identify the authoritative documentation set, establish version/date context, gather the smallest reliable evidence set, and return guidance the caller can reuse. You own external truth and current best-practice evidence for an already chosen technology; you do not inspect repo usage, implement code, decide architecture, or compare dependencies.
 </goal>
 
 <constraints>
 <scope_guard>
-- Prefer official documentation, API references, release notes, changelogs, and upstream source material over third-party summaries.
+- Prefer official documentation, API references, release notes, changelogs, standards, maintainer guidance, and upstream source material over third-party summaries.
 - Always include source URLs for important claims.
+- For current best-practice claims, state the relevant date, version, release channel, or uncertainty.
 - Flag stale, undocumented, conflicting, or version-mismatched information.
-- Separate official docs evidence from source-reference evidence.
+- Separate official docs evidence from source-reference evidence and supplemental third-party evidence.
 - Route dependency adoption/upgrade/replacement decisions to `dependency-expert`; route repo-local usage and migration-surface mapping to `explore`.
 </scope_guard>
 
@@ -31,7 +32,8 @@ Classify the request before searching:
 - Conceptual docs question: concepts, guarantees, lifecycle, configuration, official guidance.
 - Implementation reference lookup: APIs, options, signatures, examples, limits, migration steps.
 - Context/history lookup: release notes, changelog entries, deprecations, behavior changes.
-- Comprehensive research: combined docs, reference, and history answer.
+- Current best-practice research: official/upstream recommendations, standards, maintainer guidance, and dated/versioned practice for an already chosen technology.
+- Comprehensive research: combined docs, reference, history, and best-practice answer.
 </request_classification>
 
 <execution_loop>
@@ -47,15 +49,15 @@ Classify the request before searching:
 
 <success_criteria>
 - Request type and search path are explicit.
-- Official docs are primary where available.
-- Version certainty/uncertainty is stated.
+- Official docs/upstream sources are primary where available.
+- Version/date certainty or uncertainty is stated, especially for current best-practice claims.
 - Examples remain secondary to docs.
-- Docs evidence and source-reference evidence are separated.
+- Docs evidence, source-reference evidence, and supplemental third-party evidence are separated.
 - The answer is reusable without extra lookup.
 </success_criteria>
 
 <tools>
-Use web search/fetch for official docs, versioned references, release notes, migration guides, and upstream source. Use local reads only to sharpen the external research question.
+Use web search/fetch for official docs, versioned references, release notes, migration guides, standards, maintainer guidance, and upstream source. Use local reads only to sharpen the external research question.
 </tools>
 
 <style>
@@ -63,7 +65,7 @@ Use web search/fetch for official docs, versioned references, release notes, mig
 ## Research: [Query]
 
 ### Request Type
-[Conceptual docs question | Implementation reference lookup | Context/history lookup | Comprehensive research]
+[Conceptual docs question | Implementation reference lookup | Context/history lookup | Current best-practice research | Comprehensive research]
 
 ### Direct Answer
 [Actionable answer]
@@ -80,6 +82,9 @@ Use web search/fetch for official docs, versioned references, release notes, mig
 ### Source-Reference Evidence
 - Only if docs were insufficient; explain why
 
+### Supplemental Evidence
+- Third-party summaries, examples, or community material only when useful after official/upstream evidence; label limitations
+
 ### Caveats / Ambiguity Flags
 - Unresolved uncertainty or likely version drift
 
@@ -88,7 +93,7 @@ Use web search/fetch for official docs, versioned references, release notes, mig
 </output_contract>
 
 <scenario_handling>
-- If the user says `continue`, keep validating against official docs, version details, and source-reference evidence before finalizing.
+- If the user says `continue`, keep validating against official docs, version/date details, upstream references, and source-reference evidence before finalizing.
 - If only the output format changes, preserve the research goal and source requirements.
 </scenario_handling>
 

--- a/skills/best-practice-research/SKILL.md
+++ b/skills/best-practice-research/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: best-practice-research
+description: "[OMX] Bounded best-practice research wrapper using official/upstream evidence first"
+argument-hint: "<technology|decision|practice question>"
+---
+
+# Best-Practice Research
+
+Use this skill when a task depends on current external best practices, version-aware guidance, standards, official recommendations, or upstream behavior. This is a workflow wrapper: it routes evidence gathering and synthesis; it is not a new research authority and it does not replace `researcher`.
+
+## Purpose
+
+Produce a cited, reusable best-practice answer or handoff that separates current external evidence from repo-local facts and dependency-selection decisions.
+
+## Activate When
+
+- The user asks for best practices, recommended approach, current guidance, official recommendations, standards, or version-aware external behavior.
+- `$ralplan`, `$deep-interview`, `$team`, or another workflow needs current external evidence before planning or execution can be correct.
+- The task involves an already chosen technology and needs authoritative usage guidance, migration notes, API behavior, lifecycle rules, or current safety guidance.
+
+## Do Not Activate When
+
+- The answer is fully repo-local; use `explore` for codebase facts.
+- The main question is whether to adopt, replace, upgrade, or compare dependencies; use `dependency-expert`.
+- The user only needs implementation against already-grounded requirements; use `executor`, `$ralph`, or `$team` as appropriate.
+- The task can be answered from stable local project conventions without current external lookup.
+
+## Specialist Routing
+
+1. Use `explore` first for brownfield facts: current code usage, local constraints, versions, config, and integration points.
+2. Use `researcher` for official/upstream docs, release notes, standards, migration guides, source-backed examples, and current best-practice evidence for an already chosen technology.
+3. Use `dependency-expert` only for adoption/upgrade/replacement/comparison decisions.
+4. Return to the caller with explicit evidence, uncertainty, and any implementation handoff constraints.
+
+## Source-Quality Rules
+
+- Prefer official documentation, upstream source, release notes, changelogs, standards, and maintainer guidance.
+- Include source URLs for material claims.
+- State date/version context for current best-practice claims.
+- Label third-party summaries as supplemental; do not use them before official/upstream sources.
+- Flag stale, conflicting, undocumented, or version-mismatched evidence.
+- Do not over-fetch: gather the smallest evidence set that can support the decision.
+
+## Workflow
+
+1. Classify the question: conceptual best practice, implementation guidance, migration/version guidance, standards/compliance guidance, or mixed local + external guidance.
+2. Gather repo-local facts with `explore` when local usage or constraints affect the answer.
+3. Gather external evidence with `researcher` when current or version-aware practice affects correctness.
+4. Synthesize a concise answer with source quality, version/date context, caveats, and an implementation or planning handoff.
+5. Stop when the answer is grounded enough for the caller; otherwise report the exact blocker or specialist handoff needed.
+
+## Output Contract
+
+```md
+## Best-Practice Research: <question>
+
+### Direct Recommendation
+<actionable guidance or decision support>
+
+### Evidence Used
+- Official/upstream: <source URL> — <what it establishes>
+- Supplemental, if any: <source URL> — <why it is secondary>
+
+### Version / Date Context
+<versions, dates, release channels, or unknowns>
+
+### Repo-Local Context
+<facts from explore, or "not needed">
+
+### Boundaries / Non-goals
+<what this research does not decide>
+
+### Handoff
+<planning/execution/test implications>
+```
+
+## Stop Rules
+
+- Stop after a source-backed recommendation is reusable by the caller.
+- Stop and route upward if the task becomes dependency comparison, broad architecture, or implementation.
+- Do not continue researching when remaining work would only polish wording rather than change the recommendation.
+
+Task: {{ARGUMENTS}}

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -56,6 +56,7 @@ If no flag is provided, use **Standard**.
 - Reduce user effort: ask only the highest-leverage unresolved question, and never ask the user for codebase facts that can be discovered directly
 - For brownfield work, prefer evidence-backed confirmation questions such as "I found X in Y. Should this change follow that pattern?"
 - Route facts before judgment in the Ouroboros style: before presenting a user-facing interview round, classify whether the needed information is a discoverable fact, a fact needing confirmation, or a human decision. The interview is with the human for judgment, not for facts the agent can inspect.
+- When unresolved ambiguity depends on current external best practices, official/upstream guidance, standards, or version-aware behavior, use `$best-practice-research` as the bounded evidence wrapper before crystallizing requirements or handing off to planning/execution.
 - Use these transcript/spec labels only; never use them as `omx question` `source` values, and never replace the runtime `source: "deep-interview"` contract for user-facing deep-interview questions:
   - `[from-code][auto-confirmed]` — exact, high-confidence codebase facts from manifests/configs or direct source evidence, with no prescription attached.
   - `[from-code]` — codebase findings that are useful but inferred, pattern-based, or low/medium confidence and therefore need a confirmation-style user-facing round before being treated as settled.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -86,7 +86,7 @@ Before consensus planning or execution handoff, ensure a grounded context snapsh
    - unknowns/open questions
    - likely codebase touchpoints
 4. If ambiguity remains high, gather brownfield facts first. When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups with narrow, concrete prompts; otherwise use the richer normal explore path. Then run `$deep-interview --quick <task>` before continuing.
-5. If the plan depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, auto-delegate `researcher` before finalizing the planning handoff so execution does not start from repo-local recall alone.
+5. If the plan depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, use `$best-practice-research` as the bounded evidence wrapper and auto-delegate `researcher` for the official/upstream lookup before finalizing the planning handoff so execution does not start from repo-local recall alone.
 
 Do not hand off to execution modes until this intake is complete; if urgency forces progress, explicitly document the risk tradeoffs.
 

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-11T07:38:27.080Z",
+  "generatedAt": "2026-05-11T08:31:41.527Z",
   "version": "2026.02.28.1",
   "counts": {
     "skillCount": 47,
@@ -117,6 +117,13 @@
     },
     {
       "name": "deep-interview",
+      "category": "planning",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "best-practice-research",
       "category": "planning",
       "status": "active",
       "core": false,

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-05-11T08:31:41.527Z",
+  "generatedAt": "2026-05-12T05:44:35.138Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 47,
+    "skillCount": 48,
     "promptCount": 30,
-    "activeSkillCount": 25,
+    "activeSkillCount": 26,
     "activeAgentCount": 16
   },
   "coreSkills": [

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -90,6 +90,12 @@
       "status": "active"
     },
     {
+      "name": "best-practice-research",
+      "category": "planning",
+      "status": "active",
+      "core": false
+    },
+    {
       "name": "analyze",
       "category": "shortcut",
       "status": "active"

--- a/src/hooks/__tests__/best-practice-research-skill.test.ts
+++ b/src/hooks/__tests__/best-practice-research-skill.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const root = process.cwd();
+const skill = readFileSync(join(root, 'skills', 'best-practice-research', 'SKILL.md'), 'utf-8');
+const pluginSkill = readFileSync(join(root, 'plugins', 'oh-my-codex', 'skills', 'best-practice-research', 'SKILL.md'), 'utf-8');
+
+describe('best-practice-research skill contract', () => {
+  it('defines a bounded wrapper without replacing researcher', () => {
+    assert.match(skill, /^---\nname: best-practice-research/m);
+    assert.match(skill, /workflow wrapper/i);
+    assert.match(skill, /not a new research authority/i);
+    assert.match(skill, /does not replace `researcher`/i);
+  });
+
+  it('preserves specialist routing and source quality boundaries', () => {
+    assert.match(skill, /use `explore` first/i);
+    assert.match(skill, /Use `researcher` for official\/upstream docs/i);
+    assert.match(skill, /Use `dependency-expert` only/i);
+    assert.match(skill, /Prefer official documentation, upstream source/i);
+    assert.match(skill, /State date\/version context/i);
+    assert.match(skill, /third-party summaries as supplemental/i);
+  });
+
+  it('keeps plugin mirror in sync with canonical skill', () => {
+    assert.equal(pluginSkill, skill);
+  });
+});

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -85,6 +85,11 @@ describe('keyword detector team compatibility', () => {
     assert.ok(codeReview);
     assert.equal(codeReview.skill, 'code-review');
     assert.equal(codeReview.keyword, '$oh-my-codex:code-review');
+
+    const bestPracticeResearch = detectPrimaryKeyword('$oh-my-codex:best-practice-research find official best practices');
+    assert.ok(bestPracticeResearch);
+    assert.equal(bestPracticeResearch.skill, 'best-practice-research');
+    assert.equal(bestPracticeResearch.keyword, '$oh-my-codex:best-practice-research');
   });
 
   it('does not fall back to implicit keyword detection when an unknown plugin-prefixed $token is present', () => {
@@ -126,6 +131,13 @@ describe('keyword detector team compatibility', () => {
     assert.ok(match);
     assert.equal(match.skill, 'ultragoal');
     assert.equal(match.keyword.toLowerCase(), '$ultragoal');
+  });
+
+  it('maps explicit $best-practice-research invocation to the best-practice research wrapper', () => {
+    const match = detectPrimaryKeyword('$best-practice-research find current official guidance for this API');
+    assert.ok(match);
+    assert.equal(match.skill, 'best-practice-research');
+    assert.equal(match.keyword.toLowerCase(), '$best-practice-research');
   });
 
   it('maps intentful ultragoal prose without triggering artifact path mentions', () => {
@@ -366,6 +378,7 @@ describe('keyword registry coverage', () => {
     assert.ok(registryKeywords.has('investigate'));
     assert.ok(registryKeywords.has('code review'));
     assert.ok(registryKeywords.has('$code-review'));
+    assert.ok(registryKeywords.has('$best-practice-research'));
     assert.ok(registryKeywords.has('coordinated team'));
     assert.ok(registryKeywords.has('ouroboros'));
     assert.ok(registryKeywords.has("don't assume"));

--- a/src/hooks/__tests__/prompt-guidance-wave-two.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-wave-two.test.ts
@@ -28,6 +28,8 @@ describe('prompt guidance wave two contract', () => {
     assert.match(researcher, /documentation structure before page-level fetches/i);
     assert.match(researcher, /examples only after the docs baseline is grounded/i);
     assert.match(researcher, /source-reference evidence/i);
+    assert.match(researcher, /Current best-practice research/i);
+    assert.match(researcher, /official\/upstream recommendations/i);
   });
 
   it('research specialists keep explicit output-contract fixtures for source preference and boundary discipline', () => {
@@ -38,6 +40,8 @@ describe('prompt guidance wave two contract', () => {
     assert.match(researcher, /Always include source URLs/i);
     assert.match(researcher, /Prefer official documentation.*over third-party summaries/i);
     assert.match(researcher, /Version compatibility or version uncertainty is noted when relevant|### Version Note/i);
+    assert.match(researcher, /version\/date certainty or uncertainty/i);
+    assert.match(researcher, /supplemental third-party evidence/i);
     assert.match(researcher, /already chosen technology/i);
     assert.match(researcher, /not the default dependency-comparison role/i);
 

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -41,6 +41,7 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: 'consensus plan', skill: 'ralplan', priority: 11, guidance: 'Activate consensus planning (planner + architect + critic)' },
 
   { keyword: '$autoresearch', skill: 'autoresearch', priority: 10, guidance: 'Activate autoresearch validator-gated research loop' },
+  { keyword: '$best-practice-research', skill: 'best-practice-research', priority: 8, guidance: 'Activate bounded best-practice research wrapper' },
 
   { keyword: '$design', skill: 'design', priority: 6, guidance: 'Activate canonical DESIGN.md design-source-of-truth workflow' },
   { keyword: '$frontend-ui-ux', skill: 'design', priority: 5, guidance: 'Deprecated: route to $design for DESIGN.md guidance; use $visual-ralph for visual-reference implementation' },

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -109,6 +109,13 @@
       "internalRequired": false
     },
     {
+      "name": "best-practice-research",
+      "category": "planning",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "analyze",
       "category": "shortcut",
       "status": "active",


### PR DESCRIPTION
## Summary
- add a `best-practice-research` workflow skill as a bounded wrapper for official/upstream best-practice evidence
- enhance the existing `researcher` prompt without renaming it or adding a new agent
- wire catalog, plugin mirror, keyword activation, docs, and setup-installable surfaces

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/keyword-detector.test.js dist/hooks/__tests__/best-practice-research-skill.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js dist/catalog/__tests__/generator.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js`
- `node dist/scripts/generate-catalog-docs.js --check`
- `npm run verify:plugin-bundle`
- `npm run verify:native-agents`
- `git diff --check`

## Notes
- `researcher` remains the canonical native agent/prompt role; no `web-researcher` rename was introduced.
- Full `npm test` was not used as the final gate because active tmux/OMX runtime suites are environment-sensitive in this session; changed-surface gates passed.
