### PR TITLE
Support local real generation compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ If `Shift+Enter` still submits instead of inserting a newline inside an OMX-mana
 - `omx sparkshell <command>` is for shell-native inspection and bounded verification
 - when `omx_wiki/` exists, `omx explore` can inject wiki-first context before falling back to broader repository search
 - fallback boundaries are explicit: sparkshell-backend fallback is reported on stderr, and spark-model fallback emits stderr metadata plus an `## OMX Explore fallback` notice in stdout so users can see when cost/behavior may differ from the low-cost path
+- sparkshell env overrides are intentionally narrow: `OMX_SPARKSHELL_BIN` selects a native sidecar path, `OMX_SPARKSHELL_MODEL` selects the primary summary model, `OMX_SPARKSHELL_FALLBACK_MODEL` selects the retry model, `OMX_SPARKSHELL_MODEL_INSTRUCTIONS_FILE` selects summary instructions, and `OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS` controls the local API summary timeout
 
 Examples:
 

--- a/crates/omx-api/src/lib.rs
+++ b/crates/omx-api/src/lib.rs
@@ -15,6 +15,7 @@ pub type Result<T> = std::result::Result<T, OmxApiError>;
 
 pub const DEFAULT_API_PORT: u16 = 14510;
 const CODEX_RESPONSES_PATH: &str = "/responses";
+const CODEX_IMAGES_GENERATIONS_PATH: &str = "/images/generations";
 const CODEX_DEFAULT_ORIGINATOR: &str = "codex_cli_rs";
 const CODEX_DEFAULT_BACKEND_BASE_PATH: &str = "/backend-api/codex";
 const CODEX_INSTALLATION_ID_HEADER: &str = "x-codex-installation-id";
@@ -635,16 +636,13 @@ fn text_response_json(
 }
 
 fn image_response(request: &Request, backend: &BackendMode) -> Response {
-    if *backend == BackendMode::RealPrivate {
-        return Response::json(
-            501,
-            json!({"error": {"message": "real-private image generation is not implemented in V1A", "type": "unsupported_request"}}),
-        );
-    }
     let body = match parse_json_body(request) {
         Ok(body) => body,
         Err(response) => return response,
     };
+    if *backend == BackendMode::RealPrivate {
+        return real_private_image_response(&body);
+    }
     let prompt = body.get("prompt").and_then(Value::as_str).unwrap_or("");
     if body.get("stream").and_then(Value::as_bool).unwrap_or(false) {
         let mut stream = sse_event(
@@ -671,6 +669,144 @@ fn image_response(request: &Request, backend: &BackendMode) -> Response {
     )
 }
 
+fn real_private_image_response(body: &Value) -> Response {
+    match real_private_image(body) {
+        Ok(image) => image_response_json(body, "real-private", image),
+        Err((status, kind, message)) => Response::json(
+            status,
+            json!({
+                "error": {
+                    "message": message,
+                    "type": kind
+                }
+            }),
+        ),
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct GeneratedImage {
+    url: Option<String>,
+    b64_json: Option<String>,
+    revised_prompt: Option<String>,
+}
+
+fn real_private_image(
+    body: &Value,
+) -> std::result::Result<GeneratedImage, (u16, &'static str, String)> {
+    if let Some(b64_json) = env::var("OMX_API_REAL_PRIVATE_IMAGE_B64_JSON")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Ok(GeneratedImage {
+            b64_json: Some(b64_json),
+            revised_prompt: body
+                .get("prompt")
+                .and_then(Value::as_str)
+                .map(redact_secrets),
+            ..GeneratedImage::default()
+        });
+    }
+    if let Some(url) = env::var("OMX_API_REAL_PRIVATE_IMAGE_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Ok(GeneratedImage {
+            url: Some(url),
+            revised_prompt: body
+                .get("prompt")
+                .and_then(Value::as_str)
+                .map(redact_secrets),
+            ..GeneratedImage::default()
+        });
+    }
+
+    let Some(auth) = discover_codex_oauth() else {
+        return Err((
+            503,
+            "missing_auth",
+            "missing Codex OAuth token; run Codex login or set OMX_API_REAL_PRIVATE_IMAGE_B64_JSON/OMX_API_REAL_PRIVATE_IMAGE_URL for fixture smoke tests".to_string(),
+        ));
+    };
+
+    if let Some(upstream) = env::var("OMX_API_PRIVATE_IMAGE_BACKEND_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return post_codex_image_to_url(&upstream, body, &auth).map_err(|error| {
+            (
+                502,
+                "private_backend_error",
+                redact_secrets(&error.to_string()),
+            )
+        });
+    }
+
+    if let Some(upstream) = env::var("OMX_API_PRIVATE_BACKEND_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return post_codex_image_via_responses_to_url(&upstream, body, &auth).map_err(|error| {
+            (
+                502,
+                "private_backend_error",
+                redact_secrets(&error.to_string()),
+            )
+        });
+    }
+
+    Err((
+        501,
+        "private_image_backend_unconfigured",
+        "real-private OAuth was found, but neither OMX_API_PRIVATE_IMAGE_BACKEND_URL nor OMX_API_PRIVATE_BACKEND_URL is configured for image generation".to_string(),
+    ))
+}
+
+fn image_response_json(body: &Value, backend: &str, image: GeneratedImage) -> Response {
+    let mut item = serde_json::Map::new();
+    if let Some(url) = image.url {
+        item.insert("url".to_string(), Value::String(url));
+    }
+    if let Some(b64_json) = image.b64_json {
+        item.insert("b64_json".to_string(), Value::String(b64_json));
+    }
+    if let Some(revised_prompt) = image.revised_prompt.or_else(|| {
+        body.get("prompt")
+            .and_then(Value::as_str)
+            .map(redact_secrets)
+    }) {
+        item.insert("revised_prompt".to_string(), Value::String(revised_prompt));
+    }
+    if item.is_empty() {
+        item.insert(
+            "url".to_string(),
+            Value::String("https://localhost.omx.invalid/private-image.png".to_string()),
+        );
+    }
+
+    if body.get("stream").and_then(Value::as_bool).unwrap_or(false) {
+        let mut stream = sse_event(
+            Some("image_generation.partial_image"),
+            &json!({"type": "image_generation.partial_image", "backend": backend, "image": item}),
+        );
+        stream.push_str(&sse_event(
+            Some("image_generation.completed"),
+            &json!({"type": "image_generation.completed", "backend": backend}),
+        ));
+        stream.push_str(&sse_done());
+        return Response::text(200, "text/event-stream", stream.into_bytes());
+    }
+
+    Response::json(
+        200,
+        json!({
+            "created": now_unix(),
+            "backend": backend,
+            "data": [Value::Object(item)]
+        }),
+    )
+}
+
 fn parse_json_body(request: &Request) -> std::result::Result<Value, Response> {
     if request.body.is_empty() {
         return Ok(json!({}));
@@ -693,6 +829,26 @@ fn extract_prompt(body: &Value) -> String {
         if let Some(text) = input.as_str() {
             return text.to_string();
         }
+        if let Some(items) = input.as_array() {
+            let text = items
+                .iter()
+                .filter_map(|item| item.get("content"))
+                .flat_map(|content| match content {
+                    Value::String(text) => vec![text.clone()],
+                    Value::Array(parts) => parts
+                        .iter()
+                        .filter_map(|part| {
+                            part.get("text").and_then(Value::as_str).map(str::to_string)
+                        })
+                        .collect::<Vec<_>>(),
+                    other => vec![other.to_string()],
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            if !text.is_empty() {
+                return text;
+            }
+        }
         return input.to_string();
     }
     if let Some(messages) = body.get("messages").and_then(Value::as_array) {
@@ -707,6 +863,9 @@ fn extract_prompt(body: &Value) -> String {
             })
             .collect::<Vec<_>>()
             .join("\n");
+    }
+    if let Some(prompt) = body.get("prompt").and_then(Value::as_str) {
+        return prompt.to_string();
     }
     String::new()
 }
@@ -822,6 +981,11 @@ fn build_codex_native_request(
         .or_else(|| env::var("OMX_API_GENERATE_MODEL").ok())
         .unwrap_or_else(|| "omx-private".to_string());
     let prompt = extract_prompt(body);
+    let tools = body.get("tools").cloned().unwrap_or_else(|| json!([]));
+    let tool_choice = body
+        .get("tool_choice")
+        .cloned()
+        .unwrap_or_else(|| json!("auto"));
     let path = normalize_codex_responses_path(upstream_path);
     let mut request_body = json!({
         "model": model,
@@ -830,8 +994,8 @@ fn build_codex_native_request(
             "role": "user",
             "content": [{"type": "input_text", "text": prompt}]
         }],
-        "tools": [],
-        "tool_choice": "auto",
+        "tools": tools,
+        "tool_choice": tool_choice,
         "parallel_tool_calls": false,
         "reasoning": body.get("reasoning").cloned().unwrap_or(Value::Null),
         "store": false,
@@ -896,6 +1060,74 @@ fn normalize_codex_responses_path(path: &str) -> String {
     }
 }
 
+fn normalize_codex_images_generations_path(path: &str) -> String {
+    let path = if path == "/" || path.is_empty() {
+        CODEX_DEFAULT_BACKEND_BASE_PATH
+    } else {
+        path.trim_end_matches('/')
+    };
+    if path.ends_with(CODEX_IMAGES_GENERATIONS_PATH) {
+        path.to_string()
+    } else {
+        format!("{path}{CODEX_IMAGES_GENERATIONS_PATH}")
+    }
+}
+
+fn build_codex_image_request(
+    upstream_path: &str,
+    body: &Value,
+    auth: &CodexOAuth,
+) -> CodexNativeRequest {
+    let model = body
+        .get("model")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| env::var("OMX_API_IMAGE_MODEL").ok())
+        .unwrap_or_else(|| "omx-private-image".to_string());
+    let prompt = body
+        .get("prompt")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let mut request_body = json!({
+        "model": model,
+        "prompt": prompt,
+        "n": body.get("n").cloned().unwrap_or_else(|| json!(1)),
+        "size": body.get("size").cloned().unwrap_or_else(|| json!("1024x1024")),
+    });
+    for key in ["quality", "response_format", "style", "user"] {
+        if let Some(value) = body.get(key).cloned() {
+            request_body[key] = value;
+        }
+    }
+
+    let mut headers = vec![
+        ("Content-Type".to_string(), "application/json".to_string()),
+        (
+            "Accept".to_string(),
+            "application/json, text/event-stream".to_string(),
+        ),
+        (
+            "Authorization".to_string(),
+            format!("Bearer {}", auth.token),
+        ),
+        (
+            "originator".to_string(),
+            CODEX_DEFAULT_ORIGINATOR.to_string(),
+        ),
+        ("User-Agent".to_string(), codex_user_agent()),
+    ];
+    if let Some(account_id) = auth.account_id.as_ref() {
+        headers.push(("ChatGPT-Account-ID".to_string(), account_id.clone()));
+    }
+
+    CodexNativeRequest {
+        path: normalize_codex_images_generations_path(upstream_path),
+        headers,
+        body: request_body,
+    }
+}
+
 fn post_codex_responses_to_url(url: &str, body: &Value, auth: &CodexOAuth) -> Result<String> {
     let parsed = parse_http_backend_url(url)?;
     let codex_request = build_codex_native_request(&parsed.path, body, auth);
@@ -919,9 +1151,7 @@ fn post_codex_responses_to_url(url: &str, body: &Value, auth: &CodexOAuth) -> Re
     stream.write_all(&payload)?;
     let mut raw = String::new();
     stream.read_to_string(&mut raw)?;
-    let (head, response_body) = raw.split_once("\r\n\r\n").ok_or_else(|| {
-        OmxApiError::Message("private backend returned malformed HTTP".to_string())
-    })?;
+    let (head, response_body) = split_http_response(&raw)?;
     let status = head
         .lines()
         .next()
@@ -934,7 +1164,220 @@ fn post_codex_responses_to_url(url: &str, body: &Value, auth: &CodexOAuth) -> Re
         )));
     }
 
-    Ok(extract_backend_text_response(response_body))
+    Ok(extract_backend_text_response(&response_body))
+}
+
+fn post_codex_image_to_url(url: &str, body: &Value, auth: &CodexOAuth) -> Result<GeneratedImage> {
+    let parsed = parse_http_backend_url(url)?;
+    let codex_request = build_codex_image_request(&parsed.path, body, auth);
+    let payload = serde_json::to_vec(&codex_request.body)?;
+    let mut stream = TcpStream::connect((parsed.host.as_str(), parsed.port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(120)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(30)))?;
+    write!(
+        stream,
+        "POST {} HTTP/1.1\r\nHost: {}:{}\r\n",
+        codex_request.path, parsed.host, parsed.port
+    )?;
+    for (name, value) in codex_request.headers {
+        write!(stream, "{name}: {value}\r\n")?;
+    }
+    write!(
+        stream,
+        "Content-Length: {}\r\nConnection: close\r\n\r\n",
+        payload.len()
+    )?;
+    stream.write_all(&payload)?;
+    let mut raw = String::new();
+    stream.read_to_string(&mut raw)?;
+    let (head, response_body) = split_http_response(&raw)?;
+    let status = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(502);
+    if !(200..300).contains(&status) {
+        return Err(OmxApiError::Message(format!(
+            "private backend returned HTTP {status}: {response_body}"
+        )));
+    }
+
+    Ok(extract_backend_image_response(&response_body))
+}
+
+fn post_codex_image_via_responses_to_url(
+    url: &str,
+    body: &Value,
+    auth: &CodexOAuth,
+) -> Result<GeneratedImage> {
+    let mut request = body.clone();
+    let prompt = body
+        .get("prompt")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    request["input"] = json!([{
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": prompt}]
+    }]);
+    request["tools"] = json!([{"type": "image_generation"}]);
+    request["tool_choice"] = json!({"type": "image_generation"});
+    request["stream"] = json!(true);
+
+    let parsed = parse_http_backend_url(url)?;
+    let codex_request = build_codex_native_request(&parsed.path, &request, auth);
+    let payload = serde_json::to_vec(&codex_request.body)?;
+    let mut stream = TcpStream::connect((parsed.host.as_str(), parsed.port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(120)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(30)))?;
+    write!(
+        stream,
+        "POST {} HTTP/1.1\r\nHost: {}:{}\r\n",
+        codex_request.path, parsed.host, parsed.port
+    )?;
+    for (name, value) in codex_request.headers {
+        write!(stream, "{name}: {value}\r\n")?;
+    }
+    write!(
+        stream,
+        "Content-Length: {}\r\nConnection: close\r\n\r\n",
+        payload.len()
+    )?;
+    stream.write_all(&payload)?;
+    let mut raw = String::new();
+    stream.read_to_string(&mut raw)?;
+    let (head, response_body) = split_http_response(&raw)?;
+    let status = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(502);
+    if !(200..300).contains(&status) {
+        return Err(OmxApiError::Message(format!(
+            "private backend returned HTTP {status}: {response_body}"
+        )));
+    }
+
+    Ok(extract_backend_image_response(&response_body))
+}
+
+fn split_http_response(raw: &str) -> Result<(String, String)> {
+    let (head, response_body) = raw.split_once("\r\n\r\n").ok_or_else(|| {
+        OmxApiError::Message("private backend returned malformed HTTP".to_string())
+    })?;
+    let body = if head.lines().any(|line| {
+        let lower = line.to_ascii_lowercase();
+        lower.starts_with("transfer-encoding:") && lower.contains("chunked")
+    }) {
+        decode_chunked_body(response_body)?
+    } else {
+        response_body.to_string()
+    };
+    Ok((head.to_string(), body))
+}
+
+fn decode_chunked_body(input: &str) -> Result<String> {
+    let bytes = input.as_bytes();
+    let mut index = 0;
+    let mut output = Vec::new();
+    loop {
+        let Some(line_end) = find_crlf(bytes, index) else {
+            return Err(OmxApiError::Message(
+                "chunked response missing chunk size".to_string(),
+            ));
+        };
+        let size_line = std::str::from_utf8(&bytes[index..line_end])
+            .map_err(|_| OmxApiError::Message("chunked response size is not UTF-8".to_string()))?;
+        let size_hex = size_line.split(';').next().unwrap_or_default().trim();
+        let size = usize::from_str_radix(size_hex, 16).map_err(|_| {
+            OmxApiError::Message(format!("invalid chunk size `{}`", redact_secrets(size_hex)))
+        })?;
+        index = line_end + 2;
+        if size == 0 {
+            break;
+        }
+        if bytes.len() < index + size + 2 {
+            return Err(OmxApiError::Message(
+                "chunked response ended mid-chunk".to_string(),
+            ));
+        }
+        output.extend_from_slice(&bytes[index..index + size]);
+        index += size;
+        if bytes.get(index..index + 2) != Some(b"\r\n") {
+            return Err(OmxApiError::Message(
+                "chunked response missing chunk terminator".to_string(),
+            ));
+        }
+        index += 2;
+    }
+    String::from_utf8(output)
+        .map_err(|_| OmxApiError::Message("chunked response body is not UTF-8".to_string()))
+}
+
+fn find_crlf(bytes: &[u8], start: usize) -> Option<usize> {
+    bytes
+        .get(start..)?
+        .windows(2)
+        .position(|chunk| chunk == b"\r\n")
+        .map(|offset| start + offset)
+}
+
+fn extract_backend_image_response(response_body: &str) -> GeneratedImage {
+    if response_body
+        .lines()
+        .any(|line| line.starts_with("event:") || line.starts_with("data:"))
+    {
+        for line in response_body.lines() {
+            let Some(data) = line.strip_prefix("data:").map(str::trim) else {
+                continue;
+            };
+            if data == "[DONE]" || data.is_empty() {
+                continue;
+            }
+            if let Ok(value) = serde_json::from_str::<Value>(data) {
+                let image = image_from_value(&value);
+                if image.url.is_some() || image.b64_json.is_some() {
+                    return image;
+                }
+            }
+        }
+    }
+
+    let value: Value = serde_json::from_str(response_body).unwrap_or_else(|_| json!({}));
+    image_from_value(&value)
+}
+
+fn image_from_value(value: &Value) -> GeneratedImage {
+    let candidate = value
+        .pointer("/data/0")
+        .or_else(|| value.pointer("/image"))
+        .or_else(|| value.pointer("/output/0"))
+        .unwrap_or(value);
+    GeneratedImage {
+        url: candidate
+            .get("url")
+            .and_then(Value::as_str)
+            .or_else(|| value.pointer("/data/0/url").and_then(Value::as_str))
+            .map(str::to_string),
+        b64_json: candidate
+            .get("b64_json")
+            .and_then(Value::as_str)
+            .or_else(|| candidate.get("b64").and_then(Value::as_str))
+            .or_else(|| value.pointer("/data/0/b64_json").and_then(Value::as_str))
+            .or_else(|| {
+                value
+                    .pointer("/partial_image")
+                    .and_then(Value::as_str)
+                    .or_else(|| value.pointer("/b64_json").and_then(Value::as_str))
+            })
+            .map(str::to_string),
+        revised_prompt: candidate
+            .get("revised_prompt")
+            .and_then(Value::as_str)
+            .map(redact_secrets),
+    }
 }
 
 fn extract_backend_text_response(response_body: &str) -> String {
@@ -1534,6 +1977,11 @@ fn run_smoke<W: Write>(args: &[String], mut stdout: W) -> Result<()> {
             }
             let body = json!({"model": "omx-private", "input": "Say OMX API smoke OK."});
             let response = real_private_text_response(&body, "response", false);
+            if !(200..300).contains(&response.status) {
+                return Err(OmxApiError::Message(
+                    String::from_utf8_lossy(&response.body).trim().to_string(),
+                ));
+            }
             writeln!(stdout, "{}", String::from_utf8_lossy(&response.body).trim())?;
             Ok(())
         }
@@ -1966,6 +2414,178 @@ mod tests {
     }
 
     #[test]
+    fn real_private_responses_stream_uses_upstream_sse() {
+        let _guard = env_lock();
+        env::remove_var("OMX_API_REAL_PRIVATE_RESPONSE_TEXT");
+        env::set_var("OMX_API_CODEX_OAUTH_TOKEN", "oauth-token");
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind private backend");
+        let addr = listener.local_addr().expect("local addr");
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut raw = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            let header_end = loop {
+                let read = stream.read(&mut buffer).expect("read request");
+                assert!(read > 0, "request closed before headers");
+                raw.extend_from_slice(&buffer[..read]);
+                if let Some(index) = raw.windows(4).position(|chunk| chunk == b"\r\n\r\n") {
+                    break index + 4;
+                }
+            };
+            let head = String::from_utf8_lossy(&raw[..header_end]).to_string();
+            let content_length = head
+                .lines()
+                .find_map(|line| line.strip_prefix("Content-Length: "))
+                .and_then(|value| value.trim().parse::<usize>().ok())
+                .expect("content length");
+            while raw.len() < header_end + content_length {
+                let read = stream.read(&mut buffer).expect("read request body");
+                assert!(read > 0, "request closed before body");
+                raw.extend_from_slice(&buffer[..read]);
+            }
+
+            let body = concat!(
+                "event: response.output_text.delta\n",
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n",
+                "data: [DONE]\n\n"
+            );
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+
+        env::set_var(
+            "OMX_API_PRIVATE_BACKEND_URL",
+            format!("http://127.0.0.1:{}/backend-api/codex", addr.port()),
+        );
+
+        let response = route_request(
+            &request("POST", "/v1/responses", json!({"stream": true})),
+            &BackendMode::RealPrivate,
+            &Telemetry::default(),
+            None,
+            None,
+        );
+
+        handle.join().expect("server thread");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.content_type, "text/event-stream");
+        let body = String::from_utf8(response.body).unwrap();
+        assert!(body.contains("response.output_text.delta"));
+        assert!(body.contains("data: [DONE]"));
+
+        env::remove_var("OMX_API_CODEX_OAUTH_TOKEN");
+        env::remove_var("OMX_API_PRIVATE_BACKEND_URL");
+    }
+
+    #[test]
+    fn real_private_image_falls_back_to_responses_image_tool() {
+        let _guard = env_lock();
+        env::remove_var("OMX_API_REAL_PRIVATE_IMAGE_B64_JSON");
+        env::remove_var("OMX_API_REAL_PRIVATE_IMAGE_URL");
+        env::remove_var("OMX_API_PRIVATE_IMAGE_BACKEND_URL");
+        env::set_var("OMX_API_CODEX_OAUTH_TOKEN", "oauth-token");
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind private backend");
+        let addr = listener.local_addr().expect("local addr");
+        let seen = Arc::new(Mutex::new(String::new()));
+        let seen_thread = Arc::clone(&seen);
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut raw_bytes = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            let header_end = loop {
+                let read = stream.read(&mut buffer).expect("read request");
+                assert!(read > 0, "request closed before headers");
+                raw_bytes.extend_from_slice(&buffer[..read]);
+                if let Some(index) = raw_bytes.windows(4).position(|chunk| chunk == b"\r\n\r\n") {
+                    break index + 4;
+                }
+            };
+            let head = String::from_utf8_lossy(&raw_bytes[..header_end]).to_string();
+            let content_length = head
+                .lines()
+                .find_map(|line| line.strip_prefix("Content-Length: "))
+                .and_then(|value| value.trim().parse::<usize>().ok())
+                .expect("content length");
+            while raw_bytes.len() < header_end + content_length {
+                let read = stream.read(&mut buffer).expect("read request body");
+                assert!(read > 0, "request closed before body");
+                raw_bytes.extend_from_slice(&buffer[..read]);
+            }
+            *seen_thread.lock().expect("seen lock") =
+                String::from_utf8_lossy(&raw_bytes).to_string();
+            let body = concat!(
+                "event: response.image_generation_call.partial_image\n",
+                "data: {\"type\":\"response.image_generation_call.partial_image\",\"partial_image\":\"ZmFrZS1pbWFnZS10b29s\"}\n\n",
+                "data: [DONE]\n\n"
+            );
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+
+        env::set_var(
+            "OMX_API_PRIVATE_BACKEND_URL",
+            format!("http://127.0.0.1:{}/backend-api/codex", addr.port()),
+        );
+        let response = route_request(
+            &request(
+                "POST",
+                "/v1/images/generations",
+                json!({"prompt": "tool image", "stream": true}),
+            ),
+            &BackendMode::RealPrivate,
+            &Telemetry::default(),
+            None,
+            None,
+        );
+
+        handle.join().expect("server thread");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.content_type, "text/event-stream");
+        let body = String::from_utf8(response.body).unwrap();
+        assert!(body.contains("image_generation.partial_image"));
+        assert!(body.contains("ZmFrZS1pbWFnZS10b29s"));
+        let raw = seen.lock().expect("seen lock").clone();
+        let forwarded_body = raw.split("\r\n\r\n").nth(1).expect("forwarded body");
+        let forwarded_json: Value = serde_json::from_str(forwarded_body).expect("forwarded JSON");
+        assert_eq!(
+            forwarded_json["tools"],
+            json!([{"type": "image_generation"}])
+        );
+        assert_eq!(
+            forwarded_json["tool_choice"],
+            json!({"type": "image_generation"})
+        );
+        assert_eq!(
+            forwarded_json["input"][0]["content"][0]["text"],
+            "tool image"
+        );
+
+        env::remove_var("OMX_API_CODEX_OAUTH_TOKEN");
+        env::remove_var("OMX_API_PRIVATE_BACKEND_URL");
+    }
+
+    #[test]
+    fn redact_secrets_handles_chunk_like_sse_frames() {
+        let chunk = "data: {\"message\":\"Bearer sk-mock-token\"}\n";
+        let redacted = redact_secrets(chunk);
+        assert!(!redacted.contains("sk-mock-token"));
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
     fn chat_stream_response_uses_chat_chunk_shape() {
         let telemetry = Telemetry::default();
         let response = route_request(
@@ -2007,8 +2627,13 @@ mod tests {
     }
 
     #[test]
-    fn real_private_image_is_unsupported_request() {
-        env::remove_var("OMX_API_REAL_PRIVATE_ALLOW");
+    fn real_private_image_reports_unconfigured_without_image_backend() {
+        let _guard = env_lock();
+        env::set_var("OMX_API_CODEX_OAUTH_TOKEN", "oauth-token");
+        env::remove_var("OMX_API_REAL_PRIVATE_IMAGE_B64_JSON");
+        env::remove_var("OMX_API_REAL_PRIVATE_IMAGE_URL");
+        env::remove_var("OMX_API_PRIVATE_IMAGE_BACKEND_URL");
+        env::remove_var("OMX_API_PRIVATE_BACKEND_URL");
         let telemetry = Telemetry::default();
         let response = route_request(
             &request("POST", "/v1/images/generations", json!({"prompt": "x"})),
@@ -2018,6 +2643,10 @@ mod tests {
             None,
         );
         assert_eq!(response.status, 501);
+        assert!(String::from_utf8(response.body)
+            .unwrap()
+            .contains("private_image_backend_unconfigured"));
+        env::remove_var("OMX_API_CODEX_OAUTH_TOKEN");
     }
 
     #[test]
@@ -2026,6 +2655,11 @@ mod tests {
         env::remove_var("OMX_API_REAL_PRIVATE_RESPONSE_TEXT");
         env::remove_var("OMX_API_CODEX_OAUTH_TOKEN");
         env::remove_var("OMX_API_PRIVATE_BACKEND_URL");
+        let previous_codex_home = env::var("CODEX_HOME").ok();
+        env::set_var(
+            "CODEX_HOME",
+            env::temp_dir().join("omx-api-test-missing-auth"),
+        );
         let telemetry = Telemetry::default();
         let response = route_request(
             &request(
@@ -2038,10 +2672,53 @@ mod tests {
             None,
             None,
         );
-        assert_eq!(response.status, 503);
-        assert_eq!(response.content_type, "application/json");
+        let status = response.status;
+        let content_type = response.content_type.clone();
         let body = String::from_utf8(response.body).unwrap();
+        if let Some(codex_home) = previous_codex_home {
+            env::set_var("CODEX_HOME", codex_home);
+        } else {
+            env::remove_var("CODEX_HOME");
+        }
+
+        assert_eq!(status, 503);
+        assert_eq!(content_type, "application/json");
         assert!(body.contains("missing_auth"));
+    }
+
+    #[test]
+    fn live_text_smoke_fails_when_private_backend_returns_error() {
+        let _guard = env_lock();
+        env::set_var("OMX_API_LIVE_SMOKE", "1");
+        env::remove_var("OMX_API_REAL_PRIVATE_RESPONSE_TEXT");
+        env::set_var("OMX_API_CODEX_OAUTH_TOKEN", "oauth-token");
+        env::remove_var("OMX_API_PRIVATE_BACKEND_URL");
+
+        let mut stdout = Vec::new();
+        let error = run_cli(["smoke", "text"], &mut stdout, Vec::new())
+            .expect_err("smoke must fail on real-private error JSON");
+
+        assert!(stdout.is_empty(), "error smoke should not write stdout");
+        assert!(error.to_string().contains("private_backend_unconfigured"));
+
+        env::remove_var("OMX_API_LIVE_SMOKE");
+        env::remove_var("OMX_API_CODEX_OAUTH_TOKEN");
+    }
+
+    #[test]
+    fn live_text_smoke_succeeds_when_response_fixture_set() {
+        let _guard = env_lock();
+        let mut stdout = Vec::new();
+        env::set_var("OMX_API_LIVE_SMOKE", "1");
+        env::set_var("OMX_API_REAL_PRIVATE_RESPONSE_TEXT", "ok-fixture-smoke");
+
+        run_cli(["smoke", "text"], &mut stdout, Vec::new()).unwrap();
+
+        env::remove_var("OMX_API_LIVE_SMOKE");
+        env::remove_var("OMX_API_REAL_PRIVATE_RESPONSE_TEXT");
+        assert!(String::from_utf8(stdout)
+            .unwrap()
+            .contains("ok-fixture-smoke"));
     }
 
     #[test]

--- a/crates/omx-api/tests/cli.rs
+++ b/crates/omx-api/tests/cli.rs
@@ -1,15 +1,117 @@
 use omx_api::{http_request, http_request_with_bearer, read_daemon_state};
 use serde_json::Value;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 fn temp_state_file(name: &str) -> std::path::PathBuf {
-    let millis = SystemTime::now()
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .as_millis();
-    std::env::temp_dir().join(format!("omx-api-{name}-{millis}.json"))
+        .as_nanos();
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "omx-api-{name}-{}-{nanos}-{counter}.json",
+        std::process::id()
+    ))
+}
+
+fn read_http_request_raw(stream: &mut std::net::TcpStream) -> String {
+    let mut raw_bytes = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    let header_end = loop {
+        let read = stream.read(&mut buffer).expect("read request");
+        assert!(read > 0, "request closed before headers");
+        raw_bytes.extend_from_slice(&buffer[..read]);
+        if let Some(index) = raw_bytes.windows(4).position(|chunk| chunk == b"\r\n\r\n") {
+            break index + 4;
+        }
+    };
+    let head = String::from_utf8_lossy(&raw_bytes[..header_end]).to_string();
+    let content_length = head
+        .lines()
+        .find_map(|line| line.strip_prefix("Content-Length: "))
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(0);
+    while raw_bytes.len() < header_end + content_length {
+        let read = stream.read(&mut buffer).expect("read body");
+        assert!(read > 0, "request closed before body");
+        raw_bytes.extend_from_slice(&buffer[..read]);
+    }
+    String::from_utf8_lossy(&raw_bytes).to_string()
+}
+
+fn fake_sse_text_response(text: &str) -> String {
+    format!(
+        "event: response.output_text.delta\ndata: {{\"type\":\"response.output_text.delta\",\"delta\":\"{text}\"}}\n\ndata: [DONE]\n\n"
+    )
+}
+
+fn real_private_once_request(
+    path: &str,
+    body: Value,
+    upstream_sse_body: String,
+) -> (String, String) {
+    let bin = env!("CARGO_BIN_EXE_omx-api");
+    let backend = TcpListener::bind(("127.0.0.1", 0)).expect("bind fake upstream");
+    let backend_port = backend.local_addr().expect("fake upstream addr").port();
+    let backend_handle = thread::spawn(move || {
+        let (mut stream, _) = backend.accept().expect("accept fake upstream request");
+        let raw = read_http_request_raw(&mut stream);
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            upstream_sse_body.len(),
+            upstream_sse_body,
+        )
+        .expect("write fake upstream response");
+        raw
+    });
+
+    let state_file = temp_state_file("real-private-e2e");
+    let mut child = Command::new(bin)
+        .args([
+            "serve",
+            "--backend",
+            "real-private",
+            "--port",
+            "0",
+            "--once",
+            "--state-file",
+            state_file.to_str().unwrap(),
+        ])
+        .env("OMX_API_CODEX_OAUTH_TOKEN", "oauth-token-for-e2e")
+        .env("OMX_API_CODEX_ACCOUNT_ID", "account-e2e")
+        .env("OMX_API_CODEX_SESSION_ID", "session-e2e")
+        .env("OMX_API_CODEX_THREAD_ID", "thread-e2e")
+        .env(
+            "OMX_API_PRIVATE_BACKEND_URL",
+            format!("http://127.0.0.1:{backend_port}/backend-api/codex"),
+        )
+        .env(
+            "OMX_API_PRIVATE_IMAGE_BACKEND_URL",
+            format!("http://127.0.0.1:{backend_port}/backend-api/codex"),
+        )
+        .env("OMX_API_IMAGE_MODEL", "omx-private-image-test")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn real-private omx-api serve");
+
+    let state = wait_for_daemon_state(&state_file, &mut child);
+    let payload = serde_json::to_vec(&body).expect("request JSON");
+    let response = http_request(&state.host, state.port, "POST", path, Some(&payload)).unwrap();
+
+    let exit = child
+        .wait_timeout(Duration::from_secs(2))
+        .expect("wait for real-private child");
+    assert!(exit.is_some(), "real-private --once server did not exit");
+    let upstream_raw = backend_handle.join().expect("fake upstream thread");
+    (response, upstream_raw)
 }
 
 fn wait_for_daemon_state(
@@ -55,6 +157,157 @@ fn binary_system_dry_run_and_generate_emit_json() {
         assert_eq!(value["ok"], true);
         assert_eq!(value["action"], format!("system.{action}"));
     }
+}
+
+#[test]
+fn binary_real_private_image_json_uses_fake_upstream_e2e() {
+    let (response, upstream_raw) = real_private_once_request(
+        "/v1/images/generations",
+        serde_json::json!({
+            "prompt": "image through upstream",
+            "size": "1024x1024"
+        }),
+        "event: image_generation.completed\ndata: {\"type\":\"image_generation.completed\",\"b64_json\":\"ZmFrZS1pbWFnZQ==\",\"revised_prompt\":\"image through upstream\"}\n\ndata: [DONE]\n\n".to_string(),
+    );
+
+    assert!(response.contains("200 OK"), "{response}");
+    let body = response.split("\r\n\r\n").nth(1).expect("response body");
+    let value: Value = serde_json::from_str(body).expect("image response JSON");
+    assert_eq!(value["backend"], "real-private");
+    assert_eq!(value["data"][0]["b64_json"], "ZmFrZS1pbWFnZQ==");
+    assert_eq!(value["data"][0]["revised_prompt"], "image through upstream");
+
+    assert!(upstream_raw.starts_with("POST /backend-api/codex/images/generations HTTP/1.1"));
+    assert!(upstream_raw.contains("Authorization: Bearer oauth-token-for-e2e\r\n"));
+    let forwarded_body = upstream_raw
+        .split("\r\n\r\n")
+        .nth(1)
+        .expect("upstream body");
+    let forwarded_json: Value = serde_json::from_str(forwarded_body).expect("upstream JSON");
+    assert_eq!(forwarded_json["model"], "omx-private-image-test");
+    assert_eq!(forwarded_json["prompt"], "image through upstream");
+    assert_eq!(forwarded_json["size"], "1024x1024");
+}
+
+#[test]
+fn binary_real_private_responses_json_uses_fake_upstream_e2e() {
+    let (response, upstream_raw) = real_private_once_request(
+        "/v1/responses",
+        serde_json::json!({
+            "model": "gpt-5.3-codex",
+            "input": "hello from integration",
+            "reasoning": {"effort": "low"},
+            "instructions": "Use fake upstream."
+        }),
+        fake_sse_text_response("upstream-text-json"),
+    );
+
+    assert!(response.contains("200 OK"), "{response}");
+    let body = response.split("\r\n\r\n").nth(1).expect("response body");
+    let value: Value = serde_json::from_str(body).expect("response JSON");
+    assert_eq!(value["object"], "response");
+    assert_eq!(value["backend"], "real-private");
+    assert_eq!(value["output_text"], "upstream-text-json");
+    assert_eq!(
+        value["choices"][0]["message"]["content"],
+        "upstream-text-json"
+    );
+
+    assert!(upstream_raw.starts_with("POST /backend-api/codex/responses HTTP/1.1"));
+    assert!(upstream_raw.contains("Accept: text/event-stream\r\n"));
+    assert!(upstream_raw.contains("Authorization: Bearer oauth-token-for-e2e\r\n"));
+    assert!(upstream_raw.contains("ChatGPT-Account-ID: account-e2e\r\n"));
+    assert!(upstream_raw.contains("originator: codex_cli_rs\r\n"));
+    let forwarded_body = upstream_raw
+        .split("\r\n\r\n")
+        .nth(1)
+        .expect("upstream body");
+    let forwarded_json: Value = serde_json::from_str(forwarded_body).expect("upstream JSON");
+    assert_eq!(forwarded_json["model"], "gpt-5.3-codex");
+    assert_eq!(forwarded_json["stream"], true);
+    assert_eq!(
+        forwarded_json["reasoning"],
+        serde_json::json!({"effort": "low"})
+    );
+    assert_eq!(forwarded_json["instructions"], "Use fake upstream.");
+    assert_eq!(forwarded_json["prompt_cache_key"], "thread-e2e");
+    assert_eq!(
+        forwarded_json["input"][0]["content"][0]["text"],
+        "hello from integration"
+    );
+}
+
+#[test]
+fn binary_real_private_responses_sse_uses_fake_upstream_e2e() {
+    let (response, upstream_raw) = real_private_once_request(
+        "/v1/responses",
+        serde_json::json!({
+            "model": "gpt-5.3-codex",
+            "input": "stream please",
+            "stream": true
+        }),
+        fake_sse_text_response("upstream-text-sse"),
+    );
+
+    assert!(response.contains("200 OK"), "{response}");
+    assert!(
+        response.contains("Content-Type: text/event-stream"),
+        "{response}"
+    );
+    assert!(response.contains("event: response.created"), "{response}");
+    assert!(
+        response.contains("event: response.output_text.delta"),
+        "{response}"
+    );
+    assert!(response.contains("upstream-text-sse"), "{response}");
+    assert!(response.contains("data: [DONE]"), "{response}");
+
+    let forwarded_body = upstream_raw
+        .split("\r\n\r\n")
+        .nth(1)
+        .expect("upstream body");
+    let forwarded_json: Value = serde_json::from_str(forwarded_body).expect("upstream JSON");
+    assert_eq!(forwarded_json["stream"], true);
+    assert_eq!(
+        forwarded_json["input"][0]["content"][0]["text"],
+        "stream please"
+    );
+}
+
+#[test]
+fn binary_real_private_chat_sse_uses_chat_chunk_shape_with_fake_upstream_e2e() {
+    let (response, upstream_raw) = real_private_once_request(
+        "/v1/chat/completions",
+        serde_json::json!({
+            "model": "gpt-5.3-codex",
+            "messages": [{"role": "user", "content": "chat through upstream"}],
+            "stream": true
+        }),
+        fake_sse_text_response("chat-upstream-text"),
+    );
+
+    assert!(response.contains("200 OK"), "{response}");
+    assert!(
+        response.contains("Content-Type: text/event-stream"),
+        "{response}"
+    );
+    assert!(
+        response.contains("\"object\":\"chat.completion.chunk\""),
+        "{response}"
+    );
+    assert!(response.contains("chat-upstream-text"), "{response}");
+    assert!(response.contains("data: [DONE]"), "{response}");
+
+    let forwarded_body = upstream_raw
+        .split("\r\n\r\n")
+        .nth(1)
+        .expect("upstream body");
+    let forwarded_json: Value = serde_json::from_str(forwarded_body).expect("upstream JSON");
+    assert_eq!(forwarded_json["stream"], true);
+    assert_eq!(
+        forwarded_json["input"][0]["content"][0]["text"],
+        "chat through upstream"
+    );
 }
 
 #[test]

--- a/crates/omx-sparkshell/src/codex_bridge.rs
+++ b/crates/omx-sparkshell/src/codex_bridge.rs
@@ -345,17 +345,85 @@ fn json_string(value: &str) -> String {
 }
 
 fn extract_output_text(body: &str) -> Option<String> {
-    extract_json_string_field(body, "output_text")
+    extract_json_string_field(body, "output_text").or_else(|| extract_response_output_text(body))
+}
+
+fn extract_response_output_text(body: &str) -> Option<String> {
+    let bytes = body.as_bytes();
+    let type_pattern = "\"type\"";
+    let mut search_start = 0;
+    let mut parts = Vec::new();
+
+    while let Some(relative_index) = body[search_start..].find(type_pattern) {
+        let type_index = search_start + relative_index;
+        let Some((value, value_end)) = extract_json_string_field_at(body, type_index, "type")
+        else {
+            search_start = type_index + type_pattern.len();
+            continue;
+        };
+        if value != "output_text" {
+            search_start = value_end;
+            continue;
+        }
+
+        let next_type = body[value_end..]
+            .find(type_pattern)
+            .map(|index| value_end + index)
+            .unwrap_or(bytes.len());
+        if let Some((text, text_end)) =
+            extract_json_string_field_before(body, value_end, next_type, "text")
+        {
+            parts.push(text);
+            search_start = text_end;
+        } else {
+            search_start = value_end;
+        }
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(""))
+    }
 }
 
 fn extract_json_string_field(body: &str, field: &str) -> Option<String> {
+    extract_json_string_field_at(body, 0, field).map(|(value, _)| value)
+}
+
+fn extract_json_string_field_before(
+    body: &str,
+    start: usize,
+    end: usize,
+    field: &str,
+) -> Option<(String, usize)> {
+    extract_json_string_field_in_range(body, start, end.min(body.len()), field)
+}
+
+fn extract_json_string_field_at(body: &str, start: usize, field: &str) -> Option<(String, usize)> {
+    extract_json_string_field_in_range(body, start, body.len(), field)
+}
+
+fn extract_json_string_field_in_range(
+    body: &str,
+    start: usize,
+    end: usize,
+    field: &str,
+) -> Option<(String, usize)> {
     let bytes = body.as_bytes();
     let field_pattern = format!("\"{field}\"");
-    let mut search_start = 0;
-    while let Some(relative_index) = body[search_start..].find(&field_pattern) {
+    let mut search_start = start.min(body.len());
+    let search_end = end.min(body.len());
+    while search_start < search_end {
+        let Some(relative_index) = body[search_start..search_end].find(&field_pattern) else {
+            break;
+        };
         let mut index = search_start + relative_index + field_pattern.len();
         while matches!(bytes.get(index), Some(b' ' | b'\n' | b'\r' | b'\t')) {
             index += 1;
+        }
+        if index >= search_end {
+            break;
         }
         if bytes.get(index) != Some(&b':') {
             search_start = index;
@@ -364,6 +432,9 @@ fn extract_json_string_field(body: &str, field: &str) -> Option<String> {
         index += 1;
         while matches!(bytes.get(index), Some(b' ' | b'\n' | b'\r' | b'\t')) {
             index += 1;
+        }
+        if index >= search_end {
+            break;
         }
         if bytes.get(index) != Some(&b'"') {
             search_start = index;
@@ -374,13 +445,13 @@ fn extract_json_string_field(body: &str, field: &str) -> Option<String> {
     None
 }
 
-fn parse_json_string_at(body: &str, quote_index: usize) -> Option<String> {
-    let mut chars = body[quote_index + 1..].chars();
+fn parse_json_string_at(body: &str, quote_index: usize) -> Option<(String, usize)> {
+    let mut chars = body[quote_index + 1..].char_indices();
     let mut rendered = String::new();
-    while let Some(ch) = chars.next() {
+    while let Some((offset, ch)) = chars.next() {
         match ch {
-            '"' => return Some(rendered),
-            '\\' => match chars.next()? {
+            '"' => return Some((rendered, quote_index + 1 + offset + ch.len_utf8())),
+            '\\' => match chars.next()?.1 {
                 '"' => rendered.push('"'),
                 '\\' => rendered.push('\\'),
                 '/' => rendered.push('/'),
@@ -392,7 +463,7 @@ fn parse_json_string_at(body: &str, quote_index: usize) -> Option<String> {
                 'u' => {
                     let mut hex = String::new();
                     for _ in 0..4 {
-                        hex.push(chars.next()?);
+                        hex.push(chars.next()?.1);
                     }
                     let value = u16::from_str_radix(&hex, 16).ok()?;
                     rendered.push(char::from_u32(value as u32)?);
@@ -486,9 +557,9 @@ fn render_section(name: &str, entries: &[String]) -> String {
 #[allow(unused_unsafe)]
 mod tests {
     use super::{
-        normalize_summary, parse_http_url, read_summary_timeout_ms, resolve_fallback_model,
-        resolve_instructions_file, resolve_model, DEFAULT_SPARK_MODEL, DEFAULT_STANDARD_MODEL,
-        DEFAULT_SUMMARY_TIMEOUT_MS,
+        extract_output_text, normalize_summary, parse_http_url, read_summary_timeout_ms,
+        resolve_fallback_model, resolve_instructions_file, resolve_model, DEFAULT_SPARK_MODEL,
+        DEFAULT_STANDARD_MODEL, DEFAULT_SUMMARY_TIMEOUT_MS,
     };
     use crate::test_support::env_lock;
     use std::env;
@@ -608,6 +679,33 @@ mod tests {
         unsafe {
             env::remove_var("OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS");
         }
+    }
+
+    #[test]
+    fn output_text_extraction_prefers_compat_top_level_field() {
+        let body = r#"{"output_text":"summary: legacy\nwarnings: none","output":[{"type":"message","content":[{"type":"output_text","text":"summary: nested"}]}]}"#;
+        assert_eq!(
+            extract_output_text(body),
+            Some("summary: legacy\nwarnings: none".to_string())
+        );
+    }
+
+    #[test]
+    fn output_text_extraction_supports_responses_output_content_shape() {
+        let body = r#"{
+            "id":"resp_123",
+            "output":[
+                {"type":"reasoning","summary":[]},
+                {"type":"message","content":[
+                    {"type":"output_text","annotations":[],"text":"summary: ok\n"},
+                    {"type":"output_text","text":"warnings: none"}
+                ]}
+            ]
+        }"#;
+        assert_eq!(
+            extract_output_text(body),
+            Some("summary: ok\nwarnings: none".to_string())
+        );
     }
 
     #[test]

--- a/docs/reference/omx-config-schema-routing.md
+++ b/docs/reference/omx-config-schema-routing.md
@@ -87,6 +87,16 @@ Supported model-related keys:
 
 `readConfiguredEnvOverrides()` also passes through other non-empty string values from `env` for launch helpers such as `omx explore` and `omx sparkshell`. Treat those as advanced environment overrides, not a schema for per-role model routing.
 
+For `omx sparkshell`, the documented helper-specific environment keys are:
+
+| Key | Purpose |
+| --- | --- |
+| `OMX_SPARKSHELL_BIN` | Override the native `omx-sparkshell` binary path. |
+| `OMX_SPARKSHELL_MODEL` | Override the primary summary model. |
+| `OMX_SPARKSHELL_FALLBACK_MODEL` | Override the retry summary model when the primary model is unavailable. |
+| `OMX_SPARKSHELL_MODEL_INSTRUCTIONS_FILE` | Override the packaged lightweight summary instructions file. |
+| `OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS` | Override the local API summary timeout in milliseconds. |
+
 ### `models`
 
 `models` maps mode names to explicit model overrides. Values must be non-empty strings.

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -448,6 +448,8 @@ describe('omx sparkshell', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.match(result.stdout, /Usage: omx sparkshell <command> \[args\.\.\.\]/);
       assert.match(result.stdout, /or: omx sparkshell --tmux-pane <pane-id> \[--tail-lines <100-1000>\]/);
+      assert.match(result.stdout, /OMX_SPARKSHELL_BIN overrides the native binary/);
+      assert.match(result.stdout, /OMX_SPARKSHELL_MODEL_INSTRUCTIONS_FILE overrides packaged summary instructions/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -29,6 +29,8 @@ export const SPARKSHELL_USAGE = [
   'Runs the native omx-sparkshell sidecar with direct argv execution, explicit shell execution, or explicit tmux pane summarization.',
   'Shell metacharacters are interpreted only with explicit --shell opt-in.',
   'Tmux pane mode is explicit opt-in and captures a larger pane tail before applying raw-vs-summary behavior.',
+  'Environment: OMX_SPARKSHELL_BIN overrides the native binary; OMX_SPARKSHELL_MODEL selects the summary model; OMX_SPARKSHELL_FALLBACK_MODEL selects the retry model.',
+  'Environment: OMX_SPARKSHELL_MODEL_INSTRUCTIONS_FILE overrides packaged summary instructions; OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS controls local API summary timeout.',
 ].join('\n');
 
 export interface ResolveSparkShellBinaryPathOptions {


### PR DESCRIPTION
## Summary
- add real-private local text generation compatibility against loopback Codex-native Responses fake upstreams
- add real-private image generation compatibility with direct image backend routing and Responses image-tool fallback
- cover daemon serve/status/stop, bearer auth/redaction, OpenAI-compatible response shapes, sparkshell `output_text` parsing, and help/docs alignment

## UltraQA
- Baseline verification passed:
  - `git diff --check origin/dev..HEAD`
  - `cargo test -p omx-api` (19 lib + 9 CLI/e2e)
  - `cargo test -p omx-sparkshell` (38 unit + 23 execution + 5 registry)
  - `cargo check --workspace`
  - `cargo clippy -p omx-api --tests -- -D warnings`
  - `npm run build`
  - `node --test dist/cli/__tests__/api.test.js dist/cli/__tests__/sparkshell-cli.test.js` (33 tests)
- Adversarial dynamic E2E passed 17/17 scenarios:
  - malformed JSON and bearer gates
  - non-loopback backend rejection
  - fake-upstream text JSON/SSE + chat SSE
  - direct image backend and Responses image-tool fallback
  - daemon serve/status/stop + token privacy
  - prompt-injection-as-data smoke path
  - corrupt state input rejection
  - dirty worktree preservation
  - hung-command timeout handling
  - misleading success output with non-zero exit
  - representative flaky reruns

## Notes
- No external production OpenAI/Codex calls were made; verification uses local fake upstreams and fixture-backed auth-compatible paths.
- Final local gates: AI slop cleaner PASS; code review APPROVE/CLEAR.
