### PR TITLE
Add OMX API gateway and route SparkShell summaries through it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "omx-api"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
## Summary
- Add a native Rust `omx-api` localhost OpenAI-compatible gateway with `serve`, `serve --daemon`, `serve --system --dry-run`, `status`, `stop`, and `generate text|image` surfaces.
- Wire `omx api` through the TypeScript CLI/native packaging/release manifest and add contract tests for binary resolution and release artifacts.
- Move SparkShell summaries from heavyweight `codex exec` spawning to direct local `/v1/responses` HTTP calls with bearer/state-file discovery and loopback guardrails.

## Security / compatibility
- Server bind and configured hosts are loopback-only by default; private backend HTTP seam and SparkShell base URL reject non-loopback hosts unless explicitly overridden for trusted development.
- Daemon bearer token is stored in a 0600 sidecar and is not serialized or printed in daemon state.
- V1A `real-private` text uses a transport seam; image generation returns `unsupported_request` until the private backend image contract is confirmed.
- OpenAI-compatible endpoints are best-effort for `/v1/responses`, `/v1/chat/completions`, `/v1/images/generations`, and `/v1/models`.

## Tests
- `cargo test -p omx-api -p omx-sparkshell`
- `cargo clippy -p omx-api -p omx-sparkshell --all-targets -- -D warnings`
- `npm run build`
- `npm run check:no-unused`
- `npm run lint`
- `node --test --test-name-pattern='api|commandOwnsLocalHelp|resolveCliInvocation' dist/cli/__tests__/index.test.js`
- `node --test dist/cli/__tests__/api.test.js dist/cli/__tests__/package-bin-contract.test.js dist/cli/__tests__/version-sync-contract.test.js dist/verification/__tests__/explore-harness-release-workflow.test.js dist/verification/__tests__/native-release-manifest.test.js`
- `npm run build:api` plus `omx-api serve --daemon` / `generate text` / `stop` smoke
- `git diff --check`

## Notes
- Live Codex private backend smoke was not run; it requires backend/token environment not available in this lane.
- Full unfiltered `index.test.js` was not used as a completion gate because unrelated existing tmux/state cleanup cases fail outside this change scope; scoped CLI API/index checks passed.
