### PR TITLE
Suppress workflow keyword state in native subagents (review fixes)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -29,6 +29,7 @@ import { readAllState } from "../../hud/state.js";
 import { getLegacyWikiDir, serializePage, writePage } from "../../wiki/storage.js";
 import { WIKI_SCHEMA_VERSION } from "../../wiki/types.js";
 import { createUltragoalPlan, readUltragoalPlan } from "../../ultragoal/artifacts.js";
+import { getBaseStateDir } from "../../state/paths.js";
 
 function nativeHookScriptPath(): string {
   return join(process.cwd(), "dist", "scripts", "codex-native-hook.js");
@@ -11507,9 +11508,17 @@ describe("codex native hook triage integration", () => {
 
   it("does not activate workflow state for native subagent prompts even when canonical id is the child session", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-subagent-keyword-"));
+    const boxedRoot = await mkdtemp(join(tmpdir(), "omx-native-subagent-keyword-boxed-"));
+    const originalOmxRoot = process.env.OMX_ROOT;
+    const originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const originalTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
     try {
-      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
-      await writeJson(join(cwd, ".omx", "state", "subagent-tracking.json"), {
+      process.env.OMX_ROOT = boxedRoot;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      const boxedStateDir = getBaseStateDir(cwd);
+      await mkdir(boxedStateDir, { recursive: true });
+      await writeJson(join(boxedStateDir, "subagent-tracking.json"), {
         schemaVersion: 1,
         sessions: {
           "omx-parent-session": {
@@ -11557,15 +11566,27 @@ describe("codex native hook triage integration", () => {
       );
       assert.equal(additionalContext, "");
       assert.equal(
-        existsSync(join(cwd, ".omx", "state", "sessions", "child-native-session", "skill-active-state.json")),
+        existsSync(join(boxedStateDir, "sessions", "child-native-session", "skill-active-state.json")),
         false,
       );
       assert.equal(
-        existsSync(join(cwd, ".omx", "state", "sessions", "child-native-session", "autopilot-state.json")),
+        existsSync(join(boxedStateDir, "sessions", "child-native-session", "autopilot-state.json")),
         false,
       );
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "subagent-tracking.json")),
+        false,
+        "subagent tracking must not leak into the source worktree when OMX_ROOT is boxed",
+      );
     } finally {
+      if (originalOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = originalOmxRoot;
+      if (originalOmxStateRoot === undefined) delete process.env.OMX_STATE_ROOT;
+      else process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+      if (originalTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+      else process.env.OMX_TEAM_STATE_ROOT = originalTeamStateRoot;
       await rm(cwd, { recursive: true, force: true });
+      await rm(boxedRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -11504,6 +11504,71 @@ describe("codex native hook triage integration", () => {
     }
   });
 
+
+  it("does not activate workflow state for native subagent prompts even when canonical id is the child session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-subagent-keyword-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeJson(join(cwd, ".omx", "state", "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          "omx-parent-session": {
+            session_id: "omx-parent-session",
+            leader_thread_id: "parent-native-thread",
+            updated_at: "2026-05-21T19:04:40.000Z",
+            threads: {
+              "parent-native-thread": {
+                thread_id: "parent-native-thread",
+                kind: "leader",
+                first_seen_at: "2026-05-21T19:04:40.000Z",
+                last_seen_at: "2026-05-21T19:04:40.000Z",
+                turn_count: 1,
+              },
+              "child-native-session": {
+                thread_id: "child-native-session",
+                kind: "subagent",
+                first_seen_at: "2026-05-21T19:04:41.000Z",
+                last_seen_at: "2026-05-21T19:04:41.000Z",
+                turn_count: 1,
+                mode: "review",
+              },
+            },
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "child-native-session",
+          thread_id: "child-native-session",
+          turn_id: "turn-subagent-review",
+          prompt: [
+            "Read-only review only. Do not edit files. Do not inspect/mutate OMX state/hooks.",
+            "Context: The user asked for $autopilot, and this subagent must only review the patch.",
+          ].join("\n\n"),
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.equal(additionalContext, "");
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "sessions", "child-native-session", "skill-active-state.json")),
+        false,
+      );
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "sessions", "child-native-session", "autopilot-state.json")),
+        false,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not inject triage advisory for autopilot keyword prompts", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-triage-keyword-autopilot-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -14,6 +14,7 @@ import {
 } from "../state/skill-active.js";
 import {
   readSubagentSessionSummary,
+  readSubagentTrackingState,
   recordSubagentTurnForSession,
 } from "../subagents/tracker.js";
 import { resolveCanonicalTeamStateRoot, resolveWorkerNotifyTeamStateRootPath } from "../team/state-root.js";
@@ -297,18 +298,32 @@ async function isNativeSubagentHook(
   nativeSessionId: string,
   threadId: string,
 ): Promise<boolean> {
-  const sessionId = canonicalSessionId.trim();
-  if (!sessionId) return false;
-
-  const summary = await readSubagentSessionSummary(cwd, sessionId).catch(() => null);
-  if (!summary) return false;
-
   const candidateIds = [nativeSessionId, threadId]
     .map((value) => value.trim())
     .filter(Boolean);
   if (candidateIds.length === 0) return false;
 
-  return candidateIds.some((id) => summary.allSubagentThreadIds.includes(id));
+  const sessionId = canonicalSessionId.trim();
+  if (sessionId) {
+    const summary = await readSubagentSessionSummary(cwd, sessionId).catch(() => null);
+    if (summary && candidateIds.some((id) => summary.allSubagentThreadIds.includes(id))) {
+      return true;
+    }
+  }
+
+  // Native Codex resume can report the child native session as the canonical
+  // session id before OMX reconciles it back to the owning session.  In that
+  // window the per-session summary lookup above misses the child and a
+  // subagent UserPromptSubmit can accidentally activate workflow keywords from
+  // quoted review context.  Fall back to the global tracking index so any known
+  // subagent thread is treated as subagent-scoped, regardless of the current
+  // hook payload's session-id mapping.
+  const trackingState = await readSubagentTrackingState(cwd).catch(() => null);
+  if (!trackingState) return false;
+
+  return Object.values(trackingState.sessions).some((session) => (
+    candidateIds.some((id) => session.threads[id]?.kind === "subagent")
+  ));
 }
 
 function shouldSuppressSubagentLifecycleHookDispatch(): boolean {

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { getBaseStateDir } from '../state/paths.js';
 
 export const SUBAGENT_TRACKING_SCHEMA_VERSION = 1;
 export const DEFAULT_SUBAGENT_ACTIVE_WINDOW_MS = 120_000;
@@ -45,7 +46,7 @@ export interface SubagentSessionSummary {
 }
 
 export function subagentTrackingPath(cwd: string): string {
-  return join(cwd, '.omx', 'state', 'subagent-tracking.json');
+  return join(getBaseStateDir(cwd), 'subagent-tracking.json');
 }
 
 export function createSubagentTrackingState(): SubagentTrackingState {
@@ -130,7 +131,7 @@ export async function readSubagentTrackingState(cwd: string): Promise<SubagentTr
 export async function writeSubagentTrackingState(cwd: string, state: SubagentTrackingState): Promise<string> {
   const normalized = normalizeSubagentTrackingState(state);
   const path = subagentTrackingPath(cwd);
-  await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+  await mkdir(dirname(path), { recursive: true });
   await writeFile(path, `${JSON.stringify(normalized, null, 2)}\n`);
   return path;
 }


### PR DESCRIPTION
Supersedes closed PR #2446. Fixes #2445.

## Summary
- Suppress workflow keyword activation/additional context for native subagent `UserPromptSubmit` paths, including parent-keyed tracking fallback when canonical session id drift points at a child native session.
- Store/read `subagent-tracking.json` via canonical `getBaseStateDir(cwd)` instead of hardcoded `cwd/.omx/state`.
- Honor boxed state roots (`OMX_TEAM_STATE_ROOT`, `OMX_ROOT`, `OMX_STATE_ROOT`) and avoid source-worktree state leaks.

## Review fixes included
- `subagentTrackingPath(cwd)` resolves under canonical boxed state root.
- `writeSubagentTrackingState()` creates the resolved tracking-file directory.
- Regression proves contextual quoted `$autopilot` in native child prompt is suppressed while tracking lives under boxed state and no `cwd/.omx/state/subagent-tracking.json` is created.

## Verification
- `npm run build`
- explicit boxed tracker runtime probe (`recordSubagentTurnForSession` + `readSubagentSessionSummary`)
- `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/keyword-detector.test.js`
- boxed `OMX_ROOT=/tmp/omx-pr2446-boxed-root OMX_STATE_ROOT=/tmp/omx-pr2446-boxed-state-root ...` focused tests
- focused lint on changed TS/test files
- `git diff --check`
