### PR TITLE
Add RunningTeam dynamic planning mode

### DIFF
--- a/plugins/oh-my-codex/skills/runingteam/SKILL.md
+++ b/plugins/oh-my-codex/skills/runingteam/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: runingteam
+description: First-class dynamic planning + team orchestration mode; replaces manual ralplan -> team chaining with checkpoint-gated Plan/Team/Evidence/Critic/Planner loops.
+---
+
+# RuningTeam Skill
+
+RuningTeam is the dynamic planning workflow for OMX. Use it when the user wants `ralplan`-quality planning and `team`-style parallel execution without manually running `$ralplan` and then `$team`.
+
+## Core Contract
+
+RuningTeam is not a static pre-plan. It is a checkpoint-gated controller:
+
+```text
+Plan vN -> Team batch -> Evidence collection -> Critic review -> Planner revision -> Plan vN+1 -> Next batch
+```
+
+## Invocation
+
+Preferred CLI launch, equivalent to an interactive OMX launch profile:
+
+```bash
+omx --runingteam --madmax "ship the feature"
+```
+
+Alternative command form:
+
+```bash
+omx runingteam "ship the feature"
+```
+
+Prompt-side activation:
+
+```text
+$runingteam ship the feature
+```
+
+## Behavior
+
+When RuningTeam is active:
+
+1. Establish task, scope, acceptance criteria, and lane split.
+2. Launch or drive `omx team` only after a checkpoint-ready plan exists.
+3. Require workers to report evidence: claim, files changed, tests run, blockers, next needed.
+4. Review each batch through Critic before revising the plan.
+5. Revise only at checkpoints; never mutate worker instructions mid-batch.
+6. Keep state in existing OMX state surfaces and RuningTeam controller state.
+7. Require final synthesis and verification evidence before completion.
+
+## Safety Rules
+
+- Do not require a separate `$ralplan` first; RuningTeam owns dynamic planning.
+- Do not silently weaken acceptance criteria to fit failed work.
+- Do not ignore failed tests or missing worker evidence.
+- Do not spawn nested team sessions from worker panes.
+- Do not declare complete without final synthesis.
+
+## Output Contract
+
+Report concisely:
+
+- current checkpoint / plan version;
+- active lanes and owners;
+- evidence received;
+- Critic verdict;
+- next batch or final synthesis status.

--- a/skills/runingteam/SKILL.md
+++ b/skills/runingteam/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: runingteam
+description: First-class dynamic planning + team orchestration mode; replaces manual ralplan -> team chaining with checkpoint-gated Plan/Team/Evidence/Critic/Planner loops.
+---
+
+# RuningTeam Skill
+
+RuningTeam is the dynamic planning workflow for OMX. Use it when the user wants `ralplan`-quality planning and `team`-style parallel execution without manually running `$ralplan` and then `$team`.
+
+## Core Contract
+
+RuningTeam is not a static pre-plan. It is a checkpoint-gated controller:
+
+```text
+Plan vN -> Team batch -> Evidence collection -> Critic review -> Planner revision -> Plan vN+1 -> Next batch
+```
+
+## Invocation
+
+Preferred CLI launch, equivalent to an interactive OMX launch profile:
+
+```bash
+omx --runingteam --madmax "ship the feature"
+```
+
+Alternative command form:
+
+```bash
+omx runingteam "ship the feature"
+```
+
+Prompt-side activation:
+
+```text
+$runingteam ship the feature
+```
+
+## Behavior
+
+When RuningTeam is active:
+
+1. Establish task, scope, acceptance criteria, and lane split.
+2. Launch or drive `omx team` only after a checkpoint-ready plan exists.
+3. Require workers to report evidence: claim, files changed, tests run, blockers, next needed.
+4. Review each batch through Critic before revising the plan.
+5. Revise only at checkpoints; never mutate worker instructions mid-batch.
+6. Keep state in existing OMX state surfaces and RuningTeam controller state.
+7. Require final synthesis and verification evidence before completion.
+
+## Safety Rules
+
+- Do not require a separate `$ralplan` first; RuningTeam owns dynamic planning.
+- Do not silently weaken acceptance criteria to fit failed work.
+- Do not ignore failed tests or missing worker evidence.
+- Do not spawn nested team sessions from worker panes.
+- Do not declare complete without final synthesis.
+
+## Output Contract
+
+Report concisely:
+
+- current checkpoint / plan version;
+- active lanes and owners;
+- evidence received;
+- Critic verdict;
+- next batch or final synthesis status.

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-05-06T00:56:25.752Z",
+  "generatedAt": "2026-05-11T09:54:00.616Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 46,
+    "skillCount": 47,
     "promptCount": 30,
-    "activeSkillCount": 24,
+    "activeSkillCount": 25,
     "activeAgentCount": 16
   },
   "coreSkills": [
@@ -42,6 +42,13 @@
       "category": "execution",
       "status": "active",
       "core": true,
+      "internalRequired": false
+    },
+    {
+      "name": "runingteam",
+      "category": "execution",
+      "status": "active",
+      "core": false,
       "internalRequired": false
     },
     {

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -27,6 +27,12 @@
       "core": true
     },
     {
+      "name": "runingteam",
+      "category": "execution",
+      "status": "active",
+      "core": false
+    },
+    {
       "name": "ecomode",
       "category": "execution",
       "status": "deprecated",

--- a/src/cli/__tests__/runingteam.test.ts
+++ b/src/cli/__tests__/runingteam.test.ts
@@ -1,0 +1,137 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  buildRuningTeamAppendInstructions,
+  ensureRuningTeamTmuxHookAllowed,
+  extractRuningTeamTaskDescription,
+  filterRuningTeamCodexArgs,
+  runingTeamCommand,
+} from '../runingteam.js';
+import { writeCriticVerdict, writeFinalSynthesis } from '../../runingteam/runtime.js';
+
+async function withIsolatedOmxState<T>(fn: () => Promise<T>): Promise<T> {
+  const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+  const previousOmxRoot = process.env.OMX_ROOT;
+  const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+  delete process.env.OMX_TEAM_STATE_ROOT;
+  delete process.env.OMX_ROOT;
+  delete process.env.OMX_STATE_ROOT;
+  try {
+    return await fn();
+  } finally {
+    if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+    else delete process.env.OMX_TEAM_STATE_ROOT;
+    if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+    else delete process.env.OMX_ROOT;
+    if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+    else delete process.env.OMX_STATE_ROOT;
+  }
+}
+
+async function captureRuningTeam(args: string[], cwd: string): Promise<string[]> {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  try {
+    console.log = (...values: unknown[]) => logs.push(values.map(String).join(' '));
+    await withIsolatedOmxState(() => runingTeamCommand(args, cwd));
+    return logs;
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+describe('runingteam CLI', () => {
+
+
+  it('extracts task text while preserving Codex launch args for interactive profile mode', () => {
+    assert.equal(extractRuningTeamTaskDescription(['--madmax', '--model', 'gpt-5.5', 'ship', 'feature']), 'ship feature');
+    assert.deepEqual(filterRuningTeamCodexArgs(['--launch', '--json', '--madmax', 'ship']), ['--madmax', 'ship']);
+  });
+
+  it('builds launch instructions with dynamic planning contract', () => {
+    const instructions = buildRuningTeamAppendInstructions('ship feature', { sessionId: 'runingteam-demo' });
+    assert.match(instructions, /OMX RuningTeam mode/);
+    assert.match(instructions, /first-class dynamic planning system/);
+    assert.match(instructions, /Plan vN -> team batch -> evidence collection -> Critic review -> Planner revision/);
+    assert.match(instructions, /final synthesis/);
+  });
+
+  it('does not leak omx-only flags into Codex launch args', () => {
+    assert.deepEqual(filterRuningTeamCodexArgs(['--json', '--launch', '--no-launch', '--model', 'gpt-5.5', 'ship']), ['--model', 'gpt-5.5', 'ship']);
+  });
+
+  it('creates launch-mode state and instructions without spawning when --no-launch is set', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runingteam-launch-state-'));
+    try {
+      const logs = await captureRuningTeam(['--no-launch', 'ship', 'feature'], cwd);
+      assert.match(logs.join('\n'), /RuningTeam session created: runingteam-/);
+      const instructions = await readFile(join(cwd, '.omx', 'runingteam', 'session-instructions.md'), 'utf-8').catch(() => '');
+      assert.equal(instructions, '', '--no-launch create-only mode must not write launch instructions');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+  it('creates a direct first-class session without invoking team or ralplan commands', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runingteam-cli-'));
+    try {
+      const logs = await captureRuningTeam(['create', 'two', 'lane', 'fixture'], cwd);
+      assert.match(logs.join('\n'), /RuningTeam session created: runingteam-/);
+      const status = await captureRuningTeam(['status', '--json'], cwd);
+      const parsed = JSON.parse(status.join('\n')) as { sessions: Array<{ status: string; plan_version: number }> };
+      assert.equal(parsed.sessions.length, 1);
+      assert.equal(parsed.sessions[0]?.status, 'planning');
+      assert.equal(parsed.sessions[0]?.plan_version, 1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('adds runingteam to existing tmux-hook allowed modes during launch setup', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runingteam-tmux-hook-'));
+    try {
+      const { mkdir, writeFile } = await import('node:fs/promises');
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'tmux-hook.json'), JSON.stringify({
+        enabled: true,
+        target: { type: 'pane', value: '%9' },
+        allowed_modes: ['ralph', 'team'],
+      }, null, 2));
+      const changed = await ensureRuningTeamTmuxHookAllowed(cwd);
+      assert.equal(changed, true);
+      const config = JSON.parse(await readFile(join(cwd, '.omx', 'tmux-hook.json'), 'utf-8')) as { allowed_modes: string[] };
+      assert.deepEqual(config.allowed_modes, ['ralph', 'team', 'runingteam']);
+
+      const unchanged = await ensureRuningTeamTmuxHookAllowed(cwd);
+      assert.equal(unchanged, false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses finalize until final-synthesis.md exists', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runingteam-finalize-'));
+    try {
+      await withIsolatedOmxState(async () => {
+        const logs = await captureRuningTeam(['create', 'finalize fixture'], cwd);
+        const sessionId = /RuningTeam session created: (\S+)/.exec(logs.join('\n'))?.[1];
+        assert.ok(sessionId);
+        await assert.rejects(captureRuningTeam(['finalize', sessionId], cwd), /final-synthesis\.md/);
+        await writeFinalSynthesis(cwd, sessionId, '# Final synthesis\n\nReady.');
+        await assert.rejects(captureRuningTeam(['finalize', sessionId], cwd), /FINAL_SYNTHESIS_READY/);
+        await writeCriticVerdict(cwd, sessionId, {
+          iteration: 0,
+          verdict: 'FINAL_SYNTHESIS_READY',
+          acceptance_criteria_evidence: { ready: ['final synthesis'] },
+          created_at: new Date().toISOString(),
+        });
+        const finalized = await captureRuningTeam(['finalize', sessionId], cwd);
+        assert.match(finalized.join('\n'), /RuningTeam complete/);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/constants.ts
+++ b/src/cli/constants.ts
@@ -5,6 +5,7 @@ export const HIGH_REASONING_FLAG = '--high';
 export const XHIGH_REASONING_FLAG = '--xhigh';
 export const SPARK_FLAG = '--spark';
 export const MADMAX_SPARK_FLAG = '--madmax-spark';
+export const RUNINGTEAM_FLAG = '--runingteam';
 export const CONFIG_FLAG = '-c';
 export const LONG_CONFIG_FLAG = '--config';
 export const MODEL_FLAG = '--model';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ import { hooksCommand } from "./hooks.js";
 import { hudCommand } from "../hud/index.js";
 import { sidecarCommand } from "../sidecar/index.js";
 import { teamCommand } from "./team.js";
+import { runingTeamCommand } from "./runingteam.js";
 import { ralphCommand } from "./ralph.js";
 import { ultragoalCommand } from "./ultragoal.js";
 import { performanceGoalCommand } from "./performance-goal.js";
@@ -54,6 +55,7 @@ import {
   XHIGH_REASONING_FLAG,
   SPARK_FLAG,
   MADMAX_SPARK_FLAG,
+  RUNINGTEAM_FLAG,
   CONFIG_FLAG,
   LONG_CONFIG_FLAG,
 } from "./constants.js";
@@ -209,6 +211,7 @@ Usage:
   omx deepinit [path]
                 Alias for agents-init (lightweight AGENTS bootstrap only)
   omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
+  omx runingteam Launch Codex with RuningTeam dynamic planning mode active
   omx ralph     Launch Codex with ralph persistence mode active
   omx ultragoal Create, resume, and checkpoint durable multi-goal plans over Codex goal mode
   omx performance-goal
@@ -251,6 +254,8 @@ Options:
                 Workers get the configured low-complexity team model; leader model unchanged
   --madmax-spark  spark model for workers + bypass approvals for leader and workers
                 (shorthand for: --spark --madmax)
+  --runingteam  Launch Codex with RuningTeam dynamic planning mode active
+                (can be combined with --madmax, --high, --xhigh, --spark)
   --notify-temp  Enable temporary notification routing for this run/session only
   --direct       Launch the interactive leader directly without OMX tmux/HUD management
   --tmux         Launch the interactive leader session in detached tmux
@@ -305,6 +310,8 @@ const OMX_RALPH_APPEND_INSTRUCTIONS_FILE_ENV =
   "OMX_RALPH_APPEND_INSTRUCTIONS_FILE";
 const OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE_ENV =
   "OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE";
+const OMX_RUNINGTEAM_APPEND_INSTRUCTIONS_FILE_ENV =
+  "OMX_RUNINGTEAM_APPEND_INSTRUCTIONS_FILE";
 const REASONING_MODES = ["low", "medium", "high", "xhigh"] as const;
 type ReasoningMode = (typeof REASONING_MODES)[number];
 const REASONING_MODE_SET = new Set<string>(REASONING_MODES);
@@ -354,6 +361,7 @@ type CliCommand =
   | "explore"
   | "sparkshell"
   | "team"
+  | "runingteam"
   | "session"
   | "resume"
   | "version"
@@ -396,6 +404,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "session",
   "sparkshell",
   "team",
+  "runingteam",
   "tmux-hook",
 ]);
 
@@ -1242,6 +1251,7 @@ export async function main(args: string[]): Promise<void> {
     "explore",
     "sparkshell",
     "team",
+    "runingteam",
     "ralph",
     "ultragoal",
     "performance-goal",
@@ -1281,7 +1291,11 @@ export async function main(args: string[]): Promise<void> {
   try {
     switch (command) {
       case "launch":
-        await launchWithHud(launchArgs);
+        if (launchArgs.includes(RUNINGTEAM_FLAG)) {
+          await runingTeamCommand(launchArgs.filter((arg) => arg !== RUNINGTEAM_FLAG));
+        } else {
+          await launchWithHud(launchArgs);
+        }
         break;
       case "resume":
         await launchWithHud(["resume", ...launchArgs]);
@@ -1362,6 +1376,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "team":
         await teamCommand(args.slice(1), options);
+        break;
+      case "runingteam":
+        await runingTeamCommand(args.slice(1));
         break;
       case "session":
         await sessionCommand(args.slice(1));
@@ -1807,6 +1824,11 @@ export function normalizeCodexLaunchArgs(args: string[]): string[] {
         normalized.push(arg);
         hasBypass = true;
       }
+      continue;
+    }
+
+    if (arg === RUNINGTEAM_FLAG) {
+      // RuningTeam is an OMX launch profile. Its instructions are injected by the launcher, not forwarded as a Codex-native flag.
       continue;
     }
 
@@ -2768,6 +2790,7 @@ async function readLaunchAppendInstructions(): Promise<string> {
   const appendixCandidates = [
     process.env[OMX_RALPH_APPEND_INSTRUCTIONS_FILE_ENV]?.trim(),
     process.env[OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE_ENV]?.trim(),
+    process.env[OMX_RUNINGTEAM_APPEND_INSTRUCTIONS_FILE_ENV]?.trim(),
   ].filter(
     (value): value is string => typeof value === "string" && value.length > 0,
   );

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -163,7 +163,7 @@ export function readMatchedApprovedRalphExecutionHint(
   );
 }
 
-function buildRalphApprovedContextLines(approvedHint: ApprovedExecutionLaunchHint | null): string[] {
+export function buildRalphApprovedContextLines(approvedHint: ApprovedExecutionLaunchHint | null): string[] {
   if (!approvedHint) return [];
   const lines = [
     'Approved planning handoff context:',

--- a/src/cli/runingteam.ts
+++ b/src/cli/runingteam.ts
@@ -1,0 +1,317 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { startMode, updateModeState } from '../modes/base.js';
+import { readApprovedExecutionLaunchHint, type ApprovedExecutionLaunchHint } from '../planning/artifacts.js';
+import { buildFollowupStaffingPlan, resolveAvailableAgentTypes } from '../team/followup-planner.js';
+import { buildRalphApprovedContextLines } from './ralph.js';
+import {
+  createCheckpoint,
+  createRuningTeamSession,
+  ingestTeamEvidence,
+  listRuningTeamSessions,
+  readRuningTeamSession,
+  runingTeamPaths,
+  assertRuningTeamCompletionReady,
+  transitionRuningTeamSession,
+  updateRuningTeamSession,
+  writeFinalSynthesis,
+} from '../runingteam/runtime.js';
+import { ensureTmuxHookInitialized } from './tmux-hook.js';
+
+export const RUNINGTEAM_APPEND_ENV = 'OMX_RUNINGTEAM_APPEND_INSTRUCTIONS_FILE';
+const VALUE_TAKING_FLAGS = new Set(['--model', '--provider', '--config', '-c', '-i', '--images-dir']);
+const RUNINGTEAM_OMX_FLAGS = new Set(['--launch', '--no-launch', '--json']);
+
+export const RUNINGTEAM_HELP = `omx runingteam - Launch Codex with RuningTeam dynamic planning mode active
+
+Usage:
+  omx runingteam [task text...]
+  omx runingteam [runingteam-options] [codex-args...] [task text...]
+  omx runingteam create "<task>"
+  omx runingteam status <session> [--json]
+  omx runingteam checkpoint <session> [--force]
+  omx runingteam revise <session>
+  omx runingteam finalize <session>
+  omx runingteam cancel <session>
+
+Options:
+  --help, -h     Show this help message
+  --launch       Force interactive Codex launch after creating/activating state
+  --no-launch    Create a controller session only; do not launch Codex
+
+Launch shortcuts:
+  omx --runingteam [--madmax] [task text...]
+  omx --runingteam --madmax
+
+RuningTeam is a first-class dynamic planning + team orchestration mode. It
+replaces the manual ralplan -> team chain with a checkpoint-gated controller:
+Plan vN -> team batch -> evidence -> critic -> planner revision -> next batch.
+`;
+
+function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function requireSession(args: string[]): string {
+  const session = args.find((arg) => !arg.startsWith('--'));
+  if (!session) throw new Error('Missing RuningTeam session id');
+  return session;
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+export function extractRuningTeamTaskDescription(args: readonly string[], fallbackTask?: string): string {
+  const words: string[] = [];
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i];
+    if (token === '--') {
+      for (let j = i + 1; j < args.length; j++) words.push(args[j]);
+      break;
+    }
+    if (token.startsWith('--') && token.includes('=')) { i++; continue; }
+    if (token.startsWith('-') && VALUE_TAKING_FLAGS.has(token)) { i += 2; continue; }
+    if (token.startsWith('-')) { i++; continue; }
+    words.push(token);
+    i++;
+  }
+  return words.join(' ') || fallbackTask || 'runingteam-cli-launch';
+}
+
+export function filterRuningTeamCodexArgs(args: readonly string[]): string[] {
+  const filtered: string[] = [];
+  for (const token of args) {
+    if (RUNINGTEAM_OMX_FLAGS.has(token.toLowerCase())) continue;
+    filtered.push(token);
+  }
+  return filtered;
+}
+
+function resolveApprovedRuningTeamExecutionHint(
+  candidate: ApprovedExecutionLaunchHint | null,
+  explicitTask: string,
+): ApprovedExecutionLaunchHint | null {
+  if (!candidate) return null;
+  if (explicitTask === 'runingteam-cli-launch') return candidate;
+  return candidate.task.trim() === explicitTask.trim() ? candidate : null;
+}
+
+function readMatchedApprovedRuningTeamExecutionHint(cwd: string, explicitTask: string): ApprovedExecutionLaunchHint | null {
+  return resolveApprovedRuningTeamExecutionHint(
+    readApprovedExecutionLaunchHint(
+      cwd,
+      'team',
+      explicitTask === 'runingteam-cli-launch' ? {} : { task: explicitTask },
+    ),
+    explicitTask,
+  );
+}
+
+export function buildRuningTeamAppendInstructions(
+  task: string,
+  options: { sessionId?: string; approvedHint?: ApprovedExecutionLaunchHint | null },
+): string {
+  return [
+    '<runingteam_dynamic_planning>',
+    'You are in OMX RuningTeam mode.',
+    `Primary task: ${task}`,
+    options.sessionId ? `RuningTeam controller session: ${options.sessionId}` : null,
+    '',
+    'Operating contract:',
+    '- Treat RuningTeam as the first-class dynamic planning system; do not require a separate `$ralplan` before using it.',
+    '- Use checkpoint-gated planning: Plan vN -> team batch -> evidence collection -> Critic review -> Planner revision -> Plan vN+1.',
+    '- Mutate the plan only at checkpoints, never while workers are actively executing a batch.',
+    '- Prefer existing OMX team state/events/locks/mailbox surfaces; do not invent a separate orchestration root unless explicitly needed.',
+    '- Use machine-readable worker evidence where possible: claim, files_changed, tests_run, blockers, next_needed.',
+    '- Enforce lane ownership, acceptance criteria lock, final verification, and a final synthesis before completion.',
+    '- If the user asks to implement, drive `omx team`/worker lanes from the current checkpoint plan and reconcile evidence before final approval.',
+    '- If no task was supplied at launch, ask for the task in one concise question, then start the RuningTeam loop.',
+    ...buildRalphApprovedContextLines(options.approvedHint ?? null),
+    '</runingteam_dynamic_planning>',
+  ].filter((line): line is string => typeof line === 'string').join('\n');
+}
+
+export async function ensureRuningTeamTmuxHookAllowed(cwd: string): Promise<boolean> {
+  await ensureTmuxHookInitialized(cwd).catch(() => {});
+  const configPath = join(cwd, '.omx', 'tmux-hook.json');
+  if (!existsSync(configPath)) return false;
+
+  const raw = await readFile(configPath, 'utf-8').catch(() => '');
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return false;
+  }
+
+  const existingModes = Array.isArray(parsed.allowed_modes)
+    ? parsed.allowed_modes.filter((mode): mode is string => typeof mode === 'string' && mode.trim() !== '').map((mode) => mode.trim())
+    : [];
+  if (existingModes.includes('runingteam')) return false;
+
+  const allowedModes = existingModes.length > 0
+    ? [...existingModes, 'runingteam']
+    : ['ralph', 'ultrawork', 'team', 'runingteam'];
+  await writeFile(configPath, `${JSON.stringify({ ...parsed, allowed_modes: allowedModes }, null, 2)}\n`, 'utf-8');
+  return true;
+}
+
+async function writeRuningTeamSessionInstructions(
+  cwd: string,
+  task: string,
+  options: { sessionId?: string; approvedHint?: ApprovedExecutionLaunchHint | null },
+): Promise<string> {
+  const dir = join(cwd, '.omx', 'runingteam');
+  await mkdir(dir, { recursive: true });
+  const instructionsPath = join(dir, 'session-instructions.md');
+  await writeFile(instructionsPath, `${buildRuningTeamAppendInstructions(task, options)}\n`);
+  return instructionsPath;
+}
+
+async function launchRuningTeamCodex(args: string[], cwd: string): Promise<void> {
+  const explicitTask = extractRuningTeamTaskDescription(args);
+  const approvedHint = readMatchedApprovedRuningTeamExecutionHint(cwd, explicitTask);
+  const task = explicitTask === 'runingteam-cli-launch' ? approvedHint?.task ?? explicitTask : explicitTask;
+  const controllerSession = task === 'runingteam-cli-launch' ? null : await createRuningTeamSession(task, cwd);
+  const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
+  const staffingPlan = buildFollowupStaffingPlan('team', task, availableAgentTypes);
+  await startMode('runingteam', task, 50, cwd);
+  await updateModeState('runingteam', {
+    current_phase: 'planning',
+    controller_session_id: controllerSession?.session_id,
+    controller_state_path: controllerSession ? runingTeamPaths(cwd, controllerSession.session_id).root : undefined,
+    available_agent_types: availableAgentTypes,
+    staffing_summary: staffingPlan.staffingSummary,
+    staffing_allocations: staffingPlan.allocations,
+    dynamic_planning_enabled: true,
+    checkpoint_gated: true,
+    final_synthesis_required: true,
+    keep_active_after_launch: true,
+    approved_plan_path: approvedHint?.sourcePath,
+    approved_test_spec_paths: approvedHint?.testSpecPaths ?? [],
+    approved_deep_interview_spec_paths: approvedHint?.deepInterviewSpecPaths ?? [],
+  }, cwd);
+  await ensureRuningTeamTmuxHookAllowed(cwd);
+  const instructionsPath = await writeRuningTeamSessionInstructions(cwd, task, {
+    sessionId: controllerSession?.session_id,
+    approvedHint,
+  });
+  if (controllerSession) {
+    console.log(`RuningTeam session created: ${controllerSession.session_id}`);
+    console.log(`State: ${runingTeamPaths(cwd, controllerSession.session_id).root}`);
+  }
+  console.log('[runingteam] Dynamic planning mode active. Launching Codex...');
+  console.log(`[runingteam] available_agent_types: ${staffingPlan.rosterSummary}`);
+  console.log(`[runingteam] staffing_plan: ${staffingPlan.staffingSummary}`);
+  const { launchWithHud } = await import('./index.js');
+  const codexArgsBase = filterRuningTeamCodexArgs(args);
+  const codexArgs = explicitTask === 'runingteam-cli-launch' && approvedHint?.task
+    ? [...codexArgsBase, approvedHint.task]
+    : codexArgsBase;
+  const previousAppendixEnv = process.env[RUNINGTEAM_APPEND_ENV];
+  process.env[RUNINGTEAM_APPEND_ENV] = instructionsPath;
+  try {
+    await launchWithHud(codexArgs);
+  } finally {
+    if (typeof previousAppendixEnv === 'string') process.env[RUNINGTEAM_APPEND_ENV] = previousAppendixEnv;
+    else delete process.env[RUNINGTEAM_APPEND_ENV];
+  }
+}
+
+export async function runingTeamCommand(args: string[], cwd = process.cwd()): Promise<void> {
+  const subcommand = args[0];
+  if (subcommand === '--help' || subcommand === '-h' || subcommand === 'help') {
+    console.log(RUNINGTEAM_HELP.trim());
+    return;
+  }
+
+  if (!subcommand || subcommand === '--launch' || !['create', 'status', 'checkpoint', 'revise', 'finalize', 'cancel'].includes(subcommand)) {
+    if (hasFlag(args, '--no-launch') || subcommand === 'create') {
+      const taskArgs = subcommand === 'create' ? args.slice(1) : args.filter((arg) => arg !== '--no-launch');
+      const task = taskArgs.join(' ').trim();
+      if (!task) throw new Error('Missing RuningTeam task');
+      const session = await createRuningTeamSession(task, cwd);
+      console.log(`RuningTeam session created: ${session.session_id}`);
+      console.log(`State: ${runingTeamPaths(cwd, session.session_id).root}`);
+      return;
+    }
+    await launchRuningTeamCodex(args.filter((arg) => arg !== '--launch'), cwd);
+    return;
+  }
+
+  if (subcommand === 'create') {
+    const task = args.slice(1).join(' ').trim();
+    if (!task) throw new Error('Missing RuningTeam task');
+    const session = await createRuningTeamSession(task, cwd);
+    console.log(`RuningTeam session created: ${session.session_id}`);
+    console.log(`State: ${runingTeamPaths(cwd, session.session_id).root}`);
+    return;
+  }
+
+  if (subcommand === 'status') {
+    const json = hasFlag(args, '--json');
+    const sessionId = args[1]?.startsWith('--') ? undefined : args[1];
+    if (sessionId) {
+      const session = await readRuningTeamSession(cwd, sessionId);
+      const summary = {
+        ...session,
+        final_synthesis_present: existsSync(runingTeamPaths(cwd, sessionId).finalSynthesis),
+      };
+      if (json) printJson(summary);
+      else console.log(`${summary.session_id}: ${summary.status} iteration=${summary.iteration} plan=${summary.plan_version} team=${summary.team_name ?? '-'}`);
+      return;
+    }
+    const sessions = await listRuningTeamSessions(cwd);
+    if (json) printJson({ sessions });
+    else if (sessions.length === 0) console.log('No RuningTeam sessions.');
+    else for (const session of sessions) console.log(`${session.session_id}: ${session.status} iteration=${session.iteration} plan=${session.plan_version}`);
+    return;
+  }
+
+  if (subcommand === 'checkpoint') {
+    const sessionId = requireSession(args.slice(1));
+    await ingestTeamEvidence(cwd, sessionId).catch(() => []);
+    const checkpoint = await createCheckpoint(cwd, sessionId, { force: hasFlag(args, '--force') });
+    console.log(`RuningTeam checkpoint ${checkpoint.iteration} created for ${sessionId}`);
+    return;
+  }
+
+  if (subcommand === 'revise') {
+    const sessionId = requireSession(args.slice(1));
+    await updateRuningTeamSession(cwd, sessionId, { status: 'revising' });
+    console.log(`RuningTeam revision gate opened for ${sessionId}`);
+    return;
+  }
+
+  if (subcommand === 'finalize') {
+    const sessionId = requireSession(args.slice(1));
+    const paths = runingTeamPaths(cwd, sessionId);
+    try {
+      await assertRuningTeamCompletionReady(cwd, sessionId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'complete_requires_final_synthesis') {
+        throw new Error('RuningTeam cannot complete without final-synthesis.md');
+      }
+      if (message === 'complete_requires_final_synthesis_ready_verdict') {
+        throw new Error('RuningTeam cannot complete without FINAL_SYNTHESIS_READY verdict evidence');
+      }
+      throw err;
+    }
+    await transitionRuningTeamSession(cwd, sessionId, 'complete');
+    const synthesis = await readFile(paths.finalSynthesis, 'utf-8');
+    console.log(`RuningTeam complete: ${sessionId}\n${synthesis.trimEnd()}`);
+    return;
+  }
+
+  if (subcommand === 'cancel') {
+    const sessionId = requireSession(args.slice(1));
+    await updateRuningTeamSession(cwd, sessionId, { status: 'cancelled', terminal_reason: 'cancelled by user' });
+    console.log(`RuningTeam cancelled: ${sessionId}`);
+  }
+}
+
+export { writeFinalSynthesis };

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -444,9 +444,9 @@ const KEYWORD_MAP: Array<{ pattern: RegExp; skill: string; priority: number }> =
   priority: entry.priority,
 }));
 
-const KEYWORDS_REQUIRING_INTENT = new Set(['ralph', 'team', 'stop', 'abort', 'parallel', 'autoresearch', 'ultragoal']);
+const KEYWORDS_REQUIRING_INTENT = new Set(['ralph', 'team', 'runingteam', 'stop', 'abort', 'parallel', 'autoresearch', 'ultragoal']);
 
-type IntentKeyword = 'ralph' | 'team' | 'stop' | 'abort' | 'parallel' | 'autoresearch' | 'ultragoal';
+type IntentKeyword = 'ralph' | 'team' | 'runingteam' | 'stop' | 'abort' | 'parallel' | 'autoresearch' | 'ultragoal';
 
 const DEEP_INTERVIEW_ACTIVATION_PATTERNS: RegExp[] = [
   /(?:^|[^\w])\$(?:deep-interview)\b/i,
@@ -484,6 +484,12 @@ const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
     /\/prompts:team\b/i,
     /\b(?:use|run|start|enable|launch|invoke|activate|orchestrate|coordinate)\s+(?:a\s+|an\s+|the\s+)?team\b/i,
     /\bteam\s+(?:mode|orchestration|workflow|agents?)\b/i,
+  ],
+  runingteam: [
+    /(?:^|[^\w])\$(?:runingteam)\b/i,
+    /\/prompts:runingteam\b/i,
+    /\b(?:use|run|start|enable|launch|invoke|activate|orchestrate|coordinate)\s+(?:a\s+|an\s+|the\s+)?runingteam\b/i,
+    /\bruningteam\s+(?:mode|orchestration|workflow|skill|loop)\b/i,
   ],
   stop: [
     /^(?:please\s+)?stop(?:\s+now)?\s*[.!]?\s*$/i,

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -45,6 +45,9 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: '$team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
   { keyword: 'coordinated team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
 
+  { keyword: '$runingteam', skill: 'runingteam', priority: 8, guidance: 'Activate RuningTeam dynamic planning + team orchestration mode' },
+  { keyword: 'runingteam', skill: 'runingteam', priority: 8, guidance: 'Activate RuningTeam dynamic planning + team orchestration mode' },
+
   { keyword: '$cancel', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
   { keyword: 'stop', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
   { keyword: 'abort', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -40,7 +40,7 @@ export interface ModeState {
   [key: string]: unknown;
 }
 
-export type ModeName = 'autopilot' | 'autoresearch' | 'deep-interview' | 'ralph' | 'ultrawork' | 'team' | 'ultraqa' | 'ralplan';
+export type ModeName = 'autopilot' | 'autoresearch' | 'deep-interview' | 'ralph' | 'ultrawork' | 'team' | 'runingteam' | 'ultraqa' | 'ralplan';
 
 /** @deprecated These mode names were removed in v4.6. Use the canonical modes instead. */
 export type DeprecatedModeName = 'ultrapilot' | 'pipeline' | 'ecomode';

--- a/src/runingteam/__tests__/controller.test.ts
+++ b/src/runingteam/__tests__/controller.test.ts
@@ -1,0 +1,128 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  canTransitionRuningTeamStatus,
+  createCriticVerdict,
+  createFinalSynthesis,
+  createPlannerRevision,
+  createRuningTeamSession,
+  ingestTeamEvidence,
+  createCheckpoint,
+  transitionRuningTeamStatus,
+  validateCriticVerdict,
+  validatePlannerRevision,
+} from '../controller.js';
+
+async function withTempCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-runingteam-'));
+  const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+  const previousOmxRoot = process.env.OMX_ROOT;
+  const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+  delete process.env.OMX_TEAM_STATE_ROOT;
+  delete process.env.OMX_ROOT;
+  delete process.env.OMX_STATE_ROOT;
+  try {
+    await fn(cwd);
+  } finally {
+    if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+    else delete process.env.OMX_TEAM_STATE_ROOT;
+    if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+    else delete process.env.OMX_ROOT;
+    if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+    else delete process.env.OMX_STATE_ROOT;
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function writeTeamEvidence(cwd: string): Promise<void> {
+  const teamDir = join(cwd, '.omx', 'state', 'team', 'alpha');
+  await mkdir(join(teamDir, 'events'), { recursive: true });
+  await mkdir(join(teamDir, 'tasks'), { recursive: true });
+  await writeFile(join(teamDir, 'tasks', 'task-1.json'), JSON.stringify({
+    id: '1',
+    subject: 'execution lane',
+    description: 'implementation',
+    status: 'completed',
+    result: 'Implemented controller\nFiles changed: src/runingteam/controller.ts\nCommands: npm run build, node --test dist/runingteam/__tests__/controller.test.js',
+  }, null, 2));
+  await writeFile(join(teamDir, 'events', 'events.ndjson'), `${JSON.stringify({
+    event_id: 'evt-1',
+    team: 'alpha',
+    type: 'task_completed',
+    worker: 'worker-1',
+    task_id: '1',
+    created_at: '2026-05-09T00:00:00.000Z',
+  })}\n`);
+}
+
+describe('RuningTeam controller', () => {
+  it('enforces lifecycle transitions and final-synthesis completion gate', async () => {
+    await withTempCwd(async (cwd) => {
+      await createRuningTeamSession(cwd, { sessionId: 'sess1', task: 'example' });
+      assert.equal(canTransitionRuningTeamStatus('planning', 'executing'), true);
+      assert.equal(canTransitionRuningTeamStatus('executing', 'revising'), false);
+      await transitionRuningTeamStatus(cwd, 'sess1', 'executing');
+      await assert.rejects(
+        () => transitionRuningTeamStatus(cwd, 'sess1', 'complete'),
+        /complete requires final-synthesis\.md|invalid RuningTeam transition/,
+      );
+    });
+  });
+
+  it('validates critic verdict and planner revision contracts', () => {
+    assert.throws(() => validateCriticVerdict({ verdict: 'ITERATE_PLAN', required_changes: [] }), /required_changes/);
+    assert.throws(() => validateCriticVerdict({ verdict: 'REJECT_BATCH', rejected_claims: [] }), /rejected_claims/);
+    assert.throws(
+      () => validatePlannerRevision({ from_plan_version: 1, to_plan_version: 2, preserved_acceptance_criteria: false }),
+      /preserved_acceptance_criteria/,
+    );
+  });
+
+  it('ingests team evidence, writes checkpoint, verdict, revision, and preserves criteria', async () => {
+    await withTempCwd(async (cwd) => {
+      await createRuningTeamSession(cwd, { sessionId: 'sess2', task: 'example', teamName: 'alpha' });
+      await writeTeamEvidence(cwd);
+      const evidence = await ingestTeamEvidence(cwd, 'sess2');
+      assert.equal(evidence.length, 1);
+      assert.deepEqual(evidence[0].files_changed, ['src/runingteam/controller.ts']);
+
+      const checkpoint = await createCheckpoint(cwd, 'sess2');
+      assert.equal(checkpoint.evidence_count, 1);
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'runingteam', 'sess2', 'iterations', '1', 'checkpoint.md')), true);
+
+      const verdict = await createCriticVerdict(cwd, 'sess2', {
+        verdict: 'ITERATE_PLAN',
+        required_changes: ['add focused tests'],
+      });
+      assert.equal(verdict.verdict, 'ITERATE_PLAN');
+
+      const revision = await createPlannerRevision(cwd, 'sess2');
+      assert.equal(revision.from_plan_version, 1);
+      assert.equal(revision.to_plan_version, 2);
+      assert.equal(revision.preserved_acceptance_criteria, true);
+    });
+  });
+
+  it('creates final synthesis only after FINAL_SYNTHESIS_READY and then allows completion', async () => {
+    await withTempCwd(async (cwd) => {
+      const { plan } = await createRuningTeamSession(cwd, { sessionId: 'sess3', task: 'example', teamName: 'alpha' });
+      await writeTeamEvidence(cwd);
+      await ingestTeamEvidence(cwd, 'sess3');
+      await createCheckpoint(cwd, 'sess3');
+      await createCriticVerdict(cwd, 'sess3', {
+        verdict: 'FINAL_SYNTHESIS_READY',
+        acceptance_criteria_evidence: Object.fromEntries(plan.acceptance_criteria.map((criterion) => [criterion, ['worker-1/task-1']])),
+      });
+      await createFinalSynthesis(cwd, 'sess3');
+      const synthesisPath = join(cwd, '.omx', 'state', 'runingteam', 'sess3', 'final-synthesis.md');
+      assert.equal(existsSync(synthesisPath), true);
+      assert.match(await readFile(synthesisPath, 'utf-8'), /RuningTeam Final Synthesis/);
+      const complete = await transitionRuningTeamStatus(cwd, 'sess3', 'complete');
+      assert.equal(complete.status, 'complete');
+    });
+  });
+});

--- a/src/runingteam/__tests__/runtime.test.ts
+++ b/src/runingteam/__tests__/runtime.test.ts
@@ -1,0 +1,244 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  createCheckpoint,
+  createRuningTeamSession,
+  ingestTeamEvidence,
+  linkRuningTeamTeamAdapter,
+  readRuningTeamSession,
+  revisePlan,
+  runingTeamPaths,
+  transitionRuningTeamSession,
+  validateCriticVerdictRecord,
+  validatePlannerRevision,
+  validateRuningTeamSession,
+  writeCriticVerdict,
+  writeFinalSynthesis,
+} from '../runtime.js';
+import { appendTeamEvent, initTeamState } from '../../team/state.js';
+
+async function withTempRoot<T>(fn: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-runingteam-runtime-'));
+  const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+  const previousOmxRoot = process.env.OMX_ROOT;
+  const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+  delete process.env.OMX_TEAM_STATE_ROOT;
+  delete process.env.OMX_ROOT;
+  delete process.env.OMX_STATE_ROOT;
+  try {
+    return await fn(cwd);
+  } finally {
+    if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+    else delete process.env.OMX_TEAM_STATE_ROOT;
+    if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+    else delete process.env.OMX_ROOT;
+    if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+    else delete process.env.OMX_STATE_ROOT;
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('RuningTeam runtime contracts', () => {
+  it('creates first-class session state and rejects completion without final-synthesis.md', async () => {
+    await withTempRoot(async (cwd) => {
+      const session = await createRuningTeamSession('two lane fixture task', cwd, { sessionId: 'rt-final-gate' });
+      assert.equal(session.status, 'planning');
+      assert.equal(session.plan_version, 1);
+      assert.equal(session.team_name, null);
+
+      await assert.rejects(
+        transitionRuningTeamSession(cwd, session.session_id, 'complete'),
+        /complete_requires_final_synthesis/,
+      );
+
+      await writeFinalSynthesis(cwd, session.session_id, '# Final synthesis\n\nAll evidence is supported.');
+      await assert.rejects(
+        transitionRuningTeamSession(cwd, session.session_id, 'complete'),
+        /complete_requires_final_synthesis_ready_verdict/,
+      );
+      await writeCriticVerdict(cwd, session.session_id, {
+        iteration: 0,
+        verdict: 'FINAL_SYNTHESIS_READY',
+        acceptance_criteria_evidence: { 'final synthesis is created before completion': ['manual synthesis'] },
+        created_at: new Date().toISOString(),
+      });
+      const complete = await transitionRuningTeamSession(cwd, session.session_id, 'complete');
+      assert.equal(complete.status, 'complete');
+    });
+  });
+
+  it('validates schema enums and verdict/revision guardrails', () => {
+    assert.throws(
+      () => validateRuningTeamSession({ session_id: 's', task: 't', created_at: 'n', updated_at: 'n', status: 'bogus', iteration: 0, plan_version: 1, team_name: null, max_iterations: 10, terminal_reason: null }),
+      /invalid_status/,
+    );
+    assert.throws(
+      () => validateCriticVerdictRecord({ iteration: 1, verdict: 'ITERATE_PLAN', created_at: 'now' }),
+      /required_changes/,
+    );
+    assert.throws(
+      () => validateCriticVerdictRecord({ iteration: 1, verdict: 'FINAL_SYNTHESIS_READY', created_at: 'now' }),
+      /acceptance_criteria_evidence/,
+    );
+    assert.throws(
+      () => validatePlannerRevision({ iteration: 1, from_plan_version: 1, to_plan_version: 2, reason: 'r', changes: ['c'], preserved_acceptance_criteria: false, created_at: 'now' }),
+      /preserved_acceptance_criteria/,
+    );
+  });
+
+  it('ingests team events once, checkpoints evidence, and revises only after checkpoint plus verdict', async () => {
+    await withTempRoot(async (cwd) => {
+      await initTeamState('rt-team', 'fixture team', 'executor', 2, cwd);
+      const session = await createRuningTeamSession('two lane fixture task', cwd, { sessionId: 'rt-e2e' });
+      await linkRuningTeamTeamAdapter(cwd, session.session_id, {
+        team_name: 'rt-team',
+        cursor: '',
+        lane_task_map: { tests: '1', implementation: '2' },
+        evidence_guarantee: 'active',
+      });
+
+      await appendTeamEvent('rt-team', {
+        type: 'task_completed',
+        worker: 'worker-1',
+        task_id: '1',
+        reason: 'RED evidence emitted',
+        metadata: { files_changed: ['src/runingteam/__tests__/runtime.test.ts'], commands: ['node --test'], tests: ['runtime.test.ts'] },
+      }, cwd);
+      const first = await ingestTeamEvidence(cwd, session.session_id);
+      const second = await ingestTeamEvidence(cwd, session.session_id);
+      assert.equal(first.length, 1);
+      assert.equal(second.length, 0, 'stable cursor deduplicates already ingested events');
+
+      const checkpoint = await createCheckpoint(cwd, session.session_id);
+      assert.equal(checkpoint.iteration, 1);
+      assert.deepEqual(checkpoint.evidence_ids, [first[0]?.evidence_id]);
+
+      await assert.rejects(
+        revisePlan(cwd, session.session_id, {
+          iteration: 2,
+          from_plan_version: 1,
+          to_plan_version: 2,
+          reason: 'missing checkpoint',
+          changes: ['next batch'],
+          preserved_acceptance_criteria: true,
+          created_at: new Date().toISOString(),
+        }),
+        /revision_requires_checkpoint/,
+      );
+
+      await writeCriticVerdict(cwd, session.session_id, {
+        iteration: 1,
+        verdict: 'ITERATE_PLAN',
+        required_changes: ['capture passing implementation evidence'],
+        created_at: new Date().toISOString(),
+      });
+      const revised = await revisePlan(cwd, session.session_id, {
+        iteration: 1,
+        from_plan_version: 1,
+        to_plan_version: 2,
+        reason: 'critic requested iteration',
+        changes: ['next implementation batch'],
+        preserved_acceptance_criteria: true,
+        created_at: new Date().toISOString(),
+      });
+      assert.equal(revised.plan_version, 2);
+      assert.equal((await readRuningTeamSession(cwd, session.session_id)).plan_version, 2);
+    });
+  });
+
+  it('simulates two-lane E2E through final synthesis completion', async () => {
+    await withTempRoot(async (cwd) => {
+      await initTeamState('rt-e2e-team', 'fixture team', 'executor', 2, cwd);
+      const session = await createRuningTeamSession('two lane fixture task', cwd, { sessionId: 'rt-full-smoke' });
+      await linkRuningTeamTeamAdapter(cwd, session.session_id, {
+        team_name: 'rt-e2e-team',
+        cursor: '',
+        lane_task_map: { tests: '1', implementation: '2' },
+        evidence_guarantee: 'active',
+      });
+
+      await appendTeamEvent('rt-e2e-team', { type: 'task_completed', worker: 'worker-1', task_id: '1', reason: 'tests lane RED', metadata: { commands: ['npm test'], tests: ['runingteam runtime'] } }, cwd);
+      await ingestTeamEvidence(cwd, session.session_id);
+      await createCheckpoint(cwd, session.session_id);
+      await writeCriticVerdict(cwd, session.session_id, { iteration: 1, verdict: 'APPROVE_NEXT_BATCH', created_at: new Date().toISOString() });
+
+      await appendTeamEvent('rt-e2e-team', { type: 'task_failed', worker: 'worker-2', task_id: '2', reason: 'implementation failed tests', metadata: { commands: ['npm test'], tests: ['failing runingteam runtime'] } }, cwd);
+      await ingestTeamEvidence(cwd, session.session_id);
+      await createCheckpoint(cwd, session.session_id);
+      await writeCriticVerdict(cwd, session.session_id, { iteration: 2, verdict: 'ITERATE_PLAN', required_changes: ['fix implementation evidence'], created_at: new Date().toISOString() });
+      await revisePlan(cwd, session.session_id, { iteration: 2, from_plan_version: 1, to_plan_version: 2, reason: 'failed implementation evidence', changes: ['rerun implementation lane'], preserved_acceptance_criteria: true, created_at: new Date().toISOString() });
+
+      await appendTeamEvent('rt-e2e-team', { type: 'task_completed', worker: 'worker-2', task_id: '2', reason: 'implementation passing', metadata: { commands: ['npm test'], tests: ['passing runingteam runtime'] } }, cwd);
+      await ingestTeamEvidence(cwd, session.session_id);
+      await createCheckpoint(cwd, session.session_id);
+      await writeCriticVerdict(cwd, session.session_id, { iteration: 3, verdict: 'FINAL_SYNTHESIS_READY', acceptance_criteria_evidence: { 'final synthesis is created before completion': ['worker-1', 'worker-2'] }, created_at: new Date().toISOString() });
+      await writeFinalSynthesis(cwd, session.session_id, '# Final synthesis\n\nTwo-lane fixture completed.');
+      const complete = await transitionRuningTeamSession(cwd, session.session_id, 'complete');
+      assert.equal(complete.status, 'complete');
+      assert.equal(existsSync(runingTeamPaths(cwd, session.session_id).finalSynthesis), true);
+    });
+  });
+
+
+
+  it('ingests task result commands when team event metadata is empty', async () => {
+    await withTempRoot(async (cwd) => {
+      await initTeamState('rt-result-fallback-team', 'fixture team', 'executor', 1, cwd);
+      const session = await createRuningTeamSession('result fallback fixture', cwd, { sessionId: 'rt-result-fallback' });
+      await linkRuningTeamTeamAdapter(cwd, session.session_id, {
+        team_name: 'rt-result-fallback-team',
+        cursor: '',
+        lane_task_map: { implementation: '1' },
+        evidence_guarantee: 'active',
+      });
+      const taskPath = join(cwd, '.omx', 'state', 'team', 'rt-result-fallback-team', 'tasks', 'task-1.json');
+      await mkdir(join(cwd, '.omx', 'state', 'team', 'rt-result-fallback-team', 'tasks'), { recursive: true });
+      await writeFile(taskPath, JSON.stringify({
+        id: '1',
+        subject: 'implementation lane',
+        description: 'report evidence in result',
+        status: 'completed',
+        owner: 'worker-1',
+        created_at: '2026-05-10T00:00:00.000Z',
+        filePaths: ['src/runingteam/runtime.ts'],
+        result: [
+          'Implemented result fallback.',
+          'PASS - `npm test -- src/runingteam/__tests__/runtime.test.ts` → ok',
+          'PASS - `npx tsc --noEmit` → ok',
+        ].join('\n'),
+      }, null, 2));
+
+      await appendTeamEvent('rt-result-fallback-team', {
+        type: 'task_completed',
+        worker: 'worker-1',
+        task_id: '1',
+        reason: 'completed with result-only evidence',
+        metadata: {},
+      }, cwd);
+
+      const evidence = await ingestTeamEvidence(cwd, session.session_id);
+      assert.equal(evidence.length, 1);
+      assert.deepEqual(evidence[0]?.files_changed, ['src/runingteam/runtime.ts']);
+      assert.deepEqual(evidence[0]?.commands, ['npx tsc --noEmit']);
+      assert.deepEqual(evidence[0]?.tests, ['npm test -- src/runingteam/__tests__/runtime.test.ts']);
+      assert.equal(evidence[0]?.supported, true);
+    });
+  });
+
+  it('preserves omx team state when RuningTeam is inactive', async () => {
+    await withTempRoot(async (cwd) => {
+      await initTeamState('plain-team', 'plain team task', 'executor', 1, cwd);
+      const teamConfigPath = join(cwd, '.omx', 'state', 'team', 'plain-team', 'config.json');
+      const before = await readFile(teamConfigPath, 'utf-8');
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      const sessions = await import('../runtime.js').then((m) => m.listRuningTeamSessions(cwd));
+      assert.deepEqual(sessions, []);
+      const after = await readFile(teamConfigPath, 'utf-8');
+      assert.equal(after, before);
+    });
+  });
+});

--- a/src/runingteam/__tests__/team-adapter.test.ts
+++ b/src/runingteam/__tests__/team-adapter.test.ts
@@ -1,0 +1,235 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { appendTeamEvent, claimTask, createTask, initTeamState, transitionTaskStatus } from '../../team/state.js';
+import {
+  ingestRuningTeamAdapterEvidence,
+  initializeRuningTeamAdapterState,
+  readRuningTeamAdapterState,
+  runingTeamEvidenceLogPath,
+} from '../team-adapter.js';
+
+async function setup(name: string): Promise<{ cwd: string; cleanup: () => Promise<void> }> {
+  const cwd = await mkdtemp(join(tmpdir(), `omx-runingteam-adapter-${name}-`));
+  const previousOmxRoot = process.env.OMX_ROOT;
+  const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+  const previousOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+  delete process.env.OMX_ROOT;
+  delete process.env.OMX_STATE_ROOT;
+  delete process.env.OMX_TEAM_STATE_ROOT;
+  await initTeamState(name, 'runingteam adapter test', 'executor', 2, cwd);
+  return {
+    cwd,
+    cleanup: async () => {
+      if (previousOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = previousOmxRoot;
+      if (previousOmxStateRoot === undefined) delete process.env.OMX_STATE_ROOT;
+      else process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      if (previousOmxTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+      else process.env.OMX_TEAM_STATE_ROOT = previousOmxTeamStateRoot;
+      await rm(cwd, { recursive: true, force: true });
+    },
+  };
+}
+
+describe('runingteam/team-adapter', () => {
+  it('ingests team task completion evidence with lane/task/plan correlation and stable cursor', async () => {
+    const { cwd, cleanup } = await setup('rt-adapter-a');
+    try {
+      const task = await createTask('rt-adapter-a', {
+        subject: 'implementation lane',
+        description: 'implement fixture',
+        status: 'pending',
+        owner: 'worker-1',
+        lane: 'implementation',
+        filePaths: ['src/example.ts'],
+      }, cwd);
+      const claim = await claimTask('rt-adapter-a', task.id, 'worker-1', null, cwd);
+      assert.equal(claim.ok, true);
+      if (!claim.ok) throw new Error('claim failed');
+
+      const beforeCompletion = await initializeRuningTeamAdapterState({
+        cwd,
+        sessionId: 'session-a',
+        teamName: 'rt-adapter-a',
+        workerMap: { 'worker-1': 'implementation' },
+        taskMap: { [task.id]: 'implementation' },
+      });
+      const baseline = await ingestRuningTeamAdapterEvidence({
+        cwd,
+        sessionId: 'session-a',
+        iteration: 1,
+        planVersion: 2,
+        state: beforeCompletion,
+      });
+      assert.ok(baseline.ingestedCount >= 0);
+
+      const result = [
+        'Changed src/example.ts',
+        'PASS - `npm test -- src/example.test.ts` → ok',
+        'PASS - `npx tsc --noEmit` → ok',
+      ].join('\n');
+      const transitioned = await transitionTaskStatus('rt-adapter-a', task.id, 'in_progress', 'completed', claim.claimToken, cwd, { result });
+      assert.equal(transitioned.ok, true);
+
+      const first = await ingestRuningTeamAdapterEvidence({
+        cwd,
+        sessionId: 'session-a',
+        iteration: 1,
+        planVersion: 2,
+      });
+
+      assert.ok(first.ingestedCount >= 1);
+      assert.equal(first.events.at(-1)?.type, 'worker_evidence_received');
+      assert.equal(first.events.filter((event) => event.type === 'worker_evidence_received').length, 1);
+      const event = first.events.at(-1);
+      assert.equal(event?.session_id, 'session-a');
+      assert.equal(event?.iteration, 1);
+      assert.equal(event?.plan_version, 2);
+      assert.equal(event?.worker, 'worker-1');
+      assert.equal(event?.lane, 'implementation');
+      assert.equal(event?.task_id, task.id);
+      if (event?.type !== 'worker_evidence_received') throw new Error('expected worker evidence');
+      assert.deepEqual(event.files_changed, ['src/example.ts']);
+      assert.equal(event.tests_run.some((test) => test.command === 'npm test -- src/example.test.ts' && test.status === 'pass'), true);
+      assert.equal(event.commands_run.some((command) => command.command === 'npx tsc --noEmit' && command.exit_code === 0), true);
+      assert.equal(typeof first.cursor, 'string');
+
+      const second = await ingestRuningTeamAdapterEvidence({
+        cwd,
+        sessionId: 'session-a',
+        iteration: 1,
+        planVersion: 2,
+      });
+      assert.equal(second.ingestedCount, 0);
+      assert.equal(second.cursor, first.cursor);
+
+      const logRaw = await readFile(runingTeamEvidenceLogPath(cwd, 'session-a'), 'utf-8');
+      assert.equal(logRaw.trim().split('\n').length, first.ingestedCount);
+      const persisted = await readRuningTeamAdapterState(cwd, 'session-a');
+      assert.equal(persisted?.event_cursor, first.cursor);
+      assert.equal(persisted?.ingested_event_ids?.length, first.ingestedCount);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('parses task result evidence when task_completed metadata is empty', async () => {
+    const { cwd, cleanup } = await setup('rt-adapter-empty-metadata');
+    try {
+      const task = await createTask('rt-adapter-empty-metadata', {
+        subject: 'implementation lane',
+        description: 'complete work and report evidence in result text',
+        status: 'pending',
+        owner: 'worker-1',
+        lane: 'implementation',
+        filePaths: ['src/runingteam/example.ts'],
+      }, cwd);
+      const claim = await claimTask('rt-adapter-empty-metadata', task.id, 'worker-1', null, cwd);
+      assert.equal(claim.ok, true);
+      if (!claim.ok) throw new Error('claim failed');
+
+      const result = [
+        'Implemented worker result parsing fallback.',
+        'PASS - `npm test -- src/runingteam/__tests__/team-adapter.test.ts` → ok',
+        'FAIL - `npx tsc --noEmit` → typecheck failed before production fix',
+      ].join('\n');
+      const transitioned = await transitionTaskStatus('rt-adapter-empty-metadata', task.id, 'in_progress', 'completed', claim.claimToken, cwd, { result });
+      assert.equal(transitioned.ok, true);
+
+      await initializeRuningTeamAdapterState({
+        cwd,
+        sessionId: 'session-empty-metadata',
+        teamName: 'rt-adapter-empty-metadata',
+        workerMap: { 'worker-1': 'implementation' },
+        taskMap: { [task.id]: 'implementation' },
+      });
+      await appendTeamEvent('rt-adapter-empty-metadata', {
+        type: 'task_completed',
+        worker: 'worker-1',
+        task_id: task.id,
+        reason: 'completed with result-only evidence',
+        metadata: {},
+      }, cwd);
+
+      const ingested = await ingestRuningTeamAdapterEvidence({
+        cwd,
+        sessionId: 'session-empty-metadata',
+        iteration: 2,
+        planVersion: 3,
+      });
+
+      const evidence = ingested.events.find((event) => event.type === 'worker_evidence_received');
+      assert.ok(evidence, 'task_completed should become worker evidence even when event metadata is empty');
+      if (evidence?.type !== 'worker_evidence_received') throw new Error('expected worker evidence');
+      assert.deepEqual(evidence.files_changed, ['src/runingteam/example.ts']);
+      assert.equal(evidence.tests_run.some((test) => test.command === 'npm test -- src/runingteam/__tests__/team-adapter.test.ts' && test.status === 'pass'), true);
+      assert.equal(evidence.commands_run.some((command) => command.command === 'npx tsc --noEmit' && command.exit_code === 1), true);
+      assert.equal(evidence.next_needed, 'checkpoint_review');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('deduplicates normalized worker_idle events and records stale/blocker events without worker evidence claims', async () => {
+    const { cwd, cleanup } = await setup('rt-adapter-b');
+    try {
+      const baseline = await appendTeamEvent('rt-adapter-b', {
+        type: 'worker_state_changed',
+        worker: 'worker-2',
+        task_id: '2',
+        state: 'working',
+      }, cwd);
+      await appendTeamEvent('rt-adapter-b', {
+        type: 'worker_idle',
+        worker: 'worker-2',
+        task_id: '2',
+        prev_state: 'working',
+      }, cwd);
+      await appendTeamEvent('rt-adapter-b', {
+        type: 'worker_idle',
+        worker: 'worker-2',
+        task_id: '2',
+        prev_state: 'working',
+      }, cwd);
+      await appendTeamEvent('rt-adapter-b', {
+        type: 'worker_stale_stdout',
+        worker: 'worker-2',
+        task_id: '2',
+        reason: 'stdout stale',
+      }, cwd);
+
+      await initializeRuningTeamAdapterState({
+        cwd,
+        sessionId: 'session-b',
+        teamName: 'rt-adapter-b',
+        workerMap: { 'worker-2': 'tests' },
+        taskMap: { '2': 'tests' },
+      });
+      const state = await readRuningTeamAdapterState(cwd, 'session-b');
+      assert.ok(state);
+      if (state) {
+        state.event_cursor = baseline.event_id;
+      }
+
+      const result = await ingestRuningTeamAdapterEvidence({
+        cwd,
+        sessionId: 'session-b',
+        iteration: 3,
+        planVersion: 4,
+        state: state ?? undefined,
+      });
+
+      assert.equal(result.ingestedCount, 2);
+      assert.deepEqual(result.events.map((event) => event.type), ['team_event_ingested', 'team_event_ingested']);
+      assert.deepEqual(result.events.map((event) => event.lane), ['tests', 'tests']);
+      assert.equal(result.events[1]?.source_team_event_id, result.cursor);
+      if (result.events[1]?.type !== 'team_event_ingested') throw new Error('expected team event');
+      assert.deepEqual(result.events[1].blockers, ['stdout stale']);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/runingteam/contracts.ts
+++ b/src/runingteam/contracts.ts
@@ -1,0 +1,112 @@
+export const RUNINGTEAM_STATUSES = [
+  'planning',
+  'executing',
+  'checkpointing',
+  'reviewing',
+  'revising',
+  'synthesizing',
+  'complete',
+  'blocked',
+  'failed',
+  'cancelled',
+] as const;
+
+export type RuningTeamStatus = (typeof RUNINGTEAM_STATUSES)[number];
+
+export const RUNINGTEAM_TERMINAL_STATUSES: ReadonlySet<RuningTeamStatus> = new Set([
+  'complete',
+  'blocked',
+  'failed',
+  'cancelled',
+]);
+
+export const RUNINGTEAM_CRITIC_VERDICTS = [
+  'APPROVE_NEXT_BATCH',
+  'ITERATE_PLAN',
+  'REJECT_BATCH',
+  'ASK_USER',
+  'FINAL_SYNTHESIS_READY',
+  'FAIL',
+] as const;
+
+export type RuningTeamCriticVerdict = (typeof RUNINGTEAM_CRITIC_VERDICTS)[number];
+
+export interface RuningTeamSession {
+  session_id: string;
+  task: string;
+  created_at: string;
+  updated_at: string;
+  status: RuningTeamStatus;
+  iteration: number;
+  plan_version: number;
+  team_name: string | null;
+  max_iterations: number;
+  terminal_reason: string | null;
+}
+
+export interface RuningTeamPlanLane {
+  id: string;
+  title: string;
+  status: 'pending' | 'executing' | 'complete' | 'blocked';
+  acceptance_criteria: string[];
+}
+
+export interface RuningTeamPlan {
+  plan_version: number;
+  task: string;
+  intent: string;
+  acceptance_criteria: string[];
+  non_goals: string[];
+  lanes: RuningTeamPlanLane[];
+}
+
+export interface RuningTeamTeamAdapterState {
+  team_name: string;
+  cursor: string;
+  lane_task_map: Record<string, string>;
+  evidence_guarantee: 'active' | 'failed';
+}
+
+export interface RuningTeamWorkerEvidence {
+  evidence_id: string;
+  worker: string;
+  lane: string;
+  task_id: string;
+  plan_version: number;
+  files_changed: string[];
+  commands: string[];
+  tests: string[];
+  summary: string;
+  supported: boolean;
+  created_at: string;
+}
+
+export interface RuningTeamCheckpoint {
+  iteration: number;
+  plan_version: number;
+  created_at: string;
+  evidence_ids: string[];
+  lane_status: Record<string, string>;
+  blockers: string[];
+  summary: string;
+}
+
+export interface RuningTeamCriticVerdictRecord {
+  iteration: number;
+  verdict: RuningTeamCriticVerdict;
+  required_changes?: string[];
+  rejected_claims?: string[];
+  acceptance_criteria_evidence?: Record<string, string[]>;
+  created_at: string;
+}
+
+export interface RuningTeamPlannerRevision {
+  iteration: number;
+  from_plan_version: number;
+  to_plan_version: number;
+  reason: string;
+  changes: string[];
+  preserved_acceptance_criteria: boolean;
+  user_override?: string;
+  created_at: string;
+}

--- a/src/runingteam/controller.ts
+++ b/src/runingteam/controller.ts
@@ -1,0 +1,724 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { getBaseStateDir } from '../state/paths.js';
+import type { TeamEvent } from '../team/state/types.js';
+
+export const RUNINGTEAM_STATUSES = [
+  'planning',
+  'executing',
+  'checkpointing',
+  'reviewing',
+  'revising',
+  'synthesizing',
+  'complete',
+  'blocked',
+  'failed',
+  'cancelled',
+] as const;
+
+export type RuningTeamStatus = (typeof RUNINGTEAM_STATUSES)[number];
+
+export const RUNINGTEAM_CRITIC_VERDICTS = [
+  'APPROVE_NEXT_BATCH',
+  'ITERATE_PLAN',
+  'REJECT_BATCH',
+  'ASK_USER',
+  'FINAL_SYNTHESIS_READY',
+  'FAIL',
+] as const;
+
+export type RuningTeamCriticVerdict = (typeof RUNINGTEAM_CRITIC_VERDICTS)[number];
+
+export interface RuningTeamSession {
+  session_id: string;
+  task: string;
+  created_at: string;
+  updated_at: string;
+  status: RuningTeamStatus;
+  iteration: number;
+  plan_version: number;
+  team_name: string | null;
+  max_iterations: number;
+  terminal_reason: string | null;
+}
+
+export interface RuningTeamLane {
+  lane_id: string;
+  goal: string;
+  owned_paths: string[];
+  worker_profile: string;
+  status: 'pending' | 'active' | 'complete' | 'blocked' | 'rejected';
+}
+
+export interface RuningTeamPlan {
+  plan_version: number;
+  task: string;
+  intent: string;
+  acceptance_criteria: string[];
+  non_goals: string[];
+  lanes: RuningTeamLane[];
+  verification_commands: string[];
+  revision_policy: {
+    checkpoint_only: true;
+    may_change: string[];
+    must_not_change: string[];
+  };
+}
+
+export interface RuningTeamWorkerEvidence {
+  event_id: string;
+  worker: string;
+  lane_id: string;
+  team_task_id: string;
+  plan_version: number;
+  status: 'completed' | 'failed';
+  files_changed: string[];
+  commands: string[];
+  summary: string;
+  created_at: string;
+  unsupported_claims: string[];
+}
+
+export interface RuningTeamCheckpoint {
+  session_id: string;
+  iteration: number;
+  plan_version: number;
+  created_at: string;
+  evidence_count: number;
+  lane_status: Array<{ lane_id: string; status: RuningTeamLane['status']; evidence_count: number }>;
+  evidence: RuningTeamWorkerEvidence[];
+  blockers: string[];
+  open_questions: string[];
+}
+
+export interface RuningTeamCriticVerdictRecord {
+  session_id: string;
+  iteration: number;
+  plan_version: number;
+  verdict: RuningTeamCriticVerdict;
+  required_changes: string[];
+  rejected_claims: string[];
+  acceptance_criteria_evidence: Record<string, string[]>;
+  reason: string;
+  created_at: string;
+}
+
+export interface RuningTeamPlannerRevision {
+  session_id: string;
+  iteration: number;
+  from_plan_version: number;
+  to_plan_version: number;
+  reason: string;
+  changes: string[];
+  preserved_acceptance_criteria: boolean;
+  created_at: string;
+}
+
+export interface RuningTeamFinalSynthesis {
+  session_id: string;
+  plan_version: number;
+  iteration: number;
+  completed_at: string;
+  summary: string;
+  acceptance_criteria: Array<{ criterion: string; evidence: string[] }>;
+  checkpoint_count: number;
+}
+
+export interface RuningTeamControllerOptions {
+  cwd: string;
+  sessionId: string;
+}
+
+interface TeamTaskSnapshot {
+  id?: unknown;
+  subject?: unknown;
+  description?: unknown;
+  result?: unknown;
+  error?: unknown;
+  status?: unknown;
+}
+
+const TERMINAL_STATUSES = new Set<RuningTeamStatus>(['complete', 'blocked', 'failed', 'cancelled']);
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function assertObject(value: unknown, label: string): asserts value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function isStatus(value: unknown): value is RuningTeamStatus {
+  return typeof value === 'string' && RUNINGTEAM_STATUSES.includes(value as RuningTeamStatus);
+}
+
+function isVerdict(value: unknown): value is RuningTeamCriticVerdict {
+  return typeof value === 'string' && RUNINGTEAM_CRITIC_VERDICTS.includes(value as RuningTeamCriticVerdict);
+}
+
+async function ensureParentDir(filePath: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await ensureParentDir(filePath);
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  return JSON.parse(await readFile(filePath, 'utf-8')) as T;
+}
+
+async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
+  if (!existsSync(filePath)) return null;
+  return readJsonFile<T>(filePath);
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function makeMarkdownList(values: string[]): string[] {
+  return values.length > 0 ? values.map((value) => `- ${value}`) : ['- none'];
+}
+
+function parseEvidenceList(result: string, label: string): string[] {
+  const pattern = new RegExp(`^\\s*${label}\\s*:\\s*(.+)$`, 'gim');
+  const matches = [...result.matchAll(pattern)].flatMap((match) => String(match[1] || '').split(/[,;|]/));
+  return uniqueStrings(matches);
+}
+
+function inferFilesChanged(result: string): string[] {
+  const explicit = parseEvidenceList(result, 'Files changed');
+  if (explicit.length > 0) return explicit;
+  const changed = [...result.matchAll(/`([^`]+\.(?:ts|tsx|js|jsx|json|md|mdx|yml|yaml))`/g)].map((match) => match[1]);
+  return uniqueStrings(changed);
+}
+
+function inferCommands(result: string): string[] {
+  const explicit = parseEvidenceList(result, '(?:Command|Commands|Tests|Verification)');
+  if (explicit.length > 0) return explicit;
+  const commandLines = result
+    .split(/\r?\n/)
+    .filter((line) => /(?:npm|node|tsc|biome|cargo|pytest|go test|pnpm|yarn)\b/.test(line));
+  return uniqueStrings(commandLines.map((line) => line.replace(/^\s*[-*]\s*/, '').trim()));
+}
+
+function inferUnsupportedClaims(task: TeamTaskSnapshot, status: RuningTeamWorkerEvidence['status']): string[] {
+  const result = typeof task.result === 'string' ? task.result : '';
+  const unsupported = parseEvidenceList(result, 'Unsupported claims');
+  if (status === 'completed' && inferCommands(result).length === 0) unsupported.push('missing_verification_commands');
+  return uniqueStrings(unsupported);
+}
+
+function summarizeTask(task: TeamTaskSnapshot): string {
+  const raw = typeof task.result === 'string' && task.result.trim()
+    ? task.result.trim()
+    : typeof task.error === 'string' && task.error.trim()
+      ? task.error.trim()
+      : typeof task.description === 'string'
+        ? task.description.trim()
+        : typeof task.subject === 'string'
+          ? task.subject.trim()
+          : '';
+  return raw.length <= 500 ? raw : `${raw.slice(0, 500)}…`;
+}
+
+function laneForTask(plan: RuningTeamPlan, event: TeamEvent, task: TeamTaskSnapshot | null): string {
+  const subject = typeof task?.subject === 'string' ? task.subject.toLowerCase() : '';
+  const description = typeof task?.description === 'string' ? task.description.toLowerCase() : '';
+  const haystack = `${subject}\n${description}\n${event.worker}`;
+  const matched = plan.lanes.find((lane) => {
+    const id = lane.lane_id.toLowerCase();
+    return haystack.includes(id) || haystack.includes(lane.goal.toLowerCase());
+  });
+  return matched?.lane_id ?? plan.lanes[0]?.lane_id ?? 'execution';
+}
+
+function sessionRoot(cwd: string, sessionId: string): string {
+  return join(getBaseStateDir(cwd), 'runingteam', sessionId);
+}
+
+function sessionPath(cwd: string, sessionId: string): string {
+  return join(sessionRoot(cwd, sessionId), 'session.json');
+}
+
+function planPath(cwd: string, sessionId: string): string {
+  return join(sessionRoot(cwd, sessionId), 'plan.json');
+}
+
+function checkpointPath(cwd: string, sessionId: string, iteration: number): string {
+  return join(sessionRoot(cwd, sessionId), 'iterations', String(iteration), 'checkpoint.json');
+}
+
+function checkpointMarkdownPath(cwd: string, sessionId: string, iteration: number): string {
+  return join(sessionRoot(cwd, sessionId), 'iterations', String(iteration), 'checkpoint.md');
+}
+
+function verdictPath(cwd: string, sessionId: string, iteration: number): string {
+  return join(sessionRoot(cwd, sessionId), 'verdicts', `${iteration}.json`);
+}
+
+function revisionPath(cwd: string, sessionId: string, iteration: number): string {
+  return join(sessionRoot(cwd, sessionId), 'revisions', `${iteration}.json`);
+}
+
+function finalSynthesisPath(cwd: string, sessionId: string): string {
+  return join(sessionRoot(cwd, sessionId), 'final-synthesis.md');
+}
+
+function eventsPath(cwd: string, sessionId: string): string {
+  return join(sessionRoot(cwd, sessionId), 'evidence', 'events.ndjson');
+}
+
+function teamTaskPath(cwd: string, teamName: string, taskId: string): string {
+  return join(getBaseStateDir(cwd), 'team', teamName, 'tasks', `task-${taskId}.json`);
+}
+
+function teamEventsPath(cwd: string, teamName: string): string {
+  return join(getBaseStateDir(cwd), 'team', teamName, 'events', 'events.ndjson');
+}
+
+export function validateRuningTeamSession(value: unknown): RuningTeamSession {
+  assertObject(value, 'session.json');
+  const session = value as Partial<RuningTeamSession>;
+  if (typeof session.session_id !== 'string' || !session.session_id.trim()) throw new Error('session_id is required');
+  if (typeof session.task !== 'string') throw new Error('task is required');
+  if (!isStatus(session.status)) throw new Error('invalid lifecycle status');
+  if (typeof session.iteration !== 'number' || session.iteration < 0) throw new Error('iteration must be non-negative');
+  if (typeof session.plan_version !== 'number' || session.plan_version < 1) throw new Error('plan_version must be positive');
+  if (typeof session.team_name !== 'string' && session.team_name !== null) throw new Error('team_name must be string|null');
+  if (typeof session.max_iterations !== 'number' || session.max_iterations < 1) throw new Error('max_iterations must be positive');
+  return session as RuningTeamSession;
+}
+
+export function validateRuningTeamPlan(value: unknown): RuningTeamPlan {
+  assertObject(value, 'plan.json');
+  const plan = value as Partial<RuningTeamPlan>;
+  if (typeof plan.plan_version !== 'number' || plan.plan_version < 1) throw new Error('plan_version must be positive');
+  if (typeof plan.task !== 'string') throw new Error('task is required');
+  if (!Array.isArray(plan.acceptance_criteria) || plan.acceptance_criteria.length === 0) throw new Error('acceptance_criteria are required');
+  if (!Array.isArray(plan.lanes) || plan.lanes.length === 0) throw new Error('lanes are required');
+  for (const lane of plan.lanes) {
+    assertObject(lane, 'plan.lane');
+    if (typeof lane.lane_id !== 'string' || !lane.lane_id.trim()) throw new Error('lane_id is required');
+  }
+  if (plan.revision_policy?.checkpoint_only !== true) throw new Error('revision_policy.checkpoint_only must be true');
+  return plan as RuningTeamPlan;
+}
+
+export function validateCriticVerdict(value: unknown): RuningTeamCriticVerdictRecord {
+  assertObject(value, 'critic_verdict');
+  const record = value as Partial<RuningTeamCriticVerdictRecord>;
+  if (!isVerdict(record.verdict)) throw new Error('invalid verdict');
+  const requiredChanges = asStringArray(record.required_changes);
+  const rejectedClaims = asStringArray(record.rejected_claims);
+  if (record.verdict === 'ITERATE_PLAN' && requiredChanges.length === 0) throw new Error('ITERATE_PLAN requires required_changes');
+  if (record.verdict === 'REJECT_BATCH' && rejectedClaims.length === 0) throw new Error('REJECT_BATCH requires rejected_claims');
+  if (record.verdict === 'FINAL_SYNTHESIS_READY') {
+    assertObject(record.acceptance_criteria_evidence, 'acceptance_criteria_evidence');
+    if (Object.values(record.acceptance_criteria_evidence).some((items) => !Array.isArray(items) || items.length === 0)) {
+      throw new Error('FINAL_SYNTHESIS_READY requires all acceptance criteria to have evidence');
+    }
+  }
+  return { ...record, required_changes: requiredChanges, rejected_claims: rejectedClaims } as RuningTeamCriticVerdictRecord;
+}
+
+export function validatePlannerRevision(
+  revision: unknown,
+  opts: { userOverride?: boolean } = {},
+): RuningTeamPlannerRevision {
+  assertObject(revision, 'planner_revision');
+  const record = revision as Partial<RuningTeamPlannerRevision>;
+  if (record.preserved_acceptance_criteria !== true && opts.userOverride !== true) {
+    throw new Error('planner_revision.preserved_acceptance_criteria must be true unless a user override is present');
+  }
+  if (typeof record.to_plan_version !== 'number' || typeof record.from_plan_version !== 'number' || record.to_plan_version <= record.from_plan_version) {
+    throw new Error('planner_revision must increment plan version');
+  }
+  return record as RuningTeamPlannerRevision;
+}
+
+export function canTransitionRuningTeamStatus(from: RuningTeamStatus, to: RuningTeamStatus): boolean {
+  if (TERMINAL_STATUSES.has(from)) return false;
+  if (TERMINAL_STATUSES.has(to)) return true;
+  const allowed: Record<RuningTeamStatus, RuningTeamStatus[]> = {
+    planning: ['executing'],
+    executing: ['checkpointing'],
+    checkpointing: ['reviewing'],
+    reviewing: ['revising', 'synthesizing'],
+    revising: ['executing'],
+    synthesizing: ['complete'],
+    complete: [],
+    blocked: [],
+    failed: [],
+    cancelled: [],
+  };
+  return allowed[from].includes(to);
+}
+
+export function createInitialRuningTeamPlan(task: string): RuningTeamPlan {
+  return {
+    plan_version: 1,
+    task,
+    intent: task,
+    acceptance_criteria: [
+      'Direct RuningTeam invocation creates a managed session and plan.',
+      'Worker evidence is checkpointed before plan mutation.',
+      'Critic verdicts gate planner revision and final synthesis.',
+      'Completion is impossible without final-synthesis.md.',
+    ],
+    non_goals: ['no MVP framing', 'no manual ralplan pre-step'],
+    lanes: [
+      {
+        lane_id: 'execution',
+        goal: task,
+        owned_paths: [],
+        worker_profile: 'executor',
+        status: 'pending',
+      },
+    ],
+    verification_commands: ['npm run build', 'npm test'],
+    revision_policy: {
+      checkpoint_only: true,
+      may_change: ['lane_split', 'owner', 'order', 'verification', 'blocker_strategy'],
+      must_not_change: ['acceptance_criteria_without_user_override'],
+    },
+  };
+}
+
+export async function createRuningTeamSession(
+  cwd: string,
+  input: { sessionId: string; task: string; teamName?: string | null; maxIterations?: number; plan?: RuningTeamPlan },
+): Promise<{ session: RuningTeamSession; plan: RuningTeamPlan }> {
+  const now = nowIso();
+  const plan = input.plan ?? createInitialRuningTeamPlan(input.task);
+  validateRuningTeamPlan(plan);
+  const session: RuningTeamSession = {
+    session_id: input.sessionId,
+    task: input.task,
+    created_at: now,
+    updated_at: now,
+    status: 'planning',
+    iteration: 0,
+    plan_version: plan.plan_version,
+    team_name: input.teamName ?? null,
+    max_iterations: input.maxIterations ?? 10,
+    terminal_reason: null,
+  };
+  validateRuningTeamSession(session);
+  await writeJsonFile(sessionPath(cwd, input.sessionId), session);
+  await writeJsonFile(planPath(cwd, input.sessionId), plan);
+  return { session, plan };
+}
+
+export async function readRuningTeamSession(cwd: string, sessionId: string): Promise<RuningTeamSession> {
+  return validateRuningTeamSession(await readJsonFile(sessionPath(cwd, sessionId)));
+}
+
+export async function readRuningTeamPlan(cwd: string, sessionId: string): Promise<RuningTeamPlan> {
+  return validateRuningTeamPlan(await readJsonFile(planPath(cwd, sessionId)));
+}
+
+export async function transitionRuningTeamStatus(
+  cwd: string,
+  sessionId: string,
+  to: RuningTeamStatus,
+  opts: { terminalReason?: string } = {},
+): Promise<RuningTeamSession> {
+  const session = await readRuningTeamSession(cwd, sessionId);
+  if (!canTransitionRuningTeamStatus(session.status, to)) {
+    throw new Error(`invalid RuningTeam transition: ${session.status} -> ${to}`);
+  }
+  if (to === 'complete' && !existsSync(finalSynthesisPath(cwd, sessionId))) {
+    throw new Error('complete requires final-synthesis.md');
+  }
+  const next: RuningTeamSession = {
+    ...session,
+    status: to,
+    updated_at: nowIso(),
+    terminal_reason: TERMINAL_STATUSES.has(to) ? opts.terminalReason ?? session.terminal_reason : session.terminal_reason,
+  };
+  await writeJsonFile(sessionPath(cwd, sessionId), next);
+  return next;
+}
+
+async function appendEvidenceEvent(cwd: string, sessionId: string, evidence: RuningTeamWorkerEvidence): Promise<void> {
+  const file = eventsPath(cwd, sessionId);
+  await ensureParentDir(file);
+  await writeFile(file, `${JSON.stringify(evidence)}\n`, { flag: 'a', encoding: 'utf-8' });
+}
+
+async function readEvidenceEvents(cwd: string, sessionId: string): Promise<RuningTeamWorkerEvidence[]> {
+  const file = eventsPath(cwd, sessionId);
+  if (!existsSync(file)) return [];
+  const raw = await readFile(file, 'utf-8');
+  const seen = new Set<string>();
+  const out: RuningTeamWorkerEvidence[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as RuningTeamWorkerEvidence;
+      if (!parsed.event_id || seen.has(parsed.event_id)) continue;
+      seen.add(parsed.event_id);
+      out.push(parsed);
+    } catch {}
+  }
+  return out;
+}
+
+export async function ingestTeamEvidence(
+  cwd: string,
+  sessionId: string,
+  opts: { afterEventId?: string } = {},
+): Promise<RuningTeamWorkerEvidence[]> {
+  const session = await readRuningTeamSession(cwd, sessionId);
+  if (!session.team_name) return [];
+  const plan = await readRuningTeamPlan(cwd, sessionId);
+  const teamLog = teamEventsPath(cwd, session.team_name);
+  if (!existsSync(teamLog)) return [];
+  const existing = new Set((await readEvidenceEvents(cwd, sessionId)).map((event) => event.event_id));
+  const raw = await readFile(teamLog, 'utf-8');
+  const ingested: RuningTeamWorkerEvidence[] = [];
+  let started = !opts.afterEventId;
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    let event: TeamEvent;
+    try {
+      event = JSON.parse(line) as TeamEvent;
+    } catch {
+      continue;
+    }
+    if (!event.event_id) continue;
+    if (!started) {
+      if (event.event_id === opts.afterEventId) started = true;
+      continue;
+    }
+    if (existing.has(event.event_id)) continue;
+    if (event.type !== 'task_completed' && event.type !== 'task_failed') continue;
+    const taskId = typeof event.task_id === 'string' ? event.task_id : '';
+    if (!taskId) continue;
+    const task = await readJsonIfExists<TeamTaskSnapshot>(teamTaskPath(cwd, session.team_name, taskId));
+    const status: RuningTeamWorkerEvidence['status'] = event.type === 'task_failed' ? 'failed' : 'completed';
+    const result = typeof task?.result === 'string' ? task.result : '';
+    const evidence: RuningTeamWorkerEvidence = {
+      event_id: event.event_id,
+      worker: event.worker,
+      lane_id: laneForTask(plan, event, task),
+      team_task_id: taskId,
+      plan_version: session.plan_version,
+      status,
+      files_changed: inferFilesChanged(result),
+      commands: inferCommands(result),
+      summary: summarizeTask(task ?? {}),
+      created_at: event.created_at ?? nowIso(),
+      unsupported_claims: inferUnsupportedClaims(task ?? {}, status),
+    };
+    await appendEvidenceEvent(cwd, sessionId, evidence);
+    existing.add(event.event_id);
+    ingested.push(evidence);
+  }
+  return ingested;
+}
+
+export async function createCheckpoint(cwd: string, sessionId: string): Promise<RuningTeamCheckpoint> {
+  const session = await readRuningTeamSession(cwd, sessionId);
+  const plan = await readRuningTeamPlan(cwd, sessionId);
+  const evidence = (await readEvidenceEvents(cwd, sessionId)).filter((item) => item.plan_version === session.plan_version);
+  if (evidence.length === 0) throw new Error('checkpoint requires new evidence');
+  const nextIteration = session.iteration + 1;
+  const checkpoint: RuningTeamCheckpoint = {
+    session_id: sessionId,
+    iteration: nextIteration,
+    plan_version: session.plan_version,
+    created_at: nowIso(),
+    evidence_count: evidence.length,
+    lane_status: plan.lanes.map((lane) => {
+      const laneEvidence = evidence.filter((item) => item.lane_id === lane.lane_id);
+      return {
+        lane_id: lane.lane_id,
+        status: laneEvidence.some((item) => item.status === 'failed')
+          ? 'blocked'
+          : laneEvidence.some((item) => item.status === 'completed')
+            ? 'complete'
+            : lane.status,
+        evidence_count: laneEvidence.length,
+      };
+    }),
+    evidence,
+    blockers: uniqueStrings(evidence.flatMap((item) => item.unsupported_claims)),
+    open_questions: [],
+  };
+  await writeJsonFile(checkpointPath(cwd, sessionId, nextIteration), checkpoint);
+  await ensureParentDir(checkpointMarkdownPath(cwd, sessionId, nextIteration));
+  await writeFile(checkpointMarkdownPath(cwd, sessionId, nextIteration), renderCheckpointMarkdown(checkpoint), 'utf-8');
+  await writeJsonFile(sessionPath(cwd, sessionId), {
+    ...session,
+    status: 'checkpointing',
+    iteration: nextIteration,
+    updated_at: nowIso(),
+  } satisfies RuningTeamSession);
+  return checkpoint;
+}
+
+function renderCheckpointMarkdown(checkpoint: RuningTeamCheckpoint): string {
+  return [
+    `# RuningTeam Checkpoint ${checkpoint.iteration}`,
+    '',
+    `- Plan version: ${checkpoint.plan_version}`,
+    `- Evidence count: ${checkpoint.evidence_count}`,
+    '',
+    '## Lane Status',
+    ...checkpoint.lane_status.map((lane) => `- ${lane.lane_id}: ${lane.status} (${lane.evidence_count} evidence)`),
+    '',
+    '## Evidence',
+    ...checkpoint.evidence.map((item) => `- ${item.worker}/task-${item.team_task_id}: ${item.status} — ${item.summary}`),
+    '',
+    '## Blockers',
+    ...makeMarkdownList(checkpoint.blockers),
+    '',
+  ].join('\n');
+}
+
+export async function createCriticVerdict(
+  cwd: string,
+  sessionId: string,
+  input?: Partial<RuningTeamCriticVerdictRecord>,
+): Promise<RuningTeamCriticVerdictRecord> {
+  const session = await readRuningTeamSession(cwd, sessionId);
+  const plan = await readRuningTeamPlan(cwd, sessionId);
+  const checkpoint = await readJsonIfExists<RuningTeamCheckpoint>(checkpointPath(cwd, sessionId, session.iteration));
+  if (!checkpoint) throw new Error('critic verdict requires checkpoint');
+  const rejectedClaims = uniqueStrings(checkpoint.evidence.flatMap((item) => item.unsupported_claims));
+  const criteriaEvidence = Object.fromEntries(plan.acceptance_criteria.map((criterion) => [
+    criterion,
+    checkpoint.evidence
+      .filter((item) => item.status === 'completed' && item.unsupported_claims.length === 0)
+      .map((item) => `${item.worker}/task-${item.team_task_id}`),
+  ]));
+  const hasRejected = rejectedClaims.length > 0;
+  const allCriteriaSupported = Object.values(criteriaEvidence).every((items) => items.length > 0);
+  const verdict = input?.verdict ?? (hasRejected ? 'ITERATE_PLAN' : allCriteriaSupported ? 'FINAL_SYNTHESIS_READY' : 'APPROVE_NEXT_BATCH');
+  const record: RuningTeamCriticVerdictRecord = validateCriticVerdict({
+    session_id: sessionId,
+    iteration: session.iteration,
+    plan_version: session.plan_version,
+    verdict,
+    required_changes: input?.required_changes ?? (hasRejected ? rejectedClaims.map((claim) => `resolve ${claim}`) : []),
+    rejected_claims: input?.rejected_claims ?? (verdict === 'REJECT_BATCH' ? rejectedClaims : []),
+    acceptance_criteria_evidence: input?.acceptance_criteria_evidence ?? criteriaEvidence,
+    reason: input?.reason ?? (hasRejected ? 'checkpoint contains unsupported claims' : 'checkpoint evidence reviewed'),
+    created_at: nowIso(),
+  });
+  await writeJsonFile(verdictPath(cwd, sessionId, session.iteration), record);
+  await writeJsonFile(sessionPath(cwd, sessionId), { ...session, status: 'reviewing', updated_at: nowIso() } satisfies RuningTeamSession);
+  return record;
+}
+
+export async function createPlannerRevision(
+  cwd: string,
+  sessionId: string,
+  input?: { reason?: string; changes?: string[]; userOverride?: boolean },
+): Promise<RuningTeamPlannerRevision> {
+  const session = await readRuningTeamSession(cwd, sessionId);
+  const plan = await readRuningTeamPlan(cwd, sessionId);
+  const checkpoint = await readJsonIfExists<RuningTeamCheckpoint>(checkpointPath(cwd, sessionId, session.iteration));
+  if (!checkpoint) throw new Error('planner revision requires checkpoint');
+  const verdict = validateCriticVerdict(await readJsonFile(verdictPath(cwd, sessionId, session.iteration)));
+  if (verdict.verdict !== 'ITERATE_PLAN' && verdict.verdict !== 'REJECT_BATCH') {
+    throw new Error('planner revision requires ITERATE_PLAN or REJECT_BATCH verdict');
+  }
+  const changes = input?.changes ?? verdict.required_changes;
+  const nextPlan: RuningTeamPlan = {
+    ...plan,
+    plan_version: plan.plan_version + 1,
+    lanes: plan.lanes.map((lane) => ({
+      ...lane,
+      status: checkpoint.lane_status.find((item) => item.lane_id === lane.lane_id)?.status === 'blocked' ? 'active' : lane.status,
+    })),
+  };
+  const revision = validatePlannerRevision({
+    session_id: sessionId,
+    iteration: session.iteration,
+    from_plan_version: plan.plan_version,
+    to_plan_version: nextPlan.plan_version,
+    reason: input?.reason ?? verdict.reason,
+    changes,
+    preserved_acceptance_criteria: true,
+    created_at: nowIso(),
+  }, { userOverride: input?.userOverride });
+  await writeJsonFile(revisionPath(cwd, sessionId, session.iteration), revision);
+  await writeJsonFile(planPath(cwd, sessionId), nextPlan);
+  await writeJsonFile(sessionPath(cwd, sessionId), {
+    ...session,
+    status: 'revising',
+    plan_version: nextPlan.plan_version,
+    updated_at: nowIso(),
+  } satisfies RuningTeamSession);
+  return revision;
+}
+
+export async function createFinalSynthesis(cwd: string, sessionId: string): Promise<RuningTeamFinalSynthesis> {
+  const session = await readRuningTeamSession(cwd, sessionId);
+  const plan = await readRuningTeamPlan(cwd, sessionId);
+  const verdict = validateCriticVerdict(await readJsonFile(verdictPath(cwd, sessionId, session.iteration)));
+  if (verdict.verdict !== 'FINAL_SYNTHESIS_READY') throw new Error('final synthesis requires FINAL_SYNTHESIS_READY verdict');
+  const synthesis: RuningTeamFinalSynthesis = {
+    session_id: sessionId,
+    plan_version: session.plan_version,
+    iteration: session.iteration,
+    completed_at: nowIso(),
+    summary: `RuningTeam completed ${plan.task} with checkpoint-backed evidence.`,
+    acceptance_criteria: plan.acceptance_criteria.map((criterion) => ({
+      criterion,
+      evidence: verdict.acceptance_criteria_evidence[criterion] ?? [],
+    })),
+    checkpoint_count: session.iteration,
+  };
+  const markdown = [
+    '# RuningTeam Final Synthesis',
+    '',
+    `- Session: ${synthesis.session_id}`,
+    `- Plan version: ${synthesis.plan_version}`,
+    `- Iteration: ${synthesis.iteration}`,
+    `- Completed at: ${synthesis.completed_at}`,
+    '',
+    '## Summary',
+    synthesis.summary,
+    '',
+    '## Acceptance Criteria Evidence',
+    ...synthesis.acceptance_criteria.flatMap((item) => [
+      `- ${item.criterion}`,
+      ...item.evidence.map((evidence) => `  - ${evidence}`),
+    ]),
+    '',
+  ].join('\n');
+  await ensureParentDir(finalSynthesisPath(cwd, sessionId));
+  await writeFile(finalSynthesisPath(cwd, sessionId), markdown, 'utf-8');
+  await writeJsonFile(sessionPath(cwd, sessionId), { ...session, status: 'synthesizing', updated_at: nowIso() } satisfies RuningTeamSession);
+  return synthesis;
+}
+
+export async function runCheckpointReviewRevisionCycle(
+  opts: RuningTeamControllerOptions,
+): Promise<{ checkpoint: RuningTeamCheckpoint; verdict: RuningTeamCriticVerdictRecord; revision?: RuningTeamPlannerRevision; synthesis?: RuningTeamFinalSynthesis }> {
+  await ingestTeamEvidence(opts.cwd, opts.sessionId);
+  const checkpoint = await createCheckpoint(opts.cwd, opts.sessionId);
+  const verdict = await createCriticVerdict(opts.cwd, opts.sessionId);
+  if (verdict.verdict === 'FINAL_SYNTHESIS_READY') {
+    const synthesis = await createFinalSynthesis(opts.cwd, opts.sessionId);
+    return { checkpoint, verdict, synthesis };
+  }
+  if (verdict.verdict === 'ITERATE_PLAN' || verdict.verdict === 'REJECT_BATCH') {
+    const revision = await createPlannerRevision(opts.cwd, opts.sessionId);
+    return { checkpoint, verdict, revision };
+  }
+  return { checkpoint, verdict };
+}

--- a/src/runingteam/index.ts
+++ b/src/runingteam/index.ts
@@ -1,0 +1,1 @@
+export * from './team-adapter.js';

--- a/src/runingteam/runtime.ts
+++ b/src/runingteam/runtime.ts
@@ -1,0 +1,434 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { getBaseStateDir } from '../mcp/state-paths.js';
+import { readTeamEvents } from '../team/state/events.js';
+import { readTask, type TeamEvent, type TeamTask } from '../team/state.js';
+import {
+  RUNINGTEAM_CRITIC_VERDICTS,
+  RUNINGTEAM_STATUSES,
+  RUNINGTEAM_TERMINAL_STATUSES,
+  type RuningTeamCheckpoint,
+  type RuningTeamCriticVerdict,
+  type RuningTeamCriticVerdictRecord,
+  type RuningTeamPlan,
+  type RuningTeamPlannerRevision,
+  type RuningTeamSession,
+  type RuningTeamStatus,
+  type RuningTeamTeamAdapterState,
+  type RuningTeamWorkerEvidence,
+} from './contracts.js';
+
+export interface RuningTeamPaths {
+  root: string;
+  session: string;
+  plan: string;
+  lanes: string;
+  adapterTeam: string;
+  evidenceEvents: string;
+  finalSynthesis: string;
+  iterationDir: (iteration: number) => string;
+  checkpointJson: (iteration: number) => string;
+  checkpointMd: (iteration: number) => string;
+  verdictJson: (iteration: number) => string;
+  revisionJson: (iteration: number) => string;
+}
+
+export interface RuningTeamSessionSummary {
+  session_id: string;
+  status: RuningTeamStatus;
+  iteration: number;
+  plan_version: number;
+  team_name: string | null;
+  final_synthesis_present: boolean;
+}
+
+export function createRuningTeamSessionId(): string {
+  return `runingteam-${new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15)}-${randomUUID().slice(0, 8)}`;
+}
+
+export function runingTeamRoot(cwd: string): string {
+  return join(getBaseStateDir(cwd), 'runingteam');
+}
+
+export function runingTeamPaths(cwd: string, sessionId: string): RuningTeamPaths {
+  const root = join(runingTeamRoot(cwd), sessionId);
+  return {
+    root,
+    session: join(root, 'session.json'),
+    plan: join(root, 'plan.json'),
+    lanes: join(root, 'lanes.json'),
+    adapterTeam: join(root, 'adapter', 'team.json'),
+    evidenceEvents: join(root, 'evidence', 'events.ndjson'),
+    finalSynthesis: join(root, 'final-synthesis.md'),
+    iterationDir: (iteration) => join(root, 'iterations', String(iteration)),
+    checkpointJson: (iteration) => join(root, 'iterations', String(iteration), 'checkpoint.json'),
+    checkpointMd: (iteration) => join(root, 'iterations', String(iteration), 'checkpoint.md'),
+    verdictJson: (iteration) => join(root, 'verdicts', `${iteration}.json`),
+    revisionJson: (iteration) => join(root, 'revisions', `${iteration}.json`),
+  };
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, 'utf-8')) as T;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireString(value: Record<string, unknown>, key: string): string {
+  const raw = value[key];
+  if (typeof raw !== 'string' || raw.trim() === '') throw new Error(`invalid_${key}`);
+  return raw;
+}
+
+function requireNumber(value: Record<string, unknown>, key: string): number {
+  const raw = value[key];
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 0) throw new Error(`invalid_${key}`);
+  return raw;
+}
+
+function requireStringArray(value: Record<string, unknown>, key: string): string[] {
+  const raw = value[key];
+  if (!Array.isArray(raw) || raw.some((entry) => typeof entry !== 'string' || entry.trim() === '')) {
+    throw new Error(`invalid_${key}`);
+  }
+  return raw;
+}
+
+export function validateRuningTeamSession(raw: unknown): RuningTeamSession {
+  if (!isRecord(raw)) throw new Error('invalid_session');
+  const status = requireString(raw, 'status');
+  if (!RUNINGTEAM_STATUSES.includes(status as RuningTeamStatus)) throw new Error('invalid_status');
+  const teamName = raw.team_name;
+  const terminalReason = raw.terminal_reason;
+  return {
+    session_id: requireString(raw, 'session_id'),
+    task: requireString(raw, 'task'),
+    created_at: requireString(raw, 'created_at'),
+    updated_at: requireString(raw, 'updated_at'),
+    status: status as RuningTeamStatus,
+    iteration: requireNumber(raw, 'iteration'),
+    plan_version: requireNumber(raw, 'plan_version'),
+    team_name: teamName === null || typeof teamName === 'string' ? teamName : null,
+    max_iterations: requireNumber(raw, 'max_iterations'),
+    terminal_reason: terminalReason === null || typeof terminalReason === 'string' ? terminalReason : null,
+  };
+}
+
+export function validateRuningTeamPlan(raw: unknown): RuningTeamPlan {
+  if (!isRecord(raw)) throw new Error('invalid_plan');
+  const lanes = raw.lanes;
+  if (!Array.isArray(lanes) || lanes.length === 0) throw new Error('invalid_lanes');
+  return {
+    plan_version: requireNumber(raw, 'plan_version'),
+    task: requireString(raw, 'task'),
+    intent: requireString(raw, 'intent'),
+    acceptance_criteria: requireStringArray(raw, 'acceptance_criteria'),
+    non_goals: requireStringArray(raw, 'non_goals'),
+    lanes: lanes.map((lane, index) => {
+      if (!isRecord(lane)) throw new Error(`invalid_lane_${index}`);
+      const status = requireString(lane, 'status');
+      if (!['pending', 'executing', 'complete', 'blocked'].includes(status)) throw new Error(`invalid_lane_status_${index}`);
+      return {
+        id: requireString(lane, 'id'),
+        title: requireString(lane, 'title'),
+        status: status as RuningTeamPlan['lanes'][number]['status'],
+        acceptance_criteria: requireStringArray(lane, 'acceptance_criteria'),
+      };
+    }),
+  };
+}
+
+export function validateCriticVerdictRecord(raw: unknown): RuningTeamCriticVerdictRecord {
+  if (!isRecord(raw)) throw new Error('invalid_critic_verdict');
+  const verdict = requireString(raw, 'verdict');
+  if (!RUNINGTEAM_CRITIC_VERDICTS.includes(verdict as RuningTeamCriticVerdict)) throw new Error('invalid_verdict');
+  const record = raw as Record<string, unknown>;
+  if (verdict === 'ITERATE_PLAN' && (!Array.isArray(record.required_changes) || record.required_changes.length === 0)) {
+    throw new Error('iterate_plan_requires_required_changes');
+  }
+  if (verdict === 'REJECT_BATCH' && (!Array.isArray(record.rejected_claims) || record.rejected_claims.length === 0)) {
+    throw new Error('reject_batch_requires_rejected_claims');
+  }
+  if (verdict === 'FINAL_SYNTHESIS_READY' && !isRecord(record.acceptance_criteria_evidence)) {
+    throw new Error('final_synthesis_ready_requires_acceptance_criteria_evidence');
+  }
+  return {
+    iteration: requireNumber(record, 'iteration'),
+    verdict: verdict as RuningTeamCriticVerdict,
+    required_changes: Array.isArray(record.required_changes) ? record.required_changes.filter((v): v is string => typeof v === 'string') : undefined,
+    rejected_claims: Array.isArray(record.rejected_claims) ? record.rejected_claims.filter((v): v is string => typeof v === 'string') : undefined,
+    acceptance_criteria_evidence: isRecord(record.acceptance_criteria_evidence)
+      ? Object.fromEntries(Object.entries(record.acceptance_criteria_evidence).map(([key, value]) => [key, Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : []]))
+      : undefined,
+    created_at: requireString(record, 'created_at'),
+  };
+}
+
+export function validatePlannerRevision(raw: unknown): RuningTeamPlannerRevision {
+  if (!isRecord(raw)) throw new Error('invalid_planner_revision');
+  const preserved = raw.preserved_acceptance_criteria;
+  const override = raw.user_override;
+  if (preserved !== true && typeof override !== 'string') {
+    throw new Error('planner_revision_requires_preserved_acceptance_criteria_or_user_override');
+  }
+  return {
+    iteration: requireNumber(raw, 'iteration'),
+    from_plan_version: requireNumber(raw, 'from_plan_version'),
+    to_plan_version: requireNumber(raw, 'to_plan_version'),
+    reason: requireString(raw, 'reason'),
+    changes: requireStringArray(raw, 'changes'),
+    preserved_acceptance_criteria: preserved === true,
+    user_override: typeof override === 'string' ? override : undefined,
+    created_at: requireString(raw, 'created_at'),
+  };
+}
+
+export async function createRuningTeamSession(task: string, cwd: string, opts: { sessionId?: string; maxIterations?: number } = {}): Promise<RuningTeamSession> {
+  const now = new Date().toISOString();
+  const session: RuningTeamSession = {
+    session_id: opts.sessionId ?? createRuningTeamSessionId(),
+    task,
+    created_at: now,
+    updated_at: now,
+    status: 'planning',
+    iteration: 0,
+    plan_version: 1,
+    team_name: null,
+    max_iterations: opts.maxIterations ?? 10,
+    terminal_reason: null,
+  };
+  const paths = runingTeamPaths(cwd, session.session_id);
+  const plan: RuningTeamPlan = {
+    plan_version: 1,
+    task,
+    intent: `RuningTeam dynamic plan for: ${task}`,
+    acceptance_criteria: ['final synthesis is created before completion', 'worker evidence is checkpointed before revision'],
+    non_goals: ['no MVP framing', 'no manual ralplan pre-step'],
+    lanes: [
+      { id: 'tests', title: 'Tests and regression evidence', status: 'pending', acceptance_criteria: ['tests are recorded'] },
+      { id: 'implementation', title: 'Implementation lane', status: 'pending', acceptance_criteria: ['implementation evidence is recorded'] },
+    ],
+  };
+  await writeJson(paths.session, session);
+  await writeJson(paths.plan, plan);
+  await writeJson(paths.lanes, { lanes: plan.lanes });
+  return session;
+}
+
+export async function readRuningTeamSession(cwd: string, sessionId: string): Promise<RuningTeamSession> {
+  return validateRuningTeamSession(await readJson(runingTeamPaths(cwd, sessionId).session));
+}
+
+export async function readRuningTeamPlan(cwd: string, sessionId: string): Promise<RuningTeamPlan> {
+  return validateRuningTeamPlan(await readJson(runingTeamPaths(cwd, sessionId).plan));
+}
+
+export async function updateRuningTeamSession(cwd: string, sessionId: string, updates: Partial<RuningTeamSession>): Promise<RuningTeamSession> {
+  const current = await readRuningTeamSession(cwd, sessionId);
+  const next = validateRuningTeamSession({ ...current, ...updates, updated_at: new Date().toISOString() });
+  await writeJson(runingTeamPaths(cwd, sessionId).session, next);
+  return next;
+}
+
+export async function assertRuningTeamCompletionReady(cwd: string, sessionId: string): Promise<void> {
+  const paths = runingTeamPaths(cwd, sessionId);
+  if (!existsSync(paths.finalSynthesis)) {
+    throw new Error('complete_requires_final_synthesis');
+  }
+  const session = await readRuningTeamSession(cwd, sessionId);
+  const verdictPath = paths.verdictJson(session.iteration);
+  if (!existsSync(verdictPath)) {
+    throw new Error('complete_requires_final_synthesis_ready_verdict');
+  }
+  const verdict = validateCriticVerdictRecord(await readJson<unknown>(verdictPath));
+  if (verdict.verdict !== 'FINAL_SYNTHESIS_READY') {
+    throw new Error('complete_requires_final_synthesis_ready_verdict');
+  }
+}
+
+export async function transitionRuningTeamSession(cwd: string, sessionId: string, to: RuningTeamStatus): Promise<RuningTeamSession> {
+  const current = await readRuningTeamSession(cwd, sessionId);
+  if (RUNINGTEAM_TERMINAL_STATUSES.has(current.status) && current.status !== to) {
+    throw new Error('terminal_states_require_explicit_recovery');
+  }
+  if (to === 'complete') {
+    await assertRuningTeamCompletionReady(cwd, sessionId);
+  }
+  return await updateRuningTeamSession(cwd, sessionId, { status: to, terminal_reason: to === 'complete' ? 'final synthesis ready' : current.terminal_reason });
+}
+
+export async function writeFinalSynthesis(cwd: string, sessionId: string, content: string): Promise<string> {
+  const paths = runingTeamPaths(cwd, sessionId);
+  await mkdir(dirname(paths.finalSynthesis), { recursive: true });
+  await writeFile(paths.finalSynthesis, content.trimEnd() + '\n', 'utf-8');
+  await updateRuningTeamSession(cwd, sessionId, { status: 'synthesizing' });
+  return paths.finalSynthesis;
+}
+
+export async function listRuningTeamSessions(cwd: string): Promise<RuningTeamSessionSummary[]> {
+  const root = runingTeamRoot(cwd);
+  if (!existsSync(root)) return [];
+  const { readdir } = await import('node:fs/promises');
+  const entries = await readdir(root, { withFileTypes: true });
+  const sessions: RuningTeamSessionSummary[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    try {
+      const session = await readRuningTeamSession(cwd, entry.name);
+      sessions.push({
+        session_id: session.session_id,
+        status: session.status,
+        iteration: session.iteration,
+        plan_version: session.plan_version,
+        team_name: session.team_name,
+        final_synthesis_present: existsSync(runingTeamPaths(cwd, session.session_id).finalSynthesis),
+      });
+    } catch {
+      // Ignore malformed session directories in status listings.
+    }
+  }
+  return sessions.sort((a, b) => a.session_id.localeCompare(b.session_id));
+}
+
+export async function linkRuningTeamTeamAdapter(cwd: string, sessionId: string, adapter: RuningTeamTeamAdapterState): Promise<void> {
+  await writeJson(runingTeamPaths(cwd, sessionId).adapterTeam, adapter);
+  await updateRuningTeamSession(cwd, sessionId, { team_name: adapter.team_name });
+}
+
+function parseResultEvidence(result: string): { files: string[]; commands: string[]; tests: string[] } {
+  if (!result.trim()) return { files: [], commands: [], tests: [] };
+  const unique = (values: string[]) => [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+  const listMatches = (label: string) => {
+    const pattern = new RegExp(`^\\s*${label}\\s*:\\s*(.+)$`, 'gim');
+    return unique([...result.matchAll(pattern)].flatMap((match) => String(match[1] ?? '').split(/[,;|]/)));
+  };
+  const files = listMatches('Files changed');
+  const commands = listMatches('(?:Command|Commands|Verification)');
+  const tests = listMatches('(?:Test|Tests)');
+
+  for (const line of result.split(/\r?\n/).map((entry) => entry.trim())) {
+    if (!/^(?:PASS|FAIL)\b/i.test(line)) continue;
+    if (!/(?:npm|node|tsc|vitest|jest|biome|eslint|cargo|python|pytest|go test|make)\b/i.test(line)) continue;
+    const commandMatch = line.match(/(?:-|:|→)\s*`?([^`]+?)`?\s*(?:→|$)/);
+    const command = (commandMatch?.[1] ?? line.replace(/^(?:PASS|FAIL)\b\s*[-:]?\s*/i, '')).trim();
+    if (!command) continue;
+    if (/test|spec|vitest|jest|pytest|go test|cargo test/i.test(command)) tests.push(command);
+    else commands.push(command);
+  }
+
+  if (files.length === 0) {
+    files.push(...[...result.matchAll(/`([^`]+\.(?:ts|tsx|js|jsx|json|md|mdx|yml|yaml))`/g)].map((match) => match[1] ?? ''));
+  }
+
+  return { files: unique(files), commands: unique(commands), tests: unique(tests) };
+}
+
+function evidenceFromTeamEvent(event: TeamEvent, planVersion: number, laneTaskMap: Record<string, string>, task?: TeamTask | null): RuningTeamWorkerEvidence | null {
+  if (event.type !== 'task_completed' && event.type !== 'task_failed') return null;
+  const taskId = event.task_id;
+  if (!taskId) return null;
+  const lane = Object.entries(laneTaskMap).find(([, mappedTaskId]) => mappedTaskId === taskId)?.[0] ?? taskId;
+  const metadata = isRecord(event.metadata) ? event.metadata : {};
+  const parsedResult = parseResultEvidence(typeof task?.result === 'string' ? task.result : '');
+  const filesChanged = Array.isArray(metadata.files_changed)
+    ? metadata.files_changed.filter((v): v is string => typeof v === 'string')
+    : task?.filePaths?.length
+      ? task.filePaths
+      : parsedResult.files;
+  const commands = Array.isArray(metadata.commands) ? metadata.commands.filter((v): v is string => typeof v === 'string') : parsedResult.commands;
+  const tests = Array.isArray(metadata.tests) ? metadata.tests.filter((v): v is string => typeof v === 'string') : parsedResult.tests;
+  return {
+    evidence_id: event.event_id,
+    worker: event.worker,
+    lane,
+    task_id: taskId,
+    plan_version: planVersion,
+    files_changed: filesChanged,
+    commands,
+    tests,
+    summary: event.reason ?? `${event.type} from ${event.worker}`,
+    supported: event.type === 'task_completed' && commands.length + tests.length > 0,
+    created_at: event.created_at,
+  };
+}
+
+export async function ingestTeamEvidence(cwd: string, sessionId: string): Promise<RuningTeamWorkerEvidence[]> {
+  const paths = runingTeamPaths(cwd, sessionId);
+  const session = await readRuningTeamSession(cwd, sessionId);
+  const adapter = await readJson<RuningTeamTeamAdapterState>(paths.adapterTeam);
+  const events = await readTeamEvents(adapter.team_name, cwd, { afterEventId: adapter.cursor, wakeableOnly: false });
+  const seen = new Set<string>();
+  const evidence: RuningTeamWorkerEvidence[] = [];
+  for (const event of events) {
+    if (seen.has(event.event_id)) continue;
+    seen.add(event.event_id);
+    const task = event.task_id ? await readTask(adapter.team_name, event.task_id, cwd) : null;
+    const record = evidenceFromTeamEvent(event, session.plan_version, adapter.lane_task_map, task);
+    if (record) evidence.push(record);
+    adapter.cursor = event.event_id;
+  }
+  if (evidence.length > 0) {
+    await mkdir(dirname(paths.evidenceEvents), { recursive: true });
+    await appendFile(paths.evidenceEvents, evidence.map((record) => JSON.stringify({ type: 'worker_evidence_received', ...record })).join('\n') + '\n', 'utf-8');
+  }
+  await writeJson(paths.adapterTeam, adapter);
+  return evidence;
+}
+
+export async function readEvidence(cwd: string, sessionId: string): Promise<RuningTeamWorkerEvidence[]> {
+  const path = runingTeamPaths(cwd, sessionId).evidenceEvents;
+  if (!existsSync(path)) return [];
+  const raw = await readFile(path, 'utf-8');
+  return raw.split('\n').filter(Boolean).map((line) => JSON.parse(line) as RuningTeamWorkerEvidence);
+}
+
+export async function createCheckpoint(cwd: string, sessionId: string, opts: { force?: boolean } = {}): Promise<RuningTeamCheckpoint> {
+  const session = await readRuningTeamSession(cwd, sessionId);
+  const evidence = await readEvidence(cwd, sessionId);
+  if (!opts.force && evidence.length === 0) throw new Error('checkpoint_requires_new_evidence');
+  const iteration = session.iteration + 1;
+  const checkpoint: RuningTeamCheckpoint = {
+    iteration,
+    plan_version: session.plan_version,
+    created_at: new Date().toISOString(),
+    evidence_ids: evidence.map((entry) => entry.evidence_id),
+    lane_status: Object.fromEntries(evidence.map((entry) => [entry.lane, entry.supported ? 'evidence-supported' : 'evidence-unsupported'])),
+    blockers: evidence.filter((entry) => !entry.supported).map((entry) => entry.evidence_id),
+    summary: `Checkpoint ${iteration}: ${evidence.length} evidence record(s)`,
+  };
+  const paths = runingTeamPaths(cwd, sessionId);
+  await writeJson(paths.checkpointJson(iteration), checkpoint);
+  await mkdir(dirname(paths.checkpointMd(iteration)), { recursive: true });
+  await writeFile(paths.checkpointMd(iteration), `# RuningTeam Checkpoint ${iteration}\n\n${checkpoint.summary}\n`, 'utf-8');
+  await updateRuningTeamSession(cwd, sessionId, { status: 'checkpointing', iteration });
+  return checkpoint;
+}
+
+export async function writeCriticVerdict(cwd: string, sessionId: string, record: RuningTeamCriticVerdictRecord): Promise<RuningTeamCriticVerdictRecord> {
+  const validated = validateCriticVerdictRecord(record);
+  await writeJson(runingTeamPaths(cwd, sessionId).verdictJson(validated.iteration), validated);
+  await updateRuningTeamSession(cwd, sessionId, { status: 'reviewing' });
+  return validated;
+}
+
+export async function revisePlan(cwd: string, sessionId: string, revision: RuningTeamPlannerRevision): Promise<RuningTeamPlan> {
+  const validatedRevision = validatePlannerRevision(revision);
+  const paths = runingTeamPaths(cwd, sessionId);
+  if (!existsSync(paths.checkpointJson(validatedRevision.iteration))) throw new Error('revision_requires_checkpoint');
+  if (!existsSync(paths.verdictJson(validatedRevision.iteration))) throw new Error('revision_requires_critic_verdict');
+  const currentPlan = await readRuningTeamPlan(cwd, sessionId);
+  const nextPlan = validateRuningTeamPlan({ ...currentPlan, plan_version: validatedRevision.to_plan_version });
+  await writeJson(paths.revisionJson(validatedRevision.iteration), validatedRevision);
+  await writeJson(paths.plan, nextPlan);
+  await updateRuningTeamSession(cwd, sessionId, { status: 'revising', plan_version: nextPlan.plan_version });
+  return nextPlan;
+}

--- a/src/runingteam/team-adapter.ts
+++ b/src/runingteam/team-adapter.ts
@@ -1,0 +1,438 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { dirname, join, resolve } from 'node:path';
+import { omxStateDir } from '../utils/paths.js';
+import { listTasks, readTask, readTeamConfig, type TeamTask } from '../team/state.js';
+import { readTeamEvents } from '../team/state/events.js';
+import type { TeamEvent } from '../team/state.js';
+import type { TeamEventType } from '../team/contracts.js';
+
+export interface RuningTeamTeamAdapterState {
+  team_name: string;
+  team_state_root: string;
+  event_cursor: string | null;
+  worker_map: Record<string, string>;
+  task_map: Record<string, string>;
+  ingested_event_ids?: string[];
+}
+
+export interface RuningTeamCommandEvidence {
+  command: string;
+  exit_code: number;
+  summary: string;
+}
+
+export interface RuningTeamTestEvidence {
+  command: string;
+  status: 'pass' | 'fail' | 'not_run' | 'fail_expected';
+  summary: string;
+}
+
+export interface RuningTeamWorkerEvidenceReceived {
+  type: 'worker_evidence_received';
+  event_id: string;
+  session_id: string;
+  created_at: string;
+  iteration: number;
+  plan_version: number;
+  team_name: string;
+  worker: string;
+  lane: string;
+  task_id: string;
+  claim: string;
+  files_changed: string[];
+  commands_run: RuningTeamCommandEvidence[];
+  tests_run: RuningTeamTestEvidence[];
+  blockers: string[];
+  next_needed: string;
+  source_team_event_id: string;
+}
+
+export interface RuningTeamTeamEventIngested {
+  type: 'team_event_ingested';
+  event_id: string;
+  session_id: string;
+  created_at: string;
+  iteration: number;
+  plan_version: number;
+  team_name: string;
+  worker: string;
+  lane: string;
+  task_id: string;
+  team_event_type: TeamEventType;
+  source_team_event_id: string;
+  blockers: string[];
+}
+
+export type RuningTeamAdapterEvidenceEvent = RuningTeamWorkerEvidenceReceived | RuningTeamTeamEventIngested;
+
+export interface RuningTeamEvidenceIngestOptions {
+  cwd: string;
+  sessionId: string;
+  iteration: number;
+  planVersion: number;
+  teamName?: string;
+  state?: RuningTeamTeamAdapterState;
+  now?: Date;
+}
+
+export interface RuningTeamEvidenceIngestResult {
+  state: RuningTeamTeamAdapterState;
+  events: RuningTeamAdapterEvidenceEvent[];
+  cursor: string | null;
+  ingestedCount: number;
+  skippedDuplicateCount: number;
+}
+
+function runingTeamSessionDir(cwd: string, sessionId: string): string {
+  return join(resolve(cwd, '.omx', 'state'), 'runingteam', sessionId);
+}
+
+export function runingTeamAdapterStatePath(cwd: string, sessionId: string): string {
+  return join(runingTeamSessionDir(cwd, sessionId), 'adapter', 'team.json');
+}
+
+export function runingTeamEvidenceLogPath(cwd: string, sessionId: string): string {
+  return join(runingTeamSessionDir(cwd, sessionId), 'evidence', 'events.ndjson');
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => stableJson(item)).join(',')}]`;
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableJson(val)}`)
+    .join(',')}}`;
+}
+
+function stableEventId(sessionId: string, sourceTeamEventId: string, kind: string): string {
+  const hash = createHash('sha256')
+    .update(`${sessionId}:${sourceTeamEventId}:${kind}`)
+    .digest('hex')
+    .slice(0, 24);
+  return `rte_${hash}`;
+}
+
+function uniqueStrings(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return [...new Set(values.filter((value): value is string => typeof value === 'string' && value.trim() !== '').map((value) => value.trim()))];
+}
+
+function metadataRecord(event: TeamEvent): Record<string, unknown> {
+  return event.metadata && typeof event.metadata === 'object' && !Array.isArray(event.metadata)
+    ? event.metadata
+    : {};
+}
+
+function extractFilesChanged(event: TeamEvent, task: TeamTask | null): string[] {
+  const metadata = metadataRecord(event);
+  const candidates: unknown[] = [
+    metadata.files_changed,
+    metadata.changed_files,
+    metadata.files,
+    metadata.conflict_files,
+    task?.filePaths,
+  ];
+  return [...new Set(candidates.flatMap(uniqueStrings))];
+}
+
+function normalizeCommandEvidence(value: unknown): RuningTeamCommandEvidence[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry): RuningTeamCommandEvidence[] => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return [];
+    const record = entry as Record<string, unknown>;
+    const command = typeof record.command === 'string' ? record.command.trim() : '';
+    if (!command) return [];
+    const exitCode = typeof record.exit_code === 'number'
+      ? record.exit_code
+      : typeof record.exitCode === 'number'
+        ? record.exitCode
+        : 0;
+    const summary = typeof record.summary === 'string' && record.summary.trim() !== ''
+      ? record.summary.trim()
+      : `exit_code=${exitCode}`;
+    return [{ command, exit_code: exitCode, summary }];
+  });
+}
+
+function normalizeTestStatus(value: unknown): RuningTeamTestEvidence['status'] {
+  return value === 'pass' || value === 'fail' || value === 'not_run' || value === 'fail_expected'
+    ? value
+    : 'not_run';
+}
+
+function normalizeTestEvidence(value: unknown): RuningTeamTestEvidence[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry): RuningTeamTestEvidence[] => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return [];
+    const record = entry as Record<string, unknown>;
+    const command = typeof record.command === 'string' ? record.command.trim() : '';
+    if (!command) return [];
+    const status = normalizeTestStatus(record.status);
+    const summary = typeof record.summary === 'string' && record.summary.trim() !== ''
+      ? record.summary.trim()
+      : status;
+    return [{ command, status, summary }];
+  });
+}
+
+function summarizeTaskResultCommands(task: TeamTask | null): { commands: RuningTeamCommandEvidence[]; tests: RuningTeamTestEvidence[] } {
+  const result = task?.result ?? '';
+  if (!result) return { commands: [], tests: [] };
+
+  const commandLines = result
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^(?:PASS|FAIL)\b.*(?:npm|node|tsc|vitest|jest|biome|eslint|cargo|python|pytest|go test|make)\b/i.test(line));
+
+  const tests: RuningTeamTestEvidence[] = [];
+  const commands: RuningTeamCommandEvidence[] = [];
+  for (const line of commandLines) {
+    const status: RuningTeamTestEvidence['status'] = /^PASS\b/i.test(line) ? 'pass' : /^FAIL\b/i.test(line) ? 'fail' : 'not_run';
+    const commandMatch = line.match(/(?:-|:|→)\s*`?([^`]+?)`?\s*(?:→|$)/);
+    const command = commandMatch?.[1]?.trim() || line.replace(/^(?:PASS|FAIL)\b\s*[-:]?\s*/i, '').trim();
+    if (/test|spec|vitest|jest|pytest|go test|cargo test/i.test(command)) {
+      tests.push({ command, status, summary: line });
+    } else {
+      commands.push({ command, exit_code: status === 'fail' ? 1 : 0, summary: line });
+    }
+  }
+  return { commands, tests };
+}
+
+function eventType(event: TeamEvent): TeamEventType {
+  return String(event.type) as TeamEventType;
+}
+
+function extractBlockers(event: TeamEvent, task: TeamTask | null): string[] {
+  const metadata = metadataRecord(event);
+  const blockers = uniqueStrings(metadata.blockers);
+  if (event.reason && (eventType(event) === 'task_failed' || eventType(event) === 'worker_stale_diff' || eventType(event) === 'worker_stale_heartbeat' || eventType(event) === 'worker_stale_stdout')) {
+    blockers.push(event.reason);
+  }
+  if (task?.error) blockers.push(task.error);
+  return [...new Set(blockers)];
+}
+
+function eventShouldBecomeWorkerEvidence(event: TeamEvent, task: TeamTask | null): boolean {
+  const metadata = metadataRecord(event);
+  return eventType(event) === 'task_completed'
+    || eventType(event) === 'task_failed'
+    || Array.isArray(metadata.commands_run)
+    || Array.isArray(metadata.tests_run)
+    || Array.isArray(metadata.files_changed)
+    || Boolean(task?.error);
+}
+
+function mapLane(state: RuningTeamTeamAdapterState, event: TeamEvent, task: TeamTask | null): string {
+  if (event.task_id && state.task_map[event.task_id]) return state.task_map[event.task_id];
+  if (event.worker && state.worker_map[event.worker]) return state.worker_map[event.worker];
+  if (typeof task?.lane === 'string' && task.lane.trim() !== '') return task.lane.trim();
+  return event.task_id ? `team-task-${event.task_id}` : event.worker;
+}
+
+function claimFor(event: TeamEvent, task: TeamTask | null): string {
+  const metadata = metadataRecord(event);
+  const metadataClaim = typeof metadata.claim === 'string' ? metadata.claim.trim() : '';
+  if (metadataClaim) return metadataClaim;
+  if (task?.claim?.token) return task.claim.token;
+  return event.event_id;
+}
+
+function buildEvidenceEvent(params: {
+  event: TeamEvent;
+  task: TeamTask | null;
+  state: RuningTeamTeamAdapterState;
+  sessionId: string;
+  iteration: number;
+  planVersion: number;
+  createdAt: string;
+}): RuningTeamAdapterEvidenceEvent {
+  const { event, task, state, sessionId, iteration, planVersion, createdAt } = params;
+  const lane = mapLane(state, event, task);
+  const taskId = event.task_id ?? task?.id ?? '';
+  const blockers = extractBlockers(event, task);
+  if (eventShouldBecomeWorkerEvidence(event, task)) {
+    const metadata = metadataRecord(event);
+    const summarized = summarizeTaskResultCommands(task);
+    return {
+      type: 'worker_evidence_received',
+      event_id: stableEventId(sessionId, event.event_id, 'worker_evidence_received'),
+      session_id: sessionId,
+      created_at: createdAt,
+      iteration,
+      plan_version: planVersion,
+      team_name: event.team,
+      worker: event.worker,
+      lane,
+      task_id: taskId,
+      claim: claimFor(event, task),
+      files_changed: extractFilesChanged(event, task),
+      commands_run: normalizeCommandEvidence(metadata.commands_run).concat(summarized.commands),
+      tests_run: normalizeTestEvidence(metadata.tests_run).concat(summarized.tests),
+      blockers,
+      next_needed: typeof metadata.next_needed === 'string' ? metadata.next_needed : blockers.length > 0 ? 'resolve_blockers' : 'checkpoint_review',
+      source_team_event_id: event.event_id,
+    };
+  }
+
+  return {
+    type: 'team_event_ingested',
+    event_id: stableEventId(sessionId, event.event_id, 'team_event_ingested'),
+    session_id: sessionId,
+    created_at: createdAt,
+    iteration,
+    plan_version: planVersion,
+    team_name: event.team,
+    worker: event.worker,
+    lane,
+    task_id: taskId,
+    team_event_type: eventType(event),
+    source_team_event_id: event.event_id,
+    blockers,
+  };
+}
+
+function mergeState(base: RuningTeamTeamAdapterState, patch: Partial<RuningTeamTeamAdapterState>): RuningTeamTeamAdapterState {
+  return {
+    ...base,
+    ...patch,
+    worker_map: { ...base.worker_map, ...(patch.worker_map ?? {}) },
+    task_map: { ...base.task_map, ...(patch.task_map ?? {}) },
+    ingested_event_ids: [...new Set([...(base.ingested_event_ids ?? []), ...(patch.ingested_event_ids ?? [])])],
+  };
+}
+
+async function readJsonIfExists<T>(path: string): Promise<T | null> {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function readRuningTeamAdapterState(cwd: string, sessionId: string): Promise<RuningTeamTeamAdapterState | null> {
+  return await readJsonIfExists<RuningTeamTeamAdapterState>(runingTeamAdapterStatePath(cwd, sessionId));
+}
+
+export async function writeRuningTeamAdapterState(cwd: string, sessionId: string, state: RuningTeamTeamAdapterState): Promise<void> {
+  const path = runingTeamAdapterStatePath(cwd, sessionId);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+}
+
+export async function appendRuningTeamEvidenceEvents(cwd: string, sessionId: string, events: RuningTeamAdapterEvidenceEvent[]): Promise<void> {
+  if (events.length === 0) return;
+  const path = runingTeamEvidenceLogPath(cwd, sessionId);
+  await mkdir(dirname(path), { recursive: true });
+  const existingRaw = existsSync(path) ? await readFile(path, 'utf-8').catch(() => '') : '';
+  const existingIds = new Set(existingRaw
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .flatMap((line) => {
+      try {
+        const parsed = JSON.parse(line) as { event_id?: unknown };
+        return typeof parsed.event_id === 'string' ? [parsed.event_id] : [];
+      } catch {
+        return [];
+      }
+    }));
+  const lines = events
+    .filter((event) => !existingIds.has(event.event_id))
+    .map((event) => stableJson(event));
+  if (lines.length > 0) {
+    await writeFile(path, `${existingRaw}${existingRaw && !existingRaw.endsWith('\n') ? '\n' : ''}${lines.join('\n')}\n`, 'utf-8');
+  }
+}
+
+export async function initializeRuningTeamAdapterState(params: {
+  cwd: string;
+  sessionId: string;
+  teamName: string;
+  workerMap?: Record<string, string>;
+  taskMap?: Record<string, string>;
+}): Promise<RuningTeamTeamAdapterState> {
+  const existing = await readRuningTeamAdapterState(params.cwd, params.sessionId);
+  if (existing) return mergeState(existing, { team_name: params.teamName, worker_map: params.workerMap, task_map: params.taskMap });
+
+  const config = await readTeamConfig(params.teamName, params.cwd);
+  const tasks = await listTasks(params.teamName, params.cwd).catch(() => []);
+  const inferredWorkerMap: Record<string, string> = {};
+  const inferredTaskMap: Record<string, string> = {};
+  for (const task of tasks) {
+    const lane = typeof task.lane === 'string' && task.lane.trim() !== '' ? task.lane.trim() : `team-task-${task.id}`;
+    inferredTaskMap[task.id] = lane;
+    if (task.owner) inferredWorkerMap[task.owner] = lane;
+  }
+  for (const worker of config?.workers ?? []) {
+    inferredWorkerMap[worker.name] = params.workerMap?.[worker.name] ?? inferredWorkerMap[worker.name] ?? worker.assigned_tasks.map((id) => inferredTaskMap[id]).find(Boolean) ?? worker.name;
+  }
+
+  const state: RuningTeamTeamAdapterState = {
+    team_name: params.teamName,
+    team_state_root: config?.team_state_root ?? join(omxStateDir(params.cwd), 'team', params.teamName),
+    event_cursor: null,
+    worker_map: { ...inferredWorkerMap, ...(params.workerMap ?? {}) },
+    task_map: { ...inferredTaskMap, ...(params.taskMap ?? {}) },
+    ingested_event_ids: [],
+  };
+  await writeRuningTeamAdapterState(params.cwd, params.sessionId, state);
+  return state;
+}
+
+export async function ingestRuningTeamAdapterEvidence(options: RuningTeamEvidenceIngestOptions): Promise<RuningTeamEvidenceIngestResult> {
+  const existing = options.state
+    ?? await readRuningTeamAdapterState(options.cwd, options.sessionId);
+  const state = existing
+    ?? await initializeRuningTeamAdapterState({
+      cwd: options.cwd,
+      sessionId: options.sessionId,
+      teamName: options.teamName ?? '',
+    });
+  const teamName = options.teamName ?? state.team_name;
+  if (!teamName) throw new Error('team_name_required');
+
+  const teamEvents = await readTeamEvents(teamName, options.cwd, {
+    afterEventId: state.event_cursor ?? undefined,
+    wakeableOnly: false,
+  });
+  const seen = new Set(state.ingested_event_ids ?? []);
+  const produced: RuningTeamAdapterEvidenceEvent[] = [];
+  let skippedDuplicateCount = 0;
+
+  for (const event of teamEvents) {
+    if (seen.has(event.event_id)) {
+      skippedDuplicateCount++;
+      continue;
+    }
+    const task = event.task_id ? await readTask(teamName, event.task_id, options.cwd) : null;
+    produced.push(buildEvidenceEvent({
+      event,
+      task,
+      state,
+      sessionId: options.sessionId,
+      iteration: options.iteration,
+      planVersion: options.planVersion,
+      createdAt: (options.now ?? new Date()).toISOString(),
+    }));
+    seen.add(event.event_id);
+  }
+
+  const nextState = mergeState(state, {
+    team_name: teamName,
+    event_cursor: teamEvents.at(-1)?.event_id ?? state.event_cursor,
+    ingested_event_ids: [...seen],
+  });
+  await appendRuningTeamEvidenceEvents(options.cwd, options.sessionId, produced);
+  await writeRuningTeamAdapterState(options.cwd, options.sessionId, nextState);
+
+  return {
+    state: nextState,
+    events: produced,
+    cursor: nextState.event_cursor,
+    ingestedCount: produced.length,
+    skippedDuplicateCount,
+  };
+}

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -31,6 +31,13 @@
       "internalRequired": false
     },
     {
+      "name": "runingteam",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "ecomode",
       "category": "execution",
       "status": "deprecated",


### PR DESCRIPTION
## Summary
Adds RuningTeam as a first-class OMX dynamic planning mode on top of the fork's current 0.16.4 line.

RuningTeam provides a checkpoint-gated controller for the loop:

```text
Plan vN -> team batch -> evidence collection -> critic review -> planner revision -> Plan vN+1
```

## Problem statement
Before this branch, users had to manually chain planning and team execution surfaces when a task needed both ralplan-quality planning and team-style parallel execution. That made it easy to lose worker evidence, mutate plans mid-batch, or declare completion without a final synthesis gate.

## Root cause
The existing workflow model had separate planning and team modes, but no first-class controller state that tied plan versions, team event evidence, critic verdicts, planner revisions, and final synthesis readiness together.

## What changed
- Added the `runingteam` skill and mirrored plugin skill metadata.
- Added `omx runingteam` / `omx --runingteam` CLI support, including create/status/checkpoint/revise/finalize/cancel flows.
- Added RuningTeam runtime contracts and state paths under the existing OMX state root.
- Added a team adapter that ingests team events into machine-readable RuningTeam evidence.
- Added checkpoint, critic verdict, planner revision, and final synthesis gates.
- Added keyword/mode/catalog wiring so RuningTeam is available as an OMX workflow mode.
- Added focused runtime, controller, team-adapter, and CLI tests.

## Why this design
This keeps RuningTeam as a thin controller over existing OMX state/team surfaces instead of inventing a separate orchestration system. Completion is intentionally gated by both `final-synthesis.md` and a `FINAL_SYNTHESIS_READY` critic verdict so failed or unsupported worker evidence cannot be silently treated as done.

## Overlap assessment
Net-new for this fork line. I checked existing PRs for `runingteam` / `RuningTeam`; no overlapping PRs exist. Repository issues are disabled, so there were no issue records to compare. This branch is already pushed as `origin/runingteam` and is based on `origin/main` at the 0.16.4 fork line.

## Validation
- `npm run build`
- `npm run verify:native-agents`
- `npm run verify:plugin-bundle`
- `node --test dist/runingteam/__tests__/runtime.test.js dist/runingteam/__tests__/controller.test.js dist/runingteam/__tests__/team-adapter.test.js dist/cli/__tests__/runingteam.test.js` — 20 tests passing
- Manual smoke: `node dist/cli/omx.js runingteam --no-launch "investigation smoke"`, forced checkpoint, wrote `FINAL_SYNTHESIS_READY` verdict and final synthesis, then finalized successfully.

## Risk / compatibility
- Moderate scope: this adds a new mode, CLI surface, runtime state model, and catalog/keyword wiring.
- Existing team state is preserved when RuningTeam is inactive.
- The branch does not run the full `npm test` suite in this delivery pass; focused RuningTeam tests and required bundle/native-agent checks are green.

## Files changed
- `skills/runingteam/SKILL.md`
- `plugins/oh-my-codex/skills/runingteam/SKILL.md`
- `src/cli/runingteam.ts`
- `src/runingteam/contracts.ts`
- `src/runingteam/runtime.ts`
- `src/runingteam/controller.ts`
- `src/runingteam/team-adapter.ts`
- `src/cli/index.ts`, `src/cli/constants.ts`, `src/modes/base.ts`
- `src/hooks/keyword-detector.ts`, `src/hooks/keyword-registry.ts`
- `src/catalog/manifest.json`, `src/catalog/generated/public-catalog.json`, `templates/catalog-manifest.json`
- Focused tests under `src/cli/__tests__/` and `src/runingteam/__tests__/`
