### PR TITLE
Keep team leader nudges and HUD panes live

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts
@@ -35,6 +35,7 @@ function runSendPaneInputInChild(params: {
   prompt: string;
   submitKeyPresses: number;
   typePrompt: boolean;
+  queueFirstSubmit?: boolean;
 }) {
   const payload = JSON.stringify({
     paneTarget: params.paneTarget,
@@ -42,6 +43,7 @@ function runSendPaneInputInChild(params: {
     submitKeyPresses: params.submitKeyPresses,
     tmuxBin: join(params.fakeBinDir, 'tmux'),
     typePrompt: params.typePrompt,
+    queueFirstSubmit: params.queueFirstSubmit,
   });
   const script = `
     const input = ${payload};
@@ -114,6 +116,42 @@ describe('notify-hook team tmux guard bridge', () => {
       assert.equal(lines.length, 2);
       assert.match(lines[0], /send-keys -t %42 C-m/);
       assert.match(lines[1], /send-keys -t %42 C-m/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('queue-first submits with Tab before C-m when requested', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-tmux-guard-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const moduleUrl = new URL('../../../dist/scripts/notify-hook/team-tmux-guard.js', import.meta.url).href;
+      const result = runSendPaneInputInChild({
+        fakeBinDir,
+        moduleUrl,
+        paneTarget: '%42',
+        prompt: 'Read /tmp/team/mailbox/leader-fixed.json; new msg from worker-1. Review it; decide next step.',
+        submitKeyPresses: 2,
+        typePrompt: true,
+        queueFirstSubmit: true,
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.error, undefined);
+      assert.match(result.stdout, /"ok":true/);
+
+      const lines = (await readFile(tmuxLogPath, 'utf-8')).trim().split('\n').filter(Boolean);
+      assert.equal(lines.length, 4);
+      assert.match(lines[0], /send-keys -t %42 -l Read \/tmp\/team\/mailbox\/leader-fixed\.json/);
+      assert.match(lines[1], /send-keys -t %42 Tab/);
+      assert.match(lines[2], /send-keys -t %42 C-m/);
+      assert.match(lines[3], /send-keys -t %42 C-m/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -822,6 +822,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
     prompt: request.trigger_message,
     submitKeyPresses,
     typePrompt: shouldTypePrompt,
+    queueFirstSubmit: leaderTargeted,
   });
   if (!sendResult.ok) {
     return {
@@ -876,11 +877,13 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
           tmux_injection_attempted: true,
         };
       }
-      // Do not declare success while a *worker* pane is still bootstrapping / not
-      // input-ready. Otherwise a pre-ready send can be marked "confirmed" and later
-      // appear as a stuck unsent draft once the UI finishes loading.
-      // Keep leader-fixed behavior unchanged to avoid regressing leader notification flow.
-      if (request.to_worker !== 'leader-fixed' && !paneLooksReady(wideCap.stdout)) {
+      // Do not declare success while a pane is not input-ready. Otherwise a
+      // pre-ready send can be marked "confirmed" and later appear as a stuck
+      // unsent draft once the UI finishes loading. This includes leader-fixed:
+      // its Codex UI can show "tab to queue message" while busy, and marking
+      // delivered before queue/consumption confirmation loses the orchestration
+      // nudge until a human presses Tab manually.
+      if (!paneLooksReady(wideCap.stdout)) {
         continue;
       }
       if (!triggerInNarrow && !triggerNearTail) {
@@ -904,6 +907,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       prompt: request.trigger_message,
       submitKeyPresses,
       typePrompt: false,
+      queueFirstSubmit: leaderTargeted,
     }).catch(() => {});
   }
 

--- a/src/scripts/notify-hook/team-tmux-guard.ts
+++ b/src/scripts/notify-hook/team-tmux-guard.ts
@@ -134,6 +134,7 @@ export async function sendPaneInput({
   submitKeyPresses = 2,
   submitDelayMs = 0,
   typePrompt = true,
+  queueFirstSubmit = false,
 }: any): Promise<any> {
   const target = safeString(paneTarget).trim();
   if (!target) {
@@ -162,6 +163,12 @@ export async function sendPaneInput({
   try {
     if (typePrompt) {
       await runProcess('tmux', argv.typeArgv, 3000);
+    }
+    if (queueFirstSubmit && argv.submitArgv.length > 0) {
+      await runProcess('tmux', ['send-keys', '-t', target, 'Tab'], 3000);
+      if (submitDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, submitDelayMs));
+      }
     }
     for (const submit of argv.submitArgv) {
       if (submitDelayMs > 0) {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1184,10 +1184,15 @@ export function createTeamSession(
     const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
     tagPaneInstance(leaderPaneId, instanceId);
     const initialHudPaneIds = findHudPaneIds(teamTarget, leaderPaneId);
-    // Team mode prioritizes leader + worker visibility. Remove HUD panes in this window
-    // to keep a clean "leader left / workers right" layout.
-    for (const hudPaneId of initialHudPaneIds) {
-      runTmux(['kill-pane', '-t', hudPaneId]);
+    const omxEntry = resolveOmxCliEntryPath();
+    const canRecreateTeamHud = Boolean(omxEntry && omxEntry.trim() !== '');
+    // Team mode prioritizes leader + worker visibility. Remove HUD panes only
+    // when we can recreate the team HUD. Otherwise keep the existing HUD alive
+    // instead of making it disappear on team startup failures or broken installs.
+    if (canRecreateTeamHud) {
+      for (const hudPaneId of initialHudPaneIds) {
+        runTmux(['kill-pane', '-t', hudPaneId]);
+      }
     }
 
     const workerPaneIds: string[] = [];
@@ -1261,8 +1266,7 @@ export function createTeamSession(
     let hudPaneId: string | null = null;
     let resizeHookName: string | null = null;
     let resizeHookTarget: string | null = null;
-    const omxEntry = resolveOmxCliEntryPath();
-    if (omxEntry && omxEntry.trim() !== '') {
+    if (canRecreateTeamHud && omxEntry) {
       const hudCmd = `env ${OMX_TMUX_HUD_OWNER_ENV}=1 node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
       const hudCwd = translatePathForMsys(cwd);
       const hudResult = runTmux([


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Fixes two team-mode operator failures observed in a live `ultragoal` + `team` run:

1. `leader-fixed` mailbox nudges could be typed into the leader Codex prompt box and then remain there with `tab to queue message`, while dispatch state treated the nudge as delivered/notified.
2. Team startup could remove an existing HUD pane before proving a replacement team HUD could be launched, making the HUD disappear when the OMX entry path was unavailable or broken.

The change keeps team leader orchestration moving without violating the existing boundary that team runtime persists leader mailbox state while notify-hook owns tmux pane dispatch.

## Changes

- Add a queue-first submit option to the notify-hook tmux guard:
  - `sendPaneInput(..., queueFirstSubmit: true)` sends `Tab` before the existing isolated `C-m` submit sequence.
  - This matches Codex's busy-pane UI hint (`tab to queue message`) without changing default worker/Claude behavior.
- Use queue-first submit for `leader-fixed` dispatch requests:
  - `team-dispatch` now passes `queueFirstSubmit: leaderTargeted` for initial sends and retry sends.
  - This specifically targets leader mailbox review nudges, where the leader pane may be busy processing the orchestration loop.
- Stop confirming delivery for leader-fixed when the pane is not input-ready:
  - The previous guard intentionally skipped `paneLooksReady()` for `leader-fixed` to avoid regressing leader notification flow.
  - That allowed false confirmation when the trigger text was no longer in the narrow capture but the leader UI still had not reached a safe queue/consume point.
  - The new behavior applies the same ready-pane requirement to leader-fixed as worker panes before marking the dispatch delivered.
- Preserve existing HUD panes unless replacement is possible:
  - `createTeamSession()` now resolves the OMX CLI entry before killing pre-existing HUD panes.
  - If a replacement team HUD cannot be launched, the existing HUD is left alive instead of being removed first.

## Why this is needed

During a real team run, worker messages reached `mailbox/leader-fixed.json`, and notify-hook generated prompts like:

```text
Read .../mailbox/leader-fixed.json; new msg from worker-2. Review it; decide next step.
```

The leader Codex UI showed the nudge in the prompt box with:

```text
tab to queue message
```

That state means the message is not being processed yet; it still requires queue submission. However, the dispatch/mailbox layer could already consider the nudge notified/delivered based on the injection attempt rather than actual queue/consumption evidence. In `ultragoal` + `team`, this is especially visible because Ultragoal is leader-owned and depends on the leader to read team evidence and checkpoint the active goal.

The HUD issue has a similar ordering problem: team mode killed old HUD panes first, then attempted to create the team HUD. If the replacement command could not be resolved/launched, the operator lost the HUD entirely. The safer ordering is to only remove the old HUD when replacement is possible.

## Why this does not overlap existing PRs or commits

I checked the currently open PRs targeting `dev` with `gh pr list --repo Yeachan-Heo/oh-my-codex --base dev --state open` and compared their changed files against this PR's files:

- #2376 `pr/real-generation-compat-ultraqa`
- #2371 `pr/sparkshell-incremental-cache`
- #2370 `pr/sparkshell-team-diagnostics`
- #2369 `pr/sparkshell-observability`
- #2368 `feat/auto-update-mode`
- #2354 `omx-issue-2353-child-agent-notify`
- #2326 `omx-issue-2324-homebrew-codex-install-conflict`

None of those open PR branches modify these files:

- `src/scripts/notify-hook/team-dispatch.ts`
- `src/scripts/notify-hook/team-tmux-guard.ts`
- `src/team/tmux-session.ts`
- `src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts`

I also checked recent history for the same files. The closest prior work is the unsent draft hardening around worker dispatch (`Prevent team dispatch from trusting unsent tmux drafts`) and HUD resize hook ownership fixes. This PR is narrower and distinct:

- prior dispatch hardening focused on worker panes / stale drafts;
- this PR handles `leader-fixed` busy-pane queue semantics and false confirmation;
- prior HUD work kept resize hooks stable;
- this PR changes startup ordering so an existing HUD is not killed unless the replacement HUD can be launched.

## Validation

- [x] `npm run build`
- [x] `node --test dist/hooks/__tests__/notify-hook-team-tmux-guard.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js dist/team/__tests__/tmux-session.test.js`
  - 221 tests passed in the focused affected suites.
- [x] `npm run lint`
  - `Checked 646 files in 150ms. No fixes applied.`
- [ ] `npm test`
  - Ran and reached suite completion, but failed on 7 existing/unrelated OpenClaw/doctor expectation tests.
  - Failures were outside the files touched here:
    - `dist/cli/__tests__/adapt.test.js`: `missing-config` vs `invalid-config`
    - `dist/compat/__tests__/doctor-contract.test.js`: setup follow-up copy expectation
    - `dist/notifications/__tests__/custom-alias-enablement.test.js`: OpenClaw config assertion
    - `dist/notifications/__tests__/index.test.js`: ask-user-question OpenClaw dispatch count
    - `dist/notifications/__tests__/temp-mode.test.js`: temp-mode OpenClaw dispatch assertion
    - `dist/openclaw/__tests__/dispatcher.test.js`: timeout default `5000` vs `120000`
  - Summary: `# pass 5036`, `# fail 7`.
- [ ] `omx doctor`
  - Not run; this does not change setup/config behavior.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
  - Not needed: runtime hook/team behavior is covered by focused regression tests and does not change public docs or setup guidance.
- [x] Backward-compatibility impact considered
  - Default `sendPaneInput` behavior is unchanged unless `queueFirstSubmit` is explicitly requested.
  - Queue-first is applied only to `leader-fixed` dispatch in notify-hook.
  - HUD behavior is safer: existing HUD panes are preserved if replacement cannot be launched.

## Related

Closes #
