### PR TITLE
[codex] Prevent leaked process and timer resources

### DIFF
--- a/crates/omx-api/src/lib.rs
+++ b/crates/omx-api/src/lib.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::{IpAddr, Shutdown, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -1934,17 +1934,49 @@ fn spawn_daemon(config: &ServerConfig) -> Result<DaemonState> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
-    for _ in 0..100 {
-        if let Some(state) = read_daemon_state(&config.state_file)? {
-            return Ok(state);
+    wait_for_daemon_state(
+        &mut child,
+        &config.state_file,
+        100,
+        Duration::from_millis(20),
+    )
+}
+
+fn terminate_child(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn wait_for_daemon_state(
+    child: &mut Child,
+    state_file: &Path,
+    attempts: usize,
+    sleep: Duration,
+) -> Result<DaemonState> {
+    for _ in 0..attempts {
+        match read_daemon_state(state_file) {
+            Ok(Some(state)) => return Ok(state),
+            Ok(None) => {}
+            Err(error) => {
+                terminate_child(child);
+                return Err(error);
+            }
         }
-        if let Some(status) = child.try_wait()? {
-            return Err(OmxApiError::Message(format!(
-                "daemon exited before writing state: {status}"
-            )));
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return Err(OmxApiError::Message(format!(
+                    "daemon exited before writing state: {status}"
+                )));
+            }
+            Ok(None) => {}
+            Err(error) => {
+                terminate_child(child);
+                return Err(error.into());
+            }
         }
-        std::thread::sleep(Duration::from_millis(20));
+        std::thread::sleep(sleep);
     }
+    terminate_child(child);
     Err(OmxApiError::Message(
         "daemon did not write state within timeout".to_string(),
     ))
@@ -2928,6 +2960,31 @@ mod tests {
         assert_eq!(read.pid, 42);
         remove_daemon_state(&path).unwrap();
         assert!(read_daemon_state(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn daemon_startup_timeout_kills_child_process_to_avoid_process_leak() {
+        let path = env::temp_dir().join(format!("omx-api-timeout-test-{}.json", now_unix()));
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 60")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep child");
+
+        let error = wait_for_daemon_state(&mut child, &path, 1, Duration::from_millis(1))
+            .expect_err("missing state should time out");
+
+        assert!(error
+            .to_string()
+            .contains("daemon did not write state within timeout"));
+        assert!(
+            child.try_wait().unwrap().is_some(),
+            "timeout path should reap the spawned daemon child"
+        );
+        let _ = fs::remove_file(path);
     }
 
     #[test]

--- a/src/hooks/extensibility/__tests__/dispatcher.test.ts
+++ b/src/hooks/extensibility/__tests__/dispatcher.test.ts
@@ -6,6 +6,24 @@ import { describe, it } from 'node:test';
 import { isHookPluginFeatureEnabled, dispatchHookEvent } from '../dispatcher.js';
 import { buildHookEvent } from '../events.js';
 
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processExists(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  assert.fail(`process ${pid} should exit before timeout`);
+}
+
 describe('isHookPluginFeatureEnabled', () => {
   it('returns true when OMX_HOOK_PLUGINS=1', () => {
     assert.equal(isHookPluginFeatureEnabled({ OMX_HOOK_PLUGINS: '1' }), true);
@@ -208,9 +226,12 @@ export async function onHookEvent() {}
     try {
       const dir = join(cwd, '.omx', 'hooks');
       await mkdir(dir, { recursive: true });
+      const pidFile = join(cwd, 'plugin-runner.pid');
       await writeFile(
         join(dir, 'ignore-sigterm.mjs'),
-        `export async function onHookEvent() {
+        `import { writeFileSync } from 'node:fs';
+        export async function onHookEvent() {
+          writeFileSync(process.env.OMX_TEST_PLUGIN_PID_FILE, String(process.pid));
           process.on('SIGTERM', () => {});
           setInterval(() => {}, 60_000);
           await new Promise(() => {});
@@ -221,10 +242,11 @@ export async function onHookEvent() {}
       const startedAt = Date.now();
       const result = await dispatchHookEvent(event, {
         cwd,
-        timeoutMs: 50,
-        env: { ...process.env, OMX_HOOK_PLUGINS: '1' },
+        timeoutMs: 300,
+        env: { ...process.env, OMX_HOOK_PLUGINS: '1', OMX_TEST_PLUGIN_PID_FILE: pidFile },
       });
       const elapsedMs = Date.now() - startedAt;
+      const pid = Number(await readFile(pidFile, 'utf8'));
 
       assert.equal(result.enabled, true);
       assert.equal(result.plugin_count, 1);
@@ -232,6 +254,7 @@ export async function onHookEvent() {}
       assert.equal(result.results[0].ok, false);
       assert.equal(result.results[0].status, 'timeout');
       assert.ok(elapsedMs < 1500, `dispatch should timeout promptly (elapsed=${elapsedMs}ms)`);
+      await waitForProcessExit(pid);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -108,17 +108,33 @@ async function runPluginRunner(
 		let timedOut = false;
 		let sigkillTimer: NodeJS.Timeout | undefined;
 
+		const onStdoutData = (chunk: Buffer) => {
+			stdout += chunk.toString();
+		};
+		const onStderrData = (chunk: Buffer) => {
+			stderr += chunk.toString();
+		};
+		let onError: ((error: Error) => void) | undefined;
+		let onClose: (() => void) | undefined;
+		const cleanup = (clearSigkillTimer = true) => {
+			clearTimeout(timer);
+			if (clearSigkillTimer && sigkillTimer) {
+				clearTimeout(sigkillTimer);
+				sigkillTimer = undefined;
+			}
+			child.stdout.off("data", onStdoutData);
+			child.stderr.off("data", onStderrData);
+			if (onError) child.off("error", onError);
+			if (onClose) child.off("close", onClose);
+		};
+
 		const settle = (
 			result: HookPluginDispatchResult,
 			clearSigkillTimer = true,
 		) => {
 			if (done) return;
 			done = true;
-			clearTimeout(timer);
-			if (clearSigkillTimer && sigkillTimer) {
-				clearTimeout(sigkillTimer);
-				sigkillTimer = undefined;
-			}
+			cleanup(clearSigkillTimer);
 			resolve(result);
 		};
 
@@ -155,15 +171,10 @@ async function runPluginRunner(
 			);
 		}, timeoutMs);
 
-		child.stdout.on("data", (chunk) => {
-			stdout += chunk.toString();
-		});
+		child.stdout.on("data", onStdoutData);
+		child.stderr.on("data", onStderrData);
 
-		child.stderr.on("data", (chunk) => {
-			stderr += chunk.toString();
-		});
-
-		child.on("error", (error) => {
+		onError = (error) => {
 			const duration = Date.now() - started;
 			settle({
 				plugin: plugin.id,
@@ -177,9 +188,10 @@ async function runPluginRunner(
 				durationMs: duration,
 				duration_ms: duration,
 			});
-		});
+		};
+		child.on("error", onError);
 
-		child.on("close", () => {
+		onClose = () => {
 			if (done) return;
 			const duration = Date.now() - started;
 
@@ -244,7 +256,8 @@ async function runPluginRunner(
 				durationMs: duration,
 				duration_ms: duration,
 			});
-		});
+		};
+		child.on("close", onClose);
 
 		child.stdin.write(
 			JSON.stringify({

--- a/src/hud/__tests__/resource-leak-watch.test.ts
+++ b/src/hud/__tests__/resource-leak-watch.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { runWatchMode } from '../index.js';
+
+describe('HUD watch resource cleanup', () => {
+  it('unregisters SIGINT handlers when stopped to avoid listener leaks', async () => {
+    let sigintHandler: (() => void) | undefined;
+    let unregisterCalls = 0;
+    const fakeTimer = Symbol('timer') as unknown as ReturnType<typeof setInterval>;
+
+    await runWatchMode('/tmp/project', { watch: true, json: false, tmux: false }, {
+      isTTY: true,
+      env: {},
+      readHudConfigFn: async () => ({ preset: 'minimal', git: { display: 'repo-branch' }, statusLine: { preset: 'minimal' } }),
+      readAllStateFn: async () => ({ cwd: '/tmp/project', config: {}, state: {}, timestamp: '2026-05-21T00:00:00.000Z' }) as never,
+      renderHudFn: () => 'hud',
+      runAuthorityTickFn: async () => { sigintHandler?.(); },
+      writeStdout: () => {},
+      writeStderr: () => {},
+      registerSigint: (handler) => {
+        sigintHandler = handler;
+        return () => { unregisterCalls += 1; };
+      },
+      setIntervalFn: () => fakeTimer,
+      clearIntervalFn: (timer) => assert.equal(timer, fakeTimer),
+    });
+
+    assert.equal(unregisterCalls, 1);
+  });
+});

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -65,7 +65,7 @@ interface RunWatchModeDependencies {
   runAuthorityTickFn: (options: { cwd: string }) => Promise<void>;
   writeStdout: (text: string) => void;
   writeStderr: (text: string) => void;
-  registerSigint: (handler: () => void) => void;
+  registerSigint: (handler: () => void) => void | (() => void);
   setIntervalFn: (handler: () => void, intervalMs: number) => ReturnType<typeof setInterval>;
   clearIntervalFn: (timer: ReturnType<typeof setInterval>) => void;
 }
@@ -91,7 +91,10 @@ export async function runWatchMode(
     }),
     writeStdout: deps.writeStdout ?? ((text: string) => process.stdout.write(text)),
     writeStderr: deps.writeStderr ?? ((text: string) => process.stderr.write(text)),
-    registerSigint: deps.registerSigint ?? ((handler: () => void) => process.on('SIGINT', handler)),
+    registerSigint: deps.registerSigint ?? ((handler: () => void) => {
+      process.on('SIGINT', handler);
+      return () => process.off('SIGINT', handler);
+    }),
     setIntervalFn: deps.setIntervalFn ?? ((handler: () => void, intervalMs: number) => setInterval(handler, intervalMs)),
     clearIntervalFn: deps.clearIntervalFn ?? ((timer: ReturnType<typeof setInterval>) => clearInterval(timer)),
   };
@@ -114,10 +117,13 @@ export async function runWatchMode(
     resolveDone = resolve;
   });
 
+  let unregisterSigint: void | (() => void);
   const stop = () => {
     if (stopped) return;
     stopped = true;
     if (timer) dependencies.clearIntervalFn(timer);
+    unregisterSigint?.();
+    unregisterSigint = undefined;
     dependencies.writeStdout('\x1b[?25h\x1b[2J\x1b[H');
     resolveDone();
   };
@@ -161,7 +167,7 @@ export async function runWatchMode(
     }
   };
 
-  dependencies.registerSigint(stop);
+  unregisterSigint = dependencies.registerSigint(stop);
   timer = dependencies.setIntervalFn(() => {
     void renderTick();
   }, 1000);

--- a/src/notifications/__tests__/http-client-resource.test.ts
+++ b/src/notifications/__tests__/http-client-resource.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:net';
+import type { Socket } from 'node:net';
+import { afterEach, describe, it } from 'node:test';
+import { requestJson } from '../http-client.js';
+
+describe('HTTP client resource cleanup', () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((server) => server.close()));
+  });
+
+  it('destroys direct sockets on request timeout to avoid resource leaks', async () => {
+    const originalFetch = globalThis.fetch;
+    const sockets: Socket[] = [];
+    const server = createServer((socket) => {
+      sockets.push(socket);
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    servers.push({ close: () => new Promise((resolve, reject) => {
+      for (const socket of sockets) socket.destroy();
+      server.close((error) => error ? reject(error) : resolve());
+    }) });
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+
+    try {
+      // Force the Node http/https implementation so this test covers the
+      // explicit timeout cleanup path rather than the platform fetch wrapper.
+      (globalThis as { fetch?: typeof fetch }).fetch = undefined;
+      await assert.rejects(
+        () => requestJson(`http://127.0.0.1:${address.port}/notify`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+          timeoutMs: 20,
+        }, {}),
+        /Request timeout/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.equal(sockets.length, 1);
+  });
+});

--- a/src/notifications/http-client.ts
+++ b/src/notifications/http-client.ts
@@ -124,13 +124,31 @@ export function getProxyForUrl(targetUrl: string | URL, env: ProxyEnv = process.
   return url ? { url } : undefined;
 }
 
-function collectIncoming(res: IncomingMessage, timeout: NodeJS.Timeout, resolve: (value: JsonHttpResponse) => void): void {
+function collectIncoming(
+  res: IncomingMessage,
+  timeout: NodeJS.Timeout,
+  resolve: (value: JsonHttpResponse) => void,
+  reject: (reason?: unknown) => void,
+): void {
   const chunks: Buffer[] = [];
-  res.on("data", (chunk: Buffer) => chunks.push(chunk));
-  res.on("end", () => {
+  const cleanup = () => {
     clearTimeout(timeout);
+    res.off("data", onData);
+    res.off("end", onEnd);
+    res.off("error", onError);
+  };
+  const onData = (chunk: Buffer) => chunks.push(chunk);
+  const onEnd = () => {
+    cleanup();
     resolve(new BufferedHttpResponse(res.statusCode ?? 0, Buffer.concat(chunks).toString("utf-8")));
-  });
+  };
+  const onError = (error: Error) => {
+    cleanup();
+    reject(error);
+  };
+  res.on("data", onData);
+  res.once("end", onEnd);
+  res.once("error", onError);
 }
 
 async function requestDirect(url: URL, options: JsonHttpRequestOptions): Promise<JsonHttpResponse> {
@@ -145,6 +163,15 @@ async function requestDirect(url: URL, options: JsonHttpRequestOptions): Promise
 
   return new Promise<JsonHttpResponse>((resolve, reject) => {
     const request = url.protocol === "https:" ? httpsRequest : httpRequest;
+    let timedOut = false;
+    const cleanup = () => {
+      clearTimeout(timeout);
+      req.off("error", onError);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(timedOut ? new Error("Request timeout") : error);
+    };
     const req = request(
       url,
       {
@@ -152,15 +179,25 @@ async function requestDirect(url: URL, options: JsonHttpRequestOptions): Promise
         headers: options.headers,
         timeout: options.timeoutMs,
       },
-      (res) => collectIncoming(res, timeout, resolve),
+      (res) => collectIncoming(
+        res,
+        timeout,
+        (value) => {
+          cleanup();
+          resolve(value);
+        },
+        (error) => {
+          cleanup();
+          reject(error);
+        },
+      ),
     );
     const timeout = setTimeout(() => {
+      timedOut = true;
       req.destroy(new Error("Request timeout"));
+      req.socket?.destroy();
     }, options.timeoutMs);
-    req.on("error", (error) => {
-      clearTimeout(timeout);
-      reject(error);
-    });
+    req.on("error", onError);
     if (options.body) req.write(options.body);
     req.end();
   });
@@ -180,17 +217,26 @@ function openProxySocket(proxy: URL, timeoutMs: number): Promise<Socket> {
       ? tlsConnect({ host, port, servername: host })
       : netConnect({ host, port });
     const readyEvent = proxy.protocol === "https:" ? "secureConnect" : "connect";
-    const timeout = setTimeout(() => {
-      socket.destroy(new Error("Proxy connection timeout"));
-    }, timeoutMs);
-    socket.once(readyEvent, () => {
+    const cleanup = () => {
       clearTimeout(timeout);
+      socket.off(readyEvent, onReady);
+      socket.off("error", onError);
+    };
+    const onReady = () => {
+      cleanup();
       resolve(socket);
-    });
-    socket.once("error", (error) => {
-      clearTimeout(timeout);
+    };
+    const onError = (error: Error) => {
+      cleanup();
       reject(error);
-    });
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      socket.destroy();
+      reject(new Error("Proxy connection timeout"));
+    }, timeoutMs);
+    socket.once(readyEvent, onReady);
+    socket.once("error", onError);
   });
 }
 
@@ -204,7 +250,11 @@ function proxyAuthorizationHeader(proxy: URL): string | undefined {
 function readUntilHeaders(socket: Socket, timeoutMs: number): Promise<{ head: string; rest: Buffer }> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    const timeout = setTimeout(() => reject(new Error("Proxy response timeout")), timeoutMs);
+    const timeout = setTimeout(() => {
+      cleanup();
+      socket.destroy();
+      reject(new Error("Proxy response timeout"));
+    }, timeoutMs);
     const cleanup = () => {
       clearTimeout(timeout);
       socket.off("data", onData);
@@ -251,12 +301,15 @@ async function sendRawHttp(socket: Socket, rawRequest: string, timeoutMs: number
   socket.write(rawRequest);
   const chunks: Buffer[] = [];
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      socket.destroy(new Error("Request timeout"));
-    }, timeoutMs);
-    socket.on("data", (chunk: Buffer) => chunks.push(chunk));
-    socket.once("end", () => {
+    const cleanup = () => {
       clearTimeout(timeout);
+      socket.off("data", onData);
+      socket.off("end", onEnd);
+      socket.off("error", onError);
+    };
+    const onData = (chunk: Buffer) => chunks.push(chunk);
+    const onEnd = () => {
+      cleanup();
       const buffer = Buffer.concat(chunks);
       const headerEnd = buffer.indexOf("\r\n\r\n");
       if (headerEnd === -1) {
@@ -269,11 +322,19 @@ async function sendRawHttp(socket: Socket, rawRequest: string, timeoutMs: number
       const rawBody = buffer.slice(headerEnd + 4);
       const body = isChunked ? decodeChunked(rawBody) : rawBody;
       resolve(new BufferedHttpResponse(status, body.toString("utf-8")));
-    });
-    socket.once("error", (error) => {
-      clearTimeout(timeout);
+    };
+    const onError = (error: Error) => {
+      cleanup();
       reject(error);
-    });
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      socket.destroy();
+      reject(new Error("Request timeout"));
+    }, timeoutMs);
+    socket.on("data", onData);
+    socket.once("end", onEnd);
+    socket.once("error", onError);
   });
 }
 

--- a/src/openclaw/__tests__/dispatcher.test.ts
+++ b/src/openclaw/__tests__/dispatcher.test.ts
@@ -4,6 +4,9 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -15,6 +18,24 @@ import {
   resolveCommandTimeoutMs,
   wakeGateway,
 } from '../dispatcher.js';
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processExists(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  assert.fail(`process ${pid} should exit before timeout`);
+}
 
 
 describe('wakeGateway proxy routing', () => {
@@ -278,7 +299,40 @@ describe('wakeCommandGateway - command gate', () => {
       {},
     );
     assert.equal(result.success, false);
-    assert.ok(result.error?.includes('SIGTERM'));
+    assert.ok(result.error?.includes('timed out'));
+  });
+
+  it('kills shell-command descendants on timeout to avoid bash process leaks', async () => {
+    const { wakeCommandGateway } = await import('../dispatcher.js');
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-openclaw-process-leak-'));
+    try {
+      const pidFile = join(cwd, 'grandchild.pid');
+      const scriptFile = join(cwd, 'spawn-grandchild.cjs');
+      const script = `
+        const { spawn } = require('node:child_process');
+        const { writeFileSync } = require('node:fs');
+        const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+          stdio: 'ignore'
+        });
+        writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));
+        setInterval(() => {}, 1000);
+      `;
+      await writeFile(scriptFile, script);
+      process.env.OMX_OPENCLAW_COMMAND = '1';
+
+      const result = await wakeCommandGateway(
+        'test',
+        { type: 'command', command: `${process.execPath} ${scriptFile}; true`, timeout: 500 },
+        {},
+      );
+      const pid = Number(await readFile(pidFile, 'utf8'));
+
+      assert.equal(result.success, false);
+      assert.ok(result.error?.includes('timed out'));
+      await waitForProcessExit(pid);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('uses gateway timeout over env timeout', async () => {

--- a/src/openclaw/dispatcher.ts
+++ b/src/openclaw/dispatcher.ts
@@ -7,10 +7,12 @@
  *
  * SECURITY: Command gateway requires OMX_OPENCLAW_COMMAND=1 opt-in.
  * Command timeout is configurable with safe bounds.
- * Prefers execFile for simple commands; falls back to sh -c only for shell metacharacters.
+ * Prefers direct argv execution for simple commands; falls back to sh -c only
+ * for shell metacharacters. All command paths use process-tree cleanup.
  */
 
 import { requestJson } from "../notifications/http-client.js";
+import { runProcessTreeWithTimeout } from "../runtime/process-tree.js";
 
 import type {
   OpenClawCommandGatewayConfig,
@@ -190,10 +192,12 @@ export async function wakeGateway(
  * - Requires OMX_OPENCLAW_COMMAND=1 opt-in (separate gate from OMX_OPENCLAW)
  * - Timeout is configurable via gateway.timeout or OMX_OPENCLAW_COMMAND_TIMEOUT_MS
  *   with safe clamping bounds and backward-compatible default 5000ms
- * - Prefers execFile for simple commands (no metacharacters)
+ * - Prefers direct argv execution for simple commands (no metacharacters)
  * - Falls back to sh -c only when metacharacters detected
- * - detached: false to prevent orphan processes
- * - SIGTERM cleanup handler kills child on parent SIGTERM, 1s grace then SIGKILL
+ * - POSIX commands run in a process group so timeout/parent cleanup kills shell
+ *   wrappers and descendants instead of only the direct child.
+ * - SIGTERM cleanup handler kills the process tree on parent SIGTERM, 1s grace
+ *   then SIGKILL
  *
  * The command template supports {{variable}} placeholders. All variable
  * values are shell-escaped before interpolation to prevent injection.
@@ -212,11 +216,7 @@ export async function wakeCommandGateway(
     };
   }
 
-  let child: import("child_process").ChildProcess | null = null;
-  let sigtermHandler: (() => void) | null = null;
-
   try {
-    const { execFile, exec } = await import("child_process");
     const timeout = resolveCommandTimeoutMs(gatewayConfig.timeout);
 
     // Interpolate variables with shell escaping
@@ -232,74 +232,35 @@ export async function wakeCommandGateway(
     // Detect whether the interpolated command contains shell metacharacters
     const hasMetachars = SHELL_METACHAR_RE.test(interpolated);
 
-    await new Promise<void>((resolve, reject) => {
-      const cleanup = (signal: NodeJS.Signals) => {
-        if (child) {
-          child.kill(signal);
-          // 1s grace period then SIGKILL
-          setTimeout(() => {
-            try {
-              child?.kill("SIGKILL");
-            } catch (err) {
-              process.stderr.write(`[openclaw-dispatcher] operation failed: ${err}\n`);
-            }
-          }, 1000);
-        }
-      };
+    const commandParts = hasMetachars
+      ? { command: "sh", args: ["-c", interpolated] }
+      : (() => {
+          const parts = interpolated.split(/\s+/).filter(Boolean);
+          return { command: parts[0] ?? "", args: parts.slice(1) };
+        })();
+    if (!commandParts.command) {
+      return { gateway: gatewayName, success: false, error: "Command is empty" };
+    }
 
-      sigtermHandler = () => cleanup("SIGTERM");
-      process.once("SIGTERM", sigtermHandler);
+    const result = await runProcessTreeWithTimeout(
+      commandParts.command,
+      commandParts.args,
+      {
+        timeoutMs: timeout,
+        env: { ...process.env },
+        cleanupOnParentExit: true,
+      },
+    );
 
-      const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-        if (sigtermHandler) {
-          process.removeListener("SIGTERM", sigtermHandler);
-          sigtermHandler = null;
-        }
-        if (signal) {
-          reject(new Error(`Command killed by signal ${signal}`));
-        } else if (code !== 0) {
-          reject(new Error(`Command exited with code ${code}`));
-        } else {
-          resolve();
-        }
-      };
-
-      const onError = (err: Error) => {
-        if (sigtermHandler) {
-          process.removeListener("SIGTERM", sigtermHandler);
-          sigtermHandler = null;
-        }
-        reject(err);
-      };
-
-      if (hasMetachars) {
-        // Fall back to sh -c for complex commands with metacharacters
-        child = exec(interpolated, {
-          timeout,
-          env: { ...process.env },
-        });
-      } else {
-        // Parse simple command: split on whitespace, use execFile
-        const parts = interpolated.split(/\s+/).filter(Boolean);
-        const cmd = parts[0];
-        const args = parts.slice(1);
-        child = execFile(cmd, args, {
-          timeout,
-          env: { ...process.env },
-        });
-      }
-
-      // Ensure detached is false (default, but explicit via options above)
-      child.on("exit", onExit);
-      child.on("error", onError);
-    });
+    if (result.error) throw result.error;
+    if (result.timedOut) throw new Error("Command timed out");
+    if (result.outputLimitExceeded) throw new Error("Command output limit exceeded");
+    if (result.processLimitExceeded) throw new Error("Command process limit exceeded");
+    if (result.signal) throw new Error(`Command killed by signal ${result.signal}`);
+    if (result.status !== 0) throw new Error(`Command exited with code ${result.status}`);
 
     return { gateway: gatewayName, success: true };
   } catch (error) {
-    // Ensure SIGTERM handler is cleaned up on error
-    if (sigtermHandler) {
-      process.removeListener("SIGTERM", sigtermHandler);
-    }
     return {
       gateway: gatewayName,
       success: false,

--- a/src/scripts/notify-hook/process-runner.ts
+++ b/src/scripts/notify-hook/process-runner.ts
@@ -17,35 +17,59 @@ export function runProcess(command: string, args: string[], timeoutMs = 3000): P
     let stdout = '';
     let stderr = '';
     let finished = false;
+    let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
 
-    const timer = setTimeout(() => {
-      if (finished) return;
-      finished = true;
-      child.kill('SIGTERM');
-      reject(new Error(`timeout after ${effectiveTimeoutMs}ms`));
-    }, effectiveTimeoutMs);
+    const cleanup = (clearPendingSigkill = true) => {
+      clearTimeout(timer);
+      if (clearPendingSigkill && sigkillTimer) {
+        clearTimeout(sigkillTimer);
+        sigkillTimer = undefined;
+      }
+      child.stdout.off('data', onStdout);
+      child.stderr.off('data', onStderr);
+      child.off('error', onError);
+      child.off('close', onClose);
+    };
 
-    child.stdout.on('data', (chunk: Buffer) => {
+    const onStdout = (chunk: Buffer) => {
       stdout += chunk.toString();
-    });
-    child.stderr.on('data', (chunk: Buffer) => {
+    };
+    const onStderr = (chunk: Buffer) => {
       stderr += chunk.toString();
-    });
-    child.on('error', (err: Error) => {
+    };
+    const onError = (err: Error) => {
       if (finished) return;
       finished = true;
-      clearTimeout(timer);
+      cleanup();
       reject(err);
-    });
-    child.on('close', (code: number | null) => {
+    };
+    const onClose = (code: number | null) => {
       if (finished) return;
       finished = true;
-      clearTimeout(timer);
+      cleanup();
       if (code === 0) {
         resolve({ stdout, stderr, code });
       } else {
         reject(new Error(stderr.trim() || `${command} exited ${code}`));
       }
-    });
+    };
+
+    const timer = setTimeout(() => {
+      if (finished) return;
+      finished = true;
+      child.kill('SIGTERM');
+      sigkillTimer = setTimeout(() => {
+        sigkillTimer = undefined;
+        child.kill('SIGKILL');
+      }, 250);
+      sigkillTimer.unref?.();
+      cleanup(false);
+      reject(new Error(`timeout after ${effectiveTimeoutMs}ms`));
+    }, effectiveTimeoutMs);
+
+    child.stdout.on('data', onStdout);
+    child.stderr.on('data', onStderr);
+    child.on('error', onError);
+    child.on('close', onClose);
   });
 }

--- a/src/sidecar/__tests__/resource-leak-watch.test.ts
+++ b/src/sidecar/__tests__/resource-leak-watch.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { runSidecarWatch } from '../index.js';
+import type { SidecarSnapshot } from '../types.js';
+
+function snapshot(): SidecarSnapshot {
+  return {
+    schema_version: 'omx.sidecar/v1',
+    generated_at: '2026-04-27T02:01:00.000Z',
+    team_name: 'demo',
+    team_task: 'ship sidecar',
+    phase: null,
+    topology: { summary: '0 workers', nodes: ['leader'], edges: [] },
+    workers: [],
+    tasks: [],
+    events: [],
+    panes: [],
+    highlights: [],
+    source_warnings: [],
+  };
+}
+
+describe('sidecar watch resource cleanup', () => {
+  it('unregisters SIGINT handlers when watch mode exits to avoid listener leaks', async () => {
+    let sigintHandler: (() => void) | undefined;
+    let unregisterCalls = 0;
+
+    await runSidecarWatch('demo', { json: false, watch: true, tmux: false, intervalMs: 100 }, {}, {
+      collect: async () => snapshot(),
+      render: (frame) => `frame:${frame.team_name}`,
+      writeStdout: () => {},
+      writeStderr: () => {},
+      registerSigint: (handler) => {
+        sigintHandler = handler;
+        return () => { unregisterCalls += 1; };
+      },
+      sleep: async () => { sigintHandler?.(); },
+    });
+
+    assert.equal(unregisterCalls, 1);
+  });
+});

--- a/src/sidecar/index.ts
+++ b/src/sidecar/index.ts
@@ -57,11 +57,20 @@ function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
       resolve();
       return;
     }
-    const timer = setTimeout(resolve, ms);
-    signal?.addEventListener('abort', () => {
+    let timer: ReturnType<typeof setTimeout>;
+    const cleanup = () => {
       clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
       resolve();
-    }, { once: true });
+    };
+    timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }
 
@@ -71,7 +80,7 @@ export interface RunSidecarWatchDeps {
   writeStdout: (text: string) => void;
   writeStderr: (text: string) => void;
   sleep: SleepFn;
-  registerSigint: (handler: () => void) => void;
+  registerSigint: (handler: () => void) => void | (() => void);
   stdoutColumns?: () => number | undefined;
   stdoutRows?: () => number | undefined;
 }
@@ -88,7 +97,10 @@ export async function runSidecarWatch(
     writeStdout: deps.writeStdout ?? ((text) => process.stdout.write(text)),
     writeStderr: deps.writeStderr ?? ((text) => process.stderr.write(text)),
     sleep: deps.sleep ?? defaultSleep,
-    registerSigint: deps.registerSigint ?? ((handler) => process.on('SIGINT', handler)),
+    registerSigint: deps.registerSigint ?? ((handler) => {
+      process.on('SIGINT', handler);
+      return () => process.off('SIGINT', handler);
+    }),
     stdoutColumns: deps.stdoutColumns ?? (() => process.stdout.columns),
     stdoutRows: deps.stdoutRows ?? (() => process.stdout.rows),
   };
@@ -105,7 +117,7 @@ export async function runSidecarWatch(
     abortController.abort();
     dependencies.writeStdout('\x1b[?25h');
   };
-  dependencies.registerSigint(stop);
+  const unregisterSigint = dependencies.registerSigint(stop);
   dependencies.writeStdout('\x1b[?25l');
 
   const renderTick = async (): Promise<void> => {
@@ -135,13 +147,17 @@ export async function runSidecarWatch(
     }
   };
 
-  while (!stopped && !abortController.signal.aborted) {
-    const started = Date.now();
-    await renderTick();
-    if (stopped || abortController.signal.aborted) break;
-    await dependencies.sleep(Math.max(0, intervalMs - (Date.now() - started)), abortController.signal);
+  try {
+    while (!stopped && !abortController.signal.aborted) {
+      const started = Date.now();
+      await renderTick();
+      if (stopped || abortController.signal.aborted) break;
+      await dependencies.sleep(Math.max(0, intervalMs - (Date.now() - started)), abortController.signal);
+    }
+  } finally {
+    unregisterSigint?.();
+    dependencies.writeStdout('\x1b[?25h');
   }
-  dependencies.writeStdout('\x1b[?25h');
 }
 
 export async function sidecarCommand(args: string[]): Promise<void> {

--- a/src/utils/__tests__/sleep-resource.test.ts
+++ b/src/utils/__tests__/sleep-resource.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { sleep } from '../sleep.js';
+
+describe('sleep resource cleanup', () => {
+  it('removes abort listeners after timer resolution to avoid resource leaks', async () => {
+    const controller = new AbortController();
+    let adds = 0;
+    let removes = 0;
+    const originalAdd = controller.signal.addEventListener.bind(controller.signal);
+    const originalRemove = controller.signal.removeEventListener.bind(controller.signal);
+
+    controller.signal.addEventListener = ((...args: Parameters<AbortSignal['addEventListener']>) => {
+      if (args[0] === 'abort') adds += 1;
+      return originalAdd(...args);
+    }) as AbortSignal['addEventListener'];
+    controller.signal.removeEventListener = ((...args: Parameters<AbortSignal['removeEventListener']>) => {
+      if (args[0] === 'abort') removes += 1;
+      return originalRemove(...args);
+    }) as AbortSignal['removeEventListener'];
+
+    await sleep(1, controller.signal);
+
+    assert.equal(adds, 1);
+    assert.equal(removes, 1);
+  });
+
+  it('rejects already-aborted signals without registering resource-leaking listeners', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('stop'));
+    let adds = 0;
+    const originalAdd = controller.signal.addEventListener.bind(controller.signal);
+    controller.signal.addEventListener = ((...args: Parameters<AbortSignal['addEventListener']>) => {
+      if (args[0] === 'abort') adds += 1;
+      return originalAdd(...args);
+    }) as AbortSignal['addEventListener'];
+
+    await assert.rejects(() => sleep(100, controller.signal), /stop/);
+    assert.equal(adds, 0);
+  });
+});

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,16 +1,25 @@
 export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(resolve, ms);
-    if (signal) {
-      signal.addEventListener(
-        'abort',
-        () => {
-          clearTimeout(timer);
-          reject(signal.reason ?? new Error('Aborted'));
-        },
-        { once: true },
-      );
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error('Aborted'));
+      return;
     }
+
+    let timer: ReturnType<typeof setTimeout>;
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(signal?.reason ?? new Error('Aborted'));
+    };
+
+    timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }
 


### PR DESCRIPTION
## Summary

- close resource-leak gaps in abortable sleep, HUD/sidecar watch signal handlers, HTTP notification requests, and notify-hook child process execution
- reap `omx-api` daemon startup failures so timeout/read errors cannot leave spawned daemons running
- route OpenClaw command gateways through process-tree cleanup so `sh -c` wrappers cannot orphan descendants on timeout
- add focused regressions for listener cleanup, socket timeout cleanup, daemon child reaping, plugin runner timeout cleanup, and shell descendant cleanup

## Root cause

The leak audit found several lifecycle paths that settled caller promises before all owned resources were detached or terminated. The highest-risk process cases were daemon startup timeout handling and shell-command timeout handling: both could return an error while spawned work remained alive or retained listeners/timers.

## Validation

- `npm run build`
- `node --test dist/openclaw/__tests__/dispatcher.test.js dist/runtime/__tests__/process-tree.test.js dist/hooks/extensibility/__tests__/dispatcher.test.js dist/utils/__tests__/sleep-resource.test.js dist/sidecar/__tests__/resource-leak-watch.test.js dist/hud/__tests__/resource-leak-watch.test.js dist/notifications/__tests__/http-client-resource.test.js`
- `npx biome lint src/hooks/extensibility/dispatcher.ts src/hooks/extensibility/__tests__/dispatcher.test.ts src/utils/sleep.ts src/sidecar/index.ts src/hud/index.ts src/notifications/http-client.ts src/scripts/notify-hook/process-runner.ts src/utils/__tests__/sleep-resource.test.ts src/sidecar/__tests__/resource-leak-watch.test.ts src/hud/__tests__/resource-leak-watch.test.ts src/notifications/__tests__/http-client-resource.test.ts src/openclaw/dispatcher.ts src/openclaw/__tests__/dispatcher.test.ts src/runtime/process-tree.ts src/runtime/__tests__/process-tree.test.ts`
- `npm run check:no-unused`
- `cargo fmt --check`
- `cargo test -p omx-api`

## Notes

A prior broad repo-wide node discovery run exposed unrelated runtime-sensitive failures in this worktree, so this PR relies on focused leak/process suites plus lint, typecheck, build, and Rust package tests.
