### PR TITLE
docs: clarify Homebrew Codex install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,18 @@ It keeps Codex as the execution engine and makes it easier to:
 
 If you want the default OMX experience, start here:
 
+Choose one install path. If Codex CLI is already installed (Homebrew, npm, or another supported method):
+
 ```bash
-# If Codex CLI is already installed (Homebrew, npm, or another supported method):
 codex --version
 npm install -g oh-my-codex
 omx setup
 omx --madmax --high
+```
 
-# If you do not have Codex CLI yet and want npm to manage it:
+If you do not have Codex CLI yet and want npm to manage it:
+
+```bash
 npm install -g @openai/codex
 npm install -g oh-my-codex
 omx setup

--- a/README.md
+++ b/README.md
@@ -59,9 +59,19 @@ It keeps Codex as the execution engine and makes it easier to:
 If you want the default OMX experience, start here:
 
 ```bash
-npm install -g @openai/codex oh-my-codex
+# If Codex CLI is already installed (Homebrew, npm, or another supported method):
+codex --version
+npm install -g oh-my-codex
+omx setup
 omx --madmax --high
+
+# If you do not have Codex CLI yet and want npm to manage it:
+npm install -g @openai/codex
+npm install -g oh-my-codex
+omx setup
 ```
+
+Do not run a combined `npm install -g @openai/codex oh-my-codex` over an existing Homebrew-owned `codex` binary such as `/opt/homebrew/bin/codex`; npm may fail with `EEXIST` when `@openai/codex` tries to create the same binary. OMX only needs a working, authenticated `codex` command on `PATH`; it does not require Codex to be installed through npm.
 
 On a real `oh-my-codex` version bump, the global npm install now prints an explicit reminder instead of launching `omx setup` automatically. When you're ready, run `omx setup` manually or use `omx update` to check npm and then run the same setup refresh path.
 
@@ -97,7 +107,7 @@ If you want plain Codex with no extra workflow layer, you probably do not need O
 ### Requirements
 
 - Node.js 20+
-- Codex CLI installed: `npm install -g @openai/codex`
+- Codex CLI installed, verified with `codex --version`, and authenticated (Homebrew or npm are both fine; do not reinstall `@openai/codex` with npm if Homebrew already owns `codex`)
 - Codex auth configured and visible in the same shell/profile that will run OMX
 - `tmux` on macOS/Linux if you want the recommended durable team runtime
 - `psmux` on native Windows only if you intentionally want the less-supported Windows team path
@@ -180,7 +190,7 @@ Most users should think of OMX as **better task routing + better workflow + bett
 
 ## Start here if you are new
 
-1. Install or update OMX with `npm install -g @openai/codex oh-my-codex`
+1. If Codex CLI already exists, verify it with `codex --version` and install or update OMX with `npm install -g oh-my-codex`; otherwise install `@openai/codex` separately first if you want npm to manage Codex
 2. After install or real OMX version bumps, run `omx setup` yourself when you're ready, or use `omx update` when you also want npm to check for and install the latest build before refreshing setup
 3. Run `omx doctor`
 4. Run a real execution smoke test: `codex login status` and `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"`

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -25,13 +25,23 @@
       <h2>Prerequisites</h2>
       <ul>
         <li>Node.js 20+ and npm.</li>
-        <li>OpenAI Codex CLI installed and authenticated.</li>
+        <li>OpenAI Codex CLI installed, verified with <code>codex --version</code>, and authenticated (Homebrew or npm are both supported).</li>
         <li>Git (recommended) for project workflows.</li>
       </ul>
 
       <h2>Installation</h2>
-      <pre><code>npm install -g @openai/codex oh-my-codex
+      <pre><code># If Codex CLI is already installed (Homebrew, npm, or another supported method):
+codex --version
+npm install -g oh-my-codex
+omx setup
+omx doctor
+
+# If you do not have Codex CLI yet and want npm to manage it:
+npm install -g @openai/codex
+npm install -g oh-my-codex
+omx setup
 omx doctor</code></pre>
+      <p>Do not run a combined <code>npm install -g @openai/codex oh-my-codex</code> over an existing Homebrew-owned <code>codex</code> binary such as <code>/opt/homebrew/bin/codex</code>; npm may fail with <code>EEXIST</code> when <code>@openai/codex</code> tries to create the same binary. OMX only needs a working, authenticated <code>codex</code> command on <code>PATH</code>; it does not require Codex to be installed through npm.</p>
       <p>When <code>oh-my-codex</code> actually bumps to a newer version, the global npm install now prints an explicit reminder instead of launching <code>omx setup</code> automatically. When you're ready, rerun <code>omx setup</code> manually or use <code>omx update</code> to check npm and then run the same setup refresh path. Fresh OMX-managed <code>gpt-5.5</code> configs now recommend <code>model_context_window = 250000</code> and <code>model_auto_compact_token_limit = 200000</code> only when those keys are missing.</p>
       <p><code>omx doctor</code> verifies the install shape. Before treating the runtime as ready, also prove that the active Codex profile can perform a real request:</p>
       <pre><code>codex login status

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -30,14 +30,13 @@
       </ul>
 
       <h2>Installation</h2>
-      <pre><code># If Codex CLI is already installed (Homebrew, npm, or another supported method):
-codex --version
+      <p>Choose one install path. If Codex CLI is already installed (Homebrew, npm, or another supported method):</p>
+      <pre><code>codex --version
 npm install -g oh-my-codex
 omx setup
-omx doctor
-
-# If you do not have Codex CLI yet and want npm to manage it:
-npm install -g @openai/codex
+omx doctor</code></pre>
+      <p>If you do not have Codex CLI yet and want npm to manage it:</p>
+      <pre><code>npm install -g @openai/codex
 npm install -g oh-my-codex
 omx setup
 omx doctor</code></pre>

--- a/docs/readme/README.el.md
+++ b/docs/readme/README.el.md
@@ -27,9 +27,16 @@
 Αν θέλετε την προεπιλεγμένη εμπειρία OMX, ξεκινήστε εδώ:
 
 ```bash
-npm install -g @openai/codex oh-my-codex
+# If Codex CLI is already installed (for example with Homebrew):
+codex --version
+npm install -g oh-my-codex
 omx setup
 omx --madmax --high
+
+# If Codex CLI is not installed and you want npm to manage it:
+npm install -g @openai/codex
+npm install -g oh-my-codex
+omx setup
 ```
 
 Στη συνέχεια εργαστείτε κανονικά μέσα στο Codex:
@@ -59,7 +66,7 @@ $team 3:executor "execute the approved plan in parallel"
 ### Απαιτήσεις
 
 - Node.js 20+
-- Εγκατεστημένο Codex CLI: `npm install -g @openai/codex`
+- Εγκατεστημένο Codex CLI, ελεγμένο με `codex --version` (Homebrew ή npm)
 - Ρυθμισμένη αυθεντικοποίηση Codex
 - `tmux` σε macOS/Linux αν θέλετε αργότερα τον ανθεκτικό team runtime
 - `psmux` σε native Windows αν θέλετε αργότερα τη λειτουργία team για Windows

--- a/docs/readme/README.el.md
+++ b/docs/readme/README.el.md
@@ -26,14 +26,18 @@
 
 Αν θέλετε την προεπιλεγμένη εμπειρία OMX, ξεκινήστε εδώ:
 
+Choose one install path. If Codex CLI is already installed (for example with Homebrew):
+
 ```bash
-# If Codex CLI is already installed (for example with Homebrew):
 codex --version
 npm install -g oh-my-codex
 omx setup
 omx --madmax --high
+```
 
-# If Codex CLI is not installed and you want npm to manage it:
+If Codex CLI is not installed and you want npm to manage it:
+
+```bash
 npm install -g @openai/codex
 npm install -g oh-my-codex
 omx setup

--- a/docs/readme/README.pl.md
+++ b/docs/readme/README.pl.md
@@ -26,14 +26,18 @@ Codex zostaje silnikiem, który wykonuje pracę. OMX daje mu lepszy kontekst, go
 
 Jeśli chcesz po prostu zacząć:
 
+Choose one install path. If Codex CLI is already installed (for example with Homebrew):
+
 ```bash
-# If Codex CLI is already installed (for example with Homebrew):
 codex --version
 npm install -g oh-my-codex
 omx setup
 omx --madmax --high
+```
 
-# If Codex CLI is not installed and you want npm to manage it:
+If Codex CLI is not installed and you want npm to manage it:
+
+```bash
 npm install -g @openai/codex
 npm install -g oh-my-codex
 omx setup

--- a/docs/readme/README.pl.md
+++ b/docs/readme/README.pl.md
@@ -27,9 +27,16 @@ Codex zostaje silnikiem, który wykonuje pracę. OMX daje mu lepszy kontekst, go
 Jeśli chcesz po prostu zacząć:
 
 ```bash
-npm install -g @openai/codex oh-my-codex
+# If Codex CLI is already installed (for example with Homebrew):
+codex --version
+npm install -g oh-my-codex
 omx setup
 omx --madmax --high
+
+# If Codex CLI is not installed and you want npm to manage it:
+npm install -g @openai/codex
+npm install -g oh-my-codex
+omx setup
 ```
 
 Potem pracuj normalnie w Codexie:
@@ -56,7 +63,7 @@ Jeśli chcesz czystego Codexa bez żadnych dodatków, OMX pewnie nie jest dla Ci
 ### Wymagania
 
 - Node.js 20+
-- Codex CLI: `npm install -g @openai/codex`
+- Codex CLI sprawdzony przez `codex --version` (Homebrew albo npm)
 - Skonfigurowane uwierzytelnianie Codex
 - `tmux` na macOS/Linux — jeśli planujesz używać trybu zespołowego
 - `psmux` na natywnym Windows — jeśli planujesz używać trybu zespołowego

--- a/docs/readme/README.uk.md
+++ b/docs/readme/README.uk.md
@@ -50,14 +50,18 @@ OMX — це шар робочих процесів для [OpenAI Codex CLI](ht
 
 Якщо ви хочете отримати стандартний досвід OMX, почніть тут:
 
+Choose one install path. If Codex CLI is already installed (for example with Homebrew):
+
 ```bash
-# If Codex CLI is already installed (for example with Homebrew):
 codex --version
 npm install -g oh-my-codex
 omx setup
 omx --madmax --high
+```
 
-# If Codex CLI is not installed and you want npm to manage it:
+If Codex CLI is not installed and you want npm to manage it:
+
+```bash
 npm install -g @openai/codex
 npm install -g oh-my-codex
 omx setup

--- a/docs/readme/README.uk.md
+++ b/docs/readme/README.uk.md
@@ -51,9 +51,16 @@ OMX — це шар робочих процесів для [OpenAI Codex CLI](ht
 Якщо ви хочете отримати стандартний досвід OMX, почніть тут:
 
 ```bash
-npm install -g @openai/codex oh-my-codex
+# If Codex CLI is already installed (for example with Homebrew):
+codex --version
+npm install -g oh-my-codex
 omx setup
 omx --madmax --high
+
+# If Codex CLI is not installed and you want npm to manage it:
+npm install -g @openai/codex
+npm install -g oh-my-codex
+omx setup
 ```
 
 Далі працюйте звично всередині Codex:
@@ -83,7 +90,7 @@ $team 3:executor "execute the approved plan in parallel"
 ### Вимоги
 
 - Node.js 20+
-- встановлений Codex CLI: `npm install -g @openai/codex`
+- встановлений Codex CLI, перевірений через `codex --version` (Homebrew або npm)
 - налаштована автентифікація Codex
 - `tmux` на macOS/Linux, якщо пізніше знадобиться стійкий командний рушій
 - `psmux` на нативному Windows, якщо пізніше знадобиться командний режим для Windows

--- a/docs/readme/README.vi.md
+++ b/docs/readme/README.vi.md
@@ -26,14 +26,18 @@ Codex vẫn là engine chính, OMX giúp bạn:
 
 Nếu bạn muốn trải nghiệm OMX nhanh nhất, bắt đầu từ đây:
 
+Choose one install path. If Codex CLI is already installed (for example with Homebrew):
+
 ```bash
-# If Codex CLI is already installed (for example with Homebrew):
 codex --version
 npm install -g oh-my-codex
 omx setup
 omx --madmax --high
+```
 
-# If Codex CLI is not installed and you want npm to manage it:
+If Codex CLI is not installed and you want npm to manage it:
+
+```bash
 npm install -g @openai/codex
 npm install -g oh-my-codex
 omx setup

--- a/docs/readme/README.vi.md
+++ b/docs/readme/README.vi.md
@@ -27,9 +27,16 @@ Codex vẫn là engine chính, OMX giúp bạn:
 Nếu bạn muốn trải nghiệm OMX nhanh nhất, bắt đầu từ đây:
 
 ```bash
-npm install -g @openai/codex oh-my-codex
+# If Codex CLI is already installed (for example with Homebrew):
+codex --version
+npm install -g oh-my-codex
 omx setup
 omx --madmax --high
+
+# If Codex CLI is not installed and you want npm to manage it:
+npm install -g @openai/codex
+npm install -g oh-my-codex
+omx setup
 ```
 
 Sau đó làm việc bình thường trong Codex:
@@ -59,7 +66,7 @@ Nếu bạn chỉ muốn dùng Codex thuần mà không cần thêm workflow, th
 ### Yêu cầu
 
 - Node.js 20+
-- Codex CLI đã cài: `npm install -g @openai/codex`
+- Codex CLI đã cài và kiểm tra bằng `codex --version` (Homebrew hoặc npm)
 - Codex đã xác thực (auth)
 - `tmux` trên macOS/Linux nếu muốn dùng team runtime
 - `psmux` trên Windows nếu muốn dùng team mode

--- a/src/cli/__tests__/install-docs-contract.test.ts
+++ b/src/cli/__tests__/install-docs-contract.test.ts
@@ -9,6 +9,19 @@ function read(path: string): string {
   return readFileSync(join(repoRoot, path), 'utf-8');
 }
 
+function extractExecutableBlocks(content: string): string[] {
+  const markdownBlocks = Array.from(content.matchAll(/```(?:bash|sh|shell)?\n([\s\S]*?)```/g), (match) => match[1]);
+  const htmlBlocks = Array.from(content.matchAll(/<pre><code>([\s\S]*?)<\/code><\/pre>/g), (match) =>
+    match[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&'),
+  );
+
+  return [...markdownBlocks, ...htmlBlocks];
+}
+
 describe('install docs contract', () => {
   const installSurfaces = [
     'README.md',
@@ -26,6 +39,20 @@ describe('install docs contract', () => {
         /(^|\n)npm install -g @openai\/codex oh-my-codex(\n|$)/,
         `${surface} must not show the combined install command as an executable shell line`,
       );
+    }
+  });
+
+  it('keeps existing-Codex and npm-managed-Codex install paths in separate executable blocks', () => {
+    for (const surface of installSurfaces) {
+      for (const block of extractExecutableBlocks(read(surface))) {
+        const verifiesExistingCodex = /(^|\n)codex --version(\n|$)/.test(block);
+        const installsCodexWithNpm = /(^|\n)npm install -g @openai\/codex(\n|$)/.test(block);
+
+        assert.ok(
+          !(verifiesExistingCodex && installsCodexWithNpm),
+          `${surface} must not put existing-Codex verification and npm Codex installation in one copy-pasteable block`,
+        );
+      }
     }
   });
 

--- a/src/cli/__tests__/install-docs-contract.test.ts
+++ b/src/cli/__tests__/install-docs-contract.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+const repoRoot = process.cwd();
+
+function read(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf-8');
+}
+
+describe('install docs contract', () => {
+  const installSurfaces = [
+    'README.md',
+    'docs/getting-started.html',
+    'docs/readme/README.pl.md',
+    'docs/readme/README.uk.md',
+    'docs/readme/README.el.md',
+    'docs/readme/README.vi.md',
+  ];
+
+  it('does not recommend a combined Codex and OMX global npm install', () => {
+    for (const surface of installSurfaces) {
+      assert.doesNotMatch(
+        read(surface),
+        /(^|\n)npm install -g @openai\/codex oh-my-codex(\n|$)/,
+        `${surface} must not show the combined install command as an executable shell line`,
+      );
+    }
+  });
+
+  it('keeps install docs explicit about verified existing Codex installs', () => {
+    for (const surface of installSurfaces) {
+      const content = read(surface);
+      assert.match(content, /Homebrew/i, `${surface} must mention Homebrew installs`);
+      assert.match(content, /codex --version/, `${surface} must tell users to verify the existing Codex CLI`);
+      assert.match(content, /npm install -g oh-my-codex/, `${surface} must keep the OMX-only npm install command`);
+    }
+  });
+
+  it('keeps primary install docs explicit about the Homebrew-owned binary conflict', () => {
+    for (const surface of ['README.md', 'docs/getting-started.html']) {
+      assert.match(
+        read(surface),
+        /EEXIST|\/opt\/homebrew\/bin\/codex/,
+        `${surface} must explain the npm binary conflict`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Closes #2325.
Duplicate context: #2324 reported the same Homebrew-owned `/opt/homebrew/bin/codex` vs `npm install -g @openai/codex oh-my-codex` EEXIST failure and was already closed.

## Summary
- Clarify Homebrew-managed Codex install path: verify `codex --version`, then install only `oh-my-codex` with npm.
- Keep npm-managed first install path as separate `@openai/codex` and `oh-my-codex` commands instead of a combined global install.
- Add install-docs contract tests to prevent reintroducing the combined `npm install -g @openai/codex oh-my-codex` EEXIST risk.

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/install-docs-contract.test.js`
- `npm run check:no-unused`
- `git diff --check`
- `git diff --cached --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
