### PR TITLE
Clarify madmax same-directory lock diagnostic

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -268,6 +268,9 @@ describe("madmax state isolation", () => {
           assert.match(err.message, /timed out waiting for madmax detached launch context lock/);
           assert.match(err.message, new RegExp(`holder pid ${process.pid} is still running`));
           assert.match(err.message, /owner context live-context/);
+          assert.match(err.message, /Another madmax detached launch is active for this directory/);
+          assert.match(err.message, /close the existing madmax session or use --worktree for concurrent work/);
+          assert.match(err.message, /Multiple madmax sessions in one directory are unsafe/);
           return true;
         },
       );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1427,9 +1427,11 @@ function inspectMadmaxDetachedContextLock(lockPath: string): MadmaxDetachedLockI
       };
     }
     const ownerContext = owner ? `, owner context ${owner.context_key}` : ", legacy pid-only lock";
+    const sameDirectoryGuidance =
+      "Another madmax detached launch is active for this directory; close the existing madmax session or use --worktree for concurrent work. Multiple madmax sessions in one directory are unsafe";
     return {
       stale: false,
-      diagnostic: `holder pid ${holderPid} is still running${ownerContext}; lock age ${Math.round(ageMs)}ms`,
+      diagnostic: `holder pid ${holderPid} is still running${ownerContext}; lock age ${Math.round(ageMs)}ms. ${sameDirectoryGuidance}`,
     };
   }
   if (ageMs > MADMAX_DETACHED_LOCK_STALE_MS) {


### PR DESCRIPTION
## Summary
- Clarifies the live madmax detached context lock timeout with same-directory safety guidance.
- Tells users to close the existing madmax session or use `--worktree` for concurrent work.
- Preserves stale-lock recovery and independent madmax/worktree lock identity behavior from #2435.

Closes #2462.

## Evidence
- `npm run build` ✅
- `node --test --test-name-pattern="madmax state isolation" dist/cli/__tests__/index.test.js` ✅
- `node --test --test-name-pattern="madmax" dist/cli/__tests__/launch-fallback.test.js` ✅
- `npm run lint` ✅
- `npm run check:no-unused` ✅
- `git diff --check` ✅

## Notes
- Full `dist/cli/__tests__/index.test.js` was not used as the merge gate because unrelated cleanup/tmux extended-key tests fail in this environment; the changed madmax suite and launch-fallback madmax coverage pass.
