### PR TITLE
Fix project-local Codex auth persistence

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -45,6 +45,7 @@ import {
   resolveOmxRootForLaunch,
   resolveDisposableWorktreeOmxRootForLaunch,
   prepareCodexHomeForLaunch,
+  persistProjectLaunchRuntimeAuthState,
   runtimeCodexHomePath,
   buildDetachedSessionBootstrapSteps,
   buildDetachedTmuxSessionName,
@@ -1999,6 +2000,36 @@ describe("project launch scope helpers", () => {
       await prepareCodexHomeForLaunch(wd, "session-2033-repeat", {});
       assert.equal(await readFile(configPath, "utf-8"), originalConfig);
       assert.equal((await stat(configPath)).mtimeMs, beforeStat.mtimeMs);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("persists project-scope Codex auth written into the runtime CODEX_HOME mirror", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-runtime-auth-home-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await mkdir(projectCodexHome, { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      await writeFile(join(projectCodexHome, "config.toml"), 'model = "gpt-5.5"\n');
+
+      const prepared = await prepareCodexHomeForLaunch(wd, "session-auth", {});
+      const runtimeCodexHome = runtimeCodexHomePath(wd, "session-auth");
+      const opaqueAuthState = JSON.stringify({ token: "opaque-test-token" });
+      await writeFile(join(runtimeCodexHome, "auth.json"), opaqueAuthState);
+      await writeFile(join(runtimeCodexHome, "config.toml"), 'model = "gpt-5.5"\n[tui.model_availability_nux]\n"gpt-5.5" = 1\n');
+
+      await persistProjectLaunchRuntimeAuthState(
+        prepared.runtimeCodexHomeForCleanup,
+        prepared.projectLocalCodexHomeForCleanup,
+      );
+
+      assert.equal(await readFile(join(projectCodexHome, "auth.json"), "utf-8"), opaqueAuthState);
+      assert.equal(await readFile(join(projectCodexHome, "config.toml"), "utf-8"), 'model = "gpt-5.5"\n');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -709,6 +709,31 @@ function isCodexSqliteArtifact(entryName: string): boolean {
   return /^(?:state|logs)_\d+\.sqlite(?:-(?:shm|wal))?$/.test(entryName);
 }
 
+const PROJECT_LAUNCH_PERSISTED_RUNTIME_ENTRY_NAMES = new Set([
+  // Codex CLI writes browser/OTP login state here when CODEX_HOME points at
+  // the per-session mirror. Persist only the opaque file itself; never parse or
+  // log the contents.
+  "auth.json",
+]);
+
+function shouldPersistProjectLaunchRuntimeEntry(entryName: string): boolean {
+  return PROJECT_LAUNCH_PERSISTED_RUNTIME_ENTRY_NAMES.has(entryName);
+}
+
+export async function persistProjectLaunchRuntimeAuthState(
+  runtimeCodexHome: string | undefined,
+  projectCodexHome: string | undefined,
+): Promise<void> {
+  if (!runtimeCodexHome || !projectCodexHome) return;
+  if (!existsSync(runtimeCodexHome)) return;
+  await mkdir(projectCodexHome, { recursive: true });
+
+  for (const entry of await readdir(runtimeCodexHome, { withFileTypes: true })) {
+    if (!shouldPersistProjectLaunchRuntimeEntry(entry.name) || !entry.isFile()) continue;
+    await copyFile(join(runtimeCodexHome, entry.name), join(projectCodexHome, entry.name));
+  }
+}
+
 /**
  * Project-scope setup keeps durable Codex config under <repo>/.codex, but the
  * Codex TUI also stores model-availability NUX counters in CODEX_HOME/config.toml.
@@ -792,8 +817,15 @@ export async function prepareCodexHomeForLaunch(
   };
 }
 
-async function cleanupRuntimeCodexHome(runtimeCodexHomeForCleanup?: string): Promise<void> {
+async function cleanupRuntimeCodexHome(
+  runtimeCodexHomeForCleanup?: string,
+  projectCodexHomeForPersistence?: string,
+): Promise<void> {
   if (!runtimeCodexHomeForCleanup) return;
+  await persistProjectLaunchRuntimeAuthState(
+    runtimeCodexHomeForCleanup,
+    projectCodexHomeForPersistence,
+  );
   await rm(runtimeCodexHomeForCleanup, { recursive: true, force: true });
 }
 
@@ -1678,7 +1710,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
     // ── Phase 3: postLaunch ─────────────────────────────────────────────
     if (!postLaunchHandledExternally) {
       await postLaunch(cwd, sessionId, codexHomeOverride, enableNotifyFallbackAuthority, projectLocalCodexHomeForCleanup);
-      await cleanupRuntimeCodexHome(preparedCodexHome.runtimeCodexHomeForCleanup).catch(logCliOperationFailure);
+      await cleanupRuntimeCodexHome(preparedCodexHome.runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup).catch(logCliOperationFailure);
     }
   }
 }
@@ -1792,7 +1824,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
     runCodexBlocking(cwd, codexArgs, codexEnv);
   } finally {
     await postLaunch(cwd, sessionId, codexHomeOverride, true, projectLocalCodexHomeForCleanup);
-    await cleanupRuntimeCodexHome(preparedCodexHome.runtimeCodexHomeForCleanup).catch(logCliOperationFailure);
+    await cleanupRuntimeCodexHome(preparedCodexHome.runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup).catch(logCliOperationFailure);
   }
 }
 
@@ -4137,7 +4169,7 @@ export async function runDetachedSessionPostLaunch(
     false,
     projectLocalCodexHomeForCleanup,
   );
-  await cleanupRuntimeCodexHome(runtimeCodexHomeForCleanup).catch(logCliOperationFailure);
+  await cleanupRuntimeCodexHome(runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup).catch(logCliOperationFailure);
 }
 
 async function emitNativeHookEvent(


### PR DESCRIPTION
## Summary
- Persist opaque Codex auth state (`auth.json`) from the project-scope runtime CODEX_HOME mirror back to durable `<project>/.codex` before mirror cleanup
- Keep project-local config semantics unchanged by continuing to isolate transient `config.toml`/hook mirror writes
- Add regression coverage for auth written during the first project-local launch and for runtime codex-home mirror discovery behavior

Fixes #2401.

## Root cause
Project-scope launches intentionally run Codex against `.omx/runtime/codex-home/<session>` so Codex TUI writes do not dirty `<project>/.codex/config.toml`. On first browser/OTP login, Codex writes `auth.json` into that runtime mirror. OMX then cleaned up the mirror without copying the new auth state back to `<project>/.codex`, so the next `omx`/`omx resume` launch started unauthenticated again.

## Validation
- `npm ci`
- `npm run build`
- `node --test --test-name-pattern "project launch scope helpers|runtime codex-home hooks" dist/cli/__tests__/index.test.js dist/cli/__tests__/doctor-warning-copy.test.js`
- `node --test dist/cli/__tests__/resume.test.js`
- `node --test --test-name-pattern "scope|project" dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/setup-install-mode.test.js`
- `git diff --check`

## Notes
- Does not inspect, parse, or log auth contents; test uses opaque fake auth state.
- Full `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/doctor-warning-copy.test.js` still shows unrelated pre-existing/flaky failures in postLaunch mode cleanup and tmux lease tests; focused relevant tests pass.
