### PR TITLE
Add opt-in cmux mux adapter

### DIFF
--- a/crates/omx-mux/src/cmux.rs
+++ b/crates/omx-mux/src/cmux.rs
@@ -1,0 +1,235 @@
+use std::env;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+use crate::types::{MuxAdapter, MuxError, MuxOperation, MuxOutcome, MuxTarget, SubmitPolicy};
+
+fn cmux_binary() -> String {
+    env::var("OMX_CMUX_BIN")
+        .or_else(|_| env::var("OMX_MUX_BIN"))
+        .unwrap_or_else(|_| "cmux".to_string())
+}
+
+fn run_cmux(args: &[&str]) -> Result<String, MuxError> {
+    let binary = cmux_binary();
+    let output = Command::new(&binary)
+        .args(args)
+        .output()
+        .map_err(|e| MuxError::AdapterFailed(format!("failed to run {binary}: {e}")))?;
+
+    if output.status.success() {
+        String::from_utf8(output.stdout)
+            .map_err(|e| MuxError::AdapterFailed(format!("invalid utf-8 from cmux: {e}")))
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(MuxError::AdapterFailed(format!(
+            "cmux {} failed: {}",
+            args.first().unwrap_or(&""),
+            stderr.trim()
+        )))
+    }
+}
+
+fn resolve_target_handle(target: &MuxTarget) -> Result<String, MuxError> {
+    match target {
+        MuxTarget::DeliveryHandle(handle) => {
+            if handle.is_empty() {
+                Err(MuxError::InvalidTarget("empty cmux surface handle".into()))
+            } else {
+                Ok(handle.clone())
+            }
+        }
+        MuxTarget::Detached => Err(MuxError::InvalidTarget(
+            "cannot operate on a detached cmux target".into(),
+        )),
+    }
+}
+
+pub(crate) fn build_cmux_send_args<'a>(target: &'a str, text: &'a str) -> Vec<&'a str> {
+    vec!["send", "--surface", target, text]
+}
+
+pub(crate) fn build_cmux_enter_key_args(target: &str) -> Vec<String> {
+    vec![
+        "send-key".into(),
+        "--surface".into(),
+        target.into(),
+        "Enter".into(),
+    ]
+}
+
+pub fn build_cmux_capture_pane_args(target: &str, visible_lines: usize) -> Vec<String> {
+    vec![
+        "capture-pane".into(),
+        "--surface".into(),
+        target.into(),
+        "--scrollback".into(),
+        "--lines".into(),
+        visible_lines.to_string(),
+    ]
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CmuxAdapter;
+
+impl CmuxAdapter {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn status(&self) -> &'static str {
+        "cmux adapter ready"
+    }
+
+    fn do_resolve_target(&self, target: &MuxTarget) -> Result<MuxOutcome, MuxError> {
+        let handle = resolve_target_handle(target)?;
+        run_cmux(&["read-screen", "--surface", &handle, "--lines", "1"])?;
+        Ok(MuxOutcome::TargetResolved {
+            resolved_handle: handle,
+        })
+    }
+
+    fn do_send_input(
+        &self,
+        target: &MuxTarget,
+        envelope: &crate::types::InputEnvelope,
+    ) -> Result<MuxOutcome, MuxError> {
+        let handle = resolve_target_handle(target)?;
+        let text = envelope.normalized_text();
+
+        let args = build_cmux_send_args(&handle, &text);
+        run_cmux(&args)?;
+
+        if let SubmitPolicy::Enter { presses, delay_ms } = &envelope.submit {
+            for i in 0..*presses {
+                if i > 0 && *delay_ms > 0 {
+                    thread::sleep(Duration::from_millis(*delay_ms));
+                }
+                let enter_args = build_cmux_enter_key_args(&handle);
+                let str_args: Vec<&str> = enter_args.iter().map(|s| s.as_str()).collect();
+                run_cmux(&str_args)?;
+            }
+        }
+
+        Ok(MuxOutcome::InputAccepted {
+            bytes_written: text.len(),
+        })
+    }
+
+    fn do_capture_tail(
+        &self,
+        target: &MuxTarget,
+        visible_lines: usize,
+    ) -> Result<MuxOutcome, MuxError> {
+        let handle = resolve_target_handle(target)?;
+        let args = build_cmux_capture_pane_args(&handle, visible_lines);
+        let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let body = run_cmux(&str_args)?;
+
+        Ok(MuxOutcome::TailCaptured {
+            visible_lines,
+            body,
+        })
+    }
+
+    fn do_inspect_liveness(&self, target: &MuxTarget) -> Result<MuxOutcome, MuxError> {
+        let handle = resolve_target_handle(target)?;
+        let alive = run_cmux(&["read-screen", "--surface", &handle, "--lines", "1"]).is_ok();
+        Ok(MuxOutcome::LivenessChecked { alive })
+    }
+}
+
+impl MuxAdapter for CmuxAdapter {
+    fn adapter_name(&self) -> &'static str {
+        "cmux"
+    }
+
+    fn execute(&self, operation: &MuxOperation) -> Result<MuxOutcome, MuxError> {
+        match operation {
+            MuxOperation::ResolveTarget { target } => self.do_resolve_target(target),
+            MuxOperation::SendInput { target, envelope } => self.do_send_input(target, envelope),
+            MuxOperation::CaptureTail {
+                target,
+                visible_lines,
+            } => self.do_capture_tail(target, *visible_lines),
+            MuxOperation::InspectLiveness { target } => self.do_inspect_liveness(target),
+            MuxOperation::Attach { .. } => Err(MuxError::Unsupported(
+                "cmux attach is managed by the cmux application".into(),
+            )),
+            MuxOperation::Detach { .. } => Err(MuxError::Unsupported(
+                "cmux detach is managed by the cmux application".into(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::InputEnvelope;
+
+    #[test]
+    fn resolve_target_handle_rejects_empty() {
+        let err = resolve_target_handle(&MuxTarget::DeliveryHandle(String::new()))
+            .expect_err("should reject empty");
+        assert!(matches!(err, MuxError::InvalidTarget(_)));
+    }
+
+    #[test]
+    fn build_send_args_constructs_cmux_send() {
+        let args = build_cmux_send_args("surface:abc", "hello");
+        assert_eq!(args, vec!["send", "--surface", "surface:abc", "hello"]);
+    }
+
+    #[test]
+    fn build_enter_key_args_constructs_cmux_enter() {
+        let args = build_cmux_enter_key_args("surface:abc");
+        assert_eq!(args, vec!["send-key", "--surface", "surface:abc", "Enter"]);
+    }
+
+    #[test]
+    fn build_capture_args_constructs_cmux_capture() {
+        let args = build_cmux_capture_pane_args("surface:abc", 80);
+        assert_eq!(
+            args,
+            vec![
+                "capture-pane",
+                "--surface",
+                "surface:abc",
+                "--scrollback",
+                "--lines",
+                "80"
+            ]
+        );
+    }
+
+    #[test]
+    fn adapter_name_is_cmux() {
+        let adapter = CmuxAdapter::new();
+        assert_eq!(adapter.adapter_name(), "cmux");
+    }
+
+    #[test]
+    fn status_reports_ready() {
+        let adapter = CmuxAdapter::new();
+        assert_eq!(adapter.status(), "cmux adapter ready");
+    }
+
+    #[test]
+    fn attach_is_explicitly_unsupported() {
+        let adapter = CmuxAdapter::new();
+        let result = adapter.execute(&MuxOperation::Attach {
+            target: MuxTarget::DeliveryHandle("surface:abc".into()),
+        });
+        assert!(matches!(result.unwrap_err(), MuxError::Unsupported(_)));
+    }
+
+    #[test]
+    fn send_args_use_normalized_text() {
+        let envelope = InputEnvelope::new("line1\nline2", SubmitPolicy::None);
+        let text = envelope.normalized_text();
+        let args = build_cmux_send_args("surface:abc", &text);
+        assert_eq!(args[3], "line1 line2");
+    }
+}

--- a/crates/omx-mux/src/lib.rs
+++ b/crates/omx-mux/src/lib.rs
@@ -1,12 +1,14 @@
+mod cmux;
 mod tmux;
 mod types;
 
+pub use cmux::{build_cmux_capture_pane_args, CmuxAdapter};
 pub use tmux::{build_capture_pane_args, TmuxAdapter};
 pub use types::*;
 
 pub fn canonical_contract_summary() -> String {
     format!(
-        "mux-operations={operations}\nmux-target-kinds={target_kinds}\nsubmit-policy={submit_policy}\nreadiness={readiness}\nconfirmation={confirmation}\nadapter=tmux",
+        "mux-operations={operations}\nmux-target-kinds={target_kinds}\nsubmit-policy={submit_policy}\nreadiness={readiness}\nconfirmation={confirmation}\nadapters=tmux,cmux",
         operations = MUX_OPERATION_NAMES.join(", "),
         target_kinds = MUX_TARGET_KINDS.join(", "),
         submit_policy = SubmitPolicy::enter(2, 100),

--- a/docs/cmux-mux-support.md
+++ b/docs/cmux-mux-support.md
@@ -1,0 +1,66 @@
+# cmux mux support contract
+
+OMX historically called `tmux` directly from hook and team-runtime paths. The
+runtime now has a narrow mux adapter bridge so those legacy call sites can keep
+their existing tmux behavior while cmux surfaces can opt in.
+
+## Selection
+
+The mux kind is resolved in this order:
+
+1. `OMX_MUX=tmux` or `OMX_MUX=cmux`
+2. `OMX_MUX=auto` plus a cmux terminal environment (`CMUX_SURFACE_ID` or
+   `CMUX_WORKSPACE_ID`)
+3. default `tmux`
+
+Binary overrides:
+
+- `OMX_TMUX_BIN` / `OMX_TEST_TMUX_BIN`
+- `OMX_CMUX_BIN` / `OMX_TEST_CMUX_BIN`
+- generic fallback `OMX_MUX_BIN` / `OMX_TEST_MUX_BIN`
+
+`tmux` remains the default and the legacy `TMUX` / `TMUX_PANE` state keys remain
+valid. cmux uses `CMUX_WORKSPACE_ID` as the session/workspace target and
+`CMUX_SURFACE_ID` as the pane/surface target, with legacy tmux env values as
+fallbacks where needed. cmux terminal variables alone do not override the tmux
+default; use `OMX_MUX=auto` for env-driven cmux detection or `OMX_MUX=cmux` for
+an explicit cmux run. `CMUX_SOCKET_PATH` is not enough to auto-select cmux
+because it can be configured outside an attached cmux terminal.
+
+## Command subset
+
+The initial cmux bridge covers the prompt-injection subset OMX needs most often:
+
+| OMX legacy tmux argv | cmux argv |
+| --- | --- |
+| `send-keys -t <surface> -l <text>` | `send --surface <surface> <text>` |
+| `send-keys -t <surface> C-m` | `send-key --surface <surface> Enter` |
+| `capture-pane -t <surface> -p -S -<n>` | `capture-pane --surface <surface> --scrollback --lines <n>` |
+| `display-message -p ... '#{pane_in_mode}'` | `surface-health --workspace <workspace>`, normalized to `0`/`1` |
+| `display-message -p ... '#{pane_id}'` | `display-message -p <surface>` |
+| `display-message -p ... '#{pane_current_command}'` | `identify --workspace <workspace> --surface <surface>`, normalized to the target command |
+| `display-message -p ... '#{pane_start_command}'` | `identify --workspace <workspace> --surface <surface>`, normalized to the target start command or a fail-closed sentinel |
+| `display-message -p ... '#{pane_current_path}'` | `identify --workspace <workspace> --surface <surface>`, normalized to the target cwd or a fail-closed sentinel |
+| `display-message -p ... '#S'` | `display-message -p <workspace>` |
+| `list-panes -t <workspace> -F <format>` | `list-pane-surfaces --workspace <workspace>`, normalized back to the requested tmux `-F` fields |
+
+Unknown commands are passed through to cmux so its own tmux-compatible aliases
+can handle them when available.
+
+## Intentional limits
+
+- Live cmux is not required in CI; tests use mock binaries.
+- Attach/detach remain tmux-specific in the Rust mux contract because cmux
+  attachment is managed by the cmux app.
+- Broad file renames from `tmux-*` to `mux-*` are intentionally deferred to keep
+  the compatibility PR reviewable.
+
+## Verification
+
+Recommended checks for this surface:
+
+```sh
+npm run build
+node --test dist/hooks/__tests__/mux-adapter.test.js dist/hooks/__tests__/notify-hook-team-tmux-guard.test.js
+cargo test -p omx-mux
+```

--- a/src/hooks/__tests__/mux-adapter.test.ts
+++ b/src/hooks/__tests__/mux-adapter.test.ts
@@ -1,0 +1,200 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runProcess } from '../../scripts/notify-hook/process-runner.js';
+import {
+  CMUX_METADATA_UNAVAILABLE_CURRENT_PATH,
+  CMUX_METADATA_UNAVAILABLE_START_COMMAND,
+  currentMuxPaneTarget,
+  currentMuxSessionTarget,
+  normalizeMuxStdout,
+  resolveMuxInvocation,
+  resolveMuxKind,
+  translateTmuxArgvForCmux,
+} from '../../scripts/notify-hook/mux-adapter.js';
+
+describe('mux adapter selection', () => {
+  it('defaults to tmux unless cmux is requested or detected', () => {
+    assert.equal(resolveMuxKind({}), 'tmux');
+    assert.equal(resolveMuxKind({ OMX_MUX: 'tmux', CMUX_SURFACE_ID: 'surface:abc' }), 'tmux');
+    assert.equal(resolveMuxKind({ OMX_MUX: 'cmux' }), 'cmux');
+    assert.equal(resolveMuxKind({ CMUX_SURFACE_ID: 'surface:abc' }), 'tmux');
+    assert.equal(resolveMuxKind({ OMX_MUX: 'auto', CMUX_WORKSPACE_ID: 'workspace:abc' }), 'cmux');
+    assert.equal(resolveMuxKind({ CMUX_SOCKET_PATH: '/tmp/cmux.sock' }), 'tmux');
+  });
+
+  it('resolves pane and session targets with legacy tmux fallback', () => {
+    assert.equal(currentMuxPaneTarget({ OMX_MUX: 'cmux', CMUX_SURFACE_ID: 'surface:abc', TMUX_PANE: '%1' }), 'surface:abc');
+    assert.equal(currentMuxPaneTarget({ OMX_MUX: 'cmux', TMUX_PANE: '%1' }), '%1');
+    assert.equal(currentMuxPaneTarget({ CMUX_SURFACE_ID: 'surface:abc' }), '');
+    assert.equal(currentMuxSessionTarget({ OMX_MUX: 'cmux', CMUX_WORKSPACE_ID: 'workspace:abc', TMUX: 'tmux-session' }), 'workspace:abc');
+    assert.equal(currentMuxSessionTarget({ TMUX: 'tmux-session', CMUX_WORKSPACE_ID: 'workspace:abc' }), 'tmux-session');
+    assert.equal(currentMuxSessionTarget({ OMX_MUX: 'tmux', TMUX: 'tmux-session', CMUX_WORKSPACE_ID: 'workspace:abc' }), 'tmux-session');
+  });
+
+  it('translates the tmux injection argv subset to cmux argv', () => {
+    assert.deepEqual(
+      translateTmuxArgvForCmux(['send-keys', '-t', 'surface:abc', '-l', 'hello bridge']),
+      ['send', '--surface', 'surface:abc', 'hello bridge'],
+    );
+    assert.deepEqual(
+      translateTmuxArgvForCmux(['send-keys', '-t', 'surface:abc', 'C-m']),
+      ['send-key', '--surface', 'surface:abc', 'Enter'],
+    );
+    assert.deepEqual(
+      translateTmuxArgvForCmux(['capture-pane', '-t', 'surface:abc', '-p', '-S', '-80']),
+      ['capture-pane', '--surface', 'surface:abc', '--scrollback', '--lines', '80'],
+    );
+    assert.deepEqual(
+      translateTmuxArgvForCmux(
+        ['display-message', '-p', '-t', 'surface:abc', '#{pane_in_mode}'],
+        { OMX_MUX: 'cmux', CMUX_WORKSPACE_ID: 'workspace:abc' },
+      ),
+      ['surface-health', '--workspace', 'workspace:abc'],
+    );
+    assert.deepEqual(
+      translateTmuxArgvForCmux(
+        ['display-message', '-p', '-t', 'surface:abc', '#{pane_current_command}'],
+        { OMX_MUX: 'cmux', CMUX_WORKSPACE_ID: 'workspace:abc' },
+      ),
+      ['identify', '--workspace', 'workspace:abc', '--surface', 'surface:abc'],
+    );
+  });
+
+  it('normalizes cmux list-pane output back to the tmux -F contract', () => {
+    const env = {
+      OMX_MUX: 'cmux',
+      CMUX_SURFACE_ID: 'surface:current',
+      CMUX_WORKSPACE_ID: 'workspace:abc',
+    };
+    const invocation = resolveMuxInvocation(
+      'tmux',
+      ['list-panes', '-t', 'workspace:abc', '-F', '#{pane_id}\t#{pane_active}\t#{pane_current_command}\t#{pane_start_command}'],
+      env,
+    );
+
+    assert.deepEqual(invocation.args, ['list-pane-surfaces', '--workspace', 'workspace:abc']);
+    assert.equal(
+      normalizeMuxStdout(invocation, 'surface:other\nsurface:current\n', env),
+      'surface:other\t0\t\t\nsurface:current\t1\tcodex\tcodex\n',
+    );
+  });
+
+  it('normalizes cmux surface-health output for the tmux pane_in_mode guard', () => {
+    const env = {
+      OMX_MUX: 'cmux',
+      CMUX_SURFACE_ID: 'surface:abc',
+      CMUX_WORKSPACE_ID: 'workspace:abc',
+    };
+    const invocation = resolveMuxInvocation(
+      'tmux',
+      ['display-message', '-p', '-t', 'surface:abc', '#{pane_in_mode}'],
+      env,
+    );
+
+    assert.deepEqual(invocation.args, ['surface-health', '--workspace', 'workspace:abc']);
+    assert.equal(normalizeMuxStdout(invocation, 'surface:abc scroll_active=true\n', env), '1\n');
+    assert.equal(normalizeMuxStdout(invocation, 'surface:abc scroll_active=false\n', env), '0\n');
+  });
+
+  it('normalizes target-aware cmux display metadata probes', () => {
+    const env = {
+      OMX_MUX: 'cmux',
+      CMUX_SURFACE_ID: 'surface:abc',
+      CMUX_WORKSPACE_ID: 'workspace:abc',
+    };
+    const currentCommand = resolveMuxInvocation(
+      'tmux',
+      ['display-message', '-p', '-t', 'surface:abc', '#{pane_current_command}'],
+      env,
+    );
+    const startCommand = resolveMuxInvocation(
+      'tmux',
+      ['display-message', '-p', '-t', 'surface:abc', '#{pane_start_command}'],
+      env,
+    );
+    const currentPath = resolveMuxInvocation(
+      'tmux',
+      ['display-message', '-p', '-t', 'surface:abc', '#{pane_current_path}'],
+      env,
+    );
+    const metadata = JSON.stringify({
+      surface_id: 'surface:abc',
+      current_command: 'node',
+      start_command: 'codex --model gpt-5',
+      cwd: '/repo',
+    });
+
+    assert.deepEqual(currentCommand.args, ['identify', '--workspace', 'workspace:abc', '--surface', 'surface:abc']);
+    assert.equal(normalizeMuxStdout(currentCommand, metadata, env), 'node\n');
+    assert.equal(normalizeMuxStdout(startCommand, metadata, env), 'codex --model gpt-5\n');
+    assert.equal(normalizeMuxStdout(currentPath, metadata, env), '/repo\n');
+  });
+
+  it('returns conservative metadata sentinels when cmux display metadata is unavailable', () => {
+    const env = {
+      OMX_MUX: 'cmux',
+      CMUX_SURFACE_ID: 'surface:abc',
+      CMUX_WORKSPACE_ID: 'workspace:abc',
+    };
+    const startCommand = resolveMuxInvocation(
+      'tmux',
+      ['display-message', '-p', '-t', 'surface:abc', '#{pane_start_command}'],
+      env,
+    );
+    const currentPath = resolveMuxInvocation(
+      'tmux',
+      ['display-message', '-p', '-t', 'surface:abc', '#{pane_current_path}'],
+      env,
+    );
+
+    assert.equal(normalizeMuxStdout(startCommand, '', env), `${CMUX_METADATA_UNAVAILABLE_START_COMMAND}\n`);
+    assert.equal(normalizeMuxStdout(currentPath, '', env), `${CMUX_METADATA_UNAVAILABLE_CURRENT_PATH}\n`);
+  });
+
+  it('runs cmux mock binary when the legacy tmux call path is selected for cmux', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-mux-adapter-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const cmuxPath = join(fakeBinDir, 'cmux');
+    const logPath = join(cwd, 'cmux.log');
+    const previous = {
+      OMX_MUX: process.env.OMX_MUX,
+      OMX_TEST_CMUX_BIN: process.env.OMX_TEST_CMUX_BIN,
+      CMUX_SURFACE_ID: process.env.CMUX_SURFACE_ID,
+    };
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        cmuxPath,
+        `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(process.argv.slice(2)) + '\\n');
+`,
+      );
+      await chmod(cmuxPath, 0o755);
+
+      process.env.OMX_MUX = 'cmux';
+      process.env.OMX_TEST_CMUX_BIN = cmuxPath;
+      process.env.CMUX_SURFACE_ID = 'surface:abc';
+
+      await runProcess('tmux', ['send-keys', '-t', 'surface:abc', '-l', 'hello bridge']);
+      await runProcess('tmux', ['send-keys', '-t', 'surface:abc', 'C-m']);
+
+      const log = await readFile(logPath, 'utf-8');
+      const lines = log.trim().split('\n').map((line) => JSON.parse(line));
+      assert.deepEqual(lines[0], ['send', '--surface', 'surface:abc', 'hello bridge']);
+      assert.deepEqual(lines[1], ['send-key', '--surface', 'surface:abc', 'Enter']);
+    } finally {
+      if (typeof previous.OMX_MUX === 'string') process.env.OMX_MUX = previous.OMX_MUX;
+      else delete process.env.OMX_MUX;
+      if (typeof previous.OMX_TEST_CMUX_BIN === 'string') process.env.OMX_TEST_CMUX_BIN = previous.OMX_TEST_CMUX_BIN;
+      else delete process.env.OMX_TEST_CMUX_BIN;
+      if (typeof previous.CMUX_SURFACE_ID === 'string') process.env.CMUX_SURFACE_ID = previous.CMUX_SURFACE_ID;
+      else delete process.env.CMUX_SURFACE_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -909,6 +909,56 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("describes attached cmux runtime when the mux adapter is explicitly selected", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-start-cmux-"));
+    const previous = {
+      TMUX: process.env.TMUX,
+      TMUX_PANE: process.env.TMUX_PANE,
+      OMX_MUX: process.env.OMX_MUX,
+      CMUX_SURFACE_ID: process.env.CMUX_SURFACE_ID,
+      CMUX_WORKSPACE_ID: process.env.CMUX_WORKSPACE_ID,
+    };
+    delete process.env.TMUX;
+    delete process.env.TMUX_PANE;
+    process.env.OMX_MUX = "cmux";
+    process.env.CMUX_SURFACE_ID = "surface:test";
+    process.env.CMUX_WORKSPACE_ID = "workspace:test";
+
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "sess-start-cmux-1",
+        },
+        {
+          cwd,
+          sessionOwnerPid: process.pid,
+        },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /\[Execution environment\]/);
+      assert.match(additionalContext, /attached cmux runtime/);
+      assert.match(additionalContext, /mux adapter path/);
+      assert.match(additionalContext, /prefer native structured input unless an explicit question bridge is configured/);
+    } finally {
+      if (typeof previous.TMUX === "string") process.env.TMUX = previous.TMUX;
+      else delete process.env.TMUX;
+      if (typeof previous.TMUX_PANE === "string") process.env.TMUX_PANE = previous.TMUX_PANE;
+      else delete process.env.TMUX_PANE;
+      if (typeof previous.OMX_MUX === "string") process.env.OMX_MUX = previous.OMX_MUX;
+      else delete process.env.OMX_MUX;
+      if (typeof previous.CMUX_SURFACE_ID === "string") process.env.CMUX_SURFACE_ID = previous.CMUX_SURFACE_ID;
+      else delete process.env.CMUX_SURFACE_ID;
+      if (typeof previous.CMUX_WORKSPACE_ID === "string") process.env.CMUX_WORKSPACE_ID = previous.CMUX_WORKSPACE_ID;
+      else delete process.env.CMUX_WORKSPACE_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("describes direct CLI outside tmux in SessionStart context when the launch source is cli", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-start-cli-"));
     try {

--- a/src/scripts/codex-execution-surface.ts
+++ b/src/scripts/codex-execution-surface.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { resolveMuxKind } from "./notify-hook/mux-adapter.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -13,7 +14,7 @@ type CodexHookEventName =
 type CodexHookPayload = Record<string, unknown>;
 
 export type CodexLauncherKind = "native" | "cli";
-export type CodexTransportKind = "attached-tmux" | "outside-tmux";
+export type CodexTransportKind = "attached-tmux" | "attached-cmux" | "outside-tmux";
 
 export interface CodexExecutionSurface {
   launcher: CodexLauncherKind;
@@ -51,7 +52,7 @@ export function resolveCodexExecutionSurface(
 ): CodexExecutionSurface {
   const transport: CodexTransportKind = safeString(process.env.TMUX).trim()
     ? "attached-tmux"
-    : "outside-tmux";
+    : (resolveMuxKind(process.env) === "cmux" ? "attached-cmux" : "outside-tmux");
   const payloadSessionId = safeString(options.payload?.session_id ?? options.payload?.sessionId).trim();
   const payloadSource = safeString(options.payload?.source).trim().toLowerCase();
   const persistedSession = readPersistedSessionStateSync(cwd);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1197,6 +1197,7 @@ async function buildSessionStartContext(
 
 type ExecutionEnvironmentKind =
   | "attached-tmux-runtime"
+  | "attached-cmux-runtime"
   | "outside-tmux-with-bridge"
   | "native-outside-tmux"
   | "direct-cli-outside-tmux";
@@ -1240,6 +1241,21 @@ function resolveExecutionEnvironment(
       teamRuntimeInstruction: "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout.",
       teamHelpInstruction: "If you need runtime syntax, run `omx team --help` yourself.",
       deepInterviewInstruction: "Deep-interview must ask each interview round via `omx question`; do not fall back to `request_user_input` or plain-text questioning. This session is already attached to tmux, so `omx question` can open its temporary renderer directly over the leader pane. After starting `omx question` in a background terminal, wait for that terminal to finish and read the JSON answer before continuing the interview. Prefer `answers[0].answer` / `answers[]`; use legacy `answer` only as fallback. Deep-interview remains one question per round, so do not batch multiple interview rounds into one `questions[]` form. Stop remains blocked while a deep-interview question obligation is pending.",
+      leaderPaneHint,
+    };
+  }
+
+  if (executionSurface.transport === "attached-cmux") {
+    return {
+      kind: "attached-cmux-runtime",
+      launcher: executionSurface.launcher,
+      transport: executionSurface.transport,
+      surface: "attached cmux runtime - cmux",
+      tmuxWorkflowGuidance: "cmux transport detected; OMX uses the mux adapter path for pane capture and prompt delivery where supported",
+      questionGuidance: "cmux surface available from the current terminal; prefer native structured input unless an explicit question bridge is configured",
+      teamRuntimeInstruction: "Use durable OMX runtime commands only when the current command path supports cmux; do not replace durable runtime coordination with in-process fanout.",
+      teamHelpInstruction: "If you need runtime syntax, run `omx team --help` yourself.",
+      deepInterviewInstruction: "Deep-interview is active in a cmux-attached runtime. Use native structured input when available; use `omx question` only after verifying the cmux question bridge for this surface.",
       leaderPaneHint,
     };
   }

--- a/src/scripts/notify-hook/mux-adapter.ts
+++ b/src/scripts/notify-hook/mux-adapter.ts
@@ -1,0 +1,461 @@
+/**
+ * Runtime multiplexer adapter selection for notify-hook surfaces.
+ *
+ * The hook code still calls many helpers named "tmux" for compatibility.
+ * This module provides the small bridge that lets those call sites target
+ * cmux when OMX_MUX=cmux, or when OMX_MUX=auto and a cmux terminal
+ * environment is present.
+ */
+
+export type MuxKind = 'tmux' | 'cmux';
+export type MuxPreference = MuxKind | 'auto';
+
+export interface MuxInvocation {
+  command: string;
+  args: string[];
+  kind: MuxKind | null;
+  translated: boolean;
+  usingTestBinary: boolean;
+  relaxTimeout: boolean;
+  originalCommand: string;
+  originalArgs: string[];
+}
+
+export const CMUX_METADATA_UNAVAILABLE_CURRENT_COMMAND = 'sh';
+export const CMUX_METADATA_UNAVAILABLE_START_COMMAND = 'cmux metadata unavailable';
+export const CMUX_METADATA_UNAVAILABLE_CURRENT_PATH = '__omx_cmux_current_path_unavailable__';
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function stringifyField(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) return value.map((item) => stringifyField(item)).filter(Boolean).join(' ');
+  return '';
+}
+
+function normalizeMuxPreference(value: unknown): MuxPreference | null {
+  const normalized = safeString(value).trim().toLowerCase();
+  if (normalized === 'tmux' || normalized === 'cmux' || normalized === 'auto') return normalized;
+  return null;
+}
+
+export function isCmuxEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(
+    safeString(env.CMUX_SURFACE_ID).trim()
+    || safeString(env.CMUX_WORKSPACE_ID).trim(),
+  );
+}
+
+export function resolveMuxKind(env: NodeJS.ProcessEnv = process.env): MuxKind {
+  const preference = normalizeMuxPreference(env.OMX_MUX);
+  if (preference === 'tmux' || preference === 'cmux') return preference;
+  if (preference === 'auto' && isCmuxEnv(env)) return 'cmux';
+  return 'tmux';
+}
+
+export function currentMuxPaneTarget(env: NodeJS.ProcessEnv = process.env): string {
+  const kind = resolveMuxKind(env);
+  const cmuxSurface = safeString(env.CMUX_SURFACE_ID).trim();
+  const tmuxPane = safeString(env.TMUX_PANE).trim();
+  return kind === 'cmux'
+    ? (cmuxSurface || tmuxPane)
+    : tmuxPane;
+}
+
+export function currentMuxSessionTarget(env: NodeJS.ProcessEnv = process.env): string {
+  const kind = resolveMuxKind(env);
+  const cmuxWorkspace = safeString(env.CMUX_WORKSPACE_ID).trim();
+  const tmuxSession = safeString(env.TMUX).trim();
+  return kind === 'cmux'
+    ? (cmuxWorkspace || tmuxSession)
+    : tmuxSession;
+}
+
+function resolveMuxBinary(kind: MuxKind, env: NodeJS.ProcessEnv): { command: string; usingTestBinary: boolean } {
+  if (kind === 'cmux') {
+    const testBinary = safeString(env.OMX_TEST_CMUX_BIN || env.OMX_TEST_MUX_BIN).trim();
+    if (testBinary) return { command: testBinary, usingTestBinary: true };
+    const configured = safeString(env.OMX_CMUX_BIN || env.OMX_MUX_BIN).trim();
+    return { command: configured || 'cmux', usingTestBinary: false };
+  }
+
+  const testBinary = safeString(env.OMX_TEST_TMUX_BIN || env.OMX_TEST_MUX_BIN).trim();
+  if (testBinary) return { command: testBinary, usingTestBinary: true };
+  const configured = safeString(env.OMX_TMUX_BIN || env.OMX_MUX_BIN).trim();
+  return { command: configured || 'tmux', usingTestBinary: false };
+}
+
+function valueAfterFlag(args: string[], flag: string): string {
+  const index = args.indexOf(flag);
+  if (index === -1) return '';
+  return safeString(args[index + 1]).trim();
+}
+
+function trailingFormat(args: string[]): string {
+  return safeString(args[args.length - 1]).trim();
+}
+
+function tailLinesFromTmuxCaptureArgs(args: string[]): string {
+  const start = valueAfterFlag(args, '-S');
+  const numeric = start.startsWith('-') ? start.slice(1) : start;
+  return /^\d+$/.test(numeric) && numeric !== '0' ? numeric : '80';
+}
+
+function cmuxTargetArgs(target: string): string[] {
+  return target ? ['--surface', target] : [];
+}
+
+function cmuxWorkspaceArgs(workspace: string): string[] {
+  return workspace ? ['--workspace', workspace] : [];
+}
+
+/**
+ * Translate the tmux argv subset used by OMX prompt injection to cmux CLI argv.
+ * Unknown tmux-compatible commands are passed through so cmux can handle any
+ * native compatibility aliases it already implements.
+ */
+export function translateTmuxArgvForCmux(args: string[], env: NodeJS.ProcessEnv = process.env): string[] {
+  const command = safeString(args[0]).trim();
+  const target = valueAfterFlag(args, '-t') || currentMuxPaneTarget(env);
+
+  if (command === 'send-keys') {
+    const literalIndex = args.indexOf('-l');
+    if (literalIndex !== -1) {
+      return ['send', ...cmuxTargetArgs(target), safeString(args[literalIndex + 1])];
+    }
+
+    const key = safeString(args[args.length - 1]).trim();
+    const cmuxKey = key === 'C-m' ? 'Enter' : key;
+    return ['send-key', ...cmuxTargetArgs(target), cmuxKey];
+  }
+
+  if (command === 'capture-pane') {
+    return [
+      'capture-pane',
+      ...cmuxTargetArgs(target),
+      '--scrollback',
+      '--lines',
+      tailLinesFromTmuxCaptureArgs(args),
+    ];
+  }
+
+  if (command === 'display-message') {
+    const format = trailingFormat(args);
+    if (format === '#{pane_in_mode}') {
+      return ['surface-health', ...cmuxWorkspaceArgs(currentMuxSessionTarget(env))];
+    }
+    if (
+      format === '#{pane_current_command}'
+      || format === '#{pane_start_command}'
+      || format === '#{pane_current_path}'
+    ) {
+      return [
+        'identify',
+        ...cmuxWorkspaceArgs(currentMuxSessionTarget(env)),
+        ...cmuxTargetArgs(target || currentMuxPaneTarget(env)),
+      ];
+    }
+    if (format === '#{pane_id}') {
+      const pane = target || currentMuxPaneTarget(env);
+      return ['display-message', '-p', pane];
+    }
+    if (format === '#S') {
+      const session = currentMuxSessionTarget(env);
+      return session
+        ? ['display-message', '-p', session]
+        : ['current-workspace'];
+    }
+    return ['display-message', '-p', format];
+  }
+
+  if (command === 'list-panes') {
+    const workspace = valueAfterFlag(args, '-t') || currentMuxSessionTarget(env);
+    return workspace
+      ? ['list-pane-surfaces', '--workspace', workspace]
+      : ['list-pane-surfaces'];
+  }
+
+  return [...args];
+}
+
+export function resolveMuxInvocation(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): MuxInvocation {
+  if (command !== 'tmux') {
+    return {
+      command,
+      args: [...args],
+      kind: null,
+      translated: false,
+      usingTestBinary: false,
+      relaxTimeout: false,
+      originalCommand: command,
+      originalArgs: [...args],
+    };
+  }
+
+  const kind = resolveMuxKind(env);
+  const binary = resolveMuxBinary(kind, env);
+  const translatedArgs = kind === 'cmux' ? translateTmuxArgvForCmux(args, env) : [...args];
+  const relaxTimeout = kind === 'tmux'
+    ? env.OMX_TEST_RELAX_TMUX_TIMEOUT === '1'
+    : env.OMX_TEST_RELAX_CMUX_TIMEOUT === '1';
+
+  return {
+    command: binary.command,
+    args: translatedArgs,
+    kind,
+    translated: kind === 'cmux',
+    usingTestBinary: binary.usingTestBinary,
+    relaxTimeout,
+    originalCommand: command,
+    originalArgs: [...args],
+  };
+}
+
+interface CmuxSurfaceMeta {
+  id: string;
+  active: boolean;
+  currentCommand: string;
+  startCommand: string;
+  currentPath: string;
+}
+
+function truthyText(value: unknown): boolean | null {
+  const normalized = safeString(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'active', 'focused', 'selected', 'current'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'inactive', 'blurred', 'none'].includes(normalized)) return false;
+  return null;
+}
+
+function objectString(record: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = stringifyField(record[key]).trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+function objectBoolean(record: Record<string, unknown>, keys: string[]): boolean | null {
+  for (const key of keys) {
+    const parsed = truthyText(record[key]);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+function extractSurfaceObjects(parsed: unknown): Record<string, unknown>[] {
+  if (Array.isArray(parsed)) {
+    return parsed.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === 'object' && !Array.isArray(item)));
+  }
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    const record = parsed as Record<string, unknown>;
+    for (const key of ['surfaces', 'pane_surfaces', 'paneSurfaces', 'items', 'panes']) {
+      const value = record[key];
+      if (Array.isArray(value)) {
+        return value.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === 'object' && !Array.isArray(item)));
+      }
+    }
+    const nested = [record];
+    for (const key of ['surface', 'caller', 'context', 'terminal', 'pane']) {
+      const value = record[key];
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        nested.push(value as Record<string, unknown>);
+      }
+    }
+    return nested;
+  }
+  return [];
+}
+
+function metaFromObject(record: Record<string, unknown>, env: NodeJS.ProcessEnv): CmuxSurfaceMeta | null {
+  const id = objectString(record, ['surface', 'surface_id', 'surfaceId', 'surfaceID', 'surface_ref', 'surfaceRef', 'id', 'ref', 'handle']);
+  if (!id) return null;
+  const active = objectBoolean(record, ['active', 'focused', 'selected', 'current', 'is_active', 'isActive']);
+  const currentSurface = currentMuxPaneTarget(env);
+  return {
+    id,
+    active: active ?? (!!currentSurface && id === currentSurface),
+    currentCommand: objectString(record, ['pane_current_command', 'current_command', 'currentCommand', 'command', 'process', 'program']),
+    startCommand: objectString(record, ['pane_start_command', 'start_command', 'startCommand', 'startCommandLine', 'argv']),
+    currentPath: objectString(record, ['pane_current_path', 'current_path', 'currentPath', 'cwd', 'working_directory', 'workingDirectory', 'path']),
+  };
+}
+
+function keyValueFromLine(line: string, keys: string[]): string {
+  for (const key of keys) {
+    const match = line.match(new RegExp(`(?:^|\\s)${key}=([^\\s]+)`));
+    if (match?.[1]) return match[1];
+  }
+  return '';
+}
+
+function metaFromPlainLine(line: string, env: NodeJS.ProcessEnv): CmuxSurfaceMeta | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const tabParts = trimmed.split('\t');
+  if (tabParts.length >= 2) {
+    const [id = '', activeRaw = '', currentCommand = '', startCommand = '', currentPath = ''] = tabParts;
+    if (!id.trim()) return null;
+    const currentSurface = currentMuxPaneTarget(env);
+    return {
+      id: id.trim(),
+      active: truthyText(activeRaw) ?? (!!currentSurface && id.trim() === currentSurface),
+      currentCommand: currentCommand.trim(),
+      startCommand: startCommand.trim(),
+      currentPath: currentPath.trim(),
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    const [meta] = extractSurfaceObjects(parsed)
+      .map((record) => metaFromObject(record, env))
+      .filter((item): item is CmuxSurfaceMeta => item !== null);
+    if (meta) return meta;
+  } catch {
+    // Plain cmux output; parse below.
+  }
+
+  const [id = ''] = trimmed.split(/\s+/, 1);
+  if (!id) return null;
+  const explicitActive = truthyText(
+    keyValueFromLine(trimmed, ['active', 'focused', 'selected', 'current', 'is_active']),
+  );
+  const currentSurface = currentMuxPaneTarget(env);
+  return {
+    id,
+    active: explicitActive ?? (!!currentSurface && id === currentSurface),
+    currentCommand: keyValueFromLine(trimmed, ['pane_current_command', 'current_command', 'command', 'process', 'program']),
+    startCommand: keyValueFromLine(trimmed, ['pane_start_command', 'start_command', 'startCommand', 'argv']),
+    currentPath: keyValueFromLine(trimmed, ['pane_current_path', 'current_path', 'cwd', 'working_directory', 'path']),
+  };
+}
+
+function parseCmuxSurfaceRows(stdout: string, env: NodeJS.ProcessEnv): CmuxSurfaceMeta[] {
+  const trimmed = safeString(stdout).trim();
+  if (!trimmed) return [];
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    const rows = extractSurfaceObjects(parsed)
+      .map((record) => metaFromObject(record, env))
+      .filter((item): item is CmuxSurfaceMeta => item !== null);
+    if (rows.length > 0) return finalizeCmuxRows(rows, env);
+  } catch {
+    // Not a single JSON payload; try line-oriented output.
+  }
+
+  return finalizeCmuxRows(
+    trimmed
+      .split('\n')
+      .map((line) => metaFromPlainLine(line, env))
+      .filter((item): item is CmuxSurfaceMeta => item !== null),
+    env,
+  );
+}
+
+function finalizeCmuxRows(rows: CmuxSurfaceMeta[], env: NodeJS.ProcessEnv): CmuxSurfaceMeta[] {
+  const currentSurface = currentMuxPaneTarget(env);
+  const hasActive = rows.some((row) => row.active);
+  return rows.map((row, index) => {
+    const active = row.active || (!hasActive && (currentSurface ? row.id === currentSurface : rows.length === 1 || index === 0));
+    const inferredCurrentSurfaceAgent = active && currentSurface && row.id === currentSurface;
+    return {
+      ...row,
+      active,
+      currentCommand: row.currentCommand || (inferredCurrentSurfaceAgent ? 'codex' : ''),
+      startCommand: row.startCommand || (inferredCurrentSurfaceAgent ? 'codex' : ''),
+      currentPath: row.currentPath,
+    };
+  });
+}
+
+function renderTmuxFormat(format: string, row: CmuxSurfaceMeta): string {
+  return format
+    .replaceAll('#{pane_id}', row.id)
+    .replaceAll('#{pane_active}', row.active ? '1' : '0')
+    .replaceAll('#{pane_current_command}', row.currentCommand)
+    .replaceAll('#{pane_start_command}', row.startCommand)
+    .replaceAll('#{pane_current_path}', row.currentPath)
+    .replaceAll('#{pane_pid}', '');
+}
+
+function normalizeCmuxListPanesStdout(invocation: MuxInvocation, stdout: string, env: NodeJS.ProcessEnv): string {
+  const format = valueAfterFlag(invocation.originalArgs, '-F');
+  if (!format) return stdout;
+  const rows = parseCmuxSurfaceRows(stdout, env);
+  return rows.map((row) => renderTmuxFormat(format, row)).join('\n') + (rows.length > 0 ? '\n' : '');
+}
+
+function normalizeCmuxPaneInModeStdout(invocation: MuxInvocation, stdout: string, env: NodeJS.ProcessEnv): string {
+  const target = valueAfterFlag(invocation.originalArgs, '-t') || currentMuxPaneTarget(env);
+  const lines = safeString(stdout).split('\n').map((line) => line.trim()).filter(Boolean);
+  const targetLines = target
+    ? lines.filter((line) => line.includes(target))
+    : lines;
+  const inspected = targetLines.length > 0 ? targetLines : lines;
+  const body = inspected.join('\n').toLowerCase();
+  if (/(?:scroll|copy|mode|in_mode)[^=\n:]*[=:]\s*(?:1|true|active|copy|scroll)/i.test(body)) return '1\n';
+  if (/(?:scroll|copy|mode|in_mode)[^=\n:]*[=:]\s*(?:0|false|inactive|none)/i.test(body)) return '0\n';
+  if (/\b(copy-mode|scrollback-active|scroll_active|copy_active)\b/i.test(body)) return '1\n';
+  return '0\n';
+}
+
+function selectCmuxTargetMeta(rows: CmuxSurfaceMeta[], target: string): CmuxSurfaceMeta | null {
+  if (target) {
+    const exact = rows.find((row) => row.id === target);
+    if (exact) return exact;
+  }
+  return rows.find((row) => row.active) || rows[0] || null;
+}
+
+function normalizeCmuxDisplayMessageStdout(invocation: MuxInvocation, stdout: string, env: NodeJS.ProcessEnv): string {
+  const format = trailingFormat(invocation.originalArgs);
+  const target = valueAfterFlag(invocation.originalArgs, '-t') || currentMuxPaneTarget(env);
+  const row = selectCmuxTargetMeta(parseCmuxSurfaceRows(stdout, env), target);
+
+  if (format === '#{pane_current_command}') {
+    return `${row?.currentCommand || CMUX_METADATA_UNAVAILABLE_CURRENT_COMMAND}\n`;
+  }
+  if (format === '#{pane_start_command}') {
+    return `${row?.startCommand || CMUX_METADATA_UNAVAILABLE_START_COMMAND}\n`;
+  }
+  if (format === '#{pane_current_path}') {
+    return `${row?.currentPath || CMUX_METADATA_UNAVAILABLE_CURRENT_PATH}\n`;
+  }
+
+  return stdout;
+}
+
+export function normalizeMuxStdout(
+  invocation: MuxInvocation,
+  stdout: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (invocation.kind !== 'cmux' || !invocation.translated) return stdout;
+
+  const originalCommand = safeString(invocation.originalArgs[0]).trim();
+  if (originalCommand === 'list-panes') {
+    return normalizeCmuxListPanesStdout(invocation, stdout, env);
+  }
+
+  if (originalCommand === 'display-message') {
+    const format = trailingFormat(invocation.originalArgs);
+    if (format === '#{pane_in_mode}') return normalizeCmuxPaneInModeStdout(invocation, stdout, env);
+    if (
+      format === '#{pane_current_command}'
+      || format === '#{pane_start_command}'
+      || format === '#{pane_current_path}'
+    ) {
+      return normalizeCmuxDisplayMessageStdout(invocation, stdout, env);
+    }
+  }
+
+  return stdout;
+}

--- a/src/scripts/notify-hook/process-runner.ts
+++ b/src/scripts/notify-hook/process-runner.ts
@@ -3,14 +3,13 @@
  */
 
 import { spawn } from 'child_process';
+import { normalizeMuxStdout, resolveMuxInvocation } from './mux-adapter.js';
 
 export function runProcess(command: string, args: string[], timeoutMs = 3000): Promise<{ stdout: string; stderr: string; code: number | null }> {
   return new Promise((resolve, reject) => {
-    const usingTestTmux = command === 'tmux' && process.env.OMX_TEST_TMUX_BIN;
-    const relaxingTestTmuxTimeout = command === 'tmux' && process.env.OMX_TEST_RELAX_TMUX_TIMEOUT === '1';
-    const executable = usingTestTmux ? process.env.OMX_TEST_TMUX_BIN as string : command;
-    const effectiveTimeoutMs = usingTestTmux || relaxingTestTmuxTimeout ? Math.max(timeoutMs, 10_000) : timeoutMs;
-    const child = spawn(executable, args, {
+    const invocation = resolveMuxInvocation(command, args, process.env);
+    const effectiveTimeoutMs = invocation.usingTestBinary || invocation.relaxTimeout ? Math.max(timeoutMs, 10_000) : timeoutMs;
+    const child = spawn(invocation.command, invocation.args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
     });
@@ -42,9 +41,9 @@ export function runProcess(command: string, args: string[], timeoutMs = 3000): P
       finished = true;
       clearTimeout(timer);
       if (code === 0) {
-        resolve({ stdout, stderr, code });
+        resolve({ stdout: normalizeMuxStdout(invocation, stdout, process.env), stderr, code });
       } else {
-        reject(new Error(stderr.trim() || `${command} exited ${code}`));
+        reject(new Error(stderr.trim() || `${invocation.command} exited ${code}`));
       }
     });
   });

--- a/src/scripts/notify-hook/tmux-injection.ts
+++ b/src/scripts/notify-hook/tmux-injection.ts
@@ -20,6 +20,7 @@ import {
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { resolveInvocationSessionId, resolveManagedCurrentPane, resolveManagedSessionContext, verifyManagedPaneTarget } from './managed-tmux.js';
+import { CMUX_METADATA_UNAVAILABLE_START_COMMAND, resolveMuxKind } from './mux-adapter.js';
 import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPaneInput } from './team-tmux-guard.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../../state/skill-active.js';
 import {
@@ -31,6 +32,10 @@ import {
 
 function isHudPaneStartCommand(startCommand: any): boolean {
   return /\bomx\b.*\bhud\b.*--watch/i.test(safeString(startCommand));
+}
+
+function isUnavailableCmuxPaneMetadata(startCommand: any): boolean {
+  return safeString(startCommand).trim() === CMUX_METADATA_UNAVAILABLE_START_COMMAND;
 }
 
 async function resolvePaneCwdMismatch(paneId: string, expectedCwd: any): Promise<any | null> {
@@ -80,6 +85,9 @@ async function resolveCanonicalPaneFromPaneTarget(paneTarget: any, expectedCwd: 
     startCommand = safeString(startResult.stdout).trim();
   } catch {
     startCommand = '';
+  }
+  if (isUnavailableCmuxPaneMetadata(startCommand)) {
+    return { paneTarget: null, reason: 'pane_metadata_unavailable' };
   }
   if (!startCommand || !isHudPaneStartCommand(startCommand)) {
     return finalizeResolvedPane(paneId, 'ok', expectedCwd);
@@ -243,6 +251,7 @@ async function readVisibleAllowedModes(
 
 export async function resolveSessionToPane(sessionName: any): Promise<string | null> {
   const result = await runProcess('tmux', ['list-panes', '-t', sessionName, '-F', '#{pane_id}\t#{pane_active}\t#{pane_current_command}\t#{pane_start_command}']);
+  const cmuxMode = resolveMuxKind() === 'cmux';
   const rows = result.stdout
     .split('\n')
     .map((line: string) => line.trim())
@@ -259,7 +268,7 @@ export async function resolveSessionToPane(sessionName: any): Promise<string | n
         startCommand: safeString(startCommand).trim(),
       };
     })
-    .filter((row: any) => row.paneId.startsWith('%'));
+    .filter((row: any) => cmuxMode ? row.paneId !== '' : row.paneId.startsWith('%'));
   if (rows.length === 0) return null;
 
   const nonHudRows = rows.filter((row: any) => !isHudPaneStartCommand(row.startCommand));

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
+import { currentMuxPaneTarget, resolveMuxKind } from './notify-hook/mux-adapter.js';
 
 export const DEFAULT_ALLOWED_MODES = ['ralph', 'ultrawork', 'team'];
 export const DEFAULT_MARKER = '[OMX_TMUX_INJECT]';
@@ -203,6 +204,10 @@ function isHudStartCommand(startCommand: string): boolean {
  * use this instead of raw `process.env.TMUX_PANE`.
  */
 export function resolveCodexPane(): string {
+  if (resolveMuxKind() === 'cmux') {
+    return currentMuxPaneTarget();
+  }
+
   const envPane = (process.env.TMUX_PANE || '').trim();
   const tmuxCommand = resolveTmuxBinaryForPlatform() || 'tmux';
   if (!envPane) return '';


### PR DESCRIPTION
## Summary
- Add an explicit tmux/cmux mux adapter path while keeping tmux as the default behavior.
- Translate the prompt-injection tmux argv subset to cmux argv for send, enter, capture, display-message, and list-panes calls.
- Preserve downstream tmux stdout contracts for `list-panes -F ...`, `#{pane_in_mode}`, and target-aware `display-message` metadata probes when routed through cmux.
- Add a Rust `CmuxAdapter` scaffold, attached-cmux native hook context, mock-binary tests, and cmux support documentation.

## Review fixes
- Preserve pane metadata by normalizing `cmux list-pane-surfaces` output back to the requested tmux `-F` fields.
- Keep the scroll/copy-mode guard observable by probing `cmux surface-health` instead of hardcoding `#{pane_in_mode}` to `0`.
- Preserve target-aware `#{pane_current_command}`, `#{pane_start_command}`, and `#{pane_current_path}` probes through `cmux identify`; missing metadata now produces conservative sentinels rather than empty successful output.

## Notes
- cmux is selected only with `OMX_MUX=cmux`, or with `OMX_MUX=auto` plus `CMUX_SURFACE_ID`/`CMUX_WORKSPACE_ID`.
- A live cmux install is not required in CI; tests use mock binaries and argument-contract checks.
- Broad `tmux-*` to `mux-*` renames are intentionally deferred to keep this compatibility PR reviewable.

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/hooks/__tests__/mux-adapter.test.js dist/hooks/__tests__/notify-hook-team-tmux-guard.test.js dist/hooks/__tests__/notify-hook-managed-tmux.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `cargo test -p omx-mux`
- `git diff --check`

## Known validation gap
- `dist/hooks/__tests__/notify-hook-auto-nudge.test.js` still has 8 failures in this local environment, but the same failures were reproduced unchanged on `main` in a detached `/private/tmp` worktree, so they are treated as baseline/local-environment failures rather than regressions from this cmux adapter change.
