### PR TITLE
Fix SparkShell shell mode on Windows

### DIFF
--- a/crates/omx-sparkshell/src/exec.rs
+++ b/crates/omx-sparkshell/src/exec.rs
@@ -26,8 +26,82 @@ impl CommandOutput {
     }
 }
 
-pub fn execute_shell_command(script: &str) -> Result<CommandOutput, SparkshellError> {
-    execute_command(&["bash".to_string(), "-lc".to_string(), script.to_string()])
+pub fn resolve_shell_argv(script: &str) -> Vec<String> {
+    resolve_shell_argv_for_platform(script, current_platform(), command_exists_on_path)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShellPlatform {
+    Windows,
+    Posix,
+}
+
+fn current_platform() -> ShellPlatform {
+    if cfg!(windows) {
+        ShellPlatform::Windows
+    } else {
+        ShellPlatform::Posix
+    }
+}
+
+fn resolve_shell_argv_for_platform(
+    script: &str,
+    platform: ShellPlatform,
+    exists: impl Fn(&str) -> bool,
+) -> Vec<String> {
+    match platform {
+        ShellPlatform::Posix => vec!["bash".to_string(), "-lc".to_string(), script.to_string()],
+        ShellPlatform::Windows => {
+            if exists("pwsh") {
+                return vec![
+                    "pwsh".to_string(),
+                    "-NoLogo".to_string(),
+                    "-NoProfile".to_string(),
+                    "-Command".to_string(),
+                    script.to_string(),
+                ];
+            }
+            if exists("powershell.exe") {
+                return vec![
+                    "powershell.exe".to_string(),
+                    "-NoLogo".to_string(),
+                    "-NoProfile".to_string(),
+                    "-Command".to_string(),
+                    script.to_string(),
+                ];
+            }
+            vec![
+                std::env::var("ComSpec").unwrap_or_else(|_| "cmd.exe".to_string()),
+                "/d".to_string(),
+                "/s".to_string(),
+                "/c".to_string(),
+                script.to_string(),
+            ]
+        }
+    }
+}
+
+fn command_exists_on_path(command: &str) -> bool {
+    if command.contains(std::path::MAIN_SEPARATOR)
+        || command.contains('/')
+        || command.contains('\\')
+    {
+        return std::path::Path::new(command).is_file();
+    }
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| {
+        let candidate = dir.join(command);
+        candidate.is_file()
+            || if cfg!(windows) && std::path::Path::new(command).extension().is_none() {
+                ["exe", "cmd", "bat", "com"]
+                    .iter()
+                    .any(|ext| dir.join(format!("{command}.{ext}")).is_file())
+            } else {
+                false
+            }
+    })
 }
 
 pub fn execute_command(argv: &[String]) -> Result<CommandOutput, SparkshellError> {
@@ -106,7 +180,7 @@ fn build_windows_command(command_name: &str, args: &[String]) -> Command {
 
 #[cfg(test)]
 mod tests {
-    use super::execute_command;
+    use super::{execute_command, resolve_shell_argv_for_platform, ShellPlatform};
 
     #[test]
     fn rejects_missing_command() {
@@ -114,6 +188,54 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "usage: omx-sparkshell <command> [args...]"
+        );
+    }
+
+    #[test]
+    fn posix_shell_mode_uses_bash_lc() {
+        assert_eq!(
+            resolve_shell_argv_for_platform("printf ok", ShellPlatform::Posix, |_| false),
+            ["bash", "-lc", "printf ok"]
+        );
+    }
+
+    #[test]
+    fn windows_shell_mode_prefers_pwsh() {
+        assert_eq!(
+            resolve_shell_argv_for_platform("Write-Output ok", ShellPlatform::Windows, |name| {
+                name == "pwsh"
+            }),
+            [
+                "pwsh",
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                "Write-Output ok"
+            ]
+        );
+    }
+
+    #[test]
+    fn windows_shell_mode_falls_back_to_windows_powershell() {
+        assert_eq!(
+            resolve_shell_argv_for_platform("Write-Output ok", ShellPlatform::Windows, |name| {
+                name == "powershell.exe"
+            }),
+            [
+                "powershell.exe",
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                "Write-Output ok"
+            ]
+        );
+    }
+
+    #[test]
+    fn windows_shell_mode_uses_minimal_cmd_fallback() {
+        assert_eq!(
+            resolve_shell_argv_for_platform("echo ok", ShellPlatform::Windows, |_| false),
+            ["cmd.exe", "/d", "/s", "/c", "echo ok"]
         );
     }
 }

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -9,7 +9,7 @@ mod threshold;
 
 use crate::codex_bridge::summarize_output;
 use crate::error::SparkshellError;
-use crate::exec::{execute_command, execute_shell_command, CommandOutput};
+use crate::exec::{execute_command, resolve_shell_argv, CommandOutput};
 use crate::redaction::redact_output;
 use crate::threshold::{combined_visible_lines, read_line_threshold};
 use omx_mux::build_capture_pane_args;
@@ -86,9 +86,7 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
     let options = parse_input(&args)?;
     let execution_argv = match &options.target {
         SparkShellTarget::Command(command) => command.clone(),
-        SparkShellTarget::Shell(script) => {
-            vec!["bash".to_string(), "-lc".to_string(), script.clone()]
-        }
+        SparkShellTarget::Shell(script) => resolve_shell_argv(script),
         SparkShellTarget::TmuxPane {
             pane_id,
             tail_lines,
@@ -99,10 +97,7 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
         }
     };
 
-    let raw_output = match &options.target {
-        SparkShellTarget::Shell(script) => execute_shell_command(script)?,
-        _ => execute_command(&execution_argv)?,
-    };
+    let raw_output = execute_command(&execution_argv)?;
     let redacted = redact_output(&raw_output);
     let output = if options.json {
         &redacted.output
@@ -123,8 +118,9 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
         } else if cache_meta.as_ref().is_some_and(|meta| meta.cache_hit) {
             "unchanged since previous observation".to_string()
         } else {
-            summarize_output(&execution_argv, output)
-                .unwrap_or_else(|error| format!("summary unavailable: {error}"))
+            summarize_output(&execution_argv, output).unwrap_or_else(|error| {
+                format!("summary unavailable: {error}; raw output omitted from JSON report")
+            })
         };
         write_json_report(
             &options,
@@ -153,7 +149,7 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
         }
         Err(error) => {
             write_raw_output(&output.stdout, &output.stderr)?;
-            eprintln!("omx sparkshell: summary unavailable ({error})");
+            eprintln!("omx sparkshell: summary unavailable ({error}); showing raw output instead");
         }
     }
 
@@ -175,9 +171,11 @@ fn usage_text() -> String {
     format!(
         concat!(
             "usage: omx-sparkshell <command> [args...]\n",
+            "   or: omx-sparkshell --shell <shell-command>\n",
             "   or: omx-sparkshell --tmux-pane <pane-id> [--tail-lines <{min}-{max}>]\n",
             "\n",
             "Direct command mode executes argv without shell metacharacter parsing.\n",
+            "Shell mode executes through bash -lc/sh -lc on POSIX and a native Windows shell on Windows.\n",
             "Tmux pane mode captures a larger pane tail and applies the same raw-vs-summary behavior.\n"
         ),
         min = MIN_TMUX_TAIL_LINES,

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -254,6 +254,7 @@ fn summary_failure_falls_back_to_raw_output_with_notice() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("child-err"));
     assert!(stderr.contains("summary unavailable"));
+    assert!(stderr.contains("showing raw output instead"));
 }
 
 #[test]
@@ -478,6 +479,32 @@ fn summary_failure_when_api_is_missing_falls_back_to_raw_output() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("child-err"));
     assert!(stderr.contains("summary unavailable"));
+    assert!(stderr.contains("showing raw output instead"));
+}
+
+#[test]
+fn json_summary_failure_reports_raw_output_omitted() {
+    let (base_url, server) = start_api_server(1, |_request| {
+        (503, "{\"error\":\"bridge failed\"}".to_string())
+    });
+
+    let output = Command::new(sparkshell_bin())
+        .env("OMX_API_BASE_URL", base_url)
+        .env("OMX_SPARKSHELL_LINES", "1")
+        .arg("--json")
+        .arg("sh")
+        .arg("-c")
+        .arg("printf 'one\ntwo\n'")
+        .output()
+        .expect("run sparkshell");
+    server.join().expect("api server");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("summary unavailable"));
+    assert!(stdout.contains("raw output omitted from JSON report"));
+    assert!(!stdout.contains("raw output included"));
+    assert!(String::from_utf8_lossy(&output.stderr).is_empty());
 }
 
 #[test]

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -14,6 +14,7 @@ import {
   packagedSparkShellBinaryCandidatePaths,
   parseSparkShellFallbackInvocation,
   repoLocalSparkShellBinaryPath,
+  resolveFallbackShellArgv,
   resolveSparkShellBinaryPath,
   resolveSparkShellBinaryPathWithHydration,
   runSparkShellBinary,
@@ -403,6 +404,37 @@ describe('parseSparkShellFallbackInvocation', () => {
     assert.deepEqual(
       parseSparkShellFallbackInvocation(['--shell', 'printf ok']),
       { kind: 'command', argv: ['sh', '-lc', 'printf ok'] },
+    );
+  });
+
+  it('translates explicit shell fallback through pwsh on Windows when available', () => {
+    assert.deepEqual(
+      parseSparkShellFallbackInvocation(['--shell', 'Write-Output ok'], {
+        platform: 'win32',
+        commandExists: (command) => command === 'pwsh',
+      }),
+      { kind: 'command', argv: ['pwsh', '-NoLogo', '-NoProfile', '-Command', 'Write-Output ok'] },
+    );
+  });
+
+  it('falls back from pwsh to powershell.exe on Windows', () => {
+    assert.deepEqual(
+      resolveFallbackShellArgv('Write-Output ok', {
+        platform: 'win32',
+        commandExists: (command) => command === 'powershell.exe',
+      }),
+      ['powershell.exe', '-NoLogo', '-NoProfile', '-Command', 'Write-Output ok'],
+    );
+  });
+
+  it('uses minimal cmd fallback for explicit shell fallback on Windows', () => {
+    assert.deepEqual(
+      resolveFallbackShellArgv('echo ok', {
+        platform: 'win32',
+        env: {},
+        commandExists: () => false,
+      }),
+      ['cmd.exe', '/d', '/s', '/c', 'echo ok'],
     );
   });
 

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -234,7 +234,32 @@ interface RunSparkShellFallbackOptions {
   announce?: boolean;
 }
 
-export function parseSparkShellFallbackInvocation(args: readonly string[]): SparkShellFallbackInvocation {
+interface ParseSparkShellFallbackOptions {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  commandExists?: (command: string) => boolean;
+}
+
+export function resolveFallbackShellArgv(
+  script: string,
+  options: ParseSparkShellFallbackOptions = {},
+): string[] {
+  const {
+    platform = process.platform,
+    env = process.env,
+    commandExists = (command: string) => spawnSync(command, ['--version'], { encoding: 'utf-8', stdio: 'ignore' }).error === undefined,
+  } = options;
+
+  if (platform !== 'win32') return ['sh', '-lc', script];
+  if (commandExists('pwsh')) return ['pwsh', '-NoLogo', '-NoProfile', '-Command', script];
+  if (commandExists('powershell.exe')) return ['powershell.exe', '-NoLogo', '-NoProfile', '-Command', script];
+  return [env.ComSpec?.trim() || 'cmd.exe', '/d', '/s', '/c', script];
+}
+
+export function parseSparkShellFallbackInvocation(
+  args: readonly string[],
+  options: ParseSparkShellFallbackOptions = {},
+): SparkShellFallbackInvocation {
   if (args.length === 0) {
     throw new Error(`Missing command to run.\n${SPARKSHELL_USAGE}`);
   }
@@ -242,12 +267,12 @@ export function parseSparkShellFallbackInvocation(args: readonly string[]): Spar
   if (args[0] === '--shell') {
     const script = args[1];
     if (!script) throw new Error(`--shell requires a command string.\n${SPARKSHELL_USAGE}`);
-    return { kind: 'command', argv: ['sh', '-lc', script] };
+    return { kind: 'command', argv: resolveFallbackShellArgv(script, options) };
   }
   if (args[0]?.startsWith('--shell=')) {
     const script = args[0].slice('--shell='.length);
     if (!script.trim()) throw new Error(`--shell requires a command string.\n${SPARKSHELL_USAGE}`);
-    return { kind: 'command', argv: ['sh', '-lc', script] };
+    return { kind: 'command', argv: resolveFallbackShellArgv(script, options) };
   }
 
   const paneStart = args.findIndex((arg) => arg === '--tmux-pane' || arg.startsWith('--tmux-pane='));


### PR DESCRIPTION
## Summary
- Fixes `omx-sparkshell --shell` so native Windows runs use `pwsh`, then `powershell.exe`, then `cmd.exe /d /s /c` instead of assuming Bash.
- Preserves POSIX shell execution through `bash -lc` in the native sidecar and `sh -lc` for the JS raw fallback path.
- Keeps summary degradation schema-compatible: non-JSON failures emit raw output with an explicit notice; JSON failures state that raw output is omitted from the JSON report.

Closes #2418

## Root cause
`--shell` constructed POSIX shell argv in multiple places (`bash -lc` / `sh -lc`), so Windows native sidecar and JS fallback paths failed when Bash was unavailable. Summary fallback messaging was also less explicit about whether raw output was actually emitted.

## Tests
- `cargo test --manifest-path crates/omx-sparkshell/Cargo.toml`
- `cargo clippy --manifest-path crates/omx-sparkshell/Cargo.toml --all-targets -- -D warnings`
- `cargo check --manifest-path crates/omx-sparkshell/Cargo.toml --target x86_64-pc-windows-gnu`
- `cargo fmt --manifest-path crates/omx-sparkshell/Cargo.toml --check`
- `npm run build`
- `npm run lint`
- `node --test dist/cli/__tests__/sparkshell-cli.test.js`
- `npx tsc --noEmit`
- `npx biome lint src/cli/sparkshell.ts src/cli/__tests__/sparkshell-cli.test.ts`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
