### PR TITLE
Prevent stale performance goal Stop loops after mismatch blocks

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1773,6 +1773,66 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("does not repeat performance-goal reconciliation after a recorded objective mismatch blocker", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-performance-mismatch-blocked-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "goals", "performance", "latency", "state.json"), {
+        version: 1,
+        workflow: "performance-goal",
+        slug: "latency",
+        objective: "Reduce latency",
+        status: "blocked",
+        lastValidation: {
+          status: "blocked",
+          evidence: "omx performance-goal complete rejected the fresh get_goal snapshot: Codex goal objective mismatch: expected \"reduce latency\", got \"legacy objective\".",
+          recordedAt: "2026-05-20T00:00:00.000Z",
+        },
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-performance-mismatch-blocked-stop",
+        thread_id: "thread-performance-mismatch-blocked-stop",
+        last_assistant_message: "Performance goal complete; next call update_goal({status: \"complete\"}).",
+      }, { cwd });
+
+      assert.notEqual(result.outputJson?.decision, "block");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /omx performance-goal complete --slug latency/);
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /get_goal snapshot reconciliation/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block Stop for an already complete performance-goal state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-performance-complete-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "goals", "performance", "latency", "state.json"), {
+        version: 1,
+        workflow: "performance-goal",
+        slug: "latency",
+        objective: "Reduce latency",
+        status: "complete",
+        completedAt: "2026-05-20T00:00:00.000Z",
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-performance-complete-stop",
+        thread_id: "thread-performance-complete-stop",
+        last_assistant_message: "Performance goal complete; next call update_goal({status: \"complete\"}).",
+      }, { cwd });
+
+      assert.notEqual(result.outputJson?.decision, "block");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /omx performance-goal complete --slug latency/);
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /get_goal snapshot reconciliation/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks ultragoal Stop for concise generic goal completion claims", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-generic-complete-stop-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2005,6 +2005,22 @@ function reportsAutoresearchGoalObjectiveMismatch(text: string): boolean {
     && /objective mismatch/i.test(text);
 }
 
+function reportsBlockedPerformanceGoalObjectiveMismatch(state: unknown): boolean {
+  const performanceState = safeObject(state);
+  const lastValidation = safeObject(performanceState.lastValidation);
+  if (safeString(performanceState.workflow) !== "performance-goal") return false;
+  if (safeString(performanceState.status) !== "blocked") return false;
+  if (safeString(lastValidation.status) !== "blocked") return false;
+
+  const evidence = [
+    safeString(lastValidation.evidence),
+    safeString(lastValidation.message),
+    safeString(performanceState.evidence),
+    safeString(performanceState.message),
+  ].join(" ");
+  return /objective mismatch/i.test(evidence);
+}
+
 async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Promise<{ workflow: string; command: string; remediation?: string } | null> {
   const ultragoal = await readJsonIfExists(join(cwd, ".omx", "ultragoal", "goals.json"));
   const aggregateCompletion = safeObject(ultragoal?.aggregateCompletion);
@@ -2032,6 +2048,9 @@ async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Pro
     if (!entry.isDirectory()) continue;
     const state = await readJsonIfExists(join(performanceRoot, entry.name, "state.json"));
     const status = safeString(state?.status);
+    if (reportsBlockedPerformanceGoalObjectiveMismatch(state)) {
+      continue;
+    }
     if (state?.workflow === "performance-goal" && status && status !== "complete") {
       return {
         workflow: "performance-goal",


### PR DESCRIPTION
Title: Prevent stale performance goal Stop loops after objective-mismatch blocks

## Summary
- Skip repeated native Stop reconciliation prompts for performance-goal runs that are already recorded as blocked because the Codex goal snapshot objective mismatched the performance-goal objective.
- Keep the existing Stop block for active/non-final performance-goal states that still need Codex goal reconciliation.
- Add regression coverage for the blocked objective-mismatch case and for already-complete performance-goal states.

## Cause
The native Stop hook currently scans `.omx/goals/performance/*/state.json` and emits a reconciliation block for any `workflow: "performance-goal"` state whose status is present and not `complete`. That includes states already durably marked `blocked` after an attempted reconciliation failed with `Codex goal objective mismatch`, so the hook can keep re-emitting the same unreachable instruction.

## Fix
Add a narrow state predicate for performance-goal states that are:
- `workflow: "performance-goal"`
- `status: "blocked"`
- `lastValidation.status: "blocked"`
- carrying objective-mismatch evidence in the recorded validation/state text

Only those recorded mismatch blockers are skipped by the active reconciliation scan. Other non-complete performance-goal states continue to block as before.

## Validation
- `npm run build` — PASS
- `npm run lint` — PASS
- `npm run check:no-unused` — PASS
- Targeted hook regression set — PASS, 5 tests
- Red/green proof: with the source fix temporarily reverted, the new blocked-mismatch regression fails with `decision === "block"`; after restoring the fix, the same test passes.

## Full-suite note
A broad Windows run of `dist/scripts/__tests__/codex-native-hook.test.js` still has 6 unrelated environment-sensitive failures in existing tests (Windows shim path expectation and tmux-log fixtures). The new/related performance-goal and autoresearch-goal tests all pass in the targeted run.

## Risk
Narrow. The exemption is tied to durable blocked objective-mismatch evidence and does not mark anything successful, does not mutate Codex goal state, and does not alter autoresearch-goal handling.
