### PR TITLE
feat(agents): add Scholastic ontology reviewer

### DIFF
--- a/docs/agents.html
+++ b/docs/agents.html
@@ -83,6 +83,7 @@
         <thead><tr><th>Agent</th><th>Model</th><th>Description</th><th>Example</th></tr></thead>
         <tbody>
           <tr><td>critic</td><td>high</td><td>Critical challenge for plans and designs.</td><td><code>critic "challenge this plan"</code></td></tr>
+          <tr><td>scholastic</td><td>high</td><td>Ontology-first review for category mistakes, assumptions, modalities, and minimal repairs.</td><td><code>scholastic "check this spec ontology"</code></td></tr>
           <tr><td>vision</td><td>medium</td><td>Image/screenshot and diagram analysis.</td><td><code>vision "review this screenshot"</code></td></tr>
         </tbody>
       </table>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -25,7 +25,7 @@
       <h2>Canonical Workflow</h2>
       <ol>
         <li><code>$deep-interview</code> - clarify intent, boundaries, and non-goals when the task is still fuzzy.</li>
-        <li><code>$ralplan</code> - approve the plan and tradeoffs before execution; completion/skipping requires recorded Architect review evidence followed by Critic review evidence, not just PRD/test-spec files.</li>
+        <li><code>$ralplan</code> - approve the plan and tradeoffs before execution; completion/skipping requires recorded Architect review evidence followed by Critic review evidence, not just PRD/test-spec files. Scholastic is available as a separate advisory ontology reviewer/persona for concept-heavy planning evidence.</li>
         <li><code>$prometheus-strict</code> - harden high-risk plans with Metis clarification, Momus critique, and Oracle synthesis.</li>
         <li><code>$ultragoal</code> - execute and verify through durable goal/ledger checkpoints; launch <code>$team</code> only when parallel lanes are warranted.</li>
         <li><code>$code-review</code> then <code>$ultraqa</code> - finish with merge-readiness and adversarial QA gates.</li>
@@ -47,7 +47,7 @@
       <h2>Planning & Clarification</h2>
       <ul>
         <li><code>$deep-interview</code> - requirements clarification before planning or execution</li>
-        <li><code>$ralplan</code> - planner/architect/critic consensus planning with durable Architect→Critic approval evidence before execution handoff</li>
+        <li><code>$ralplan</code> - planner/architect/critic consensus planning with durable Architect→Critic approval evidence before execution handoff; may cite separate Scholastic advisory evidence for concept-heavy plans</li>
         <li><code>$plan</code> - supporting strategic planning when you are not using the canonical path</li>
         <li><code>$prometheus-strict</code> - clean-room interview-driven planner that writes durable plans under <code>.omx/plans/prometheus-strict/</code> when warranted and hands off to <code>$ultragoal</code>/<code>$team</code>; credit: Inspired by OMO Prometheus (<code>code-yeongyu/oh-my-openagent</code>), reimplemented from concept under MIT.</li>
         <li><code>$best-practice-research</code> - bounded official/upstream best-practice evidence wrapper when current external guidance affects correctness</li>

--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -132,7 +132,7 @@ The final ultragoal story is not complete until the active agent has run the fin
 1. Run targeted verification for the story.
 2. Run `ai-slop-cleaner` on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
 3. Rerun verification after the cleaner pass.
-4. Run `$code-review`. Clean means `codeReview.recommendation: "APPROVE"` and `codeReview.architectStatus: "CLEAR"`; `COMMENT`, `WATCH`, `REQUEST CHANGES`, and `BLOCK` are non-clean.
+4. Run `$code-review`. Clean means `codeReview.recommendation: "APPROVE"` and `codeReview.architectStatus: "CLEAR"`; `COMMENT`, `WATCH`, `REQUEST CHANGES`, and `BLOCK` are non-clean. If the approved plan already used Scholastic for ontology-heavy review, carry that advisory evidence into the quality gate; non-clean Scholastic findings should be treated as blocker evidence rather than a completion claim.
 5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
 
    ```sh
@@ -154,6 +154,14 @@ The final ultragoal story is not complete until the active agent has run the fin
   "aiSlopCleaner": { "status": "passed", "evidence": "cleaner report" },
   "verification": { "status": "passed", "commands": ["npm test"], "evidence": "post-cleaner verification" },
   "codeReview": { "recommendation": "APPROVE", "architectStatus": "CLEAR", "evidence": "final review synthesis" }
+}
+```
+
+When Scholastic advisory evidence exists for ontology-heavy goals, add it alongside the required fields:
+
+```json
+{
+  "scholasticReview": { "recommendation": "APPROVE", "ontologyStatus": "SOUND", "evidence": "terms normalized; no category mistake; modal claims separated" }
 }
 ```
 

--- a/plugins/oh-my-codex/skills/ralplan/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralplan/SKILL.md
@@ -5,7 +5,7 @@ description: Alias for $plan --consensus
 
 # Ralplan (Consensus Planning Alias)
 
-Ralplan is a shorthand alias for `$plan --consensus`. It triggers iterative planning with Planner, Architect, and Critic agents until consensus is reached, with **RALPLAN-DR structured deliberation** (short mode by default, deliberate mode for high-risk work).
+Ralplan is a shorthand alias for `$plan --consensus`. It triggers iterative planning with Planner, Architect, and Critic agents until consensus is reached, with **RALPLAN-DR structured deliberation** (short mode by default, deliberate mode for high-risk work). Scholastic is available as a separate advisory native agent/persona for ontology-heavy planning evidence, but it is not part of the durable consensus gate.
 
 ## Usage
 
@@ -17,6 +17,10 @@ $ralplan "task description"
 
 - `--interactive`: Enables user prompts at key decision points (draft review in step 2 and final approval in step 6). Without this flag the workflow runs fully automated — Planner → Architect → Critic loop — and outputs the final plan without asking for confirmation.
 - `--deliberate`: Forces deliberate mode for high-risk work. Adds pre-mortem (3 scenarios) and expanded test planning (unit/integration/e2e/observability). Without this flag, deliberate mode can still auto-enable when the request explicitly signals high risk (auth/security, migrations, destructive changes, production incidents, compliance/PII, public API breakage).
+
+## Ontology-heavy review
+
+For requirements semantics, taxonomy, prompt/spec design, policy distinctions, or category-risk architecture, Scholastic may be cited as an available advisory ontology reviewer/persona. Its findings can inform the plan or follow-up evidence when explicitly used, but `$ralplan` itself remains the Planner → Architect → Critic consensus workflow and the durable gate remains Architect→Critic only.
 
 ## Usage with interactive mode
 
@@ -48,7 +52,7 @@ The consensus workflow:
 3. **Architect** reviews for architectural soundness and must provide the strongest steelman antithesis, at least one real tradeoff tension, and (when possible) synthesis — **await completion before step 4**. In deliberate mode, Architect should explicitly flag principle violations.
 4. **Critic** evaluates against quality criteria — run only after step 3 completes. Critic must enforce principle-option consistency, fair alternatives, risk mitigation clarity, testable acceptance criteria, and concrete verification steps. In deliberate mode, Critic must reject missing/weak pre-mortem or expanded test plan.
 5. **Re-review loop** (max 5 iterations): Any non-`APPROVE` Critic verdict (`ITERATE` or `REJECT`) MUST run the same full closed loop:
-   a. Collect Architect + Critic feedback
+   a. Collect Architect and Critic feedback
    b. Revise the plan with Planner
    c. Return to Architect review
    d. Return to Critic evaluation

--- a/prompts/scholastic.md
+++ b/prompts/scholastic.md
@@ -1,0 +1,11 @@
+---
+description: "Ontology-first reasoning reviewer: category mistakes, hidden assumptions, modality separation, scholastic critique, and minimal-repair proposals."
+---
+
+You are a reasoning assistant grounded in structured inquiry and Greek–scholastic traditions. When responding:
+
+1. Define key terms (scholastic style) to remove ambiguity; if the author uses them inconsistently, flag it and state your normalization.
+2. Validate ontology first: test whether the framework collapses the subject via a category mistake or conflict with real examples. If it does, say so immediately, give a concrete counterexample, label the failure (categorical vs empirical), and do not rescue it by charitable interpretation.
+3. Analyze the logic: surface hidden assumptions; check for inconsistencies and for “salvage by trivialization” (saving the argument only by reducing it to a tautology). State this explicitly when it occurs.
+4. Infer and separate modalities in the text (kinds of possibility and necessity).
+5. Present a structured argument (premises → steps → conclusion); distinguish hypotheses from established claims, and keep hypotheses testable. If the ontology fails, propose the minimal repair or restate the problem under a sound ontology and, where feasible, re-run the argument.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -5,7 +5,7 @@ description: Alias for $plan --consensus
 
 # Ralplan (Consensus Planning Alias)
 
-Ralplan is a shorthand alias for `$plan --consensus`. It triggers iterative planning with Planner, Architect, and Critic agents until consensus is reached, with **RALPLAN-DR structured deliberation** (short mode by default, deliberate mode for high-risk work).
+Ralplan is a shorthand alias for `$plan --consensus`. It triggers iterative planning with Planner, Architect, and Critic agents until consensus is reached, with **RALPLAN-DR structured deliberation** (short mode by default, deliberate mode for high-risk work). Scholastic is available as a separate advisory native agent/persona for ontology-heavy planning evidence, but it is not part of the durable consensus gate.
 
 ## Usage
 
@@ -17,6 +17,10 @@ $ralplan "task description"
 
 - `--interactive`: Enables user prompts at key decision points (draft review in step 2 and final approval in step 6). Without this flag the workflow runs fully automated — Planner → Architect → Critic loop — and outputs the final plan without asking for confirmation.
 - `--deliberate`: Forces deliberate mode for high-risk work. Adds pre-mortem (3 scenarios) and expanded test planning (unit/integration/e2e/observability). Without this flag, deliberate mode can still auto-enable when the request explicitly signals high risk (auth/security, migrations, destructive changes, production incidents, compliance/PII, public API breakage).
+
+## Ontology-heavy review
+
+For requirements semantics, taxonomy, prompt/spec design, policy distinctions, or category-risk architecture, Scholastic may be cited as an available advisory ontology reviewer/persona. Its findings can inform the plan or follow-up evidence when explicitly used, but `$ralplan` itself remains the Planner → Architect → Critic consensus workflow and the durable gate remains Architect→Critic only.
 
 ## Usage with interactive mode
 
@@ -48,7 +52,7 @@ The consensus workflow:
 3. **Architect** reviews for architectural soundness and must provide the strongest steelman antithesis, at least one real tradeoff tension, and (when possible) synthesis — **await completion before step 4**. In deliberate mode, Architect should explicitly flag principle violations.
 4. **Critic** evaluates against quality criteria — run only after step 3 completes. Critic must enforce principle-option consistency, fair alternatives, risk mitigation clarity, testable acceptance criteria, and concrete verification steps. In deliberate mode, Critic must reject missing/weak pre-mortem or expanded test plan.
 5. **Re-review loop** (max 5 iterations): Any non-`APPROVE` Critic verdict (`ITERATE` or `REJECT`) MUST run the same full closed loop:
-   a. Collect Architect + Critic feedback
+   a. Collect Architect and Critic feedback
    b. Revise the plan with Planner
    c. Return to Architect review
    d. Return to Critic evaluation

--- a/src/agents/__tests__/definitions.test.ts
+++ b/src/agents/__tests__/definitions.test.ts
@@ -65,6 +65,17 @@ describe('agents/definitions', () => {
     assert.ok(panel.every((agent) => agent.routingRole === 'leader'));
   });
 
+  it('defines the Scholastic ontology reviewer as a first-class coordination agent', () => {
+    const scholastic = AGENT_DEFINITIONS.scholastic;
+
+    assert.equal(scholastic.name, 'scholastic');
+    assert.equal(scholastic.category, 'coordination');
+    assert.equal(scholastic.routingRole, 'leader');
+    assert.equal(scholastic.modelClass, 'frontier');
+    assert.equal(scholastic.tools, 'read-only');
+    assert.match(scholastic.description, /Ontology-first reasoning reviewer/);
+  });
+
   it('keeps the installable agent model split aligned with the OMX subagent matrix', () => {
     assert.equal(AGENT_DEFINITIONS.architect.modelClass, 'frontier');
     assert.equal(AGENT_DEFINITIONS['security-reviewer'].modelClass, 'frontier');

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -144,6 +144,7 @@ describe("agents/native-config", () => {
 
     for (const role of [
       "debugger",
+      "scholastic",
       "prometheus-strict-metis",
       "prometheus-strict-momus",
       "prometheus-strict-oracle",

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -353,6 +353,16 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
     tools: 'read-only',
     category: 'coordination',
   },
+  'scholastic': {
+    name: 'scholastic',
+    description: 'Ontology-first reasoning reviewer: category mistakes, hidden assumptions, modality separation, scholastic critique, and minimal-repair proposals',
+    reasoningEffort: 'high',
+    posture: 'frontier-orchestrator',
+    modelClass: 'frontier',
+    routingRole: 'leader',
+    tools: 'read-only',
+    category: 'coordination',
+  },
   'vision': {
     name: 'vision',
     description: 'Image/screenshot/diagram analysis',

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2026-05-23T11:27:07.940Z",
+  "generatedAt": "2026-05-24T12:14:18.921Z",
   "version": "2026.02.28.1",
   "counts": {
     "skillCount": 49,
-    "promptCount": 33,
+    "promptCount": 34,
     "activeSkillCount": 27,
-    "activeAgentCount": 19
+    "activeAgentCount": 20
   },
   "coreSkills": [
     "autopilot",
@@ -537,6 +537,11 @@
     },
     {
       "name": "critic",
+      "category": "coordination",
+      "status": "active"
+    },
+    {
+      "name": "scholastic",
       "category": "coordination",
       "status": "active"
     },

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -466,6 +466,11 @@
       "status": "active"
     },
     {
+      "name": "scholastic",
+      "category": "coordination",
+      "status": "active"
+    },
+    {
       "name": "vision",
       "category": "coordination",
       "status": "active"

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -527,6 +527,11 @@
       "status": "active"
     },
     {
+      "name": "scholastic",
+      "category": "coordination",
+      "status": "active"
+    },
+    {
       "name": "vision",
       "category": "coordination",
       "status": "active"


### PR DESCRIPTION
## Summary

Adds **Scholastic** as a first-class ontology-first native reviewer/persona rather than a new skill or workflow keyword.

This intentionally follows the acceptance lessons from:
- #2474 — avoid disconnected public-surface bloat; new surfaces need clear catalog/docs/workflow connectivity.
- #2414 — prior planning-surface feedback showed we should reduce/avoid new workflow surfaces when a compact reviewer persona is enough.
- #597 / #595 — critique/review agents need a clear invocation model and should not be orphaned.

## What changed

- Added `prompts/scholastic.md` with the agreed Greek-scholastic prompt body preserved exactly after frontmatter.
- Added `scholastic` to native agent definitions as a read-only frontier coordination reviewer.
- Added Scholastic to catalog manifests/generated catalog and docs.
- Updated Ralplan/Ultragoal docs carefully:
  - Ralplan remains Planner → Architect → Critic.
  - Scholastic is only a separate advisory native agent/persona for ontology-heavy planning evidence.
  - No new mandatory runtime gate, no new skill keyword, no unsupported flag.
- Added focused tests for the agent definition/native install path.

## Verification

- `npm run build`
- `node --test dist/agents/__tests__/definitions.test.js dist/agents/__tests__/native-config.test.js`
- `npm run verify:native-agents`
- `npm run sync:plugin:check`
- `node dist/scripts/generate-catalog-docs.js --check`
- `npm run lint -- src/agents/definitions.ts src/agents/__tests__/definitions.test.ts src/agents/__tests__/native-config.test.ts`
- `npm run check:no-unused`
- `git diff --check upstream/dev...HEAD`

## Review notes

I ran an OMX review pass before opening this. It initially caught over-claiming in Ralplan/Ultragoal wording; those were softened so Scholastic is advisory evidence only. Final focused recheck returned `APPROVE`.
