### PR TITLE
Accept compact Lore commits with OmX provenance

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -85,6 +85,13 @@ native `PreToolUse` checks, including document-refresh warnings and command
 safety checks, still run. `omx doctor` reports when the guard is explicitly
 disabled by environment or config.
 
+When the guard is enabled, the required inline shape is intentionally small:
+an intent-first subject, the normal blank separator, and the exact
+`Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer. A narrative body and
+decision trailers such as `Constraint:` or `Tested:` remain supported for
+changes that need decision context, but the guard should not require them when
+the commit message already carries the OmX co-author trailer.
+
 Warning scope is intentionally narrow and rule-scoped:
 
 - **Commit path:** `PreToolUse` is Bash-only in this MVP and evaluates only

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4403,6 +4403,60 @@ exit 0
     }
   });
 
+  it("stays silent on PreToolUse for compact git commit with only the OmX co-author trailer", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-compact-coauthor-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-compact-coauthor",
+          tool_input: {
+            command: [
+              'git commit',
+              '-m "Record lvisai onboarding launch"',
+              '-m "Co-authored-by: OmX <omx@oh-my-codex.dev>"',
+            ].join(" "),
+          },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("stays silent on PreToolUse when optional Lore body is omitted but OmX co-author is present", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-body-optional-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-body-optional",
+          tool_input: {
+            command: [
+              'git commit',
+              '-m "Launch lvisai.xyz intro site"',
+              '-m "Constraint: lvisai.xyz needs a no-build static intro site that can deploy from GitHub Pages.\nTested: python3 -m http.server 4173 and curl checks\n\nCo-authored-by: OmX <omx@oh-my-codex.dev>"',
+            ].join(" "),
+          },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("warns on PreToolUse git commit when mapped source changes lack staged docs refresh", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-document-refresh-warn-"));
     try {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -794,13 +794,20 @@ function buildGitCommitComplianceErrors(message: string | null): string[] {
   }
 
   const { bodyText, trailerLines } = splitBodyAndTrailerLines(lines.slice(2).join("\n"));
+  const hasOmxCoauthorTrailer = trailerLines.includes(OMX_COAUTHOR_TRAILER);
+  // The Lore template treats the body and decision trailers as optional context;
+  // the OmX co-author trailer is the required provenance anchor.
+  if (errors.length === 0 && hasOmxCoauthorTrailer) {
+    return [];
+  }
+
   if (!bodyText) {
     errors.push("Add a narrative body paragraph explaining the decision context.");
   }
   if (!trailerLines.some((line) => LORE_TRAILER_PREFIXES.some((prefix) => line.startsWith(prefix)))) {
     errors.push("Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.");
   }
-  if (!trailerLines.includes(OMX_COAUTHOR_TRAILER)) {
+  if (!hasOmxCoauthorTrailer) {
     errors.push(`Add the required co-author trailer: \`${OMX_COAUTHOR_TRAILER}\`.`);
   }
 


### PR DESCRIPTION
## Summary

- allow compact inline Lore commits when the subject/separator are valid and the exact OmX co-author trailer is present
- keep the existing full Lore commit format working as-is
- document the compact accepted shape and add regression coverage for body-optional commit messages

## Context

This addresses #2321. The current guard requires a narrative body paragraph even though the Lore template describes the body as optional and says decision trailers should be used only when they add context. That mismatch can make Codex repeatedly retry longer messages or attempt the explicit opt-out path even when the commit already includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.

The change keeps the default Lore guard enabled and does not alter external file/editor/reuse/fixup message blocking. It only makes the enabled inline guard accept the compact OmX-provenance path.

## Tests

- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint -- src/scripts/codex-native-pre-post.ts src/scripts/__tests__/codex-native-hook.test.ts`

Closes #2321
