### PR TITLE
[codex] Respect plugin-owned hooks without overwriting user surfaces

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -835,6 +835,75 @@ OMX_LORE_COMMIT_GUARD = "truee"
 		}
 	});
 
+	it("accepts plugin-scoped native hooks when hooks.json contains user-owned hooks", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-scoped-hooks-user-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await mkdir(codexDir, { recursive: true });
+			const cacheDir = await installPluginCacheFixture(codexDir);
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				`${JSON.stringify({ scope: "user", installMode: "plugin", mcpMode: "none" }, null, 2)}\n`,
+			);
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"plugin_hooks = true",
+					"goals = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "local"',
+					`source = ${JSON.stringify(repoRoot())}`,
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+			await writeFile(
+				join(codexDir, "hooks.json"),
+				JSON.stringify(
+					{
+						hooks: {
+							Stop: [
+								{
+									hooks: [
+										{
+											type: "command",
+											command: "/usr/bin/python3 /tmp/user-notify.py",
+											timeout: 5,
+										},
+									],
+								},
+							],
+						},
+					},
+					null,
+					2,
+				),
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				new RegExp(
+					`\\[OK\\] Native hooks: plugin-scoped hooks are enabled; existing hooks\\.json at .*\\.codex[\\/]+hooks\\.json is treated as user-owned because plugin-scoped hooks are enabled, and plugin cache native hook coverage smoke passed via ${join(cacheDir, "hooks", "hooks.json").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+				),
+			);
+			assert.doesNotMatch(res.stdout, /hooks\.json is missing OMX-managed coverage/);
+			assert.doesNotMatch(res.stdout, /run "omx setup --force" to restore native hooks/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("warns when hooks.json is missing OMX-managed native hook coverage", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-coverage-"));
 		try {

--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, readlink, rm, symlink, writeFile } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -296,6 +296,40 @@ describe('omx setup AGENTS refresh behavior', () => {
       assert.doesNotMatch(output, /Refreshed AGENTS\.md model capability table/);
       assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
       assert.equal(existsSync(join(wd, '.omx', 'backups', 'setup')), false);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves symlinked user-scope AGENTS.md during plugin-mode cleanup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-symlink-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const dotfilesAgentsPath = join(wd, 'dotfiles', '.codex', 'AGENTS.md');
+    const codexAgentsPath = join(home, '.codex', 'AGENTS.md');
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(wd, 'dotfiles', '.codex'), { recursive: true });
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await writeFile(
+        dotfilesAgentsPath,
+        addGeneratedAgentsMarker('# oh-my-codex - Intelligent Multi-Agent Orchestration\n\nDotfiles-owned guidance.\n'),
+      );
+      await symlink(dotfilesAgentsPath, codexAgentsPath);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        force: true,
+      });
+
+      assert.match(output, /AGENTS\.md generation skipped; no legacy OMX-generated AGENTS\.md found and defaults not selected\./);
+      assert.equal(await readlink(codexAgentsPath), dotfilesAgentsPath);
+      assert.match(await readFile(codexAgentsPath, 'utf-8'), /Dotfiles-owned guidance\./);
+      assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
     } finally {
       restoreHome();
       restoreTty();

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1114,13 +1114,16 @@ async function checkPluginScopedNativeHooks(
 	codexHomeDir: string,
 	setupHooksPath: string,
 ): Promise<Check> {
+	const setupHooksPathDescription = existsSync(setupHooksPath)
+		? `existing hooks.json at ${setupHooksPath} is treated as user-owned because plugin-scoped hooks are enabled`
+		: `setup-owned hooks.json is intentionally absent at ${setupHooksPath}`;
 	const packagedMarketplace = await resolvePackagedOmxMarketplace(getPackageRoot());
 	if (!packagedMarketplace) {
 		return {
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks are enabled and setup-owned hooks.json is intentionally absent at ${setupHooksPath}, but packaged ${OMX_LOCAL_MARKETPLACE_NAME} metadata was not found`,
+				`plugin-scoped hooks are enabled and ${setupHooksPathDescription}, but packaged ${OMX_LOCAL_MARKETPLACE_NAME} metadata was not found`,
 		};
 	}
 
@@ -1138,7 +1141,7 @@ async function checkPluginScopedNativeHooks(
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks are enabled, but the expected Codex plugin cache manifest is missing at ${join(expectedCacheDir, ".codex-plugin", "plugin.json")}; setup-owned hooks.json is intentionally absent at ${setupHooksPath}; run "omx setup --plugin --force" to refresh the plugin cache`,
+				`plugin-scoped hooks are enabled, but the expected Codex plugin cache manifest is missing at ${join(expectedCacheDir, ".codex-plugin", "plugin.json")}; ${setupHooksPathDescription}; run "omx setup --plugin --force" to refresh the plugin cache`,
 		};
 	}
 
@@ -1157,7 +1160,7 @@ async function checkPluginScopedNativeHooks(
 				name: "Native hooks",
 				status: "warn",
 				message:
-					`plugin-scoped hooks are enabled, but expected plugin hook file is missing at ${expectedPath}; setup-owned hooks.json is intentionally absent at ${setupHooksPath}; run "omx setup --plugin --force" to refresh the plugin cache`,
+					`plugin-scoped hooks are enabled, but expected plugin hook file is missing at ${expectedPath}; ${setupHooksPathDescription}; run "omx setup --plugin --force" to refresh the plugin cache`,
 			};
 		}
 	}
@@ -1236,7 +1239,7 @@ async function checkPluginScopedNativeHooks(
 		name: "Native hooks",
 		status: "pass",
 		message:
-			`plugin-scoped hooks are enabled; setup-owned hooks.json is intentionally absent at ${setupHooksPath}, and plugin cache native hook coverage smoke passed via ${expectedHooksPath}`,
+			`plugin-scoped hooks are enabled; ${setupHooksPathDescription}, and plugin cache native hook coverage smoke passed via ${expectedHooksPath}`,
 	};
 }
 
@@ -1245,14 +1248,23 @@ async function checkNativeHooks(
 	configPath: string,
 	context: NativeHookCheckContext,
 ): Promise<Check> {
+	if (existsSync(configPath) && context.installMode === "plugin") {
+		try {
+			const configContent = await readFile(configPath, "utf-8");
+			if (configEnablesPluginScopedHooks(configContent)) {
+				return checkPluginScopedNativeHooks(context.codexHomeDir, hooksPath);
+			}
+		} catch {
+			// Fall through to the hooks.json checks; the dedicated config check will
+			// report read failures separately.
+		}
+	}
+
 	if (!existsSync(hooksPath)) {
 		if (existsSync(configPath)) {
 			try {
 				const configContent = await readFile(configPath, "utf-8");
 				if (context.installMode === "plugin") {
-					if (configEnablesPluginScopedHooks(configContent)) {
-						return checkPluginScopedNativeHooks(context.codexHomeDir, hooksPath);
-					}
 					if (configHasOmxEntries(configContent)) {
 						return {
 							name: "Native hooks",

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -12,6 +12,7 @@ import {
 	rename,
 	writeFile,
 	stat,
+	lstat,
 	rm,
 } from "fs/promises";
 import { join, dirname, relative, basename } from "path";
@@ -1559,7 +1560,7 @@ async function applyPluginModeHooksConfig(
 		? await readFile(configPath, "utf-8")
 		: "";
 	const nextConfigBase = upsertPluginModeRuntimeFeatureFlags(
-		stripManagedCodexHookTrustState(existingConfig),
+		stripManagedCodexHookTrustState(existingConfig, { hooksPath }),
 		options.codexHookFeatureFlag,
 		{ pluginScopedHooks: options.pluginScopedHooks },
 	);
@@ -1744,6 +1745,15 @@ async function cleanupPluginModeLegacyAgentsMd(
 	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<boolean> {
 	if (!existsSync(agentsMdPath)) return false;
+	const fileInfo = await lstat(agentsMdPath);
+	if (fileInfo.isSymbolicLink()) {
+		if (options.verbose) {
+			console.log(
+				`  preserved symlinked AGENTS.md at ${agentsMdPath}; plugin mode only removes direct legacy OMX-generated files`,
+			);
+		}
+		return false;
+	}
 
 	const content = await readFile(agentsMdPath, "utf-8");
 	if (!isOmxGeneratedAgentsMd(content)) return false;

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -1119,6 +1119,43 @@ describe("config generator idempotency (#384)", () => {
     assert.doesNotThrow(() => TOML.parse(stripped));
   });
 
+  it("removes orphaned managed hook trust-state tables for the setup hooks path", () => {
+    const orphaned = [
+      'model = "gpt-5.5"',
+      "",
+      "[hooks.state]",
+      "",
+      '[plugins."oh-my-codex@oh-my-codex-local"]',
+      "enabled = true",
+      "",
+      '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
+      'trusted_hash = "sha256:managed"',
+      "",
+      '[hooks.state."custom:/hooks.json:stop:0:0"]',
+      'trusted_hash = "sha256:user"',
+      "",
+      '[hooks.state."/tmp/codex/hooks.json:stop:0:0"]',
+      'trusted_hash = "sha256:managed-stop"',
+      "# End OMX-owned Codex hook trust state",
+      "",
+      "[desktop]",
+      "git-create-pull-request-as-draft = true",
+      "",
+    ].join("\n");
+
+    const stripped = stripManagedCodexHookTrustState(orphaned, {
+      hooksPath: "/tmp/codex/hooks.json",
+    });
+
+    assert.doesNotMatch(stripped, /\/tmp\/codex\/hooks\.json:post_compact:0:0/);
+    assert.doesNotMatch(stripped, /\/tmp\/codex\/hooks\.json:stop:0:0/);
+    assert.doesNotMatch(stripped, /End OMX-owned Codex hook trust state/);
+    assert.match(stripped, /^\[hooks\.state\."custom:\/hooks\.json:stop:0:0"\]$/m);
+    assert.match(stripped, /^trusted_hash = "sha256:user"$/m);
+    assert.match(stripped, /^\[desktop\]$/m);
+    assert.doesNotThrow(() => TOML.parse(stripped));
+  });
+
   it("dedupes prior fenced managed hook trust-state blocks before writing a replacement", () => {
     const first = upsertManagedCodexHookTrustState(
       [

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -944,7 +944,54 @@ export function syncProjectScopeTrustStateFromRuntime(
   return `${stripped}\n\n${block}`;
 }
 
-export function stripManagedCodexHookTrustState(config: string): string {
+const MANAGED_CODEX_HOOK_EVENT_LABELS = [
+  "session_start",
+  "pre_tool_use",
+  "post_tool_use",
+  "user_prompt_submit",
+  "pre_compact",
+  "post_compact",
+  "stop",
+] as const;
+
+function stripOrphanedManagedCodexHookTrustState(
+  config: string,
+  hooksPath: string,
+): string {
+  const managedHeaders = new Set(
+    MANAGED_CODEX_HOOK_EVENT_LABELS.map(
+      (eventLabel) =>
+        `[hooks.state."${escapeTomlBasicString(`${hooksPath}:${eventLabel}:0:0`)}"]`,
+    ),
+  );
+  const lines = config.split(/\r?\n/);
+  const kept: string[] = [];
+
+  for (let i = 0; i < lines.length;) {
+    const trimmed = lines[i].trim();
+    if (trimmed === OMX_HOOK_TRUST_END_MARKER) {
+      i += 1;
+      continue;
+    }
+    if (!managedHeaders.has(trimmed)) {
+      kept.push(lines[i]);
+      i += 1;
+      continue;
+    }
+
+    i += 1;
+    while (i < lines.length && !/^\s*\[/.test(lines[i])) {
+      i += 1;
+    }
+  }
+
+  return kept.join("\n");
+}
+
+export function stripManagedCodexHookTrustState(
+  config: string,
+  options: { hooksPath?: string } = {},
+): string {
   const lines = config.split(/\r?\n/);
   const kept: string[] = [];
 
@@ -972,7 +1019,12 @@ export function stripManagedCodexHookTrustState(config: string): string {
     i = nextEndIdx + 1;
   }
 
-  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+  const stripped = kept.join("\n");
+  const withoutOrphans = options.hooksPath
+    ? stripOrphanedManagedCodexHookTrustState(stripped, options.hooksPath)
+    : stripped;
+
+  return withoutOrphans.replace(/\n{3,}/g, "\n\n").trimEnd();
 }
 
 function managedCodexHookTrustStateHeaders(


### PR DESCRIPTION
## Summary

- Treat existing `hooks.json` as user-owned when plugin-scoped hooks are enabled.
- Preserve symlinked `AGENTS.md` during plugin-mode cleanup so dotfiles-managed installs are not removed.
- Strip stale managed hook trust-state tables for the old setup-owned hook path during plugin-mode setup.

## Root cause

`omx doctor` checked setup-owned `hooks.json` before recognizing that plugin mode with `plugin_hooks = true` validates hooks through the plugin cache. If a user kept their own `~/.codex/hooks.json` entry, doctor reported missing OMX-managed native coverage even though plugin-scoped hook coverage was correct.

## Validation

- `npm run build`
- `node --test dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/doctor-warning-copy.test.js`
- `node --test --test-name-pattern 'preserves symlinked user-scope AGENTS.md during plugin-mode cleanup' dist/cli/__tests__/setup-agents-overwrite.test.js`
- Local `omx setup --force` followed by `omx doctor` reports `16 passed, 0 warnings, 0 failed`.
