### PR TITLE
Fail draft-only team startup after ready timeout

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -2240,6 +2240,118 @@ esac
     }
   });
 
+  it('startTeam rejects ready-prompt timeout when dispatch never produces startup evidence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-ready-timeout-no-evidence-'));
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousReadyTimeout = process.env.OMX_TEAM_READY_TIMEOUT_MS;
+    const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+    const previousStartupDispatchRetries = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+    const teamName = `trt-${process.pid}-${Date.now().toString(36)}`;
+    let receiptNotifier: NodeJS.Timeout | null = null;
+    let runtimeTeamName: string | null = null;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-ready-timeout-no-evidence-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*) echo "120" ;;
+      *) echo "leader:0 %1" ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"*) printf "%%1\\tnode\\t'codex'\\n" ;;
+      *"#{pane_dead} #{pane_pid}"*) echo "0 4242" ;;
+      *"#{pane_dead}"*) echo "0" ;;
+      *"#{pane_pid}"*) echo "4242" ;;
+      *) exit 0 ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    printf 'worker process is still starting; no agent prompt yet\\n'
+    exit 0
+    ;;
+  split-window)
+    echo "%2"
+    exit 0
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-pane|kill-session|resize-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          binaries: [{ name: 'codex', content: fakeCodexNodeScript('process.stdin.resume();\n') }],
+        },
+        async ({ tmuxLogPath }) => {
+          delete process.env.TMUX;
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'codex';
+          process.env.OMX_TEAM_READY_TIMEOUT_MS = '5000';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
+
+          receiptNotifier = setInterval(() => {
+            void markPendingInboxDispatchesNotified(teamName, cwd);
+          }, 20);
+
+          await assert.rejects(
+            withoutTeamWorkerEnv(() =>
+              startTeam(
+                teamName,
+                'ready prompt timeout should not count a draft-only worker as started',
+                'executor',
+                1,
+                [{ subject: 'w1', description: 'worker one', owner: 'worker-1' }],
+                cwd,
+              )),
+            /worker_notify_failed:worker-1:codex_startup_no_evidence_after_fallback/,
+          );
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /send-keys -t %2 -l --/);
+          runtimeTeamName = await resolveRuntimeTeamName(cwd, teamName).catch(() => null);
+        },
+      );
+    } finally {
+      if (receiptNotifier) clearInterval(receiptNotifier);
+      if (runtimeTeamName) await shutdownTeam(runtimeTeamName, cwd, { force: true }).catch(() => {});
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousReadyTimeout === 'string') process.env.OMX_TEAM_READY_TIMEOUT_MS = previousReadyTimeout;
+      else delete process.env.OMX_TEAM_READY_TIMEOUT_MS;
+      if (typeof previousStartupEvidenceTimeout === 'string') process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = previousStartupEvidenceTimeout;
+      else delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+      if (typeof previousStartupDispatchRetries === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = previousStartupDispatchRetries;
+      else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam starts worker-2 readiness before delayed worker-1 readiness settles', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-parallel-ready-'));
     const previousTmux = process.env.TMUX;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1728,12 +1728,13 @@ async function recordRecoverableStartupIssue(params: {
 }): Promise<void> {
   const { teamName, workerName, taskIds, reason, cwd } = params;
   const updatedAt = new Date().toISOString();
+  const currentTaskId = reason === 'ready_prompt_timeout' ? undefined : taskIds[0];
   await writeWorkerStatus(
     teamName,
     workerName,
     {
       state: 'unknown',
-      current_task_id: taskIds[0],
+      current_task_id: currentTaskId,
       reason,
       updated_at: updatedAt,
     },
@@ -2819,6 +2820,8 @@ export async function startTeam(
         })
         : null;
 
+      let startupReadyPromptObserved = false;
+      let startupReadyPromptTimedOut = false;
       if (workerLaunchMode === 'interactive' && !skipWorkerReadyWait && !initialPrompt && !startupDirectOutcome?.ok) {
         startupTiming.mark('ready_wait_start', { worker: workerName, pane_id: paneId });
         const ready = await waitForWorkerReadyAsync(sessionName, workerIndex, workerReadyTimeoutMs, paneId);
@@ -2833,19 +2836,19 @@ export async function startTeam(
               reason: 'ready_prompt_timeout',
               cwd: leaderCwd,
             });
-            return { ok: true, workerIndex, workerName };
+            startupReadyPromptTimedOut = true;
+          } else {
+            return {
+              ok: false,
+              workerIndex,
+              workerName,
+              error: new Error(`Worker ${workerName} did not become ready in tmux session ${sessionName}`),
+            };
           }
-          return {
-            ok: false,
-            workerIndex,
-            workerName,
-            error: new Error(`Worker ${workerName} did not become ready in tmux session ${sessionName}`),
-          };
+        } else {
+          startupReadyPromptObserved = true;
         }
       }
-
-      const startupReadyPromptObserved =
-        workerLaunchMode === 'interactive' && !skipWorkerReadyWait && !initialPrompt;
 
       let dispatchOutcome: DispatchOutcome = initialPrompt
         ? { ok: true, transport: 'none', reason: 'startup_prompt_delivered_at_launch' }
@@ -2903,6 +2906,7 @@ export async function startTeam(
         if (
           workerLaunchMode === 'interactive'
           && workerAlive
+          && !startupReadyPromptTimedOut
           && isRecoverableInteractiveStartupReason(dispatchOutcome.reason)
         ) {
           await recordRecoverableStartupIssue({


### PR DESCRIPTION
## Summary
- keep `ready_prompt_timeout` as recoverable diagnostic evidence, but no longer return startup success solely because the worker pane is alive
- continue into the critical inbox dispatch/startup-evidence path after readiness timeout
- prevent a timeout worker with only a typed trigger draft from being counted as successful execution
- add a focused regression for readiness timeout followed by dispatch notification without worker startup evidence

Fixes #2310.

## Verification
- `npm run build`
- `node --test --test-name-pattern "startup direct trigger falls back|rejects ready-prompt timeout|records recoverable issue when tmux fallback" dist/team/__tests__/runtime.test.js`
- `npm run lint`
- `npm run check:no-unused`

## Review
- AI-slop cleanup gate: passed/no-op for changed files only
- Final changed-file review: APPROVE / architectural status CLEAR

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
