### PR TITLE
Deprecate first-party OMX MCP setup by default

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -709,6 +709,101 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("warns and preserves existing first-party MCP registrations in non-interactive default setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-mcp-preserve-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const configPath = join(codexHomeDir, "config.toml");
+				await writeFile(
+					configPath,
+					[
+						"[mcp_servers.omx_state]",
+						'command = "node"',
+						'args = ["/tmp/state-server.js"]',
+						"",
+						"[mcp_servers.user_tool]",
+						'command = "user-tool"',
+						"",
+					].join("\n"),
+				);
+				const output = await runSetupWithCapturedLogs(wd, {
+					scope: "user",
+					installMode: "legacy",
+				});
+				const config = await readFile(configPath, "utf-8");
+				assert.match(output, /deprecated first-party OMX MCP registrations were detected but preserved/);
+				assert.match(config, /^\[mcp_servers\.omx_state\]$/m);
+				assert.match(config, /^\[mcp_servers\.user_tool\]$/m);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("removes existing first-party MCP registrations only when the interactive migration prompt is accepted", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-mcp-remove-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const configPath = join(codexHomeDir, "config.toml");
+				await writeFile(
+					configPath,
+					[
+						"[mcp_servers.omx_state]",
+						'command = "node"',
+						'args = ["/tmp/state-server.js"]',
+						"",
+						"[mcp_servers.omx_team_run]",
+						'command = "node"',
+						"",
+						"[mcp_servers.user_tool]",
+						'command = "user-tool"',
+						"",
+					].join("\n"),
+				);
+				const output = await runSetupWithCapturedLogs(wd, {
+					scope: "user",
+					installMode: "legacy",
+					firstPartyMcpRemovalPrompt: async (_path, kinds) => {
+						assert.deepEqual(kinds, ["config.toml [mcp_servers.omx_*]"]);
+						return true;
+					},
+				});
+				const config = await readFile(configPath, "utf-8");
+				assert.match(output, /Deprecated first-party OMX MCP registrations will be removed/);
+				assert.doesNotMatch(config, /^\[mcp_servers\.omx_state\]$/m);
+				assert.doesNotMatch(config, /^\[mcp_servers\.omx_team_run\]$/m);
+				assert.match(config, /^\[mcp_servers\.user_tool\]$/m);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves existing first-party MCP registrations when the interactive migration prompt is declined", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-mcp-decline-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const configPath = join(codexHomeDir, "config.toml");
+				await writeFile(
+					configPath,
+					"[mcp_servers.omx_memory]\ncommand = \"node\"\n\n[mcp_servers.user_tool]\ncommand = \"user-tool\"\n",
+				);
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						firstPartyMcpRemovalPrompt: async () => false,
+					});
+				});
+				const config = await readFile(configPath, "utf-8");
+				assert.match(config, /^\[mcp_servers\.omx_memory\]$/m);
+				assert.match(config, /^\[mcp_servers\.user_tool\]$/m);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("defaults to plugin mode when an installed oh-my-codex plugin cache is discovered", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
@@ -1066,7 +1161,7 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
-	it("enables plugin MCP subtables only when compat MCP mode is requested", async () => {
+	it("registers plugin MCP subtables only when compat MCP mode is requested", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
@@ -1106,9 +1201,82 @@ describe("omx setup install mode behavior", () => {
 					assert.equal(
 						parsed.plugins?.["oh-my-codex@oh-my-codex-local"]?.mcp_servers
 							?.omx_state?.enabled,
-						false,
+						true,
 					);
 				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("removes plugin MCP registrations only when the migration prompt is accepted", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-plugin-mcp-remove-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const configPath = join(codexHomeDir, "config.toml");
+				await writeFile(
+					configPath,
+					[
+						"[mcp_servers.omx_state]",
+						'command = "node"',
+						"",
+						'[plugins."oh-my-codex@oh-my-codex-local"]',
+						"enabled = true",
+						"",
+						'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_memory]',
+						"enabled = true",
+						"",
+					].join("\n"),
+				);
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						firstPartyMcpRemovalPrompt: async (_path, kinds) => {
+							assert.deepEqual(kinds, [
+								"config.toml [mcp_servers.omx_*]",
+								"plugin mcp_servers overrides",
+							]);
+							return true;
+						},
+					});
+				});
+				const config = await readFile(configPath, "utf-8");
+				assert.doesNotMatch(config, /mcp_servers\.omx_state/);
+				assert.doesNotMatch(config, /mcp_servers\.omx_memory/);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves plugin-mode top-level MCP registrations without duplicating them when removal is declined", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-plugin-mcp-preserve-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const configPath = join(codexHomeDir, "config.toml");
+				await writeFile(
+					configPath,
+					[
+						"[mcp_servers.omx_state]",
+						'command = "node"',
+						"",
+						"[mcp_servers.user_tool]",
+						'command = "user-tool"',
+						"",
+					].join("\n"),
+				);
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						firstPartyMcpRemovalPrompt: async () => false,
+					});
+				});
+				const config = await readFile(configPath, "utf-8");
+				assert.equal(config.match(/^\[mcp_servers\.omx_state\]$/gm)?.length, 1);
+				assert.match(config, /^\[mcp_servers\.user_tool\]$/m);
 			});
 		} finally {
 			await rm(wd, { recursive: true, force: true });
@@ -1255,7 +1423,7 @@ describe("omx setup install mode behavior", () => {
 					assert.match(config, /^hooks = true$/m);
 					assert.doesNotMatch(config, /notify-hook/);
 					assert.doesNotMatch(config, /^\s*\[mcp_servers[.\]]/m);
-					assert.match(config, /mcp_servers\.omx_state]\nenabled = false/);
+					assert.doesNotMatch(config, /mcp_servers\.omx_state/);
 
 					const agentsMd = await readFile(
 						join(codexHomeDir, "AGENTS.md"),

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -648,7 +648,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
-  it("repairs retired omx_team_run config during setup refresh", async () => {
+  it("warns and preserves retired omx_team_run config until interactive removal is confirmed", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       await mkdir(join(wd, ".omx", "state"), { recursive: true });
@@ -668,9 +668,9 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
       assert.match(
         output,
-        /Removed retired \[mcp_servers\.omx_team_run\] config during refresh\./,
+        /deprecated first-party OMX MCP registrations were detected but preserved/,
       );
-      assert.doesNotMatch(config, /^\[mcp_servers\.omx_team_run\]$/m);
+      assert.match(config, /^\[mcp_servers\.omx_team_run\]$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1597,13 +1597,19 @@ function describePluginMcpState(content: string, mcpMode?: SetupMcpMode): Check 
 	const missingCount = states.filter((state) => state === null).length;
 	const expectedEnabled = mcpMode === "compat";
 
-	if (missingCount === 0 && enabledCount === (expectedEnabled ? states.length : 0)) {
+	if (expectedEnabled && missingCount === 0 && enabledCount === states.length) {
 		return {
 			name: "MCP Servers",
 			status: "pass",
-			message: expectedEnabled
-				? `plugin MCP compatibility enabled by setup MCP mode compat (${enabledCount}/${states.length} first-party servers enabled)`
-				: `CLI-first plugin mode: first-party MCP compatibility explicitly disabled (${disabledCount}/${states.length} first-party servers disabled)`,
+			message: `plugin MCP compatibility enabled by setup MCP mode compat (${enabledCount}/${states.length} first-party servers enabled)`,
+		};
+	}
+
+	if (!expectedEnabled && enabledCount === 0) {
+		return {
+			name: "MCP Servers",
+			status: "pass",
+			message: `CLI-first plugin mode: first-party MCP compatibility explicitly disabled (${enabledCount}/${states.length} first-party servers enabled; ${disabledCount} disabled, ${missingCount} omitted)`,
 		};
 	}
 

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -301,6 +301,32 @@ function localPluginMcpServerTableHeaderPattern(serverName: string): RegExp {
 	);
 }
 
+export function hasLocalOmxPluginMcpServerRegistrations(config: string): boolean {
+	const lines = config.split(/\r?\n/);
+	return OMX_FIRST_PARTY_MCP_SERVER_NAMES.some((serverName) =>
+		lines.some((line) => localPluginMcpServerTableHeaderPattern(serverName).test(line)),
+	);
+}
+
+export function stripLocalOmxPluginMcpServerRegistrations(config: string): string {
+	let lines = config.split(/\r?\n/);
+	for (const serverName of OMX_FIRST_PARTY_MCP_SERVER_NAMES) {
+		const headerPattern = localPluginMcpServerTableHeaderPattern(serverName);
+		const start = lines.findIndex((line) => headerPattern.test(line));
+		if (start < 0) continue;
+
+		let end = lines.length;
+		for (let index = start + 1; index < lines.length; index += 1) {
+			if (isTomlTableHeader(lines[index])) {
+				end = index;
+				break;
+			}
+		}
+		lines = [...lines.slice(0, start), ...lines.slice(end)];
+	}
+	return lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+}
+
 function upsertTomlTableBooleanKey(
 	config: string,
 	header: string,
@@ -389,13 +415,21 @@ export function upsertLocalOmxPluginEnablement(config: string): string {
 export function upsertLocalOmxPluginMcpServerEnablement(
 	config: string,
 	enabled: boolean,
+	options: { removeWhenDisabled?: boolean } = {},
 ): string {
+	if (!enabled && options.removeWhenDisabled) {
+		const stripped = stripLocalOmxPluginMcpServerRegistrations(config);
+		return stripped ? `${stripped}\n` : "";
+	}
+	if (!enabled) {
+		return config;
+	}
 	let next = config;
 	for (const serverName of OMX_FIRST_PARTY_MCP_SERVER_NAMES) {
 		const header = `[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}.mcp_servers.${serverName}]`;
 		const headerPattern = localPluginMcpServerTableHeaderPattern(serverName);
 		next = upsertTomlTableBooleanKey(next, header, headerPattern, "enabled", enabled, {
-			create: true,
+			create: enabled,
 		});
 	}
 	return next;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -47,6 +47,9 @@ import {
 	upsertManagedCodexHookTrustState,
 	stripManagedCodexHookTrustState,
 	OMX_PLUGIN_DEVELOPER_INSTRUCTIONS,
+	hasFirstPartyOmxMcpRegistrations,
+	extractFirstPartyOmxMcpSections,
+	stripFirstPartyOmxMcpSections,
 } from "../config/generator.js";
 import type { CodexHookFeatureFlag } from "../config/codex-feature-flags.js";
 import {
@@ -100,6 +103,7 @@ import {
 	upsertLocalOmxMarketplaceRegistration,
 	upsertLocalOmxPluginEnablement,
 	upsertLocalOmxPluginMcpServerEnablement,
+	hasLocalOmxPluginMcpServerRegistrations,
 } from "./plugin-marketplace.js";
 import { resolveCodexHookFeatureFlagForCli } from "./codex-feature-probe.js";
 
@@ -156,6 +160,10 @@ interface SetupOptions {
 	pluginDeveloperInstructionsPrompt?: (configPath: string) => Promise<boolean>;
 	pluginDeveloperInstructionsOverwritePrompt?: (
 		configPath: string,
+	) => Promise<boolean>;
+	firstPartyMcpRemovalPrompt?: (
+		configPath: string,
+		registrationKinds: string[],
 	) => Promise<boolean>;
 	mcpRegistryCandidates?: string[];
 }
@@ -631,6 +639,35 @@ async function promptForSetupInstallMode(
 		if (answer === "2" || answer === "plugin") return "plugin";
 		if (answer === "1" || answer === "legacy") return "legacy";
 		return defaultMode;
+	} finally {
+		rl.close();
+	}
+}
+
+async function promptForFirstPartyMcpRemoval(
+	configPath: string,
+	registrationKinds: string[],
+): Promise<boolean> {
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return false;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		console.log("Deprecated first-party OMX MCP registration detected:");
+		console.log(`  ${configPath}`);
+		console.log(`  ${registrationKinds.join(", ")}`);
+		console.log(
+			"  OMX is CLI-first by default now; first-party MCP compatibility is legacy/explicit.",
+		);
+		const answer = (
+			await rl.question("Remove first-party OMX MCP registrations now? [y/N]: ")
+		)
+			.trim()
+			.toLowerCase();
+		return answer === "y" || answer === "yes";
 	} finally {
 		rl.close();
 	}
@@ -1404,6 +1441,7 @@ async function ensurePluginMarketplaceRegistration(
 	configPath: string,
 	pkgRoot: string,
 	mcpMode: SetupMcpMode,
+	removeFirstPartyMcp: boolean,
 	backupContext: SetupBackupContext,
 	summary: SetupCategorySummary,
 	options: Pick<SetupOptions, "dryRun" | "verbose">,
@@ -1421,6 +1459,7 @@ async function ensurePluginMarketplaceRegistration(
 		upsertLocalOmxPluginMcpServerEnablement(
 			upsertLocalOmxPluginEnablement(existingConfig),
 			mcpMode === "compat",
+			{ removeWhenDisabled: removeFirstPartyMcp },
 		),
 		pkgRoot,
 	);
@@ -1581,12 +1620,18 @@ async function applyPluginDeveloperInstructionsDefault(
 async function cleanupPluginModeLegacyConfig(
 	configPath: string,
 	backupContext: SetupBackupContext,
-	options: Pick<SetupOptions, "dryRun" | "verbose">,
+	options: Pick<SetupOptions, "dryRun" | "verbose"> & {
+		preserveFirstPartyMcp?: boolean;
+	},
 ): Promise<boolean> {
 	if (!existsSync(configPath)) return false;
 
 	const original = await readFile(configPath, "utf-8");
+	const preservedFirstPartyMcp = options.preserveFirstPartyMcp
+		? extractFirstPartyOmxMcpSections(original)
+		: "";
 	let config = original;
+	config = stripFirstPartyOmxMcpSections(config);
 	config = stripExistingOmxBlocks(config).cleaned;
 	config = stripExistingSharedMcpRegistryBlock(config).cleaned;
 	config = stripPluginModeLegacyRootDefaults(config);
@@ -1594,6 +1639,9 @@ async function cleanupPluginModeLegacyConfig(
 	config = stripOmxFeatureFlags(config);
 	config = stripManagedCodexHookTrustState(config);
 	config = stripOmxEnvSettings(config);
+	if (preservedFirstPartyMcp) {
+		config = `${config.trimEnd()}\n\n${preservedFirstPartyMcp}\n`;
+	}
 	config = config.trim();
 	const nextConfig = config.length > 0 ? `${config}\n` : "";
 
@@ -1656,6 +1704,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		pluginAgentsMdPrompt,
 		pluginDeveloperInstructionsPrompt,
 		pluginDeveloperInstructionsOverwritePrompt,
+		firstPartyMcpRemovalPrompt,
 	} = options;
 	const pkgRoot = getPackageRoot();
 	const projectRoot = process.cwd();
@@ -1713,6 +1762,37 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		persistedPreferences,
 	);
 	const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
+	const existingConfigForMcpMigration = existsSync(scopeDirs.codexConfigFile)
+		? await readFile(scopeDirs.codexConfigFile, "utf-8")
+		: "";
+	const firstPartyMcpRegistrationKinds = [
+		hasFirstPartyOmxMcpRegistrations(existingConfigForMcpMigration)
+			? "config.toml [mcp_servers.omx_*]"
+			: null,
+		hasLocalOmxPluginMcpServerRegistrations(existingConfigForMcpMigration)
+			? "plugin mcp_servers overrides"
+			: null,
+	].filter((kind): kind is string => typeof kind === "string");
+	let removeFirstPartyMcpRegistrations = false;
+	const shouldOfferFirstPartyMcpRemoval =
+		resolvedMcpMode.mcpMode !== "compat" &&
+		firstPartyMcpRegistrationKinds.length > 0;
+	if (shouldOfferFirstPartyMcpRemoval) {
+		const canPrompt =
+			typeof firstPartyMcpRemovalPrompt === "function" ||
+			(process.stdin.isTTY && process.stdout.isTTY);
+		if (canPrompt) {
+			removeFirstPartyMcpRegistrations = firstPartyMcpRemovalPrompt
+				? await firstPartyMcpRemovalPrompt(
+						scopeDirs.codexConfigFile,
+						firstPartyMcpRegistrationKinds,
+					)
+				: await promptForFirstPartyMcpRemoval(
+						scopeDirs.codexConfigFile,
+						firstPartyMcpRegistrationKinds,
+					);
+		}
+	}
 	const scopeSourceMessage =
 		resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
 	const backupContext = getBackupContext(resolvedScope.scope, projectRoot);
@@ -1755,6 +1835,17 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	console.log(
 		`Using setup MCP mode: ${resolvedMcpMode.mcpMode}${mcpModeSourceMessage}\n`,
 	);
+	if (shouldOfferFirstPartyMcpRemoval) {
+		if (removeFirstPartyMcpRegistrations) {
+			console.log(
+				"Deprecated first-party OMX MCP registrations will be removed from config.toml during this setup run.\n",
+			);
+		} else {
+			console.log(
+				"warning: deprecated first-party OMX MCP registrations were detected but preserved. OMX supports CLI-first setup by default; rerun interactively and answer yes to remove them, or use --mcp compat only when explicit MCP compatibility is required.\n",
+			);
+		}
+	}
 
 	// Step 1: Ensure directories exist
 	console.log("[1/8] Creating directories...");
@@ -1993,7 +2084,13 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		const configCleaned = await cleanupPluginModeLegacyConfig(
 			scopeDirs.codexConfigFile,
 			backupContext,
-			{ dryRun, verbose },
+			{
+				dryRun,
+				verbose,
+				preserveFirstPartyMcp:
+					shouldOfferFirstPartyMcpRemoval &&
+					!removeFirstPartyMcpRegistrations,
+			},
 		);
 		if (configCleaned) summary.config.removed += 1;
 		console.log(
@@ -2015,6 +2112,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			scopeDirs.codexConfigFile,
 			pkgRoot,
 			resolvedMcpMode.mcpMode,
+			removeFirstPartyMcpRegistrations,
 			backupContext,
 			summary.config,
 			{ dryRun, verbose },
@@ -2124,6 +2222,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			pkgRoot,
 			sharedMcpRegistry,
 			resolvedMcpMode.mcpMode,
+			shouldOfferFirstPartyMcpRemoval && !removeFirstPartyMcpRegistrations,
 			resolvedScope.scope,
 			scopeDirs.codexHomeDir,
 			summary.config,
@@ -3321,6 +3420,7 @@ async function updateManagedConfig(
 	pkgRoot: string,
 	sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
 	mcpMode: SetupMcpMode,
+	preserveExistingFirstPartyMcp: boolean,
 	scope: SetupScope,
 	codexHomeDir: string,
 	summary: SetupCategorySummary,
@@ -3373,6 +3473,7 @@ async function updateManagedConfig(
 		forceStatusLinePreset: options.forceStatusLinePreset,
 		notifyCommand: notifyPlan.notifyCommand,
 		includeFirstPartyMcp: mcpMode === "compat",
+		preserveExistingFirstPartyMcp,
 	});
 	const changed = existing !== finalConfig;
 

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -48,6 +48,7 @@ interface MergeOptions {
   forceStatusLinePreset?: boolean;
   notifyCommand?: string[] | false;
   includeFirstPartyMcp?: boolean;
+  preserveExistingFirstPartyMcp?: boolean;
 }
 
 function escapeTomlString(value: string): string {
@@ -1244,6 +1245,65 @@ function stripOrphanedOmxSections(config: string): string {
   return result.join("\n");
 }
 
+export function hasFirstPartyOmxMcpRegistrations(config: string): boolean {
+  const firstPartyNames = new Set<string>([
+    ...OMX_FIRST_PARTY_MCP_SERVER_NAMES,
+    "omx_team_run",
+  ]);
+  for (const line of config.split(/\r?\n/)) {
+    const match = line.match(/^\s*\[mcp_servers\.(?:"([^"]+)"|([A-Za-z0-9_-]+))\]\s*$/);
+    const name = match?.[1] ?? match?.[2];
+    if (name && firstPartyNames.has(name)) return true;
+  }
+  return false;
+}
+
+export function extractFirstPartyOmxMcpSections(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const sections: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const tableMatch = lines[i].match(/^\s*\[([^\]]+)\]\s*$/);
+    if (!tableMatch || !isOmxFirstPartyMcpSection(tableMatch[1])) {
+      i += 1;
+      continue;
+    }
+
+    const sectionLines: string[] = [];
+    sectionLines.push(lines[i]);
+    i += 1;
+    while (i < lines.length && !/^\s*\[/.test(lines[i])) {
+      sectionLines.push(lines[i]);
+      i += 1;
+    }
+    sections.push(sectionLines.join("\n").trimEnd());
+  }
+
+  return sections.filter(Boolean).join("\n\n");
+}
+
+export function stripFirstPartyOmxMcpSections(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const result: string[] = [];
+
+  for (let index = 0; index < lines.length; ) {
+    const tableMatch = lines[index].match(/^\s*\[([^\]]+)\]\s*$/);
+    if (tableMatch && isOmxFirstPartyMcpSection(tableMatch[1])) {
+      index += 1;
+      while (index < lines.length && !/^\s*\[/.test(lines[index])) {
+        index += 1;
+      }
+      continue;
+    }
+
+    result.push(lines[index]);
+    index += 1;
+  }
+
+  return result.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+}
+
 function extractCustomizedTuiSectionsFromOmxBlocks(config: string): string[] {
   const sections: string[] = [];
   let searchStart = 0;
@@ -1885,6 +1945,11 @@ export function buildMergedConfig(
   options: MergeOptions = {},
 ): string {
   let existing = existingConfig;
+  const preservedFirstPartyMcpSections =
+    options.preserveExistingFirstPartyMcp === true &&
+    options.includeFirstPartyMcp !== true
+      ? extractFirstPartyOmxMcpSections(existing)
+      : "";
   const includeTui = options.includeTui !== false;
   const statusLinePreset =
     options.statusLinePreset ?? DEFAULT_STATUS_LINE_PRESET;
@@ -1925,6 +1990,9 @@ export function buildMergedConfig(
     existing = stripRootLevelKeys(existing, ["model"]);
   }
   existing = stripOrphanedOmxSections(existing);
+  if (preservedFirstPartyMcpSections) {
+    existing = `${existing.trimEnd()}\n\n${preservedFirstPartyMcpSections}\n`;
+  }
   existing = upsertFeatureFlags(existing, options.codexHookFeatureFlag);
   existing = upsertEnvSettings(existing);
   existing = upsertAgentsSettings(existing);


### PR DESCRIPTION
## Summary
- stop default setup/plugin registration from writing first-party OMX MCP registrations unless compat mode is active
- detect existing first-party OMX MCP registrations and recommend removal during setup
- remove classic/plugin first-party MCP registrations only after confirmation, while preserving user MCP servers when declined/non-interactive

## Validation
- npm run build
- node --test dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/setup-refresh.test.js dist/config/__tests__/generator-idempotent.test.js
- git diff --check
- npm run check:no-unused

## Notes
Full npm test was attempted locally but the active OMX/tmux environment hit pre-existing environment-sensitive failures in adapt/autoresearch/tmux/MCP parity suites unrelated to this diff; targeted setup/config coverage passes.