### PR TITLE
Fix madmax detached lock identity for independent launches

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -151,39 +151,65 @@ describe("madmax state isolation", () => {
       const env: NodeJS.ProcessEnv = { OMX_RUNS_DIR: runs };
       const runDir = createMadmaxIsolatedRoot(wd, ["--madmax", "--xhigh", "--tmux"], env);
       const metadata = JSON.parse(await readFile(join(runDir, ".omxbox-run.json"), "utf-8"));
-      const expectedContext = buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--xhigh", "--tmux"]);
+      const expectedContext = buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--xhigh", "--tmux"], runDir);
       assert.equal(metadata.detached_launch_context, expectedContext);
       assert.equal(env.OMX_MADMAX_DETACHED_CONTEXT, expectedContext);
       assert.equal(
-        expectedContext,
-        buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--xhigh"]),
+        buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--xhigh", "--tmux"], runDir),
+        buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--xhigh"], runDir),
         "explicit --tmux is a transport choice and must not create a second context",
       );
       assert.equal(
-        expectedContext,
-        buildMadmaxDetachedLaunchContextKey(wd, ["--xhigh", "--madmax", "--direct"]),
+        buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--xhigh", "--tmux"], runDir),
+        buildMadmaxDetachedLaunchContextKey(wd, ["--xhigh", "--madmax", "--direct"], runDir),
         "argument order and transport choices must not create duplicate detached contexts",
       );
       assert.notEqual(
         expectedContext,
-        buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--low"]),
+        buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--low"], runDir),
         "different launch semantics may run concurrently",
       );
       assert.notEqual(
-        buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--high", "--xhigh"]),
-        buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--xhigh", "--high"]),
+        buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--high", "--xhigh"], runDir),
+        buildMadmaxDetachedLaunchContextKey(wd, ["--madmax", "--xhigh", "--high"], runDir),
         "last reasoning shorthand wins, so reversed reasoning order is a distinct context",
       );
       const otherWd = await mkdtemp(join(tmpdir(), "omx-madmax-other-source-"));
       try {
         assert.notEqual(
           expectedContext,
-          buildMadmaxDetachedLaunchContextKey(otherWd, ["--madmax", "--xhigh"]),
+          buildMadmaxDetachedLaunchContextKey(otherWd, ["--madmax", "--xhigh"], runDir),
           "different work contexts may run concurrently",
         );
       } finally {
         await rm(otherWd, { recursive: true, force: true });
       }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(runs, { recursive: true, force: true });
+    }
+  });
+
+  it("gives independent madmax run roots distinct detached launch context locks", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-madmax-source-"));
+    const runs = await mkdtemp(join(tmpdir(), "omx-madmax-runs-"));
+    try {
+      const firstEnv: NodeJS.ProcessEnv = { OMX_RUNS_DIR: runs };
+      const secondEnv: NodeJS.ProcessEnv = { OMX_RUNS_DIR: runs };
+      const firstRunDir = createMadmaxIsolatedRoot(wd, ["--madmax", "--high"], firstEnv);
+      const secondRunDir = createMadmaxIsolatedRoot(wd, ["--madmax", "--high"], secondEnv);
+
+      assert.notEqual(firstRunDir, secondRunDir);
+      assert.notEqual(
+        firstEnv.OMX_MADMAX_DETACHED_CONTEXT,
+        secondEnv.OMX_MADMAX_DETACHED_CONTEXT,
+        "same cwd and argv from independent boxed runs must not contend on one active-detached lock",
+      );
+      assert.equal(
+        firstEnv.OMX_MADMAX_DETACHED_CONTEXT,
+        buildMadmaxDetachedLaunchContextKey(wd, ["--high", "--madmax", "--tmux"], firstRunDir),
+        "transport and order normalization still deduplicates within the same isolated run",
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
       await rm(runs, { recursive: true, force: true });

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -299,7 +299,7 @@ printf 'fake-codex:%s\n' "$*"
 });
 
 describe('omx launcher when tmux is available', () => {
-  it('reuses an active madmax detached launch context instead of spawning duplicate tmux sessions', async () => {
+  it('reuses the same boxed madmax detached launch context instead of spawning duplicate tmux sessions', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-reuse-'));
     try {
       const runs = join(wd, 'runs');
@@ -351,6 +351,8 @@ exit 0
       const baseEnv = {
         ...env,
         OMX_RUNS_DIR: runs,
+        OMXBOX_ACTIVE: '1',
+        OMX_MADMAX_DETACHED_CONTEXT: 'boxed-context-under-test',
         OMX_LAUNCH_POLICY: 'direct',
         TMUX: '',
         TMUX_PANE: '',
@@ -371,14 +373,73 @@ exit 0
       assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 1);
       assert.equal((tmuxLog.match(/tmux:has-session/g) || []).length, 1);
       assert.equal((tmuxLog.match(/tmux:attach-session/g) || []).length, 2);
-      const firstRegistryEntry = JSON.parse(
-        (await readFile(join(runs, 'registry.jsonl'), 'utf-8')).trim().split('\n')[0],
-      );
       const activeRecords = await readFile(
-        join(runs, 'active-detached', `${firstRegistryEntry.detached_launch_context}.json`),
+        join(runs, 'active-detached', 'boxed-context-under-test.json'),
         'utf-8',
       );
       assert.match(activeRecords, /"tmux_session_name"/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not reuse the same active-detached lock for independent --madmax --high launches', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-independent-high-'));
+    try {
+      const runs = join(wd, 'runs');
+      const { env, tmuxLogPath } = await createLaunchFixture(
+        wd,
+        (logPath) => `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${logPath}"
+case "$1" in
+  -V) printf 'tmux 3.4\n'; exit 0 ;;
+  has-session) exit 1 ;;
+  new-session) printf 'leader-pane\n'; exit 0 ;;
+  split-window) printf 'hud-pane\n'; exit 0 ;;
+  display-message) if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then printf '/tmp/tmux-test.sock\n'; else printf '0\n'; fi; exit 0 ;;
+  show-options) printf 'off\n'; exit 0 ;;
+  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane) exit 0 ;;
+esac
+exit 0
+`,
+      );
+      const baseEnv = {
+        ...env,
+        OMX_RUNS_DIR: runs,
+        OMX_LAUNCH_POLICY: 'direct',
+        TMUX: '',
+        TMUX_PANE: '',
+      };
+
+      const first = runOmx(wd, ['--madmax', '--high', '--tmux'], baseEnv);
+      const second = runOmx(wd, ['--madmax', '--high', '--tmux'], baseEnv);
+      if (shouldSkipForSpawnPermissions(first.error) || shouldSkipForSpawnPermissions(second.error)) return;
+      assert.equal(first.status, 0, first.error || first.stderr || first.stdout);
+      assert.equal(second.status, 0, second.error || second.stderr || second.stdout);
+      assert.doesNotMatch(first.stderr + second.stderr, /timed out waiting for madmax detached launch context lock/);
+      assert.doesNotMatch(second.stderr, /madmax detached launch already active for this context/);
+
+      const registryEntries = (await readFile(join(runs, 'registry.jsonl'), 'utf-8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line) as { detached_launch_context: string });
+      assert.equal(registryEntries.length, 2);
+      assert.notEqual(
+        registryEntries[0]!.detached_launch_context,
+        registryEntries[1]!.detached_launch_context,
+        'independent launches must get distinct active-detached lock identities',
+      );
+      assert.equal(
+        existsSync(join(runs, 'active-detached', `${registryEntries[0]!.detached_launch_context}.json`)),
+        true,
+      );
+      assert.equal(
+        existsSync(join(runs, 'active-detached', `${registryEntries[1]!.detached_launch_context}.json`)),
+        true,
+      );
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 2);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1297,10 +1297,16 @@ function normalizeMadmaxDetachedLaunchArgv(argv: readonly string[]): string[] {
 export function buildMadmaxDetachedLaunchContextKey(
   sourceCwd: string,
   argv: readonly string[],
+  runIdentity = "",
 ): string {
+  // The boxed run root is part of the lock identity for auto-isolated madmax
+  // launches. That lets independent `omx --madmax --high` sessions share the
+  // same source cwd/argv without contending on one active-detached lock, while
+  // callers that intentionally reuse the same boxed context keep one key.
   const payload = JSON.stringify({
     source_cwd: canonicalizeLaunchCwd(sourceCwd),
     argv: normalizeMadmaxDetachedLaunchArgv(argv),
+    run_identity: runIdentity,
   });
   return createHash("sha256").update(payload).digest("hex").slice(0, 32);
 }
@@ -1436,7 +1442,7 @@ export function createMadmaxIsolatedRoot(
   const suffix = Math.random().toString(16).slice(2, 6);
   const runDir = join(runsRoot, sanitizeRunIdSegment(`run-${stamp}-${suffix}`));
   mkdirSync(runDir, { recursive: false });
-  const detachedLaunchContext = buildMadmaxDetachedLaunchContextKey(sourceCwd, argv);
+  const detachedLaunchContext = buildMadmaxDetachedLaunchContextKey(sourceCwd, argv, runDir);
 
   const metadata = {
     launcher: "omx --madmax",


### PR DESCRIPTION
## Summary

- Fixes madmax detached launch context keys so auto-isolated boxed run roots produce distinct `active-detached` lock identities even when source cwd and argv are identical.
- Keeps intentional same boxed-context reuse intact via the existing `OMX_MADMAX_DETACHED_CONTEXT` env contract.
- Adds focused regressions for independent `--madmax --high` launches and same boxed-context reuse.

Closes #2435.

## Test evidence

- `npm run build`
- `node --test --test-name-pattern='madmax state isolation' dist/cli/__tests__/index.test.js`
- `node --test dist/cli/__tests__/launch-fallback.test.js`
- `git diff --check`

## Notes

- `npx biome check src/cli/index.ts src/cli/__tests__/index.test.ts src/cli/__tests__/launch-fallback.test.ts` reports existing file-wide formatting/import-order findings, so this PR avoids unrelated formatting churn.
- A full `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js` run still shows unrelated pre-existing failures in the mode-state cleanup and tmux extended-key lease suites; the madmax-focused suites pass.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
