### PR TITLE
feat: add deferred OMX auto-update mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ omx --madmax --high
 
 On a real `oh-my-codex` version bump, the global npm install now prints an explicit reminder instead of launching `omx setup` automatically. When you're ready, run `omx setup` manually or use `omx update` to check npm and then run the same setup refresh path.
 
+OMX also checks for npm updates at launch on a throttled cadence and prompts before scheduling the update after the current session exits. Set `OMX_AUTO_UPDATE=0` to disable the launch-time check, or set `OMX_AUTO_UPDATE=defer` to schedule the same deferred update without prompting.
+
 **Codex plugin install note:** this repo also ships an official Codex plugin layout at `plugins/oh-my-codex` with marketplace metadata in `.agents/plugins/marketplace.json`. That plugin bundles the mirrored skill surface plus plugin-scoped companion metadata for optional MCP compatibility servers and apps, disabled by default. Native/runtime hooks still stay on the setup/runtime side rather than the installable plugin manifest. It is still **not** a replacement for `npm install -g oh-my-codex` plus `omx setup`: legacy setup mode installs native agents and prompts, while plugin setup mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompts/native-agent TOMLs so stale role files cannot shadow plugin behavior.
 
 Then work normally inside Codex:
@@ -229,6 +231,7 @@ These are operator/support surfaces:
   - `omx setup --merge-agents` preserves existing `AGENTS.md` guidance while inserting or refreshing generated OMX sections between `<!-- OMX:AGENTS:START -->` / `<!-- OMX:AGENTS:END -->`; without `--merge-agents` or `--force`, non-interactive setup keeps skipping existing `AGENTS.md` files
   - `omx uninstall` removes OMX-managed wrappers from `.codex/hooks.json` but keeps the file when user hooks remain
 - `omx update` checks npm immediately, installs the newest global OMX build, then reruns the same interactive setup refresh path
+- launch-time update checks are throttled and prompt by default; use `OMX_AUTO_UPDATE=0` to disable them or `OMX_AUTO_UPDATE=defer` to schedule deferred updates without a prompt
 - fresh OMX-managed `gpt-5.5` config seeding now recommends `model_context_window = 250000` and `model_auto_compact_token_limit = 200000`, but only when those keys are missing
 - `.omx-config.json` model/env routing is documented in [the model/env routing reference](./docs/reference/omx-config-schema-routing.md); only edit keys supported by your installed OMX version
 - `omx doctor` verifies the install when something seems wrong; it does not prove that the active Codex profile can make an authenticated model call

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -32,7 +32,7 @@
       <h2>Installation</h2>
       <pre><code>npm install -g @openai/codex oh-my-codex
 omx doctor</code></pre>
-      <p>When <code>oh-my-codex</code> actually bumps to a newer version, the global npm install now prints an explicit reminder instead of launching <code>omx setup</code> automatically. When you're ready, rerun <code>omx setup</code> manually or use <code>omx update</code> to check npm and then run the same setup refresh path. Fresh OMX-managed <code>gpt-5.5</code> configs now recommend <code>model_context_window = 250000</code> and <code>model_auto_compact_token_limit = 200000</code> only when those keys are missing.</p>
+      <p>When <code>oh-my-codex</code> actually bumps to a newer version, the global npm install now prints an explicit reminder instead of launching <code>omx setup</code> automatically. When you're ready, rerun <code>omx setup</code> manually or use <code>omx update</code> to check npm and then run the same setup refresh path. OMX also checks for npm updates at launch on a throttled cadence and prompts before scheduling the update after the current session exits. Set <code>OMX_AUTO_UPDATE=0</code> to disable the launch-time check, or <code>OMX_AUTO_UPDATE=defer</code> to schedule the deferred update without prompting. Fresh OMX-managed <code>gpt-5.5</code> configs now recommend <code>model_context_window = 250000</code> and <code>model_auto_compact_token_limit = 200000</code> only when those keys are missing.</p>
       <p><code>omx doctor</code> verifies the install shape. Before treating the runtime as ready, also prove that the active Codex profile can perform a real request:</p>
       <pre><code>codex login status
 omx exec --skip-git-repo-check -C . &quot;Reply with exactly OMX-EXEC-OK&quot;</code></pre>
@@ -45,7 +45,7 @@ omx                    # standard launch</code></pre>
       <ol>
         <li>Create or enter a project directory.</li>
         <li>Install or update OMX globally.</li>
-        <li>After install or real OMX version bumps, rerun <code>omx setup</code> yourself when you're ready, or use <code>omx update</code> when you also want npm to update OMX first.</li>
+        <li>After install or real OMX version bumps, rerun <code>omx setup</code> yourself when you're ready, use <code>omx update</code> when you also want npm to update OMX first, or set <code>OMX_AUTO_UPDATE=defer</code> for no-prompt deferred launch-time updates.</li>
         <li>Run <code>omx doctor</code>, then the <code>codex login status</code> plus <code>omx exec</code> smoke test above.</li>
         <li>Start Codex CLI with <code>omx</code>.</li>
         <li>Use <code>$deep-interview "clarify the auth change"</code> when intent or boundaries are still unclear.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
         <h1>oh-my-codex</h1>
         <p>Multi-agent orchestration for OpenAI Codex CLI.</p>
         <pre><code>npm install -g oh-my-codex</code></pre>
-        <p>Real global version bumps now print an explicit reminder instead of auto-launching <code>omx setup</code>. When you're ready, run <code>omx setup</code> manually or use <code>omx update</code> to check npm and then run the same setup refresh path. Fresh OMX-managed <code>gpt-5.5</code> configs recommend <code>250000 / 200000</code> only when those keys are missing.</p>
+        <p>Real global version bumps now print an explicit reminder instead of auto-launching <code>omx setup</code>. When you're ready, run <code>omx setup</code> manually or use <code>omx update</code> to check npm and then run the same setup refresh path. Launch-time update checks are throttled and prompt by default; set <code>OMX_AUTO_UPDATE=0</code> to disable them or <code>OMX_AUTO_UPDATE=defer</code> to schedule deferred updates without prompting. Fresh OMX-managed <code>gpt-5.5</code> configs recommend <code>250000 / 200000</code> only when those keys are missing.</p>
       </section>
 
       <section aria-labelledby="whats-new-060">

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -8,6 +8,7 @@ import {
   isNewerVersion,
   maybeCheckAndPromptUpdate,
   readUserInstallStamp,
+  resolveAutoUpdateMode,
   resolveInstalledCliEntry,
   runDeferredGlobalUpdate,
   runImmediateUpdate,
@@ -94,6 +95,33 @@ describe('shouldCheckForUpdates', () => {
     const customInterval = 60 * 1000;
     const recentCheck = new Date(now - 30 * 1000).toISOString();
     assert.equal(shouldCheckForUpdates(now, { last_checked_at: recentCheck }, customInterval), false);
+  });
+});
+
+describe('resolveAutoUpdateMode', () => {
+  it('defaults to prompt mode when the env var is unset', () => {
+    const originalMode = process.env.OMX_AUTO_UPDATE;
+    delete process.env.OMX_AUTO_UPDATE;
+
+    try {
+      assert.equal(resolveAutoUpdateMode(), 'prompt');
+      assert.equal(resolveAutoUpdateMode(''), 'prompt');
+    } finally {
+      if (typeof originalMode === 'string') {
+        process.env.OMX_AUTO_UPDATE = originalMode;
+      }
+    }
+  });
+
+  it('supports the explicit legacy disabled value', () => {
+    assert.equal(resolveAutoUpdateMode('0'), 'disabled');
+  });
+
+  it('supports only defer for no-prompt mode and keeps other truthy values in prompt mode', () => {
+    assert.equal(resolveAutoUpdateMode('defer'), 'defer');
+    for (const value of ['1', 'true', 'false', 'off', 'no', 'never', 'disabled', 'deferred', 'always', 'auto', 'silent']) {
+      assert.equal(resolveAutoUpdateMode(value), 'prompt');
+    }
   });
 });
 
@@ -238,6 +266,55 @@ describe('maybeCheckAndPromptUpdate', () => {
       assert.deepEqual(receivedCwds, [cwd]);
     } finally {
       console.log = originalLog;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('schedules deferred update without a TTY prompt when OMX_AUTO_UPDATE=defer', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
+    const originalMode = process.env.OMX_AUTO_UPDATE;
+    const originalStdinTty = process.stdin.isTTY;
+    const originalStdoutTty = process.stdout.isTTY;
+    const deferredCwds: string[] = [];
+
+    process.env.OMX_AUTO_UPDATE = 'defer';
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: false,
+    });
+
+    try {
+      await maybeCheckAndPromptUpdate(cwd, {
+        getCurrentVersion: async () => '0.13.0',
+        fetchLatestVersion: async () => '0.13.1',
+        askYesNo: async () => {
+          throw new Error('defer mode must not prompt');
+        },
+        runDeferredGlobalUpdate: (deferredCwd) => {
+          deferredCwds.push(deferredCwd);
+          return { ok: true, stderr: '', logPath: join(deferredCwd, '.omx', 'logs', 'update-test.log') };
+        },
+      });
+
+      assert.deepEqual(deferredCwds, [cwd]);
+    } finally {
+      if (typeof originalMode === 'string') {
+        process.env.OMX_AUTO_UPDATE = originalMode;
+      } else {
+        delete process.env.OMX_AUTO_UPDATE;
+      }
+      Object.defineProperty(process.stdin, 'isTTY', {
+        configurable: true,
+        value: originalStdinTty,
+      });
+      Object.defineProperty(process.stdout, 'isTTY', {
+        configurable: true,
+        value: originalStdoutTty,
+      });
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -45,9 +45,18 @@ type RunSetupRefreshResult = { ok: boolean; stderr: string };
 type RunDeferredUpdateResult = { ok: boolean; stderr: string; logPath?: string };
 type SpawnSyncLike = typeof spawnSync;
 type SpawnLike = typeof spawn;
+export type AutoUpdateMode = 'disabled' | 'prompt' | 'defer';
 
 const PACKAGE_NAME = 'oh-my-codex';
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12h
+
+export function resolveAutoUpdateMode(value = process.env.OMX_AUTO_UPDATE): AutoUpdateMode {
+  const normalized = (value ?? '').trim().toLowerCase();
+  if (!normalized) return 'prompt';
+  if (normalized === '0') return 'disabled';
+  if (normalized === 'defer') return 'defer';
+  return 'prompt';
+}
 
 function parseSemver(version: string): [number, number, number] | null {
   const m = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)$/);
@@ -536,8 +545,9 @@ export async function maybeCheckAndPromptUpdate(
   dependencies: Partial<UpdateDependencies> = {},
 ): Promise<void> {
   const updateDependencies = { ...defaultUpdateDependencies, ...dependencies };
-  if (process.env.OMX_AUTO_UPDATE === '0') return;
-  if (!process.stdin.isTTY || !process.stdout.isTTY) return;
+  const autoUpdateMode = resolveAutoUpdateMode();
+  if (autoUpdateMode === 'disabled') return;
+  if (autoUpdateMode === 'prompt' && (!process.stdin.isTTY || !process.stdout.isTTY)) return;
 
   const now = Date.now();
   const state = await readUpdateState(cwd);
@@ -546,7 +556,7 @@ export async function maybeCheckAndPromptUpdate(
   await executeUpdate({
     cwd,
     dependencies: updateDependencies,
-    prompt: true,
+    prompt: autoUpdateMode === 'prompt',
     immediate: false,
     nowMs: now,
   });


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Launch-time OMX update checks already prompt before scheduling the existing deferred updater, but non-interactive/no-prompt environments did not have an explicit way to opt into that deferred update path. This adds `OMX_AUTO_UPDATE=defer` for no-prompt deferred launch-time updates while preserving the default prompt mode and legacy `OMX_AUTO_UPDATE=0` disable behavior.

## Changes

- Add an explicit auto-update mode resolver for launch-time checks.
- Keep default/unknown `OMX_AUTO_UPDATE` values in prompt mode and keep only `OMX_AUTO_UPDATE=0` as disabled.
- Allow `OMX_AUTO_UPDATE=defer` to schedule the existing deferred updater without requiring a TTY prompt.
- Add regression coverage for mode resolution and no-TTY defer scheduling.
- Document the launch-time prompt/defer/disable behavior in README and generated docs pages.

## Validation

- [x] `npm run build`
- [ ] `npm test` — attempted locally; the full suite still fails in environment-sensitive tmux/team runtime suites unrelated to this diff after the targeted update suite passes. Latest captured run: 5028 pass / 17 fail / 1 skipped.
- [x] `omx doctor` (when setup/config behavior changes) — `node dist/cli/omx.js doctor` returned 11 passed, 4 warnings, 0 failed; warnings are local setup/config state.

Additional checks run:

- [x] `npm run lint`
- [x] `node --test dist/cli/__tests__/update.test.js` — 40 pass / 0 fail
- [x] `npm run verify:native-agents && npm run verify:plugin-bundle && node dist/scripts/generate-catalog-docs.js --check`
- [x] `git diff --check`
- [x] Added-line static scan for hardcoded secrets and dangerous code patterns

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered — default prompt behavior, unknown truthy values, and `OMX_AUTO_UPDATE=0` are preserved

## Related

N/A
