### PR TITLE
Fix autoresearch-goal Stop reconciliation loops

### DIFF
--- a/src/cli/__tests__/autoresearch-goal.test.ts
+++ b/src/cli/__tests__/autoresearch-goal.test.ts
@@ -184,7 +184,7 @@ describe('cli/autoresearch-goal', () => {
   });
 
   it('requires matching complete Codex goal proof for completion', async () => {
-    await withCwd(async () => {
+    await withCwd(async (cwd) => {
       await capture(() => autoresearchGoalCommand([
         'create',
         '--topic', 'Research goal snapshots',
@@ -209,6 +209,31 @@ describe('cli/autoresearch-goal', () => {
       assert.equal(incomplete.exitCode, 1);
       assert.match(incomplete.stderr.join('\n'), /objective mismatch/);
       assert.match(incomplete.stderr.join('\n'), /not complete/);
+
+      const mismatched = await capture(() => autoresearchGoalCommand([
+        'complete',
+        '--slug', 'research-goal-snapshots',
+        '--codex-goal-json', '{"goal":{"objective":"Autoresearch goal: Different completed mission","status":"complete"}}',
+      ]));
+
+      assert.equal(mismatched.exitCode, 1);
+      assert.match(mismatched.stderr.join('\n'), /objective mismatch/);
+
+      const completion = JSON.parse(
+        await readFile(join(cwd, '.omx/goals/autoresearch/research-goal-snapshots/completion.json'), 'utf-8'),
+      ) as {
+        verdict: string;
+        passed: boolean;
+        codex_goal_reconciliation?: unknown;
+      };
+      assert.equal(completion.verdict, 'pass');
+      assert.equal(completion.passed, true);
+      assert.equal(completion.codex_goal_reconciliation, undefined);
+
+      const mission = JSON.parse(
+        await readFile(join(cwd, '.omx/goals/autoresearch/research-goal-snapshots/mission.json'), 'utf-8'),
+      ) as { status: string };
+      assert.equal(mission.status, 'passed');
     });
   });
 });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1704,6 +1704,71 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("does not repeat Stop block when the last autoresearch-goal completion attempt reported objective mismatch", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autoresearch-mismatch-reported-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "goals", "autoresearch", "mismatched-mission", "mission.json"), {
+        version: 1,
+        workflow: "autoresearch-goal",
+        slug: "mismatched-mission",
+        topic: "Passing research bound to another Codex goal",
+        status: "passed",
+      });
+      await writeJson(join(cwd, ".omx", "goals", "autoresearch", "mismatched-mission", "completion.json"), {
+        verdict: "pass",
+        passed: true,
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-autoresearch-mismatch-reported-stop",
+        thread_id: "thread-autoresearch-mismatch-reported-stop",
+        last_assistant_message: [
+          "I called get_goal and ran omx autoresearch-goal complete --slug mismatched-mission --codex-goal-json /tmp/snapshot.json.",
+          "The autoresearch-goal completion failed with Codex goal objective mismatch, so I will not repeat the same complete command blindly in this thread.",
+        ].join("\n"),
+      }, { cwd });
+
+      assert.notEqual(result.outputJson?.decision, "block");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /autoresearch-goal complete --slug mismatched-mission/);
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /get_goal snapshot reconciliation/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("still blocks later autoresearch-goal completion claims after an objective mismatch if no mismatch is reported in the final answer", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autoresearch-mismatch-later-retry-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "goals", "autoresearch", "retryable-mission", "mission.json"), {
+        version: 1,
+        workflow: "autoresearch-goal",
+        slug: "retryable-mission",
+        topic: "Passing research that can still retry with the correct snapshot",
+        status: "passed",
+      });
+      await writeJson(join(cwd, ".omx", "goals", "autoresearch", "retryable-mission", "completion.json"), {
+        verdict: "pass",
+        passed: true,
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-autoresearch-mismatch-later-retry-stop",
+        thread_id: "thread-autoresearch-mismatch-later-retry-stop",
+        last_assistant_message: "Autoresearch goal complete; next call update_goal({status: \"complete\"}).",
+      }, { cwd });
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /get_goal snapshot reconciliation/);
+      assert.match(JSON.stringify(result.outputJson), /omx autoresearch-goal complete --slug retryable-mission/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("treats workflow keywords in native subagent prompt text as literal delegation text", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-subagent-keyword-literal-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1889,6 +1889,12 @@ export function looksLikeGoalCompletionPrompt(text: string): boolean {
     || /(?:^|[.!?]\s+)(?:the\s+)?goal\s+(?:is\s+|now\s+|has\s+been\s+)?(?:complete|completed|finished|closed)(?:\s*(?:[.!?]|$)|\s*[:;]\s*\S|\s*[—–-]\s*\S)/i.test(text);
 }
 
+function reportsAutoresearchGoalObjectiveMismatch(text: string): boolean {
+  return /\bautoresearch[-\s]goal\b/i.test(text)
+    && /\b(?:complete|completion|reconciliation)\b/i.test(text)
+    && /objective mismatch/i.test(text);
+}
+
 async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Promise<{ workflow: string; command: string; remediation?: string } | null> {
   const ultragoal = await readJsonIfExists(join(cwd, ".omx", "ultragoal", "goals.json"));
   const aggregateCompletion = safeObject(ultragoal?.aggregateCompletion);
@@ -1932,10 +1938,19 @@ async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Pro
     const completion = await readJsonIfExists(join(autoresearchRoot, entry.name, "completion.json"));
     const completionVerdict = safeString(completion?.verdict);
     const completionPassed = completion?.passed === true || completionVerdict === "pass";
-    if (mission?.workflow === "autoresearch-goal" && status && status !== "complete" && completionPassed) {
+    if (
+      mission?.workflow === "autoresearch-goal"
+      && status
+      && status !== "complete"
+      && completionPassed
+    ) {
       return {
         workflow: "autoresearch-goal",
         command: `omx autoresearch-goal complete --slug ${safeString(mission.slug) || entry.name} --codex-goal-json '<get_goal JSON or path>'`,
+        remediation: [
+          "If that command fails with a Codex goal objective mismatch after a fresh get_goal snapshot, do not repeat the same complete command blindly in this thread.",
+          "Either retry with a correct fresh snapshot or record an explicit blocked verdict for this autoresearch-goal and continue it from a fresh Codex thread.",
+        ].join(" "),
       };
     }
   }
@@ -1963,6 +1978,9 @@ async function buildGoalWorkflowReconciliationStopOutput(
   if (!looksLikeGoalCompletionPrompt(lastAssistantMessage)) return null;
   const requirement = await findActiveGoalWorkflowReconciliationRequirement(cwd);
   if (!requirement) return null;
+  if (requirement.workflow === "autoresearch-goal" && reportsAutoresearchGoalObjectiveMismatch(lastAssistantMessage)) {
+    return null;
+  }
   const systemMessage =
     [
       `OMX ${requirement.workflow} requires get_goal snapshot reconciliation before completion; call get_goal and pass --codex-goal-json to ${requirement.command}.`,


### PR DESCRIPTION
## Summary

Fix autoresearch-goal Stop hook loops without treating one arbitrary `--codex-goal-json` input as durable proof.

This mirrors the stale Stop-state class behind the Ralph session-drift fixes, but for the autoresearch-goal reconciliation gate:

- Passing autoresearch-goal missions still hard-block Stop until a `get_goal` snapshot reconciliation is attempted.
- `omx autoresearch-goal complete` remains read-only on reconciliation failure and does **not** persist objective-mismatch state from an arbitrary JSON/path input.
- If the last assistant message already reports that an autoresearch-goal completion attempt failed with `Codex goal objective mismatch`, the Stop hook does not immediately repeat the same hard block for that turn.
- A later completion-like message still blocks again, so retrying with the correct fresh `get_goal` snapshot can still succeed.
- The Stop prompt now includes explicit remediation: retry with a correct fresh snapshot, or record an explicit blocked verdict / continue from a fresh Codex thread.

## Why

In one Codex thread, a completed legacy/current goal can prevent a later autoresearch-goal from binding to Codex goal mode. If the later OMX mission is recorded as `pass`, Stop repeatedly asks for `get_goal -> omx autoresearch-goal complete`, but completion may fail with `Codex goal objective mismatch`. The loop should not re-fire immediately after the assistant reports that mismatch, but a wrong/stale snapshot must not permanently suppress future correct retries.

## Validation

- `npm run build`
- `node --test --test-name-pattern "autoresearch-goal|Autoresearch" dist/cli/__tests__/autoresearch-goal.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `node --test dist/cli/__tests__/autoresearch-goal.test.js dist/scripts/__tests__/codex-native-hook.test.js` — 316/316 pass
- `npm run check:no-unused`
- `npm run lint`
- `git diff --check`