### PR TITLE
fix(codex-hooks): normalize Homebrew node path so managed hooks survive node upgrades

### DIFF
--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -18,17 +18,46 @@ import {
   isRuntimeCodexHomeMirrorPath,
   mergeManagedCodexHooksConfig,
   removeManagedCodexHooks,
+  resolveStableNodePath,
 } from "../codex-hooks.js";
 
 describe("codex hooks helpers", () => {
 
-  it("uses the current JavaScript runtime for managed hook commands", () => {
+  it("normalizes Homebrew Cellar node paths to the stable bin symlink", () => {
+    assert.equal(
+      resolveStableNodePath("/opt/homebrew/Cellar/node/26.0.0/bin/node"),
+      "/opt/homebrew/bin/node",
+    );
+    assert.equal(
+      resolveStableNodePath(
+        "/home/linuxbrew/.linuxbrew/Cellar/node/24.1.0/bin/node",
+      ),
+      "/home/linuxbrew/.linuxbrew/bin/node",
+    );
+  });
+
+  it("leaves non-Homebrew node paths unchanged", () => {
+    assert.equal(
+      resolveStableNodePath("/usr/local/bin/node"),
+      "/usr/local/bin/node",
+    );
+    assert.equal(
+      resolveStableNodePath("/usr/bin/node"),
+      "/usr/bin/node",
+    );
+    assert.equal(
+      resolveStableNodePath("/opt/homebrew/bin/node"),
+      "/opt/homebrew/bin/node",
+    );
+  });
+
+  it("uses a stable node path for managed hook commands", () => {
     const config = buildManagedCodexHooksConfig("/repo");
     const command = (config.hooks.SessionStart[0] as { hooks?: Array<{ command?: string }> } | undefined)?.hooks?.[0]?.command;
 
     assert.equal(
       command,
-      `"${process.execPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}" "/repo/dist/scripts/codex-native-hook.js"`,
+      `"${resolveStableNodePath(process.execPath).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}" "/repo/dist/scripts/codex-native-hook.js"`,
     );
   });
 
@@ -228,7 +257,7 @@ describe("codex hooks helpers", () => {
   it("matches Codex's normalized command hook hash identity", async () => {
     const state = buildManagedCodexHookTrustState("/hooks.json", "/repo");
     const command =
-      `"${process.execPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}" "/repo/dist/scripts/codex-native-hook.js"`;
+      `"${resolveStableNodePath(process.execPath).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}" "/repo/dist/scripts/codex-native-hook.js"`;
     const expectedIdentity = {
       event_name: "pre_tool_use",
       hooks: [

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -140,6 +140,21 @@ export function buildManagedCodexNativeHookWindowsShimPath(
   return win32.join(codexHomeDir, ...WINDOWS_NATIVE_HOOK_SHIM_RELATIVE_PATH);
 }
 
+/**
+ * Homebrew and Linuxbrew expose node through a stable `bin/node` symlink that is
+ * repointed on every `brew upgrade node`, while `process.execPath` resolves to
+ * the version-pinned Cellar path (e.g. `/opt/homebrew/Cellar/node/26.0.0/bin/node`).
+ * Persisting that pinned path into `~/.codex/hooks.json` makes every managed
+ * codex hook exit 127 the moment node is upgraded and the old Cellar directory
+ * is cleaned up. Normalize it back to the stable symlink so hooks survive node
+ * upgrades. Non-Homebrew paths are returned unchanged.
+ */
+export function resolveStableNodePath(
+  execPath: string = process.execPath,
+): string {
+  return execPath.replace(/\/Cellar\/node\/[^/]+\/bin\/node$/, "/bin/node");
+}
+
 export function buildManagedCodexNativeHookWindowsShimContent(
   pkgRoot: string,
   options: Pick<ManagedCodexHookOptions, "hookScriptPath" | "nodePath"> = {},
@@ -147,7 +162,7 @@ export function buildManagedCodexNativeHookWindowsShimContent(
   const hookScript =
     options.hookScriptPath ??
     win32.join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
-  const nodePath = options.nodePath ?? process.execPath;
+  const nodePath = options.nodePath ?? resolveStableNodePath();
 
   return [
     "$ErrorActionPreference = 'Stop'",
@@ -192,7 +207,7 @@ export function buildManagedCodexNativeHookCommand(
     return `powershell.exe -NoProfile -ExecutionPolicy Bypass -File ${quoteWindowsCommandPart(shimPath)}`;
   }
 
-  return `${quoteCommandPart(process.execPath)} ${quoteCommandPart(hookScript)}`;
+  return `${quoteCommandPart(resolveStableNodePath())} ${quoteCommandPart(hookScript)}`;
 }
 
 function buildCommandHook(


### PR DESCRIPTION
## Problem

`buildManagedCodexNativeHookCommand` (and the Windows shim fallback) persist
`process.execPath` into `~/.codex/hooks.json`. On Homebrew, `process.execPath`
resolves to the version-pinned Cellar path, e.g.
`/opt/homebrew/Cellar/node/26.0.0/bin/node`.

When `brew upgrade node` (or `brew cleanup`) removes the old Cellar directory,
that absolute path no longer exists, so **every managed codex hook command**
(`Stop`, `PreToolUse`, `SessionStart`, `PreCompact`, `PostCompact`, …) fails with
`error: hook exited with code 127`. The codex session is degraded until the user
re-runs setup — and it recurs on every node upgrade.

Observed in the wild: 7 hardcoded `/opt/homebrew/Cellar/node/<ver>/bin/node`
entries in a generated `hooks.json`, all breaking after a routine `brew upgrade`.

## Fix

Add `resolveStableNodePath()` which rewrites a Homebrew/Linuxbrew
`.../Cellar/node/<ver>/bin/node` path to the stable `.../bin/node` symlink that
Homebrew repoints on every upgrade. Non-Homebrew paths (`/usr/bin/node`,
`/usr/local/bin/node`, nvm, an already-stable `/opt/homebrew/bin/node`, …) are
returned unchanged, so behavior outside Homebrew is identical.

Applied at both sites that embedded `process.execPath`:
- the Unix managed hook command
- the Windows shim `nodePath` fallback

## Tests

- New unit tests for `resolveStableNodePath` (Homebrew + Linuxbrew normalization,
  non-Homebrew passthrough).
- Updated the command/trust-hash identity tests to assert the normalized command
  (the path that is actually written to `hooks.json`).
- Full `codex-hooks` suite: 26 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
