### PR TITLE
docs: clarify official OMX project naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 
 **Community:** [Discord](https://discord.gg/PUwSMR9XNk) — shared OMX/community server for oh-my-codex and related tooling.
 
+## Official project and package
+
+The official/original OMX project is this repository, [`Yeachan-Heo/oh-my-codex`](https://github.com/Yeachan-Heo/oh-my-codex), and the official npm package for this project is [`oh-my-codex`](https://www.npmjs.com/package/oh-my-codex). Install this project with `npm install -g oh-my-codex` (or alongside Codex CLI as shown below).
+
+Third-party projects or forks that use names such as “OMX v2” are not official continuations, replacements, or release lines for this repository unless this README or the docs explicitly say so. When in doubt, trust this repository and the `oh-my-codex` package as the official install target.
+
 OMX is a workflow layer for [OpenAI Codex CLI](https://github.com/openai/codex).
 
 <table>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -30,6 +30,7 @@
       </ul>
 
       <h2>Installation</h2>
+      <p><strong>Official install target:</strong> use the <a href="https://www.npmjs.com/package/oh-my-codex"><code>oh-my-codex</code></a> npm package from the official <a href="https://github.com/Yeachan-Heo/oh-my-codex"><code>Yeachan-Heo/oh-my-codex</code></a> repository. Third-party “OMX v2” projects are not official release lines for this project unless this repository documents that relationship.</p>
       <p>Choose one install path. If Codex CLI is already installed (Homebrew, npm, or another supported method):</p>
       <pre><code>codex --version
 npm install -g oh-my-codex

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,6 +23,7 @@
         <span class="badge">GitHub Pages</span>
         <h1>oh-my-codex</h1>
         <p>Multi-agent orchestration for OpenAI Codex CLI.</p>
+        <p><strong>Official project:</strong> <a href="https://github.com/Yeachan-Heo/oh-my-codex">Yeachan-Heo/oh-my-codex</a>. <strong>Official package:</strong> <a href="https://www.npmjs.com/package/oh-my-codex">oh-my-codex</a>. Third-party projects or forks using names such as “OMX v2” are not official continuations or release lines unless these docs explicitly say so.</p>
         <pre><code>npm install -g oh-my-codex</code></pre>
         <p>Real global version bumps now print an explicit reminder instead of auto-launching <code>omx setup</code>. When you're ready, run <code>omx setup</code> manually or use <code>omx update</code> to check npm and then run the same setup refresh path. Launch-time update checks are throttled and prompt by default; set <code>OMX_AUTO_UPDATE=0</code> to disable them or <code>OMX_AUTO_UPDATE=defer</code> to schedule deferred updates without prompting. Fresh OMX-managed <code>gpt-5.5</code> configs recommend <code>250000 / 200000</code> only when those keys are missing.</p>
       </section>


### PR DESCRIPTION
## Summary
- clarify that `Yeachan-Heo/oh-my-codex` is the official OMX project repository
- clarify that `oh-my-codex` is the official npm install target
- note that third-party “OMX v2” naming is not an official release line unless documented here

Fixes #2383

## Verification
- `npm run build`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
