### PR TITLE
fix: coalesce stale HUD panes by leader

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3030,6 +3030,18 @@ describe("detached tmux new-session sequencing", () => {
     assert.doesNotMatch(argsText, /fake-provider-key/);
   });
 
+  it("runCodex coalesces stale same-leader HUD panes across session ids", async () => {
+    const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
+    assert.match(
+      source,
+      /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\);/,
+    );
+    assert.doesNotMatch(
+      source,
+      /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\);/,
+    );
+  });
+
   it("runCodex builds inside-tmux HUD command with OMX_SESSION_ID and OMX_ROOT when set", async () => {
     const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
     assert.match(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3954,7 +3954,7 @@ function runCodex(
 
   if (launchPolicy === "inside-tmux") {
     // Already in tmux: launch codex in current pane, HUD in bottom split
-    const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId });
+    const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow(currentPaneId, { leaderPaneId: currentPaneId });
     for (const paneId of staleHudPaneIds) {
       killTmuxPane(paneId);
     }

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -183,6 +183,49 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(killed, ['%2', '%3']);
   });
 
+  it('coalesces same-leader HUD panes across session ids', async () => {
+    const killed: string[] = [];
+    const created: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-old-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+        {
+          paneId: '%3',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-old-b' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+        {
+          paneId: '%4',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-other' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%9' node omx hud --watch`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, cmd) => {
+        created.push(cmd);
+        return '%8';
+      },
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.paneId, '%8');
+    assert.equal(result.duplicateCount, 1);
+    assert.deepEqual(killed, ['%2', '%3']);
+    assert.match(created[0] || '', /OMX_SESSION_ID='sess-new'/);
+  });
+
   it('does not resize, kill, or reuse another active leader session HUD in the same tmux window', async () => {
     const killed: string[] = [];
     const resized: string[] = [];

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -157,6 +157,20 @@ describe('HUD pane ownership helpers', () => {
     assert.deepEqual(findHudWatchPaneIds(panes, '%3', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2']);
   });
 
+  it('matches same-leader HUD panes across session ids for same-pane relaunch cleanup', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        `%2\tnode\texec env OMX_SESSION_ID='old-session' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+        `%3\tnode\texec env OMX_SESSION_ID='new-session' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+        `%4\tnode\texec env OMX_SESSION_ID='other-session' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%9' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), ['%2', '%3']);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'new-session', leaderPaneId: '%1' }), ['%3']);
+  });
+
   it('does not owner-match untagged HUD panes when an owner scope is requested', () => {
     const panes = parseTmuxPaneSnapshot(
       [

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -107,7 +107,6 @@ export async function reconcileHudForPromptSubmit(
   const panes = listPanes(currentPaneId);
   const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
   const hudPaneIds = findHudWatchPaneIds(panes, currentPaneId, {
-    sessionId: resolvedSessionId,
     leaderPaneId: currentPaneId,
   });
   const duplicateCount = Math.max(0, hudPaneIds.length - 1);


### PR DESCRIPTION
## Summary
- coalesce stale inside-tmux HUD panes by `OMX_TMUX_HUD_LEADER_PANE`, not by the new OMX session id
- keep independent leaders isolated by retaining the leader-pane owner filter
- add regression coverage for same-leader HUD panes with different session ids

## Root cause
Inside-tmux launch created a fresh HUD pane after looking for stale HUD panes with both `{ sessionId, leaderPaneId }`. If the same tmux leader pane was reused by a later `omx --madmax resume`, old HUD panes had the same leader pane id but an older `OMX_SESSION_ID`, so startup cleanup did not select them.

## Test Plan
- `npm run build`
- `node --test dist/hud/__tests__/tmux.test.js dist/cli/__tests__/index.test.js`
- `npm run lint -- src/cli/index.ts src/cli/__tests__/index.test.ts src/hud/__tests__/tmux.test.ts`
- `npm run check:no-unused`

Note: `npm test` was also attempted as a broader smoke check, but it hung in an unrelated later suite after the focused checks above had passed; it was terminated after several minutes with no failure output.

Closes #2479
