### PR TITLE
Fix Windows MCP duplicate sibling watchdog

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -8,7 +8,9 @@ import {
   MCP_ENTRYPOINT_MARKER_ENV,
   extractMcpEntrypointMarker,
   isParentProcessAlive,
+  listProcessTable,
   parseProcessTable,
+  parseWindowsProcessTable,
   resolveCurrentMcpEntrypointMarker,
   resolveDuplicateSiblingWatchdogInitialDelayMs,
   shouldAutoStartMcpServer,
@@ -234,6 +236,112 @@ describe('mcp duplicate sibling detection', () => {
     assert.deepEqual(
       parseProcessTable('101 55 node /tmp/dist/mcp/state-server.js\n'),
       [{ pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' }],
+    );
+  });
+
+  it('parses PowerShell CIM process JSON arrays for Windows process tables', () => {
+    assert.deepEqual(
+      parseWindowsProcessTable(JSON.stringify([
+        {
+          ProcessId: 101,
+          ParentProcessId: 55,
+          CommandLine: 'node C:\\tmp\\dist\\mcp\\state-server.js',
+          Name: 'node.exe',
+        },
+        {
+          ProcessId: '140',
+          ParentProcessId: '55',
+          CommandLine: 'node C:\\tmp\\dist\\mcp\\state-server.js',
+          Name: 'node.exe',
+        },
+      ])),
+      [
+        { pid: 101, ppid: 55, command: 'node C:\\tmp\\dist\\mcp\\state-server.js' },
+        { pid: 140, ppid: 55, command: 'node C:\\tmp\\dist\\mcp\\state-server.js' },
+      ],
+    );
+  });
+
+  it('parses single-object PowerShell CIM JSON from one Windows process', () => {
+    assert.deepEqual(
+      parseWindowsProcessTable(JSON.stringify({
+        ProcessId: 101,
+        ParentProcessId: 55,
+        CommandLine: 'node C:\\tmp\\dist\\mcp\\state-server.js',
+      })),
+      [{ pid: 101, ppid: 55, command: 'node C:\\tmp\\dist\\mcp\\state-server.js' }],
+    );
+  });
+
+  it('treats invalid Windows process-table JSON as unavailable', () => {
+    assert.equal(parseWindowsProcessTable('not json'), null);
+  });
+
+  it('uses bounded PowerShell CIM lookup on Windows and falls back to null on failure', () => {
+    const calls: Array<{
+      command: string;
+      args: readonly string[];
+      options: { timeout?: number; maxBuffer?: number };
+    }> = [];
+    const readWindowsProcessTable = (
+      command: string,
+      args: readonly string[] = [],
+      options: { timeout?: number; maxBuffer?: number } = {},
+    ): string => {
+      calls.push({ command, args, options });
+      return JSON.stringify({
+        ProcessId: 101,
+        ParentProcessId: 55,
+        CommandLine: 'node C:\\tmp\\dist\\mcp\\state-server.js',
+      });
+    };
+
+    assert.deepEqual(
+      listProcessTable(
+        readWindowsProcessTable as typeof import('node:child_process').execFileSync,
+        'win32',
+      ),
+      [{ pid: 101, ppid: 55, command: 'node C:\\tmp\\dist\\mcp\\state-server.js' }],
+    );
+    assert.equal(calls[0]?.command, 'powershell.exe');
+    assert.deepEqual(calls[0]?.args.slice(0, 4), [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+    ]);
+    assert.ok(calls[0]?.args.includes('Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine,Name | ConvertTo-Json -Compress'));
+    assert.equal(calls[0]?.options.timeout, 2_000);
+    assert.equal(calls[0]?.options.maxBuffer, 4 * 1024 * 1024);
+
+    const failingRead = (() => {
+      throw new Error('powershell unavailable');
+    }) as typeof import('node:child_process').execFileSync;
+    assert.equal(listProcessTable(failingRead, 'win32'), null);
+  });
+
+  it('detects duplicate Windows siblings through the process-table watchdog path', () => {
+    const processes = parseWindowsProcessTable(JSON.stringify([
+      {
+        ProcessId: 101,
+        ParentProcessId: 55,
+        CommandLine: 'node C:\\tmp\\dist\\mcp\\state-server.js',
+      },
+      {
+        ProcessId: 140,
+        ParentProcessId: 55,
+        CommandLine: 'node C:\\tmp\\dist\\mcp\\state-server.js',
+      },
+    ]));
+
+    assert.ok(processes, 'Windows process table should parse');
+    const older = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+
+    assert.equal(older.status, 'older_duplicate');
+    assert.deepEqual(older.newerSiblingPids, [140]);
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(older, 11_100, 9_000, null),
+      true,
     );
   });
 

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -113,11 +113,99 @@ export function parseProcessTable(output: string): ProcessTableEntry[] {
     .filter((entry): entry is ProcessTableEntry => entry !== null);
 }
 
-export function listProcessTable(
-  readPs: typeof execFileSync = execFileSync,
-): ProcessTableEntry[] | null {
-  if (process.platform === 'win32') {
+const WINDOWS_PROCESS_TABLE_TIMEOUT_MS = 2_000;
+const WINDOWS_PROCESS_TABLE_MAX_BUFFER_BYTES = 4 * 1024 * 1024;
+
+type ProcessTableReader = typeof execFileSync;
+
+interface WindowsProcessRecord {
+  ProcessId?: unknown;
+  ParentProcessId?: unknown;
+  CommandLine?: unknown;
+  Name?: unknown;
+}
+
+function parsePositiveInteger(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value > 0 ? value : null;
+  }
+  if (typeof value !== 'string' || value.trim() === '') return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseNonNegativeInteger(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== 'string' || value.trim() === '') return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+export function parseWindowsProcessTable(output: string): ProcessTableEntry[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
     return null;
+  }
+
+  const records = Array.isArray(parsed) ? parsed : [parsed];
+  const entries: ProcessTableEntry[] = [];
+
+  for (const record of records) {
+    if (!record || typeof record !== 'object') continue;
+    const processRecord = record as WindowsProcessRecord;
+    const pid = parsePositiveInteger(processRecord.ProcessId);
+    const ppid = parseNonNegativeInteger(processRecord.ParentProcessId);
+    const rawCommand = typeof processRecord.CommandLine === 'string' && processRecord.CommandLine.trim()
+      ? processRecord.CommandLine
+      : typeof processRecord.Name === 'string'
+        ? processRecord.Name
+        : '';
+    const command = rawCommand.trim();
+
+    if (pid === null || ppid === null || !command) continue;
+    entries.push({ pid, ppid, command });
+  }
+
+  return entries;
+}
+
+function listWindowsProcessTable(
+  readProcessTable: ProcessTableReader,
+): ProcessTableEntry[] | null {
+  try {
+    const output = readProcessTable(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine,Name | ConvertTo-Json -Compress',
+      ],
+      {
+        encoding: 'utf-8',
+        windowsHide: true,
+        timeout: WINDOWS_PROCESS_TABLE_TIMEOUT_MS,
+        maxBuffer: WINDOWS_PROCESS_TABLE_MAX_BUFFER_BYTES,
+      },
+    );
+    return parseWindowsProcessTable(output);
+  } catch {
+    return null;
+  }
+}
+
+export function listProcessTable(
+  readPs: ProcessTableReader = execFileSync,
+  platform: NodeJS.Platform = process.platform,
+): ProcessTableEntry[] | null {
+  if (platform === 'win32') {
+    return listWindowsProcessTable(readPs);
   }
 
   try {


### PR DESCRIPTION
## Summary
- Fixes #2348
- add a bounded Windows PowerShell/CIM process-table adapter for MCP bootstrap duplicate-sibling watchdogs
- preserve the existing Unix `ps` process-table path
- cover Windows JSON array parsing, single-object JSON, invalid output fallback, command failure fallback, and duplicate watchdog analysis

## Tests
- npm run build
- node --test dist/mcp/__tests__/bootstrap.test.js
- npm run lint
- npm run check:no-unused
- git diff --check

## Notes
- Not tested with a live Windows Codex.app MCP teardown smoke in this Linux workspace.