### PR TITLE
Clarify Ultragoal goal-clear behavior

### DIFF
--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -14,6 +14,8 @@ Upstream Codex goal source also constrains objectives to 4,000 characters, track
 
 New ultragoal plans default to **aggregate Codex goal mode**: Codex gets one objective for the whole ultragoal run, while OMX owns G001/G002 story state and ledger checkpoints. This avoids the impossible same-thread transition from a completed G001 Codex goal to a new G002 Codex goal. Legacy or explicitly requested **per-story** plans remain supported for users who want one Codex thread per story.
 
+Ultragoal intentionally does **not** call Codex `/goal clear`. The interactive TUI/app-server may expose `thread/goal/clear`, but the agent/tool contract available to OMX is only `get_goal` / `create_goal` / `update_goal`; shell commands and hooks cannot clear hidden thread goal state. After completing one ultragoal run, start the next run in a fresh Codex thread or manually run `/goal clear` in the Codex UI before `create_goal` for the new run. Otherwise `get_goal` may still report the previous completed aggregate objective, and the next same-thread `create_goal` can be blocked or confusing even though the OMX ledger for the previous run is complete.
+
 ## Artifacts
 
 All artifacts live under `.omx/ultragoal/`:
@@ -161,6 +163,7 @@ The final ultragoal story is not complete until the active agent has run the fin
 - `create_goal` starts the active objective; it is not a general plan store.
 - `update_goal` is completion-only; pause/resume/budget state is controlled by Codex/user/system, not OMX.
 - Aggregate mode is the default: one Codex objective covers the whole ultragoal run, and G001/G002 are OMX ledger stories.
+- Ultragoal does not invoke `/goal clear` or any hidden `thread/goal/clear` route. For multiple sequential ultragoal runs in one Codex session/thread, clear the completed Codex goal manually with `/goal clear` or open a fresh Codex thread before creating the next run's aggregate goal.
 - Intermediate aggregate story checkpoints require a matching `active` Codex snapshot. A `complete` snapshot before the final story is rejected to prevent premature `update_goal`. A non-clean final review records the old story as `review_blocked` and appends a pending blocker story before any completion checkpoint.
 - Final aggregate story checkpoints require a matching `complete` Codex snapshot captured after `update_goal({status: "complete"})`.
 - There is currently no Codex goal-tool reset/new-goal surface for replacing a completed legacy thread goal. In per-story mode, if `get_goal` returns a different completed objective and `create_goal` rejects because the thread already has a goal, record `omx ultragoal checkpoint --status blocked` with that `get_goal` JSON, then continue in a fresh Codex thread on the same branch/worktree and call `create_goal` there for the ultragoal payload.

--- a/plugins/oh-my-codex/skills/ultragoal/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultragoal/SKILL.md
@@ -9,7 +9,7 @@ Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durabl
 
 ## Purpose
 
-`ultragoal` turns a brief into repo-native artifacts and then drives a Codex goal safely through goal tools. New plans default to a stable pointer-style aggregate Codex goal for the whole durable plan in `.omx/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while OMX tracks G001/G002 story progress in the ledger.
+`ultragoal` turns a brief into repo-native artifacts and then drives a Codex goal safely through goal tools. New plans default to a stable pointer-style aggregate Codex goal for the whole durable plan in `.omx/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while OMX tracks G001/G002 story progress in the ledger. Ultragoal does not call Codex `/goal clear`; before multiple sequential ultragoal runs in one Codex session/thread, manually run `/goal clear` in the Codex UI or start a fresh Codex thread so the previous completed aggregate goal does not block or confuse the next `create_goal`.
 
 - `.omx/ultragoal/brief.md`
 - `.omx/ultragoal/goals.json`
@@ -122,6 +122,8 @@ The final ultragoal story is not complete until the active agent has run the fin
 ## Constraints
 
 - The shell command cannot directly invoke Codex interactive `/goal`; it emits a model-facing handoff for the active Codex agent.
+- Ultragoal intentionally does not invoke `/goal clear` or hidden `thread/goal/clear`; the model-facing tool surface only provides `get_goal`, `create_goal`, and `update_goal`.
+- After a completed aggregate ultragoal run, clear the Codex goal manually with `/goal clear` or open a fresh Codex thread before starting another ultragoal run in the same session/thread.
 - Never call `create_goal` when `get_goal` reports a different active goal.
 - Never call `update_goal` unless the aggregate run or legacy per-story goal is actually complete.
 - In aggregate mode, intermediate story checkpoints require a matching `active` Codex snapshot; final story completion requires a matching `complete` snapshot after `update_goal`.

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -9,7 +9,7 @@ Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durabl
 
 ## Purpose
 
-`ultragoal` turns a brief into repo-native artifacts and then drives a Codex goal safely through goal tools. New plans default to a stable pointer-style aggregate Codex goal for the whole durable plan in `.omx/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while OMX tracks G001/G002 story progress in the ledger.
+`ultragoal` turns a brief into repo-native artifacts and then drives a Codex goal safely through goal tools. New plans default to a stable pointer-style aggregate Codex goal for the whole durable plan in `.omx/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while OMX tracks G001/G002 story progress in the ledger. Ultragoal does not call Codex `/goal clear`; before multiple sequential ultragoal runs in one Codex session/thread, manually run `/goal clear` in the Codex UI or start a fresh Codex thread so the previous completed aggregate goal does not block or confuse the next `create_goal`.
 
 - `.omx/ultragoal/brief.md`
 - `.omx/ultragoal/goals.json`
@@ -122,6 +122,8 @@ The final ultragoal story is not complete until the active agent has run the fin
 ## Constraints
 
 - The shell command cannot directly invoke Codex interactive `/goal`; it emits a model-facing handoff for the active Codex agent.
+- Ultragoal intentionally does not invoke `/goal clear` or hidden `thread/goal/clear`; the model-facing tool surface only provides `get_goal`, `create_goal`, and `update_goal`.
+- After a completed aggregate ultragoal run, clear the Codex goal manually with `/goal clear` or open a fresh Codex thread before starting another ultragoal run in the same session/thread.
 - Never call `create_goal` when `get_goal` reports a different active goal.
 - Never call `update_goal` unless the aggregate run or legacy per-story goal is actually complete.
 - In aggregate mode, intermediate story checkpoints require a matching `active` Codex snapshot; final story completion requires a matching `complete` snapshot after `update_goal`.

--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -50,6 +50,8 @@ describe('cli/ultragoal', () => {
     assert.match(ULTRAGOAL_HELP, /blocked/);
     assert.match(ULTRAGOAL_HELP, /fresh Codex thread/);
     assert.match(ULTRAGOAL_HELP, /get_goal\/create_goal\/update_goal/);
+    assert.match(ULTRAGOAL_HELP, /does not call \/goal clear/);
+    assert.match(ULTRAGOAL_HELP, /multiple sequential ultragoal runs/);
     assert.match(ULTRAGOAL_HELP, /add-goal/);
     assert.match(ULTRAGOAL_HELP, /record-review-blockers/);
     assert.match(ULTRAGOAL_HELP, /quality-gate-json/);
@@ -68,7 +70,8 @@ describe('cli/ultragoal', () => {
       assert.match(output, /Ultragoal aggregate-goal handoff/);
       assert.match(output, /create_goal payload/);
       assert.match(output, /Codex goal = the whole ultragoal run/);
-      assert.doesNotMatch(output, /fresh Codex thread/);
+      assert.match(output, /does not call \/goal clear/);
+      assert.match(output, /After a completed aggregate run/);
       assert.match(output, /omx ultragoal checkpoint --goal-id G001-first-milestone --status complete/);
 
       const goals = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { activeGoalId?: string; codexGoalMode?: string; codexObjective?: string };

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -50,6 +50,10 @@ Codex goal integration:
   This command cannot directly invoke the interactive /goal tool from a shell.
   complete-goals writes durable state and prints a model-facing handoff that tells
   the active Codex agent when to call get_goal/create_goal/update_goal safely.
+  Ultragoal does not call /goal clear or hidden thread/goal/clear routes. For
+  multiple sequential ultragoal runs in one Codex session/thread, manually run
+  /goal clear in the Codex UI or start a fresh Codex thread before creating the
+  next aggregate goal.
   New plans default to aggregate mode: one Codex goal covers the whole ultragoal
   run while OMX checkpoints G001/G002 stories in the durable ledger. Legacy
   per-story plans retain fresh Codex thread blocker handling when a completed thread

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2165,6 +2165,8 @@ describe("codex native hook dispatch", () => {
       assert.match(message, /get_goal/);
       assert.match(message, /create_goal/);
       assert.match(message, /update_goal/);
+      assert.match(message, /does not call `\/goal clear`/);
+      assert.match(message, /multiple sequential ultragoal runs/);
       assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-ultragoal-1", "ultragoal-state.json")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1714,7 +1714,7 @@ function buildAdditionalContextMessage(
     ? "Ultrawork protocol: ground the task before editing, define pass/fail acceptance criteria, keep shared-file work local, and use direct-tool plus background evidence lanes only for truly independent work. Direct ultrawork provides lightweight verification only; Ralph owns persistence and the full verified-completion promise."
     : null;
   const ultragoalPromptActivationNote = match.skill === "ultragoal"
-    ? "Ultragoal protocol: use `omx ultragoal create-goals` / `complete-goals` / `checkpoint` for `.omx/ultragoal` artifacts, then use Codex goal model tools only from the active agent handoff (`get_goal`, `create_goal`, `update_goal`) and never overwrite a different active Codex goal."
+    ? "Ultragoal protocol: use `omx ultragoal create-goals` / `complete-goals` / `checkpoint` for `.omx/ultragoal` artifacts, then use Codex goal model tools only from the active agent handoff (`get_goal`, `create_goal`, `update_goal`) and never overwrite a different active Codex goal. Ultragoal does not call `/goal clear`; for multiple sequential ultragoal runs in one Codex session/thread, manually clear the completed Codex goal in the UI or start a fresh Codex thread."
     : null;
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -142,13 +142,13 @@ describe('ultragoal artifacts', () => {
       assert.match(instruction, /Codex goal = the whole ultragoal run/i);
       assert.match(instruction, /same aggregate objective as active/i);
       assert.match(instruction, /do not call update_goal yet/i);
-      assert.doesNotMatch(instruction, /fresh Codex thread/i);
       assert.match(instruction, /--codex-goal-json/);
       assert.match(instruction, /Complete the durable ultragoal plan/);
       assert.match(instruction, /including later accepted\/appended stories/);
       assert.match(instruction, /\.omx\/ultragoal\/ledger\.jsonl/);
       assert.match(instruction, /Complete first milestone/);
-      assert.doesNotMatch(instruction, /\/goal\b/);
+      assert.match(instruction, /does not call \/goal clear/);
+      assert.match(instruction, /start a fresh Codex thread/);
       assert.doesNotMatch(instruction, /\.\.\/\.\.\/codex/);
       assert.doesNotMatch(instruction, /`codex\s+goal\b/i);
     });

--- a/src/ultragoal/__tests__/docs-contract.test.ts
+++ b/src/ultragoal/__tests__/docs-contract.test.ts
@@ -18,8 +18,26 @@ describe('ultragoal docs contract', () => {
     assert.match(doc, /default to \*\*aggregate Codex goal mode\*\*/i);
     assert.match(doc, /Codex gets one objective for the whole ultragoal run/i);
     assert.match(doc, /G001\/G002 story state/i);
+    assert.match(doc, /does \*\*not\*\* call Codex `\/goal clear`/i);
+    assert.match(doc, /manual(?:ly)? run `\/goal clear`/i);
+    assert.match(doc, /multiple sequential ultragoal runs/i);
     assert.match(doc, /Intermediate aggregate story checkpoints require a matching `active` Codex snapshot/i);
     assert.match(doc, /Final aggregate story checkpoints require a matching `complete` Codex snapshot/i);
+  });
+
+  it('documents sequential same-thread runs and /goal clear limitations in mirrored skill guidance', () => {
+    const docs = [
+      loadDoc('skills/ultragoal/SKILL.md'),
+      loadDoc('plugins/oh-my-codex/skills/ultragoal/SKILL.md'),
+    ];
+
+    for (const doc of docs) {
+      assert.match(doc, /does not call Codex `\/goal clear`/i);
+      assert.match(doc, /does not invoke `\/goal clear` or hidden `thread\/goal\/clear`/i);
+      assert.match(doc, /only provides `get_goal`, `create_goal`, and `update_goal`/i);
+      assert.match(doc, /multiple sequential ultragoal runs/i);
+      assert.match(doc, /fresh Codex thread/i);
+    }
   });
 
   it('documents the completed legacy Codex-goal blocked checkpoint workaround', () => {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1297,6 +1297,7 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
     'Codex goal integration constraints:',
     '- First call get_goal. If no active goal exists, call create_goal with the payload below.',
     '- If a different active Codex goal exists, finish/checkpoint that goal before starting this ultragoal.',
+    '- Ultragoal cannot call /goal clear from the model/shell tool surface. For another per-story goal in the same session/thread after a completed Codex goal, manually run /goal clear in the Codex UI or continue in a fresh Codex thread.',
     '- If get_goal returns a different completed legacy/thread goal and create_goal rejects because this thread already has a completed goal, continue this ultragoal in a fresh Codex thread (same repo/worktree) and create the payload there.',
     `- To preserve the durable ledger before switching threads, record the non-terminal blocker without failing this goal: omx ultragoal checkpoint --goal-id ${goal.id} --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json "<get_goal JSON or path>"`,
     '- Work only this goal until its completion audit passes.',
@@ -1344,6 +1345,7 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
     '- First call get_goal. If no active goal exists, call create_goal with the aggregate payload below.',
     '- If get_goal reports the same aggregate objective as active, continue this OMX story without creating a new Codex goal.',
     '- If a different active or incomplete Codex goal exists, finish/checkpoint that goal before starting this ultragoal; do not replace hidden Codex state from the shell.',
+    '- Ultragoal does not call /goal clear. After a completed aggregate run, manually run /goal clear in the Codex UI or start a fresh Codex thread before starting another ultragoal run in the same session/thread.',
     finalStory
       ? '- This is the final pending story: run the mandatory final ai-slop-cleaner pass, rerun verification, and run $code-review before any update_goal call.'
       : '- This is not the final story: do not call update_goal yet; the aggregate Codex goal must remain active while later OMX stories remain.',


### PR DESCRIPTION
## Summary
- Clarifies that Ultragoal defaults to one aggregate Codex goal for the whole run while OMX tracks G001/G002 ledger stories.
- Documents that Ultragoal does not call `/goal clear` or hidden `thread/goal/clear`; the agent-facing surface is `get_goal` / `create_goal` / `update_goal`.
- Adds same-session guidance: before multiple sequential Ultragoal runs in one Codex session/thread, manually run `/goal clear` in the Codex UI or start a fresh Codex thread.

Fixes #2392

## Tests
- `npm run build`
- `node --test dist/cli/__tests__/ultragoal.test.js dist/ultragoal/__tests__/artifacts.test.js dist/ultragoal/__tests__/docs-contract.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run sync:plugin:check`
- `git diff --check`

## Review gates
- ai-slop-cleaner scoped pass: no new cleanup edits needed; fallback-like scan only found existing test fixtures outside this patch.
- code-review: APPROVE / architect CLEAR.