### PR TITLE
fix: preserve user generated AGENTS in session instructions

### DIFF
--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -829,6 +829,48 @@ describe("session-scoped model instructions file", () => {
     assert.match(sessionContent, /<!-- OMX:RUNTIME:START -->/);
   });
 
+  it("preserves generated user AGENTS while omitting pure generated project AGENTS", async () => {
+    await mkdir(join(tempDir, "home", ".codex"), { recursive: true });
+    await writeFile(
+      join(tempDir, "home", ".codex", "AGENTS.md"),
+      [
+        "<!-- AUTONOMY DIRECTIVE — DO NOT REMOVE -->",
+        "YOU ARE AN AUTONOMOUS CODING AGENT.",
+        "<!-- END AUTONOMY DIRECTIVE -->",
+        OMX_GENERATED_AGENTS_MARKER,
+        "",
+        "# oh-my-codex - Intelligent Multi-Agent Orchestration",
+        "",
+        "User profile OMX brain.",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(tempDir, "AGENTS.md"),
+      [
+        "<!-- AUTONOMY DIRECTIVE — DO NOT REMOVE -->",
+        "YOU ARE AN AUTONOMOUS CODING AGENT.",
+        "<!-- END AUTONOMY DIRECTIVE -->",
+        OMX_GENERATED_AGENTS_MARKER,
+        "",
+        "# oh-my-codex - Intelligent Multi-Agent Orchestration",
+        "",
+        "Project generated OMX boilerplate.",
+      ].join("\n"),
+    );
+
+    const overlay = await generateOverlay(tempDir, "session-user-generated");
+    const writtenPath = await writeSessionModelInstructionsFile(
+      tempDir,
+      "session-user-generated",
+      overlay,
+    );
+    const sessionContent = await readFile(writtenPath, "utf-8");
+
+    assert.match(sessionContent, /User profile OMX brain\./);
+    assert.doesNotMatch(sessionContent, /Project generated OMX boilerplate\./);
+    assert.match(sessionContent, /<!-- OMX:RUNTIME:START -->/);
+  });
+
   it("preserves real unmarked project AGENTS guidance distinct from generated session AGENTS", async () => {
     await mkdir(join(tempDir, "home", ".codex"), { recursive: true });
     await rm(join(tempDir, "home", ".codex", "AGENTS.md"), { force: true });

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -671,7 +671,8 @@ export async function writeSessionModelInstructionsFile(
   await mkdir(dirname(sessionPath), { recursive: true });
 
   const baseParts: string[] = [];
-  const sourcePaths = [join(codexHome(), "AGENTS.md"), join(cwd, "AGENTS.md")];
+  const userAgentsPath = join(codexHome(), "AGENTS.md");
+  const sourcePaths = [userAgentsPath, join(cwd, "AGENTS.md")];
   const seenPaths = new Set<string>();
   const installedSkills = await listInstalledSkillDirectories(cwd);
   const projectSkillNames = new Set(
@@ -686,12 +687,13 @@ export async function writeSessionModelInstructionsFile(
 
     let content = await readFile(sourcePath, "utf-8");
     content = stripOverlayContent(content).trim();
-    content = stripGeneratedOmxAgentsForSession(content);
-    if (sourcePath === join(codexHome(), "AGENTS.md")) {
+    if (sourcePath === userAgentsPath) {
       content = dropShadowedSkillReferenceLines(
         content,
         projectSkillNames,
       ).trim();
+    } else {
+      content = stripGeneratedOmxAgentsForSession(content);
     }
     if (!content) continue;
     baseParts.push(content);


### PR DESCRIPTION
## Summary

Preserve the generated user/profile `CODEX_HOME/AGENTS.md` orchestration brain when composing session-scoped model instructions, while still filtering pure generated project-local `AGENTS.md` boilerplate.

## Changes

- Treat `CODEX_HOME/AGENTS.md` as the user/profile source and skip pure-generated stripping for that file after removing runtime overlays.
- Keep project-local generated AGENTS filtering unchanged.
- Add regression coverage for a generated user AGENTS plus generated project AGENTS composition case.

## Validation

- [x] `npm run build`
- [x] `node --test dist/hooks/__tests__/agents-overlay.test.js`
- [x] `npm run lint`
- [x] `git diff --check`
- [ ] `npm test` attempted locally; the broad suite failed in unrelated environment-sensitive tmux/MCP/path tests, while the targeted overlay regression suite passed.
- [ ] `omx doctor` not run; no setup/config behavior changed.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed; no docs update needed for this internal composition fix
- [x] Backward-compatibility impact considered

## Related

N/A
