### PR TITLE
Forward OMX_ROOT to tmux HUD watch panes

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2845,11 +2845,15 @@ describe("detached tmux new-session sequencing", () => {
     assert.doesNotMatch(argsText, /fake-provider-key/);
   });
 
-  it("runCodex builds inside-tmux HUD command with OMX_SESSION_ID", async () => {
+  it("runCodex builds inside-tmux HUD command with OMX_SESSION_ID and OMX_ROOT when set", async () => {
     const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
     assert.match(
       source,
-      /buildTmuxPaneCommand\("env",\s*\[\s*`OMX_SESSION_ID=\$\{sessionId\}`,\s*`\$\{OMX_TMUX_HUD_OWNER_ENV\}=1`,\s*"node",\s*omxBin,\s*"hud",\s*"--watch",?\s*\]\)/,
+      /const hudEnvArgs = \[\s*`OMX_SESSION_ID=\$\{sessionId\}`,\s*`\$\{OMX_TMUX_HUD_OWNER_ENV\}=1`,\s*\.\.\.\(omxRootOverride \? \[`OMX_ROOT=\$\{omxRootOverride\}`\] : \[\]\),\s*\]/,
+    );
+    assert.match(
+      source,
+      /buildTmuxPaneCommand\("env",\s*\[\.\.\.hudEnvArgs,\s*"node",\s*omxBin,\s*"hud",\s*"--watch"\]\)/,
     );
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3798,9 +3798,15 @@ function runCodex(
   if (!omxBin) {
     throw new Error("Unable to resolve OMX launcher path for tmux HUD bootstrap");
   }
+  const omxRootOverride = resolveOmxRootForLaunch(cwd, process.env);
+  const hudEnvArgs = [
+    `OMX_SESSION_ID=${sessionId}`,
+    `${OMX_TMUX_HUD_OWNER_ENV}=1`,
+    ...(omxRootOverride ? [`OMX_ROOT=${omxRootOverride}`] : []),
+  ];
   const hudCmd = nativeWindows
     ? buildWindowsPromptCommand("node", [omxBin, "hud", "--watch"])
-    : buildTmuxPaneCommand("env", [`OMX_SESSION_ID=${sessionId}`, `${OMX_TMUX_HUD_OWNER_ENV}=1`, "node", omxBin, "hud", "--watch"]);
+    : buildTmuxPaneCommand("env", [...hudEnvArgs, "node", omxBin, "hud", "--watch"]);
   const inheritLeaderFlags = process.env[TEAM_INHERIT_LEADER_FLAGS_ENV] !== "0";
   const workerLaunchArgs = resolveTeamWorkerLaunchArgsEnv(
     process.env[TEAM_WORKER_LAUNCH_ARGS_ENV],
@@ -3808,7 +3814,6 @@ function runCodex(
     inheritLeaderFlags,
     workerDefaultModel,
   );
-  const omxRootOverride = resolveOmxRootForLaunch(cwd, process.env);
   const codexBaseEnv = {
     ...process.env,
     ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),

--- a/src/hud/__tests__/hud-tmux-injection.test.ts
+++ b/src/hud/__tests__/hud-tmux-injection.test.ts
@@ -11,6 +11,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { shellEscape, buildTmuxSplitArgs } from '../index.js';
 import { HUD_TMUX_HEIGHT_LINES } from '../constants.js';
+import { buildHudWatchCommand } from '../tmux.js';
 
 const runtimePrefix = shellEscape(process.execPath);
 
@@ -208,5 +209,47 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', 'focused', 'sess-managed');
     const cmd = args[6];
     assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=focused`);
+  });
+
+  it('forwards OMX_ROOT with OMX_SESSION_ID using shell-safe quoting', () => {
+    const args = buildTmuxSplitArgs(
+      '/home/user',
+      '/usr/bin/omx.js',
+      'focused',
+      'sess managed',
+      "/tmp/boxed root/it's/$(literal)",
+    );
+    const cmd = args[6];
+    assert.equal(
+      cmd,
+      `exec env OMX_SESSION_ID='sess managed' OMX_ROOT='/tmp/boxed root/it'\\''s/$(literal)' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=focused`,
+    );
+  });
+
+  it('omits OMX_ROOT when unset while preserving existing OMX_SESSION_ID behavior', () => {
+    const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', undefined, 'sess-managed');
+    const cmd = args[6];
+    assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
+    assert.doesNotMatch(cmd, /OMX_ROOT=/);
+  });
+});
+
+describe('buildHudWatchCommand', () => {
+  it('forwards OMX_ROOT for reconciled HUD panes with shell-safe quoting', () => {
+    const cmd = buildHudWatchCommand(
+      '/usr/bin/omx.js',
+      'minimal',
+      'sess managed',
+      "/tmp/boxed root/it's/$(literal)",
+    );
+    assert.equal(
+      cmd,
+      `exec env OMX_SESSION_ID='sess managed' OMX_ROOT='/tmp/boxed root/it'\\''s/$(literal)' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=minimal`,
+    );
+  });
+
+  it('does not add an env wrapper when OMX_SESSION_ID and OMX_ROOT are unset', () => {
+    const cmd = buildHudWatchCommand('/usr/bin/omx.js');
+    assert.equal(cmd, `exec ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
   });
 });

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -88,6 +88,36 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.doesNotMatch(created[0]?.cmd || '', /sess-stale/);
   });
 
+  it('forwards OMX_ROOT when recreating HUD with shell-safe quoting', async () => {
+    const created: Array<{ cmd: string }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: {
+        TMUX: '1',
+        TMUX_PANE: '%1',
+        OMX_SESSION_ID: 'sess boxed',
+        OMX_ROOT: "/tmp/boxed root/it's/$(literal)",
+        [OMX_TMUX_HUD_OWNER_ENV]: '1',
+      },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      createHudWatchPane: (_cwd, cmd) => {
+        created.push({ cmd });
+        return '%9';
+      },
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'recreated');
+    assert.equal(created.length, 1);
+    assert.match(
+      created[0]?.cmd || '',
+      /^exec env OMX_SESSION_ID='sess boxed' OMX_ROOT='\/tmp\/boxed root\/it'\\''s\/\$\(literal\)' '.*' '.*omx\.js' hud --watch/,
+    );
+  });
+
   it('targets the emitting pane window when listing and creating HUD panes', async () => {
     const listArgs: Array<string | undefined> = [];
     const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -262,12 +262,18 @@ export function buildTmuxSplitArgs(
   omxBin: string,
   preset?: string,
   sessionId?: string,
+  omxRoot?: string,
 ): string[] {
   // Defense-in-depth: keep preset constrained even if this helper is reused.
   const safePreset = parseHudPreset(preset);
   const presetArg = safePreset ? ` --preset=${safePreset}` : '';
   const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
-  const envPrefix = safeSessionId ? `env OMX_SESSION_ID=${shellEscape(safeSessionId)} ` : '';
+  const safeOmxRoot = typeof omxRoot === 'string' ? omxRoot : '';
+  const envAssignments = [
+    safeSessionId ? `OMX_SESSION_ID=${shellEscape(safeSessionId)}` : '',
+    safeOmxRoot.trim() ? `OMX_ROOT=${shellEscape(safeOmxRoot)}` : '',
+  ].filter(Boolean);
+  const envPrefix = envAssignments.length > 0 ? `env ${envAssignments.join(' ')} ` : '';
   const cmd = `exec ${envPrefix}${shellEscape(process.execPath)} ${shellEscape(omxBin)} hud --watch${presetArg}`;
   return ['split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES), '-c', cwd, cmd];
 }
@@ -284,7 +290,7 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
     console.error('Failed to resolve OMX launcher path for tmux HUD startup.');
     process.exit(1);
   }
-  const args = buildTmuxSplitArgs(cwd, omxBin, flags.preset, process.env.OMX_SESSION_ID);
+  const args = buildTmuxSplitArgs(cwd, omxBin, flags.preset, process.env.OMX_SESSION_ID, process.env.OMX_ROOT);
 
   try {
     // Split bottom pane, 4 lines tall, running omx hud --watch.

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -114,7 +114,7 @@ export async function reconcileHudForPromptSubmit(
   const hudConfig = await readHudConfigFn(cwd).catch(() => null);
   const preset = hudConfig?.preset;
   const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
-  const hudCmd = buildHudWatchCommand(omxBin, preset, resolvedSessionId);
+  const hudCmd = buildHudWatchCommand(omxBin, preset, resolvedSessionId, env.OMX_ROOT);
 
   if (hudPaneIds.length === 1) {
     const resized = resizePane(hudPaneIds[0], desiredHeight);

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -143,12 +143,29 @@ function buildHudResizeHookCommand(
   return `${resizeOrUnregister}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeOrUnregister}`;
 }
 
-export function buildHudWatchCommand(omxBin: string, preset?: string, sessionId?: string): string {
+function buildEnvPrefix(env: Record<string, string | undefined>): string {
+  const assignments = Object.entries(env)
+    .map(([key, value]) => [key, typeof value === 'string' ? value : ''] as const)
+    .filter(([, value]) => value.trim() !== '')
+    .map(([key, value]) => `${key}=${shellEscapeSingle(value)}`);
+  return assignments.length > 0 ? `env ${assignments.join(' ')} ` : '';
+}
+
+export function buildHudWatchCommand(
+  omxBin: string,
+  preset?: string,
+  sessionId?: string,
+  omxRoot?: string,
+): string {
   const safePreset = preset === 'minimal' || preset === 'focused' || preset === 'full'
     ? ` --preset=${preset}`
     : '';
   const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
-  const envPrefix = safeSessionId ? `env OMX_SESSION_ID=${shellEscapeSingle(safeSessionId)} ` : '';
+  const safeOmxRoot = typeof omxRoot === 'string' ? omxRoot : '';
+  const envPrefix = buildEnvPrefix({
+    OMX_SESSION_ID: safeSessionId,
+    OMX_ROOT: safeOmxRoot,
+  });
   return `exec ${envPrefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
 }
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -3837,6 +3837,49 @@ esac
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('restores standalone HUD panes with OMX_ROOT forwarded and shell-escaped', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-root-hud-'));
+    const previousOmxRoot = process.env.OMX_ROOT;
+
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-root-standalone-hud-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  split-window)
+    echo "%44"
+    exit 0
+    ;;
+  run-shell|select-pane|resize-pane|set-hook)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          process.env.OMX_ROOT = "/tmp/boxed root/it's/$(literal)";
+
+          const paneId = restoreStandaloneHudPane('%11', cwd);
+          assert.equal(paneId, '%44');
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(
+            tmuxLog,
+            /exec env OMX_TMUX_HUD_OWNER=1 OMX_ROOT='\/tmp\/boxed root\/it'\\''s\/\$\(literal\)' .*hud --watch/,
+          );
+        },
+      );
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('dismissTrustPromptIfPresent capture shape', () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -404,6 +404,16 @@ function shellQuoteSingle(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+function formatHudEnvAssignments(env: NodeJS.ProcessEnv = process.env): string {
+  const assignments = [
+    `${OMX_TMUX_HUD_OWNER_ENV}=1`,
+    ...(typeof env.OMX_ROOT === 'string' && env.OMX_ROOT.trim() !== ''
+      ? [`OMX_ROOT=${shellQuoteSingle(env.OMX_ROOT)}`]
+      : []),
+  ];
+  return assignments.join(' ');
+}
+
 function quotePowerShellArg(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
@@ -1267,7 +1277,7 @@ export function createTeamSession(
     let resizeHookName: string | null = null;
     let resizeHookTarget: string | null = null;
     if (canRecreateTeamHud && omxEntry) {
-      const hudCmd = `exec env ${OMX_TMUX_HUD_OWNER_ENV}=1 node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+      const hudCmd = `exec env ${formatHudEnvAssignments()} node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
       const hudCwd = translatePathForMsys(cwd);
       const hudResult = runTmux([
         'split-window', '-v', '-f', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', teamTarget, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,
@@ -1394,7 +1404,7 @@ export function restoreStandaloneHudPane(
   const omxEntry = resolveOmxCliEntryPath();
   if (!omxEntry || omxEntry.trim() === '') return null;
 
-  const hudCmd = `exec env ${OMX_TMUX_HUD_OWNER_ENV}=1 ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+  const hudCmd = `exec env ${formatHudEnvAssignments()} ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
   const hudCwd = translatePathForMsys(cwd);
   const hudResult = runTmux([
     'split-window',


### PR DESCRIPTION
## Summary
- Forward `OMX_ROOT` into tmux HUD watch commands when set, including direct HUD tmux launch, prompt-submit HUD reconciliation, inside-tmux launch bootstrap, and standalone/team HUD restore paths.
- Preserve existing behavior when `OMX_ROOT` is unset.
- Add focused regression coverage for command/env inclusion and shell-safe quoting/escaping.

Closes #2440.

## Validation
- `git diff --check`
- `npm run build`
- `node --test dist/hud/__tests__/hud-tmux-injection.test.js dist/hud/__tests__/reconcile.test.js`
- `node --test --test-name-pattern "runCodex builds inside-tmux HUD command with OMX_SESSION_ID and OMX_ROOT|restores standalone HUD panes with OMX_ROOT forwarded" dist/cli/__tests__/index.test.js dist/team/__tests__/tmux-session.test.js`
- `npm run lint`

Note: A broader ad-hoc run of full `dist/cli/__tests__/index.test.js` plus full `dist/team/__tests__/tmux-session.test.js` showed unrelated pre-existing failures in mode cleanup / tmux extended-keys lease tests, so final evidence is the focused HUD/tmux coverage above.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
