### PR TITLE
Fix team tmux submit confirmation for wrapped drafts

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -1011,6 +1011,12 @@ exit 0
       assert.match(tmuxLog, /display-message -p -t %93 #\{pane_in_mode\}/);
       assert.match(tmuxLog, /capture-pane -t %93 -p -S -80/);
       assert.match(tmuxLog, /send-keys -t %93 -l .*Team busy-live-pane:/);
+      assert.match(tmuxLog, /send-keys -t %93 Tab/);
+      assert.match(tmuxLog, /send-keys -t %93 C-m/);
+      assert.ok(
+        tmuxLog.indexOf('send-keys -t %93 Tab') < tmuxLog.indexOf('send-keys -t %93 C-m'),
+        'busy leader queue path should press Tab before C-m',
+      );
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should keep the injection marker on busy-pane sends');
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
@@ -1405,6 +1411,12 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /capture-pane/);
       assert.match(tmuxLog, /send-keys -t %73/, 'should inject into a busy leader pane so Codex can queue the message');
+      assert.match(tmuxLog, /send-keys -t %73 Tab/);
+      assert.match(tmuxLog, /send-keys -t %73 C-m/);
+      assert.ok(
+        tmuxLog.indexOf('send-keys -t %73 Tab') < tmuxLog.indexOf('send-keys -t %73 C-m'),
+        'busy leader queue path should press Tab before C-m',
+      );
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       if (existsSync(eventsPath)) {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -62,7 +62,10 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
-function buildWorkerStopFakeTmux(tmuxLogPath: string, options: { failSend?: boolean } = {}): string {
+function buildWorkerStopFakeTmux(
+  tmuxLogPath: string,
+  options: { failSend?: boolean; busyLeader?: boolean } = {},
+): string {
   return `#!/usr/bin/env bash
 set -eu
 echo "$@" >> "${tmuxLogPath}"
@@ -90,7 +93,7 @@ if [[ "$cmd" == "display-message" ]]; then
   exit 0
 fi
 if [[ "$cmd" == "capture-pane" ]]; then
-  echo "› ready"
+  ${options.busyLeader ? 'echo "• Working… (esc to interrupt)"' : 'echo "› ready"'}
   exit 0
 fi
 if [[ "$cmd" == "send-keys" ]]; then
@@ -5995,6 +5998,98 @@ exit 0
       assert.equal(stopNudges.length, 1, "allowed worker Stop should nudge leader exactly once inside cooldown");
       const nudgeState = JSON.parse(await readFile(join(workerDir, "worker-stop-nudge.json"), "utf-8"));
       assert.equal(nudgeState.delivery, "sent");
+    } finally {
+      if (typeof prevTeamWorker === "string") process.env.OMX_TEAM_WORKER = prevTeamWorker;
+      else delete process.env.OMX_TEAM_WORKER;
+      if (typeof prevTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof prevPath === "string") process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("queues worker Stop leader nudge with Tab and submit when leader pane is busy", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-busy-leader-"));
+    const prevTeamWorker = process.env.OMX_TEAM_WORKER;
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const prevPath = process.env.PATH;
+    try {
+      await initTeamState(
+        "worker-stop-team-busy-leader",
+        "worker stop busy leader",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-team-worker-busy-leader" },
+      );
+      const fakeBinDir = join(cwd, "fake-bin");
+      const tmuxLogPath = join(cwd, "tmux.log");
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, "tmux"), buildWorkerStopFakeTmux(tmuxLogPath, { busyLeader: true }));
+      await chmod(join(fakeBinDir, "tmux"), 0o755);
+      const stateDir = join(cwd, ".omx", "state");
+      const teamDir = join(stateDir, "team", "worker-stop-team-busy-leader");
+      const workerDir = join(teamDir, "workers", "worker-1");
+      await writeJson(join(teamDir, "config.json"), {
+        name: "worker-stop-team-busy-leader",
+        tmux_session: "omx-team-worker-stop",
+        leader_pane_id: "%42",
+        workers: [{ name: "worker-1", index: 1, pane_id: "%10" }],
+      });
+      await writeJson(join(teamDir, "manifest.v2.json"), {
+        name: "worker-stop-team-busy-leader",
+        tmux_session: "omx-team-worker-stop",
+        leader_pane_id: "%42",
+        workers: [{ name: "worker-1", index: 1, pane_id: "%10" }],
+      });
+      await writeJson(join(workerDir, "identity.json"), {
+        name: "worker-1",
+        index: 1,
+        role: "executor",
+        assigned_tasks: ["1"],
+        worktree_path: cwd,
+        team_state_root: stateDir,
+      });
+      await writeJson(join(workerDir, "status.json"), {
+        state: "done",
+        current_task_id: "1",
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(teamDir, "tasks", "task-1.json"), {
+        id: "1",
+        subject: "hook task",
+        description: "finish hook task",
+        status: "completed",
+        owner: "worker-1",
+        created_at: new Date().toISOString(),
+      });
+
+      process.env.OMX_TEAM_WORKER = "worker-stop-team-busy-leader/worker-1";
+      process.env.OMX_TEAM_STATE_ROOT = stateDir;
+      process.env.PATH = `${fakeBinDir}:${prevPath || ""}`;
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-worker-busy-leader",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+      const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+      assert.match(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-1 native Stop allowed/);
+      assert.match(tmuxLog, /send-keys -t %42 Tab/);
+      assert.match(tmuxLog, /send-keys -t %42 C-m/);
+      assert.ok(
+        tmuxLog.indexOf("send-keys -t %42 Tab") < tmuxLog.indexOf("send-keys -t %42 C-m"),
+        "busy worker-stop nudge should press Tab before C-m",
+      );
+      const nudgeState = JSON.parse(await readFile(join(workerDir, "worker-stop-nudge.json"), "utf-8"));
+      assert.equal(nudgeState.delivery, "queued");
     } finally {
       if (typeof prevTeamWorker === "string") process.env.OMX_TEAM_WORKER = prevTeamWorker;
       else delete process.env.OMX_TEAM_WORKER;

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -726,12 +726,14 @@ function resolveWorkerCliForRequest(request, config) {
 
 function capturedPaneContainsTrigger(captured, trigger) {
   if (!captured || !trigger) return false;
-  return normalizeTmuxCapture(captured).includes(normalizeTmuxCapture(trigger));
+  const normalizeForDraftMatch = (value) => normalizeTmuxCapture(value).replace(/-\s+/g, '-');
+  return normalizeForDraftMatch(captured).includes(normalizeForDraftMatch(trigger));
 }
 
 function capturedPaneContainsTriggerNearTail(captured, trigger, nonEmptyTailLines = 24) {
   if (!captured || !trigger) return false;
-  const normalizedTrigger = normalizeTmuxCapture(trigger);
+  const normalizeForDraftMatch = (value) => normalizeTmuxCapture(value).replace(/-\s+/g, '-');
+  const normalizedTrigger = normalizeForDraftMatch(trigger);
   if (!normalizedTrigger) return false;
   const lines = safeString(captured)
     .split('\n')
@@ -739,7 +741,13 @@ function capturedPaneContainsTriggerNearTail(captured, trigger, nonEmptyTailLine
     .filter((line) => line.length > 0);
   if (lines.length === 0) return false;
   const tail = lines.slice(-Math.max(1, nonEmptyTailLines)).join(' ');
-  return normalizeTmuxCapture(tail).includes(normalizedTrigger);
+  return normalizeForDraftMatch(tail).includes(normalizedTrigger);
+}
+
+function buildJoinedCapturePaneArgv(paneTarget, tailLines = 80) {
+  // Join wrapped visual lines so long path-like trigger text split by tmux
+  // remains comparable with the original trigger.
+  return ['capture-pane', '-J', '-t', paneTarget, '-p', '-S', `-${tailLines}`];
 }
 
 const INJECT_VERIFY_DELAY_MS = 250;
@@ -791,7 +799,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
   if (attemptCountAtStart >= 1) {
     try {
       // Narrow capture (8 lines) to scope check to input area, not scrollback output
-      const preCapture = await runProcess('tmux', buildCapturePaneArgv(resolution.paneTarget, 8), 2000);
+      const preCapture = await runProcess('tmux', buildJoinedCapturePaneArgv(resolution.paneTarget, 8), 2000);
       preCaptureHasTrigger = capturedPaneContainsTrigger(preCapture.stdout, request.trigger_message);
     } catch {
       preCaptureHasTrigger = false;
@@ -830,8 +838,8 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
   // Post-injection verification: confirm the trigger text was consumed.
   // Fixes #391: without this, dispatch marks 'notified' even when the worker
   // pane is sitting on an unsent draft (C-m was not effectively applied).
-  const verifyNarrowArgv = buildCapturePaneArgv(resolution.paneTarget, 8);
-  const verifyWideArgv = buildCapturePaneArgv(resolution.paneTarget);
+  const verifyNarrowArgv = buildJoinedCapturePaneArgv(resolution.paneTarget, 8);
+  const verifyWideArgv = buildJoinedCapturePaneArgv(resolution.paneTarget);
   for (let round = 0; round < INJECT_VERIFY_ROUNDS; round++) {
     await new Promise((r) => setTimeout(r, INJECT_VERIFY_DELAY_MS));
     try {
@@ -842,6 +850,19 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       // full-scrollback false positives.
       const narrowCap = await runProcess('tmux', verifyNarrowArgv, 2000);
       const wideCap = await runProcess('tmux', verifyWideArgv, 2000);
+      const triggerInNarrow = capturedPaneContainsTrigger(narrowCap.stdout, request.trigger_message);
+      const triggerNearTail = capturedPaneContainsTriggerNearTail(wideCap.stdout, request.trigger_message);
+      if (triggerInNarrow || triggerNearTail) {
+        // Draft is still visible, so C-m has not actually submitted it yet.
+        // Do not let transient spinner/active-task text mask an unsent draft.
+        await sendPaneInput({
+          paneTarget: resolution.paneTarget,
+          prompt: request.trigger_message,
+          submitKeyPresses,
+          typePrompt: false,
+        }).catch(() => {});
+        continue;
+      }
       // Worker is actively processing (mirrors sync path tmux-session.ts:1292-1294)
       if (paneHasActiveTask(wideCap.stdout)) {
         runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir, request.team_name);
@@ -862,8 +883,6 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       if (request.to_worker !== 'leader-fixed' && !paneLooksReady(wideCap.stdout)) {
         continue;
       }
-      const triggerInNarrow = capturedPaneContainsTrigger(narrowCap.stdout, request.trigger_message);
-      const triggerNearTail = capturedPaneContainsTriggerNearTail(wideCap.stdout, request.trigger_message);
       if (!triggerInNarrow && !triggerNearTail) {
         runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir, request.team_name);
         return {

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -11,14 +11,14 @@ import { asNumber, safeString, isTerminalPhase } from './utils.js';
 import { readJsonIfExists, getScopedStateDirsForCurrentSession } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
-import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
+import { evaluatePaneInjectionReadiness, queuePaneInput, sendPaneInput } from './team-tmux-guard.js';
 import { resolvePaneTarget } from './tmux-injection.js';
 import { listNotifyCanonicalActiveTeams } from './active-team.js';
 import {
   classifyLeaderActionState,
   resolveLeaderNudgeIntent,
 } from './orchestration-intent.js';
-import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
+import { DEFAULT_MARKER, paneHasActiveTask } from '../tmux-hook-engine.js';
 import { isLeaderRuntimeStale } from '../../team/leader-activity.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
 import { writeTeamLeaderAttention } from '../../team/state.js';
@@ -967,14 +967,27 @@ export async function maybeNudgeTeamLeader({
     }
 
     try {
-      const sendResult = await sendPaneInput({
-        paneTarget: tmuxTarget,
-        prompt: markedText,
-        submitKeyPresses: 2,
-        submitDelayMs: 100,
-      });
-      if (!sendResult.ok) {
-        throw new Error(sendResult.error || sendResult.reason);
+      const leaderHasActiveTask = paneHasActiveTask(paneGuard.paneCapture);
+      let deliveryMode = 'sent';
+      if (leaderHasActiveTask) {
+        const sendResult = await queuePaneInput({
+          paneTarget: tmuxTarget,
+          prompt: markedText,
+        });
+        if (!sendResult.ok) {
+          throw new Error(sendResult.error || sendResult.reason);
+        }
+        deliveryMode = 'queued';
+      } else {
+        const sendResult = await sendPaneInput({
+          paneTarget: tmuxTarget,
+          prompt: markedText,
+          submitKeyPresses: 2,
+          submitDelayMs: 100,
+        });
+        if (!sendResult.ok) {
+          throw new Error(sendResult.error || sendResult.reason);
+        }
       }
       nudgeState.last_nudged_by_team[teamName] = {
         at: nowIso,
@@ -1005,6 +1018,7 @@ export async function maybeNudgeTeamLeader({
           message_count: messages.length,
           stalled_for_ms: undefined,
           missing_signal_workers: progressSnapshot.missingSignalWorkers,
+          delivery: deliveryMode,
         });
       } catch { /* ignore */ }
       await appendTeamDeliveryLog(logsDir, {
@@ -1013,7 +1027,7 @@ export async function maybeNudgeTeamLeader({
         team: teamName,
         to_worker: 'leader-fixed',
         transport: 'send-keys',
-        result: 'sent',
+        result: deliveryMode,
         reason: nudgeReason,
         orchestration_intent: orchestrationIntent,
       }).catch(() => {});

--- a/src/scripts/notify-hook/team-tmux-guard.ts
+++ b/src/scripts/notify-hook/team-tmux-guard.ts
@@ -182,6 +182,48 @@ export async function sendPaneInput({
   }
 }
 
+export async function queuePaneInput({
+  paneTarget,
+  prompt,
+  submitDelayMs = 80,
+}: any): Promise<any> {
+  const sendResult = await sendPaneInput({
+    paneTarget,
+    prompt,
+    submitKeyPresses: 0,
+  });
+  if (!sendResult.ok) return sendResult;
+
+  const target = safeString(paneTarget).trim();
+  const submitArgv = [
+    ['send-keys', '-t', target, 'Tab'],
+    ['send-keys', '-t', target, 'C-m'],
+  ];
+  try {
+    await runProcess('tmux', submitArgv[0], 3000);
+    if (submitDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, submitDelayMs));
+    }
+    await runProcess('tmux', submitArgv[1], 3000);
+    return {
+      ok: true,
+      sent: true,
+      reason: 'queued',
+      paneTarget: target,
+      argv: { typeArgv: sendResult.argv?.typeArgv || null, submitArgv },
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      sent: false,
+      reason: 'queue_failed',
+      paneTarget: target,
+      argv: { typeArgv: sendResult.argv?.typeArgv || null, submitArgv },
+      error: error instanceof Error ? error.message : safeString(error),
+    };
+  }
+}
+
 export async function checkPaneReadyForTeamSendKeys(paneTarget: any): Promise<any> {
   return evaluatePaneInjectionReadiness(paneTarget);
 }

--- a/src/scripts/notify-hook/team-worker-stop.ts
+++ b/src/scripts/notify-hook/team-worker-stop.ts
@@ -8,12 +8,12 @@
 
 import { appendFile, mkdir, rename, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
-import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
+import { DEFAULT_MARKER, paneHasActiveTask } from '../tmux-hook-engine.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
 import { safeString, asNumber } from './utils.js';
 import { readJsonIfExists } from './state-io.js';
 import { logTmuxHookEvent } from './log.js';
-import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
+import { evaluatePaneInjectionReadiness, queuePaneInput, sendPaneInput } from './team-tmux-guard.js';
 import { resolvePaneTarget } from './tmux-injection.js';
 import { readTeamWorkersForIdleCheck } from './team-worker.js';
 
@@ -185,17 +185,28 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     + DEFAULT_MARKER;
 
   try {
-    const sendResult = await sendPaneInput({
-      paneTarget: tmuxTarget,
-      prompt,
-      submitKeyPresses: 2,
-      submitDelayMs: 100,
-    });
-    if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    const leaderHasActiveTask = paneHasActiveTask(paneGuard.paneCapture);
+    let deliveryMode = 'sent';
+    if (leaderHasActiveTask) {
+      const sendResult = await queuePaneInput({
+        paneTarget: tmuxTarget,
+        prompt,
+      });
+      if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+      deliveryMode = 'queued';
+    } else {
+      const sendResult = await sendPaneInput({
+        paneTarget: tmuxTarget,
+        prompt,
+        submitKeyPresses: 2,
+        submitDelayMs: 100,
+      });
+      if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    }
 
     await writeStopNudgeState(statePath, {
       ...nextState,
-      delivery: 'sent',
+      delivery: deliveryMode,
       leader_pane_id: leaderPaneId || null,
       tmux_target: tmuxTarget,
     });
@@ -205,7 +216,7 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
       type: 'worker_stop_leader_nudge',
       worker: workerName,
       to_worker: 'leader-fixed',
-      delivery: 'sent',
+      delivery: deliveryMode,
       created_at: nowIso,
       source_type: SOURCE_TYPE,
     });
@@ -225,10 +236,10 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
       from_worker: workerName,
       to_worker: 'leader-fixed',
       transport: 'send-keys',
-      result: 'sent',
+      result: deliveryMode,
       reason: 'worker_stop_allowed',
     }).catch(() => {});
-    return { ok: true, result: 'sent' };
+    return { ok: true, result: deliveryMode };
   } catch (err) {
     await recordDeferred({
       stateDir,

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -606,6 +606,72 @@ esac
       },
     );
   });
+
+  it('does not confirm delivery while a wrapped hyphenated trigger remains as an unsent draft', async () => {
+    const trigger = 'Read .omx/state/team/team-x/workers/worker-1/inbox.md';
+    await withMockTmuxFixture(
+      'omx-tmux-codex-wrapped-trigger-draft-',
+      (logPath) => `#!/bin/sh
+set -eu
+state_dir="$(dirname "${logPath}")"
+text_sent_file="$state_dir/text-sent"
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    if [ -f "$text_sent_file" ]; then
+      cat <<'EOF'
+${READY_HELPER_CAPTURE}
+
+› Read .omx/state/team/team-x/workers/worker-
+  1/inbox.md
+EOF
+    else
+      cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+    fi
+    exit 0
+    ;;
+  send-keys)
+    if [ "\${4:-}" = "-l" ] && [ "\${6:-}" = "${trigger}" ]; then
+      : > "$text_sent_file"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        await assert.rejects(
+          () => sendToWorker('omx-team-x', 1, trigger),
+          /submit_failed/,
+        );
+        const log = await readFile(logPath, 'utf-8');
+        const enterCount = (log.match(/send-keys -t omx-team-x:1 C-m/g) || []).length;
+        assert.ok(
+          enterCount >= 4,
+          `expected repeated submit nudges before failing on the still-visible wrapped draft:\n${log}`,
+        );
+      },
+    );
+  });
+});
+
+describe('sendToWorker adaptive retry matching', () => {
+  it('recognizes hyphen-wrapped trigger drafts as still visible', () => {
+    assert.equal(
+      shouldAttemptAdaptiveRetry(
+        'auto',
+        true,
+        true,
+        `${READY_HELPER_CAPTURE}\n\n› Read .omx/state/team/team-x/workers/worker-\n  1/inbox.md`,
+        'Read .omx/state/team/team-x/workers/worker-1/inbox.md',
+      ),
+      true,
+    );
+  });
 });
 
 describe('startup direct trigger safety', () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1605,10 +1605,10 @@ export function shouldAttemptAdaptiveRetry(
   if (!paneBusyAtStart) return false;
   if (typeof latestCapture !== 'string') return false;
 
-  const normalizedText = normalizeTmuxCapture(text);
+  const normalizedText = normalizeWorkerTriggerForDraftMatch(text);
   if (normalizedText === '') return false;
 
-  const normalizedCapture = normalizeTmuxCapture(latestCapture);
+  const normalizedCapture = normalizeWorkerTriggerForDraftMatch(latestCapture);
   if (!normalizedCapture.includes(normalizedText)) return false;
   if (paneHasActiveTask(latestCapture)) return false;
   if (!paneLooksReady(latestCapture)) return false;
@@ -1656,9 +1656,9 @@ async function attemptSubmitRounds(
       capturePaneAsync(target),
       captureVisiblePaneAsync(target),
     ]);
-    const normalizedCapture = normalizeTmuxCapture(captured);
+    const normalizedCapture = normalizeWorkerTriggerForDraftMatch(captured);
     if (
-      !normalizedCapture.includes(normalizeTmuxCapture(text))
+      !normalizedCapture.includes(normalizeWorkerTriggerForDraftMatch(text))
       && !paneHasQueuedCodexSubmission(visibleCapture)
     ) {
       return true;
@@ -1842,6 +1842,13 @@ export function dismissTrustPromptIfPresent(
 
 export const normalizeTmuxCapture = sharedNormalizeTmuxCapture;
 
+function normalizeWorkerTriggerForDraftMatch(value: string | null | undefined): string {
+  // Codex/tmux can wrap long path-like trigger text after a hyphen, e.g.
+  // `worker-\n  1/inbox.md`. Treat those visual wraps as the original token so
+  // delivery verification does not mistake an unsent draft for consumed input.
+  return normalizeTmuxCapture(value ?? '').replace(/-\s+/g, '-');
+}
+
 function assertWorkerTriggerText(text: string): void {
   if (text.length >= 200) {
     throw new Error('sendToWorker: text must be < 200 characters');
@@ -1953,7 +1960,7 @@ export async function sendToWorker(
   if (verifyCapture) {
     if (paneHasActiveTask(verifyCapture)) return;
     if (
-      !normalizeTmuxCapture(verifyCapture).includes(normalizeTmuxCapture(text))
+      !normalizeWorkerTriggerForDraftMatch(verifyCapture).includes(normalizeWorkerTriggerForDraftMatch(text))
       && !paneHasQueuedCodexSubmission(verifyVisibleCapture)
     ) {
       return;
@@ -1965,6 +1972,14 @@ export async function sendToWorker(
     const finalVisibleCapture = await captureVisiblePaneAsync(target);
     if (paneHasQueuedCodexSubmission(finalVisibleCapture)) {
       throw new Error('sendToWorker: submit_queued_after_tool_call');
+    }
+    const finalCapture = await capturePaneAsync(target);
+    if (
+      normalizeWorkerTriggerForDraftMatch(finalCapture).includes(normalizeWorkerTriggerForDraftMatch(text))
+      && !paneHasActiveTask(finalCapture)
+      && paneLooksReady(finalCapture)
+    ) {
+      throw new Error('sendToWorker: submit_failed (trigger text still visible after retries)');
     }
   }
 }


### PR DESCRIPTION
## Summary

- keep team dispatch verification from treating hyphen-wrapped Codex/tmux trigger drafts as consumed
- retry Enter while the trigger draft is still visible before allowing active-task confirmation
- queue leader/team-stop nudges with a shared Tab + submit helper when the leader pane is actively working
- add regression coverage for wrapped `worker-1/inbox.md` drafts and busy-leader queued nudges

## Why

A live `omx team` smoke on macOS/tmux showed worker panes stuck with the trigger text typed but not submitted. Runtime state still marked delivery as `tmux_send_keys_confirmed` / `fallback_confirmed:tmux_send_keys_sent`, leaving tasks pending until manual Enter was pressed.

The pane capture wrapped `worker-1` as `worker-\n  1`, so simple normalized string matching missed the still-visible draft. Busy leader nudges also need a true queue-submit sequence (`Tab` + `C-m`) instead of recording `queued` after typing only.

## Verification

- `npm run build`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/scripts/__tests__/codex-native-hook.test.js`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/team/__tests__/tmux-session.test.js`
- `npx biome lint` changed files
- `npm run check:no-unused`
- `git diff --check origin/dev...HEAD`

## Review note

`queued` continues to mean the tmux queue-submit sequence was sent successfully. A future follow-up can add Codex queued-banner confirmation or rename the telemetry if stricter semantics are desired.