### PR TITLE
Reduce dev PR CI waste with targeted lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,204 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect CI lanes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      full_suite: ${{ steps.classify.outputs.full_suite }}
+      docs_changed: ${{ steps.classify.outputs.docs_changed }}
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      ts_changed: ${{ steps.classify.outputs.ts_changed }}
+      rust_changed: ${{ steps.classify.outputs.rust_changed }}
+      native_changed: ${{ steps.classify.outputs.native_changed }}
+      shared_config_changed: ${{ steps.classify.outputs.shared_config_changed }}
+      reason: ${{ steps.classify.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
+          PUSH_AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          full_suite=false
+          reason=targeted
+          base_sha=""
+          head_sha="$PUSH_AFTER_SHA"
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base_sha="$PR_BASE_SHA"
+            head_sha="$PR_HEAD_SHA"
+            if [[ "$PR_BASE_REF" == "main" ]]; then
+              full_suite=true
+              reason="pull request targets main"
+            fi
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            base_sha="$PUSH_BEFORE_SHA"
+            head_sha="$PUSH_AFTER_SHA"
+            if [[ "$REF_NAME" == "main" ]]; then
+              full_suite=true
+              reason="push to main"
+            fi
+          else
+            full_suite=true
+            reason="unknown event: $EVENT_NAME"
+          fi
+
+          if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ || -z "$head_sha" ]]; then
+            full_suite=true
+            reason="missing or first-push base sha"
+          fi
+
+          : > changed-files.tsv
+          if [[ "$full_suite" == "false" ]]; then
+            if ! git cat-file -e "$base_sha^{commit}" || ! git cat-file -e "$head_sha^{commit}"; then
+              full_suite=true
+              reason="unable to resolve diff commits"
+            else
+              git diff --name-status "$base_sha" "$head_sha" > changed-files.tsv
+            fi
+          fi
+
+          export full_suite reason
+
+          node <<'NODE'
+          const fs = require('node:fs');
+
+          const lines = fs.readFileSync('changed-files.tsv', 'utf8')
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+
+          const out = {
+            full_suite: process.env.full_suite === 'true',
+            docs_changed: false,
+            docs_only: false,
+            ts_changed: false,
+            rust_changed: false,
+            native_changed: false,
+            shared_config_changed: false,
+            reason: process.env.reason || 'targeted',
+          };
+
+          function addOutput(key, value) {
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+          }
+
+          function pathsFromNameStatus(line) {
+            const parts = line.split(/\t+/);
+            const status = parts[0] || '';
+            if (/^[RC]/.test(status)) return parts.slice(1, 3).filter(Boolean);
+            return parts.slice(1, 2).filter(Boolean);
+          }
+
+          function isDocs(path) {
+            return /^docs\//.test(path)
+              || /^missions\//.test(path)
+              || /^\.github\/(ISSUE_TEMPLATE\/|PULL_REQUEST_TEMPLATE\.md$)/.test(path)
+              || /^(README|CHANGELOG|CONTRIBUTING|COVERAGE|DEMO|RELEASE_BODY|RELEASE_PROTOCOL)\.md$/.test(path);
+          }
+
+          function isTs(path) {
+            return /^src\/.*\.(ts|tsx|mts|cts)$/.test(path)
+              || /^playground\/.*\.(ts|tsx|js|mjs|cjs|json)$/.test(path);
+          }
+
+          function isRust(path) {
+            return /^crates\//.test(path) || path === 'Cargo.lock' || path === 'Cargo.toml';
+          }
+
+          function isNative(path) {
+            return path === 'dist-workspace.toml'
+              || /^crates\/omx-(api|explore|mux|runtime-core|runtime|sparkshell)\//.test(path);
+          }
+
+          function isSharedConfig(path) {
+            return /^\.github\//.test(path)
+              || /^templates\//.test(path)
+              || /^prompts\//.test(path)
+              || /^skills\//.test(path)
+              || /^plugins\//.test(path)
+              || /^biome\.json$/.test(path)
+              || /^tsconfig.*\.json$/.test(path)
+              || /^package(-lock)?\.json$/.test(path)
+              || path === 'Cargo.lock'
+              || path === 'Cargo.toml'
+              || path === 'dist-workspace.toml';
+          }
+
+          const paths = lines.flatMap(pathsFromNameStatus);
+          if (paths.length === 0 && !out.full_suite) {
+            out.full_suite = true;
+            out.reason = 'empty diff or classifier uncertainty';
+          }
+
+          for (const path of paths) {
+            if (isDocs(path)) out.docs_changed = true;
+            if (isTs(path)) out.ts_changed = true;
+            if (isRust(path)) out.rust_changed = true;
+            if (isNative(path)) out.native_changed = true;
+            if (isSharedConfig(path)) out.shared_config_changed = true;
+          }
+
+          const allDocs = paths.length > 0 && paths.every(isDocs);
+          out.docs_only = allDocs;
+
+          // Fail closed for shared config, workflow, version, lockfile, native packaging, or ambiguous repo assets.
+          const known = (path) => isDocs(path) || isTs(path) || isRust(path) || isNative(path) || isSharedConfig(path);
+          const unknown = paths.filter((path) => !known(path));
+          if (out.shared_config_changed || unknown.length > 0) {
+            out.full_suite = true;
+            out.reason = out.shared_config_changed
+              ? 'shared config, workflow, manifest, lockfile, or packaging change'
+              : `unclassified path(s): ${unknown.join(', ')}`;
+          }
+
+          for (const [key, value] of Object.entries(out)) addOutput(key, value);
+          NODE
+      - name: Summarize lane decision
+        run: |
+          {
+            echo '## CI lane decision'
+            echo ''
+            echo '- full_suite: `${{ steps.classify.outputs.full_suite }}`'
+            echo '- docs_changed: `${{ steps.classify.outputs.docs_changed }}`'
+            echo '- docs_only: `${{ steps.classify.outputs.docs_only }}`'
+            echo '- ts_changed: `${{ steps.classify.outputs.ts_changed }}`'
+            echo '- rust_changed: `${{ steps.classify.outputs.rust_changed }}`'
+            echo '- native_changed: `${{ steps.classify.outputs.native_changed }}`'
+            echo '- shared_config_changed: `${{ steps.classify.outputs.shared_config_changed }}`'
+            echo '- reason: `${{ steps.classify.outputs.reason }}`'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  docs-check:
+    name: Docs Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [changes]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.docs_changed == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check documentation whitespace
+        run: git diff --check HEAD~1..HEAD || git diff --check
+
   rustfmt:
     name: Rust Format
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [changes]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
@@ -29,6 +223,8 @@ jobs:
     name: Rust Clippy
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [changes]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
@@ -45,6 +241,8 @@ jobs:
     name: Rust Tests + Coverage Signal
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    needs: [changes]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
@@ -84,6 +282,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [changes]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
@@ -97,6 +297,8 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: [changes]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
@@ -111,6 +313,8 @@ jobs:
     name: Build dist artifact
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: [changes]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
@@ -130,7 +334,8 @@ jobs:
     name: Test (Node ${{ matrix.node-version }} / ${{ matrix.lane }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [build-dist]
+    needs: [changes, build-dist]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -223,7 +428,8 @@ jobs:
     name: Coverage Gate (Team Critical)
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: [build-dist]
+    needs: [changes, build-dist]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
@@ -266,7 +472,8 @@ jobs:
     name: Ralph Persistence Gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [build-dist]
+    needs: [changes, build-dist]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
@@ -286,7 +493,8 @@ jobs:
     name: Build (Full Source Build)
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: [build-dist]
+    needs: [changes, build-dist]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
@@ -313,29 +521,105 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [rustfmt, clippy, rust-tests, lint, typecheck, test, coverage-team-critical, ralph-persistence-gate, build]
+    needs: [changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, test, coverage-team-critical, ralph-persistence-gate, build]
     steps:
       - name: Check required job results
+        shell: bash
+        env:
+          FULL_SUITE: ${{ needs.changes.outputs.full_suite }}
+          DOCS_CHANGED: ${{ needs.changes.outputs.docs_changed }}
+          TS_CHANGED: ${{ needs.changes.outputs.ts_changed }}
+          RUST_CHANGED: ${{ needs.changes.outputs.rust_changed }}
+          NATIVE_CHANGED: ${{ needs.changes.outputs.native_changed }}
+          SHARED_CONFIG_CHANGED: ${{ needs.changes.outputs.shared_config_changed }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          DOCS_CHECK_RESULT: ${{ needs.docs-check.result }}
+          RUSTFMT_RESULT: ${{ needs.rustfmt.result }}
+          CLIPPY_RESULT: ${{ needs.clippy.result }}
+          RUST_TESTS_RESULT: ${{ needs.rust-tests.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          TYPECHECK_RESULT: ${{ needs.typecheck.result }}
+          BUILD_DIST_RESULT: ${{ needs.build-dist.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          COVERAGE_TEAM_CRITICAL_RESULT: ${{ needs.coverage-team-critical.result }}
+          RALPH_PERSISTENCE_GATE_RESULT: ${{ needs.ralph-persistence-gate.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          REASON: ${{ needs.changes.outputs.reason }}
         run: |
-          if [[ "${{ needs.rustfmt.result }}" != "success" ]] ||
-             [[ "${{ needs.clippy.result }}" != "success" ]] ||
-             [[ "${{ needs.rust-tests.result }}" != "success" ]] ||
-             [[ "${{ needs.lint.result }}" != "success" ]] ||
-             [[ "${{ needs.typecheck.result }}" != "success" ]] ||
-             [[ "${{ needs.test.result }}" != "success" ]] ||
-             [[ "${{ needs.coverage-team-critical.result }}" != "success" ]] ||
-             [[ "${{ needs.ralph-persistence-gate.result }}" != "success" ]] ||
-             [[ "${{ needs.build.result }}" != "success" ]]; then
-            echo "::error::One or more required CI jobs failed"
-            echo "  rustfmt: ${{ needs.rustfmt.result }}"
-            echo "  clippy: ${{ needs.clippy.result }}"
-            echo "  rust-tests: ${{ needs.rust-tests.result }}"
-            echo "  lint: ${{ needs.lint.result }}"
-            echo "  typecheck: ${{ needs.typecheck.result }}"
-            echo "  test: ${{ needs.test.result }}"
-            echo "  coverage-team-critical: ${{ needs.coverage-team-critical.result }}"
-            echo "  ralph-persistence-gate: ${{ needs.ralph-persistence-gate.result }}"
-            echo "  build: ${{ needs.build.result }}"
+          set -euo pipefail
+
+          failures=0
+          bool_any() {
+            for value in "$@"; do
+              [[ "$value" == "true" ]] && return 0
+            done
+            return 1
+          }
+
+          check_job() {
+            local name="$1"
+            local result="$2"
+            local active="$3"
+            if [[ "$active" == "true" ]]; then
+              if [[ "$result" != "success" ]]; then
+                echo "::error::$name must succeed when active, got $result"
+                failures=$((failures + 1))
+              fi
+            else
+              if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+                echo "::error::$name inactive lane should be success or skipped, got $result"
+                failures=$((failures + 1))
+              fi
+            fi
+          }
+
+          echo "CI lane reason: ${REASON:-unknown}"
+          echo "  full_suite: $FULL_SUITE"
+          echo "  docs_changed: $DOCS_CHANGED"
+          echo "  ts_changed: $TS_CHANGED"
+          echo "  rust_changed: $RUST_CHANGED"
+          echo "  native_changed: $NATIVE_CHANGED"
+          echo "  shared_config_changed: $SHARED_CONFIG_CHANGED"
+          echo "  changes: $CHANGES_RESULT"
+          echo "  docs-check: $DOCS_CHECK_RESULT"
+          echo "  rustfmt: $RUSTFMT_RESULT"
+          echo "  clippy: $CLIPPY_RESULT"
+          echo "  rust-tests: $RUST_TESTS_RESULT"
+          echo "  lint: $LINT_RESULT"
+          echo "  typecheck: $TYPECHECK_RESULT"
+          echo "  build-dist: $BUILD_DIST_RESULT"
+          echo "  test: $TEST_RESULT"
+          echo "  coverage-team-critical: $COVERAGE_TEAM_CRITICAL_RESULT"
+          echo "  ralph-persistence-gate: $RALPH_PERSISTENCE_GATE_RESULT"
+          echo "  build: $BUILD_RESULT"
+
+          check_job changes "$CHANGES_RESULT" true
+
+          docs_active=false
+          rust_active=false
+          ts_active=false
+          dist_active=false
+          build_active=false
+          if [[ "$FULL_SUITE" == "true" ]] || [[ "$DOCS_CHANGED" == "true" ]]; then docs_active=true; fi
+          if [[ "$FULL_SUITE" == "true" ]] || bool_any "$RUST_CHANGED" "$NATIVE_CHANGED"; then rust_active=true; fi
+          if [[ "$FULL_SUITE" == "true" ]] || bool_any "$TS_CHANGED" "$SHARED_CONFIG_CHANGED"; then ts_active=true; fi
+          if [[ "$FULL_SUITE" == "true" ]] || bool_any "$TS_CHANGED" "$RUST_CHANGED" "$NATIVE_CHANGED" "$SHARED_CONFIG_CHANGED"; then dist_active=true; fi
+          if [[ "$FULL_SUITE" == "true" ]] || bool_any "$RUST_CHANGED" "$NATIVE_CHANGED" "$SHARED_CONFIG_CHANGED"; then build_active=true; fi
+
+          check_job docs-check "$DOCS_CHECK_RESULT" "$docs_active"
+          check_job rustfmt "$RUSTFMT_RESULT" "$rust_active"
+          check_job clippy "$CLIPPY_RESULT" "$rust_active"
+          check_job rust-tests "$RUST_TESTS_RESULT" "$rust_active"
+          check_job lint "$LINT_RESULT" "$ts_active"
+          check_job typecheck "$TYPECHECK_RESULT" "$ts_active"
+          check_job build-dist "$BUILD_DIST_RESULT" "$dist_active"
+          check_job test "$TEST_RESULT" "$ts_active"
+          check_job coverage-team-critical "$COVERAGE_TEAM_CRITICAL_RESULT" "$ts_active"
+          check_job ralph-persistence-gate "$RALPH_PERSISTENCE_GATE_RESULT" "$ts_active"
+          check_job build "$BUILD_RESULT" "$build_active"
+
+          if (( failures > 0 )); then
+            echo "::error::$failures CI status requirement(s) failed"
             exit 1
           fi
-          echo "All required CI checks passed"
+          echo "All required CI checks passed for active lanes"

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -10,7 +10,7 @@ function readCiWorkflow(): string {
 }
 
 function jobBlock(workflow: string, jobName: string): string {
-  const startMatch = workflow.match(new RegExp(`(^|\\n)  ${jobName}:\\n`));
+  const startMatch = workflow.match(new RegExp(`(^|\n)  ${jobName}:\n`));
   assert.ok(startMatch?.index !== undefined, `missing CI job block for ${jobName}`);
 
   const start = startMatch.index + startMatch[1].length;
@@ -20,7 +20,77 @@ function jobBlock(workflow: string, jobName: string): string {
   return workflow.slice(start, end);
 }
 
+function assertJobIf(workflow: string, jobName: string, expected: RegExp): void {
+  assert.match(jobBlock(workflow, jobName), expected, `${jobName} should have the expected lane predicate`);
+}
+
 describe('CI Rust gates', () => {
+  it('detects changed-file lanes once and exposes fail-closed outputs for targeted CI', () => {
+    const workflow = readCiWorkflow();
+    const changesJob = jobBlock(workflow, 'changes');
+
+    assert.match(workflow, /changes:\s*\n\s+name:\s*Detect CI lanes/);
+    for (const outputName of [
+      'full_suite',
+      'docs_changed',
+      'docs_only',
+      'ts_changed',
+      'rust_changed',
+      'native_changed',
+      'shared_config_changed',
+      'reason',
+    ]) {
+      assert.equal(changesJob.includes(`${outputName}: $` + `{{ steps.classify.outputs.${outputName} }}`), true);
+    }
+
+    assert.match(changesJob, /fetch-depth:\s*0/);
+    assert.match(changesJob, /pull request targets main/);
+    assert.match(changesJob, /push to main/);
+    assert.match(changesJob, /missing or first-push base sha/);
+    assert.match(changesJob, /unable to resolve diff commits/);
+    assert.match(changesJob, /empty diff or classifier uncertainty/);
+    assert.match(changesJob, /shared config, workflow, manifest, lockfile, or packaging change/);
+  });
+
+  it('classifies docs, TypeScript, Rust/native, shared config, renames, and unknown paths explicitly', () => {
+    const workflow = readCiWorkflow();
+    const changesJob = jobBlock(workflow, 'changes');
+
+    assert.match(changesJob, /function pathsFromNameStatus/);
+    assert.match(changesJob, /if \(\/\^\[RC\]\/\.test\(status\)\) return parts\.slice\(1, 3\)/);
+    assert.match(changesJob, /function isDocs\(path\)/);
+    assert.match(changesJob, /\^docs\\\//);
+    assert.match(changesJob, /README\|CHANGELOG\|CONTRIBUTING\|COVERAGE\|DEMO\|RELEASE_BODY\|RELEASE_PROTOCOL/);
+    assert.match(changesJob, /function isTs\(path\)/);
+    assert.match(changesJob, /\^src\\\/\.\*\\\.\(ts\|tsx\|mts\|cts\)\$/);
+    assert.match(changesJob, /function isRust\(path\)/);
+    assert.match(changesJob, /Cargo\.lock/);
+    assert.match(changesJob, /function isNative\(path\)/);
+    assert.match(changesJob, /dist-workspace\.toml/);
+    assert.match(changesJob, /function isSharedConfig\(path\)/);
+    assert.match(changesJob, /\^\\\.github\\\//);
+    assert.match(changesJob, /package\(-lock\)\?\\\.json/);
+    assert.match(changesJob, /const unknown = paths\.filter/);
+  });
+
+  it('gates expensive jobs by lane while preserving full-suite fail-closed behavior', () => {
+    const workflow = readCiWorkflow();
+
+    assertJobIf(workflow, 'docs-check', /full_suite == 'true'.*docs_changed == 'true'/s);
+    for (const jobName of ['rustfmt', 'clippy', 'rust-tests']) {
+      assertJobIf(workflow, jobName, /full_suite == 'true'.*rust_changed == 'true'.*native_changed == 'true'/s);
+    }
+    for (const jobName of ['lint', 'typecheck', 'test', 'coverage-team-critical', 'ralph-persistence-gate']) {
+      assertJobIf(workflow, jobName, /full_suite == 'true'.*ts_changed == 'true'.*shared_config_changed == 'true'/s);
+    }
+    assertJobIf(
+      workflow,
+      'build-dist',
+      /full_suite == 'true'.*ts_changed == 'true'.*rust_changed == 'true'.*native_changed == 'true'.*shared_config_changed == 'true'/s,
+    );
+    assertJobIf(workflow, 'build', /full_suite == 'true'.*rust_changed == 'true'.*native_changed == 'true'.*shared_config_changed == 'true'/s);
+  });
+
   it('requires rustfmt, clippy, and Rust test coverage gates plus an explicit Rust toolchain setup for the final native build lane', () => {
     const workflow = readCiWorkflow();
     const rustTestsJob = jobBlock(workflow, 'rust-tests');
@@ -48,7 +118,7 @@ describe('CI Rust gates', () => {
     );
   });
 
-  it('reuses a prebuilt dist artifact only on the gated lanes that can overlap prerequisite work', () => {
+  it('reuses a prebuilt dist artifact on every compiled lane and also builds it for Rust/native changes', () => {
     const workflow = readCiWorkflow();
     const testJob = jobBlock(workflow, 'test');
 
@@ -56,9 +126,11 @@ describe('CI Rust gates', () => {
     assert.match(workflow, /name:\s*Build dist artifact/);
     assert.match(workflow, /name:\s*Upload prebuilt dist artifact/);
     assert.match(workflow, /name:\s*ci-dist-node20/);
-    assert.match(workflow, /^  coverage-team-critical:\s*\n(?:.*\n)*?^\s+needs:\s*\[build-dist\]/m);
-    assert.match(workflow, /^  ralph-persistence-gate:\s*\n(?:.*\n)*?^\s+needs:\s*\[build-dist\]/m);
-    assert.match(workflow, /^  build:\s*\n(?:.*\n)*?^\s+needs:\s*\[build-dist\]/m);
+    assert.match(jobBlock(workflow, 'build-dist'), /rust_changed == 'true'/);
+    assert.match(jobBlock(workflow, 'build-dist'), /native_changed == 'true'/);
+    assert.match(workflow, /^  coverage-team-critical:\s*\n(?:.*\n)*?^\s+needs:\s*\[changes, build-dist\]/m);
+    assert.match(workflow, /^  ralph-persistence-gate:\s*\n(?:.*\n)*?^\s+needs:\s*\[changes, build-dist\]/m);
+    assert.match(workflow, /^  build:\s*\n(?:.*\n)*?^\s+needs:\s*\[changes, build-dist\]/m);
 
     for (const jobName of ['test', 'coverage-team-critical', 'ralph-persistence-gate', 'build']) {
       assert.match(
@@ -93,7 +165,10 @@ describe('CI Rust gates', () => {
       assert.match(jobBlock(workflow, jobName), /uses:\s*Swatinem\/rust-cache@v2/);
     }
 
-    assert.match(workflow, /needs:\s*\[rustfmt, clippy, rust-tests, lint, typecheck, test, coverage-team-critical, ralph-persistence-gate, build\]/);
+    assert.match(
+      workflow,
+      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, test, coverage-team-critical, ralph-persistence-gate, build\]/,
+    );
   });
 
   it('avoids path-filtered CI triggers so required checks cannot be skipped into a pending state', () => {
@@ -104,16 +179,18 @@ describe('CI Rust gates', () => {
     assert.doesNotMatch(workflow, /^\s+paths-ignore:\s*/m);
   });
 
-
-  it('marks every required CI lane as required and reported in the CI status gate', () => {
+  it('marks every active CI lane as required and reported in the CI status gate while accepting inactive skipped lanes', () => {
     const workflow = readCiWorkflow();
     const ciStatusJob = jobBlock(workflow, 'ci-status');
     const requiredJobs = [
+      'changes',
+      'docs-check',
       'rustfmt',
       'clippy',
       'rust-tests',
       'lint',
       'typecheck',
+      'build-dist',
       'test',
       'coverage-team-critical',
       'ralph-persistence-gate',
@@ -122,19 +199,25 @@ describe('CI Rust gates', () => {
 
     assert.match(
       ciStatusJob,
-      /needs:\s*\[rustfmt, clippy, rust-tests, lint, typecheck, test, coverage-team-critical, ralph-persistence-gate, build\]/,
+      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, test, coverage-team-critical, ralph-persistence-gate, build\]/,
     );
 
     for (const jobName of requiredJobs) {
-      assert.match(ciStatusJob, new RegExp(`needs\\.${jobName}\\.result`), `${jobName} result should be checked`);
-      assert.match(
-        ciStatusJob,
-        new RegExp(`echo \"  ${jobName}: \\$\\{\\{ needs\\.${jobName}\\.result \\}\\}\"`),
-        `${jobName} result should be reported`,
-      );
+      const envName = jobName.toUpperCase().replaceAll('-', '_');
+      assert.equal(ciStatusJob.includes(`${envName}_RESULT: $` + `{{ needs.${jobName}.result }}`), true, `${jobName} result should be captured`);
+      assert.match(ciStatusJob, new RegExp(`echo "  ${jobName}: \\$${envName}_RESULT"`), `${jobName} result should be reported`);
     }
-  });
 
+    assert.match(ciStatusJob, /check_job\(\) \{/);
+    assert.match(ciStatusJob, /must succeed when active/);
+    assert.match(ciStatusJob, /inactive lane should be success or skipped/);
+    assert.match(ciStatusJob, /docs_active=false/);
+    assert.match(ciStatusJob, /rust_active=false/);
+    assert.match(ciStatusJob, /ts_active=false/);
+    assert.match(ciStatusJob, /dist_active=false/);
+    assert.match(ciStatusJob, /build_active=false/);
+    assert.match(ciStatusJob, /All required CI checks passed for active lanes/);
+  });
 
   it('keeps expensive report-only coverage out of the required CI path', () => {
     const workflow = readCiWorkflow();
@@ -157,6 +240,8 @@ describe('CI Rust gates', () => {
     const workflow = readCiWorkflow();
 
     for (const jobName of [
+      'changes',
+      'docs-check',
       'rustfmt',
       'clippy',
       'rust-tests',
@@ -176,5 +261,4 @@ describe('CI Rust gates', () => {
       );
     }
   });
-
 });


### PR DESCRIPTION
## Summary
- add fail-closed CI lane detection for dev-targeted PRs
- gate docs, TypeScript/Node, Rust/native, and shared-config lanes by changed paths
- keep aggregate `CI Status` stable so branch protection can require one check
- expand CI contract tests for targeted lane behavior and full-suite safety

## Safety / full-suite cases
Full CI still runs for:
- PRs targeting `main` including dev -> main
- pushes to `main`
- workflow/shared config/manifest/lock/native packaging changes
- ambiguous, empty, first-push, deletion/rename, or unclassified diffs

## Verification
- [x] `npm run build && node --test dist/verification/__tests__/ci-rust-gates.test.js`

## Notes
- `dev` branch protection has been updated to require aggregate `CI Status`.
- `actionlint` was not installed locally, so live GitHub Actions validation is expected to provide YAML/action syntax coverage.
