### PR TITLE
Fix omx-runtime packaging and update smoke

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "omx": "dist/cli/omx.js"
+    "omx": "dist/cli/omx.js",
+    "omx-runtime": "dist/cli/omx-runtime.js"
   },
   "scripts": {
-    "build": "node -e \"const fs=require('fs'); fs.rmSync('dist',{recursive:true,force:true});\" && tsc && node -e \"require('fs').chmodSync('dist/cli/omx.js', 0o755)\"",
+    "build": "node -e \"const fs=require('fs'); fs.rmSync('dist',{recursive:true,force:true});\" && tsc && node -e \"const fs=require('fs'); fs.chmodSync('dist/cli/omx.js', 0o755); fs.chmodSync('dist/cli/omx-runtime.js', 0o755)\"",
     "build:explore": "cargo build -p omx-explore-harness",
     "build:full": "npm run build && npm run build:explore:release && npm run build:sparkshell && npm run build:api",
     "build:explore:release": "node dist/scripts/build-explore-harness.js",

--- a/src/cli/__tests__/doctor-team.test.ts
+++ b/src/cli/__tests__/doctor-team.test.ts
@@ -17,7 +17,7 @@ function runOmx(
   const r = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',
-    env: { ...process.env, ...envOverrides },
+    env: { ...process.env, OMX_RUNTIME_BRIDGE: '0', ...envOverrides },
   });
   return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error?.message };
 }
@@ -36,6 +36,23 @@ async function createFakeTmuxBin(wd: string, script: string): Promise<string> {
 }
 
 describe('omx doctor --team', () => {
+  it('fails when the runtime bridge is enabled but omx-runtime is missing', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-team-runtime-'));
+    try {
+      const res = runOmx(wd, ['doctor', '--team'], {
+        OMX_RUNTIME_BRIDGE: '1',
+        OMX_RUNTIME_BINARY: join(wd, 'missing-omx-runtime'),
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 1, res.stderr || res.stdout);
+      assert.match(res.stdout, /runtime_binary_unavailable/);
+      assert.match(res.stdout, /omx-runtime schema probe failed/);
+      assert.match(res.stdout, /omx update/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('exits non-zero and prints resume_blocker when team state references missing tmux session', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-team-'));
     try {

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -25,7 +25,7 @@ type NpmPackDryRunResult = {
 };
 
 describe('package bin contract', () => {
-  it('declares omx with an explicit relative bin path and avoids packaging platform-specific native binaries', () => {
+  it('declares omx and omx-runtime with explicit relative bin paths and avoids packaging platform-specific native binaries', () => {
     const packageJsonPath = join(process.cwd(), 'package.json');
     const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
     const binaryName = platform() === 'win32' ? 'omx-sparkshell.exe' : 'omx-sparkshell';
@@ -37,7 +37,10 @@ describe('package bin contract', () => {
       binaryName,
     );
 
-    assert.deepEqual(pkg.bin, { omx: 'dist/cli/omx.js' });
+    assert.deepEqual(pkg.bin, {
+      omx: 'dist/cli/omx.js',
+      'omx-runtime': 'dist/cli/omx-runtime.js',
+    });
     assert.equal(pkg.scripts?.['build:explore'], 'cargo build -p omx-explore-harness');
     assert.equal(pkg.scripts?.['build:explore:release'], 'node dist/scripts/build-explore-harness.js');
     assert.equal(pkg.scripts?.['build:full'], 'npm run build && npm run build:explore:release && npm run build:sparkshell && npm run build:api');
@@ -98,11 +101,15 @@ describe('package bin contract', () => {
     assert.ok(pkg.files?.includes('.agents/plugins/marketplace.json'));
 
     const binPath = join(process.cwd(), 'dist', 'cli', 'omx.js');
+    const runtimeBinPath = join(process.cwd(), 'dist', 'cli', 'omx-runtime.js');
     const compiledCliPath = join(process.cwd(), 'dist', 'cli', 'index.js');
 
     const binSource = readFileSync(binPath, 'utf-8');
+    const runtimeBinSource = readFileSync(runtimeBinPath, 'utf-8');
     const compiledCliSource = readFileSync(compiledCliPath, 'utf-8');
     assert.match(binSource, /^#!\/usr\/bin\/env node/);
+    assert.match(runtimeBinSource, /^#!\/usr\/bin\/env node/);
+    assert.match(runtimeBinSource, /hydrateNativeBinary\(PRODUCT/);
     const mcpInitialize = JSON.stringify({
       jsonrpc: '2.0',
       id: 1,
@@ -162,6 +169,8 @@ describe('package bin contract', () => {
 
     const binEntry = results[0]?.files?.find((file) => file.path === 'dist/cli/omx.js');
     assert.ok(binEntry, 'expected npm pack output to include dist/cli/omx.js');
+    const runtimeBinEntry = results[0]?.files?.find((file) => file.path === 'dist/cli/omx-runtime.js');
+    assert.ok(runtimeBinEntry, 'expected npm pack output to include dist/cli/omx-runtime.js');
 
     const packagedHarnessPath = process.platform === 'win32' ? 'bin/omx-explore-harness.exe' : 'bin/omx-explore-harness';
     const packagedHarnessEntry = results[0]?.files?.find((file) => file.path === packagedHarnessPath);

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -454,6 +454,7 @@ describe('runImmediateUpdate', () => {
     const refreshCwds: string[] = [];
     let updateCalls = 0;
     let latestCalls = 0;
+    let runtimeSmokeCalls = 0;
 
     console.log = (...args: unknown[]) => {
       logs.push(args.map((arg) => String(arg)).join(' '));
@@ -483,15 +484,20 @@ describe('runImmediateUpdate', () => {
           refreshCwds.push(refreshCwd);
           return { ok: true, stderr: '' };
         },
+        runPostUpdateRuntimeSmoke: async () => {
+          runtimeSmokeCalls += 1;
+          return { ok: true, stderr: '' };
+        },
       });
 
       assert.equal(result.status, 'updated');
       assert.equal(latestCalls, 1);
       assert.equal(updateCalls, 1);
       assert.equal(setupCalls, 1);
+      assert.equal(runtimeSmokeCalls, 1);
       assert.deepEqual(refreshCwds, [cwd]);
       assert.match(logs.join('\n'), /Running: npm install -g oh-my-codex@latest/);
-      assert.match(logs.join('\n'), /Updated to v0\.14\.1/);
+      assert.match(logs.join('\n'), /Updated to v0\.14\.1; runtime smoke passed/);
 
       const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
         installed_version: string;
@@ -569,6 +575,7 @@ describe('runImmediateUpdate', () => {
     const originalLog = console.log;
     const logs: string[] = [];
     let refreshCalls = 0;
+    let runtimeSmokeCalls = 0;
 
     console.log = (...args: unknown[]) => {
       logs.push(args.map((arg) => String(arg)).join(' '));
@@ -595,12 +602,17 @@ describe('runImmediateUpdate', () => {
           refreshCalls += 1;
           return { ok: true, stderr: '' };
         },
+        runPostUpdateRuntimeSmoke: async () => {
+          runtimeSmokeCalls += 1;
+          return { ok: true, stderr: '' };
+        },
       });
 
       assert.equal(result.status, 'up-to-date');
       assert.equal(refreshCalls, 1);
+      assert.equal(runtimeSmokeCalls, 1);
       assert.match(logs.join('\n'), /Running setup refresh/);
-      assert.match(logs.join('\n'), /Setup refresh completed for v0\.14\.0/);
+      assert.match(logs.join('\n'), /Setup refresh and runtime smoke completed for v0\.14\.0/);
 
       const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
         installed_version: string;
@@ -625,6 +637,7 @@ describe('runImmediateUpdate', () => {
     const logs: string[] = [];
     let updateCalls = 0;
     let refreshCalls = 0;
+    let runtimeSmokeCalls = 0;
 
     console.log = (...args: unknown[]) => {
       logs.push(args.map((arg) => String(arg)).join(' '));
@@ -645,12 +658,17 @@ describe('runImmediateUpdate', () => {
           refreshCalls += 1;
           return { ok: true, stderr: '' };
         },
+        runPostUpdateRuntimeSmoke: async () => {
+          runtimeSmokeCalls += 1;
+          return { ok: true, stderr: '' };
+        },
       });
 
       assert.equal(result.status, 'updated');
       assert.equal(updateCalls, 1);
       assert.equal(refreshCalls, 1);
-      assert.match(logs.join('\n'), /Updated to v0\.14\.1/);
+      assert.equal(runtimeSmokeCalls, 1);
+      assert.match(logs.join('\n'), /Updated to v0\.14\.1; runtime smoke passed/);
     } finally {
       console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
@@ -685,6 +703,46 @@ describe('runImmediateUpdate', () => {
       assert.equal(result.status, 'failed');
       assert.equal(refreshCalls, 1);
       assert.match(logs.join('\n'), /Update installed, but the setup refresh failed/);
+      await assert.rejects(readFile(stampPath, 'utf-8'));
+    } finally {
+      console.log = originalLog;
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails without writing the success stamp when the post-update runtime smoke fails', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
+    const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
+    const originalCodexHome = process.env.CODEX_HOME;
+    const originalLog = console.log;
+    const logs: string[] = [];
+
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+
+    process.env.CODEX_HOME = join(cwd, '.codex');
+
+    try {
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.14.0',
+        fetchLatestVersion: async () => '0.14.1',
+        runGlobalUpdate: () => ({ ok: true, stderr: '' }),
+        runSetupRefresh: async () => ({ ok: true, stderr: '' }),
+        runPostUpdateRuntimeSmoke: async () => ({
+          ok: false,
+          stderr: 'omx-runtime schema --json: spawn omx-runtime ENOENT',
+        }),
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.match(logs.join('\n'), /runtime smoke check failed/);
+      assert.match(logs.join('\n'), /omx-runtime schema --json/);
       await assert.rejects(readFile(stampPath, 'utf-8'));
     } finally {
       console.log = originalLog;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -298,7 +298,8 @@ interface TeamDoctorIssue {
 		| "orphan_tmux_session"
 		| "resume_blocker"
 		| "prompt_resume_unavailable"
-		| "stale_leader";
+		| "stale_leader"
+		| "runtime_binary_unavailable";
 	message: string;
 	severity: "warn" | "fail";
 }
@@ -344,23 +345,60 @@ async function collectTeamDoctorIssues(
 	// and authority as the semantic truth source for runtime health.
 	if (isBridgeEnabled()) {
 		const bridge = getDefaultBridge(stateDir);
-		const readiness = bridge.readReadiness();
-		const authority = bridge.readAuthority();
-		if (readiness && !readiness.ready) {
-			for (const reason of readiness.reasons) {
+		const runtimeProbe = spawnSync(bridge.getBinaryPath(), ["schema", "--json"], {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+			timeout: 10_000,
+			windowsHide: true,
+		});
+		if (runtimeProbe.error || runtimeProbe.status !== 0) {
+			const detail =
+				runtimeProbe.error?.message ??
+				(runtimeProbe.stderr || "").trim() ??
+				`exit ${runtimeProbe.status}`;
+			issues.push({
+				code: "runtime_binary_unavailable",
+				message: `omx-runtime schema probe failed (${detail || "unknown error"}). Run \`omx update\` or set OMX_RUNTIME_BINARY to a compatible runtime.`,
+				severity: "fail",
+			});
+		} else {
+			try {
+				const schema = JSON.parse(runtimeProbe.stdout || "{}") as { commands?: unknown };
+				if (!Array.isArray(schema.commands) || !schema.commands.includes("queue-dispatch")) {
+					issues.push({
+						code: "runtime_binary_unavailable",
+						message: "omx-runtime schema is missing queue-dispatch; update oh-my-codex or set OMX_RUNTIME_BINARY to a compatible runtime.",
+						severity: "fail",
+					});
+				}
+			} catch {
 				issues.push({
-					code: "resume_blocker",
-					message: `runtime not ready: ${reason}`,
+					code: "runtime_binary_unavailable",
+					message: "omx-runtime schema probe returned non-JSON output; update oh-my-codex or set OMX_RUNTIME_BINARY to a compatible runtime.",
 					severity: "fail",
 				});
 			}
 		}
-		if (authority?.stale) {
-			issues.push({
-				code: "stale_leader",
-				message: `authority stale (owner: ${authority.owner ?? "unknown"}): ${authority.stale_reason ?? "unknown reason"}`,
-				severity: "fail",
-			});
+
+		if (!issues.some((issue) => issue.code === "runtime_binary_unavailable")) {
+			const readiness = bridge.readReadiness();
+			const authority = bridge.readAuthority();
+			if (readiness && !readiness.ready) {
+				for (const reason of readiness.reasons) {
+					issues.push({
+						code: "resume_blocker",
+						message: `runtime not ready: ${reason}`,
+						severity: "fail",
+					});
+				}
+			}
+			if (authority?.stale) {
+				issues.push({
+					code: "stale_leader",
+					message: `authority stale (owner: ${authority.owner ?? "unknown"}): ${authority.stale_reason ?? "unknown reason"}`,
+					severity: "fail",
+				});
+			}
 		}
 	}
 

--- a/src/cli/native-assets.ts
+++ b/src/cli/native-assets.ts
@@ -8,7 +8,7 @@ import { Readable } from 'node:stream';
 import { spawnPlatformCommandSync } from '../utils/platform-command.js';
 import { getPackageRoot } from '../utils/package.js';
 
-export type NativeProduct = 'omx-explore-harness' | 'omx-sparkshell' | 'omx-api';
+export type NativeProduct = 'omx-explore-harness' | 'omx-sparkshell' | 'omx-api' | 'omx-runtime';
 export type NativeLibc = 'musl' | 'glibc';
 
 export interface NativeReleaseAsset {

--- a/src/cli/omx-runtime.ts
+++ b/src/cli/omx-runtime.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import { existsSync, realpathSync } from 'node:fs';
+import { arch, platform } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import {
+  getPackageVersion,
+  hydrateNativeBinary,
+  resolveCachedNativeBinaryCandidatePaths,
+} from './native-assets.js';
+import { getPackageRoot } from '../utils/package.js';
+
+const PRODUCT = 'omx-runtime';
+const SELF_PATH = fileURLToPath(import.meta.url);
+
+function binaryName(): string {
+  return platform() === 'win32' ? `${PRODUCT}.exe` : PRODUCT;
+}
+
+function firstExisting(paths: string[]): string | undefined {
+  return paths.find((candidate) => existsSync(candidate));
+}
+
+function isSelfReference(candidate: string): boolean {
+  if (candidate === PRODUCT) return true;
+  if (!existsSync(candidate)) return false;
+  try {
+    return realpathSync(candidate) === realpathSync(SELF_PATH);
+  } catch {
+    return resolve(candidate) === resolve(SELF_PATH);
+  }
+}
+
+async function resolveRuntimeBinary(): Promise<string | undefined> {
+  const override = process.env.OMX_RUNTIME_BINARY?.trim();
+  if (override && !isSelfReference(override)) return override;
+
+  const packageRoot = getPackageRoot();
+  const name = binaryName();
+  const version = await getPackageVersion(packageRoot).catch(() => undefined);
+  if (version) {
+    const cached = firstExisting(
+      resolveCachedNativeBinaryCandidatePaths(PRODUCT, version, platform(), arch(), process.env),
+    );
+    if (cached) return cached;
+  }
+
+  const packaged = firstExisting([
+    join(packageRoot, 'bin', 'native', `${platform()}-${arch()}`, name),
+    join(packageRoot, 'target', 'release', name),
+    join(packageRoot, 'crates', PRODUCT, 'target', 'release', name),
+  ]);
+  if (packaged) return packaged;
+
+  return await hydrateNativeBinary(PRODUCT, { packageRoot });
+}
+
+const runtimeBinary = await resolveRuntimeBinary();
+if (!runtimeBinary) {
+  console.error(
+    [
+      '[omx-runtime] Native runtime binary is not installed for this platform.',
+      '[omx-runtime] Try: omx update',
+      '[omx-runtime] Or set OMX_RUNTIME_BINARY to a compatible omx-runtime binary.',
+    ].join('\n'),
+  );
+  process.exit(127);
+}
+
+const child = spawnSync(runtimeBinary, process.argv.slice(2), {
+  stdio: 'inherit',
+  windowsHide: true,
+});
+
+if (child.error) {
+  console.error(`[omx-runtime] Failed to launch ${runtimeBinary}: ${child.error.message}`);
+  process.exit(127);
+}
+
+process.exit(child.status ?? 1);

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -42,6 +42,7 @@ export interface UpdateExecutionResult {
 
 type RunGlobalUpdateResult = { ok: boolean; stderr: string };
 type RunSetupRefreshResult = { ok: boolean; stderr: string };
+type RunPostUpdateRuntimeSmokeResult = { ok: boolean; stderr: string };
 type RunDeferredUpdateResult = { ok: boolean; stderr: string; logPath?: string };
 type SpawnSyncLike = typeof spawnSync;
 type SpawnLike = typeof spawn;
@@ -262,6 +263,7 @@ interface UpdateDependencies {
   runGlobalUpdate: typeof runGlobalUpdate;
   runDeferredGlobalUpdate: typeof runDeferredGlobalUpdate;
   runSetupRefresh: (cwd: string) => Promise<RunSetupRefreshResult>;
+  runPostUpdateRuntimeSmoke: (cwd: string) => Promise<RunPostUpdateRuntimeSmokeResult>;
   writeUpdateState: typeof writeUpdateState;
 }
 
@@ -273,6 +275,7 @@ const defaultUpdateDependencies: UpdateDependencies = {
   runGlobalUpdate,
   runDeferredGlobalUpdate,
   runSetupRefresh,
+  runPostUpdateRuntimeSmoke,
   writeUpdateState,
 };
 
@@ -424,6 +427,44 @@ async function runSetupRefresh(cwd: string): Promise<RunSetupRefreshResult> {
   return spawnInstalledSetupRefresh(cliEntry, cwd);
 }
 
+function summarizeRuntimeSmokeFailure(stderr: string): string {
+  const details = stderr.trim().split(/\r?\n/).filter(Boolean).slice(0, 4).join(' | ');
+  return [
+    '[omx] Update installed, but the runtime smoke check failed.',
+    details ? `[omx] runtime smoke: ${details}` : undefined,
+    '[omx] Expected checks: omx-runtime schema --json; omx doctor --team',
+    '[omx] Retry with: omx update',
+  ].filter((line): line is string => typeof line === 'string').join('\n');
+}
+
+function spawnSmokeCommand(command: string, args: string[], cwd: string): RunPostUpdateRuntimeSmokeResult {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 30_000,
+    windowsHide: true,
+  });
+  if (result.error) return { ok: false, stderr: `${command} ${args.join(' ')}: ${result.error.message}` };
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      stderr: `${command} ${args.join(' ')} exited ${result.status}: ${(result.stderr || result.stdout || '').trim()}`,
+    };
+  }
+  return { ok: true, stderr: '' };
+}
+
+export async function runPostUpdateRuntimeSmoke(cwd: string): Promise<RunPostUpdateRuntimeSmokeResult> {
+  const schema = spawnSmokeCommand('omx-runtime', ['schema', '--json'], cwd);
+  if (!schema.ok) return schema;
+
+  const doctor = spawnSmokeCommand('omx', ['doctor', '--team'], cwd);
+  if (!doctor.ok) return doctor;
+
+  return { ok: true, stderr: '' };
+}
+
 async function executeUpdate(
   options: {
     cwd: string;
@@ -470,8 +511,13 @@ async function executeUpdate(
           );
           return { status: 'failed', currentVersion: current, latestVersion: latest };
         }
+        const runtimeSmokeResult = await dependencies.runPostUpdateRuntimeSmoke(cwd);
+        if (!runtimeSmokeResult.ok) {
+          console.log(summarizeRuntimeSmokeFailure(runtimeSmokeResult.stderr));
+          return { status: 'failed', currentVersion: current, latestVersion: latest };
+        }
         await writeSuccessfulInstallStamp(current);
-        console.log(`[omx] Setup refresh completed for v${current}. Restart to use current code.`);
+        console.log(`[omx] Setup refresh and runtime smoke completed for v${current}. Restart to use current code.`);
         return { status: 'up-to-date', currentVersion: current, latestVersion: latest };
       }
     }
@@ -522,8 +568,14 @@ async function executeUpdate(
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
 
+  const runtimeSmokeResult = await dependencies.runPostUpdateRuntimeSmoke(cwd);
+  if (!runtimeSmokeResult.ok) {
+    console.log(summarizeRuntimeSmokeFailure(runtimeSmokeResult.stderr));
+    return { status: 'failed', currentVersion: current, latestVersion: latest };
+  }
+
   await writeSuccessfulInstallStamp(latest);
-  console.log(`[omx] Updated to v${latest}. Restart to use new code.`);
+  console.log(`[omx] Updated to v${latest}; runtime smoke passed. Restart to use new code.`);
   return { status: 'updated', currentVersion: current, latestVersion: latest };
 }
 

--- a/src/runtime/__tests__/bridge.test.ts
+++ b/src/runtime/__tests__/bridge.test.ts
@@ -43,10 +43,50 @@ describe('resolveRuntimeBinaryPath', () => {
     assert.equal(actual, '/release/runtime');
   });
 
+  it('prefers cached native runtime before PATH fallback', () => {
+    const actual = resolveRuntimeBinaryPath({
+      debugPath: '/debug/runtime',
+      releasePath: '/release/runtime',
+      cachedPath: '/cache/native/0.18.1/darwin-arm64/omx-runtime/omx-runtime',
+      packagedNativePath: '/package/bin/native/darwin-arm64/omx-runtime',
+      fallbackBinary: 'omx-runtime',
+      exists: (candidate) => candidate === '/cache/native/0.18.1/darwin-arm64/omx-runtime/omx-runtime',
+    });
+    assert.equal(actual, '/cache/native/0.18.1/darwin-arm64/omx-runtime/omx-runtime');
+  });
+
+  it('prefers packaged native runtime before PATH fallback', () => {
+    const actual = resolveRuntimeBinaryPath({
+      debugPath: '/debug/runtime',
+      releasePath: '/release/runtime',
+      cachedPath: '/cache/runtime',
+      packagedNativePath: '/package/bin/native/darwin-arm64/omx-runtime',
+      fallbackBinary: 'omx-runtime',
+      exists: (candidate) => candidate === '/package/bin/native/darwin-arm64/omx-runtime',
+    });
+    assert.equal(actual, '/package/bin/native/darwin-arm64/omx-runtime');
+  });
+
+  it('derives cached native runtime from OMX_NATIVE_CACHE_DIR and package version', () => {
+    const actual = resolveRuntimeBinaryPath({
+      debugPath: '/debug/runtime',
+      releasePath: '/release/runtime',
+      fallbackBinary: 'omx-runtime',
+      env: { OMX_NATIVE_CACHE_DIR: '/tmp/omx-native-cache' },
+      packageVersion: '0.18.1',
+      platform: 'darwin',
+      arch: 'arm64',
+      exists: (candidate) => candidate === '/tmp/omx-native-cache/0.18.1/darwin-arm64/omx-runtime/omx-runtime',
+    });
+    assert.equal(actual, '/tmp/omx-native-cache/0.18.1/darwin-arm64/omx-runtime/omx-runtime');
+  });
+
   it('falls back to PATH binary when local builds are unavailable', () => {
     const actual = resolveRuntimeBinaryPath({
       debugPath: '/debug/runtime',
       releasePath: '/release/runtime',
+      cachedPath: '/cache/runtime',
+      packagedNativePath: '/package/runtime',
       fallbackBinary: 'omx-runtime',
       exists: () => false,
     });

--- a/src/runtime/bridge.ts
+++ b/src/runtime/bridge.ts
@@ -8,12 +8,14 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveCanonicalTeamStateRoot } from '../team/state-root.js';
 import { safeJsonParse } from '../utils/safe-json.js';
 
 const __bridge_dirname = dirname(fileURLToPath(import.meta.url));
+const RUNTIME_PRODUCT = 'omx-runtime';
 
 // ---------------------------------------------------------------------------
 // Types matching Rust JSON schema
@@ -135,20 +137,78 @@ let schemaValidated = false;
 export interface RuntimeBinaryDiscoveryOptions {
   debugPath?: string;
   releasePath?: string;
+  cachedPath?: string;
+  packagedNativePath?: string;
   fallbackBinary?: string;
+  env?: NodeJS.ProcessEnv;
   exists?: (path: string) => boolean;
+  packageVersion?: string;
+  platform?: NodeJS.Platform;
+  arch?: string;
+}
+
+function runtimeBinaryName(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? `${RUNTIME_PRODUCT}.exe` : RUNTIME_PRODUCT;
+}
+
+function readPackageVersion(): string | undefined {
+  try {
+    const packageJsonPath = resolve(__bridge_dirname, '../../package.json');
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as { version?: string };
+    return typeof pkg.version === 'string' && pkg.version.trim() !== '' ? pkg.version.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveNativeCacheRoot(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.OMX_NATIVE_CACHE_DIR?.trim();
+  if (override) return resolve(override);
+  if (process.platform === 'win32') {
+    return resolve(env.LOCALAPPDATA?.trim() || join(homedir(), 'AppData', 'Local'), 'oh-my-codex', 'native');
+  }
+  return resolve(env.XDG_CACHE_HOME?.trim() || join(homedir(), '.cache'), 'oh-my-codex', 'native');
+}
+
+function resolveCachedRuntimeBinaryPath(options: RuntimeBinaryDiscoveryOptions): string | undefined {
+  const version = options.packageVersion ?? readPackageVersion();
+  if (!version) return undefined;
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+  return join(
+    resolveNativeCacheRoot(options.env),
+    version,
+    `${platform}-${arch}`,
+    RUNTIME_PRODUCT,
+    runtimeBinaryName(platform),
+  );
 }
 
 export function resolveRuntimeBinaryPath(options: RuntimeBinaryDiscoveryOptions = {}): string {
   const exists = options.exists ?? existsSync;
-  const envOverride = process.env.OMX_RUNTIME_BINARY?.trim();
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+  const name = runtimeBinaryName(platform);
+  const envOverride = env.OMX_RUNTIME_BINARY?.trim();
   if (envOverride) return envOverride;
 
-  const workspaceDebug = options.debugPath ?? resolve(__bridge_dirname, '../../target/debug/omx-runtime');
+  const workspaceDebug = options.debugPath ?? resolve(__bridge_dirname, '../../target/debug', name);
   if (exists(workspaceDebug)) return workspaceDebug;
 
-  const workspaceRelease = options.releasePath ?? resolve(__bridge_dirname, '../../target/release/omx-runtime');
+  const workspaceRelease = options.releasePath ?? resolve(__bridge_dirname, '../../target/release', name);
   if (exists(workspaceRelease)) return workspaceRelease;
+
+  const cachedRuntime = options.cachedPath ?? resolveCachedRuntimeBinaryPath({ ...options, env, platform, arch });
+  if (cachedRuntime && exists(cachedRuntime)) return cachedRuntime;
+
+  const packagedNative = options.packagedNativePath ?? resolve(
+    __bridge_dirname,
+    '../../bin/native',
+    `${platform}-${arch}`,
+    name,
+  );
+  if (exists(packagedNative)) return packagedNative;
 
   return options.fallbackBinary ?? 'omx-runtime';
 }
@@ -171,6 +231,11 @@ export class RuntimeBridge {
   /** Whether the bridge is enabled (OMX_RUNTIME_BRIDGE != '0'). */
   isEnabled(): boolean {
     return this.enabled;
+  }
+
+  /** Resolved native runtime binary path used by this bridge instance. */
+  getBinaryPath(): string {
+    return this.binaryPath;
   }
 
   /** Execute a RuntimeCommand and return the resulting RuntimeEvent. */


### PR DESCRIPTION
## Summary
- publish an `omx-runtime` npm bin wrapper that resolves cached or packaged native runtime assets and hydrates release assets when needed
- teach RuntimeBridge and doctor --team to fail explicitly when the runtime binary/schema is unavailable
- run post-update runtime smoke checks after explicit update/setup refresh before marking installs successful

## Verification
- npm run build
- node --test dist/runtime/__tests__/bridge.test.js dist/cli/__tests__/doctor-team.test.js dist/cli/__tests__/update.test.js dist/cli/__tests__/package-bin-contract.test.js dist/cli/__tests__/native-assets.test.js
- npx biome lint src/cli/omx-runtime.ts src/cli/native-assets.ts src/runtime/bridge.ts src/cli/doctor.ts src/cli/update.ts src/runtime/__tests__/bridge.test.ts src/cli/__tests__/doctor-team.test.ts src/cli/__tests__/package-bin-contract.test.ts src/cli/__tests__/update.test.ts
- npm run check:no-unused

## Notes
Reopened against `dev` per maintainer guidance on #2458. This fixes installs where `omx-runtime` release assets exist but npm never exposed or verified an `omx-runtime` executable.