### PR TITLE
Remove misleading Ultragoal fresh-session guidance

### DIFF
--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -14,7 +14,7 @@ Upstream Codex goal source also constrains objectives to 4,000 characters, track
 
 New ultragoal plans default to **aggregate Codex goal mode**: Codex gets one objective for the whole ultragoal run, while OMX owns G001/G002 story state and ledger checkpoints. This avoids the impossible same-thread transition from a completed G001 Codex goal to a new G002 Codex goal. Legacy or explicitly requested **per-story** plans remain supported for users who want one Codex thread per story.
 
-Ultragoal intentionally does **not** call Codex `/goal clear`. The interactive TUI/app-server may expose `thread/goal/clear`, but the agent/tool contract available to OMX is only `get_goal` / `create_goal` / `update_goal`; shell commands and hooks cannot clear hidden thread goal state. After completing one ultragoal run, start the next run in a fresh Codex thread or manually run `/goal clear` in the Codex UI before `create_goal` for the new run. Otherwise `get_goal` may still report the previous completed aggregate objective, and the next same-thread `create_goal` can be blocked or confusing even though the OMX ledger for the previous run is complete.
+Ultragoal intentionally does **not** call Codex `/goal clear`. The interactive TUI/app-server may expose `thread/goal/clear`, but the agent/tool contract available to OMX is only `get_goal` / `create_goal` / `update_goal`; shell commands and hooks cannot clear hidden thread goal state. After completing one ultragoal run, manually run `/goal clear` in the Codex UI before `create_goal` for a new same-thread run. Otherwise `get_goal` may still report the previous completed aggregate objective, and the next same-thread `create_goal` can be blocked or confusing even though the OMX ledger for the previous run is complete.
 
 ## Artifacts
 
@@ -39,7 +39,7 @@ Create a plan:
 omx ultragoal create-goals --brief "Ship the feature in three safe milestones"
 omx ultragoal create-goals --brief-file docs/my-brief.md
 cat docs/my-brief.md | omx ultragoal create-goals --from-stdin
-omx ultragoal create-goals --codex-goal-mode per-story --brief "Use one fresh Codex thread per story"
+omx ultragoal create-goals --codex-goal-mode per-story --brief "Use one Codex goal context per story"
 ```
 
 Start or resume the next goal:
@@ -71,7 +71,7 @@ Completed legacy thread-goal blocker handling:
 omx ultragoal checkpoint --goal-id G001-example --status blocked --evidence "completed legacy Codex goal blocks create_goal in this thread" --codex-goal-json ./get-goal.json
 ```
 
-`--status blocked` is a non-terminal ledger checkpoint for legacy per-story or pre-aggregate sessions: a previous, different Codex thread goal is already `complete`, and the current `get_goal`/`create_goal` tool surface has no reset/new-goal operation that can clear that completed goal from the same thread. This writes a `goal_blocked` event, preserves the ultragoal as `in_progress`, and records that the agent must continue the same repo/worktree from a fresh Codex thread where `create_goal` can start the active ultragoal objective.
+`--status blocked` is a non-terminal ledger checkpoint for legacy per-story or pre-aggregate sessions: a previous, different Codex thread goal is already `complete`, and the current `get_goal`/`create_goal` tool surface has no reset/new-goal operation that can clear that completed goal from the same thread. This writes a `goal_blocked` event, preserves the ultragoal as `in_progress`, and records that the agent must continue the same repo/worktree only from a Codex goal context where `create_goal` can start the active ultragoal objective.
 
 Status:
 
@@ -139,7 +139,7 @@ The final ultragoal story is not complete until the active agent has run the fin
    omx ultragoal record-review-blockers --goal-id <id> --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json <active-get-goal-json-or-path>
    ```
 
-   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need a fresh/available Codex goal context because the old per-story Codex goal remains active/incomplete.
+   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need an available Codex goal context because the old per-story Codex goal remains active/incomplete.
 
 6. If review is clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
 
@@ -163,10 +163,10 @@ The final ultragoal story is not complete until the active agent has run the fin
 - `create_goal` starts the active objective; it is not a general plan store.
 - `update_goal` is completion-only; pause/resume/budget state is controlled by Codex/user/system, not OMX.
 - Aggregate mode is the default: one Codex objective covers the whole ultragoal run, and G001/G002 are OMX ledger stories.
-- Ultragoal does not invoke `/goal clear` or any hidden `thread/goal/clear` route. For multiple sequential ultragoal runs in one Codex session/thread, clear the completed Codex goal manually with `/goal clear` or open a fresh Codex thread before creating the next run's aggregate goal.
+- Ultragoal does not invoke `/goal clear` or any hidden `thread/goal/clear` route. For multiple sequential ultragoal runs in one Codex session/thread, clear the completed Codex goal manually with `/goal clear` before creating the next run's aggregate goal.
 - Intermediate aggregate story checkpoints require a matching `active` Codex snapshot. A `complete` snapshot before the final story is rejected to prevent premature `update_goal`. A non-clean final review records the old story as `review_blocked` and appends a pending blocker story before any completion checkpoint.
 - Final aggregate story checkpoints require a matching `complete` Codex snapshot captured after `update_goal({status: "complete"})`.
-- There is currently no Codex goal-tool reset/new-goal surface for replacing a completed legacy thread goal. In per-story mode, if `get_goal` returns a different completed objective and `create_goal` rejects because the thread already has a goal, record `omx ultragoal checkpoint --status blocked` with that `get_goal` JSON, then continue in a fresh Codex thread on the same branch/worktree and call `create_goal` there for the ultragoal payload.
+- There is currently no Codex goal-tool reset/new-goal surface for replacing a completed legacy thread goal. In per-story mode, if `get_goal` returns a different completed objective and `create_goal` rejects because the thread already has a goal, record `omx ultragoal checkpoint --status blocked` with that `get_goal` JSON, then continue only from a Codex goal context with no active/completed conflicting goal on the same branch/worktree and call `create_goal` there for the ultragoal payload.
 - Ultragoal owns durable plan and ledger state; Codex goal mode owns active-thread focus and accounting.
 - OMX never edits upstream Codex source such as `../../codex`, never shells out to a hidden `/goal` mutator, and never claims that `omx ultragoal checkpoint` changes Codex's active thread goal. The only Codex goal-mode handoff is explicit: `get_goal`, then `create_goal` when no active goal exists, then `update_goal({status: "complete"})` after the real completion audit passes.
 - Completion checkpoints require a fresh `get_goal` snapshot. Save or pass the JSON from `get_goal` with `--codex-goal-json <json-or-path>`; OMX compares the objective and enforces the mode-specific status (`active` for intermediate aggregate stories, `complete` for final aggregate or per-story completion).

--- a/plugins/oh-my-codex/skills/ultragoal/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultragoal/SKILL.md
@@ -9,7 +9,7 @@ Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durabl
 
 ## Purpose
 
-`ultragoal` turns a brief into repo-native artifacts and then drives a Codex goal safely through goal tools. New plans default to a stable pointer-style aggregate Codex goal for the whole durable plan in `.omx/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while OMX tracks G001/G002 story progress in the ledger. Ultragoal does not call Codex `/goal clear`; before multiple sequential ultragoal runs in one Codex session/thread, manually run `/goal clear` in the Codex UI or start a fresh Codex thread so the previous completed aggregate goal does not block or confuse the next `create_goal`.
+`ultragoal` turns a brief into repo-native artifacts and then drives a Codex goal safely through goal tools. New plans default to a stable pointer-style aggregate Codex goal for the whole durable plan in `.omx/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while OMX tracks G001/G002 story progress in the ledger. Ultragoal does not call Codex `/goal clear`; before multiple sequential ultragoal runs in one Codex session/thread, manually run `/goal clear` in the Codex UI so the previous completed aggregate goal does not block or confuse the next `create_goal`.
 
 - `.omx/ultragoal/brief.md`
 - `.omx/ultragoal/goals.json`
@@ -23,7 +23,7 @@ Existing aggregate plans with the legacy enumerated objective are migrated to th
    - `omx ultragoal create-goals --brief "<brief>"`
    - `omx ultragoal create-goals --brief-file <path>`
    - `cat <brief> | omx ultragoal create-goals --from-stdin`
-   - `omx ultragoal create-goals --codex-goal-mode per-story --brief "<brief>"` only when one fresh Codex thread per story is explicitly preferred
+   - `omx ultragoal create-goals --codex-goal-mode per-story --brief "<brief>"` only when one Codex goal context per story is explicitly preferred
 2. Inspect `.omx/ultragoal/goals.json` and refine if needed.
 
 ## Complete goals
@@ -101,7 +101,7 @@ The final ultragoal story is not complete until the active agent has run the fin
    omx ultragoal record-review-blockers --goal-id <id> --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json <active-get-goal-json-or-path>
    ```
 
-   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need a fresh/available Codex goal context because the old per-story Codex goal remains active/incomplete.
+   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need an available Codex goal context because the old per-story Codex goal remains active/incomplete.
 
 6. If review is clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
 
@@ -123,7 +123,7 @@ The final ultragoal story is not complete until the active agent has run the fin
 
 - The shell command cannot directly invoke Codex interactive `/goal`; it emits a model-facing handoff for the active Codex agent.
 - Ultragoal intentionally does not invoke `/goal clear` or hidden `thread/goal/clear`; the model-facing tool surface only provides `get_goal`, `create_goal`, and `update_goal`.
-- After a completed aggregate ultragoal run, clear the Codex goal manually with `/goal clear` or open a fresh Codex thread before starting another ultragoal run in the same session/thread.
+- After a completed aggregate ultragoal run, clear the Codex goal manually with `/goal clear` before starting another ultragoal run in the same session/thread.
 - Never call `create_goal` when `get_goal` reports a different active goal.
 - Never call `update_goal` unless the aggregate run or legacy per-story goal is actually complete.
 - In aggregate mode, intermediate story checkpoints require a matching `active` Codex snapshot; final story completion requires a matching `complete` snapshot after `update_goal`.

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -9,7 +9,7 @@ Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durabl
 
 ## Purpose
 
-`ultragoal` turns a brief into repo-native artifacts and then drives a Codex goal safely through goal tools. New plans default to a stable pointer-style aggregate Codex goal for the whole durable plan in `.omx/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while OMX tracks G001/G002 story progress in the ledger. Ultragoal does not call Codex `/goal clear`; before multiple sequential ultragoal runs in one Codex session/thread, manually run `/goal clear` in the Codex UI or start a fresh Codex thread so the previous completed aggregate goal does not block or confuse the next `create_goal`.
+`ultragoal` turns a brief into repo-native artifacts and then drives a Codex goal safely through goal tools. New plans default to a stable pointer-style aggregate Codex goal for the whole durable plan in `.omx/ultragoal/goals.json`, including later accepted/appended stories under the original brief constraints, while OMX tracks G001/G002 story progress in the ledger. Ultragoal does not call Codex `/goal clear`; before multiple sequential ultragoal runs in one Codex session/thread, manually run `/goal clear` in the Codex UI so the previous completed aggregate goal does not block or confuse the next `create_goal`.
 
 - `.omx/ultragoal/brief.md`
 - `.omx/ultragoal/goals.json`
@@ -23,7 +23,7 @@ Existing aggregate plans with the legacy enumerated objective are migrated to th
    - `omx ultragoal create-goals --brief "<brief>"`
    - `omx ultragoal create-goals --brief-file <path>`
    - `cat <brief> | omx ultragoal create-goals --from-stdin`
-   - `omx ultragoal create-goals --codex-goal-mode per-story --brief "<brief>"` only when one fresh Codex thread per story is explicitly preferred
+   - `omx ultragoal create-goals --codex-goal-mode per-story --brief "<brief>"` only when one Codex goal context per story is explicitly preferred
 2. Inspect `.omx/ultragoal/goals.json` and refine if needed.
 
 ## Complete goals
@@ -101,7 +101,7 @@ The final ultragoal story is not complete until the active agent has run the fin
    omx ultragoal record-review-blockers --goal-id <id> --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json <active-get-goal-json-or-path>
    ```
 
-   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need a fresh/available Codex goal context because the old per-story Codex goal remains active/incomplete.
+   This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need an available Codex goal context because the old per-story Codex goal remains active/incomplete.
 
 6. If review is clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
 
@@ -123,7 +123,7 @@ The final ultragoal story is not complete until the active agent has run the fin
 
 - The shell command cannot directly invoke Codex interactive `/goal`; it emits a model-facing handoff for the active Codex agent.
 - Ultragoal intentionally does not invoke `/goal clear` or hidden `thread/goal/clear`; the model-facing tool surface only provides `get_goal`, `create_goal`, and `update_goal`.
-- After a completed aggregate ultragoal run, clear the Codex goal manually with `/goal clear` or open a fresh Codex thread before starting another ultragoal run in the same session/thread.
+- After a completed aggregate ultragoal run, clear the Codex goal manually with `/goal clear` before starting another ultragoal run in the same session/thread.
 - Never call `create_goal` when `get_goal` reports a different active goal.
 - Never call `update_goal` unless the aggregate run or legacy per-story goal is actually complete.
 - In aggregate mode, intermediate story checkpoints require a matching `active` Codex snapshot; final story completion requires a matching `complete` snapshot after `update_goal`.

--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -48,7 +48,7 @@ describe('cli/ultragoal', () => {
     assert.match(ULTRAGOAL_HELP, /complete-goals/);
     assert.match(ULTRAGOAL_HELP, /aggregate mode/);
     assert.match(ULTRAGOAL_HELP, /blocked/);
-    assert.match(ULTRAGOAL_HELP, /fresh Codex thread/);
+    assert.doesNotMatch(ULTRAGOAL_HELP, /fresh (?:Codex )?(?:thread|session)s?/i);
     assert.match(ULTRAGOAL_HELP, /get_goal\/create_goal\/update_goal/);
     assert.match(ULTRAGOAL_HELP, /does not call \/goal clear/);
     assert.match(ULTRAGOAL_HELP, /multiple sequential ultragoal runs/);
@@ -398,7 +398,8 @@ describe('cli/ultragoal', () => {
       assert.equal(mismatch.exitCode, 1);
       assert.match(mismatch.stderr.join('\n'), /objective mismatch/);
       assert.match(mismatch.stderr.join('\n'), /--status blocked/);
-      assert.match(mismatch.stderr.join('\n'), /fresh Codex thread/);
+      assert.match(mismatch.stderr.join('\n'), /Codex goal context/);
+      assert.doesNotMatch(mismatch.stderr.join('\n'), /fresh (?:Codex )?(?:thread|session)s?/i);
     });
   });
 

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -52,11 +52,10 @@ Codex goal integration:
   the active Codex agent when to call get_goal/create_goal/update_goal safely.
   Ultragoal does not call /goal clear or hidden thread/goal/clear routes. For
   multiple sequential ultragoal runs in one Codex session/thread, manually run
-  /goal clear in the Codex UI or start a fresh Codex thread before creating the
-  next aggregate goal.
+  /goal clear in the Codex UI before creating the next aggregate goal.
   New plans default to aggregate mode: one Codex goal covers the whole ultragoal
   run while OMX checkpoints G001/G002 stories in the durable ledger. Legacy
-  per-story plans retain fresh Codex thread blocker handling when a completed thread
+  per-story plans retain completed-goal blocker handling when a completed thread
   goal prevents create_goal for the next story.
   Dynamic steering is explicit-only: steer accepts structured fields or directive JSON,
   audits accepted/rejected/deduped results in .omx/ultragoal/ledger.jsonl, and

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1915,7 +1915,7 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("blocks ultragoal Stop with blocked checkpoint and fresh-thread remediation for completed legacy snapshots", async () => {
+  it("blocks ultragoal Stop with blocked checkpoint and available-goal-context remediation for completed legacy snapshots", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-legacy-stop-"));
     try {
       await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
@@ -1936,7 +1936,8 @@ describe("codex native hook dispatch", () => {
       assert.equal(result.outputJson?.decision, "block");
       assert.match(output, /omx ultragoal checkpoint --goal-id G001-demo --status complete/);
       assert.match(output, /--status blocked/);
-      assert.match(output, /fresh Codex thread/);
+      assert.match(output, /Codex goal context/);
+      assert.doesNotMatch(output, /fresh (?:Codex )?(?:thread|session)s?/i);
       assert.match(output, /Hooks must not mutate Codex goal state/);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2077,8 +2077,8 @@ async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Pro
         workflow: "autoresearch-goal",
         command: `omx autoresearch-goal complete --slug ${safeString(mission.slug) || entry.name} --codex-goal-json '<get_goal JSON or path>'`,
         remediation: [
-          "If that command fails with a Codex goal objective mismatch after a fresh get_goal snapshot, do not repeat the same complete command blindly in this thread.",
-          "Either retry with a correct fresh snapshot or record an explicit blocked verdict for this autoresearch-goal and continue it from a fresh Codex thread.",
+          "If that command fails with a Codex goal objective mismatch after a refreshed get_goal snapshot, do not repeat the same complete command blindly in this thread.",
+          "Either retry with a correct refreshed snapshot or record an explicit blocked verdict for this autoresearch-goal and continue from the explicit blocker path.",
         ].join(" "),
       };
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1714,7 +1714,7 @@ function buildAdditionalContextMessage(
     ? "Ultrawork protocol: ground the task before editing, define pass/fail acceptance criteria, keep shared-file work local, and use direct-tool plus background evidence lanes only for truly independent work. Direct ultrawork provides lightweight verification only; Ralph owns persistence and the full verified-completion promise."
     : null;
   const ultragoalPromptActivationNote = match.skill === "ultragoal"
-    ? "Ultragoal protocol: use `omx ultragoal create-goals` / `complete-goals` / `checkpoint` for `.omx/ultragoal` artifacts, then use Codex goal model tools only from the active agent handoff (`get_goal`, `create_goal`, `update_goal`) and never overwrite a different active Codex goal. Ultragoal does not call `/goal clear`; for multiple sequential ultragoal runs in one Codex session/thread, manually clear the completed Codex goal in the UI or start a fresh Codex thread."
+    ? "Ultragoal protocol: use `omx ultragoal create-goals` / `complete-goals` / `checkpoint` for `.omx/ultragoal` artifacts, then use Codex goal model tools only from the active agent handoff (`get_goal`, `create_goal`, `update_goal`) and never overwrite a different active Codex goal. Ultragoal does not call `/goal clear`; for multiple sequential ultragoal runs in one Codex session/thread, manually clear the completed Codex goal in the UI before creating the next aggregate goal."
     : null;
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;
@@ -2038,7 +2038,7 @@ async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Pro
         `If get_goal returns a completed task-scoped objective for the same aggregate ultragoal plan, checkpoint ${goalId} with evidence naming ${goalId} plus .omx/ultragoal/goals.json or ledger.jsonl and pass final quality-gate JSON; OMX will reconcile the completed planned scope without mutating Codex goal state.`,
         `If get_goal instead returns a different completed legacy objective and complete checkpointing fails, do not repeat --status complete in this thread.`,
         `Record the non-terminal blocker with: omx ultragoal checkpoint --goal-id ${goalId} --status blocked --codex-goal-json '<different completed get_goal JSON or path>' --evidence '<completed legacy Codex goal blocks create_goal in this thread>'.`,
-        "Then continue this ultragoal from a fresh Codex thread in the same repo/worktree and create the intended goal there.",
+        "Then continue only from a Codex goal context with no active/completed conflicting goal in the same repo/worktree and create the intended goal there.",
       ].join(" "),
     };
   }

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -148,7 +148,8 @@ describe('ultragoal artifacts', () => {
       assert.match(instruction, /\.omx\/ultragoal\/ledger\.jsonl/);
       assert.match(instruction, /Complete first milestone/);
       assert.match(instruction, /does not call \/goal clear/);
-      assert.match(instruction, /start a fresh Codex thread/);
+      assert.match(instruction, /manually run \/goal clear/);
+      assert.doesNotMatch(instruction, /fresh (?:Codex )?(?:thread|session)s?/i);
       assert.doesNotMatch(instruction, /\.\.\/\.\.\/codex/);
       assert.doesNotMatch(instruction, /`codex\s+goal\b/i);
     });
@@ -389,7 +390,8 @@ describe('ultragoal artifacts', () => {
       const first = await startNextUltragoal(cwd);
       const instruction = buildCodexGoalInstruction(first.goal!, first.plan);
       assert.match(instruction, /Ultragoal active-goal handoff/);
-      assert.match(instruction, /fresh Codex thread/);
+      assert.match(instruction, /Codex goal context/);
+      assert.doesNotMatch(instruction, /fresh (?:Codex )?(?:thread|session)s?/i);
 
       await checkpointUltragoal(cwd, {
         goalId: first.goal!.id,
@@ -1138,7 +1140,7 @@ describe('ultragoal artifacts', () => {
     }
   });
 
-  it('guides different completed legacy snapshots to blocked checkpoints and fresh threads', async () => {
+  it('guides different completed legacy snapshots to blocked checkpoints and available goal contexts', async () => {
     await withTempRepo(async (cwd) => {
       await createUltragoalPlan(cwd, {
         brief: 'brief',
@@ -1159,7 +1161,8 @@ describe('ultragoal artifacts', () => {
         (error: unknown) => {
           assert.match(String(error), /objective mismatch/);
           assert.match(String(error), /--status blocked/);
-          assert.match(String(error), /fresh Codex thread/);
+          assert.match(String(error), /Codex goal context/);
+          assert.doesNotMatch(String(error), /fresh (?:Codex )?(?:thread|session)s?/i);
           return true;
         },
       );

--- a/src/ultragoal/__tests__/docs-contract.test.ts
+++ b/src/ultragoal/__tests__/docs-contract.test.ts
@@ -36,7 +36,7 @@ describe('ultragoal docs contract', () => {
       assert.match(doc, /does not invoke `\/goal clear` or hidden `thread\/goal\/clear`/i);
       assert.match(doc, /only provides `get_goal`, `create_goal`, and `update_goal`/i);
       assert.match(doc, /multiple sequential ultragoal runs/i);
-      assert.match(doc, /fresh Codex thread/i);
+      assert.doesNotMatch(doc, /fresh (?:Codex )?(?:thread|session)s?/i);
     }
   });
 
@@ -46,7 +46,8 @@ describe('ultragoal docs contract', () => {
     assert.match(doc, /checkpoint --goal-id G001-example --status blocked/);
     assert.match(doc, /`goal_blocked`/);
     assert.match(doc, /no Codex goal-tool reset\/new-goal surface/i);
-    assert.match(doc, /fresh Codex thread/i);
+    assert.match(doc, /Codex goal context/i);
+    assert.doesNotMatch(doc, /fresh (?:Codex )?(?:thread|session)s?/i);
     assert.match(doc, /same branch\/worktree/i);
     assert.match(doc, /Active or incomplete wrong Codex goals remain strict mismatch errors/i);
     assert.match(doc, /must not be used to bypass active-goal mismatch protection/i);

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -387,7 +387,7 @@ function buildCompletedLegacyGoalRemediation(goal: UltragoalItem): string {
   return [
     'If get_goal returns a different completed legacy/thread objective, do not repeat --status complete in this thread.',
     `Record a non-terminal blocker with: omx ultragoal checkpoint --goal-id ${goal.id} --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json "<different completed get_goal JSON or path>".`,
-    'Then continue this ultragoal in a fresh Codex thread in the same repo/worktree and create the intended goal there.',
+    'Then continue only from a Codex goal context with no active/completed conflicting goal, in the same repo/worktree, and create the intended goal there.',
   ].join(' ');
 }
 
@@ -1256,7 +1256,7 @@ export async function recordFinalReviewBlockers(cwd: string, options: RecordFina
     codexGoal: options.codexGoal,
     message: aggregateMode
       ? 'Final aggregate code-review was not clean; blocker story was appended while Codex goal remains active.'
-      : 'Final per-story code-review was not clean; blocker story was appended and may require a fresh/available Codex goal context.',
+      : 'Final per-story code-review was not clean; blocker story was appended and may require an available Codex goal context.',
   });
   await appendLedger(cwd, {
     ts: now,
@@ -1297,8 +1297,8 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
     'Codex goal integration constraints:',
     '- First call get_goal. If no active goal exists, call create_goal with the payload below.',
     '- If a different active Codex goal exists, finish/checkpoint that goal before starting this ultragoal.',
-    '- Ultragoal cannot call /goal clear from the model/shell tool surface. For another per-story goal in the same session/thread after a completed Codex goal, manually run /goal clear in the Codex UI or continue in a fresh Codex thread.',
-    '- If get_goal returns a different completed legacy/thread goal and create_goal rejects because this thread already has a completed goal, continue this ultragoal in a fresh Codex thread (same repo/worktree) and create the payload there.',
+    '- Ultragoal cannot call /goal clear from the model/shell tool surface. For another per-story goal in the same session/thread after a completed Codex goal, manually run /goal clear in the Codex UI before creating the next goal.',
+    '- If get_goal returns a different completed legacy/thread goal and create_goal rejects because this thread already has a completed goal, continue only from a Codex goal context with no active/completed conflicting goal in the same repo/worktree and create the payload there.',
     `- To preserve the durable ledger before switching threads, record the non-terminal blocker without failing this goal: omx ultragoal checkpoint --goal-id ${goal.id} --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json "<get_goal JSON or path>"`,
     '- Work only this goal until its completion audit passes.',
     finalStory
@@ -1311,7 +1311,7 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
       ? `  omx ultragoal record-review-blockers --goal-id ${goal.id} --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json "<active get_goal JSON or path>"`
       : `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh get_goal JSON or path>"`,
     finalStory
-      ? '- In legacy per-story mode, the blocker story may require a fresh/available Codex goal context because this story remains an active incomplete Codex goal; do not claim it is complete.'
+      ? '- In legacy per-story mode, the blocker story may require an available Codex goal context because this story remains an active incomplete Codex goal; do not claim it is complete.'
       : null,
     finalStory
       ? '- If final $code-review is clean (APPROVE + CLEAR), call update_goal({status: "complete"}), call get_goal again, then checkpoint with --quality-gate-json:'
@@ -1345,7 +1345,7 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
     '- First call get_goal. If no active goal exists, call create_goal with the aggregate payload below.',
     '- If get_goal reports the same aggregate objective as active, continue this OMX story without creating a new Codex goal.',
     '- If a different active or incomplete Codex goal exists, finish/checkpoint that goal before starting this ultragoal; do not replace hidden Codex state from the shell.',
-    '- Ultragoal does not call /goal clear. After a completed aggregate run, manually run /goal clear in the Codex UI or start a fresh Codex thread before starting another ultragoal run in the same session/thread.',
+    '- Ultragoal does not call /goal clear. After a completed aggregate run, manually run /goal clear in the Codex UI before starting another ultragoal run in the same session/thread.',
     finalStory
       ? '- This is the final pending story: run the mandatory final ai-slop-cleaner pass, rerun verification, and run $code-review before any update_goal call.'
       : '- This is not the final story: do not call update_goal yet; the aggregate Codex goal must remain active while later OMX stories remain.',


### PR DESCRIPTION
## Summary
- remove blanket Ultragoal guidance that told users to start/open a fresh Codex thread/session for aggregate reruns
- keep the exceptional legacy completed-goal blocker guidance narrowed to an available Codex goal context
- strengthen Ultragoal help/docs/handoff tests to reject fresh thread/session wording

Closes #2409.

## Verification
- npm run build
- node --test dist/cli/__tests__/ultragoal.test.js dist/ultragoal/__tests__/artifacts.test.js dist/ultragoal/__tests__/docs-contract.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npm run lint
- npm run verify:plugin-bundle
- git diff --check

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*