### PR TITLE
docs: align ralplan example with Ultragoal default

### DIFF
--- a/plugins/oh-my-codex/skills/ralplan/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralplan/SKILL.md
@@ -150,9 +150,10 @@ The gate auto-passes when it detects **any** concrete signal. You do not need al
    - **Architect** reviews for soundness
    - **Critic** validates quality and testability
 5. On consensus approval, user chooses execution path:
-   - **ralph**: sequential execution with verification
-   - **team**: parallel coordinated agents
-6. Execution begins with a clear, bounded plan
+   - **ultragoal**: default durable goal execution with sequential Codex goals and ledger checkpoints
+   - **team**: parallel coordinated agents for stories that need multiple lanes
+   - **ralph**: explicit fallback for a single-owner completion loop when durable goal tracking is not needed
+6. Execution begins with a clear, bounded plan and the default handoff follows `$deep-interview` -> `$ralplan` -> `$ultragoal`
 
 ### Troubleshooting
 

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -150,9 +150,10 @@ The gate auto-passes when it detects **any** concrete signal. You do not need al
    - **Architect** reviews for soundness
    - **Critic** validates quality and testability
 5. On consensus approval, user chooses execution path:
-   - **ralph**: sequential execution with verification
-   - **team**: parallel coordinated agents
-6. Execution begins with a clear, bounded plan
+   - **ultragoal**: default durable goal execution with sequential Codex goals and ledger checkpoints
+   - **team**: parallel coordinated agents for stories that need multiple lanes
+   - **ralph**: explicit fallback for a single-owner completion loop when durable goal tracking is not needed
+6. Execution begins with a clear, bounded plan and the default handoff follows `$deep-interview` -> `$ralplan` -> `$ultragoal`
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Summary
- updates the ralplan end-to-end example to list `$ultragoal` as the default durable execution handoff after consensus approval
- keeps `$team` as the parallel execution option and `$ralph` as an explicit fallback only
- mirrors the same wording into the Codex plugin skill bundle

Closes #2453

## Self-test
- `npm run build`
- `npm run sync:plugin:check`
- Python content assertions confirmed README keeps `$deep-interview` -> `$ralplan` -> `$ultragoal`, both ralplan skill copies include `ultragoal` as default, and the stale `ralph: sequential execution with verification` recommendation is absent
- Added-line static scan: no secret/injection/eval/deserialization/SQL findings
- Independent review: passed; no security concerns or logic errors
