### PR TITLE
fix: coalesce launch HUD panes by leader

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3034,11 +3034,19 @@ describe("detached tmux new-session sequencing", () => {
     const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\);/,
+      /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\)\s*: \[\];/,
     );
     assert.doesNotMatch(
       source,
       /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\);/,
+    );
+  });
+
+  it("runCodex skips launch-time HUD cleanup when TMUX_PANE is unavailable", async () => {
+    const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
+    assert.match(
+      source,
+      /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\)\s*: \[\];/,
     );
   });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3030,6 +3030,18 @@ describe("detached tmux new-session sequencing", () => {
     assert.doesNotMatch(argsText, /fake-provider-key/);
   });
 
+  it("runCodex coalesces stale same-leader HUD panes across session ids", async () => {
+    const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
+    assert.match(
+      source,
+      /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\);/,
+    );
+    assert.doesNotMatch(
+      source,
+      /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\);/,
+    );
+  });
+
   it("runCodex builds inside-tmux HUD command with OMX_SESSION_ID and OMX_ROOT when set", async () => {
     const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
     assert.match(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3954,7 +3954,7 @@ function runCodex(
 
   if (launchPolicy === "inside-tmux") {
     // Already in tmux: launch codex in current pane, HUD in bottom split
-    const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId });
+    const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow(currentPaneId, { leaderPaneId: currentPaneId });
     for (const paneId of staleHudPaneIds) {
       killTmuxPane(paneId);
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3954,7 +3954,9 @@ function runCodex(
 
   if (launchPolicy === "inside-tmux") {
     // Already in tmux: launch codex in current pane, HUD in bottom split
-    const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow(currentPaneId, { leaderPaneId: currentPaneId });
+    const staleHudPaneIds = currentPaneId
+      ? listHudWatchPaneIdsInCurrentWindow(currentPaneId, { leaderPaneId: currentPaneId })
+      : [];
     for (const paneId of staleHudPaneIds) {
       killTmuxPane(paneId);
     }

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -157,6 +157,20 @@ describe('HUD pane ownership helpers', () => {
     assert.deepEqual(findHudWatchPaneIds(panes, '%3', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2']);
   });
 
+  it('matches same-leader HUD panes across session ids for same-pane relaunch cleanup', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        `%2\tnode\texec env OMX_SESSION_ID='old-session' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+        `%3\tnode\texec env OMX_SESSION_ID='new-session' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+        `%4\tnode\texec env OMX_SESSION_ID='other-session' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%9' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), ['%2', '%3']);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'new-session', leaderPaneId: '%1' }), ['%3']);
+  });
+
   it('does not owner-match untagged HUD panes when an owner scope is requested', () => {
     const panes = parseTmuxPaneSnapshot(
       [


### PR DESCRIPTION
## Summary
- replace the closed `main`-based #2480 with a clean `dev`-based branch
- coalesce stale inside-tmux HUD panes by `leaderPaneId` at launch/resume time
- add coverage for same-leader HUD panes carrying different `OMX_SESSION_ID` values while preserving strict session+leader matching for prompt-submit/session reconcile

## Scope notes
This is intentionally narrow:
- launch-time stale HUD cleanup uses `{ leaderPaneId: currentPaneId }`, so relaunches clean up HUD panes from older sessions owned by the same leader pane
- prompt-submit/session reconcile remains strict and unchanged (`{ sessionId, leaderPaneId }`)
- neighboring leaders in the same tmux window remain isolated by the leader-pane owner tag
- this PR does not claim to fix broader lifecycle/teardown cleanup behavior

Fixes #2479.
Replaces #2480.

## Local checks
- `git diff --check upstream/dev...HEAD`
- `npm run build`
- `node --test dist/hud/__tests__/tmux.test.js dist/cli/__tests__/index.test.js`
- `npm run lint -- src/cli/index.ts src/cli/__tests__/index.test.ts src/hud/__tests__/tmux.test.ts`
- `npm run check:no-unused`

## Pre-publication review
A fresh tmux OMX code-review pass was run against this branch before publication:
- verdict: APPROVE
- blocking findings: 0
- noted caveat: keep the PR body narrow about launch-time cleanup only; do not claim broader lifecycle cleanup changes
