### PR TITLE
Stop reopening closed HUD panes

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from '../reconcile.js';
+import { OMX_TMUX_HUD_AUTO_CREATE_ENV, OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from '../reconcile.js';
 
 describe('reconcileHudForPromptSubmit', () => {
   it('skips reconciliation outside tmux', async () => {
@@ -36,12 +36,32 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(created, false);
   });
 
-  it('recreates a missing HUD in explicit OMX-owned tmux', async () => {
+  it('does not auto-create a missing HUD in explicit OMX-owned tmux by default', async () => {
+    let created = false;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      createHudWatchPane: () => {
+        created = true;
+        return '%9';
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'skipped_autocreate_disabled');
+    assert.equal(result.paneId, null);
+    assert.equal(created, false);
+  });
+
+  it('recreates a missing HUD in explicit OMX-owned tmux when auto-create is enabled', async () => {
     const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1', [OMX_TMUX_HUD_AUTO_CREATE_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
       ],
@@ -69,7 +89,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const created: Array<{ cmd: string }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-stale', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-stale', [OMX_TMUX_HUD_OWNER_ENV]: '1', [OMX_TMUX_HUD_AUTO_CREATE_ENV]: '1' },
       sessionId: 'sess-canonical',
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
@@ -93,7 +113,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%leader', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%leader', [OMX_TMUX_HUD_OWNER_ENV]: '1', [OMX_TMUX_HUD_AUTO_CREATE_ENV]: '1' },
       listCurrentWindowPanes: (currentPaneId) => {
         listArgs.push(currentPaneId);
         return [
@@ -166,7 +186,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1', [OMX_TMUX_HUD_AUTO_CREATE_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
         { paneId: '%2', currentCommand: 'node', startCommand: 'node omx hud --watch' },
@@ -189,7 +209,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1', [OMX_TMUX_HUD_AUTO_CREATE_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
       ],

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -15,9 +15,14 @@ import {
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
 
 export const OMX_TMUX_HUD_OWNER_ENV = 'OMX_TMUX_HUD_OWNER';
+export const OMX_TMUX_HUD_AUTO_CREATE_ENV = 'OMX_TMUX_HUD_AUTO_CREATE';
 
 function isExplicitOmxOwnedTmuxEnv(env: NodeJS.ProcessEnv): boolean {
   return env[OMX_TMUX_HUD_OWNER_ENV] === '1';
+}
+
+function shouldAutoCreateHudPane(env: NodeJS.ProcessEnv): boolean {
+  return env[OMX_TMUX_HUD_AUTO_CREATE_ENV] === '1';
 }
 
 export interface ReconcileHudForPromptSubmitResult {
@@ -25,6 +30,7 @@ export interface ReconcileHudForPromptSubmitResult {
     | 'skipped_not_tmux'
     | 'skipped_no_entry'
     | 'skipped_not_omx_owned_tmux'
+    | 'skipped_autocreate_disabled'
     | 'resized'
     | 'recreated'
     | 'replaced_duplicates'
@@ -115,6 +121,15 @@ export async function reconcileHudForPromptSubmit(
   const preset = hudConfig?.preset;
   const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
   const hudCmd = buildHudWatchCommand(omxBin, preset, resolvedSessionId);
+
+  if (hudPaneIds.length === 0 && !shouldAutoCreateHudPane(env)) {
+    return {
+      status: 'skipped_autocreate_disabled',
+      paneId: null,
+      desiredHeight,
+      duplicateCount,
+    };
+  }
 
   if (hudPaneIds.length === 1) {
     const resized = resizePane(hudPaneIds[0], desiredHeight);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3807,16 +3807,15 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Add a blank line after the subject before the narrative body.",
           "- Add a narrative body paragraph explaining the decision context.",
           "- Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
         ].join("\n"),
       });
       const hookSpecificOutput = (result.outputJson as { hookSpecificOutput?: Record<string, unknown> })
@@ -4127,16 +4126,15 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Add a blank line after the subject before the narrative body.",
           "- Add a narrative body paragraph explaining the decision context.",
           "- Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
         ].join("\n"),
       });
     } finally {
@@ -4162,16 +4160,15 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Add a blank line after the subject before the narrative body.",
           "- Add a narrative body paragraph explaining the decision context.",
           "- Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
         ].join("\n"),
       });
     } finally {
@@ -4197,16 +4194,15 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Add a blank line after the subject before the narrative body.",
           "- Add a narrative body paragraph explaining the decision context.",
           "- Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
         ].join("\n"),
       });
     } finally {
@@ -4232,16 +4228,15 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Add a blank line after the subject before the narrative body.",
           "- Add a narrative body paragraph explaining the decision context.",
           "- Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
         ].join("\n"),
       });
     } finally {
@@ -4267,16 +4262,15 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Add a blank line after the subject before the narrative body.",
           "- Add a narrative body paragraph explaining the decision context.",
           "- Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
         ].join("\n"),
       });
     } finally {
@@ -4302,16 +4296,15 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Add a blank line after the subject before the narrative body.",
           "- Add a narrative body paragraph explaining the decision context.",
           "- Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
         ].join("\n"),
       });
     } finally {
@@ -4337,16 +4330,15 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Add a blank line after the subject before the narrative body.",
           "- Add a narrative body paragraph explaining the decision context.",
           "- Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
         ].join("\n"),
       });
     } finally {
@@ -4372,16 +4364,15 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Add a blank line after the subject before the narrative body.",
           "- Add a narrative body paragraph explaining the decision context.",
           "- Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
         ].join("\n"),
       });
     } finally {
@@ -4407,16 +4398,15 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Add a blank line after the subject before the narrative body.",
           "- Add a narrative body paragraph explaining the decision context.",
           "- Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
         ].join("\n"),
       });
     } finally {
@@ -4442,12 +4432,12 @@ exit 0
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+          "git commit is blocked until the inline commit message satisfies the Lore format.",
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
         },
         systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+          "git commit is blocked until the inline commit message follows the Lore protocol.",
           "- Use inline `git commit -m ...` paragraphs for Lore-format commits in this path; file/editor/reuse/fixup message sources are not inspectable safely from pre-tool-use enforcement.",
         ].join("\n"),
       });
@@ -4456,20 +4446,20 @@ exit 0
     }
   });
 
-  it("blocks PreToolUse git commit when Lore trailers exist but the OmX co-author trailer is missing", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-missing-omx-coauthor-"));
+  it("stays silent on PreToolUse when Lore trailers exist without an OmX co-author trailer", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-no-omx-coauthor-"));
     try {
       const result = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
           cwd,
           tool_name: "Bash",
-          tool_use_id: "tool-git-commit-missing-omx-coauthor",
+          tool_use_id: "tool-git-commit-no-omx-coauthor",
           tool_input: {
             command: [
               'git commit',
               '-m "Prevent invalid history from bypassing Lore enforcement"',
-              '-m "The native pre-tool-use hook now blocks inline git commit messages that skip Lore trailers or the required OmX co-author trailer."',
+              '-m "The native pre-tool-use hook now blocks inline git commit messages that skip Lore trailers."',
               '-m "Constraint: Native PreToolUse can only inspect the Bash command text"',
               '-m "Tested: node --test dist/scripts/__tests__/codex-native-hook.test.js"',
             ].join(" "),
@@ -4479,24 +4469,13 @@ exit 0
       );
 
       assert.equal(result.omxEventName, "pre-tool-use");
-      assert.deepEqual(result.outputJson, {
-        decision: "block",
-        reason:
-          "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
-        hookSpecificOutput: {
-          hookEventName: "PreToolUse",
-        },
-        systemMessage: [
-          "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
-          "- Add the required co-author trailer: `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
-        ].join("\n"),
-      });
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it("stays silent on PreToolUse for Lore-compliant git commit with OmX co-author trailer", async () => {
+  it("stays silent on PreToolUse for Lore-compliant git commit with optional OmX co-author trailer", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-valid-"));
     try {
       const result = await dispatchCodexNativeHook(
@@ -4509,7 +4488,7 @@ exit 0
             command: [
               'git commit',
               '-m "Prevent invalid history from bypassing Lore enforcement"',
-              '-m "The native pre-tool-use hook now blocks inline git commit messages that skip Lore trailers or the required OmX co-author trailer."',
+              '-m "The native pre-tool-use hook now blocks inline git commit messages that skip Lore trailers."',
               '-m "Constraint: Native PreToolUse can only inspect the Bash command text"',
               '-m "Tested: node --test dist/scripts/__tests__/codex-native-hook.test.js"',
               '-m "Co-authored-by: OmX <omx@oh-my-codex.dev>"',
@@ -4526,7 +4505,7 @@ exit 0
     }
   });
 
-  it("stays silent on PreToolUse for compact inline Lore commit with only OmX co-author trailer", async () => {
+  it("blocks PreToolUse for compact inline commit with only an OmX co-author trailer", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-git-commit-compact-coauthor-"));
     try {
       const result = await dispatchCodexNativeHook(
@@ -4547,7 +4526,8 @@ exit 0
       );
 
       assert.equal(result.omxEventName, "pre-tool-use");
-      assert.equal(result.outputJson, null);
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /Add at least one Lore trailer/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -24,7 +24,7 @@ import {
 import { writeSessionStart } from "../../hooks/session.js";
 import { resetTriageConfigCache } from "../../hooks/triage-config.js";
 import { executeStateOperation } from "../../state/operations.js";
-import { OMX_TMUX_HUD_OWNER_ENV } from "../../hud/reconcile.js";
+import { OMX_TMUX_HUD_AUTO_CREATE_ENV, OMX_TMUX_HUD_OWNER_ENV } from "../../hud/reconcile.js";
 import { readAllState } from "../../hud/state.js";
 import { getLegacyWikiDir, serializePage, writePage } from "../../wiki/storage.js";
 import { WIKI_SCHEMA_VERSION } from "../../wiki/types.js";
@@ -2786,11 +2786,13 @@ export async function onHookEvent(event) {
     const originalTmuxPane = process.env.TMUX_PANE;
     const originalPath = process.env.PATH;
     const originalHudOwner = process.env[OMX_TMUX_HUD_OWNER_ENV];
+    const originalHudAutoCreate = process.env[OMX_TMUX_HUD_AUTO_CREATE_ENV];
     const originalArgv = process.argv;
     try {
       process.env.TMUX = "1";
       process.env.TMUX_PANE = "%1";
       process.env[OMX_TMUX_HUD_OWNER_ENV] = "1";
+      process.env[OMX_TMUX_HUD_AUTO_CREATE_ENV] = "1";
       await mkdir(join(cwd, ".omx", "state"), { recursive: true });
       await writeFile(
         join(cwd, ".omx", "hud-config.json"),
@@ -2855,6 +2857,11 @@ esac
         delete process.env[OMX_TMUX_HUD_OWNER_ENV];
       } else {
         process.env[OMX_TMUX_HUD_OWNER_ENV] = originalHudOwner;
+      }
+      if (originalHudAutoCreate === undefined) {
+        delete process.env[OMX_TMUX_HUD_AUTO_CREATE_ENV];
+      } else {
+        process.env[OMX_TMUX_HUD_AUTO_CREATE_ENV] = originalHudAutoCreate;
       }
       process.env.PATH = originalPath;
       process.argv = originalArgv;

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -242,7 +242,7 @@ const LORE_TRAILER_PREFIXES = [
   "Related:",
 ] as const;
 
-const OMX_COAUTHOR_TRAILER = "Co-authored-by: OmX <omx@oh-my-codex.dev>";
+const OPTIONAL_OMX_COAUTHOR_TRAILER = "Co-authored-by: OmX <omx@oh-my-codex.dev>";
 
 function isDoubleQuotedShellEscapeTarget(char: string | undefined): boolean {
   return char === "\"" || char === "\\" || char === "$" || char === "`" || char === "\n";
@@ -751,7 +751,7 @@ function buildEffectiveLoreCommitGuardEnv(parsed: GitCommitCommandParseResult): 
 }
 
 function isLoreTrailerLine(line: string): boolean {
-  return line === OMX_COAUTHOR_TRAILER
+  return line === OPTIONAL_OMX_COAUTHOR_TRAILER
     || LORE_TRAILER_PREFIXES.some((prefix) => line.startsWith(prefix));
 }
 
@@ -799,7 +799,7 @@ function buildGitCommitComplianceErrors(message: string | null): string[] {
   const normalized = message.replace(/\r\n?/g, "\n").trim();
   if (!normalized) {
     return [
-      "Provide a non-empty Lore-format commit message with an intent-first subject, narrative body, Lore trailers, and the OmX co-author trailer.",
+      "Provide a non-empty Lore-format commit message with an intent-first subject, narrative body, and Lore trailers.",
     ];
   }
 
@@ -815,18 +815,15 @@ function buildGitCommitComplianceErrors(message: string | null): string[] {
   const hasSubject = (lines[0]?.trim() ?? "") !== "";
   const hasBlankSeparator = lines.length >= 2 && lines[1]?.trim() === "";
   const { bodyText, trailerLines } = splitBodyAndTrailerLines(lines.slice(2).join("\n"));
-  const hasOmxCoauthorTrailer = trailerLines.includes(OMX_COAUTHOR_TRAILER);
-  const usesCompactLorePath = hasSubject && hasBlankSeparator && !bodyText && hasOmxCoauthorTrailer;
+  const hasLoreTrailer = trailerLines.some((line) => LORE_TRAILER_PREFIXES.some((prefix) => line.startsWith(prefix)));
+  const usesCompactLorePath = hasSubject && hasBlankSeparator && !bodyText && hasLoreTrailer;
   if (!usesCompactLorePath) {
     if (!bodyText) {
       errors.push("Add a narrative body paragraph explaining the decision context.");
     }
-    if (!trailerLines.some((line) => LORE_TRAILER_PREFIXES.some((prefix) => line.startsWith(prefix)))) {
+    if (!hasLoreTrailer) {
       errors.push("Add at least one Lore trailer such as `Constraint:`, `Confidence:`, or `Tested:`.");
     }
-  }
-  if (!hasOmxCoauthorTrailer) {
-    errors.push(`Add the required co-author trailer: \`${OMX_COAUTHOR_TRAILER}\`.`);
   }
 
   return errors;
@@ -849,12 +846,12 @@ function buildGitCommitEnforcementOutput(commandText: string): Record<string, un
   return {
     decision: "block",
     reason:
-      "git commit is blocked until the inline commit message satisfies the Lore format and includes the required OmX co-author trailer.",
+      "git commit is blocked until the inline commit message satisfies the Lore format.",
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
     },
     systemMessage: [
-      "git commit is blocked until the inline commit message follows the Lore protocol and includes `Co-authored-by: OmX <omx@oh-my-codex.dev>`.",
+      "git commit is blocked until the inline commit message follows the Lore protocol.",
       ...errors.map((error) => `- ${error}`),
     ].join("\n"),
   };


### PR DESCRIPTION
Prompt-submit reconciliation should not bring the HUD back after a user closes it. It now creates a missing HUD pane only when OMX_TMUX_HUD_AUTO_CREATE=1, while keeping resize and duplicate cleanup behavior.

Constraint: Preserve existing duplicate HUD cleanup and explicit auto-create behavior.
Tested: npm run build
Tested: node --test dist/hud/__tests__/reconcile.test.js dist/scripts/__tests__/codex-native-hook.test.js
Tested: npm run lint

## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Describe the problem and why this change is needed.

## Changes

-

## Validation

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [ ] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [ ] Backward-compatibility impact considered

## Related

Closes #
