### PR TITLE
Cache sparkshell pane observations for incremental monitoring

### DIFF
--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -62,6 +62,7 @@ struct CacheMeta {
 const DEFAULT_BUDGET: usize = 1000;
 const STALE_HEARTBEAT_MS: u64 = 120_000;
 const DEFAULT_CACHE_TTL_MS: u64 = 10 * 60 * 1000;
+const CACHE_BODY_VERSION: &str = "omx-sparkshell-cache-v2";
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -504,6 +505,7 @@ fn handle_cache_at_path(
 ) -> Result<Option<CacheMeta>, SparkshellError> {
     let now = now_ms();
     let current = combined_text(output);
+    let current_line_count = current.lines().count();
     let mut previous_hash = None;
     let mut cache_hit = false;
     let mut changed_line_ranges = Vec::new();
@@ -516,20 +518,53 @@ fn handle_cache_at_path(
         let old_hash = parts.next().unwrap_or("").to_string();
         let old_body = parts.next().unwrap_or("");
         if now.saturating_sub(timestamp) <= ttl_ms {
+            let old_line_count = cached_line_count(old_body);
             previous_hash = Some(old_hash.clone());
             cache_hit = old_hash == current_hash;
             if !cache_hit {
-                changed_line_ranges = changed_ranges(old_body, &current);
+                changed_line_ranges = changed_ranges(
+                    old_hash.as_str(),
+                    current_hash,
+                    old_line_count,
+                    current_line_count,
+                );
             }
         }
     }
-    fs::write(path, format!("{now}\n{current_hash}\n{current}"))?;
+    fs::write(
+        path,
+        cache_contents(now, current_hash, output, current_line_count),
+    )?;
     Ok(Some(CacheMeta {
         cache_hit,
         previous_hash,
         current_hash: current_hash.to_string(),
         changed_line_ranges,
     }))
+}
+
+fn cache_contents(
+    timestamp_ms: u64,
+    current_hash: &str,
+    output: &CommandOutput,
+    current_line_count: usize,
+) -> String {
+    format!(
+        "{timestamp_ms}\n{current_hash}\n{CACHE_BODY_VERSION}\nlines={current_line_count}\nstdout_lines={}\nstderr_lines={}\n",
+        String::from_utf8_lossy(&output.stdout).lines().count(),
+        String::from_utf8_lossy(&output.stderr).lines().count()
+    )
+}
+
+fn cached_line_count(body: &str) -> usize {
+    if let Some(metadata) = body.strip_prefix(CACHE_BODY_VERSION) {
+        return metadata
+            .lines()
+            .find_map(|line| line.strip_prefix("lines="))
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(0);
+    }
+    body.lines().count()
 }
 
 fn since_last_summary(output: &CommandOutput, cache: Option<&CacheMeta>, budget: usize) -> String {
@@ -571,12 +606,15 @@ fn since_last_summary(output: &CommandOutput, cache: Option<&CacheMeta>, budget:
     }
 }
 
-fn changed_ranges(old: &str, new: &str) -> Vec<String> {
-    let old_count = old.lines().count();
-    let new_count = new.lines().count();
-    if new_count > old_count {
-        vec![format!("{}-{}", old_count + 1, new_count)]
-    } else if old != new {
+fn changed_ranges(
+    old_hash: &str,
+    current_hash: &str,
+    old_line_count: usize,
+    current_line_count: usize,
+) -> Vec<String> {
+    if current_line_count > old_line_count {
+        vec![format!("{}-{}", old_line_count + 1, current_line_count)]
+    } else if old_hash != current_hash {
         vec!["1-*".to_string()]
     } else {
         Vec::new()

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -482,9 +482,7 @@ fn handle_cache(
         return Ok(None);
     }
     let key = match &options.target {
-        SparkShellTarget::TmuxPane { pane_id, .. } => {
-            format!("pane-{}", pane_id.replace('%', "pct"))
-        }
+        SparkShellTarget::TmuxPane { pane_id, .. } => pane_cache_key(pane_id),
         SparkShellTarget::Command(_) => return Ok(None),
     };
     let dir = cache_dir();
@@ -495,6 +493,27 @@ fn handle_cache(
         current_hash,
         options.cache_ttl_ms,
     )
+}
+
+fn pane_cache_key(pane_id: &str) -> String {
+    let percent_escaped = pane_id.replace('%', "pct");
+    if percent_escaped
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return format!("pane-{percent_escaped}");
+    }
+
+    format!("pane-h{:016x}", fnv1a64(pane_id.as_bytes()))
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
 }
 
 fn handle_cache_at_path(

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -690,3 +690,48 @@ fn pane_json_cache_reports_hits_and_since_last_changes() {
 
     let _ = fs::remove_dir_all(temp);
 }
+
+#[test]
+fn pane_cache_does_not_persist_raw_secret_like_text() {
+    let temp = unique_temp_dir("pane-cache-secret");
+    let tmux = temp.join("tmux");
+    let cache = temp.join("cache");
+    let pane = temp.join("pane.txt");
+    let secret_line = "OPENAI_API_KEY=sk-test-secret";
+    fs::write(&pane, format!("starting\n{secret_line}\nfinished\n")).expect("pane");
+    write_executable(&tmux, &format!("#!/bin/sh\ncat {}\n", pane.display()));
+    let path = format!(
+        "{}:{}",
+        temp.display(),
+        env::var("PATH").unwrap_or_default()
+    );
+
+    let output = Command::new(sparkshell_bin())
+        .env("PATH", &path)
+        .env("OMX_SPARKSHELL_CACHE_DIR", cache.display().to_string())
+        .arg("--json")
+        .arg("--tmux-pane")
+        .arg("%99")
+        .output()
+        .expect("run sparkshell");
+
+    assert!(output.status.success());
+    let cache_file = cache.join("pane-pct99.txt");
+    let cached = fs::read_to_string(&cache_file).expect("cache file");
+    assert!(
+        !cached.contains(secret_line),
+        "cache file persisted raw secret-like pane text: {cached}"
+    );
+    assert!(
+        !cached.contains("sk-test-secret"),
+        "cache file persisted raw token value: {cached}"
+    );
+    assert!(
+        !cached.contains("OPENAI_API_KEY"),
+        "cache file persisted raw secret variable name: {cached}"
+    );
+    assert!(cached.contains("omx-sparkshell-cache-v2"));
+    assert!(cached.contains("lines=3"));
+
+    let _ = fs::remove_dir_all(temp);
+}

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -692,6 +692,62 @@ fn pane_json_cache_reports_hits_and_since_last_changes() {
 }
 
 #[test]
+fn pane_cache_key_does_not_escape_cache_dir_for_path_like_pane_ids() {
+    let temp = unique_temp_dir("pane-cache-traversal");
+    let tmux = temp.join("tmux");
+    let cache = temp.join("cache");
+    let intermediate = cache.join("pane-..");
+    let outside = temp.join("outside-pr2371.txt");
+
+    fs::create_dir_all(&intermediate).expect("intermediate cache dir");
+    write_executable(&tmux, "#!/bin/sh\nprintf 'safe pane output\n'\n");
+    let path = format!(
+        "{}:{}",
+        temp.display(),
+        env::var("PATH").unwrap_or_default()
+    );
+
+    let output = Command::new(sparkshell_bin())
+        .env("PATH", &path)
+        .env("OMX_SPARKSHELL_CACHE_DIR", cache.display().to_string())
+        .arg("--json")
+        .arg("--tmux-pane")
+        .arg("../../../outside-pr2371")
+        .output()
+        .expect("run sparkshell");
+
+    assert!(
+        output.status.success(),
+        "sparkshell failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !outside.exists(),
+        "path-like pane id wrote outside cache dir at {}",
+        outside.display()
+    );
+
+    let cache_files = fs::read_dir(&cache)
+        .expect("cache dir")
+        .map(|entry| entry.expect("cache entry").path())
+        .collect::<Vec<_>>();
+    assert!(
+        cache_files.iter().any(|path| {
+            path.is_file()
+                && path.parent() == Some(cache.as_path())
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("pane-h") && name.ends_with(".txt"))
+        }),
+        "expected sanitized pane cache file directly under cache dir, got {cache_files:?}"
+    );
+
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[test]
 fn pane_cache_does_not_persist_raw_secret_like_text() {
     let temp = unique_temp_dir("pane-cache-secret");
     let tmux = temp.join("tmux");

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -732,10 +732,13 @@ fn pane_cache_key_does_not_escape_cache_dir_for_path_like_pane_ids() {
     let outside = temp.join("outside-pr2371.txt");
 
     fs::create_dir_all(&intermediate).expect("intermediate cache dir");
-    write_executable(&tmux, "#!/bin/sh
+    write_executable(
+        &tmux,
+        "#!/bin/sh
 printf 'safe pane output
 '
-");
+",
+    );
     let path = format!(
         "{}:{}",
         temp.display(),
@@ -789,13 +792,25 @@ fn pane_cache_does_not_persist_raw_secret_like_text() {
     let cache = temp.join("cache");
     let pane = temp.join("pane.txt");
     let secret_line = "OPENAI_API_KEY=sk-test-secret";
-    fs::write(&pane, format!("starting
+    fs::write(
+        &pane,
+        format!(
+            "starting
 {secret_line}
 finished
-")).expect("pane");
-    write_executable(&tmux, &format!("#!/bin/sh
+"
+        ),
+    )
+    .expect("pane");
+    write_executable(
+        &tmux,
+        &format!(
+            "#!/bin/sh
 cat {}
-", pane.display()));
+",
+            pane.display()
+        ),
+    );
     let path = format!(
         "{}:{}",
         temp.display(),


### PR DESCRIPTION
## Why

Team runs can last a long time, and leaders often inspect the same worker pane repeatedly. Re-summarizing identical pane tails wastes context and hides the important question: what changed since the last observation?

## Intent

This PR adds an incremental observation layer for tmux pane mode. The design makes repeated monitoring cheaper and clearer by surfacing cache hits, previous/current hashes, and changed line ranges.

## What changed

- Added pane observation cache metadata for tmux pane mode.
- Added `--since-last`, `--cache=on|off`, and `--cache-ttl-ms` options.
- Stores pane observation hashes under `.omx/cache/sparkshell` or the team-state-root-adjacent cache path.
- Emits cache metadata in JSON output: `cache_hit`, `previous_hash`, `current_hash`, and `changed_line_ranges`.
- Makes `--since-last` prioritize newly added lines when a previous observation exists.
- Added regression coverage for first observation, cache hit, changed line range, and since-last summary behavior.

## Verification

- `cargo test -p omx-sparkshell --quiet`

## Notes

Caching is scoped to tmux pane observations. Direct command mode remains uncached so command invocations stay simple and explicit.
