### PR TITLE
fix: forward OMX_ROOT to tmux HUD panes

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -79,7 +79,7 @@ import { ensureReusableNodeModules } from "../../utils/repo-deps.js";
 import { readAllState } from "../../hud/state.js";
 import { generateOverlay } from "../../hooks/agents-overlay.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../../hud/constants.js";
-import { createHudWatchPane as createSharedHudWatchPane, listCurrentWindowHudPaneIds } from "../../hud/tmux.js";
+import { buildHudWatchCommand, createHudWatchPane as createSharedHudWatchPane, listCurrentWindowHudPaneIds } from "../../hud/tmux.js";
 import {
   DEFAULT_FRONTIER_MODEL,
   getTeamLowComplexityModel,
@@ -2596,6 +2596,15 @@ describe("tmux HUD pane helpers", () => {
       "node /repo/dist/cli/omx.js hud --watch",
     ]);
   });
+
+  it("buildHudWatchCommand forwards OMX_ROOT when set", () => {
+    const command = buildHudWatchCommand("/tmp/omx.js", undefined, "sess-1", {
+      OMX_ROOT: "/tmp/omx root",
+    });
+
+    assert.match(command, /OMX_SESSION_ID='sess-1'/);
+    assert.match(command, /OMX_ROOT='\/tmp\/omx root'/);
+  });
 });
 
 describe("detached tmux new-session sequencing", () => {
@@ -2845,11 +2854,11 @@ describe("detached tmux new-session sequencing", () => {
     assert.doesNotMatch(argsText, /fake-provider-key/);
   });
 
-  it("runCodex builds inside-tmux HUD command with OMX_SESSION_ID", async () => {
+  it("runCodex builds inside-tmux HUD command with session and OMX_ROOT env", async () => {
     const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
     assert.match(
       source,
-      /buildTmuxPaneCommand\("env",\s*\[\s*`OMX_SESSION_ID=\$\{sessionId\}`,\s*`\$\{OMX_TMUX_HUD_OWNER_ENV\}=1`,\s*"node",\s*omxBin,\s*"hud",\s*"--watch",?\s*\]\)/,
+      /buildTmuxPaneCommand\("env",\s*\[\s*`OMX_SESSION_ID=\$\{sessionId\}`,\s*`\$\{OMX_TMUX_HUD_OWNER_ENV\}=1`,\s*\.\.\.\(omxRootOverride \? \[`OMX_ROOT=\$\{omxRootOverride\}`\] : \[\]\),\s*"node",\s*omxBin,\s*"hud",\s*"--watch",?\s*\]\)/,
     );
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3798,9 +3798,18 @@ function runCodex(
   if (!omxBin) {
     throw new Error("Unable to resolve OMX launcher path for tmux HUD bootstrap");
   }
+  const omxRootOverride = resolveOmxRootForLaunch(cwd, process.env);
   const hudCmd = nativeWindows
     ? buildWindowsPromptCommand("node", [omxBin, "hud", "--watch"])
-    : buildTmuxPaneCommand("env", [`OMX_SESSION_ID=${sessionId}`, `${OMX_TMUX_HUD_OWNER_ENV}=1`, "node", omxBin, "hud", "--watch"]);
+    : buildTmuxPaneCommand("env", [
+      `OMX_SESSION_ID=${sessionId}`,
+      `${OMX_TMUX_HUD_OWNER_ENV}=1`,
+      ...(omxRootOverride ? [`OMX_ROOT=${omxRootOverride}`] : []),
+      "node",
+      omxBin,
+      "hud",
+      "--watch",
+    ]);
   const inheritLeaderFlags = process.env[TEAM_INHERIT_LEADER_FLAGS_ENV] !== "0";
   const workerLaunchArgs = resolveTeamWorkerLaunchArgsEnv(
     process.env[TEAM_WORKER_LAUNCH_ARGS_ENV],
@@ -3808,7 +3817,6 @@ function runCodex(
     inheritLeaderFlags,
     workerDefaultModel,
   );
-  const omxRootOverride = resolveOmxRootForLaunch(cwd, process.env);
   const codexBaseEnv = {
     ...process.env,
     ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -143,12 +143,21 @@ function buildHudResizeHookCommand(
   return `${resizeOrUnregister}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeOrUnregister}`;
 }
 
-export function buildHudWatchCommand(omxBin: string, preset?: string, sessionId?: string): string {
+export function buildHudWatchCommand(
+  omxBin: string,
+  preset?: string,
+  sessionId?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
   const safePreset = preset === 'minimal' || preset === 'focused' || preset === 'full'
     ? ` --preset=${preset}`
     : '';
   const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
-  const envPrefix = safeSessionId ? `env OMX_SESSION_ID=${shellEscapeSingle(safeSessionId)} ` : '';
+  const envPairs = [
+    ...(safeSessionId ? [`OMX_SESSION_ID=${shellEscapeSingle(safeSessionId)}`] : []),
+    ...(env.OMX_ROOT?.trim() ? [`OMX_ROOT=${shellEscapeSingle(env.OMX_ROOT.trim())}`] : []),
+  ];
+  const envPrefix = envPairs.length > 0 ? `env ${envPairs.join(' ')} ` : '';
   return `exec ${envPrefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
 }
 


### PR DESCRIPTION
## Summary

Fixes the boxed-state HUD split case: when `OMX_ROOT` is set, tmux HUD watch panes should read the same runtime root as the launched Codex process.

## Changes

- Forward `OMX_ROOT` into the inside-tmux HUD watch command.
- Teach `buildHudWatchCommand` to preserve `OMX_ROOT` for recreated HUD panes.
- Add focused regression coverage.

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/cli/__tests__/index.test.js dist/hud/__tests__/reconcile.test.js`
- [x] `npm run lint -- src/cli/index.ts src/hud/tmux.ts src/cli/__tests__/index.test.ts`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — not needed; behavior is covered by tests
- [x] Backward-compatibility impact considered

## Related

Closes #2440
