### PR TITLE
Prevent stale notify wrapper recursion

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -221,6 +221,68 @@ describe("notify setup scope", () => {
 		}
 	});
 
+	it("does not preserve stale turn-ended wrappers with OMX previous notify metadata", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-stale-wrapper-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await mkdir(codexHomeDir, { recursive: true });
+				const metadataPath = join(
+					codexHomeDir,
+					".omx",
+					"notify-dispatch.json",
+				);
+				const stalePkgRoot = join(wd, "old-global", "oh-my-codex");
+				const staleDispatcher = join(
+					stalePkgRoot,
+					"dist",
+					"scripts",
+					"notify-dispatcher.js",
+				);
+				const staleTurnEndedWrapper = join(wd, "SkyComputerUseClient");
+				await mkdir(dirname(metadataPath), { recursive: true });
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					`notify = ["node", "${staleDispatcher}", "--metadata", "${metadataPath}"]\napproval_policy = "on-failure"\n`,
+				);
+				await writeFile(
+					metadataPath,
+					JSON.stringify({
+						managedBy: "oh-my-codex",
+						version: 1,
+						previousNotify: [
+							"node",
+							staleTurnEndedWrapper,
+							"turn-ended",
+							"--previous-notify",
+							JSON.stringify([
+								"node",
+								staleDispatcher,
+								"--metadata",
+								metadataPath,
+							]),
+						],
+						omxNotify: [
+							"node",
+							join(stalePkgRoot, "dist", "scripts", "notify-hook.js"),
+						],
+						dispatcherNotify: ["node", staleDispatcher, "--metadata", metadataPath],
+					}),
+				);
+
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.match(config, /^notify = \["node", ".*notify-hook\.js"\]$/m);
+				assert.doesNotMatch(config, /notify-dispatcher\.js/);
+				assert.doesNotMatch(config, /SkyComputerUseClient/);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("does not wrap stale global OMX notify hooks as user notify commands", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-stale-hook-notify-"));
 		try {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -317,6 +317,49 @@ function resolveNotifyEntrypoint(command: readonly string[]): string | undefined
   return command.slice(1).find((arg) => !arg.startsWith("-"));
 }
 
+function getPreviousNotifyWrapperValue(
+  command: readonly string[],
+): string | undefined {
+  for (let index = 0; index < command.length; index += 1) {
+    const part = command[index];
+    if (part === "--previous-notify") {
+      return command[index + 1];
+    }
+    if (part.startsWith("--previous-notify=")) {
+      return part.slice("--previous-notify=".length);
+    }
+  }
+  return undefined;
+}
+
+function isOmxManagedPreviousNotifyWrapper(
+  command: readonly string[] | null | undefined,
+  pkgRoot?: string,
+): boolean {
+  if (!command) return false;
+  if (!command.some((part) => part === "turn-ended")) return false;
+  const previousNotify = getPreviousNotifyWrapperValue(command);
+  if (!previousNotify) return false;
+
+  try {
+    const parsed = JSON.parse(previousNotify) as unknown;
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((item) => typeof item === "string")
+    ) {
+      return isOmxManagedNotifyCommand(parsed, pkgRoot);
+    }
+  } catch {
+    // Fall back to a conservative text match for legacy wrapper payloads.
+  }
+
+  return (
+    /(?:^|[\\/])notify-(?:hook|dispatcher)\.js(?:\s|$|["'])/.test(
+      previousNotify,
+    ) && /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(previousNotify)
+  );
+}
+
 export function isOmxManagedNotifyCommand(
   command: readonly string[] | null | undefined,
   pkgRoot?: string,
@@ -343,6 +386,7 @@ export function sanitizePreviousNotifyCommand(
 ): string[] | null {
   if (!command || command.length === 0) return null;
   if (isOmxManagedNotifyCommand(command, pkgRoot)) return null;
+  if (isOmxManagedPreviousNotifyWrapper(command, pkgRoot)) return null;
   return [...command];
 }
 

--- a/src/scripts/__tests__/notify-dispatcher.test.ts
+++ b/src/scripts/__tests__/notify-dispatcher.test.ts
@@ -91,6 +91,92 @@ describe("notify dispatcher previousNotify guard", () => {
 		}
 	});
 
+	it("skips stale turn-ended wrappers whose previousNotify is an OMX dispatcher", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-wrapper-"));
+		try {
+			const oldPkgScripts = join(wd, "global", "oh-my-codex", "dist", "scripts");
+			mkdirSync(oldPkgScripts, { recursive: true });
+			const stalePreviousMarker = join(wd, "stale-wrapper-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const staleDispatcher = join(oldPkgScripts, "notify-dispatcher.js");
+			const turnEndedWrapper = join(wd, "SkyComputerUseClient");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(
+				turnEndedWrapper,
+				`import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(stalePreviousMarker)}, "ran");\n`,
+			);
+			writeFileSync(omxHook, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [
+						process.execPath,
+						turnEndedWrapper,
+						"turn-ended",
+						"--previous-notify",
+						JSON.stringify([
+							process.execPath,
+							staleDispatcher,
+							"--metadata",
+							metadataPath,
+						]),
+					],
+					omxNotify: [process.execPath, omxHook],
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.equal(existsSync(stalePreviousMarker), false);
+			assert.equal(readFileSync(omxMarker, "utf-8"), "ran");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("skips stale turn-ended wrappers whose previousNotify text is an OMX hook", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-wrapper-text-"));
+		try {
+			const oldPkgScripts = join(wd, "global", "oh-my-codex", "dist", "scripts");
+			mkdirSync(oldPkgScripts, { recursive: true });
+			const stalePreviousMarker = join(wd, "stale-wrapper-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const staleHook = join(oldPkgScripts, "notify-hook.js");
+			const turnEndedWrapper = join(wd, "SkyComputerUseClient");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(
+				turnEndedWrapper,
+				`import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(stalePreviousMarker)}, "ran");\n`,
+			);
+			writeFileSync(omxHook, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [
+						process.execPath,
+						turnEndedWrapper,
+						"turn-ended",
+						`--previous-notify=node ${staleHook}`,
+					],
+					omxNotify: [process.execPath, omxHook],
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.equal(existsSync(stalePreviousMarker), false);
+			assert.equal(readFileSync(omxMarker, "utf-8"), "ran");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves and runs real user previousNotify entries", () => {
 		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-user-"));
 		try {

--- a/src/scripts/notify-dispatcher.ts
+++ b/src/scripts/notify-dispatcher.ts
@@ -52,6 +52,21 @@ function resolveNotifyEntrypoint(command: readonly string[]): string | undefined
 	return command.slice(1).find((arg) => !arg.startsWith("-"));
 }
 
+function getPreviousNotifyWrapperValue(
+	command: readonly string[],
+): string | undefined {
+	for (let index = 0; index < command.length; index += 1) {
+		const part = command[index];
+		if (part === "--previous-notify") {
+			return command[index + 1];
+		}
+		if (part.startsWith("--previous-notify=")) {
+			return part.slice("--previous-notify=".length);
+		}
+	}
+	return undefined;
+}
+
 function isOmxManagedNotifyCommand(command: readonly string[] | null | undefined): boolean {
 	if (!command) return false;
 	const entrypoint = resolveNotifyEntrypoint(command);
@@ -62,12 +77,40 @@ function isOmxManagedNotifyCommand(command: readonly string[] | null | undefined
 	return /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(entrypoint);
 }
 
+function isOmxManagedPreviousNotifyWrapper(
+	command: readonly string[] | null | undefined,
+): boolean {
+	if (!command) return false;
+	if (!command.some((part) => part === "turn-ended")) return false;
+	const previousNotify = getPreviousNotifyWrapperValue(command);
+	if (!previousNotify) return false;
+
+	try {
+		const parsed = JSON.parse(previousNotify) as unknown;
+		if (
+			Array.isArray(parsed) &&
+			parsed.every((item) => typeof item === "string")
+		) {
+			return isOmxManagedNotifyCommand(parsed);
+		}
+	} catch {
+		// Fall back to a conservative text match for legacy wrapper payloads.
+	}
+
+	return (
+		/(?:^|[\\/])notify-(?:hook|dispatcher)\.js(?:\s|$|["'])/.test(
+			previousNotify,
+		) && /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(previousNotify)
+	);
+}
+
 function isManagedPreviousNotify(
 	previousNotify: readonly string[] | null | undefined,
 	metadata: NotifyDispatcherMetadata | null,
 ): boolean {
 	return (
 		isOmxManagedNotifyCommand(previousNotify) ||
+		isOmxManagedPreviousNotifyWrapper(previousNotify) ||
 		sameCommand(previousNotify, metadata?.omxNotify) ||
 		sameCommand(previousNotify, metadata?.dispatcherNotify)
 	);


### PR DESCRIPTION
## Summary
- strip stale Codex Computer Use `turn-ended --previous-notify` wrappers when their embedded command is an OMX notify hook/dispatcher
- apply the guard both when setup sanitizes persisted previousNotify metadata and when notify-dispatcher decides whether to run previousNotify
- add regressions for stale dispatcher metadata and wrapper payloads so recursive notify-dispatcher/SkyComputerUseClient chains are skipped while real user notify commands still run

Closes #2254.

## Tests
- `npm run build`
- `node --test dist/scripts/__tests__/notify-dispatcher.test.js dist/cli/__tests__/setup-install-mode.test.js dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/uninstall.test.js`
- `npm run lint`
- `git diff --check`

## Review
- Local review: no blocker found
- Architect review: WATCH, no merge-blocking concern; noted duplicated classifier as a future maintainability watch item kept out of this narrow regression fix
