### PR TITLE
Prevent recursive notify previousNotify wrappers

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -16,6 +16,7 @@ import { parse as parseToml } from "@iarna/toml";
 import { setup } from "../setup.js";
 import { uninstall } from "../uninstall.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../../config/omx-first-party-mcp.js";
+import { formatTomlStringArray } from "../../config/generator.js";
 
 const packageRoot = process.cwd();
 
@@ -161,6 +162,117 @@ describe("notify setup scope", () => {
 					new RegExp('^notify = \\["node", "/tmp/user-notify\\.js"\\]$', "m"),
 				);
 				assert.doesNotMatch(restored, /notify-dispatcher\.js/);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("strips nested OMX previous-notify wrappers from user notify metadata", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-nested-wrapper-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await mkdir(codexHomeDir, { recursive: true });
+				const metadataPath = join(
+					codexHomeDir,
+					".omx",
+					"notify-dispatch.json",
+				);
+				const wrapperNotify = [
+					"/Users/alice/.codex/computer-use/SkyComputerUseClient",
+					"turn-ended",
+					"--previous-notify",
+					JSON.stringify([
+						"node",
+						join(
+							"/opt",
+							"homebrew",
+							"lib",
+							"node_modules",
+							"oh-my-codex",
+							"dist",
+							"scripts",
+							"notify-dispatcher.js",
+						),
+						"--metadata",
+						metadataPath,
+					]),
+				];
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					`notify = ${formatTomlStringArray(wrapperNotify)}\napproval_policy = "on-failure"\n`,
+				);
+
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.match(
+					config,
+					/^notify = \["node", ".*notify-dispatcher\.js", "--metadata", ".*notify-dispatch\.json"\]$/m,
+				);
+				const metadata = JSON.parse(await readFile(metadataPath, "utf-8"));
+				assert.deepEqual(metadata.previousNotify, [
+					"/Users/alice/.codex/computer-use/SkyComputerUseClient",
+					"turn-ended",
+				]);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("sanitizes nested OMX previous-notify wrappers from existing dispatcher metadata", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-existing-nested-wrapper-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await mkdir(codexHomeDir, { recursive: true });
+				const metadataPath = join(
+					codexHomeDir,
+					".omx",
+					"notify-dispatch.json",
+				);
+				const dispatcherNotify = [
+					"node",
+					join(packageRoot, "dist", "scripts", "notify-dispatcher.js"),
+					"--metadata",
+					metadataPath,
+				];
+				const wrapperNotify = [
+					"/Users/alice/.codex/computer-use/SkyComputerUseClient",
+					"turn-ended",
+					"--previous-notify",
+					JSON.stringify(dispatcherNotify),
+				];
+				await mkdir(dirname(metadataPath), { recursive: true });
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					`notify = ${formatTomlStringArray(dispatcherNotify)}\napproval_policy = "on-failure"\n`,
+				);
+				await writeFile(
+					metadataPath,
+					JSON.stringify({
+						managedBy: "oh-my-codex",
+						version: 1,
+						previousNotify: wrapperNotify,
+						omxNotify: [
+							"node",
+							join(packageRoot, "dist", "scripts", "notify-hook.js"),
+						],
+						dispatcherNotify,
+					}),
+				);
+
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user" });
+				});
+
+				const metadata = JSON.parse(await readFile(metadataPath, "utf-8"));
+				assert.deepEqual(metadata.previousNotify, [
+					"/Users/alice/.codex/computer-use/SkyComputerUseClient",
+					"turn-ended",
+				]);
 			});
 		} finally {
 			await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { buildManagedCodexHooksConfig } from '../../config/codex-hooks.js';
+import { formatTomlStringArray } from '../../config/generator.js';
 
 function runOmx(
   cwd: string,
@@ -354,6 +355,71 @@ describe('omx uninstall', () => {
       const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
       assert.match(config, /^approval_policy = "on-failure"$/m);
       assert.doesNotMatch(config, /^notify\s*=/m);
+      assert.doesNotMatch(config, /notify-dispatcher\.js/);
+      assert.doesNotMatch(config, /oh-my-codex \(OMX\) Configuration/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('restores wrapper notify commands without nested OMX previous-notify payloads', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-nested-notify-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const metadataPath = join(codexDir, '.omx', 'notify-dispatch.json');
+      const dispatcherNotify = [
+        'node',
+        join(process.cwd(), 'dist', 'scripts', 'notify-dispatcher.js'),
+        '--metadata',
+        metadataPath,
+      ];
+      const wrapperNotify = [
+        '/Users/alice/.codex/computer-use/SkyComputerUseClient',
+        'turn-ended',
+        '--previous-notify',
+        JSON.stringify(dispatcherNotify),
+      ];
+      await mkdir(dirname(metadataPath), { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        [
+          '# User settings',
+          'approval_policy = "on-failure"',
+          `notify = ${formatTomlStringArray(dispatcherNotify)}`,
+          '',
+          '# ============================================================',
+          '# oh-my-codex (OMX) Configuration',
+          '# Managed by omx setup - manual edits preserved on next setup',
+          '# ============================================================',
+          '[mcp_servers.omx_state]',
+          'command = "node"',
+          'args = ["/path/to/state-server.js"]',
+          'enabled = true',
+          '# ============================================================',
+          '# End oh-my-codex',
+          '',
+        ].join('\n'),
+      );
+      await writeFile(
+        metadataPath,
+        JSON.stringify({
+          managedBy: 'oh-my-codex',
+          version: 1,
+          previousNotify: wrapperNotify,
+        }),
+      );
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      assert.match(config, /^approval_policy = "on-failure"$/m);
+      assert.match(
+        config,
+        /^notify = \["\/Users\/alice\/\.codex\/computer-use\/SkyComputerUseClient", "turn-ended"\]$/m,
+      );
       assert.doesNotMatch(config, /notify-dispatcher\.js/);
       assert.doesNotMatch(config, /oh-my-codex \(OMX\) Configuration/);
     } finally {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -3412,13 +3412,21 @@ async function buildNotifyMergePlan(
 		return { notifyCommand: omxNotify };
 	}
 
+	const sanitizedExistingNotify = sanitizePreviousNotifyCommand(
+		existingNotify,
+		pkgRoot,
+	);
+	if (!sanitizedExistingNotify) {
+		return { notifyCommand: omxNotify };
+	}
+
 	return {
 		notifyCommand: dispatcherNotify,
 		metadataPath,
 		metadata: {
 			managedBy: "oh-my-codex",
 			version: 1,
-			previousNotify: sanitizePreviousNotifyCommand(existingNotify, pkgRoot),
+			previousNotify: sanitizedExistingNotify,
 			omxNotify,
 			dispatcherNotify,
 		},

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -3,7 +3,13 @@ import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { buildMergedConfig, mergeConfig, OMX_DEVELOPER_INSTRUCTIONS, upsertPluginModeRuntimeFeatureFlags } from '../generator.js';
+import {
+  buildMergedConfig,
+  formatTomlStringArray,
+  mergeConfig,
+  OMX_DEVELOPER_INSTRUCTIONS,
+  upsertPluginModeRuntimeFeatureFlags,
+} from '../generator.js';
 
 describe('config generator', () => {
   it('places top-level keys before [features]', async () => {
@@ -603,6 +609,35 @@ describe('config generator', () => {
       merged,
       /^notify = \["node", "\/tmp\/user-notify\.js", "\/opt\/homebrew\/lib\/node_modules\/oh-my-codex\/dist\/scripts\/notify-hook\.js"\]$/m,
     );
+    assert.match(merged, /^approval_policy = "never"$/m);
+  });
+
+  it('strips OMX-managed nested previous-notify payloads from preserved user notify commands', () => {
+    const pkgRoot = '/current/install/oh-my-codex';
+    const wrapperNotify = [
+      '/Users/alice/.codex/computer-use/SkyComputerUseClient',
+      'turn-ended',
+      '--previous-notify',
+      JSON.stringify([
+        'node',
+        '/opt/homebrew/lib/node_modules/oh-my-codex/dist/scripts/notify-dispatcher.js',
+        '--metadata',
+        '/tmp/notify-dispatch.json',
+      ]),
+    ];
+    const userNotify = [
+      `notify = ${formatTomlStringArray(wrapperNotify)}`,
+      'approval_policy = "never"',
+      '',
+    ].join('\n');
+
+    const merged = buildMergedConfig(userNotify, pkgRoot, { notifyCommand: false });
+
+    assert.match(
+      merged,
+      /^notify = \["\/Users\/alice\/\.codex\/computer-use\/SkyComputerUseClient", "turn-ended"\]$/m,
+    );
+    assert.doesNotMatch(merged, /notify-dispatcher\.js/);
     assert.match(merged, /^approval_policy = "never"$/m);
   });
 });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -317,6 +317,31 @@ function resolveNotifyEntrypoint(command: readonly string[]): string | undefined
   return command.slice(1).find((arg) => !arg.startsWith("-"));
 }
 
+function parseStringArray(value: string): string[] | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      !Array.isArray(parsed) ||
+      !parsed.every((item) => typeof item === "string")
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function getNestedPreviousNotifyCommand(
+  command: readonly string[],
+): string[] | null {
+  const flagIndex = command.indexOf("--previous-notify");
+  if (flagIndex < 0) return null;
+  const encodedCommand = command[flagIndex + 1];
+  if (!encodedCommand) return null;
+  return parseStringArray(encodedCommand) ?? command.slice(flagIndex + 1);
+}
+
 export function isOmxManagedNotifyCommand(
   command: readonly string[] | null | undefined,
   pkgRoot?: string,
@@ -337,13 +362,28 @@ export function isOmxManagedNotifyCommand(
   return /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(entrypoint);
 }
 
+function stripOmxManagedNestedPreviousNotify(
+  command: readonly string[],
+  pkgRoot?: string,
+): string[] {
+  const nestedPreviousNotify = getNestedPreviousNotifyCommand(command);
+  if (!isOmxManagedNotifyCommand(nestedPreviousNotify, pkgRoot)) {
+    return [...command];
+  }
+  const flagIndex = command.indexOf("--previous-notify");
+  const encodedCommand = command[flagIndex + 1];
+  const removeCount = parseStringArray(encodedCommand ?? "") ? 2 : command.length - flagIndex;
+  return [...command.slice(0, flagIndex), ...command.slice(flagIndex + removeCount)];
+}
+
 export function sanitizePreviousNotifyCommand(
   command: readonly string[] | null | undefined,
   pkgRoot?: string,
 ): string[] | null {
   if (!command || command.length === 0) return null;
   if (isOmxManagedNotifyCommand(command, pkgRoot)) return null;
-  return [...command];
+  const sanitized = stripOmxManagedNestedPreviousNotify(command, pkgRoot);
+  return sanitized.length > 0 ? sanitized : null;
 }
 
 function getOmxTopLevelLines(
@@ -1968,10 +2008,11 @@ export function buildMergedConfig(
     existing = stripped.cleaned;
   }
 
+  const rootNotify = getRootTomlArray(existing, "notify");
   const userNotifyToPreserve =
     options.notifyCommand === false &&
-    !isOmxManagedNotifyCommand(getRootTomlArray(existing, "notify"), pkgRoot)
-      ? getRootTomlArray(existing, "notify")
+    !isOmxManagedNotifyCommand(rootNotify, pkgRoot)
+      ? sanitizePreviousNotifyCommand(rootNotify, pkgRoot)
       : null;
   existing = stripOmxTopLevelKeys(existing);
   if (userNotifyToPreserve) {

--- a/src/scripts/__tests__/notify-dispatcher.test.ts
+++ b/src/scripts/__tests__/notify-dispatcher.test.ts
@@ -91,6 +91,126 @@ describe("notify dispatcher previousNotify guard", () => {
 		}
 	});
 
+	it("runs wrapper previousNotify commands without nested OMX dispatcher payloads", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-wrapper-"));
+		try {
+			const oldPkgScripts = join(wd, "global", "oh-my-codex", "dist", "scripts");
+			mkdirSync(oldPkgScripts, { recursive: true });
+			const wrapperMarker = join(wd, "wrapper-ran");
+			const stalePreviousMarker = join(wd, "stale-previous-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const staleDispatcher = join(oldPkgScripts, "notify-dispatcher.js");
+			const wrapperScript = join(wd, "wrapper.js");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(staleDispatcher, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(stalePreviousMarker)}, "ran");\n`);
+			writeFileSync(
+				wrapperScript,
+				[
+					'import { writeFileSync } from "node:fs";',
+					'import { spawnSync } from "node:child_process";',
+					`writeFileSync(${JSON.stringify(wrapperMarker)}, process.argv.slice(2).join("\\n"));`,
+					'const index = process.argv.indexOf("--previous-notify");',
+					'if (index >= 0) {',
+					'  const nested = JSON.parse(process.argv[index + 1]);',
+					'  spawnSync(nested[0], [...nested.slice(1), process.argv.at(-1) ?? ""], { stdio: "ignore" });',
+					'}',
+					"",
+				].join("\n"),
+			);
+			writeFileSync(omxHook, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [
+						process.execPath,
+						wrapperScript,
+						"turn-ended",
+						"--previous-notify",
+						JSON.stringify([
+							process.execPath,
+							staleDispatcher,
+							"--metadata",
+							metadataPath,
+						]),
+					],
+					omxNotify: [process.execPath, omxHook],
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.doesNotMatch(readFileSync(wrapperMarker, "utf-8"), /--previous-notify/);
+			assert.equal(existsSync(stalePreviousMarker), false);
+			assert.equal(readFileSync(omxMarker, "utf-8"), "ran");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("strips nested previousNotify payloads that match dispatcher metadata outside oh-my-codex paths", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-metadata-wrapper-"));
+		try {
+			const oldPkgScripts = join(wd, "global", "renamed-package", "dist", "scripts");
+			mkdirSync(oldPkgScripts, { recursive: true });
+			const wrapperMarker = join(wd, "wrapper-ran");
+			const stalePreviousMarker = join(wd, "stale-previous-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const staleDispatcher = join(oldPkgScripts, "notify-dispatcher.js");
+			const wrapperScript = join(wd, "wrapper.js");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(staleDispatcher, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(stalePreviousMarker)}, "ran");\n`);
+			writeFileSync(
+				wrapperScript,
+				[
+					'import { writeFileSync } from "node:fs";',
+					'import { spawnSync } from "node:child_process";',
+					`writeFileSync(${JSON.stringify(wrapperMarker)}, process.argv.slice(2).join("\\n"));`,
+					'const index = process.argv.indexOf("--previous-notify");',
+					'if (index >= 0) {',
+					'  const nested = JSON.parse(process.argv[index + 1]);',
+					'  spawnSync(nested[0], [...nested.slice(1), process.argv.at(-1) ?? ""], { stdio: "ignore" });',
+					'}',
+					"",
+				].join("\n"),
+			);
+			writeFileSync(omxHook, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			const dispatcherNotify = [
+				process.execPath,
+				staleDispatcher,
+				"--metadata",
+				metadataPath,
+			];
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [
+						process.execPath,
+						wrapperScript,
+						"turn-ended",
+						"--previous-notify",
+						JSON.stringify(dispatcherNotify),
+					],
+					omxNotify: [process.execPath, omxHook],
+					dispatcherNotify,
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.doesNotMatch(readFileSync(wrapperMarker, "utf-8"), /--previous-notify/);
+			assert.equal(existsSync(stalePreviousMarker), false);
+			assert.equal(readFileSync(omxMarker, "utf-8"), "ran");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves and runs real user previousNotify entries", () => {
 		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-user-"));
 		try {

--- a/src/scripts/notify-dispatcher.ts
+++ b/src/scripts/notify-dispatcher.ts
@@ -52,7 +52,34 @@ function resolveNotifyEntrypoint(command: readonly string[]): string | undefined
 	return command.slice(1).find((arg) => !arg.startsWith("-"));
 }
 
-function isOmxManagedNotifyCommand(command: readonly string[] | null | undefined): boolean {
+function parseStringArray(value: string): string[] | null {
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		if (
+			!Array.isArray(parsed) ||
+			!parsed.every((item) => typeof item === "string")
+		) {
+			return null;
+		}
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+function getNestedPreviousNotifyCommand(
+	command: readonly string[],
+): string[] | null {
+	const flagIndex = command.indexOf("--previous-notify");
+	if (flagIndex < 0) return null;
+	const encodedCommand = command[flagIndex + 1];
+	if (!encodedCommand) return null;
+	return parseStringArray(encodedCommand) ?? command.slice(flagIndex + 1);
+}
+
+function isOmxManagedNotifyCommand(
+	command: readonly string[] | null | undefined,
+): boolean {
 	if (!command) return false;
 	const entrypoint = resolveNotifyEntrypoint(command);
 	if (!entrypoint) return false;
@@ -60,6 +87,26 @@ function isOmxManagedNotifyCommand(command: readonly string[] | null | undefined
 		return false;
 	}
 	return /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(entrypoint);
+}
+
+function stripOmxManagedNestedPreviousNotify(
+	command: readonly string[],
+	metadata: NotifyDispatcherMetadata | null,
+): string[] {
+	const nestedPreviousNotify = getNestedPreviousNotifyCommand(command);
+	if (
+		!isOmxManagedNotifyCommand(nestedPreviousNotify) &&
+		!sameCommand(nestedPreviousNotify, metadata?.omxNotify) &&
+		!sameCommand(nestedPreviousNotify, metadata?.dispatcherNotify)
+	) {
+		return [...command];
+	}
+	const flagIndex = command.indexOf("--previous-notify");
+	const encodedCommand = command[flagIndex + 1];
+	const removeCount = parseStringArray(encodedCommand ?? "")
+		? 2
+		: command.length - flagIndex;
+	return [...command.slice(0, flagIndex), ...command.slice(flagIndex + removeCount)];
 }
 
 function isManagedPreviousNotify(
@@ -71,6 +118,16 @@ function isManagedPreviousNotify(
 		sameCommand(previousNotify, metadata?.omxNotify) ||
 		sameCommand(previousNotify, metadata?.dispatcherNotify)
 	);
+}
+
+function sanitizePreviousNotifyCommand(
+	command: readonly string[] | null | undefined,
+	metadata: NotifyDispatcherMetadata | null,
+): string[] | null {
+	if (!isCommand(command) || command.length === 0) return null;
+	if (isManagedPreviousNotify(command, metadata)) return null;
+	const sanitized = stripOmxManagedNestedPreviousNotify(command, metadata);
+	return sanitized.length > 0 ? sanitized : null;
 }
 
 async function readMetadata(
@@ -104,9 +161,7 @@ async function main(): Promise<void> {
 	const { metadataPath, payloadArg } = parseArgs();
 	if (!payloadArg || payloadArg.startsWith("-")) return;
 	const metadata = await readMetadata(metadataPath);
-	if (!isManagedPreviousNotify(metadata?.previousNotify, metadata)) {
-		runNotify(metadata?.previousNotify, payloadArg);
-	}
+	runNotify(sanitizePreviousNotifyCommand(metadata?.previousNotify, metadata), payloadArg);
 	runNotify(metadata?.omxNotify, payloadArg);
 }
 


### PR DESCRIPTION
## Summary
- Strip OMX-managed nested `--previous-notify` payloads from preserved notify wrapper commands.
- Keep the outer Codex Computer Use / user notify wrapper intact so the real notifier still runs.
- Apply the guard in setup metadata migration, config merge, uninstall restore, and runtime notify-dispatcher execution.

## Investigation evidence
- Local slowdown evidence showed `SkyComputerUseClient turn-ended --previous-notify <OMX notify-dispatcher JSON>` persisted as dispatcher `previousNotify`, so dispatcher execution could re-enter OMX.
- Latest npm/local installed OMX was 0.17.3, and upstream `main` still only filtered direct OMX notify entries, not nested `--previous-notify` payloads.
- A narrow upstream issue search for notify/previousNotify recursion did not find an existing tracked fix.

## Patch notes
- `sanitizePreviousNotifyCommand` now removes only nested payloads that resolve to OMX-managed notify-hook/notify-dispatcher commands.
- Setup falls back to plain OMX notify when stale dispatcher metadata has no real user notify left.
- Runtime dispatcher also sanitizes stale metadata before spawning `previousNotify`, including metadata-equal nested dispatcher commands outside literal `oh-my-codex` paths.
- Regression tests cover setup, config merge, uninstall, and runtime execution.

## Verification
- ✅ `npm run build`
- ✅ `node --test dist/scripts/__tests__/notify-dispatcher.test.js dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/uninstall.test.js` (112/112)
- ✅ `node --test dist/config/__tests__/generator-idempotent.test.js dist/config/__tests__/generator-status-line-presets.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js dist/cli/__tests__/setup-refresh.test.js` (92/92)
- ✅ `npm run lint`
- ✅ `npm run check:no-unused`
- ✅ `git diff --check`

## Full-suite note
`npm test` is still red locally in unrelated env/platform-dependent suites: explore harness/native binary wording, macOS `/var` vs `/private/var` temp-path checks, tmux/session ancestry expectations, missing cargo for sparkshell packaging, and process-timing assertions. The notify/setup/config/uninstall suites affected by this patch pass.