### PR TITLE
Prevent HUD tmux shell wrapper fan-out

### DIFF
--- a/src/hud/__tests__/hud-tmux-injection.test.ts
+++ b/src/hud/__tests__/hud-tmux-injection.test.ts
@@ -100,8 +100,15 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
       'split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES),
       // split height should come from shared HUD constants
       '-c', '/home/user/project',
-      `${runtimePrefix} '/usr/local/bin/omx.js' hud --watch`,
+      `exec ${runtimePrefix} '/usr/local/bin/omx.js' hud --watch`,
     ]);
+  });
+
+  it('starts HUD watch via exec so tmux shell wrappers cannot accumulate bash processes (#2420)', () => {
+    const args = buildTmuxSplitArgs('/home/user/project', '/usr/local/bin/omx.js');
+    const cmd = args[6];
+    assert.match(cmd, /^exec /);
+    assert.doesNotMatch(cmd, /^env /);
   });
 
   it('cwd is an isolated array element – never shell-interpreted', () => {
@@ -133,7 +140,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
       cmd.includes("'\\''"),
       `Expected escaped single quote in: ${cmd}`,
     );
-    assert.equal(cmd, `${runtimePrefix} '/tmp/it'\\''s/omx.js' hud --watch`);
+    assert.equal(cmd, `exec ${runtimePrefix} '/tmp/it'\\''s/omx.js' hud --watch`);
   });
 
   it('omxBin with $() is neutralised by single-quote wrapping', () => {
@@ -142,7 +149,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     const cmd = args[6];
 
     // Inside single quotes, $() is literal.
-    assert.equal(cmd, `${runtimePrefix} '/tmp/$(id)/omx.js' hud --watch`);
+    assert.equal(cmd, `exec ${runtimePrefix} '/tmp/$(id)/omx.js' hud --watch`);
   });
 
   it('omxBin with backticks is neutralised by single-quote wrapping', () => {
@@ -150,7 +157,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     const args = buildTmuxSplitArgs('/home/user', maliciousOmx);
     const cmd = args[6];
 
-    assert.equal(cmd, `${runtimePrefix} '/tmp/\`whoami\`/omx.js' hud --watch`);
+    assert.equal(cmd, `exec ${runtimePrefix} '/tmp/\`whoami\`/omx.js' hud --watch`);
   });
 
   it("omxBin with ';command' breakout attempt is neutralised", () => {
@@ -162,10 +169,10 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     // quotes escaped as '\''.  In a POSIX shell the result is a single word;
     // the semicolons never act as command separators.
     //
-    // Raw expected value: node '/tmp/x'\'';touch /tmp/pwned;echo '\''/omx.js' hud --watch
+    // Raw expected value: exec node '/tmp/x'\'';touch /tmp/pwned;echo '\''/omx.js' hud --watch
     assert.equal(
       cmd,
-      `${runtimePrefix} '/tmp/x'\\'';touch /tmp/pwned;echo '\\''/omx.js' hud --watch`,
+      `exec ${runtimePrefix} '/tmp/x'\\'';touch /tmp/pwned;echo '\\''/omx.js' hud --watch`,
     );
 
     // Both original single quotes are escaped (two '\'' sequences).
@@ -193,13 +200,13 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
       'minimal;touch /tmp/pwned',
     );
     const cmd = args[6];
-    assert.equal(cmd, `${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
+    assert.equal(cmd, `exec ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
     assert.ok(!cmd.includes('--preset='));
   });
 
   it('prepends OMX_SESSION_ID when provided', () => {
     const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', 'focused', 'sess-managed');
     const cmd = args[6];
-    assert.equal(cmd, `OMX_SESSION_ID='sess-managed' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=focused`);
+    assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=focused`);
   });
 });

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -59,7 +59,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.status, 'recreated');
     assert.equal(result.paneId, '%9');
     assert.equal(created.length, 1);
-    assert.match(created[0]?.cmd || '', /\/repo\/dist\/cli\/omx\.js' hud --watch/);
+    assert.match(created[0]?.cmd || '', /exec .*\/repo\/dist\/cli\/omx\.js' hud --watch/);
     assert.equal(created[0]?.options?.heightLines, 3);
     assert.equal(resized.length, 1);
     assert.equal(resized[0]?.heightLines, 3);
@@ -84,7 +84,7 @@ describe('reconcileHudForPromptSubmit', () => {
 
     assert.equal(result.status, 'recreated');
     assert.equal(created.length, 1);
-    assert.match(created[0]?.cmd || '', /^OMX_SESSION_ID='sess-canonical' '.*' '.*omx\.js' hud --watch/);
+    assert.match(created[0]?.cmd || '', /^exec env OMX_SESSION_ID='sess-canonical' '.*' '.*omx\.js' hud --watch/);
     assert.doesNotMatch(created[0]?.cmd || '', /sess-stale/);
   });
 

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -261,8 +261,8 @@ export function buildTmuxSplitArgs(
   const safePreset = parseHudPreset(preset);
   const presetArg = safePreset ? ` --preset=${safePreset}` : '';
   const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
-  const sessionPrefix = safeSessionId ? `OMX_SESSION_ID=${shellEscape(safeSessionId)} ` : '';
-  const cmd = `${sessionPrefix}${shellEscape(process.execPath)} ${shellEscape(omxBin)} hud --watch${presetArg}`;
+  const envPrefix = safeSessionId ? `env OMX_SESSION_ID=${shellEscape(safeSessionId)} ` : '';
+  const cmd = `exec ${envPrefix}${shellEscape(process.execPath)} ${shellEscape(omxBin)} hud --watch${presetArg}`;
   return ['split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES), '-c', cwd, cmd];
 }
 

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -148,8 +148,8 @@ export function buildHudWatchCommand(omxBin: string, preset?: string, sessionId?
     ? ` --preset=${preset}`
     : '';
   const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
-  const sessionPrefix = safeSessionId ? `OMX_SESSION_ID=${shellEscapeSingle(safeSessionId)} ` : '';
-  return `${sessionPrefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
+  const envPrefix = safeSessionId ? `env OMX_SESSION_ID=${shellEscapeSingle(safeSessionId)} ` : '';
+  return `exec ${envPrefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
 }
 
 export function listCurrentWindowPanes(

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -3206,7 +3206,7 @@ esac
           assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id omx-pane-scope/);
-          assert.match(tmuxLog, /OMX_TMUX_HUD_OWNER=1 .*hud --watch/);
+          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER=1 .*hud --watch/);
         },
       );
     } finally {
@@ -3778,7 +3778,7 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, new RegExp(escapeRegExp(launcherPath)));
           assert.doesNotMatch(tmuxLog, /'dist\/cli\/omx\.js' hud --watch/);
-          assert.match(tmuxLog, /OMX_TMUX_HUD_OWNER=1 .*hud --watch/);
+          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER=1 .*hud --watch/);
         },
       );
     } finally {
@@ -3824,7 +3824,7 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, /dist\/cli\/omx\.js' hud --watch/);
           assert.doesNotMatch(tmuxLog, /\/tmp\/codex-host-binary' hud --watch/);
-          assert.match(tmuxLog, /OMX_TMUX_HUD_OWNER=1 .*hud --watch/);
+          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER=1 .*hud --watch/);
         },
       );
     } finally {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1267,7 +1267,7 @@ export function createTeamSession(
     let resizeHookName: string | null = null;
     let resizeHookTarget: string | null = null;
     if (canRecreateTeamHud && omxEntry) {
-      const hudCmd = `env ${OMX_TMUX_HUD_OWNER_ENV}=1 node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+      const hudCmd = `exec env ${OMX_TMUX_HUD_OWNER_ENV}=1 node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
       const hudCwd = translatePathForMsys(cwd);
       const hudResult = runTmux([
         'split-window', '-v', '-f', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', teamTarget, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,
@@ -1394,7 +1394,7 @@ export function restoreStandaloneHudPane(
   const omxEntry = resolveOmxCliEntryPath();
   if (!omxEntry || omxEntry.trim() === '') return null;
 
-  const hudCmd = `env ${OMX_TMUX_HUD_OWNER_ENV}=1 ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+  const hudCmd = `exec env ${OMX_TMUX_HUD_OWNER_ENV}=1 ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
   const hudCwd = translatePathForMsys(cwd);
   const hudResult = runTmux([
     'split-window',


### PR DESCRIPTION
## Summary
- replace tmux HUD watch shell wrappers with `exec` so `hud --watch` takes over the tmux-spawned shell instead of leaving bash/sh wrappers alive
- cover standalone HUD launch, prompt-submit HUD reconciliation, team HUD recreation, and standalone HUD restoration paths
- keep existing quoting/session-id behavior and avoid broader watcher/runtime changes

Closes #2420.

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/hud/__tests__/hud-tmux-injection.test.js dist/hud/__tests__/reconcile.test.js dist/team/__tests__/tmux-session.test.js`
- `git diff --check`

## Notes
- Did not run an unbounded OOM/process fan-out reproducer; verification uses bounded unit/integration fixtures only.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
