### PR TITLE
Use plugin-scoped hooks for plugin installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ On a real `oh-my-codex` version bump, the global npm install now prints an expli
 
 OMX also checks for npm updates at launch on a throttled cadence and prompts before scheduling the update after the current session exits. Set `OMX_AUTO_UPDATE=0` to disable the launch-time check, or set `OMX_AUTO_UPDATE=defer` to schedule the same deferred update without prompting.
 
-**Codex plugin install note:** this repo also ships an official Codex plugin layout at `plugins/oh-my-codex` with marketplace metadata in `.agents/plugins/marketplace.json`. That plugin bundles the mirrored skill surface plus plugin-scoped companion metadata for optional MCP compatibility servers and apps, disabled by default. Native/runtime hooks still stay on the setup/runtime side rather than the installable plugin manifest. It is still **not** a replacement for `npm install -g oh-my-codex` plus `omx setup`: legacy setup mode installs native agents and prompts, while plugin setup mode relies on plugin discovery for bundled skills and archives/removes legacy OMX-managed prompts/native-agent TOMLs so stale role files cannot shadow plugin behavior.
+**Codex plugin install note:** this repo also ships an official Codex plugin layout at `plugins/oh-my-codex` with marketplace metadata in `.agents/plugins/marketplace.json`. That plugin bundles the mirrored skill surface plus plugin-scoped companion metadata for official Codex lifecycle hooks, optional MCP compatibility servers, and apps. It is still **not** a replacement for `npm install -g oh-my-codex` plus `omx setup`: plugin-scoped hooks launch the installed `omx` CLI, legacy setup mode installs native agents and prompts, and plugin setup mode relies on plugin discovery for bundled skills while archiving/removing legacy OMX-managed prompts/native-agent TOMLs so stale role files cannot shadow plugin behavior.
 
 Then work normally inside Codex:
 
@@ -245,8 +245,8 @@ omx team shutdown <team-name>
 ### Setup, doctor, and HUD
 
 These are operator/support surfaces:
-- Codex plugin marketplace install/discovery can cache the plugin under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (local installs may use `local` as the version identifier); that packaged plugin includes plugin-scoped companion metadata for optional MCP compatibility servers and apps (disabled by default), while native/runtime hooks remain setup-owned, so it is still not the full OMX runtime setup
-- `omx setup` installs prompts, skills, AGENTS scaffolding, `.codex/config.toml`, and OMX-managed native Codex hooks in `.codex/hooks.json`
+- Codex plugin marketplace install/discovery can cache the plugin under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (local installs may use `local` as the version identifier); that packaged plugin includes plugin-scoped companion metadata for official Codex lifecycle hooks, optional MCP compatibility servers, and apps (MCP/apps disabled by default), so it is still paired with the installed `omx` CLI for runtime execution
+- `omx setup` installs prompts, skills, AGENTS scaffolding, `.codex/config.toml`, and (for legacy installs or older Codex without `plugin_hooks`) OMX-managed native Codex hooks in `.codex/hooks.json`
   - setup refresh preserves non-OMX hook entries in `.codex/hooks.json` and only rewrites OMX-managed wrappers
   - `omx setup --merge-agents` preserves existing `AGENTS.md` guidance while inserting or refreshing generated OMX sections between `<!-- OMX:AGENTS:START -->` / `<!-- OMX:AGENTS:END -->`; without `--merge-agents` or `--force`, non-interactive setup keeps skipping existing `AGENTS.md` files
   - `omx uninstall` removes OMX-managed wrappers from `.codex/hooks.json` but keeps the file when user hooks remain
@@ -258,7 +258,8 @@ These are operator/support surfaces:
 - `omx hud --watch` is a monitoring/status surface, not the primary user workflow
 
 For non-team sessions, native Codex hooks are now the canonical lifecycle surface:
-- `.codex/hooks.json` = native Codex hook registrations
+- `plugins/oh-my-codex/hooks/hooks.json` = official plugin-scoped hook registrations for plugin installs
+- `.codex/hooks.json` = legacy/fallback native Codex hook registrations preserved for legacy installs and older Codex versions
 - `.omx/hooks/*.mjs` = OMX plugin hooks
 - `omx tmux-hook` / notify-hook / derived watcher = tmux + runtime fallback paths
 

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -6,13 +6,21 @@ This page is the canonical answer to:
 
 ## Install surface
 
-`omx setup` now owns both of these native Codex artifacts:
+For plugin installs on Codex versions that report official plugin-scoped hook
+support, the packaged plugin is the hook registration surface:
 
-- `.codex/config.toml` → enables setup-owned runtime feature flags including the installed-Codex hook flag (`[features].hooks = true`, or legacy `[features].codex_hooks = true` when that is the only reported feature) and `[features].goals = true`
+- `plugins/oh-my-codex/.codex-plugin/plugin.json` → points Codex at `./hooks/hooks.json`
+- `plugins/oh-my-codex/hooks/hooks.json` → registers the OMX lifecycle hook commands with `${PLUGIN_ROOT}`
+- `.codex/config.toml` → enables `[features].plugin_hooks = true` and `[features].goals = true`
+
+`omx setup` still owns the legacy/fallback native Codex artifacts for legacy
+installs and older Codex versions that do not report `plugin_hooks`:
+
+- `.codex/config.toml` → enables the installed-Codex hook flag (`[features].hooks = true`, or legacy `[features].codex_hooks = true` when that is the only reported feature) and `[features].goals = true`
 - `.codex/hooks.json` → registers the OMX-managed native hook command while preserving non-OMX hook entries already in the file
 - `.codex/config.toml` → also records `hooks.state."<hooks.json>:<event>:<group>:<handler>".trusted_hash` for the OMX-owned wrappers so recent Codex releases do not require a manual `/hooks` review for setup-managed hooks
 
-Compatibility note: Codex CLI 0.129/0.130 treats `hooks` as the canonical stable feature key and keeps `codex_hooks` only as a legacy alias. Some public hook examples may still show `[features].codex_hooks = true`; OMX-generated config intentionally emits `[features].hooks = true` while setup/uninstall migration paths still accept and normalize older `codex_hooks` entries so existing user configs do not lose hook enablement.
+Compatibility note: Codex CLI 0.129/0.130 treats `hooks` as the canonical stable feature key and keeps `codex_hooks` only as a legacy alias. Some public hook examples may still show `[features].codex_hooks = true`; OMX-generated fallback config intentionally emits `[features].hooks = true` while setup/uninstall migration paths still accept and normalize older `codex_hooks` entries so existing user configs do not lose hook enablement.
 
 For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of source control.
 `omx uninstall` removes only the OMX-managed wrapper entries from `.codex/hooks.json`; if user hooks remain, the file stays in place.
@@ -22,7 +30,8 @@ Project launches use a session-scoped `.omx/runtime/codex-home/<session>/` mirro
 
 ## Ownership split
 
-- **Native Codex hooks**: `.codex/hooks.json`
+- **Plugin-scoped Codex hooks**: `plugins/oh-my-codex/hooks/hooks.json` for plugin installs on Codex versions with `[features].plugin_hooks`
+- **Legacy/fallback native Codex hooks**: `.codex/hooks.json`
 - **OMX plugin hooks**: `.omx/hooks/*.mjs`
 - **tmux/runtime fallbacks**: `omx tmux-hook`, notify-hook, derived watcher, idle/session-end reporters
 

--- a/docs/plugin-bundle-ssot.md
+++ b/docs/plugin-bundle-ssot.md
@@ -8,7 +8,7 @@ The repository keeps one canonical authoring surface for each plugin/setup asset
 - **Plugin skill membership:** `templates/catalog-manifest.json` controls which catalog skills are installable. Active/internal skills, plus setup-only policy additions, must have canonical root skill directories and plugin mirrors.
 - **Plugin MCP metadata:** `src/config/omx-first-party-mcp.ts` is canonical. `plugins/oh-my-codex/.mcp.json` must match `buildOmxPluginMcpManifest()`.
 - **Plugin manifest version and paths:** `package.json` is canonical for the plugin version. The plugin manifest must point to `./skills/`, `./.mcp.json`, and `./.app.json`.
-- **Native agents and prompts:** root `prompts/` plus `src/agents/definitions.ts` are setup-owned canonical sources for legacy setup mode. The official plugin intentionally does not ship plugin-scoped `agents`, `prompts`, or hooks; plugin setup archives/removes legacy OMX-managed prompt and native-agent files so users do not keep stale mixed surfaces.
+- **Native agents and prompts:** root `prompts/` plus `src/agents/definitions.ts` are setup-owned canonical sources for legacy setup mode. The official plugin intentionally does not ship plugin-scoped `agents` or `prompts`; plugin setup archives/removes legacy OMX-managed prompt and native-agent files so users do not keep stale mixed surfaces. Official Codex plugin-scoped lifecycle hooks live under `plugins/oh-my-codex/hooks/hooks.json` and shell through the installed `omx` CLI.
 
 ## Commands
 
@@ -49,4 +49,4 @@ The verifier fails when installable catalog agents are missing definitions or pr
 
 `omx setup` converges generated native-agent TOMLs safely: normal setup removes stale non-installable TOMLs only when they carry the exact `# oh-my-codex agent: <name>` generated marker for the same cataloged agent name. User-authored or ambiguous TOMLs are preserved during normal setup; `--force` remains the explicit destructive cleanup path for stale non-installable native-agent files. Prompt cleanup uses the prompt asset policy, so cataloged prompt files and explicit setup prompt assets are preserved even when they are not installable native-agent TOMLs.
 
-The official plugin manifest must continue to omit `agents`, `prompts`, and `hooks`; legacy setup mode installs prompts/native agents, while plugin setup mode removes archived legacy copies instead of refreshing plugin-scoped prompt or agent assets.
+The official plugin manifest must continue to omit `agents` and `prompts`; lifecycle hooks are now plugin-scoped via `hooks = ./hooks/hooks.json`. Legacy setup mode installs prompts/native agents and `.codex/hooks.json`; plugin setup mode removes archived legacy prompt/agent copies and, when Codex reports `[features].plugin_hooks`, removes setup-managed `.codex/hooks.json` wrappers instead of refreshing them.

--- a/plugins/oh-my-codex/.codex-plugin/plugin.json
+++ b/plugins/oh-my-codex/.codex-plugin/plugin.json
@@ -23,8 +23,9 @@
   "interface": {
     "displayName": "oh-my-codex",
     "shortDescription": "Workflow layer and skill bundle for OpenAI Codex CLI.",
-    "longDescription": "Plugin = OMX skill/workflow discovery plus plugin-scoped companion metadata for MCP servers and apps. Setup = runtime wiring; legacy setup installs native agents/prompts, while plugin setup archives stale legacy native agents/prompts and keeps config, native .codex/hooks.json coverage, optional AGENTS.md, HUD, and runtime state current.",
+    "longDescription": "Plugin = OMX skill/workflow discovery plus plugin-scoped companion metadata for hooks, MCP servers, and apps. Setup = runtime wiring; legacy setup installs native agents/prompts, while plugin setup enables official plugin-scoped hooks, archives stale legacy native agents/prompts, and keeps config, optional AGENTS.md, HUD, and runtime state current.",
     "developerName": "Yeachan Heo",
     "category": "Developer Tools"
-  }
+  },
+  "hooks": "./hooks/hooks.json"
 }

--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const command = process.env.OMX_NATIVE_HOOK_COMMAND || 'omx';
+const child = spawn(command, ['codex-native-hook'], {
+  stdio: ['pipe', 'pipe', 'pipe'],
+  env: process.env,
+  shell: process.platform === 'win32',
+});
+
+process.stdin.pipe(child.stdin);
+child.stdout.pipe(process.stdout);
+child.stderr.pipe(process.stderr);
+child.on('error', (error) => {
+  console.error(`[oh-my-codex] failed to launch ${command} codex-native-hook: ${error.message}`);
+  process.exitCode = 1;
+});
+child.on('exit', (code, signal) => {
+  if (signal) {
+    console.error(`[oh-my-codex] codex-native-hook terminated by ${signal}`);
+    process.exitCode = 1;
+    return;
+  }
+  process.exitCode = code ?? 0;
+});

--- a/plugins/oh-my-codex/hooks/hooks.json
+++ b/plugins/oh-my-codex/hooks/hooks.json
@@ -1,0 +1,77 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex-native-hook.mjs\""
+          }
+        ],
+        "matcher": "startup|resume|clear"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex-native-hook.mjs\""
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex-native-hook.mjs\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex-native-hook.mjs\""
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex-native-hook.mjs\""
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex-native-hook.mjs\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex-native-hook.mjs\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -56,6 +56,7 @@ const pluginRoot = join(root, 'plugins', pluginName);
 const pluginManifestPath = join(pluginRoot, '.codex-plugin', 'plugin.json');
 const pluginMcpPath = join(pluginRoot, '.mcp.json');
 const pluginAppsPath = join(pluginRoot, '.app.json');
+const pluginHooksPath = join(pluginRoot, 'hooks', 'hooks.json');
 const marketplacePath = join(root, '.agents', 'plugins', 'marketplace.json');
 const omxBin = join(root, 'dist', 'cli', 'omx.js');
 
@@ -159,18 +160,27 @@ describe('official Codex plugin layout', () => {
     assert.ok(manifest.interface?.developerName, 'expected developerName');
   });
 
-  it('ships disabled-by-default plugin-scoped MCP compatibility metadata while hooks stay setup-owned', async () => {
-    const [mcpManifest, appsManifest] = await Promise.all([
+  it('ships plugin-scoped hooks and disabled-by-default MCP compatibility metadata', async () => {
+    const [mcpManifest, appsManifest, hooksManifest] = await Promise.all([
       readJson<PluginMcpManifest>(pluginMcpPath),
       readJson<PluginAppsManifest>(pluginAppsPath),
+      readJson<{ hooks?: Record<string, Array<{ hooks?: Array<{ command?: string }> }>> }>(pluginHooksPath),
     ]);
     const expectedPluginMcpManifest = buildOmxPluginMcpManifest();
 
     const pluginManifest = await readJson<PluginManifest>(pluginManifestPath);
     assert.equal(pluginManifest.agents, undefined);
     assert.equal(pluginManifest.prompts, undefined);
-    assert.equal(pluginManifest.hooks, undefined);
+    assert.equal(pluginManifest.hooks, './hooks/hooks.json');
     assert.deepEqual(appsManifest, { apps: {} });
+    const hookCommands = Object.values(hooksManifest.hooks ?? {})
+      .flatMap((entries) => entries)
+      .flatMap((entry) => entry.hooks ?? [])
+      .map((hook) => hook.command);
+    assert.ok(
+      hookCommands.every((command) => command === 'node "${PLUGIN_ROOT}/hooks/codex-native-hook.mjs"'),
+      'plugin hooks should use Codex PLUGIN_ROOT instead of setup-owned .codex/hooks.json',
+    );
     assert.deepEqual(mcpManifest, expectedPluginMcpManifest);
 
     for (const [serverName, server] of Object.entries(mcpManifest.mcpServers ?? {})) {
@@ -229,12 +239,13 @@ describe('official Codex plugin layout', () => {
     }
   });
 
-  it('does not stage plugin-scoped hook manifests or runtime hook directories', async () => {
+  it('does not stage setup-owned hook or runtime directories inside the plugin', async () => {
     const pluginEntries = await readdir(pluginRoot);
 
     assert.equal(pluginEntries.includes('.codex'), false, 'official plugin should not ship setup-owned .codex hook assets');
     assert.equal(pluginEntries.includes('.omx'), false, 'official plugin should not ship runtime hook directories');
-    assert.equal(pluginEntries.includes('hooks.json'), false, 'official plugin should not ship a plugin-scoped hooks manifest');
+    assert.equal(pluginEntries.includes('hooks.json'), false, 'official plugin hook metadata should stay under hooks/');
+    assert.equal(pluginEntries.includes('hooks'), true, 'official plugin should ship plugin-scoped lifecycle hooks');
   });
 
   it('registers the plugin in the repo marketplace with explicit source, policy, and category', async () => {
@@ -315,7 +326,7 @@ describe('official Codex plugin layout', () => {
     assert.match(combined, /plugins\/cache\/\$MARKETPLACE_NAME\/oh-my-codex\/\$VERSION\//);
     assert.match(combined, /not a replacement for `npm install -g oh-my-codex` plus `omx setup`/);
     assert.match(combined, /legacy setup mode installs native agents(?:\/| and )prompts|plugin setup mode archives stale legacy prompt\/native-agent files/);
-    assert.match(combined, /plugin-scoped companion metadata for optional MCP compatibility servers and apps/i);
-    assert.match(combined, /hooks stay setup-owned|hooks remain setup-owned|native \.codex\/hooks\.json coverage/i);
+    assert.match(combined, /plugin-scoped companion metadata for official Codex lifecycle hooks/i);
+    assert.match(combined, /legacy\/fallback native Codex hook registrations|legacy setup mode installs prompts\/native agents and \.codex\/hooks\.json/i);
   });
 });

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -446,10 +446,10 @@ approval_policy = "on-failure"
 });
 
 async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {
-	const hooks = await readFile(join(wd, ".codex", "hooks.json"), "utf-8");
-	assert.match(hooks, /codex-native-hook\.js/);
+	assert.equal(existsSync(join(wd, ".codex", "hooks.json")), false);
 	const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-	assert.match(config, /^hooks = true$/m);
+	assert.match(config, /^plugin_hooks = true$/m);
+	assert.doesNotMatch(config, /^hooks = true$/m);
 	assert.match(config, /^goals = true$/m);
 	assert.doesNotMatch(config, /developer_instructions|notify-hook/g);
 	assert.equal(
@@ -1025,11 +1025,7 @@ describe("omx setup install mode behavior", () => {
 						existsSync(join(codexHomeDir, "skills", "ask", "SKILL.md")),
 						false,
 					);
-					const hooks = await readFile(
-						join(codexHomeDir, "hooks.json"),
-						"utf-8",
-					);
-					assert.match(hooks, /codex-native-hook\.js/);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
 				});
 			});
 		} finally {
@@ -1275,7 +1271,8 @@ describe("omx setup install mode behavior", () => {
 						existsSync(join(cacheDir, "skills", "ask", "SKILL.md")),
 						true,
 					);
-					assert.match(config, /^hooks = true$/m);
+					assert.match(config, /^plugin_hooks = true$/m);
+					assert.doesNotMatch(config, /^hooks = true$/m);
 					assert.doesNotMatch(config, /^codex_hooks = true$/m);
 					assert.doesNotMatch(config, /\[mcp_servers\./);
 					assert.equal(
@@ -1499,7 +1496,7 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
-	it("installs user-scoped native hooks when plugin mode is selected", async () => {
+	it("uses plugin-scoped hooks when plugin mode is selected", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
@@ -1507,38 +1504,16 @@ describe("omx setup install mode behavior", () => {
 					await setup({ scope: "user", installMode: "plugin" });
 					await setup({ scope: "user", installMode: "plugin" });
 
-					const hooks = await readFile(
-						join(codexHomeDir, "hooks.json"),
-						"utf-8",
-					);
-					assert.match(hooks, /codex-native-hook\.js/);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
 					const config = await readFile(
 						join(codexHomeDir, "config.toml"),
 						"utf-8",
 					);
-					const parsed = parseToml(config) as {
-						hooks?: { state?: Record<string, unknown> };
-					};
-					const managedHookStateKeys = Object.keys(
-						parsed.hooks?.state ?? {},
-					).filter((key) => key.includes(`${codexHomeDir}/hooks.json:`));
-					assert.equal(managedHookStateKeys.length, 7);
-					assert.match(config, /^hooks = true$/m);
+					assert.match(config, /^plugin_hooks = true$/m);
+					assert.doesNotMatch(config, /^hooks = true$/m);
 					assert.doesNotMatch(config, /^codex_hooks = true$/m);
 					assert.match(config, /^goals = true$/m);
-					assert.match(
-						config,
-						/^\[hooks\.state\.".*hooks\.json:pre_tool_use:0:0"\]$/m,
-					);
-					assert.equal(
-						(
-							config.match(
-								/^\[hooks\.state\.".*hooks\.json:pre_tool_use:0:0"\]$/gm,
-							) ?? []
-						).length,
-						1,
-					);
-					assert.match(config, /^trusted_hash = "sha256:[a-f0-9]{64}"$/m);
+					assert.doesNotMatch(config, /\[hooks\.state\./);
 					assert.doesNotMatch(
 						config,
 						/developer_instructions|notify-hook/g,
@@ -1575,11 +1550,7 @@ describe("omx setup install mode behavior", () => {
 						pluginDeveloperInstructionsPrompt: async () => true,
 					});
 
-					const hooks = await readFile(
-						join(codexHomeDir, "hooks.json"),
-						"utf-8",
-					);
-					assert.match(hooks, /codex-native-hook\.js/);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
 					assert.equal(
 						existsSync(join(codexHomeDir, "skills", "ask", "SKILL.md")),
 						false,
@@ -1609,7 +1580,7 @@ describe("omx setup install mode behavior", () => {
 					);
 					assert.doesNotMatch(config, /Native subagents live in \.codex\/agents/);
 					assert.doesNotMatch(config, /Treat installed prompts as narrower execution surfaces/);
-					assert.match(config, /^hooks = true$/m);
+					assert.match(config, /^plugin_hooks = true$/m);
 					assert.doesNotMatch(config, /notify-hook/);
 					assert.doesNotMatch(config, /^\s*\[mcp_servers[.\]]/m);
 					assert.doesNotMatch(config, /mcp_servers\.omx_state/);
@@ -1697,7 +1668,7 @@ describe("omx setup install mode behavior", () => {
 
 					const config = await readFile(configPath, "utf-8");
 					assert.match(config, /^developer_instructions = "custom"$/m);
-					assert.match(config, /^hooks = true$/m);
+					assert.match(config, /^plugin_hooks = true$/m);
 					assert.equal(
 						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
 						1,
@@ -1731,8 +1702,8 @@ describe("omx setup install mode behavior", () => {
 						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
 						1,
 					);
-					assert.match(config, /^hooks = true$/m);
-					assert.match(config, /^\[hooks\.state\.".*hooks\.json:pre_tool_use:0:0"\]$/m);
+					assert.match(config, /^plugin_hooks = true$/m);
+					assert.doesNotMatch(config, /\[hooks\.state\./);
 				});
 			});
 		} finally {
@@ -1766,7 +1737,48 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
-	it("preserves existing user hooks while installing plugin-mode native hooks", async () => {
+	it("removes legacy setup-managed hook wrappers when plugin-scoped hooks are supported", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						codexFeaturesProbe: () =>
+							"hooks                                   stable             true\n",
+					});
+
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					assert.equal(existsSync(hooksPath), true);
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						codexFeaturesProbe: () =>
+							[
+								"hooks                                   stable             true",
+								"plugin_hooks                            experimental       true",
+								"",
+							].join("\n"),
+					});
+
+					assert.equal(existsSync(hooksPath), false);
+					const config = await readFile(
+						join(codexHomeDir, "config.toml"),
+						"utf-8",
+					);
+					assert.match(config, /^plugin_hooks = true$/m);
+					assert.doesNotMatch(config, /^hooks = true$/m);
+					assert.doesNotMatch(config, /\[hooks\.state\./);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves existing user hooks while using plugin-scoped hooks", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
@@ -1780,12 +1792,12 @@ describe("omx setup install mode behavior", () => {
 
 					const hooks = await readFile(hooksPath, "utf-8");
 					assert.match(hooks, /"UserPromptSubmit"/);
-					assert.match(hooks, /codex-native-hook\.js/);
+					assert.doesNotMatch(hooks, /codex-native-hook\.js/);
 					const config = await readFile(
 						join(codexHomeDir, "config.toml"),
 						"utf-8",
 					);
-					assert.match(config, /^hooks = true$/m);
+					assert.match(config, /^plugin_hooks = true$/m);
 				});
 			});
 		} finally {
@@ -1822,8 +1834,7 @@ describe("omx setup install mode behavior", () => {
 					existsSync(join(wd, ".codex", "prompts", "executor.md")),
 					false,
 				);
-				const hooks = await readFile(join(wd, ".codex", "hooks.json"), "utf-8");
-				assert.match(hooks, /codex-native-hook\.js/);
+				assert.equal(existsSync(join(wd, ".codex", "hooks.json")), false);
 			});
 		} finally {
 			await rm(wd, { recursive: true, force: true });
@@ -1960,7 +1971,7 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
-	it("installs project-scoped native hooks when plugin mode is explicitly requested", async () => {
+	it("uses project-scoped plugin hooks when plugin mode is explicitly requested", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
 			await withTempCwd(wd, async () => {
@@ -1998,7 +2009,7 @@ describe("omx setup install mode behavior", () => {
 					assert.match(pluginOutput, /Using setup install mode: plugin/);
 					assert.match(
 						pluginOutput,
-						/Native Codex hooks and runtime feature flags refresh complete .*hooks, goals/,
+						/Plugin-scoped Codex hooks and runtime feature flags refresh complete .*plugin_hooks, goals/,
 					);
 					assert.doesNotMatch(pluginOutput, /user-scope skill delivery mode/);
 					assert.doesNotMatch(
@@ -2090,12 +2101,10 @@ describe("omx setup install mode behavior", () => {
 					assert.equal(existsSync(askSkillPath), false);
 					assert.equal(existsSync(promptPath), false);
 					assert.equal(existsSync(agentPath), false);
-					assert.equal(existsSync(hooksPath), true);
+					assert.equal(existsSync(hooksPath), false);
 					assert.equal(existsSync(agentsMdPath), false);
-					const hooks = await readFile(hooksPath, "utf-8");
-					assert.match(hooks, /codex-native-hook\.js/);
 					const config = await readFile(configPath, "utf-8");
-					assert.match(config, /^hooks = true$/m);
+					assert.match(config, /^plugin_hooks = true$/m);
 					assert.doesNotMatch(
 						config,
 						/^\s*(?:notify|developer_instructions)\s*=|^\s*\[mcp_servers[.\]]/m,

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1,7 +1,8 @@
-import { describe, it } from "node:test";
+import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
 import {
+	chmod,
 	cp,
 	mkdir,
 	mkdtemp,
@@ -18,6 +19,45 @@ import { uninstall } from "../uninstall.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../../config/omx-first-party-mcp.js";
 
 const packageRoot = process.cwd();
+let previousPathForFakeCodex: string | undefined;
+let fakeCodexBinDir: string | null = null;
+
+before(async () => {
+	previousPathForFakeCodex = process.env.PATH;
+	fakeCodexBinDir = await mkdtemp(join(tmpdir(), "omx-fake-codex-"));
+	const fakeCodexPath = join(fakeCodexBinDir, "codex");
+	await writeFile(
+		fakeCodexPath,
+		[
+			"#!/usr/bin/env node",
+			"if (process.argv[2] === 'features' && process.argv[3] === 'list') {",
+			"  console.log('hooks                                   stable             true');",
+			"  console.log('plugin_hooks                            experimental       true');",
+			"  console.log('goals                                   experimental       true');",
+			"  process.exit(0);",
+			"}",
+			"if (process.argv.includes('--version') || process.argv[2] === '--version') {",
+			"  console.log('codex-cli 0.999.0');",
+			"  process.exit(0);",
+			"}",
+			"process.exit(0);",
+			"",
+		].join("\n"),
+	);
+	await chmod(fakeCodexPath, 0o755);
+	process.env.PATH = `${fakeCodexBinDir}${process.env.PATH ? `:${process.env.PATH}` : ""}`;
+});
+
+after(async () => {
+	if (previousPathForFakeCodex === undefined) {
+		delete process.env.PATH;
+	} else {
+		process.env.PATH = previousPathForFakeCodex;
+	}
+	if (fakeCodexBinDir !== null) {
+		await rm(fakeCodexBinDir, { recursive: true, force: true });
+	}
+});
 
 async function withTempCwd(wd: string, fn: () => Promise<void>): Promise<void> {
 	const previousCwd = process.cwd();

--- a/src/cli/codex-feature-probe.ts
+++ b/src/cli/codex-feature-probe.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "child_process";
 import {
   DEFAULT_CODEX_HOOK_FEATURE_FLAG,
   resolveCodexHookFeatureFlag,
+  supportsCodexPluginScopedHooks,
   type CodexHookFeatureFlag,
 } from "../config/codex-feature-flags.js";
 
@@ -26,15 +27,29 @@ export function probeInstalledCodexVersion(): string | null {
   return [result.stdout, result.stderr].filter(Boolean).join("\n") || null;
 }
 
-export function resolveCodexHookFeatureFlagForCli(
+export interface CodexHookFeatureSupport {
+  hookFeatureFlag: CodexHookFeatureFlag;
+  pluginScopedHooks: boolean;
+}
+
+export function resolveCodexHookFeatureSupportForCli(
   options: CodexFeatureProbeOptions = {},
-): CodexHookFeatureFlag {
+): CodexHookFeatureSupport {
   const featuresListOutput =
     options.codexFeaturesProbe?.() ?? probeInstalledCodexFeatureList();
   const versionOutput = options.codexVersionProbe?.() ?? probeInstalledCodexVersion();
-  return resolveCodexHookFeatureFlag({
-    featuresListOutput,
-    versionOutput,
-    fallback: DEFAULT_CODEX_HOOK_FEATURE_FLAG,
-  });
+  return {
+    hookFeatureFlag: resolveCodexHookFeatureFlag({
+      featuresListOutput,
+      versionOutput,
+      fallback: DEFAULT_CODEX_HOOK_FEATURE_FLAG,
+    }),
+    pluginScopedHooks: supportsCodexPluginScopedHooks({ featuresListOutput }),
+  };
+}
+
+export function resolveCodexHookFeatureFlagForCli(
+  options: CodexFeatureProbeOptions = {},
+): CodexHookFeatureFlag {
+  return resolveCodexHookFeatureSupportForCli(options).hookFeatureFlag;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -373,6 +373,7 @@ type CliCommand =
   | "cancel"
   | "help"
   | "reasoning"
+  | "codex-native-hook"
   | string;
 
 const NESTED_HELP_COMMANDS = new Set<CliCommand>([
@@ -1668,6 +1669,11 @@ export async function main(args: string[]): Promise<void> {
       case "reasoning":
         await reasoningCommand(args.slice(1));
         break;
+      case "codex-native-hook": {
+        const { runCodexNativeHookCli } = await import("../scripts/codex-native-hook.js");
+        await runCodexNativeHookCli();
+        break;
+      }
       case "help":
       case "--help":
       case "-h":

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -26,6 +26,7 @@ interface PluginManifest {
 	name?: unknown;
 	version?: unknown;
 	skills?: unknown;
+	hooks?: unknown;
 }
 
 export async function resolvePackagedOmxMarketplace(
@@ -177,6 +178,7 @@ export interface OmxPluginCacheState {
 	manifestVersion: string | null;
 	skillsPointer: string | null;
 	skillNames: string[] | null;
+	hooksPointer: string | null;
 }
 
 export async function readOmxPluginCacheState(
@@ -192,6 +194,7 @@ export async function readOmxPluginCacheState(
 			typeof manifest.version === "string" ? manifest.version : null,
 		skillsPointer: typeof manifest.skills === "string" ? manifest.skills : null,
 		skillNames: await listChildDirectoryNames(join(cacheDir, "skills")),
+		hooksPointer: typeof manifest.hooks === "string" ? manifest.hooks : null,
 	};
 }
 
@@ -210,6 +213,9 @@ export async function hasExpectedOmxPluginCache(
 	return (
 		state?.manifestVersion === version &&
 		state.skillsPointer === "./skills/" &&
+		state.hooksPointer === "./hooks/hooks.json" &&
+		existsSync(join(state.cacheDir, "hooks", "hooks.json")) &&
+		existsSync(join(state.cacheDir, "hooks", "codex-native-hook.mjs")) &&
 		JSON.stringify(state.skillNames) === JSON.stringify(expectedSkillNames)
 	);
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -56,6 +56,7 @@ import {
 	buildManagedCodexNativeHookWindowsShimContent,
 	buildManagedCodexNativeHookWindowsShimPath,
 	mergeManagedCodexHooksConfig,
+	removeManagedCodexHooks,
 } from "../config/codex-hooks.js";
 import {
 	getLegacyUnifiedMcpRegistryCandidate,
@@ -106,7 +107,7 @@ import {
 	upsertLocalOmxPluginMcpServerEnablement,
 	hasLocalOmxPluginMcpServerRegistrations,
 } from "./plugin-marketplace.js";
-import { resolveCodexHookFeatureFlagForCli } from "./codex-feature-probe.js";
+import { resolveCodexHookFeatureSupportForCli } from "./codex-feature-probe.js";
 
 async function resolveStatusLinePresetForSetup(
 	projectRoot: string,
@@ -897,6 +898,7 @@ interface OmxPluginCacheManifest {
 	name: string | null;
 	version: string | null;
 	skills: string | null;
+	hooks: string | null;
 }
 
 async function readPluginManifestSummary(
@@ -909,11 +911,13 @@ async function readPluginManifestSummary(
 			name?: unknown;
 			version?: unknown;
 			skills?: unknown;
+			hooks?: unknown;
 		};
 		return {
 			name: typeof manifest.name === "string" ? manifest.name : null,
 			version: typeof manifest.version === "string" ? manifest.version : null,
 			skills: typeof manifest.skills === "string" ? manifest.skills : null,
+			hooks: typeof manifest.hooks === "string" ? manifest.hooks : null,
 		};
 	} catch {
 		return null;
@@ -1019,12 +1023,21 @@ async function refreshOmxPluginDiscoveryCache(
 		const versionChanged =
 			expectedVersion !== null && manifest.version !== expectedVersion;
 		const skillsPointerChanged = manifest.skills !== "./skills/";
+		const hooksPointerChanged = manifest.hooks !== "./hooks/hooks.json";
+		const hookFilesMissing = !existsSync(join(cacheDir, "hooks", "hooks.json"))
+			|| !existsSync(join(cacheDir, "hooks", "codex-native-hook.mjs"));
 		const skillListChanged =
 			expectedSkillNames !== null &&
 			cachedSkillNames !== null &&
 			JSON.stringify(cachedSkillNames) !== JSON.stringify(expectedSkillNames);
 
-		if (!versionChanged && !skillsPointerChanged && !skillListChanged) continue;
+		if (
+			!versionChanged &&
+			!skillsPointerChanged &&
+			!hooksPointerChanged &&
+			!hookFilesMissing &&
+			!skillListChanged
+		) continue;
 
 		staleDirs.push(cacheDir);
 		if (!options.dryRun) {
@@ -1038,6 +1051,10 @@ async function refreshOmxPluginDiscoveryCache(
 				skillsPointerChanged
 					? `skills pointer ${manifest.skills ?? "missing"} -> ./skills/`
 					: null,
+				hooksPointerChanged
+					? `hooks pointer ${manifest.hooks ?? "missing"} -> ./hooks/hooks.json`
+					: null,
+				hookFilesMissing ? "plugin hook files missing" : null,
 				skillListChanged ? "skill directory list changed" : null,
 			].filter(Boolean);
 			console.log(
@@ -1489,6 +1506,42 @@ async function ensurePluginMarketplaceRegistration(
 	return "updated";
 }
 
+async function cleanupPluginModeManagedHooksJson(
+	existingHooksContent: string | null,
+	hooksPath: string,
+	backupContext: SetupBackupContext,
+	summary: SetupCategorySummary,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<void> {
+	if (existingHooksContent === null) {
+		summary.unchanged += 1;
+		return;
+	}
+
+	const removed = removeManagedCodexHooks(existingHooksContent);
+	if (removed.removedCount === 0) {
+		summary.unchanged += 1;
+		return;
+	}
+
+	if (await ensureBackup(hooksPath, true, backupContext, options)) {
+		summary.backedUp += 1;
+	}
+	if (!options.dryRun) {
+		if (removed.nextContent === null) {
+			await rm(hooksPath, { force: true });
+		} else {
+			await writeFile(hooksPath, removed.nextContent);
+		}
+	}
+	summary.removed += removed.removedCount;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would remove" : "removed"} ${removed.removedCount} legacy setup-managed hook wrapper(s) from ${hooksPath}`,
+		);
+	}
+}
+
 async function applyPluginModeHooksConfig(
 	configPath: string,
 	hooksPath: string,
@@ -1498,20 +1551,25 @@ async function applyPluginModeHooksConfig(
 	summary: SetupCategorySummary,
 	options: Pick<SetupOptions, "dryRun" | "verbose"> & {
 		codexHookFeatureFlag: CodexHookFeatureFlag;
+		pluginScopedHooks: boolean;
 	},
 ): Promise<void> {
 	const existingConfig = existsSync(configPath)
 		? await readFile(configPath, "utf-8")
 		: "";
-	const nextConfig = upsertManagedCodexHookTrustState(
-		upsertPluginModeRuntimeFeatureFlags(
-			stripManagedCodexHookTrustState(existingConfig),
-			options.codexHookFeatureFlag,
-		),
-		pkgRoot,
-		hooksPath,
-		{ platform: process.platform, codexHomeDir },
+	const nextConfigBase = upsertPluginModeRuntimeFeatureFlags(
+		stripManagedCodexHookTrustState(existingConfig),
+		options.codexHookFeatureFlag,
+		{ pluginScopedHooks: options.pluginScopedHooks },
 	);
+	const nextConfig = options.pluginScopedHooks
+		? nextConfigBase
+		: upsertManagedCodexHookTrustState(
+			nextConfigBase,
+			pkgRoot,
+			hooksPath,
+			{ platform: process.platform, codexHomeDir },
+		);
 	if (nextConfig !== existingConfig) {
 		if (
 			await ensureBackup(
@@ -1535,33 +1593,46 @@ async function applyPluginModeHooksConfig(
 	const existingHooksContent = existsSync(hooksPath)
 		? await readFile(hooksPath, "utf-8")
 		: null;
-	const hooksConfig = mergeManagedCodexHooksConfig(
-		existingHooksContent,
-		pkgRoot,
-		hooksPath,
-		{ platform: process.platform, codexHomeDir },
-	);
-	await syncManagedContent(
-		hooksConfig,
-		hooksPath,
-		summary,
-		backupContext,
-		options,
-		`native hooks ${hooksPath}`,
-	);
-	await syncManagedWindowsNativeHookShim(
-		codexHomeDir,
-		pkgRoot,
-		summary,
-		backupContext,
-		options,
-	);
+	if (options.pluginScopedHooks) {
+		await cleanupPluginModeManagedHooksJson(
+			existingHooksContent,
+			hooksPath,
+			backupContext,
+			summary,
+			options,
+		);
+	} else {
+		const hooksConfig = mergeManagedCodexHooksConfig(
+			existingHooksContent,
+			pkgRoot,
+			hooksPath,
+			{ platform: process.platform, codexHomeDir },
+		);
+		await syncManagedContent(
+			hooksConfig,
+			hooksPath,
+			summary,
+			backupContext,
+			options,
+			`native hooks ${hooksPath}`,
+		);
+		await syncManagedWindowsNativeHookShim(
+			codexHomeDir,
+			pkgRoot,
+			summary,
+			backupContext,
+			options,
+		);
+	}
 
-		if (options.verbose) {
-			console.log(
-				`  ${options.dryRun ? "would configure" : "configured"} plugin-mode native hooks and runtime feature flags at ${hooksPath}`,
-			);
-		}
+	if (options.verbose) {
+		const surface = options.pluginScopedHooks
+			? "official plugin-scoped hooks"
+			: `legacy native hooks at ${hooksPath}`;
+		console.log(
+			`  ${options.dryRun ? "would configure" : "configured"} plugin-mode ${surface} and runtime feature flags`,
+		);
+	}
 }
 
 async function applyPluginDeveloperInstructionsDefault(
@@ -2044,13 +2115,18 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	console.log("[5/8] Updating config.toml...");
 	let resolvedConfig = "";
 	let omxManagesTui = false;
-	const codexHookFeatureFlag = resolveCodexHookFeatureFlagForCli({
+	const codexHookFeatureSupport = resolveCodexHookFeatureSupportForCli({
 		codexFeaturesProbe: options.codexFeaturesProbe,
 		codexVersionProbe: options.codexVersionProbe,
 	});
+	const codexHookFeatureFlag = codexHookFeatureSupport.hookFeatureFlag;
+	const pluginScopedHooksSupported = codexHookFeatureSupport.pluginScopedHooks;
 	if (verbose) {
 		console.log(
 			`  Native Codex hook feature flag: [features].${codexHookFeatureFlag}`,
+		);
+		console.log(
+			`  Plugin-scoped Codex hooks: ${pluginScopedHooksSupported ? "supported" : "not reported; using legacy setup fallback"}`,
 		);
 	}
 	const shouldSyncSharedMcpRegistry = resolvedMcpMode.mcpMode === "compat";
@@ -2107,7 +2183,12 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			scopeDirs.codexHomeDir,
 			backupContext,
 			summary.config,
-			{ dryRun, verbose, codexHookFeatureFlag },
+			{
+				dryRun,
+				verbose,
+				codexHookFeatureFlag,
+				pluginScopedHooks: pluginScopedHooksSupported,
+			},
 		);
 		const pluginMarketplaceResult = await ensurePluginMarketplaceRegistration(
 			scopeDirs.codexConfigFile,
@@ -2180,7 +2261,9 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			? await readFile(scopeDirs.codexConfigFile, "utf-8")
 			: "";
 		console.log(
-			`  Native Codex hooks and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; hooks, goals).\n`,
+			pluginScopedHooksSupported
+				? "  Plugin-scoped Codex hooks and runtime feature flags refresh complete (plugin_hooks, goals).\n"
+				: `  Native Codex hooks fallback and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; hooks, goals).\n`,
 		);
 
 		if (usePluginDeveloperInstructionsDefault) {

--- a/src/config/__tests__/codex-feature-flags.test.ts
+++ b/src/config/__tests__/codex-feature-flags.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   parseCodexFeatureNames,
   resolveCodexHookFeatureFlag,
+  supportsCodexPluginScopedHooks,
 } from "../codex-feature-flags.js";
 
 describe("Codex feature flag resolution", () => {
@@ -28,6 +29,18 @@ describe("Codex feature flag resolution", () => {
       resolveCodexHookFeatureFlag({ featuresListOutput: output }),
       "codex_hooks",
     );
+  });
+
+  it("detects official plugin-scoped hook support separately from legacy hooks", () => {
+    const output = [
+      "hooks                                   stable             true",
+      "plugin_hooks                            experimental       true",
+      "goals                                   experimental       true",
+      "",
+    ].join("\n");
+
+    assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: output }), true);
+    assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: "hooks stable true" }), false);
   });
 
   it("uses version fallback for current Codex releases when feature listing is unavailable", () => {

--- a/src/config/codex-feature-flags.ts
+++ b/src/config/codex-feature-flags.ts
@@ -1,4 +1,5 @@
 export const CODEX_HOOK_FEATURE_FLAGS = ["hooks", "codex_hooks"] as const;
+export const CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG = "plugin_hooks";
 
 export type CodexHookFeatureFlag = (typeof CODEX_HOOK_FEATURE_FLAGS)[number];
 
@@ -52,6 +53,14 @@ export function isCodexCliVersionAtLeast(
     if (parsed[i] < minimum[i]) return false;
   }
   return true;
+}
+
+export function supportsCodexPluginScopedHooks(options: {
+  featuresListOutput?: string | null;
+} = {}): boolean {
+  return parseCodexFeatureNames(options.featuresListOutput).has(
+    CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG,
+  );
 }
 
 export function resolveCodexHookFeatureFlag(options: {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -20,6 +20,7 @@ import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 import {
   DEFAULT_CODEX_HOOK_FEATURE_FLAG,
   CODEX_HOOK_FEATURE_FLAGS,
+  CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG,
   formatCodexHookFeatureFlagLine,
   normalizeCodexHookFeatureFlag,
   type CodexHookFeatureFlag,
@@ -639,20 +640,25 @@ function isAnyCodexHookFeatureFlagLine(line: string): boolean {
   return CODEX_HOOK_FEATURE_FLAGS.some((flag) => isFeatureFlagLine(line, flag));
 }
 
-function upsertCodexHookFeatureFlagInSection(
+function isAnyPluginModeHookFeatureFlagLine(line: string): boolean {
+  return isAnyCodexHookFeatureFlagLine(line)
+    || isFeatureFlagLine(line, CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG);
+}
+
+function upsertFeatureFlagLineInSection(
   lines: string[],
   featuresStart: number,
   sectionEnd: number,
-  codexHookFeatureFlag: CodexHookFeatureFlag,
+  featureFlag: string,
+  aliases: (line: string) => boolean,
 ): { sectionEnd: number; featureFlagIndex: number } {
-  const featureFlag = normalizeCodexHookFeatureFlag(codexHookFeatureFlag);
   let featureFlagIdx = -1;
   let fallbackAliasIdx = -1;
 
   for (let i = featuresStart + 1; i < sectionEnd; i++) {
     if (isFeatureFlagLine(lines[i], featureFlag)) {
       featureFlagIdx = i;
-    } else if (isAnyCodexHookFeatureFlagLine(lines[i]) && fallbackAliasIdx < 0) {
+    } else if (aliases(lines[i]) && fallbackAliasIdx < 0) {
       fallbackAliasIdx = i;
     }
   }
@@ -662,15 +668,15 @@ function upsertCodexHookFeatureFlagInSection(
   }
 
   if (featureFlagIdx >= 0) {
-    lines[featureFlagIdx] = formatCodexHookFeatureFlagLine(featureFlag);
+    lines[featureFlagIdx] = `${featureFlag} = true`;
   } else {
-    lines.splice(sectionEnd, 0, formatCodexHookFeatureFlagLine(featureFlag));
+    lines.splice(sectionEnd, 0, `${featureFlag} = true`);
     featureFlagIdx = sectionEnd;
     sectionEnd += 1;
   }
 
   for (let i = sectionEnd - 1; i > featuresStart; i--) {
-    if (i !== featureFlagIdx && isAnyCodexHookFeatureFlagLine(lines[i])) {
+    if (i !== featureFlagIdx && aliases(lines[i])) {
       lines.splice(i, 1);
       sectionEnd -= 1;
       if (featureFlagIdx > i) featureFlagIdx -= 1;
@@ -678,6 +684,36 @@ function upsertCodexHookFeatureFlagInSection(
   }
 
   return { sectionEnd, featureFlagIndex: featureFlagIdx };
+}
+
+function upsertCodexHookFeatureFlagInSection(
+  lines: string[],
+  featuresStart: number,
+  sectionEnd: number,
+  codexHookFeatureFlag: CodexHookFeatureFlag,
+): { sectionEnd: number; featureFlagIndex: number } {
+  const featureFlag = normalizeCodexHookFeatureFlag(codexHookFeatureFlag);
+  return upsertFeatureFlagLineInSection(
+    lines,
+    featuresStart,
+    sectionEnd,
+    featureFlag,
+    isAnyCodexHookFeatureFlagLine,
+  );
+}
+
+function upsertPluginScopedHookFeatureFlagInSection(
+  lines: string[],
+  featuresStart: number,
+  sectionEnd: number,
+): { sectionEnd: number; featureFlagIndex: number } {
+  return upsertFeatureFlagLineInSection(
+    lines,
+    featuresStart,
+    sectionEnd,
+    CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG,
+    isAnyPluginModeHookFeatureFlagLine,
+  );
 }
 
 function upsertFeatureFlags(
@@ -870,14 +906,15 @@ export function upsertManagedCodexHookTrustState(
 export function upsertPluginModeRuntimeFeatureFlags(
   config: string,
   codexHookFeatureFlag: CodexHookFeatureFlag = DEFAULT_CODEX_HOOK_FEATURE_FLAG,
+  options: { pluginScopedHooks?: boolean } = {},
 ): string {
   const lines = config.split(/\r?\n/);
   const featuresStart = lines.findIndex((line) =>
     /^\s*\[features\]\s*$/.test(line),
   );
-  const hookFeatureFlagLine = formatCodexHookFeatureFlagLine(
-    codexHookFeatureFlag,
-  );
+  const hookFeatureFlagLine = options.pluginScopedHooks
+    ? `${CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG} = true`
+    : formatCodexHookFeatureFlagLine(codexHookFeatureFlag);
 
   if (featuresStart < 0) {
     const base = config.trimEnd();
@@ -910,12 +947,14 @@ export function upsertPluginModeRuntimeFeatureFlags(
     }
   }
 
-  ({ sectionEnd } = upsertCodexHookFeatureFlagInSection(
-    lines,
-    featuresStart,
-    sectionEnd,
-    codexHookFeatureFlag,
-  ));
+  ({ sectionEnd } = options.pluginScopedHooks
+    ? upsertPluginScopedHookFeatureFlagInSection(lines, featuresStart, sectionEnd)
+    : upsertCodexHookFeatureFlagInSection(
+        lines,
+        featuresStart,
+        sectionEnd,
+        codexHookFeatureFlag,
+      ));
 
   let goalsIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {

--- a/src/scripts/sync-plugin-mirror.ts
+++ b/src/scripts/sync-plugin-mirror.ts
@@ -55,7 +55,6 @@ const PLUGIN_NAME = "oh-my-codex";
 const SETUP_OWNED_PLUGIN_MANIFEST_FIELDS = [
 	"agents",
 	"prompts",
-	"hooks",
 ] as const;
 
 async function readJsonFile<T>(path: string): Promise<T> {
@@ -199,13 +198,14 @@ async function assertPluginManifestPolicy(
 	const pkg = await readJsonFile<PackageJson>(join(root, "package.json"));
 	const expectedFields: Pick<
 		PluginManifest,
-		"name" | "version" | "skills" | "mcpServers" | "apps"
+		"name" | "version" | "skills" | "mcpServers" | "apps" | "hooks"
 	> = {
 		name: PLUGIN_NAME,
 		version: pkg.version,
 		skills: "./skills/",
 		mcpServers: "./.mcp.json",
 		apps: "./.app.json",
+		hooks: "./hooks/hooks.json",
 	};
 
 	for (const [field, expectedValue] of Object.entries(expectedFields)) {
@@ -229,7 +229,7 @@ async function assertPluginManifestPolicy(
 					"plugin_bundle_metadata_out_of_sync",
 					"kind=plugin-manifest",
 					`field=${field}`,
-					"message=setup-owned agents/prompts/hooks must not be plugin-scoped",
+					"message=setup-owned agents/prompts must not be plugin-scoped",
 				].join("\n"),
 			);
 		}


### PR DESCRIPTION
## Summary
- Add official Codex plugin-scoped hook metadata to the packaged `oh-my-codex` plugin and point the manifest at `./hooks/hooks.json`.
- In plugin setup mode, enable `[features].plugin_hooks` when Codex reports support and remove only legacy OMX-managed `.codex/hooks.json` wrappers; preserve the old `.codex/hooks.json` fallback for legacy installs or older Codex versions.
- Update plugin cache validation, SSOT checks, tests, and docs to make the plugin-scoped route explicit.

Fixes #2406

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/config/__tests__/codex-feature-flags.test.js dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/setup-install-mode.test.js` (85 tests)
- `npm run test:plugin-boundaries:compiled` (19 tests)
- `npm run verify:plugin-bundle`
- `git diff --check`

## Review notes
- Kept legacy/fallback behavior limited to non-plugin installs or plugin installs on Codex versions that do not report `plugin_hooks`.
- Did not touch unrelated Lore/default behavior or owner-confirmation-gated PR surfaces #2379/#2387.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
