### PR TITLE
Fix doctor plugin hook diagnostics

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+	cp,
 	mkdir,
 	mkdtemp,
 	readFile,
@@ -70,12 +71,46 @@ function quoteCommandPart(value: string): string {
 	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function currentNativeHookCommand(codexHomeDir: string): string {
+function repoRoot(): string {
 	const testDir = dirname(fileURLToPath(import.meta.url));
-	const repoRoot = join(testDir, "..", "..", "..");
-	return buildManagedCodexNativeHookCommand(repoRoot, {
+	return join(testDir, "..", "..", "..");
+}
+
+function currentNativeHookCommand(codexHomeDir: string): string {
+	return buildManagedCodexNativeHookCommand(repoRoot(), {
 		codexHomeDir,
 	});
+}
+
+async function installPluginCacheFixture(codexDir: string): Promise<string> {
+	const root = repoRoot();
+	const sourcePluginDir = join(root, "plugins", "oh-my-codex");
+	const manifest = JSON.parse(
+		await readFile(join(sourcePluginDir, ".codex-plugin", "plugin.json"), "utf-8"),
+	) as { version: string };
+	const cacheDir = join(
+		codexDir,
+		"plugins",
+		"cache",
+		"oh-my-codex-local",
+		"oh-my-codex",
+		manifest.version,
+	);
+	await rm(cacheDir, { recursive: true, force: true });
+	await mkdir(dirname(cacheDir), { recursive: true });
+	await cp(sourcePluginDir, cacheDir, { recursive: true });
+	await writeFile(
+		join(cacheDir, "hooks", "omx-command.json"),
+		`${JSON.stringify(
+			{
+				command: process.execPath,
+				argsPrefix: [join(root, "dist", "cli", "omx.js")],
+			},
+			null,
+			2,
+		)}\n`,
+	);
+	return cacheDir;
 }
 
 async function packagedPluginVersion(): Promise<string> {
@@ -745,6 +780,62 @@ OMX_LORE_COMMIT_GUARD = "truee"
 		}
 	});
 
+	it("accepts plugin-scoped native hooks when setup-owned hooks.json is intentionally absent", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-scoped-hooks-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await mkdir(codexDir, { recursive: true });
+			const cacheDir = await installPluginCacheFixture(codexDir);
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				`${JSON.stringify({ scope: "user", installMode: "plugin", mcpMode: "none" }, null, 2)}\n`,
+			);
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"[features]",
+					"plugin_hooks = true",
+					"goals = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "local"',
+					`source = ${JSON.stringify(repoRoot())}`,
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+
+			const setupOwnedHooksPath = join(codexDir, "hooks.json");
+			assert.equal(existsSync(setupOwnedHooksPath), false);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(res.stdout, /Resolved setup install mode: plugin/);
+			assert.match(
+				res.stdout,
+				new RegExp(
+					`\\[OK\\] Native hooks: plugin-scoped hooks are enabled; setup-owned hooks\\.json is intentionally absent at .*\\.codex[\\/]+hooks\\.json, and plugin cache native hook coverage smoke passed via ${join(cacheDir, "hooks", "hooks.json").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+				),
+			);
+			assert.match(
+				res.stdout,
+				/Skills: plugin marketplace oh-my-codex-local registered; OMX skills are supplied by/,
+			);
+			assert.doesNotMatch(res.stdout, /hooks\.json not found even though config\.toml has OMX entries/);
+			assert.doesNotMatch(res.stdout, /run "omx setup --force" to restore native hook coverage/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("warns when hooks.json is missing OMX-managed native hook coverage", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-coverage-"));
 		try {
@@ -860,7 +951,7 @@ command = "node"
 			assert.equal(res.status, 0, res.stderr || res.stdout);
 			assert.match(
 				res.stdout,
-				/Native hooks: hooks\.json not found even though config\.toml has OMX entries; run "omx setup --force" to restore native hook coverage/,
+				/Native hooks: expected setup-owned hooks\.json is missing at .*\.codex[\/]+hooks\.json even though config\.toml has OMX entries; run "omx setup --force" to restore native hook coverage/,
 			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -795,7 +795,6 @@ OMX_LORE_COMMIT_GUARD = "truee"
 			await writeFile(
 				join(codexDir, "config.toml"),
 				[
-					"[features]",
 					"plugin_hooks = true",
 					"goals = true",
 					"",

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -33,6 +33,7 @@ import {
 	getModelContextRecommendation,
 } from "../config/generator.js";
 import {
+	MANAGED_HOOK_EVENTS,
 	buildManagedCodexNativeHookCommand,
 	discoverCodexHookConfigPaths,
 	getManagedCodexHookCommandsForEvent,
@@ -196,7 +197,12 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	if (contextRecommendationCheck) checks.push(contextRecommendationCheck);
 
 	// Check 4.25: Native hooks coverage
-	checks.push(await checkNativeHooks(paths.hooksPath, paths.configPath));
+	checks.push(
+		await checkNativeHooks(paths.hooksPath, paths.configPath, {
+			codexHomeDir: paths.codexHomeDir,
+			installMode: scopeResolution.installMode,
+		}),
+	);
 	checks.push(await checkNativeHookDistSmoke());
 	if (options.verbose) {
 		const postCompactRuntimeCheck = await checkNativePostCompactHookRuntime(
@@ -1054,23 +1060,214 @@ function isExplicitLoreCommitGuardOptOut(value: string): boolean {
 	);
 }
 
+interface NativeHookCheckContext {
+	codexHomeDir: string;
+	installMode?: SetupInstallMode;
+}
+
+function isEnabledTomlValue(value: unknown): boolean {
+	return value === true || (typeof value === "string" && ["1", "true", "yes", "on"].includes(value.trim().toLowerCase()));
+}
+
+function configHasOmxEntries(configContent: string): boolean {
+	return configContent.includes("omx_") || configContent.includes("oh-my-codex");
+}
+
+function configEnablesPluginScopedHooks(configContent: string): boolean {
+	try {
+		const parsed = parseToml(configContent) as {
+			features?: Record<string, unknown>;
+		};
+		return isEnabledTomlValue(parsed.features?.plugin_hooks);
+	} catch {
+		return /^\s*plugin_hooks\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(configContent);
+	}
+}
+
+function pluginHooksJsonHasNativeCoverage(content: string): boolean | null {
+	try {
+		const parsed = JSON.parse(content) as { hooks?: Record<string, unknown> };
+		if (!parsed || typeof parsed !== "object" || typeof parsed.hooks !== "object" || parsed.hooks === null) {
+			return false;
+		}
+		return MANAGED_HOOK_EVENTS.every((eventName) => {
+			const entries = parsed.hooks?.[eventName];
+			if (!Array.isArray(entries)) return false;
+			return entries.some((entry) => {
+				if (!entry || typeof entry !== "object") return false;
+				const hooks = (entry as { hooks?: unknown }).hooks;
+				if (!Array.isArray(hooks)) return false;
+				return hooks.some((hook) => {
+					if (!hook || typeof hook !== "object") return false;
+					const command = (hook as { command?: unknown }).command;
+					return typeof command === "string" && command.includes("codex-native-hook.mjs");
+				});
+			});
+		});
+	} catch {
+		return null;
+	}
+}
+
+async function checkPluginScopedNativeHooks(
+	codexHomeDir: string,
+	setupHooksPath: string,
+): Promise<Check> {
+	const packagedMarketplace = await resolvePackagedOmxMarketplace(getPackageRoot());
+	if (!packagedMarketplace) {
+		return {
+			name: "Native hooks",
+			status: "warn",
+			message:
+				`plugin-scoped hooks are enabled and setup-owned hooks.json is intentionally absent at ${setupHooksPath}, but packaged ${OMX_LOCAL_MARKETPLACE_NAME} metadata was not found`,
+		};
+	}
+
+	const version = await packagedOmxPluginVersion(packagedMarketplace);
+	const expectedCacheDir = version
+		? join(codexHomeDir, "plugins", "cache", OMX_LOCAL_MARKETPLACE_NAME, "oh-my-codex", version)
+		: join(codexHomeDir, "plugins", "cache", OMX_LOCAL_MARKETPLACE_NAME, "oh-my-codex", "<version>");
+	const expectedHooksPath = join(expectedCacheDir, "hooks", "hooks.json");
+	const expectedHookLauncherPath = join(expectedCacheDir, "hooks", "codex-native-hook.mjs");
+	const expectedPinnedLauncherPath = join(expectedCacheDir, "hooks", "omx-command.json");
+	const state = await readOmxPluginCacheState(expectedCacheDir);
+
+	if (!state) {
+		return {
+			name: "Native hooks",
+			status: "warn",
+			message:
+				`plugin-scoped hooks are enabled, but the expected Codex plugin cache manifest is missing at ${join(expectedCacheDir, ".codex-plugin", "plugin.json")}; setup-owned hooks.json is intentionally absent at ${setupHooksPath}; run "omx setup --plugin --force" to refresh the plugin cache`,
+		};
+	}
+
+	if (state.hooksPointer !== "./hooks/hooks.json") {
+		return {
+			name: "Native hooks",
+			status: "warn",
+			message:
+				`plugin-scoped hooks are enabled, but the Codex plugin cache manifest points hooks to ${String(state.hooksPointer)} instead of ./hooks/hooks.json at ${expectedHooksPath}; run "omx setup --plugin --force" to refresh the plugin cache`,
+		};
+	}
+
+	for (const expectedPath of [expectedHooksPath, expectedHookLauncherPath, expectedPinnedLauncherPath]) {
+		if (!existsSync(expectedPath)) {
+			return {
+				name: "Native hooks",
+				status: "warn",
+				message:
+					`plugin-scoped hooks are enabled, but expected plugin hook file is missing at ${expectedPath}; setup-owned hooks.json is intentionally absent at ${setupHooksPath}; run "omx setup --plugin --force" to refresh the plugin cache`,
+			};
+		}
+	}
+
+	let hookContent: string;
+	try {
+		hookContent = await readFile(expectedHooksPath, "utf-8");
+	} catch {
+		return {
+			name: "Native hooks",
+			status: "fail",
+			message: `cannot read plugin-scoped hooks.json at ${expectedHooksPath}`,
+		};
+	}
+
+	const hasCoverage = pluginHooksJsonHasNativeCoverage(hookContent);
+	if (hasCoverage === null) {
+		return {
+			name: "Native hooks",
+			status: "fail",
+			message: `invalid plugin-scoped hooks.json at ${expectedHooksPath}`,
+		};
+	}
+	if (!hasCoverage) {
+		return {
+			name: "Native hooks",
+			status: "warn",
+			message:
+				`plugin-scoped hooks.json at ${expectedHooksPath} is missing OMX native coverage for one or more events; run "omx setup --plugin --force" to refresh the plugin cache`,
+		};
+	}
+
+	const smokeCwd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-hook-"));
+	try {
+		const payload = JSON.stringify({
+			hook_event_name: "UserPromptSubmit",
+			session_id: "omx-doctor-plugin-hook-smoke",
+			transcript_path: join(smokeCwd, "nonexistent-transcript.jsonl"),
+			cwd: smokeCwd,
+			prompt: "doctor plugin hook smoke test",
+		});
+		const result = spawnSync(process.execPath, [expectedHookLauncherPath], {
+			cwd: smokeCwd,
+			encoding: "utf-8",
+			env: {
+				...process.env,
+				OMX_NATIVE_HOOK_DOCTOR_SMOKE: "1",
+				OMX_ROOT: join(smokeCwd, ".omx-doctor-root"),
+				OMX_SESSION_ID: "omx-doctor-plugin-hook-smoke",
+				OMX_SOURCE_CWD: smokeCwd,
+				OMX_STARTUP_CWD: smokeCwd,
+			},
+			input: payload,
+			timeout: 5_000,
+		});
+		if (result.error) {
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message: `plugin-scoped native hook smoke failed to run from ${expectedHookLauncherPath} (${result.error.message})`,
+			};
+		}
+		if (result.status !== 0) {
+			const detail = (result.stderr || result.stdout || `exit ${result.status}`).trim();
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message: `plugin-scoped native hook smoke failed from ${expectedHookLauncherPath} (${detail})`,
+			};
+		}
+	} finally {
+		await rm(smokeCwd, { recursive: true, force: true });
+	}
+
+	return {
+		name: "Native hooks",
+		status: "pass",
+		message:
+			`plugin-scoped hooks are enabled; setup-owned hooks.json is intentionally absent at ${setupHooksPath}, and plugin cache native hook coverage smoke passed via ${expectedHooksPath}`,
+	};
+}
+
 async function checkNativeHooks(
 	hooksPath: string,
 	configPath: string,
+	context: NativeHookCheckContext,
 ): Promise<Check> {
 	if (!existsSync(hooksPath)) {
 		if (existsSync(configPath)) {
 			try {
 				const configContent = await readFile(configPath, "utf-8");
-				const hasOmx =
-					configContent.includes("omx_") ||
-					configContent.includes("oh-my-codex");
-				if (hasOmx) {
+				if (context.installMode === "plugin") {
+					if (configEnablesPluginScopedHooks(configContent)) {
+						return checkPluginScopedNativeHooks(context.codexHomeDir, hooksPath);
+					}
+					if (configHasOmxEntries(configContent)) {
+						return {
+							name: "Native hooks",
+							status: "warn",
+							message:
+								`plugin mode is using legacy native hook fallback, but expected setup-owned hooks.json is missing at ${hooksPath}; run "omx setup --plugin --force" to restore the fallback hook file, or upgrade Codex to plugin_hooks support so setup can use plugin-scoped hooks`,
+						};
+					}
+				}
+
+				if (configHasOmxEntries(configContent)) {
 					return {
 						name: "Native hooks",
 						status: "warn",
 						message:
-							'hooks.json not found even though config.toml has OMX entries; run "omx setup --force" to restore native hook coverage',
+							`expected setup-owned hooks.json is missing at ${hooksPath} even though config.toml has OMX entries; run "omx setup --force" to restore native hook coverage`,
 					};
 				}
 			} catch {
@@ -1082,7 +1279,7 @@ async function checkNativeHooks(
 		return {
 			name: "Native hooks",
 			status: "pass",
-			message: "hooks.json not found yet (expected before first setup)",
+			message: `hooks.json not found at ${hooksPath} yet (expected before first setup)`,
 		};
 	}
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1076,9 +1076,10 @@ function configHasOmxEntries(configContent: string): boolean {
 function configEnablesPluginScopedHooks(configContent: string): boolean {
 	try {
 		const parsed = parseToml(configContent) as {
+			plugin_hooks?: unknown;
 			features?: Record<string, unknown>;
 		};
-		return isEnabledTomlValue(parsed.features?.plugin_hooks);
+		return isEnabledTomlValue(parsed.plugin_hooks) || isEnabledTomlValue(parsed.features?.plugin_hooks);
 	} catch {
 		return /^\s*plugin_hooks\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(configContent);
 	}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1279,7 +1279,7 @@ async function checkNativeHooks(
 		return {
 			name: "Native hooks",
 			status: "pass",
-			message: `hooks.json not found at ${hooksPath} yet (expected before first setup)`,
+			message: "hooks.json not found yet (expected before first setup)",
 		};
 	}
 


### PR DESCRIPTION
## Summary
- Treat plugin-mode `plugin_hooks = true` as an intentional plugin-scoped native hook surface when setup-owned `hooks.json` is absent.
- Validate the cached OMX plugin hook manifest, hook files, event coverage, and launcher smoke path before passing doctor.
- Name exact missing hook paths in diagnostics and avoid the misleading bare `setup --force` loop for plugin-scoped hook installs.

Fixes #2429

## Verification
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node --test dist/cli/__tests__/doctor-warning-copy.test.js`
- `node --test dist/cli/__tests__/setup-install-mode.test.js dist/config/__tests__/generator-notify.test.js dist/config/__tests__/codex-hooks.test.js`

Signed-off-by: Codex <codex@openai.com>