### PR TITLE
Protect Team startup from idle Ultragoal plans

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -2949,6 +2949,44 @@ describe('teamCommand status', () => {
     }
   });
 
+  it('omits Ultragoal checkpoint guidance in JSON status for completed plans without activeGoalId', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-ultragoal-idle-json-'));
+    const previousCwd = process.cwd();
+    const logs: string[] = [];
+    const originalLog = console.log;
+    try {
+      process.chdir(wd);
+      await withoutTeamTestWorkerEnv(() => initTeamState('ultragoal-idle-json-team', 'inspect idle ultragoal status', 'executor', 1, wd));
+      await mkdir(join(wd, '.omx', 'ultragoal'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'ultragoal', 'goals.json'),
+        `${JSON.stringify({
+          version: 1,
+          codexGoalMode: 'aggregate',
+          goals: [{
+            id: 'G001-completed-story',
+            title: 'Completed story',
+            status: 'complete',
+          }],
+        })}\n`,
+      );
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+
+      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'ultragoal-idle-json-team', '--json']));
+
+      const payload = JSON.parse(logs[0] ?? '{}') as {
+        status?: string;
+        ultragoal_checkpoint_guidance?: unknown;
+      };
+      assert.equal(payload.status, 'ok');
+      assert.equal('ultragoal_checkpoint_guidance' in payload, false);
+    } finally {
+      console.log = originalLog;
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('prints Ultragoal checkpoint guidance in text status with fresh get_goal requirement', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-ultragoal-text-'));
     const previousCwd = process.cwd();

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6628,6 +6628,63 @@ esac
     }
   });
 
+  it('startTeam treats a completed Ultragoal plan without activeGoalId as no active bridge context', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-ultragoal-idle-start-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(cwd, '.omx', 'ultragoal'), { recursive: true });
+    await writeFile(
+      join(cwd, '.omx', 'ultragoal', 'goals.json'),
+      `${JSON.stringify({
+        version: 1,
+        codexGoalMode: 'aggregate',
+        goals: [{
+          id: 'G001-completed-story',
+          title: 'Completed story',
+          status: 'complete',
+        }],
+      })}\n`,
+    );
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withPromptModeCodexEnv(binDir, {}, () =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-ultragoal-idle-start',
+            'completed Ultragoal artifacts must not block unrelated team startup',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            cwd,
+          ),
+        ),
+      );
+
+      const teamStateRoot = runtime.config.team_state_root ?? join(cwd, '.omx', 'state');
+      assert.equal(
+        existsSync(join(teamStateRoot, 'team', runtime.teamName, 'ultragoal-context.json')),
+        false,
+      );
+      const inbox = await readFile(
+        join(teamStateRoot, 'team', runtime.teamName, 'workers', 'worker-1', 'inbox.md'),
+        'utf-8',
+      );
+      assert.doesNotMatch(inbox, /Leader-owned Ultragoal context/);
+      assert.doesNotMatch(inbox, /omx ultragoal checkpoint --goal-id G001-completed-story/);
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam injects approved handoff context into ready approved worker inboxes', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-approved-handoff-'));
     const binDir = join(cwd, 'bin');


### PR DESCRIPTION
## Summary
- Follow-up to #2311 after it merged to dev.
- Adds Team startup regression coverage for completed .omx/ultragoal/goals.json without activeGoalId so startup treats it as no active bridge context.
- Adds Team status JSON regression coverage to ensure idle completed Ultragoal plans do not emit checkpoint guidance.

## Verification
- npm run build
- npx biome lint src/team/ultragoal-context.ts src/team/runtime.ts src/team/__tests__/worker-bootstrap.test.ts src/team/__tests__/runtime.test.ts src/cli/__tests__/team.test.ts
- node --test --test-name-pattern='Ultragoal|ultragoal' dist/team/__tests__/worker-bootstrap.test.js dist/team/__tests__/runtime.test.js dist/cli/__tests__/team.test.js

## Notes
- Test-only follow-up; no workflow/docs contract changes. Owner confirmation is not required for this follow-up.
- Full repository npm test was accidentally started before focused verification and interrupted after unrelated pre-existing failures; focused verification above passed cleanly.