### PR TITLE
Fix ultragoal repeated auth blocker retries

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -444,6 +444,65 @@ describe('cli/ultragoal', () => {
     });
   });
 
+  it('circuit-breaks repeated GHCR authorization blockers and skips them on retry-failed', async () => {
+    await withCwd(async (cwd) => {
+      const ghcrBlocker = [
+        'GHCR_USERNAME/GHCR_READ_TOKEN/GHCR_BEARER_TOKEN unset;',
+        'gh auth scopes omit read:packages;',
+        'package API returns HTTP 403 requiring read:packages;',
+        'anonymous image verifier returns HTTP 401 authentication required.',
+      ].join(' ');
+
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- Prove GHCR smoke service']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        const checkpoint = await capture(() => ultragoalCommand([
+          'checkpoint',
+          '--goal-id', 'G001-prove-ghcr-smoke-service',
+          '--status', 'failed',
+          '--evidence', ghcrBlocker,
+          '--json',
+        ]));
+        assert.equal(checkpoint.exitCode, undefined);
+        const parsed = JSON.parse(checkpoint.stdout.join('\n')) as {
+          plan: { goals: Array<{ status: string; blockerOccurrenceCount?: number; requiredExternalDecision?: string; nonRetriable?: boolean }> };
+          summary: { failed: number; needsUserDecision: number };
+        };
+        const goal = parsed.plan.goals[0];
+        if (attempt < 3) {
+          assert.equal(goal.status, 'failed');
+          assert.equal(parsed.summary.failed, 1);
+          assert.equal(parsed.summary.needsUserDecision, 0);
+          await capture(() => ultragoalCommand(['complete-goals', '--retry-failed']));
+        } else {
+          assert.equal(goal.status, 'needs_user_decision');
+          assert.equal(goal.blockerOccurrenceCount, 3);
+          assert.equal(goal.nonRetriable, true);
+          assert.match(goal.requiredExternalDecision ?? '', /make the GHCR package public/);
+          assert.equal(parsed.summary.failed, 0);
+          assert.equal(parsed.summary.needsUserDecision, 1);
+        }
+      }
+
+      const retry = await capture(() => ultragoalCommand(['complete-goals', '--retry-failed']));
+      const output = retry.stdout.join('\n');
+      assert.doesNotMatch(output, /Ultragoal aggregate-goal handoff/);
+      assert.match(output, /blocked on repeated external authorization/);
+      assert.match(output, /Required external decision: make the GHCR package public/);
+      assert.match(output, /Do not run complete-goals --retry-failed again/);
+
+      const plan = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { activeGoalId?: string; goals: Array<{ status: string; nonRetriable?: boolean }> };
+      assert.equal(plan.activeGoalId, undefined);
+      assert.equal(plan.goals[0].status, 'needs_user_decision');
+      assert.equal(plan.goals[0].nonRetriable, true);
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"goal_needs_user_decision"/);
+      assert.match(ledger, /GHCR_PULL_ACCESS/);
+    });
+  });
+
   it('does not let blocked checkpoints bypass active Codex-goal mismatch protection', async () => {
     await withCwd(async () => {
       await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone', '--codex-goal-mode', 'per-story']));

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -57,6 +57,9 @@ Codex goal integration:
   Dynamic steering is explicit-only: steer accepts structured fields or directive JSON,
   audits accepted/rejected/deduped results in .omx/ultragoal/ledger.jsonl, and
   rejects broad natural-language mutation requests.
+  Repeated identical external authorization blockers become non-retriable
+  needs_user_decision stories; complete-goals --retry-failed skips them and prints
+  the required external decision instead of looping.
   Final completion is mandatory-gated: run ai-slop-cleaner, rerun verification,
   run $code-review, and pass --quality-gate-json with APPROVE + CLEAR evidence.
   Non-clean final review must use record-review-blockers before update_goal.
@@ -127,14 +130,25 @@ function printStatus(plan: Awaited<ReturnType<typeof readUltragoalPlan>>): void 
   const summary = summarizeUltragoalPlan(plan);
   if (summary.aggregateComplete) {
     console.log('ultragoal aggregate product: complete');
-    console.log(`microgoal ledger bookkeeping (progress-only): ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked`);
+    console.log(`microgoal ledger bookkeeping (progress-only): ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked, ${summary.needsUserDecision} needs-user-decision`);
   } else {
-    console.log(`ultragoal: ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked`);
+    console.log(`ultragoal: ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked, ${summary.needsUserDecision} needs-user-decision`);
   }
   for (const goal of plan.goals) {
     const marker = goal.id === plan.activeGoalId ? '*' : '-';
     console.log(`${marker} ${goal.id} [${goal.status}] ${goal.title}`);
   }
+}
+
+function blockedDecisionHandoff(plan: Awaited<ReturnType<typeof readUltragoalPlan>>): string | null {
+  const blocked = plan.goals.find((goal) => goal.status === 'needs_user_decision' && goal.nonRetriable);
+  if (!blocked) return null;
+  return [
+    'ultragoal: blocked on repeated external authorization; no retryable failed goals remain.',
+    `Goal: ${blocked.id} — ${blocked.title}`,
+    `Required external decision: ${blocked.requiredExternalDecision ?? 'provide the missing authorization/credential, or explicitly choose a different unblock path'}.`,
+    'Do not run complete-goals --retry-failed again until that external state changes or the user explicitly authorizes an unblock path.',
+  ].join('\n');
 }
 
 async function parseCodexGoalJson(raw: string | undefined): Promise<unknown> {
@@ -384,8 +398,17 @@ export async function ultragoalCommand(args: string[]): Promise<void> {
     if (command === 'complete' || command === 'complete-goals' || command === 'next' || command === 'start-next') {
       const result = await startNextUltragoal(cwd, { retryFailed: hasFlag(rest, '--retry-failed') });
       if (!result.goal) {
-        if (json) printJson({ ok: true, done: result.done, summary: summarizeUltragoalPlan(result.plan) });
-        else console.log(result.done ? 'ultragoal: all goals complete' : 'ultragoal: no pending goals (use --retry-failed to retry failed goals)');
+        const handoff = blockedDecisionHandoff(result.plan);
+        if (json) {
+          printJson({
+            ok: true,
+            done: result.done,
+            blocked: Boolean(handoff),
+            handoff,
+            blockedGoals: result.plan.goals.filter((goal) => goal.status === 'needs_user_decision'),
+            summary: summarizeUltragoalPlan(result.plan),
+          });
+        } else console.log(handoff ?? (result.done ? 'ultragoal: all goals complete' : 'ultragoal: no pending goals (use --retry-failed to retry failed goals)'));
         return;
       }
       const instruction = buildCodexGoalInstruction(result.goal, result.plan);

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -12,7 +12,7 @@ export const ULTRAGOAL_BRIEF = 'brief.md';
 export const ULTRAGOAL_GOALS = 'goals.json';
 export const ULTRAGOAL_LEDGER = 'ledger.jsonl';
 
-export type UltragoalStatus = 'pending' | 'in_progress' | 'complete' | 'failed' | 'review_blocked';
+export type UltragoalStatus = 'pending' | 'in_progress' | 'complete' | 'failed' | 'review_blocked' | 'needs_user_decision';
 export type UltragoalCodexGoalMode = 'aggregate' | 'per_story';
 export type UltragoalSteeringStatus = 'superseded' | 'blocked';
 export type UltragoalSteeringMutationKind =
@@ -126,6 +126,10 @@ export interface UltragoalItem {
   supersededBy?: string[];
   supersedes?: string[];
   blockedReason?: string;
+  blockerSignature?: string;
+  blockerOccurrenceCount?: number;
+  requiredExternalDecision?: string;
+  nonRetriable?: boolean;
   steeringEvidence?: string;
   steeringRationale?: string;
 }
@@ -161,6 +165,7 @@ export interface UltragoalLedgerEntry {
     | 'goal_completed'
     | 'goal_blocked'
     | 'goal_failed'
+    | 'goal_needs_user_decision'
     | 'goal_retried'
     | 'aggregate_completed'
     | 'aggregate_objective_migrated'
@@ -180,6 +185,9 @@ export interface UltragoalLedgerEntry {
   after?: unknown;
   mutationKind?: UltragoalSteeringMutationKind;
   idempotencyKey?: string;
+  blockerSignature?: string;
+  blockerOccurrenceCount?: number;
+  requiredExternalDecision?: string;
 }
 
 export interface CreateUltragoalOptions {
@@ -266,6 +274,63 @@ function cleanLine(line: string): string {
 
 function normalizeObjective(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeBlockerEvidence(value: string | undefined): string {
+  return (value ?? '')
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, ' ')
+    .replace(/[`"'()[\]{}:,;]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+interface ExternalAuthorizationBlocker {
+  signature: string;
+  requiredDecision: string;
+}
+
+function classifyExternalAuthorizationBlocker(evidence: string | undefined): ExternalAuthorizationBlocker | null {
+  const normalized = normalizeBlockerEvidence(evidence);
+  if (!normalized) return null;
+
+  const mentionsAuthorization = /\b(auth|authorization|credential|credentials|token|permission|permissions|scope|scopes|access|unauthorized|forbidden|401|403)\b/.test(normalized);
+  const mentionsMissingAuthority = /\b(unset|missing|required|requires|without|omit|omits|not set|not available|no read packages|read packages)\b/.test(normalized);
+  if (!mentionsAuthorization || !mentionsMissingAuthority) return null;
+
+  const mentionsGhcr = /\b(ghcr|github container registry|read packages|imagepullsecret|package api|anonymous image|container image)\b/.test(normalized);
+  if (mentionsGhcr) {
+    const has401 = /\b(401|unauthorized|anonymous pull|authentication required)\b/.test(normalized);
+    const has403 = /\b(403|forbidden|read packages|package api)\b/.test(normalized);
+    const status = [has401 ? 'HTTP_401_ANONYMOUS' : null, has403 ? 'HTTP_403_NO_READ_PACKAGES' : null]
+      .filter((part): part is string => Boolean(part))
+      .join('+') || 'AUTHORIZATION_REQUIRED';
+    return {
+      signature: `GHCR_PULL_ACCESS:${status}:GHCR_VISIBILITY_OR_CREDENTIAL_REQUIRED`,
+      requiredDecision: 'make the GHCR package public, or provide/authorize a least-privilege read:packages credential and imagePullSecret/SOPS path',
+    };
+  }
+
+  return {
+    signature: 'EXTERNAL_AUTHORIZATION_REQUIRED',
+    requiredDecision: 'provide the missing external authorization/credential, or explicitly choose a different unblock path',
+  };
+}
+
+function sameBlockerOccurrences(entries: readonly UltragoalLedgerEntry[], goalId: string, signature: string): number {
+  return entries.filter((entry) => (
+    entry.goalId === goalId
+    && (entry.event === 'goal_failed' || entry.event === 'goal_needs_user_decision')
+    && entry.blockerSignature === signature
+  )).length;
+}
+
+function clearGoalBlockerFields(goal: UltragoalItem): void {
+  goal.blockedReason = undefined;
+  goal.blockerSignature = undefined;
+  goal.blockerOccurrenceCount = undefined;
+  goal.requiredExternalDecision = undefined;
+  goal.nonRetriable = undefined;
 }
 
 
@@ -532,7 +597,7 @@ export async function createUltragoalPlan(cwd: string, options: CreateUltragoalO
   return plan;
 }
 
-export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; superseded: number; steeringBlocked: number; aggregateComplete: boolean; activeGoalId?: string } {
+export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; needsUserDecision: number; superseded: number; steeringBlocked: number; aggregateComplete: boolean; activeGoalId?: string } {
   return {
     total: plan.goals.length,
     pending: plan.goals.filter((goal) => goal.status === 'pending').length,
@@ -540,6 +605,7 @@ export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pe
     complete: plan.goals.filter((goal) => goal.status === 'complete').length,
     failed: plan.goals.filter((goal) => goal.status === 'failed').length,
     reviewBlocked: plan.goals.filter((goal) => goal.status === 'review_blocked').length,
+    needsUserDecision: plan.goals.filter((goal) => goal.status === 'needs_user_decision').length,
     superseded: plan.goals.filter((goal) => goal.steeringStatus === 'superseded').length,
     steeringBlocked: plan.goals.filter((goal) => goal.steeringStatus === 'blocked').length,
     aggregateComplete: plan.aggregateCompletion?.status === 'complete',
@@ -972,7 +1038,7 @@ export async function startNextUltragoal(cwd: string, options: StartNextOptions 
 
   let next = plan.goals.find((goal) => goal.status === 'pending' && isScheduleEligible(goal));
   if (!next && options.retryFailed) {
-    next = plan.goals.find((goal) => goal.status === 'failed' && isScheduleEligible(goal));
+    next = plan.goals.find((goal) => goal.status === 'failed' && !goal.nonRetriable && isScheduleEligible(goal));
     if (next) await appendLedger(cwd, { ts: now, event: 'goal_retried', goalId: next.id, status: 'pending', message: next.failureReason });
   }
   if (!next) return { plan, goal: null, resumed: false, done: isUltragoalDone(plan) };
@@ -982,6 +1048,7 @@ export async function startNextUltragoal(cwd: string, options: StartNextOptions 
   next.startedAt = now;
   next.failedAt = undefined;
   next.failureReason = undefined;
+  clearGoalBlockerFields(next);
   next.updatedAt = now;
   plan.activeGoalId = next.id;
   plan.updatedAt = now;
@@ -1099,22 +1166,42 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     goal.evidence = options.evidence;
     goal.failureReason = undefined;
     goal.failedAt = undefined;
+    clearGoalBlockerFields(goal);
     if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
   } else {
+    const blocker = classifyExternalAuthorizationBlocker(options.evidence);
+    const previousEntries = blocker ? await readSteeringLedgerEntries(cwd) : [];
+    const occurrenceCount = blocker ? sameBlockerOccurrences(previousEntries, goal.id, blocker.signature) + 1 : 0;
+    const shouldCircuitBreak = blocker !== null && occurrenceCount >= 3;
     goal.failedAt = now;
     goal.failureReason = options.evidence;
+    goal.blockerSignature = blocker?.signature;
+    goal.blockerOccurrenceCount = blocker ? occurrenceCount : undefined;
+    goal.requiredExternalDecision = blocker?.requiredDecision;
+    goal.nonRetriable = shouldCircuitBreak || undefined;
+    if (shouldCircuitBreak) {
+      goal.status = 'needs_user_decision';
+      goal.blockedReason = options.evidence;
+    }
     if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
   }
   plan.updatedAt = now;
   await writePlan(cwd, plan);
+  const blockerEvent = goal.status === 'needs_user_decision';
   await appendLedger(cwd, {
     ts: now,
-    event: options.status === 'complete' ? 'goal_completed' : 'goal_failed',
+    event: options.status === 'complete' ? 'goal_completed' : blockerEvent ? 'goal_needs_user_decision' : 'goal_failed',
     goalId: goal.id,
     status: goal.status,
     evidence: options.evidence,
     codexGoal: options.codexGoal,
     qualityGate,
+    blockerSignature: goal.blockerSignature,
+    blockerOccurrenceCount: goal.blockerOccurrenceCount,
+    requiredExternalDecision: goal.requiredExternalDecision,
+    message: blockerEvent
+      ? `Blocked on repeated external authorization. Required decision: ${goal.requiredExternalDecision}.`
+      : undefined,
   });
   return plan;
 }


### PR DESCRIPTION
## Summary
- add an ultragoal external authorization blocker signature for GHCR-style 401/403/read:packages failures
- convert the third repeated matching authorization failure into non-retriable `needs_user_decision` state with the required external decision recorded
- make `complete-goals --retry-failed` skip non-retriable blockers and print a concise user handoff instead of emitting another goal handoff
- add regression coverage for the GHCR incident shape from #2390

Fixes #2390

## Test evidence
- `npm run build`
- `node --test dist/cli/__tests__/ultragoal.test.js`
- `npm run check:no-unused`
- `npm run lint`

## Notes
- `npm test` was attempted after the targeted gates, but this attached OMX/tmux runtime has pre-existing environment-coupled failures in unrelated suites (for example adapt foundation/autoresearch/team/tmux/session parity); it was terminated after confirming unrelated failures.
