### PR TITLE
Retain OMX owner across native session replacement

### DIFF
--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -239,7 +239,7 @@ describe('session lifecycle manager', () => {
     }
   });
 
-  it('starts a fresh canonical session when a new native SessionStart arrives after an earlier native session', async () => {
+  it('starts a fresh native session while retaining the owner OMX launch session when native SessionStart changes', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-fresh-'));
     try {
       await writeSessionStart(cwd, 'omx-old-session', {
@@ -253,11 +253,153 @@ describe('session lifecycle manager', () => {
 
       assert.equal(reconciled.session_id, 'codex-native-new');
       assert.equal(reconciled.native_session_id, 'codex-native-new');
+      assert.equal(reconciled.previous_native_session_id, 'codex-native-old');
+      assert.equal(reconciled.owner_omx_session_id, 'omx-old-session');
+      assert.match(reconciled.native_session_switched_at ?? '', /^\d{4}-\d{2}-\d{2}T/);
       assert.equal(reconciled.pid, 54321);
 
       const persisted = await readSessionState(cwd);
       assert.equal(persisted?.session_id, 'codex-native-new');
       assert.equal(persisted?.native_session_id, 'codex-native-new');
+      assert.equal(persisted?.previous_native_session_id, 'codex-native-old');
+      assert.equal(persisted?.owner_omx_session_id, 'omx-old-session');
+
+      const dailyLogPath = join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`);
+      const dailyLog = await readFile(dailyLogPath, 'utf-8');
+      assert.match(dailyLog, /"event":"native_session_replaced"/);
+      assert.match(dailyLog, /"event":"session_start"/);
+      assert.match(dailyLog, /"previous_native_session_id":"codex-native-old"/);
+      assert.match(dailyLog, /"native_session_id":"codex-native-new"/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('lets an owner OMX launch session end the fresh native session it spawned', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-end-'));
+    try {
+      await writeSessionStart(cwd, 'omx-owner-session', {
+        nativeSessionId: 'codex-native-old',
+      });
+      await reconcileNativeSessionStart(cwd, 'codex-native-new', {
+        pid: 54321,
+        platform: 'win32',
+      });
+
+      await writeSessionEnd(cwd, 'omx-owner-session');
+
+      assert.equal(await readSessionState(cwd), null);
+      const historyLines = (await readFile(join(cwd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+      assert.equal(historyLines.length, 1);
+      const historyEntry = JSON.parse(historyLines[0]) as SessionHistoryEntry & {
+        active_session_id?: string;
+      };
+      assert.equal(historyEntry.session_id, 'omx-owner-session');
+      assert.equal(historyEntry.native_session_id, 'codex-native-new');
+      assert.equal(historyEntry.active_session_id, 'codex-native-new');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves owner OMX metadata when reconciling the same fresh native session', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-reconcile-'));
+    try {
+      await writeSessionStart(cwd, 'omx-owner-session', {
+        nativeSessionId: 'codex-native-old',
+      });
+      await reconcileNativeSessionStart(cwd, 'codex-native-new', {
+        pid: process.pid,
+        platform: 'win32',
+      });
+
+      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-new', {
+        pid: process.pid,
+        platform: 'win32',
+      });
+
+      assert.equal(reconciled.session_id, 'codex-native-new');
+      assert.equal(reconciled.native_session_id, 'codex-native-new');
+      assert.equal(reconciled.previous_native_session_id, 'codex-native-old');
+      assert.equal(reconciled.owner_omx_session_id, 'omx-owner-session');
+      assert.equal(reconciled.pid, process.pid);
+
+      await writeSessionEnd(cwd, 'omx-owner-session');
+      assert.equal(await readSessionState(cwd), null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('carries the owner OMX launch session across chained native SessionStart replacements', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-chain-'));
+    try {
+      await writeSessionStart(cwd, 'omx-owner-session', {
+        nativeSessionId: 'codex-native-a',
+      });
+      await reconcileNativeSessionStart(cwd, 'codex-native-b', {
+        pid: process.pid,
+        platform: 'win32',
+      });
+
+      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-c', {
+        pid: process.pid,
+        platform: 'win32',
+      });
+
+      assert.equal(reconciled.session_id, 'codex-native-c');
+      assert.equal(reconciled.native_session_id, 'codex-native-c');
+      assert.equal(reconciled.previous_native_session_id, 'codex-native-b');
+      assert.equal(reconciled.owner_omx_session_id, 'omx-owner-session');
+
+      const dailyLogPath = join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`);
+      const dailyLog = await readFile(dailyLogPath, 'utf-8');
+      assert.match(dailyLog, /"session_id":"omx-owner-session"/);
+      assert.match(dailyLog, /"active_session_id":"codex-native-b"/);
+      assert.match(dailyLog, /"previous_native_session_id":"codex-native-b"/);
+      assert.match(dailyLog, /"replaced_by_native_session_id":"codex-native-c"/);
+
+      await writeSessionEnd(cwd, 'omx-owner-session');
+      assert.equal(await readSessionState(cwd), null);
+      const historyLines = (await readFile(join(cwd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+      const historyEntry = JSON.parse(historyLines.at(-1) ?? '{}') as SessionHistoryEntry & {
+        active_session_id?: string;
+      };
+      assert.equal(historyEntry.session_id, 'omx-owner-session');
+      assert.equal(historyEntry.native_session_id, 'codex-native-c');
+      assert.equal(historyEntry.active_session_id, 'codex-native-c');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('starts a fresh canonical session when a non-OMX native session is replaced', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-non-omx-fresh-'));
+    try {
+      await writeSessionStart(cwd, 'codex-native-old', {
+        nativeSessionId: 'codex-native-old',
+      });
+
+      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-new', {
+        pid: 54321,
+        platform: 'win32',
+      });
+
+      assert.equal(reconciled.session_id, 'codex-native-new');
+      assert.equal(reconciled.native_session_id, 'codex-native-new');
+      assert.equal(reconciled.previous_native_session_id, undefined);
+      assert.equal(reconciled.pid, 54321);
+
+      const persisted = await readSessionState(cwd);
+      assert.equal(persisted?.session_id, 'codex-native-new');
+      assert.equal(persisted?.native_session_id, 'codex-native-new');
+      assert.equal(persisted?.previous_native_session_id, undefined);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -14,6 +14,12 @@ import { getStateFilePath } from '../mcp/state-paths.js';
 export interface SessionState {
   session_id: string;
   native_session_id?: string;
+  // Native session replacement metadata used when Codex /new swaps the native
+  // session while the original OMX launch wrapper is still responsible for
+  // archiving/cleanup.
+  previous_native_session_id?: string;
+  native_session_switched_at?: string;
+  owner_omx_session_id?: string;
   started_at: string;
   cwd: string;
   pid: number;
@@ -159,6 +165,9 @@ interface SessionStartOptions {
   pid?: number;
   platform?: NodeJS.Platform;
   nativeSessionId?: string;
+  previousNativeSessionId?: string;
+  nativeSessionSwitchedAt?: string;
+  ownerOmxSessionId?: string;
   tmuxSessionName?: string;
 }
 
@@ -222,6 +231,9 @@ function createSessionState(
   options: {
     nowIso?: string;
     nativeSessionId?: string;
+    previousNativeSessionId?: string;
+    nativeSessionSwitchedAt?: string;
+    ownerOmxSessionId?: string;
     startedAt?: string;
     tmuxSessionName?: string;
   } = {},
@@ -233,10 +245,25 @@ function createSessionState(
   const tmuxSessionName = typeof options.tmuxSessionName === 'string' && options.tmuxSessionName.trim()
     ? options.tmuxSessionName.trim()
     : undefined;
+  const previousNativeSessionId =
+    typeof options.previousNativeSessionId === 'string' && options.previousNativeSessionId.trim()
+      ? options.previousNativeSessionId.trim()
+      : undefined;
+  const nativeSessionSwitchedAt =
+    typeof options.nativeSessionSwitchedAt === 'string' && options.nativeSessionSwitchedAt.trim()
+      ? options.nativeSessionSwitchedAt.trim()
+      : undefined;
+  const ownerOmxSessionId =
+    typeof options.ownerOmxSessionId === 'string' && options.ownerOmxSessionId.trim()
+      ? options.ownerOmxSessionId.trim()
+      : undefined;
 
   return {
     session_id: sessionId,
     ...(nativeSessionId ? { native_session_id: nativeSessionId } : {}),
+    ...(previousNativeSessionId ? { previous_native_session_id: previousNativeSessionId } : {}),
+    ...(nativeSessionSwitchedAt ? { native_session_switched_at: nativeSessionSwitchedAt } : {}),
+    ...(ownerOmxSessionId ? { owner_omx_session_id: ownerOmxSessionId } : {}),
     started_at: options.startedAt ?? nowIso,
     cwd,
     pid,
@@ -300,6 +327,9 @@ export async function writeSessionStart(
     : null;
   const state = createSessionState(cwd, sessionId, pid, platform, linuxIdentity, {
     nativeSessionId: options.nativeSessionId,
+    previousNativeSessionId: options.previousNativeSessionId,
+    nativeSessionSwitchedAt: options.nativeSessionSwitchedAt,
+    ownerOmxSessionId: options.ownerOmxSessionId,
     tmuxSessionName: options.tmuxSessionName,
   });
 
@@ -314,11 +344,21 @@ export async function writeSessionStart(
   return state;
 }
 
+function getOmxLaunchSessionId(state: SessionState): string | undefined {
+  if (state.session_id.startsWith('omx-')) return state.session_id;
+  if (typeof state.owner_omx_session_id === 'string' && state.owner_omx_session_id.startsWith('omx-')) {
+    return state.owner_omx_session_id;
+  }
+  return undefined;
+}
+
 /**
  * Reconcile a native/Codex SessionStart with the canonical OMX launch session.
- * If an authoritative current session already exists for this cwd/run, preserve
- * its OMX scope id and refresh PID/native metadata. Otherwise establish a fresh
- * canonical session using the native session id.
+ * Same-native restarts preserve the current logical session and refresh
+ * PID/native metadata. Native-session replacements start a fresh native-scoped
+ * session to avoid inheriting stale task-scoped state; when the replaced session
+ * belongs to an OMX launch wrapper, retain that wrapper as owner for later
+ * archive/cleanup and log the replacement chain.
  */
 export async function reconcileNativeSessionStart(
   cwd: string,
@@ -339,6 +379,31 @@ export async function reconcileNativeSessionStart(
     ? existing.native_session_id.trim()
     : '';
   if (existingNativeSessionId && existingNativeSessionId !== nativeSessionId) {
+    const ownerOmxSessionId = getOmxLaunchSessionId(existing);
+    if (ownerOmxSessionId) {
+      const pid = Number.isInteger(options.pid) && options.pid && options.pid > 0
+        ? options.pid
+        : process.pid;
+      const nowIso = new Date().toISOString();
+      await appendToLog(cwd, {
+        event: 'native_session_replaced',
+        session_id: ownerOmxSessionId,
+        ...(existing.session_id !== ownerOmxSessionId ? { active_session_id: existing.session_id } : {}),
+        previous_native_session_id: existingNativeSessionId,
+        replaced_by_native_session_id: nativeSessionId,
+        pid,
+        timestamp: nowIso,
+      });
+
+      return await writeSessionStart(cwd, nativeSessionId, {
+        ...options,
+        nativeSessionId,
+        previousNativeSessionId: existingNativeSessionId,
+        nativeSessionSwitchedAt: nowIso,
+        ownerOmxSessionId,
+      });
+    }
+
     return await writeSessionStart(cwd, nativeSessionId, {
       ...options,
       nativeSessionId,
@@ -356,6 +421,9 @@ export async function reconcileNativeSessionStart(
   const state = createSessionState(cwd, existing.session_id, pid, platform, linuxIdentity, {
     nowIso,
     nativeSessionId,
+    previousNativeSessionId: existing.previous_native_session_id,
+    nativeSessionSwitchedAt: existing.native_session_switched_at,
+    ownerOmxSessionId: existing.owner_omx_session_id,
     startedAt: existing.started_at,
     tmuxSessionName: existing.tmux_session_name,
   });
@@ -379,19 +447,25 @@ export async function writeSessionEnd(cwd: string, sessionId: string): Promise<v
   const endTime = new Date().toISOString();
   const ownsCurrentSessionFile = state == null
     || state.session_id === sessionId
-    || state.native_session_id === sessionId;
+    || state.native_session_id === sessionId
+    || state.owner_omx_session_id === sessionId;
 
   // Archive to session history
   const logsDir = omxLogsDir(cwd);
   await mkdir(logsDir, { recursive: true });
 
   const historyEntry = {
-    session_id: ownsCurrentSessionFile ? state?.session_id || sessionId : sessionId,
+    session_id: ownsCurrentSessionFile
+      ? (state?.owner_omx_session_id === sessionId ? sessionId : state?.session_id || sessionId)
+      : sessionId,
     ...(ownsCurrentSessionFile && state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
     started_at: ownsCurrentSessionFile ? state?.started_at || 'unknown' : 'unknown',
     ended_at: endTime,
     cwd,
     pid: ownsCurrentSessionFile ? state?.pid || process.pid : process.pid,
+    ...(ownsCurrentSessionFile && state?.owner_omx_session_id === sessionId && state?.session_id
+      ? { active_session_id: state.session_id }
+      : {}),
     ...(!ownsCurrentSessionFile && state?.session_id
       ? { preserved_active_session_id: state.session_id }
       : {}),
@@ -413,8 +487,13 @@ export async function writeSessionEnd(cwd: string, sessionId: string): Promise<v
 
   await appendToLog(cwd, {
     event: 'session_end',
-    session_id: ownsCurrentSessionFile ? state?.session_id || sessionId : sessionId,
+    session_id: ownsCurrentSessionFile
+      ? (state?.owner_omx_session_id === sessionId ? sessionId : state?.session_id || sessionId)
+      : sessionId,
     ...(ownsCurrentSessionFile && state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
+    ...(ownsCurrentSessionFile && state?.owner_omx_session_id === sessionId && state?.session_id
+      ? { active_session_id: state.session_id }
+      : {}),
     ...(!ownsCurrentSessionFile && state?.session_id
       ? { preserved_active_session_id: state.session_id }
       : {}),


### PR DESCRIPTION
## Summary

- track native session replacement metadata in OMX session state
- keep fresh native session boundaries on replacement so task-scoped state is not inherited
- retain the original OMX launch owner so wrapper-driven session end archives and cleans up the active native session
- add regression coverage for owner cleanup, same-native reconciliation, chained native replacements, and non-OMX fallback behavior

## Tests

- npm run build
- env -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/hooks/__tests__/session.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npm run check:no-unused