### PR TITLE
Fix team tmux submit confirmation for wrapped drafts

### DIFF
--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -726,12 +726,14 @@ function resolveWorkerCliForRequest(request, config) {
 
 function capturedPaneContainsTrigger(captured, trigger) {
   if (!captured || !trigger) return false;
-  return normalizeTmuxCapture(captured).includes(normalizeTmuxCapture(trigger));
+  const normalizeForDraftMatch = (value) => normalizeTmuxCapture(value).replace(/-\s+/g, '-');
+  return normalizeForDraftMatch(captured).includes(normalizeForDraftMatch(trigger));
 }
 
 function capturedPaneContainsTriggerNearTail(captured, trigger, nonEmptyTailLines = 24) {
   if (!captured || !trigger) return false;
-  const normalizedTrigger = normalizeTmuxCapture(trigger);
+  const normalizeForDraftMatch = (value) => normalizeTmuxCapture(value).replace(/-\s+/g, '-');
+  const normalizedTrigger = normalizeForDraftMatch(trigger);
   if (!normalizedTrigger) return false;
   const lines = safeString(captured)
     .split('\n')
@@ -739,7 +741,13 @@ function capturedPaneContainsTriggerNearTail(captured, trigger, nonEmptyTailLine
     .filter((line) => line.length > 0);
   if (lines.length === 0) return false;
   const tail = lines.slice(-Math.max(1, nonEmptyTailLines)).join(' ');
-  return normalizeTmuxCapture(tail).includes(normalizedTrigger);
+  return normalizeForDraftMatch(tail).includes(normalizedTrigger);
+}
+
+function buildJoinedCapturePaneArgv(paneTarget, tailLines = 80) {
+  // Join wrapped visual lines so long path-like trigger text split by tmux
+  // remains comparable with the original trigger.
+  return ['capture-pane', '-J', '-t', paneTarget, '-p', '-S', `-${tailLines}`];
 }
 
 const INJECT_VERIFY_DELAY_MS = 250;
@@ -791,7 +799,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
   if (attemptCountAtStart >= 1) {
     try {
       // Narrow capture (8 lines) to scope check to input area, not scrollback output
-      const preCapture = await runProcess('tmux', buildCapturePaneArgv(resolution.paneTarget, 8), 2000);
+      const preCapture = await runProcess('tmux', buildJoinedCapturePaneArgv(resolution.paneTarget, 8), 2000);
       preCaptureHasTrigger = capturedPaneContainsTrigger(preCapture.stdout, request.trigger_message);
     } catch {
       preCaptureHasTrigger = false;
@@ -830,8 +838,8 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
   // Post-injection verification: confirm the trigger text was consumed.
   // Fixes #391: without this, dispatch marks 'notified' even when the worker
   // pane is sitting on an unsent draft (C-m was not effectively applied).
-  const verifyNarrowArgv = buildCapturePaneArgv(resolution.paneTarget, 8);
-  const verifyWideArgv = buildCapturePaneArgv(resolution.paneTarget);
+  const verifyNarrowArgv = buildJoinedCapturePaneArgv(resolution.paneTarget, 8);
+  const verifyWideArgv = buildJoinedCapturePaneArgv(resolution.paneTarget);
   for (let round = 0; round < INJECT_VERIFY_ROUNDS; round++) {
     await new Promise((r) => setTimeout(r, INJECT_VERIFY_DELAY_MS));
     try {
@@ -842,6 +850,19 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       // full-scrollback false positives.
       const narrowCap = await runProcess('tmux', verifyNarrowArgv, 2000);
       const wideCap = await runProcess('tmux', verifyWideArgv, 2000);
+      const triggerInNarrow = capturedPaneContainsTrigger(narrowCap.stdout, request.trigger_message);
+      const triggerNearTail = capturedPaneContainsTriggerNearTail(wideCap.stdout, request.trigger_message);
+      if (triggerInNarrow || triggerNearTail) {
+        // Draft is still visible, so C-m has not actually submitted it yet.
+        // Do not let transient spinner/active-task text mask an unsent draft.
+        await sendPaneInput({
+          paneTarget: resolution.paneTarget,
+          prompt: request.trigger_message,
+          submitKeyPresses,
+          typePrompt: false,
+        }).catch(() => {});
+        continue;
+      }
       // Worker is actively processing (mirrors sync path tmux-session.ts:1292-1294)
       if (paneHasActiveTask(wideCap.stdout)) {
         runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir, request.team_name);
@@ -862,8 +883,6 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       if (request.to_worker !== 'leader-fixed' && !paneLooksReady(wideCap.stdout)) {
         continue;
       }
-      const triggerInNarrow = capturedPaneContainsTrigger(narrowCap.stdout, request.trigger_message);
-      const triggerNearTail = capturedPaneContainsTriggerNearTail(wideCap.stdout, request.trigger_message);
       if (!triggerInNarrow && !triggerNearTail) {
         runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir, request.team_name);
         return {

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -18,7 +18,7 @@ import {
   classifyLeaderActionState,
   resolveLeaderNudgeIntent,
 } from './orchestration-intent.js';
-import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
+import { DEFAULT_MARKER, paneHasActiveTask } from '../tmux-hook-engine.js';
 import { isLeaderRuntimeStale } from '../../team/leader-activity.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
 import { writeTeamLeaderAttention } from '../../team/state.js';
@@ -967,14 +967,29 @@ export async function maybeNudgeTeamLeader({
     }
 
     try {
-      const sendResult = await sendPaneInput({
-        paneTarget: tmuxTarget,
-        prompt: markedText,
-        submitKeyPresses: 2,
-        submitDelayMs: 100,
-      });
-      if (!sendResult.ok) {
-        throw new Error(sendResult.error || sendResult.reason);
+      const leaderHasActiveTask = paneHasActiveTask(paneGuard.paneCapture);
+      let deliveryMode = 'sent';
+      if (leaderHasActiveTask) {
+        const sendResult = await sendPaneInput({
+          paneTarget: tmuxTarget,
+          prompt: markedText,
+          submitKeyPresses: 0,
+        });
+        if (!sendResult.ok) {
+          throw new Error(sendResult.error || sendResult.reason);
+        }
+        await runProcess('tmux', ['send-keys', '-t', tmuxTarget, 'Tab'], 3000);
+        deliveryMode = 'queued';
+      } else {
+        const sendResult = await sendPaneInput({
+          paneTarget: tmuxTarget,
+          prompt: markedText,
+          submitKeyPresses: 2,
+          submitDelayMs: 100,
+        });
+        if (!sendResult.ok) {
+          throw new Error(sendResult.error || sendResult.reason);
+        }
       }
       nudgeState.last_nudged_by_team[teamName] = {
         at: nowIso,
@@ -1005,6 +1020,7 @@ export async function maybeNudgeTeamLeader({
           message_count: messages.length,
           stalled_for_ms: undefined,
           missing_signal_workers: progressSnapshot.missingSignalWorkers,
+          delivery: deliveryMode,
         });
       } catch { /* ignore */ }
       await appendTeamDeliveryLog(logsDir, {
@@ -1013,7 +1029,7 @@ export async function maybeNudgeTeamLeader({
         team: teamName,
         to_worker: 'leader-fixed',
         transport: 'send-keys',
-        result: 'sent',
+        result: deliveryMode,
         reason: nudgeReason,
         orchestration_intent: orchestrationIntent,
       }).catch(() => {});

--- a/src/scripts/notify-hook/team-worker-stop.ts
+++ b/src/scripts/notify-hook/team-worker-stop.ts
@@ -8,7 +8,7 @@
 
 import { appendFile, mkdir, rename, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
-import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
+import { DEFAULT_MARKER, paneHasActiveTask } from '../tmux-hook-engine.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
 import { safeString, asNumber } from './utils.js';
 import { readJsonIfExists } from './state-io.js';
@@ -16,6 +16,7 @@ import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import { resolvePaneTarget } from './tmux-injection.js';
 import { readTeamWorkersForIdleCheck } from './team-worker.js';
+import { runProcess } from './process-runner.js';
 
 const STOP_NUDGE_COOLDOWN_MS = 30_000;
 const SOURCE_TYPE = 'worker_stop';
@@ -185,17 +186,30 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     + DEFAULT_MARKER;
 
   try {
-    const sendResult = await sendPaneInput({
-      paneTarget: tmuxTarget,
-      prompt,
-      submitKeyPresses: 2,
-      submitDelayMs: 100,
-    });
-    if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    const leaderHasActiveTask = paneHasActiveTask(paneGuard.paneCapture);
+    let deliveryMode = 'sent';
+    if (leaderHasActiveTask) {
+      const sendResult = await sendPaneInput({
+        paneTarget: tmuxTarget,
+        prompt,
+        submitKeyPresses: 0,
+      });
+      if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, 'Tab'], 3000);
+      deliveryMode = 'queued';
+    } else {
+      const sendResult = await sendPaneInput({
+        paneTarget: tmuxTarget,
+        prompt,
+        submitKeyPresses: 2,
+        submitDelayMs: 100,
+      });
+      if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    }
 
     await writeStopNudgeState(statePath, {
       ...nextState,
-      delivery: 'sent',
+      delivery: deliveryMode,
       leader_pane_id: leaderPaneId || null,
       tmux_target: tmuxTarget,
     });
@@ -205,7 +219,7 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
       type: 'worker_stop_leader_nudge',
       worker: workerName,
       to_worker: 'leader-fixed',
-      delivery: 'sent',
+      delivery: deliveryMode,
       created_at: nowIso,
       source_type: SOURCE_TYPE,
     });
@@ -225,10 +239,10 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
       from_worker: workerName,
       to_worker: 'leader-fixed',
       transport: 'send-keys',
-      result: 'sent',
+      result: deliveryMode,
       reason: 'worker_stop_allowed',
     }).catch(() => {});
-    return { ok: true, result: 'sent' };
+    return { ok: true, result: deliveryMode };
   } catch (err) {
     await recordDeferred({
       stateDir,

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -606,6 +606,72 @@ esac
       },
     );
   });
+
+  it('does not confirm delivery while a wrapped hyphenated trigger remains as an unsent draft', async () => {
+    const trigger = 'Read .omx/state/team/team-x/workers/worker-1/inbox.md';
+    await withMockTmuxFixture(
+      'omx-tmux-codex-wrapped-trigger-draft-',
+      (logPath) => `#!/bin/sh
+set -eu
+state_dir="$(dirname "${logPath}")"
+text_sent_file="$state_dir/text-sent"
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    if [ -f "$text_sent_file" ]; then
+      cat <<'EOF'
+${READY_HELPER_CAPTURE}
+
+› Read .omx/state/team/team-x/workers/worker-
+  1/inbox.md
+EOF
+    else
+      cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+    fi
+    exit 0
+    ;;
+  send-keys)
+    if [ "\${4:-}" = "-l" ] && [ "\${6:-}" = "${trigger}" ]; then
+      : > "$text_sent_file"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        await assert.rejects(
+          () => sendToWorker('omx-team-x', 1, trigger),
+          /submit_failed/,
+        );
+        const log = await readFile(logPath, 'utf-8');
+        const enterCount = (log.match(/send-keys -t omx-team-x:1 C-m/g) || []).length;
+        assert.ok(
+          enterCount >= 4,
+          `expected repeated submit nudges before failing on the still-visible wrapped draft:\n${log}`,
+        );
+      },
+    );
+  });
+});
+
+describe('sendToWorker adaptive retry matching', () => {
+  it('recognizes hyphen-wrapped trigger drafts as still visible', () => {
+    assert.equal(
+      shouldAttemptAdaptiveRetry(
+        'auto',
+        true,
+        true,
+        `${READY_HELPER_CAPTURE}\n\n› Read .omx/state/team/team-x/workers/worker-\n  1/inbox.md`,
+        'Read .omx/state/team/team-x/workers/worker-1/inbox.md',
+      ),
+      true,
+    );
+  });
 });
 
 describe('startup direct trigger safety', () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1605,10 +1605,10 @@ export function shouldAttemptAdaptiveRetry(
   if (!paneBusyAtStart) return false;
   if (typeof latestCapture !== 'string') return false;
 
-  const normalizedText = normalizeTmuxCapture(text);
+  const normalizedText = normalizeWorkerTriggerForDraftMatch(text);
   if (normalizedText === '') return false;
 
-  const normalizedCapture = normalizeTmuxCapture(latestCapture);
+  const normalizedCapture = normalizeWorkerTriggerForDraftMatch(latestCapture);
   if (!normalizedCapture.includes(normalizedText)) return false;
   if (paneHasActiveTask(latestCapture)) return false;
   if (!paneLooksReady(latestCapture)) return false;
@@ -1656,9 +1656,9 @@ async function attemptSubmitRounds(
       capturePaneAsync(target),
       captureVisiblePaneAsync(target),
     ]);
-    const normalizedCapture = normalizeTmuxCapture(captured);
+    const normalizedCapture = normalizeWorkerTriggerForDraftMatch(captured);
     if (
-      !normalizedCapture.includes(normalizeTmuxCapture(text))
+      !normalizedCapture.includes(normalizeWorkerTriggerForDraftMatch(text))
       && !paneHasQueuedCodexSubmission(visibleCapture)
     ) {
       return true;
@@ -1842,6 +1842,13 @@ export function dismissTrustPromptIfPresent(
 
 export const normalizeTmuxCapture = sharedNormalizeTmuxCapture;
 
+function normalizeWorkerTriggerForDraftMatch(value: string | null | undefined): string {
+  // Codex/tmux can wrap long path-like trigger text after a hyphen, e.g.
+  // `worker-\n  1/inbox.md`. Treat those visual wraps as the original token so
+  // delivery verification does not mistake an unsent draft for consumed input.
+  return normalizeTmuxCapture(value ?? '').replace(/-\s+/g, '-');
+}
+
 function assertWorkerTriggerText(text: string): void {
   if (text.length >= 200) {
     throw new Error('sendToWorker: text must be < 200 characters');
@@ -1953,7 +1960,7 @@ export async function sendToWorker(
   if (verifyCapture) {
     if (paneHasActiveTask(verifyCapture)) return;
     if (
-      !normalizeTmuxCapture(verifyCapture).includes(normalizeTmuxCapture(text))
+      !normalizeWorkerTriggerForDraftMatch(verifyCapture).includes(normalizeWorkerTriggerForDraftMatch(text))
       && !paneHasQueuedCodexSubmission(verifyVisibleCapture)
     ) {
       return;
@@ -1965,6 +1972,14 @@ export async function sendToWorker(
     const finalVisibleCapture = await captureVisiblePaneAsync(target);
     if (paneHasQueuedCodexSubmission(finalVisibleCapture)) {
       throw new Error('sendToWorker: submit_queued_after_tool_call');
+    }
+    const finalCapture = await capturePaneAsync(target);
+    if (
+      normalizeWorkerTriggerForDraftMatch(finalCapture).includes(normalizeWorkerTriggerForDraftMatch(text))
+      && !paneHasActiveTask(finalCapture)
+      && paneLooksReady(finalCapture)
+    ) {
+      throw new Error('sendToWorker: submit_failed (trigger text still visible after retries)');
     }
   }
 }


### PR DESCRIPTION
## Summary

- keep team dispatch verification from treating hyphen-wrapped Codex/tmux trigger drafts as consumed
- retry Enter while the trigger draft is still visible before allowing active-task confirmation
- queue leader/team-stop nudges with Tab when the leader pane is actively working instead of direct Enter submission
- add regression coverage for wrapped `worker-1/inbox.md` drafts remaining unsent

## Why

A live `omx team` smoke on macOS/tmux showed worker panes stuck with the trigger text typed but not submitted. Runtime state still marked delivery as `tmux_send_keys_confirmed` / `fallback_confirmed:tmux_send_keys_sent`, leaving tasks pending until manual Enter was pressed.

The pane capture wrapped `worker-1` as `worker-\n  1`, so simple normalized string matching missed the still-visible draft. Leader nudges could also type into a busy leader pane without queueing.

## Verification

- `npm run build`
- `node --test dist/team/__tests__/tmux-session.test.js`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js`
- `npx biome lint src/scripts/notify-hook/team-dispatch.ts src/scripts/notify-hook/team-leader-nudge.ts src/scripts/notify-hook/team-worker-stop.ts src/team/tmux-session.ts src/team/__tests__/tmux-session.test.ts`