### PR TITLE
Preserve autopilot review across compaction

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1050,6 +1050,95 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     }
   });
 
+  it("preserves review-pending Autopilot state across postLaunch compact cleanup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-autopilot-review-pending-"));
+    const sessionId = "sess-autopilot-review-pending";
+    const stateDir = join(wd, ".omx", "state");
+    const sessionStateDir = join(stateDir, "sessions", sessionId);
+
+    try {
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeFile(
+        join(stateDir, "skill-active-state.json"),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: "autopilot",
+          phase: "code-review",
+          session_id: sessionId,
+          initialized_state_path: `.omx/state/sessions/${sessionId}/autopilot-state.json`,
+          active_skills: [
+            { skill: "autopilot", phase: "code-review", active: true, session_id: sessionId },
+          ],
+        }, null, 2),
+        "utf-8",
+      );
+      await writeFile(
+        join(sessionStateDir, "skill-active-state.json"),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: "autopilot",
+          phase: "code-review",
+          session_id: sessionId,
+          active_skills: [
+            { skill: "autopilot", phase: "code-review", active: true, session_id: sessionId },
+          ],
+        }, null, 2),
+        "utf-8",
+      );
+      await writeFile(
+        join(sessionStateDir, "autopilot-state.json"),
+        JSON.stringify({
+          active: true,
+          mode: "autopilot",
+          current_phase: "code-review",
+          iteration: 1,
+          review_cycle: 0,
+          state: {
+            phase_cycle: ["ralplan", "ralph", "code-review"],
+            handoff_artifacts: {
+              ralplan: ".omx/plans/prd-issue-2366.md",
+              ralph: { verification: ["npm test"], changed_files: ["src/cli/index.ts"] },
+              code_review: null,
+            },
+            review_verdict: null,
+            return_to_ralplan_reason: null,
+          },
+        }, null, 2),
+        "utf-8",
+      );
+
+      await cleanupPostLaunchModeStateFiles(wd, sessionId, {
+        now: () => new Date("2026-05-16T11:00:00.000Z"),
+      });
+
+      const autopilotState = JSON.parse(
+        await readFile(join(sessionStateDir, "autopilot-state.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(autopilotState.active, true);
+      assert.equal(autopilotState.current_phase, "code-review");
+      assert.equal(autopilotState.completed_at, undefined);
+      assert.equal((autopilotState.state as Record<string, unknown>)?.review_verdict, null);
+
+      const sessionSkill = JSON.parse(
+        await readFile(join(sessionStateDir, "skill-active-state.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(sessionSkill.active, true);
+      assert.equal(sessionSkill.skill, "autopilot");
+      assert.equal(sessionSkill.phase, "code-review");
+
+      const rootSkill = JSON.parse(
+        await readFile(join(stateDir, "skill-active-state.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(rootSkill.active, true);
+      assert.equal(rootSkill.skill, "autopilot");
+      assert.equal(rootSkill.phase, "code-review");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("clears canonical skill-active entries during cleanup and hides them from HUD/overlay readers", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-skill-active-cleanup-"));
     const sessionId = "sess-skill-active-cleanup";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3101,6 +3101,25 @@ function cleanPostLaunchString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function isAutopilotReviewPendingPostLaunchState(state: Record<string, unknown> | null): boolean {
+  if (!state || state.active !== true) return false;
+  const mode = cleanPostLaunchString(state.mode).toLowerCase();
+  if (mode && mode !== "autopilot") return false;
+  const phase = cleanPostLaunchString(state.current_phase ?? state.currentPhase)
+    .toLowerCase()
+    .replace(/_/g, "-");
+  if (phase === "code-review" || phase === "review" || phase === "reviewing" || phase === "review-pending") {
+    return true;
+  }
+  const nestedState = state.state && typeof state.state === "object"
+    ? state.state as Record<string, unknown>
+    : {};
+  return state.review_pending === true
+    || state.reviewPending === true
+    || nestedState.review_pending === true
+    || nestedState.reviewPending === true;
+}
+
 function postLaunchUniqueStrings(values: string[]): string[] {
   return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
 }
@@ -3211,9 +3230,18 @@ export async function cleanupPostLaunchModeStateFiles(
   const rootSkillActiveStateBeforeCleanup = sessionId
     ? await readSkillActiveState(getSkillActiveStatePathsForStateDir(rootStateDir).rootPath)
     : null;
+  let preserveSkillActiveForReviewPendingAutopilot = false;
 
   for (const stateDir of scopedDirs) {
     const files = await readdir(stateDir).catch(() => [] as string[]);
+    const autopilotPath = join(stateDir, "autopilot-state.json");
+    const autopilotPrecheck = files.includes("autopilot-state.json")
+      ? await readPostLaunchModeStateFile(autopilotPath, dependencies)
+      : null;
+    const preserveReviewPendingAutopilot = autopilotPrecheck?.kind === "ok"
+      && isAutopilotReviewPendingPostLaunchState(autopilotPrecheck.state);
+    preserveSkillActiveForReviewPendingAutopilot ||= preserveReviewPendingAutopilot;
+
     for (const file of files) {
       if (!file.endsWith("-state.json") || file === "session.json") continue;
       const path = join(stateDir, file);
@@ -3279,6 +3307,12 @@ export async function cleanupPostLaunchModeStateFiles(
         }
         continue;
       }
+      if (
+        preserveReviewPendingAutopilot
+        && (mode === "autopilot" || mode === SKILL_ACTIVE_STATE_MODE)
+      ) {
+        continue;
+      }
 
       try {
         const completedAt = now().toISOString();
@@ -3320,13 +3354,15 @@ export async function cleanupPostLaunchModeStateFiles(
 
   if (sessionId) {
     try {
-      await scrubPostLaunchRootSkillActiveForSession(
-        rootStateDir,
-        sessionId,
-        now().toISOString(),
-        writeFile,
-        rootSkillActiveStateBeforeCleanup,
-      );
+      if (!preserveSkillActiveForReviewPendingAutopilot) {
+        await scrubPostLaunchRootSkillActiveForSession(
+          rootStateDir,
+          sessionId,
+          now().toISOString(),
+          writeFile,
+          rootSkillActiveStateBeforeCleanup,
+        );
+      }
     } catch (err) {
       writeWarn(
         `[omx] postLaunch: failed to reconcile root skill-active state: ${err instanceof Error ? err.message : err}`,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5455,6 +5455,61 @@ exit 0
     }
   });
 
+  it("requires Autopilot code review after a compact-boundary Stop exemption", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-autopilot-review-compact-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stop-autopilot-review-compact";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "code-review",
+        state: {
+          phase_cycle: ["ralplan", "ralph", "code-review"],
+          handoff_artifacts: {
+            ralplan: ".omx/plans/prd-issue-2366.md",
+            ralph: { verification: ["npm test"] },
+            code_review: null,
+          },
+          review_verdict: null,
+        },
+      });
+
+      const compactBoundary = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          stop_reason: "context compact",
+        },
+        { cwd },
+      );
+      const resumedStop = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+        },
+        { cwd },
+      );
+
+      assert.equal(compactBoundary.omxEventName, "stop");
+      assert.equal(compactBoundary.outputJson, null);
+      assert.equal(resumedStop.omxEventName, "stop");
+      assert.deepEqual(resumedStop.outputJson, {
+        decision: "block",
+        reason:
+          "OMX autopilot is still active (phase: code-review); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "autopilot_code-review",
+        systemMessage:
+          "OMX autopilot is still active (phase: code-review). Run the required $code-review step before completing or clearing Autopilot state.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("suppresses duplicate Autopilot planning Stop replays so stale planning state cannot loop indefinitely", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-autopilot-planning-replay-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1870,11 +1870,14 @@ async function buildModeBasedStopOutput(
   const state = await readModeStateForActiveDecision(mode, sessionId?.trim() || undefined, cwd);
   if (!state || !shouldContinueRun(state)) return null;
   const phase = formatPhase(state.current_phase);
+  const systemMessage = mode === "autopilot" && phase.toLowerCase().replace(/_/g, "-") === "code-review"
+    ? "OMX autopilot is still active (phase: code-review). Run the required $code-review step before completing or clearing Autopilot state."
+    : `OMX ${mode} is still active (phase: ${phase}).`;
   return {
     decision: "block",
     reason: `OMX ${mode} is still active (phase: ${phase}); continue the task and gather fresh verification evidence before stopping.`,
     stopReason: `${mode}_${phase}`,
-    systemMessage: `OMX ${mode} is still active (phase: ${phase}).`,
+    systemMessage,
   };
 }
 


### PR DESCRIPTION
## Summary
- Preserve active Autopilot `code-review` / review-pending state during postLaunch compact cleanup instead of cancelling it.
- Keep session/root skill-active markers intact while review is pending so resume can continue from the review gate.
- Make resumed Stop output for Autopilot `code-review` explicitly require `$code-review` before completion/cleanup.

Fixes #2366

## Tests
- `npm run build`
- `env -u OMX_ROOT -u OMX_STATE_ROOT node --test --test-name-pattern 'Autopilot|autopilot|compact' dist/cli/__tests__/index.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `env -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/cli/__tests__/index.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`
- `git diff --check`
- `git diff --check origin/dev...HEAD`

## Risk / notes
- Scope is limited to Autopilot review-pending cleanup and Stop guidance.
- Terminal/completed/failure cleanup paths are left intact; cleanup is not disabled globally.
- Live reporter compact logs were not available, so the regression targets the discovered compact cleanup contract directly.
