### PR TITLE
Stop reopening closed HUD panes

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from '../reconcile.js';
+import { OMX_TMUX_HUD_AUTO_CREATE_ENV, OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from '../reconcile.js';
 
 describe('reconcileHudForPromptSubmit', () => {
   it('skips reconciliation outside tmux', async () => {
@@ -36,12 +36,32 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(created, false);
   });
 
-  it('recreates a missing HUD in explicit OMX-owned tmux', async () => {
+  it('does not auto-create a missing HUD in explicit OMX-owned tmux by default', async () => {
+    let created = false;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      createHudWatchPane: () => {
+        created = true;
+        return '%9';
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'skipped_autocreate_disabled');
+    assert.equal(result.paneId, null);
+    assert.equal(created, false);
+  });
+
+  it('recreates a missing HUD in explicit OMX-owned tmux when auto-create is enabled', async () => {
     const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1', [OMX_TMUX_HUD_AUTO_CREATE_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
       ],
@@ -69,7 +89,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const created: Array<{ cmd: string }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-stale', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-stale', [OMX_TMUX_HUD_OWNER_ENV]: '1', [OMX_TMUX_HUD_AUTO_CREATE_ENV]: '1' },
       sessionId: 'sess-canonical',
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
@@ -93,7 +113,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%leader', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%leader', [OMX_TMUX_HUD_OWNER_ENV]: '1', [OMX_TMUX_HUD_AUTO_CREATE_ENV]: '1' },
       listCurrentWindowPanes: (currentPaneId) => {
         listArgs.push(currentPaneId);
         return [
@@ -166,7 +186,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1', [OMX_TMUX_HUD_AUTO_CREATE_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
         { paneId: '%2', currentCommand: 'node', startCommand: 'node omx hud --watch' },
@@ -189,7 +209,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1', [OMX_TMUX_HUD_AUTO_CREATE_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
       ],

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -15,9 +15,14 @@ import {
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
 
 export const OMX_TMUX_HUD_OWNER_ENV = 'OMX_TMUX_HUD_OWNER';
+export const OMX_TMUX_HUD_AUTO_CREATE_ENV = 'OMX_TMUX_HUD_AUTO_CREATE';
 
 function isExplicitOmxOwnedTmuxEnv(env: NodeJS.ProcessEnv): boolean {
   return env[OMX_TMUX_HUD_OWNER_ENV] === '1';
+}
+
+function shouldAutoCreateHudPane(env: NodeJS.ProcessEnv): boolean {
+  return env[OMX_TMUX_HUD_AUTO_CREATE_ENV] === '1';
 }
 
 export interface ReconcileHudForPromptSubmitResult {
@@ -25,6 +30,7 @@ export interface ReconcileHudForPromptSubmitResult {
     | 'skipped_not_tmux'
     | 'skipped_no_entry'
     | 'skipped_not_omx_owned_tmux'
+    | 'skipped_autocreate_disabled'
     | 'resized'
     | 'recreated'
     | 'replaced_duplicates'
@@ -115,6 +121,15 @@ export async function reconcileHudForPromptSubmit(
   const preset = hudConfig?.preset;
   const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
   const hudCmd = buildHudWatchCommand(omxBin, preset, resolvedSessionId);
+
+  if (hudPaneIds.length === 0 && !shouldAutoCreateHudPane(env)) {
+    return {
+      status: 'skipped_autocreate_disabled',
+      paneId: null,
+      desiredHeight,
+      duplicateCount,
+    };
+  }
 
   if (hudPaneIds.length === 1) {
     const resized = resizePane(hudPaneIds[0], desiredHeight);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -24,7 +24,7 @@ import {
 import { writeSessionStart } from "../../hooks/session.js";
 import { resetTriageConfigCache } from "../../hooks/triage-config.js";
 import { executeStateOperation } from "../../state/operations.js";
-import { OMX_TMUX_HUD_OWNER_ENV } from "../../hud/reconcile.js";
+import { OMX_TMUX_HUD_AUTO_CREATE_ENV, OMX_TMUX_HUD_OWNER_ENV } from "../../hud/reconcile.js";
 import { readAllState } from "../../hud/state.js";
 import { getLegacyWikiDir, serializePage, writePage } from "../../wiki/storage.js";
 import { WIKI_SCHEMA_VERSION } from "../../wiki/types.js";
@@ -3237,11 +3237,13 @@ export async function onHookEvent(event) {
     const originalTmuxPane = process.env.TMUX_PANE;
     const originalPath = process.env.PATH;
     const originalHudOwner = process.env[OMX_TMUX_HUD_OWNER_ENV];
+    const originalHudAutoCreate = process.env[OMX_TMUX_HUD_AUTO_CREATE_ENV];
     const originalArgv = process.argv;
     try {
       process.env.TMUX = "1";
       process.env.TMUX_PANE = "%1";
       process.env[OMX_TMUX_HUD_OWNER_ENV] = "1";
+      process.env[OMX_TMUX_HUD_AUTO_CREATE_ENV] = "1";
       await mkdir(join(cwd, ".omx", "state"), { recursive: true });
       await writeFile(
         join(cwd, ".omx", "hud-config.json"),
@@ -3306,6 +3308,11 @@ esac
         delete process.env[OMX_TMUX_HUD_OWNER_ENV];
       } else {
         process.env[OMX_TMUX_HUD_OWNER_ENV] = originalHudOwner;
+      }
+      if (originalHudAutoCreate === undefined) {
+        delete process.env[OMX_TMUX_HUD_AUTO_CREATE_ENV];
+      } else {
+        process.env[OMX_TMUX_HUD_AUTO_CREATE_ENV] = originalHudAutoCreate;
       }
       process.env.PATH = originalPath;
       process.argv = originalArgv;


### PR DESCRIPTION
Prompt-submit reconciliation should not bring the HUD back after a user closes it. It now creates a missing HUD pane only when OMX_TMUX_HUD_AUTO_CREATE=1, while keeping resize and duplicate cleanup behavior.

Constraint: Preserve existing duplicate HUD cleanup and explicit auto-create behavior.
Tested: npm run build
Tested: node --test dist/hud/__tests__/reconcile.test.js dist/scripts/__tests__/codex-native-hook.test.js
Tested: npm run lint

## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Describe the problem and why this change is needed.

## Changes

-

## Validation

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [ ] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [ ] Backward-compatibility impact considered

## Related

Closes #
