### PR TITLE
Stop worker tmux rc fan-out

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -19,6 +19,7 @@ import {
   buildUnregisterClientAttachedReconcileArgs,
   buildUnregisterResizeHookArgs,
   buildWorkerStartupCommand,
+  shouldSourceTeamWorkerShellRc,
   buildHudPaneTarget,
   chooseTeamLeaderPaneId,
   createTeamSession,
@@ -1041,7 +1042,7 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
-  it('uses zsh with ~/.zshrc and non-login shell exec semantics', () => {
+  it('uses zsh without sourcing ~/.zshrc by default and keeps non-login exec semantics', () => {
     const prevShell = process.env.SHELL;
     process.env.SHELL = '/bin/zsh';
     const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
@@ -1053,7 +1054,7 @@ describe('buildWorkerStartupCommand', () => {
       assert.match(cmd, /OMX_TEAM_WORKER=alpha\/worker-2/);
       assert.match(cmd, /'\/bin\/zsh' -c/);
       assert.doesNotMatch(cmd, /'\/bin\/zsh' -lc\b/);
-      assert.match(cmd, /source ~\/\.zshrc/);
+      assert.doesNotMatch(cmd, /source ~\/\.zshrc/);
       assert.match(cmd, /exec .*codex/);
     } finally {
       if (typeof prevShell === 'string') process.env.SHELL = prevShell;
@@ -1074,7 +1075,7 @@ describe('buildWorkerStartupCommand', () => {
       );
       assert.match(cmd, /'\/opt\/homebrew\/bin\/zsh' -c/);
       assert.doesNotMatch(cmd, /'\/bin\/sh' -c/);
-      assert.match(cmd, /source ~\/\.zshrc/);
+      assert.doesNotMatch(cmd, /source ~\/\.zshrc/);
     } finally {
       if (typeof prevShell === 'string') process.env.SHELL = prevShell;
       else delete process.env.SHELL;
@@ -1094,7 +1095,7 @@ describe('buildWorkerStartupCommand', () => {
       );
       assert.match(cmd, /'\/opt\/local\/bin\/zsh' -c/);
       assert.doesNotMatch(cmd, /'\/bin\/sh' -c/);
-      assert.match(cmd, /source ~\/\.zshrc/);
+      assert.doesNotMatch(cmd, /source ~\/\.zshrc/);
     } finally {
       if (typeof prevShell === 'string') process.env.SHELL = prevShell;
       else delete process.env.SHELL;
@@ -1103,14 +1104,14 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
-  it('uses bash with ~/.bashrc and preserves launch args', () => {
+  it('prevents issue #2358 bash rc fan-out by default and preserves launch args', () => {
     const prevShell = process.env.SHELL;
     process.env.SHELL = '/bin/bash';
     const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
     process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
     try {
       const cmd = buildWorkerStartupCommand('alpha', 1, ['--model', 'gpt-5']);
-      assert.match(cmd, /source ~\/\.bashrc/);
+      assert.doesNotMatch(cmd, /source ~\/\.bashrc/);
       assert.match(cmd, /exec .*codex/);
       assert.match(cmd, /--model/);
       assert.match(cmd, /gpt-5/);
@@ -1119,6 +1120,49 @@ describe('buildWorkerStartupCommand', () => {
       else delete process.env.SHELL;
       if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
       else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('sources worker shell rc files only when explicitly opted in', () => {
+    const prevShell = process.env.SHELL;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevSourceRc = process.env.OMX_TMUX_SOURCE_SHELL_RC;
+    process.env.SHELL = '/bin/bash';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      delete process.env.OMX_TMUX_SOURCE_SHELL_RC;
+      assert.equal(shouldSourceTeamWorkerShellRc(process.env), false);
+      assert.doesNotMatch(
+        buildWorkerStartupCommand('alpha', 1, ['--model', 'gpt-5']),
+        /source ~\/\.bashrc/,
+      );
+
+      process.env.OMX_TMUX_SOURCE_SHELL_RC = '1';
+      assert.equal(shouldSourceTeamWorkerShellRc(process.env), true);
+      assert.match(
+        buildWorkerStartupCommand('alpha', 1, ['--model', 'gpt-5']),
+        /source ~\/\.bashrc/,
+      );
+
+      delete process.env.OMX_TMUX_SOURCE_SHELL_RC;
+      assert.match(
+        buildWorkerStartupCommand(
+          'alpha',
+          1,
+          ['--model', 'gpt-5'],
+          process.cwd(),
+          { OMX_TMUX_SOURCE_SHELL_RC: '1' },
+        ),
+        /source ~\/\.bashrc/,
+        'per-worker explicit opt-in should be honored',
+      );
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevSourceRc === 'string') process.env.OMX_TMUX_SOURCE_SHELL_RC = prevSourceRc;
+      else delete process.env.OMX_TMUX_SOURCE_SHELL_RC;
     }
   });
 
@@ -1877,7 +1921,7 @@ describe('buildWorkerStartupCommand', () => {
         buildWorkerStartupCommand('alpha', 1, [], process.cwd()),
       );
       assert.match(cmd, /\/bin\/bash\b/, 'must fall back to bash when zsh is unavailable');
-      assert.match(cmd, /\.bashrc/, 'must source bash rc file for bash fallback');
+      assert.doesNotMatch(cmd, /\.bashrc/, 'must not source bash rc file for bash fallback by default');
       assert.doesNotMatch(cmd, /fish/, 'must not launch unsupported fish shell');
     } finally {
       if (typeof prevShell === 'string') process.env.SHELL = prevShell;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -601,6 +601,12 @@ function buildShellLaunchSpec(shell: string, rcFile: string | null): WorkerLaunc
   return { shell, rcFile };
 }
 
+export function shouldSourceTeamWorkerShellRc(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return String(env.OMX_TMUX_SOURCE_SHELL_RC ?? '').trim() === '1';
+}
+
 function resolveSupportedShellAffinity(shellPath: string | undefined): WorkerLaunchSpec | null {
   if (!shellPath || shellPath.trim() === '' || !existsSync(shellPath)) return null;
   if (/\/zsh$/i.test(shellPath)) return buildShellLaunchSpec(shellPath, '~/.zshrc');
@@ -971,7 +977,15 @@ export function buildWorkerStartupCommand(
   const quotedArgs = startupArgs.map(shellQuoteSingle).join(' ');
   const quotedCommand = shellQuoteSingle(processSpec.command);
   const cliInvocation = quotedArgs.length > 0 ? `exec ${quotedCommand} ${quotedArgs}` : `exec ${quotedCommand}`;
-  const rcPrefix = launchSpec.rcFile ? `if [ -f ${launchSpec.rcFile} ]; then source ${launchSpec.rcFile}; fi; ` : '';
+  // Keep worker tmux panes non-interactive and rc-free by default. PR #2283
+  // blocked rc sourcing for detached leader/HUD panes, but team workers still
+  // sourced ~/.bashrc or ~/.zshrc here, leaving the same #2239/#2282/#2358
+  // recursive bash fan-out path open when team/ultrawork created workers.
+  // Users who intentionally need legacy shell PATH bootstrapping can opt in
+  // with the same tmux-pane escape hatch used by buildTmuxPaneCommand().
+  const rcPrefix = shouldSourceTeamWorkerShellRc({ ...process.env, ...extraEnv }) && launchSpec.rcFile
+    ? `if [ -f ${launchSpec.rcFile} ]; then source ${launchSpec.rcFile}; fi; `
+    : '';
   const inner = `${rcPrefix}${pathPrefix}${cliInvocation}`;
   const envParts = Object.entries(startupEnv).map(([key, value]) => `${key}=${value}`);
 


### PR DESCRIPTION
## Summary
- Fix the remaining bash fan-out path from #2358 by stopping team worker tmux panes from sourcing `~/.bashrc` / `~/.zshrc` by default before `exec`.
- Keep the explicit compatibility escape hatch: `OMX_TMUX_SOURCE_SHELL_RC=1` now applies to worker startup too, including per-worker `extraEnv` overrides.
- Add regression coverage for bash/zsh worker startup defaults and explicit opt-in behavior.

## Diagnosis
Issue #2358's attached v0.17.3 logs still show 4,538 `bash` entries in the OOM dump after #2283. PR #2283 fixed `buildTmuxPaneCommand()` for detached leader/HUD panes, but `buildWorkerStartupCommand()` in `src/team/tmux-session.ts` still unconditionally sourced user shell rc files for team/ultrawork worker panes. That left the same recursive shell-rc fan-out path open when worker panes launched.

## Tests
- `npm ci`
- `npm run build`
- `node --test --test-name-pattern 'buildWorkerStartupCommand|buildTmuxPaneCommand' dist/team/__tests__/tmux-session.test.js dist/cli/__tests__/index.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

## Review gates
- AI slop cleaner pass on changed files: passed/no-op after fallback review.
- Code review: APPROVE.
- Architecture review: CLEAR.

Fixes #2358
