### PR TITLE
Polish sparkshell safety and operator UX

### DIFF
--- a/crates/omx-sparkshell/src/exec.rs
+++ b/crates/omx-sparkshell/src/exec.rs
@@ -26,6 +26,10 @@ impl CommandOutput {
     }
 }
 
+pub fn execute_shell_command(script: &str) -> Result<CommandOutput, SparkshellError> {
+    execute_command(&["bash".to_string(), "-lc".to_string(), script.to_string()])
+}
+
 pub fn execute_command(argv: &[String]) -> Result<CommandOutput, SparkshellError> {
     if argv.is_empty() {
         return Err(SparkshellError::InvalidArgs(

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -12,8 +12,10 @@ use crate::exec::{execute_command, CommandOutput};
 use crate::threshold::{combined_visible_lines, read_line_threshold};
 use omx_mux::build_capture_pane_args;
 use std::collections::hash_map::DefaultHasher;
+use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
+use std::path::PathBuf;
 use std::process;
 
 const DEFAULT_TMUX_TAIL_LINES: usize = 200;
@@ -31,6 +33,8 @@ struct SparkShellOptions {
     target: SparkShellTarget,
     json: bool,
     budget: usize,
+    team: Option<String>,
+    worker: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +48,7 @@ struct Evidence {
 }
 
 const DEFAULT_BUDGET: usize = 1000;
+const STALE_HEARTBEAT_MS: u64 = 120_000;
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -149,6 +154,8 @@ fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
     let mut positional = Vec::new();
     let mut json = false;
     let mut budget = DEFAULT_BUDGET;
+    let mut team = None;
+    let mut worker = None;
 
     let mut index = 0;
     while index < args.len() {
@@ -170,6 +177,46 @@ fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
         }
         if let Some(value) = token.strip_prefix("--budget=") {
             budget = parse_positive_usize(value, "--budget")?;
+            index += 1;
+            continue;
+        }
+        if token == "--team" {
+            let Some(next) = args.get(index + 1) else {
+                return Err(SparkshellError::InvalidArgs(
+                    "--team requires a value".to_string(),
+                ));
+            };
+            team = Some(next.clone());
+            index += 2;
+            continue;
+        }
+        if let Some(value) = token.strip_prefix("--team=") {
+            if value.trim().is_empty() {
+                return Err(SparkshellError::InvalidArgs(
+                    "--team requires a value".to_string(),
+                ));
+            }
+            team = Some(value.to_string());
+            index += 1;
+            continue;
+        }
+        if token == "--worker" {
+            let Some(next) = args.get(index + 1) else {
+                return Err(SparkshellError::InvalidArgs(
+                    "--worker requires a value".to_string(),
+                ));
+            };
+            worker = Some(next.clone());
+            index += 2;
+            continue;
+        }
+        if let Some(value) = token.strip_prefix("--worker=") {
+            if value.trim().is_empty() {
+                return Err(SparkshellError::InvalidArgs(
+                    "--worker requires a value".to_string(),
+                ));
+            }
+            worker = Some(value.to_string());
             index += 1;
             continue;
         }
@@ -243,6 +290,8 @@ fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
         target,
         json,
         budget,
+        team,
+        worker,
     })
 }
 
@@ -348,6 +397,137 @@ fn optional_json_string(value: &Option<String>) -> String {
         .unwrap_or_else(|| "null".to_string())
 }
 
+#[derive(Debug, Clone)]
+struct Diagnostics {
+    classification: String,
+    next_action: String,
+    confidence: f32,
+    errors: Vec<String>,
+    warnings: Vec<String>,
+}
+
+fn classify(options: &SparkShellOptions, output: &CommandOutput) -> Diagnostics {
+    let text = combined_text(output).to_ascii_lowercase();
+    let mut diagnostics = Diagnostics {
+        classification: "unknown".to_string(),
+        next_action: "inspect raw output".to_string(),
+        confidence: 0.45,
+        errors: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    if text.contains("authorization") || text.contains("authentication") || text.contains("401") {
+        diagnostics.classification = "auth_error".to_string();
+        diagnostics.confidence = 0.8;
+        diagnostics
+            .errors
+            .push("authentication-like error in output".to_string());
+    } else if text.contains("typeerror") || text.contains("type error") {
+        diagnostics.classification = "type_error".to_string();
+        diagnostics.confidence = 0.75;
+        diagnostics
+            .errors
+            .push("type error pattern in output".to_string());
+    } else if text.contains("test failed") || text.contains("failures:") || text.contains("failed")
+    {
+        diagnostics.classification = "test_failure".to_string();
+        diagnostics.confidence = 0.65;
+        diagnostics
+            .errors
+            .push("failure pattern in output".to_string());
+    } else if text.contains("press enter")
+        || text.contains("waiting for input")
+        || text.contains("continue?")
+    {
+        diagnostics.classification = "waiting_for_input".to_string();
+        diagnostics.confidence = 0.75;
+    } else if text.contains("thinking") || text.contains("running") || text.contains("building") {
+        diagnostics.classification = "busy_processing".to_string();
+        diagnostics.next_action = "wait".to_string();
+        diagnostics.confidence = 0.65;
+        diagnostics.warnings.push("do not shutdown yet".to_string());
+    }
+
+    if let (Some(team), Some(worker)) = (&options.team, &options.worker) {
+        if let Some(team_diagnostics) = classify_team(team, worker) {
+            diagnostics = team_diagnostics;
+        }
+    }
+
+    diagnostics
+}
+
+fn classify_team(team: &str, worker: &str) -> Option<Diagnostics> {
+    let state_root = std::env::var("OMX_TEAM_STATE_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(".omx/state"));
+    let base = state_root
+        .join("team")
+        .join(team)
+        .join("workers")
+        .join(worker);
+    if !base.exists() {
+        return None;
+    }
+
+    if let Ok(heartbeat) = fs::read_to_string(base.join("heartbeat.json")) {
+        if let Some(timestamp) = extract_number_after(&heartbeat, "timestamp")
+            .or_else(|| extract_number_after(&heartbeat, "updated_at_ms"))
+        {
+            if now_ms().saturating_sub(timestamp) > STALE_HEARTBEAT_MS {
+                return Some(Diagnostics {
+                    classification: "stale_heartbeat".to_string(),
+                    next_action: "run omx team status".to_string(),
+                    confidence: 0.78,
+                    errors: Vec::new(),
+                    warnings: vec!["heartbeat is stale".to_string()],
+                });
+            }
+        }
+    }
+
+    if let Ok(status) = fs::read_to_string(base.join("status.json")) {
+        let normalized = status.to_ascii_lowercase();
+        if normalized.contains("blocked") || normalized.contains("needs_input") {
+            return Some(Diagnostics {
+                classification: "waiting_for_input".to_string(),
+                next_action: "inspect raw pane".to_string(),
+                confidence: 0.7,
+                errors: Vec::new(),
+                warnings: Vec::new(),
+            });
+        }
+        if normalized.contains("busy") || normalized.contains("in_progress") {
+            return Some(Diagnostics {
+                classification: "busy_processing".to_string(),
+                next_action: "wait".to_string(),
+                confidence: 0.72,
+                errors: Vec::new(),
+                warnings: vec!["do not shutdown yet".to_string()],
+            });
+        }
+    }
+
+    None
+}
+
+fn extract_number_after(text: &str, key: &str) -> Option<u64> {
+    let start = text.find(key)?;
+    let digits: String = text[start + key.len()..]
+        .chars()
+        .skip_while(|ch| !ch.is_ascii_digit())
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
 fn write_json_report(
     options: &SparkShellOptions,
     output: &CommandOutput,
@@ -363,12 +543,12 @@ fn write_json_report(
     } else {
         "failed"
     };
-    let errors = if output.status.success() {
-        Vec::new()
-    } else {
-        vec![compact_text(&output.stderr_text(), options.budget)]
-    };
-    let warnings: Vec<String> = Vec::new();
+    let mut diagnostics = classify(options, output);
+    if !output.status.success() && diagnostics.errors.is_empty() {
+        diagnostics
+            .errors
+            .push(compact_text(&output.stderr_text(), options.budget));
+    }
     let tail_lines = evidence
         .tail_lines
         .map(|value| value.to_string())
@@ -385,7 +565,8 @@ fn write_json_report(
             "  \"warnings\": {},\n",
             "  \"evidence\": {{\"stdout_lines\":{},\"stderr_lines\":{},\"raw_hash\":{},\"pane_id\":{},\"tail_lines\":{},\"line_range\":{}}},\n",
             "  \"next_action\": {},\n",
-            "  \"confidence\": 0.80\n",
+            "  \"confidence\": {:.2},\n",
+            "  \"classification\": {}\n",
             "}}\n"
         ),
         output.status.success(),
@@ -393,15 +574,17 @@ fn write_json_report(
         json_str(status),
         output.exit_code(),
         json_str(&compact_text(summary, options.budget)),
-        json_string_array(&errors),
-        json_string_array(&warnings),
+        json_string_array(&diagnostics.errors),
+        json_string_array(&diagnostics.warnings),
         evidence.stdout_lines,
         evidence.stderr_lines,
         json_str(&evidence.raw_hash),
         optional_json_string(&evidence.pane_id),
         tail_lines,
         optional_json_string(&evidence.line_range),
-        json_str(if output.status.success() { "none" } else { "inspect raw output" }),
+        json_str(&diagnostics.next_action),
+        diagnostics.confidence,
+        json_str(&diagnostics.classification),
     );
     io::stdout().write_all(json.as_bytes())?;
     Ok(())

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -8,9 +8,11 @@ mod threshold;
 
 use crate::codex_bridge::summarize_output;
 use crate::error::SparkshellError;
-use crate::exec::execute_command;
+use crate::exec::{execute_command, CommandOutput};
 use crate::threshold::{combined_visible_lines, read_line_threshold};
 use omx_mux::build_capture_pane_args;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
 use std::process;
 
@@ -19,10 +21,29 @@ const MIN_TMUX_TAIL_LINES: usize = 100;
 const MAX_TMUX_TAIL_LINES: usize = 1000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum SparkShellInput {
+enum SparkShellTarget {
     Command(Vec<String>),
     TmuxPane { pane_id: String, tail_lines: usize },
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SparkShellOptions {
+    target: SparkShellTarget,
+    json: bool,
+    budget: usize,
+}
+
+#[derive(Debug, Clone)]
+struct Evidence {
+    stdout_lines: usize,
+    stderr_lines: usize,
+    raw_hash: String,
+    pane_id: Option<String>,
+    tail_lines: Option<usize>,
+    line_range: Option<String>,
+}
+
+const DEFAULT_BUDGET: usize = 1000;
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -40,14 +61,15 @@ fn main() {
 }
 
 fn run(args: Vec<String>) -> Result<(), SparkshellError> {
-    let execution_argv = match parse_input(&args)? {
-        SparkShellInput::Command(command) => command,
-        SparkShellInput::TmuxPane {
+    let options = parse_input(&args)?;
+    let execution_argv = match &options.target {
+        SparkShellTarget::Command(command) => command.clone(),
+        SparkShellTarget::TmuxPane {
             pane_id,
             tail_lines,
         } => {
             let mut argv = vec!["tmux".to_string()];
-            argv.extend(build_capture_pane_args(&pane_id, tail_lines));
+            argv.extend(build_capture_pane_args(pane_id, *tail_lines));
             argv
         }
     };
@@ -55,6 +77,18 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
     let output = execute_command(&execution_argv)?;
     let threshold = read_line_threshold();
     let line_count = combined_visible_lines(&output.stdout, &output.stderr);
+
+    if options.json {
+        let summary = if line_count <= threshold {
+            compact_text(&combined_text(&output), options.budget)
+        } else {
+            summarize_output(&execution_argv, &output)
+                .unwrap_or_else(|error| format!("summary unavailable: {error}"))
+        };
+        let evidence = build_evidence(&options, &output);
+        write_json_report(&options, &output, &summary, &evidence)?;
+        process::exit(output.exit_code());
+    }
 
     if line_count <= threshold {
         write_raw_output(&output.stdout, &output.stderr)?;
@@ -64,7 +98,7 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
     match summarize_output(&execution_argv, &output) {
         Ok(summary) => {
             let mut stdout = io::stdout().lock();
-            stdout.write_all(summary.as_bytes())?;
+            stdout.write_all(compact_text(&summary, options.budget).as_bytes())?;
             if !summary.ends_with('\n') {
                 stdout.write_all(b"\n")?;
             }
@@ -104,7 +138,7 @@ fn usage_text() -> String {
     )
 }
 
-fn parse_input(args: &[String]) -> Result<SparkShellInput, SparkshellError> {
+fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
     if args.is_empty() {
         return Err(SparkshellError::InvalidArgs(usage_text()));
     }
@@ -113,10 +147,32 @@ fn parse_input(args: &[String]) -> Result<SparkShellInput, SparkshellError> {
     let mut tail_lines = DEFAULT_TMUX_TAIL_LINES;
     let mut explicit_tail_lines = false;
     let mut positional = Vec::new();
+    let mut json = false;
+    let mut budget = DEFAULT_BUDGET;
 
     let mut index = 0;
     while index < args.len() {
         let token = &args[index];
+        if token == "--json" {
+            json = true;
+            index += 1;
+            continue;
+        }
+        if token == "--budget" {
+            let Some(next) = args.get(index + 1) else {
+                return Err(SparkshellError::InvalidArgs(
+                    "--budget requires a numeric value".to_string(),
+                ));
+            };
+            budget = parse_positive_usize(next, "--budget")?;
+            index += 2;
+            continue;
+        }
+        if let Some(value) = token.strip_prefix("--budget=") {
+            budget = parse_positive_usize(value, "--budget")?;
+            index += 1;
+            continue;
+        }
         if token == "--tmux-pane" {
             let Some(next) = args.get(index + 1) else {
                 return Err(SparkshellError::InvalidArgs(
@@ -164,25 +220,191 @@ fn parse_input(args: &[String]) -> Result<SparkShellInput, SparkshellError> {
         index += 1;
     }
 
-    if let Some(pane_id) = pane_id {
+    let target = if let Some(pane_id) = pane_id {
         if !positional.is_empty() {
             return Err(SparkshellError::InvalidArgs(
                 "tmux pane mode does not accept an additional command".to_string(),
             ));
         }
-        return Ok(SparkShellInput::TmuxPane {
+        SparkShellTarget::TmuxPane {
             pane_id,
             tail_lines,
-        });
-    }
+        }
+    } else {
+        if explicit_tail_lines {
+            return Err(SparkshellError::InvalidArgs(
+                "--tail-lines requires --tmux-pane".to_string(),
+            ));
+        }
+        SparkShellTarget::Command(positional)
+    };
 
-    if explicit_tail_lines {
-        return Err(SparkshellError::InvalidArgs(
-            "--tail-lines requires --tmux-pane".to_string(),
-        ));
-    }
+    Ok(SparkShellOptions {
+        target,
+        json,
+        budget,
+    })
+}
 
-    Ok(SparkShellInput::Command(positional))
+fn parse_positive_usize(raw: &str, flag: &str) -> Result<usize, SparkshellError> {
+    raw.trim()
+        .parse::<usize>()
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or_else(|| SparkshellError::InvalidArgs(format!("{flag} requires a positive integer")))
+}
+
+fn build_evidence(options: &SparkShellOptions, output: &CommandOutput) -> Evidence {
+    let text = combined_text(output);
+    let lines = text.lines().count();
+    let (pane_id, tail_lines) = match &options.target {
+        SparkShellTarget::TmuxPane {
+            pane_id,
+            tail_lines,
+        } => (Some(pane_id.clone()), Some(*tail_lines)),
+        SparkShellTarget::Command(_) => (None, None),
+    };
+    Evidence {
+        stdout_lines: String::from_utf8_lossy(&output.stdout).lines().count(),
+        stderr_lines: String::from_utf8_lossy(&output.stderr).lines().count(),
+        raw_hash: hash_text(&text),
+        pane_id,
+        tail_lines,
+        line_range: (lines > 0).then(|| format!("1-{lines}")),
+    }
+}
+
+fn combined_text(output: &CommandOutput) -> String {
+    format!("{}{}", output.stdout_text(), output.stderr_text())
+}
+
+fn hash_text(text: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    text.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn compact_text(text: &str, budget: usize) -> String {
+    if text.len() <= budget {
+        return text.to_string();
+    }
+    let end = safe_boundary(text, budget);
+    format!(
+        "{}\n[truncated: {} chars omitted]",
+        &text[..end],
+        text.len().saturating_sub(end)
+    )
+}
+
+fn safe_boundary(text: &str, max: usize) -> usize {
+    let mut end = 0;
+    for (index, ch) in text.char_indices() {
+        let next = index + ch.len_utf8();
+        if next > max {
+            break;
+        }
+        end = next;
+    }
+    end
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::new();
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{08}' => escaped.push_str("\\b"),
+            '\u{0c}' => escaped.push_str("\\f"),
+            ch if ch <= '\u{1f}' => escaped.push_str(&format!("\\u{:04x}", ch as u32)),
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn json_str(value: &str) -> String {
+    format!("\"{}\"", json_escape(value))
+}
+
+fn json_string_array(values: &[String]) -> String {
+    format!(
+        "[{}]",
+        values
+            .iter()
+            .map(|value| json_str(value))
+            .collect::<Vec<_>>()
+            .join(",")
+    )
+}
+
+fn optional_json_string(value: &Option<String>) -> String {
+    value
+        .as_ref()
+        .map(|value| json_str(value))
+        .unwrap_or_else(|| "null".to_string())
+}
+
+fn write_json_report(
+    options: &SparkShellOptions,
+    output: &CommandOutput,
+    summary: &str,
+    evidence: &Evidence,
+) -> Result<(), SparkshellError> {
+    let mode = match options.target {
+        SparkShellTarget::Command(_) => "command",
+        SparkShellTarget::TmuxPane { .. } => "tmux-pane",
+    };
+    let status = if output.status.success() {
+        "ok"
+    } else {
+        "failed"
+    };
+    let errors = if output.status.success() {
+        Vec::new()
+    } else {
+        vec![compact_text(&output.stderr_text(), options.budget)]
+    };
+    let warnings: Vec<String> = Vec::new();
+    let tail_lines = evidence
+        .tail_lines
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "null".to_string());
+    let json = format!(
+        concat!(
+            "{{\n",
+            "  \"ok\": {},\n",
+            "  \"mode\": {},\n",
+            "  \"status\": {},\n",
+            "  \"exit_code\": {},\n",
+            "  \"summary\": {},\n",
+            "  \"errors\": {},\n",
+            "  \"warnings\": {},\n",
+            "  \"evidence\": {{\"stdout_lines\":{},\"stderr_lines\":{},\"raw_hash\":{},\"pane_id\":{},\"tail_lines\":{},\"line_range\":{}}},\n",
+            "  \"next_action\": {},\n",
+            "  \"confidence\": 0.80\n",
+            "}}\n"
+        ),
+        output.status.success(),
+        json_str(mode),
+        json_str(status),
+        output.exit_code(),
+        json_str(&compact_text(summary, options.budget)),
+        json_string_array(&errors),
+        json_string_array(&warnings),
+        evidence.stdout_lines,
+        evidence.stderr_lines,
+        json_str(&evidence.raw_hash),
+        optional_json_string(&evidence.pane_id),
+        tail_lines,
+        optional_json_string(&evidence.line_range),
+        json_str(if output.status.success() { "none" } else { "inspect raw output" }),
+    );
+    io::stdout().write_all(json.as_bytes())?;
+    Ok(())
 }
 
 fn parse_tail_lines(raw: &str) -> Result<usize, SparkshellError> {
@@ -201,7 +423,7 @@ fn parse_tail_lines(raw: &str) -> Result<usize, SparkshellError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_input, SparkShellInput};
+    use super::{parse_input, SparkShellTarget};
 
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
@@ -211,8 +433,8 @@ mod tests {
     fn parses_direct_command_mode() {
         let parsed = parse_input(&strings(&["git", "status"])).expect("parsed");
         assert_eq!(
-            parsed,
-            SparkShellInput::Command(strings(&["git", "status"]))
+            parsed.target,
+            SparkShellTarget::Command(strings(&["git", "status"]))
         );
     }
 
@@ -220,8 +442,8 @@ mod tests {
     fn parses_tmux_pane_mode_with_default_tail_lines() {
         let parsed = parse_input(&strings(&["--tmux-pane", "%11"])).expect("parsed");
         assert_eq!(
-            parsed,
-            SparkShellInput::TmuxPane {
+            parsed.target,
+            SparkShellTarget::TmuxPane {
                 pane_id: "%11".to_string(),
                 tail_lines: 200,
             }
@@ -233,8 +455,8 @@ mod tests {
         let parsed =
             parse_input(&strings(&["--tmux-pane=%22", "--tail-lines=400"])).expect("parsed");
         assert_eq!(
-            parsed,
-            SparkShellInput::TmuxPane {
+            parsed.target,
+            SparkShellTarget::TmuxPane {
                 pane_id: "%22".to_string(),
                 tail_lines: 400,
             }
@@ -301,15 +523,15 @@ mod tests {
         let max = parse_input(&strings(&["--tmux-pane", "%11", "--tail-lines", "1000"]))
             .expect("max parsed");
         assert_eq!(
-            min,
-            SparkShellInput::TmuxPane {
+            min.target,
+            SparkShellTarget::TmuxPane {
                 pane_id: "%11".to_string(),
                 tail_lines: 100
             }
         );
         assert_eq!(
-            max,
-            SparkShellInput::TmuxPane {
+            max.target,
+            SparkShellTarget::TmuxPane {
                 pane_id: "%11".to_string(),
                 tail_lines: 1000
             }

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -8,7 +8,7 @@ mod threshold;
 
 use crate::codex_bridge::summarize_output;
 use crate::error::SparkshellError;
-use crate::exec::{execute_command, CommandOutput};
+use crate::exec::{execute_command, execute_shell_command, CommandOutput};
 use crate::threshold::{combined_visible_lines, read_line_threshold};
 use omx_mux::build_capture_pane_args;
 use std::collections::hash_map::DefaultHasher;
@@ -26,6 +26,7 @@ const MAX_TMUX_TAIL_LINES: usize = 1000;
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum SparkShellTarget {
     Command(Vec<String>),
+    Shell(String),
     TmuxPane { pane_id: String, tail_lines: usize },
 }
 
@@ -82,6 +83,9 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
     let options = parse_input(&args)?;
     let execution_argv = match &options.target {
         SparkShellTarget::Command(command) => command.clone(),
+        SparkShellTarget::Shell(script) => {
+            vec!["bash".to_string(), "-lc".to_string(), script.clone()]
+        }
         SparkShellTarget::TmuxPane {
             pane_id,
             tail_lines,
@@ -92,7 +96,12 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
         }
     };
 
-    let output = execute_command(&execution_argv)?;
+    let raw_output = match &options.target {
+        SparkShellTarget::Shell(script) => execute_shell_command(script)?,
+        _ => execute_command(&execution_argv)?,
+    };
+    let redacted = redact_output(&raw_output);
+    let output = redacted.output;
     let threshold = read_line_threshold();
     let line_count = combined_visible_lines(&output.stdout, &output.stderr);
     let evidence = build_evidence(&options, &output);
@@ -109,7 +118,14 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
             summarize_output(&execution_argv, &output)
                 .unwrap_or_else(|error| format!("summary unavailable: {error}"))
         };
-        write_json_report(&options, &output, &summary, &evidence, cache_meta)?;
+        write_json_report(
+            &options,
+            &output,
+            &summary,
+            &evidence,
+            cache_meta,
+            redacted.count,
+        )?;
         process::exit(output.exit_code());
     }
 
@@ -177,6 +193,7 @@ fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
     let mut since_last = false;
     let mut cache = true;
     let mut cache_ttl_ms = DEFAULT_CACHE_TTL_MS;
+    let mut shell = None;
 
     let mut index = 0;
     while index < args.len() {
@@ -206,6 +223,26 @@ fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
         }
         if let Some(value) = token.strip_prefix("--budget=") {
             budget = parse_positive_usize(value, "--budget")?;
+            index += 1;
+            continue;
+        }
+        if token == "--shell" {
+            let Some(next) = args.get(index + 1) else {
+                return Err(SparkshellError::InvalidArgs(
+                    "--shell requires a command string".to_string(),
+                ));
+            };
+            shell = Some(next.clone());
+            index += 2;
+            continue;
+        }
+        if let Some(value) = token.strip_prefix("--shell=") {
+            if value.trim().is_empty() {
+                return Err(SparkshellError::InvalidArgs(
+                    "--shell requires a command string".to_string(),
+                ));
+            }
+            shell = Some(value.to_string());
             index += 1;
             continue;
         }
@@ -329,7 +366,14 @@ fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
         index += 1;
     }
 
-    let target = if let Some(pane_id) = pane_id {
+    let target = if let Some(script) = shell {
+        if pane_id.is_some() || !positional.is_empty() {
+            return Err(SparkshellError::InvalidArgs(
+                "--shell does not accept --tmux-pane or additional argv".to_string(),
+            ));
+        }
+        SparkShellTarget::Shell(script)
+    } else if let Some(pane_id) = pane_id {
         if !positional.is_empty() {
             return Err(SparkshellError::InvalidArgs(
                 "tmux pane mode does not accept an additional command".to_string(),
@@ -368,6 +412,66 @@ fn parse_positive_usize(raw: &str, flag: &str) -> Result<usize, SparkshellError>
         .ok_or_else(|| SparkshellError::InvalidArgs(format!("{flag} requires a positive integer")))
 }
 
+#[derive(Debug, Clone)]
+struct RedactedOutput {
+    output: CommandOutput,
+    count: usize,
+}
+
+fn redact_output(output: &CommandOutput) -> RedactedOutput {
+    let (stdout, stdout_count) = redact_bytes(&output.stdout);
+    let (stderr, stderr_count) = redact_bytes(&output.stderr);
+    RedactedOutput {
+        output: CommandOutput {
+            status: output.status,
+            stdout,
+            stderr,
+        },
+        count: stdout_count + stderr_count,
+    }
+}
+
+fn redact_bytes(bytes: &[u8]) -> (Vec<u8>, usize) {
+    let (text, count) = redact_text(&String::from_utf8_lossy(bytes));
+    (text.into_bytes(), count)
+}
+
+fn redact_text(text: &str) -> (String, usize) {
+    let mut count = 0;
+    let mut lines = Vec::new();
+    for line in text.lines() {
+        let mut redacted = line.to_string();
+        let lower = redacted.to_ascii_lowercase();
+        if lower.contains("authorization: bearer ") {
+            redacted = "Authorization: Bearer [REDACTED]".to_string();
+            count += 1;
+        }
+        if let Some(eq) = redacted.find('=') {
+            let key = redacted[..eq].to_ascii_lowercase();
+            if key.contains("token") || key.contains("key") || key.contains("secret") {
+                redacted = format!("{}=[REDACTED]", &redacted[..eq]);
+                count += 1;
+            }
+        }
+        for marker in ["sk-", "ghp_", "xoxb-"] {
+            if let Some(start) = redacted.find(marker) {
+                let end = redacted[start..]
+                    .find(char::is_whitespace)
+                    .map(|offset| start + offset)
+                    .unwrap_or(redacted.len());
+                redacted.replace_range(start..end, "[REDACTED]");
+                count += 1;
+            }
+        }
+        lines.push(redacted);
+    }
+    let mut rendered = lines.join("\n");
+    if text.ends_with('\n') {
+        rendered.push('\n');
+    }
+    (rendered, count)
+}
+
 fn build_evidence(options: &SparkShellOptions, output: &CommandOutput) -> Evidence {
     let text = combined_text(output);
     let lines = text.lines().count();
@@ -376,7 +480,7 @@ fn build_evidence(options: &SparkShellOptions, output: &CommandOutput) -> Eviden
             pane_id,
             tail_lines,
         } => (Some(pane_id.clone()), Some(*tail_lines)),
-        SparkShellTarget::Command(_) => (None, None),
+        SparkShellTarget::Command(_) | SparkShellTarget::Shell(_) => (None, None),
     };
     Evidence {
         stdout_lines: String::from_utf8_lossy(&output.stdout).lines().count(),
@@ -484,7 +588,7 @@ fn handle_cache(
         SparkShellTarget::TmuxPane { pane_id, .. } => {
             format!("pane-{}", pane_id.replace('%', "pct"))
         }
-        SparkShellTarget::Command(_) => return Ok(None),
+        SparkShellTarget::Command(_) | SparkShellTarget::Shell(_) => return Ok(None),
     };
     let dir = cache_dir();
     fs::create_dir_all(&dir)?;
@@ -769,9 +873,11 @@ fn write_json_report(
     summary: &str,
     evidence: &Evidence,
     cache: Option<CacheMeta>,
+    redaction_count: usize,
 ) -> Result<(), SparkshellError> {
     let mode = match options.target {
         SparkShellTarget::Command(_) => "command",
+        SparkShellTarget::Shell(_) => "shell",
         SparkShellTarget::TmuxPane { .. } => "tmux-pane",
     };
     let status = if output.status.success() {
@@ -814,7 +920,8 @@ fn write_json_report(
             "  \"next_action\": {},\n",
             "  \"confidence\": {:.2},\n",
             "  \"classification\": {},\n",
-            "  \"cache\": {}\n",
+            "  \"cache\": {},\n",
+            "  \"redactions\": {{\"count\": {}}}\n",
             "}}\n"
         ),
         output.status.success(),
@@ -834,6 +941,7 @@ fn write_json_report(
         diagnostics.confidence,
         json_str(&diagnostics.classification),
         cache_json,
+        redaction_count,
     );
     io::stdout().write_all(json.as_bytes())?;
     Ok(())

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -2,6 +2,7 @@ mod codex_bridge;
 mod error;
 mod exec;
 mod prompt;
+mod redaction;
 #[cfg(test)]
 mod test_support;
 mod threshold;
@@ -9,6 +10,7 @@ mod threshold;
 use crate::codex_bridge::summarize_output;
 use crate::error::SparkshellError;
 use crate::exec::{execute_command, execute_shell_command, CommandOutput};
+use crate::redaction::redact_output;
 use crate::threshold::{combined_visible_lines, read_line_threshold};
 use omx_mux::build_capture_pane_args;
 use std::collections::hash_map::DefaultHasher;
@@ -106,6 +108,7 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
     } else {
         &raw_output
     };
+    let summary_output = &redacted.output;
     let threshold = read_line_threshold();
     let line_count = combined_visible_lines(&output.stdout, &output.stderr);
     let evidence = build_evidence(&options, output);
@@ -138,7 +141,7 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
         process::exit(output.exit_code());
     }
 
-    match summarize_output(&execution_argv, output) {
+    match summarize_output(&execution_argv, summary_output) {
         Ok(summary) => {
             let mut stdout = io::stdout().lock();
             stdout.write_all(compact_text(&summary, options.budget).as_bytes())?;
@@ -414,66 +417,6 @@ fn parse_positive_usize(raw: &str, flag: &str) -> Result<usize, SparkshellError>
         .ok()
         .filter(|value| *value > 0)
         .ok_or_else(|| SparkshellError::InvalidArgs(format!("{flag} requires a positive integer")))
-}
-
-#[derive(Debug, Clone)]
-struct RedactedOutput {
-    output: CommandOutput,
-    count: usize,
-}
-
-fn redact_output(output: &CommandOutput) -> RedactedOutput {
-    let (stdout, stdout_count) = redact_bytes(&output.stdout);
-    let (stderr, stderr_count) = redact_bytes(&output.stderr);
-    RedactedOutput {
-        output: CommandOutput {
-            status: output.status,
-            stdout,
-            stderr,
-        },
-        count: stdout_count + stderr_count,
-    }
-}
-
-fn redact_bytes(bytes: &[u8]) -> (Vec<u8>, usize) {
-    let (text, count) = redact_text(&String::from_utf8_lossy(bytes));
-    (text.into_bytes(), count)
-}
-
-fn redact_text(text: &str) -> (String, usize) {
-    let mut count = 0;
-    let mut lines = Vec::new();
-    for line in text.lines() {
-        let mut redacted = line.to_string();
-        let lower = redacted.to_ascii_lowercase();
-        if lower.contains("authorization: bearer ") {
-            redacted = "Authorization: Bearer [REDACTED]".to_string();
-            count += 1;
-        }
-        if let Some(eq) = redacted.find('=') {
-            let key = redacted[..eq].to_ascii_lowercase();
-            if key.contains("token") || key.contains("key") || key.contains("secret") {
-                redacted = format!("{}=[REDACTED]", &redacted[..eq]);
-                count += 1;
-            }
-        }
-        for marker in ["sk-", "ghp_", "xoxb-"] {
-            if let Some(start) = redacted.find(marker) {
-                let end = redacted[start..]
-                    .find(char::is_whitespace)
-                    .map(|offset| start + offset)
-                    .unwrap_or(redacted.len());
-                redacted.replace_range(start..end, "[REDACTED]");
-                count += 1;
-            }
-        }
-        lines.push(redacted);
-    }
-    let mut rendered = lines.join("\n");
-    if text.ends_with('\n') {
-        rendered.push('\n');
-    }
-    (rendered, count)
 }
 
 fn build_evidence(options: &SparkShellOptions, output: &CommandOutput) -> Evidence {

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -17,6 +17,7 @@ use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const DEFAULT_TMUX_TAIL_LINES: usize = 200;
 const MIN_TMUX_TAIL_LINES: usize = 100;
@@ -160,6 +161,14 @@ fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
     let mut index = 0;
     while index < args.len() {
         let token = &args[index];
+        if !positional.is_empty() {
+            positional.extend(args[index..].iter().cloned());
+            break;
+        }
+        if token == "--" {
+            positional.extend(args[index + 1..].iter().cloned());
+            break;
+        }
         if token == "--json" {
             json = true;
             index += 1;
@@ -471,9 +480,7 @@ fn classify_team(team: &str, worker: &str) -> Option<Diagnostics> {
     }
 
     if let Ok(heartbeat) = fs::read_to_string(base.join("heartbeat.json")) {
-        if let Some(timestamp) = extract_number_after(&heartbeat, "timestamp")
-            .or_else(|| extract_number_after(&heartbeat, "updated_at_ms"))
-        {
+        if let Some(timestamp) = extract_heartbeat_ms(&heartbeat) {
             if now_ms().saturating_sub(timestamp) > STALE_HEARTBEAT_MS {
                 return Some(Diagnostics {
                     classification: "stale_heartbeat".to_string(),
@@ -511,19 +518,70 @@ fn classify_team(team: &str, worker: &str) -> Option<Diagnostics> {
     None
 }
 
-fn extract_number_after(text: &str, key: &str) -> Option<u64> {
-    let start = text.find(key)?;
-    let digits: String = text[start + key.len()..]
+fn extract_heartbeat_ms(text: &str) -> Option<u64> {
+    extract_json_number(text, "updated_at_ms")
+        .or_else(|| extract_json_number(text, "timestamp"))
+        .or_else(|| {
+            extract_json_string(text, "last_turn_at")
+                .and_then(|value| parse_iso_timestamp_ms(&value))
+        })
+}
+
+fn extract_json_number(text: &str, key: &str) -> Option<u64> {
+    let key_pattern = format!("\"{key}\"");
+    let start = text.find(&key_pattern)? + key_pattern.len();
+    let after_colon = text[start..].split_once(':')?.1.trim_start();
+    let digits: String = after_colon
         .chars()
-        .skip_while(|ch| !ch.is_ascii_digit())
         .take_while(|ch| ch.is_ascii_digit())
         .collect();
+    if digits.is_empty() {
+        return None;
+    }
     digits.parse().ok()
 }
 
+fn extract_json_string(text: &str, key: &str) -> Option<String> {
+    let key_pattern = format!("\"{key}\"");
+    let start = text.find(&key_pattern)? + key_pattern.len();
+    let after_colon = text[start..].split_once(':')?.1.trim_start();
+    let after_quote = after_colon.strip_prefix('"')?;
+    let value = after_quote.split('"').next()?;
+    Some(value.to_string())
+}
+
+fn parse_iso_timestamp_ms(value: &str) -> Option<u64> {
+    let trimmed = value.strip_suffix('Z').unwrap_or(value);
+    let (date, time) = trimmed.split_once('T')?;
+    let mut date_parts = date.split('-').map(|part| part.parse::<i64>().ok());
+    let year = date_parts.next()??;
+    let month = date_parts.next()??;
+    let day = date_parts.next()??;
+    let mut time_parts = time.split(':');
+    let hour = time_parts.next()?.parse::<i64>().ok()?;
+    let minute = time_parts.next()?.parse::<i64>().ok()?;
+    let second_part = time_parts.next()?;
+    let second = second_part.split('.').next()?.parse::<i64>().ok()?;
+    let days = days_from_civil(year, month, day)?;
+    Some(((days * 86_400 + hour * 3_600 + minute * 60 + second) as u64) * 1000)
+}
+
+fn days_from_civil(year: i64, month: i64, day: i64) -> Option<i64> {
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    let year = year - i64::from(month <= 2);
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let yoe = year - era * 400;
+    let mp = month + if month > 2 { -3 } else { 9 };
+    let doy = (153 * mp + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    Some(era * 146_097 + doe - 719_468)
+}
+
 fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
 }

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -101,26 +101,30 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
         _ => execute_command(&execution_argv)?,
     };
     let redacted = redact_output(&raw_output);
-    let output = redacted.output;
+    let output = if options.json {
+        &redacted.output
+    } else {
+        &raw_output
+    };
     let threshold = read_line_threshold();
     let line_count = combined_visible_lines(&output.stdout, &output.stderr);
-    let evidence = build_evidence(&options, &output);
-    let cache_meta = handle_cache(&options, &output, &evidence.raw_hash)?;
+    let evidence = build_evidence(&options, output);
+    let cache_meta = handle_cache(&options, output, &evidence.raw_hash)?;
 
     if options.json {
         let summary = if options.since_last {
-            since_last_summary(&output, cache_meta.as_ref(), options.budget)
+            since_last_summary(output, cache_meta.as_ref(), options.budget)
         } else if line_count <= threshold {
-            compact_text(&combined_text(&output), options.budget)
+            compact_text(&combined_text(output), options.budget)
         } else if cache_meta.as_ref().is_some_and(|meta| meta.cache_hit) {
             "unchanged since previous observation".to_string()
         } else {
-            summarize_output(&execution_argv, &output)
+            summarize_output(&execution_argv, output)
                 .unwrap_or_else(|error| format!("summary unavailable: {error}"))
         };
         write_json_report(
             &options,
-            &output,
+            output,
             &summary,
             &evidence,
             cache_meta,
@@ -134,7 +138,7 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
         process::exit(output.exit_code());
     }
 
-    match summarize_output(&execution_argv, &output) {
+    match summarize_output(&execution_argv, output) {
         Ok(summary) => {
             let mut stdout = io::stdout().lock();
             stdout.write_all(compact_text(&summary, options.budget).as_bytes())?;

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -15,7 +15,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -36,6 +36,9 @@ struct SparkShellOptions {
     budget: usize,
     team: Option<String>,
     worker: Option<String>,
+    since_last: bool,
+    cache: bool,
+    cache_ttl_ms: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -48,8 +51,17 @@ struct Evidence {
     line_range: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct CacheMeta {
+    cache_hit: bool,
+    previous_hash: Option<String>,
+    current_hash: String,
+    changed_line_ranges: Vec<String>,
+}
+
 const DEFAULT_BUDGET: usize = 1000;
 const STALE_HEARTBEAT_MS: u64 = 120_000;
+const DEFAULT_CACHE_TTL_MS: u64 = 10 * 60 * 1000;
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -83,16 +95,21 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
     let output = execute_command(&execution_argv)?;
     let threshold = read_line_threshold();
     let line_count = combined_visible_lines(&output.stdout, &output.stderr);
+    let evidence = build_evidence(&options, &output);
+    let cache_meta = handle_cache(&options, &output, &evidence.raw_hash)?;
 
     if options.json {
-        let summary = if line_count <= threshold {
+        let summary = if options.since_last {
+            since_last_summary(&output, cache_meta.as_ref(), options.budget)
+        } else if line_count <= threshold {
             compact_text(&combined_text(&output), options.budget)
+        } else if cache_meta.as_ref().is_some_and(|meta| meta.cache_hit) {
+            "unchanged since previous observation".to_string()
         } else {
             summarize_output(&execution_argv, &output)
                 .unwrap_or_else(|error| format!("summary unavailable: {error}"))
         };
-        let evidence = build_evidence(&options, &output);
-        write_json_report(&options, &output, &summary, &evidence)?;
+        write_json_report(&options, &output, &summary, &evidence, cache_meta)?;
         process::exit(output.exit_code());
     }
 
@@ -157,6 +174,9 @@ fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
     let mut budget = DEFAULT_BUDGET;
     let mut team = None;
     let mut worker = None;
+    let mut since_last = false;
+    let mut cache = true;
+    let mut cache_ttl_ms = DEFAULT_CACHE_TTL_MS;
 
     let mut index = 0;
     while index < args.len() {
@@ -186,6 +206,39 @@ fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
         }
         if let Some(value) = token.strip_prefix("--budget=") {
             budget = parse_positive_usize(value, "--budget")?;
+            index += 1;
+            continue;
+        }
+        if token == "--since-last" {
+            since_last = true;
+            index += 1;
+            continue;
+        }
+        if token == "--cache-ttl-ms" {
+            let Some(next) = args.get(index + 1) else {
+                return Err(SparkshellError::InvalidArgs(
+                    "--cache-ttl-ms requires a numeric value".to_string(),
+                ));
+            };
+            cache_ttl_ms = parse_positive_usize(next, "--cache-ttl-ms")? as u64;
+            index += 2;
+            continue;
+        }
+        if let Some(value) = token.strip_prefix("--cache-ttl-ms=") {
+            cache_ttl_ms = parse_positive_usize(value, "--cache-ttl-ms")? as u64;
+            index += 1;
+            continue;
+        }
+        if let Some(value) = token.strip_prefix("--cache=") {
+            cache = match value {
+                "on" => true,
+                "off" => false,
+                _ => {
+                    return Err(SparkshellError::InvalidArgs(
+                        "--cache must be on or off".to_string(),
+                    ))
+                }
+            };
             index += 1;
             continue;
         }
@@ -301,6 +354,9 @@ fn parse_input(args: &[String]) -> Result<SparkShellOptions, SparkshellError> {
         budget,
         team,
         worker,
+        since_last,
+        cache,
+        cache_ttl_ms,
     })
 }
 
@@ -404,6 +460,127 @@ fn optional_json_string(value: &Option<String>) -> String {
         .as_ref()
         .map(|value| json_str(value))
         .unwrap_or_else(|| "null".to_string())
+}
+
+fn cache_dir() -> PathBuf {
+    std::env::var("OMX_SPARKSHELL_CACHE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::env::var("OMX_TEAM_STATE_ROOT")
+                .map(|root| PathBuf::from(root).join("../cache/sparkshell"))
+                .unwrap_or_else(|_| PathBuf::from(".omx/cache/sparkshell"))
+        })
+}
+
+fn handle_cache(
+    options: &SparkShellOptions,
+    output: &CommandOutput,
+    current_hash: &str,
+) -> Result<Option<CacheMeta>, SparkshellError> {
+    if !options.cache {
+        return Ok(None);
+    }
+    let key = match &options.target {
+        SparkShellTarget::TmuxPane { pane_id, .. } => {
+            format!("pane-{}", pane_id.replace('%', "pct"))
+        }
+        SparkShellTarget::Command(_) => return Ok(None),
+    };
+    let dir = cache_dir();
+    fs::create_dir_all(&dir)?;
+    handle_cache_at_path(
+        &dir.join(format!("{key}.txt")),
+        output,
+        current_hash,
+        options.cache_ttl_ms,
+    )
+}
+
+fn handle_cache_at_path(
+    path: &Path,
+    output: &CommandOutput,
+    current_hash: &str,
+    ttl_ms: u64,
+) -> Result<Option<CacheMeta>, SparkshellError> {
+    let now = now_ms();
+    let current = combined_text(output);
+    let mut previous_hash = None;
+    let mut cache_hit = false;
+    let mut changed_line_ranges = Vec::new();
+    if let Ok(previous) = fs::read_to_string(path) {
+        let mut parts = previous.splitn(3, '\n');
+        let timestamp = parts
+            .next()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0);
+        let old_hash = parts.next().unwrap_or("").to_string();
+        let old_body = parts.next().unwrap_or("");
+        if now.saturating_sub(timestamp) <= ttl_ms {
+            previous_hash = Some(old_hash.clone());
+            cache_hit = old_hash == current_hash;
+            if !cache_hit {
+                changed_line_ranges = changed_ranges(old_body, &current);
+            }
+        }
+    }
+    fs::write(path, format!("{now}\n{current_hash}\n{current}"))?;
+    Ok(Some(CacheMeta {
+        cache_hit,
+        previous_hash,
+        current_hash: current_hash.to_string(),
+        changed_line_ranges,
+    }))
+}
+
+fn since_last_summary(output: &CommandOutput, cache: Option<&CacheMeta>, budget: usize) -> String {
+    let Some(cache) = cache else {
+        return compact_text(&combined_text(output), budget);
+    };
+    if cache.cache_hit {
+        return "unchanged since previous observation".to_string();
+    }
+    if cache.changed_line_ranges.is_empty() {
+        return compact_text(&combined_text(output), budget);
+    }
+    let text = combined_text(output);
+    let lines: Vec<&str> = text.lines().collect();
+    let mut selected = Vec::new();
+    for range in &cache.changed_line_ranges {
+        if let Some((start, end)) = range.split_once('-') {
+            if let (Ok(start), Ok(end)) = (start.parse::<usize>(), end.parse::<usize>()) {
+                for line in lines
+                    .iter()
+                    .skip(start.saturating_sub(1))
+                    .take(end.saturating_sub(start).saturating_add(1))
+                {
+                    selected.push((*line).to_string());
+                }
+            }
+        }
+    }
+    if selected.is_empty() {
+        compact_text(&combined_text(output), budget)
+    } else {
+        compact_text(
+            &format!(
+                "new findings since last observation:\n{}",
+                selected.join("\n")
+            ),
+            budget,
+        )
+    }
+}
+
+fn changed_ranges(old: &str, new: &str) -> Vec<String> {
+    let old_count = old.lines().count();
+    let new_count = new.lines().count();
+    if new_count > old_count {
+        vec![format!("{}-{}", old_count + 1, new_count)]
+    } else if old != new {
+        vec!["1-*".to_string()]
+    } else {
+        Vec::new()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -591,6 +768,7 @@ fn write_json_report(
     output: &CommandOutput,
     summary: &str,
     evidence: &Evidence,
+    cache: Option<CacheMeta>,
 ) -> Result<(), SparkshellError> {
     let mode = match options.target {
         SparkShellTarget::Command(_) => "command",
@@ -611,6 +789,17 @@ fn write_json_report(
         .tail_lines
         .map(|value| value.to_string())
         .unwrap_or_else(|| "null".to_string());
+    let cache_json = cache
+        .map(|cache| {
+            format!(
+                "{{\"cache_hit\":{},\"previous_hash\":{},\"current_hash\":{},\"changed_line_ranges\":{}}}",
+                cache.cache_hit,
+                optional_json_string(&cache.previous_hash),
+                json_str(&cache.current_hash),
+                json_string_array(&cache.changed_line_ranges),
+            )
+        })
+        .unwrap_or_else(|| "null".to_string());
     let json = format!(
         concat!(
             "{{\n",
@@ -624,7 +813,8 @@ fn write_json_report(
             "  \"evidence\": {{\"stdout_lines\":{},\"stderr_lines\":{},\"raw_hash\":{},\"pane_id\":{},\"tail_lines\":{},\"line_range\":{}}},\n",
             "  \"next_action\": {},\n",
             "  \"confidence\": {:.2},\n",
-            "  \"classification\": {}\n",
+            "  \"classification\": {},\n",
+            "  \"cache\": {}\n",
             "}}\n"
         ),
         output.status.success(),
@@ -643,6 +833,7 @@ fn write_json_report(
         json_str(&diagnostics.next_action),
         diagnostics.confidence,
         json_str(&diagnostics.classification),
+        cache_json,
     );
     io::stdout().write_all(json.as_bytes())?;
     Ok(())

--- a/crates/omx-sparkshell/src/prompt.rs
+++ b/crates/omx-sparkshell/src/prompt.rs
@@ -1,4 +1,5 @@
 use crate::exec::CommandOutput;
+use crate::redaction::redact_output;
 use std::borrow::Cow;
 use std::env;
 use std::path::Path;
@@ -111,8 +112,10 @@ fn command_basename(command: &str) -> Cow<'_, str> {
 pub fn build_summary_prompt(command: &[String], output: &CommandOutput) -> String {
     let executable = command.first().map(String::as_str).unwrap_or("unknown");
     let family = select_command_family(executable);
-    let stdout_text = output.stdout_text();
-    let stderr_text = output.stderr_text();
+    let redacted = redact_output(output);
+    let safe_output = &redacted.output;
+    let stdout_text = safe_output.stdout_text();
+    let stderr_text = safe_output.stderr_text();
     let stdout_lines = count_lines(&stdout_text);
     let stderr_lines = count_lines(&stderr_text);
     let stdout_excerpt = truncate_for_prompt(&stdout_text, "stdout");
@@ -141,7 +144,7 @@ pub fn build_summary_prompt(command: &[String], output: &CommandOutput) -> Strin
         family_pattern = family.pattern,
         family_description = family.description,
         family_what_it_does = family.what_it_does,
-        exit_code = output.exit_code(),
+        exit_code = safe_output.exit_code(),
         stdout_lines = stdout_lines,
         stdout_bytes = stdout_text.len(),
         stderr_lines = stderr_lines,
@@ -306,6 +309,25 @@ mod tests {
         assert!(prompt.contains("Command family: git"));
         assert!(prompt.contains("<<<STDOUT"));
         assert!(prompt.contains("<<<STDERR"));
+    }
+
+    #[test]
+    fn prompt_redacts_secret_like_stdout_and_stderr_before_embedding() {
+        let output = CommandOutput {
+            status: ok_status(),
+            stdout: b"API_TOKEN=super-secret\nsk-prod-secret\nvisible\n".to_vec(),
+            stderr: b"Authorization: Bearer bearer-secret\nghp_secret\n".to_vec(),
+        };
+
+        let prompt = build_summary_prompt(&["env".into()], &output);
+
+        assert!(prompt.contains("API_TOKEN=[REDACTED]"));
+        assert!(prompt.contains("Authorization: Bearer [REDACTED]"));
+        assert!(prompt.contains("visible"));
+        assert!(!prompt.contains("super-secret"));
+        assert!(!prompt.contains("sk-prod-secret"));
+        assert!(!prompt.contains("bearer-secret"));
+        assert!(!prompt.contains("ghp_secret"));
     }
 
     #[test]

--- a/crates/omx-sparkshell/src/redaction.rs
+++ b/crates/omx-sparkshell/src/redaction.rs
@@ -1,0 +1,98 @@
+use crate::exec::CommandOutput;
+
+#[derive(Debug, Clone)]
+pub(crate) struct RedactedOutput {
+    pub(crate) output: CommandOutput,
+    pub(crate) count: usize,
+}
+
+pub(crate) fn redact_output(output: &CommandOutput) -> RedactedOutput {
+    let (stdout, stdout_count) = redact_bytes(&output.stdout);
+    let (stderr, stderr_count) = redact_bytes(&output.stderr);
+    RedactedOutput {
+        output: CommandOutput {
+            status: output.status,
+            stdout,
+            stderr,
+        },
+        count: stdout_count + stderr_count,
+    }
+}
+
+fn redact_bytes(bytes: &[u8]) -> (Vec<u8>, usize) {
+    let (text, count) = redact_text(&String::from_utf8_lossy(bytes));
+    (text.into_bytes(), count)
+}
+
+fn redact_text(text: &str) -> (String, usize) {
+    let mut count = 0;
+    let mut lines = Vec::new();
+    for line in text.lines() {
+        let mut redacted = line.to_string();
+        let lower = redacted.to_ascii_lowercase();
+        if lower.contains("authorization: bearer ") {
+            redacted = "Authorization: Bearer [REDACTED]".to_string();
+            count += 1;
+        }
+        if let Some(eq) = redacted.find('=') {
+            let key = redacted[..eq].to_ascii_lowercase();
+            if key.contains("token") || key.contains("key") || key.contains("secret") {
+                redacted = format!("{}=[REDACTED]", &redacted[..eq]);
+                count += 1;
+            }
+        }
+        for marker in ["sk-", "ghp_", "xoxb-"] {
+            if let Some(start) = redacted.find(marker) {
+                let end = redacted[start..]
+                    .find(char::is_whitespace)
+                    .map(|offset| start + offset)
+                    .unwrap_or(redacted.len());
+                redacted.replace_range(start..end, "[REDACTED]");
+                count += 1;
+            }
+        }
+        lines.push(redacted);
+    }
+    let mut rendered = lines.join("\n");
+    if text.ends_with('\n') {
+        rendered.push('\n');
+    }
+    (rendered, count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_output;
+    use crate::exec::CommandOutput;
+    use std::process::Command;
+
+    fn ok_status() -> std::process::ExitStatus {
+        Command::new("sh")
+            .arg("-c")
+            .arg("exit 0")
+            .status()
+            .expect("status")
+    }
+
+    #[test]
+    fn redacts_secret_like_stdout_and_stderr() {
+        let output = CommandOutput {
+            status: ok_status(),
+            stdout: b"API_TOKEN=secret-value\nplain\nsk-live123\n".to_vec(),
+            stderr: b"Authorization: Bearer bearer-secret\nghp_secret123\n".to_vec(),
+        };
+
+        let redacted = redact_output(&output);
+        let stdout = String::from_utf8(redacted.output.stdout).expect("stdout utf8");
+        let stderr = String::from_utf8(redacted.output.stderr).expect("stderr utf8");
+
+        assert_eq!(redacted.count, 4);
+        assert!(stdout.contains("API_TOKEN=[REDACTED]"));
+        assert!(stdout.contains("[REDACTED]"));
+        assert!(stderr.contains("Authorization: Bearer [REDACTED]"));
+        assert!(!stdout.contains("secret-value"));
+        assert!(!stdout.contains("sk-live123"));
+        assert!(!stderr.contains("bearer-secret"));
+        assert!(!stderr.contains("ghp_secret123"));
+    }
+}

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -534,3 +534,51 @@ fn json_mode_reports_failed_command_details() {
     assert!(stdout.contains("\"exit_code\": 9"));
     assert!(stdout.contains("bad"));
 }
+
+#[test]
+fn json_mode_classifies_auth_errors() {
+    let output = Command::new(sparkshell_bin())
+        .arg("--json")
+        .arg("sh")
+        .arg("-c")
+        .arg("printf 'Authorization failed\n' >&2; exit 1")
+        .output()
+        .expect("run sparkshell");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"classification\": \"auth_error\""));
+    assert!(stdout.contains("authentication-like error"));
+}
+
+#[test]
+fn json_mode_reads_team_state_from_env_root() {
+    let temp = unique_temp_dir("team-state");
+    let worker_dir = temp.join("team/demo/workers/worker-1");
+    fs::create_dir_all(&worker_dir).expect("worker dir");
+    fs::write(
+        worker_dir.join("status.json"),
+        r#"{"state":"busy","task":"in_progress"}"#,
+    )
+    .expect("status");
+
+    let output = Command::new(sparkshell_bin())
+        .env("OMX_TEAM_STATE_ROOT", temp.display().to_string())
+        .arg("--json")
+        .arg("--team")
+        .arg("demo")
+        .arg("--worker")
+        .arg("worker-1")
+        .arg("sh")
+        .arg("-c")
+        .arg("printf 'quiet\n'")
+        .output()
+        .expect("run sparkshell");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"classification\": \"busy_processing\""));
+    assert!(stdout.contains("do not shutdown yet"));
+
+    let _ = fs::remove_dir_all(temp);
+}

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -496,3 +496,41 @@ fn summary_module_does_not_shell_out_to_codex() {
     assert!(!source.contains(".arg(\"exec\")"));
     assert!(!source.contains("codex exec"));
 }
+
+#[test]
+fn json_mode_emits_machine_readable_contract() {
+    let output = Command::new(sparkshell_bin())
+        .arg("--json")
+        .arg("sh")
+        .arg("-c")
+        .arg("printf 'ok\n'")
+        .output()
+        .expect("run sparkshell");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"ok\": true"));
+    assert!(stdout.contains("\"mode\": \"command\""));
+    assert!(stdout.contains("\"status\": \"ok\""));
+    assert!(stdout.contains("\"summary\":"));
+    assert!(stdout.contains("\"evidence\":"));
+    assert!(stdout.contains("\"raw_hash\":"));
+}
+
+#[test]
+fn json_mode_reports_failed_command_details() {
+    let output = Command::new(sparkshell_bin())
+        .arg("--json")
+        .arg("sh")
+        .arg("-c")
+        .arg("printf 'bad\n' >&2; exit 9")
+        .output()
+        .expect("run sparkshell");
+
+    assert_eq!(output.status.code(), Some(9));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"ok\": false"));
+    assert!(stdout.contains("\"status\": \"failed\""));
+    assert!(stdout.contains("\"exit_code\": 9"));
+    assert!(stdout.contains("bad"));
+}

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -552,6 +552,59 @@ fn json_mode_classifies_auth_errors() {
 }
 
 #[test]
+fn direct_command_preserves_child_json_flag() {
+    let temp = unique_temp_dir("child-json-flag");
+    let script = temp.join("echo-argv");
+    write_executable(
+        &script,
+        r#"#!/usr/bin/env bash
+printf '%s\n' "$@"
+"#,
+    );
+
+    let output = Command::new(sparkshell_bin())
+        .arg(script)
+        .arg("--json")
+        .arg("value")
+        .output()
+        .expect("run sparkshell");
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "--json\nvalue\n");
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[test]
+fn team_diagnostics_reads_last_turn_at_heartbeat() {
+    let temp = unique_temp_dir("last-turn-heartbeat");
+    let worker_dir = temp.join("team/demo/workers/worker-1");
+    fs::create_dir_all(&worker_dir).expect("worker dir");
+    fs::write(
+        worker_dir.join("heartbeat.json"),
+        r#"{"last_turn_at":"1970-01-01T00:00:00.000Z"}"#,
+    )
+    .expect("heartbeat");
+
+    let output = Command::new(sparkshell_bin())
+        .env("OMX_TEAM_STATE_ROOT", temp.display().to_string())
+        .arg("--json")
+        .arg("--team")
+        .arg("demo")
+        .arg("--worker")
+        .arg("worker-1")
+        .arg("printf")
+        .arg("ok\n")
+        .output()
+        .expect("run sparkshell");
+
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("\"classification\": \"stale_heartbeat\"")
+    );
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[test]
 fn json_mode_reads_team_state_from_env_root() {
     let temp = unique_temp_dir("team-state");
     let worker_dir = temp.join("team/demo/workers/worker-1");

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -635,3 +635,58 @@ fn json_mode_reads_team_state_from_env_root() {
 
     let _ = fs::remove_dir_all(temp);
 }
+
+#[test]
+fn pane_json_cache_reports_hits_and_since_last_changes() {
+    let temp = unique_temp_dir("pane-cache");
+    let tmux = temp.join("tmux");
+    let cache = temp.join("cache");
+    let pane = temp.join("pane.txt");
+    fs::write(&pane, "line-1\nline-2\n").expect("pane");
+    write_executable(&tmux, &format!("#!/bin/sh\ncat {}\n", pane.display()));
+    let path = format!(
+        "{}:{}",
+        temp.display(),
+        env::var("PATH").unwrap_or_default()
+    );
+
+    let first = Command::new(sparkshell_bin())
+        .env("PATH", &path)
+        .env("OMX_SPARKSHELL_CACHE_DIR", cache.display().to_string())
+        .arg("--json")
+        .arg("--tmux-pane")
+        .arg("%31")
+        .output()
+        .expect("first");
+    assert!(first.status.success());
+    assert!(String::from_utf8_lossy(&first.stdout).contains("\"cache_hit\":false"));
+
+    let second = Command::new(sparkshell_bin())
+        .env("PATH", &path)
+        .env("OMX_SPARKSHELL_CACHE_DIR", cache.display().to_string())
+        .arg("--json")
+        .arg("--tmux-pane")
+        .arg("%31")
+        .output()
+        .expect("second");
+    assert!(second.status.success());
+    assert!(String::from_utf8_lossy(&second.stdout).contains("\"cache_hit\":true"));
+
+    fs::write(&pane, "line-1\nline-2\nline-3\n").expect("pane update");
+    let third = Command::new(sparkshell_bin())
+        .env("PATH", &path)
+        .env("OMX_SPARKSHELL_CACHE_DIR", cache.display().to_string())
+        .arg("--json")
+        .arg("--since-last")
+        .arg("--tmux-pane")
+        .arg("%31")
+        .output()
+        .expect("third");
+    assert!(third.status.success());
+    let stdout = String::from_utf8_lossy(&third.stdout);
+    assert!(stdout.contains("\"changed_line_ranges\":[\"3-3\"]"));
+    assert!(stdout.contains("new findings since last observation"));
+    assert!(stdout.contains("line-3"));
+
+    let _ = fs::remove_dir_all(temp);
+}

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -690,3 +690,20 @@ fn pane_json_cache_reports_hits_and_since_last_changes() {
 
     let _ = fs::remove_dir_all(temp);
 }
+
+#[test]
+fn shell_mode_executes_explicit_shell_and_redacts_json_output() {
+    let output = Command::new(sparkshell_bin())
+        .arg("--json")
+        .arg("--shell")
+        .arg("printf 'left && right\n'; printf 'Authorization: Bearer secret-token\n' >&2")
+        .output()
+        .expect("run sparkshell");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"mode\": \"shell\""));
+    assert!(stdout.contains("left && right"));
+    assert!(stdout.contains("Authorization: Bearer [REDACTED]"));
+    assert!(stdout.contains("\"redactions\": {\"count\": 1}"));
+}

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -692,6 +692,27 @@ fn pane_json_cache_reports_hits_and_since_last_changes() {
 }
 
 #[test]
+fn raw_mode_preserves_non_utf8_bytes() {
+    let temp = unique_temp_dir("raw-non-utf8");
+    let script = temp.join("raw-bytes");
+    write_executable(
+        &script,
+        r#"#!/usr/bin/env bash
+printf '\xff\xfe\n'
+"#,
+    );
+
+    let output = Command::new(sparkshell_bin())
+        .arg(script)
+        .output()
+        .expect("run sparkshell");
+
+    assert!(output.status.success());
+    assert_eq!(output.stdout, vec![0xff, 0xfe, b'\n']);
+    let _ = fs::remove_dir_all(temp);
+}
+
+#[test]
 fn shell_mode_executes_explicit_shell_and_redacts_json_output() {
     let output = Command::new(sparkshell_bin())
         .arg("--json")

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -164,6 +164,38 @@ fn summary_mode_uses_local_api_and_model_override() {
 }
 
 #[test]
+fn summary_mode_redacts_secret_like_output_before_prompt_request() {
+    let request_log = Arc::new(Mutex::new(String::new()));
+    let request_log_for_server = Arc::clone(&request_log);
+    let (base_url, server) = start_api_server(1, move |request| {
+        *request_log_for_server.lock().expect("request log") = request;
+        (200, response_json("- summary: redacted output summarized"))
+    });
+
+    let output = Command::new(sparkshell_bin())
+        .env("OMX_API_BASE_URL", base_url)
+        .env("OMX_SPARKSHELL_LINES", "1")
+        .env("CHILD_API_TOKEN", "super-secret-token")
+        .env("CHILD_BEARER", "bearer-secret-token")
+        .arg("sh")
+        .arg("-c")
+        .arg("printf 'API_TOKEN=%s\\nline-2\\n' \"$CHILD_API_TOKEN\"; printf 'Authorization: Bearer %s\\n' \"$CHILD_BEARER\" >&2")
+        .output()
+        .expect("run sparkshell");
+    server.join().expect("api server");
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("redacted output summarized"));
+
+    let request = request_log.lock().expect("request log");
+    assert!(request.contains("API_TOKEN=[REDACTED]"));
+    assert!(request.contains("Authorization: Bearer [REDACTED]"));
+    assert!(request.contains("line-2"));
+    assert!(!request.contains("super-secret-token"));
+    assert!(!request.contains("bearer-secret-token"));
+}
+
+#[test]
 fn summary_mode_injects_model_instructions_file_override() {
     let temp = unique_temp_dir("api-instructions-file");
     let instructions_file = temp.join("sparkshell-lightweight-AGENTS.md");

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -915,6 +915,30 @@ describe('exploreCommand', () => {
     }
   });
 
+  it('emits verbose telemetry when explore uses the sparkshell backend', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-sparkshell-telemetry-'));
+    try {
+      const sparkshellStub = join(wd, 'sparkshell-stub.sh');
+      const harnessStub = join(wd, 'explore-stub.sh');
+      await writeFile(sparkshellStub, `#!/bin/sh\nprintf '# Answer\\n- telemetry route\\n'\n`);
+      await writeFile(harnessStub, '#!/bin/sh\nprintf harness-should-not-run\n');
+      await chmod(sparkshellStub, 0o755);
+      await chmod(harnessStub, 0o755);
+
+      const result = runOmx(wd, ['explore', '--verbose', '--prompt', 'git log --oneline'], {
+        OMX_SPARKSHELL_BIN: sparkshellStub,
+        OMX_EXPLORE_BIN: harnessStub,
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /backend=sparkshell reason=long-output/);
+      assert.match(result.stdout, /telemetry route/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('routes qualifying read-only shell commands through sparkshell instead of the direct harness', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-explore-sparkshell-route-'));
     try {

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -399,6 +399,13 @@ describe('parseSparkShellFallbackInvocation', () => {
     );
   });
 
+  it('translates explicit shell fallback through sh -lc', () => {
+    assert.deepEqual(
+      parseSparkShellFallbackInvocation(['--shell', 'printf ok']),
+      { kind: 'command', argv: ['sh', '-lc', 'printf ok'] },
+    );
+  });
+
   it('matches the shared notification capture-pane argv contract', () => {
     const parsed = parseSparkShellFallbackInvocation(['--tmux-pane', '%12', '--tail-lines', '400']);
     assert.deepEqual(parsed, {

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -35,6 +35,8 @@ export const EXPLORE_USAGE = [
 
 const PROMPT_FLAG = '--prompt';
 const PROMPT_FILE_FLAG = '--prompt-file';
+const VERBOSE_FLAG = '--verbose';
+const JSON_FLAG = '--json';
 export const EXPLORE_BIN_ENV = EXPLORE_BIN_ENV_SHARED;
 const EXPLORE_SPARK_MODEL_ENV = 'OMX_EXPLORE_SPARK_MODEL';
 const EXPLORE_INSTRUCTIONS_FILE_ENV = 'OMX_EXPLORE_MODEL_INSTRUCTIONS_FILE';
@@ -55,11 +57,43 @@ const WINDOWS_BUILTIN_EXPLORE_HARNESS_REASON =
 export interface ParsedExploreArgs {
   prompt?: string;
   promptFile?: string;
+  verbose?: boolean;
+  json?: boolean;
 }
 
 interface ExploreHarnessCommand {
   command: string;
   args: string[];
+}
+
+interface ExploreTelemetryEvent {
+  backend: 'local-fast-path' | 'sparkshell' | 'explore-harness';
+  reason: string;
+  fallbackReason?: string;
+  elapsedMs?: number;
+}
+
+function telemetryEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.OMX_EXPLORE_VERBOSE === '1' || env.OMX_EXPLORE_JSON === '1';
+}
+
+function emitExploreTelemetry(event: ExploreTelemetryEvent, env: NodeJS.ProcessEnv = process.env): void {
+  if (!telemetryEnabled(env)) return;
+  const payload = {
+    backend: event.backend,
+    reason: event.reason,
+    fallback_reason: event.fallbackReason ?? null,
+    elapsed_ms: event.elapsedMs ?? null,
+  };
+  if (env.OMX_EXPLORE_JSON === '1') {
+    process.stderr.write(`[omx explore telemetry] ${JSON.stringify(payload)}\n`);
+    return;
+  }
+  process.stderr.write(
+    `[omx explore] backend=${payload.backend} reason=${payload.reason}`
+      + `${payload.fallback_reason ? ` fallback=${payload.fallback_reason}` : ''}`
+      + `${payload.elapsed_ms !== null ? ` elapsed_ms=${payload.elapsed_ms}` : ''}\n`,
+  );
 }
 
 
@@ -470,9 +504,19 @@ function hasPromptSource(tokens: readonly string[], flag: string): boolean {
 export function parseExploreArgs(args: readonly string[]): ParsedExploreArgs {
   let prompt: string | undefined;
   let promptFile: string | undefined;
+  let verbose = false;
+  let json = false;
 
   for (let i = 0; i < args.length; i += 1) {
     const token = args[i];
+    if (token === VERBOSE_FLAG) {
+      verbose = true;
+      continue;
+    }
+    if (token === JSON_FLAG) {
+      json = true;
+      continue;
+    }
     if (token === PROMPT_FLAG) {
       const remaining = args.slice(i + 1);
       if (remaining.length === 0 || remaining[0].startsWith('-')) {
@@ -516,6 +560,8 @@ export function parseExploreArgs(args: readonly string[]): ParsedExploreArgs {
   return {
     ...(prompt ? { prompt } : {}),
     ...(promptFile ? { promptFile } : {}),
+    ...(verbose ? { verbose } : {}),
+    ...(json ? { json } : {}),
   };
 }
 
@@ -643,9 +689,15 @@ export async function exploreCommand(args: string[]): Promise<void> {
   const parsed = parseExploreArgs(args);
   const prompt = await loadExplorePrompt(parsed);
   const cwd = process.cwd();
-  const exploreEnv = resolveExploreEnv(cwd, process.env);
+  const exploreEnv = resolveExploreEnv(cwd, {
+    ...process.env,
+    ...(parsed.verbose ? { OMX_EXPLORE_VERBOSE: '1' } : {}),
+    ...(parsed.json ? { OMX_EXPLORE_JSON: '1' } : {}),
+  });
+  const startedAt = Date.now();
   const localFastPath = await resolveExploreLocalFastPath(prompt, cwd);
   if (localFastPath) {
+    emitExploreTelemetry({ backend: 'local-fast-path', reason: `${localFastPath.kind} lookup`, elapsedMs: Date.now() - startedAt }, exploreEnv);
     if (localFastPath.kind === 'file') {
       process.stdout.write([
         `[omx explore] local fast-path used (file lookup).`,
@@ -665,6 +717,7 @@ export async function exploreCommand(args: string[]): Promise<void> {
   const sparkShellRoute = resolveExploreSparkShellRoute(prompt);
   if (sparkShellRoute) {
     try {
+      emitExploreTelemetry({ backend: 'sparkshell', reason: sparkShellRoute.reason, elapsedMs: Date.now() - startedAt }, exploreEnv);
       await runExploreViaSparkShell(sparkShellRoute, exploreEnv);
       return;
     } catch (error) {
@@ -673,6 +726,7 @@ export async function exploreCommand(args: string[]): Promise<void> {
     }
   }
 
+  emitExploreTelemetry({ backend: 'explore-harness', reason: sparkShellRoute ? 'sparkshell-fallback' : 'default', elapsedMs: Date.now() - startedAt }, exploreEnv);
   const packageRoot = getPackageRoot();
   assertBuiltinExploreHarnessSupported(process.platform, exploreEnv);
   const harness = await resolveExploreHarnessCommandWithHydration(packageRoot, exploreEnv);

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -23,9 +23,11 @@ const OMX_SPARKSHELL_INSTRUCTIONS_FILE_ENV = 'OMX_SPARKSHELL_MODEL_INSTRUCTIONS_
 
 export const SPARKSHELL_USAGE = [
   'Usage: omx sparkshell <command> [args...]',
+  '   or: omx sparkshell [--json] [--budget <chars>] <command> [args...]',
+  '   or: omx sparkshell --shell \'<shell command>\'',
   '   or: omx sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]',
-  'Runs the native omx-sparkshell sidecar with direct argv execution or explicit tmux pane summarization.',
-  'Shell metacharacters such as pipes and redirects are not interpreted in v1.',
+  'Runs the native omx-sparkshell sidecar with direct argv execution, explicit shell execution, or explicit tmux pane summarization.',
+  'Shell metacharacters are interpreted only with explicit --shell opt-in.',
   'Tmux pane mode is explicit opt-in and captures a larger pane tail before applying raw-vs-summary behavior.',
 ].join('\n');
 
@@ -235,7 +237,12 @@ export function parseSparkShellFallbackInvocation(args: readonly string[]): Spar
     throw new Error(`Missing command to run.\n${SPARKSHELL_USAGE}`);
   }
 
-  if (args[0] !== '--tmux-pane' && !args[0]?.startsWith('--tmux-pane=')) {
+  if (args[0] === '--shell' || args[0]?.startsWith('--shell=')) {
+    return { kind: 'command', argv: [...args] };
+  }
+
+  const paneStart = args.findIndex((arg) => arg === '--tmux-pane' || arg.startsWith('--tmux-pane='));
+  if (paneStart < 0) {
     return { kind: 'command', argv: [...args] };
   }
 

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -237,8 +237,15 @@ export function parseSparkShellFallbackInvocation(args: readonly string[]): Spar
     throw new Error(`Missing command to run.\n${SPARKSHELL_USAGE}`);
   }
 
-  if (args[0] === '--shell' || args[0]?.startsWith('--shell=')) {
-    return { kind: 'command', argv: [...args] };
+  if (args[0] === '--shell') {
+    const script = args[1];
+    if (!script) throw new Error(`--shell requires a command string.\n${SPARKSHELL_USAGE}`);
+    return { kind: 'command', argv: ['sh', '-lc', script] };
+  }
+  if (args[0]?.startsWith('--shell=')) {
+    const script = args[0].slice('--shell='.length);
+    if (!script.trim()) throw new Error(`--shell requires a command string.\n${SPARKSHELL_USAGE}`);
+    return { kind: 'command', argv: ['sh', '-lc', script] };
   }
 
   const paneStart = args.findIndex((arg) => arg === '--tmux-pane' || arg.startsWith('--tmux-pane='));


### PR DESCRIPTION
## Why

Operational pane and command output can contain tokens, API keys, auth headers, or endpoint secrets. At the same time, users sometimes need shell syntax such as pipes and `&&`, but the current argv-only behavior deliberately does not interpret shell metacharacters. Explore also adapts to the sparkshell backend, but operators need to know when and why that happened.

## Intent

This PR makes the convenience/safety boundary explicit:

- default execution remains argv-only;
- shell parsing is available only through explicit `--shell`;
- secret-like output is redacted before summary/JSON emission;
- explore can emit backend telemetry for debugging routing decisions.

## What changed

- Added `--shell` to the native sidecar using explicit `bash -lc` opt-in.
- Added redaction for Authorization bearer headers, env-style token/key/secret assignments, and common token prefixes.
- Reports redaction count in JSON output.
- Updates CLI help text to document `--shell` and JSON usage.
- Allows the JS fallback path to preserve new sparkshell flags instead of treating them as unexpected tmux commands.
- Adds explore `--verbose` / `--json` telemetry for backend choice, reason, fallback reason, and elapsed time.
- Added regression coverage for shell execution, redaction, and explore telemetry.

## Verification

- `npm run build`
- `cargo test -p omx-sparkshell --quiet`
- `node --test dist/cli/__tests__/sparkshell-cli.test.js dist/cli/__tests__/explore.test.js`

## Notes

`--shell` is intentionally opt-in because shell parsing changes the injection-risk boundary. The default argv-only path remains the safer default.
