### PR TITLE
fix: reap dead-leader HUD panes on omx --madmax launch (#2488)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -131,8 +131,10 @@ import {
   createHudWatchPane as createSharedHudWatchPane,
   killTmuxPane as killSharedTmuxPane,
   listCurrentWindowHudPaneIds,
+  listCurrentWindowPanes,
   OMX_TMUX_HUD_LEADER_PANE_ENV,
   parsePaneIdFromTmuxOutput,
+  reapDeadHudPanes,
   registerHudResizeHook,
 } from "../hud/tmux.js";
 
@@ -3954,6 +3956,18 @@ function runCodex(
 
   if (launchPolicy === "inside-tmux") {
     // Already in tmux: launch codex in current pane, HUD in bottom split
+    const currentWindowPanes = currentPaneId ? listCurrentWindowPanes(undefined, currentPaneId) : [];
+    reapDeadHudPanes(currentWindowPanes, {
+      killPane: (paneId) => {
+        try {
+          return killSharedTmuxPane(paneId);
+        } catch (err) {
+          logCliOperationFailure(err);
+          return false;
+        }
+      },
+    });
+
     const staleHudPaneIds = currentPaneId
       ? listHudWatchPaneIdsInCurrentWindow(currentPaneId, { leaderPaneId: currentPaneId })
       : [];

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -9,6 +9,7 @@ import {
   OMX_TMUX_HUD_LEADER_PANE_ENV,
   parseTmuxPaneSnapshot,
   readHudPaneOwner,
+  reapDeadHudPanes,
   parseHudResizeHookContext,
   registerHudResizeHook,
   unregisterHudResizeHook,
@@ -209,5 +210,100 @@ describe('HUD pane ownership helpers', () => {
     assert.doesNotMatch(cmd, /OMX_SESSION_ID=/);
     assert.match(cmd, /OMX_TMUX_HUD_OWNER='1'/);
     assert.match(cmd, new RegExp(`${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1'`));
+  });
+});
+
+describe('dead HUD pane reaper', () => {
+  it('kills HUD panes whose leader pane is not present in the snapshot', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        `%2\tnode\texec env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%9' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+    const killed: string[] = [];
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+    });
+
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+  });
+
+  it('preserves HUD panes whose leader pane is alive', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        `%2\tnode\texec env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: () => {
+        throw new Error('live leader HUD should not be killed');
+      },
+    });
+
+    assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+  });
+
+  it('preserves legacy HUD panes with no leader tag by default', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        '%2\tnode\tnode /tmp/bin/omx.js hud --watch',
+      ].join('\n'),
+    );
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: () => {
+        throw new Error('legacy untagged HUD should not be killed');
+      },
+    });
+
+    assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+  });
+
+  it('does not touch non-HUD panes', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        `%2\tnode\texec env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%9' /node /omx.js sidecar --watch`,
+      ].join('\n'),
+    );
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: () => {
+        throw new Error('non-HUD panes should not be killed');
+      },
+    });
+
+    assert.deepEqual(result, { reaped: [], preserved: [] });
+  });
+
+  it('uses an explicit live-pane predicate for reaper decisions', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        `%2\tnode\texec env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+        `%3\tnode\texec env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%9' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+    const killed: string[] = [];
+
+    const result = reapDeadHudPanes(panes, {
+      isLivePane: (paneId) => paneId === '%9',
+      killPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+    });
+
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(result, { reaped: ['%2'], preserved: ['%3'] });
   });
 });

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -101,6 +101,43 @@ export function findHudWatchPaneIds(
     .map((pane) => pane.paneId);
 }
 
+export function reapDeadHudPanes(
+  panes: TmuxPaneSnapshot[],
+  opts: {
+    isLivePane?: (paneId: string) => boolean;
+    killPane?: (paneId: string) => boolean;
+  } = {},
+): { reaped: string[]; preserved: string[] } {
+  const livePaneIds = new Set(panes.map((pane) => pane.paneId));
+  const isLivePane = opts.isLivePane ?? ((paneId: string) => livePaneIds.has(paneId));
+  const killPane = opts.killPane ?? ((paneId: string) => killTmuxPane(paneId));
+  const reaped: string[] = [];
+  const preserved: string[] = [];
+
+  for (const pane of panes) {
+    if (!isHudWatchPane(pane)) continue;
+
+    const leaderPaneId = readHudPaneOwner(pane).leaderPaneId;
+    if (!leaderPaneId) {
+      preserved.push(pane.paneId);
+      continue;
+    }
+
+    if (isLivePane(leaderPaneId)) {
+      preserved.push(pane.paneId);
+      continue;
+    }
+
+    if (killPane(pane.paneId)) {
+      reaped.push(pane.paneId);
+    } else {
+      preserved.push(pane.paneId);
+    }
+  }
+
+  return { reaped, preserved };
+}
+
 export function parsePaneIdFromTmuxOutput(rawOutput: string): string | null {
   const paneId = rawOutput.split('\n')[0]?.trim() || '';
   return paneId.startsWith('%') ? paneId : null;


### PR DESCRIPTION
Closes #2488.

## What changed

PR #2481 narrowed launch-time HUD cleanup to the current leader pane owner. That narrowing was correct for PR #2460 neighbor isolation because it prevents one live sibling pane from killing another live session's HUD, but it missed a second lifecycle case: a recycled tmux window where the prior worktree/session leader pane is already dead. In that case the old HUD has a different leader pane id, so owner-scoped same-leader cleanup never sees it.

This PR adds an additive window-scoped reaper without changing `findHudWatchPaneIds` or `hudPaneMatchesOwner` semantics:

```ts
reapDeadHudPanes(
  panes: TmuxPaneSnapshot[],
  opts?: {
    isLivePane?: (paneId: string) => boolean;
    killPane?: (paneId: string) => boolean;
  },
): { reaped: string[]; preserved: string[] }
```

The reaper only considers panes already recognized by `isHudWatchPane()`. It reads the HUD owner from the pane command string via the existing env parsing path for `OMX_TMUX_HUD_LEADER_PANE`, which is reliable after PR #2486 because `buildHudWatchCommand` now emits both `OMX_TMUX_HUD_OWNER=1` and `OMX_TMUX_HUD_LEADER_PANE=<leaderPaneId>` into the watch command. If the tagged leader pane is no longer live in the current window snapshot, the HUD pane is killed; otherwise it is preserved. Legacy untagged HUD panes are preserved by default.

The inside-tmux `omx --madmax` launch path now runs this reaper before creating the new HUD pane, then keeps the existing same-leader duplicate cleanup path intact.

## Acceptance demo

- A) Recycled window with dead prior session: prior tagged HUD references a leader pane id missing from the current window snapshot, so the old HUD is reaped before the new launch creates its HUD.
- B) Two live OMX sessions in the same window: each tagged HUD references a live leader pane, so both HUDs are preserved and PR #2460 neighbor isolation remains intact.
- C) Legacy untagged HUD: no `OMX_TMUX_HUD_LEADER_PANE` tag is present, so the reaper preserves it by default for backward compatibility.

## Verification

- Verified real tmux pane metadata contains `OMX_TMUX_HUD_LEADER_PANE` in `pane_start_command` with `tmux list-panes -F '#{pane_start_command} #{pane_current_command}'`.
- `npm run build`
- `npm run lint -- src/hud/ src/cli/`
- `npm run check:no-unused`
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js`
- `npm run sync:plugin:check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
