### PR TITLE
fix(team): tolerate tmux resize hook failures

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -3221,6 +3221,116 @@ esac
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('continues startup with best-effort resize fallback when indexed window-resized hook registration fails', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-resize-hook-fallback-'));
+    const prevTmux = process.env.TMUX;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevWarn = console.warn;
+    const warnings: string[] = [];
+
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-resize-hook-fallback-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.2a"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"*)
+        printf "%%1\tnode\t'codex'\n"
+        ;;
+      *)
+        printf "%%1\n"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  set-hook)
+    case "$*" in
+      *"window-resized["*)
+        echo "invalid option: window-resized[]" >&2
+        exit 1
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    ;;
+  set-option|resize-pane|select-layout|set-window-option|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          const fakeBinDir = join(logPath, '..');
+          const geminiPath = join(fakeBinDir, 'gemini');
+          await writeFile(geminiPath, '#!/bin/sh\nexit 0\n');
+          await chmod(geminiPath, 0o755);
+
+          process.env.TMUX = 'leader-session,stub,0';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+          console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
+
+          const session = createTeamSession('Resize Hook Fallback', 1, cwd);
+          assert.equal(session.hudPaneId, '%3');
+          assert.equal(session.resizeHookName, null);
+          assert.equal(session.resizeHookTarget, null);
+          assert.match(warnings.join('\n'), /tmux resize hook unavailable/);
+          assert.match(warnings.join('\n'), /invalid option: window-resized\[\]/);
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /set-hook -w -t leader:0 window-resized\[\d+\]/);
+          assert.match(tmuxLog, /set-hook -t leader:0 client-attached\[\d+\]/);
+          assert.match(tmuxLog, new RegExp(`run-shell -b sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+          assert.match(tmuxLog, new RegExp(`run-shell .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %3/);
+        },
+      );
+    } finally {
+      console.warn = prevWarn;
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('native Windows HUD reconciliation', () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1290,29 +1290,46 @@ export function createTeamSession(
               throw new Error(`failed to reconcile HUD resize: ${reconcile.stderr}`);
             }
           } else {
-            resizeHookTarget = buildResizeHookTarget(sessionName, windowIndex);
-            resizeHookName = buildResizeHookName(safeTeamName, sessionName, windowIndex, hudPaneId);
-            const registerHook = runTmux(buildRegisterResizeHookArgs(resizeHookTarget, resizeHookName, hudPaneId));
-            if (!registerHook.ok) {
-              throw new Error(`failed to register resize hook ${resizeHookName}: ${registerHook.stderr}`);
-            }
-            registeredResizeHook = { name: resizeHookName, target: resizeHookTarget };
-
+            const hookTarget = buildResizeHookTarget(sessionName, windowIndex);
+            const hookName = buildResizeHookName(safeTeamName, sessionName, windowIndex, hudPaneId);
+            const registerHook = runTmux(buildRegisterResizeHookArgs(hookTarget, hookName, hudPaneId));
             const clientAttachedHookName = buildClientAttachedReconcileHookName(
               safeTeamName,
               sessionName,
               windowIndex,
               hudPaneId,
             );
+            if (registerHook.ok) {
+              resizeHookTarget = hookTarget;
+              resizeHookName = hookName;
+              registeredResizeHook = { name: resizeHookName, target: resizeHookTarget };
+            } else {
+              // tmux versions/builds that reject indexed window-resized hooks should not
+              // abort madmax/team startup after panes were successfully created. Keep the
+              // fallback narrow: skip only the long-lived resize hook metadata, then
+              // still try the one-shot client-attached reconcile plus the explicit
+              // delayed/direct resize checks below so real tmux/run-shell failures
+              // still surface.
+              console.warn(
+                `[omx] tmux resize hook unavailable for ${hookTarget} (${hookName}): ${registerHook.stderr}; `
+                  + 'continuing with best-effort HUD resize fallback.',
+              );
+            }
             const registerClientAttachedHook = runTmux(
-              buildRegisterClientAttachedReconcileArgs(resizeHookTarget, clientAttachedHookName, hudPaneId),
+              buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId),
             );
-            if (!registerClientAttachedHook.ok) {
+            if (registerClientAttachedHook.ok) {
+              registeredClientAttachedHook = { name: clientAttachedHookName, target: hookTarget };
+            } else if (registerHook.ok) {
               throw new Error(
                 `failed to register client-attached reconcile hook ${clientAttachedHookName}: ${registerClientAttachedHook.stderr}`,
               );
+            } else {
+              console.warn(
+                `[omx] tmux client-attached resize fallback unavailable for ${hookTarget} `
+                  + `(${clientAttachedHookName}): ${registerClientAttachedHook.stderr}; continuing with delayed HUD resize fallback.`,
+              );
             }
-            registeredClientAttachedHook = { name: clientAttachedHookName, target: resizeHookTarget };
 
             const delayed = runTmux(buildScheduleDelayedHudResizeArgs(hudPaneId));
             if (!delayed.ok) {


### PR DESCRIPTION
## Summary
- Guard team HUD `window-resized[...]` hook registration so Ubuntu/tmux builds that reject the indexed hook no longer abort `omx --madmax --xhigh` startup.
- Preserve diagnostics and continue through client-attached, delayed, and direct HUD resize reconciliation fallbacks without masking real tmux/split/run-shell failures.
- Add a regression fixture for failed indexed `window-resized` hook registration that verifies startup continues, fallback resize commands run, and detached madmax-created worker/HUD panes are not rolled back.

Fixes #2384

## Verification
- `npm run build`
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/hud-tmux-injection.test.js dist/team/__tests__/tmux-session.test.js`
- `node --test dist/team/__tests__/tmux-session.test.js`
- `npm run lint`
- `git diff --check`

## Review / signed status
- AI slop cleanup: passed; fallback classified as a grounded external tmux compatibility/fail-safe path with stderr-preserving diagnostics and regression coverage.
- Code review: APPROVE; architect status CLEAR.

Signed-off-by: Codex <codex@openai.com>
