### PR TITLE
Preserve responses metadata through OMX API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
           const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8'));
           const workspace = TOML.parse(fs.readFileSync(path.join(root, 'Cargo.toml'), 'utf-8'));
           const expectedMembers = [
+            'crates/omx-api',
             'crates/omx-explore',
             'crates/omx-mux',
             'crates/omx-runtime-core',
@@ -48,6 +49,7 @@ jobs:
             'crates/omx-sparkshell',
           ];
           const manifests = [
+            'crates/omx-api/Cargo.toml',
             'crates/omx-explore/Cargo.toml',
             'crates/omx-runtime-core/Cargo.toml',
             'crates/omx-mux/Cargo.toml',
@@ -181,7 +183,7 @@ jobs:
             --artifacts-dir release-assets \
             --out release-assets/native-release-manifest.json \
             --release-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}" \
-            --require-products "omx-explore-harness,omx-sparkshell"
+            --require-products "omx-api,omx-explore-harness,omx-sparkshell"
       - name: Upload release asset bundle for follow-up jobs
         uses: actions/upload-artifact@v4
         with:
@@ -268,6 +270,7 @@ jobs:
           const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8'));
           const workspace = TOML.parse(fs.readFileSync(path.join(root, 'Cargo.toml'), 'utf-8'));
           const expectedMembers = [
+            'crates/omx-api',
             'crates/omx-explore',
             'crates/omx-mux',
             'crates/omx-runtime-core',
@@ -275,6 +278,7 @@ jobs:
             'crates/omx-sparkshell',
           ];
           const manifests = [
+            'crates/omx-api/Cargo.toml',
             'crates/omx-explore/Cargo.toml',
             'crates/omx-runtime-core/Cargo.toml',
             'crates/omx-mux/Cargo.toml',

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "omx-api"
+version = "0.17.2"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "omx-explore-harness"
 version = "0.17.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "crates/omx-api",
   "crates/omx-explore",
   "crates/omx-mux",
   "crates/omx-runtime-core",

--- a/crates/omx-api/Cargo.toml
+++ b/crates/omx-api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "omx-api"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "omx_api"
+path = "src/lib.rs"
+
+[[bin]]
+name = "omx-api"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/omx-api/src/lib.rs
+++ b/crates/omx-api/src/lib.rs
@@ -14,6 +14,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 pub type Result<T> = std::result::Result<T, OmxApiError>;
 
 pub const DEFAULT_API_PORT: u16 = 14510;
+const CODEX_RESPONSES_PATH: &str = "/responses";
+const CODEX_DEFAULT_ORIGINATOR: &str = "codex_cli_rs";
+const CODEX_DEFAULT_BACKEND_BASE_PATH: &str = "/backend-api/codex";
+const CODEX_INSTALLATION_ID_HEADER: &str = "x-codex-installation-id";
+const CODEX_WINDOW_ID_HEADER: &str = "x-codex-window-id";
 
 #[derive(Debug)]
 pub enum OmxApiError {
@@ -559,7 +564,7 @@ fn real_private_text(body: &Value) -> std::result::Result<String, (u16, &'static
         return Ok(fixture);
     }
 
-    let Some(token) = discover_codex_oauth_token() else {
+    let Some(auth) = discover_codex_oauth() else {
         return Err((
             503,
             "missing_auth",
@@ -578,7 +583,7 @@ fn real_private_text(body: &Value) -> std::result::Result<String, (u16, &'static
         ));
     };
 
-    match post_json_to_url(&upstream, body, &token) {
+    match post_codex_responses_to_url(&upstream, body, &auth) {
         Ok(text) => Ok(text),
         Err(error) => Err((
             502,
@@ -706,12 +711,23 @@ fn extract_prompt(body: &Value) -> String {
     String::new()
 }
 
-fn discover_codex_oauth_token() -> Option<String> {
+#[derive(Clone, Debug, Default)]
+struct CodexOAuth {
+    token: String,
+    account_id: Option<String>,
+}
+
+fn discover_codex_oauth() -> Option<CodexOAuth> {
     if let Some(token) = env::var("OMX_API_CODEX_OAUTH_TOKEN")
         .ok()
         .filter(|value| !value.trim().is_empty())
     {
-        return Some(token);
+        return Some(CodexOAuth {
+            token,
+            account_id: env::var("OMX_API_CODEX_ACCOUNT_ID")
+                .ok()
+                .filter(|value| !value.trim().is_empty()),
+        });
     }
 
     let auth_path = env::var("CODEX_HOME")
@@ -726,7 +742,10 @@ fn discover_codex_oauth_token() -> Option<String> {
         .map(|home| home.join("auth.json"))?;
     let bytes = fs::read(auth_path).ok()?;
     let value: Value = serde_json::from_slice(&bytes).ok()?;
-    find_oauth_token(&value)
+    Some(CodexOAuth {
+        token: find_oauth_token(&value)?,
+        account_id: find_codex_account_id(&value),
+    })
 }
 
 fn find_oauth_token(value: &Value) -> Option<String> {
@@ -748,19 +767,150 @@ fn find_oauth_token(value: &Value) -> Option<String> {
     }
 }
 
-fn post_json_to_url(url: &str, body: &Value, bearer: &str) -> Result<String> {
+fn find_codex_account_id(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            for preferred in ["account_id", "chatgpt_account_id"] {
+                if let Some(account_id) = map
+                    .get(preferred)
+                    .and_then(Value::as_str)
+                    .filter(|account_id| !account_id.trim().is_empty())
+                {
+                    return Some(account_id.to_string());
+                }
+            }
+            map.values().find_map(find_codex_account_id)
+        }
+        Value::Array(items) => items.iter().find_map(find_codex_account_id),
+        _ => None,
+    }
+}
+
+#[derive(Debug)]
+struct CodexNativeRequest {
+    path: String,
+    headers: Vec<(String, String)>,
+    body: Value,
+}
+
+fn build_codex_native_request(
+    upstream_path: &str,
+    body: &Value,
+    auth: &CodexOAuth,
+) -> CodexNativeRequest {
+    let session_id = env::var("OMX_API_CODEX_SESSION_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "omx-api-local-session".to_string());
+    let thread_id = env::var("OMX_API_CODEX_THREAD_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "omx-api-local-thread".to_string());
+    let installation_id = env::var("OMX_API_CODEX_INSTALLATION_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "omx-api-local-installation".to_string());
+    let window_id = env::var("OMX_API_CODEX_WINDOW_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "omx-api-local-window".to_string());
+    let model = body
+        .get("model")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| env::var("OMX_API_GENERATE_MODEL").ok())
+        .unwrap_or_else(|| "omx-private".to_string());
+    let prompt = extract_prompt(body);
+    let path = normalize_codex_responses_path(upstream_path);
+    let request_body = json!({
+        "model": model,
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": prompt}]
+        }],
+        "tools": [],
+        "tool_choice": "auto",
+        "parallel_tool_calls": false,
+        "reasoning": null,
+        "store": false,
+        "stream": true,
+        "include": [],
+        "prompt_cache_key": thread_id,
+        "client_metadata": {
+            CODEX_INSTALLATION_ID_HEADER: installation_id.clone()
+        }
+    });
+
+    let mut headers = vec![
+        ("Content-Type".to_string(), "application/json".to_string()),
+        ("Accept".to_string(), "text/event-stream".to_string()),
+        (
+            "Authorization".to_string(),
+            format!("Bearer {}", auth.token),
+        ),
+        (
+            "originator".to_string(),
+            CODEX_DEFAULT_ORIGINATOR.to_string(),
+        ),
+        ("User-Agent".to_string(), codex_user_agent()),
+        ("x-client-request-id".to_string(), thread_id.clone()),
+        ("session_id".to_string(), session_id.clone()),
+        ("session-id".to_string(), session_id),
+        ("thread_id".to_string(), thread_id.clone()),
+        ("thread-id".to_string(), thread_id),
+        (CODEX_WINDOW_ID_HEADER.to_string(), window_id),
+    ];
+    if let Some(account_id) = auth.account_id.as_ref() {
+        headers.push(("ChatGPT-Account-ID".to_string(), account_id.clone()));
+    }
+
+    CodexNativeRequest {
+        path,
+        headers,
+        body: request_body,
+    }
+}
+
+fn codex_user_agent() -> String {
+    env::var("OMX_API_CODEX_USER_AGENT")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "codex_cli_rs/0.130.0 (omx-api)".to_string())
+}
+
+fn normalize_codex_responses_path(path: &str) -> String {
+    let path = if path == "/" || path.is_empty() {
+        CODEX_DEFAULT_BACKEND_BASE_PATH
+    } else {
+        path.trim_end_matches('/')
+    };
+    if path.ends_with(CODEX_RESPONSES_PATH) {
+        path.to_string()
+    } else {
+        format!("{path}{CODEX_RESPONSES_PATH}")
+    }
+}
+
+fn post_codex_responses_to_url(url: &str, body: &Value, auth: &CodexOAuth) -> Result<String> {
     let parsed = parse_http_backend_url(url)?;
-    let payload = serde_json::to_vec(body)?;
+    let codex_request = build_codex_native_request(&parsed.path, body, auth);
+    let payload = serde_json::to_vec(&codex_request.body)?;
     let mut stream = TcpStream::connect((parsed.host.as_str(), parsed.port))?;
     stream.set_read_timeout(Some(Duration::from_secs(120)))?;
     stream.set_write_timeout(Some(Duration::from_secs(30)))?;
     write!(
         stream,
-        "POST {} HTTP/1.1\r\nHost: {}:{}\r\nContent-Type: application/json\r\nAccept: application/json\r\nAuthorization: Bearer {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-        parsed.path,
-        parsed.host,
-        parsed.port,
-        bearer,
+        "POST {} HTTP/1.1\r\nHost: {}:{}\r\n",
+        codex_request.path, parsed.host, parsed.port
+    )?;
+    for (name, value) in codex_request.headers {
+        write!(stream, "{name}: {value}\r\n")?;
+    }
+    write!(
+        stream,
+        "Content-Length: {}\r\nConnection: close\r\n\r\n",
         payload.len()
     )?;
     stream.write_all(&payload)?;
@@ -781,9 +931,46 @@ fn post_json_to_url(url: &str, body: &Value, bearer: &str) -> Result<String> {
         )));
     }
 
+    Ok(extract_backend_text_response(response_body))
+}
+
+fn extract_backend_text_response(response_body: &str) -> String {
+    if response_body
+        .lines()
+        .any(|line| line.starts_with("event:") || line.starts_with("data:"))
+    {
+        let mut text = String::new();
+        for line in response_body.lines() {
+            let Some(data) = line.strip_prefix("data:").map(str::trim) else {
+                continue;
+            };
+            if data == "[DONE]" || data.is_empty() {
+                continue;
+            }
+            if let Ok(value) = serde_json::from_str::<Value>(data) {
+                if let Some(delta) = value.get("delta").and_then(Value::as_str) {
+                    text.push_str(delta);
+                } else if let Some(delta) = value
+                    .pointer("/item/content/0/text")
+                    .and_then(Value::as_str)
+                {
+                    text.push_str(delta);
+                } else if let Some(delta) = value
+                    .pointer("/response/output_text")
+                    .and_then(Value::as_str)
+                {
+                    text.push_str(delta);
+                }
+            }
+        }
+        if !text.is_empty() {
+            return text;
+        }
+    }
+
     let value: Value = serde_json::from_str(response_body)
         .unwrap_or_else(|_| json!({"output_text": response_body}));
-    Ok(value
+    value
         .get("output_text")
         .and_then(Value::as_str)
         .or_else(|| {
@@ -797,7 +984,7 @@ fn post_json_to_url(url: &str, body: &Value, bearer: &str) -> Result<String> {
                 .and_then(Value::as_str)
         })
         .unwrap_or(response_body)
-        .to_string())
+        .to_string()
 }
 
 #[derive(Debug)]
@@ -1589,6 +1776,171 @@ mod tests {
         let error = parse_http_backend_url("http://127.0.0.1.evil.test/v1/responses")
             .expect_err("hostname prefix must not bypass loopback check");
         assert!(error.to_string().contains("not loopback"));
+    }
+
+    #[test]
+    fn codex_native_request_matches_installed_codex_responses_wire_shape() {
+        let _guard = env_lock();
+        env::set_var("OMX_API_CODEX_SESSION_ID", "session-1");
+        env::set_var("OMX_API_CODEX_THREAD_ID", "thread-1");
+        env::set_var("OMX_API_CODEX_INSTALLATION_ID", "install-1");
+        env::set_var("OMX_API_CODEX_WINDOW_ID", "window-1");
+        env::set_var("OMX_API_CODEX_USER_AGENT", "codex_cli_rs/test");
+
+        let auth = CodexOAuth {
+            token: "oauth-token".to_string(),
+            account_id: Some("account-1".to_string()),
+        };
+        let request = build_codex_native_request(
+            "/backend-api/codex",
+            &json!({"model": "gpt-5.3-codex", "input": "summarize this"}),
+            &auth,
+        );
+
+        assert_eq!(request.path, "/backend-api/codex/responses");
+        assert!(request
+            .headers
+            .contains(&("Accept".to_string(), "text/event-stream".to_string())));
+        assert!(request.headers.contains(&(
+            "Authorization".to_string(),
+            "Bearer oauth-token".to_string()
+        )));
+        assert!(request
+            .headers
+            .contains(&("ChatGPT-Account-ID".to_string(), "account-1".to_string())));
+        assert!(request
+            .headers
+            .contains(&("originator".to_string(), "codex_cli_rs".to_string())));
+        assert!(request
+            .headers
+            .contains(&("x-client-request-id".to_string(), "thread-1".to_string())));
+        assert!(request
+            .headers
+            .contains(&("session_id".to_string(), "session-1".to_string())));
+        assert!(request
+            .headers
+            .contains(&("session-id".to_string(), "session-1".to_string())));
+        assert!(request
+            .headers
+            .contains(&("thread_id".to_string(), "thread-1".to_string())));
+        assert!(request
+            .headers
+            .contains(&("thread-id".to_string(), "thread-1".to_string())));
+        assert!(!request
+            .headers
+            .iter()
+            .any(|(name, _)| name == CODEX_INSTALLATION_ID_HEADER));
+
+        assert_eq!(request.body["model"], "gpt-5.3-codex");
+        assert_eq!(request.body["tools"], json!([]));
+        assert_eq!(request.body["tool_choice"], "auto");
+        assert_eq!(request.body["parallel_tool_calls"], false);
+        assert_eq!(request.body["store"], false);
+        assert_eq!(request.body["stream"], true);
+        assert_eq!(request.body["include"], json!([]));
+        assert_eq!(request.body["prompt_cache_key"], "thread-1");
+        assert_eq!(
+            request.body["client_metadata"][CODEX_INSTALLATION_ID_HEADER],
+            "install-1"
+        );
+        assert_eq!(
+            request.body["input"],
+            json!([{
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "summarize this"}]
+            }])
+        );
+
+        env::remove_var("OMX_API_CODEX_SESSION_ID");
+        env::remove_var("OMX_API_CODEX_THREAD_ID");
+        env::remove_var("OMX_API_CODEX_INSTALLATION_ID");
+        env::remove_var("OMX_API_CODEX_WINDOW_ID");
+        env::remove_var("OMX_API_CODEX_USER_AGENT");
+    }
+
+    #[test]
+    fn real_private_posts_codex_native_request_and_parses_sse_text() {
+        let _guard = env_lock();
+        env::remove_var("OMX_API_REAL_PRIVATE_RESPONSE_TEXT");
+        env::set_var("OMX_API_CODEX_OAUTH_TOKEN", "oauth-token");
+        env::set_var("OMX_API_CODEX_ACCOUNT_ID", "account-1");
+        env::set_var("OMX_API_CODEX_THREAD_ID", "thread-1");
+        env::set_var("OMX_API_CODEX_SESSION_ID", "session-1");
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind private backend");
+        let addr = listener.local_addr().expect("local addr");
+        let seen = Arc::new(Mutex::new(String::new()));
+        let seen_thread = Arc::clone(&seen);
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut raw_bytes = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            let header_end = loop {
+                let read = stream.read(&mut buffer).expect("read request");
+                assert!(read > 0, "request closed before headers");
+                raw_bytes.extend_from_slice(&buffer[..read]);
+                if let Some(index) = raw_bytes.windows(4).position(|chunk| chunk == b"\r\n\r\n") {
+                    break index + 4;
+                }
+            };
+            let head = String::from_utf8_lossy(&raw_bytes[..header_end]).to_string();
+            let content_length = head
+                .lines()
+                .find_map(|line| line.strip_prefix("Content-Length: "))
+                .and_then(|value| value.trim().parse::<usize>().ok())
+                .expect("content length");
+            while raw_bytes.len() < header_end + content_length {
+                let read = stream.read(&mut buffer).expect("read body");
+                assert!(read > 0, "request closed before body");
+                raw_bytes.extend_from_slice(&buffer[..read]);
+            }
+            let raw = String::from_utf8_lossy(&raw_bytes).to_string();
+            *seen_thread.lock().expect("seen lock") = raw;
+            let body = concat!(
+                "event: response.output_text.delta\n",
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n",
+                "data: [DONE]\n\n"
+            );
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+
+        env::set_var(
+            "OMX_API_PRIVATE_BACKEND_URL",
+            format!("http://127.0.0.1:{}/backend-api/codex", addr.port()),
+        );
+        let text = real_private_text(&json!({"model": "gpt-5.3-codex", "input": "ping"}))
+            .expect("private text response");
+        handle.join().expect("server thread");
+
+        assert_eq!(text, "hello");
+        let raw = seen.lock().expect("seen lock").clone();
+        assert!(raw.starts_with("POST /backend-api/codex/responses HTTP/1.1"));
+        assert!(raw.contains("Accept: text/event-stream\r\n"));
+        assert!(raw.contains("Authorization: Bearer oauth-token\r\n"));
+        assert!(raw.contains("ChatGPT-Account-ID: account-1\r\n"));
+        assert!(raw.contains("originator: codex_cli_rs\r\n"));
+        assert!(raw.contains("\"stream\":true") || raw.contains("\"stream\": true"));
+        assert!(
+            raw.contains("\"prompt_cache_key\":\"thread-1\"")
+                || raw.contains("\"prompt_cache_key\": \"thread-1\"")
+        );
+        assert!(
+            raw.contains("\"type\":\"input_text\"") || raw.contains("\"type\": \"input_text\"")
+        );
+        assert!(raw.contains("\"text\":\"ping\"") || raw.contains("\"text\": \"ping\""));
+
+        env::remove_var("OMX_API_CODEX_OAUTH_TOKEN");
+        env::remove_var("OMX_API_CODEX_ACCOUNT_ID");
+        env::remove_var("OMX_API_CODEX_THREAD_ID");
+        env::remove_var("OMX_API_CODEX_SESSION_ID");
+        env::remove_var("OMX_API_PRIVATE_BACKEND_URL");
     }
 
     #[test]

--- a/crates/omx-api/src/lib.rs
+++ b/crates/omx-api/src/lib.rs
@@ -453,7 +453,10 @@ fn canonical_route(path: &str) -> &'static str {
 }
 
 fn responses_response(request: &Request, backend: &BackendMode) -> Response {
-    let body = parse_body(&request.body);
+    let body = match parse_json_body(request) {
+        Ok(body) => body,
+        Err(response) => return response,
+    };
     if body.get("stream").and_then(Value::as_bool).unwrap_or(false) {
         if *backend == BackendMode::RealPrivate {
             return real_private_text_response(&body, "response", true);
@@ -487,7 +490,10 @@ fn responses_response(request: &Request, backend: &BackendMode) -> Response {
 }
 
 fn chat_response(request: &Request, backend: &BackendMode) -> Response {
-    let body = parse_body(&request.body);
+    let body = match parse_json_body(request) {
+        Ok(body) => body,
+        Err(response) => return response,
+    };
     if body.get("stream").and_then(Value::as_bool).unwrap_or(false) {
         let text = if *backend == BackendMode::RealPrivate {
             match real_private_text(&body) {
@@ -630,7 +636,10 @@ fn image_response(request: &Request, backend: &BackendMode) -> Response {
             json!({"error": {"message": "real-private image generation is not implemented in V1A", "type": "unsupported_request"}}),
         );
     }
-    let body = parse_body(&request.body);
+    let body = match parse_json_body(request) {
+        Ok(body) => body,
+        Err(response) => return response,
+    };
     let prompt = body.get("prompt").and_then(Value::as_str).unwrap_or("");
     if body.get("stream").and_then(Value::as_bool).unwrap_or(false) {
         let mut stream = sse_event(
@@ -657,8 +666,21 @@ fn image_response(request: &Request, backend: &BackendMode) -> Response {
     )
 }
 
-fn parse_body(body: &[u8]) -> Value {
-    serde_json::from_slice(body).unwrap_or_else(|_| json!({}))
+fn parse_json_body(request: &Request) -> std::result::Result<Value, Response> {
+    if request.body.is_empty() {
+        return Ok(json!({}));
+    }
+    serde_json::from_slice(&request.body).map_err(|error| {
+        Response::json(
+            400,
+            json!({
+                "error": {
+                    "message": format!("invalid JSON request body: {error}"),
+                    "type": "invalid_request_error"
+                }
+            }),
+        )
+    })
 }
 
 fn extract_prompt(body: &Value) -> String {
@@ -955,6 +977,7 @@ pub fn write_http_response(stream: &mut TcpStream, response: Response) -> Result
 fn reason_phrase(status: u16) -> &'static str {
     match status {
         200 => "OK",
+        400 => "Bad Request",
         401 => "Unauthorized",
         404 => "Not Found",
         503 => "Service Unavailable",
@@ -1500,6 +1523,27 @@ mod tests {
         let body = String::from_utf8(response.body).unwrap();
         assert!(body.contains("[REDACTED]"));
         assert!(!body.contains("sk-secret123"));
+    }
+
+    #[test]
+    fn post_endpoints_reject_malformed_json() {
+        let telemetry = Telemetry::default();
+        for path in [
+            "/v1/responses",
+            "/v1/chat/completions",
+            "/v1/images/generations",
+        ] {
+            let malformed = Request {
+                method: "POST".to_string(),
+                path: path.to_string(),
+                headers: BTreeMap::new(),
+                body: b"{bad json".to_vec(),
+            };
+            let response = route_request(&malformed, &BackendMode::Mock, &telemetry, None, None);
+            assert_eq!(response.status, 400, "{path} should reject malformed JSON");
+            let body = String::from_utf8(response.body).unwrap();
+            assert!(body.contains("invalid_request_error"));
+        }
     }
 
     #[test]

--- a/crates/omx-api/src/lib.rs
+++ b/crates/omx-api/src/lib.rs
@@ -1,0 +1,1657 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::net::{IpAddr, Shutdown, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub type Result<T> = std::result::Result<T, OmxApiError>;
+
+pub const DEFAULT_API_PORT: u16 = 14510;
+
+#[derive(Debug)]
+pub enum OmxApiError {
+    Io(io::Error),
+    Json(serde_json::Error),
+    Message(String),
+}
+
+impl std::fmt::Display for OmxApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "{error}"),
+            Self::Json(error) => write!(f, "{error}"),
+            Self::Message(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for OmxApiError {}
+
+impl From<io::Error> for OmxApiError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for OmxApiError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BackendMode {
+    Mock,
+    RealPrivate,
+}
+
+impl BackendMode {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "mock" => Ok(Self::Mock),
+            "real-private" => Ok(Self::RealPrivate),
+            other => Err(OmxApiError::Message(format!(
+                "unsupported backend mode '{other}'; expected mock or real-private"
+            ))),
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Mock => "mock",
+            Self::RealPrivate => "real-private",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub backend: BackendMode,
+    pub state_file: PathBuf,
+    pub once: bool,
+    pub daemon: bool,
+    pub local_bearer_token: Option<String>,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".to_string(),
+            port: DEFAULT_API_PORT,
+            backend: BackendMode::Mock,
+            state_file: default_state_file(),
+            once: false,
+            daemon: false,
+            local_bearer_token: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DaemonState {
+    pub pid: u32,
+    pub host: String,
+    pub port: u16,
+    pub backend: BackendMode,
+    pub started_at_unix: u64,
+    #[serde(skip)]
+    pub local_bearer_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_bearer_token_file: Option<PathBuf>,
+}
+
+impl DaemonState {
+    pub fn base_url(&self) -> String {
+        format!("http://{}:{}", self.host, self.port)
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct TelemetrySnapshot {
+    pub requests_total: u64,
+    pub by_route: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Default)]
+pub struct Telemetry {
+    inner: Mutex<TelemetrySnapshot>,
+}
+
+impl Telemetry {
+    pub fn record(&self, route: &str) {
+        let mut inner = self.inner.lock().expect("telemetry lock poisoned");
+        inner.requests_total += 1;
+        *inner.by_route.entry(route.to_string()).or_insert(0) += 1;
+    }
+
+    pub fn snapshot(&self) -> TelemetrySnapshot {
+        self.inner.lock().expect("telemetry lock poisoned").clone()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Request {
+    pub method: String,
+    pub path: String,
+    pub headers: BTreeMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Response {
+    pub status: u16,
+    pub content_type: String,
+    pub body: Vec<u8>,
+    pub extra_headers: Vec<(String, String)>,
+}
+
+impl Response {
+    pub fn json(status: u16, value: Value) -> Self {
+        let body = serde_json::to_vec(&value).expect("JSON serialization should not fail");
+        Self {
+            status,
+            content_type: "application/json".to_string(),
+            body,
+            extra_headers: Vec::new(),
+        }
+    }
+
+    pub fn text(status: u16, content_type: &str, body: impl Into<Vec<u8>>) -> Self {
+        Self {
+            status,
+            content_type: content_type.to_string(),
+            body: body.into(),
+            extra_headers: Vec::new(),
+        }
+    }
+}
+
+pub fn default_state_file() -> PathBuf {
+    env::temp_dir().join("omx-api-daemon.json")
+}
+
+pub fn write_daemon_state(path: impl AsRef<Path>, state: &DaemonState) -> Result<()> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let bytes = serde_json::to_vec_pretty(state)?;
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+pub fn read_daemon_state(path: impl AsRef<Path>) -> Result<Option<DaemonState>> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(path)?;
+    Ok(Some(serde_json::from_slice(&bytes)?))
+}
+
+pub fn remove_daemon_state(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn token_file_for_state(path: impl AsRef<Path>) -> PathBuf {
+    let mut path = path.as_ref().to_path_buf();
+    path.set_extension("token");
+    path
+}
+
+fn write_local_bearer_token(path: impl AsRef<Path>, token: &str) -> Result<()> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(token.as_bytes())?;
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        fs::write(path, token)?;
+        Ok(())
+    }
+}
+
+fn read_local_bearer_token(path: impl AsRef<Path>) -> Result<Option<String>> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Ok(None);
+    }
+    Ok(Some(fs::read_to_string(path)?.trim().to_string()).filter(|token| !token.is_empty()))
+}
+
+fn remove_local_bearer_token(path: impl AsRef<Path>) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub fn redact_secrets(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut redact_next = false;
+    for (index, token) in input.split_whitespace().enumerate() {
+        if index > 0 {
+            out.push(' ');
+        }
+        let lower = token.to_ascii_lowercase();
+        if redact_next
+            || lower.starts_with("sk-")
+            || lower.starts_with("sess-")
+            || lower.starts_with("bearer")
+            || lower.contains("api_key=")
+            || lower.contains("apikey=")
+            || lower.contains("authorization:")
+        {
+            out.push_str("[REDACTED]");
+            redact_next =
+                lower == "bearer" || lower.ends_with("bearer") || lower.contains("authorization:");
+        } else {
+            out.push_str(token);
+            redact_next = false;
+        }
+    }
+    redact_json_secret_values(&out)
+}
+
+fn redact_json_secret_values(input: &str) -> String {
+    let mut value: Value = match serde_json::from_str(input) {
+        Ok(value) => value,
+        Err(_) => return input.to_string(),
+    };
+    redact_value(&mut value);
+    serde_json::to_string(&value).unwrap_or_else(|_| input.to_string())
+}
+
+fn redact_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, nested) in map {
+                let key = key.to_ascii_lowercase();
+                if key.contains("key")
+                    || key.contains("token")
+                    || key.contains("secret")
+                    || key == "authorization"
+                {
+                    *nested = Value::String("[REDACTED]".to_string());
+                } else {
+                    redact_value(nested);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                redact_value(item);
+            }
+        }
+        Value::String(text) if text.starts_with("sk-") || text.starts_with("Bearer ") => {
+            *text = "[REDACTED]".to_string();
+        }
+        _ => {}
+    }
+}
+
+pub fn sse_event(event: Option<&str>, data: &Value) -> String {
+    let mut output = String::new();
+    if let Some(event) = event {
+        output.push_str("event: ");
+        output.push_str(event);
+        output.push('\n');
+    }
+    let json = serde_json::to_string(data).expect("JSON serialization should not fail");
+    for line in json.lines() {
+        output.push_str("data: ");
+        output.push_str(line);
+        output.push('\n');
+    }
+    output.push('\n');
+    output
+}
+
+pub fn sse_done() -> String {
+    "data: [DONE]\n\n".to_string()
+}
+
+pub fn route_request(
+    request: &Request,
+    backend: &BackendMode,
+    telemetry: &Telemetry,
+    shutdown: Option<&AtomicBool>,
+    expected_bearer: Option<&str>,
+) -> Response {
+    let route = canonical_route(&request.path);
+    telemetry.record(route);
+
+    if let Some(expected) = expected_bearer.filter(|token| !token.is_empty()) {
+        if !has_matching_local_bearer(request, expected) {
+            return Response::json(
+                401,
+                json!({
+                    "error": {
+                        "message": "matching local bearer token required",
+                        "type": "unauthorized"
+                    }
+                }),
+            );
+        }
+    } else if local_bearer_required() && !has_local_bearer(request) {
+        return Response::json(
+            401,
+            json!({
+                "error": {
+                    "message": "local bearer token required by OMX_API_REQUIRE_LOCAL_BEARER",
+                    "type": "unauthorized"
+                }
+            }),
+        );
+    }
+
+    match (request.method.as_str(), request.path.as_str()) {
+        ("GET", "/health") => Response::json(
+            200,
+            json!({
+                "status": "ok",
+                "backend": backend.as_str(),
+            }),
+        ),
+        ("GET", "/v1/models") => Response::json(
+            200,
+            json!({
+                "object": "list",
+                "data": [
+                    {"id": "omx-mock", "object": "model", "owned_by": "omx"},
+                    {"id": "omx-private", "object": "model", "owned_by": "local"}
+                ]
+            }),
+        ),
+        ("POST", "/v1/responses") => responses_response(request, backend),
+        ("POST", "/v1/chat/completions") => chat_response(request, backend),
+        ("POST", "/v1/images/generations") => image_response(request, backend),
+        ("GET", "/__admin/telemetry") => Response::json(200, json!(telemetry.snapshot())),
+        ("POST", "/__admin/stop") => {
+            if let Some(flag) = shutdown {
+                flag.store(true, Ordering::SeqCst);
+            }
+            Response::json(200, json!({"status": "stopping"}))
+        }
+        _ => Response::json(
+            404,
+            json!({
+                "error": {
+                    "message": format!("no route for {} {}", request.method, request.path),
+                    "type": "not_found"
+                }
+            }),
+        ),
+    }
+}
+
+fn local_bearer_required() -> bool {
+    env::var("OMX_API_REQUIRE_LOCAL_BEARER")
+        .ok()
+        .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+fn has_matching_local_bearer(request: &Request, expected: &str) -> bool {
+    request
+        .headers
+        .get("authorization")
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .is_some_and(|token| token == expected)
+}
+
+fn has_local_bearer(request: &Request) -> bool {
+    request
+        .headers
+        .get("authorization")
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .is_some()
+}
+
+fn canonical_route(path: &str) -> &'static str {
+    match path {
+        "/health" => "/health",
+        "/v1/models" => "/v1/models",
+        "/v1/responses" => "/v1/responses",
+        "/v1/chat/completions" => "/v1/chat/completions",
+        "/v1/images/generations" => "/v1/images/generations",
+        "/__admin/telemetry" => "/__admin/telemetry",
+        "/__admin/stop" => "/__admin/stop",
+        _ => "unknown",
+    }
+}
+
+fn responses_response(request: &Request, backend: &BackendMode) -> Response {
+    let body = parse_body(&request.body);
+    if body.get("stream").and_then(Value::as_bool).unwrap_or(false) {
+        if *backend == BackendMode::RealPrivate {
+            return real_private_text_response(&body, "response", true);
+        }
+        let payload = json!({"type": "message", "delta": "omx mock response"});
+        let mut stream = sse_event(Some("response.output_text.delta"), &payload);
+        stream.push_str(&sse_done());
+        return Response::text(200, "text/event-stream", stream.into_bytes());
+    }
+
+    if *backend == BackendMode::RealPrivate {
+        return real_private_text_response(&body, "response", false);
+    }
+
+    let input = extract_prompt(&body);
+    Response::json(
+        200,
+        json!({
+            "id": format!("omx-{}", now_unix()),
+            "object": "response",
+            "model": body.get("model").and_then(Value::as_str).unwrap_or("omx-mock"),
+            "backend": backend.as_str(),
+            "output_text": format!("omx mock response to: {}", redact_secrets(&input)),
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "omx mock response"},
+                "finish_reason": "stop"
+            }]
+        }),
+    )
+}
+
+fn chat_response(request: &Request, backend: &BackendMode) -> Response {
+    let body = parse_body(&request.body);
+    if body.get("stream").and_then(Value::as_bool).unwrap_or(false) {
+        let text = if *backend == BackendMode::RealPrivate {
+            match real_private_text(&body) {
+                Ok(text) => text,
+                Err((status, kind, message)) => {
+                    return Response::json(
+                        status,
+                        json!({"error": {"message": message, "type": kind}}),
+                    );
+                }
+            }
+        } else {
+            "omx mock response".to_string()
+        };
+        let chunk = json!({
+            "id": format!("chatcmpl-omx-{}", now_unix()),
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": null}]
+        });
+        let mut stream = sse_event(None, &chunk);
+        stream.push_str(&sse_done());
+        return Response::text(200, "text/event-stream", stream.into_bytes());
+    }
+    if *backend == BackendMode::RealPrivate {
+        return real_private_text_response(&body, "chat.completion", false);
+    }
+    Response::json(
+        200,
+        json!({
+            "id": format!("chatcmpl-omx-{}", now_unix()),
+            "object": "chat.completion",
+            "model": body.get("model").and_then(Value::as_str).unwrap_or("omx-mock"),
+            "backend": backend.as_str(),
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "omx mock response"},
+                "finish_reason": "stop"
+            }]
+        }),
+    )
+}
+
+fn real_private_text_response(body: &Value, object: &str, stream: bool) -> Response {
+    match real_private_text(body) {
+        Ok(text) => text_response_json(body, object, "real-private", &text, stream),
+        Err((status, kind, message)) => Response::json(
+            status,
+            json!({
+                "error": {
+                    "message": message,
+                    "type": kind
+                }
+            }),
+        ),
+    }
+}
+
+fn real_private_text(body: &Value) -> std::result::Result<String, (u16, &'static str, String)> {
+    if let Some(fixture) = env::var("OMX_API_REAL_PRIVATE_RESPONSE_TEXT")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Ok(fixture);
+    }
+
+    let Some(token) = discover_codex_oauth_token() else {
+        return Err((
+            503,
+            "missing_auth",
+            "missing Codex OAuth token; run Codex login or set OMX_API_REAL_PRIVATE_RESPONSE_TEXT for fixture smoke tests".to_string(),
+        ));
+    };
+
+    let Some(upstream) = env::var("OMX_API_PRIVATE_BACKEND_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Err((
+            501,
+            "private_backend_unconfigured",
+            "real-private OAuth was found, but OMX_API_PRIVATE_BACKEND_URL is not configured for this private backend build".to_string(),
+        ));
+    };
+
+    match post_json_to_url(&upstream, body, &token) {
+        Ok(text) => Ok(text),
+        Err(error) => Err((
+            502,
+            "private_backend_error",
+            redact_secrets(&error.to_string()),
+        )),
+    }
+}
+
+fn text_response_json(
+    body: &Value,
+    object: &str,
+    backend: &str,
+    text: &str,
+    stream: bool,
+) -> Response {
+    if stream {
+        let mut output = sse_event(
+            Some("response.created"),
+            &json!({"type": "response.created", "response": {"backend": backend}}),
+        );
+        output.push_str(&sse_event(
+            Some("response.output_text.delta"),
+            &json!({"type": "response.output_text.delta", "delta": text}),
+        ));
+        output.push_str(&sse_event(
+            Some("response.completed"),
+            &json!({"type": "response.completed"}),
+        ));
+        output.push_str(&sse_done());
+        return Response::text(200, "text/event-stream", output.into_bytes());
+    }
+
+    Response::json(
+        200,
+        json!({
+            "id": format!("omx-{}", now_unix()),
+            "object": object,
+            "model": body.get("model").and_then(Value::as_str).unwrap_or("omx-private"),
+            "backend": backend,
+            "output_text": text,
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop"
+            }]
+        }),
+    )
+}
+
+fn image_response(request: &Request, backend: &BackendMode) -> Response {
+    if *backend == BackendMode::RealPrivate {
+        return Response::json(
+            501,
+            json!({"error": {"message": "real-private image generation is not implemented in V1A", "type": "unsupported_request"}}),
+        );
+    }
+    let body = parse_body(&request.body);
+    let prompt = body.get("prompt").and_then(Value::as_str).unwrap_or("");
+    if body.get("stream").and_then(Value::as_bool).unwrap_or(false) {
+        let mut stream = sse_event(
+            Some("image_generation.partial_image"),
+            &json!({"type": "image_generation.partial_image", "b64_json": "omx-mock-image-fragment"}),
+        );
+        stream.push_str(&sse_event(
+            Some("image_generation.completed"),
+            &json!({"type": "image_generation.completed"}),
+        ));
+        stream.push_str(&sse_done());
+        return Response::text(200, "text/event-stream", stream.into_bytes());
+    }
+    Response::json(
+        200,
+        json!({
+            "created": now_unix(),
+            "backend": backend.as_str(),
+            "data": [{
+                "url": "https://localhost.omx.invalid/mock-image.png",
+                "revised_prompt": redact_secrets(prompt)
+            }]
+        }),
+    )
+}
+
+fn parse_body(body: &[u8]) -> Value {
+    serde_json::from_slice(body).unwrap_or_else(|_| json!({}))
+}
+
+fn extract_prompt(body: &Value) -> String {
+    if let Some(input) = body.get("input") {
+        if let Some(text) = input.as_str() {
+            return text.to_string();
+        }
+        return input.to_string();
+    }
+    if let Some(messages) = body.get("messages").and_then(Value::as_array) {
+        return messages
+            .iter()
+            .filter_map(|message| message.get("content"))
+            .map(|content| {
+                content
+                    .as_str()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| content.to_string())
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+    String::new()
+}
+
+fn discover_codex_oauth_token() -> Option<String> {
+    if let Some(token) = env::var("OMX_API_CODEX_OAUTH_TOKEN")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Some(token);
+    }
+
+    let auth_path = env::var("CODEX_HOME")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            env::var("HOME")
+                .ok()
+                .map(|home| PathBuf::from(home).join(".codex"))
+        })
+        .map(|home| home.join("auth.json"))?;
+    let bytes = fs::read(auth_path).ok()?;
+    let value: Value = serde_json::from_slice(&bytes).ok()?;
+    find_oauth_token(&value)
+}
+
+fn find_oauth_token(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            for preferred in ["access_token", "id_token", "oauth_token", "token"] {
+                if let Some(token) = map
+                    .get(preferred)
+                    .and_then(Value::as_str)
+                    .filter(|token| token.len() > 20)
+                {
+                    return Some(token.to_string());
+                }
+            }
+            map.values().find_map(find_oauth_token)
+        }
+        Value::Array(items) => items.iter().find_map(find_oauth_token),
+        _ => None,
+    }
+}
+
+fn post_json_to_url(url: &str, body: &Value, bearer: &str) -> Result<String> {
+    let parsed = parse_http_backend_url(url)?;
+    let payload = serde_json::to_vec(body)?;
+    let mut stream = TcpStream::connect((parsed.host.as_str(), parsed.port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(120)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(30)))?;
+    write!(
+        stream,
+        "POST {} HTTP/1.1\r\nHost: {}:{}\r\nContent-Type: application/json\r\nAccept: application/json\r\nAuthorization: Bearer {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        parsed.path,
+        parsed.host,
+        parsed.port,
+        bearer,
+        payload.len()
+    )?;
+    stream.write_all(&payload)?;
+    let mut raw = String::new();
+    stream.read_to_string(&mut raw)?;
+    let (head, response_body) = raw.split_once("\r\n\r\n").ok_or_else(|| {
+        OmxApiError::Message("private backend returned malformed HTTP".to_string())
+    })?;
+    let status = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(502);
+    if !(200..300).contains(&status) {
+        return Err(OmxApiError::Message(format!(
+            "private backend returned HTTP {status}: {response_body}"
+        )));
+    }
+
+    let value: Value = serde_json::from_str(response_body)
+        .unwrap_or_else(|_| json!({"output_text": response_body}));
+    Ok(value
+        .get("output_text")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            value
+                .pointer("/choices/0/message/content")
+                .and_then(Value::as_str)
+        })
+        .or_else(|| {
+            value
+                .pointer("/output/0/content/0/text")
+                .and_then(Value::as_str)
+        })
+        .unwrap_or(response_body)
+        .to_string())
+}
+
+#[derive(Debug)]
+struct BackendUrl {
+    host: String,
+    port: u16,
+    path: String,
+}
+
+fn parse_http_backend_url(url: &str) -> Result<BackendUrl> {
+    let rest = url.strip_prefix("http://").ok_or_else(|| {
+        OmxApiError::Message(
+            "OMX_API_PRIVATE_BACKEND_URL must use http:// in V1A; use a localhost TLS terminator for HTTPS backends".to_string(),
+        )
+    })?;
+    let (authority, path) = rest
+        .split_once('/')
+        .map(|(authority, path)| (authority, format!("/{path}")))
+        .unwrap_or((rest, "/".to_string()));
+    let (host, port) = if let Some((host, port)) = authority.rsplit_once(':') {
+        let parsed = port
+            .parse::<u16>()
+            .map_err(|_| OmxApiError::Message(format!("invalid private backend port in {url}")))?;
+        (host.to_string(), parsed)
+    } else {
+        (authority.to_string(), 80)
+    };
+    if host.is_empty() {
+        return Err(OmxApiError::Message(format!(
+            "empty private backend host in {url}"
+        )));
+    }
+    if !is_loopback_host(&host) && env::var_os("OMX_API_ALLOW_UNSAFE_PRIVATE_BACKEND").is_none() {
+        return Err(OmxApiError::Message(format!(
+            "private backend host `{host}` is not loopback; set OMX_API_ALLOW_UNSAFE_PRIVATE_BACKEND=1 only for trusted development"
+        )));
+    }
+    Ok(BackendUrl { host, port, path })
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    if host == "localhost" {
+        return true;
+    }
+    let trimmed = host.trim_matches(['[', ']']);
+    trimmed
+        .parse::<IpAddr>()
+        .map(|addr| addr.is_loopback())
+        .unwrap_or(false)
+}
+
+pub fn serve(config: ServerConfig) -> Result<DaemonState> {
+    validate_loopback_host(&config.host)?;
+    let listener = TcpListener::bind((config.host.as_str(), config.port))?;
+    let port = listener.local_addr()?.port();
+    let state = DaemonState {
+        pid: std::process::id(),
+        host: config.host.clone(),
+        port,
+        backend: config.backend.clone(),
+        started_at_unix: now_unix(),
+        local_bearer_token: config.local_bearer_token.clone(),
+        local_bearer_token_file: config
+            .local_bearer_token
+            .as_ref()
+            .map(|_| token_file_for_state(&config.state_file)),
+    };
+    if let Some(token) = config.local_bearer_token.as_deref() {
+        write_local_bearer_token(token_file_for_state(&config.state_file), token)?;
+    }
+    write_daemon_state(&config.state_file, &state)?;
+
+    let telemetry = Arc::new(Telemetry::default());
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    for stream in listener.incoming() {
+        let stream = stream?;
+        handle_connection(
+            stream,
+            &config.backend,
+            &telemetry,
+            &shutdown,
+            config.local_bearer_token.as_deref(),
+        )?;
+        if config.once || shutdown.load(Ordering::SeqCst) {
+            break;
+        }
+    }
+    remove_local_bearer_token(token_file_for_state(&config.state_file))?;
+    remove_daemon_state(&config.state_file)?;
+    Ok(state)
+}
+
+fn handle_connection(
+    mut stream: TcpStream,
+    backend: &BackendMode,
+    telemetry: &Telemetry,
+    shutdown: &AtomicBool,
+    expected_bearer: Option<&str>,
+) -> Result<()> {
+    stream.set_read_timeout(Some(Duration::from_secs(10)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(10)))?;
+    let request = read_http_request(&mut stream)?;
+    let response = route_request(
+        &request,
+        backend,
+        telemetry,
+        Some(shutdown),
+        expected_bearer,
+    );
+    write_http_response(&mut stream, response)?;
+    let _ = stream.shutdown(Shutdown::Both);
+    Ok(())
+}
+
+pub fn read_http_request(stream: &mut TcpStream) -> Result<Request> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut request_line = String::new();
+    reader.read_line(&mut request_line)?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or_default().to_string();
+    let path = parts
+        .next()
+        .unwrap_or("/")
+        .split('?')
+        .next()
+        .unwrap_or("/")
+        .to_string();
+
+    let mut headers = BTreeMap::new();
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line)?;
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((key, value)) = trimmed.split_once(':') {
+            headers.insert(key.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+
+    let length = headers
+        .get("content-length")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    let mut body = vec![0; length];
+    reader.read_exact(&mut body)?;
+
+    Ok(Request {
+        method,
+        path,
+        headers,
+        body,
+    })
+}
+
+pub fn write_http_response(stream: &mut TcpStream, response: Response) -> Result<()> {
+    let reason = reason_phrase(response.status);
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n",
+        response.status,
+        reason,
+        response.content_type,
+        response.body.len()
+    )?;
+    for (key, value) in response.extra_headers {
+        write!(stream, "{}: {}\r\n", key, value)?;
+    }
+    write!(stream, "\r\n")?;
+    stream.write_all(&response.body)?;
+    stream.flush()?;
+    Ok(())
+}
+
+fn reason_phrase(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        401 => "Unauthorized",
+        404 => "Not Found",
+        503 => "Service Unavailable",
+        _ => "OK",
+    }
+}
+
+pub fn stop_daemon(state_file: impl AsRef<Path>) -> Result<Value> {
+    let Some(state) = read_daemon_state(&state_file)? else {
+        return Ok(json!({"status": "not-running"}));
+    };
+    let response = http_request_with_bearer(
+        &state.host,
+        state.port,
+        "POST",
+        "/__admin/stop",
+        Some(b"{}"),
+        read_local_bearer_token(
+            state
+                .local_bearer_token_file
+                .as_ref()
+                .unwrap_or(&token_file_for_state(state_file.as_ref())),
+        )?
+        .as_deref(),
+    )?;
+    remove_local_bearer_token(
+        state
+            .local_bearer_token_file
+            .as_ref()
+            .unwrap_or(&token_file_for_state(state_file.as_ref())),
+    )?;
+    remove_daemon_state(state_file)?;
+    Ok(json!({"status": "stopped", "response": response}))
+}
+
+pub fn status(state_file: impl AsRef<Path>) -> Result<Value> {
+    Ok(match read_daemon_state(state_file)? {
+        Some(state) => json!({"status": "running", "daemon": state, "base_url": state.base_url()}),
+        None => json!({"status": "not-running"}),
+    })
+}
+
+pub fn http_request(
+    host: &str,
+    port: u16,
+    method: &str,
+    path: &str,
+    body: Option<&[u8]>,
+) -> Result<String> {
+    http_request_with_bearer(host, port, method, path, body, None)
+}
+
+pub fn http_request_with_bearer(
+    host: &str,
+    port: u16,
+    method: &str,
+    path: &str,
+    body: Option<&[u8]>,
+    bearer: Option<&str>,
+) -> Result<String> {
+    let mut stream = TcpStream::connect((host, port))?;
+    let body = body.unwrap_or_default();
+    write!(
+        stream,
+        "{} {} HTTP/1.1\r\nHost: {}:{}\r\nContent-Length: {}\r\n",
+        method,
+        path,
+        host,
+        port,
+        body.len()
+    )?;
+    if let Some(token) = bearer.filter(|token| !token.is_empty()) {
+        write!(stream, "Authorization: Bearer {token}\r\n")?;
+    }
+    write!(stream, "Connection: close\r\n\r\n")?;
+    stream.write_all(body)?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    Ok(response)
+}
+
+pub fn http_json_request(
+    host: &str,
+    port: u16,
+    method: &str,
+    path: &str,
+    body: &Value,
+    bearer: Option<&str>,
+) -> Result<String> {
+    let payload = serde_json::to_vec(body)?;
+    let raw = http_request_with_bearer(host, port, method, path, Some(&payload), bearer)?;
+    let (head, response_body) = raw
+        .split_once("\r\n\r\n")
+        .ok_or_else(|| OmxApiError::Message("local API returned malformed HTTP".to_string()))?;
+    let status = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(502);
+    if !(200..300).contains(&status) {
+        return Err(OmxApiError::Message(format!(
+            "local API returned HTTP {status}: {response_body}"
+        )));
+    }
+    Ok(response_body.to_string())
+}
+
+fn resolve_client_target(state_file: PathBuf) -> Result<(String, u16, Option<String>)> {
+    if let Some(url) = env::var("OMX_API_BASE_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        let parsed = parse_http_backend_url(url.trim_end_matches('/'))?;
+        return Ok((
+            parsed.host,
+            parsed.port,
+            env::var("OMX_API_LOCAL_BEARER").ok(),
+        ));
+    }
+    if let Some(state) = read_daemon_state(&state_file)? {
+        let token = read_local_bearer_token(
+            state
+                .local_bearer_token_file
+                .as_ref()
+                .unwrap_or(&token_file_for_state(&state_file)),
+        )?;
+        return Ok((state.host, state.port, token));
+    }
+    let port = env::var("OMX_API_PORT")
+        .ok()
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(DEFAULT_API_PORT);
+    Ok((
+        "127.0.0.1".to_string(),
+        port,
+        env::var("OMX_API_LOCAL_BEARER").ok(),
+    ))
+}
+
+fn spawn_daemon(config: &ServerConfig) -> Result<DaemonState> {
+    let exe = env::current_exe()?;
+    let token = config
+        .local_bearer_token
+        .clone()
+        .unwrap_or_else(generate_local_bearer_token);
+    let mut args = vec![
+        "serve".to_string(),
+        "--host".to_string(),
+        config.host.clone(),
+        "--port".to_string(),
+        config.port.to_string(),
+        "--backend".to_string(),
+        config.backend.as_str().to_string(),
+        "--state-file".to_string(),
+        config.state_file.display().to_string(),
+    ];
+    if config.once {
+        args.push("--once".to_string());
+    }
+    let mut child = Command::new(exe)
+        .args(args)
+        .env("OMX_API_LOCAL_BEARER", &token)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    for _ in 0..100 {
+        if let Some(state) = read_daemon_state(&config.state_file)? {
+            return Ok(state);
+        }
+        if let Some(status) = child.try_wait()? {
+            return Err(OmxApiError::Message(format!(
+                "daemon exited before writing state: {status}"
+            )));
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    Err(OmxApiError::Message(
+        "daemon did not write state within timeout".to_string(),
+    ))
+}
+
+pub fn run_cli<I, W, E>(args: I, mut stdout: W, _stderr: E) -> Result<()>
+where
+    I: IntoIterator,
+    I::Item: Into<String>,
+    W: Write,
+    E: Write,
+{
+    let args: Vec<String> = args.into_iter().map(Into::into).collect();
+    match args.first().map(String::as_str) {
+        Some("serve") => {
+            if args[1..].iter().any(|arg| arg == "--system") {
+                if args[1..].iter().any(|arg| arg == "--dry-run") {
+                    run_system_plan(&args[1..], stdout)?;
+                    return Ok(());
+                }
+                return Err(OmxApiError::Message(
+                    "serve --system is dry-run only in V1A; pass --dry-run to inspect the service plan"
+                        .to_string(),
+                ));
+            }
+            let config = parse_server_config(&args[1..])?;
+            if config.daemon {
+                let state = spawn_daemon(&config)?;
+                writeln!(
+                    stdout,
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "status": "started",
+                        "daemon": state,
+                        "base_url": state.base_url()
+                    }))?
+                )?;
+            } else if config.once {
+                let state = serve(config)?;
+                writeln!(
+                    stdout,
+                    "{}",
+                    serde_json::to_string(&json!({"served": state}))?
+                )?;
+            } else {
+                serve(config)?;
+            }
+        }
+        Some("generate") => run_generate(&args[1..], stdout)?,
+        Some("smoke") => run_smoke(&args[1..], stdout)?,
+        Some("status") => {
+            let state_file = parse_state_file(&args[1..])?;
+            writeln!(
+                stdout,
+                "{}",
+                serde_json::to_string_pretty(&status(state_file)?)?
+            )?;
+        }
+        Some("stop") => {
+            let state_file = parse_state_file(&args[1..])?;
+            writeln!(
+                stdout,
+                "{}",
+                serde_json::to_string_pretty(&stop_daemon(state_file)?)?
+            )?;
+        }
+        Some("system") => run_system(&args[1..], stdout)?,
+        Some("help") | Some("--help") | Some("-h") | None => {
+            writeln!(stdout, "{}", help_text())?;
+        }
+        Some(other) => {
+            return Err(OmxApiError::Message(format!(
+                "unknown subcommand '{other}'"
+            )))
+        }
+    }
+    Ok(())
+}
+
+fn run_system<W: Write>(args: &[String], mut stdout: W) -> Result<()> {
+    match args.first().map(String::as_str) {
+        Some("dry-run") => writeln!(
+            stdout,
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "action": "system.dry-run",
+                "would_start": "omx-api serve --backend mock"
+            }))?
+        )?,
+        Some("generate") => writeln!(
+            stdout,
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "action": "system.generate",
+                "files": ["state-file", "localhost-http-server"]
+            }))?
+        )?,
+        Some(other) => {
+            return Err(OmxApiError::Message(format!(
+                "unknown system action '{other}'"
+            )))
+        }
+        None => {
+            return Err(OmxApiError::Message(
+                "system requires dry-run or generate".to_string(),
+            ))
+        }
+    }
+    Ok(())
+}
+
+fn run_system_plan<W: Write>(args: &[String], mut stdout: W) -> Result<()> {
+    let mut service_args = vec!["serve".to_string()];
+    for arg in args {
+        if arg != "--system" && arg != "--dry-run" {
+            service_args.push(arg.clone());
+        }
+    }
+    writeln!(
+        stdout,
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "ok": true,
+            "action": "serve.system.dry-run",
+            "platform": env::consts::OS,
+            "install_supported": false,
+            "reason": "V1A emits a platform-aware service plan but refuses persistent service installation",
+            "argv": service_args
+        }))?
+    )?;
+    Ok(())
+}
+
+fn run_generate<W: Write>(args: &[String], mut stdout: W) -> Result<()> {
+    let Some(kind) = args.first().map(String::as_str) else {
+        return Err(OmxApiError::Message(
+            "generate requires text or image".to_string(),
+        ));
+    };
+    let mut state_file = default_state_file();
+    let mut prompt_parts = Vec::new();
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--state-file" => {
+                index += 1;
+                state_file = PathBuf::from(required_value(args, index, "--state-file")?);
+            }
+            value => prompt_parts.push(value.to_string()),
+        }
+        index += 1;
+    }
+    let prompt = prompt_parts.join(" ");
+    if prompt.trim().is_empty() {
+        return Err(OmxApiError::Message(format!(
+            "generate {kind} requires a prompt"
+        )));
+    }
+    let (host, port, bearer) = resolve_client_target(state_file)?;
+    let (path, body) = match kind {
+        "text" => (
+            "/v1/responses",
+            json!({"model": env::var("OMX_API_GENERATE_MODEL").unwrap_or_else(|_| "omx-private".to_string()), "input": prompt}),
+        ),
+        "image" => ("/v1/images/generations", json!({"prompt": prompt})),
+        other => {
+            return Err(OmxApiError::Message(format!(
+                "unknown generate kind '{other}'; expected text or image"
+            )))
+        }
+    };
+    let response = http_json_request(&host, port, "POST", path, &body, bearer.as_deref())?;
+    writeln!(stdout, "{response}")?;
+    Ok(())
+}
+
+fn run_smoke<W: Write>(args: &[String], mut stdout: W) -> Result<()> {
+    match args.first().map(String::as_str) {
+        Some("text") => {
+            if env::var_os("OMX_API_LIVE_SMOKE").is_none() {
+                return Err(OmxApiError::Message(
+                    "set OMX_API_LIVE_SMOKE=1 to run the real-private text smoke".to_string(),
+                ));
+            }
+            let body = json!({"model": "omx-private", "input": "Say OMX API smoke OK."});
+            let response = real_private_text_response(&body, "response", false);
+            writeln!(stdout, "{}", String::from_utf8_lossy(&response.body).trim())?;
+            Ok(())
+        }
+        _ => Err(OmxApiError::Message(
+            "smoke requires text (example: OMX_API_LIVE_SMOKE=1 omx-api smoke text)".to_string(),
+        )),
+    }
+}
+
+fn parse_server_config(args: &[String]) -> Result<ServerConfig> {
+    let mut config = ServerConfig {
+        local_bearer_token: env::var("OMX_API_LOCAL_BEARER")
+            .ok()
+            .filter(|value| !value.trim().is_empty()),
+        ..ServerConfig::default()
+    };
+    if let Some(backend) = env::var("OMX_API_BACKEND")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        config.backend = BackendMode::parse(&backend)?;
+    }
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--host" => {
+                index += 1;
+                config.host = required_value(args, index, "--host")?.to_string();
+            }
+            "--port" => {
+                index += 1;
+                config.port = required_value(args, index, "--port")?
+                    .parse()
+                    .map_err(|_| OmxApiError::Message("--port must be an integer".to_string()))?;
+            }
+            "--backend" => {
+                index += 1;
+                config.backend = BackendMode::parse(required_value(args, index, "--backend")?)?;
+            }
+            "--state-file" => {
+                index += 1;
+                config.state_file = PathBuf::from(required_value(args, index, "--state-file")?);
+            }
+            "--once" => config.once = true,
+            "--daemon" => config.daemon = true,
+            "--dry-run" => {}
+            "--system" => {}
+            other => {
+                return Err(OmxApiError::Message(format!(
+                    "unknown serve flag '{other}'"
+                )))
+            }
+        }
+        index += 1;
+    }
+    validate_loopback_host(&config.host)?;
+    Ok(config)
+}
+
+fn validate_loopback_host(host: &str) -> Result<()> {
+    if is_loopback_host(host) {
+        Ok(())
+    } else {
+        Err(OmxApiError::Message(format!(
+            "omx-api is localhost-only; refusing non-loopback host `{host}`"
+        )))
+    }
+}
+
+fn generate_local_bearer_token() -> String {
+    let mut bytes = [0_u8; 32];
+    if fs::File::open("/dev/urandom")
+        .and_then(|mut file| file.read_exact(&mut bytes))
+        .is_err()
+    {
+        let seed = format!("{}-{}", std::process::id(), now_unix());
+        for (index, byte) in seed.as_bytes().iter().enumerate() {
+            bytes[index % bytes.len()] ^= *byte;
+        }
+    }
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn parse_state_file(args: &[String]) -> Result<PathBuf> {
+    let mut state_file = default_state_file();
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--state-file" => {
+                index += 1;
+                state_file = PathBuf::from(required_value(args, index, "--state-file")?);
+            }
+            other => return Err(OmxApiError::Message(format!("unknown flag '{other}'"))),
+        }
+        index += 1;
+    }
+    Ok(state_file)
+}
+
+fn required_value<'a>(args: &'a [String], index: usize, flag: &str) -> Result<&'a str> {
+    args.get(index)
+        .map(String::as_str)
+        .ok_or_else(|| OmxApiError::Message(format!("{flag} requires a value")))
+}
+
+fn help_text() -> &'static str {
+    "omx-api serve [--daemon] [--system --dry-run]|status|stop|generate text|generate image|smoke text"
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock")
+    }
+
+    fn request(method: &str, path: &str, body: Value) -> Request {
+        Request {
+            method: method.to_string(),
+            path: path.to_string(),
+            headers: BTreeMap::new(),
+            body: serde_json::to_vec(&body).unwrap(),
+        }
+    }
+
+    #[test]
+    fn routes_health_and_models() {
+        let telemetry = Telemetry::default();
+        let health = route_request(
+            &request("GET", "/health", json!({})),
+            &BackendMode::Mock,
+            &telemetry,
+            None,
+            None,
+        );
+        assert_eq!(health.status, 200);
+        assert!(String::from_utf8(health.body).unwrap().contains("mock"));
+
+        let models = route_request(
+            &request("GET", "/v1/models", json!({})),
+            &BackendMode::Mock,
+            &telemetry,
+            None,
+            None,
+        );
+        assert_eq!(models.status, 200);
+        assert!(String::from_utf8(models.body).unwrap().contains("omx-mock"));
+        assert_eq!(telemetry.snapshot().requests_total, 2);
+    }
+
+    #[test]
+    fn response_endpoint_redacts_prompt_secrets() {
+        let telemetry = Telemetry::default();
+        let response = route_request(
+            &request(
+                "POST",
+                "/v1/responses",
+                json!({"input": "use sk-secret123 please"}),
+            ),
+            &BackendMode::Mock,
+            &telemetry,
+            None,
+            None,
+        );
+        let body = String::from_utf8(response.body).unwrap();
+        assert!(body.contains("[REDACTED]"));
+        assert!(!body.contains("sk-secret123"));
+    }
+
+    #[test]
+    fn redacts_bearer_credentials_as_pairs() {
+        let redacted = redact_secrets("Authorization: Bearer abc123 and Bearer def456");
+        assert!(!redacted.contains("abc123"));
+        assert!(!redacted.contains("def456"));
+        assert!(redacted.contains("[REDACTED] [REDACTED]"));
+    }
+
+    #[test]
+    fn route_requires_matching_local_bearer_when_configured() {
+        let telemetry = Telemetry::default();
+        let response = route_request(
+            &request("GET", "/v1/models", json!({})),
+            &BackendMode::Mock,
+            &telemetry,
+            None,
+            Some("secret-token"),
+        );
+        assert_eq!(response.status, 401);
+
+        let mut authed = request("GET", "/v1/models", json!({}));
+        authed.headers.insert(
+            "authorization".to_string(),
+            "Bearer secret-token".to_string(),
+        );
+        let response = route_request(
+            &authed,
+            &BackendMode::Mock,
+            &telemetry,
+            None,
+            Some("secret-token"),
+        );
+        assert_eq!(response.status, 200);
+    }
+
+    #[test]
+    fn private_backend_url_rejects_non_loopback_plain_http() {
+        let error = parse_http_backend_url("http://example.com/v1/responses")
+            .expect_err("non-loopback private backend must be rejected");
+        assert!(error.to_string().contains("not loopback"));
+        let error = parse_http_backend_url("http://127.0.0.1.evil.test/v1/responses")
+            .expect_err("hostname prefix must not bypass loopback check");
+        assert!(error.to_string().contains("not loopback"));
+    }
+
+    #[test]
+    fn chat_stream_response_uses_chat_chunk_shape() {
+        let telemetry = Telemetry::default();
+        let response = route_request(
+            &request(
+                "POST",
+                "/v1/chat/completions",
+                json!({"stream": true, "messages": []}),
+            ),
+            &BackendMode::Mock,
+            &telemetry,
+            None,
+            None,
+        );
+        assert_eq!(response.content_type, "text/event-stream");
+        let body = String::from_utf8(response.body).unwrap();
+        assert!(body.contains("\"object\":\"chat.completion.chunk\""));
+        assert!(body.contains("\"delta\":{\"content\":\"omx mock response\"}"));
+        assert!(body.contains("data: [DONE]"));
+    }
+
+    #[test]
+    fn image_stream_response_uses_image_events() {
+        let telemetry = Telemetry::default();
+        let response = route_request(
+            &request(
+                "POST",
+                "/v1/images/generations",
+                json!({"stream": true, "prompt": "x"}),
+            ),
+            &BackendMode::Mock,
+            &telemetry,
+            None,
+            None,
+        );
+        assert_eq!(response.content_type, "text/event-stream");
+        let body = String::from_utf8(response.body).unwrap();
+        assert!(body.contains("event: image_generation.partial_image"));
+        assert!(body.contains("data: [DONE]"));
+    }
+
+    #[test]
+    fn real_private_image_is_unsupported_request() {
+        env::remove_var("OMX_API_REAL_PRIVATE_ALLOW");
+        let telemetry = Telemetry::default();
+        let response = route_request(
+            &request("POST", "/v1/images/generations", json!({"prompt": "x"})),
+            &BackendMode::RealPrivate,
+            &telemetry,
+            None,
+            None,
+        );
+        assert_eq!(response.status, 501);
+    }
+
+    #[test]
+    fn real_private_chat_stream_preserves_backend_errors() {
+        let _guard = env_lock();
+        env::remove_var("OMX_API_REAL_PRIVATE_RESPONSE_TEXT");
+        env::remove_var("OMX_API_CODEX_OAUTH_TOKEN");
+        env::remove_var("OMX_API_PRIVATE_BACKEND_URL");
+        let telemetry = Telemetry::default();
+        let response = route_request(
+            &request(
+                "POST",
+                "/v1/chat/completions",
+                json!({"stream": true, "messages": []}),
+            ),
+            &BackendMode::RealPrivate,
+            &telemetry,
+            None,
+            None,
+        );
+        assert_eq!(response.status, 503);
+        assert_eq!(response.content_type, "application/json");
+        let body = String::from_utf8(response.body).unwrap();
+        assert!(body.contains("missing_auth"));
+    }
+
+    #[test]
+    fn daemon_state_round_trips() {
+        let path = env::temp_dir().join(format!("omx-api-test-{}.json", now_unix()));
+        let state = DaemonState {
+            pid: 42,
+            host: "127.0.0.1".to_string(),
+            port: 9999,
+            backend: BackendMode::Mock,
+            started_at_unix: 1,
+            local_bearer_token: None,
+            local_bearer_token_file: None,
+        };
+        write_daemon_state(&path, &state).unwrap();
+        let raw = fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("local_bearer_token"));
+        let read = read_daemon_state(&path).unwrap().unwrap();
+        assert_eq!(read.pid, 42);
+        remove_daemon_state(&path).unwrap();
+        assert!(read_daemon_state(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn cli_system_dry_run_is_json() {
+        let mut out = Vec::new();
+        run_cli(["system", "dry-run"], &mut out, io::sink()).unwrap();
+        let value: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(value["action"], "system.dry-run");
+    }
+}

--- a/crates/omx-api/src/lib.rs
+++ b/crates/omx-api/src/lib.rs
@@ -823,7 +823,7 @@ fn build_codex_native_request(
         .unwrap_or_else(|| "omx-private".to_string());
     let prompt = extract_prompt(body);
     let path = normalize_codex_responses_path(upstream_path);
-    let request_body = json!({
+    let mut request_body = json!({
         "model": model,
         "input": [{
             "type": "message",
@@ -833,7 +833,7 @@ fn build_codex_native_request(
         "tools": [],
         "tool_choice": "auto",
         "parallel_tool_calls": false,
-        "reasoning": null,
+        "reasoning": body.get("reasoning").cloned().unwrap_or(Value::Null),
         "store": false,
         "stream": true,
         "include": [],
@@ -842,6 +842,9 @@ fn build_codex_native_request(
             CODEX_INSTALLATION_ID_HEADER: installation_id.clone()
         }
     });
+    if let Some(instructions) = body.get("instructions").cloned() {
+        request_body["instructions"] = instructions;
+    }
 
     let mut headers = vec![
         ("Content-Type".to_string(), "application/json".to_string()),
@@ -1793,7 +1796,12 @@ mod tests {
         };
         let request = build_codex_native_request(
             "/backend-api/codex",
-            &json!({"model": "gpt-5.3-codex", "input": "summarize this"}),
+            &json!({
+                "model": "gpt-5.3-codex",
+                "input": "summarize this",
+                "reasoning": {"effort": "low"},
+                "instructions": "Follow the sparkshell summary contract."
+            }),
             &auth,
         );
 
@@ -1835,6 +1843,11 @@ mod tests {
         assert_eq!(request.body["tools"], json!([]));
         assert_eq!(request.body["tool_choice"], "auto");
         assert_eq!(request.body["parallel_tool_calls"], false);
+        assert_eq!(request.body["reasoning"], json!({"effort": "low"}));
+        assert_eq!(
+            request.body["instructions"],
+            "Follow the sparkshell summary contract."
+        );
         assert_eq!(request.body["store"], false);
         assert_eq!(request.body["stream"], true);
         assert_eq!(request.body["include"], json!([]));
@@ -1915,8 +1928,13 @@ mod tests {
             "OMX_API_PRIVATE_BACKEND_URL",
             format!("http://127.0.0.1:{}/backend-api/codex", addr.port()),
         );
-        let text = real_private_text(&json!({"model": "gpt-5.3-codex", "input": "ping"}))
-            .expect("private text response");
+        let text = real_private_text(&json!({
+            "model": "gpt-5.3-codex",
+            "input": "ping",
+            "reasoning": {"effort": "low"},
+            "instructions": "Summarize via sparkshell."
+        }))
+        .expect("private text response");
         handle.join().expect("server thread");
 
         assert_eq!(text, "hello");
@@ -1935,6 +1953,10 @@ mod tests {
             raw.contains("\"type\":\"input_text\"") || raw.contains("\"type\": \"input_text\"")
         );
         assert!(raw.contains("\"text\":\"ping\"") || raw.contains("\"text\": \"ping\""));
+        let forwarded_body = raw.split("\r\n\r\n").nth(1).expect("forwarded body");
+        let forwarded_json: Value = serde_json::from_str(forwarded_body).expect("forwarded JSON");
+        assert_eq!(forwarded_json["reasoning"], json!({"effort": "low"}));
+        assert_eq!(forwarded_json["instructions"], "Summarize via sparkshell.");
 
         env::remove_var("OMX_API_CODEX_OAUTH_TOKEN");
         env::remove_var("OMX_API_CODEX_ACCOUNT_ID");

--- a/crates/omx-api/src/main.rs
+++ b/crates/omx-api/src/main.rs
@@ -1,0 +1,10 @@
+fn main() {
+    if let Err(error) = omx_api::run_cli(
+        std::env::args().skip(1),
+        std::io::stdout(),
+        std::io::stderr(),
+    ) {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}

--- a/crates/omx-api/tests/cli.rs
+++ b/crates/omx-api/tests/cli.rs
@@ -1,0 +1,242 @@
+use omx_api::{http_request, http_request_with_bearer, read_daemon_state};
+use serde_json::Value;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn temp_state_file(name: &str) -> std::path::PathBuf {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    std::env::temp_dir().join(format!("omx-api-{name}-{millis}.json"))
+}
+
+#[test]
+fn binary_system_dry_run_and_generate_emit_json() {
+    let bin = env!("CARGO_BIN_EXE_omx-api");
+    for action in ["dry-run", "generate"] {
+        let output = Command::new(bin)
+            .args(["system", action])
+            .output()
+            .expect("run omx-api system action");
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let value: Value = serde_json::from_slice(&output.stdout).expect("json stdout");
+        assert_eq!(value["ok"], true);
+        assert_eq!(value["action"], format!("system.{action}"));
+    }
+}
+
+#[test]
+fn binary_serve_status_and_stop_work_together() {
+    let bin = env!("CARGO_BIN_EXE_omx-api");
+    let state_file = temp_state_file("serve-status-stop");
+    let mut child = Command::new(bin)
+        .args([
+            "serve",
+            "--port",
+            "0",
+            "--state-file",
+            state_file.to_str().unwrap(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn omx-api serve");
+
+    let state = (0..50)
+        .find_map(|_| {
+            let state = read_daemon_state(&state_file).ok().flatten();
+            if state.is_none() {
+                thread::sleep(Duration::from_millis(20));
+            }
+            state
+        })
+        .expect("server wrote daemon state");
+
+    let status = Command::new(bin)
+        .args(["status", "--state-file", state_file.to_str().unwrap()])
+        .output()
+        .expect("run status");
+    assert!(status.status.success());
+    let status_json: Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_eq!(status_json["status"], "running");
+
+    let health = http_request(&state.host, state.port, "GET", "/health", None).unwrap();
+    assert!(health.contains("200 OK"));
+    assert!(health.contains("\"status\":\"ok\""));
+
+    let stop = Command::new(bin)
+        .args(["stop", "--state-file", state_file.to_str().unwrap()])
+        .output()
+        .expect("run stop");
+    assert!(
+        stop.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
+
+    let exit = child
+        .wait_timeout(Duration::from_secs(2))
+        .expect("wait for child");
+    if exit.is_none() {
+        let _ = child.kill();
+        panic!("server did not stop after stop command");
+    }
+}
+
+#[test]
+fn binary_local_bearer_gate_rejects_missing_authorization() {
+    let bin = env!("CARGO_BIN_EXE_omx-api");
+    let state_file = temp_state_file("bearer-required");
+    let mut child = Command::new(bin)
+        .args([
+            "serve",
+            "--port",
+            "0",
+            "--once",
+            "--state-file",
+            state_file.to_str().unwrap(),
+        ])
+        .env("OMX_API_REQUIRE_LOCAL_BEARER", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn omx-api serve");
+
+    let state = (0..50)
+        .find_map(|_| {
+            let state = read_daemon_state(&state_file).ok().flatten();
+            if state.is_none() {
+                thread::sleep(Duration::from_millis(20));
+            }
+            state
+        })
+        .expect("server wrote daemon state");
+
+    let response = http_request(&state.host, state.port, "GET", "/v1/models", None).unwrap();
+    assert!(response.contains("401 Unauthorized"), "{response}");
+    assert!(
+        response.contains("local bearer token required"),
+        "{response}"
+    );
+
+    let exit = child
+        .wait_timeout(Duration::from_secs(2))
+        .expect("wait for child");
+    assert!(exit.is_some(), "server did not exit after --once request");
+}
+
+#[test]
+fn binary_daemon_token_is_not_printed_but_controls_generate_and_stop() {
+    let bin = env!("CARGO_BIN_EXE_omx-api");
+    let state_file = temp_state_file("daemon-token");
+    let start = Command::new(bin)
+        .args([
+            "serve",
+            "--port",
+            "0",
+            "--daemon",
+            "--state-file",
+            state_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("start daemon");
+    assert!(
+        start.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&start.stdout);
+    assert!(!stdout.contains("local_bearer_token\":"), "{stdout}");
+
+    let state = read_daemon_state(&state_file).unwrap().unwrap();
+    assert!(state.local_bearer_token.is_none());
+    let token_file = state
+        .local_bearer_token_file
+        .clone()
+        .expect("token file path");
+    let token = std::fs::read_to_string(&token_file).expect("token file");
+    assert!(!stdout.contains(token.trim()), "daemon stdout leaked token");
+
+    let unauthorized = http_request(&state.host, state.port, "GET", "/v1/models", None).unwrap();
+    assert!(unauthorized.contains("401 Unauthorized"), "{unauthorized}");
+    let authorized = http_request_with_bearer(
+        &state.host,
+        state.port,
+        "GET",
+        "/v1/models",
+        None,
+        Some(token.trim()),
+    )
+    .unwrap();
+    assert!(authorized.contains("200 OK"), "{authorized}");
+
+    let generated = Command::new(bin)
+        .args([
+            "generate",
+            "text",
+            "hello",
+            "--state-file",
+            state_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("generate through daemon");
+    assert!(
+        generated.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&generated.stderr)
+    );
+    assert!(String::from_utf8_lossy(&generated.stdout).contains("omx mock response"));
+
+    let stop = Command::new(bin)
+        .args(["stop", "--state-file", state_file.to_str().unwrap()])
+        .output()
+        .expect("stop daemon");
+    assert!(
+        stop.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
+    assert!(!token_file.exists(), "token file should be removed on stop");
+}
+
+#[test]
+fn binary_rejects_non_loopback_host() {
+    let bin = env!("CARGO_BIN_EXE_omx-api");
+    let output = Command::new(bin)
+        .args(["serve", "--host", "0.0.0.0", "--once"])
+        .output()
+        .expect("run omx-api serve");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("localhost-only"));
+}
+
+trait WaitTimeout {
+    fn wait_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> std::io::Result<Option<std::process::ExitStatus>>;
+}
+
+impl WaitTimeout for std::process::Child {
+    fn wait_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> std::io::Result<Option<std::process::ExitStatus>> {
+        let start = std::time::Instant::now();
+        loop {
+            if let Some(status) = self.try_wait()? {
+                return Ok(Some(status));
+            }
+            if start.elapsed() >= timeout {
+                return Ok(None);
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+}

--- a/crates/omx-sparkshell/src/codex_bridge.rs
+++ b/crates/omx-sparkshell/src/codex_bridge.rs
@@ -2,12 +2,13 @@ use crate::error::SparkshellError;
 use crate::exec::CommandOutput;
 use crate::prompt::build_summary_prompt;
 use std::env;
+use std::fs;
 use std::io::{Read, Write};
-use std::process::{Command, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::net::{IpAddr, TcpStream, ToSocketAddrs};
+use std::time::Duration;
 
 pub const DEFAULT_SUMMARY_TIMEOUT_MS: u64 = 60_000;
+pub const DEFAULT_API_BASE_URL: &str = "http://127.0.0.1:14510";
 pub const DEFAULT_SPARK_MODEL: &str = "gpt-5.3-codex-spark";
 pub const DEFAULT_STANDARD_MODEL: &str = "gpt-5.4-mini";
 
@@ -63,43 +64,32 @@ pub fn summarize_output(
     let model = resolve_model();
     let fallback_model = resolve_fallback_model();
     let timeout_ms = read_summary_timeout_ms();
-    let (stdout, stderr, status_ok) = run_codex_exec(&prompt, &model, timeout_ms)?;
-    if !status_ok {
-        let should_retry = fallback_model != model && should_retry_with_fallback(&stderr);
-        if should_retry {
-            let (fallback_stdout, fallback_stderr, fallback_ok) =
-                run_codex_exec(&prompt, &fallback_model, timeout_ms)?;
-            if !fallback_ok {
-                let primary_message = if stderr.trim().is_empty() {
-                    "codex exec exited unsuccessfully".to_string()
-                } else {
-                    stderr.trim().to_string()
-                };
-                let fallback_message = if fallback_stderr.trim().is_empty() {
-                    "codex exec exited unsuccessfully".to_string()
-                } else {
-                    fallback_stderr.trim().to_string()
-                };
-                return Err(SparkshellError::SummaryBridge(format!(
-                    "codex exec failed for primary model `{model}` ({primary_message}) and fallback model `{fallback_model}` ({fallback_message})"
-                )));
+    match request_summary(&prompt, &model, timeout_ms) {
+        Ok(stdout) => normalize_summary(&stdout).ok_or_else(|| {
+            SparkshellError::SummaryBridge(
+                "local API returned no valid summary sections".to_string(),
+            )
+        }),
+        Err(primary_error) => {
+            let primary_message = primary_error.to_string();
+            if fallback_model != model && should_retry_with_fallback(&primary_message) {
+                match request_summary(&prompt, &fallback_model, timeout_ms) {
+                    Ok(fallback_stdout) => normalize_summary(&fallback_stdout).ok_or_else(|| {
+                        SparkshellError::SummaryBridge(
+                            "local API fallback returned no valid summary sections".to_string(),
+                        )
+                    }),
+                    Err(fallback_error) => Err(SparkshellError::SummaryBridge(format!(
+                        "local API failed for primary model `{model}` ({primary_message}) and fallback model `{fallback_model}` ({fallback_error})"
+                    ))),
+                }
+            } else {
+                Err(SparkshellError::SummaryBridge(format!(
+                    "local API summary request failed: {primary_message}"
+                )))
             }
-            return normalize_summary(&fallback_stdout).ok_or_else(|| {
-                SparkshellError::SummaryBridge(
-                    "codex exec fallback returned no valid summary sections".to_string(),
-                )
-            });
         }
-        let message = if stderr.trim().is_empty() {
-            "codex exec exited unsuccessfully".to_string()
-        } else {
-            format!("codex exec exited unsuccessfully: {}", stderr.trim())
-        };
-        return Err(SparkshellError::SummaryBridge(message));
     }
-    normalize_summary(&stdout).ok_or_else(|| {
-        SparkshellError::SummaryBridge("codex exec returned no valid summary sections".to_string())
-    })
 }
 
 fn should_retry_with_fallback(stderr: &str) -> bool {
@@ -119,93 +109,300 @@ fn should_retry_with_fallback(stderr: &str) -> bool {
     .any(|needle| normalized.contains(needle))
 }
 
-fn run_codex_exec(
-    prompt: &str,
-    model: &str,
-    timeout_ms: u64,
-) -> Result<(String, String, bool), SparkshellError> {
-    let mut child = Command::new("codex")
-        .arg("exec")
-        .arg("--model")
-        .arg(model)
-        .arg("--sandbox")
-        .arg("read-only")
-        .arg("-c")
-        .arg("model_reasoning_effort=\"low\"")
-        .args(resolve_instructions_file().into_iter().flat_map(|path| {
-            [
-                "-c".to_string(),
-                format!("model_instructions_file=\"{}\"", escape_toml_string(&path)),
-            ]
-        }))
-        .arg("--skip-git-repo-check")
-        .arg("--color")
-        .arg("never")
-        .arg("-")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    let mut stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| SparkshellError::SummaryBridge("failed to open codex stdin".to_string()))?;
-    let mut stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| SparkshellError::SummaryBridge("failed to open codex stdout".to_string()))?;
-    let mut stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| SparkshellError::SummaryBridge("failed to open codex stderr".to_string()))?;
-
-    let prompt_owned = prompt.to_string();
-    let stdin_writer = thread::spawn(move || stdin.write_all(prompt_owned.as_bytes()));
-    let stdout_reader = thread::spawn(move || {
-        let mut buffer = Vec::new();
-        let _ = stdout.read_to_end(&mut buffer);
-        buffer
-    });
-    let stderr_reader = thread::spawn(move || {
-        let mut buffer = Vec::new();
-        let _ = stderr.read_to_end(&mut buffer);
-        buffer
-    });
-
-    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
-    let status = loop {
-        if let Some(status) = child.try_wait()? {
-            break status;
-        }
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = stdin_writer.join();
-            let _ = stdout_reader.join();
-            let _ = stderr_reader.join();
-            return Err(SparkshellError::SummaryTimeout(timeout_ms));
-        }
-        thread::sleep(Duration::from_millis(25));
-    };
-
-    let _ = stdin_writer.join();
-    let stdout_bytes = stdout_reader
-        .join()
-        .map_err(|_| SparkshellError::SummaryBridge("failed reading codex stdout".to_string()))?;
-    let stderr_bytes = stderr_reader
-        .join()
-        .map_err(|_| SparkshellError::SummaryBridge("failed reading codex stderr".to_string()))?;
-
-    Ok((
-        String::from_utf8_lossy(&stdout_bytes).into_owned(),
-        String::from_utf8_lossy(&stderr_bytes).into_owned(),
-        status.success(),
-    ))
+fn request_summary(prompt: &str, model: &str, timeout_ms: u64) -> Result<String, SparkshellError> {
+    let api_base_url = resolve_api_base_url();
+    let endpoint = join_api_path(&api_base_url, "/v1/responses");
+    let request = build_responses_request(prompt, model)?;
+    let response_body = post_json(&endpoint, &request, timeout_ms, resolve_api_bearer())?;
+    extract_output_text(&response_body).ok_or_else(|| {
+        SparkshellError::SummaryBridge("local API response did not include output_text".to_string())
+    })
 }
 
-fn escape_toml_string(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
+fn resolve_api_base_url() -> String {
+    env::var("OMX_API_BASE_URL")
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            env::var("OMX_API_PORT")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .map(|port| format!("http://127.0.0.1:{port}"))
+        })
+        .unwrap_or_else(|| DEFAULT_API_BASE_URL.to_string())
+}
+
+fn resolve_api_bearer() -> Option<String> {
+    env::var("OMX_API_LOCAL_BEARER")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            let path = env::var("OMX_API_STATE_FILE")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| {
+                    env::temp_dir()
+                        .join("omx-api-daemon.json")
+                        .display()
+                        .to_string()
+                });
+            fs::read_to_string(path)
+                .ok()
+                .and_then(|state| extract_json_string_field(&state, "local_bearer_token_file"))
+                .and_then(|token_file| fs::read_to_string(token_file).ok())
+                .map(|token| token.trim().to_string())
+                .filter(|token| !token.is_empty())
+        })
+}
+
+fn build_responses_request(prompt: &str, model: &str) -> Result<String, SparkshellError> {
+    let mut fields = vec![
+        format!("\"model\":{}", json_string(model)),
+        format!("\"input\":{}", json_string(prompt)),
+        "\"reasoning\":{\"effort\":\"low\"}".to_string(),
+        "\"stream\":false".to_string(),
+    ];
+
+    if let Some(path) = resolve_instructions_file() {
+        let instructions = fs::read_to_string(&path).map_err(|error| {
+            SparkshellError::SummaryBridge(format!(
+                "failed to read summary instructions file `{path}`: {error}"
+            ))
+        })?;
+        fields.push(format!("\"instructions\":{}", json_string(&instructions)));
+    }
+
+    Ok(format!("{{{}}}", fields.join(",")))
+}
+
+fn join_api_path(base_url: &str, path: &str) -> String {
+    format!(
+        "{}{}{}",
+        base_url.trim_end_matches('/'),
+        if path.starts_with('/') { "" } else { "/" },
+        path
+    )
+}
+
+fn post_json(
+    url: &str,
+    body: &str,
+    timeout_ms: u64,
+    bearer: Option<String>,
+) -> Result<String, SparkshellError> {
+    let parsed = parse_http_url(url)?;
+    let timeout = Duration::from_millis(timeout_ms);
+    let mut addrs = (parsed.host.as_str(), parsed.port)
+        .to_socket_addrs()
+        .map_err(|error| {
+            SparkshellError::SummaryBridge(format!(
+                "failed to resolve local API host `{}`: {error}",
+                parsed.host
+            ))
+        })?;
+    let addr = addrs.next().ok_or_else(|| {
+        SparkshellError::SummaryBridge(format!(
+            "failed to resolve local API host `{}`",
+            parsed.host
+        ))
+    })?;
+    let mut stream = TcpStream::connect_timeout(&addr, timeout)
+        .map_err(|error| map_api_io_error(error, timeout_ms, "local API connection failed"))?;
+    stream.set_read_timeout(Some(timeout)).map_err(|error| {
+        map_api_io_error(error, timeout_ms, "local API read timeout setup failed")
+    })?;
+    stream.set_write_timeout(Some(timeout)).map_err(|error| {
+        map_api_io_error(error, timeout_ms, "local API write timeout setup failed")
+    })?;
+
+    let host_header = if parsed.explicit_port {
+        format!("{}:{}", parsed.host, parsed.port)
+    } else {
+        parsed.host.clone()
+    };
+    let auth_header = bearer
+        .as_deref()
+        .map(|token| format!("Authorization: Bearer {token}\r\n"))
+        .unwrap_or_default();
+    let request = format!(
+        "POST {} HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nAccept: application/json\r\n{}Connection: close\r\nContent-Length: {}\r\n\r\n{}",
+        parsed.path, host_header, auth_header, body.len(), body
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| map_api_io_error(error, timeout_ms, "local API write failed"))?;
+    stream
+        .flush()
+        .map_err(|error| map_api_io_error(error, timeout_ms, "local API flush failed"))?;
+
+    let mut raw = Vec::new();
+    stream
+        .read_to_end(&mut raw)
+        .map_err(|error| map_api_io_error(error, timeout_ms, "local API read failed"))?;
+    let response = String::from_utf8_lossy(&raw);
+    let (head, response_body) = response.split_once("\r\n\r\n").ok_or_else(|| {
+        SparkshellError::SummaryBridge("local API returned malformed HTTP response".to_string())
+    })?;
+    let status_line = head.lines().next().unwrap_or_default();
+    let status_code = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|value| value.parse::<u16>().ok())
+        .ok_or_else(|| {
+            SparkshellError::SummaryBridge("local API returned malformed HTTP status".to_string())
+        })?;
+    if !(200..300).contains(&status_code) {
+        return Err(SparkshellError::SummaryBridge(format!(
+            "local API returned HTTP {status_code}: {}",
+            response_body.trim()
+        )));
+    }
+    Ok(response_body.to_string())
+}
+
+fn map_api_io_error(error: std::io::Error, timeout_ms: u64, context: &str) -> SparkshellError {
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+    ) {
+        SparkshellError::SummaryTimeout(timeout_ms)
+    } else {
+        SparkshellError::SummaryBridge(format!("{context}: {error}"))
+    }
+}
+
+#[derive(Debug)]
+struct HttpUrl {
+    host: String,
+    port: u16,
+    path: String,
+    explicit_port: bool,
+}
+
+fn parse_http_url(url: &str) -> Result<HttpUrl, SparkshellError> {
+    let rest = url.strip_prefix("http://").ok_or_else(|| {
+        SparkshellError::SummaryBridge(format!("local API URL must use http://, got `{url}`"))
+    })?;
+    let (authority, path) = match rest.split_once('/') {
+        Some((authority, path)) => (authority, format!("/{path}")),
+        None => (rest, "/".to_string()),
+    };
+    let (host, port, explicit_port) = if let Some((host, port)) = authority.rsplit_once(':') {
+        let port = port.parse::<u16>().map_err(|_| {
+            SparkshellError::SummaryBridge(format!("local API URL has invalid port in `{url}`"))
+        })?;
+        (host.to_string(), port, true)
+    } else {
+        (authority.to_string(), 80, false)
+    };
+    if host.is_empty() {
+        return Err(SparkshellError::SummaryBridge(format!(
+            "local API URL has empty host in `{url}`"
+        )));
+    }
+    if !is_loopback_host(&host) && std::env::var_os("OMX_API_ALLOW_UNSAFE_BASE_URL").is_none() {
+        return Err(SparkshellError::SummaryBridge(format!(
+            "local API URL host `{host}` is not loopback; set OMX_API_ALLOW_UNSAFE_BASE_URL=1 only for trusted development"
+        )));
+    }
+    Ok(HttpUrl {
+        host,
+        port,
+        path,
+        explicit_port,
+    })
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    if host == "localhost" {
+        return true;
+    }
+    let trimmed = host.trim_matches(['[', ']']);
+    trimmed
+        .parse::<IpAddr>()
+        .map(|addr| addr.is_loopback())
+        .unwrap_or(false)
+}
+
+fn json_string(value: &str) -> String {
+    let mut rendered = String::from("\"");
+    for ch in value.chars() {
+        match ch {
+            '\\' => rendered.push_str("\\\\"),
+            '"' => rendered.push_str("\\\""),
+            '\n' => rendered.push_str("\\n"),
+            '\r' => rendered.push_str("\\r"),
+            '\t' => rendered.push_str("\\t"),
+            ch if ch.is_control() => rendered.push_str(&format!("\\u{:04x}", ch as u32)),
+            ch => rendered.push(ch),
+        }
+    }
+    rendered.push('"');
+    rendered
+}
+
+fn extract_output_text(body: &str) -> Option<String> {
+    extract_json_string_field(body, "output_text")
+}
+
+fn extract_json_string_field(body: &str, field: &str) -> Option<String> {
+    let bytes = body.as_bytes();
+    let field_pattern = format!("\"{field}\"");
+    let mut search_start = 0;
+    while let Some(relative_index) = body[search_start..].find(&field_pattern) {
+        let mut index = search_start + relative_index + field_pattern.len();
+        while matches!(bytes.get(index), Some(b' ' | b'\n' | b'\r' | b'\t')) {
+            index += 1;
+        }
+        if bytes.get(index) != Some(&b':') {
+            search_start = index;
+            continue;
+        }
+        index += 1;
+        while matches!(bytes.get(index), Some(b' ' | b'\n' | b'\r' | b'\t')) {
+            index += 1;
+        }
+        if bytes.get(index) != Some(&b'"') {
+            search_start = index;
+            continue;
+        }
+        return parse_json_string_at(body, index);
+    }
+    None
+}
+
+fn parse_json_string_at(body: &str, quote_index: usize) -> Option<String> {
+    let mut chars = body[quote_index + 1..].chars();
+    let mut rendered = String::new();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' => return Some(rendered),
+            '\\' => match chars.next()? {
+                '"' => rendered.push('"'),
+                '\\' => rendered.push('\\'),
+                '/' => rendered.push('/'),
+                'b' => rendered.push('\u{0008}'),
+                'f' => rendered.push('\u{000c}'),
+                'n' => rendered.push('\n'),
+                'r' => rendered.push('\r'),
+                't' => rendered.push('\t'),
+                'u' => {
+                    let mut hex = String::new();
+                    for _ in 0..4 {
+                        hex.push(chars.next()?);
+                    }
+                    let value = u16::from_str_radix(&hex, 16).ok()?;
+                    rendered.push(char::from_u32(value as u32)?);
+                }
+                _ => return None,
+            },
+            ch => rendered.push(ch),
+        }
+    }
+    None
 }
 
 fn normalize_summary(raw: &str) -> Option<String> {
@@ -289,7 +486,7 @@ fn render_section(name: &str, entries: &[String]) -> String {
 #[allow(unused_unsafe)]
 mod tests {
     use super::{
-        normalize_summary, read_summary_timeout_ms, resolve_fallback_model,
+        normalize_summary, parse_http_url, read_summary_timeout_ms, resolve_fallback_model,
         resolve_instructions_file, resolve_model, DEFAULT_SPARK_MODEL, DEFAULT_STANDARD_MODEL,
         DEFAULT_SUMMARY_TIMEOUT_MS,
     };
@@ -450,5 +647,24 @@ warnings: caution
 notes: nope"
         )
         .is_none());
+    }
+
+    #[test]
+    fn api_base_url_parser_rejects_non_loopback_hosts_by_default() {
+        let _guard = env_lock();
+        unsafe {
+            env::remove_var("OMX_API_ALLOW_UNSAFE_BASE_URL");
+        }
+
+        assert!(parse_http_url("http://127.0.0.1:14510/v1/responses").is_ok());
+        assert!(parse_http_url("http://localhost:14510/v1/responses").is_ok());
+        assert!(parse_http_url("http://example.com:14510/v1/responses")
+            .expect_err("non-loopback host should be rejected")
+            .to_string()
+            .contains("not loopback"));
+        assert!(parse_http_url("http://127.0.0.1.evil:14510/v1/responses")
+            .expect_err("prefix spoof host should be rejected")
+            .to_string()
+            .contains("not loopback"));
     }
 }

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -1,7 +1,11 @@
 use std::env;
 use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn sparkshell_bin() -> &'static str {
@@ -32,6 +36,80 @@ fn write_executable(path: &Path, body: &str) {
     }
 }
 
+fn start_api_server<F>(expected_requests: usize, mut handler: F) -> (String, JoinHandle<()>)
+where
+    F: FnMut(String) -> (u16, String) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind api server");
+    let address = listener.local_addr().expect("api address");
+    let handle = thread::spawn(move || {
+        for _ in 0..expected_requests {
+            let (stream, _) = listener.accept().expect("accept api request");
+            let request = read_http_request(stream.try_clone().expect("clone stream"));
+            let (status, body) = handler(request);
+            write_http_response(stream, status, &body);
+        }
+    });
+    (format!("http://{}", address), handle)
+}
+
+fn read_http_request(mut stream: TcpStream) -> String {
+    let mut buffer = Vec::new();
+    let mut scratch = [0; 1024];
+    loop {
+        let count = stream.read(&mut scratch).expect("read request");
+        assert!(count > 0, "connection closed before request headers");
+        buffer.extend_from_slice(&scratch[..count]);
+        if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+    let request = String::from_utf8_lossy(&buffer).into_owned();
+    let content_length = request
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Content-Length:")
+                .or_else(|| line.strip_prefix("content-length:"))
+                .and_then(|value| value.trim().parse::<usize>().ok())
+        })
+        .unwrap_or(0);
+    let body_start = buffer
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .expect("header boundary")
+        + 4;
+    while buffer.len() - body_start < content_length {
+        let count = stream.read(&mut scratch).expect("read request body");
+        assert!(count > 0, "connection closed before request body");
+        buffer.extend_from_slice(&scratch[..count]);
+    }
+    String::from_utf8_lossy(&buffer).into_owned()
+}
+
+fn write_http_response(mut stream: TcpStream, status: u16, body: &str) {
+    let reason = if (200..300).contains(&status) {
+        "OK"
+    } else {
+        "ERROR"
+    };
+    let response = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream
+        .write_all(response.as_bytes())
+        .expect("write response");
+}
+
+fn response_json(text: &str) -> String {
+    format!(
+        "{{\"object\":\"response\",\"output_text\":\"{}\"}}",
+        text.replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', "\\n")
+    )
+}
+
 #[test]
 fn raw_mode_preserves_stdout_and_stderr() {
     let output = Command::new(sparkshell_bin())
@@ -48,27 +126,19 @@ fn raw_mode_preserves_stdout_and_stderr() {
 }
 
 #[test]
-fn summary_mode_uses_codex_exec_and_model_override() {
-    let temp = unique_temp_dir("codex-success");
-    let codex = temp.join("codex");
-    let args_log = temp.join("args.log");
-    let prompt_log = temp.join("prompt.log");
-    write_executable(
-        &codex,
-        &format!(
-            "#!/bin/sh\nprintf '%s\n' \"$@\" > '{}'\ncat > '{}'\nprintf '%s\n' '- summary: command produced long output' '- warnings: stderr was empty'\n",
-            args_log.display(),
-            prompt_log.display()
-        ),
-    );
+fn summary_mode_uses_local_api_and_model_override() {
+    let request_log = Arc::new(Mutex::new(String::new()));
+    let request_log_for_server = Arc::clone(&request_log);
+    let (base_url, server) = start_api_server(1, move |request| {
+        *request_log_for_server.lock().expect("request log") = request;
+        (
+            200,
+            response_json("- summary: command produced long output\n- warnings: stderr was empty"),
+        )
+    });
 
-    let path = format!(
-        "{}:{}",
-        temp.display(),
-        env::var("PATH").unwrap_or_default()
-    );
     let output = Command::new(sparkshell_bin())
-        .env("PATH", path)
+        .env("OMX_API_BASE_URL", base_url)
         .env("OMX_SPARKSHELL_LINES", "1")
         .env("OMX_SPARKSHELL_MODEL", "spark-test-model")
         .arg("sh")
@@ -76,6 +146,7 @@ fn summary_mode_uses_codex_exec_and_model_override() {
         .arg("printf 'one\ntwo\n'")
         .output()
         .expect("run sparkshell");
+    server.join().expect("api server");
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -83,42 +154,33 @@ fn summary_mode_uses_codex_exec_and_model_override() {
     assert!(stdout.contains("- warnings: stderr was empty"));
     assert!(String::from_utf8_lossy(&output.stderr).is_empty());
 
-    let args = fs::read_to_string(args_log).expect("args log");
-    assert!(args.contains("exec"));
-    assert!(args.contains("--model"));
-    assert!(args.contains("spark-test-model"));
-    assert!(args.contains("model_reasoning_effort=\"low\""));
-
-    let prompt = fs::read_to_string(prompt_log).expect("prompt log");
-    assert!(prompt.contains("Command family: generic-shell"));
-    assert!(prompt.contains("<<<STDOUT"));
-    assert!(prompt.contains("one\ntwo"));
-
-    let _ = fs::remove_dir_all(temp);
+    let request = request_log.lock().expect("request log");
+    assert!(request.starts_with("POST /v1/responses HTTP/1.1"));
+    assert!(request.contains("\"model\":\"spark-test-model\""));
+    assert!(request.contains("\"reasoning\":{\"effort\":\"low\"}"));
+    assert!(request.contains("Command family: generic-shell"));
+    assert!(request.contains("<<<STDOUT"));
+    assert!(request.contains("one\\ntwo"));
 }
 
 #[test]
 fn summary_mode_injects_model_instructions_file_override() {
-    let temp = unique_temp_dir("codex-instructions-file");
-    let codex = temp.join("codex");
-    let args_log = temp.join("args.log");
+    let temp = unique_temp_dir("api-instructions-file");
     let instructions_file = temp.join("sparkshell-lightweight-AGENTS.md");
-    write_executable(
-        &codex,
-        &format!(
-            "#!/bin/sh\nprintf '%s\n' \"$@\" > '{}'\nprintf '%s\n' '- summary: command produced long output'\n",
-            args_log.display()
-        ),
-    );
     fs::write(&instructions_file, "# sparkshell instructions\n").expect("write instructions file");
 
-    let path = format!(
-        "{}:{}",
-        temp.display(),
-        env::var("PATH").unwrap_or_default()
-    );
+    let request_log = Arc::new(Mutex::new(String::new()));
+    let request_log_for_server = Arc::clone(&request_log);
+    let (base_url, server) = start_api_server(1, move |request| {
+        *request_log_for_server.lock().expect("request log") = request;
+        (
+            200,
+            response_json("- summary: command produced long output"),
+        )
+    });
+
     let output = Command::new(sparkshell_bin())
-        .env("PATH", path)
+        .env("OMX_API_BASE_URL", base_url)
         .env("OMX_SPARKSHELL_LINES", "1")
         .env(
             "OMX_SPARKSHELL_MODEL_INSTRUCTIONS_FILE",
@@ -129,87 +191,63 @@ fn summary_mode_injects_model_instructions_file_override() {
         .arg("printf 'one\ntwo\n'")
         .output()
         .expect("run sparkshell");
+    server.join().expect("api server");
 
     assert!(output.status.success());
-    let args = fs::read_to_string(args_log).expect("args log");
-    assert!(args.contains("model_reasoning_effort=\"low\""));
-    assert!(args.contains(&format!(
-        "model_instructions_file=\"{}\"",
-        instructions_file
-            .display()
-            .to_string()
-            .replace('\\', "\\\\")
-            .replace('"', "\\\"")
-    )));
+    let request = request_log.lock().expect("request log");
+    assert!(request.contains("\"reasoning\":{\"effort\":\"low\"}"));
+    assert!(request.contains("\"instructions\":\"# sparkshell instructions\\n\""));
 
     let _ = fs::remove_dir_all(temp);
 }
 
 #[test]
 fn summary_failure_falls_back_to_raw_output_with_notice() {
-    let temp = unique_temp_dir("codex-fail");
-    let codex = temp.join("codex");
-    write_executable(
-        &codex,
-        "#!/bin/sh\nprintf '%s\n' 'bridge failed' >&2\nexit 9\n",
-    );
+    let (base_url, server) = start_api_server(1, |_request| {
+        (503, "{\"error\":\"bridge failed\"}".to_string())
+    });
 
-    let path = format!(
-        "{}:{}",
-        temp.display(),
-        env::var("PATH").unwrap_or_default()
-    );
     let output = Command::new(sparkshell_bin())
-        .env("PATH", path)
+        .env("OMX_API_BASE_URL", base_url)
         .env("OMX_SPARKSHELL_LINES", "1")
         .arg("/bin/sh")
         .arg("-c")
         .arg("printf 'one\ntwo\n'; printf 'child-err\n' >&2")
         .output()
         .expect("run sparkshell");
+    server.join().expect("api server");
 
     assert!(output.status.success());
     assert_eq!(String::from_utf8_lossy(&output.stdout), "one\ntwo\n");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("child-err"));
     assert!(stderr.contains("summary unavailable"));
-
-    let _ = fs::remove_dir_all(temp);
 }
 
 #[test]
 fn summary_mode_retries_with_fallback_model_when_spark_is_unavailable() {
-    let temp = unique_temp_dir("codex-fallback-model");
-    let codex = temp.join("codex");
-    let args_log = temp.join("args.log");
-    write_executable(
-        &codex,
-        &format!(
-            "#!/bin/sh
-printf '%s\n' \"$@\" >> '{}'
-model=''
-prev=''
-for arg in \"$@\"; do
-  if [ \"$prev\" = '--model' ]; then model=\"$arg\"; fi
-  prev=\"$arg\"
-done
-if [ \"$model\" = 'spark-test-model' ]; then
-  printf '%s\n' 'rate limit exceeded for spark model' >&2
-  exit 17
-fi
-printf '%s\n' '- summary: fallback model recovered summary'
-",
-            args_log.display()
-        ),
-    );
+    let request_log = Arc::new(Mutex::new(Vec::new()));
+    let request_log_for_server = Arc::clone(&request_log);
+    let (base_url, server) = start_api_server(2, move |request| {
+        request_log_for_server
+            .lock()
+            .expect("request log")
+            .push(request.clone());
+        if request.contains("\"model\":\"spark-test-model\"") {
+            (
+                429,
+                "{\"error\":\"rate limit exceeded for spark model\"}".to_string(),
+            )
+        } else {
+            (
+                200,
+                response_json("- summary: fallback model recovered summary"),
+            )
+        }
+    });
 
-    let path = format!(
-        "{}:{}",
-        temp.display(),
-        env::var("PATH").unwrap_or_default()
-    );
     let output = Command::new(sparkshell_bin())
-        .env("PATH", path)
+        .env("OMX_API_BASE_URL", base_url)
         .env("OMX_SPARKSHELL_LINES", "1")
         .env("OMX_SPARKSHELL_MODEL", "spark-test-model")
         .env("OMX_SPARKSHELL_FALLBACK_MODEL", "frontier-test-model")
@@ -218,47 +256,36 @@ printf '%s\n' '- summary: fallback model recovered summary'
         .arg("printf 'one\ntwo\n'")
         .output()
         .expect("run sparkshell");
+    server.join().expect("api server");
 
     assert!(output.status.success());
     assert!(String::from_utf8_lossy(&output.stdout).contains("fallback model recovered summary"));
     assert!(String::from_utf8_lossy(&output.stderr).is_empty());
 
-    let args = fs::read_to_string(args_log).expect("args log");
-    assert!(args.contains("spark-test-model"));
-    assert!(args.contains("frontier-test-model"));
-
-    let _ = fs::remove_dir_all(temp);
+    let requests = request_log.lock().expect("request log");
+    assert_eq!(requests.len(), 2);
+    assert!(requests[0].contains("\"model\":\"spark-test-model\""));
+    assert!(requests[1].contains("\"model\":\"frontier-test-model\""));
 }
 
 #[test]
 fn summary_mode_reports_both_models_when_fallback_also_fails() {
-    let temp = unique_temp_dir("codex-fallback-model-fail");
-    let codex = temp.join("codex");
-    write_executable(
-        &codex,
-        "#!/bin/sh
-model=''
-prev=''
-for arg in \"$@\"; do
-  if [ \"$prev\" = '--model' ]; then model=\"$arg\"; fi
-  prev=\"$arg\"
-done
-if [ \"$model\" = 'spark-test-model' ]; then
-  printf '%s\n' 'quota exhausted for spark model' >&2
-  exit 17
-fi
-printf '%s\n' 'fallback backend unavailable' >&2
-exit 29
-",
-    );
+    let (base_url, server) = start_api_server(2, |request| {
+        if request.contains("\"model\":\"spark-test-model\"") {
+            (
+                429,
+                "{\"error\":\"quota exhausted for spark model\"}".to_string(),
+            )
+        } else {
+            (
+                503,
+                "{\"error\":\"fallback backend unavailable\"}".to_string(),
+            )
+        }
+    });
 
-    let path = format!(
-        "{}:{}",
-        temp.display(),
-        env::var("PATH").unwrap_or_default()
-    );
     let output = Command::new(sparkshell_bin())
-        .env("PATH", path)
+        .env("OMX_API_BASE_URL", base_url)
         .env("OMX_SPARKSHELL_LINES", "1")
         .env("OMX_SPARKSHELL_MODEL", "spark-test-model")
         .env("OMX_SPARKSHELL_FALLBACK_MODEL", "frontier-test-model")
@@ -267,6 +294,7 @@ exit 29
         .arg("printf 'one\ntwo\n'; printf 'child-err\n' >&2")
         .output()
         .expect("run sparkshell");
+    server.join().expect("api server");
 
     assert!(output.status.success());
     assert_eq!(String::from_utf8_lossy(&output.stdout), "one\ntwo\n");
@@ -274,48 +302,34 @@ exit 29
     assert!(stderr.contains("child-err"));
     assert!(stderr.contains("primary model `spark-test-model`"));
     assert!(stderr.contains("fallback model `frontier-test-model`"));
-
-    let _ = fs::remove_dir_all(temp);
 }
 
 #[test]
 fn summary_mode_preserves_child_exit_code() {
-    let temp = unique_temp_dir("codex-exit");
-    let codex = temp.join("codex");
-    write_executable(
-        &codex,
-        "#!/bin/sh\nprintf '%s\n' '- failures: command exited non-zero'\n",
-    );
+    let (base_url, server) = start_api_server(1, |_request| {
+        (200, response_json("- failures: command exited non-zero"))
+    });
 
-    let path = format!(
-        "{}:{}",
-        temp.display(),
-        env::var("PATH").unwrap_or_default()
-    );
     let output = Command::new(sparkshell_bin())
-        .env("PATH", path)
+        .env("OMX_API_BASE_URL", base_url)
         .env("OMX_SPARKSHELL_LINES", "1")
         .arg("sh")
         .arg("-c")
         .arg("printf 'one\ntwo\n'; exit 7")
         .output()
         .expect("run sparkshell");
+    server.join().expect("api server");
 
     assert_eq!(output.status.code(), Some(7));
     assert!(String::from_utf8_lossy(&output.stdout).contains("- failures: command exited non-zero"));
     assert!(String::from_utf8_lossy(&output.stderr).is_empty());
-
-    let _ = fs::remove_dir_all(temp);
 }
 
 #[test]
 fn tmux_pane_mode_captures_large_tail_and_summarizes() {
     let temp = unique_temp_dir("tmux-pane-summary");
     let tmux = temp.join("tmux");
-    let codex = temp.join("codex");
     let args_log = temp.join("tmux-args.log");
-    let prompt_log = temp.join("pane-prompt.log");
-
     write_executable(
         &tmux,
         &format!(
@@ -323,13 +337,16 @@ fn tmux_pane_mode_captures_large_tail_and_summarizes() {
             args_log.display()
         ),
     );
-    write_executable(
-        &codex,
-        &format!(
-            "#!/bin/sh\ncat > '{}'\nprintf '%s\n' '- summary: tmux pane summarized' '- warnings: tail captured'\n",
-            prompt_log.display()
-        ),
-    );
+
+    let request_log = Arc::new(Mutex::new(String::new()));
+    let request_log_for_server = Arc::clone(&request_log);
+    let (base_url, server) = start_api_server(1, move |request| {
+        *request_log_for_server.lock().expect("request log") = request;
+        (
+            200,
+            response_json("- summary: tmux pane summarized\n- warnings: tail captured"),
+        )
+    });
 
     let path = format!(
         "{}:{}",
@@ -338,6 +355,7 @@ fn tmux_pane_mode_captures_large_tail_and_summarizes() {
     );
     let output = Command::new(sparkshell_bin())
         .env("PATH", path)
+        .env("OMX_API_BASE_URL", base_url)
         .env("OMX_SPARKSHELL_LINES", "1")
         .arg("--tmux-pane")
         .arg("%17")
@@ -345,6 +363,7 @@ fn tmux_pane_mode_captures_large_tail_and_summarizes() {
         .arg("400")
         .output()
         .expect("run sparkshell");
+    server.join().expect("api server");
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -356,36 +375,16 @@ fn tmux_pane_mode_captures_large_tail_and_summarizes() {
     assert!(tmux_args.contains("%17"));
     assert!(tmux_args.contains("-400"));
 
-    let prompt = fs::read_to_string(prompt_log).expect("prompt log");
-    assert!(prompt.contains("Command: tmux capture-pane"));
-    assert!(prompt.contains("line-1"));
+    let request = request_log.lock().expect("request log");
+    assert!(request.contains("Command: tmux capture-pane"));
+    assert!(request.contains("line-1"));
 
     let _ = fs::remove_dir_all(temp);
 }
 
 #[test]
 fn raw_mode_keeps_boundary_output_without_summary() {
-    let temp = unique_temp_dir("boundary-raw");
-    let codex = temp.join("codex");
-    let codex_log = temp.join("codex.log");
-    write_executable(
-        &codex,
-        &format!(
-            "#!/bin/sh
-printf '%s\n' invoked > '{}'
-exit 0
-",
-            codex_log.display()
-        ),
-    );
-
-    let path = format!(
-        "{}:{}",
-        temp.display(),
-        env::var("PATH").unwrap_or_default()
-    );
     let output = Command::new(sparkshell_bin())
-        .env("PATH", path)
         .env("OMX_SPARKSHELL_LINES", "2")
         .arg("sh")
         .arg("-c")
@@ -394,67 +393,47 @@ exit 0
         .expect("run sparkshell");
 
     assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "one
-two
-"
-    );
-    assert!(
-        !codex_log.exists(),
-        "codex should not run at the raw/summary boundary"
-    );
-
-    let _ = fs::remove_dir_all(temp);
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "one\ntwo\n");
 }
 
 #[test]
 fn summary_mode_uses_combined_stdout_and_stderr_threshold() {
-    let temp = unique_temp_dir("combined-threshold");
-    let codex = temp.join("codex");
-    let prompt_log = temp.join("prompt.log");
-    write_executable(
-        &codex,
-        &format!(
-            "#!/bin/sh
-cat > '{}'
-printf '%s\n' '- summary: combined output exceeded threshold'
-",
-            prompt_log.display()
-        ),
-    );
+    let request_log = Arc::new(Mutex::new(String::new()));
+    let request_log_for_server = Arc::clone(&request_log);
+    let (base_url, server) = start_api_server(1, move |request| {
+        *request_log_for_server.lock().expect("request log") = request;
+        (
+            200,
+            response_json("- summary: combined output exceeded threshold"),
+        )
+    });
 
-    let path = format!(
-        "{}:{}",
-        temp.display(),
-        env::var("PATH").unwrap_or_default()
-    );
     let output = Command::new(sparkshell_bin())
-        .env("PATH", path)
+        .env("OMX_API_BASE_URL", base_url)
         .env("OMX_SPARKSHELL_LINES", "2")
         .arg("sh")
         .arg("-c")
         .arg("printf 'one\n' && printf 'warn\nextra\n' >&2")
         .output()
         .expect("run sparkshell");
+    server.join().expect("api server");
 
     assert!(output.status.success());
     assert!(String::from_utf8_lossy(&output.stdout).contains("combined output exceeded threshold"));
-    let prompt = fs::read_to_string(prompt_log).expect("prompt log");
-    assert!(prompt.contains("<<<STDERR"));
-    assert!(prompt.contains(
-        "warn
-extra"
-    ));
-
-    let _ = fs::remove_dir_all(temp);
+    let request = request_log.lock().expect("request log");
+    assert!(request.contains("<<<STDERR"));
+    assert!(request.contains("warn\\nextra"));
 }
 
 #[test]
-fn summary_failure_when_codex_is_missing_falls_back_to_raw_output() {
-    let empty_path = unique_temp_dir("missing-codex");
+fn summary_failure_when_api_is_missing_falls_back_to_raw_output() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("reserve port");
+    let base_url = format!("http://{}", listener.local_addr().expect("address"));
+    drop(listener);
+
     let output = Command::new(sparkshell_bin())
-        .env("PATH", empty_path.display().to_string())
+        .env("OMX_API_BASE_URL", base_url)
+        .env("OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS", "500")
         .env("OMX_SPARKSHELL_LINES", "1")
         .arg("/bin/sh")
         .arg("-c")
@@ -463,41 +442,27 @@ fn summary_failure_when_codex_is_missing_falls_back_to_raw_output() {
         .expect("run sparkshell");
 
     assert!(output.status.success());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "one
-two
-"
-    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "one\ntwo\n");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("child-err"));
     assert!(stderr.contains("summary unavailable"));
-
-    let _ = fs::remove_dir_all(empty_path);
 }
 
 #[test]
 fn tmux_pane_mode_uses_default_tail_lines_when_not_overridden() {
     let temp = unique_temp_dir("tmux-default-tail");
     let tmux = temp.join("tmux");
-    let codex = temp.join("codex");
     let args_log = temp.join("tmux-args.log");
     write_executable(
         &tmux,
         &format!(
-            "#!/bin/sh
-printf '%s\n' \"$@\" > '{}'
-printf 'line-1\nline-2\nline-3\n'
-",
+            "#!/bin/sh\nprintf '%s\n' \"$@\" > '{}'\nprintf 'line-1\nline-2\nline-3\n'\n",
             args_log.display()
         ),
     );
-    write_executable(
-        &codex,
-        "#!/bin/sh
-printf '%s\n' '- summary: used default tmux tail'
-",
-    );
+    let (base_url, server) = start_api_server(1, |_request| {
+        (200, response_json("- summary: used default tmux tail"))
+    });
 
     let path = format!(
         "{}:{}",
@@ -506,11 +471,13 @@ printf '%s\n' '- summary: used default tmux tail'
     );
     let output = Command::new(sparkshell_bin())
         .env("PATH", path)
+        .env("OMX_API_BASE_URL", base_url)
         .env("OMX_SPARKSHELL_LINES", "1")
         .arg("--tmux-pane")
         .arg("%21")
         .output()
         .expect("run sparkshell");
+    server.join().expect("api server");
 
     assert!(output.status.success());
     let tmux_args = fs::read_to_string(args_log).expect("tmux args");
@@ -518,4 +485,14 @@ printf '%s\n' '- summary: used default tmux tail'
     assert!(String::from_utf8_lossy(&output.stdout).contains("used default tmux tail"));
 
     let _ = fs::remove_dir_all(temp);
+}
+
+#[test]
+fn summary_module_does_not_shell_out_to_codex() {
+    let source =
+        fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/codex_bridge.rs"))
+            .expect("source");
+    assert!(!source.contains("Command::new(\"codex\")"));
+    assert!(!source.contains(".arg(\"exec\")"));
+    assert!(!source.contains("codex exec"));
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "node -e \"const fs=require('fs'); fs.rmSync('dist',{recursive:true,force:true});\" && tsc && node -e \"require('fs').chmodSync('dist/cli/omx.js', 0o755)\"",
     "build:explore": "cargo build -p omx-explore-harness",
-    "build:full": "npm run build && npm run build:explore:release && npm run build:sparkshell",
+    "build:full": "npm run build && npm run build:explore:release && npm run build:sparkshell && npm run build:api",
     "build:explore:release": "node dist/scripts/build-explore-harness.js",
     "check:no-unused": "tsc -p tsconfig.no-unused.json",
     "clean:native-package-assets": "node dist/scripts/cleanup-explore-harness.js",
@@ -54,7 +54,8 @@
     "sync:plugin:check": "node dist/scripts/sync-plugin-mirror.js --check",
     "verify:plugin-bundle": "node dist/scripts/sync-plugin-mirror.js --check",
     "verify:native-agents": "node dist/scripts/verify-native-agents.js",
-    "prompt:inventory": "node dist/scripts/prompt-inventory.js"
+    "prompt:inventory": "node dist/scripts/prompt-inventory.js",
+    "build:api": "node dist/scripts/build-api.js"
   },
   "engines": {
     "node": ">=20"

--- a/src/cli/__tests__/api.test.ts
+++ b/src/cli/__tests__/api.test.ts
@@ -1,0 +1,213 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import {
+  nestedRepoLocalApiBinaryPath,
+  packagedApiBinaryCandidatePaths,
+  repoLocalApiBinaryPath,
+  resolveApiBinaryPath,
+  resolveApiBinaryPathWithHydration,
+  runApiBinary,
+} from '../api.js';
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {},
+): { status: number | null; stdout: string; stderr: string; error?: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
+  const result = spawnSync('node', [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error?.message,
+  };
+}
+
+function shouldSkipForSpawnPermissions(err?: string): boolean {
+  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+describe('resolveApiBinaryPath', () => {
+  it('prefers OMX_API_BIN override', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-api-override-'));
+    try {
+      assert.equal(
+        resolveApiBinaryPath({
+          cwd,
+          env: { OMX_API_BIN: './bin/custom-api' },
+          packageRoot: '/unused',
+        }),
+        join(cwd, 'bin', 'custom-api'),
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('checks Linux musl packaged paths before glibc and legacy paths', () => {
+    assert.deepEqual(
+      packagedApiBinaryCandidatePaths('/repo', 'linux', 'x64', {}, ['musl', 'glibc']),
+      [
+        '/repo/bin/native/linux-x64-musl/omx-api',
+        '/repo/bin/native/linux-x64-glibc/omx-api',
+        '/repo/bin/native/linux-x64/omx-api',
+      ],
+    );
+  });
+
+  it('falls back from packaged binary to repo-local build artifact', () => {
+    const packageRoot = '/repo';
+    const repoLocal = repoLocalApiBinaryPath(packageRoot);
+    assert.equal(
+      resolveApiBinaryPath({ packageRoot, exists: (path) => path === repoLocal }),
+      repoLocal,
+    );
+  });
+
+  it('falls back to nested repo-local native build artifact when present', () => {
+    const packageRoot = '/repo';
+    const nestedRepoLocal = nestedRepoLocalApiBinaryPath(packageRoot);
+    assert.equal(
+      resolveApiBinaryPath({ packageRoot, exists: (path) => path === nestedRepoLocal }),
+      nestedRepoLocal,
+    );
+  });
+
+  it('throws with checked paths when neither packaged nor repo-local binary exists', () => {
+    assert.throws(
+      () => resolveApiBinaryPath({ packageRoot: '/repo', exists: () => false }),
+      /native binary not found/,
+    );
+  });
+
+
+  it('prefers a cached hydrated omx-api binary before packaged and repo-local paths', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-api-cached-'));
+    try {
+      await writeFile(join(cwd, 'package.json'), JSON.stringify({ version: '0.8.15' }));
+      const cacheDir = join(cwd, 'cache');
+      const cachedDir = join(cacheDir, '0.8.15', 'linux-x64-musl', 'omx-api');
+      const cachedBinary = join(cachedDir, 'omx-api');
+      await mkdir(cachedDir, { recursive: true });
+      await writeFile(cachedBinary, '#!/bin/sh\n');
+      await chmod(cachedBinary, 0o755);
+
+      assert.equal(
+        await resolveApiBinaryPathWithHydration({
+          packageRoot: cwd,
+          platform: 'linux',
+          arch: 'x64',
+          linuxLibcPreference: ['musl', 'glibc'],
+          env: { OMX_NATIVE_CACHE_DIR: cacheDir, OMX_NATIVE_AUTO_FETCH: '0' },
+        }),
+        cachedBinary,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runApiBinary', () => {
+  it('forwards argv, cwd, and env to the native binary', () => {
+    const calls: { binary: string; args: string[]; options: unknown }[] = [];
+    const result = runApiBinary('/fake/omx-api', ['generate', 'text', 'hello'], {
+      cwd: '/work',
+      env: { TEST_ENV: '1' },
+      spawnImpl: ((binary: string, args: string[], options: unknown) => {
+        calls.push({ binary, args, options });
+        return { status: 0, signal: null, output: [], stdout: 'ok\n', stderr: '', pid: 123 };
+      }) as unknown as typeof spawnSync,
+    });
+
+    assert.equal(result.stdout, 'ok\n');
+    assert.equal(calls[0]?.binary, '/fake/omx-api');
+    assert.deepEqual(calls[0]?.args, ['generate', 'text', 'hello']);
+    assert.deepEqual(calls[0]?.options, {
+      cwd: '/work',
+      env: { TEST_ENV: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+    });
+  });
+});
+
+describe('omx api', () => {
+  it('includes api in top-level help output', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-api-help-'));
+    try {
+      const result = runOmx(cwd, ['--help']);
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /omx api\s+Run native omx-api localhost gateway commands \(serve\|status\|stop\|generate\)/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('prints api usage when invoked with top-level or nested --help', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-api-subhelp-'));
+    try {
+      for (const argv of [['api', '--help'], ['api', 'serve', '--help'], ['api', 'generate', '--help']]) {
+        const result = runOmx(cwd, argv);
+        if (shouldSkipForSpawnPermissions(result.error)) return;
+
+        assert.equal(result.status, 0, `${argv.join(' ')} stderr=${result.stderr} stdout=${result.stdout}`);
+        assert.match(result.stdout, /Usage: omx api <command> \[args\.\.\.\]/);
+        assert.match(result.stdout, /generate text <prompt\.\.\.>/);
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves child stdout, stderr, and exit code through the JS bridge', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-api-bridge-'));
+    try {
+      const binDir = join(cwd, 'bin');
+      const stubPath = join(binDir, process.platform === 'win32' ? 'omx-api.cmd' : 'omx-api');
+      await mkdir(binDir, { recursive: true });
+      if (process.platform === 'win32') {
+        await writeFile(stubPath, '@echo off\r\necho api-stdout\r\n>&2 echo api-stderr\r\nexit /b 7\r\n');
+      } else {
+        await writeFile(stubPath, '#!/bin/sh\necho api-stdout\necho api-stderr 1>&2\nexit 7\n');
+        await chmod(stubPath, 0o755);
+      }
+
+      const result = runOmx(cwd, ['api', 'generate', 'text', 'hello'], { OMX_API_BIN: stubPath });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 7, result.stderr || result.stdout);
+      assert.equal(result.stdout, 'api-stdout\n');
+      assert.equal(result.stderr, 'api-stderr\n');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails clearly when the configured native binary path does not exist', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-api-missing-'));
+    try {
+      const result = runOmx(cwd, ['api', 'status'], { OMX_API_BIN: join(cwd, 'bin', 'missing-api') });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 1, result.stderr || result.stdout);
+      assert.match(result.stderr, /failed to launch native binary: executable not found/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1364,6 +1364,7 @@ describe("commandOwnsLocalHelp", () => {
     for (const command of [
       "adapt",
       "agents-init",
+      "api",
       "ask",
       "question",
       "autoresearch",
@@ -1397,6 +1398,16 @@ describe("commandOwnsLocalHelp", () => {
 });
 
 describe("resolveCliInvocation", () => {
+  it("resolves api to api command", () => {
+    assert.deepEqual(
+      resolveCliInvocation(["api", "status"]),
+      {
+        command: "api",
+        launchArgs: [],
+      },
+    );
+  });
+
   it("resolves explore to explore command", () => {
     assert.deepEqual(
       resolveCliInvocation(["explore", "--prompt", "find", "auth"]),

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -40,7 +40,8 @@ describe('package bin contract', () => {
     assert.deepEqual(pkg.bin, { omx: 'dist/cli/omx.js' });
     assert.equal(pkg.scripts?.['build:explore'], 'cargo build -p omx-explore-harness');
     assert.equal(pkg.scripts?.['build:explore:release'], 'node dist/scripts/build-explore-harness.js');
-    assert.equal(pkg.scripts?.['build:full'], 'npm run build && npm run build:explore:release && npm run build:sparkshell');
+    assert.equal(pkg.scripts?.['build:full'], 'npm run build && npm run build:explore:release && npm run build:sparkshell && npm run build:api');
+    assert.equal(pkg.scripts?.['build:api'], 'node dist/scripts/build-api.js');
     assert.equal(pkg.scripts?.['clean:native-package-assets'], 'node dist/scripts/cleanup-explore-harness.js');
     assert.equal(pkg.scripts?.['sync:plugin'], 'node dist/scripts/sync-plugin-mirror.js');
     assert.equal(pkg.scripts?.['sync:plugin:check'], 'node dist/scripts/sync-plugin-mirror.js --check');
@@ -165,7 +166,7 @@ describe('package bin contract', () => {
     const packagedHarnessPath = process.platform === 'win32' ? 'bin/omx-explore-harness.exe' : 'bin/omx-explore-harness';
     const packagedHarnessEntry = results[0]?.files?.find((file) => file.path === packagedHarnessPath);
     const packagedHarnessMetaEntry = results[0]?.files?.find((file) => file.path === 'bin/omx-explore-harness.meta.json');
-    const sparkshellEntry = results[0]?.files?.find((file) => file.path.includes('bin/native/'));
+    const nativeBinaryEntry = results[0]?.files?.find((file) => file.path.includes('bin/native/'));
     const cargoTomlEntry = results[0]?.files?.find((file) => file.path === 'Cargo.toml');
     const cargoLockEntry = results[0]?.files?.find((file) => file.path === 'Cargo.lock');
     const crateManifestEntry = results[0]?.files?.find((file) => file.path === 'crates/omx-explore/Cargo.toml');
@@ -192,7 +193,7 @@ describe('package bin contract', () => {
 
     assert.equal(packagedHarnessEntry, undefined, `did not expect ${packagedHarnessPath} in npm pack output`);
     assert.equal(packagedHarnessMetaEntry, undefined, 'did not expect packaged explore harness metadata in npm pack output');
-    assert.equal(sparkshellEntry, undefined, 'did not expect staged sparkshell binaries in npm pack output');
+    assert.equal(nativeBinaryEntry, undefined, 'did not expect staged native binaries in npm pack output');
     assert.ok(cargoTomlEntry, 'expected npm pack output to include Cargo.toml');
     assert.ok(cargoLockEntry, 'expected npm pack output to include Cargo.lock');
     assert.ok(crateManifestEntry, 'expected npm pack output to include crates/omx-explore/Cargo.toml');

--- a/src/cli/__tests__/version-sync-contract.test.ts
+++ b/src/cli/__tests__/version-sync-contract.test.ts
@@ -20,6 +20,9 @@ describe('version sync contract', () => {
     const workspace = TOML.parse(readFileSync(join(process.cwd(), 'Cargo.toml'), 'utf-8')) as {
       workspace?: { package?: WorkspacePackageMetadata; members?: string[] };
     };
+    const api = TOML.parse(readFileSync(join(process.cwd(), 'crates', 'omx-api', 'Cargo.toml'), 'utf-8')) as {
+      package?: WorkspaceMemberPackageMetadata;
+    };
     const explore = TOML.parse(readFileSync(join(process.cwd(), 'crates', 'omx-explore', 'Cargo.toml'), 'utf-8')) as {
       package?: WorkspaceMemberPackageMetadata;
     };
@@ -38,6 +41,7 @@ describe('version sync contract', () => {
 
     assert.equal(workspace.workspace?.package?.version, pkg.version);
     assert.deepEqual(workspace.workspace?.members, [
+      'crates/omx-api',
       'crates/omx-explore',
       'crates/omx-mux',
       'crates/omx-runtime-core',
@@ -45,11 +49,13 @@ describe('version sync contract', () => {
       'crates/omx-sparkshell',
     ]);
     assert.equal(workspace.workspace?.package?.['rust-version'], '1.73');
+    assert.deepEqual(api.package?.version, { workspace: true });
     assert.deepEqual(explore.package?.version, { workspace: true });
     assert.deepEqual(runtimeCore.package?.version, { workspace: true });
     assert.deepEqual(mux.package?.version, { workspace: true });
     assert.deepEqual(runtime.package?.version, { workspace: true });
     assert.deepEqual(sparkshell.package?.version, { workspace: true });
+    assert.deepEqual(api.package?.['rust-version'], { workspace: true });
     assert.deepEqual(explore.package?.['rust-version'], { workspace: true });
     assert.deepEqual(runtimeCore.package?.['rust-version'], { workspace: true });
     assert.deepEqual(mux.package?.['rust-version'], { workspace: true });

--- a/src/cli/api.ts
+++ b/src/cli/api.ts
@@ -1,0 +1,231 @@
+import {
+  spawnSync,
+  type SpawnSyncOptionsWithStringEncoding,
+  type SpawnSyncReturns,
+} from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { arch as osArch, constants as osConstants } from 'node:os';
+import { isAbsolute, join, resolve } from 'node:path';
+import { getPackageRoot } from '../utils/package.js';
+import { classifySpawnError } from '../utils/platform-command.js';
+import {
+  API_BIN_ENV as API_BIN_ENV_SHARED,
+  getPackageVersion,
+  hydrateNativeBinary,
+  resolveCachedNativeBinaryCandidatePaths,
+  resolveLinuxNativeLibcPreference,
+} from './native-assets.js';
+
+const OMX_API_BIN_ENV = API_BIN_ENV_SHARED;
+
+export const API_USAGE = [
+  'Usage: omx api <command> [args...]',
+  '',
+  'Commands:',
+  '  serve [--host 127.0.0.1] [--port N] [--daemon] [--system] [--dry-run]',
+  '  status',
+  '  stop',
+  '  generate text <prompt...> [--state-file path]',
+  '  generate image <prompt...> [--state-file path]',
+  '',
+  'Runs the native omx-api localhost gateway sidecar and forwards arguments unchanged.',
+  `Set ${OMX_API_BIN_ENV} to override the native binary path.`,
+].join('\n');
+
+export interface ResolveApiBinaryPathOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  packageRoot?: string;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  linuxLibcPreference?: readonly ('musl' | 'glibc')[];
+  exists?: (path: string) => boolean;
+}
+
+export interface RunApiBinaryOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  spawnImpl?: typeof spawnSync;
+}
+
+function resolveSignalExitCode(signal: NodeJS.Signals | null): number {
+  if (!signal) return 1;
+  const signalNumber = osConstants.signals[signal];
+  if (typeof signalNumber === 'number' && Number.isFinite(signalNumber)) return 128 + signalNumber;
+  return 1;
+}
+
+export function apiBinaryName(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? 'omx-api.exe' : 'omx-api';
+}
+
+export function packagedApiBinaryPath(
+  packageRoot = getPackageRoot(),
+  platform: NodeJS.Platform = process.platform,
+  arch: string = osArch(),
+  libc?: 'musl' | 'glibc',
+): string {
+  const platformKey = libc ? `${platform}-${arch}-${libc}` : `${platform}-${arch}`;
+  return join(packageRoot, 'bin', 'native', platformKey, apiBinaryName(platform));
+}
+
+export function packagedApiBinaryCandidatePaths(
+  packageRoot = getPackageRoot(),
+  platform: NodeJS.Platform = process.platform,
+  arch: string = osArch(),
+  env: NodeJS.ProcessEnv = process.env,
+  linuxLibcPreference?: readonly ('musl' | 'glibc')[],
+): string[] {
+  const candidates: string[] = [];
+  if (platform === 'linux') {
+    for (const libc of linuxLibcPreference ?? resolveLinuxNativeLibcPreference({ env })) {
+      candidates.push(packagedApiBinaryPath(packageRoot, platform, arch, libc));
+    }
+  }
+  candidates.push(packagedApiBinaryPath(packageRoot, platform, arch));
+  return [...new Set(candidates)];
+}
+
+export function repoLocalApiBinaryPath(
+  packageRoot = getPackageRoot(),
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return join(packageRoot, 'target', 'release', apiBinaryName(platform));
+}
+
+export function nestedRepoLocalApiBinaryPath(
+  packageRoot = getPackageRoot(),
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return join(packageRoot, 'native', 'omx-api', 'target', 'release', apiBinaryName(platform));
+}
+
+export function resolveApiBinaryPath(options: ResolveApiBinaryPathOptions = {}): string {
+  const {
+    cwd = process.cwd(),
+    env = process.env,
+    packageRoot = getPackageRoot(),
+    platform = process.platform,
+    arch = osArch(),
+    linuxLibcPreference,
+    exists = existsSync,
+  } = options;
+
+  const override = env[OMX_API_BIN_ENV]?.trim();
+  if (override) return isAbsolute(override) ? override : resolve(cwd, override);
+
+  for (const packaged of packagedApiBinaryCandidatePaths(packageRoot, platform, arch, env, linuxLibcPreference)) {
+    if (exists(packaged)) return packaged;
+  }
+
+  const repoLocal = repoLocalApiBinaryPath(packageRoot, platform);
+  if (exists(repoLocal)) return repoLocal;
+
+  const nestedRepoLocal = nestedRepoLocalApiBinaryPath(packageRoot, platform);
+  if (exists(nestedRepoLocal)) return nestedRepoLocal;
+
+  const packagedCandidates = packagedApiBinaryCandidatePaths(packageRoot, platform, arch, env, linuxLibcPreference);
+  throw new Error(
+    `[api] native binary not found. Checked ${packagedCandidates.join(', ')}, ${repoLocal}, and ${nestedRepoLocal}. `
+      + `Set ${OMX_API_BIN_ENV} to override the path.`,
+  );
+}
+
+export async function resolveApiBinaryPathWithHydration(
+  options: ResolveApiBinaryPathOptions = {},
+): Promise<string> {
+  const {
+    cwd = process.cwd(),
+    env = process.env,
+    packageRoot = getPackageRoot(),
+    platform = process.platform,
+    arch = osArch(),
+    linuxLibcPreference,
+    exists = existsSync,
+  } = options;
+
+  const override = env[OMX_API_BIN_ENV]?.trim();
+  if (override) return isAbsolute(override) ? override : resolve(cwd, override);
+
+  const version = await getPackageVersion(packageRoot);
+  for (const cached of resolveCachedNativeBinaryCandidatePaths('omx-api', version, platform, arch, env, {
+    linuxLibcPreference: platform === 'linux'
+      ? (linuxLibcPreference ?? resolveLinuxNativeLibcPreference({ env }))
+      : undefined,
+  })) {
+    if (exists(cached)) return cached;
+  }
+
+  for (const packaged of packagedApiBinaryCandidatePaths(packageRoot, platform, arch, env, linuxLibcPreference)) {
+    if (exists(packaged)) return packaged;
+  }
+
+  const repoLocal = repoLocalApiBinaryPath(packageRoot, platform);
+  if (exists(repoLocal)) return repoLocal;
+
+  const nestedRepoLocal = nestedRepoLocalApiBinaryPath(packageRoot, platform);
+  if (exists(nestedRepoLocal)) return nestedRepoLocal;
+
+  const hydrated = await hydrateNativeBinary('omx-api', { packageRoot, env, platform, arch });
+  if (hydrated) return hydrated;
+
+  throw new Error(
+    `[api] native binary not found. Checked cached/native candidates under ${packageRoot}, ${repoLocal}, and ${nestedRepoLocal}. `
+      + `Reconnect to the network so OMX can fetch the release asset, or set ${OMX_API_BIN_ENV} to override the path.`,
+  );
+}
+
+export function runApiBinary(
+  binaryPath: string,
+  args: readonly string[],
+  options: RunApiBinaryOptions = {},
+): SpawnSyncReturns<string> {
+  const { cwd = process.cwd(), env = process.env, spawnImpl = spawnSync } = options;
+  const spawnOptions: SpawnSyncOptionsWithStringEncoding = {
+    cwd,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+  };
+  return spawnImpl(binaryPath, [...args], spawnOptions);
+}
+
+function writeApiResultOutput(result: SpawnSyncReturns<string>): void {
+  if (typeof result.stdout === 'string' && result.stdout.length > 0) process.stdout.write(result.stdout);
+  if (typeof result.stderr === 'string' && result.stderr.length > 0) process.stderr.write(result.stderr);
+}
+
+function isHelpRequest(args: readonly string[]): boolean {
+  if (args.length === 0) return true;
+  return args.includes('--help') || args.includes('-h');
+}
+
+export async function apiCommand(args: string[]): Promise<void> {
+  if (isHelpRequest(args)) {
+    console.log(API_USAGE);
+    return;
+  }
+
+  let binaryPath: string;
+  try {
+    binaryPath = await resolveApiBinaryPathWithHydration();
+  } catch (error) {
+    throw error;
+  }
+
+  const result = runApiBinary(binaryPath, args);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    const kind = classifySpawnError(errno);
+    if (kind === 'missing') throw new Error(`[api] failed to launch native binary: executable not found (${binaryPath})`);
+    if (kind === 'blocked') throw new Error(`[api] failed to launch native binary: executable is blocked (${errno.code || 'blocked'})`);
+    throw new Error(`[api] failed to launch native binary: ${errno.message}`);
+  }
+
+  writeApiResultOutput(result);
+  if (result.status !== 0) {
+    process.exitCode = typeof result.status === 'number'
+      ? result.status
+      : resolveSignalExitCode(result.signal);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,6 +38,7 @@ import {
 } from "./cleanup.js";
 import { exploreCommand } from "./explore.js";
 import { sparkshellCommand } from "./sparkshell.js";
+import { apiCommand } from "./api.js";
 import { agentsInitCommand } from "./agents-init.js";
 import { agentsCommand } from "./agents.js";
 import { sessionCommand } from "./session-search.js";
@@ -202,6 +203,7 @@ Usage:
   omx adapt     Scaffold OMX-owned adapter foundations for persistent external targets
   omx resume    Resume a previous interactive Codex session
   omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
+  omx api       Run native omx-api localhost gateway commands (serve|status|stop|generate)
   omx session   Search prior local session transcripts and history artifacts
   omx agents-init [path]
                 Bootstrap lightweight AGENTS.md files for a repo/subtree
@@ -352,6 +354,7 @@ type CliCommand =
   | "question"
   | "adapt"
   | "explore"
+  | "api"
   | "sparkshell"
   | "team"
   | "session"
@@ -394,6 +397,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "performance-goal",
   "resume",
   "session",
+  "api",
   "sparkshell",
   "team",
   "tmux-hook",
@@ -1240,6 +1244,7 @@ export async function main(args: string[]): Promise<void> {
     "autoresearch",
   "autoresearch-goal",
     "explore",
+    "api",
     "sparkshell",
     "team",
     "ralph",
@@ -1346,6 +1351,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "explore":
         await exploreCommand(args.slice(1));
+        break;
+      case "api":
+        await apiCommand(args.slice(1));
         break;
       case "exec":
         if (launchArgs[0] === "inject") {

--- a/src/cli/native-assets.ts
+++ b/src/cli/native-assets.ts
@@ -8,7 +8,7 @@ import { Readable } from 'node:stream';
 import { spawnPlatformCommandSync } from '../utils/platform-command.js';
 import { getPackageRoot } from '../utils/package.js';
 
-export type NativeProduct = 'omx-explore-harness' | 'omx-sparkshell';
+export type NativeProduct = 'omx-explore-harness' | 'omx-sparkshell' | 'omx-api';
 export type NativeLibc = 'musl' | 'glibc';
 
 export interface NativeReleaseAsset {
@@ -56,6 +56,7 @@ const NATIVE_RELEASE_BASE_URL_ENV = 'OMX_NATIVE_RELEASE_BASE_URL';
 const NATIVE_CACHE_DIR_ENV = 'OMX_NATIVE_CACHE_DIR';
 export const EXPLORE_BIN_ENV = 'OMX_EXPLORE_BIN';
 export const SPARKSHELL_BIN_ENV = 'OMX_SPARKSHELL_BIN';
+export const API_BIN_ENV = 'OMX_API_BIN';
 
 function packageJsonPath(packageRoot = getPackageRoot()): string {
   return join(packageRoot, 'package.json');

--- a/src/scripts/build-api.ts
+++ b/src/scripts/build-api.ts
@@ -1,0 +1,48 @@
+import { chmodSync, copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { arch, platform } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, '..', '..');
+const nativeRoot = join(projectRoot, 'crates', 'omx-api');
+const manifestPath = process.env.OMX_API_MANIFEST ?? join(nativeRoot, 'Cargo.toml');
+const binaryName = platform() === 'win32' ? 'omx-api.exe' : 'omx-api';
+const releaseBinaryPath = join(projectRoot, 'target', 'release', binaryName);
+const stagedBinaryRoot = process.env.OMX_API_STAGE_DIR
+  ? join(process.env.OMX_API_STAGE_DIR, `${platform()}-${arch()}`)
+  : join(projectRoot, 'bin', 'native', `${platform()}-${arch()}`);
+const packagedBinaryDir = stagedBinaryRoot;
+const packagedBinaryPath = join(packagedBinaryDir, binaryName);
+const extraArgs = process.argv.slice(2);
+const args = ['build', '--manifest-path', manifestPath, '--release', ...extraArgs];
+
+if (!existsSync(manifestPath)) {
+  console.error(`omx api build: missing Rust manifest at ${manifestPath}`);
+  process.exit(1);
+}
+
+const result = spawnSync('cargo', args, {
+  cwd: projectRoot,
+  stdio: 'inherit',
+  env: process.env,
+});
+
+if (result.error) {
+  console.error(`omx api build: failed to launch cargo: ${result.error.message}`);
+  process.exit(1);
+}
+
+if ((result.status ?? 1) !== 0) process.exit(result.status ?? 1);
+
+if (!existsSync(releaseBinaryPath)) {
+  console.error(`omx api build: expected release binary at ${releaseBinaryPath}`);
+  process.exit(1);
+}
+
+mkdirSync(packagedBinaryDir, { recursive: true });
+copyFileSync(releaseBinaryPath, packagedBinaryPath);
+if (platform() !== 'win32') chmodSync(packagedBinaryPath, 0o755);
+console.log(`omx api build: staged native binary at ${packagedBinaryPath}`);

--- a/src/verification/__tests__/explore-harness-release-workflow.test.ts
+++ b/src/verification/__tests__/explore-harness-release-workflow.test.ts
@@ -32,6 +32,7 @@ describe('native release workflow', () => {
     assert.match(workflow, /actions\/download-artifact@v8/);
     assert.match(workflow, /softprops\/action-gh-release@v3/);
     assert.match(workflow, /generate-release-body\.js/);
+    assert.match(workflow, /omx-api/);
     assert.match(workflow, /omx-explore-harness/);
     assert.match(workflow, /omx-sparkshell/);
     assert.match(workflow, /native-release-manifest\.json/);


### PR DESCRIPTION
Fixes the current PR #2332 blocker by preserving `/v1/responses` `reasoning` and optional `instructions` when `omx-api` forwards requests to the real-private Codex endpoint.

This is a follow-up fix branch from PR #2332 head.

Verification:
- `cargo test -p omx-api`
- `cargo test -p omx-sparkshell`
- `npm run build` when local Node deps were available in the worktree

Related: #2332

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
