### PR TITLE
Fix Ralph Stop session drift

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -8068,6 +8068,138 @@ exit 0
     }
   });
 
+  it("retires prompt-seeded Ralph starting state when canonical Ralph already completed with audit", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-shadowed-starting-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const nativeSessionId = "native-hook-seed";
+      const canonicalSessionId = "omx-runtime-session";
+      await mkdir(join(stateDir, "sessions", nativeSessionId), { recursive: true });
+      await mkdir(join(stateDir, "sessions", canonicalSessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: canonicalSessionId,
+        cwd,
+      });
+      await writeJson(join(stateDir, "sessions", nativeSessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "starting",
+        session_id: nativeSessionId,
+        iteration: 0,
+        task_slug: "mvp-h-local-method-preflight-execution",
+        started_at: "2026-05-14T07:00:00.000Z",
+      });
+      await writeJson(join(stateDir, "sessions", nativeSessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralph",
+        phase: "starting",
+        session_id: nativeSessionId,
+        active_skills: [{ skill: "ralph", phase: "starting", active: true, session_id: nativeSessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", canonicalSessionId, "ralph-state.json"), {
+        active: false,
+        mode: "ralph",
+        current_phase: "complete",
+        session_id: canonicalSessionId,
+        completed_at: "2026-05-14T07:30:00.000Z",
+        completion_audit: {
+          passed: true,
+          prompt_to_artifact_checklist: ["task evidence mapped"],
+          verification_evidence: ["fresh verification evidence recorded"],
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: nativeSessionId,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+      const retiredState = JSON.parse(await readFile(join(stateDir, "sessions", nativeSessionId, "ralph-state.json"), "utf-8"));
+      assert.equal(retiredState.active, false);
+      assert.equal(retiredState.current_phase, "complete");
+      assert.equal(retiredState.stop_reason, "shadowed_by_completed_canonical_ralph");
+      assert.equal(retiredState.shadowed_by_completed_canonical_ralph.session_id, canonicalSessionId);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not retire prompt-seeded Ralph starting state from a completed canonical Ralph owned by another thread", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-shadowed-thread-mismatch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const nativeSessionId = "native-hook-seed";
+      const canonicalSessionId = "omx-runtime-session";
+      await mkdir(join(stateDir, "sessions", nativeSessionId), { recursive: true });
+      await mkdir(join(stateDir, "sessions", canonicalSessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: canonicalSessionId,
+        cwd,
+      });
+      await writeJson(join(stateDir, "sessions", nativeSessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "starting",
+        session_id: nativeSessionId,
+        iteration: 0,
+        task_slug: "mvp-h-local-method-preflight-execution",
+        started_at: "2026-05-14T07:00:00.000Z",
+      });
+      await writeJson(join(stateDir, "sessions", nativeSessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralph",
+        phase: "starting",
+        session_id: nativeSessionId,
+        active_skills: [{ skill: "ralph", phase: "starting", active: true, session_id: nativeSessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", canonicalSessionId, "ralph-state.json"), {
+        active: false,
+        mode: "ralph",
+        current_phase: "complete",
+        session_id: canonicalSessionId,
+        owner_codex_thread_id: "thread-A",
+        completed_at: "2026-05-14T07:30:00.000Z",
+        completion_audit: {
+          passed: true,
+          prompt_to_artifact_checklist: ["task evidence mapped"],
+          verification_evidence: ["fresh verification evidence recorded"],
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: nativeSessionId,
+          thread_id: "thread-B",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX Ralph is still active (phase: starting; state: .omx/state/sessions/native-hook-seed/ralph-state.json); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ralph_starting",
+        systemMessage:
+          "OMX Ralph is still active (phase: starting; state: .omx/state/sessions/native-hook-seed/ralph-state.json); continue the task and gather fresh verification evidence before stopping.",
+      });
+      const preservedState = JSON.parse(await readFile(join(stateDir, "sessions", nativeSessionId, "ralph-state.json"), "utf-8"));
+      assert.equal(preservedState.active, true);
+      assert.equal(preservedState.current_phase, "starting");
+      assert.equal(preservedState.stop_reason, undefined);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block Stop from another session-scoped Ralph state when an explicit session_id has no active Ralph state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-explicit-session-ralph-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -644,6 +644,99 @@ async function hasConsistentRalphSkillActivation(stateDir: string, sessionId: st
   return true;
 }
 
+function isShadowableRalphStartingSeed(state: Record<string, unknown>): boolean {
+  if (state.active !== true) return false;
+  if (!isRalphStartingPhase(state)) return false;
+  if (state.completion_audit || state.completionAudit) return false;
+  const iteration = numericValue(state.iteration);
+  return iteration === null || iteration <= 0;
+}
+
+function hasPassingCompletedRalphAudit(state: Record<string, unknown> | null, cwd: string): boolean {
+  if (!state) return false;
+  if (state.mode && safeString(state.mode) !== "ralph") return false;
+  if (!isRalphCompletePhase(state.current_phase ?? state.currentPhase)) return false;
+  if (state.active === true) return false;
+  return evaluateRalphCompletionAuditEvidence(state, cwd).complete === true;
+}
+
+function shouldRetireShadowedRalphStartingSeed(
+  seedState: Record<string, unknown>,
+  completedState: Record<string, unknown> | null,
+  cwd: string,
+  ownerContext?: {
+    completedSessionId?: string;
+    payloadSessionId?: string;
+    threadId?: string;
+    currentNativeSessionId?: string;
+    tmuxPaneId?: string;
+  },
+): boolean {
+  if (!isShadowableRalphStartingSeed(seedState)) return false;
+  if (!hasPassingCompletedRalphAudit(completedState, cwd)) return false;
+  if (!completedState) return false;
+
+  const completedSessionId = safeString(ownerContext?.completedSessionId ?? completedState.session_id).trim();
+  if (
+    completedSessionId
+    && !activeRalphStateMatchesStopOwner(completedState, {
+      sessionId: completedSessionId,
+      payloadSessionId: safeString(ownerContext?.payloadSessionId).trim(),
+      threadId: safeString(ownerContext?.threadId).trim(),
+      currentNativeSessionId: safeString(ownerContext?.currentNativeSessionId).trim(),
+      tmuxPaneId: safeString(ownerContext?.tmuxPaneId).trim(),
+    })
+  ) {
+    return false;
+  }
+
+  const seedThreadId = safeString(seedState.owner_codex_thread_id ?? seedState.thread_id).trim();
+  const completedThreadId = safeString(completedState?.owner_codex_thread_id ?? completedState?.thread_id).trim();
+  const stopThreadId = safeString(ownerContext?.threadId).trim();
+  if (seedThreadId && completedThreadId && seedThreadId !== completedThreadId) return false;
+  if (seedThreadId && stopThreadId && seedThreadId !== stopThreadId) return false;
+  if (completedThreadId && stopThreadId && completedThreadId !== stopThreadId) return false;
+
+  const seedPaneId = safeString(seedState.tmux_pane_id).trim();
+  const completedPaneId = safeString(completedState?.tmux_pane_id).trim();
+  const stopPaneId = safeString(ownerContext?.tmuxPaneId).trim();
+  if (seedPaneId && completedPaneId && seedPaneId !== completedPaneId) return false;
+  if (seedPaneId && stopPaneId && seedPaneId !== stopPaneId) return false;
+  if (completedPaneId && stopPaneId && completedPaneId !== stopPaneId) return false;
+
+  const seedStartedAt = parseTimestampMs(seedState.started_at ?? seedState.startedAt);
+  const completedAt = parseTimestampMs(completedState?.completed_at ?? completedState?.completedAt);
+  if (completedAt === null) return false;
+  if (seedStartedAt !== null && seedStartedAt > completedAt) return false;
+
+  return true;
+}
+
+async function retireShadowedRalphStartingSeed(
+  path: string,
+  seedState: Record<string, unknown>,
+  completedSessionId: string,
+  completedPath: string,
+  completedState: Record<string, unknown>,
+): Promise<void> {
+  const nowIso = new Date().toISOString();
+  const completedAt = safeString(completedState.completed_at ?? completedState.completedAt).trim() || nowIso;
+  const next: Record<string, unknown> = {
+    ...seedState,
+    active: false,
+    current_phase: "complete",
+    completed_at: completedAt,
+    stop_reason: "shadowed_by_completed_canonical_ralph",
+    shadowed_by_completed_canonical_ralph: {
+      session_id: completedSessionId,
+      state_path: completedPath,
+      completed_at: completedAt,
+      reconciled_at: nowIso,
+    },
+  };
+  await writeFile(path, JSON.stringify(next, null, 2));
+}
+
 
 async function readRalphCompletionAuditBlockState(
   cwd: string,
@@ -733,6 +826,12 @@ async function readActiveRalphState(
     safeString(preferredSessionId).trim(),
     currentOmxSessionId,
   ].filter(Boolean))];
+  const completedCanonicalPath = currentOmxSessionId
+    ? getStateFilePath("ralph-state.json", cwd, currentOmxSessionId)
+    : "";
+  const completedCanonicalState = completedCanonicalPath
+    ? await readJsonIfExists(completedCanonicalPath)
+    : null;
 
   // Ralph Stop stays authoritative-scope-only once the Stop payload is session-bound.
   // That is intentionally stricter than generic state MCP reads: do not scan sibling
@@ -747,6 +846,27 @@ async function readActiveRalphState(
     const sessionScopedPath = getStateFilePath("ralph-state.json", cwd, sessionId);
     const sessionScoped = await readJsonIfExists(sessionScopedPath);
     if (sessionScoped?.active === true) {
+      if (
+        currentOmxSessionId
+        && sessionId !== currentOmxSessionId
+        && completedCanonicalState
+        && shouldRetireShadowedRalphStartingSeed(sessionScoped, completedCanonicalState, cwd, {
+          completedSessionId: currentOmxSessionId,
+          payloadSessionId: safeString(ownerContext?.payloadSessionId).trim(),
+          threadId: safeString(ownerContext?.threadId).trim(),
+          currentNativeSessionId,
+          tmuxPaneId: safeString(ownerContext?.tmuxPaneId).trim(),
+        })
+      ) {
+        await retireShadowedRalphStartingSeed(
+          sessionScopedPath,
+          sessionScoped,
+          currentOmxSessionId,
+          completedCanonicalPath,
+          completedCanonicalState,
+        );
+        continue;
+      }
       if (await isStaleOrphanedRalphStartingState(sessionScoped, sessionScopedPath)) {
         continue;
       }
@@ -1965,7 +2085,7 @@ function readPayloadSessionId(payload: CodexHookPayload): string {
 }
 
 function readPayloadThreadId(payload: CodexHookPayload): string {
-  return safeString(payload.thread_id ?? payload.threadId).trim();
+  return safeString(payload.owner_codex_thread_id ?? payload.thread_id ?? payload.threadId).trim();
 }
 
 function readPayloadTurnId(payload: CodexHookPayload): string {


### PR DESCRIPTION
## Summary

Fix Ralph Stop hook session drift where a prompt-seeded native-session `starting` state can remain visible after the canonical OMX session has already completed Ralph with passing machine-readable audit evidence.

This happened when Codex native hook state and later `omx state write` completion state landed under different session ids: Stop kept honoring the older native-session seed and repeatedly blocked final output even though canonical Ralph completion was already verified.

## Changes

- Detect visible session-scoped Ralph `starting` seeds shadowed by a canonical completed Ralph state with passing `completion_audit`.
- Retire only safe seed states: starting phase, no completion audit, iteration unset/zero, and not newer than the canonical completion timestamp.
- Preserve active/new Ralph protection with thread/pane mismatch checks and timestamp ordering.
- Add regression coverage for native/canonical session drift with a task slug and visible skill-active state.

## Validation

- [x] `npm run build`
- [x] `node --test --test-name-pattern "Ralph starting" dist/scripts/__tests__/codex-native-hook.test.js`
- [x] `npm run check:no-unused`
- [x] `git diff --check upstream/dev...HEAD`

## Related

Follow-up to the Ralph native/canonical session drift behavior observed after verified completion.
