### PR TITLE
Honor config.toml Lore guard opt-out in native hooks

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -83,9 +83,14 @@ OMX_LORE_COMMIT_GUARD = "1"
 
 The opt-in controls only the Lore-style `git commit` blocking guard. Other
 native `PreToolUse` checks, including document-refresh warnings and command
-safety checks, still run. `omx doctor` reports whether the guard is enabled by
-explicit opt-in, disabled by default/config/environment, or disabled because an
-explicit value is invalid.
+safety checks, still run. Native hook enforcement reads the same persistent
+Codex config fallback when the hook process does not already have
+`OMX_LORE_COMMIT_GUARD` in its environment. Inline command environment still
+wins for that command, so `OMX_LORE_COMMIT_GUARD=0 git commit ...` disables a
+persistent opt-in and `env -u OMX_LORE_COMMIT_GUARD git commit ...` removes the
+persistent fallback for that invocation. `omx doctor` reports whether the guard
+is enabled by explicit opt-in, disabled by default/config/environment, or
+disabled because an explicit value is invalid.
 
 Warning scope is intentionally narrow and rule-scoped:
 

--- a/src/config/commit-lore-guard.ts
+++ b/src/config/commit-lore-guard.ts
@@ -1,6 +1,16 @@
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { parse as parseToml } from "@iarna/toml";
+
 export const OMX_LORE_COMMIT_GUARD_ENV = "OMX_LORE_COMMIT_GUARD";
 
 const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
+
+interface CodexLoreCommitGuardConfig {
+	env?: Record<string, unknown>;
+	shell_environment_policy?: { set?: Record<string, unknown> };
+}
 
 export function isLoreCommitGuardEnabled(
 	env: NodeJS.ProcessEnv = process.env,
@@ -8,4 +18,30 @@ export function isLoreCommitGuardEnabled(
 	const raw = env[OMX_LORE_COMMIT_GUARD_ENV];
 	if (typeof raw !== "string") return false;
 	return ENABLED_VALUES.has(raw.trim().toLowerCase());
+}
+
+function resolveCodexHome(env: NodeJS.ProcessEnv): string {
+	const configured = env.CODEX_HOME?.trim();
+	if (configured) return configured;
+
+	const home = env.HOME?.trim() || homedir();
+	return join(home, ".codex");
+}
+
+export function readConfiguredLoreCommitGuardValue(
+	env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+	const configPath = join(resolveCodexHome(env), "config.toml");
+	if (!existsSync(configPath)) return undefined;
+
+	try {
+		const parsed = parseToml(readFileSync(configPath, "utf-8")) as CodexLoreCommitGuardConfig;
+		const value =
+			parsed?.shell_environment_policy?.set?.[OMX_LORE_COMMIT_GUARD_ENV]
+			?? parsed?.env?.[OMX_LORE_COMMIT_GUARD_ENV];
+		return typeof value === "string" ? value : undefined;
+	} catch {
+		// Invalid config leaves the guard at its default-off behavior.
+		return undefined;
+	}
 }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -63,6 +63,40 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+async function withLoreGuardConfig<T>(
+  value: string,
+  prefix: string,
+  run: (cwd: string) => Promise<T>,
+): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-pretool-git-commit-lore-${prefix}-`));
+  const codexHome = await mkdtemp(join(tmpdir(), `omx-native-hook-codex-home-lore-${prefix}-`));
+  const defaultHome = await mkdtemp(join(tmpdir(), `omx-native-hook-home-lore-${prefix}-`));
+  const originalGuard = process.env.OMX_LORE_COMMIT_GUARD;
+  const originalCodexHome = process.env.CODEX_HOME;
+  const originalHome = process.env.HOME;
+  try {
+    delete process.env.OMX_LORE_COMMIT_GUARD;
+    process.env.CODEX_HOME = codexHome;
+    process.env.HOME = defaultHome;
+    await writeFile(
+      join(codexHome, "config.toml"),
+      `[shell_environment_policy.set]\nOMX_LORE_COMMIT_GUARD = "${value}"\n`,
+      "utf-8",
+    );
+    return await run(cwd);
+  } finally {
+    if (originalGuard === undefined) delete process.env.OMX_LORE_COMMIT_GUARD;
+    else process.env.OMX_LORE_COMMIT_GUARD = originalGuard;
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = originalCodexHome;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    await rm(cwd, { recursive: true, force: true });
+    await rm(codexHome, { recursive: true, force: true });
+    await rm(defaultHome, { recursive: true, force: true });
+  }
+}
+
 function buildWorkerStopFakeTmux(
   tmuxLogPath: string,
   options: { failSend?: boolean; busyLeader?: boolean } = {},
@@ -4385,6 +4419,80 @@ exit 0
     }
   });
 
+  it("blocks non-Lore git commit messages when the Lore commit guard is enabled in CODEX_HOME config.toml", async () => {
+    await withLoreGuardConfig("1", "config-enabled", async (cwd) => {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-config-enabled",
+          tool_input: { command: 'git commit -m "fix: conventional"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /Lore protocol/);
+    });
+  });
+
+  it("allows non-Lore git commit messages when the Lore commit guard is disabled in CODEX_HOME config.toml", async () => {
+    await withLoreGuardConfig("0", "config-disabled", async (cwd) => {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-config-disabled",
+          tool_input: { command: 'git commit -m "fix: use conventional commit"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    });
+  });
+
+  it("lets inline Lore commit guard values override a disabled CODEX_HOME config.toml", async () => {
+    await withLoreGuardConfig("0", "config-inline-enabled", async (cwd) => {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-config-inline-enabled",
+          tool_input: { command: 'OMX_LORE_COMMIT_GUARD=1 git commit -m "fix: conventional"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /Lore protocol/);
+    });
+  });
+
+  it("restores default-off Lore guard when env -u removes a disabled CODEX_HOME config source", async () => {
+    await withLoreGuardConfig("0", "config-codex-home-unset", async (cwd) => {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-config-codex-home-unset",
+          tool_input: { command: 'env -u CODEX_HOME git commit -m "fix: conventional"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    });
+  });
+
   it("allows non-Lore git commit messages when the Lore commit guard is disabled inline", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-lore-inline-disabled-"));
     try {
@@ -4451,6 +4559,24 @@ exit 0
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it("restores default-off Lore guard when env -u unsets a config.toml fallback", async () => {
+    await withLoreGuardConfig("1", "config-env-unset", async (cwd) => {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-git-commit-lore-config-env-unset",
+          tool_input: { command: 'env -u OMX_LORE_COMMIT_GUARD git commit -m "fix: conventional"' },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    });
   });
 
   it("restores default-off Lore guard when env -u unsets an enabled process env", async () => {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -2,7 +2,11 @@ import {
   buildDocumentRefreshAdvisoryOutput,
   evaluateStagedDocumentRefresh,
 } from "../document-refresh/enforcer.js";
-import { isLoreCommitGuardEnabled } from "../config/commit-lore-guard.js";
+import {
+  OMX_LORE_COMMIT_GUARD_ENV,
+  isLoreCommitGuardEnabled,
+  readConfiguredLoreCommitGuardValue,
+} from "../config/commit-lore-guard.js";
 import { resolveCodexExecutionSurface } from "./codex-execution-surface.js";
 
 type CodexHookPayload = Record<string, unknown>;
@@ -746,6 +750,17 @@ function buildEffectiveLoreCommitGuardEnv(parsed: GitCommitCommandParseResult): 
   }
   for (const [name, value] of Object.entries(parsed.inlineEnvironment)) {
     if (typeof value === "string") effectiveEnvironment[name] = value;
+  }
+
+  if (
+    !parsed.environmentStartsClean
+    && !parsed.unsetEnvironmentNames.includes(OMX_LORE_COMMIT_GUARD_ENV)
+    && typeof effectiveEnvironment[OMX_LORE_COMMIT_GUARD_ENV] !== "string"
+  ) {
+    const configuredValue = readConfiguredLoreCommitGuardValue(effectiveEnvironment);
+    if (typeof configuredValue === "string") {
+      effectiveEnvironment[OMX_LORE_COMMIT_GUARD_ENV] = configuredValue;
+    }
   }
   return effectiveEnvironment;
 }


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Native `PreToolUse` Lore commit enforcement currently reads `OMX_LORE_COMMIT_GUARD` from the effective command/process environment, but not from persistent Codex `config.toml`.

This change makes native hook enforcement honor the documented `CODEX_HOME/config.toml` opt-out while preserving command-level environment precedence.

## Changes

- Add a config reader for `shell_environment_policy.set.OMX_LORE_COMMIT_GUARD`
- Apply that config value as a fallback only when the effective hook/command environment does not already define or unset the guard
- Preserve command/env precedence:
  - inline env wins
  - `env -u OMX_LORE_COMMIT_GUARD` removes the config fallback for that invocation
  - `env -i` keeps clean-environment behavior
- Add regression coverage for config opt-out, inline override, and `env -u`
- Update native hook docs to describe the fallback and precedence behavior

## Validation

- [x] `npm run build`
- [x] `node --test dist/scripts/__tests__/codex-native-hook.test.js --test-name-pattern "Lore commit guard"`
  - `316 pass / 0 fail`
- [x] `npm run lint`
- [x] `git diff --check`
- [ ] `npm test`
  - Attempted locally, but the full suite did not produce a clean signal in the active OMX runtime because unrelated suites failed before completion. The scoped native-hook regression suite, build, lint, and diff checks pass.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed
- [x] Backward-compatibility impact considered

## Related

Closes #2386
