### PR TITLE
Guard native hook dist smoke

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -19,6 +19,7 @@ import {
 } from "./packaged-explore-harness-lock.js";
 import {
 	checkExploreHarness,
+	checkNativeHookDistSmoke,
 	classifyPostCompactHookStdout,
 } from "../doctor.js";
 import { buildManagedCodexNativeHookCommand } from "../../config/codex-hooks.js";
@@ -910,6 +911,43 @@ command = "node"
 				res.stdout,
 				/\[OK\] Native PostCompact hook: verbose smoke validation confirmed the effective PostCompact hook exits successfully with no stdout/,
 			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("doctor smoke-validates the installed native hook dist script by default", async () => {
+		const check = await checkNativeHookDistSmoke();
+
+		assert.equal(check.name, "Native hook dist smoke");
+		assert.equal(check.status, "pass");
+		assert.match(
+			check.message,
+			/installed dist\/scripts\/codex-native-hook\.js parsed and accepted a minimal UserPromptSubmit payload/,
+		);
+	});
+
+	it("doctor reports reinstall guidance when the installed native hook dist script fails to parse", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-native-hook-dist-fail-"));
+		try {
+			const distScriptsDir = join(wd, "dist", "scripts");
+			await mkdir(distScriptsDir, { recursive: true });
+			await writeFile(join(wd, "package.json"), JSON.stringify({ version: "0.18.0" }));
+			await writeFile(join(distScriptsDir, "codex-native-hook.js"), "export const broken = ;\n");
+
+			const check = await checkNativeHookDistSmoke({
+				packageRoot: wd,
+				runner: ((cmd, args, options) => spawnSync(cmd, args, options)) as typeof spawnSync,
+			});
+
+			assert.equal(check.name, "Native hook dist smoke");
+			assert.equal(check.status, "fail");
+			assert.match(check.message, /minimal UserPromptSubmit smoke/);
+			assert.match(
+				check.message,
+				/npm install -g oh-my-codex@0\.18\.0 --force --min-release-age=0 --before=/,
+			);
+			assert.match(check.message, /omx setup --force/);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -80,6 +80,12 @@ interface Check {
 	message: string;
 }
 
+interface NativeHookDistSmokeOptions {
+	packageRoot?: string;
+	nodePath?: string;
+	runner?: typeof spawnSync;
+}
+
 type DoctorSetupScope = "user" | "project";
 
 interface DoctorScopeResolution {
@@ -191,6 +197,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
 	// Check 4.25: Native hooks coverage
 	checks.push(await checkNativeHooks(paths.hooksPath, paths.configPath));
+	checks.push(await checkNativeHookDistSmoke());
 	if (options.verbose) {
 		const postCompactRuntimeCheck = await checkNativePostCompactHookRuntime(
 			paths.hooksPath,
@@ -1075,6 +1082,85 @@ async function checkNativeHooks(
 			status: "fail",
 			message: "cannot read hooks.json",
 		};
+	}
+}
+
+export async function checkNativeHookDistSmoke(
+	options: NativeHookDistSmokeOptions = {},
+): Promise<Check> {
+	const packageRoot = options.packageRoot ?? getPackageRoot();
+	const nodePath = options.nodePath ?? process.execPath;
+	const runner = options.runner ?? spawnSync;
+	const scriptPath = join(packageRoot, "dist", "scripts", "codex-native-hook.js");
+	const packageJsonPath = join(packageRoot, "package.json");
+	let packageVersion = "current";
+	try {
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { version?: unknown };
+		if (typeof packageJson.version === "string" && packageJson.version.trim()) {
+			packageVersion = packageJson.version.trim();
+		}
+	} catch {
+		// Keep the generic recovery copy when package metadata is not readable.
+	}
+
+	if (!existsSync(scriptPath)) {
+		return {
+			name: "Native hook dist smoke",
+			status: "fail",
+			message: `installed native hook script is missing at ${scriptPath}; reinstall oh-my-codex and run "omx setup --force"`,
+		};
+	}
+
+	const smokeCwd = await mkdtemp(join(tmpdir(), "omx-doctor-native-hook-dist-"));
+	try {
+		const payload = JSON.stringify({
+			hook_event_name: "UserPromptSubmit",
+			session_id: "omx-doctor-native-hook-dist-smoke",
+			transcript_path: join(smokeCwd, "nonexistent-transcript.jsonl"),
+			cwd: smokeCwd,
+			prompt: "doctor smoke test",
+		});
+		const result = runner(nodePath, [scriptPath], {
+			cwd: smokeCwd,
+			encoding: "utf-8",
+			env: {
+				...process.env,
+				OMX_NATIVE_HOOK_DOCTOR_SMOKE: "1",
+				OMX_ROOT: join(smokeCwd, ".omx-doctor-root"),
+				OMX_SESSION_ID: "omx-doctor-native-hook-dist-smoke",
+				OMX_SOURCE_CWD: smokeCwd,
+				OMX_STARTUP_CWD: smokeCwd,
+			},
+			input: payload,
+			timeout: 5_000,
+		});
+
+		if (result.error) {
+			return {
+				name: "Native hook dist smoke",
+				status: "fail",
+				message: `installed native hook dist smoke failed to run (${result.error.message}); reinstall oh-my-codex and run "omx setup --force"`,
+			};
+		}
+		if (result.status !== 0) {
+			const stderr = (result.stderr || "").trim();
+			const stdout = (result.stdout || "").trim();
+			const detail = stderr || stdout || `exit ${result.status}`;
+			return {
+				name: "Native hook dist smoke",
+				status: "fail",
+				message: `installed native hook dist failed a minimal UserPromptSubmit smoke (${detail}); reinstall with "npm install -g oh-my-codex@${packageVersion} --force --min-release-age=0 --before=" and then run "omx setup --force"`,
+			};
+		}
+
+		return {
+			name: "Native hook dist smoke",
+			status: "pass",
+			message:
+				"installed dist/scripts/codex-native-hook.js parsed and accepted a minimal UserPromptSubmit payload",
+		};
+	} finally {
+		await rm(smokeCwd, { recursive: true, force: true });
 	}
 }
 

--- a/src/compat/__tests__/doctor-contract.test.ts
+++ b/src/compat/__tests__/doctor-contract.test.ts
@@ -74,6 +74,9 @@ function normalizeInstallDoctorOutput(text: string, home: string, cwd: string): 
       if (line.startsWith('Run "omx setup')) {
         return 'Run <SETUP_FOLLOWUP>';
       }
+      if (line.startsWith('Review warnings above. Use "omx setup')) {
+        return 'Run <SETUP_FOLLOWUP>';
+      }
       return line;
     })
     .join('\n');

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -9,6 +9,7 @@ Resolved setup scope: user
   [OK] Codex home: <CODEX_HOME>
   [!!] Config: config.toml exists but no OMX entries yet (expected before first setup; run "omx setup --force" once)
   [OK] Native hooks: hooks.json not found yet (expected before first setup)
+  [OK] Native hook dist smoke: installed dist/scripts/codex-native-hook.js parsed and accepted a minimal UserPromptSubmit payload
   [OK] Explore routing: enabled by default
   [OK] Lore commit guard: enabled by default
   [!!] Prompts: prompts directory not found

--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -7,10 +7,13 @@ import { test } from 'node:test';
 import {
   ensureRepoDependencies,
   hasUsableNodeModules,
+  buildNativeHookSmokePayload,
+  PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS,
   PACKED_INSTALL_SMOKE_CORE_COMMANDS,
   parseNpmPackJsonOutput,
   resolveGitCommonDir,
   resolveReusableNodeModulesSource,
+  validateHookStdout,
 } from '../smoke-packed-install.js';
 
 test('packed install smoke stays limited to boot + core commands', () => {
@@ -27,6 +30,34 @@ test('packed install smoke stays limited to boot + core commands', () => {
   assert.equal(
     PACKED_INSTALL_SMOKE_CORE_COMMANDS.some((argv) => argv.includes('sparkshell')),
     true,
+  );
+});
+
+test('packed install smoke covers every installed native hook event with minimal payloads', () => {
+  assert.deepEqual(PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS, [
+    'SessionStart',
+    'PreToolUse',
+    'PostToolUse',
+    'UserPromptSubmit',
+    'PreCompact',
+    'PostCompact',
+    'Stop',
+  ]);
+
+  for (const eventName of PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS) {
+    const payload = buildNativeHookSmokePayload(eventName, '/tmp/omx-packed-hook-smoke');
+    assert.equal(payload.hook_event_name, eventName);
+    assert.equal(typeof payload.session_id, 'string');
+    assert.equal(payload.cwd, '/tmp/omx-packed-hook-smoke');
+  }
+});
+
+test('packed install native hook stdout validation allows empty or JSON output only', () => {
+  assert.doesNotThrow(() => validateHookStdout('PostCompact', ''));
+  assert.doesNotThrow(() => validateHookStdout('Stop', '{}\n'));
+  assert.throws(
+    () => validateHookStdout('UserPromptSubmit', '{not json'),
+    /native hook UserPromptSubmit emitted invalid JSON stdout/,
   );
 });
 

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -1,5 +1,6 @@
 import {
   mkdtempSync,
+  realpathSync,
   rmSync,
 } from 'node:fs';
 import { mkdirSync } from 'node:fs';
@@ -22,6 +23,16 @@ export const PACKED_INSTALL_SMOKE_CORE_COMMANDS = [
   ['version'],
   ['api', '--help'],
   ['sparkshell', '--help'],
+] as const;
+
+export const PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS = [
+  'SessionStart',
+  'PreToolUse',
+  'PostToolUse',
+  'UserPromptSubmit',
+  'PreCompact',
+  'PostCompact',
+  'Stop',
 ] as const;
 
 function usage(): string {
@@ -112,6 +123,99 @@ function npmBinName(name: string): string {
   return process.platform === 'win32' ? `${name}.cmd` : name;
 }
 
+function resolveGlobalNodeModules(prefixDir: string): string {
+  const result = run('npm', ['root', '-g', '--prefix', prefixDir], { cwd: prefixDir });
+  const root = String(result.stdout || '').trim();
+  if (!root) throw new Error('npm root -g did not return a node_modules directory');
+  return root;
+}
+
+export function validateHookStdout(eventName: string, stdout: string): void {
+  const trimmed = stdout.trim();
+  if (!trimmed) return;
+  try {
+    JSON.parse(trimmed);
+  } catch (error) {
+    throw new Error(
+      `native hook ${eventName} emitted invalid JSON stdout: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export function buildNativeHookSmokePayload(
+  eventName: typeof PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS[number],
+  smokeCwd: string,
+): Record<string, unknown> {
+  const base = {
+    hook_event_name: eventName,
+    session_id: `packed-install-smoke-${eventName}`,
+    cwd: smokeCwd,
+  };
+  switch (eventName) {
+    case 'SessionStart':
+      return {
+        ...base,
+        transcript_path: join(smokeCwd, 'nonexistent-transcript.jsonl'),
+      };
+    case 'PreToolUse':
+      return {
+        ...base,
+        tool_name: 'Bash',
+        tool_use_id: 'packed-install-smoke-tool',
+        tool_input: { command: 'echo packed install smoke' },
+      };
+    case 'PostToolUse':
+      return {
+        ...base,
+        tool_name: 'Bash',
+        tool_use_id: 'packed-install-smoke-tool',
+        tool_input: { command: 'echo packed install smoke' },
+        tool_response: {
+          exit_code: 0,
+          stdout: 'packed install smoke\n',
+          stderr: '',
+        },
+      };
+    case 'UserPromptSubmit':
+      return {
+        ...base,
+        transcript_path: join(smokeCwd, 'nonexistent-transcript.jsonl'),
+        prompt: 'packed install native hook smoke test',
+      };
+    case 'PreCompact':
+    case 'PostCompact':
+    case 'Stop':
+      return base;
+  }
+}
+
+function smokeInstalledNativeHookDist(prefixDir: string): void {
+  const globalNodeModules = resolveGlobalNodeModules(prefixDir);
+  const packageRoot = join(globalNodeModules, 'oh-my-codex');
+  const hookScript = join(packageRoot, 'dist', 'scripts', 'codex-native-hook.js');
+  const smokeCwd = mkdtempSync(join(tmpdir(), 'omx-packed-hook-smoke-'));
+  try {
+    for (const eventName of PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS) {
+      const payload = buildNativeHookSmokePayload(eventName, smokeCwd);
+      const result = run(process.execPath, [realpathSync(hookScript)], {
+        cwd: smokeCwd,
+        env: {
+          ...process.env,
+          OMX_NATIVE_HOOK_DOCTOR_SMOKE: '1',
+          OMX_ROOT: join(smokeCwd, '.omx-packed-hook-root'),
+          OMX_SESSION_ID: `packed-install-smoke-${eventName}`,
+          OMX_SOURCE_CWD: smokeCwd,
+          OMX_STARTUP_CWD: smokeCwd,
+        },
+        input: JSON.stringify(payload),
+      });
+      validateHookStdout(eventName, result.stdout as string);
+    }
+  } finally {
+    rmSync(smokeCwd, { recursive: true, force: true });
+  }
+}
+
 export function parseNpmPackJsonOutput(stdout: string): Array<{ filename: string }> {
   const start = stdout.lastIndexOf('\n[');
   const jsonText = (start >= 0 ? stdout.slice(start + 1) : stdout).trim();
@@ -147,6 +251,7 @@ async function main(): Promise<void> {
     for (const argv of PACKED_INSTALL_SMOKE_CORE_COMMANDS) {
       run(omxPath, argv, { cwd: repoRoot });
     }
+    smokeInstalledNativeHookDist(prefixDir);
 
     console.log('packed install smoke: PASS');
   } finally {


### PR DESCRIPTION
## Summary\n- add a default doctor smoke check that executes the installed dist native hook with a minimal UserPromptSubmit payload and emits reinstall/setup guidance on parse/runtime failure\n- extend packed-install release smoke to execute installed dist/scripts/codex-native-hook.js across all Codex native hook events\n- cover the new doctor and packaging smoke behavior with focused tests\n\nFixes #2394.\n\n## Verification\n- npm run build\n- node --test dist/scripts/__tests__/smoke-packed-install.test.js dist/cli/__tests__/doctor-warning-copy.test.js\n- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/package-bin-contract.test.js\n- npm run smoke:packed-install\n- node --check dist/scripts/codex-native-pre-post.js\n- git diff --check\n\n—\n*[repo owner's gaebal-gajae (clawdbot) 🦞]*