### PR TITLE
Fix notify dispatcher recursive previousNotify forks

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -347,6 +347,69 @@ describe("notify setup scope", () => {
 		}
 	});
 
+	it("repairs reporter-shaped SkyComputerUseClient dispatcher metadata on rerun", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-reporter-wrapper-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await mkdir(codexHomeDir, { recursive: true });
+				const metadataPath = join(
+					codexHomeDir,
+					".omx",
+					"notify-dispatch.json",
+				);
+				const stalePkgRoot = join(wd, "pkg-without-managed-name");
+				const staleDispatcher = join(
+					stalePkgRoot,
+					"dist",
+					"scripts",
+					"notify-dispatcher.js",
+				);
+				const staleTurnEndedWrapper = join(wd, "SkyComputerUseClient");
+				await mkdir(dirname(metadataPath), { recursive: true });
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					`notify = ["node", "${staleDispatcher}", "--metadata", "${metadataPath}"]
+approval_policy = "on-failure"
+`,
+				);
+				await writeFile(
+					metadataPath,
+					JSON.stringify({
+						managedBy: "oh-my-codex",
+						version: 1,
+						previousNotify: [
+							staleTurnEndedWrapper,
+							"turn-ended",
+							"--previous-notify",
+							JSON.stringify([
+								"node",
+								staleDispatcher,
+								"--metadata",
+								metadataPath,
+							]),
+						],
+						omxNotify: [
+							"node",
+							join(stalePkgRoot, "dist", "scripts", "notify-hook.js"),
+						],
+						dispatcherNotify: ["node", staleDispatcher, "--metadata", metadataPath],
+					}),
+				);
+
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.match(config, /^notify = \["node", ".*notify-hook\.js"\]$/m);
+				assert.doesNotMatch(config, /notify-dispatcher\.js/);
+				assert.doesNotMatch(config, /SkyComputerUseClient/);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("does not wrap stale global OMX notify hooks as user notify commands", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-stale-hook-notify-"));
 		try {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -332,12 +332,27 @@ function getPreviousNotifyWrapperValue(
   return undefined;
 }
 
+function isOmxDispatcherMetadataCommand(command: readonly string[] | null | undefined): boolean {
+  if (!command) return false;
+  const entrypoint = resolveNotifyEntrypoint(command);
+  if (!entrypoint || !/(?:^|[\\/])notify-dispatcher\.js$/.test(entrypoint)) {
+    return false;
+  }
+  const metadataIndex = command.indexOf("--metadata");
+  const metadataPath = metadataIndex >= 0 ? command[metadataIndex + 1] : undefined;
+  return typeof metadataPath === "string" && /(?:^|[\\/])(?:\.omx[\\/])?notify-dispatch\.json$/.test(metadataPath);
+}
+
 function isOmxManagedPayloadText(value: string): boolean {
-  return (
+  const containsManagedPackageNotify =
     /(?:^|[\\/])notify-(?:hook|dispatcher)\.js(?:\s|$|["'])/.test(
       value,
-    ) && /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(value)
-  );
+    ) && /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(value);
+  const containsDispatcherMetadataNotify =
+    /(?:^|[\\/])notify-dispatcher\.js(?:\s|$|["'])/.test(value) &&
+    /--metadata(?:\s|=)/.test(value) &&
+    /(?:^|[\\/])(?:\.omx[\\/])?notify-dispatch\.json(?:\s|$|["'])/.test(value);
+  return containsManagedPackageNotify || containsDispatcherMetadataNotify;
 }
 
 function parseJsonString(value: string): unknown | undefined {
@@ -370,6 +385,7 @@ function containsOmxManagedNotifyPayload(
       const nestedCommand = value as string[];
       return (
         isOmxManagedNotifyCommand(nestedCommand, pkgRoot) ||
+        isOmxDispatcherMetadataCommand(nestedCommand) ||
         isOmxManagedPreviousNotifyWrapper(nestedCommand, pkgRoot)
       );
     }
@@ -408,6 +424,7 @@ export function isOmxManagedNotifyCommand(
   pkgRoot?: string,
 ): boolean {
   if (!command) return false;
+  if (isOmxDispatcherMetadataCommand(command)) return true;
   const entrypoint = resolveNotifyEntrypoint(command);
   if (!entrypoint) return false;
   if (!/(?:^|[\\/])notify-(?:hook|dispatcher)\.js$/.test(entrypoint)) {

--- a/src/scripts/__tests__/notify-dispatcher.test.ts
+++ b/src/scripts/__tests__/notify-dispatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { chmodSync, existsSync } from "node:fs";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -260,6 +260,54 @@ describe("notify dispatcher previousNotify guard", () => {
 
 			assert.equal(existsSync(stalePreviousMarker), false);
 			assert.equal(readFileSync(omxMarker, "utf-8"), "ran");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("skips reporter-shaped SkyComputerUseClient previousNotify dispatcher recursion", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-reporter-wrapper-"));
+		try {
+			const pkgScripts = join(wd, "pkg-without-managed-name", "dist", "scripts");
+			mkdirSync(pkgScripts, { recursive: true });
+			const stalePreviousMarker = join(wd, "skycomputer-ran");
+			const omxMarker = join(wd, "omx-ran");
+			const dispatcher = join(pkgScripts, "notify-dispatcher.js");
+			const turnEndedWrapper = join(wd, "SkyComputerUseClient");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(dispatcher, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(stalePreviousMarker)}, "dispatcher");\n`);
+			writeFileSync(
+				turnEndedWrapper,
+				`#!/usr/bin/env node\nimport { appendFileSync } from "node:fs"; appendFileSync(${JSON.stringify(stalePreviousMarker)}, "wrapper\\n");\n`,
+			);
+			chmodSync(turnEndedWrapper, 0o755);
+			writeFileSync(omxHook, `import { appendFileSync } from "node:fs"; appendFileSync(${JSON.stringify(omxMarker)}, "omx\\n");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(
+				metadataPath,
+				JSON.stringify({
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: [
+						turnEndedWrapper,
+						"turn-ended",
+						"--previous-notify",
+						JSON.stringify([
+							"node",
+							dispatcher,
+							"--metadata",
+							metadataPath,
+						]),
+					],
+					omxNotify: [process.execPath, omxHook],
+					dispatcherNotify: ["node", dispatcher, "--metadata", metadataPath],
+				}),
+			);
+
+			runDispatcher(metadataPath);
+
+			assert.equal(existsSync(stalePreviousMarker), false);
+			assert.equal(readFileSync(omxMarker, "utf-8"), "omx\n");
 		} finally {
 			rmSync(wd, { recursive: true, force: true });
 		}

--- a/src/scripts/notify-dispatcher.ts
+++ b/src/scripts/notify-dispatcher.ts
@@ -77,12 +77,27 @@ function isOmxManagedNotifyCommand(command: readonly string[] | null | undefined
 	return /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(entrypoint);
 }
 
+function isOmxDispatcherMetadataCommand(command: readonly string[] | null | undefined): boolean {
+	if (!command) return false;
+	const entrypoint = resolveNotifyEntrypoint(command);
+	if (!entrypoint || !/(?:^|[\\/])notify-dispatcher\.js$/.test(entrypoint)) {
+		return false;
+	}
+	const metadataIndex = command.indexOf("--metadata");
+	const metadataPath = metadataIndex >= 0 ? command[metadataIndex + 1] : undefined;
+	return typeof metadataPath === "string" && /(?:^|[\\/])(?:\.omx[\\/])?notify-dispatch\.json$/.test(metadataPath);
+}
+
 function isOmxManagedPayloadText(value: string): boolean {
-	return (
+	const containsManagedPackageNotify =
 		/(?:^|[\\/])notify-(?:hook|dispatcher)\.js(?:\s|$|["'])/.test(
 			value,
-		) && /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(value)
-	);
+		) && /(?:^|[\\/])oh-my-codex(?:[\\/]|$)/.test(value);
+	const containsDispatcherMetadataNotify =
+		/(?:^|[\\/])notify-dispatcher\.js(?:\s|$|["'])/.test(value) &&
+		/--metadata(?:\s|=)/.test(value) &&
+		/(?:^|[\\/])(?:\.omx[\\/])?notify-dispatch\.json(?:\s|$|["'])/.test(value);
+	return containsManagedPackageNotify || containsDispatcherMetadataNotify;
 }
 
 function parseJsonString(value: string): unknown | undefined {
@@ -111,6 +126,7 @@ function containsOmxManagedNotifyPayload(value: unknown, depth = 0): boolean {
 			const command = value as string[];
 			return (
 				isOmxManagedNotifyCommand(command) ||
+				isOmxDispatcherMetadataCommand(command) ||
 				isOmxManagedPreviousNotifyWrapper(command)
 			);
 		}
@@ -147,6 +163,7 @@ function isManagedPreviousNotify(
 ): boolean {
 	return (
 		isOmxManagedNotifyCommand(previousNotify) ||
+		isOmxDispatcherMetadataCommand(previousNotify) ||
 		isOmxManagedPreviousNotifyWrapper(previousNotify) ||
 		sameCommand(previousNotify, metadata?.omxNotify) ||
 		sameCommand(previousNotify, metadata?.dispatcherNotify)


### PR DESCRIPTION
## Summary
- Treat `notify-dispatcher.js --metadata ...notify-dispatch.json` as OMX-managed even when it appears inside a SkyComputerUseClient/codex `turn-ended --previous-notify` wrapper.
- Apply the same sanitizer behavior during setup reruns so v0.17.3-style metadata is repaired instead of preserved as user notify.
- Add reporter-shaped regressions proving the wrapped previous notify is skipped and `omxNotify` still runs exactly once.

Fixes #2373.

## Verification
- `npm run build`
- `node --test dist/scripts/__tests__/notify-dispatcher.test.js dist/cli/__tests__/setup-install-mode.test.js`
- `npm run lint`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
