### PR TITLE
[deep-interview] Support deepInterview runtime config overrides

### DIFF
--- a/plugins/oh-my-codex/skills/deep-interview/SKILL.md
+++ b/plugins/oh-my-codex/skills/deep-interview/SKILL.md
@@ -462,6 +462,16 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 <Advanced>
 ## Suggested Config (optional)
 
+Deep-interview reads runtime defaults from the first existing config source in this order:
+
+1. Repository-local `.omx/config.toml`
+2. Repository-root `omx.toml`
+3. User-global `~/.omx/config.toml`
+
+This section is currently a deep-interview-specific runtime override surface, not a general replacement for Codex `config.toml` or `.omx-config.json` model/env routing.
+Malformed config files are ignored fail-soft so `$deep-interview` activation can continue with built-in defaults.
+Explicit `--quick`, `--standard`, or `--deep` invocation flags override `defaultProfile`.
+
 ```toml
 [omx.deepInterview]
 defaultProfile = "standard"

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -462,6 +462,16 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 <Advanced>
 ## Suggested Config (optional)
 
+Deep-interview reads runtime defaults from the first existing config source in this order:
+
+1. Repository-local `.omx/config.toml`
+2. Repository-root `omx.toml`
+3. User-global `~/.omx/config.toml`
+
+This section is currently a deep-interview-specific runtime override surface, not a general replacement for Codex `config.toml` or `.omx-config.json` model/env routing.
+Malformed config files are ignored fail-soft so `$deep-interview` activation can continue with built-in defaults.
+Explicit `--quick`, `--standard`, or `--deep` invocation flags override `defaultProfile`.
+
 ```toml
 [omx.deepInterview]
 defaultProfile = "standard"

--- a/src/config/__tests__/deep-interview.test.ts
+++ b/src/config/__tests__/deep-interview.test.ts
@@ -240,6 +240,31 @@ deepMaxRounds = 30
     }
   });
 
+  it('does not cascade to lower-precedence configs when an existing higher-precedence file omits deepInterview', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-config-no-table-precedence-'));
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-deep-interview-home-no-table-precedence-'));
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(join(homeDir, '.omx'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'config.toml'), '[omx.other]\nenabled = true\n');
+      await writeFile(
+        join(homeDir, '.omx', 'config.toml'),
+        `[omx.deepInterview]
+defaultProfile = "deep"
+deepThreshold = 0.01
+deepMaxRounds = 30
+`,
+      );
+
+      const config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview' });
+
+      assert.equal(config, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
   it('parses supported profile flags only', () => {
     assert.equal(parseDeepInterviewProfileFromText('$deep-interview --quick'), 'quick');
     assert.equal(parseDeepInterviewProfileFromText('$deep-interview --standard'), 'standard');

--- a/src/config/__tests__/deep-interview.test.ts
+++ b/src/config/__tests__/deep-interview.test.ts
@@ -269,6 +269,11 @@ deepMaxRounds = 30
     assert.equal(parseDeepInterviewProfileFromText('$deep-interview --quick'), 'quick');
     assert.equal(parseDeepInterviewProfileFromText('$deep-interview --standard'), 'standard');
     assert.equal(parseDeepInterviewProfileFromText('$deep-interview --deep'), 'deep');
+    assert.equal(parseDeepInterviewProfileFromText('$oh-my-codex:deep-interview --deep'), 'deep');
+    assert.equal(parseDeepInterviewProfileFromText('deep interview --quick'), 'quick');
     assert.equal(parseDeepInterviewProfileFromText('$deep-interview --deeper'), undefined);
+    assert.equal(parseDeepInterviewProfileFromText('$deep-interview clarify this and run other-tool --deep'), undefined);
+    assert.equal(parseDeepInterviewProfileFromText('$deep-interview clarify the plain-text --deep option'), undefined);
+    assert.equal(parseDeepInterviewProfileFromText('explain the --deep option'), undefined);
   });
 });

--- a/src/config/__tests__/deep-interview.test.ts
+++ b/src/config/__tests__/deep-interview.test.ts
@@ -207,6 +207,39 @@ standardMaxRounds = 1.5
     }
   });
 
+  it('does not cascade to lower-precedence configs after a parse failure', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-config-malformed-precedence-'));
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-deep-interview-home-malformed-precedence-'));
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    try {
+      console.warn = (message?: unknown) => {
+        warnings.push(String(message));
+      };
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(join(homeDir, '.omx'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'config.toml'), '[omx.deepInterview\nstandardThreshold = 0.05\n');
+      await writeFile(
+        join(homeDir, '.omx', 'config.toml'),
+        `[omx.deepInterview]
+defaultProfile = "deep"
+deepThreshold = 0.01
+deepMaxRounds = 30
+`,
+      );
+
+      const config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview' });
+
+      assert.equal(config, null);
+      assert.equal(warnings.length, 1);
+      assert.match(warnings[0] ?? '', /ignoring malformed deep-interview config/);
+    } finally {
+      console.warn = originalWarn;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
   it('parses supported profile flags only', () => {
     assert.equal(parseDeepInterviewProfileFromText('$deep-interview --quick'), 'quick');
     assert.equal(parseDeepInterviewProfileFromText('$deep-interview --standard'), 'standard');

--- a/src/config/__tests__/deep-interview.test.ts
+++ b/src/config/__tests__/deep-interview.test.ts
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  getDeepInterviewConfigCandidatePaths,
+  parseDeepInterviewProfileFromText,
+  resolveDeepInterviewRuntimeConfig,
+} from '../deep-interview.js';
+
+describe('deep-interview runtime config', () => {
+  it('resolves project .omx/config.toml and applies profile-specific values', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-config-'));
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-deep-interview-home-'));
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'config.toml'),
+        `[omx.deepInterview]
+defaultProfile = "standard"
+standardThreshold = 0.05
+standardMaxRounds = 15
+enableChallengeModes = false
+`,
+      );
+
+      const config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview clarify this' });
+
+      assert.deepEqual(config, {
+        profile: 'standard',
+        threshold: 0.05,
+        maxRounds: 15,
+        enableChallengeModes: false,
+        sourcePath: join(cwd, '.omx', 'config.toml'),
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses explicit --quick/--standard/--deep flags over configured defaultProfile', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-config-'));
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-deep-interview-home-'));
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'config.toml'),
+        `[omx.deepInterview]
+defaultProfile = "quick"
+quickThreshold = 0.11
+quickMaxRounds = 3
+deepThreshold = 0.01
+deepMaxRounds = 30
+`,
+      );
+
+      const config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview --deep clarify this' });
+
+      assert.equal(config?.profile, 'deep');
+      assert.equal(config?.threshold, 0.01);
+      assert.equal(config?.maxRounds, 30);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers project config over root omx.toml and user config', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-config-'));
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-deep-interview-home-'));
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(join(homeDir, '.omx'), { recursive: true });
+      await writeFile(join(homeDir, '.omx', 'config.toml'), '[omx.deepInterview]\nstandardThreshold = 0.40\n');
+      await writeFile(join(cwd, 'omx.toml'), '[omx.deepInterview]\nstandardThreshold = 0.30\n');
+      await writeFile(join(cwd, '.omx', 'config.toml'), '[omx.deepInterview]\nstandardThreshold = 0.10\n');
+
+      const config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview' });
+
+      assert.equal(config?.threshold, 0.10);
+      assert.equal(config?.sourcePath, join(cwd, '.omx', 'config.toml'));
+      assert.deepEqual(getDeepInterviewConfigCandidatePaths({ cwd, homeDir }).map((entry) => entry.precedence), [
+        'project-omx',
+        'project-root',
+        'user',
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves each documented config source when higher-precedence sources are absent', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-config-sources-'));
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-deep-interview-home-sources-'));
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(join(homeDir, '.omx'), { recursive: true });
+
+      await writeFile(join(cwd, '.omx', 'config.toml'), '[omx.deepInterview]\nstandardThreshold = 0.11\n');
+      let config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview' });
+      assert.equal(config?.threshold, 0.11);
+      assert.equal(config?.sourcePath, join(cwd, '.omx', 'config.toml'));
+
+      await rm(join(cwd, '.omx', 'config.toml'), { force: true });
+      await writeFile(join(cwd, 'omx.toml'), '[omx.deepInterview]\nstandardThreshold = 0.22\n');
+      config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview' });
+      assert.equal(config?.threshold, 0.22);
+      assert.equal(config?.sourcePath, join(cwd, 'omx.toml'));
+
+      await rm(join(cwd, 'omx.toml'), { force: true });
+      await writeFile(join(homeDir, '.omx', 'config.toml'), '[omx.deepInterview]\nstandardThreshold = 0.33\n');
+      config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview' });
+      assert.equal(config?.threshold, 0.33);
+      assert.equal(config?.sourcePath, join(homeDir, '.omx', 'config.toml'));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves repository config from nested working directories', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-config-'));
+    const nestedCwd = join(cwd, 'src', 'nested');
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-deep-interview-home-'));
+    try {
+      await mkdir(join(cwd, '.git'), { recursive: true });
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(nestedCwd, { recursive: true });
+      await writeFile(join(cwd, '.omx', 'config.toml'), '[omx.deepInterview]\nstandardThreshold = 0.05\n');
+
+      const config = resolveDeepInterviewRuntimeConfig({ cwd: nestedCwd, homeDir, text: '$deep-interview' });
+
+      assert.equal(config?.threshold, 0.05);
+      assert.equal(config?.sourcePath, join(cwd, '.omx', 'config.toml'));
+      assert.equal(getDeepInterviewConfigCandidatePaths({ cwd: nestedCwd, homeDir })[0]?.path, join(cwd, '.omx', 'config.toml'));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to built-in profile defaults when a config omits that profile value', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-config-'));
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-deep-interview-home-'));
+    try {
+      await writeFile(join(cwd, 'omx.toml'), '[omx.deepInterview]\ndefaultProfile = "deep"\n');
+
+      const config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview' });
+
+      assert.equal(config?.profile, 'deep');
+      assert.equal(config?.threshold, 0.15);
+      assert.equal(config?.maxRounds, 20);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes profile names and ignores invalid numeric overrides', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-config-'));
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-deep-interview-home-'));
+    try {
+      await writeFile(
+        join(cwd, 'omx.toml'),
+        `[omx.deepInterview]
+defaultProfile = "STANDARD"
+standardThreshold = 2
+standardMaxRounds = 1.5
+`,
+      );
+
+      const config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview' });
+
+      assert.equal(config?.profile, 'standard');
+      assert.equal(config?.threshold, 0.20);
+      assert.equal(config?.maxRounds, 12);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores malformed TOML without throwing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-config-'));
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-deep-interview-home-'));
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    try {
+      console.warn = (message?: unknown) => {
+        warnings.push(String(message));
+      };
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'config.toml'), '[omx.deepInterview\nstandardThreshold = 0.05\n');
+
+      const config = resolveDeepInterviewRuntimeConfig({ cwd, homeDir, text: '$deep-interview' });
+
+      assert.equal(config, null);
+      assert.equal(warnings.length, 1);
+      assert.match(warnings[0] ?? '', /ignoring malformed deep-interview config/);
+    } finally {
+      console.warn = originalWarn;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses supported profile flags only', () => {
+    assert.equal(parseDeepInterviewProfileFromText('$deep-interview --quick'), 'quick');
+    assert.equal(parseDeepInterviewProfileFromText('$deep-interview --standard'), 'standard');
+    assert.equal(parseDeepInterviewProfileFromText('$deep-interview --deep'), 'deep');
+    assert.equal(parseDeepInterviewProfileFromText('$deep-interview --deeper'), undefined);
+  });
+});

--- a/src/config/deep-interview.ts
+++ b/src/config/deep-interview.ts
@@ -45,6 +45,12 @@ interface DeepInterviewProfileSpec {
   };
 }
 
+type DeepInterviewConfigReadResult =
+  | { status: 'missing' }
+  | { status: 'malformed' }
+  | { status: 'no-table' }
+  | { status: 'table'; table: DeepInterviewConfigTable };
+
 const DEFAULT_PROFILE: DeepInterviewProfile = 'standard';
 const DEFAULT_ENABLE_CHALLENGE_MODES = true;
 
@@ -104,14 +110,15 @@ function extractDeepInterviewTable(parsed: unknown): DeepInterviewConfigTable | 
   return parsed.omx.deepInterview as DeepInterviewConfigTable;
 }
 
-function readDeepInterviewConfigTable(configPath: string): DeepInterviewConfigTable | null {
-  if (!existsSync(configPath)) return null;
+function readDeepInterviewConfigTable(configPath: string): DeepInterviewConfigReadResult {
+  if (!existsSync(configPath)) return { status: 'missing' };
 
   try {
-    return extractDeepInterviewTable(parseToml(readFileSync(configPath, 'utf-8')) as unknown);
+    const table = extractDeepInterviewTable(parseToml(readFileSync(configPath, 'utf-8')) as unknown);
+    return table ? { status: 'table', table } : { status: 'no-table' };
   } catch (error) {
     warnMalformedConfig(configPath, error);
-    return null;
+    return { status: 'malformed' };
   }
 }
 
@@ -165,8 +172,9 @@ export function getDeepInterviewConfigCandidatePaths(options: Pick<DeepInterview
 
 export function resolveDeepInterviewRuntimeConfig(options: DeepInterviewConfigOptions): DeepInterviewRuntimeConfig | null {
   for (const candidate of getDeepInterviewConfigCandidatePaths(options)) {
-    const table = readDeepInterviewConfigTable(candidate.path);
-    if (table) return buildRuntimeConfig(candidate, table, options);
+    const result = readDeepInterviewConfigTable(candidate.path);
+    if (result.status === 'malformed') return null;
+    if (result.status === 'table') return buildRuntimeConfig(candidate, result.table, options);
   }
 
   return null;

--- a/src/config/deep-interview.ts
+++ b/src/config/deep-interview.ts
@@ -72,7 +72,8 @@ const PROFILE_SPECS: Record<DeepInterviewProfile, DeepInterviewProfileSpec> = {
   },
 };
 
-const PROFILE_FLAG_PATTERN = /(?:^|\s)--(quick|standard|deep)(?=\s|$)/i;
+const DEEP_INTERVIEW_INVOCATION_PATTERN = /(?:^|\s)(?:\$(?:[A-Za-z0-9_-]+:)?deep-interview|deep[-\s]interview)(?=\s|$)/i;
+const PROFILE_FLAG_TOKEN_PATTERN = /^--(quick|standard|deep)$/i;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -157,7 +158,19 @@ function buildRuntimeConfig(
 }
 
 export function parseDeepInterviewProfileFromText(text: string | undefined): DeepInterviewProfile | undefined {
-  return normalizeProfile(PROFILE_FLAG_PATTERN.exec(text ?? '')?.[1]);
+  const input = text ?? '';
+  const invocationMatch = DEEP_INTERVIEW_INVOCATION_PATTERN.exec(input);
+  if (!invocationMatch) return undefined;
+
+  const afterInvocation = input.slice((invocationMatch.index ?? 0) + invocationMatch[0].length).trimStart();
+  for (const token of afterInvocation.split(/\s+/)) {
+    if (!token) continue;
+    if (!token.startsWith('--')) return undefined;
+    const profile = normalizeProfile(PROFILE_FLAG_TOKEN_PATTERN.exec(token)?.[1]);
+    if (profile) return profile;
+  }
+
+  return undefined;
 }
 
 export function getDeepInterviewConfigCandidatePaths(options: Pick<DeepInterviewConfigOptions, 'cwd' | 'homeDir'>): DeepInterviewConfigCandidate[] {

--- a/src/config/deep-interview.ts
+++ b/src/config/deep-interview.ts
@@ -173,7 +173,7 @@ export function getDeepInterviewConfigCandidatePaths(options: Pick<DeepInterview
 export function resolveDeepInterviewRuntimeConfig(options: DeepInterviewConfigOptions): DeepInterviewRuntimeConfig | null {
   for (const candidate of getDeepInterviewConfigCandidatePaths(options)) {
     const result = readDeepInterviewConfigTable(candidate.path);
-    if (result.status === 'malformed') return null;
+    if (result.status === 'malformed' || result.status === 'no-table') return null;
     if (result.status === 'table') return buildRuntimeConfig(candidate, result.table, options);
   }
 

--- a/src/config/deep-interview.ts
+++ b/src/config/deep-interview.ts
@@ -1,0 +1,196 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { parse as parseToml } from '@iarna/toml';
+import { findGitLayout } from '../utils/git-layout.js';
+
+export type DeepInterviewProfile = 'quick' | 'standard' | 'deep';
+
+export interface DeepInterviewConfigOptions {
+  cwd: string;
+  text?: string;
+  homeDir?: string;
+}
+
+export interface DeepInterviewConfigCandidate {
+  path: string;
+  precedence: 'project-omx' | 'project-root' | 'user';
+}
+
+export interface DeepInterviewRuntimeConfig {
+  profile: DeepInterviewProfile;
+  threshold: number;
+  maxRounds: number;
+  enableChallengeModes: boolean;
+  sourcePath: string;
+}
+
+interface DeepInterviewConfigTable {
+  defaultProfile?: unknown;
+  quickThreshold?: unknown;
+  standardThreshold?: unknown;
+  deepThreshold?: unknown;
+  quickMaxRounds?: unknown;
+  standardMaxRounds?: unknown;
+  deepMaxRounds?: unknown;
+  enableChallengeModes?: unknown;
+}
+
+interface DeepInterviewProfileSpec {
+  thresholdKey: keyof DeepInterviewConfigTable;
+  maxRoundsKey: keyof DeepInterviewConfigTable;
+  defaults: {
+    threshold: number;
+    maxRounds: number;
+  };
+}
+
+const DEFAULT_PROFILE: DeepInterviewProfile = 'standard';
+const DEFAULT_ENABLE_CHALLENGE_MODES = true;
+
+const PROFILE_SPECS: Record<DeepInterviewProfile, DeepInterviewProfileSpec> = {
+  quick: {
+    thresholdKey: 'quickThreshold',
+    maxRoundsKey: 'quickMaxRounds',
+    defaults: { threshold: 0.30, maxRounds: 5 },
+  },
+  standard: {
+    thresholdKey: 'standardThreshold',
+    maxRoundsKey: 'standardMaxRounds',
+    defaults: { threshold: 0.20, maxRounds: 12 },
+  },
+  deep: {
+    thresholdKey: 'deepThreshold',
+    maxRoundsKey: 'deepMaxRounds',
+    defaults: { threshold: 0.15, maxRounds: 20 },
+  },
+};
+
+const PROFILE_FLAG_PATTERN = /(?:^|\s)--(quick|standard|deep)(?=\s|$)/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function normalizeProfile(value: unknown): DeepInterviewProfile | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.toLowerCase();
+  return normalized === 'quick' || normalized === 'standard' || normalized === 'deep'
+    ? normalized
+    : undefined;
+}
+
+function normalizeFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeThreshold(value: unknown): number | undefined {
+  const normalized = normalizeFiniteNumber(value);
+  return normalized !== undefined && normalized > 0 && normalized <= 1 ? normalized : undefined;
+}
+
+function normalizeMaxRounds(value: unknown): number | undefined {
+  const normalized = normalizeFiniteNumber(value);
+  return normalized !== undefined && Number.isInteger(normalized) && normalized > 0 ? normalized : undefined;
+}
+
+function warnMalformedConfig(configPath: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`[omx] warning: ignoring malformed deep-interview config at ${configPath}: ${message}`);
+}
+
+function extractDeepInterviewTable(parsed: unknown): DeepInterviewConfigTable | null {
+  if (!isRecord(parsed) || !isRecord(parsed.omx) || !isRecord(parsed.omx.deepInterview)) return null;
+  return parsed.omx.deepInterview as DeepInterviewConfigTable;
+}
+
+function readDeepInterviewConfigTable(configPath: string): DeepInterviewConfigTable | null {
+  if (!existsSync(configPath)) return null;
+
+  try {
+    return extractDeepInterviewTable(parseToml(readFileSync(configPath, 'utf-8')) as unknown);
+  } catch (error) {
+    warnMalformedConfig(configPath, error);
+    return null;
+  }
+}
+
+function resolveProfile(table: DeepInterviewConfigTable, text: string | undefined): DeepInterviewProfile {
+  return parseDeepInterviewProfileFromText(text)
+    ?? normalizeProfile(table.defaultProfile)
+    ?? DEFAULT_PROFILE;
+}
+
+function resolveProfileConfig(table: DeepInterviewConfigTable, profile: DeepInterviewProfile): Pick<DeepInterviewRuntimeConfig, 'threshold' | 'maxRounds'> {
+  const spec = PROFILE_SPECS[profile];
+  return {
+    threshold: normalizeThreshold(table[spec.thresholdKey]) ?? spec.defaults.threshold,
+    maxRounds: normalizeMaxRounds(table[spec.maxRoundsKey]) ?? spec.defaults.maxRounds,
+  };
+}
+
+function resolveEnableChallengeModes(table: DeepInterviewConfigTable): boolean {
+  return typeof table.enableChallengeModes === 'boolean'
+    ? table.enableChallengeModes
+    : DEFAULT_ENABLE_CHALLENGE_MODES;
+}
+
+function buildRuntimeConfig(
+  candidate: DeepInterviewConfigCandidate,
+  table: DeepInterviewConfigTable,
+  options: Pick<DeepInterviewConfigOptions, 'text'>,
+): DeepInterviewRuntimeConfig {
+  const profile = resolveProfile(table, options.text);
+  return {
+    profile,
+    ...resolveProfileConfig(table, profile),
+    enableChallengeModes: resolveEnableChallengeModes(table),
+    sourcePath: candidate.path,
+  };
+}
+
+export function parseDeepInterviewProfileFromText(text: string | undefined): DeepInterviewProfile | undefined {
+  return normalizeProfile(PROFILE_FLAG_PATTERN.exec(text ?? '')?.[1]);
+}
+
+export function getDeepInterviewConfigCandidatePaths(options: Pick<DeepInterviewConfigOptions, 'cwd' | 'homeDir'>): DeepInterviewConfigCandidate[] {
+  const home = options.homeDir || homedir();
+  const projectRoot = findGitLayout(options.cwd)?.worktreeRoot ?? options.cwd;
+  return [
+    { path: join(projectRoot, '.omx', 'config.toml'), precedence: 'project-omx' },
+    { path: join(projectRoot, 'omx.toml'), precedence: 'project-root' },
+    { path: join(home, '.omx', 'config.toml'), precedence: 'user' },
+  ];
+}
+
+export function resolveDeepInterviewRuntimeConfig(options: DeepInterviewConfigOptions): DeepInterviewRuntimeConfig | null {
+  for (const candidate of getDeepInterviewConfigCandidatePaths(options)) {
+    const table = readDeepInterviewConfigTable(candidate.path);
+    if (table) return buildRuntimeConfig(candidate, table, options);
+  }
+
+  return null;
+}
+
+export function buildDeepInterviewConfigStateFields(
+  config: DeepInterviewRuntimeConfig | null | undefined,
+): Record<string, unknown> {
+  if (!config) return {};
+
+  const deepInterviewConfig = {
+    profile: config.profile,
+    threshold: config.threshold,
+    maxRounds: config.maxRounds,
+    enableChallengeModes: config.enableChallengeModes,
+    sourcePath: config.sourcePath,
+  };
+
+  return {
+    deep_interview_config: deepInterviewConfig,
+    profile: deepInterviewConfig.profile,
+    threshold: deepInterviewConfig.threshold,
+    max_rounds: deepInterviewConfig.maxRounds,
+    enable_challenge_modes: deepInterviewConfig.enableChallengeModes,
+    config_source: deepInterviewConfig.sourcePath,
+  };
+}

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -17,6 +17,19 @@ import { SKILL_ACTIVE_STATE_FILE } from '../../state/skill-active.js';
 import { isUnderspecifiedForExecution, applyRalplanGate } from '../keyword-detector.js';
 import { KEYWORD_TRIGGER_DEFINITIONS } from '../keyword-registry.js';
 
+async function withIsolatedHome<T>(prefix: string, run: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), `omx-keyword-home-${prefix}-`));
+  const previousHome = process.env.HOME;
+  try {
+    process.env.HOME = homeDir;
+    return await run(homeDir);
+  } finally {
+    if (typeof previousHome === 'string') process.env.HOME = previousHome;
+    else delete process.env.HOME;
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
 describe('keyword detector team compatibility', () => {
   it('keeps explicit $skill order in detectKeywords results (left-to-right)', () => {
     const matches = detectKeywords('$analyze $ultraqa $code-review now');
@@ -1392,72 +1405,131 @@ enableChallengeModes = false
     }
   });
 
-  it('shows before-after state change when deep-interview config is added at runtime', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-config-before-after-'));
+  it('persists deep-interview config when mixed workflow prompts defer execution modes', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-config-mixed-'));
     const stateDir = join(cwd, '.omx', 'state');
-    const sessionId = 'sess-deep-interview-config-before-after';
-    const statePath = join(stateDir, 'sessions', sessionId, DEEP_INTERVIEW_STATE_FILE);
+    const sessionId = 'sess-deep-interview-config-mixed';
     try {
       await mkdir(join(cwd, '.omx'), { recursive: true });
       await mkdir(stateDir, { recursive: true });
-
-      const before = await recordSkillActivation({
-        stateDir,
-        sourceCwd: cwd,
-        text: '$deep-interview prove config before state',
-        sessionId,
-        nowIso: '2026-02-25T00:00:00.000Z',
-      });
-      const beforeModeState = JSON.parse(await readFile(statePath, 'utf-8')) as {
-        deep_interview_config?: unknown;
-        profile?: string;
-        threshold?: number;
-        max_rounds?: number;
-        config_source?: string;
-      };
-      assert.ok(before);
-      assert.equal(before.deep_interview_config, undefined);
-      assert.equal(beforeModeState.deep_interview_config, undefined);
-      assert.equal(beforeModeState.profile, undefined);
-      assert.equal(beforeModeState.threshold, undefined);
-      assert.equal(beforeModeState.max_rounds, undefined);
-      assert.equal(beforeModeState.config_source, undefined);
-
       await writeFile(
         join(cwd, '.omx', 'config.toml'),
         `[omx.deepInterview]
+defaultProfile = "deep"
+deepThreshold = 0.13
+deepMaxRounds = 21
+enableChallengeModes = false
+`,
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$autopilot $deep-interview prove mixed workflow config',
+        sessionId,
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'deep-interview');
+      assert.deepEqual(result.deferred_skills, ['autopilot']);
+      assert.equal(result.input_lock?.active, true);
+      assert.equal(result.deep_interview_config?.profile, 'deep');
+      assert.equal(result.deep_interview_config?.threshold, 0.13);
+      assert.equal(result.deep_interview_config?.maxRounds, 21);
+      assert.equal(result.deep_interview_config?.enableChallengeModes, false);
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, DEEP_INTERVIEW_STATE_FILE), 'utf-8'),
+      ) as {
+        profile?: string;
+        threshold?: number;
+        max_rounds?: number;
+        enable_challenge_modes?: boolean;
+        config_source?: string;
+        deep_interview_config?: { profile?: string; threshold?: number; maxRounds?: number };
+        input_lock?: { active?: boolean };
+      };
+      assert.equal(modeState.profile, 'deep');
+      assert.equal(modeState.threshold, 0.13);
+      assert.equal(modeState.max_rounds, 21);
+      assert.equal(modeState.enable_challenge_modes, false);
+      assert.equal(modeState.config_source, join(cwd, '.omx', 'config.toml'));
+      assert.equal(modeState.deep_interview_config?.profile, 'deep');
+      assert.equal(modeState.input_lock?.active, true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shows before-after state change when deep-interview config is added at runtime', async () => {
+    await withIsolatedHome('deep-interview-config-before-after', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-config-before-after-'));
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-deep-interview-config-before-after';
+      const statePath = join(stateDir, 'sessions', sessionId, DEEP_INTERVIEW_STATE_FILE);
+      try {
+        await mkdir(join(cwd, '.omx'), { recursive: true });
+        await mkdir(stateDir, { recursive: true });
+
+        const before = await recordSkillActivation({
+          stateDir,
+          sourceCwd: cwd,
+          text: '$deep-interview prove config before state',
+          sessionId,
+          nowIso: '2026-02-25T00:00:00.000Z',
+        });
+        const beforeModeState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+          deep_interview_config?: unknown;
+          profile?: string;
+          threshold?: number;
+          max_rounds?: number;
+          config_source?: string;
+        };
+        assert.ok(before);
+        assert.equal(before.deep_interview_config, undefined);
+        assert.equal(beforeModeState.deep_interview_config, undefined);
+        assert.equal(beforeModeState.profile, undefined);
+        assert.equal(beforeModeState.threshold, undefined);
+        assert.equal(beforeModeState.max_rounds, undefined);
+        assert.equal(beforeModeState.config_source, undefined);
+
+        await writeFile(
+          join(cwd, '.omx', 'config.toml'),
+          `[omx.deepInterview]
 defaultProfile = "standard"
 standardThreshold = 0.05
 standardMaxRounds = 15
 `,
-      );
+        );
 
-      const after = await recordSkillActivation({
-        stateDir,
-        sourceCwd: cwd,
-        text: '$deep-interview prove config after state',
-        sessionId,
-        nowIso: '2026-02-25T00:00:01.000Z',
-      });
-      const afterModeState = JSON.parse(await readFile(statePath, 'utf-8')) as {
-        deep_interview_config?: { profile?: string; threshold?: number; maxRounds?: number; sourcePath?: string };
-        profile?: string;
-        threshold?: number;
-        max_rounds?: number;
-        config_source?: string;
-      };
-      assert.ok(after);
-      assert.equal(after.deep_interview_config?.profile, 'standard');
-      assert.equal(after.deep_interview_config?.threshold, 0.05);
-      assert.equal(after.deep_interview_config?.maxRounds, 15);
-      assert.equal(afterModeState.deep_interview_config?.profile, 'standard');
-      assert.equal(afterModeState.profile, 'standard');
-      assert.equal(afterModeState.threshold, 0.05);
-      assert.equal(afterModeState.max_rounds, 15);
-      assert.equal(afterModeState.config_source, join(cwd, '.omx', 'config.toml'));
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
+        const after = await recordSkillActivation({
+          stateDir,
+          sourceCwd: cwd,
+          text: '$deep-interview prove config after state',
+          sessionId,
+          nowIso: '2026-02-25T00:00:01.000Z',
+        });
+        const afterModeState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+          deep_interview_config?: { profile?: string; threshold?: number; maxRounds?: number; sourcePath?: string };
+          profile?: string;
+          threshold?: number;
+          max_rounds?: number;
+          config_source?: string;
+        };
+        assert.ok(after);
+        assert.equal(after.deep_interview_config?.profile, 'standard');
+        assert.equal(after.deep_interview_config?.threshold, 0.05);
+        assert.equal(after.deep_interview_config?.maxRounds, 15);
+        assert.equal(afterModeState.deep_interview_config?.profile, 'standard');
+        assert.equal(afterModeState.profile, 'standard');
+        assert.equal(afterModeState.threshold, 0.05);
+        assert.equal(afterModeState.max_rounds, 15);
+        assert.equal(afterModeState.config_source, join(cwd, '.omx', 'config.toml'));
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
   });
 
   it('preserves deep-interview config values during continuation prompts', async () => {
@@ -1561,42 +1633,44 @@ standardMaxRounds = 15
   });
 
   it('keeps deep-interview activation alive when repo config TOML is malformed', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-malformed-config-'));
-    const stateDir = join(cwd, '.omx', 'state');
-    const originalWarn = console.warn;
-    try {
-      console.warn = () => {};
-      await mkdir(join(cwd, '.omx'), { recursive: true });
-      await mkdir(stateDir, { recursive: true });
-      await writeFile(join(cwd, '.omx', 'config.toml'), '[omx.deepInterview\nstandardThreshold = 0.05\n');
+    await withIsolatedHome('deep-interview-malformed-config', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-malformed-config-'));
+      const stateDir = join(cwd, '.omx', 'state');
+      const originalWarn = console.warn;
+      try {
+        console.warn = () => {};
+        await mkdir(join(cwd, '.omx'), { recursive: true });
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(join(cwd, '.omx', 'config.toml'), '[omx.deepInterview\nstandardThreshold = 0.05\n');
 
-      const result = await recordSkillActivation({
-        stateDir,
-        sourceCwd: cwd,
-        text: '$deep-interview clarify despite malformed config',
-        sessionId: 'sess-deep-interview-malformed-config',
-        nowIso: '2026-02-25T00:00:00.000Z',
-      });
+        const result = await recordSkillActivation({
+          stateDir,
+          sourceCwd: cwd,
+          text: '$deep-interview clarify despite malformed config',
+          sessionId: 'sess-deep-interview-malformed-config',
+          nowIso: '2026-02-25T00:00:00.000Z',
+        });
 
-      assert.ok(result);
-      assert.equal(result.skill, 'deep-interview');
-      assert.equal(result.active, true);
-      assert.equal(result.deep_interview_config, undefined);
+        assert.ok(result);
+        assert.equal(result.skill, 'deep-interview');
+        assert.equal(result.active, true);
+        assert.equal(result.deep_interview_config, undefined);
 
-      const modeState = JSON.parse(
-        await readFile(join(stateDir, 'sessions', 'sess-deep-interview-malformed-config', DEEP_INTERVIEW_STATE_FILE), 'utf-8'),
-      ) as {
-        mode?: string;
-        active?: boolean;
-        deep_interview_config?: unknown;
-      };
-      assert.equal(modeState.mode, 'deep-interview');
-      assert.equal(modeState.active, true);
-      assert.equal(modeState.deep_interview_config, undefined);
-    } finally {
-      console.warn = originalWarn;
-      await rm(cwd, { recursive: true, force: true });
-    }
+        const modeState = JSON.parse(
+          await readFile(join(stateDir, 'sessions', 'sess-deep-interview-malformed-config', DEEP_INTERVIEW_STATE_FILE), 'utf-8'),
+        ) as {
+          mode?: string;
+          active?: boolean;
+          deep_interview_config?: unknown;
+        };
+        assert.equal(modeState.mode, 'deep-interview');
+        assert.equal(modeState.active, true);
+        assert.equal(modeState.deep_interview_config, undefined);
+      } finally {
+        console.warn = originalWarn;
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
   });
 
   it('creates the session-scoped deep-interview state directory before persisting mode state', async () => {

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1583,6 +1583,59 @@ standardMaxRounds = 15
     }
   });
 
+  it('preserves explicit deep-interview profile flags during continuation prompts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-config-profile-continuation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-deep-interview-config-profile-continuation';
+    const statePath = join(stateDir, 'sessions', sessionId, DEEP_INTERVIEW_STATE_FILE);
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'config.toml'),
+        `[omx.deepInterview]
+defaultProfile = "standard"
+standardThreshold = 0.22
+standardMaxRounds = 13
+deepThreshold = 0.13
+deepMaxRounds = 21
+`,
+      );
+
+      const started = await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$deep-interview --deep prove explicit profile continuation',
+        sessionId,
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+      const continued = await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: 'continue',
+        sessionId,
+        nowIso: '2026-02-25T00:00:01.000Z',
+      });
+      const modeState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+        deep_interview_config?: { profile?: string; threshold?: number; maxRounds?: number };
+        profile?: string;
+        threshold?: number;
+        max_rounds?: number;
+      };
+
+      assert.equal(started?.deep_interview_config?.profile, 'deep');
+      assert.equal(continued?.deep_interview_config?.profile, 'deep');
+      assert.equal(continued?.deep_interview_config?.threshold, 0.13);
+      assert.equal(continued?.deep_interview_config?.maxRounds, 21);
+      assert.equal(modeState.deep_interview_config?.profile, 'deep');
+      assert.equal(modeState.profile, 'deep');
+      assert.equal(modeState.threshold, 0.13);
+      assert.equal(modeState.max_rounds, 21);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('keeps the documented deep-interview Suggested Config executable through activation state', async () => {
     const skillDoc = await readFile(join(process.cwd(), 'skills', 'deep-interview', 'SKILL.md'), 'utf-8');
     const markerIndex = skillDoc.indexOf('## Suggested Config (optional)');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1340,6 +1340,265 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('persists repo-local deep-interview config values into activation and mode state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-config-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'config.toml'),
+        `[omx.deepInterview]
+defaultProfile = "standard"
+standardThreshold = 0.05
+standardMaxRounds = 15
+enableChallengeModes = false
+`,
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$deep-interview clarify runtime config',
+        sessionId: 'sess-deep-interview-config',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'deep-interview');
+      assert.equal(result.deep_interview_config?.profile, 'standard');
+      assert.equal(result.deep_interview_config?.threshold, 0.05);
+      assert.equal(result.deep_interview_config?.maxRounds, 15);
+      assert.equal(result.initialized_state_path, '.omx/state/sessions/sess-deep-interview-config/deep-interview-state.json');
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-deep-interview-config', DEEP_INTERVIEW_STATE_FILE), 'utf-8'),
+      ) as {
+        profile?: string;
+        threshold?: number;
+        max_rounds?: number;
+        enable_challenge_modes?: boolean;
+        config_source?: string;
+        deep_interview_config?: { sourcePath?: string };
+      };
+      assert.equal(modeState.profile, 'standard');
+      assert.equal(modeState.threshold, 0.05);
+      assert.equal(modeState.max_rounds, 15);
+      assert.equal(modeState.enable_challenge_modes, false);
+      assert.equal(modeState.config_source, join(cwd, '.omx', 'config.toml'));
+      assert.equal(modeState.deep_interview_config?.sourcePath, join(cwd, '.omx', 'config.toml'));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shows before-after state change when deep-interview config is added at runtime', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-config-before-after-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-deep-interview-config-before-after';
+    const statePath = join(stateDir, 'sessions', sessionId, DEEP_INTERVIEW_STATE_FILE);
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+
+      const before = await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$deep-interview prove config before state',
+        sessionId,
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+      const beforeModeState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+        deep_interview_config?: unknown;
+        profile?: string;
+        threshold?: number;
+        max_rounds?: number;
+        config_source?: string;
+      };
+      assert.ok(before);
+      assert.equal(before.deep_interview_config, undefined);
+      assert.equal(beforeModeState.deep_interview_config, undefined);
+      assert.equal(beforeModeState.profile, undefined);
+      assert.equal(beforeModeState.threshold, undefined);
+      assert.equal(beforeModeState.max_rounds, undefined);
+      assert.equal(beforeModeState.config_source, undefined);
+
+      await writeFile(
+        join(cwd, '.omx', 'config.toml'),
+        `[omx.deepInterview]
+defaultProfile = "standard"
+standardThreshold = 0.05
+standardMaxRounds = 15
+`,
+      );
+
+      const after = await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$deep-interview prove config after state',
+        sessionId,
+        nowIso: '2026-02-25T00:00:01.000Z',
+      });
+      const afterModeState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+        deep_interview_config?: { profile?: string; threshold?: number; maxRounds?: number; sourcePath?: string };
+        profile?: string;
+        threshold?: number;
+        max_rounds?: number;
+        config_source?: string;
+      };
+      assert.ok(after);
+      assert.equal(after.deep_interview_config?.profile, 'standard');
+      assert.equal(after.deep_interview_config?.threshold, 0.05);
+      assert.equal(after.deep_interview_config?.maxRounds, 15);
+      assert.equal(afterModeState.deep_interview_config?.profile, 'standard');
+      assert.equal(afterModeState.profile, 'standard');
+      assert.equal(afterModeState.threshold, 0.05);
+      assert.equal(afterModeState.max_rounds, 15);
+      assert.equal(afterModeState.config_source, join(cwd, '.omx', 'config.toml'));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves deep-interview config values during continuation prompts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-config-continuation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-deep-interview-config-continuation';
+    const statePath = join(stateDir, 'sessions', sessionId, DEEP_INTERVIEW_STATE_FILE);
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'config.toml'),
+        `[omx.deepInterview]
+defaultProfile = "standard"
+standardThreshold = 0.05
+standardMaxRounds = 15
+`,
+      );
+
+      await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$deep-interview prove config continuation',
+        sessionId,
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+      const continued = await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: 'continue',
+        sessionId,
+        nowIso: '2026-02-25T00:00:01.000Z',
+      });
+      const modeState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+        deep_interview_config?: { profile?: string; threshold?: number; maxRounds?: number };
+        profile?: string;
+        threshold?: number;
+        max_rounds?: number;
+      };
+
+      assert.equal(continued?.skill, 'deep-interview');
+      assert.equal(continued?.deep_interview_config?.profile, 'standard');
+      assert.equal(continued?.deep_interview_config?.threshold, 0.05);
+      assert.equal(continued?.deep_interview_config?.maxRounds, 15);
+      assert.equal(modeState.deep_interview_config?.profile, 'standard');
+      assert.equal(modeState.profile, 'standard');
+      assert.equal(modeState.threshold, 0.05);
+      assert.equal(modeState.max_rounds, 15);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the documented deep-interview Suggested Config executable through activation state', async () => {
+    const skillDoc = await readFile(join(process.cwd(), 'skills', 'deep-interview', 'SKILL.md'), 'utf-8');
+    const markerIndex = skillDoc.indexOf('## Suggested Config (optional)');
+    assert.notEqual(markerIndex, -1);
+    const configMatch = skillDoc.slice(markerIndex).match(/```toml\n([\s\S]*?)\n```/);
+    assert.ok(configMatch);
+    const documentedConfig = configMatch[1]?.trimEnd();
+    assert.ok(documentedConfig);
+    assert.match(documentedConfig, /standardThreshold = 0\.20/);
+    assert.match(documentedConfig, /standardMaxRounds = 12/);
+
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-doc-config-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-deep-interview-doc-config';
+    const statePath = join(stateDir, 'sessions', sessionId, DEEP_INTERVIEW_STATE_FILE);
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(cwd, '.omx', 'config.toml'), `${documentedConfig}\n`);
+
+      const result = await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$deep-interview prove documented config runtime contract',
+        sessionId,
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+      const modeState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+        deep_interview_config?: { profile?: string; threshold?: number; maxRounds?: number; sourcePath?: string };
+        profile?: string;
+        threshold?: number;
+        max_rounds?: number;
+        config_source?: string;
+      };
+
+      assert.ok(result);
+      assert.equal(result.deep_interview_config?.profile, 'standard');
+      assert.equal(result.deep_interview_config?.threshold, 0.2);
+      assert.equal(result.deep_interview_config?.maxRounds, 12);
+      assert.equal(modeState.deep_interview_config?.profile, 'standard');
+      assert.equal(modeState.profile, 'standard');
+      assert.equal(modeState.threshold, 0.2);
+      assert.equal(modeState.max_rounds, 12);
+      assert.equal(modeState.config_source, join(cwd, '.omx', 'config.toml'));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps deep-interview activation alive when repo config TOML is malformed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-malformed-config-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const originalWarn = console.warn;
+    try {
+      console.warn = () => {};
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(cwd, '.omx', 'config.toml'), '[omx.deepInterview\nstandardThreshold = 0.05\n');
+
+      const result = await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$deep-interview clarify despite malformed config',
+        sessionId: 'sess-deep-interview-malformed-config',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'deep-interview');
+      assert.equal(result.active, true);
+      assert.equal(result.deep_interview_config, undefined);
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-deep-interview-malformed-config', DEEP_INTERVIEW_STATE_FILE), 'utf-8'),
+      ) as {
+        mode?: string;
+        active?: boolean;
+        deep_interview_config?: unknown;
+      };
+      assert.equal(modeState.mode, 'deep-interview');
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.deep_interview_config, undefined);
+    } finally {
+      console.warn = originalWarn;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('creates the session-scoped deep-interview state directory before persisting mode state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-session-dir-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/deep-interview-config-instruction.ts
+++ b/src/hooks/deep-interview-config-instruction.ts
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { getBaseStateDir } from '../mcp/state-paths.js';
+import type { SkillActiveState } from './keyword-detector.js';
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function resolveInitializedStatePath(cwd: string, statePath: string): string {
+  if (statePath.startsWith('/')) return statePath;
+  const normalized = statePath.replace(/\\/g, '/');
+  const statePrefix = '.omx/state/';
+  if (normalized.startsWith(statePrefix)) {
+    return join(getBaseStateDir(cwd), normalized.slice(statePrefix.length));
+  }
+  return resolve(cwd, statePath);
+}
+
+export function buildDeepInterviewConfigInstruction(cwd: string, skillState?: SkillActiveState | null): string | null {
+  if (skillState?.initialized_mode !== 'deep-interview' || !skillState.initialized_state_path) return null;
+  const statePath = resolveInitializedStatePath(cwd, skillState.initialized_state_path);
+  try {
+    if (!existsSync(statePath)) return null;
+    const parsed = JSON.parse(readFileSync(statePath, 'utf-8')) as Record<string, unknown>;
+    const nested = parsed.deep_interview_config && typeof parsed.deep_interview_config === 'object'
+      ? parsed.deep_interview_config as Record<string, unknown>
+      : {};
+    const profile = safeString(parsed.profile ?? nested.profile).trim();
+    const sourcePath = safeString(parsed.config_source ?? nested.sourcePath).trim();
+    const threshold = typeof parsed.threshold === 'number' ? parsed.threshold : nested.threshold;
+    const maxRounds = typeof parsed.max_rounds === 'number' ? parsed.max_rounds : nested.maxRounds;
+    const enableChallengeModes = typeof parsed.enable_challenge_modes === 'boolean'
+      ? parsed.enable_challenge_modes
+      : nested.enableChallengeModes;
+    if (!profile || typeof threshold !== 'number' || typeof maxRounds !== 'number') return null;
+    return [
+      `Deep-interview config override active${sourcePath ? ` from ${sourcePath}` : ''}:`,
+      `profile=${profile}, threshold=${threshold}, max_rounds=${maxRounds}, enableChallengeModes=${enableChallengeModes !== false}.`,
+      'Use these values instead of SKILL.md defaults for ambiguity scoring, challenge-mode gating, and round caps.',
+    ].join(' ');
+  } catch {
+    return null;
+  }
+}

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -851,22 +851,32 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     )
   ));
 
-  const deepInterviewInputLock = match.skill === 'deep-interview'
+  const isTrackedWorkflowMatch = isTrackedWorkflowMode(match.skill);
+  const trackedMatchSkill = isTrackedWorkflowMatch ? match.skill : null;
+  const normalizedInputText = isTrackedWorkflowMatch
+    ? normalizeWorkflowKeyboardTypos(input.text)
+    : input.text;
+  const workflowMatches: TrackedWorkflowMode[] = isTrackedWorkflowMatch
+    ? parseExplicitSkillInvocations(normalizedInputText).matches
+      .map((entry) => entry.skill)
+      .filter(isTrackedWorkflowMode)
+    : [];
+  const resolvedWorkflowRequest = isTrackedWorkflowMatch
+    ? resolveRequestedWorkflowSkills(workflowMatches.length > 0 ? workflowMatches : [trackedMatchSkill as TrackedWorkflowMode])
+    : null;
+  const requestedWorkflowSkills = resolvedWorkflowRequest?.requestedSkills ?? [];
+  const deferredSkills = resolvedWorkflowRequest?.deferredSkills ?? [];
+  const willActivateDeepInterview = match.skill === 'deep-interview'
+    || requestedWorkflowSkills.includes('deep-interview');
+
+  const deepInterviewInputLock = willActivateDeepInterview
     ? createDeepInterviewInputLock(nowIso, previous?.input_lock)
     : releaseDeepInterviewInputLock(previous?.input_lock, nowIso);
-  const deepInterviewConfig = match.skill === 'deep-interview'
+  const deepInterviewConfig = willActivateDeepInterview
     ? resolveDeepInterviewRuntimeConfig({ cwd: sourceCwd, text: input.text })
     : null;
 
-  if (isTrackedWorkflowMode(match.skill)) {
-    const normalizedInputText = normalizeWorkflowKeyboardTypos(input.text);
-    const workflowMatches = parseExplicitSkillInvocations(normalizedInputText).matches
-      .map((entry) => entry.skill)
-      .filter(isTrackedWorkflowMode);
-    const { requestedSkills: requestedWorkflowSkills, deferredSkills } = resolveRequestedWorkflowSkills(
-      workflowMatches.length > 0 ? workflowMatches : [match.skill],
-    );
-
+  if (isTrackedWorkflowMatch) {
     let nextWorkflowEntries = previousWorkflowEntries.map((entry) => ({ ...entry }));
     const transitionMessages: string[] = [];
     for (const requestedMode of requestedWorkflowSkills) {
@@ -881,7 +891,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
           active: previous?.active ?? nextWorkflowEntries.length > 0,
           skill: previous?.skill || match.skill,
           keyword: previous?.keyword || match.keyword,
-          phase: previous?.phase || initialWorkflowPhaseForMode(match.skill),
+          phase: previous?.phase || initialWorkflowPhaseForMode(trackedMatchSkill as TrackedWorkflowMode),
           activated_at: previous?.activated_at || nowIso,
           updated_at: nowIso,
           source: 'keyword-detector',

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -723,6 +723,21 @@ function shouldReusePreviousSkillForContinuation(
     || isNamedActiveSkillContinuationPrompt(text, previousSkill);
 }
 
+function isDeepInterviewRuntimeConfig(value: unknown): value is DeepInterviewRuntimeConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const candidate = value as Partial<DeepInterviewRuntimeConfig>;
+  return (
+    (candidate.profile === 'quick' || candidate.profile === 'standard' || candidate.profile === 'deep')
+    && typeof candidate.threshold === 'number'
+    && Number.isFinite(candidate.threshold)
+    && typeof candidate.maxRounds === 'number'
+    && Number.isInteger(candidate.maxRounds)
+    && typeof candidate.enableChallengeModes === 'boolean'
+    && typeof candidate.sourcePath === 'string'
+    && candidate.sourcePath.trim().length > 0
+  );
+}
+
 function resolveContinuationKeywordMatch(
   text: string,
   previous: SkillActiveState | null,
@@ -872,8 +887,11 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   const deepInterviewInputLock = willActivateDeepInterview
     ? createDeepInterviewInputLock(nowIso, previous?.input_lock)
     : releaseDeepInterviewInputLock(previous?.input_lock, nowIso);
+  const reusableDeepInterviewConfig = sameSkillContinuation && isDeepInterviewRuntimeConfig(previous?.deep_interview_config)
+    ? previous.deep_interview_config
+    : null;
   const deepInterviewConfig = willActivateDeepInterview
-    ? resolveDeepInterviewRuntimeConfig({ cwd: sourceCwd, text: input.text })
+    ? reusableDeepInterviewConfig ?? resolveDeepInterviewRuntimeConfig({ cwd: sourceCwd, text: input.text })
     : null;
 
   if (isTrackedWorkflowMatch) {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -36,6 +36,11 @@ import {
   clearDeepInterviewQuestionObligation,
   type DeepInterviewQuestionEnforcementState,
 } from '../question/deep-interview.js';
+import {
+  buildDeepInterviewConfigStateFields,
+  resolveDeepInterviewRuntimeConfig,
+  type DeepInterviewRuntimeConfig,
+} from '../config/deep-interview.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -78,6 +83,7 @@ export interface SkillActiveState {
   thread_id?: string;
   turn_id?: string;
   input_lock?: DeepInterviewInputLock;
+  deep_interview_config?: DeepInterviewRuntimeConfig;
   active_skills?: SkillActiveEntry[];
   initialized_mode?: string;
   initialized_state_path?: string;
@@ -253,6 +259,7 @@ export async function persistDeepInterviewModeState(
   const previousModeState = await readExistingDeepInterviewState(statePath);
 
   if (nextSkill?.skill === 'deep-interview' && nextSkill.active) {
+    const configStateFields = buildDeepInterviewConfigStateFields(nextSkill.deep_interview_config);
     const nextQuestionEnforcement = clearDeepInterviewQuestionObligation(
       previousModeState?.question_enforcement,
       'handoff',
@@ -271,6 +278,7 @@ export async function persistDeepInterviewModeState(
         session_id: input.sessionId ?? previousModeState?.session_id,
         thread_id: input.threadId ?? previousModeState?.thread_id,
         turn_id: input.turnId ?? previousModeState?.turn_id,
+        ...configStateFields,
         ...(nextSkill.input_lock ? { input_lock: nextSkill.input_lock } : {}),
         ...(nextQuestionEnforcement ? { question_enforcement: nextQuestionEnforcement } : {}),
         ...(previousModeState?.downstream_authority ? { downstream_authority: previousModeState.downstream_authority } : {}),
@@ -393,6 +401,10 @@ async function persistStatefulSkillSeedState(
     const defaultMaxIterations = config.mode === 'autopilot' ? 10 : 50;
     baseState.iteration = typeof existingModeState?.iteration === 'number' ? existingModeState.iteration : defaultIteration;
     baseState.max_iterations = typeof existingModeState?.max_iterations === 'number' ? existingModeState.max_iterations : defaultMaxIterations;
+  }
+
+  if (config.mode === 'deep-interview') {
+    Object.assign(baseState, buildDeepInterviewConfigStateFields(nextSkill.deep_interview_config));
   }
 
   if (config.mode === 'autopilot') {
@@ -842,6 +854,9 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   const deepInterviewInputLock = match.skill === 'deep-interview'
     ? createDeepInterviewInputLock(nowIso, previous?.input_lock)
     : releaseDeepInterviewInputLock(previous?.input_lock, nowIso);
+  const deepInterviewConfig = match.skill === 'deep-interview'
+    ? resolveDeepInterviewRuntimeConfig({ cwd: sourceCwd, text: input.text })
+    : null;
 
   if (isTrackedWorkflowMode(match.skill)) {
     const normalizedInputText = normalizeWorkflowKeyboardTypos(input.text);
@@ -958,6 +973,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       ...(requestedWorkflowSkills.length > 1 ? { requested_skills: requestedWorkflowSkills } : {}),
       ...(deferredSkills.length > 0 ? { deferred_skills: deferredSkills } : {}),
       ...(deepInterviewInputLock ? { input_lock: deepInterviewInputLock } : {}),
+      ...(primarySkill === 'deep-interview' && deepInterviewConfig ? { deep_interview_config: deepInterviewConfig } : {}),
     };
 
     try {
@@ -972,6 +988,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
             phase: requestedEntry.phase || workflowState.phase,
             activated_at: requestedEntry.activated_at || workflowState.activated_at,
             updated_at: requestedEntry.updated_at || workflowState.updated_at,
+            ...(requestedEntry.skill === 'deep-interview' && deepInterviewConfig ? { deep_interview_config: deepInterviewConfig } : {}),
           },
           nowIso,
           previous,
@@ -1023,6 +1040,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       turn_id: input.turnId,
     }],
     ...(deepInterviewInputLock ? { input_lock: deepInterviewInputLock } : {}),
+    ...(match.skill === 'deep-interview' && deepInterviewConfig ? { deep_interview_config: deepInterviewConfig } : {}),
   };
 
   try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1865,6 +1865,64 @@ standardMaxRounds = 15
     }
   });
 
+  it("keeps explicit deep-interview profile flags reflected on continuation prompts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-config-profile-continuation-"));
+    const sessionId = "sess-deep-interview-config-profile-continuation";
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(
+        join(cwd, ".omx", "config.toml"),
+        `[omx.deepInterview]
+defaultProfile = "standard"
+standardThreshold = 0.22
+standardMaxRounds = 13
+deepThreshold = 0.13
+deepMaxRounds = 21
+`,
+      );
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-profile-continuation",
+          turn_id: "turn-start",
+          prompt: "$deep-interview --deep prove explicit profile continuation",
+        },
+        { cwd },
+      );
+      const continued = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-profile-continuation",
+          turn_id: "turn-continue",
+          prompt: "continue",
+        },
+        { cwd },
+      );
+      const serializedOutput = JSON.stringify(continued.outputJson);
+      const modeState = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "sessions", sessionId, "deep-interview-state.json"), "utf-8"),
+      ) as { threshold?: number; max_rounds?: number; profile?: string; deep_interview_config?: { profile?: string } };
+
+      assert.equal(continued.skillState?.skill, "deep-interview");
+      assert.equal(continued.skillState?.deep_interview_config?.profile, "deep");
+      assert.match(serializedOutput, /Deep-interview config override active/);
+      assert.match(serializedOutput, /profile=deep/);
+      assert.match(serializedOutput, /threshold=0\.13/);
+      assert.match(serializedOutput, /max_rounds=21/);
+      assert.equal(modeState.deep_interview_config?.profile, "deep");
+      assert.equal(modeState.profile, "deep");
+      assert.equal(modeState.threshold, 0.13);
+      assert.equal(modeState.max_rounds, 21);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps the documented deep-interview Suggested Config reflected in UserPromptSubmit context", async () => {
     const skillDoc = await readFile(join(process.cwd(), "skills", "deep-interview", "SKILL.md"), "utf-8");
     const markerIndex = skillDoc.indexOf("## Suggested Config (optional)");

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1752,6 +1752,66 @@ standardMaxRounds = 15
     }
   });
 
+  it("injects deep-interview config for mixed workflow prompts that defer execution modes", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-config-mixed-"));
+    const sessionId = "sess-deep-interview-config-mixed";
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(
+        join(cwd, ".omx", "config.toml"),
+        `[omx.deepInterview]
+defaultProfile = "deep"
+deepThreshold = 0.13
+deepMaxRounds = 21
+enableChallengeModes = false
+`,
+      );
+
+      const result = await withIsolatedHome("deep-interview-config-mixed", async () => (
+        dispatchCodexNativeHook(
+          {
+            hook_event_name: "UserPromptSubmit",
+            cwd,
+            session_id: sessionId,
+            thread_id: "thread-mixed-config",
+            turn_id: "turn-mixed-config",
+            prompt: "$autopilot $deep-interview prove mixed config context",
+          },
+          { cwd },
+        )
+      ));
+      const serializedOutput = JSON.stringify(result.outputJson);
+      const modeState = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "sessions", sessionId, "deep-interview-state.json"), "utf-8"),
+      ) as {
+        deep_interview_config?: { profile?: string; threshold?: number; maxRounds?: number; enableChallengeModes?: boolean };
+        profile?: string;
+        threshold?: number;
+        max_rounds?: number;
+        enable_challenge_modes?: boolean;
+      };
+
+      assert.equal(result.skillState?.skill, "deep-interview");
+      assert.deepEqual(result.skillState?.deferred_skills, ["autopilot"]);
+      assert.equal(result.skillState?.deep_interview_config?.profile, "deep");
+      assert.equal(result.skillState?.deep_interview_config?.threshold, 0.13);
+      assert.equal(result.skillState?.deep_interview_config?.maxRounds, 21);
+      assert.equal(result.skillState?.deep_interview_config?.enableChallengeModes, false);
+      assert.match(serializedOutput, /Deep-interview config override active/);
+      assert.match(serializedOutput, /profile=deep/);
+      assert.match(serializedOutput, /threshold=0\.13/);
+      assert.match(serializedOutput, /max_rounds=21/);
+      assert.match(serializedOutput, /enableChallengeModes=false/);
+      assert.equal(modeState.deep_interview_config?.profile, "deep");
+      assert.equal(modeState.profile, "deep");
+      assert.equal(modeState.threshold, 0.13);
+      assert.equal(modeState.max_rounds, 21);
+      assert.equal(modeState.enable_challenge_modes, false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps deep-interview config override context on continuation prompts", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-config-continuation-"));
     const sessionId = "sess-deep-interview-config-continuation";

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -65,6 +65,19 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+async function withIsolatedHome<T>(prefix: string, run: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), `omx-native-hook-home-${prefix}-`));
+  const previousHome = process.env.HOME;
+  try {
+    process.env.HOME = homeDir;
+    return await run(homeDir);
+  } finally {
+    if (typeof previousHome === "string") process.env.HOME = previousHome;
+    else delete process.env.HOME;
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
 async function withLoreGuardConfig<T>(
   value: string,
   prefix: string,
@@ -1617,6 +1630,287 @@ describe("codex native hook dispatch", () => {
       assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-1", "ralplan-state.json")), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("injects deep-interview config overrides into UserPromptSubmit developer context", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-config-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(
+        join(cwd, ".omx", "config.toml"),
+        `[omx.deepInterview]
+defaultProfile = "standard"
+standardThreshold = 0.05
+standardMaxRounds = 15
+enableChallengeModes = false
+`,
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-deep-interview-config",
+          thread_id: "thread-1",
+          turn_id: "turn-1",
+          prompt: "$deep-interview prove config reflection",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "deep-interview");
+      const serializedOutput = JSON.stringify(result.outputJson);
+      assert.match(serializedOutput, /Deep-interview config override active/);
+      assert.match(serializedOutput, /threshold=0\.05/);
+      assert.match(serializedOutput, /max_rounds=15/);
+      assert.match(serializedOutput, /enableChallengeModes=false/);
+
+      const modeState = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "sessions", "sess-deep-interview-config", "deep-interview-state.json"), "utf-8"),
+      ) as { threshold?: number; max_rounds?: number; profile?: string };
+      assert.equal(modeState.profile, "standard");
+      assert.equal(modeState.threshold, 0.05);
+      assert.equal(modeState.max_rounds, 15);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("proves UserPromptSubmit context changes before and after adding deep-interview config", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-config-before-after-"));
+    const sessionId = "sess-deep-interview-config-before-after";
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      const before = await withIsolatedHome("deep-interview-config-before-after", async () => (
+        dispatchCodexNativeHook(
+          {
+            hook_event_name: "UserPromptSubmit",
+            cwd,
+            session_id: sessionId,
+            thread_id: "thread-before-after",
+            turn_id: "turn-before",
+            prompt: "$deep-interview prove before config context",
+          },
+          { cwd },
+        )
+      ));
+      const beforeOutput = JSON.stringify(before.outputJson);
+      const beforeState = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "sessions", sessionId, "deep-interview-state.json"), "utf-8"),
+      ) as {
+        deep_interview_config?: unknown;
+        threshold?: number;
+        max_rounds?: number;
+      };
+      assert.equal(before.skillState?.skill, "deep-interview");
+      assert.doesNotMatch(beforeOutput, /Deep-interview config override active/);
+      assert.equal(before.skillState?.deep_interview_config, undefined);
+      assert.equal(beforeState.deep_interview_config, undefined);
+      assert.equal(beforeState.threshold, undefined);
+      assert.equal(beforeState.max_rounds, undefined);
+
+      await writeFile(
+        join(cwd, ".omx", "config.toml"),
+        `[omx.deepInterview]
+defaultProfile = "standard"
+standardThreshold = 0.05
+standardMaxRounds = 15
+`,
+      );
+
+      const after = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-before-after",
+          turn_id: "turn-after",
+          prompt: "$deep-interview prove after config context",
+        },
+        { cwd },
+      );
+      const afterOutput = JSON.stringify(after.outputJson);
+      const afterState = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "sessions", sessionId, "deep-interview-state.json"), "utf-8"),
+      ) as {
+        deep_interview_config?: { profile?: string; threshold?: number; maxRounds?: number };
+        threshold?: number;
+        max_rounds?: number;
+      };
+      assert.equal(after.skillState?.deep_interview_config?.profile, "standard");
+      assert.match(afterOutput, /Deep-interview config override active/);
+      assert.match(afterOutput, /threshold=0\.05/);
+      assert.match(afterOutput, /max_rounds=15/);
+      assert.equal(afterState.deep_interview_config?.profile, "standard");
+      assert.equal(afterState.threshold, 0.05);
+      assert.equal(afterState.max_rounds, 15);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps deep-interview config override context on continuation prompts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-config-continuation-"));
+    const sessionId = "sess-deep-interview-config-continuation";
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(
+        join(cwd, ".omx", "config.toml"),
+        `[omx.deepInterview]
+defaultProfile = "standard"
+standardThreshold = 0.05
+standardMaxRounds = 15
+`,
+      );
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-continuation",
+          turn_id: "turn-start",
+          prompt: "$deep-interview prove config continuation",
+        },
+        { cwd },
+      );
+      const continued = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-continuation",
+          turn_id: "turn-continue",
+          prompt: "continue",
+        },
+        { cwd },
+      );
+      const serializedOutput = JSON.stringify(continued.outputJson);
+      const modeState = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "sessions", sessionId, "deep-interview-state.json"), "utf-8"),
+      ) as { threshold?: number; max_rounds?: number; profile?: string };
+
+      assert.equal(continued.skillState?.skill, "deep-interview");
+      assert.match(serializedOutput, /Deep-interview config override active/);
+      assert.match(serializedOutput, /threshold=0\.05/);
+      assert.match(serializedOutput, /max_rounds=15/);
+      assert.equal(modeState.profile, "standard");
+      assert.equal(modeState.threshold, 0.05);
+      assert.equal(modeState.max_rounds, 15);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the documented deep-interview Suggested Config reflected in UserPromptSubmit context", async () => {
+    const skillDoc = await readFile(join(process.cwd(), "skills", "deep-interview", "SKILL.md"), "utf-8");
+    const markerIndex = skillDoc.indexOf("## Suggested Config (optional)");
+    assert.notEqual(markerIndex, -1);
+    const configMatch = skillDoc.slice(markerIndex).match(/```toml\n([\s\S]*?)\n```/);
+    assert.ok(configMatch);
+    const documentedConfig = configMatch[1]?.trimEnd();
+    assert.ok(documentedConfig);
+    assert.match(documentedConfig, /standardThreshold = 0\.20/);
+    assert.match(documentedConfig, /standardMaxRounds = 12/);
+
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-doc-config-"));
+    const sessionId = "sess-deep-interview-doc-config";
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(join(cwd, ".omx", "config.toml"), `${documentedConfig}\n`);
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-doc-config",
+          turn_id: "turn-doc-config",
+          prompt: "$deep-interview prove documented config context",
+        },
+        { cwd },
+      );
+      const serializedOutput = JSON.stringify(result.outputJson);
+      const modeState = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "sessions", sessionId, "deep-interview-state.json"), "utf-8"),
+      ) as {
+        deep_interview_config?: { profile?: string; threshold?: number; maxRounds?: number };
+        profile?: string;
+        threshold?: number;
+        max_rounds?: number;
+      };
+
+      assert.equal(result.skillState?.deep_interview_config?.profile, "standard");
+      assert.equal(result.skillState?.deep_interview_config?.threshold, 0.2);
+      assert.equal(result.skillState?.deep_interview_config?.maxRounds, 12);
+      assert.match(serializedOutput, /Deep-interview config override active/);
+      assert.match(serializedOutput, /profile=standard/);
+      assert.match(serializedOutput, /threshold=0\.2/);
+      assert.match(serializedOutput, /max_rounds=12/);
+      assert.equal(modeState.deep_interview_config?.profile, "standard");
+      assert.equal(modeState.profile, "standard");
+      assert.equal(modeState.threshold, 0.2);
+      assert.equal(modeState.max_rounds, 12);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("injects deep-interview config overrides when state is boxed under OMX_ROOT", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-config-boxed-"));
+    const cwd = join(root, "source");
+    const omxRoot = join(root, "box");
+    const sessionId = "sess-boxed-deep-interview-config";
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(
+        join(cwd, ".omx", "config.toml"),
+        `[omx.deepInterview]
+defaultProfile = "standard"
+standardThreshold = 0.05
+standardMaxRounds = 15
+`,
+      );
+      process.env.OMX_ROOT = omxRoot;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-boxed",
+          turn_id: "turn-boxed",
+          prompt: "$deep-interview prove boxed config reflection",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.initialized_state_path, `.omx/state/sessions/${sessionId}/deep-interview-state.json`);
+      const boxedStatePath = join(omxRoot, ".omx", "state", "sessions", sessionId, "deep-interview-state.json");
+      assert.equal(existsSync(boxedStatePath), true);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", sessionId, "deep-interview-state.json")), false);
+
+      const serializedOutput = JSON.stringify(result.outputJson);
+      assert.match(serializedOutput, /Deep-interview config override active/);
+      assert.match(serializedOutput, /threshold=0\.05/);
+      assert.match(serializedOutput, /max_rounds=15/);
+    } finally {
+      if (typeof previousOmxRoot === "string") process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === "string") process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(root, { recursive: true, force: true });
     }
   });
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -44,6 +44,7 @@ import {
   recordSkillActivation,
   type SkillActiveState,
 } from "../hooks/keyword-detector.js";
+import { buildDeepInterviewConfigInstruction } from "../hooks/deep-interview-config-instruction.js";
 import {
   detectNativeStopStallPattern,
   loadAutoNudgeConfig,
@@ -1720,7 +1721,24 @@ function buildAdditionalContextMessage(
   const promptPriorityMessage = buildPromptPriorityMessage(prompt);
   const matches = detectKeywords(prompt);
   const match = detectPrimaryKeyword(prompt);
-  if (!match) return promptPriorityMessage;
+  if (!match) {
+    const continuedSkill = safeString(skillState?.skill).trim();
+    if (!continuedSkill) return promptPriorityMessage;
+    const deepInterviewPromptActivationNote = skillState?.initialized_mode === "deep-interview"
+      ? buildDeepInterviewQuestionBridgeInstruction(cwd, payload)
+      : null;
+    const deepInterviewConfigPromptActivationNote = buildDeepInterviewConfigInstruction(cwd, skillState);
+    return [
+      `OMX native UserPromptSubmit continued active workflow skill "${continuedSkill}".`,
+      promptPriorityMessage,
+      skillState?.initialized_mode && skillState.initialized_state_path
+        ? buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path)
+        : null,
+      deepInterviewPromptActivationNote,
+      deepInterviewConfigPromptActivationNote,
+      "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
+    ].filter(Boolean).join(" ");
+  }
   const detectedKeywordMessage = matches.length > 1
     ? `OMX native UserPromptSubmit detected workflow keywords ${matches.map((entry) => `"${entry.keyword}" -> ${entry.skill}`).join(", ")}.`
     : `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`;
@@ -1737,6 +1755,7 @@ function buildAdditionalContextMessage(
   const deepInterviewPromptActivationNote = skillState?.initialized_mode === "deep-interview"
     ? buildDeepInterviewQuestionBridgeInstruction(cwd, payload)
     : null;
+  const deepInterviewConfigPromptActivationNote = buildDeepInterviewConfigInstruction(cwd, skillState);
   const ultraworkPromptActivationNote = skillState?.initialized_mode === "ultrawork"
     ? "Ultrawork protocol: ground the task before editing, define pass/fail acceptance criteria, keep shared-file work local, and use direct-tool plus background evidence lanes only for truly independent work. Direct ultrawork provides lightweight verification only; Ralph owns persistence and the full verified-completion promise."
     : null;
@@ -1772,6 +1791,7 @@ function buildAdditionalContextMessage(
       promptPriorityMessage,
       ultragoalPromptActivationNote,
       autopilotPromptActivationNote,
+      deepInterviewConfigPromptActivationNote,
       skillState.initialized_mode && skillState.initialized_state_path
         ? buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path)
         : null,
@@ -1796,6 +1816,7 @@ function buildAdditionalContextMessage(
       promptPriorityMessage,
       initializedStateMessage,
       deepInterviewPromptActivationNote,
+      deepInterviewConfigPromptActivationNote,
       ultraworkPromptActivationNote,
       ultragoalPromptActivationNote,
       autopilotPromptActivationNote,
@@ -1815,6 +1836,7 @@ function buildAdditionalContextMessage(
       promptPriorityMessage,
       buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path),
       deepInterviewPromptActivationNote,
+      deepInterviewConfigPromptActivationNote,
       ultraworkPromptActivationNote,
       ultragoalPromptActivationNote,
       autopilotPromptActivationNote,


### PR DESCRIPTION
## Summary

This PR makes the documented `[omx.deepInterview]` TOML config actually affect deep-interview runtime behavior.

Deep-interview already documents a Suggested Config surface, but before this change the prompt/runtime path did not propagate those values into the active deep-interview state or UserPromptSubmit developer context. As a result, custom thresholds such as `deepThreshold = 0.13` could be present in `.omx/config.toml` / `~/.omx/config.toml` but deep-interview would still behave as if static SKILL.md defaults were active.

## What changed

- Add a deep-interview TOML runtime config resolver.
- Resolve config from:
  1. repo-local `.omx/config.toml`
  2. repo-root `omx.toml`
  3. user-global `~/.omx/config.toml`
- Persist resolved values into deep-interview mode state:
  - `profile`
  - `threshold`
  - `max_rounds`
  - `enable_challenge_modes`
  - `config_source`
  - `deep_interview_config`
- Inject the resolved config into UserPromptSubmit developer context so the skill uses runtime config instead of only static defaults.
- Keep malformed config fail-soft.
- Preserve config behavior through continuation/resume-style prompts.
- Add regression coverage for:
  - resolver behavior
  - keyword activation state
  - UserPromptSubmit context
  - documented Suggested Config staying executable
  - host `~/.omx/config.toml` isolation in tests

## Manual proof

I verified the behavior in a fresh temp folder using the same config shape as my local `~/.omx/config.toml`:

```toml
[omx.deepInterview]
defaultProfile = "deep"
quickThreshold = 0.31
standardThreshold = 0.22
deepThreshold = 0.13
quickMaxRounds = 6
standardMaxRounds = 13
deepMaxRounds = 21
enableChallengeModes = false
```

Result:

- upstream dev / main behavior:
  - `deep_interview_config: None`
  - `state.threshold: None`
  - `developer_context_has_override: False`
- this branch:
  - `state.profile: deep`
  - `state.threshold: 0.13`
  - `state.max_rounds: 21`
  - `state.enable_challenge_modes: False`
  - `developer_context_has_override: True`
  - UserPromptSubmit context includes:
    - `profile=deep`
    - `threshold=0.13`
    - `max_rounds=21`
    - `enableChallengeModes=false`

## Screenshots

<img width="2200" height="1700" alt="00-comparison-latest-current-config" src="https://github.com/user-attachments/assets/03872d0e-62ad-4830-a2f3-22b7a2c00e5b" />

## Tested

- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `npm run sync:plugin:check`
- Targeted node tests for:
  - `dist/config/__tests__/deep-interview.test.js`
  - `dist/hooks/__tests__/keyword-detector.test.js`
  - `dist/hooks/__tests__/deep-interview-contract.test.js`
  - `dist/scripts/__tests__/codex-native-hook.test.js`
- Manual fresh-folder proof against latest upstream and this branch

## Not tested

- Full `npm test` suite.

Full suite was not used as the merge blocker for this PR because the change is covered by targeted runtime/config/hook tests and manual before/after proof.
