### PR TITLE
Prevent notify dispatcher fork bombs

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3358,7 +3358,7 @@ exit 0
   it("reapStaleNotifyFallbackWatcher sends SIGTERM only after confirming watcher identity", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-reap-pid-confirmed-"));
     const pidPath = join(cwd, "watcher.pid");
-    await writeFile(pidPath, JSON.stringify({ pid: 12345, started_at: new Date().toISOString() }));
+    await writeFile(pidPath, JSON.stringify({ pid: 12345, started_at: "2026-04-05T00:00:00.000Z" }));
 
     const killed: number[] = [];
     await reapStaleNotifyFallbackWatcher(pidPath, {
@@ -3367,6 +3367,24 @@ exit 0
     });
 
     assert.deepEqual(killed, [12345], "should SIGTERM the verified watcher process");
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("reapStaleNotifyFallbackWatcher skips recently started watcher records to avoid respawn loops", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-reap-pid-recent-"));
+    const pidPath = join(cwd, "watcher.pid");
+    await writeFile(pidPath, JSON.stringify({ pid: 24680, started_at: "2026-05-15T00:00:00.000Z" }));
+
+    const killed: number[] = [];
+    const result = await reapStaleNotifyFallbackWatcher(pidPath, {
+      isWatcherProcess: () => true,
+      nowMs: () => Date.parse("2026-05-15T00:00:03.000Z"),
+      reapGraceMs: 5000,
+      tryKillPid: (pid) => { killed.push(pid); return true; },
+    });
+
+    assert.equal(result, "recent_active");
+    assert.equal(killed.length, 0, "should not kill a watcher still inside the startup grace window");
     await rm(cwd, { recursive: true, force: true });
   });
 

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -221,6 +221,70 @@ describe("notify setup scope", () => {
 		}
 	});
 
+	it("does not preserve nested encoded stale turn-ended previous notify metadata", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-stale-nested-wrapper-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await mkdir(codexHomeDir, { recursive: true });
+				const metadataPath = join(
+					codexHomeDir,
+					".omx",
+					"notify-dispatch.json",
+				);
+				const stalePkgRoot = join(wd, "old-global", "oh-my-codex");
+				const staleDispatcher = join(
+					stalePkgRoot,
+					"dist",
+					"scripts",
+					"notify-dispatcher.js",
+				);
+				const staleTurnEndedWrapper = join(wd, "SkyComputerUseClient");
+				await mkdir(dirname(metadataPath), { recursive: true });
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					`notify = ["node", "${staleDispatcher}", "--metadata", "${metadataPath}"]\napproval_policy = "on-failure"\n`,
+				);
+				const nestedWrapper = JSON.stringify([
+					"node",
+					staleTurnEndedWrapper,
+					"turn-ended",
+					"--previous-notify",
+					JSON.stringify(["node", staleDispatcher, "--metadata", metadataPath]),
+				]);
+				await writeFile(
+					metadataPath,
+					JSON.stringify({
+						managedBy: "oh-my-codex",
+						version: 1,
+						previousNotify: [
+							"node",
+							staleTurnEndedWrapper,
+							"turn-ended",
+							"--previous-notify",
+							JSON.stringify(nestedWrapper),
+						],
+						omxNotify: [
+							"node",
+							join(stalePkgRoot, "dist", "scripts", "notify-hook.js"),
+						],
+						dispatcherNotify: ["node", staleDispatcher, "--metadata", metadataPath],
+					}),
+				);
+
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.match(config, /^notify = \["node", ".*notify-hook\.js"\]$/m);
+				assert.doesNotMatch(config, /notify-dispatcher\.js/);
+				assert.doesNotMatch(config, /SkyComputerUseClient/);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("does not preserve stale turn-ended wrappers with OMX previous notify metadata", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-stale-wrapper-notify-"));
 		try {

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -18,7 +18,7 @@ describe('Windows popup loop contracts', () => {
     assert.match(cliIndex, /buildWindowsMsysBackgroundHelperBootstrapScript/);
     assert.match(
       cliIndex,
-      /const pidPath = notifyFallbackPidPath\(cwd\);\s+await reapStaleNotifyFallbackWatcher\(pidPath\);\s+if \(!shouldEnableNotifyFallbackWatcher\(process\.env,\s*process\.platform\)\) return;/,
+      /const pidPath = notifyFallbackPidPath\(cwd\);\s+const reapResult = await reapStaleNotifyFallbackWatcher\(pidPath\);\s+if \(reapResult === "recent_active"\) return;\s+if \(!shouldEnableNotifyFallbackWatcher\(process\.env,\s*process\.platform\)\) return;/,
     );
     assert.match(cliIndex, /detached:\s*shouldDetachBackgroundHelper\(options\.env,\s*process\.platform\),\s*[\s\S]*?stdio:\s*"ignore",\s*[\s\S]*?windowsHide:\s*true/);
     assert.match(cliIndex, /spawnSync\([\s\S]*?buildWindowsMsysBackgroundHelperBootstrapScript\([\s\S]*?windowsHide:\s*true/);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4189,6 +4189,34 @@ interface WatcherPidRecord {
   startedAt: string | null;
 }
 
+export type NotifyFallbackReapResult =
+  | "missing"
+  | "invalid"
+  | "identity_mismatch"
+  | "recent_active"
+  | "reaped"
+  | "failed";
+
+const DEFAULT_NOTIFY_FALLBACK_REAP_GRACE_MS = 5000;
+
+function resolveNotifyFallbackReapGraceMs(env: NodeJS.ProcessEnv = process.env): number {
+  const parsed = Number.parseInt(env.OMX_NOTIFY_FALLBACK_REAP_GRACE_MS || "", 10);
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  return DEFAULT_NOTIFY_FALLBACK_REAP_GRACE_MS;
+}
+
+function isWatcherRecordWithinReapGrace(
+  record: WatcherPidRecord,
+  nowMs = Date.now(),
+  graceMs = resolveNotifyFallbackReapGraceMs(),
+): boolean {
+  if (graceMs <= 0 || !record.startedAt) return false;
+  const startedMs = Date.parse(record.startedAt);
+  if (!Number.isFinite(startedMs)) return false;
+  const ageMs = nowMs - startedMs;
+  return ageMs >= 0 && ageMs < graceMs;
+}
+
 function parseWatcherPidRecord(content: string): WatcherPidRecord | null {
   const trimmed = content.trim();
   if (!trimmed) return null;
@@ -4244,10 +4272,12 @@ export async function reapStaleNotifyFallbackWatcher(
     hasErrnoCode?: (error: unknown, code: string) => boolean;
     warn?: (message?: unknown, ...optionalParams: unknown[]) => void;
     isWatcherProcess?: (pid: number) => boolean;
+    nowMs?: () => number;
+    reapGraceMs?: number;
   } = {},
-): Promise<void> {
+): Promise<NotifyFallbackReapResult> {
   const exists = deps.exists ?? existsSync;
-  if (!exists(pidPath)) return;
+  if (!exists(pidPath)) return "missing";
 
   const { readFile } = await import("fs/promises");
   const readFileImpl = deps.readFile ?? readFile;
@@ -4258,9 +4288,17 @@ export async function reapStaleNotifyFallbackWatcher(
 
   try {
     const record = parseWatcherPidRecord(await readFileImpl(pidPath, "utf-8"));
-    if (record && isWatcherProcessImpl(record.pid)) {
-      tryKillPidImpl(record.pid, "SIGTERM");
+    if (!record) return "invalid";
+    if (!isWatcherProcessImpl(record.pid)) return "identity_mismatch";
+    if (isWatcherRecordWithinReapGrace(
+      record,
+      deps.nowMs?.() ?? Date.now(),
+      deps.reapGraceMs ?? resolveNotifyFallbackReapGraceMs(),
+    )) {
+      return "recent_active";
     }
+    tryKillPidImpl(record.pid, "SIGTERM");
+    return "reaped";
   } catch (error: unknown) {
     if (!hasErrnoCodeImpl(error, "ESRCH")) {
       warn(
@@ -4271,6 +4309,7 @@ export async function reapStaleNotifyFallbackWatcher(
         },
       );
     }
+    return "failed";
   }
 }
 
@@ -4291,7 +4330,8 @@ async function startNotifyFallbackWatcher(
 ): Promise<void> {
   const { mkdir, writeFile } = await import("fs/promises");
   const pidPath = notifyFallbackPidPath(cwd);
-  await reapStaleNotifyFallbackWatcher(pidPath);
+  const reapResult = await reapStaleNotifyFallbackWatcher(pidPath);
+  if (reapResult === "recent_active") return;
 
   if (!shouldEnableNotifyFallbackWatcher(process.env, process.platform)) return;
 

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -332,6 +332,65 @@ function getPreviousNotifyWrapperValue(
   return undefined;
 }
 
+function isOmxManagedPayloadText(value: string): boolean {
+  return (
+    /(?:^|[\\/])notify-(?:hook|dispatcher)\.js(?:\s|$|["'])/.test(
+      value,
+    ) && /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(value)
+  );
+}
+
+function parseJsonString(value: string): unknown | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const first = trimmed[0];
+  if (first !== "[" && first !== "{" && first !== '"') return undefined;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function containsOmxManagedNotifyPayload(
+  value: unknown,
+  pkgRoot: string | undefined,
+  depth = 0,
+): boolean {
+  if (depth > 8 || value == null) return false;
+  if (typeof value === "string") {
+    const parsed = parseJsonString(value);
+    if (parsed !== undefined && parsed !== value) {
+      return containsOmxManagedNotifyPayload(parsed, pkgRoot, depth + 1);
+    }
+    return isOmxManagedPayloadText(value);
+  }
+  if (Array.isArray(value)) {
+    if (value.every((item) => typeof item === "string")) {
+      const nestedCommand = value as string[];
+      return (
+        isOmxManagedNotifyCommand(nestedCommand, pkgRoot) ||
+        isOmxManagedPreviousNotifyWrapper(nestedCommand, pkgRoot)
+      );
+    }
+    return value.some((item) =>
+      containsOmxManagedNotifyPayload(item, pkgRoot, depth + 1),
+    );
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return [
+      record.previousNotify,
+      record.previous_notify,
+      record.notify,
+      record.command,
+      record.argv,
+      record.args,
+    ].some((item) => containsOmxManagedNotifyPayload(item, pkgRoot, depth + 1));
+  }
+  return false;
+}
+
 function isOmxManagedPreviousNotifyWrapper(
   command: readonly string[] | null | undefined,
   pkgRoot?: string,
@@ -341,23 +400,7 @@ function isOmxManagedPreviousNotifyWrapper(
   const previousNotify = getPreviousNotifyWrapperValue(command);
   if (!previousNotify) return false;
 
-  try {
-    const parsed = JSON.parse(previousNotify) as unknown;
-    if (
-      Array.isArray(parsed) &&
-      parsed.every((item) => typeof item === "string")
-    ) {
-      return isOmxManagedNotifyCommand(parsed, pkgRoot);
-    }
-  } catch {
-    // Fall back to a conservative text match for legacy wrapper payloads.
-  }
-
-  return (
-    /(?:^|[\\/])notify-(?:hook|dispatcher)\.js(?:\s|$|["'])/.test(
-      previousNotify,
-    ) && /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(previousNotify)
-  );
+  return containsOmxManagedNotifyPayload(previousNotify, pkgRoot);
 }
 
 export function isOmxManagedNotifyCommand(

--- a/src/scripts/__tests__/notify-dispatcher.test.ts
+++ b/src/scripts/__tests__/notify-dispatcher.test.ts
@@ -177,6 +177,94 @@ describe("notify dispatcher previousNotify guard", () => {
 		}
 	});
 
+	it("skips SkyComputerUseClient wrappers with quoted nested previousNotify self-references", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-nested-wrapper-"));
+		try {
+			const oldPkgScripts = join(wd, "global", "oh-my-codex", "dist", "scripts");
+			mkdirSync(oldPkgScripts, { recursive: true });
+			const stalePreviousMarker = join(wd, "nested-wrapper-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const staleDispatcher = join(oldPkgScripts, "notify-dispatcher.js");
+			const turnEndedWrapper = join(wd, "SkyComputerUseClient");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(
+				turnEndedWrapper,
+				`import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(stalePreviousMarker)}, "ran");\n`,
+			);
+			writeFileSync(omxHook, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			const nestedSelfReference = JSON.stringify([
+				process.execPath,
+				turnEndedWrapper,
+				"turn-ended",
+				"--previous-notify",
+				JSON.stringify([process.execPath, staleDispatcher, "--metadata", metadataPath]),
+			]);
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [
+						process.execPath,
+						turnEndedWrapper,
+						"turn-ended",
+						"--previous-notify",
+						JSON.stringify(nestedSelfReference),
+					],
+					omxNotify: [process.execPath, omxHook],
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.equal(existsSync(stalePreviousMarker), false);
+			assert.equal(readFileSync(omxMarker, "utf-8"), "ran");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("skips wrapper metadata objects with encoded OMX dispatcher payloads", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-object-wrapper-"));
+		try {
+			const oldPkgScripts = join(wd, "global", "oh-my-codex", "dist", "scripts");
+			mkdirSync(oldPkgScripts, { recursive: true });
+			const stalePreviousMarker = join(wd, "object-wrapper-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const staleDispatcher = join(oldPkgScripts, "notify-dispatcher.js");
+			const turnEndedWrapper = join(wd, "SkyComputerUseClient");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(
+				turnEndedWrapper,
+				`import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(stalePreviousMarker)}, "ran");\n`,
+			);
+			writeFileSync(omxHook, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [
+						process.execPath,
+						turnEndedWrapper,
+						"turn-ended",
+						`--previous-notify=${JSON.stringify({ previousNotify: JSON.stringify([process.execPath, staleDispatcher]) })}`,
+					],
+					omxNotify: [process.execPath, omxHook],
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.equal(existsSync(stalePreviousMarker), false);
+			assert.equal(readFileSync(omxMarker, "utf-8"), "ran");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves and runs real user previousNotify entries", () => {
 		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-user-"));
 		try {

--- a/src/scripts/notify-dispatcher.ts
+++ b/src/scripts/notify-dispatcher.ts
@@ -77,6 +77,59 @@ function isOmxManagedNotifyCommand(command: readonly string[] | null | undefined
 	return /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(entrypoint);
 }
 
+function isOmxManagedPayloadText(value: string): boolean {
+	return (
+		/(?:^|[\\/])notify-(?:hook|dispatcher)\.js(?:\s|$|["'])/.test(
+			value,
+		) && /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(value)
+	);
+}
+
+function parseJsonString(value: string): unknown | undefined {
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+	const first = trimmed[0];
+	if (first !== "[" && first !== "{" && first !== '"') return undefined;
+	try {
+		return JSON.parse(trimmed) as unknown;
+	} catch {
+		return undefined;
+	}
+}
+
+function containsOmxManagedNotifyPayload(value: unknown, depth = 0): boolean {
+	if (depth > 8 || value == null) return false;
+	if (typeof value === "string") {
+		const parsed = parseJsonString(value);
+		if (parsed !== undefined && parsed !== value) {
+			return containsOmxManagedNotifyPayload(parsed, depth + 1);
+		}
+		return isOmxManagedPayloadText(value);
+	}
+	if (Array.isArray(value)) {
+		if (value.every((item) => typeof item === "string")) {
+			const command = value as string[];
+			return (
+				isOmxManagedNotifyCommand(command) ||
+				isOmxManagedPreviousNotifyWrapper(command)
+			);
+		}
+		return value.some((item) => containsOmxManagedNotifyPayload(item, depth + 1));
+	}
+	if (typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		return [
+			record.previousNotify,
+			record.previous_notify,
+			record.notify,
+			record.command,
+			record.argv,
+			record.args,
+		].some((item) => containsOmxManagedNotifyPayload(item, depth + 1));
+	}
+	return false;
+}
+
 function isOmxManagedPreviousNotifyWrapper(
 	command: readonly string[] | null | undefined,
 ): boolean {
@@ -85,23 +138,7 @@ function isOmxManagedPreviousNotifyWrapper(
 	const previousNotify = getPreviousNotifyWrapperValue(command);
 	if (!previousNotify) return false;
 
-	try {
-		const parsed = JSON.parse(previousNotify) as unknown;
-		if (
-			Array.isArray(parsed) &&
-			parsed.every((item) => typeof item === "string")
-		) {
-			return isOmxManagedNotifyCommand(parsed);
-		}
-	} catch {
-		// Fall back to a conservative text match for legacy wrapper payloads.
-	}
-
-	return (
-		/(?:^|[\\/])notify-(?:hook|dispatcher)\.js(?:\s|$|["'])/.test(
-			previousNotify,
-		) && /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(previousNotify)
-	);
+	return containsOmxManagedNotifyPayload(previousNotify);
 }
 
 function isManagedPreviousNotify(


### PR DESCRIPTION
Fixes #2350.\n\n## Summary\n- Recursively detects OMX notify hook/dispatcher self-references in quoted or nested SkyComputerUseClient --previous-notify payloads.\n- Applies the same nested sanitization during setup metadata preservation so stale OMX wrappers are not re-wrapped.\n- Adds a bounded fallback watcher reap grace window to avoid immediate kill/relaunch loops for freshly started verified watcher PID records.\n\n## Tests\n- npm ci\n- npm run build\n- node --test dist/scripts/__tests__/notify-dispatcher.test.js\n- node --test --test-name-pattern 'nested encoded stale turn-ended|stale turn-ended wrappers|stale OMX dispatcher metadata|wraps and restores' dist/cli/__tests__/setup-install-mode.test.js\n- node --test --test-name-pattern 'reapStaleNotifyFallbackWatcher' dist/cli/__tests__/index.test.js\n- npm run lint\n- npm run check:no-unused\n- git diff --check\n\nNote: A broader full dist/cli/__tests__/index.test.js run was attempted and showed unrelated cleanup/tmux lease failures outside this change; the focused watcher reap tests passed.