### PR TITLE
Preserve provider API keys in managed tmux

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2534,6 +2534,89 @@ describe("detached tmux new-session sequencing", () => {
     );
   });
 
+  it("buildDetachedSessionBootstrapSteps forwards active provider env_key to detached tmux session", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "omx-detached-provider-env-"));
+    await writeFile(join(codexHome, "config.toml"), [
+      'model_provider = "cliproxy"',
+      "",
+      "[model_providers.cliproxy]",
+      'name = "cliproxy"',
+      'base_url = "http://localhost:4000/v1"',
+      'wire_api = "responses"',
+      'env_key = "CLIPROXY_LLM_API_KEY"',
+      "",
+    ].join("\n"));
+
+    try {
+      const steps = buildDetachedSessionBootstrapSteps(
+        "omx-demo",
+        "/tmp/project",
+        "'codex' '--model' 'gpt-5'",
+        "'node' '/tmp/omx.js' 'hud' '--watch'",
+        null,
+        codexHome,
+        null,
+        false,
+        "sess-detached-managed",
+        undefined,
+        undefined,
+        undefined,
+        {
+          CLIPROXY_LLM_API_KEY: "dummy-provider-key",
+          UNRELATED_API_KEY: "dummy-unrelated-key",
+        },
+      );
+      const newSession = steps.find((step) => step.name === "new-session");
+      assert.ok(newSession);
+      assert.equal(
+        newSession.args.some((arg) => arg === "CLIPROXY_LLM_API_KEY=dummy-provider-key"),
+        true,
+      );
+      assert.equal(
+        newSession.args.some((arg) => arg === "UNRELATED_API_KEY=dummy-unrelated-key"),
+        false,
+      );
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  it("buildDetachedSessionBootstrapSteps forwards general *_LLM_API_KEY env vars to detached tmux session", () => {
+    const steps = buildDetachedSessionBootstrapSteps(
+      "omx-demo",
+      "/tmp/project",
+      "'codex' '--model' 'gpt-5'",
+      "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null,
+      undefined,
+      null,
+      false,
+      "sess-detached-managed",
+      undefined,
+      undefined,
+      undefined,
+      {
+        CLIPROXY_LLM_API_KEY: "dummy-provider-key",
+        OTHER_LLM_API_KEY: "dummy-other-provider-key",
+        AWS_SECRET_ACCESS_KEY: "dummy-non-provider-secret",
+      },
+    );
+    const newSession = steps.find((step) => step.name === "new-session");
+    assert.ok(newSession);
+    assert.equal(
+      newSession.args.some((arg) => arg === "CLIPROXY_LLM_API_KEY=dummy-provider-key"),
+      true,
+    );
+    assert.equal(
+      newSession.args.some((arg) => arg === "OTHER_LLM_API_KEY=dummy-other-provider-key"),
+      true,
+    );
+    assert.equal(
+      newSession.args.some((arg) => arg === "AWS_SECRET_ACCESS_KEY=dummy-non-provider-secret"),
+      false,
+    );
+  });
+
   it("buildDetachedSessionBootstrapSteps forwards OMX_ROOT override to detached tmux session", () => {
     const steps = buildDetachedSessionBootstrapSteps(
       "omx-demo",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -146,9 +146,11 @@ import { buildHookEvent } from "../hooks/extensibility/events.js";
 import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import {
   collectInheritableTeamWorkerArgs as collectInheritableTeamWorkerArgsShared,
+  extractModelProviderOverrideValue,
   resolveTeamWorkerLaunchArgs,
   resolveTeamLowComplexityDefaultModel,
 } from "../team/model-contract.js";
+import { readActiveProviderEnvOverrides } from "../config/models.js";
 import {
   parseWorktreeMode,
   planWorktreeTarget,
@@ -2536,6 +2538,40 @@ function buildDetachedSessionPostLaunchHelperCommand(
 
 type TmuxExecSync = (file: string, args: readonly string[]) => string;
 
+const PROVIDER_LLM_API_KEY_ENV_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*_LLM_API_KEY$/;
+const VALID_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function isValidEnvName(key: string): boolean {
+  return VALID_ENV_NAME_PATTERN.test(key);
+}
+
+function collectDetachedSessionProviderEnv(
+  env: NodeJS.ProcessEnv,
+  codexHomeOverride?: string,
+  activeProviderOverride?: string,
+): Record<string, string> {
+  const collected: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(env)) {
+    if (!PROVIDER_LLM_API_KEY_ENV_PATTERN.test(key)) continue;
+    if (typeof value !== "string" || value.trim() === "") continue;
+    collected[key] = value;
+  }
+
+  const activeProviderEnv = readActiveProviderEnvOverrides(
+    env,
+    codexHomeOverride,
+    activeProviderOverride,
+  );
+  for (const [key, value] of Object.entries(activeProviderEnv)) {
+    if (!isValidEnvName(key)) continue;
+    if (typeof value !== "string" || value.trim() === "") continue;
+    collected[key] = value;
+  }
+
+  return Object.fromEntries(Object.entries(collected).sort(([left], [right]) => left.localeCompare(right)));
+}
+
 function execTmuxSync(
   args: readonly string[],
   execFileSyncImpl: TmuxExecSync = (file, tmuxArgs) =>
@@ -2706,7 +2742,13 @@ export function buildDetachedSessionBootstrapSteps(
   omxRootOverride?: string,
   env: NodeJS.ProcessEnv = process.env,
   sqliteHomeOverride?: string,
+  activeProviderOverride?: string,
 ): DetachedSessionTmuxStep[] {
+  const providerEnv = collectDetachedSessionProviderEnv(
+    env,
+    codexHomeOverride,
+    activeProviderOverride,
+  );
   const detachedLeaderCmd = nativeWindows
     ? "powershell.exe"
     : buildDetachedSessionLeaderCommand(
@@ -2736,6 +2778,7 @@ export function buildDetachedSessionBootstrapSteps(
     ...(codexHomeOverride ? ["-e", `CODEX_HOME=${codexHomeOverride}`] : []),
     ...(sqliteHomeOverride ? ["-e", `${CODEX_SQLITE_HOME_ENV}=${sqliteHomeOverride}`] : []),
     ...(omxRootOverride ? ["-e", `OMX_ROOT=${omxRootOverride}`] : []),
+    ...Object.entries(providerEnv).flatMap(([key, value]) => ["-e", `${key}=${value}`]),
     ...(env.OMX_STATE_ROOT ? ["-e", `OMX_STATE_ROOT=${env.OMX_STATE_ROOT}`] : []),
     ...(env.OMXBOX_ACTIVE ? ["-e", `OMXBOX_ACTIVE=${env.OMXBOX_ACTIVE}`] : []),
     ...(env.OMX_SOURCE_CWD ? ["-e", `OMX_SOURCE_CWD=${env.OMX_SOURCE_CWD}`] : []),
@@ -3597,6 +3640,7 @@ function runCodex(
         omxRootOverride,
         process.env,
         sqliteHomeOverride,
+        extractModelProviderOverrideValue(launchArgs),
       );
       for (const step of bootstrapSteps) {
         const output = execTmuxFileSync(step.args, {


### PR DESCRIPTION
## Summary
- Fixes #2363.
- Forward Codex active provider `env_key` values into OMX-managed detached tmux `new-session` startup.
- Also forward a narrow general provider-key pattern (`*_LLM_API_KEY`) while avoiding broad secret inheritance.
- Add deterministic regression coverage for configured provider `env_key` and general `*_LLM_API_KEY` propagation with dummy values only.

## Verification
- `npm run build`
- `npm run lint`
- `node --test --test-name-pattern "provider env|\\*_LLM_API_KEY" dist/cli/__tests__/index.test.js`

Note: I also ran full `node --test dist/cli/__tests__/index.test.js`; it still has unrelated pre-existing cleanup/lease failures in this worktree, while the new provider-env tests pass.
