### PR TITLE
Preserve provider env for interactive tmux launches

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -69,6 +69,7 @@ import {
   resolveNativeSessionName,
   releaseTmuxExtendedKeysLease,
   withTmuxExtendedKeys,
+  serializeDetachedSessionParentEnv,
   CODEX_SQLITE_HOME_ENV,
 } from "../index.js";
 import { mergeConfig, repairConfigIfNeeded } from "../../config/generator.js";
@@ -2590,6 +2591,65 @@ describe("detached tmux new-session sequencing", () => {
       newSession.args.some((arg) => arg === "OMX_SOURCE_CWD=/tmp/source-project"),
       true,
     );
+  });
+
+  it("serializes custom parent env for the interactive detached tmux leader without logging values in tmux args", () => {
+    const envFilePath = "/tmp/omx-runtime/tmux-env/sess.env";
+    const steps = buildDetachedSessionBootstrapSteps(
+      "omx-demo",
+      "/tmp/project",
+      "'codex' '--model' 'gpt-5'",
+      "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null,
+      undefined,
+      null,
+      false,
+      "sess-detached-managed",
+      undefined,
+      undefined,
+      undefined,
+      { CUSTOM_LLM_API_KEY: "fake-provider-key", IS_GAJAE_SLOP_GENERATOR: "1" },
+      undefined,
+      envFilePath,
+    );
+    const newSession = steps.find((step) => step.name === "new-session");
+    assert.ok(newSession);
+    const argsText = newSession.args.join("\n");
+    assert.match(argsText, new RegExp(envFilePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.doesNotMatch(argsText, /fake-provider-key/);
+    assert.doesNotMatch(argsText, /CUSTOM_LLM_API_KEY=/);
+
+    const envScript = serializeDetachedSessionParentEnv({
+      CUSTOM_LLM_API_KEY: "fake-provider-key",
+      IS_GAJAE_SLOP_GENERATOR: "1",
+      "not-a-shell-name": "ignored",
+    });
+    assert.match(envScript, /export CUSTOM_LLM_API_KEY='fake-provider-key'/);
+    assert.match(envScript, /export IS_GAJAE_SLOP_GENERATOR='1'/);
+    assert.doesNotMatch(envScript, /not-a-shell-name/);
+  });
+
+  it("keeps detached tmux bootstrap bounded when no interactive parent env file is requested", () => {
+    const steps = buildDetachedSessionBootstrapSteps(
+      "omx-demo",
+      "/tmp/project",
+      "'codex' '--model' 'gpt-5'",
+      "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null,
+      undefined,
+      null,
+      false,
+      "sess-detached-managed",
+      undefined,
+      undefined,
+      undefined,
+      { CUSTOM_LLM_API_KEY: "fake-provider-key" },
+    );
+    const newSession = steps.find((step) => step.name === "new-session");
+    assert.ok(newSession);
+    const argsText = newSession.args.join("\n");
+    assert.doesNotMatch(argsText, /CUSTOM_LLM_API_KEY/);
+    assert.doesNotMatch(argsText, /fake-provider-key/);
   });
 
   it("runCodex builds inside-tmux HUD command with OMX_SESSION_ID", async () => {

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -377,6 +377,98 @@ exit 0
     }
   });
 
+  it('preserves parent provider env for interactive OMX-created tmux without logging secret values', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-parent-env-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const envLogPath = join(wd, 'codex-env.log');
+      const tmuxLogPath = join(wd, 'tmux.log');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeExecutable(
+        join(fakeBin, 'codex'),
+        `#!/bin/sh
+{
+  printf 'custom=%s\n' "$CUSTOM_LLM_API_KEY"
+  printf 'marker=%s\n' "$IS_GAJAE_SLOP_GENERATOR"
+} > "${envLogPath}"
+exit 130
+`,
+      );
+      await writeExecutable(join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n');
+      await writeExecutable(
+        join(fakeBin, 'tmux'),
+        `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    printf 'tmux 3.4\\n'
+    exit 0
+    ;;
+  new-session)
+    last=''
+    for arg in "$@"; do last="$arg"; done
+    sh -c "$last" >/dev/null 2>&1 || true
+    printf 'leader-pane\\n'
+    exit 0
+    ;;
+  split-window)
+    printf 'hud-pane\\n'
+    exit 0
+    ;;
+  display-message)
+    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\\n'
+    else
+      printf '0\\n'
+    fi
+    exit 0
+    ;;
+  show-options)
+    printf 'off\\n'
+    exit 0
+    ;;
+  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane)
+    exit 0
+    ;;
+esac
+exit 0
+`,
+      );
+
+      const result = runOmx(
+        wd,
+        ['--tmux', '--madmax'],
+        {
+          HOME: home,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          TMUX: '',
+          TMUX_PANE: '',
+          CUSTOM_LLM_API_KEY: 'fake-provider-key',
+          IS_GAJAE_SLOP_GENERATOR: '1',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.equal(
+        await readFile(envLogPath, 'utf-8'),
+        'custom=fake-provider-key\nmarker=1\n',
+      );
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /fake-provider-key/);
+      assert.doesNotMatch(tmuxLog, /CUSTOM_LLM_API_KEY=/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('launches directly with --direct and skips detached tmux bootstrap', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-direct-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2457,10 +2457,19 @@ function buildDetachedSessionLeaderCommand(
   codexHomeOverride?: string,
   projectLocalCodexHomeForCleanup?: string,
   runtimeCodexHomeForCleanup?: string,
+  parentEnvFilePath?: string,
 ): string {
   const detachedPostLaunchHelper = sessionId
     ? `${buildDetachedSessionPostLaunchHelperCommand(cwd, sessionId, codexHomeOverride, projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup)} >/dev/null 2>&1 || true;`
     : "";
+  const parentEnvSource =
+    parentEnvFilePath && parentEnvFilePath.trim()
+      ? `if [ -r ${quoteShellArg(parentEnvFilePath)} ]; then . ${quoteShellArg(parentEnvFilePath)}; rm -f ${quoteShellArg(parentEnvFilePath)}; fi;`
+      : "";
+  const parentEnvCleanup =
+    parentEnvFilePath && parentEnvFilePath.trim()
+      ? `rm -f ${quoteShellArg(parentEnvFilePath)} 2>/dev/null || true;`
+      : "";
   const wrapped = [
     buildTmuxExtendedKeysAcquireShellSnippet(cwd),
     'exec 3<&0;',
@@ -2474,6 +2483,7 @@ function buildDetachedSessionLeaderCommand(
     "fi;",
     'exec 3<&- 2>/dev/null || true;',
     buildTmuxExtendedKeysReleaseShellSnippet(cwd),
+    parentEnvCleanup,
     detachedPostLaunchHelper,
     'if [ "$status" -eq 0 ]; then',
     `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
@@ -2481,6 +2491,7 @@ function buildDetachedSessionLeaderCommand(
     "exit $status;",
     "};",
     "trap omx_detached_session_cleanup 0 INT TERM HUP;",
+    parentEnvSource,
     "omx_codex_started_at=$(date +%s 2>/dev/null || printf 0);",
     `${codexCmd} <&3 &`,
     "omx_codex_pid=$!;",
@@ -2674,6 +2685,44 @@ function buildTmuxExtendedKeysReleaseShellSnippet(cwd: string): string {
   return `if [ -n "\${OMX_TMUX_EXTENDED_KEYS_LEASE:-}" ]; then ${buildTmuxExtendedKeysHelperCommand(cwd, "release")} "\${OMX_TMUX_EXTENDED_KEYS_LEASE}" >/dev/null 2>&1 || true; fi;`;
 }
 
+const SHELL_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function serializeDetachedSessionParentEnv(
+  env: NodeJS.ProcessEnv,
+): string {
+  const lines: string[] = [];
+  for (const key of Object.keys(env).sort()) {
+    if (!SHELL_ENV_NAME_PATTERN.test(key)) continue;
+    const value = env[key];
+    if (typeof value !== "string") continue;
+    if (value.includes("\0")) continue;
+    lines.push(`export ${key}=${quoteShellArg(value)}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export function detachedSessionParentEnvFilePath(
+  cwd: string,
+  sessionId: string,
+): string {
+  const safeSessionId = sessionId.replace(/[^A-Za-z0-9_.-]/g, "_");
+  return join(omxRoot(cwd), "runtime", "tmux-env", `${safeSessionId}.env`);
+}
+
+export function writeDetachedSessionParentEnvFile(
+  cwd: string,
+  sessionId: string,
+  env: NodeJS.ProcessEnv,
+): string {
+  const filePath = detachedSessionParentEnvFilePath(cwd, sessionId);
+  mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 });
+  writeFileSync(filePath, serializeDetachedSessionParentEnv(env), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  return filePath;
+}
+
 export function withTmuxExtendedKeys<T>(
   cwd: string,
   run: () => T,
@@ -2706,6 +2755,7 @@ export function buildDetachedSessionBootstrapSteps(
   omxRootOverride?: string,
   env: NodeJS.ProcessEnv = process.env,
   sqliteHomeOverride?: string,
+  parentEnvFilePath?: string,
 ): DetachedSessionTmuxStep[] {
   const detachedLeaderCmd = nativeWindows
     ? "powershell.exe"
@@ -2717,6 +2767,7 @@ export function buildDetachedSessionBootstrapSteps(
         codexHomeOverride,
         projectLocalCodexHomeForCleanup,
         runtimeCodexHomeForCleanup,
+        parentEnvFilePath,
       );
   const newSessionArgs: string[] = [
     "new-session",
@@ -3581,7 +3632,21 @@ function runCodex(
     let registeredHookTarget: string | null = null;
     let registeredHookName: string | null = null;
     let registeredClientAttachedHookName: string | null = null;
+    let detachedParentEnvFilePath: string | undefined;
     try {
+      // This path is the user-shell interactive launch: OMX creates a tmux
+      // session and immediately attaches the user's terminal to it. If a tmux
+      // server already exists, `new-session -e` only forwards explicit values,
+      // so provider-specific parent-shell keys would disappear. Source a
+      // private env file inside the leader shell instead of putting every
+      // parent env value on the tmux command line or in logs.
+      if (!nativeWindows) {
+        detachedParentEnvFilePath = writeDetachedSessionParentEnvFile(
+          cwd,
+          sessionId,
+          codexEnvWithNotify,
+        );
+      }
       const bootstrapSteps = buildDetachedSessionBootstrapSteps(
         sessionName,
         cwd,
@@ -3597,6 +3662,7 @@ function runCodex(
         omxRootOverride,
         process.env,
         sqliteHomeOverride,
+        detachedParentEnvFilePath,
       );
       for (const step of bootstrapSteps) {
         const output = execTmuxFileSync(step.args, {
@@ -3694,6 +3760,9 @@ function runCodex(
       return { postLaunchHandledExternally: !nativeWindows };
     } catch (err) {
       logCliOperationFailure(err);
+      if (detachedParentEnvFilePath) {
+        rmSync(detachedParentEnvFilePath, { force: true });
+      }
       if (createdDetachedSession) {
         const rollbackSteps = buildDetachedSessionRollbackSteps(
           sessionName,


### PR DESCRIPTION
## Summary
- Preserve the parent shell environment for interactive OMX-created tmux launches by sourcing a private session env file in the detached leader shell.
- Keep tmux bootstrap command args bounded so custom provider values are not written into tmux args/logs.
- Add regression coverage for custom provider env propagation and bounded/minimal bootstrap behavior.

## Tests
- npm run build
- node --test dist/cli/__tests__/launch-fallback.test.js
- node --test --test-name-pattern 'serializes custom parent env|keeps detached tmux bootstrap bounded' dist/cli/__tests__/index.test.js
- npm run lint

## Notes
- A full ▶ madmax state isolation
  ✔ auto-isolates only madmax launch and exec invocations (0.793171ms)
  ✔ creates a per-run OMX_ROOT registry entry without touching source .omx (9.894774ms)
✔ madmax state isolation (11.481145ms)
▶ resolveOmxRootForLaunch
  ✔ preserves POSIX absolute OMX_ROOT (0.251345ms)
  ✔ preserves Windows drive-letter absolute OMX_ROOT (0.186721ms)
  ✔ preserves Windows drive-letter absolute OMX_STATE_ROOT (0.178404ms)
  ✔ preserves UNC absolute OMX_ROOT (0.157363ms)
  ✔ joins relative OMX_ROOT to cwd (0.126775ms)
  ✔ returns undefined for blank OMX_ROOT and OMX_STATE_ROOT (0.142955ms)
  ✔ prefers OMX_ROOT over OMX_STATE_ROOT (0.138668ms)
✔ resolveOmxRootForLaunch (1.558057ms)
▶ disposable worktree state root resolution
  ✔ uses the source repo root for launch worktrees when no explicit root is set (0.247698ms)
  ✔ preserves explicit OMX_ROOT and OMX_STATE_ROOT precedence (0.163144ms)
  ✔ does not affect non-worktree launches (0.117617ms)
✔ disposable worktree state root resolution (0.661577ms)
▶ normalizeCodexLaunchArgs
  ✔ maps --madmax to codex bypass flag (0.441261ms)
  ✔ does not forward --madmax and preserves other args (0.126063ms)
  ✔ avoids duplicate bypass flags when both are present (0.219654ms)
  ✔ deduplicates repeated bypass-related flags (0.133447ms)
  ✔ leaves unrelated args unchanged (0.167313ms)
  ✔ maps --high to reasoning override (0.130001ms)
  ✔ maps --xhigh to reasoning override (0.151182ms)
  ✔ uses the last reasoning shorthand when both are present (0.121695ms)
  ✔ maps --xhigh --madmax to codex-native flags only (0.132896ms)
  ✔ --spark is stripped from leader args (model goes to workers only) (0.141293ms)
  ✔ --spark alone produces no leader args (0.140331ms)
  ✔ --madmax-spark adds bypass flag to leader args and is otherwise consumed (0.103479ms)
  ✔ --madmax-spark deduplicates bypass when --madmax also present (0.141443ms)
  ✔ --madmax-spark does not inject spark model into leader args (0.226727ms)
  ✔ strips detached worktree flag from leader codex args (0.161281ms)
  ✔ strips named worktree flag from leader codex args (0.108149ms)
  ✔ does not forward notify-temp flags/selectors to leader codex args (0.317773ms)
  ✔ strips --tmux from leader codex args (0.090424ms)
  ✔ strips --direct from leader codex args (0.084934ms)
  ✔ preserves literal --tmux after -- in leader codex args (0.086387ms)
  ✔ preserves literal --direct after -- in leader codex args (0.092288ms)
✔ normalizeCodexLaunchArgs (3.925013ms)
▶ resolveLeaderLaunchPolicyOverride
  ✔ detects explicit detached tmux launch requests (0.149458ms)
  ✔ detects explicit direct launch requests (0.08275ms)
  ✔ uses the last CLI launch policy flag before -- (0.095163ms)
  ✔ returns undefined when no explicit policy override is present (0.127296ms)
  ✔ stops scanning for --tmux after the end-of-options marker (0.077209ms)
  ✔ stops scanning for --direct after the end-of-options marker (0.125462ms)
✔ resolveLeaderLaunchPolicyOverride (0.862644ms)
▶ resolveEnvLaunchPolicyOverride
  ✔ accepts direct, tmux, detached-tmux, auto, and empty policy values (0.16074ms)
  ✔ warns once for invalid OMX_LAUNCH_POLICY and falls back to auto (0.396404ms)
✔ resolveEnvLaunchPolicyOverride (0.670985ms)
▶ resolveEffectiveLeaderLaunchPolicyOverride
  ✔ uses env policy when no CLI policy flag is present (0.161792ms)
  ✔ lets CLI policy flags override OMX_LAUNCH_POLICY (0.089723ms)
✔ resolveEffectiveLeaderLaunchPolicyOverride (0.32134ms)
▶ resolveNotifyTempContract
  ✔ activates from --notify-temp with no providers (0.13491ms)
  ✔ auto-activates when provider selectors are present (0.163055ms)
  ✔ supports repeated --custom forms and canonicalizes selectors (0.114731ms)
  ✔ activates from OMX_NOTIFY_TEMP=1 env parity (0.151603ms)
✔ resolveNotifyTempContract (0.672959ms)
▶ cleanupLaunchOrphanedMcpProcesses
  ✔ reaps only detached OMX MCP processes without a live Codex ancestor (1.560842ms)
✔ cleanupLaunchOrphanedMcpProcesses (1.614836ms)
▶ reapPostLaunchOrphanedMcpProcesses
  ✔ logs postLaunch reaped MCP orphans and keeps cleanup non-fatal (0.306572ms)
  ✔ writes a non-fatal postLaunch cleanup error when the cleanup step throws (0.203042ms)
✔ reapPostLaunchOrphanedMcpProcesses (0.596551ms)
▶ cleanupPostLaunchModeStateFiles
  ✖ repairs empty or truncated mode state files and still cancels valid siblings (25.097469ms)
  ✖ does not preserve complete Ralph cleanup state without completion-audit evidence (3.711292ms)
  ✔ preserves complete Ralph cleanup state when completion-audit evidence is present (3.677367ms)
  ✖ marks active Ralph state cancelled with interrupted metadata during postLaunch cleanup (2.144118ms)
  ✖ does not cancel root mode state during session-scoped postLaunch cleanup (2.555491ms)
  ✖ retries a transient parse failure before cancelling the rewritten mode state (1.038253ms)
  ✖ warns on structurally complete malformed JSON without aborting sibling cleanup (1.493993ms)
  ✖ reconciles root skill-active entries for the finished terminal session (2.598895ms)
  ✖ preserves other-session active skills when session mode cleanup syncs before root scrub (2.442453ms)
  ✖ clears canonical skill-active entries during cleanup and hides them from HUD/overlay readers (1.796176ms)
✖ cleanupPostLaunchModeStateFiles (47.051444ms)
▶ watcher script path resolution
  ✔ resolves packaged watcher entrypoints from dist/scripts (0.164558ms)
✔ watcher script path resolution (0.211608ms)
▶ buildNotifyFallbackWatcherEnv
  ✔ enables watcher authority and propagates CODEX_HOME override when requested (0.172733ms)
  ✔ disables watcher authority explicitly when not requested (0.085726ms)
✔ buildNotifyFallbackWatcherEnv (0.310549ms)
▶ shouldEnableNotifyFallbackWatcher
  ✔ keeps notify fallback enabled by default on non-Windows hosts (0.117317ms)
  ✔ disables notify fallback explicitly on non-Windows hosts (0.087308ms)
  ✔ disables notify fallback by default on win32 (0.0775ms)
  ✔ allows explicit opt-in for notify fallback on win32 (0.074855ms)
✔ shouldEnableNotifyFallbackWatcher (0.444888ms)
▶ reapStaleNotifyFallbackWatcher
  ✔ stops an existing watcher even when a later startup gate would skip relaunch (2.986923ms)
  ✔ ignores missing pid files (0.483754ms)
  ✔ suppresses ESRCH cleanup errors but warns on unexpected failures (1.191019ms)
✔ reapStaleNotifyFallbackWatcher (4.770264ms)
▶ buildNotifyTempStartupMessages
  ✔ always emits summary when temp mode is active (0.146463ms)
  ✔ emits no-valid-provider warning when no provider is configured (0.089973ms)
✔ buildNotifyTempStartupMessages (0.29511ms)
▶ resolveWorkerSparkModel
  ✔ returns spark model string when --spark is present (0.344134ms)
  ✔ returns spark model string when --madmax-spark is present (0.135532ms)
  ✔ returns undefined when neither spark flag is present (0.107427ms)
  ✔ returns undefined for empty args (0.089492ms)
  ✔ reads low-complexity team model from config when codexHomeOverride is provided (1.914204ms)
✔ resolveWorkerSparkModel (2.731581ms)
▶ resolveTeamWorkerLaunchArgsEnv (spark)
  ✔ injects spark model as worker default when no explicit env model (0.805284ms)
  ✔ explicit env model overrides spark default (0.22798ms)
  ✔ inherited leader model overrides spark default (0.140781ms)
✔ resolveTeamWorkerLaunchArgsEnv (spark) (1.249572ms)
▶ commandOwnsLocalHelp
  ✔ returns true for nested commands that render their own help output (0.11909ms)
  ✔ returns false for top-level help-only commands (0.079934ms)
✔ commandOwnsLocalHelp (0.245744ms)
▶ resolveCliInvocation
  ✔ resolves api to api command (0.200237ms)
  ✔ resolves explore to explore command (0.073682ms)
  ✔ resolves ask to ask command (0.083802ms)
  ✔ resolves question to question command (0.096105ms)
  ✔ resolves autoresearch to autoresearch command (0.072029ms)
  ✔ resolves session to session command (0.073001ms)
  ✔ resolves resume to resume command and forwards trailing args (0.07779ms)
  ✔ resolves resume session id and prompt as forwarded args (0.069324ms)
  ✔ resolves exec to non-interactive launch passthrough and forwards trailing args (0.068703ms)
  ✔ resolves update to update command (0.074584ms)
  ✔ resolves hooks to hooks command (0.079523ms)
  ✔ resolves agents-init to agents-init command (0.084363ms)
  ✔ resolves deepinit to deepinit alias command (0.079744ms)
  ✔ resolves --help to the help command instead of launch (0.087108ms)
  ✔ resolves --version to the version command instead of launch (0.075255ms)
  ✔ resolves -v to the version command instead of launch (0.069193ms)
  ✔ keeps unknown long flags as launch passthrough args (0.06738ms)
  ✔ advertises the explicit update command in top-level help (0.097739ms)
  ✔ advertises concise launch policy controls in top-level help (0.219464ms)
✔ resolveCliInvocation (2.032172ms)
▶ resolveSetupInstallModeArg
  ✔ maps explicit setup install mode flags (0.184656ms)
  ✔ rejects invalid setup install mode flags (0.454837ms)
✔ resolveSetupInstallModeArg (0.688518ms)
▶ resolveSetupMcpModeArg
  ✔ maps explicit setup MCP mode flags (0.180689ms)
  ✔ rejects invalid or conflicting setup MCP mode flags (0.168736ms)
✔ resolveSetupMcpModeArg (0.401956ms)
▶ resolveSetupScopeArg
  ✔ returns undefined when scope is omitted (0.142335ms)
  ✔ parses --scope <value> form (0.068522ms)
  ✔ parses --scope=<value> form (0.063452ms)
  ✔ throws on invalid scope value (0.091076ms)
  ✔ throws when --scope value is missing (0.105363ms)
✔ resolveSetupScopeArg (0.565151ms)
▶ project launch scope helpers
  ✔ reads persisted setup scope when valid (6.714535ms)
  ✔ reads persisted setup preferences when install mode is present (0.97974ms)
  ✔ ignores malformed persisted setup scope (0.889146ms)
  ✔ uses project CODEX_HOME when persisted scope is project (0.932129ms)
  ✔ uses project CODEX_HOME when persisted scope is project even if HOME is unusable (1.176561ms)
  ✔ uses project config.toml for launch repair when persisted scope is project (0.918703ms)
  ✔ preserves explicit compat MCP during launch config repair (9.889743ms)
  ✔ preserves existing compat MCP during launch repair without cwd-local preferences (3.178494ms)
  ✔ marks only persisted project CODEX_HOME as project-local cleanup target (0.930696ms)
  ✔ does not mark explicit CODEX_HOME as project-local cleanup target (0.95346ms)
  ✔ uses a session-scoped CODEX_HOME mirror for project launch config writes (5.896448ms)
  ✔ rewrites setup-owned hook trust state for the runtime CODEX_HOME mirror (12.602269ms)
  ✔ uses boxed runtime root for project-scope CODEX_HOME mirrors (3.140459ms)
  ✔ keeps explicit CODEX_HOME persistent instead of creating a runtime mirror (0.945143ms)
  ✔ respects explicit CODEX_SQLITE_HOME for project-scope launches (2.130391ms)
  ✔ keeps explicit CODEX_HOME override from env (1.016702ms)
  ✔ uses explicit CODEX_HOME config.toml for launch repair overrides (0.944924ms)
  ✔ migrates legacy "project-local" persisted scope to "project" (0.965403ms)
  ✔ resolves CODEX_HOME for legacy "project-local" persisted scope (0.936488ms)
✔ project launch scope helpers (55.644565ms)
▶ resolveCodexLaunchPolicy
  ✔ uses detached tmux on macOS when outside tmux and tmux is available (0.227339ms)
  ✔ uses tmux-aware launch path when already inside tmux (0.113509ms)
  ✔ uses tmux-aware launch path when already inside tmux on native Windows (0.094914ms)
  ✔ uses detached tmux on non-macOS hosts when outside tmux and tmux is available (0.083922ms)
  ✔ launches directly on native Windows even when tmux is available (0.075105ms)
  ✔ does not force direct launch for MSYS or Git Bash on win32 (0.086287ms)
  ✔ honors explicit detached tmux launch requests when tmux is available (0.102037ms)
  ✔ honors explicit direct launch requests outside tmux (0.099823ms)
  ✔ honors explicit direct launch requests inside tmux (0.079954ms)
  ✔ keeps explicit tmux policy tmux-aware inside tmux (0.075856ms)
  ✔ falls back directly for explicit tmux requests when tmux is unavailable (0.079714ms)
  ✔ launches directly when stdin is not a tty outside tmux (0.07766ms)
  ✔ launches directly when stdout is not a tty outside tmux (0.087228ms)
  ✔ launches directly when tmux is unavailable outside tmux (0.085014ms)
  ✔ launches directly on native Windows when tmux is unavailable (0.076899ms)
✔ resolveCodexLaunchPolicy (1.716182ms)
▶ resolveBackgroundHelperLaunchMode
  ✔ uses the hidden Windows MSYS bootstrap for win32 Git Bash (0.162844ms)
  ✔ spawns helpers directly on native win32 (0.13485ms)
  ✔ spawns helpers directly on non-Windows platforms (0.076007ms)
✔ resolveBackgroundHelperLaunchMode (0.444117ms)
▶ shouldDetachBackgroundHelper
  ✔ keeps the long-running helper detached under win32 Git Bash (0.111956ms)
  ✔ keeps detached helpers on native win32 (0.073903ms)
  ✔ keeps detached helpers on non-Windows platforms (0.071438ms)
✔ shouldDetachBackgroundHelper (0.342541ms)
▶ classifyCodexExecFailure
  ✔ classifies child process exit status as codex exit (0.203793ms)
  ✔ classifies signal termination as codex exit and maps to signal-based exit code (0.148075ms)
  ✔ classifies ENOENT as launch error (0.102117ms)
✔ classifyCodexExecFailure (0.52862ms)
▶ tmux HUD pane helpers
  ✔ findHudWatchPaneIds detects stale HUD watch panes and excludes current pane (0.347961ms)
  ✔ buildHudPaneCleanupTargets de-dupes pane ids and includes created pane (0.123719ms)
  ✔ buildHudPaneCleanupTargets excludes leader pane from existing ids (0.07787ms)
  ✔ buildHudPaneCleanupTargets excludes leader pane even when it matches the created HUD pane id (0.080425ms)
  ✔ buildHudPaneCleanupTargets is a no-op guard when leaderPaneId is absent (0.094733ms)
  ✔ listCurrentWindowHudPaneIds scopes tmux pane listing to the emitting pane (0.20237ms)
  ✔ createHudWatchPane splits from the emitting pane target when provided (0.173535ms)
✔ tmux HUD pane helpers (1.242948ms)
▶ detached tmux new-session sequencing
  ✔ buildDetachedSessionBootstrapSteps uses shared HUD height and split-capture ordering (0.703387ms)
  ✔ buildDetachedSessionBootstrapSteps forwards temp contract env to detached tmux session (0.171631ms)
  ✔ buildDetachedSessionBootstrapSteps forwards OMX_SESSION_ID to detached tmux session (0.174817ms)
  ✔ buildDetachedSessionBootstrapSteps forwards CODEX_HOME override to detached tmux session (0.147324ms)
  ✔ buildDetachedSessionBootstrapSteps forwards CODEX_SQLITE_HOME override to detached tmux session (0.183214ms)
  ✔ buildDetachedSessionBootstrapSteps forwards OMX_ROOT override to detached tmux session (0.153396ms)
  ✔ buildDetachedSessionBootstrapSteps forwards boxed env to detached tmux session (0.235685ms)
  ✔ serializes custom parent env for the interactive detached tmux leader without logging values in tmux args (0.295921ms)
  ✔ keeps detached tmux bootstrap bounded when no interactive parent env file is requested (0.156261ms)
  ✔ runCodex builds inside-tmux HUD command with OMX_SESSION_ID (8.592502ms)
  ✔ runCodex registers a HUD resize hook immediately for inside-tmux launches (0.798801ms)
  ✔ buildDetachedSessionBootstrapSteps starts native Windows detached sessions with powershell (0.309507ms)
  ✔ buildDetachedWindowsBootstrapScript targets the resolved tmux-compatible command (0.158235ms)
  ✔ buildDetachedSessionBootstrapSteps kills detached tmux session on normal shell exit (0.265082ms)
  ✔ buildDetachedSessionBootstrapSteps finalizes postLaunch inside the detached leader when a session id is available (0.174947ms)
  ✔ detached leader command keeps stdin open for the Codex child (456.660039ms)
  ✔ detached leader command preserves cwd and cleanup without shell-quote breakage (442.667427ms)
  ✔ detached leader command preserves the detached tmux session on signal-derived exits (452.694766ms)
  ✔ detached leader command keeps child startup errors visible instead of killing the session (457.040441ms)
  ✔ detached leader command keeps immediate zero-code exits visible instead of silently closing (464.911577ms)
  ✔ detached leader command terminates codex child on external SIGHUP (531.932115ms)
  ✔ withTmuxExtendedKeys enables tmux extended keys during codex launch and restores them afterwards (2.647758ms)
  ✔ acquireTmuxExtendedKeysLease can bind lease liveness to a long-lived owner pid (1.538158ms)
  ✖ overlapping tmux extended-keys leases restore only after the last holder exits (2.100373ms)
[cli/index] operation failed: Error: tmux unavailable
  ✔ withTmuxExtendedKeys degrades cleanly when tmux option probing fails (1.405052ms)
  ✔ withTmuxExtendedKeys ignores tmux versions without the extended-keys option (1.107988ms)
  ✔ acquireTmuxExtendedKeysLease returns no lease when extended-keys is unsupported (1.115072ms)
  ✔ reapStaleNotifyFallbackWatcher skips kill when process identity does not match a watcher (0.990351ms)
  ✔ reapStaleNotifyFallbackWatcher sends SIGTERM only after confirming watcher identity (1.00549ms)
  ✔ reapStaleNotifyFallbackWatcher skips recently started watcher records to avoid respawn loops (0.936387ms)
  ✔ reuses legacy plain-text PID parsing without widening stale reap semantics across PID reuse (0.951316ms)
  ✔ reaps watcher-record PIDs only after the record path confirms watcher identity across PID reuse (0.932128ms)
  ✖ acquireTmuxExtendedKeysLease recovers from a stale lock left by a crashed process (1.364593ms)
  ✖ acquireTmuxExtendedKeysLease reaps dead holders and restores before taking a new lease (2.60696ms)
  ✔ releaseTmuxExtendedKeysLease preserves live legacy string holders (1.785276ms)
  ✖ acquireTmuxExtendedKeysLease reaps Linux PID-reuse identity mismatches (2.460308ms)
  ✖ releaseTmuxExtendedKeysLease restores when all remaining holders are dead (1.67353ms)
  ✔ buildDetachedSessionFinalizeSteps keeps schedule after split-capture and before attach (0.61102ms)
  ✔ buildDetachedSessionFinalizeSteps uses quiet best-effort tmux resize commands (0.262086ms)
  ✔ buildDetachedSessionFinalizeSteps skips detached resize hooks on native Windows (0.097539ms)
  ✔ buildDetachedSessionFinalizeSteps sanitizes copy-mode styling before attach when mouse mode is enabled (0.146412ms)
  ✔ buildDetachedSessionFinalizeSteps never appends server-global terminal-overrides (0.126805ms)
  ✔ buildDetachedSessionRollbackSteps unregisters hooks before killing session (0.204746ms)
  ✔ buildDetachedSessionRollbackSteps only kills session when no hook metadata exists (0.084744ms)
✖ detached tmux new-session sequencing (2845.890252ms)
▶ buildTmuxShellCommand
  ✔ preserves quoted config values for tmux shell-command execution (0.097498ms)
✔ buildTmuxShellCommand (0.131133ms)
▶ buildTmuxPaneCommand
  ✔ wraps command with zsh without sourcing rc files by default (0.127646ms)
  ✔ keeps Homebrew zsh instead of downgrading to /bin/sh (0.084122ms)
  ✔ keeps MacPorts zsh instead of downgrading to /bin/sh (0.091256ms)
  ✔ prevents issue #2282 bash rc fan-out by default (0.189756ms)
  ✔ sources zsh and bash rc files only when explicitly opted in (0.15039ms)
  ✔ skips rc sourcing for unknown shells without using a login shell (0.100063ms)
  ✔ falls back to /bin/sh without using a login shell when shell path is empty (0.087859ms)
✔ buildTmuxPaneCommand (0.965202ms)
▶ buildWindowsPromptCommand
  ✔ encodes detached Windows commands for safe PowerShell prompt injection (0.120102ms)
✔ buildWindowsPromptCommand (0.154328ms)
▶ buildTmuxSessionName
  ✔ uses detached fallback quietly outside git repos (2.711511ms)
  ✔ sanitizes invalid characters (2.662708ms)
  ✔ includes repo name when cwd is inside .omx-worktrees (3.056949ms)
  ✔ includes repo name for detached worktree paths (2.490576ms)
  ✔ includes repo name when cwd is inside .omx/worktrees (2.947898ms)
✔ buildTmuxSessionName (14.126609ms)
▶ buildDetachedTmuxSessionName
  ✔ reuses the OMX session id for the detached tmux session name (2.89692ms)
✔ buildDetachedTmuxSessionName (2.97945ms)
▶ native Windows psmux-compatible tmux resolution
  ✔ resolveNativeSessionName uses the shared tmux-aware resolver for current session lookup (14.670389ms)
  ✔ detectDetachedSessionWindowIndex uses the shared tmux-aware resolver on native Windows (5.006812ms)
✔ native Windows psmux-compatible tmux resolution (19.877297ms)
▶ worktree dependency bootstrap helpers
  ✔ returns an explicit warning when reusable worktree dependencies are unavailable (0.650506ms)
✔ worktree dependency bootstrap helpers (0.724869ms)
▶ team worker launch arg inheritance helpers
  ✔ collectInheritableTeamWorkerArgs extracts bypass, reasoning, and model overrides (0.376606ms)
  ✔ collectInheritableTeamWorkerArgs supports --model=<value> syntax (0.163435ms)
  ✔ collectInheritableTeamWorkerArgs preserves only safe model_provider config overrides (0.358923ms)
  ✔ resolveTeamWorkerLaunchArgsEnv merges and normalizes with de-dupe + last reasoning/model wins (0.236687ms)
  ✔ resolveTeamWorkerLaunchArgsEnv can opt out of leader inheritance (0.183494ms)
  ✔ resolveTeamWorkerLaunchArgsEnv uses inherited model when env model is absent (0.167133ms)
  ✔ resolveTeamWorkerLaunchArgsEnv uses frontier default model when env and inherited models are absent (0.193674ms)
  ✔ resolveTeamWorkerLaunchArgsEnv keeps exactly one final model with precedence env > inherited > default (0.21288ms)
  ✔ resolveTeamWorkerLaunchArgsEnv prefers inherited model over default when env model is absent (0.173465ms)
✔ team worker launch arg inheritance helpers (2.380574ms)
▶ readTopLevelTomlString
  ✔ reads a top-level string value (0.461931ms)
  ✔ ignores table-local values (0.204575ms)
✔ readTopLevelTomlString (0.759215ms)
▶ injectModelInstructionsBypassArgs
  ✔ appends model_instructions_file override by default (0.392397ms)
  ✔ does not append when bypass is disabled via env (0.146933ms)
  ✔ does not append when model_instructions_file is already set (0.422395ms)
  ✔ respects OMX_MODEL_INSTRUCTIONS_FILE env override (0.187963ms)
  ✔ uses session-scoped default model_instructions_file when provided (0.200757ms)
✔ injectModelInstructionsBypassArgs (1.553367ms)
▶ upsertTopLevelTomlString
  ✔ replaces an existing top-level key (0.563287ms)
  ✔ inserts before the first table when key is missing (0.275571ms)
✔ upsertTopLevelTomlString (0.981814ms)
ℹ tests 240
ℹ suites 41
ℹ pass 226
ℹ fail 14
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 5981.78361

✖ failing tests:

test at dist/cli/__tests__/index.test.js:411:5
✖ repairs empty or truncated mode state files and still cancels valid siblings (25.097469ms)
  SyntaxError: Unexpected end of JSON input
      at JSON.parse (<anonymous>)
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:426:36)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Promise.all (index 0)
      at async Suite.run (node:internal/test_runner/test:1518:7)
      at async Test.processPendingSubtests (node:internal/test_runner/test:788:7)

test at dist/cli/__tests__/index.test.js:454:5
✖ does not preserve complete Ralph cleanup state without completion-audit evidence (3.711292ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  + actual - expected
  
  + 'complete'
  - 'cancelled'
  
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:471:20)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: 'complete',
    expected: 'cancelled',
    operator: 'strictEqual',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:509:5
✖ marks active Ralph state cancelled with interrupted metadata during postLaunch cleanup (2.144118ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  
  true !== false
  
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:525:20)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: true,
    expected: false,
    operator: 'strictEqual',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:535:5
✖ does not cancel root mode state during session-scoped postLaunch cleanup (2.555491ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  
  true !== false
  
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:548:20)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: true,
    expected: false,
    operator: 'strictEqual',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:555:5
✖ retries a transient parse failure before cancelling the rewritten mode state (1.038253ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  
  0 !== 2
  
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:584:16)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: 0,
    expected: 2,
    operator: 'strictEqual',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:591:5
✖ warns on structurally complete malformed JSON without aborting sibling cleanup (1.493993ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  
  true !== false
  
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:605:16)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: true,
    expected: false,
    operator: 'strictEqual',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:617:5
✖ reconciles root skill-active entries for the finished terminal session (2.598895ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
  + actual - expected
  
    [
      {
        active: true,
  +     phase: 'ralph',
  +     session_id: 'sess-terminal-autopilot',
  +     skill: 'autopilot'
  +   },
  +   {
  +     active: true,
        phase: 'running',
        session_id: 'sess-other',
        skill: 'team'
      }
    ]
  
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:640:20)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: [ { skill: 'autopilot', phase: 'ralph', active: true, session_id: 'sess-terminal-autopilot' }, { skill: 'team', phase: 'running', active: true, session_id: 'sess-other' } ],
    expected: [ { skill: 'team', phase: 'running', active: true, session_id: 'sess-other' } ],
    operator: 'deepStrictEqual',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:648:5
✖ preserves other-session active skills when session mode cleanup syncs before root scrub (2.442453ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  
  true !== false
  
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:671:20)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: true,
    expected: false,
    operator: 'strictEqual',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:685:5
✖ clears canonical skill-active entries during cleanup and hides them from HUD/overlay readers (1.796176ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  
  true !== false
  
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:704:16)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: true,
    expected: false,
    operator: 'strictEqual',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:2139:5
✖ overlapping tmux extended-keys leases restore only after the last holder exits (2.100373ms)
  Error: ENOENT: no such file or directory, open '/tmp/omx-tmux-lease-overlap-I4BtGT/.omx/state/tmux-extended-keys/tmp-tmux-test-sock.json'
      at async open (node:internal/fs/promises:641:25)
      at async readFile (node:internal/fs/promises:1279:14)
      at async TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:2156:45)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    errno: -2,
    code: 'ENOENT',
    syscall: 'open',
    path: '/tmp/omx-tmux-lease-overlap-I4BtGT/.omx/state/tmux-extended-keys/tmp-tmux-test-sock.json'
  }

test at dist/cli/__tests__/index.test.js:2337:5
✖ acquireTmuxExtendedKeysLease recovers from a stale lock left by a crashed process (1.364593ms)
  AssertionError [ERR_ASSERTION]: stale lock directory should be removed
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:2353:16)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: false,
    code: 'ERR_ASSERTION',
    actual: false,
    expected: true,
    operator: '==',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:2358:5
✖ acquireTmuxExtendedKeysLease reaps dead holders and restores before taking a new lease (2.60696ms)
  AssertionError [ERR_ASSERTION]: The input did not match the regular expression /^3956087-/. Input:
  
  '2147483647-stale-holder'
  
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:2383:20)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: '2147483647-stale-holder',
    expected: /^3956087-/,
    operator: 'match',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:2425:5
✖ acquireTmuxExtendedKeysLease reaps Linux PID-reuse identity mismatches (2.460308ms)
  AssertionError [ERR_ASSERTION]: The input was expected to not match the regular expression /reused-holder/. Input:
  
  '{"originalMode":"off","holders":[{"id":"3956087-reused-holder","pid":3956087,"platform":"linux","linuxStartTicks":-1}]}'
  
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:2456:24)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: '{"originalMode":"off","holders":[{"id":"3956087-reused-holder","pid":3956087,"platform":"linux","linuxStartTicks":-1}]}',
    expected: /reused-holder/,
    operator: 'doesNotMatch',
    diff: 'simple'
  }

test at dist/cli/__tests__/index.test.js:2474:5
✖ releaseTmuxExtendedKeysLease restores when all remaining holders are dead (1.67353ms)
  AssertionError [ERR_ASSERTION]: stale-only lease file should be removed
      at TestContext.<anonymous> (file:///home/bellman/Workspace/oh-my-codex-issue-2363-interactive-env/dist/cli/__tests__/index.test.js:2490:20)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: false,
    code: 'ERR_ASSERTION',
    actual: false,
    expected: true,
    operator: '==',
    diff: 'simple'
  } run still shows unrelated pre-existing concurrent state/extended-keys failures in this workspace; the new targeted tests pass.