### PR TITLE
[codex] Respect plugin-owned hooks without overwriting user surfaces

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -835,6 +835,75 @@ OMX_LORE_COMMIT_GUARD = "truee"
 		}
 	});
 
+	it("accepts plugin-scoped native hooks when hooks.json contains user-owned hooks", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-scoped-hooks-user-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await mkdir(codexDir, { recursive: true });
+			const cacheDir = await installPluginCacheFixture(codexDir);
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				`${JSON.stringify({ scope: "user", installMode: "plugin", mcpMode: "none" }, null, 2)}\n`,
+			);
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"plugin_hooks = true",
+					"goals = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "local"',
+					`source = ${JSON.stringify(repoRoot())}`,
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+			await writeFile(
+				join(codexDir, "hooks.json"),
+				JSON.stringify(
+					{
+						hooks: {
+							Stop: [
+								{
+									hooks: [
+										{
+											type: "command",
+											command: "/usr/bin/python3 /tmp/user-notify.py",
+											timeout: 5,
+										},
+									],
+								},
+							],
+						},
+					},
+					null,
+					2,
+				),
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				new RegExp(
+					`\\[OK\\] Native hooks: plugin-scoped hooks are enabled; existing hooks\\.json at .*\\.codex[\\/]+hooks\\.json is treated as user-owned because plugin-scoped hooks are enabled, and plugin cache native hook coverage smoke passed via ${join(cacheDir, "hooks", "hooks.json").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+				),
+			);
+			assert.doesNotMatch(res.stdout, /hooks\.json is missing OMX-managed coverage/);
+			assert.doesNotMatch(res.stdout, /run "omx setup --force" to restore native hooks/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("warns when hooks.json is missing OMX-managed native hook coverage", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-coverage-"));
 		try {

--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, readlink, rm, symlink, writeFile } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -296,6 +296,40 @@ describe('omx setup AGENTS refresh behavior', () => {
       assert.doesNotMatch(output, /Refreshed AGENTS\.md model capability table/);
       assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
       assert.equal(existsSync(join(wd, '.omx', 'backups', 'setup')), false);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves symlinked user-scope AGENTS.md during plugin-mode cleanup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-symlink-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const dotfilesAgentsPath = join(wd, 'dotfiles', '.codex', 'AGENTS.md');
+    const codexAgentsPath = join(home, '.codex', 'AGENTS.md');
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(wd, 'dotfiles', '.codex'), { recursive: true });
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await writeFile(
+        dotfilesAgentsPath,
+        addGeneratedAgentsMarker('# oh-my-codex - Intelligent Multi-Agent Orchestration\n\nDotfiles-owned guidance.\n'),
+      );
+      await symlink(dotfilesAgentsPath, codexAgentsPath);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        force: true,
+      });
+
+      assert.match(output, /AGENTS\.md generation skipped; no legacy OMX-generated AGENTS\.md found and defaults not selected\./);
+      assert.equal(await readlink(codexAgentsPath), dotfilesAgentsPath);
+      assert.match(await readFile(codexAgentsPath, 'utf-8'), /Dotfiles-owned guidance\./);
+      assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
     } finally {
       restoreHome();
       restoreTty();

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1845,6 +1845,72 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("preserves same-key user hook trust state in plugin-scoped setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					await writeFile(
+						hooksPath,
+						JSON.stringify(
+							{
+								hooks: {
+									PostCompact: [
+										{
+											hooks: [
+												{
+													type: "command",
+													command: "/usr/bin/python3 /tmp/user-hook.py",
+													timeout: 5,
+												},
+											],
+										},
+									],
+								},
+							},
+							null,
+							2,
+						) + "\n",
+					);
+					await writeFile(
+						configPath,
+						[
+							'model = "gpt-5.5"',
+							"",
+							`[hooks.state."${hooksPath}:post_compact:0:0"]`,
+							'trusted_hash = "sha256:user"',
+							"enabled = false",
+							"",
+						].join("\n"),
+					);
+
+					await setup({ scope: "user", installMode: "plugin" });
+
+					const config = await readFile(configPath, "utf-8");
+					assert.match(config, /^plugin_hooks = true$/m);
+					assert.match(config, /^trusted_hash = "sha256:user"$/m);
+					assert.match(config, /^enabled = false$/m);
+					assert.equal(
+						config
+							.split(/\r?\n/)
+							.filter(
+								(line) =>
+									line.trim() ===
+									`[hooks.state."${hooksPath}:post_compact:0:0"]`,
+							).length,
+						1,
+						"plugin setup must not duplicate preserved user hook trust state",
+					);
+					assert.doesNotThrow(() => parseToml(config));
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("honors persisted project-scoped plugin mode on repeat setup", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1114,13 +1114,16 @@ async function checkPluginScopedNativeHooks(
 	codexHomeDir: string,
 	setupHooksPath: string,
 ): Promise<Check> {
+	const setupHooksPathDescription = existsSync(setupHooksPath)
+		? `existing hooks.json at ${setupHooksPath} is treated as user-owned because plugin-scoped hooks are enabled`
+		: `setup-owned hooks.json is intentionally absent at ${setupHooksPath}`;
 	const packagedMarketplace = await resolvePackagedOmxMarketplace(getPackageRoot());
 	if (!packagedMarketplace) {
 		return {
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks are enabled and setup-owned hooks.json is intentionally absent at ${setupHooksPath}, but packaged ${OMX_LOCAL_MARKETPLACE_NAME} metadata was not found`,
+				`plugin-scoped hooks are enabled and ${setupHooksPathDescription}, but packaged ${OMX_LOCAL_MARKETPLACE_NAME} metadata was not found`,
 		};
 	}
 
@@ -1138,7 +1141,7 @@ async function checkPluginScopedNativeHooks(
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks are enabled, but the expected Codex plugin cache manifest is missing at ${join(expectedCacheDir, ".codex-plugin", "plugin.json")}; setup-owned hooks.json is intentionally absent at ${setupHooksPath}; run "omx setup --plugin --force" to refresh the plugin cache`,
+				`plugin-scoped hooks are enabled, but the expected Codex plugin cache manifest is missing at ${join(expectedCacheDir, ".codex-plugin", "plugin.json")}; ${setupHooksPathDescription}; run "omx setup --plugin --force" to refresh the plugin cache`,
 		};
 	}
 
@@ -1157,7 +1160,7 @@ async function checkPluginScopedNativeHooks(
 				name: "Native hooks",
 				status: "warn",
 				message:
-					`plugin-scoped hooks are enabled, but expected plugin hook file is missing at ${expectedPath}; setup-owned hooks.json is intentionally absent at ${setupHooksPath}; run "omx setup --plugin --force" to refresh the plugin cache`,
+					`plugin-scoped hooks are enabled, but expected plugin hook file is missing at ${expectedPath}; ${setupHooksPathDescription}; run "omx setup --plugin --force" to refresh the plugin cache`,
 			};
 		}
 	}
@@ -1236,7 +1239,7 @@ async function checkPluginScopedNativeHooks(
 		name: "Native hooks",
 		status: "pass",
 		message:
-			`plugin-scoped hooks are enabled; setup-owned hooks.json is intentionally absent at ${setupHooksPath}, and plugin cache native hook coverage smoke passed via ${expectedHooksPath}`,
+			`plugin-scoped hooks are enabled; ${setupHooksPathDescription}, and plugin cache native hook coverage smoke passed via ${expectedHooksPath}`,
 	};
 }
 
@@ -1245,14 +1248,23 @@ async function checkNativeHooks(
 	configPath: string,
 	context: NativeHookCheckContext,
 ): Promise<Check> {
+	if (existsSync(configPath) && context.installMode === "plugin") {
+		try {
+			const configContent = await readFile(configPath, "utf-8");
+			if (configEnablesPluginScopedHooks(configContent)) {
+				return checkPluginScopedNativeHooks(context.codexHomeDir, hooksPath);
+			}
+		} catch {
+			// Fall through to the hooks.json checks; the dedicated config check will
+			// report read failures separately.
+		}
+	}
+
 	if (!existsSync(hooksPath)) {
 		if (existsSync(configPath)) {
 			try {
 				const configContent = await readFile(configPath, "utf-8");
 				if (context.installMode === "plugin") {
-					if (configEnablesPluginScopedHooks(configContent)) {
-						return checkPluginScopedNativeHooks(context.codexHomeDir, hooksPath);
-					}
 					if (configHasOmxEntries(configContent)) {
 						return {
 							name: "Native hooks",

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -12,6 +12,7 @@ import {
 	rename,
 	writeFile,
 	stat,
+	lstat,
 	rm,
 } from "fs/promises";
 import { join, dirname, relative, basename } from "path";
@@ -1559,7 +1560,7 @@ async function applyPluginModeHooksConfig(
 		? await readFile(configPath, "utf-8")
 		: "";
 	const nextConfigBase = upsertPluginModeRuntimeFeatureFlags(
-		stripManagedCodexHookTrustState(existingConfig),
+		stripManagedCodexHookTrustState(existingConfig, { hooksPath }),
 		options.codexHookFeatureFlag,
 		{ pluginScopedHooks: options.pluginScopedHooks },
 	);
@@ -1744,6 +1745,15 @@ async function cleanupPluginModeLegacyAgentsMd(
 	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<boolean> {
 	if (!existsSync(agentsMdPath)) return false;
+	const fileInfo = await lstat(agentsMdPath);
+	if (fileInfo.isSymbolicLink()) {
+		if (options.verbose) {
+			console.log(
+				`  preserved symlinked AGENTS.md at ${agentsMdPath}; plugin mode only removes direct legacy OMX-generated files`,
+			);
+		}
+		return false;
+	}
 
 	const content = await readFile(agentsMdPath, "utf-8");
 	if (!isOmxGeneratedAgentsMd(content)) return false;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -54,6 +54,7 @@ import {
 } from "../config/generator.js";
 import type { CodexHookFeatureFlag } from "../config/codex-feature-flags.js";
 import {
+	buildManagedCodexHookTrustState,
 	buildManagedCodexNativeHookWindowsShimContent,
 	buildManagedCodexNativeHookWindowsShimPath,
 	mergeManagedCodexHooksConfig,
@@ -1559,8 +1560,13 @@ async function applyPluginModeHooksConfig(
 	const existingConfig = existsSync(configPath)
 		? await readFile(configPath, "utf-8")
 		: "";
+	const managedTrustState = buildManagedCodexHookTrustState(
+		hooksPath,
+		pkgRoot,
+		{ platform: process.platform, codexHomeDir },
+	);
 	const nextConfigBase = upsertPluginModeRuntimeFeatureFlags(
-		stripManagedCodexHookTrustState(existingConfig, { hooksPath }),
+		stripManagedCodexHookTrustState(existingConfig, { managedTrustState }),
 		options.codexHookFeatureFlag,
 		{ pluginScopedHooks: options.pluginScopedHooks },
 	);

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -16,6 +16,7 @@ import {
   stripManagedCodexHookTrustState,
   upsertManagedCodexHookTrustState,
 } from "../generator.js";
+import { buildManagedCodexHookTrustState } from "../codex-hooks.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../omx-first-party-mcp.js";
 
 /** Count occurrences of a pattern in text */
@@ -1119,7 +1120,14 @@ describe("config generator idempotency (#384)", () => {
     assert.doesNotThrow(() => TOML.parse(stripped));
   });
 
-  it("removes orphaned managed hook trust-state tables for the setup hooks path", () => {
+  it("removes orphaned managed hook trust-state tables only when hashes prove ownership", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const managedPostCompactHash =
+      managedTrustState[`${hooksPath}:post_compact:0:0`]?.trusted_hash;
+    const managedStopHash = managedTrustState[`${hooksPath}:stop:0:0`]?.trusted_hash;
+    assert.ok(managedPostCompactHash);
+    assert.ok(managedStopHash);
     const orphaned = [
       'model = "gpt-5.5"',
       "",
@@ -1129,13 +1137,14 @@ describe("config generator idempotency (#384)", () => {
       "enabled = true",
       "",
       '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
-      'trusted_hash = "sha256:managed"',
+      `trusted_hash = "${managedPostCompactHash}"`,
+      "",
+      '[hooks.state."/tmp/codex/hooks.json:stop:0:0"]',
+      `trusted_hash = "${managedStopHash}"`,
       "",
       '[hooks.state."custom:/hooks.json:stop:0:0"]',
       'trusted_hash = "sha256:user"',
       "",
-      '[hooks.state."/tmp/codex/hooks.json:stop:0:0"]',
-      'trusted_hash = "sha256:managed-stop"',
       "# End OMX-owned Codex hook trust state",
       "",
       "[desktop]",
@@ -1144,16 +1153,120 @@ describe("config generator idempotency (#384)", () => {
     ].join("\n");
 
     const stripped = stripManagedCodexHookTrustState(orphaned, {
-      hooksPath: "/tmp/codex/hooks.json",
+      managedTrustState,
     });
 
     assert.doesNotMatch(stripped, /\/tmp\/codex\/hooks\.json:post_compact:0:0/);
     assert.doesNotMatch(stripped, /\/tmp\/codex\/hooks\.json:stop:0:0/);
-    assert.doesNotMatch(stripped, /End OMX-owned Codex hook trust state/);
+    assert.match(stripped, /^# End OMX-owned Codex hook trust state$/m);
     assert.match(stripped, /^\[hooks\.state\."custom:\/hooks\.json:stop:0:0"\]$/m);
     assert.match(stripped, /^trusted_hash = "sha256:user"$/m);
     assert.match(stripped, /^\[desktop\]$/m);
     assert.doesNotThrow(() => TOML.parse(stripped));
+  });
+
+  it("preserves same-key user hook trust state and suppresses generated duplicates", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const config = [
+      'model = "gpt-5.5"',
+      "",
+      '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
+      'trusted_hash = "sha256:user"',
+      "enabled = false",
+      "",
+    ].join("\n");
+
+    const refreshed = upsertManagedCodexHookTrustState(
+      config,
+      "/tmp/omx",
+      hooksPath,
+    );
+
+    assert.match(refreshed, /^trusted_hash = "sha256:user"$/m);
+    assert.match(refreshed, /^enabled = false$/m);
+    assert.equal(
+      count(
+        refreshed,
+        /^\[hooks\.state\."\/tmp\/codex\/hooks\.json:post_compact:0:0"\]$/gm,
+      ),
+      1,
+      "preserved same-key user trust state must not be duplicated",
+    );
+    assert.doesNotThrow(() => TOML.parse(refreshed));
+  });
+
+  it("preserves unproven same-key hook trust-state tables", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const fixtures = [
+      [
+        "missing hash",
+        [
+          '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
+          "enabled = false",
+        ],
+      ],
+      [
+        "malformed hash",
+        [
+          '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
+          "trusted_hash = true",
+        ],
+      ],
+      [
+        "extra assignment",
+        [
+          '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
+          'trusted_hash = "sha256:user"',
+          "enabled = false",
+        ],
+      ],
+      [
+        "body comment",
+        [
+          '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
+          "# user comment",
+          'trusted_hash = "sha256:user"',
+        ],
+      ],
+      [
+        "inline body comment",
+        [
+          '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
+          'trusted_hash = "sha256:user" # user comment',
+        ],
+      ],
+      [
+        "inline header comment",
+        [
+          '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"] # user comment',
+          'trusted_hash = "sha256:user"',
+        ],
+      ],
+    ] as const;
+
+    for (const [name, table] of fixtures) {
+      const stripped = stripManagedCodexHookTrustState(table.join("\n"), {
+        managedTrustState,
+      });
+      assert.match(
+        stripped,
+        /^\[hooks\.state\."\/tmp\/codex\/hooks\.json:post_compact:0:0"\]/m,
+        `${name} should be preserved`,
+      );
+    }
+  });
+
+  it("does not remove unfenced hook trust-state tables without a proof map", () => {
+    const config = [
+      '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
+      'trusted_hash = "sha256:managed-looking"',
+      "",
+    ].join("\n");
+
+    const stripped = stripManagedCodexHookTrustState(config);
+
+    assert.match(stripped, /managed-looking/);
   });
 
   it("dedupes prior fenced managed hook trust-state blocks before writing a replacement", () => {

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -1119,6 +1119,43 @@ describe("config generator idempotency (#384)", () => {
     assert.doesNotThrow(() => TOML.parse(stripped));
   });
 
+  it("removes orphaned managed hook trust-state tables for the setup hooks path", () => {
+    const orphaned = [
+      'model = "gpt-5.5"',
+      "",
+      "[hooks.state]",
+      "",
+      '[plugins."oh-my-codex@oh-my-codex-local"]',
+      "enabled = true",
+      "",
+      '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
+      'trusted_hash = "sha256:managed"',
+      "",
+      '[hooks.state."custom:/hooks.json:stop:0:0"]',
+      'trusted_hash = "sha256:user"',
+      "",
+      '[hooks.state."/tmp/codex/hooks.json:stop:0:0"]',
+      'trusted_hash = "sha256:managed-stop"',
+      "# End OMX-owned Codex hook trust state",
+      "",
+      "[desktop]",
+      "git-create-pull-request-as-draft = true",
+      "",
+    ].join("\n");
+
+    const stripped = stripManagedCodexHookTrustState(orphaned, {
+      hooksPath: "/tmp/codex/hooks.json",
+    });
+
+    assert.doesNotMatch(stripped, /\/tmp\/codex\/hooks\.json:post_compact:0:0/);
+    assert.doesNotMatch(stripped, /\/tmp\/codex\/hooks\.json:stop:0:0/);
+    assert.doesNotMatch(stripped, /End OMX-owned Codex hook trust state/);
+    assert.match(stripped, /^\[hooks\.state\."custom:\/hooks\.json:stop:0:0"\]$/m);
+    assert.match(stripped, /^trusted_hash = "sha256:user"$/m);
+    assert.match(stripped, /^\[desktop\]$/m);
+    assert.doesNotThrow(() => TOML.parse(stripped));
+  });
+
   it("dedupes prior fenced managed hook trust-state blocks before writing a replacement", () => {
     const first = upsertManagedCodexHookTrustState(
       [

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -30,8 +30,9 @@ import {
   getOmxFirstPartySetupMcpServers,
 } from "./omx-first-party-mcp.js";
 import {
-  buildManagedCodexHookTrustToml,
+  buildManagedCodexHookTrustState,
   escapeTomlBasicString,
+  type ManagedCodexHookTrustState,
   type ManagedCodexHookOptions,
 } from "./codex-hooks.js";
 import type { HudPreset } from "../hud/types.js";
@@ -944,54 +945,111 @@ export function syncProjectScopeTrustStateFromRuntime(
   return `${stripped}\n\n${block}`;
 }
 
-const MANAGED_CODEX_HOOK_EVENT_LABELS = [
-  "session_start",
-  "pre_tool_use",
-  "post_tool_use",
-  "user_prompt_submit",
-  "pre_compact",
-  "post_compact",
-  "stop",
-] as const;
+type ManagedCodexHookTrustStateMap = Record<string, ManagedCodexHookTrustState>;
 
-function stripOrphanedManagedCodexHookTrustState(
-  config: string,
-  hooksPath: string,
-): string {
-  const managedHeaders = new Set(
-    MANAGED_CODEX_HOOK_EVENT_LABELS.map(
-      (eventLabel) =>
-        `[hooks.state."${escapeTomlBasicString(`${hooksPath}:${eventLabel}:0:0`)}"]`,
-    ),
+interface HookTrustStateStripResult {
+  config: string;
+  preservedConflictKeys: Set<string>;
+}
+
+interface HooksStateHeader {
+  key: string;
+  hasInlineComment: boolean;
+}
+
+function decodeTomlBasicString(raw: string): string | undefined {
+  try {
+    const parsed = TOML.parse(`value = "${raw}"`) as { value?: unknown };
+    return typeof parsed.value === "string" ? parsed.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseHooksStateHeader(line: string): HooksStateHeader | undefined {
+  const match = line.match(
+    /^\s*\[hooks\.state\."((?:\\.|[^"\\])*)"\]\s*(#.*)?$/,
   );
+  if (!match) return undefined;
+  const key = decodeTomlBasicString(match[1] ?? "");
+  if (key === undefined) return undefined;
+  return { key, hasInlineComment: match[2] !== undefined };
+}
+
+function isTomlTableHeader(line: string): boolean {
+  return /^\s*\[\[?[^\]]+\]?\]\s*(?:#.*)?$/.test(line);
+}
+
+function isExactlyManagedHookTrustBody(
+  bodyLines: readonly string[],
+  expectedHash: string,
+): boolean {
+  const nonBlank = bodyLines.filter((line) => line.trim().length > 0);
+  if (nonBlank.length !== 1) return false;
+
+  const expected = expectedHash.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^\\s*trusted_hash\\s*=\\s*"${expected}"\\s*$`).test(
+    nonBlank[0] ?? "",
+  );
+}
+
+function stripProofManagedCodexHookTrustStateTables(
+  config: string,
+  managedTrustState: ManagedCodexHookTrustStateMap,
+): HookTrustStateStripResult {
+  if (Object.keys(managedTrustState).length === 0) {
+    return { config, preservedConflictKeys: new Set() };
+  }
+
   const lines = config.split(/\r?\n/);
   const kept: string[] = [];
+  const preservedConflictKeys = new Set<string>();
 
   for (let i = 0; i < lines.length;) {
-    const trimmed = lines[i].trim();
-    if (trimmed === OMX_HOOK_TRUST_END_MARKER) {
-      i += 1;
-      continue;
-    }
-    if (!managedHeaders.has(trimmed)) {
+    const header = parseHooksStateHeader(lines[i] ?? "");
+    if (!header) {
       kept.push(lines[i]);
       i += 1;
       continue;
     }
 
-    i += 1;
-    while (i < lines.length && !/^\s*\[/.test(lines[i])) {
-      i += 1;
+    let tableEnd = lines.length;
+    for (let next = i + 1; next < lines.length; next += 1) {
+      if (isTomlTableHeader(lines[next] ?? "")) {
+        tableEnd = next;
+        break;
+      }
     }
+
+    const expectedState = managedTrustState[header.key];
+    const removable =
+      expectedState !== undefined &&
+      !header.hasInlineComment &&
+      isExactlyManagedHookTrustBody(
+        lines.slice(i + 1, tableEnd),
+        expectedState.trusted_hash,
+      );
+
+    if (removable) {
+      i = tableEnd;
+      continue;
+    }
+
+    if (expectedState !== undefined) {
+      preservedConflictKeys.add(header.key);
+    }
+
+    kept.push(...lines.slice(i, tableEnd));
+    i = tableEnd;
   }
 
-  return kept.join("\n");
+  return { config: kept.join("\n"), preservedConflictKeys };
 }
 
-export function stripManagedCodexHookTrustState(
+function stripManagedCodexHookTrustStateWithResult(
   config: string,
-  options: { hooksPath?: string } = {},
-): string {
+  options: { managedTrustState?: ManagedCodexHookTrustStateMap } = {},
+): HookTrustStateStripResult {
   const lines = config.split(/\r?\n/);
   const kept: string[] = [];
 
@@ -1019,51 +1077,50 @@ export function stripManagedCodexHookTrustState(
     i = nextEndIdx + 1;
   }
 
-  const stripped = kept.join("\n");
-  const withoutOrphans = options.hooksPath
-    ? stripOrphanedManagedCodexHookTrustState(stripped, options.hooksPath)
-    : stripped;
+  const withoutFenced = kept.join("\n");
+  const proofStripped = options.managedTrustState
+    ? stripProofManagedCodexHookTrustStateTables(
+        withoutFenced,
+        options.managedTrustState,
+      )
+    : { config: withoutFenced, preservedConflictKeys: new Set<string>() };
 
-  return withoutOrphans.replace(/\n{3,}/g, "\n\n").trimEnd();
+  return {
+    config: proofStripped.config.replace(/\n{3,}/g, "\n\n").trimEnd(),
+    preservedConflictKeys: proofStripped.preservedConflictKeys,
+  };
 }
 
-function managedCodexHookTrustStateHeaders(
-  hookTrustToml: string,
-): ReadonlySet<string> {
-  const headers = new Set<string>();
-  for (const line of hookTrustToml.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (/^\[hooks\.state\./.test(trimmed)) {
-      headers.add(trimmed);
-    }
-  }
-  return headers;
-}
-
-function stripUnfencedManagedCodexHookTrustState(
+export function stripManagedCodexHookTrustState(
   config: string,
-  hookTrustToml: string,
+  options: { managedTrustState?: ManagedCodexHookTrustStateMap } = {},
 ): string {
-  const managedHeaders = managedCodexHookTrustStateHeaders(hookTrustToml);
-  if (managedHeaders.size === 0) return config;
+  return stripManagedCodexHookTrustStateWithResult(config, options).config;
+}
 
-  const lines = config.split(/\r?\n/);
-  const kept: string[] = [];
+function renderManagedCodexHookTrustToml(
+  managedTrustState: ManagedCodexHookTrustStateMap,
+  excludedKeys: ReadonlySet<string> = new Set(),
+): string {
+  return Object.entries(managedTrustState)
+    .filter(([key]) => !excludedKeys.has(key))
+    .sort(([left], [right]) => left.localeCompare(right))
+    .flatMap(([key, hookState]) => [
+      `[hooks.state."${escapeTomlBasicString(key)}"]`,
+      `trusted_hash = "${escapeTomlBasicString(hookState.trusted_hash)}"`,
+      "",
+    ])
+    .join("\n")
+    .trimEnd();
+}
 
-  for (let i = 0; i < lines.length;) {
-    if (!managedHeaders.has(lines[i].trim())) {
-      kept.push(lines[i]);
-      i += 1;
-      continue;
-    }
-
-    i += 1;
-    while (i < lines.length && !TOML_TABLE_HEADER_PATTERN.test(lines[i])) {
-      i += 1;
-    }
-  }
-
-  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+function buildManagedCodexHookTrustStateForConfig(
+  codexHooksFile: string | undefined,
+  pkgRoot: string,
+  options: ManagedCodexHookOptions = {},
+): ManagedCodexHookTrustStateMap {
+  if (!codexHooksFile) return {};
+  return buildManagedCodexHookTrustState(codexHooksFile, pkgRoot, options);
 }
 
 export function upsertManagedCodexHookTrustState(
@@ -1072,10 +1129,18 @@ export function upsertManagedCodexHookTrustState(
   codexHooksFile: string | undefined,
   options: ManagedCodexHookOptions = {},
 ): string {
-  const hookTrustToml = buildManagedCodexHookTrustToml(codexHooksFile, pkgRoot, options);
-  const stripped = stripUnfencedManagedCodexHookTrustState(
-    stripManagedCodexHookTrustState(config),
-    hookTrustToml,
+  const managedTrustState = buildManagedCodexHookTrustStateForConfig(
+    codexHooksFile,
+    pkgRoot,
+    options,
+  );
+  const strippedResult = stripManagedCodexHookTrustStateWithResult(config, {
+    managedTrustState,
+  });
+  const stripped = strippedResult.config;
+  const hookTrustToml = renderManagedCodexHookTrustToml(
+    managedTrustState,
+    strippedResult.preservedConflictKeys,
   );
   if (!hookTrustToml) return `${stripped}\n`;
   return [
@@ -2195,6 +2260,7 @@ function getOmxTablesBlock(
   codexHooksFile?: string,
   hookOptions: ManagedCodexHookOptions = {},
   includeFirstPartyMcp = false,
+  excludedHookTrustStateKeys: ReadonlySet<string> = new Set(),
 ): string {
   const lines = [
     "",
@@ -2222,10 +2288,13 @@ function getOmxTablesBlock(
     }
   }
 
-  const hookTrustToml = buildManagedCodexHookTrustToml(
-    codexHooksFile,
-    pkgRoot,
-    hookOptions,
+  const hookTrustToml = renderManagedCodexHookTrustToml(
+    buildManagedCodexHookTrustStateForConfig(
+      codexHooksFile,
+      pkgRoot,
+      hookOptions,
+    ),
+    excludedHookTrustStateKeys,
   );
   if (hookTrustToml) {
     lines.push("");
@@ -2307,14 +2376,18 @@ export function buildMergedConfig(
     existing = `${`notify = ${formatTomlStringArray(userNotifyToPreserve)}`}\n${existing.trimStart()}`;
   }
   existing = stripOrphanedManagedNotify(existing, pkgRoot);
-  existing = stripManagedCodexHookTrustState(existing);
-  existing = stripUnfencedManagedCodexHookTrustState(
-    existing,
-    buildManagedCodexHookTrustToml(options.codexHooksFile, pkgRoot, {
+  const managedTrustState = buildManagedCodexHookTrustStateForConfig(
+    options.codexHooksFile,
+    pkgRoot,
+    {
       codexHomeDir: options.codexHomeDir,
       platform: options.hookCommandPlatform,
-    }),
+    },
   );
+  const hookTrustStrip = stripManagedCodexHookTrustStateWithResult(existing, {
+    managedTrustState,
+  });
+  existing = hookTrustStrip.config;
   if (options.modelOverride) {
     existing = stripRootLevelKeys(existing, ["model"]);
   }
@@ -2350,6 +2423,7 @@ export function buildMergedConfig(
       platform: options.hookCommandPlatform,
     },
     options.includeFirstPartyMcp === true,
+    hookTrustStrip.preservedConflictKeys,
   );
   const sharedRegistryBlock = getSharedMcpRegistryBlock(
     options.sharedMcpServers ?? [],

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -944,7 +944,54 @@ export function syncProjectScopeTrustStateFromRuntime(
   return `${stripped}\n\n${block}`;
 }
 
-export function stripManagedCodexHookTrustState(config: string): string {
+const MANAGED_CODEX_HOOK_EVENT_LABELS = [
+  "session_start",
+  "pre_tool_use",
+  "post_tool_use",
+  "user_prompt_submit",
+  "pre_compact",
+  "post_compact",
+  "stop",
+] as const;
+
+function stripOrphanedManagedCodexHookTrustState(
+  config: string,
+  hooksPath: string,
+): string {
+  const managedHeaders = new Set(
+    MANAGED_CODEX_HOOK_EVENT_LABELS.map(
+      (eventLabel) =>
+        `[hooks.state."${escapeTomlBasicString(`${hooksPath}:${eventLabel}:0:0`)}"]`,
+    ),
+  );
+  const lines = config.split(/\r?\n/);
+  const kept: string[] = [];
+
+  for (let i = 0; i < lines.length;) {
+    const trimmed = lines[i].trim();
+    if (trimmed === OMX_HOOK_TRUST_END_MARKER) {
+      i += 1;
+      continue;
+    }
+    if (!managedHeaders.has(trimmed)) {
+      kept.push(lines[i]);
+      i += 1;
+      continue;
+    }
+
+    i += 1;
+    while (i < lines.length && !/^\s*\[/.test(lines[i])) {
+      i += 1;
+    }
+  }
+
+  return kept.join("\n");
+}
+
+export function stripManagedCodexHookTrustState(
+  config: string,
+  options: { hooksPath?: string } = {},
+): string {
   const lines = config.split(/\r?\n/);
   const kept: string[] = [];
 
@@ -972,7 +1019,12 @@ export function stripManagedCodexHookTrustState(config: string): string {
     i = nextEndIdx + 1;
   }
 
-  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+  const stripped = kept.join("\n");
+  const withoutOrphans = options.hooksPath
+    ? stripOrphanedManagedCodexHookTrustState(stripped, options.hooksPath)
+    : stripped;
+
+  return withoutOrphans.replace(/\n{3,}/g, "\n\n").trimEnd();
 }
 
 function managedCodexHookTrustStateHeaders(


### PR DESCRIPTION
## Note

Hey @Yeachan-Heo, didn't really mean to open this against upstream, but given clawdbot seems receptive, here it is against the dev branch!

## Summary

- Treat existing `hooks.json` as user-owned when plugin-scoped hooks are enabled.
- Preserve symlinked `AGENTS.md` during plugin-mode cleanup so dotfiles-managed installs are not removed.
- Strip stale managed hook trust-state tables for the old setup-owned hook path during plugin-mode setup.

## Root cause

`omx doctor` checked setup-owned `hooks.json` before recognizing that plugin mode with `plugin_hooks = true` validates hooks through the plugin cache. If a user kept their own `~/.codex/hooks.json` entry, doctor reported missing OMX-managed native coverage even though plugin-scoped hook coverage was correct.

## Validation

- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node --test dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/doctor-warning-copy.test.js`
- `node --test --test-name-pattern 'preserves symlinked user-scope AGENTS.md during plugin-mode cleanup' dist/cli/__tests__/setup-agents-overwrite.test.js`
- Local `omx setup --force` followed by `omx doctor` reports `16 passed, 0 warnings, 0 failed`.
