### PR TITLE
Protect AGENTS contract from silent overwrites

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,6 +21,18 @@ Treat the boundary this way:
 - `codex login status` green: the active Codex profile can see login state.
 - `omx exec ...` returns `OMX-EXEC-OK`: real execution, auth, provider routing, and current working-directory assumptions are working together.
 
+## AGENTS.md exists, but doctor says the OMX contract is missing
+
+Other Codex ecosystem tools may rewrite `AGENTS.md` while leaving OMX prompts, skills, hooks, and config in place. In that case `omx doctor` warns when the file exists but no longer carries the generated OMX AGENTS contract marker.
+
+To preserve local guidance and restore the OMX-managed contract sections, run:
+
+```bash
+omx setup --scope user --merge-agents
+```
+
+Use `--scope project` for project-scoped setup. If you intentionally want to replace the existing file, use `omx setup --scope <user|project> --force`; setup backs up the old file before replacement.
+
 ## Green doctor, but `omx exec` fails with auth errors
 
 Common failure strings include `401 Unauthorized`, `Missing bearer or basic authentication in header`, or `Incorrect API key provided`.

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -161,6 +161,60 @@ command = "node"
 		}
 	});
 
+	it("warns when an existing user AGENTS.md lacks OMX contract markers", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-agents-contract-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(join(codexDir, "AGENTS.md"), "# context-mode instructions\n");
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(res.stdout, /\[!!\] AGENTS\.md: OMX AGENTS contract markers missing/);
+			assert.match(res.stdout, /may have been overwritten by another tool/);
+			assert.match(res.stdout, /omx setup --scope user --merge-agents/);
+			assert.match(res.stdout, /omx setup --scope user --force/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("passes when user AGENTS.md contains the generated OMX contract marker", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-agents-contract-ok-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "AGENTS.md"),
+				[
+					"<!-- AUTONOMY DIRECTIVE — DO NOT REMOVE -->",
+					"<!-- END AUTONOMY DIRECTIVE -->",
+					"<!-- omx:generated:agents-md -->",
+					"# oh-my-codex - Intelligent Multi-Agent Orchestration",
+					"AGENTS.md is the top-level operating contract for the workspace.",
+					"",
+				].join("\n"),
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(res.stdout, /\[OK\] AGENTS\.md: found OMX contract in /);
+			assert.doesNotMatch(res.stdout, /AGENTS contract markers missing/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("treats plugin-mode setup omissions as expected and verifies marketplace registration", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-mode-"));
 		try {

--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -291,6 +291,8 @@ describe('omx setup AGENTS refresh behavior', () => {
       });
 
       assert.match(output, /Skipped AGENTS\.md overwrite/);
+      assert.match(output, /WARNING: Existing AGENTS\.md .* lacks OMX contract markers/);
+      assert.match(output, /omx setup --scope project --merge-agents/);
       assert.doesNotMatch(output, /Refreshed AGENTS\.md model capability table/);
       assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
       assert.equal(existsSync(join(wd, '.omx', 'backups', 'setup')), false);

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -53,6 +53,13 @@ function shouldSkipForSpawnPermissions(err: string): boolean {
   return typeof err === "string" && /(EPERM|EACCES)/i.test(err);
 }
 
+const MINIMAL_OMX_AGENTS_CONTRACT = [
+  "<!-- omx:generated:agents-md -->",
+  "# oh-my-codex - Intelligent Multi-Agent Orchestration",
+  "AGENTS.md is the top-level operating contract for the workspace.",
+  "",
+].join("\n");
+
 describe("omx setup scope behavior", () => {
   it("accepts --scope project form", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-scope-"));
@@ -402,7 +409,10 @@ describe("omx setup scope behavior", () => {
         join(wd, ".omx", "setup-scope.json"),
         JSON.stringify({ scope: "user" }),
       );
-      await writeFile(join(home, ".codex", "AGENTS.md"), "# user agents\n");
+      await writeFile(
+        join(home, ".codex", "AGENTS.md"),
+        MINIMAL_OMX_AGENTS_CONTRACT,
+      );
       await writeFile(
         join(home, ".codex", "prompts", "executor.md"),
         "# executor\n",
@@ -428,7 +438,7 @@ describe("omx setup scope behavior", () => {
       );
       assert.match(
         res.stdout,
-        /\[OK\] AGENTS\.md: found in .*home\/\.codex\/AGENTS\.md/,
+        /\[OK\] AGENTS\.md: found OMX contract in .*home\/\.codex\/AGENTS\.md/,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,7 +2,7 @@
  * omx doctor - Validate oh-my-codex installation
  */
 
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { mkdtemp, readdir, readFile, rm } from "fs/promises";
 import { spawnSync } from "child_process";
 import { join } from "path";
@@ -65,6 +65,7 @@ import {
 	readOmxPluginCacheState,
 	resolvePackagedOmxMarketplace,
 } from "./plugin-marketplace.js";
+import { hasOmxAgentsContract } from "../utils/agents-md.js";
 
 interface DoctorOptions {
 	verbose?: boolean;
@@ -269,7 +270,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	if (failCount > 0) {
 		console.log('\nRun "omx setup" to fix installation issues.');
 	} else if (warnCount > 0) {
-		console.log('\nRun "omx setup --force" to refresh all components.');
+		console.log(
+			'\nReview warnings above. Use "omx setup --force" only when a warning recommends full replacement; for AGENTS.md preservation prefer "omx setup --merge-agents".',
+		);
 	} else {
 		console.log("\nAll checks passed! oh-my-codex is ready.");
 	}
@@ -1469,13 +1472,34 @@ function checkAgentsMd(
 	codexHomeDir: string,
 	installMode?: SetupInstallMode,
 ): Check {
+	const scopeFlag = scope === "project" ? "--scope project" : "--scope user";
+	const repairMessage =
+		`OMX AGENTS contract markers missing; file may have been overwritten by another tool. ` +
+		`Run "omx setup ${scopeFlag} --merge-agents" to preserve local guidance while restoring OMX-managed sections, ` +
+		`or "omx setup ${scopeFlag} --force" to replace it after backup.`;
+
 	if (scope === "user") {
 		const userAgentsMd = join(codexHomeDir, "AGENTS.md");
 		if (existsSync(userAgentsMd)) {
+			if (installMode === "plugin") {
+				return {
+					name: "AGENTS.md",
+					status: "pass",
+					message: `optional plugin-mode AGENTS.md defaults found in ${userAgentsMd}; contract validation skipped`,
+				};
+			}
+			const content = readFileSync(userAgentsMd, "utf-8");
+			if (!hasOmxAgentsContract(content)) {
+				return {
+					name: "AGENTS.md",
+					status: "warn",
+					message: `${repairMessage} Path: ${userAgentsMd}`,
+				};
+			}
 			return {
 				name: "AGENTS.md",
 				status: "pass",
-				message: `found in ${userAgentsMd}`,
+				message: `found OMX contract in ${userAgentsMd}`,
 			};
 		}
 		if (installMode === "plugin") {
@@ -1494,10 +1518,26 @@ function checkAgentsMd(
 
 	const projectAgentsMd = join(process.cwd(), "AGENTS.md");
 	if (existsSync(projectAgentsMd)) {
+		if (installMode === "plugin") {
+			return {
+				name: "AGENTS.md",
+				status: "pass",
+				message:
+					"optional plugin-mode AGENTS.md defaults found in project root; contract validation skipped",
+			};
+		}
+		const content = readFileSync(projectAgentsMd, "utf-8");
+		if (!hasOmxAgentsContract(content)) {
+			return {
+				name: "AGENTS.md",
+				status: "warn",
+				message: `${repairMessage} Path: ${projectAgentsMd}`,
+			};
+		}
 		return {
 			name: "AGENTS.md",
 			status: "pass",
-			message: "found in project root",
+			message: "found OMX contract in project root",
 		};
 	}
 	if (installMode === "plugin") {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -76,6 +76,7 @@ import { tryReadCatalogManifest } from "../catalog/reader.js";
 import { DEFAULT_FRONTIER_MODEL } from "../config/models.js";
 import {
 	addGeneratedAgentsMarker,
+	hasOmxAgentsContract,
 	hasOmxManagedAgentsSections,
 	isOmxGeneratedAgentsMd,
 	upsertManagedAgentsBlock,
@@ -2303,6 +2304,16 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			if (agentsMdExists) {
 				const existing = await readFile(agentsMdDst, "utf-8");
 				changed = existing !== rewritten;
+				if (!hasOmxAgentsContract(existing)) {
+					const scopeFlag =
+						resolvedScope.scope === "project" ? "--scope project" : "--scope user";
+					console.log(
+						`  WARNING: Existing AGENTS.md at ${agentsMdDst} lacks OMX contract markers; it may have been overwritten by another tool.`,
+					);
+					console.log(
+						`  Repair safely with "omx setup ${scopeFlag} --merge-agents" to preserve local guidance, or "omx setup ${scopeFlag} --force" to replace it after backup.`,
+					);
+				}
 				if (options.mergeAgents) {
 					mergedAgentsContent = upsertManagedAgentsBlock(existing, rewritten);
 					canApplyManagedAgentsMerge = mergedAgentsContent !== existing;

--- a/src/utils/__tests__/agents-md.test.ts
+++ b/src/utils/__tests__/agents-md.test.ts
@@ -2,9 +2,12 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   addGeneratedAgentsMarker,
+  hasOmxAgentsContract,
   hasOmxManagedAgentsSections,
   isOmxGeneratedAgentsMd,
   OMX_GENERATED_AGENTS_MARKER,
+  OMX_MANAGED_AGENTS_END_MARKER,
+  OMX_MANAGED_AGENTS_START_MARKER,
 } from '../agents-md.js';
 
 describe('agents-md helpers', () => {
@@ -31,6 +34,13 @@ describe('agents-md helpers', () => {
     assert.equal(addGeneratedAgentsMarker(content), content);
   });
 
+  it('does not treat a standalone generated marker as the full OMX contract', () => {
+    const content = `header\n${OMX_GENERATED_AGENTS_MARKER}\nbody\n`;
+
+    assert.equal(isOmxGeneratedAgentsMd(content), true);
+    assert.equal(hasOmxAgentsContract(content), false);
+  });
+
   it('treats autonomy-directive generated files as OMX-managed once marked', () => {
     const content = [
       '<!-- AUTONOMY DIRECTIVE — DO NOT REMOVE -->',
@@ -38,9 +48,11 @@ describe('agents-md helpers', () => {
       '<!-- END AUTONOMY DIRECTIVE -->',
       OMX_GENERATED_AGENTS_MARKER,
       '# oh-my-codex - Intelligent Multi-Agent Orchestration',
+      'AGENTS.md is the top-level operating contract for the workspace.',
     ].join('\n');
 
     assert.equal(isOmxGeneratedAgentsMd(content), true);
+    assert.equal(hasOmxAgentsContract(content), true);
   });
 
   it('does not treat title-only user AGENTS.md content as OMX-generated', () => {
@@ -52,6 +64,7 @@ describe('agents-md helpers', () => {
 
     assert.equal(isOmxGeneratedAgentsMd(content), false);
     assert.equal(hasOmxManagedAgentsSections(content), false);
+    assert.equal(hasOmxAgentsContract(content), false);
   });
 
   it('recognizes explicit OMX-owned model table blocks as managed sections', () => {
@@ -65,5 +78,47 @@ describe('agents-md helpers', () => {
 
     assert.equal(isOmxGeneratedAgentsMd(content), false);
     assert.equal(hasOmxManagedAgentsSections(content), true);
+    assert.equal(hasOmxAgentsContract(content), false);
+  });
+
+  it('recognizes merged AGENTS blocks as carrying the OMX contract only when the generated marker is inside', () => {
+    const content = [
+      '# Shared ownership AGENTS',
+      '',
+      OMX_MANAGED_AGENTS_START_MARKER,
+      '<!-- AUTONOMY DIRECTIVE — DO NOT REMOVE -->',
+      '<!-- END AUTONOMY DIRECTIVE -->',
+      OMX_GENERATED_AGENTS_MARKER,
+      '# oh-my-codex - Intelligent Multi-Agent Orchestration',
+      'AGENTS.md is the top-level operating contract for the workspace.',
+      OMX_MANAGED_AGENTS_END_MARKER,
+    ].join('\n');
+
+    assert.equal(isOmxGeneratedAgentsMd(content), true);
+    assert.equal(hasOmxManagedAgentsSections(content), true);
+    assert.equal(hasOmxAgentsContract(content), true);
+  });
+
+  it('does not accept a generated marker plus heading without the semantic contract text', () => {
+    const content = [
+      OMX_GENERATED_AGENTS_MARKER,
+      '# oh-my-codex - Intelligent Multi-Agent Orchestration',
+      'User-authored text that happens to reuse the title.',
+    ].join('\n');
+
+    assert.equal(hasOmxAgentsContract(content), false);
+  });
+
+  it('does not accept a managed AGENTS block that lacks the generated contract marker', () => {
+    const content = [
+      '# Shared ownership AGENTS',
+      '',
+      OMX_MANAGED_AGENTS_START_MARKER,
+      '# oh-my-codex - Intelligent Multi-Agent Orchestration',
+      'AGENTS.md is the top-level operating contract for the workspace.',
+      OMX_MANAGED_AGENTS_END_MARKER,
+    ].join('\n');
+
+    assert.equal(hasOmxAgentsContract(content), false);
   });
 });

--- a/src/utils/agents-md.ts
+++ b/src/utils/agents-md.ts
@@ -6,6 +6,13 @@ import {
 export const OMX_GENERATED_AGENTS_MARKER = '<!-- omx:generated:agents-md -->'
 export const OMX_MANAGED_AGENTS_START_MARKER = '<!-- OMX:AGENTS:START -->'
 export const OMX_MANAGED_AGENTS_END_MARKER = '<!-- OMX:AGENTS:END -->'
+export const OMX_AGENTS_CONTRACT_HEADING =
+  '# oh-my-codex - Intelligent Multi-Agent Orchestration'
+const OMX_AGENTS_CONTRACT_REQUIRED_TEXT = [
+  OMX_GENERATED_AGENTS_MARKER,
+  OMX_AGENTS_CONTRACT_HEADING,
+  'AGENTS.md is the top-level operating contract for the workspace.',
+] as const
 const AUTONOMY_DIRECTIVE_END_MARKER = '<!-- END AUTONOMY DIRECTIVE -->'
 
 export function isOmxGeneratedAgentsMd(content: string): boolean {
@@ -19,6 +26,26 @@ export function hasOmxManagedAgentsSections(content: string): boolean {
       content.includes(OMX_MANAGED_AGENTS_END_MARKER)) ||
     (content.includes(OMX_MODELS_START_MARKER) &&
       content.includes(OMX_MODELS_END_MARKER))
+  )
+}
+
+export function hasOmxAgentsContract(content: string): boolean {
+  if (candidateHasOmxAgentsContract(content)) return true
+
+  const startIndex = content.indexOf(OMX_MANAGED_AGENTS_START_MARKER)
+  const endIndex = content.indexOf(OMX_MANAGED_AGENTS_END_MARKER)
+  if (startIndex === -1 || endIndex <= startIndex) return false
+
+  const managedBlock = content.slice(
+    startIndex + OMX_MANAGED_AGENTS_START_MARKER.length,
+    endIndex,
+  )
+  return candidateHasOmxAgentsContract(managedBlock)
+}
+
+function candidateHasOmxAgentsContract(content: string): boolean {
+  return OMX_AGENTS_CONTRACT_REQUIRED_TEXT.every((text) =>
+    content.includes(text),
   )
 }
 


### PR DESCRIPTION
Closes #2328

## Summary
- add conservative OMX AGENTS contract detection requiring the generated marker, canonical heading, and semantic contract text
- warn in doctor/setup when an existing AGENTS.md appears overwritten, with preservation-first merge repair guidance
- document the AGENTS.md repair flow and add regression coverage for healthy, missing, and merged contract cases

## Evidence
- `unset OMX_ROOT OMX_STATE_ROOT; npm run build && node --test dist/utils/__tests__/agents-md.test.js dist/cli/__tests__/setup-agents-overwrite.test.js dist/cli/__tests__/doctor-warning-copy.test.js && npm run lint && npm run check:no-unused && git diff --check`
- focused test result: 44 tests passed across agents-md, setup AGENTS overwrite, and doctor warning copy suites

## Notes
- Did not merge.
