### PR TITLE
Keep tmux HUD panes scoped to leader sessions

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2910,7 +2910,7 @@ describe("detached tmux new-session sequencing", () => {
     const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
     assert.match(
       source,
-      /const hudEnvArgs = \[\s*`OMX_SESSION_ID=\$\{sessionId\}`,\s*`\$\{OMX_TMUX_HUD_OWNER_ENV\}=1`,\s*\.\.\.\(omxRootOverride \? \[`OMX_ROOT=\$\{omxRootOverride\}`\] : \[\]\),\s*\]/,
+      /const hudEnvArgs = \[\s*`OMX_SESSION_ID=\$\{sessionId\}`,\s*`\$\{OMX_TMUX_HUD_OWNER_ENV\}=1`,\s*\.\.\.\(currentPaneId \? \[`\$\{OMX_TMUX_HUD_LEADER_PANE_ENV\}=\$\{currentPaneId\}`\] : \[\]\),\s*\.\.\.\(omxRootOverride \? \[`OMX_ROOT=\$\{omxRootOverride\}`\] : \[\]\),\s*\]/,
     );
     assert.match(
       source,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -131,6 +131,7 @@ import {
   createHudWatchPane as createSharedHudWatchPane,
   killTmuxPane as killSharedTmuxPane,
   listCurrentWindowHudPaneIds,
+  OMX_TMUX_HUD_LEADER_PANE_ENV,
   parsePaneIdFromTmuxOutput,
   registerHudResizeHook,
 } from "../hud/tmux.js";
@@ -3886,9 +3887,11 @@ function runCodex(
     throw new Error("Unable to resolve OMX launcher path for tmux HUD bootstrap");
   }
   const omxRootOverride = resolveOmxRootForLaunch(cwd, process.env);
+  const currentPaneId = process.env.TMUX_PANE;
   const hudEnvArgs = [
     `OMX_SESSION_ID=${sessionId}`,
     `${OMX_TMUX_HUD_OWNER_ENV}=1`,
+    ...(currentPaneId ? [`${OMX_TMUX_HUD_LEADER_PANE_ENV}=${currentPaneId}`] : []),
     ...(omxRootOverride ? [`OMX_ROOT=${omxRootOverride}`] : []),
   ];
   const hudCmd = nativeWindows
@@ -3931,15 +3934,17 @@ function runCodex(
 
   if (launchPolicy === "inside-tmux") {
     // Already in tmux: launch codex in current pane, HUD in bottom split
-    const currentPaneId = process.env.TMUX_PANE;
-    const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow(currentPaneId);
+    const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId });
     for (const paneId of staleHudPaneIds) {
       killTmuxPane(paneId);
     }
 
     let hudPaneId: string | null = null;
     try {
-      hudPaneId = createHudWatchPane(cwd, hudCmd);
+      hudPaneId = createHudWatchPane(cwd, hudCmd, {
+        heightLines: HUD_TMUX_HEIGHT_LINES,
+        targetPaneId: currentPaneId,
+      });
       if (hudPaneId && currentPaneId) {
         registerHudResizeHook(hudPaneId, currentPaneId, HUD_TMUX_HEIGHT_LINES);
       }
@@ -4228,17 +4233,27 @@ function runCodex(
   }
 }
 
-function listHudWatchPaneIdsInCurrentWindow(currentPaneId?: string): string[] {
+function listHudWatchPaneIdsInCurrentWindow(
+  currentPaneId?: string,
+  owner: { sessionId?: string; leaderPaneId?: string } = {},
+): string[] {
   try {
-    return listCurrentWindowHudPaneIds(currentPaneId);
+    return listCurrentWindowHudPaneIds(currentPaneId, undefined, owner);
   } catch (err) {
     logCliOperationFailure(err);
     return [];
   }
 }
 
-function createHudWatchPane(cwd: string, hudCmd: string): string | null {
-  return createSharedHudWatchPane(cwd, hudCmd, { heightLines: HUD_TMUX_HEIGHT_LINES });
+function createHudWatchPane(
+  cwd: string,
+  hudCmd: string,
+  options: { heightLines?: number; targetPaneId?: string } = {},
+): string | null {
+  return createSharedHudWatchPane(cwd, hudCmd, {
+    heightLines: options.heightLines ?? HUD_TMUX_HEIGHT_LINES,
+    targetPaneId: options.targetPaneId,
+  });
 }
 
 function killTmuxPane(paneId: string): void {

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from '../reconcile.js';
+import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../tmux.js';
 
 describe('reconcileHudForPromptSubmit', () => {
   it('skips reconciliation outside tmux', async () => {
@@ -84,7 +85,10 @@ describe('reconcileHudForPromptSubmit', () => {
 
     assert.equal(result.status, 'recreated');
     assert.equal(created.length, 1);
-    assert.match(created[0]?.cmd || '', /^exec env OMX_SESSION_ID='sess-canonical' '.*' '.*omx\.js' hud --watch/);
+    assert.match(
+      created[0]?.cmd || '',
+      /^exec env OMX_SESSION_ID='sess-canonical' OMX_TMUX_HUD_LEADER_PANE='%1' '.*' '.*omx\.js' hud --watch/,
+    );
     assert.doesNotMatch(created[0]?.cmd || '', /sess-stale/);
   });
 
@@ -114,7 +118,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(created.length, 1);
     assert.match(
       created[0]?.cmd || '',
-      /^exec env OMX_SESSION_ID='sess boxed' OMX_ROOT='\/tmp\/boxed root\/it'\\''s\/\$\(literal\)' '.*' '.*omx\.js' hud --watch/,
+      /^exec env OMX_SESSION_ID='sess boxed' OMX_TMUX_HUD_LEADER_PANE='%1' OMX_ROOT='\/tmp\/boxed root\/it'\\''s\/\$\(literal\)' '.*' '.*omx\.js' hud --watch/,
     );
   });
 
@@ -147,11 +151,19 @@ describe('reconcileHudForPromptSubmit', () => {
     const killed: string[] = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
-        { paneId: '%2', currentCommand: 'node', startCommand: 'node omx hud --watch' },
-        { paneId: '%3', currentCommand: 'node', startCommand: 'node omx hud --watch' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+        {
+          paneId: '%3',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
         { paneId: '%4', currentCommand: 'codex', startCommand: 'codex' },
       ],
       killTmuxPane: (paneId) => {
@@ -171,13 +183,93 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(killed, ['%2', '%3']);
   });
 
+  it('does not resize, kill, or reuse another active leader session HUD in the same tmux window', async () => {
+    const killed: string[] = [];
+    const resized: string[] = [];
+    const created: Array<{ cmd: string; options?: { targetPaneId?: string } }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%3', OMX_SESSION_ID: 'sess-b', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+        { paneId: '%3', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      resizeTmuxPane: (paneId) => {
+        resized.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, cmd, options) => {
+        created.push({ cmd, options });
+        return '%4';
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%4');
+    assert.deepEqual(killed, []);
+    assert.deepEqual(resized, ['%4']);
+    assert.equal(created[0]?.options?.targetPaneId, '%3');
+    assert.match(created[0]?.cmd || '', /OMX_SESSION_ID='sess-b'/);
+    assert.match(created[0]?.cmd || '', new RegExp(`${OMX_TMUX_HUD_LEADER_PANE_ENV}='%3'`));
+  });
+
+  it('still cleans stale duplicate HUD panes for the same session and leader owner', async () => {
+    const killed: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+        {
+          paneId: '%3',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+        {
+          paneId: '%4',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-b' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%5' node omx hud --watch`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: () => '%9',
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.deepEqual(killed, ['%2', '%3']);
+  });
+
   it('resizes an existing single HUD pane instead of recreating it', async () => {
     const resized: Array<{ paneId: string; heightLines: number }> = [];
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
-        { paneId: '%2', currentCommand: 'node', startCommand: 'node omx hud --watch' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
       ],
       resizeTmuxPane: (paneId, heightLines) => {
         resized.push({ paneId, heightLines });
@@ -196,10 +288,14 @@ describe('reconcileHudForPromptSubmit', () => {
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
-        { paneId: '%2', currentCommand: 'node', startCommand: 'node omx hud --watch' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
       ],
       resizeTmuxPane: () => true,
       registerHudResizeHook: (hudPaneId, currentPaneId, heightLines) => {

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -3,6 +3,12 @@ import assert from 'node:assert/strict';
 import {
   buildHudResizeHookName,
   buildHudResizeHookSlot,
+  buildHudWatchCommand,
+  findHudWatchPaneIds,
+  hudPaneMatchesOwner,
+  OMX_TMUX_HUD_LEADER_PANE_ENV,
+  parseTmuxPaneSnapshot,
+  readHudPaneOwner,
   parseHudResizeHookContext,
   registerHudResizeHook,
   unregisterHudResizeHook,
@@ -109,5 +115,76 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%10', '%1', 3, execTmuxSync), true);
 
     assert.equal(registered[0]?.[3], registered[1]?.[3]);
+  });
+});
+
+describe('HUD pane ownership helpers', () => {
+  it('reads session and leader ownership from env-prefixed HUD commands', () => {
+    const [pane] = parseTmuxPaneSnapshot(
+      `%9\tnode\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+    );
+
+    assert.deepEqual(readHudPaneOwner(pane!), {
+      sessionId: 'sess-a',
+      leaderPaneId: '%1',
+    });
+    assert.equal(hudPaneMatchesOwner(pane!, { sessionId: 'sess-a', leaderPaneId: '%1' }), true);
+    assert.equal(hudPaneMatchesOwner(pane!, { sessionId: 'sess-b', leaderPaneId: '%2' }), false);
+  });
+
+  it('reads ownership from quoted tmux shell env arguments used by inside-tmux launch', () => {
+    const [pane] = parseTmuxPaneSnapshot(
+      `%9\tnode\t/bin/zsh -c 'exec '\\''env'\\'' '\\''OMX_SESSION_ID=sess-a'\\'' '\\''${OMX_TMUX_HUD_LEADER_PANE_ENV}=%1'\\'' '\\''node'\\'' '\\''/omx.js'\\'' '\\''hud'\\'' '\\''--watch'\\'''`,
+    );
+
+    assert.deepEqual(readHudPaneOwner(pane!), {
+      sessionId: 'sess-a',
+      leaderPaneId: '%1',
+    });
+  });
+
+  it('keeps independent leaders in one tmux window from matching each other HUD panes', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        `%2\tnode\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+        '%3\tcodex\tcodex',
+        `%4\tnode\texec env OMX_SESSION_ID='sess-b' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%3' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+
+    assert.deepEqual(findHudWatchPaneIds(panes, '%3', { sessionId: 'sess-b', leaderPaneId: '%3' }), ['%4']);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%3', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2']);
+  });
+
+  it('does not owner-match untagged HUD panes when an owner scope is requested', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        '%2\tnode\tnode /tmp/bin/omx.js hud --watch',
+      ].join('\n'),
+    );
+
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), []);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1'), ['%2']);
+  });
+
+  it('matches session-owned legacy HUD panes without leader tags for same-session cleanup', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        "%2\tnode\texec env OMX_SESSION_ID='sess-a' /node /omx.js hud --watch",
+        "%3\tnode\texec env OMX_SESSION_ID='sess-b' /node /omx.js hud --watch",
+      ].join('\n'),
+    );
+
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2']);
+  });
+
+  it('tags reconciled HUD watch commands with the leader pane owner', () => {
+    const cmd = buildHudWatchCommand('/usr/bin/omx.js', undefined, 'sess-a', undefined, '%1');
+
+    assert.match(cmd, /OMX_SESSION_ID='sess-a'/);
+    assert.match(cmd, new RegExp(`${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1'`));
   });
 });

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -105,7 +105,11 @@ export async function reconcileHudForPromptSubmit(
 
   const currentPaneId = env.TMUX_PANE?.trim();
   const panes = listPanes(currentPaneId);
-  const hudPaneIds = findHudWatchPaneIds(panes, currentPaneId);
+  const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
+  const hudPaneIds = findHudWatchPaneIds(panes, currentPaneId, {
+    sessionId: resolvedSessionId,
+    leaderPaneId: currentPaneId,
+  });
   const duplicateCount = Math.max(0, hudPaneIds.length - 1);
   const nonHudPaneCount = panes.filter((pane) => !isHudWatchPane(pane)).length;
   const desiredHeight = HUD_TMUX_HEIGHT_LINES;
@@ -113,8 +117,7 @@ export async function reconcileHudForPromptSubmit(
   const readHudConfigFn = deps.readHudConfig ?? readHudConfig;
   const hudConfig = await readHudConfigFn(cwd).catch(() => null);
   const preset = hudConfig?.preset;
-  const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
-  const hudCmd = buildHudWatchCommand(omxBin, preset, resolvedSessionId, env.OMX_ROOT);
+  const hudCmd = buildHudWatchCommand(omxBin, preset, resolvedSessionId, env.OMX_ROOT, currentPaneId);
 
   if (hudPaneIds.length === 1) {
     const resized = resizePane(hudPaneIds[0], desiredHeight);

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -8,6 +8,13 @@ export interface TmuxPaneSnapshot {
   startCommand: string;
 }
 
+export const OMX_TMUX_HUD_LEADER_PANE_ENV = 'OMX_TMUX_HUD_LEADER_PANE';
+
+export interface HudPaneOwner {
+  sessionId?: string;
+  leaderPaneId?: string;
+}
+
 type TmuxExecSync = (args: string[]) => string;
 
 /** Upper bound for tmux hook indices (signed 32-bit max). */
@@ -45,13 +52,51 @@ export function isHudWatchPane(pane: TmuxPaneSnapshot): boolean {
   );
 }
 
+
+function parseShellEnvAssignment(command: string, key: string): string | undefined {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = command.match(
+    new RegExp(
+      `(?:^|\\s)(?:'${escapedKey}=([^']*)'|${escapedKey}=(?:'((?:'\\\\''|[^'])*)'|([^\\s]+)))`,
+    ),
+  );
+  const fallbackMatch = match
+    ? null
+    : command.match(new RegExp(`(?:^|[\\s'])${escapedKey}=([^'\\s]+)`));
+  const raw = match?.[1] ?? match?.[2] ?? match?.[3] ?? fallbackMatch?.[1];
+  if (typeof raw !== 'string') return undefined;
+  const value = raw.replace(/'\\''/g, "'").trim();
+  return value === '' ? undefined : value;
+}
+
+export function readHudPaneOwner(pane: TmuxPaneSnapshot): HudPaneOwner {
+  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  return {
+    sessionId: parseShellEnvAssignment(command, 'OMX_SESSION_ID'),
+    leaderPaneId: parseShellEnvAssignment(command, OMX_TMUX_HUD_LEADER_PANE_ENV),
+  };
+}
+
+export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner = {}): boolean {
+  if (!isHudWatchPane(pane)) return false;
+  const wantsSession = typeof owner.sessionId === 'string' && owner.sessionId.trim() !== '';
+  const wantsLeaderPane = typeof owner.leaderPaneId === 'string' && owner.leaderPaneId.trim() !== '';
+  if (!wantsSession && !wantsLeaderPane) return true;
+  const paneOwner = readHudPaneOwner(pane);
+  if (wantsSession && paneOwner.sessionId !== owner.sessionId?.trim()) return false;
+  if (wantsSession && wantsLeaderPane && !paneOwner.leaderPaneId) return true;
+  if (wantsLeaderPane && paneOwner.leaderPaneId !== owner.leaderPaneId?.trim()) return false;
+  return true;
+}
+
 export function findHudWatchPaneIds(
   panes: TmuxPaneSnapshot[],
   currentPaneId?: string,
+  owner: HudPaneOwner = {},
 ): string[] {
   return panes
     .filter((pane) => pane.paneId !== currentPaneId)
-    .filter((pane) => isHudWatchPane(pane))
+    .filter((pane) => hudPaneMatchesOwner(pane, owner))
     .map((pane) => pane.paneId);
 }
 
@@ -156,14 +201,17 @@ export function buildHudWatchCommand(
   preset?: string,
   sessionId?: string,
   omxRoot?: string,
+  leaderPaneId?: string,
 ): string {
   const safePreset = preset === 'minimal' || preset === 'focused' || preset === 'full'
     ? ` --preset=${preset}`
     : '';
   const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
   const safeOmxRoot = typeof omxRoot === 'string' ? omxRoot : '';
+  const safeLeaderPaneId = typeof leaderPaneId === 'string' ? leaderPaneId.trim() : '';
   const envPrefix = buildEnvPrefix({
     OMX_SESSION_ID: safeSessionId,
+    [OMX_TMUX_HUD_LEADER_PANE_ENV]: safeLeaderPaneId,
     OMX_ROOT: safeOmxRoot,
   });
   return `exec ${envPrefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
@@ -190,8 +238,9 @@ export function listCurrentWindowPanes(
 export function listCurrentWindowHudPaneIds(
   currentPaneId?: string,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+  owner: HudPaneOwner = {},
 ): string[] {
-  return findHudWatchPaneIds(listCurrentWindowPanes(execTmuxSync, currentPaneId), currentPaneId);
+  return findHudWatchPaneIds(listCurrentWindowPanes(execTmuxSync, currentPaneId), currentPaneId, owner);
 }
 
 export function readCurrentWindowSize(


### PR DESCRIPTION
## Summary
- scope tmux HUD discovery/cleanup by `OMX_SESSION_ID` and launching leader pane ownership
- tag HUD watch panes with `OMX_TMUX_HUD_LEADER_PANE` and target inside-tmux HUD splits back to the emitting pane
- add regressions for two independent leaders in one tmux window and same-owner stale duplicate cleanup

Closes #2460.

## Verification
- `npm ci`
- `npm run build`
- `npm run lint`
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/hud-tmux-injection.test.js`
- `node --test --test-name-pattern "runCodex builds inside-tmux HUD command|createHudWatchPane splits from the emitting pane target" dist/cli/__tests__/index.test.js`
- `git diff --check`

Note: a broader `dist/cli/__tests__/index.test.js` pattern also exposed unrelated pre-existing extended-keys failures; the targeted changed-path tests above pass.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
