### PR TITLE
Clarify Ralph completion audit stop guidance

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7665,7 +7665,11 @@ exit 0
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.match(String(result.outputJson?.reason), /Ralph completion audit is missing required evidence/);
+      const reason = String(result.outputJson?.reason);
+      assert.match(reason, /Ralph completion audit is missing required evidence/);
+      assert.match(reason, /state\.completion_audit = \{ passed: true, prompt_to_artifact_checklist: \[\.\.\.\], verification_evidence: \[\.\.\.\] \}/);
+      assert.match(reason, /repo-relative JSON file/);
+      assert.match(reason, /Markdown artifacts and flat top-level checklist\/evidence fields are not accepted/);
       assert.equal(result.outputJson?.stopReason, "ralph_completion_audit_missing_completion_audit");
       const reopened = JSON.parse(await readFile(statePath, "utf-8")) as Record<string, unknown>;
       assert.equal(reopened.active, true);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2784,8 +2784,14 @@ async function buildStopHookOutput(
   if (ralphCompletionAuditBlock) {
     await reopenRalphCompletionAuditBlock(ralphCompletionAuditBlock);
     const blockingPath = formatStopStatePath(cwd, ralphCompletionAuditBlock.path);
-    const systemMessage =
-      `OMX Ralph completion audit is missing required evidence (${ralphCompletionAuditBlock.reason}; state: ${blockingPath}); continue verification, record a prompt-to-artifact checklist plus verification evidence, and do not report complete yet.`;
+    const systemMessage = [
+      `OMX Ralph completion audit is missing required evidence (${ralphCompletionAuditBlock.reason}; state: ${blockingPath}).`,
+      "Continue verification and do not report complete yet.",
+      "Record machine-readable completion evidence before stopping:",
+      "- either set state.completion_audit = { passed: true, prompt_to_artifact_checklist: [...], verification_evidence: [...] }",
+      "- or set completion_audit_path / completion_audit_evidence_path to a repo-relative JSON file with those same fields.",
+      "Markdown artifacts and flat top-level checklist/evidence fields are not accepted by the Ralph Stop gate.",
+    ].join(" ");
     return await returnPersistentStopBlock(
       payload,
       stateDir,


### PR DESCRIPTION
## Summary

Clarify the Ralph completion-audit Stop hook remediation message so agents record evidence in the machine-readable shape that the Stop gate actually accepts.

The gate already requires either:

- `completion_audit.passed === true` with non-empty `prompt_to_artifact_checklist` and `verification_evidence`, or
- a repo-relative JSON artifact via `completion_audit_path` / `completion_audit_evidence_path` with the same fields.

The previous Stop hook message only said to "record a prompt-to-artifact checklist plus verification evidence", which can lead agents to write a Markdown audit or flat top-level fields that the evaluator rejects as `missing_completion_audit`.

## Changes

- Expand the Ralph completion-audit Stop hook message with the exact accepted state/artifact contract.
- Explicitly say Markdown artifacts and flat top-level checklist/evidence fields are not accepted by the Ralph Stop gate.
- Add regression assertions so the Stop hook guidance remains specific.

## Verification

```bash
npm run build
node --test dist/ralph/__tests__/completion-audit.test.js dist/scripts/__tests__/codex-native-hook.test.js
```

Result: 296 tests passed.