### PR TITLE
feat(hud): show ultragoal progress

### DIFF
--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -256,7 +256,6 @@ describe('renderHud – ultragoal', () => {
         failed: 0,
         reviewBlocked: 0,
         needsUserDecision: 0,
-        progressCurrent: 3,
         progressTotal: 5,
         activeGoal: {
           id: 'G003-tests',
@@ -279,6 +278,58 @@ describe('renderHud – ultragoal', () => {
   it('omits ultragoal when null', () => {
     const result = renderHud(emptyCtx(), 'focused');
     assert.ok(!result.includes('ultragoal'));
+  });
+
+  it('omits completed ultragoal plans instead of showing stale progress', () => {
+    const ctx = {
+      ...emptyCtx(),
+      ultragoal: {
+        active: false,
+        status: 'complete',
+        total: 2,
+        complete: 2,
+        pending: 0,
+        inProgress: 0,
+        failed: 0,
+        reviewBlocked: 0,
+        needsUserDecision: 0,
+        progressTotal: 2,
+      },
+    };
+
+    const result = renderHud(ctx, 'focused');
+    assert.ok(!result.includes('ultragoal'));
+  });
+
+  it('truncates long ultragoal objectives', () => {
+    const longObjective = 'show active ultragoal objective in OMX HUD '.repeat(8);
+    const ctx = {
+      ...emptyCtx(),
+      ultragoal: {
+        active: true,
+        status: 'in_progress',
+        total: 1,
+        complete: 0,
+        pending: 0,
+        inProgress: 1,
+        failed: 0,
+        reviewBlocked: 0,
+        needsUserDecision: 0,
+        progressTotal: 1,
+        activeGoal: {
+          id: 'G001-long',
+          title: 'Long objective',
+          objective: longObjective,
+          status: 'in_progress',
+          index: 1,
+        },
+      },
+    };
+
+    const result = stripSgr(renderHud(ctx, 'focused'));
+    assert.ok(result.includes('objective: show active ultragoal objective in OMX HUD'));
+    assert.ok(result.includes('…'));
+    assert.ok(!result.includes(longObjective));
   });
 });
 

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -240,6 +240,48 @@ describe('renderHud – team', () => {
   });
 });
 
+// ── Ultragoal ────────────────────────────────────────────────────────────────
+
+describe('renderHud – ultragoal', () => {
+  it('renders active ultragoal progress and objective in English', () => {
+    const ctx = {
+      ...emptyCtx(),
+      ultragoal: {
+        active: true,
+        status: 'in_progress',
+        total: 5,
+        complete: 2,
+        pending: 2,
+        inProgress: 1,
+        failed: 0,
+        reviewBlocked: 0,
+        needsUserDecision: 0,
+        progressCurrent: 3,
+        progressTotal: 5,
+        activeGoal: {
+          id: 'G003-tests',
+          title: 'HUD progress display',
+          objective: 'show active ultragoal objective in OMX HUD',
+          status: 'in_progress',
+          index: 3,
+        },
+      },
+      metrics: { total_turns: 12, session_turns: 12, last_activity: '' },
+    };
+
+    const result = stripSgr(renderHud(ctx, 'focused'));
+
+    assert.ok(result.includes('ultragoal 2/5 ▶ G003-tests: HUD progress display'));
+    assert.ok(result.includes('objective: show active ultragoal objective in OMX HUD'));
+    assert.ok(!result.includes('목표'));
+  });
+
+  it('omits ultragoal when null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('ultragoal'));
+  });
+});
+
 // ── Metrics – turns ───────────────────────────────────────────────────────────
 
 describe('renderHud – metrics (turns)', () => {

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -263,7 +263,6 @@ describe('readUltragoalState', { concurrency: false }, () => {
         failed: 0,
         reviewBlocked: 0,
         needsUserDecision: 0,
-        progressCurrent: 2,
         progressTotal: 3,
         activeGoal: {
           id: 'G002-hud-progress',
@@ -278,6 +277,16 @@ describe('readUltragoalState', { concurrency: false }, () => {
 
   it('returns null when no ultragoal plan exists', async () => {
     await withTempRepo('omx-hud-ultragoal-missing-', async (cwd) => {
+      assert.equal(await readUltragoalState(cwd), null);
+    });
+  });
+
+  it('returns null for malformed ultragoal JSON', async () => {
+    await withTempRepo('omx-hud-ultragoal-malformed-', async (cwd) => {
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), '{bad json');
+
       assert.equal(await readUltragoalState(cwd), null);
     });
   });

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -12,6 +12,7 @@ import {
   readHudNotifyState,
   readRalphState,
   readRalplanState,
+  readUltragoalState,
   readDeepInterviewState,
   readAutoresearchState,
   readUltraqaState,
@@ -230,6 +231,54 @@ describe('buildGitBranchLabel', () => {
       await withWindowsPlatform(() => {
         assert.equal(buildGitBranchLabel(cwd), `${basename(cwd)}/worktree-branch`);
       });
+    });
+  });
+});
+
+
+describe('readUltragoalState', { concurrency: false }, () => {
+  it('summarizes active ultragoal progress from goals.json', async () => {
+    await withTempRepo('omx-hud-ultragoal-', async (cwd) => {
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G002-hud-progress',
+        goals: [
+          { id: 'G001-plan', title: 'Plan', objective: 'Create the plan', status: 'complete' },
+          { id: 'G002-hud-progress', title: 'HUD progress display', objective: 'show active ultragoal objective in OMX HUD', status: 'in_progress' },
+          { id: 'G003-tests', title: 'Tests', objective: 'Validate the HUD display', status: 'pending' },
+        ],
+      }));
+
+      const state = await readUltragoalState(cwd);
+
+      assert.deepEqual(state, {
+        active: true,
+        status: 'in_progress',
+        total: 3,
+        complete: 1,
+        pending: 1,
+        inProgress: 1,
+        failed: 0,
+        reviewBlocked: 0,
+        needsUserDecision: 0,
+        progressCurrent: 2,
+        progressTotal: 3,
+        activeGoal: {
+          id: 'G002-hud-progress',
+          title: 'HUD progress display',
+          objective: 'show active ultragoal objective in OMX HUD',
+          status: 'in_progress',
+          index: 2,
+        },
+      });
+    });
+  });
+
+  it('returns null when no ultragoal plan exists', async () => {
+    await withTempRepo('omx-hud-ultragoal-missing-', async (cwd) => {
+      assert.equal(await readUltragoalState(cwd), null);
     });
   });
 });

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -124,6 +124,22 @@ function renderTeam(ctx: HudRenderContext): string | null {
   return green('team');
 }
 
+
+function renderUltragoal(ctx: HudRenderContext): string | null {
+  if (!ctx.ultragoal) return null;
+  const total = ctx.ultragoal.progressTotal;
+  const complete = ctx.ultragoal.complete;
+  if (!Number.isFinite(total) || total <= 0 || !Number.isFinite(complete)) return null;
+
+  const progress = `ultragoal ${complete}/${total}`;
+  const id = ctx.ultragoal.activeGoal?.id ? sanitizeDynamicText(ctx.ultragoal.activeGoal.id) : '';
+  const title = ctx.ultragoal.activeGoal?.title ? sanitizeDynamicText(ctx.ultragoal.activeGoal.title) : '';
+  const objective = ctx.ultragoal.activeGoal?.objective ? sanitizeDynamicText(ctx.ultragoal.activeGoal.objective) : '';
+  const heading = [id, title].filter(Boolean).join(': ');
+  const summary = heading ? `${progress} ▶ ${heading}` : progress;
+  return cyan(objective ? `${summary} · objective: ${objective}` : summary);
+}
+
 function renderTurns(ctx: HudRenderContext): string | null {
   if (!ctx.metrics || !isCurrentSessionMetrics(ctx)) return null;
   return dim(`turns:${ctx.metrics.session_turns}`);
@@ -198,6 +214,7 @@ const MINIMAL_ELEMENTS: ElementRenderer[] = [
   renderAutoresearch,
   renderUltraqa,
   renderTeam,
+  renderUltragoal,
   renderTurns,
 ];
 
@@ -211,6 +228,7 @@ const FOCUSED_ELEMENTS: ElementRenderer[] = [
   renderAutoresearch,
   renderUltraqa,
   renderTeam,
+  renderUltragoal,
   renderTurns,
   renderTokens,
   renderQuota,
@@ -228,6 +246,7 @@ const FULL_ELEMENTS: ElementRenderer[] = [
   renderAutoresearch,
   renderUltraqa,
   renderTeam,
+  renderUltragoal,
   renderTurns,
   renderTokens,
   renderQuota,

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -125,8 +125,14 @@ function renderTeam(ctx: HudRenderContext): string | null {
 }
 
 
+function truncateDynamicText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  if (maxLength <= 1) return '…';
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
 function renderUltragoal(ctx: HudRenderContext): string | null {
-  if (!ctx.ultragoal) return null;
+  if (!ctx.ultragoal?.active) return null;
   const total = ctx.ultragoal.progressTotal;
   const complete = ctx.ultragoal.complete;
   if (!Number.isFinite(total) || total <= 0 || !Number.isFinite(complete)) return null;
@@ -134,7 +140,8 @@ function renderUltragoal(ctx: HudRenderContext): string | null {
   const progress = `ultragoal ${complete}/${total}`;
   const id = ctx.ultragoal.activeGoal?.id ? sanitizeDynamicText(ctx.ultragoal.activeGoal.id) : '';
   const title = ctx.ultragoal.activeGoal?.title ? sanitizeDynamicText(ctx.ultragoal.activeGoal.title) : '';
-  const objective = ctx.ultragoal.activeGoal?.objective ? sanitizeDynamicText(ctx.ultragoal.activeGoal.objective) : '';
+  const rawObjective = ctx.ultragoal.activeGoal?.objective ? sanitizeDynamicText(ctx.ultragoal.activeGoal.objective) : '';
+  const objective = rawObjective ? truncateDynamicText(rawObjective, 96) : '';
   const heading = [id, title].filter(Boolean).join(': ');
   const summary = heading ? `${progress} ▶ ${heading}` : progress;
   return cyan(objective ? `${summary} · objective: ${objective}` : summary);

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -186,7 +186,6 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
     failed: failed_goals,
     reviewBlocked: review_blocked_goals,
     needsUserDecision: needs_user_decision_goals,
-    progressCurrent: activeIndex >= 0 ? activeIndex + 1 : completed_goals,
     progressTotal: goals.length,
     activeGoal: activeGoal && activeIndex >= 0 ? {
       id: activeGoal.id,

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -18,6 +18,7 @@ import { readUsableSessionState } from '../hooks/session.js';
 import { listActiveSkills, readVisibleSkillActiveStateForStateDir } from '../state/skill-active.js';
 import type {
   RalphStateForHud,
+  UltragoalStateForHud,
   UltraworkStateForHud,
   AutopilotStateForHud,
   RalplanStateForHud,
@@ -111,6 +112,90 @@ export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedH
   }
 
   return normalized;
+}
+
+interface RawUltragoalGoal {
+  id?: unknown;
+  title?: unknown;
+  objective?: unknown;
+  status?: unknown;
+}
+
+interface RawUltragoalPlan {
+  activeGoalId?: unknown;
+  aggregateCompletion?: unknown;
+  goals?: unknown;
+}
+
+const ULTRAGOAL_ACTIVE_STATUSES = new Set(['in_progress', 'review_blocked', 'needs_user_decision']);
+const ULTRAGOAL_UNRESOLVED_STATUSES = new Set(['pending', 'in_progress', 'failed', 'review_blocked', 'needs_user_decision']);
+
+type NormalizedUltragoalGoal = {
+  id: string;
+  title: string;
+  objective: string;
+  status: string;
+};
+
+function normalizeUltragoalGoal(raw: unknown): NormalizedUltragoalGoal | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const goal = raw as RawUltragoalGoal;
+  const id = sanitizeOptionalString(goal.id);
+  const title = sanitizeOptionalString(goal.title);
+  const objective = sanitizeOptionalString(goal.objective);
+  const status = sanitizeOptionalString(goal.status);
+  if (!id || !title || !objective || !status) return null;
+  return { id, title, objective, status };
+}
+
+function isAggregateComplete(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  return (value as { status?: unknown }).status === 'complete';
+}
+
+export async function readUltragoalState(cwd: string): Promise<UltragoalStateForHud | null> {
+  const plan = await readJsonFile<RawUltragoalPlan>(join(cwd, '.omx', 'ultragoal', 'goals.json'));
+  if (!plan || typeof plan !== 'object' || !Array.isArray(plan.goals)) return null;
+
+  const goals = plan.goals.map(normalizeUltragoalGoal).filter((goal): goal is NormalizedUltragoalGoal => goal !== null);
+  if (goals.length === 0) return null;
+
+  const completed_goals = goals.filter((goal) => goal.status === 'complete').length;
+  const pending_goals = goals.filter((goal) => goal.status === 'pending').length;
+  const in_progress_goals = goals.filter((goal) => goal.status === 'in_progress').length;
+  const failed_goals = goals.filter((goal) => goal.status === 'failed').length;
+  const review_blocked_goals = goals.filter((goal) => goal.status === 'review_blocked').length;
+  const needs_user_decision_goals = goals.filter((goal) => goal.status === 'needs_user_decision').length;
+  const unresolved_goals = goals.length - completed_goals;
+  const activeGoalId = sanitizeOptionalString(plan.activeGoalId);
+  const activeGoal = (
+    (activeGoalId ? goals.find((goal) => goal.id === activeGoalId && goal.status !== 'complete') : undefined)
+    ?? goals.find((goal) => ULTRAGOAL_ACTIVE_STATUSES.has(goal.status))
+    ?? goals.find((goal) => ULTRAGOAL_UNRESOLVED_STATUSES.has(goal.status))
+  );
+  const activeIndex = activeGoal ? goals.findIndex((goal) => goal.id === activeGoal.id) : -1;
+  const complete = isAggregateComplete(plan.aggregateCompletion) || unresolved_goals === 0;
+
+  return {
+    active: !complete,
+    status: complete ? 'complete' : activeGoal?.status ?? 'active',
+    total: goals.length,
+    complete: completed_goals,
+    pending: pending_goals,
+    inProgress: in_progress_goals,
+    failed: failed_goals,
+    reviewBlocked: review_blocked_goals,
+    needsUserDecision: needs_user_decision_goals,
+    progressCurrent: activeIndex >= 0 ? activeIndex + 1 : completed_goals,
+    progressTotal: goals.length,
+    activeGoal: activeGoal && activeIndex >= 0 ? {
+      id: activeGoal.id,
+      title: activeGoal.title,
+      objective: activeGoal.objective,
+      status: activeGoal.status,
+      index: activeIndex + 1,
+    } : undefined,
+  };
 }
 
 export async function readRalphState(cwd: string): Promise<RalphStateForHud | null> {
@@ -417,6 +502,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
 
   const [
     ralphDetail,
+    ultragoal,
     ultraworkDetail,
     autopilotDetail,
     ralplanDetail,
@@ -426,6 +512,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     teamDetail,
   ] = await Promise.all([
     readSessionAwareModeState<RalphStateForHud>(cwd, 'ralph'),
+    readUltragoalState(cwd),
     readSessionAwareModeState<UltraworkStateForHud>(cwd, 'ultrawork'),
     readSessionAwareModeState<AutopilotStateForHud>(cwd, 'autopilot'),
     readSessionAwareModeState<RalplanStateForHud>(cwd, 'ralplan'),
@@ -489,6 +576,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     version,
     gitBranch,
     ralph,
+    ultragoal,
     ultrawork,
     autopilot,
     ralplan,

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -28,7 +28,6 @@ export interface UltragoalStateForHud {
   failed: number;
   reviewBlocked: number;
   needsUserDecision: number;
-  progressCurrent?: number;
   progressTotal: number;
   activeGoal?: UltragoalActiveGoalForHud;
 }

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -9,6 +9,30 @@ export interface RalphStateForHud {
   max_iterations?: number;
 }
 
+/** Ultragoal durable goal-plan state for HUD display */
+export interface UltragoalActiveGoalForHud {
+  id: string;
+  title: string;
+  objective: string;
+  status: string;
+  index: number;
+}
+
+export interface UltragoalStateForHud {
+  active: boolean;
+  status?: string;
+  total: number;
+  complete: number;
+  pending: number;
+  inProgress: number;
+  failed: number;
+  reviewBlocked: number;
+  needsUserDecision: number;
+  progressCurrent?: number;
+  progressTotal: number;
+  activeGoal?: UltragoalActiveGoalForHud;
+}
+
 /** Ultrawork state for HUD display */
 export interface UltraworkStateForHud {
   active: boolean;
@@ -86,6 +110,7 @@ export interface HudRenderContext {
   version: string | null;
   gitBranch: string | null;
   ralph: RalphStateForHud | null;
+  ultragoal?: UltragoalStateForHud | null;
   ultrawork: UltraworkStateForHud | null;
   autopilot: AutopilotStateForHud | null;
   ralplan: RalplanStateForHud | null;


### PR DESCRIPTION
## Summary
- Surface active Ultragoal progress in the OMX HUD.
- Show the active goal id/title plus English-only `objective:` text.
- Read `.omx/ultragoal/goals.json` directly and tolerate missing/malformed state by omitting the HUD segment.

## Changes
- Added `UltragoalStateForHud` types and `readUltragoalState` summarization.
- Added HUD rendering: `ultragoal <complete>/<total> ▶ <id>: <title> · objective: <objective>`.
- Added TDD coverage for state parsing, render output, null omission, and no Korean label regression.

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] `env -u OMX_SESSION_ID -u OMX_TEAM_STATE_ROOT -u OMX_TEAM_LEADER_CWD -u OMX_TEAM_WORKER -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js`
- [x] `env -u OMX_SESSION_ID -u OMX_TEAM_STATE_ROOT -u OMX_TEAM_LEADER_CWD -u OMX_TEAM_WORKER -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_OPENCLAW -u OMX_OPENCLAW_COMMAND -u OMX_OPENCLAW_COMMAND_TIMEOUT_MS -u OMX_OPENCLAW_CONFIG -u OMX_ENTRY_PATH -u OMXBOX_ACTIVE -u OMX_TMUX_HUD_OWNER npm test`

## Checklist
- [x] Tests added/updated
- [x] Lint/build/full test suite passed
- [x] No product docs required (`Document-refresh: not-needed | HUD display/state-only change`)

## Related
- No matching open HUD/Ultragoal PR found against `dev` during preflight.
