### PR TITLE
Fix tmux 3.2a HUD resize hook registration

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3913,9 +3913,9 @@ exit 0
       (step) => step.name === "reconcile-hud-resize",
     );
 
-    assert.match(registerHook?.args[5] ?? "", />\/dev\/null 2>&1 \|\| true/);
+    assert.match(registerHook?.args[4] ?? "", />\/dev\/null 2>&1 \|\| true/);
     assert.match(
-      registerHook?.args[5] ?? "",
+      registerHook?.args[4] ?? "",
       new RegExp(`-y ${HUD_TMUX_HEIGHT_LINES}\\b`),
     );
     assert.match(schedule?.args[2] ?? "", />\/dev\/null 2>&1 \|\| true/);
@@ -4003,7 +4003,8 @@ exit 0
     assert.equal(steps[0]?.args[2], "-t");
     assert.equal(steps[0]?.args[3], "omx-demo:0");
     assert.match(steps[0]?.args[4] ?? "", /^client-attached\[\d+\]$/);
-    assert.match(steps[1]?.args[5] ?? "", /^window-resized\[\d+\]$/);
+    assert.match(steps[1]?.args[4] ?? "", /^client-resized\[\d+\]$/);
+    assert.doesNotMatch(steps[1]?.args.join(" ") ?? "", /window-resized/);
     assert.deepEqual(steps[2]?.args, ["kill-session", "-t", "omx-demo"]);
   });
 

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -162,7 +162,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(resized[0]?.heightLines, 3);
   });
 
-  it('registers window-resized hook scoped to the emitting window after resizing an existing HUD pane', async () => {
+  it('registers client-resized hook scoped from the emitting pane after resizing an existing HUD pane', async () => {
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
@@ -185,7 +185,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(registered[0]?.heightLines, 3);
   });
 
-  it('registers window-resized hook scoped to the emitting window after creating a new HUD pane', async () => {
+  it('registers client-resized hook scoped from the emitting pane after creating a new HUD pane', async () => {
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -14,11 +14,11 @@ describe('HUD resize hook helpers', () => {
     assert.equal(buildHudResizeHookName('$7', '@3'), 'omx_hud_resize_7_3');
   });
 
-  it('builds a bounded numeric window-resized slot', () => {
+  it('builds a bounded numeric client-resized slot', () => {
     const slot = buildHudResizeHookSlot('omx_hud_resize_7_3');
-    assert.match(slot, /^window-resized\[\d+\]$/);
+    assert.match(slot, /^client-resized\[\d+\]$/);
 
-    const index = Number.parseInt(slot.replace(/^window-resized\[|\]$/g, ''), 10);
+    const index = Number.parseInt(slot.replace(/^client-resized\[|\]$/g, ''), 10);
     assert.ok(index >= 0);
     assert.ok(index < 2147483647);
   });
@@ -34,7 +34,7 @@ describe('HUD resize hook helpers', () => {
     });
   });
 
-  it('registers a window-resized hook at window scope with exact HUD pane targeting', () => {
+  it('registers a client-resized hook at session scope with exact HUD pane targeting', () => {
     const calls: string[][] = [];
 
     const result = registerHudResizeHook('%9', '%1', 3, (args) => {
@@ -47,17 +47,15 @@ describe('HUD resize hook helpers', () => {
     assert.equal(result, true);
     assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
     assert.equal(calls[1]?.[0], 'set-hook');
-    assert.equal(calls[1]?.[1], '-w');
-    assert.equal(calls[1]?.[2], '-t');
-    assert.equal(calls[1]?.[3], '@3');
-    assert.equal(calls[1]?.[4], hookSlot);
-    assert.notEqual(calls[1]?.[4], 'client-resized[99]');
-    assert.match(calls[1]?.[5] ?? '', /^run-shell -b /);
-    assert.match(calls[1]?.[5] ?? '', /resize-pane/);
-    assert.match(calls[1]?.[5] ?? '', /set-hook/);
-    assert.match(calls[1]?.[5] ?? '', /'-w'/);
-    assert.match(calls[1]?.[5] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
-    assert.match(calls[1]?.[5] ?? '', new RegExp(hookSlot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.equal(calls[1]?.[1], '-t');
+    assert.equal(calls[1]?.[2], '$7');
+    assert.equal(calls[1]?.[3], hookSlot);
+    assert.match(calls[1]?.[4] ?? '', /^run-shell -b /);
+    assert.match(calls[1]?.[4] ?? '', /resize-pane/);
+    assert.match(calls[1]?.[4] ?? '', /set-hook/);
+    assert.doesNotMatch(calls[1]?.[4] ?? '', /'-w'/);
+    assert.match(calls[1]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
+    assert.match(calls[1]?.[4] ?? '', new RegExp(hookSlot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   });
 
   it('unregisters the same per-window hook slot', () => {
@@ -74,9 +72,8 @@ describe('HUD resize hook helpers', () => {
     assert.deepEqual(calls[1], [
       'set-hook',
       '-u',
-      '-w',
       '-t',
-      '@3',
+      '$7',
       buildHudResizeHookSlot('omx_hud_resize_7_3'),
     ]);
   });
@@ -93,10 +90,10 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%9', '%1', 3, execFor('@3')), true);
     assert.equal(registerHudResizeHook('%10', '%2', 3, execFor('@4')), true);
 
-    const firstSlot = registered[0]?.[4];
-    const secondSlot = registered[1]?.[4];
-    assert.match(firstSlot ?? '', /^window-resized\[\d+\]$/);
-    assert.match(secondSlot ?? '', /^window-resized\[\d+\]$/);
+    const firstSlot = registered[0]?.[3];
+    const secondSlot = registered[1]?.[3];
+    assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
+    assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
     assert.notEqual(firstSlot, secondSlot);
   });
 
@@ -111,6 +108,6 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
     assert.equal(registerHudResizeHook('%10', '%1', 3, execTmuxSync), true);
 
-    assert.equal(registered[0]?.[4], registered[1]?.[4]);
+    assert.equal(registered[0]?.[3], registered[1]?.[3]);
   });
 });

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -82,7 +82,7 @@ export function buildHudResizeHookSlot(hookName: string): string {
   for (let i = 0; i < hookName.length; i++) {
     hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
   }
-  return `window-resized[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
+  return `client-resized[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
 }
 
 export interface HudResizeHookContext {
@@ -138,7 +138,7 @@ function buildHudResizeHookCommand(
   context: HudResizeHookContext,
 ): string {
   const resize = buildNestedTmuxCommand(tmuxBin, ['resize-pane', '-t', hudPaneId, '-y', height]);
-  const unregister = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-w', '-t', context.windowId, context.hookSlot]);
+  const unregister = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-t', context.sessionId, context.hookSlot]);
   const resizeOrUnregister = `${resize} >/dev/null 2>&1 || ${unregister} >/dev/null 2>&1 || true`;
   return `${resizeOrUnregister}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeOrUnregister}`;
 }
@@ -278,7 +278,7 @@ export function registerHudResizeHook(
   const height = String(Math.max(1, Math.floor(heightLines)));
   const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, context));
   try {
-    execTmuxSync(['set-hook', '-w', '-t', context.windowId, context.hookSlot, `run-shell -b ${resizeCmd}`]);
+    execTmuxSync(['set-hook', '-t', context.sessionId, context.hookSlot, `run-shell -b ${resizeCmd}`]);
     return true;
   } catch {
     return false;
@@ -292,7 +292,7 @@ export function unregisterHudResizeHook(
   const context = readHudResizeHookContext(currentPaneId, execTmuxSync);
   if (!context) return false;
   try {
-    execTmuxSync(['set-hook', '-u', '-w', '-t', context.windowId, context.hookSlot]);
+    execTmuxSync(['set-hook', '-u', '-t', context.sessionId, context.hookSlot]);
     return true;
   } catch {
     return false;

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -3847,7 +3847,7 @@ exit 0
           const standaloneHudSplitRe = new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
           assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 1);
-          assert.equal(tmuxLog.match(/set-hook -w -t leader:0 window-resized\[\d+\]/g)?.length ?? 0, 2);
+          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
           assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
@@ -5492,7 +5492,7 @@ esac
           assert.equal(existsSync(teamRoot), false);
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /set-hook -u -w -t omx-team-team-shutdown-gate-failed:0 window-resized\[\d+\]/);
+          assert.match(tmuxLog, /set-hook -u -t omx-team-team-shutdown-gate-failed:0 client-resized\[\d+\]/);
           assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-gate-failed/);
         },
       );

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -198,15 +198,14 @@ describe('HUD resize hook command builders', () => {
     assert.equal(buildHudPaneTarget('41'), '%41');
   });
 
-  it('buildRegisterResizeHookArgs uses window target and numeric window-resized hook slot', () => {
+  it('buildRegisterResizeHookArgs uses target and numeric client-resized hook slot', () => {
     const args = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1');
     assert.equal(args[0], 'set-hook');
-    assert.equal(args[1], '-w');
-    assert.equal(args[2], '-t');
-    assert.equal(args[3], 'my-session:0');
-    assert.match(args[4] ?? '', /^window-resized\[\d+\]$/);
+    assert.equal(args[1], '-t');
+    assert.equal(args[2], 'my-session:0');
+    assert.match(args[3] ?? '', /^client-resized\[\d+\]$/);
     assert.equal(
-      args[5],
+      args[4],
       `run-shell -b 'tmux resize-pane -t %1 -y ${HUD_TMUX_TEAM_HEIGHT_LINES} >/dev/null 2>&1 || true; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; tmux resize-pane -t %1 -y ${HUD_TMUX_TEAM_HEIGHT_LINES} >/dev/null 2>&1 || true'`,
     );
   });
@@ -214,7 +213,7 @@ describe('HUD resize hook command builders', () => {
   it('buildUnregisterResizeHookArgs removes the exact numeric hook slot', () => {
     const registered = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1');
     const unregistered = buildUnregisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1');
-    assert.deepEqual(unregistered, ['set-hook', '-u', '-w', '-t', 'my-session:0', registered[4] as string]);
+    assert.deepEqual(unregistered, ['set-hook', '-u', '-t', 'my-session:0', registered[3] as string]);
   });
 
   it('buildClientAttachedReconcileHookName normalizes all segments into collision-safe tokens', () => {
@@ -247,7 +246,7 @@ describe('HUD resize hook command builders', () => {
     const resizeArgs = buildRegisterResizeHookArgs('sess:0', longName, '%1');
     const attachedArgs = buildRegisterClientAttachedReconcileArgs('sess:0', longName, '%1');
 
-    const resizeSlot = resizeArgs[4] ?? '';
+    const resizeSlot = resizeArgs[3] ?? '';
     const attachedSlot = attachedArgs[3] ?? '';
 
     const resizeIndex = Number((resizeSlot.match(/\[(\d+)\]/) ?? [])[1]);
@@ -263,7 +262,7 @@ describe('HUD resize hook command builders', () => {
     const name = 'omx_resize_team_session_0_1';
     const a = buildRegisterResizeHookArgs('s:0', name, '%1');
     const b = buildRegisterResizeHookArgs('s:0', name, '%1');
-    assert.equal(a[4], b[4]);
+    assert.equal(a[3], b[3]);
 
     const c = buildRegisterClientAttachedReconcileArgs('s:0', name, '%1');
     const d = buildRegisterClientAttachedReconcileArgs('s:0', name, '%1');
@@ -302,8 +301,8 @@ describe('HUD resize hook command builders', () => {
       const delayedArgs = buildScheduleDelayedHudResizeArgs('%1');
       const reconcileArgs = buildReconcileHudResizeArgs('%1');
 
-      assert.match(resizeArgs[5] ?? '', new RegExp(escapeRegExp(tmuxPath)));
-      assert.doesNotMatch(resizeArgs[5] ?? '', /^run-shell -b 'tmux resize-pane/);
+      assert.match(resizeArgs[4] ?? '', new RegExp(escapeRegExp(tmuxPath)));
+      assert.doesNotMatch(resizeArgs[4] ?? '', /^run-shell -b 'tmux resize-pane/);
       assert.match(delayedArgs[2] ?? '', new RegExp(escapeRegExp(tmuxPath)));
       assert.doesNotMatch(delayedArgs[2] ?? '', /sleep \d+; tmux resize-pane/);
       assert.match(reconcileArgs[1] ?? '', new RegExp(escapeRegExp(tmuxPath)));
@@ -3222,7 +3221,7 @@ esac
     }
   });
 
-  it('continues startup with best-effort resize fallback when indexed window-resized hook registration fails', async () => {
+  it('uses tmux 3.2a-compatible client-resized hook registration for team HUD resize', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-resize-hook-fallback-'));
     const prevTmux = process.env.TMUX;
     const prevTmuxPane = process.env.TMUX_PANE;
@@ -3280,6 +3279,10 @@ case "\${1:-}" in
         echo "invalid option: window-resized[]" >&2
         exit 1
         ;;
+      *" -w "*)
+        echo "invalid option: -w" >&2
+        exit 1
+        ;;
       *)
         exit 0
         ;;
@@ -3306,13 +3309,14 @@ esac
 
           const session = createTeamSession('Resize Hook Fallback', 1, cwd);
           assert.equal(session.hudPaneId, '%3');
-          assert.equal(session.resizeHookName, null);
-          assert.equal(session.resizeHookTarget, null);
-          assert.match(warnings.join('\n'), /tmux resize hook unavailable/);
-          assert.match(warnings.join('\n'), /invalid option: window-resized\[\]/);
+          assert.ok(session.resizeHookName);
+          assert.equal(session.resizeHookTarget, 'leader:0');
+          assert.equal(warnings.join('\n'), '');
 
           const tmuxLog = await readFile(logPath, 'utf-8');
-          assert.match(tmuxLog, /set-hook -w -t leader:0 window-resized\[\d+\]/);
+          assert.match(tmuxLog, /set-hook -t leader:0 client-resized\[\d+\]/);
+          assert.doesNotMatch(tmuxLog, /window-resized\[/);
+          assert.doesNotMatch(tmuxLog, /set-hook -w /);
           assert.match(tmuxLog, /set-hook -t leader:0 client-attached\[\d+\]/);
           assert.match(tmuxLog, new RegExp(`run-shell -b sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.match(tmuxLog, new RegExp(`run-shell .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
@@ -3532,7 +3536,8 @@ esac
 
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
-          assert.doesNotMatch(tmuxLog, /set-hook -w -t leader:0 window-resized\[\d+\]/);
+          assert.doesNotMatch(tmuxLog, /set-hook -w /);
+          assert.doesNotMatch(tmuxLog, /window-resized\[/);
           assert.doesNotMatch(tmuxLog, /set-hook -t leader:0 client-attached\[\d+\]/);
           assert.doesNotMatch(tmuxLog, /run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/);
           assert.doesNotMatch(tmuxLog, /run-shell tmux resize-pane -t %3 -y \d+ >/);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -513,7 +513,7 @@ function buildResizeHookSlot(hookName: string): string {
   for (let i = 0; i < hookName.length; i++) {
     hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
   }
-  return `window-resized[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
+  return `client-resized[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
 }
 
 function buildClientAttachedHookSlot(hookName: string): string {
@@ -534,11 +534,11 @@ export function buildRegisterResizeHookArgs(
   const hookCommand = shellQuoteSingle(
     `${resizeCommand}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeCommand}`,
   );
-  return ['set-hook', '-w', '-t', hookTarget, buildResizeHookSlot(hookName), `run-shell -b ${hookCommand}`];
+  return ['set-hook', '-t', hookTarget, buildResizeHookSlot(hookName), `run-shell -b ${hookCommand}`];
 }
 
 export function buildUnregisterResizeHookArgs(hookTarget: string, hookName: string): string[] {
-  return ['set-hook', '-u', '-w', '-t', hookTarget, buildResizeHookSlot(hookName)];
+  return ['set-hook', '-u', '-t', hookTarget, buildResizeHookSlot(hookName)];
 }
 
 export function buildClientAttachedReconcileHookName(
@@ -1304,7 +1304,7 @@ export function createTeamSession(
               resizeHookName = hookName;
               registeredResizeHook = { name: resizeHookName, target: resizeHookTarget };
             } else {
-              // tmux versions/builds that reject indexed window-resized hooks should not
+              // tmux versions/builds that reject indexed client-resized hooks should not
               // abort madmax/team startup after panes were successfully created. Keep the
               // fallback narrow: skip only the long-lived resize hook metadata, then
               // still try the one-shot client-attached reconcile plus the explicit


### PR DESCRIPTION
## Summary
- Replaces HUD/team long-lived resize hook registration with `client-resized[...]` without `-w`, avoiding tmux 3.2a's `invalid option: window-resized[...]` failure.
- Keeps hashed unique hook slots and existing best-effort resize fallback behavior.
- Updates HUD/team/launch rollback regression coverage to assert no `window-resized[...]` resize hook syntax is emitted.

Closes #2433.

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js dist/team/__tests__/tmux-session.test.js`
- `node --test --test-name-pattern "buildDetachedSessionFinalizeSteps|buildDetachedSessionRollbackSteps" dist/cli/__tests__/index.test.js`
- `git diff --check`
- tmux smoke: `tmux set-hook -t "$session_id" 'client-resized[2433]' 'run-shell -b true'` then unset succeeded locally

## Notes
- A broad `dist/cli/__tests__/index.test.js` run still reports unrelated pre-existing post-launch cleanup / tmux extended-keys lease failures; the detached hook tests touched by this change pass when run by name.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
