### PR TITLE
hud: prevent resize hook ownership collisions across windows

### DIFF
--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildHudResizeHookName,
+  buildHudResizeHookSlot,
+  parseHudResizeHookContext,
+  registerHudResizeHook,
+  unregisterHudResizeHook,
+} from '../tmux.js';
+
+describe('HUD resize hook helpers', () => {
+  it('builds a deterministic hook name from the tmux session and window identity', () => {
+    assert.equal(buildHudResizeHookName('$7', '@3'), 'omx_hud_resize_7_3');
+  });
+
+  it('builds a bounded numeric client-resized slot', () => {
+    const slot = buildHudResizeHookSlot('omx_hud_resize_7_3');
+    assert.match(slot, /^client-resized\[\d+\]$/);
+
+    const index = Number.parseInt(slot.replace(/^client-resized\[|\]$/g, ''), 10);
+    assert.ok(index >= 0);
+    assert.ok(index < 2147483647);
+  });
+
+  it('parses hook context from tmux display-message output', () => {
+    const context = parseHudResizeHookContext('$7\t@3\n');
+
+    assert.deepEqual(context, {
+      sessionId: '$7',
+      windowId: '@3',
+      hookName: 'omx_hud_resize_7_3',
+      hookSlot: buildHudResizeHookSlot('omx_hud_resize_7_3'),
+    });
+  });
+
+  it('registers a session hook in a stable per-window slot with exact HUD pane targeting', () => {
+    const calls: string[][] = [];
+
+    const result = registerHudResizeHook('%9', '%1', 3, (args) => {
+      calls.push(args);
+      if (args[0] === 'display-message') return '$7\t@3\n';
+      return '';
+    });
+
+    const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3');
+    assert.equal(result, true);
+    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
+    assert.equal(calls[1]?.[0], 'set-hook');
+    assert.equal(calls[1]?.[1], '-t');
+    assert.equal(calls[1]?.[2], '$7');
+    assert.equal(calls[1]?.[3], hookSlot);
+    assert.notEqual(calls[1]?.[3], 'client-resized[99]');
+    assert.match(calls[1]?.[4] ?? '', /^run-shell -b /);
+    assert.match(calls[1]?.[4] ?? '', /resize-pane/);
+    assert.match(calls[1]?.[4] ?? '', /set-hook/);
+    assert.match(calls[1]?.[4] ?? '', new RegExp(hookSlot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+
+  it('unregisters the same per-window hook slot', () => {
+    const calls: string[][] = [];
+
+    const result = unregisterHudResizeHook('%1', (args) => {
+      calls.push(args);
+      if (args[0] === 'display-message') return '$7\t@3\n';
+      return '';
+    });
+
+    assert.equal(result, true);
+    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
+    assert.deepEqual(calls[1], [
+      'set-hook',
+      '-u',
+      '-t',
+      '$7',
+      buildHudResizeHookSlot('omx_hud_resize_7_3'),
+    ]);
+  });
+
+  it('uses distinct hook slots for different windows in the same session', () => {
+    const registered: string[][] = [];
+
+    const execFor = (windowId: string) => (args: string[]) => {
+      if (args[0] === 'display-message') return `$7\t${windowId}\n`;
+      registered.push(args);
+      return '';
+    };
+
+    assert.equal(registerHudResizeHook('%9', '%1', 3, execFor('@3')), true);
+    assert.equal(registerHudResizeHook('%10', '%2', 3, execFor('@4')), true);
+
+    const firstSlot = registered[0]?.[3];
+    const secondSlot = registered[1]?.[3];
+    assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
+    assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
+    assert.notEqual(firstSlot, secondSlot);
+  });
+
+  it('reuses the same hook slot when a HUD pane is recreated in the same window', () => {
+    const registered: string[][] = [];
+    const execTmuxSync = (args: string[]) => {
+      if (args[0] === 'display-message') return '$7\t@3\n';
+      registered.push(args);
+      return '';
+    };
+
+    assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
+    assert.equal(registerHudResizeHook('%10', '%1', 3, execTmuxSync), true);
+
+    assert.equal(registered[0]?.[3], registered[1]?.[3]);
+  });
+});

--- a/src/hud/constants.ts
+++ b/src/hud/constants.ts
@@ -1,5 +1,4 @@
 export const HUD_TMUX_HEIGHT_LINES = 3;
-export const HUD_RESIZE_HOOK_SLOT = 99;
 export const HUD_TMUX_TEAM_HEIGHT_LINES = 3;
 export const HUD_TMUX_MAX_HEIGHT_LINES = 5;
 export const HUD_RESIZE_RECONCILE_DELAY_SECONDS = 2;

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process';
-import { HUD_TMUX_HEIGHT_LINES, HUD_RESIZE_HOOK_SLOT } from './constants.js';
+import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 
 export interface TmuxPaneSnapshot {
@@ -9,6 +9,9 @@ export interface TmuxPaneSnapshot {
 }
 
 type TmuxExecSync = (args: string[]) => string;
+
+/** Upper bound for tmux hook indices (signed 32-bit max). */
+const TMUX_HOOK_INDEX_MAX = 2147483647;
 
 function defaultExecTmuxSync(args: string[]): string {
   return execFileSync(resolveTmuxBinaryForPlatform() || 'tmux', args, {
@@ -59,6 +62,84 @@ export function parsePaneIdFromTmuxOutput(rawOutput: string): string | null {
 
 export function shellEscapeSingle(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function normalizeTmuxHookToken(value: string): string {
+  const normalized = value.trim().replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  return normalized || 'unknown';
+}
+
+export function buildHudResizeHookName(sessionId: string, windowId: string): string {
+  return [
+    'omx_hud_resize',
+    normalizeTmuxHookToken(sessionId),
+    normalizeTmuxHookToken(windowId),
+  ].join('_');
+}
+
+export function buildHudResizeHookSlot(hookName: string): string {
+  let hash = 0;
+  for (let i = 0; i < hookName.length; i++) {
+    hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
+  }
+  return `client-resized[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
+}
+
+export interface HudResizeHookContext {
+  sessionId: string;
+  windowId: string;
+  hookName: string;
+  hookSlot: string;
+}
+
+export function parseHudResizeHookContext(output: string): HudResizeHookContext | null {
+  const [sessionId = '', windowId = ''] = output
+    .split('\n')[0]
+    ?.split('\t')
+    .map((part) => part.trim()) ?? [];
+  if (!sessionId || !windowId) return null;
+  const hookName = buildHudResizeHookName(sessionId, windowId);
+  return {
+    sessionId,
+    windowId,
+    hookName,
+    hookSlot: buildHudResizeHookSlot(hookName),
+  };
+}
+
+export function readHudResizeHookContext(
+  currentPaneId: string | undefined,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): HudResizeHookContext | null {
+  if (!currentPaneId?.startsWith('%')) return null;
+  try {
+    return parseHudResizeHookContext(
+      execTmuxSync([
+        'display-message',
+        '-p',
+        '-t',
+        currentPaneId,
+        '#{session_id}\t#{window_id}',
+      ]),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function buildNestedTmuxCommand(tmuxBin: string, args: string[]): string {
+  return [tmuxBin, ...args].map((part) => shellEscapeSingle(part)).join(' ');
+}
+
+function buildHudResizeHookCommand(
+  tmuxBin: string,
+  hudPaneId: string,
+  height: string,
+  context: HudResizeHookContext,
+): string {
+  const resize = buildNestedTmuxCommand(tmuxBin, ['resize-pane', '-t', hudPaneId, '-y', height]);
+  const unregister = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-t', context.sessionId, context.hookSlot]);
+  return `${resize} >/dev/null 2>&1 || ${unregister} >/dev/null 2>&1 || true`;
 }
 
 export function buildHudWatchCommand(omxBin: string, preset?: string, sessionId?: string): string {
@@ -190,12 +271,13 @@ export function registerHudResizeHook(
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): boolean {
   if (!hudPaneId.startsWith('%')) return false;
+  const context = readHudResizeHookContext(currentPaneId, execTmuxSync);
+  if (!context) return false;
   const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
   const height = String(Math.max(1, Math.floor(heightLines)));
-  const resizeCmd = shellEscapeSingle(`${tmuxBin} resize-pane -t ${hudPaneId} -y ${height} 2>/dev/null || true`);
-  if (!currentPaneId?.startsWith('%')) return false;
+  const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, context));
   try {
-    execTmuxSync(['set-hook', '-t', currentPaneId, `client-resized[${HUD_RESIZE_HOOK_SLOT}]`, `run-shell -b ${resizeCmd}`]);
+    execTmuxSync(['set-hook', '-t', context.sessionId, context.hookSlot, `run-shell -b ${resizeCmd}`]);
     return true;
   } catch {
     return false;
@@ -206,9 +288,10 @@ export function unregisterHudResizeHook(
   currentPaneId: string | undefined,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): boolean {
-  if (!currentPaneId?.startsWith('%')) return false;
+  const context = readHudResizeHookContext(currentPaneId, execTmuxSync);
+  if (!context) return false;
   try {
-    execTmuxSync(['set-hook', '-u', '-t', currentPaneId, `client-resized[${HUD_RESIZE_HOOK_SLOT}]`]);
+    execTmuxSync(['set-hook', '-u', '-t', context.sessionId, context.hookSlot]);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Problem

PR #2305 (merged) registered the `client-resized` hook on `currentPaneId` with a fixed slot index (`HUD_RESIZE_HOOK_SLOT = 99`). Two issues remain:

1. **Cross-window collision**: every HUD window in the same tmux session writes to the same `client-resized[99]` slot on its emitting pane. The last registration wins and silently orphans the other windows' hooks.

2. **Stale slot accumulation**: the slot is derived from the emitting pane (`currentPaneId`), not the HUD pane. If the HUD pane exits naturally (outside the reconciler's kill path), `findHudWatchPaneIds` returns empty so the unregister loop never runs. The next reconcile then writes a new slot for the new HUD pane ID, leaving stale `run-shell` entries accumulating on every resize.

## Solution

Derive the hook identity from the **tmux session + window IDs** instead of pane IDs.

- `buildHudResizeHookName(sessionId, windowId)` → `omx_hud_resize_{session}_{window}` (stable, human-readable)
- `buildHudResizeHookSlot(hookName)` → deterministic 31-multiplier hash % INT32_MAX → `client-resized[N]` (unique per window, bounded, avoids the unindexed-clobber issue)
- `readHudResizeHookContext(currentPaneId)` → reads `#{session_id}\t#{window_id}` from tmux and builds the full context
- Hook command uses `shellEscapeSingle` on every nested tmux argument (shell-safe)
- Hook command self-unregisters on `resize-pane` failure: `resize-pane ... || set-hook -u ... || true` — stale hooks for dead panes clean up automatically on the next resize without any reconciler involvement

### Why session+window, not pane ID

| Approach | Cross-window isolation | Survives pane recreation | Self-cleaning |
|---|---|---|---|
| Fixed slot on emitting pane (`[99]`) | ✗ same slot all windows | ✗ slot tied to pane | ✗ manual only |
| Slot from HUD pane ID | ✓ unique per HUD | ✗ new slot each creation | ✗ accumulates |
| **Slot from session+window ID** | ✓ unique per window | ✓ same slot after recreate | ✓ self-unregisters |

## Changes

- `src/hud/tmux.ts`: replace fixed-slot registration with session+window-derived context; shell-escape nested tmux args; self-unregister stale pane hooks on resize failure
- `src/hud/constants.ts`: remove `HUD_RESIZE_HOOK_SLOT = 99` (no longer needed)
- `src/hud/__tests__/tmux.test.ts`: new — 7 tests covering hook name/slot derivation, register/unregister call shape, cross-window distinct slots, and same-window slot stability

## Test plan

- [x] `buildHudResizeHookName` produces stable, normalized name
- [x] `buildHudResizeHookSlot` produces bounded `client-resized[N]` slot
- [x] `parseHudResizeHookContext` parses tmux display-message output
- [x] `registerHudResizeHook` calls `display-message` then `set-hook -t <sessionId> <slot>` with exact HUD pane targeting
- [x] `unregisterHudResizeHook` calls `set-hook -u -t <sessionId> <slot>` with same slot
- [x] Two HUD windows in the same session get **distinct** slots
- [x] Recreating a HUD pane in the same window reuses the **same** slot
- [x] All 10 existing `reconcileHudForPromptSubmit` tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)