### PR TITLE
fix: HUD reconcile preserves session id + owner env (#2485)

### DIFF
--- a/src/hud/__tests__/hud-tmux-injection.test.ts
+++ b/src/hud/__tests__/hud-tmux-injection.test.ts
@@ -235,7 +235,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
 });
 
 describe('buildHudWatchCommand', () => {
-  it('forwards OMX_ROOT for reconciled HUD panes with shell-safe quoting', () => {
+  it('forwards OMX_ROOT and OMX_TMUX_HUD_OWNER for reconciled HUD panes with shell-safe quoting', () => {
     const cmd = buildHudWatchCommand(
       '/usr/bin/omx.js',
       'minimal',
@@ -244,12 +244,12 @@ describe('buildHudWatchCommand', () => {
     );
     assert.equal(
       cmd,
-      `exec env OMX_SESSION_ID='sess managed' OMX_ROOT='/tmp/boxed root/it'\\''s/$(literal)' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=minimal`,
+      `exec env OMX_SESSION_ID='sess managed' OMX_TMUX_HUD_OWNER='1' OMX_ROOT='/tmp/boxed root/it'\\''s/$(literal)' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=minimal`,
     );
   });
 
-  it('does not add an env wrapper when OMX_SESSION_ID and OMX_ROOT are unset', () => {
+  it('always emits OMX_TMUX_HUD_OWNER even when OMX_SESSION_ID and OMX_ROOT are unset', () => {
     const cmd = buildHudWatchCommand('/usr/bin/omx.js');
-    assert.equal(cmd, `exec ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
+    assert.equal(cmd, `exec env OMX_TMUX_HUD_OWNER='1' ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
   });
 });

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -37,7 +37,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(created, false);
   });
 
-  it('recreates a missing HUD in explicit OMX-owned tmux', async () => {
+  it('skips recreating a missing HUD in explicit OMX-owned tmux without a session id', async () => {
     const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
 
@@ -57,10 +57,38 @@ describe('reconcileHudForPromptSubmit', () => {
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
+    assert.equal(result.status, 'skipped_no_session_id');
+    assert.equal(result.paneId, null);
+    assert.equal(created.length, 0);
+    assert.equal(resized.length, 0);
+  });
+
+  it('recreates a missing HUD in explicit OMX-owned tmux with a session id', async () => {
+    const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      createHudWatchPane: (cwd, cmd, options) => {
+        created.push({ cwd, cmd, options });
+        return '%9';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
     assert.equal(result.status, 'recreated');
     assert.equal(result.paneId, '%9');
     assert.equal(created.length, 1);
     assert.match(created[0]?.cmd || '', /exec .*\/repo\/dist\/cli\/omx\.js' hud --watch/);
+    assert.match(created[0]?.cmd || '', /OMX_SESSION_ID='sess-a'/);
+    assert.match(created[0]?.cmd || '', /OMX_TMUX_HUD_OWNER='1'/);
     assert.equal(created[0]?.options?.heightLines, 3);
     assert.equal(resized.length, 1);
     assert.equal(resized[0]?.heightLines, 3);
@@ -87,7 +115,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(created.length, 1);
     assert.match(
       created[0]?.cmd || '',
-      /^exec env OMX_SESSION_ID='sess-canonical' OMX_TMUX_HUD_LEADER_PANE='%1' '.*' '.*omx\.js' hud --watch/,
+      /^exec env OMX_SESSION_ID='sess-canonical' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' '.*' '.*omx\.js' hud --watch/,
     );
     assert.doesNotMatch(created[0]?.cmd || '', /sess-stale/);
   });
@@ -118,7 +146,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(created.length, 1);
     assert.match(
       created[0]?.cmd || '',
-      /^exec env OMX_SESSION_ID='sess boxed' OMX_TMUX_HUD_LEADER_PANE='%1' OMX_ROOT='\/tmp\/boxed root\/it'\\''s\/\$\(literal\)' '.*' '.*omx\.js' hud --watch/,
+      /^exec env OMX_SESSION_ID='sess boxed' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' OMX_ROOT='\/tmp\/boxed root\/it'\\''s\/\$\(literal\)' '.*' '.*omx\.js' hud --watch/,
     );
   });
 
@@ -127,7 +155,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%leader', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: (currentPaneId) => {
         listArgs.push(currentPaneId);
         return [
@@ -149,6 +177,7 @@ describe('reconcileHudForPromptSubmit', () => {
 
   it('kills duplicate HUD panes and recreates one full-width pane', async () => {
     const killed: string[] = [];
+    const created: Array<{ cmd: string }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
       env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
@@ -170,7 +199,8 @@ describe('reconcileHudForPromptSubmit', () => {
         killed.push(paneId);
         return true;
       },
-      createHudWatchPane: (_cwd, _cmd, options) => {
+      createHudWatchPane: (_cwd, cmd, options) => {
+        created.push({ cmd });
         assert.equal(options?.fullWidth, true);
         assert.equal(options?.heightLines, 3);
         return '%9';
@@ -181,6 +211,8 @@ describe('reconcileHudForPromptSubmit', () => {
 
     assert.equal(result.status, 'replaced_duplicates');
     assert.deepEqual(killed, ['%2', '%3']);
+    assert.match(created[0]?.cmd || '', /OMX_SESSION_ID='sess-a'/);
+    assert.match(created[0]?.cmd || '', /OMX_TMUX_HUD_OWNER='1'/);
   });
 
   it('does not resize, kill, or reuse another active leader session HUD in the same tmux window', async () => {
@@ -284,6 +316,37 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(resized[0]?.heightLines, 3);
   });
 
+  it('resizes an existing single HUD pane even without a fresh session id', async () => {
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    const created: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+      ],
+      createHudWatchPane: () => {
+        created.push('create');
+        return '%9';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'resized');
+    assert.equal(result.paneId, '%2');
+    assert.deepEqual(created, []);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: 3 }]);
+  });
+
   it('registers client-resized hook scoped from the emitting pane after resizing an existing HUD pane', async () => {
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
 
@@ -315,7 +378,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
       ],
@@ -339,11 +402,11 @@ describe('reconcileHudForPromptSubmit', () => {
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
-        { paneId: '%2', currentCommand: 'node', startCommand: 'node omx hud --watch' },
-        { paneId: '%3', currentCommand: 'node', startCommand: 'node omx hud --watch' },
+        { paneId: '%2', currentCommand: 'node', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch` },
+        { paneId: '%3', currentCommand: 'node', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch` },
       ],
       killTmuxPane: () => true,
       createHudWatchPane: () => '%9',

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -199,6 +199,15 @@ describe('HUD pane ownership helpers', () => {
     const cmd = buildHudWatchCommand('/usr/bin/omx.js', undefined, 'sess-a', undefined, '%1');
 
     assert.match(cmd, /OMX_SESSION_ID='sess-a'/);
+    assert.match(cmd, /OMX_TMUX_HUD_OWNER='1'/);
+    assert.match(cmd, new RegExp(`${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1'`));
+  });
+
+  it('tags reconciled HUD watch commands as OMX-owned even without a session id', () => {
+    const cmd = buildHudWatchCommand('/usr/bin/omx.js', undefined, '', undefined, '%1');
+
+    assert.doesNotMatch(cmd, /OMX_SESSION_ID=/);
+    assert.match(cmd, /OMX_TMUX_HUD_OWNER='1'/);
     assert.match(cmd, new RegExp(`${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1'`));
   });
 });

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -25,6 +25,7 @@ export interface ReconcileHudForPromptSubmitResult {
     | 'skipped_not_tmux'
     | 'skipped_no_entry'
     | 'skipped_not_omx_owned_tmux'
+    | 'skipped_no_session_id'
     | 'resized'
     | 'recreated'
     | 'replaced_duplicates'
@@ -125,6 +126,15 @@ export async function reconcileHudForPromptSubmit(
     return {
       status: resized ? 'resized' : 'failed',
       paneId: hudPaneIds[0],
+      desiredHeight,
+      duplicateCount,
+    };
+  }
+
+  if (!resolvedSessionId) {
+    return {
+      status: 'skipped_no_session_id',
+      paneId: null,
       desiredHeight,
       duplicateCount,
     };

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -9,6 +9,7 @@ export interface TmuxPaneSnapshot {
 }
 
 export const OMX_TMUX_HUD_LEADER_PANE_ENV = 'OMX_TMUX_HUD_LEADER_PANE';
+const OMX_TMUX_HUD_OWNER_ENV = 'OMX_TMUX_HUD_OWNER';
 
 export interface HudPaneOwner {
   sessionId?: string;
@@ -211,6 +212,7 @@ export function buildHudWatchCommand(
   const safeLeaderPaneId = typeof leaderPaneId === 'string' ? leaderPaneId.trim() : '';
   const envPrefix = buildEnvPrefix({
     OMX_SESSION_ID: safeSessionId,
+    [OMX_TMUX_HUD_OWNER_ENV]: '1',
     [OMX_TMUX_HUD_LEADER_PANE_ENV]: safeLeaderPaneId,
     OMX_ROOT: safeOmxRoot,
   });


### PR DESCRIPTION
Closes #2485.

## Summary
- Aligned reconciled HUD watch commands with the tmux launch env contract by carrying `OMX_TMUX_HUD_OWNER=1` and the resolved `OMX_SESSION_ID` when present.
- Added `skipped_no_session_id` for reconcile paths that would create/recreate/replace HUD watch panes without a session id.
- Preserved resize-only behavior for an already-matched single HUD pane even when prompt-submit does not provide a fresh session id.

## Root cause / env mismatch
- Launch path evidence: `src/cli/index.ts:3911-3914` builds HUD launch env args with both `OMX_SESSION_ID=${sessionId}` and `${OMX_TMUX_HUD_OWNER_ENV}=1`.
- Reconcile path evidence: `src/hud/reconcile.ts:109` resolves the session id from deps or `env.OMX_SESSION_ID`, then `src/hud/reconcile.ts:121` delegates watch-command construction to `buildHudWatchCommand`.
- Fixed reconcile command construction in `src/hud/tmux.ts:213-215` so `buildHudWatchCommand` always includes `OMX_TMUX_HUD_OWNER=1`, while `OMX_SESSION_ID` still only appears when non-empty.

## New no-session guard
- `reconcileHudForPromptSubmit` now returns `skipped_no_session_id` at `src/hud/reconcile.ts:134-140` when there is no resolved session id and the path would otherwise create/recreate/replace a HUD watch pane.
- Rationale: spawning a HUD watch without the canonical session id can render empty/stale state and also violates the next reconcile matcher contract. Resize-only remains safe because it operates on one already-matched pane and does not spawn a new watch process.

## Tests
- Added/updated tmux command tests for owner env with and without session id.
- Added/updated reconcile tests for no-session recreate skip, valid-session recreate, resize-only without fresh session id, and duplicate replacement env propagation.

## Verification
All passed:
- `npm run build`
- `npm run lint -- src/hud/`
- `npm run check:no-unused`
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js`
- `npm run sync:plugin:check`

## Out of scope / follow-up
- HUD watch pane matcher owner-agnosticism is orthogonal and intentionally unchanged in this PR.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
