### PR TITLE
fix(ralph): enforce completion audit state contract

### DIFF
--- a/plugins/oh-my-codex/skills/ralph/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralph/SKILL.md
@@ -127,6 +127,13 @@ Use the CLI-first state surface for Ralph lifecycle state (`omx state write/read
   `omx state write --input '{"mode":"ralph","current_phase":"verifying"}' --json` or `omx state write --input '{"mode":"ralph","current_phase":"fixing"}' --json`
 - **On completion** (only after the completion audit passes with real evidence):
   `omx state write --input '{"mode":"ralph","active":false,"current_phase":"complete","completed_at":"<now>","completion_audit":{"passed":true,"prompt_to_artifact_checklist":["<requirement mapped to artifact/evidence>"],"verification_evidence":["<fresh test/build/lint command and result>"]}}' --json`
+- **Before the final answer**:
+  1. Run fresh verification and read the output.
+  2. Build `prompt_to_artifact_checklist` entries that map every user requirement, workflow gate, named file, command, PR/delivery requirement, and stop condition to a concrete artifact or evidence item.
+  3. Build `verification_evidence` entries with concrete commands, exit status, files inspected, PR URLs, or other machine-checkable evidence.
+  4. Write the Ralph completion state with a top-level `completion_audit` field on the Ralph state object. Do not write bare top-level `prompt_to_artifact_checklist` or `verification_evidence` fields by themselves; the Stop gate will reject them.
+  5. Read the state back with `omx state read --input '{"mode":"ralph"}' --json` and verify `completion_audit.passed === true`, a non-empty checklist, and non-empty verification evidence before producing the final answer.
+  6. If Codex goal mode is active, call `update_goal({status:"complete"})` only after this Ralph audit read-back succeeds.
 - **On cancellation/cleanup**:
   run `$cancel` (which should call `omx state clear --input '{"mode":"ralph"}' --json`)
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -127,6 +127,13 @@ Use the CLI-first state surface for Ralph lifecycle state (`omx state write/read
   `omx state write --input '{"mode":"ralph","current_phase":"verifying"}' --json` or `omx state write --input '{"mode":"ralph","current_phase":"fixing"}' --json`
 - **On completion** (only after the completion audit passes with real evidence):
   `omx state write --input '{"mode":"ralph","active":false,"current_phase":"complete","completed_at":"<now>","completion_audit":{"passed":true,"prompt_to_artifact_checklist":["<requirement mapped to artifact/evidence>"],"verification_evidence":["<fresh test/build/lint command and result>"]}}' --json`
+- **Before the final answer**:
+  1. Run fresh verification and read the output.
+  2. Build `prompt_to_artifact_checklist` entries that map every user requirement, workflow gate, named file, command, PR/delivery requirement, and stop condition to a concrete artifact or evidence item.
+  3. Build `verification_evidence` entries with concrete commands, exit status, files inspected, PR URLs, or other machine-checkable evidence.
+  4. Write the Ralph completion state with a top-level `completion_audit` field on the Ralph state object. Do not write bare top-level `prompt_to_artifact_checklist` or `verification_evidence` fields by themselves; the Stop gate will reject them.
+  5. Read the state back with `omx state read --input '{"mode":"ralph"}' --json` and verify `completion_audit.passed === true`, a non-empty checklist, and non-empty verification evidence before producing the final answer.
+  6. If Codex goal mode is active, call `update_goal({status:"complete"})` only after this Ralph audit read-back succeeds.
 - **On cancellation/cleanup**:
   run `$cancel` (which should call `omx state clear --input '{"mode":"ralph"}' --json`)
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -8558,16 +8558,29 @@ exit 0
       assert.equal(result.omxEventName, "stop");
       const reason = String(result.outputJson?.reason);
       assert.match(reason, /Ralph completion audit is missing required evidence/);
-      assert.match(reason, /state\.completion_audit = \{ passed: true, prompt_to_artifact_checklist: \[\.\.\.\], verification_evidence: \[\.\.\.\] \}/);
+      assert.match(reason, /set "completion_audit" on the Ralph state object/);
+      assert.doesNotMatch(reason, /state\.completion_audit/);
       assert.match(reason, /repo-relative JSON file/);
       assert.match(reason, /Markdown artifacts and flat top-level checklist\/evidence fields are not accepted/);
       assert.equal(result.outputJson?.stopReason, "ralph_completion_audit_missing_completion_audit");
       const reopened = JSON.parse(await readFile(statePath, "utf-8")) as Record<string, unknown>;
-      assert.equal(reopened.active, true);
-      assert.equal(reopened.current_phase, "verifying");
+      assert.equal(reopened.active, false);
+      assert.equal(reopened.current_phase, "complete");
       assert.equal(reopened.completion_audit_gate, "blocked");
       assert.equal(reopened.completion_audit_missing_reason, "missing_completion_audit");
-      assert.equal(typeof reopened.completed_at, "undefined");
+      assert.equal(reopened.completed_at, "2026-05-10T12:00:00.000Z");
+
+      const repeat = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          last_assistant_message: "Done. Ralph complete.",
+        },
+        { cwd },
+      );
+      assert.equal(repeat.outputJson?.stopReason, "ralph_completion_audit_missing_completion_audit");
+      assert.doesNotMatch(String(repeat.outputJson?.reason), /Ralph is still active/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -896,13 +896,12 @@ async function reopenRalphCompletionAuditBlock(block: RalphCompletionAuditBlockS
   const nowIso = new Date().toISOString();
   const next: Record<string, unknown> = {
     ...block.state,
-    active: true,
-    current_phase: "verifying",
+    active: false,
+    current_phase: "complete",
     completion_audit_gate: "blocked",
     completion_audit_missing_reason: block.reason,
     completion_audit_blocked_at: nowIso,
   };
-  delete next.completed_at;
   await writeFile(block.path, JSON.stringify(next, null, 2));
 }
 
@@ -3143,7 +3142,7 @@ async function buildStopHookOutput(
       `OMX Ralph completion audit is missing required evidence (${ralphCompletionAuditBlock.reason}; state: ${blockingPath}).`,
       "Continue verification and do not report complete yet.",
       "Record machine-readable completion evidence before stopping:",
-      "- either set state.completion_audit = { passed: true, prompt_to_artifact_checklist: [...], verification_evidence: [...] }",
+      '- either set "completion_audit" on the Ralph state object, for example: omx state write --input \'{"mode":"ralph","active":false,"current_phase":"complete","completion_audit":{"passed":true,"prompt_to_artifact_checklist":["..."],"verification_evidence":["..."]}}\' --json',
       "- or set completion_audit_path / completion_audit_evidence_path to a repo-relative JSON file with those same fields.",
       "Markdown artifacts and flat top-level checklist/evidence fields are not accepted by the Ralph Stop gate.",
     ].join(" ");

--- a/src/state/__tests__/operations-ralph-phase.test.ts
+++ b/src/state/__tests__/operations-ralph-phase.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -79,6 +79,99 @@ describe('state operations Ralph phase contract', () => {
       assert.equal(response.isError, true);
       const body = response.payload as { error?: string };
       assert.match(body.error || '', /terminal Ralph phases require active=false/i);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects complete Ralph state without completion-audit evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ralph-complete-audit-'));
+    try {
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        active: false,
+        current_phase: 'complete',
+      });
+      assert.equal(response.isError, true);
+      const body = response.payload as { error?: string };
+      assert.match(body.error || '', /requires passing completion_audit/i);
+      assert.match(body.error || '', /missing_completion_audit/i);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects complete Ralph state without completion-audit evidence when active is omitted', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ralph-complete-audit-'));
+    try {
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        current_phase: 'complete',
+      });
+      assert.equal(response.isError, true);
+      const body = response.payload as { error?: string };
+      assert.match(body.error || '', /requires passing completion_audit/i);
+      assert.match(body.error || '', /missing_completion_audit/i);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts complete Ralph state with in-state completion-audit evidence and clears stale audit gate markers', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ralph-complete-audit-'));
+    try {
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        active: false,
+        current_phase: 'complete',
+        completion_audit_gate: 'blocked',
+        completion_audit_missing_reason: 'missing_completion_checklist',
+        completion_audit_blocked_at: '2026-05-10T12:00:00.000Z',
+        completion_audit: {
+          passed: true,
+          prompt_to_artifact_checklist: ['requirement mapped to committed source changes'],
+          verification_evidence: ['npm run build exited 0'],
+        },
+      });
+      assert.equal(response.isError, undefined);
+
+      const file = join(wd, '.omx', 'state', 'ralph-state.json');
+      const state = JSON.parse(await readFile(file, 'utf-8'));
+      assert.equal(state.current_phase, 'complete');
+      assert.equal(state.active, false);
+      assert.equal(typeof state.completed_at, 'string');
+      assert.equal(state.completion_audit_gate, undefined);
+      assert.equal(state.completion_audit_missing_reason, undefined);
+      assert.equal(state.completion_audit_blocked_at, undefined);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts complete Ralph state with repo-relative completion-audit artifact', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ralph-complete-audit-path-'));
+    try {
+      await writeFile(
+        join(wd, 'audit.json'),
+        JSON.stringify({
+          passed: true,
+          prompt_to_artifact_checklist: ['prompt requirement has an artifact'],
+          verification_evidence: ['node --test dist/state/__tests__/operations-ralph-phase.test.js exited 0'],
+        }),
+        'utf-8',
+      );
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        active: false,
+        current_phase: 'complete',
+        completion_audit_path: 'audit.json',
+      });
+      assert.equal(response.isError, undefined);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -16,6 +16,7 @@ import {
   validateSessionId,
   validateStateModeSegment,
 } from '../mcp/state-paths.js';
+import { evaluateRalphCompletionAuditEvidence } from '../ralph/completion-audit.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
@@ -287,6 +288,16 @@ export async function executeStateOperation(
               validation.state.ralph_phase_normalized_from = originalPhase;
             }
             Object.assign(mergedRaw, validation.state);
+            if (mergedRaw.current_phase === 'complete') {
+              const completionAudit = evaluateRalphCompletionAuditEvidence(mergedRaw, cwd);
+              if (!completionAudit.complete) {
+                validationError = `ralph complete state requires passing completion_audit or repo-relative completion_audit_path (${completionAudit.reason})`;
+                return;
+              }
+              delete mergedRaw.completion_audit_gate;
+              delete mergedRaw.completion_audit_missing_reason;
+              delete mergedRaw.completion_audit_blocked_at;
+            }
             ensureRalphArtifacts = true;
           }
 


### PR DESCRIPTION
## Summary

- clarify Ralph completion-audit Stop guidance so agents write top-level `completion_audit` on the Ralph state object instead of inferring nested `state.completion_audit`
- keep completed Ralph states terminal when the audit gate blocks, adding audit-block metadata without flipping back to `active:true`/`verifying` or deleting `completed_at`
- enforce the completion-audit contract in `state_write` for every successful Ralph `complete` state, including writes that omit `active`, while clearing stale audit-block markers once a passing audit is present
- strengthen Ralph skill finalization docs and sync the plugin mirror

## Verification

Environment note: state-operation tests were run with `OMX_ROOT`/`OMX_SESSION_ID` unset to avoid the live OMX session redirecting test state into the active runtime root.

- `npm run build`
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD -u OMXBOX_ACTIVE node --test dist/state/__tests__/operations-ralph-phase.test.js dist/ralph/__tests__/completion-audit.test.js dist/scripts/__tests__/codex-native-hook.test.js` — 331 pass, 0 fail
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD -u OMXBOX_ACTIVE npm run test:explicit-terminal-contract:compiled` — 437 pass, 0 fail
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD -u OMXBOX_ACTIVE npm run test:recent-bug-regressions:compiled` — 589 pass, 0 fail (run before the final omitted-active edge-case patch; the later targeted and explicit-terminal runs cover the final diff)
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD -u OMXBOX_ACTIVE npm run verify:plugin-bundle`
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD -u OMXBOX_ACTIVE npm run verify:native-agents`

## Review

- Architect re-review: APPROVED, no must-fix items.
