### PR TITLE
Bound notify dispatcher turn-ended storms

### DIFF
--- a/src/scripts/__tests__/notify-dispatcher.test.ts
+++ b/src/scripts/__tests__/notify-dispatcher.test.ts
@@ -6,15 +6,76 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
-function runDispatcher(metadataPath: string): void {
+function runDispatcher(metadataPath: string, payload: Record<string, unknown> = { type: "test" }): void {
 	const dispatcherScript = join(process.cwd(), "dist", "scripts", "notify-dispatcher.js");
 	const result = spawnSync(
 		process.execPath,
-		[dispatcherScript, "--metadata", metadataPath, JSON.stringify({ type: "test" })],
+		[dispatcherScript, "--metadata", metadataPath, JSON.stringify(payload)],
 		{ encoding: "utf-8", windowsHide: true },
 	);
 	assert.equal(result.status, 0, result.stderr || result.stdout);
 }
+
+describe("notify dispatcher turn-ended storm guard", () => {
+	it("coalesces rapid turn-ended dispatcher callbacks to one OMX notify run", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-rapid-"));
+		try {
+			const omxMarker = join(wd, "omx-ran");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(omxHook, `import { appendFileSync } from "node:fs"; appendFileSync(${JSON.stringify(omxMarker)}, "omx|");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(metadataPath, JSON.stringify({ managedBy: "oh-my-codex", version: 1, omxNotify: [process.execPath, omxHook] }));
+
+			for (let index = 0; index < 10; index += 1) {
+				runDispatcher(metadataPath, { type: "agent-turn-complete", thread_id: "desktop-thread", turn_id: `queued-${index}` });
+			}
+
+			assert.equal(readFileSync(omxMarker, "utf-8"), "omx|");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("drops stale turn-ended dispatcher callbacks before spawning notify hooks", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-stale-event-"));
+		try {
+			const omxMarker = join(wd, "omx-ran");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(omxHook, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(omxMarker)}, "ran");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(metadataPath, JSON.stringify({ managedBy: "oh-my-codex", version: 1, omxNotify: [process.execPath, omxHook] }));
+
+			runDispatcher(metadataPath, {
+				type: "agent-turn-complete",
+				timestamp: new Date(Date.now() - 10 * 60_000).toISOString(),
+				thread_id: "desktop-thread",
+				turn_id: "stale-turn",
+			});
+
+			assert.equal(existsSync(omxMarker), false);
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves normal non-turn notify dispatches", () => {
+		const wd = mkdtempSync(join(tmpdir(), "omx-notify-dispatcher-normal-"));
+		try {
+			const omxMarker = join(wd, "omx-ran");
+			const omxHook = join(wd, "current-notify-hook.js");
+			writeFileSync(omxHook, `import { appendFileSync } from "node:fs"; appendFileSync(${JSON.stringify(omxMarker)}, "omx|");\n`);
+			const metadataPath = join(wd, "notify-dispatch.json");
+			writeFileSync(metadataPath, JSON.stringify({ managedBy: "oh-my-codex", version: 1, omxNotify: [process.execPath, omxHook] }));
+
+			runDispatcher(metadataPath, { type: "test", id: 1 });
+			runDispatcher(metadataPath, { type: "test", id: 2 });
+
+			assert.equal(readFileSync(omxMarker, "utf-8"), "omx|omx|");
+		} finally {
+			rmSync(wd, { recursive: true, force: true });
+		}
+	});
+});
 
 describe("notify dispatcher previousNotify guard", () => {
 	it("skips stale OMX-managed previousNotify dispatcher entries", () => {

--- a/src/scripts/notify-dispatcher.ts
+++ b/src/scripts/notify-dispatcher.ts
@@ -7,6 +7,9 @@
 
 import { readFile } from "fs/promises";
 import { spawnSync } from "child_process";
+import { closeSync, mkdirSync, openSync, readFileSync, statSync, unlinkSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { tmpdir } from "os";
 
 interface NotifyDispatcherMetadata {
 	managedBy?: string;
@@ -14,6 +17,124 @@ interface NotifyDispatcherMetadata {
 	previousNotify?: string[] | null;
 	omxNotify?: string[];
 	dispatcherNotify?: string[];
+}
+
+const DISPATCH_LOCK_STALE_MS = 45_000;
+const DEFAULT_TURN_DISPATCH_MIN_INTERVAL_MS = 1_000;
+const DEFAULT_STALE_EVENT_AGE_MS = 5 * 60_000;
+
+interface DispatchGuard {
+	ok: boolean;
+	release?: () => void;
+}
+
+function parseNonNegativeEnvMs(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (typeof raw !== "string" || raw.trim() === "") return fallback;
+	const parsed = Number(raw);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function parsePayloadObject(payloadArg: string): Record<string, unknown> | null {
+	try {
+		const parsed = JSON.parse(payloadArg) as unknown;
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function isTurnEndedPayload(payload: Record<string, unknown> | null): boolean {
+	if (!payload) return false;
+	const type = String(payload.type ?? payload.event ?? payload.hook_event_name ?? "")
+		.trim()
+		.toLowerCase();
+	return type === ""
+		|| type === "agent-turn-complete"
+		|| type === "turn-complete"
+		|| type === "turn-ended";
+}
+
+function readPayloadTimestampMs(payload: Record<string, unknown>): number | null {
+	for (const key of ["timestamp", "created_at", "createdAt", "event_time", "eventTime", "time"]) {
+		const value = payload[key];
+		if (typeof value === "number" && Number.isFinite(value)) {
+			return value > 1_000_000_000_000 ? value : value * 1000;
+		}
+		if (typeof value === "string" && value.trim()) {
+			const parsed = Date.parse(value);
+			if (Number.isFinite(parsed)) return parsed;
+		}
+	}
+	return null;
+}
+
+function dispatchGuardDir(metadataPath: string): string {
+	if (metadataPath) return dirname(metadataPath);
+	return join(tmpdir(), "oh-my-codex-notify-dispatch");
+}
+
+function acquireTurnDispatchGuard(metadataPath: string, payloadArg: string): DispatchGuard {
+	const payload = parsePayloadObject(payloadArg);
+	if (!isTurnEndedPayload(payload)) return { ok: true };
+
+	const now = Date.now();
+	const staleEventAgeMs = parseNonNegativeEnvMs("OMX_NOTIFY_DISPATCH_STALE_EVENT_AGE_MS", DEFAULT_STALE_EVENT_AGE_MS);
+	const eventTimestampMs = payload ? readPayloadTimestampMs(payload) : null;
+	if (eventTimestampMs !== null && staleEventAgeMs > 0 && now - eventTimestampMs > staleEventAgeMs) {
+		return { ok: false };
+	}
+
+	const dir = dispatchGuardDir(metadataPath);
+	mkdirSync(dir, { recursive: true });
+	const lockPath = join(dir, "notify-dispatch.lock");
+	const statePath = join(dir, "notify-dispatch.guard.json");
+	try {
+		const lockStat = statSync(lockPath);
+		if (now - lockStat.mtimeMs > DISPATCH_LOCK_STALE_MS) unlinkSync(lockPath);
+	} catch {
+		// Missing or unreadable lock: try to acquire below.
+	}
+
+	let fd: number;
+	try {
+		fd = openSync(lockPath, "wx");
+		writeFileSync(fd, String(process.pid));
+		closeSync(fd);
+	} catch {
+		return { ok: false };
+	}
+
+	const release = () => {
+		try {
+			unlinkSync(lockPath);
+		} catch {
+			// Best effort.
+		}
+	};
+
+	try {
+		const minIntervalMs = parseNonNegativeEnvMs("OMX_NOTIFY_DISPATCH_MIN_INTERVAL_MS", DEFAULT_TURN_DISPATCH_MIN_INTERVAL_MS);
+		if (minIntervalMs > 0) {
+			try {
+				const parsed = JSON.parse(readFileSync(statePath, "utf-8")) as { lastDispatchAt?: unknown };
+				const lastDispatchAt = typeof parsed.lastDispatchAt === "number" ? parsed.lastDispatchAt : 0;
+				if (lastDispatchAt > 0 && now - lastDispatchAt < minIntervalMs) {
+					release();
+					return { ok: false };
+				}
+			} catch {
+				// No prior guard state.
+			}
+		}
+		writeFileSync(statePath, JSON.stringify({ lastDispatchAt: now, pid: process.pid }));
+		return { ok: true, release };
+	} catch {
+		release();
+		return { ok: false };
+	}
 }
 
 function parseArgs(): { metadataPath: string; payloadArg: string } {
@@ -200,11 +321,17 @@ function runNotify(
 async function main(): Promise<void> {
 	const { metadataPath, payloadArg } = parseArgs();
 	if (!payloadArg || payloadArg.startsWith("-")) return;
-	const metadata = await readMetadata(metadataPath);
-	if (!isManagedPreviousNotify(metadata?.previousNotify, metadata)) {
-		runNotify(metadata?.previousNotify, payloadArg);
+	const guard = acquireTurnDispatchGuard(metadataPath, payloadArg);
+	if (!guard.ok) return;
+	try {
+		const metadata = await readMetadata(metadataPath);
+		if (!isManagedPreviousNotify(metadata?.previousNotify, metadata)) {
+			runNotify(metadata?.previousNotify, payloadArg);
+		}
+		runNotify(metadata?.omxNotify, payloadArg);
+	} finally {
+		guard.release?.();
 	}
-	runNotify(metadata?.omxNotify, payloadArg);
 }
 
 main().catch(() => {});


### PR DESCRIPTION
Closes #2456.

## Summary
- Added dispatcher-side turn-ended guardrails before spawning previous/OMX notify commands.
- Coalesces rapid queued `agent-turn-complete` / `turn-complete` / `turn-ended` callbacks with a metadata-scoped lock + short dispatch interval.
- Drops stale timestamped turn-ended payloads before spawning notify hooks.
- Leaves normal non-turn notify dispatches unchanged.

## Evidence
- `npm run build` ✅
- `node --test dist/scripts/__tests__/notify-dispatcher.test.js` ✅
- `npm run lint` ✅
- `npm run check:no-unused` ✅
- `node --test dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/setup-install-mode.test.js dist/cli/__tests__/uninstall.test.js` ✅
- `npm audit --audit-level=high` ✅ (reports existing moderate `brace-expansion`, no high/critical)

## Notes
- Independently verified the runtime path in `src/scripts/notify-dispatcher.ts`; the fix does not rely on the external reporter’s suggested implementation.
- No docs/changelog update needed for this narrow runtime guard.
- Not tested live against Codex Desktop shutdown on macOS.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
