### PR TITLE
Add team-aware sparkshell diagnostics

### DIFF
--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -503,6 +503,7 @@ fn classify_team(team: &str, worker: &str) -> Option<Diagnostics> {
 }
 
 fn classify_worker_status(status: &str) -> Option<Diagnostics> {
+    // Keep this mapping aligned with the WorkerStatus.state union in src/team/state.ts.
     let state = extract_json_string(status, "state")
         .map(|value| value.to_ascii_lowercase())
         .unwrap_or_else(|| status.to_ascii_lowercase());

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -494,28 +494,62 @@ fn classify_team(team: &str, worker: &str) -> Option<Diagnostics> {
     }
 
     if let Ok(status) = fs::read_to_string(base.join("status.json")) {
-        let normalized = status.to_ascii_lowercase();
-        if normalized.contains("blocked") || normalized.contains("needs_input") {
-            return Some(Diagnostics {
-                classification: "waiting_for_input".to_string(),
-                next_action: "inspect raw pane".to_string(),
-                confidence: 0.7,
-                errors: Vec::new(),
-                warnings: Vec::new(),
-            });
+        if let Some(diagnostics) = classify_worker_status(&status) {
+            return Some(diagnostics);
         }
-        if normalized.contains("busy") || normalized.contains("in_progress") {
-            return Some(Diagnostics {
+    }
+
+    None
+}
+
+fn classify_worker_status(status: &str) -> Option<Diagnostics> {
+    let state = extract_json_string(status, "state")
+        .map(|value| value.to_ascii_lowercase())
+        .unwrap_or_else(|| status.to_ascii_lowercase());
+
+    match state.as_str() {
+        "working" | "busy" | "in_progress" => Some(Diagnostics {
+            classification: "busy_processing".to_string(),
+            next_action: "wait".to_string(),
+            confidence: 0.72,
+            errors: Vec::new(),
+            warnings: vec!["do not shutdown yet".to_string()],
+        }),
+        "blocked" | "needs_input" => Some(Diagnostics {
+            classification: "waiting_for_input".to_string(),
+            next_action: "inspect raw pane".to_string(),
+            confidence: 0.7,
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        }),
+        "failed" => Some(Diagnostics {
+            classification: "test_failure".to_string(),
+            next_action: "inspect raw pane".to_string(),
+            confidence: 0.7,
+            errors: vec!["worker status is failed".to_string()],
+            warnings: Vec::new(),
+        }),
+        _ if state.contains("working")
+            || state.contains("busy")
+            || state.contains("in_progress") =>
+        {
+            Some(Diagnostics {
                 classification: "busy_processing".to_string(),
                 next_action: "wait".to_string(),
                 confidence: 0.72,
                 errors: Vec::new(),
                 warnings: vec!["do not shutdown yet".to_string()],
-            });
+            })
         }
+        _ if state.contains("blocked") || state.contains("needs_input") => Some(Diagnostics {
+            classification: "waiting_for_input".to_string(),
+            next_action: "inspect raw pane".to_string(),
+            confidence: 0.7,
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        }),
+        _ => None,
     }
-
-    None
 }
 
 fn extract_heartbeat_ms(text: &str) -> Option<u64> {

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -584,6 +584,11 @@ fn team_diagnostics_reads_last_turn_at_heartbeat() {
         r#"{"last_turn_at":"1970-01-01T00:00:00.000Z"}"#,
     )
     .expect("heartbeat");
+    fs::write(
+        worker_dir.join("status.json"),
+        r#"{"state":"working","current_task_id":"1","updated_at":"2026-05-17T20:00:00.000Z"}"#,
+    )
+    .expect("status");
 
     let output = Command::new(sparkshell_bin())
         .env("OMX_TEAM_STATE_ROOT", temp.display().to_string())
@@ -602,6 +607,52 @@ fn team_diagnostics_reads_last_turn_at_heartbeat() {
         String::from_utf8_lossy(&output.stdout).contains("\"classification\": \"stale_heartbeat\"")
     );
     let _ = fs::remove_dir_all(temp);
+}
+
+fn run_team_status_diagnostics(status_json: &str) -> String {
+    let temp = unique_temp_dir("team-status");
+    let worker_dir = temp.join("team/demo/workers/worker-1");
+    fs::create_dir_all(&worker_dir).expect("worker dir");
+    fs::write(worker_dir.join("status.json"), status_json).expect("status");
+
+    let output = Command::new(sparkshell_bin())
+        .env("OMX_TEAM_STATE_ROOT", temp.display().to_string())
+        .arg("--json")
+        .arg("--team")
+        .arg("demo")
+        .arg("--worker")
+        .arg("worker-1")
+        .arg("sh")
+        .arg("-c")
+        .arg("printf 'quiet\n'")
+        .output()
+        .expect("run sparkshell");
+
+    let _ = fs::remove_dir_all(temp);
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn json_mode_treats_worker_status_working_as_busy() {
+    let stdout = run_team_status_diagnostics(
+        r#"{"state":"working","current_task_id":"1","updated_at":"2026-05-17T20:00:00.000Z"}"#,
+    );
+
+    assert!(stdout.contains("\"classification\": \"busy_processing\""));
+    assert!(stdout.contains("\"next_action\": \"wait\""));
+    assert!(stdout.contains("do not shutdown yet"));
+    assert!(!stdout.contains("\"classification\": \"unknown\""));
+}
+
+#[test]
+fn json_mode_reports_failed_worker_status() {
+    let stdout = run_team_status_diagnostics(
+        r#"{"state":"failed","updated_at":"2026-05-17T20:00:00.000Z"}"#,
+    );
+
+    assert!(stdout.contains("\"classification\": \"test_failure\""));
+    assert!(stdout.contains("worker status is failed"));
 }
 
 #[test]

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -646,6 +646,16 @@ fn json_mode_treats_worker_status_working_as_busy() {
 }
 
 #[test]
+fn json_mode_reports_blocked_worker_status() {
+    let stdout = run_team_status_diagnostics(
+        r#"{"state":"blocked","updated_at":"2026-05-17T20:00:00.000Z"}"#,
+    );
+
+    assert!(stdout.contains("\"classification\": \"waiting_for_input\""));
+    assert!(stdout.contains("\"next_action\": \"inspect raw pane\""));
+}
+
+#[test]
 fn json_mode_reports_failed_worker_status() {
     let stdout = run_team_status_diagnostics(
         r#"{"state":"failed","updated_at":"2026-05-17T20:00:00.000Z"}"#,
@@ -653,6 +663,18 @@ fn json_mode_reports_failed_worker_status() {
 
     assert!(stdout.contains("\"classification\": \"test_failure\""));
     assert!(stdout.contains("worker status is failed"));
+}
+
+#[test]
+fn json_mode_leaves_inactive_worker_statuses_to_output_heuristics() {
+    for state in ["idle", "done", "draining", "unknown"] {
+        let stdout = run_team_status_diagnostics(&format!(
+            r#"{{"state":"{state}","updated_at":"2026-05-17T20:00:00.000Z"}}"#
+        ));
+
+        assert!(stdout.contains("\"classification\": \"unknown\""));
+        assert!(!stdout.contains("do not shutdown yet"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Why

During team mode, the tmux pane is only one signal. A worker can look quiet while still holding a task, or a pane can look alive while the worker heartbeat is stale. Relying only on scrollback can lead to premature shutdowns, blind Enter spam, or incorrect retries.

## Intent

This PR extends `sparkshell` diagnostics so a leader can combine pane output with optional team worker state. The goal is not to automate destructive actions, but to give the leader evidence-backed classifications and safer next-action hints.

## What changed

- Added `--team` and `--worker` options for opt-in team context.
- Reads worker status/heartbeat from `OMX_TEAM_STATE_ROOT` when available, falling back to `.omx/state`.
- Adds classification values such as `auth_error`, `type_error`, `test_failure`, `waiting_for_input`, `busy_processing`, and `stale_heartbeat`.
- Emits confidence, warnings, errors, and next-action guidance in JSON output.
- Marks busy/in-progress team state with a clear `do not shutdown yet` warning.
- Added regression coverage for auth classification and team-state-root lookup.

## Verification

- `cargo test -p omx-sparkshell --quiet`

## Notes

The classifier is intentionally conservative and evidence-oriented. It should guide operator judgment, not replace `omx team status` or the team lifecycle gate.
