### PR TITLE
Default Autopilot to Ultragoal

### DIFF
--- a/docs/skills.html
+++ b/docs/skills.html
@@ -26,7 +26,8 @@
       <ol>
         <li><code>$deep-interview</code> - clarify intent, boundaries, and non-goals when the task is still fuzzy.</li>
         <li><code>$ralplan</code> - approve the plan and tradeoffs before execution.</li>
-        <li><code>$team</code> or <code>$ralph</code> - choose <code>$team</code> for coordinated parallel execution, or <code>$ralph</code> for a persistent completion loop.</li>
+        <li><code>$ultragoal</code> - execute and verify through durable goal/ledger checkpoints; launch <code>$team</code> only when parallel lanes are warranted.</li>
+        <li><code>$code-review</code> then <code>$ultraqa</code> - finish with merge-readiness and adversarial QA gates.</li>
       </ol>
 
       <h2>Execution Modes</h2>
@@ -77,9 +78,9 @@
       <h2>Usage Examples</h2>
       <pre><code>$deep-interview "clarify the auth change"
 $ralplan "approve the auth plan and review tradeoffs"
-$ralph "carry the approved plan to completion"
-$team 3:executor "execute the approved plan in parallel"
-$ultragoal "split this launch into durable Codex goals"
+$ultragoal "carry the approved plan to completion"
+$team 3:executor "execute the active Ultragoal story in parallel"
+$ralph "carry the approved plan to completion with the explicit legacy loop"
 $best-practice-research "find current official best practices for this API"
 $code-review "review current branch"
 $doctor</code></pre>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -33,7 +33,7 @@
       <ul>
         <li><code>$team</code> - coordinated multi-agent execution for the approved plan</li>
         <li><code>$ralph</code> - persistence loop until completion</li>
-        <li><code>$autopilot</code> - strict autonomous loop over <code>$ralplan -> $ralph -> $code-review</code>, returning to planning when review is not clean</li>
+        <li><code>$autopilot</code> - strict autonomous loop over <code>$deep-interview -> $ralplan -> $ultragoal (+ $team if needed) -> $code-review -> $ultraqa</code>, returning to planning when review or QA is not clean</li>
         <li><code>$ultrawork</code> - max parallel execution</li>
         <li><code>$ultragoal</code> - durable multi-goal planning and execution over <code>.omx/ultragoal</code> artifacts plus Codex goal handoff</li>
         <li><code>$visual-verdict</code> - structured visual QA loop for screenshot/reference matching</li>

--- a/plugins/oh-my-codex/skills/autopilot/SKILL.md
+++ b/plugins/oh-my-codex/skills/autopilot/SKILL.md
@@ -1,56 +1,66 @@
 ---
 name: autopilot
-description: "[OMX] Strict autonomous loop: $ralplan -> $ralph -> $code-review"
+description: "[OMX] Strict autonomous loop: $deep-interview -> $ralplan -> $ultragoal (+ $team if needed) -> $code-review -> $ultraqa"
 ---
 
 <Purpose>
-Autopilot is the strict autonomous delivery loop for non-trivial work. Its primary contract is exactly:
+Autopilot is the strict autonomous delivery loop for non-trivial work. Its recommended/default contract is exactly:
 
 ```text
-$ralplan -> $ralph -> $code-review
+$deep-interview -> $ralplan -> $ultragoal (+ $team if needed) -> $code-review -> $ultraqa
 ```
 
-If `$code-review` is not clean, Autopilot returns to `$ralplan` with the review findings as the next planning input, then continues again through `$ralph` and `$code-review` until the review is clean or a hard blocker is reported.
+If `$code-review` or `$ultraqa` is not clean, Autopilot returns to `$ralplan` with the findings as the next planning input, then continues again through `$ultragoal`, `$code-review`, and `$ultraqa` until the gates are clean or a hard blocker is reported. Ralph is a legacy/explicit alternate execution loop only; do not advertise Ralph as the default Autopilot path.
 </Purpose>
 
 <Use_When>
-- User wants hands-off execution from a concrete idea, issue, PRD, or requirements artifact to reviewed code
+- User wants hands-off execution from a concrete idea, issue, PRD, or requirements artifact to reviewed and QA-checked code
 - User says `$autopilot`, "autopilot", "auto pilot", "autonomous", "build me", "create me", "make me", "full auto", "handle it all", or "I want a/an..."
-- Task needs planning, implementation, verification, and code review with automatic follow-up when review is not clean
+- Task needs clarification, planning, durable execution, verification, code review, and QA with automatic follow-up when gates are not clean
 </Use_When>
 
 <Do_Not_Use_When>
 - User wants to explore options or brainstorm -- use `$plan` / `$ralplan`
 - User says "just explain", "draft only", or "what would you suggest" -- respond conversationally
-- User wants a single focused code change -- use `$ralph` or direct executor work
+- User wants a single focused code change -- use `$ultragoal`, `$ralph` only when explicitly requested, or direct executor work
 - User wants only review/critique of existing code -- use `$code-review`
 </Do_Not_Use_When>
 
 <Strict_Loop_Contract>
-Autopilot must not run a separate broad expansion/planning/execution/QA/validation lifecycle as its primary behavior. It delegates those concerns to the three canonical workflow phases below:
+Autopilot must not run a separate broad expansion/planning/execution/QA/validation lifecycle as its primary behavior. It delegates those concerns to the canonical workflow phases below:
 
-1. **Phase `ralplan`** — consensus planning gate
-   - Ground the task with pre-context intake.
+1. **Phase `deep-interview`** — Socratic requirements clarification gate
+   - Run or resume `$deep-interview` to clarify intent, scope, non-goals, constraints, and decision boundaries.
+   - Required handoff artifact: a clarified spec or concise requirements summary suitable for `$ralplan`.
+
+2. **Phase `ralplan`** — consensus planning gate
+   - Ground the task with pre-context intake and the deep-interview artifact.
    - Run or resume `$ralplan` to produce/update PRD and test-spec artifacts.
-   - When returning from a non-clean review, include `return_to_ralplan_reason` and the review findings as first-class planning input.
-   - Required handoff artifact: an approved plan/test spec suitable for `$ralph`.
+   - When returning from a non-clean review or QA pass, include `return_to_ralplan_reason` and the findings as first-class planning input.
+   - Required handoff artifact: an approved plan/test spec suitable for `$ultragoal`.
 
-2. **Phase `ralph`** — implementation + verification loop
-   - Run `$ralph` from the approved ralplan artifacts.
-   - Ralph owns implementation, tests, build/lint/typecheck evidence, deslop where applicable, and architect verification.
-   - Required handoff artifact: implementation evidence and changed-file summary suitable for `$code-review`.
+3. **Phase `ultragoal`** — durable implementation + verification loop
+   - Run `$ultragoal` from the approved ralplan artifacts.
+   - Ultragoal owns durable Codex goal handoffs, `.omx/ultragoal` ledger checkpoints, implementation, tests, build/lint/typecheck evidence, cleanup, and final review gate discipline.
+   - Use `$team` only inside an active Ultragoal story when the story clearly benefits from coordinated parallel execution (for example independent file/module lanes, broad test matrix work, or multi-domain implementation). Team remains explicit and leader-owned; Ultragoal keeps the goal/ledger state.
+   - Required handoff artifact: implementation evidence, changed-file summary, verification evidence, and Ultragoal ledger/checkpoint references suitable for `$code-review`.
 
-3. **Phase `code-review`** — merge-readiness gate
-   - Run `$code-review` on the diff/artifacts produced by `$ralph`.
+4. **Phase `code-review`** — merge-readiness gate
+   - Run `$code-review` on the diff/artifacts produced by `$ultragoal`.
    - A clean review means final recommendation `APPROVE` with architectural status `CLEAR`.
    - `COMMENT`, `REQUEST CHANGES`, any architectural `WATCH`/`BLOCK`, or any unresolved finding is not clean.
    - If not clean, increment the review cycle, persist `review_verdict`, set `return_to_ralplan_reason`, and transition back to Phase `ralplan`.
 
-The only normal terminal state is `complete` after a clean code review. Cancellation, blocked credentials, unrecoverable repeated failures, or explicit user stop may terminate earlier with preserved state.
+5. **Phase `ultraqa`** — adversarial QA gate
+   - Run `$ultraqa` after a clean code review when user-facing behavior, workflows, CLI/runtime behavior, integration surfaces, or regression risk warrant adversarial QA.
+   - For docs-only or trivially non-runtime changes, record `ultraqa` as skipped with an explicit condition and evidence.
+   - If UltraQA finds issues, persist the QA verdict/evidence, set `return_to_ralplan_reason`, and transition back to Phase `ralplan`.
+
+The only normal terminal state is `complete` after clean code review and a passed or explicitly skipped UltraQA gate. Cancellation, blocked credentials, unrecoverable repeated failures, or explicit user stop may terminate earlier with preserved state.
 </Strict_Loop_Contract>
 
 <Pre-context Intake>
-Before Phase `ralplan` starts or resumes:
+Before Phase `deep-interview` or `ralplan` starts or resumes:
 1. Derive a task slug from the request.
 2. Reuse the latest relevant `.omx/context/{slug}-*.md` snapshot when available.
 3. If none exists, create `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) with:
@@ -60,16 +70,18 @@ Before Phase `ralplan` starts or resumes:
    - constraints
    - unknowns/open questions
    - likely codebase touchpoints
-4. If ambiguity remains high, run `explore` first for brownfield facts, then run the Socratic `$deep-interview --quick <task>` before `$ralplan`.
+4. If brownfield facts are missing, run `explore` first before or during `$deep-interview` (`$deep-interview --quick <task>` remains acceptable for bounded low-ambiguity intake); do not skip the clarification gate merely because the task sounds actionable.
 5. Carry the snapshot path in Autopilot state and all handoff artifacts.
 </Pre-context Intake>
 
 <Execution_Policy>
-- Always execute phases in order: `ralplan`, then `ralph`, then `code-review`.
-- Never skip directly from vague/freeform expansion to implementation; unclear input must be clarified or planned through `$ralplan`.
-- A non-clean `$code-review` always returns to `$ralplan`; do not patch findings ad hoc outside the loop.
+- Always execute the recommended phases in order: `deep-interview`, then `ralplan`, then `ultragoal`, then `code-review`, then `ultraqa`.
+- `$team` is conditional and explicit: use it only within an Ultragoal story when parallel execution materially improves throughput, quality, or safety.
+- Never skip directly from vague/freeform expansion to implementation; unclear input must be clarified and planned through `$deep-interview` and `$ralplan`.
+- A non-clean `$code-review` or failed `$ultraqa` always returns to `$ralplan`; do not patch findings ad hoc outside the loop.
 - Each phase must write/update Autopilot state before handing off.
-- Use existing hooks, `.omx/state`, `$ralplan`, `$ralph`, `$code-review`, and pipeline primitives; do not invent a separate execution framework.
+- Use existing hooks, `.omx/state`, `$deep-interview`, `$ralplan`, `$ultragoal`, optional `$team`, `$code-review`, `$ultraqa`, and pipeline primitives; do not invent a separate execution framework.
+- Preserve legacy compatibility: if a user explicitly requests the old Ralph execution lane, use `$ralph` as an intentional alternate execution phase, but do not present it as Autopilot's default recommended loop.
 - Continue automatically through safe reversible phase transitions. Ask only for destructive, credential-gated, or materially preference-dependent branches.
 - Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step execution, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 </Execution_Policy>
@@ -83,81 +95,99 @@ Required fields:
 {
   "mode": "autopilot",
   "active": true,
-  "current_phase": "ralplan",
+  "current_phase": "deep-interview",
   "iteration": 1,
   "review_cycle": 0,
   "max_iterations": 10,
-  "phase_cycle": ["ralplan", "ralph", "code-review"],
+  "phase_cycle": ["deep-interview", "ralplan", "ultragoal", "code-review", "ultraqa"],
   "handoff_artifacts": {
     "context_snapshot_path": ".omx/context/<slug>-<timestamp>.md",
+    "deep_interview": null,
     "ralplan": null,
-    "ralph": null,
-    "code_review": null
+    "ultragoal": null,
+    "code_review": null,
+    "ultraqa": null
   },
   "review_verdict": null,
+  "qa_verdict": null,
   "return_to_ralplan_reason": null
 }
 ```
 
-- **On start**: `omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan","iteration":1,"review_cycle":0,"state":{"phase_cycle":["ralplan","ralph","code-review"],"handoff_artifacts":{"context_snapshot_path":"<snapshot-path>","ralplan":null,"ralph":null,"code_review":null},"review_verdict":null,"return_to_ralplan_reason":null}}' --json`
-- **On ralplan -> ralph**: set `current_phase:"ralph"`, persist the plan/test-spec paths under `handoff_artifacts.ralplan`.
-- **On ralph -> code-review**: set `current_phase:"code-review"`, persist implementation/test evidence under `handoff_artifacts.ralph`.
-- **On clean review**: set `active:false`, `current_phase:"complete"`, persist `review_verdict:{recommendation:"APPROVE", architectural_status:"CLEAR", clean:true}` and `completed_at`.
-- **On non-clean review**: increment `iteration` and `review_cycle`, set `current_phase:"ralplan"`, persist `review_verdict:{..., clean:false}`, persist `handoff_artifacts.code_review`, and set `return_to_ralplan_reason` to a concise review-driven reason.
+- **On start**: `omx state write --input '{"mode":"autopilot","active":true,"current_phase":"deep-interview","iteration":1,"review_cycle":0,"state":{"phase_cycle":["deep-interview","ralplan","ultragoal","code-review","ultraqa"],"handoff_artifacts":{"context_snapshot_path":"<snapshot-path>","deep_interview":null,"ralplan":null,"ultragoal":null,"code_review":null,"ultraqa":null},"review_verdict":null,"qa_verdict":null,"return_to_ralplan_reason":null}}' --json`
+- **On deep-interview -> ralplan**: set `current_phase:"ralplan"`, persist the clarified spec/requirements under `handoff_artifacts.deep_interview`.
+- **On ralplan -> ultragoal**: set `current_phase:"ultragoal"`, persist the plan/test-spec paths under `handoff_artifacts.ralplan`.
+- **On ultragoal -> code-review**: set `current_phase:"code-review"`, persist implementation/test/ledger evidence under `handoff_artifacts.ultragoal`.
+- **On code-review -> ultraqa**: set `current_phase:"ultraqa"`, persist the clean review under `handoff_artifacts.code_review`.
+- **On clean review + passed/skipped QA**: set `active:false`, `current_phase:"complete"`, persist `review_verdict:{recommendation:"APPROVE", architectural_status:"CLEAR", clean:true}`, `qa_verdict:{clean:true, skipped:<boolean>, reason:<string|null>}`, and `completed_at`.
+- **On non-clean review or failed QA**: increment `iteration` and `review_cycle`, set `current_phase:"ralplan"`, persist `review_verdict` or `qa_verdict`, persist the phase handoff, and set `return_to_ralplan_reason` to a concise findings-driven reason.
+- **Legacy Ralph state**: if a user explicitly selected the legacy Ralph execution lane, phase names and handoff keys may include `ralph`; preserve and resume them rather than rewriting history to Ultragoal.
 - **On cancellation**: run `$cancel`; preserve progress for resume rather than deleting handoff artifacts.
 </State_Management>
 
 <Continuation_And_Resume>
 When the user says `continue`, `resume`, or `keep going` while Autopilot is active, read `autopilot-state.json` and continue from `current_phase`:
+- `deep-interview`: clarify requirements and record the handoff artifact.
 - `ralplan`: run/update consensus planning from current handoffs and any `return_to_ralplan_reason`.
-- `ralph`: execute the approved plan and record verification evidence.
+- `ultragoal`: execute the approved plan durably and record verification/ledger evidence.
+- `team`: continue explicit team work only when it is nested under the active Ultragoal story and report evidence back to the leader.
 - `code-review`: review the current diff and decide clean vs return-to-ralplan.
+- `ultraqa`: run or explicitly skip adversarial QA based on the documented condition, then finish if clean or transition to `ralplan` with findings if not clean.
+- `ralph`: resume only for explicit legacy Ralph-path Autopilot state.
 - `complete`: report completion evidence; do not restart.
 
 Do not restart discovery or discard handoff artifacts on continuation.
 </Continuation_And_Resume>
 
 <Pipeline_Orchestrator>
-Autopilot may be represented by the configurable pipeline orchestrator (`src/pipeline/`) when useful. The Autopilot pipeline contract is:
+Autopilot may be represented by the configurable pipeline orchestrator (`src/pipeline/`) when useful. The default Autopilot pipeline contract is:
 
 ```text
-ralplan -> ralph -> code-review
+deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa
 ```
 
-Pipeline state should use `current_phase` values that match the same phase names (`ralplan`, `ralph`, `code-review`, `complete`, `failed`) and should carry `iteration`, `review_cycle`, `handoff_artifacts`, `review_verdict`, and `return_to_ralplan_reason` alongside stage results.
+Pipeline state should use `current_phase` values that match the same phase names (`deep-interview`, `ralplan`, `ultragoal`, `code-review`, `ultraqa`, `complete`, `failed`) and should carry `iteration`, `review_cycle`, `handoff_artifacts`, `review_verdict`, `qa_verdict`, and `return_to_ralplan_reason` alongside stage results. `$team` is not a default pipeline stage; it is an explicit conditional execution engine inside an Ultragoal story.
 </Pipeline_Orchestrator>
 
 <Escalation_And_Stop_Conditions>
 - Stop and report a blocker when required credentials/authority are missing.
-- Stop and report when the same review or verification failure recurs across 3 review cycles with no meaningful new plan.
+- Stop and report when the same review or QA failure recurs across 3 review cycles with no meaningful new plan.
 - Stop when the user says "stop", "cancel", or "abort" and run `$cancel`.
-- Otherwise, continue the loop until `$code-review` is clean.
+- Otherwise, continue the loop until `$code-review` is clean and `$ultraqa` has passed or been explicitly skipped with evidence.
 </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>
+- [ ] Phase `deep-interview` produced/updated clarified requirements or a concise spec
 - [ ] Phase `ralplan` produced/updated approved planning artifacts
-- [ ] Phase `ralph` implemented and verified the plan with fresh evidence
+- [ ] Phase `ultragoal` implemented and verified the plan with fresh evidence and durable ledger/checkpoint references
+- [ ] `$team` was used only if the active Ultragoal story needed coordinated parallel work, or explicitly recorded as not needed
 - [ ] Phase `code-review` returned a clean verdict (`APPROVE` + `CLEAR`)
-- [ ] `review_verdict.clean` is true and `return_to_ralplan_reason` is null
-- [ ] Tests/build/lint/typecheck evidence from Ralph is available in handoff artifacts
+- [ ] Phase `ultraqa` passed, or was explicitly skipped because the change was docs-only/trivially non-runtime with evidence
+- [ ] `review_verdict.clean` is true, `qa_verdict.clean` is true, and `return_to_ralplan_reason` is null
+- [ ] Tests/build/lint/typecheck evidence from Ultragoal is available in handoff artifacts
 - [ ] Autopilot state is marked `complete` or cancellation state is preserved coherently
-- [ ] User receives a concise summary with plan, implementation, verification, and review evidence
+- [ ] User receives a concise summary with clarification, plan, implementation, verification, review, and QA evidence
 </Final_Checklist>
 
 <Examples>
 <Good>
 User: `$autopilot implement GitHub issue #42`
-Flow: create/load context snapshot -> `$ralplan` issue plan -> `$ralph` implementation + tests -> `$code-review`; if review requests changes, return to `$ralplan` with findings.
+Flow: create/load context snapshot -> `$deep-interview` requirements check -> `$ralplan` issue plan -> `$ultragoal` durable implementation + tests (launch `$team` only if a story needs parallel lanes) -> `$code-review` -> `$ultraqa`; if review or QA requests changes, return to `$ralplan` with findings.
 </Good>
 
 <Good>
 User: `continue`
 Context: Autopilot state says `current_phase:"code-review"`.
-Flow: run `$code-review` on current diff, persist verdict, finish if clean or transition to `ralplan` with findings if not clean.
+Flow: run `$code-review` on current diff, persist verdict, transition to `ultraqa` if clean or to `ralplan` with findings if not clean.
+</Good>
+
+<Good>
+User: `$autopilot --legacy-ralph finish the migration`
+Flow: preserve the explicit legacy Ralph execution choice and run the old Ralph execution lane as an alternate, without changing the documented default Autopilot recommendation.
 </Good>
 
 <Bad>
 Autopilot invents independent "Expansion", "QA", and "Validation" phases and treats them as the primary lifecycle.
-Why bad: this bypasses the strict `$ralplan -> $ralph -> $code-review` contract.
+Why bad: this bypasses the strict `$deep-interview -> $ralplan -> $ultragoal -> $code-review -> $ultraqa` contract.
 </Bad>
 </Examples>

--- a/plugins/oh-my-codex/skills/cancel/SKILL.md
+++ b/plugins/oh-my-codex/skills/cancel/SKILL.md
@@ -56,7 +56,7 @@ For Ralph-targeted cancellation (standalone or linked), completion is defined by
 See: `docs/contracts/ralph-cancel-contract.md`.
 
 Active modes are still cancelled in dependency order:
-1. Autopilot (includes linked ralph/ultraqa/ecomode cleanup)
+1. Autopilot (includes linked ultragoal/ultraqa/ecomode cleanup plus explicit legacy Ralph cleanup)
 2. Ralph (cleans its linked ultrawork or ecomode)
 3. Ultrawork (standalone)
 4. Ecomode (standalone)
@@ -374,7 +374,7 @@ Mode-specific subsections below describe what extra cleanup each handler perform
 
 ## Notes
 
-- **Dependency-aware**: Autopilot cancellation cleans up Ralph and UltraQA
+- **Dependency-aware**: Autopilot cancellation cleans up Ultragoal/UltraQA state and any explicit legacy Ralph state
 - **Link-aware**: Ralph cancellation cleans up linked Ultrawork or Ecomode
 - **Safe**: Only clears linked Ultrawork, preserves standalone Ultrawork
 - **Local-only**: Clears state files in `.omx/state/` directory

--- a/plugins/oh-my-codex/skills/pipeline/SKILL.md
+++ b/plugins/oh-my-codex/skills/pipeline/SKILL.md
@@ -10,11 +10,13 @@ through a uniform `PipelineStage` interface, with state persistence and resume s
 
 ## Default Autopilot Pipeline
 
-The canonical OMX pipeline sequences:
+The default Autopilot pipeline sequences:
 
 ```
-RALPLAN (consensus planning) -> team-exec (Codex CLI workers) -> ralph-verify (architect verification)
+deep-interview -> ralplan -> ultragoal (+ team if needed) -> code-review -> ultraqa
 ```
+
+`$team` is conditional: use it only inside an active Ultragoal story when independent lanes or broad verification make coordinated parallel execution useful. Explicit legacy Ralph pipelines remain available through custom stages, but Ralph is not the advertised default Autopilot loop.
 
 ## Configuration
 
@@ -22,7 +24,7 @@ Pipeline parameters are configurable per run:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `maxRalphIterations` | 10 | Ralph verification iteration ceiling |
+| `maxRalphIterations` | 10 | Quality-gate retry ceiling; legacy option name retained for compatibility |
 | `workerCount` | 2 | Number of Codex CLI team workers |
 | `agentType` | `executor` | Agent type for team workers |
 
@@ -43,9 +45,12 @@ return a `StageResult` with status, artifacts, and duration.
 
 ## Built-in Stages
 
+- **deep-interview**: Requirements clarification and ambiguity gate.
 - **ralplan**: Consensus planning (planner + architect + critic). Skips only when both `prd-*.md` and `test-spec-*.md` planning artifacts already exist, and carries any `deep-interview-*.md` spec paths forward for traceability.
-- **team-exec**: Team execution via Codex CLI workers. Always the OMX execution backend.
-- **ralph-verify**: Ralph verification loop with configurable iteration count.
+- **ultragoal**: Durable goal-mode execution with `.omx/ultragoal` ledgers. Launch `$team` only from inside an Ultragoal story when parallel lanes are warranted.
+- **code-review**: Merge-readiness review gate.
+- **ultraqa**: Adversarial QA gate after a clean review; docs-only/trivially non-runtime changes may record an explicit skip reason.
+- **team-exec** and **ralph-verify**: Legacy/custom pipeline adapters retained for explicit non-default pipelines.
 
 ## State Management
 
@@ -62,16 +67,20 @@ The HUD renders pipeline phase automatically. Resume is supported from the last 
 import {
   runPipeline,
   createAutopilotPipelineConfig,
+  createDeepInterviewStage,
   createRalplanStage,
-  createTeamExecStage,
-  createRalphVerifyStage,
+  createUltragoalStage,
+  createCodeReviewStage,
+  createUltraqaStage,
 } from './pipeline/index.js';
 
 const config = createAutopilotPipelineConfig('build feature X', {
   stages: [
+    createDeepInterviewStage(),
     createRalplanStage(),
-    createTeamExecStage({ workerCount: 3, agentType: 'executor' }),
-    createRalphVerifyStage({ maxIterations: 15 }),
+    createUltragoalStage(),
+    createCodeReviewStage(),
+    createUltraqaStage(),
   ],
 });
 
@@ -82,5 +91,7 @@ const result = await runPipeline(config);
 
 - **autopilot**: Autopilot can use pipeline as its execution engine (v0.8+)
 - **team**: Pipeline delegates execution to team mode (Codex CLI workers)
-- **ralph**: Pipeline delegates verification to ralph (configurable iterations)
-- **ralplan**: Pipeline's first stage runs RALPLAN consensus planning
+- **ultragoal**: Autopilot delegates durable execution to Ultragoal by default
+- **team**: Optional execution engine inside an Ultragoal story when parallel lanes are needed
+- **ralph**: Available only for explicit legacy/custom pipelines
+- **ralplan**: Pipeline planning runs RALPLAN consensus planning

--- a/plugins/oh-my-codex/skills/ultrawork/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultrawork/SKILL.md
@@ -16,7 +16,7 @@ Ultrawork is a parallel execution engine for high-throughput task completion. It
 
 <Do_Not_Use_When>
 - Task requires guaranteed completion with persistence, architect verification, or deslop/reverification -- use `ralph` instead (Ralph includes ultrawork)
-- Task requires a full autonomous pipeline -- use `autopilot` instead (autopilot includes Ralph which includes ultrawork)
+- Task requires a full autonomous pipeline -- use `autopilot` instead (autopilot defaults to Ultragoal, with Team/parallel execution used only when needed)
 - There is only one sequential task with no parallelism opportunity -- execute directly or delegate to a single `executor`
 - The request is still in plan-consensus mode -- keep planning artifacts in `ralplan` until execution is explicitly authorized
 - User needs session persistence for resume -- use `ralph`, which adds persistence on top of ultrawork

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -1,56 +1,66 @@
 ---
 name: autopilot
-description: "[OMX] Strict autonomous loop: $ralplan -> $ralph -> $code-review"
+description: "[OMX] Strict autonomous loop: $deep-interview -> $ralplan -> $ultragoal (+ $team if needed) -> $code-review -> $ultraqa"
 ---
 
 <Purpose>
-Autopilot is the strict autonomous delivery loop for non-trivial work. Its primary contract is exactly:
+Autopilot is the strict autonomous delivery loop for non-trivial work. Its recommended/default contract is exactly:
 
 ```text
-$ralplan -> $ralph -> $code-review
+$deep-interview -> $ralplan -> $ultragoal (+ $team if needed) -> $code-review -> $ultraqa
 ```
 
-If `$code-review` is not clean, Autopilot returns to `$ralplan` with the review findings as the next planning input, then continues again through `$ralph` and `$code-review` until the review is clean or a hard blocker is reported.
+If `$code-review` or `$ultraqa` is not clean, Autopilot returns to `$ralplan` with the findings as the next planning input, then continues again through `$ultragoal`, `$code-review`, and `$ultraqa` until the gates are clean or a hard blocker is reported. Ralph is a legacy/explicit alternate execution loop only; do not advertise Ralph as the default Autopilot path.
 </Purpose>
 
 <Use_When>
-- User wants hands-off execution from a concrete idea, issue, PRD, or requirements artifact to reviewed code
+- User wants hands-off execution from a concrete idea, issue, PRD, or requirements artifact to reviewed and QA-checked code
 - User says `$autopilot`, "autopilot", "auto pilot", "autonomous", "build me", "create me", "make me", "full auto", "handle it all", or "I want a/an..."
-- Task needs planning, implementation, verification, and code review with automatic follow-up when review is not clean
+- Task needs clarification, planning, durable execution, verification, code review, and QA with automatic follow-up when gates are not clean
 </Use_When>
 
 <Do_Not_Use_When>
 - User wants to explore options or brainstorm -- use `$plan` / `$ralplan`
 - User says "just explain", "draft only", or "what would you suggest" -- respond conversationally
-- User wants a single focused code change -- use `$ralph` or direct executor work
+- User wants a single focused code change -- use `$ultragoal`, `$ralph` only when explicitly requested, or direct executor work
 - User wants only review/critique of existing code -- use `$code-review`
 </Do_Not_Use_When>
 
 <Strict_Loop_Contract>
-Autopilot must not run a separate broad expansion/planning/execution/QA/validation lifecycle as its primary behavior. It delegates those concerns to the three canonical workflow phases below:
+Autopilot must not run a separate broad expansion/planning/execution/QA/validation lifecycle as its primary behavior. It delegates those concerns to the canonical workflow phases below:
 
-1. **Phase `ralplan`** — consensus planning gate
-   - Ground the task with pre-context intake.
+1. **Phase `deep-interview`** — Socratic requirements clarification gate
+   - Run or resume `$deep-interview` to clarify intent, scope, non-goals, constraints, and decision boundaries.
+   - Required handoff artifact: a clarified spec or concise requirements summary suitable for `$ralplan`.
+
+2. **Phase `ralplan`** — consensus planning gate
+   - Ground the task with pre-context intake and the deep-interview artifact.
    - Run or resume `$ralplan` to produce/update PRD and test-spec artifacts.
-   - When returning from a non-clean review, include `return_to_ralplan_reason` and the review findings as first-class planning input.
-   - Required handoff artifact: an approved plan/test spec suitable for `$ralph`.
+   - When returning from a non-clean review or QA pass, include `return_to_ralplan_reason` and the findings as first-class planning input.
+   - Required handoff artifact: an approved plan/test spec suitable for `$ultragoal`.
 
-2. **Phase `ralph`** — implementation + verification loop
-   - Run `$ralph` from the approved ralplan artifacts.
-   - Ralph owns implementation, tests, build/lint/typecheck evidence, deslop where applicable, and architect verification.
-   - Required handoff artifact: implementation evidence and changed-file summary suitable for `$code-review`.
+3. **Phase `ultragoal`** — durable implementation + verification loop
+   - Run `$ultragoal` from the approved ralplan artifacts.
+   - Ultragoal owns durable Codex goal handoffs, `.omx/ultragoal` ledger checkpoints, implementation, tests, build/lint/typecheck evidence, cleanup, and final review gate discipline.
+   - Use `$team` only inside an active Ultragoal story when the story clearly benefits from coordinated parallel execution (for example independent file/module lanes, broad test matrix work, or multi-domain implementation). Team remains explicit and leader-owned; Ultragoal keeps the goal/ledger state.
+   - Required handoff artifact: implementation evidence, changed-file summary, verification evidence, and Ultragoal ledger/checkpoint references suitable for `$code-review`.
 
-3. **Phase `code-review`** — merge-readiness gate
-   - Run `$code-review` on the diff/artifacts produced by `$ralph`.
+4. **Phase `code-review`** — merge-readiness gate
+   - Run `$code-review` on the diff/artifacts produced by `$ultragoal`.
    - A clean review means final recommendation `APPROVE` with architectural status `CLEAR`.
    - `COMMENT`, `REQUEST CHANGES`, any architectural `WATCH`/`BLOCK`, or any unresolved finding is not clean.
    - If not clean, increment the review cycle, persist `review_verdict`, set `return_to_ralplan_reason`, and transition back to Phase `ralplan`.
 
-The only normal terminal state is `complete` after a clean code review. Cancellation, blocked credentials, unrecoverable repeated failures, or explicit user stop may terminate earlier with preserved state.
+5. **Phase `ultraqa`** — adversarial QA gate
+   - Run `$ultraqa` after a clean code review when user-facing behavior, workflows, CLI/runtime behavior, integration surfaces, or regression risk warrant adversarial QA.
+   - For docs-only or trivially non-runtime changes, record `ultraqa` as skipped with an explicit condition and evidence.
+   - If UltraQA finds issues, persist the QA verdict/evidence, set `return_to_ralplan_reason`, and transition back to Phase `ralplan`.
+
+The only normal terminal state is `complete` after clean code review and a passed or explicitly skipped UltraQA gate. Cancellation, blocked credentials, unrecoverable repeated failures, or explicit user stop may terminate earlier with preserved state.
 </Strict_Loop_Contract>
 
 <Pre-context Intake>
-Before Phase `ralplan` starts or resumes:
+Before Phase `deep-interview` or `ralplan` starts or resumes:
 1. Derive a task slug from the request.
 2. Reuse the latest relevant `.omx/context/{slug}-*.md` snapshot when available.
 3. If none exists, create `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) with:
@@ -60,16 +70,18 @@ Before Phase `ralplan` starts or resumes:
    - constraints
    - unknowns/open questions
    - likely codebase touchpoints
-4. If ambiguity remains high, run `explore` first for brownfield facts, then run the Socratic `$deep-interview --quick <task>` before `$ralplan`.
+4. If brownfield facts are missing, run `explore` first before or during `$deep-interview` (`$deep-interview --quick <task>` remains acceptable for bounded low-ambiguity intake); do not skip the clarification gate merely because the task sounds actionable.
 5. Carry the snapshot path in Autopilot state and all handoff artifacts.
 </Pre-context Intake>
 
 <Execution_Policy>
-- Always execute phases in order: `ralplan`, then `ralph`, then `code-review`.
-- Never skip directly from vague/freeform expansion to implementation; unclear input must be clarified or planned through `$ralplan`.
-- A non-clean `$code-review` always returns to `$ralplan`; do not patch findings ad hoc outside the loop.
+- Always execute the recommended phases in order: `deep-interview`, then `ralplan`, then `ultragoal`, then `code-review`, then `ultraqa`.
+- `$team` is conditional and explicit: use it only within an Ultragoal story when parallel execution materially improves throughput, quality, or safety.
+- Never skip directly from vague/freeform expansion to implementation; unclear input must be clarified and planned through `$deep-interview` and `$ralplan`.
+- A non-clean `$code-review` or failed `$ultraqa` always returns to `$ralplan`; do not patch findings ad hoc outside the loop.
 - Each phase must write/update Autopilot state before handing off.
-- Use existing hooks, `.omx/state`, `$ralplan`, `$ralph`, `$code-review`, and pipeline primitives; do not invent a separate execution framework.
+- Use existing hooks, `.omx/state`, `$deep-interview`, `$ralplan`, `$ultragoal`, optional `$team`, `$code-review`, `$ultraqa`, and pipeline primitives; do not invent a separate execution framework.
+- Preserve legacy compatibility: if a user explicitly requests the old Ralph execution lane, use `$ralph` as an intentional alternate execution phase, but do not present it as Autopilot's default recommended loop.
 - Continue automatically through safe reversible phase transitions. Ask only for destructive, credential-gated, or materially preference-dependent branches.
 - Apply the shared workflow guidance pattern: outcome-first framing, concise visible updates for multi-step execution, local overrides for the active workflow branch, validation proportional to risk, explicit stop rules, and automatic continuation for safe reversible steps. Ask only for material, destructive, credentialed, external-production, or preference-dependent branches.
 </Execution_Policy>
@@ -83,81 +95,99 @@ Required fields:
 {
   "mode": "autopilot",
   "active": true,
-  "current_phase": "ralplan",
+  "current_phase": "deep-interview",
   "iteration": 1,
   "review_cycle": 0,
   "max_iterations": 10,
-  "phase_cycle": ["ralplan", "ralph", "code-review"],
+  "phase_cycle": ["deep-interview", "ralplan", "ultragoal", "code-review", "ultraqa"],
   "handoff_artifacts": {
     "context_snapshot_path": ".omx/context/<slug>-<timestamp>.md",
+    "deep_interview": null,
     "ralplan": null,
-    "ralph": null,
-    "code_review": null
+    "ultragoal": null,
+    "code_review": null,
+    "ultraqa": null
   },
   "review_verdict": null,
+  "qa_verdict": null,
   "return_to_ralplan_reason": null
 }
 ```
 
-- **On start**: `omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan","iteration":1,"review_cycle":0,"state":{"phase_cycle":["ralplan","ralph","code-review"],"handoff_artifacts":{"context_snapshot_path":"<snapshot-path>","ralplan":null,"ralph":null,"code_review":null},"review_verdict":null,"return_to_ralplan_reason":null}}' --json`
-- **On ralplan -> ralph**: set `current_phase:"ralph"`, persist the plan/test-spec paths under `handoff_artifacts.ralplan`.
-- **On ralph -> code-review**: set `current_phase:"code-review"`, persist implementation/test evidence under `handoff_artifacts.ralph`.
-- **On clean review**: set `active:false`, `current_phase:"complete"`, persist `review_verdict:{recommendation:"APPROVE", architectural_status:"CLEAR", clean:true}` and `completed_at`.
-- **On non-clean review**: increment `iteration` and `review_cycle`, set `current_phase:"ralplan"`, persist `review_verdict:{..., clean:false}`, persist `handoff_artifacts.code_review`, and set `return_to_ralplan_reason` to a concise review-driven reason.
+- **On start**: `omx state write --input '{"mode":"autopilot","active":true,"current_phase":"deep-interview","iteration":1,"review_cycle":0,"state":{"phase_cycle":["deep-interview","ralplan","ultragoal","code-review","ultraqa"],"handoff_artifacts":{"context_snapshot_path":"<snapshot-path>","deep_interview":null,"ralplan":null,"ultragoal":null,"code_review":null,"ultraqa":null},"review_verdict":null,"qa_verdict":null,"return_to_ralplan_reason":null}}' --json`
+- **On deep-interview -> ralplan**: set `current_phase:"ralplan"`, persist the clarified spec/requirements under `handoff_artifacts.deep_interview`.
+- **On ralplan -> ultragoal**: set `current_phase:"ultragoal"`, persist the plan/test-spec paths under `handoff_artifacts.ralplan`.
+- **On ultragoal -> code-review**: set `current_phase:"code-review"`, persist implementation/test/ledger evidence under `handoff_artifacts.ultragoal`.
+- **On code-review -> ultraqa**: set `current_phase:"ultraqa"`, persist the clean review under `handoff_artifacts.code_review`.
+- **On clean review + passed/skipped QA**: set `active:false`, `current_phase:"complete"`, persist `review_verdict:{recommendation:"APPROVE", architectural_status:"CLEAR", clean:true}`, `qa_verdict:{clean:true, skipped:<boolean>, reason:<string|null>}`, and `completed_at`.
+- **On non-clean review or failed QA**: increment `iteration` and `review_cycle`, set `current_phase:"ralplan"`, persist `review_verdict` or `qa_verdict`, persist the phase handoff, and set `return_to_ralplan_reason` to a concise findings-driven reason.
+- **Legacy Ralph state**: if a user explicitly selected the legacy Ralph execution lane, phase names and handoff keys may include `ralph`; preserve and resume them rather than rewriting history to Ultragoal.
 - **On cancellation**: run `$cancel`; preserve progress for resume rather than deleting handoff artifacts.
 </State_Management>
 
 <Continuation_And_Resume>
 When the user says `continue`, `resume`, or `keep going` while Autopilot is active, read `autopilot-state.json` and continue from `current_phase`:
+- `deep-interview`: clarify requirements and record the handoff artifact.
 - `ralplan`: run/update consensus planning from current handoffs and any `return_to_ralplan_reason`.
-- `ralph`: execute the approved plan and record verification evidence.
+- `ultragoal`: execute the approved plan durably and record verification/ledger evidence.
+- `team`: continue explicit team work only when it is nested under the active Ultragoal story and report evidence back to the leader.
 - `code-review`: review the current diff and decide clean vs return-to-ralplan.
+- `ultraqa`: run or explicitly skip adversarial QA based on the documented condition, then finish if clean or transition to `ralplan` with findings if not clean.
+- `ralph`: resume only for explicit legacy Ralph-path Autopilot state.
 - `complete`: report completion evidence; do not restart.
 
 Do not restart discovery or discard handoff artifacts on continuation.
 </Continuation_And_Resume>
 
 <Pipeline_Orchestrator>
-Autopilot may be represented by the configurable pipeline orchestrator (`src/pipeline/`) when useful. The Autopilot pipeline contract is:
+Autopilot may be represented by the configurable pipeline orchestrator (`src/pipeline/`) when useful. The default Autopilot pipeline contract is:
 
 ```text
-ralplan -> ralph -> code-review
+deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa
 ```
 
-Pipeline state should use `current_phase` values that match the same phase names (`ralplan`, `ralph`, `code-review`, `complete`, `failed`) and should carry `iteration`, `review_cycle`, `handoff_artifacts`, `review_verdict`, and `return_to_ralplan_reason` alongside stage results.
+Pipeline state should use `current_phase` values that match the same phase names (`deep-interview`, `ralplan`, `ultragoal`, `code-review`, `ultraqa`, `complete`, `failed`) and should carry `iteration`, `review_cycle`, `handoff_artifacts`, `review_verdict`, `qa_verdict`, and `return_to_ralplan_reason` alongside stage results. `$team` is not a default pipeline stage; it is an explicit conditional execution engine inside an Ultragoal story.
 </Pipeline_Orchestrator>
 
 <Escalation_And_Stop_Conditions>
 - Stop and report a blocker when required credentials/authority are missing.
-- Stop and report when the same review or verification failure recurs across 3 review cycles with no meaningful new plan.
+- Stop and report when the same review or QA failure recurs across 3 review cycles with no meaningful new plan.
 - Stop when the user says "stop", "cancel", or "abort" and run `$cancel`.
-- Otherwise, continue the loop until `$code-review` is clean.
+- Otherwise, continue the loop until `$code-review` is clean and `$ultraqa` has passed or been explicitly skipped with evidence.
 </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>
+- [ ] Phase `deep-interview` produced/updated clarified requirements or a concise spec
 - [ ] Phase `ralplan` produced/updated approved planning artifacts
-- [ ] Phase `ralph` implemented and verified the plan with fresh evidence
+- [ ] Phase `ultragoal` implemented and verified the plan with fresh evidence and durable ledger/checkpoint references
+- [ ] `$team` was used only if the active Ultragoal story needed coordinated parallel work, or explicitly recorded as not needed
 - [ ] Phase `code-review` returned a clean verdict (`APPROVE` + `CLEAR`)
-- [ ] `review_verdict.clean` is true and `return_to_ralplan_reason` is null
-- [ ] Tests/build/lint/typecheck evidence from Ralph is available in handoff artifacts
+- [ ] Phase `ultraqa` passed, or was explicitly skipped because the change was docs-only/trivially non-runtime with evidence
+- [ ] `review_verdict.clean` is true, `qa_verdict.clean` is true, and `return_to_ralplan_reason` is null
+- [ ] Tests/build/lint/typecheck evidence from Ultragoal is available in handoff artifacts
 - [ ] Autopilot state is marked `complete` or cancellation state is preserved coherently
-- [ ] User receives a concise summary with plan, implementation, verification, and review evidence
+- [ ] User receives a concise summary with clarification, plan, implementation, verification, review, and QA evidence
 </Final_Checklist>
 
 <Examples>
 <Good>
 User: `$autopilot implement GitHub issue #42`
-Flow: create/load context snapshot -> `$ralplan` issue plan -> `$ralph` implementation + tests -> `$code-review`; if review requests changes, return to `$ralplan` with findings.
+Flow: create/load context snapshot -> `$deep-interview` requirements check -> `$ralplan` issue plan -> `$ultragoal` durable implementation + tests (launch `$team` only if a story needs parallel lanes) -> `$code-review` -> `$ultraqa`; if review or QA requests changes, return to `$ralplan` with findings.
 </Good>
 
 <Good>
 User: `continue`
 Context: Autopilot state says `current_phase:"code-review"`.
-Flow: run `$code-review` on current diff, persist verdict, finish if clean or transition to `ralplan` with findings if not clean.
+Flow: run `$code-review` on current diff, persist verdict, transition to `ultraqa` if clean or to `ralplan` with findings if not clean.
+</Good>
+
+<Good>
+User: `$autopilot --legacy-ralph finish the migration`
+Flow: preserve the explicit legacy Ralph execution choice and run the old Ralph execution lane as an alternate, without changing the documented default Autopilot recommendation.
 </Good>
 
 <Bad>
 Autopilot invents independent "Expansion", "QA", and "Validation" phases and treats them as the primary lifecycle.
-Why bad: this bypasses the strict `$ralplan -> $ralph -> $code-review` contract.
+Why bad: this bypasses the strict `$deep-interview -> $ralplan -> $ultragoal -> $code-review -> $ultraqa` contract.
 </Bad>
 </Examples>

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -56,7 +56,7 @@ For Ralph-targeted cancellation (standalone or linked), completion is defined by
 See: `docs/contracts/ralph-cancel-contract.md`.
 
 Active modes are still cancelled in dependency order:
-1. Autopilot (includes linked ralph/ultraqa/ecomode cleanup)
+1. Autopilot (includes linked ultragoal/ultraqa/ecomode cleanup plus explicit legacy Ralph cleanup)
 2. Ralph (cleans its linked ultrawork or ecomode)
 3. Ultrawork (standalone)
 4. Ecomode (standalone)
@@ -374,7 +374,7 @@ Mode-specific subsections below describe what extra cleanup each handler perform
 
 ## Notes
 
-- **Dependency-aware**: Autopilot cancellation cleans up Ralph and UltraQA
+- **Dependency-aware**: Autopilot cancellation cleans up Ultragoal/UltraQA state and any explicit legacy Ralph state
 - **Link-aware**: Ralph cancellation cleans up linked Ultrawork or Ecomode
 - **Safe**: Only clears linked Ultrawork, preserves standalone Ultrawork
 - **Local-only**: Clears state files in `.omx/state/` directory

--- a/skills/pipeline/SKILL.md
+++ b/skills/pipeline/SKILL.md
@@ -10,11 +10,13 @@ through a uniform `PipelineStage` interface, with state persistence and resume s
 
 ## Default Autopilot Pipeline
 
-The canonical OMX pipeline sequences:
+The default Autopilot pipeline sequences:
 
 ```
-RALPLAN (consensus planning) -> team-exec (Codex CLI workers) -> ralph-verify (architect verification)
+deep-interview -> ralplan -> ultragoal (+ team if needed) -> code-review -> ultraqa
 ```
+
+`$team` is conditional: use it only inside an active Ultragoal story when independent lanes or broad verification make coordinated parallel execution useful. Explicit legacy Ralph pipelines remain available through custom stages, but Ralph is not the advertised default Autopilot loop.
 
 ## Configuration
 
@@ -22,7 +24,7 @@ Pipeline parameters are configurable per run:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `maxRalphIterations` | 10 | Ralph verification iteration ceiling |
+| `maxRalphIterations` | 10 | Quality-gate retry ceiling; legacy option name retained for compatibility |
 | `workerCount` | 2 | Number of Codex CLI team workers |
 | `agentType` | `executor` | Agent type for team workers |
 
@@ -43,9 +45,12 @@ return a `StageResult` with status, artifacts, and duration.
 
 ## Built-in Stages
 
+- **deep-interview**: Requirements clarification and ambiguity gate.
 - **ralplan**: Consensus planning (planner + architect + critic). Skips only when both `prd-*.md` and `test-spec-*.md` planning artifacts already exist, and carries any `deep-interview-*.md` spec paths forward for traceability.
-- **team-exec**: Team execution via Codex CLI workers. Always the OMX execution backend.
-- **ralph-verify**: Ralph verification loop with configurable iteration count.
+- **ultragoal**: Durable goal-mode execution with `.omx/ultragoal` ledgers. Launch `$team` only from inside an Ultragoal story when parallel lanes are warranted.
+- **code-review**: Merge-readiness review gate.
+- **ultraqa**: Adversarial QA gate after a clean review; docs-only/trivially non-runtime changes may record an explicit skip reason.
+- **team-exec** and **ralph-verify**: Legacy/custom pipeline adapters retained for explicit non-default pipelines.
 
 ## State Management
 
@@ -62,16 +67,20 @@ The HUD renders pipeline phase automatically. Resume is supported from the last 
 import {
   runPipeline,
   createAutopilotPipelineConfig,
+  createDeepInterviewStage,
   createRalplanStage,
-  createTeamExecStage,
-  createRalphVerifyStage,
+  createUltragoalStage,
+  createCodeReviewStage,
+  createUltraqaStage,
 } from './pipeline/index.js';
 
 const config = createAutopilotPipelineConfig('build feature X', {
   stages: [
+    createDeepInterviewStage(),
     createRalplanStage(),
-    createTeamExecStage({ workerCount: 3, agentType: 'executor' }),
-    createRalphVerifyStage({ maxIterations: 15 }),
+    createUltragoalStage(),
+    createCodeReviewStage(),
+    createUltraqaStage(),
   ],
 });
 
@@ -82,5 +91,7 @@ const result = await runPipeline(config);
 
 - **autopilot**: Autopilot can use pipeline as its execution engine (v0.8+)
 - **team**: Pipeline delegates execution to team mode (Codex CLI workers)
-- **ralph**: Pipeline delegates verification to ralph (configurable iterations)
-- **ralplan**: Pipeline's first stage runs RALPLAN consensus planning
+- **ultragoal**: Autopilot delegates durable execution to Ultragoal by default
+- **team**: Optional execution engine inside an Ultragoal story when parallel lanes are needed
+- **ralph**: Available only for explicit legacy/custom pipelines
+- **ralplan**: Pipeline planning runs RALPLAN consensus planning

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -16,7 +16,7 @@ Ultrawork is a parallel execution engine for high-throughput task completion. It
 
 <Do_Not_Use_When>
 - Task requires guaranteed completion with persistence, architect verification, or deslop/reverification -- use `ralph` instead (Ralph includes ultrawork)
-- Task requires a full autonomous pipeline -- use `autopilot` instead (autopilot includes Ralph which includes ultrawork)
+- Task requires a full autonomous pipeline -- use `autopilot` instead (autopilot defaults to Ultragoal, with Team/parallel execution used only when needed)
 - There is only one sequential task with no parallelism opportunity -- execute directly or delegate to a single `executor`
 - The request is still in plan-consensus mode -- keep planning artifacts in `ralplan` until execution is explicitly authorized
 - User needs session persistence for resume -- use `ralph`, which adds persistence on top of ultrawork

--- a/src/hooks/__tests__/autopilot-skill-contract.test.ts
+++ b/src/hooks/__tests__/autopilot-skill-contract.test.ts
@@ -7,15 +7,17 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const autopilotSkill = readFileSync(join(__dirname, '../../../skills/autopilot/SKILL.md'), 'utf-8');
 
-describe('autopilot skill strict 3-phase contract', () => {
-  it('makes ralplan -> ralph -> code-review the primary contract', () => {
-    assert.match(autopilotSkill, /\$ralplan\s*->\s*\$ralph\s*->\s*\$code-review/);
-    assert.match(autopilotSkill, /strict autonomous delivery loop/i);
+describe('autopilot skill default Ultragoal contract', () => {
+  it('makes deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa the recommended/default contract', () => {
+    assert.match(autopilotSkill, /\$deep-interview\s*->\s*\$ralplan\s*->\s*\$ultragoal\s*\(\+ \$team if needed\)\s*->\s*\$code-review\s*->\s*\$ultraqa/);
+    assert.match(autopilotSkill, /recommended\/default contract/i);
+    assert.match(autopilotSkill, /Ralph is a legacy\/explicit alternate execution loop only/i);
   });
 
-  it('returns non-clean code-review findings to ralplan', () => {
-    assert.match(autopilotSkill, /If `\$code-review` is not clean, Autopilot returns to `\$ralplan`/i);
+  it('returns non-clean code-review or ultraqa findings to ralplan', () => {
+    assert.match(autopilotSkill, /If `\$code-review` or `\$ultraqa` is not clean, Autopilot returns to `\$ralplan`/i);
     assert.match(autopilotSkill, /COMMENT.*REQUEST CHANGES.*WATCH.*BLOCK/s);
+    assert.match(autopilotSkill, /UltraQA finds issues.*transition back to Phase `ralplan`/s);
   });
 
   it('requires tight phase, cycle, handoff, review state fields', () => {
@@ -26,6 +28,7 @@ describe('autopilot skill strict 3-phase contract', () => {
       'phase_cycle',
       'handoff_artifacts',
       'review_verdict',
+      'qa_verdict',
       'return_to_ralplan_reason',
     ]) {
       assert.match(autopilotSkill, new RegExp(field));
@@ -37,5 +40,6 @@ describe('autopilot skill strict 3-phase contract', () => {
     assert.doesNotMatch(autopilotSkill, /Phase 0 - Expansion/i);
     assert.doesNotMatch(autopilotSkill, /Phase 4 - Validation/i);
     assert.match(autopilotSkill, /must not run a separate broad expansion\/planning\/execution\/QA\/validation lifecycle as its primary behavior/i);
+    assert.doesNotMatch(autopilotSkill, /primary contract is exactly:\n\n```text\n\$ralplan\s*->\s*\$ralph\s*->\s*\$code-review/);
   });
 });

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -553,18 +553,20 @@ describe('keyword detector skill-active-state lifecycle', () => {
           phase_cycle: string[];
           handoff_artifacts: Record<string, unknown>;
           review_verdict: unknown;
+          qa_verdict: unknown;
           return_to_ralplan_reason: string | null;
         };
       };
       assert.equal(modeState.mode, 'autopilot');
       assert.equal(modeState.active, true);
-      assert.equal(modeState.current_phase, 'ralplan');
+      assert.equal(modeState.current_phase, 'deep-interview');
       assert.equal(modeState.iteration, 1);
       assert.equal(modeState.review_cycle, 0);
       assert.equal(modeState.max_iterations, 10);
-      assert.deepEqual(modeState.state.phase_cycle, ['ralplan', 'ralph', 'code-review']);
-      assert.deepEqual(modeState.state.handoff_artifacts, { ralplan: null, ralph: null, code_review: null });
+      assert.deepEqual(modeState.state.phase_cycle, ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa']);
+      assert.deepEqual(modeState.state.handoff_artifacts, { deep_interview: null, ralplan: null, ultragoal: null, code_review: null, ultraqa: null });
       assert.equal(modeState.state.review_verdict, null);
+      assert.equal(modeState.state.qa_verdict, null);
       assert.equal(modeState.state.return_to_ralplan_reason, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -132,7 +132,7 @@ const EXECUTION_LIKE_WORKFLOW_SKILLS = new Set<TrackedWorkflowMode>([
 
 const STATEFUL_SKILL_SEED_CONFIG: Record<StatefulSkillMode, StatefulSkillSeedConfig> = {
   'deep-interview': { mode: 'deep-interview', initialPhase: 'intent-first' },
-  autopilot: { mode: 'autopilot', initialPhase: 'ralplan', includeIteration: true },
+  autopilot: { mode: 'autopilot', initialPhase: 'deep-interview', includeIteration: true },
   autoresearch: { mode: 'autoresearch', initialPhase: 'executing' },
   ralph: { mode: 'ralph', initialPhase: 'starting', includeIteration: true },
   ralplan: { mode: 'ralplan', initialPhase: 'planning' },
@@ -395,15 +395,20 @@ async function persistStatefulSkillSeedState(
     baseState.review_cycle = typeof existingModeState?.review_cycle === 'number' ? existingModeState.review_cycle : 0;
     baseState.state = {
       ...existingState,
-      phase_cycle: Array.isArray(existingState.phase_cycle) ? existingState.phase_cycle : ['ralplan', 'ralph', 'code-review'],
+      phase_cycle: Array.isArray(existingState.phase_cycle) ? existingState.phase_cycle : ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa'],
       handoff_artifacts: {
+        deep_interview: null,
         ralplan: null,
-        ralph: null,
+        ultragoal: null,
         code_review: null,
+        ultraqa: null,
         ...existingHandoffs,
       },
       review_verdict: Object.prototype.hasOwnProperty.call(existingState, 'review_verdict')
         ? existingState.review_verdict
+        : null,
+      qa_verdict: Object.prototype.hasOwnProperty.call(existingState, 'qa_verdict')
+        ? existingState.qa_verdict
         : null,
       return_to_ralplan_reason: Object.prototype.hasOwnProperty.call(existingState, 'return_to_ralplan_reason')
         ? existingState.return_to_ralplan_reason

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -361,13 +361,14 @@ export const PROMPT_REFACTOR_INVARIANT_CONTRACTS: GuidanceSurfaceContract[] = [
     ],
   },
   {
-    id: 'autopilot-strict-3phase-loop',
+    id: 'autopilot-default-ultragoal-loop',
     path: 'skills/autopilot/SKILL.md',
     requiredPatterns: [
-      rx('\\$ralplan\\s*->\\s*\\$ralph\\s*->\\s*\\$code-review'),
+      rx('\\$deep-interview\\s*->\\s*\\$ralplan\\s*->\\s*\\$ultragoal.*\\$code-review\\s*->\\s*\\$ultraqa'),
       rx('return[s]? to `?\\$ralplan`?|current_phase.*ralplan'),
       rx('review_cycle'),
       rx('review_verdict'),
+      rx('qa_verdict'),
       rx('return_to_ralplan_reason'),
     ],
   },

--- a/src/pipeline/__tests__/orchestrator.test.ts
+++ b/src/pipeline/__tests__/orchestrator.test.ts
@@ -192,6 +192,71 @@ describe('Pipeline Orchestrator', () => {
       assert.equal(Object.prototype.hasOwnProperty.call(ext?.handoff_artifacts ?? {}, 'review_verdict'), false);
     });
 
+    it('returns to ralplan rather than deep-interview after default quality-gate failures', async () => {
+      const order: string[] = [];
+      let qaRuns = 0;
+      const stages: PipelineStage[] = [
+        makeStage('deep-interview', undefined, {
+          canSkip: () => {
+            order.push('deep-interview:skip-check');
+            return false;
+          },
+        }),
+        {
+          name: 'ralplan',
+          async run(): Promise<StageResult> {
+            order.push('ralplan');
+            return { status: 'completed', artifacts: { plan: `cycle-${order.length}` }, duration_ms: 0 };
+          },
+        },
+        makeStage('ultragoal', { artifacts: { implemented: true } }),
+        makeStage('code-review', {
+          artifacts: {
+            review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+            return_to_ralplan_reason: null,
+          },
+        }),
+        {
+          name: 'ultraqa',
+          async run(): Promise<StageResult> {
+            order.push('ultraqa');
+            qaRuns += 1;
+            const clean = qaRuns > 1;
+            return {
+              status: 'completed',
+              artifacts: {
+                qa_verdict: { clean, skipped: false, summary: clean ? 'QA clean.' : 'QA found a regression.' },
+                return_to_ralplan_reason: clean ? null : 'QA found a regression.',
+              },
+              duration_ms: 0,
+            };
+          },
+        },
+      ];
+
+      const result = await runPipeline({
+        name: 'default-quality-loop-test',
+        task: 'loop until QA clean',
+        stages,
+        cwd: tempDir,
+        maxRalphIterations: 3,
+      });
+
+      assert.equal(result.status, 'completed');
+      assert.deepEqual(order, [
+        'deep-interview:skip-check',
+        'ralplan',
+        'ultraqa',
+        'ralplan',
+        'ultraqa',
+      ]);
+
+      const ext = await readPipelineState(tempDir);
+      assert.equal(ext?.review_cycle, 1);
+      assert.equal((ext?.qa_verdict as { clean?: boolean } | undefined)?.clean, true);
+      assert.equal(ext?.return_to_ralplan_reason, null);
+    });
+
     it('fails after bounded non-clean code-review cycles', async () => {
       const stages: PipelineStage[] = [
         makeStage('ralplan'),

--- a/src/pipeline/__tests__/orchestrator.test.ts
+++ b/src/pipeline/__tests__/orchestrator.test.ts
@@ -218,7 +218,7 @@ describe('Pipeline Orchestrator', () => {
 
       assert.equal(result.status, 'failed');
       assert.equal(result.failedStage, 'code-review');
-      assert.match(result.error ?? '', /Code review was not clean after 2 cycle/);
+      assert.match(result.error ?? '', /Autopilot quality gates were not clean after 2 cycle/);
     });
 
     it('passes artifacts between stages', async () => {
@@ -565,6 +565,7 @@ describe('Pipeline Orchestrator', () => {
       assert.equal(ext.pipeline_max_ralph_iterations, 5);
       assert.equal(ext.pipeline_worker_count, 3);
       assert.equal(ext.pipeline_agent_type, 'analyst');
+      assert.equal(ext.qa_verdict, null);
     });
   });
 
@@ -583,13 +584,13 @@ describe('Pipeline Orchestrator', () => {
       assert.equal(config.maxRalphIterations, 10);
       assert.equal(config.workerCount, 2);
       assert.equal(config.agentType, 'executor');
-      assert.deepEqual(config.stages.map((stage) => stage.name), ['ralplan', 'ralph', 'code-review']);
+      assert.deepEqual(config.stages.map((stage) => stage.name), ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa']);
     });
 
 
 
     it('exposes strict default autopilot stages', () => {
-      assert.deepEqual(createStrictAutopilotStages().map((stage) => stage.name), ['ralplan', 'ralph', 'code-review']);
+      assert.deepEqual(createStrictAutopilotStages().map((stage) => stage.name), ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa']);
     });
 
     it('accepts custom overrides', () => {

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -6,10 +6,13 @@ import { basename, dirname, join, relative } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
 import type { StageContext } from '../types.js';
+import { createDeepInterviewStage, buildDeepInterviewInstruction } from '../stages/deep-interview.js';
 import { createRalplanStage } from '../stages/ralplan.js';
 import { createTeamExecStage, buildTeamInstruction } from '../stages/team-exec.js';
 import { createRalphVerifyStage, createRalphStage, buildRalphInstruction } from '../stages/ralph-verify.js';
 import { createCodeReviewStage, buildCodeReviewInstruction } from '../stages/code-review.js';
+import { createUltragoalStage, buildUltragoalInstruction } from '../stages/ultragoal.js';
+import { createUltraqaStage, buildUltraqaInstruction } from '../stages/ultraqa.js';
 import { buildFollowupStaffingPlan } from '../../team/followup-planner.js';
 import { packageRoot } from '../../utils/paths.js';
 
@@ -1188,15 +1191,15 @@ describe('Ralph Verify Stage', () => {
 // Strict Autopilot stage tests
 // ---------------------------------------------------------------------------
 
-describe('Strict Autopilot Ralph Stage', () => {
+describe('Explicit Legacy Ralph Stage', () => {
   beforeEach(async () => { await setup(); });
   afterEach(async () => { await cleanup(); });
 
-  it('uses the strict phase name ralph', () => {
+  it('uses the explicit legacy phase name ralph', () => {
     assert.equal(createRalphStage().name, 'ralph');
   });
 
-  it('uses ralplan artifacts as the primary strict ralph execution input', async () => {
+  it('uses ralplan artifacts as the primary explicit legacy Ralph execution input', async () => {
     const result = await createRalphStage().run(makeCtx({
       artifacts: {
         ralplan: { plan: 'approved plan' },
@@ -1209,15 +1212,63 @@ describe('Strict Autopilot Ralph Stage', () => {
   });
 });
 
+
+describe('Default Autopilot Ultragoal Stage Adapters', () => {
+  beforeEach(async () => { await setup(); });
+  afterEach(async () => { await cleanup(); });
+
+  it('creates a deep-interview descriptor and instruction', async () => {
+    const stage = createDeepInterviewStage();
+    assert.equal(stage.name, 'deep-interview');
+    const result = await stage.run(makeCtx());
+    const artifacts = result.artifacts as Record<string, unknown>;
+    assert.equal(artifacts.stage, 'deep-interview');
+    assert.match(artifacts.instruction as string, /^\$deep-interview /);
+    assert.match(buildDeepInterviewInstruction('clarify me'), /^\$deep-interview /);
+  });
+
+  it('creates an ultragoal descriptor with explicit team condition', async () => {
+    const stage = createUltragoalStage();
+    assert.equal(stage.name, 'ultragoal');
+    const result = await stage.run(makeCtx({ artifacts: { ralplan: { plan: 'approved' } } }));
+    const artifacts = result.artifacts as Record<string, unknown>;
+    const descriptor = artifacts.ultragoalDescriptor as Record<string, unknown>;
+    assert.equal(artifacts.stage, 'ultragoal');
+    assert.deepEqual(descriptor.ralplanArtifacts, { plan: 'approved' });
+    assert.match(artifacts.team_condition as string, /Launch \$team only inside an active Ultragoal story/);
+    assert.match(buildUltragoalInstruction('execute me'), /^\$ultragoal /);
+  });
+
+  it('creates an ultraqa gate that fails closed without evidence and can record clean skips', async () => {
+    const missingEvidence = await createUltraqaStage().run(makeCtx({
+      artifacts: { ultragoal: { tests: 'passed' }, 'code-review': { review_verdict: { clean: true } } },
+    }));
+    const missingArtifacts = missingEvidence.artifacts as Record<string, unknown>;
+    const missingVerdict = missingArtifacts.qa_verdict as Record<string, unknown>;
+    assert.equal(missingVerdict.clean, false);
+    assert.equal(missingArtifacts.return_to_ralplan_reason, 'UltraQA evidence missing; fail closed and return to ralplan.');
+
+    const skipped = await createUltraqaStage({ skipped: true, summary: 'Docs-only change; QA not applicable.' }).run(makeCtx());
+    const skippedArtifacts = skipped.artifacts as Record<string, unknown>;
+    const skippedVerdict = skippedArtifacts.qa_verdict as Record<string, unknown>;
+    assert.equal(skippedVerdict.clean, true);
+    assert.equal(skippedVerdict.skipped, true);
+    assert.equal(skippedArtifacts.return_to_ralplan_reason, null);
+    assert.match(buildUltraqaInstruction('qa me'), /^\$ultraqa /);
+  });
+});
+
 describe('Code Review Stage', () => {
   beforeEach(async () => { await setup(); });
   afterEach(async () => { await cleanup(); });
 
-  it('creates a strict code-review stage that fails closed without review evidence', async () => {
+  it('creates a code-review stage that fails closed without review evidence', async () => {
     const stage = createCodeReviewStage();
     assert.equal(stage.name, 'code-review');
-    const result = await stage.run(makeCtx({ artifacts: { ralph: { tests: 'passed' } } }));
+    const result = await stage.run(makeCtx({ artifacts: { ultragoal: { tests: 'passed' } } }));
     const artifacts = result.artifacts as Record<string, unknown>;
+    const descriptor = artifacts.codeReviewDescriptor as Record<string, unknown>;
+    assert.deepEqual(descriptor.executionArtifacts, { tests: 'passed' });
     const verdict = artifacts.review_verdict as Record<string, unknown>;
     assert.equal(result.status, 'completed');
     assert.equal(verdict.clean, false);

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -1,8 +1,8 @@
 /**
  * Pipeline orchestrator for oh-my-codex
  *
- * Configurable pipeline that sequences: ralplan -> ralph -> code-review.
- * This is the strict Autopilot loop; legacy team/ralph-verify adapters remain available.
+ * Configurable pipeline that sequences: deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa.
+ * This is the default Autopilot loop; legacy team/ralph-verify adapters remain available.
  *
  * @module pipeline
  */
@@ -24,11 +24,17 @@ export {
   runPipeline,
 } from './orchestrator.js';
 
+export { createDeepInterviewStage, buildDeepInterviewInstruction } from './stages/deep-interview.js';
+export type { DeepInterviewDescriptor } from './stages/deep-interview.js';
 export { createRalplanStage } from './stages/ralplan.js';
 export type { CreateRalplanStageOptions } from './stages/ralplan.js';
 export { createTeamExecStage, buildTeamInstruction } from './stages/team-exec.js';
 export type { TeamExecStageOptions, TeamExecDescriptor } from './stages/team-exec.js';
 export { createRalphVerifyStage, createRalphStage, buildRalphInstruction } from './stages/ralph-verify.js';
 export type { RalphVerifyStageOptions, RalphVerifyDescriptor } from './stages/ralph-verify.js';
+export { createUltragoalStage, buildUltragoalInstruction } from './stages/ultragoal.js';
+export type { UltragoalDescriptor } from './stages/ultragoal.js';
 export { createCodeReviewStage, buildCodeReviewInstruction } from './stages/code-review.js';
 export type { CodeReviewStageOptions, CodeReviewDescriptor, CodeReviewVerdict } from './stages/code-review.js';
+export { createUltraqaStage, buildUltraqaInstruction } from './stages/ultraqa.js';
+export type { UltraqaStageOptions, UltraqaDescriptor, UltraqaVerdict } from './stages/ultraqa.js';

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -1,19 +1,21 @@
 /**
  * Pipeline Orchestrator for oh-my-codex
  *
- * Sequences configurable stages (ralplan -> ralph -> code-review)
+ * Sequences configurable stages (deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa)
  * and persists state through the ModeState system.
  *
  * Mirrors OMC #1130 pipeline design with OMX-specific adaptations:
- * - Ralph iteration count is configurable
+ * - Legacy Ralph iteration count is configurable
  * - Code review is the merge-readiness gate
  * - Non-clean review artifacts can drive a return to ralplan
  */
 
 import { startMode, readModeState, updateModeState, cancelMode } from '../modes/base.js';
+import { createDeepInterviewStage } from './stages/deep-interview.js';
 import { createRalplanStage } from './stages/ralplan.js';
-import { createRalphStage } from './stages/ralph-verify.js';
+import { createUltragoalStage } from './stages/ultragoal.js';
 import { createCodeReviewStage } from './stages/code-review.js';
+import { createUltraqaStage } from './stages/ultraqa.js';
 import { isNonCleanReviewVerdict } from './review-verdict.js';
 import type {
   PipelineConfig,
@@ -57,6 +59,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     pipeline_agent_type: agentType,
     review_cycle: 0,
     review_verdict: null,
+    qa_verdict: null,
     return_to_ralplan_reason: null,
     handoff_artifacts: {},
   };
@@ -143,19 +146,28 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
 
     const resultArtifacts = result.artifacts as Record<string, unknown>;
     const reviewVerdict = stage.name === 'code-review' ? resultArtifacts.review_verdict : undefined;
-    const returnToRalplanReason = stage.name === 'code-review'
+    const qaVerdict = stage.name === 'ultraqa' ? resultArtifacts.qa_verdict : undefined;
+    const returnToRalplanReason = (stage.name === 'code-review' || stage.name === 'ultraqa')
       ? resultArtifacts.return_to_ralplan_reason as string | null | undefined
       : undefined;
     const reviewIsNotClean = stage.name === 'code-review'
       && result.status === 'completed'
       && isNonCleanReviewVerdict(reviewVerdict);
+    const qaIsNotClean = stage.name === 'ultraqa'
+      && result.status === 'completed'
+      && isNonCleanQaVerdict(qaVerdict);
+    const shouldReturnToRalplan = reviewIsNotClean || qaIsNotClean;
 
     if (stage.name === 'code-review') {
       artifacts.review_verdict = reviewVerdict ?? null;
       artifacts.return_to_ralplan_reason = returnToRalplanReason ?? null;
     }
+    if (stage.name === 'ultraqa') {
+      artifacts.qa_verdict = qaVerdict ?? null;
+      artifacts.return_to_ralplan_reason = returnToRalplanReason ?? null;
+    }
 
-    if (reviewIsNotClean) {
+    if (shouldReturnToRalplan) {
       reviewCycle += 1;
     }
 
@@ -163,14 +175,19 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
 
     // Persist stage result
     await updateModeState(MODE_NAME, {
-      current_phase: reviewIsNotClean ? 'ralplan' : (result.status === 'completed' ? stage.name : `${stage.name}:${result.status}`),
+      current_phase: shouldReturnToRalplan ? 'ralplan' : (result.status === 'completed' ? stage.name : `${stage.name}:${result.status}`),
       handoff_artifacts: handoffArtifacts,
       ...(stage.name === 'code-review' ? {
         review_verdict: reviewVerdict,
         return_to_ralplan_reason: returnToRalplanReason ?? null,
         review_cycle: reviewCycle,
       } : {}),
-      pipeline_stage_index: reviewIsNotClean ? 0 : i,
+      ...(stage.name === 'ultraqa' ? {
+        qa_verdict: qaVerdict,
+        return_to_ralplan_reason: returnToRalplanReason ?? null,
+        review_cycle: reviewCycle,
+      } : {}),
+      pipeline_stage_index: shouldReturnToRalplan ? 0 : i,
       pipeline_stage_results: { ...stageResults },
     } as Partial<PipelineModeStateExtension>, cwd);
 
@@ -195,11 +212,11 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       };
     }
 
-    if (reviewIsNotClean) {
+    if (shouldReturnToRalplan) {
       if (reviewCycle >= maxRalphIterations) {
         const error = returnToRalplanReason
-          ? `Code review was not clean after ${reviewCycle} cycle(s): ${returnToRalplanReason}`
-          : `Code review was not clean after ${reviewCycle} cycle(s).`;
+          ? `Autopilot quality gates were not clean after ${reviewCycle} cycle(s): ${returnToRalplanReason}`
+          : `Autopilot quality gates were not clean after ${reviewCycle} cycle(s).`;
         const duration_ms = Date.now() - startTime;
 
         await updateModeState(MODE_NAME, {
@@ -285,6 +302,7 @@ export async function readPipelineState(
     pipeline_agent_type: state.pipeline_agent_type as string,
     review_cycle: state.review_cycle as number | undefined,
     review_verdict: state.review_verdict,
+    qa_verdict: state.qa_verdict,
     return_to_ralplan_reason: state.return_to_ralplan_reason as string | null | undefined,
     handoff_artifacts: state.handoff_artifacts as Record<string, unknown> | undefined,
   };
@@ -310,7 +328,14 @@ function normalizeHandoffArtifactKeys(artifacts: Record<string, unknown>): Recor
 }
 
 function toHandoffArtifactKey(stageName: string): string {
-  return stageName === 'code-review' ? 'code_review' : stageName;
+  switch (stageName) {
+    case 'code-review':
+      return 'code_review';
+    case 'deep-interview':
+      return 'deep_interview';
+    default:
+      return stageName;
+  }
 }
 
 function validateConfig(config: PipelineConfig): void {
@@ -356,8 +381,9 @@ function validateConfig(config: PipelineConfig): void {
 /**
  * Create the default autopilot pipeline configuration.
  *
- * Sequences: ralplan -> ralph -> code-review.
- * This is the strict Autopilot loop required by the skill contract.
+ * Sequences: deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa.
+ * This is the default Autopilot loop required by the skill contract.
+ * Custom stages can still preserve explicit legacy Ralph execution paths.
  */
 export function createAutopilotPipelineConfig(
   task: string,
@@ -385,5 +411,16 @@ export function createAutopilotPipelineConfig(
 }
 
 export function createStrictAutopilotStages(): PipelineConfig['stages'] {
-  return [createRalplanStage(), createRalphStage(), createCodeReviewStage()];
+  return [
+    createDeepInterviewStage(),
+    createRalplanStage(),
+    createUltragoalStage(),
+    createCodeReviewStage(),
+    createUltraqaStage(),
+  ];
+}
+
+function isNonCleanQaVerdict(verdict: unknown): boolean {
+  if (!verdict || typeof verdict !== 'object') return true;
+  return (verdict as { clean?: unknown }).clean !== true;
 }

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -21,6 +21,7 @@ import type {
   PipelineConfig,
   PipelineResult,
   PipelineModeStateExtension,
+  PipelineStage,
   StageContext,
   StageResult,
 } from './types.js';
@@ -187,7 +188,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
         return_to_ralplan_reason: returnToRalplanReason ?? null,
         review_cycle: reviewCycle,
       } : {}),
-      pipeline_stage_index: shouldReturnToRalplan ? 0 : i,
+      pipeline_stage_index: shouldReturnToRalplan ? findStageIndex(config.stages, 'ralplan') : i,
       pipeline_stage_results: { ...stageResults },
     } as Partial<PipelineModeStateExtension>, cwd);
 
@@ -241,7 +242,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       }
       lastStageName = undefined;
       previousResult = result;
-      i = -1;
+      i = findStageIndex(config.stages, 'ralplan') - 1;
       continue;
     }
 
@@ -336,6 +337,11 @@ function toHandoffArtifactKey(stageName: string): string {
     default:
       return stageName;
   }
+}
+
+function findStageIndex(stages: readonly PipelineStage[], stageName: string): number {
+  const index = stages.findIndex((stage) => stage.name === stageName);
+  return index >= 0 ? index : 0;
 }
 
 function validateConfig(config: PipelineConfig): void {

--- a/src/pipeline/stages/code-review.ts
+++ b/src/pipeline/stages/code-review.ts
@@ -1,5 +1,5 @@
 /**
- * Code-review stage adapter for the strict Autopilot loop.
+ * Code-review stage adapter for the default Autopilot loop.
  *
  * The stage produces a descriptor/instruction for the existing `$code-review`
  * skill and reports whether the latest review is clean. A non-clean review is
@@ -24,7 +24,7 @@ export interface CodeReviewDescriptor {
   task: string;
   cwd: string;
   sessionId?: string;
-  ralphArtifacts: Record<string, unknown>;
+  executionArtifacts: Record<string, unknown>;
   instruction: string;
 }
 
@@ -41,12 +41,14 @@ export function createCodeReviewStage(options: CodeReviewStageOptions = {}): Pip
 
     async run(ctx: StageContext): Promise<StageResult> {
       const startTime = Date.now();
-      const ralphArtifacts = ctx.artifacts.ralph as Record<string, unknown> | undefined;
+      const executionArtifacts = (ctx.artifacts.ultragoal as Record<string, unknown> | undefined)
+        ?? (ctx.artifacts.ralph as Record<string, unknown> | undefined)
+        ?? {};
       const descriptor: CodeReviewDescriptor = {
         task: ctx.task,
         cwd: ctx.cwd,
         sessionId: ctx.sessionId,
-        ralphArtifacts: ralphArtifacts ?? {},
+        executionArtifacts,
         instruction: buildCodeReviewInstruction(ctx.task),
       };
       const hasReviewEvidence = options.recommendation !== undefined || options.architecturalStatus !== undefined;

--- a/src/pipeline/stages/deep-interview.ts
+++ b/src/pipeline/stages/deep-interview.ts
@@ -1,0 +1,44 @@
+/**
+ * Deep-interview stage adapter for the default Autopilot loop.
+ *
+ * Produces a model-facing instruction for the requirements clarification gate.
+ */
+
+import type { PipelineStage, StageContext, StageResult } from '../types.js';
+
+export interface DeepInterviewDescriptor {
+  task: string;
+  cwd: string;
+  sessionId?: string;
+  instruction: string;
+}
+
+export function createDeepInterviewStage(): PipelineStage {
+  return {
+    name: 'deep-interview',
+
+    async run(ctx: StageContext): Promise<StageResult> {
+      const startTime = Date.now();
+      const descriptor: DeepInterviewDescriptor = {
+        task: ctx.task,
+        cwd: ctx.cwd,
+        sessionId: ctx.sessionId,
+        instruction: buildDeepInterviewInstruction(ctx.task),
+      };
+
+      return {
+        status: 'completed',
+        artifacts: {
+          stage: 'deep-interview',
+          deepInterviewDescriptor: descriptor,
+          instruction: descriptor.instruction,
+        },
+        duration_ms: Date.now() - startTime,
+      };
+    },
+  };
+}
+
+export function buildDeepInterviewInstruction(task: string): string {
+  return `$deep-interview ${JSON.stringify(task)}`;
+}

--- a/src/pipeline/stages/ralph-verify.ts
+++ b/src/pipeline/stages/ralph-verify.ts
@@ -12,13 +12,13 @@ import {
 } from '../../team/followup-planner.js';
 
 export interface RalphVerifyStageOptions {
-  /** Stage name. Strict Autopilot uses 'ralph'; legacy pipeline adapters use 'ralph-verify'. */
+  /** Stage name. Explicit legacy Ralph paths use 'ralph'; legacy pipeline adapters use 'ralph-verify'. */
   stageName?: string;
 
   /**
    * Ordered artifact keys used as Ralph execution input.
-   * Legacy ralph-verify keeps reading prior ralph/team-exec output; strict Autopilot
-   * Ralph reads ralplan first so implementation starts from approved planning.
+   * Legacy ralph-verify keeps reading prior ralph/team-exec output; explicit legacy
+   * Ralph execution reads ralplan first so implementation starts from approved planning.
    */
   executionArtifactKeys?: readonly string[];
 
@@ -33,7 +33,7 @@ export interface RalphVerifyStageOptions {
  * Create a ralph-verify pipeline stage.
  *
  * This stage wraps the ralph persistence loop for the verification phase
- * of legacy pipelines. Strict Autopilot uses `createRalphStage()` for the
+ * of legacy pipelines. Explicit legacy Ralph execution uses `createRalphStage()` for the
  * implementation/verification phase before code-review.
  *
  * The iteration count is configurable, addressing issue #396 requirement
@@ -129,7 +129,7 @@ function pickFirstArtifact(
   return undefined;
 }
 
-/** Create the strict Autopilot Ralph phase adapter. */
+/** Create the explicit legacy Ralph execution phase adapter. */
 export function createRalphStage(options: RalphVerifyStageOptions = {}): PipelineStage {
   return createRalphVerifyStage({
     ...options,

--- a/src/pipeline/stages/ultragoal.ts
+++ b/src/pipeline/stages/ultragoal.ts
@@ -1,0 +1,52 @@
+/**
+ * Ultragoal stage adapter for the default Autopilot loop.
+ *
+ * Produces a model-facing instruction for durable goal-mode execution. Team is
+ * intentionally conditional and must be launched explicitly inside an Ultragoal
+ * story when parallel execution is warranted.
+ */
+
+import type { PipelineStage, StageContext, StageResult } from '../types.js';
+
+export interface UltragoalDescriptor {
+  task: string;
+  cwd: string;
+  sessionId?: string;
+  ralplanArtifacts: Record<string, unknown>;
+  instruction: string;
+  teamCondition: string;
+}
+
+export function createUltragoalStage(): PipelineStage {
+  return {
+    name: 'ultragoal',
+
+    async run(ctx: StageContext): Promise<StageResult> {
+      const startTime = Date.now();
+      const ralplanArtifacts = ctx.artifacts.ralplan as Record<string, unknown> | undefined;
+      const descriptor: UltragoalDescriptor = {
+        task: ctx.task,
+        cwd: ctx.cwd,
+        sessionId: ctx.sessionId,
+        ralplanArtifacts: ralplanArtifacts ?? {},
+        instruction: buildUltragoalInstruction(ctx.task),
+        teamCondition: 'Launch $team only inside an active Ultragoal story when independent lanes or broad verification make coordinated parallel work useful; Ultragoal remains leader-owned for goal and ledger state.',
+      };
+
+      return {
+        status: 'completed',
+        artifacts: {
+          stage: 'ultragoal',
+          ultragoalDescriptor: descriptor,
+          team_condition: descriptor.teamCondition,
+          instruction: descriptor.instruction,
+        },
+        duration_ms: Date.now() - startTime,
+      };
+    },
+  };
+}
+
+export function buildUltragoalInstruction(task: string): string {
+  return `$ultragoal ${JSON.stringify(task)}`;
+}

--- a/src/pipeline/stages/ultraqa.ts
+++ b/src/pipeline/stages/ultraqa.ts
@@ -1,0 +1,77 @@
+/**
+ * UltraQA stage adapter for the default Autopilot loop.
+ *
+ * Produces a model-facing instruction for adversarial QA after clean review.
+ */
+
+import type { PipelineStage, StageContext, StageResult } from '../types.js';
+
+export interface UltraqaStageOptions {
+  /** Optional QA verdict injected by tests or runtime adapters. */
+  clean?: boolean;
+
+  /** Whether QA was explicitly skipped for a documented low-risk condition. */
+  skipped?: boolean;
+
+  /** Human-readable QA summary or skip reason. */
+  summary?: string;
+}
+
+export interface UltraqaDescriptor {
+  task: string;
+  cwd: string;
+  sessionId?: string;
+  ultragoalArtifacts: Record<string, unknown>;
+  codeReviewArtifacts: Record<string, unknown>;
+  instruction: string;
+}
+
+export interface UltraqaVerdict {
+  clean: boolean;
+  skipped: boolean;
+  summary: string;
+}
+
+export function createUltraqaStage(options: UltraqaStageOptions = {}): PipelineStage {
+  return {
+    name: 'ultraqa',
+
+    async run(ctx: StageContext): Promise<StageResult> {
+      const startTime = Date.now();
+      const descriptor: UltraqaDescriptor = {
+        task: ctx.task,
+        cwd: ctx.cwd,
+        sessionId: ctx.sessionId,
+        ultragoalArtifacts: (ctx.artifacts.ultragoal as Record<string, unknown> | undefined) ?? {},
+        codeReviewArtifacts: (ctx.artifacts['code-review'] as Record<string, unknown> | undefined) ?? {},
+        instruction: buildUltraqaInstruction(ctx.task),
+      };
+      const hasQaEvidence = options.clean !== undefined || options.skipped !== undefined;
+      const skipped = options.skipped ?? false;
+      const clean = hasQaEvidence ? (options.clean ?? skipped) : false;
+      const verdict: UltraqaVerdict = {
+        clean,
+        skipped,
+        summary: options.summary ?? (hasQaEvidence
+          ? (clean ? 'UltraQA gate clean.' : 'UltraQA found issues; return to ralplan.')
+          : 'UltraQA evidence missing; fail closed and return to ralplan.'),
+      };
+
+      return {
+        status: 'completed',
+        artifacts: {
+          stage: 'ultraqa',
+          ultraqaDescriptor: descriptor,
+          qa_verdict: verdict,
+          return_to_ralplan_reason: clean ? null : verdict.summary,
+          instruction: descriptor.instruction,
+        },
+        duration_ms: Date.now() - startTime,
+      };
+    },
+  };
+}
+
+export function buildUltraqaInstruction(task: string): string {
+  return `$ultraqa ${JSON.stringify(task)}`;
+}

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -1,8 +1,8 @@
 /**
  * Pipeline stage interfaces for oh-my-codex
  *
- * Shared stage contracts for the strict Autopilot loop.
- * The pipeline sequences: ralplan -> ralph -> code-review.
+ * Shared stage contracts for the default Autopilot loop.
+ * The pipeline sequences: deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa.
  */
 
 // ---------------------------------------------------------------------------
@@ -52,10 +52,10 @@ export interface StageResult {
 
 /**
  * A single stage in the pipeline. Implementations wrap concrete execution
- * backends (ralplan, ralph, code-review, and legacy team adapters) behind this uniform interface.
+ * backends (deep-interview, ralplan, ultragoal, code-review, ultraqa, and legacy team/Ralph adapters) behind this uniform interface.
  */
 export interface PipelineStage {
-  /** Unique name for this stage (e.g. 'ralplan', 'ralph', 'code-review'). */
+  /** Unique name for this stage (e.g. 'deep-interview', 'ralplan', 'ultragoal', 'code-review'). */
   readonly name: string;
 
   /** Execute the stage. Must return a StageResult. */
@@ -162,13 +162,16 @@ export interface PipelineModeStateExtension {
   /** Latest code-review verdict artifact. */
   review_verdict?: unknown;
 
+  /** Latest UltraQA verdict artifact. */
+  qa_verdict?: unknown;
+
   /** Reason Autopilot returned to ralplan after a non-clean review. */
   return_to_ralplan_reason?: string | null;
 
-  /** Phase handoff artifacts keyed by contract names: ralplan, ralph, and code_review. */
+  /** Phase handoff artifacts keyed by contract names such as deep_interview, ralplan, ultragoal, code_review, and ultraqa. */
   handoff_artifacts?: Record<string, unknown>;
 
-  /** Ralph iteration ceiling for the verification stage. */
+  /** Quality-gate retry ceiling; legacy name retained for API compatibility. */
   pipeline_max_ralph_iterations: number;
 
   /** Worker count for team execution. */


### PR DESCRIPTION
Closes #2408.

## Summary
- Updates Autopilot skill/help/docs to advertise `deep-interview -> ralplan -> ultragoal (+ team if needed) -> code-review -> ultraqa` as the recommended/default chain.
- Seeds Autopilot runtime state with `deep-interview`, `ultragoal`, `ultraqa`, and `qa_verdict`; default pipeline stages now use Ultragoal instead of Ralph.
- Keeps explicit legacy Ralph adapters available without advertising Ralph as the default Autopilot path.
- Adds/updates regression tests for skill contract text, keyword-seeded state, pipeline order, and new stage adapters.

## Verification
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `npm run verify:plugin-bundle`
- `node dist/scripts/generate-catalog-docs.js --check`
- `env -u OMX_SESSION_ID -u CODEX_SESSION_ID -u SESSION_ID -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT npm run test:node`
- Focused autopilot/keyword/pipeline contract tests
- `git diff --check`

## Known unrelated blocker
- `npm test` currently stops at `npm run verify:native-agents` with `native_agent_plugin_boundary_violation field="hooks"`; the manifest `hooks` field is unchanged from `HEAD` and appears unrelated to this Autopilot contract update.

Document-refresh: not-needed | User-facing workflow docs/help were refreshed in the Autopilot/Pipeline skills and `docs/skills.html`; the prompt-guidance source change only updates regression contract coverage for this same Autopilot behavior.
