### PR TITLE
Keep team workers out of redundant MCP startup

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1341,6 +1341,41 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+
+  it('disables first-party OMX MCP compatibility servers for Codex team workers by default', () => {
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevCompat = process.env.OMX_TEAM_WORKER_MCP_COMPAT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    delete process.env.OMX_TEAM_WORKER_MCP_COMPAT;
+    try {
+      const cmd = buildWorkerStartupCommand('alpha', 1, [], '/tmp/project', {}, 'codex');
+      for (const server of ['omx_state', 'omx_memory', 'omx_code_intel', 'omx_trace', 'omx_wiki', 'omx_hermes']) {
+        assert.match(cmd, new RegExp(`mcp_servers\\.${server}\\.enabled=false`));
+      }
+    } finally {
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevCompat === 'string') process.env.OMX_TEAM_WORKER_MCP_COMPAT = prevCompat;
+      else delete process.env.OMX_TEAM_WORKER_MCP_COMPAT;
+    }
+  });
+
+  it('preserves explicit team-worker MCP compatibility opt-in', () => {
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevCompat = process.env.OMX_TEAM_WORKER_MCP_COMPAT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.OMX_TEAM_WORKER_MCP_COMPAT = '1';
+    try {
+      const cmd = buildWorkerStartupCommand('alpha', 1, [], '/tmp/project', {}, 'codex');
+      assert.doesNotMatch(cmd, /mcp_servers\.omx_state\.enabled=false/);
+    } finally {
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevCompat === 'string') process.env.OMX_TEAM_WORKER_MCP_COMPAT = prevCompat;
+      else delete process.env.OMX_TEAM_WORKER_MCP_COMPAT;
+    }
+  });
+
   it('does not inject model_instructions_file override when disabled', () => {
     const prevShell = process.env.SHELL;
     process.env.SHELL = '/bin/bash';

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -61,6 +61,7 @@ const OMX_TEAM_WORKER_CLI_ENV = 'OMX_TEAM_WORKER_CLI';
 const OMX_TEAM_WORKER_CLI_MAP_ENV = 'OMX_TEAM_WORKER_CLI_MAP';
 const OMX_TEAM_WORKER_LAUNCH_MODE_ENV = 'OMX_TEAM_WORKER_LAUNCH_MODE';
 const OMX_TEAM_AUTO_INTERRUPT_RETRY_ENV = 'OMX_TEAM_AUTO_INTERRUPT_RETRY';
+const OMX_TEAM_WORKER_MCP_COMPAT_ENV = 'OMX_TEAM_WORKER_MCP_COMPAT';
 const CODEX_SQLITE_HOME_ENV = 'CODEX_SQLITE_HOME';
 const GEMINI_PROMPT_INTERACTIVE_FLAG = '-i';
 const GEMINI_APPROVAL_MODE_FLAG = '--approval-mode';
@@ -74,6 +75,15 @@ const TMUX_WORKER_AMBIENT_ENV_ALLOWLIST = [
   'https_proxy',
   'http_proxy',
   'no_proxy',
+] as const;
+
+const TEAM_WORKER_DISABLED_OMX_MCP_SERVERS = [
+  'omx_state',
+  'omx_memory',
+  'omx_code_intel',
+  'omx_trace',
+  'omx_wiki',
+  'omx_hermes',
 ] as const;
 const TMUX_NO_UNDERLINE_STYLE_FLAGS = [
   'nounderscore',
@@ -838,6 +848,38 @@ function readTmuxWorkerAmbientEnv(env: NodeJS.ProcessEnv = process.env): Record<
   return inherited;
 }
 
+function hasConfigOverride(args: readonly string[], key: string): boolean {
+  const prefix = `${key}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === CONFIG_FLAG || arg === LONG_CONFIG_FLAG) {
+      const value = args[index + 1];
+      if (typeof value === 'string' && value.trim().startsWith(prefix)) return true;
+      index += 1;
+      continue;
+    }
+    if (typeof arg === 'string' && arg.startsWith(`${LONG_CONFIG_FLAG}=`)) {
+      const value = arg.slice(`${LONG_CONFIG_FLAG}=`.length);
+      if (value.trim().startsWith(prefix)) return true;
+    }
+  }
+  return false;
+}
+
+function shouldDisableOmxMcpForTeamWorker(env: NodeJS.ProcessEnv): boolean {
+  const raw = env[OMX_TEAM_WORKER_MCP_COMPAT_ENV]?.trim().toLowerCase();
+  return !(raw === '1' || raw === 'true' || raw === 'on' || raw === 'compat');
+}
+
+function appendTeamWorkerMcpDisableOverrides(args: string[], env: NodeJS.ProcessEnv): void {
+  if (!shouldDisableOmxMcpForTeamWorker(env)) return;
+  for (const server of TEAM_WORKER_DISABLED_OMX_MCP_SERVERS) {
+    const key = `mcp_servers.${server}.enabled`;
+    if (hasConfigOverride(args, key)) continue;
+    args.push(CONFIG_FLAG, `${key}=false`);
+  }
+}
+
 function resolveWorkerLaunchArgs(extraArgs: string[] = [], cwd: string = process.cwd(), env: NodeJS.ProcessEnv = process.env): string[] {
   const merged = [...extraArgs];
   const wantsBypass = process.argv.includes(CODEX_BYPASS_FLAG) || process.argv.includes(MADMAX_FLAG);
@@ -874,6 +916,10 @@ export function buildWorkerStartupCommand(
     ...readTmuxWorkerAmbientEnv(process.env),
     ...processSpec.env,
   };
+  const startupArgs = [...processSpec.args];
+  if (processSpec.workerCli === 'codex') {
+    appendTeamWorkerMcpDisableOverrides(startupArgs, { ...process.env, ...extraEnv });
+  }
   const resolvedLeaderNodePath = processSpec.env[OMX_LEADER_NODE_PATH_ENV]?.trim() || resolveLeaderNodePath();
   const leaderNodeDir = /[\\/]/.test(resolvedLeaderNodePath)
     ? resolvedLeaderNodePath.replace(/[\\/][^\\/]+$/, '')
@@ -886,7 +932,7 @@ export function buildWorkerStartupCommand(
     const envAssignments = Object.entries(startupEnv)
       .map(([key, value]) => `$env:${key} = ${quotePowerShellArg(value)}`)
       .join('; ');
-    const invocation = ['&', quotePowerShellArg(processSpec.command), ...processSpec.args.map(quotePowerShellArg)].join(' ');
+    const invocation = ['&', quotePowerShellArg(processSpec.command), ...startupArgs.map(quotePowerShellArg)].join(' ');
     const encodedCommand = encodePowerShellCommand(
       [
         "$ErrorActionPreference = 'Stop'",
@@ -900,7 +946,7 @@ export function buildWorkerStartupCommand(
 
   const launchSpec = buildWorkerLaunchSpec(process.env.SHELL);
   const pathPrefix = leaderNodeDir ? `export PATH=${shellQuoteSingle(leaderNodeDir)}:$PATH; ` : '';
-  const quotedArgs = processSpec.args.map(shellQuoteSingle).join(' ');
+  const quotedArgs = startupArgs.map(shellQuoteSingle).join(' ');
   const quotedCommand = shellQuoteSingle(processSpec.command);
   const cliInvocation = quotedArgs.length > 0 ? `exec ${quotedCommand} ${quotedArgs}` : `exec ${quotedCommand}`;
   const rcPrefix = launchSpec.rcFile ? `if [ -f ${launchSpec.rcFile} ]; then source ${launchSpec.rcFile}; fi; ` : '';


### PR DESCRIPTION
## Summary

- Disable setup-managed first-party OMX MCP compatibility servers for Codex team worker tmux startup commands by default.
- Preserve an explicit opt-in via `OMX_TEAM_WORKER_MCP_COMPAT=1|true|on|compat` for debugging or compatibility runs that intentionally need those MCP tools inside worker panes.
- Add regression coverage for both the default disable behavior and the opt-in path.

## Problem statement

Codex team workers can inherit the user's global `~/.codex/config.toml` MCP configuration. When that config enables first-party OMX compatibility servers, worker startup may block on a status such as:

```text
Starting MCP servers (5/6): omx_state (... • esc to interrupt)
```

Team workers do not need those compatibility MCP servers to receive assignments or report progress: team mode already coordinates through `.omx/state/team/...` files, CLI dispatch, and mailbox/state artifacts. Letting every worker initialize the same first-party compatibility MCP set adds startup cost and can prevent worker readiness entirely.

## Root cause

`buildWorkerStartupCommand` preserved the normal Codex launch args for team workers. That meant worker Codex processes also loaded setup-managed first-party OMX MCP compatibility entries from the user's Codex config, including `omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`, `omx_wiki`, and local `omx_hermes` when configured.

In team mode, those MCP servers are redundant and can be fragile under many worker panes because each worker starts its own MCP process set before it becomes ready.

## What changed

- Added tmux-startup-only Codex config overrides for team workers:
  - `mcp_servers.omx_state.enabled=false`
  - `mcp_servers.omx_memory.enabled=false`
  - `mcp_servers.omx_code_intel.enabled=false`
  - `mcp_servers.omx_trace.enabled=false`
  - `mcp_servers.omx_wiki.enabled=false`
  - `mcp_servers.omx_hermes.enabled=false`
- Applied those overrides only to Codex worker startup commands, not to the lower-level process launch spec used by prompt workers/tests.
- Added `OMX_TEAM_WORKER_MCP_COMPAT` as an explicit opt-in escape hatch.
- Preserved existing launch args, worker env, model instruction injection, Claude/Gemini handling, and user-owned non-OMX MCP servers.

## Why this design

Team mode is CLI/state-file first. Disabling only first-party OMX compatibility MCP servers in Codex team workers removes the startup blocker without mutating the user's global Codex config and without affecting normal interactive Codex sessions. The opt-in environment variable keeps a compatibility/debug path available when a worker intentionally needs those MCP tools.

## Overlap assessment

Adjacent but distinct.

- Issue #1635 and PR #1646 addressed a leader HUD/UI state problem where stale `omx_state` startup detail stayed visible even though child work could continue.
- This PR addresses a different gap: Codex team workers themselves can still spend readiness time starting redundant first-party OMX MCP compatibility servers inherited from user config.
- Searches for `team MCP startup`, `OMX_TEAM_WORKER_MCP_COMPAT`, and `omx_state worker` found no duplicate open PR for this worker-launch contract change.

## Validation

- `npm run build`
- `node --test dist/team/__tests__/tmux-session.test.js` — 185 tests passed, 0 failed
- `git diff --check`

## Risks / compatibility

- User-owned non-OMX MCP servers remain untouched.
- Normal interactive Codex sessions remain untouched.
- Workers that intentionally need first-party OMX MCP compatibility can opt in with `OMX_TEAM_WORKER_MCP_COMPAT=1`.
- Not tested: live GitHub CI and a full tmux team launch after pushing.

## Changed files

- `src/team/tmux-session.ts`
- `src/team/__tests__/tmux-session.test.ts`
