### PR TITLE
ultragoal: collapse nested markdown plan bullets into story-level goals

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ultragoalCommand, ULTRAGOAL_HELP } from '../ultragoal.js';
@@ -80,6 +80,32 @@ describe('cli/ultragoal', () => {
       assert.match(goals.codexObjective ?? '', /Complete the durable ultragoal plan/);
       assert.match(goals.codexObjective ?? '', /including later accepted\/appended stories/);
       assert.doesNotMatch(goals.codexObjective ?? '', /G001-first-milestone/);
+    });
+  });
+
+  it('creates story-level goals from a nested markdown brief file', async () => {
+    await withCwd(async (cwd) => {
+      const briefPath = join(cwd, 'nested-plan.md');
+      await writeFile(briefPath, [
+        '# Nested plan',
+        '',
+        '### P0',
+        '1. Fix extractor',
+        '   - Keep nested checklists under the story.',
+        '2. Add tests',
+        '   - Artifacts coverage.',
+        '3. Verify handoff',
+        '   - Prepare PR body.',
+      ].join('\n'));
+
+      const created = await capture(() => ultragoalCommand(['create-goals', '--brief-file', briefPath]));
+      assert.equal(created.exitCode, undefined);
+      assert.match(created.stdout.join('\n'), /ultragoal plan created: 3 goal/);
+
+      const goals = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { goals: Array<{ title: string; objective: string }> };
+      assert.equal(goals.goals.length, 3);
+      assert.equal(goals.goals[0]?.title, 'Fix extractor');
+      assert.match(goals.goals[0]?.objective ?? '', /Keep nested checklists under the story/);
     });
   });
 

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -117,6 +117,111 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('derives story-level goals from nested markdown plans', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '# Improvement plan',
+          '',
+          '### P0',
+          '1. **Fix extractor boundaries**',
+          '   - Parse parent list items only.',
+          '   - Acceptance criteria:',
+          '     - Nested checklist text stays in the parent objective.',
+          '2. Add regression tests',
+          '   - Cover nested bullets.',
+          '3. Verify and hand off',
+          '   1. Run focused tests.',
+          '',
+          '### Immediate next actions',
+          '1. Do not become a fourth story.',
+          '2. Nor a fifth.',
+        ].join('\n'),
+      });
+
+      assert.equal(plan.goals.length, 3);
+      assert.equal(plan.goals[0]?.id, 'G001-fix-extractor-boundaries');
+      assert.equal(plan.goals[0]?.title, 'Fix extractor boundaries');
+      assert.match(plan.goals[0]?.objective ?? '', /Parse parent list items only/);
+      assert.match(plan.goals[0]?.objective ?? '', /Acceptance criteria/);
+      assert.match(plan.goals[0]?.objective ?? '', /Nested checklist text stays/);
+      assert.doesNotMatch(plan.goals.map((goal) => goal.title).join('\n'), /Do not become a fourth story/);
+    });
+  });
+
+  it('prefers story sections over longer non-story ordered checklists', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '# Improvement plan',
+          '',
+          '### Stories',
+          '1. Build the extractor repair',
+          '   - Keep nested criteria attached.',
+          '2. Add regression coverage',
+          '3. Prepare handoff',
+          '',
+          '### Verification checklist',
+          '1. Run unit tests',
+          '2. Run lint',
+          '3. Update PR body',
+          '4. Check status',
+          '',
+          '### Validation',
+          '1. Also do not become a story.',
+        ].join('\n'),
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), [
+        'Build the extractor repair',
+        'Add regression coverage',
+        'Prepare handoff',
+      ]);
+    });
+  });
+
+  it('keeps repeated markdown auto-numbered story items in one run', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '### Stories',
+          '1. First story',
+          '1. Second story',
+          '1. Third story',
+          '',
+          '### Next actions',
+          '1. Do not become a story.',
+        ].join('\n'),
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), [
+        'First story',
+        'Second story',
+        'Third story',
+      ]);
+    });
+  });
+
+  it('keeps explicit goals authoritative over derived markdown candidates', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '1. Derived story',
+          '   - Nested checklist item',
+          '2. Another derived story',
+          '3. Third derived story',
+        ].join('\n'),
+        goals: [
+          { title: 'Explicit story', objective: 'Run only the explicit story queue.' },
+        ],
+      });
+
+      assert.equal(plan.goals.length, 1);
+      assert.equal(plan.goals[0]?.id, 'G001-explicit-story');
+      assert.equal(plan.goals[0]?.objective, 'Run only the explicit story queue.');
+    });
+  });
+
   it('starts one story at a time and emits an aggregate Codex goal handoff by default', async () => {
     await withTempRepo(async (cwd) => {
       await createUltragoalPlan(cwd, {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -286,6 +286,49 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('does not append later non-story sections to the previous story objective', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '### Stories',
+          '1. Ship the parser fix',
+          '   - Keep real acceptance criteria attached.',
+          '',
+          '### Verification checklist',
+          '   1. Run unit tests',
+          '   2. Run lint',
+        ].join('\n'),
+      });
+
+      assert.equal(plan.goals.length, 1);
+      assert.match(plan.goals[0]?.objective ?? '', /Keep real acceptance criteria attached/);
+      assert.doesNotMatch(plan.goals[0]?.objective ?? '', /Run unit tests/);
+      assert.doesNotMatch(plan.goals[0]?.objective ?? '', /Run lint/);
+    });
+  });
+
+  it('recognizes Setext non-story headings before selecting story items', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          'Stories',
+          '-------',
+          '1. Implement parser fix',
+          '2. Add regression coverage',
+          '',
+          'Verification checklist',
+          '----------------------',
+          '1. Do not become a story.',
+        ].join('\n'),
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), [
+        'Implement parser fix',
+        'Add regression coverage',
+      ]);
+    });
+  });
+
   it('keeps explicit goals authoritative over derived markdown candidates', async () => {
     await withTempRepo(async (cwd) => {
       const plan = await createUltragoalPlan(cwd, {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -230,6 +230,46 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('keeps two-story ordered briefs in story extraction mode', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '### Stories',
+          '1. Implement the focused fix',
+          '2. Add regression coverage',
+          '',
+          '### Next actions',
+          '- Do not become a queued goal.',
+        ].join('\n'),
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), [
+        'Implement the focused fix',
+        'Add regression coverage',
+      ]);
+    });
+  });
+
+  it('treats testing-focused plan headings as story sections', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '### Test plan',
+          '1. Add parser regression coverage',
+          '2. Run the focused suite',
+          '',
+          '### Verification checklist',
+          '1. Do not become a story.',
+        ].join('\n'),
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), [
+        'Add parser regression coverage',
+        'Run the focused suite',
+      ]);
+    });
+  });
+
   it('keeps explicit goals authoritative over derived markdown candidates', async () => {
     await withTempRepo(async (cwd) => {
       const plan = await createUltragoalPlan(cwd, {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -202,6 +202,22 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('preserves underscores in derived goal titles and ids', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '### Stories',
+          '1. Fix `foo_bar` extraction',
+          '2. Verify omx_ultragoal handoff',
+        ].join('\n'),
+      });
+
+      assert.equal(plan.goals[0]?.title, 'Fix foo_bar extraction');
+      assert.equal(plan.goals[0]?.id, 'G001-fix-foo-bar-extraction');
+      assert.equal(plan.goals[1]?.title, 'Verify omx_ultragoal handoff');
+    });
+  });
+
   it('keeps all valid ordered story sections when numbering restarts', async () => {
     await withTempRepo(async (cwd) => {
       const plan = await createUltragoalPlan(cwd, {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -379,6 +379,26 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('computes story indent after filtering non-story sections', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '### Stories',
+          '  1. Indented story one',
+          '  2. Indented story two',
+          '',
+          '### Verification checklist',
+          '1. Do not reset the story indent.',
+        ].join('\n'),
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), [
+        'Indented story one',
+        'Indented story two',
+      ]);
+    });
+  });
+
   it('keeps explicit goals authoritative over derived markdown candidates', async () => {
     await withTempRepo(async (cwd) => {
       const plan = await createUltragoalPlan(cwd, {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -329,6 +329,24 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('keeps mixed top-level bullet and ordered goals together', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '- Milestone A',
+          '- Milestone B',
+          '1. Ordered follow-up that is still top-level work',
+        ].join('\n'),
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), [
+        'Milestone A',
+        'Milestone B',
+        'Ordered follow-up that is still top-level work',
+      ]);
+    });
+  });
+
   it('keeps explicit goals authoritative over derived markdown candidates', async () => {
     await withTempRepo(async (cwd) => {
       const plan = await createUltragoalPlan(cwd, {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -202,6 +202,34 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('keeps all valid ordered story sections when numbering restarts', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '### P0',
+          '1. Repair parser boundary',
+          '2. Add extractor regression tests',
+          '',
+          '### P1',
+          '1. Refresh operator docs',
+          '2. Prepare upstream handoff',
+          '',
+          '### Verification checklist',
+          '1. Run tests',
+          '2. Run lint',
+          '3. Check PR status',
+        ].join('\n'),
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), [
+        'Repair parser boundary',
+        'Add extractor regression tests',
+        'Refresh operator docs',
+        'Prepare upstream handoff',
+      ]);
+    });
+  });
+
   it('keeps explicit goals authoritative over derived markdown candidates', async () => {
     await withTempRepo(async (cwd) => {
       const plan = await createUltragoalPlan(cwd, {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -218,6 +218,21 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('preserves literal glob and home-path markers in derived titles', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '### Stories',
+          '1. Clean dist/* artifacts',
+          '2. Edit ~/.codex/config.toml',
+        ].join('\n'),
+      });
+
+      assert.equal(plan.goals[0]?.title, 'Clean dist/* artifacts');
+      assert.equal(plan.goals[1]?.title, 'Edit ~/.codex/config.toml');
+    });
+  });
+
   it('keeps all valid ordered story sections when numbering restarts', async () => {
     await withTempRepo(async (cwd) => {
       const plan = await createUltragoalPlan(cwd, {
@@ -304,6 +319,23 @@ describe('ultragoal artifacts', () => {
       assert.match(plan.goals[0]?.objective ?? '', /Keep real acceptance criteria attached/);
       assert.doesNotMatch(plan.goals[0]?.objective ?? '', /Run unit tests/);
       assert.doesNotMatch(plan.goals[0]?.objective ?? '', /Run lint/);
+    });
+  });
+
+  it('does not append plain non-story section labels to the previous story objective', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '### Stories',
+          '1. Ship the parser fix',
+          '',
+          'Verification checklist:',
+          '   1. Run unit tests',
+        ].join('\n'),
+      });
+
+      assert.equal(plan.goals.length, 1);
+      assert.doesNotMatch(plan.goals[0]?.objective ?? '', /Run unit tests/);
     });
   });
 

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -357,12 +357,6 @@ function selectedItemObjective(parent: MarkdownListItem, lines: readonly string[
   return parts.join('\n');
 }
 
-function topLevelOrderedStoryItems(items: readonly MarkdownListItem[]): MarkdownListItem[] {
-  const minIndent = Math.min(...items.map((item) => item.indent));
-  const orderedTopLevelItems = items.filter((item) => item.indent === minIndent && item.ordered && !headingLooksNonStory(item.heading));
-  return orderedTopLevelItems;
-}
-
 function topLevelListItems(items: readonly MarkdownListItem[]): MarkdownListItem[] {
   const minIndent = Math.min(...items.map((item) => item.indent));
   return items.filter((item) => item.indent === minIndent && !headingLooksNonStory(item.heading));
@@ -588,8 +582,7 @@ function titleFromObjective(objective: string, fallback: string): string {
 export function deriveGoalCandidates(brief: string): Array<{ title: string; objective: string }> {
   const lines = brief.split(/\r?\n/);
   const listItems = parseMarkdownListItems(lines);
-  const storyItems = listItems.length > 0 ? topLevelOrderedStoryItems(listItems) : [];
-  const parentItems = storyItems.length > 0 ? storyItems : topLevelListItems(listItems);
+  const parentItems = topLevelListItems(listItems);
   const bulletGoals = parentItems
     .map((item, index) => selectedItemObjective(item, lines, parentItems[index + 1]?.lineIndex))
     .filter((objective, index, all) => all.findIndex((candidate) => candidate === objective) === index);

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -301,7 +301,7 @@ function normalizeHeading(line: string): string | undefined {
 
 function headingLooksNonStory(heading: string | undefined): boolean {
   if (!heading) return false;
-  return /\b(?:acceptance|criteria|verification|validation|checklist|checks?|tests?|evidence|notes?|constraints?|risks?|immediate next actions?|next actions?|follow-?ups?|status)\b/.test(heading);
+  return /\b(?:acceptance\s+criteria|verification(?:\s+checklist)?|validation(?:\s+checklist)?|checklist|evidence|notes?|constraints?|risks?|immediate\s+next\s+actions?|next\s+actions?|follow-?ups?|status)\b/.test(heading);
 }
 
 function parseMarkdownListItems(lines: readonly string[]): MarkdownListItem[] {
@@ -346,7 +346,7 @@ function selectedItemObjective(parent: MarkdownListItem, lines: readonly string[
 function topLevelOrderedStoryItems(items: readonly MarkdownListItem[]): MarkdownListItem[] {
   const minIndent = Math.min(...items.map((item) => item.indent));
   const orderedTopLevelItems = items.filter((item) => item.indent === minIndent && item.ordered && !headingLooksNonStory(item.heading));
-  return orderedTopLevelItems.length >= 3 ? orderedTopLevelItems : [];
+  return orderedTopLevelItems;
 }
 
 function topLevelListItems(items: readonly MarkdownListItem[]): MarkdownListItem[] {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -363,8 +363,10 @@ function selectedItemObjective(parent: MarkdownListItem, lines: readonly string[
 }
 
 function topLevelListItems(items: readonly MarkdownListItem[]): MarkdownListItem[] {
-  const minIndent = Math.min(...items.map((item) => item.indent));
-  return items.filter((item) => item.indent === minIndent && !headingLooksNonStory(item.heading));
+  const storyCandidates = items.filter((item) => !headingLooksNonStory(item.heading));
+  if (storyCandidates.length === 0) return [];
+  const minIndent = Math.min(...storyCandidates.map((item) => item.indent));
+  return storyCandidates.filter((item) => item.indent === minIndent);
 }
 
 function normalizeObjective(value: string): string {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -273,6 +273,104 @@ function cleanLine(line: string): string {
   return line.replace(/^\s*(?:[-*+]\s+|\d+[.)]\s+)/, '').trim();
 }
 
+function stripInlineMarkdown(value: string): string {
+  return value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[`*_~]+/g, '')
+    .trim();
+}
+
+interface MarkdownListItem {
+  lineIndex: number;
+  indent: number;
+  ordered: boolean;
+  number?: number;
+  text: string;
+  heading?: string;
+}
+
+function lineIndentWidth(line: string): number {
+  const match = /^(\s*)/.exec(line);
+  return (match?.[1] ?? '').replace(/\t/g, '  ').length;
+}
+
+function normalizeHeading(line: string): string | undefined {
+  const match = /^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/.exec(line);
+  return match ? stripInlineMarkdown(match[1]).toLowerCase() : undefined;
+}
+
+function headingLooksNonStory(heading: string | undefined): boolean {
+  if (!heading) return false;
+  return /\b(?:acceptance|criteria|verification|validation|checklist|checks?|tests?|evidence|notes?|constraints?|risks?|immediate next actions?|next actions?|follow-?ups?|status)\b/.test(heading);
+}
+
+function parseMarkdownListItems(lines: readonly string[]): MarkdownListItem[] {
+  const items: MarkdownListItem[] = [];
+  let heading: string | undefined;
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    heading = normalizeHeading(lines[lineIndex] ?? '') ?? heading;
+    const line = lines[lineIndex] ?? '';
+    const match = /^(\s*)([-*+]|\d+[.)])\s+(.+)$/.exec(line);
+    if (!match) continue;
+    const marker = match[2];
+    const text = cleanLine(line);
+    if (!text || text.length > 1200) continue;
+    items.push({
+      lineIndex,
+      indent: match[1].replace(/\t/g, '  ').length,
+      ordered: /^\d+[.)]$/.test(marker),
+      number: /^\d+[.)]$/.test(marker) ? Number.parseInt(marker, 10) : undefined,
+      text,
+      heading,
+    });
+  }
+  return items;
+}
+
+function selectedItemObjective(parent: MarkdownListItem, lines: readonly string[], nextParentLineIndex?: number): string {
+  const parts = [parent.text];
+  const endLineIndex = nextParentLineIndex ?? lines.length;
+  for (let lineIndex = parent.lineIndex + 1; lineIndex < endLineIndex; lineIndex += 1) {
+    const line = lines[lineIndex] ?? '';
+    if (!line.trim()) continue;
+    const indent = lineIndentWidth(line);
+    if (/^\s*(?:[-*+]\s+|\d+[.)]\s+)/.test(line) && indent <= parent.indent) break;
+    if (indent <= parent.indent) continue;
+    const nested = cleanLine(line);
+    if (!nested || nested.length > 1200) continue;
+    parts.push(nested);
+  }
+  return parts.join('\n');
+}
+
+function longestTopLevelOrderedRun(items: readonly MarkdownListItem[]): MarkdownListItem[] {
+  const minIndent = Math.min(...items.map((item) => item.indent));
+  const orderedTopLevelItems = items.filter((item) => item.indent === minIndent && item.ordered && !headingLooksNonStory(item.heading));
+  const runs: MarkdownListItem[][] = [];
+  let current: MarkdownListItem[] = [];
+  for (const item of orderedTopLevelItems) {
+    const previous = current.at(-1);
+    const startsNewNumberedSection = previous?.number !== undefined
+      && item.number !== undefined
+      && item.number <= previous.number
+      && !(item.number === 1 && item.heading === previous.heading);
+    if (startsNewNumberedSection) {
+      runs.push(current);
+      current = [];
+    }
+    current.push(item);
+  }
+  if (current.length > 0) runs.push(current);
+  return runs
+    .filter((run) => run.length >= 3)
+    .sort((left, right) => right.length - left.length || left[0].lineIndex - right[0].lineIndex)[0] ?? [];
+}
+
+function topLevelListItems(items: readonly MarkdownListItem[]): MarkdownListItem[] {
+  const minIndent = Math.min(...items.map((item) => item.indent));
+  return items.filter((item) => item.indent === minIndent && !headingLooksNonStory(item.heading));
+}
+
 function normalizeObjective(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
 }
@@ -492,14 +590,12 @@ function titleFromObjective(objective: string, fallback: string): string {
 
 export function deriveGoalCandidates(brief: string): Array<{ title: string; objective: string }> {
   const lines = brief.split(/\r?\n/);
-  const bulletGoals = lines
-    .map((line) => ({ original: line, cleaned: cleanLine(line) }))
-    .filter(({ cleaned }) => cleaned.length > 0 && cleaned.length <= 1200)
-    .filter(({ original, cleaned }, index, all) => (
-      /^\s*(?:[-*+]\s+|\d+[.)]\s+)/.test(original)
-      && all.findIndex((candidate) => candidate.cleaned === cleaned) === index
-    ))
-    .map(({ cleaned }) => cleaned);
+  const listItems = parseMarkdownListItems(lines);
+  const storyRun = listItems.length > 0 ? longestTopLevelOrderedRun(listItems) : [];
+  const parentItems = storyRun.length > 0 ? storyRun : topLevelListItems(listItems);
+  const bulletGoals = parentItems
+    .map((item, index) => selectedItemObjective(item, lines, parentItems[index + 1]?.lineIndex))
+    .filter((objective, index, all) => all.findIndex((candidate) => candidate === objective) === index);
 
   const objectives = bulletGoals.length > 0
     ? bulletGoals
@@ -510,7 +606,7 @@ export function deriveGoalCandidates(brief: string): Array<{ title: string; obje
 
   const selected = objectives.length > 0 ? objectives : [brief.trim() || 'Complete the requested project objective.'];
   return selected.map((objective, index) => ({
-    title: titleFromObjective(objective, `Goal ${index + 1}`),
+    title: titleFromObjective(stripInlineMarkdown(objective), `Goal ${index + 1}`),
     objective,
   }));
 }

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -294,9 +294,22 @@ function lineIndentWidth(line: string): number {
   return (match?.[1] ?? '').replace(/\t/g, '  ').length;
 }
 
-function normalizeHeading(line: string): string | undefined {
+function normalizeAtxHeading(line: string): string | undefined {
   const match = /^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/.exec(line);
   return match ? stripInlineMarkdown(match[1]).toLowerCase() : undefined;
+}
+
+function normalizeSetextHeading(lines: readonly string[], lineIndex: number): string | undefined {
+  const line = lines[lineIndex] ?? '';
+  if (!/^\s{0,3}(?:=+|-+)\s*$/.test(line)) return undefined;
+  const previous = lines[lineIndex - 1] ?? '';
+  const text = previous.trim();
+  if (!text || /^\s*(?:[-*+]\s+|\d+[.)]\s+)/.test(previous)) return undefined;
+  return stripInlineMarkdown(text).toLowerCase();
+}
+
+function normalizeHeading(lines: readonly string[], lineIndex: number): string | undefined {
+  return normalizeAtxHeading(lines[lineIndex] ?? '') ?? normalizeSetextHeading(lines, lineIndex);
 }
 
 function headingLooksNonStory(heading: string | undefined): boolean {
@@ -308,7 +321,7 @@ function parseMarkdownListItems(lines: readonly string[]): MarkdownListItem[] {
   const items: MarkdownListItem[] = [];
   let heading: string | undefined;
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
-    heading = normalizeHeading(lines[lineIndex] ?? '') ?? heading;
+    heading = normalizeHeading(lines, lineIndex) ?? heading;
     const line = lines[lineIndex] ?? '';
     const match = /^(\s*)([-*+]|\d+[.)])\s+(.+)$/.exec(line);
     if (!match) continue;
@@ -332,6 +345,7 @@ function selectedItemObjective(parent: MarkdownListItem, lines: readonly string[
   const endLineIndex = nextParentLineIndex ?? lines.length;
   for (let lineIndex = parent.lineIndex + 1; lineIndex < endLineIndex; lineIndex += 1) {
     const line = lines[lineIndex] ?? '';
+    if (headingLooksNonStory(normalizeHeading(lines, lineIndex))) break;
     if (!line.trim()) continue;
     const indent = lineIndentWidth(line);
     if (/^\s*(?:[-*+]\s+|\d+[.)]\s+)/.test(line) && indent <= parent.indent) break;

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -343,27 +343,10 @@ function selectedItemObjective(parent: MarkdownListItem, lines: readonly string[
   return parts.join('\n');
 }
 
-function longestTopLevelOrderedRun(items: readonly MarkdownListItem[]): MarkdownListItem[] {
+function topLevelOrderedStoryItems(items: readonly MarkdownListItem[]): MarkdownListItem[] {
   const minIndent = Math.min(...items.map((item) => item.indent));
   const orderedTopLevelItems = items.filter((item) => item.indent === minIndent && item.ordered && !headingLooksNonStory(item.heading));
-  const runs: MarkdownListItem[][] = [];
-  let current: MarkdownListItem[] = [];
-  for (const item of orderedTopLevelItems) {
-    const previous = current.at(-1);
-    const startsNewNumberedSection = previous?.number !== undefined
-      && item.number !== undefined
-      && item.number <= previous.number
-      && !(item.number === 1 && item.heading === previous.heading);
-    if (startsNewNumberedSection) {
-      runs.push(current);
-      current = [];
-    }
-    current.push(item);
-  }
-  if (current.length > 0) runs.push(current);
-  return runs
-    .filter((run) => run.length >= 3)
-    .sort((left, right) => right.length - left.length || left[0].lineIndex - right[0].lineIndex)[0] ?? [];
+  return orderedTopLevelItems.length >= 3 ? orderedTopLevelItems : [];
 }
 
 function topLevelListItems(items: readonly MarkdownListItem[]): MarkdownListItem[] {
@@ -591,8 +574,8 @@ function titleFromObjective(objective: string, fallback: string): string {
 export function deriveGoalCandidates(brief: string): Array<{ title: string; objective: string }> {
   const lines = brief.split(/\r?\n/);
   const listItems = parseMarkdownListItems(lines);
-  const storyRun = listItems.length > 0 ? longestTopLevelOrderedRun(listItems) : [];
-  const parentItems = storyRun.length > 0 ? storyRun : topLevelListItems(listItems);
+  const storyItems = listItems.length > 0 ? topLevelOrderedStoryItems(listItems) : [];
+  const parentItems = storyItems.length > 0 ? storyItems : topLevelListItems(listItems);
   const bulletGoals = parentItems
     .map((item, index) => selectedItemObjective(item, lines, parentItems[index + 1]?.lineIndex))
     .filter((objective, index, all) => all.findIndex((candidate) => candidate === objective) === index);

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -276,7 +276,10 @@ function cleanLine(line: string): string {
 function stripInlineMarkdown(value: string): string {
   return value
     .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/[`*~]+/g, '')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
     .trim();
 }
 
@@ -345,9 +348,11 @@ function selectedItemObjective(parent: MarkdownListItem, lines: readonly string[
   const endLineIndex = nextParentLineIndex ?? lines.length;
   for (let lineIndex = parent.lineIndex + 1; lineIndex < endLineIndex; lineIndex += 1) {
     const line = lines[lineIndex] ?? '';
-    if (headingLooksNonStory(normalizeHeading(lines, lineIndex))) break;
-    if (!line.trim()) continue;
     const indent = lineIndentWidth(line);
+    const plainSectionLabel = line.trim().replace(/:$/, '').toLowerCase();
+    if (headingLooksNonStory(normalizeHeading(lines, lineIndex))
+      || (indent <= parent.indent && headingLooksNonStory(plainSectionLabel))) break;
+    if (!line.trim()) continue;
     if (/^\s*(?:[-*+]\s+|\d+[.)]\s+)/.test(line) && indent <= parent.indent) break;
     if (indent <= parent.indent) continue;
     const nested = cleanLine(line);

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -276,7 +276,7 @@ function cleanLine(line: string): string {
 function stripInlineMarkdown(value: string): string {
   return value
     .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/[`*_~]+/g, '')
+    .replace(/[`*~]+/g, '')
     .trim();
 }
 


### PR DESCRIPTION
## Summary
- Fix automatic `deriveGoalCandidates()` so nested markdown plans produce story-level Ultragoal queue entries instead of checklist-level microgoals.
- Prefer story-level top-level ordered runs, fold nested bullets/acceptance details into the parent objective, and ignore non-story checklist/verification/validation sections.
- Preserve explicit `--goal` precedence and simple flat top-level bullet behavior.

## Evidence / root cause
`omx ultragoal create-goals` previously flattened every markdown bullet/numbered line at any indentation depth into a durable goal. In a real MediaGen/Comfy run, that produced 74 autogenerated goals before manual normalization to 12 executable stories.

## Tests
- `npm run build`
- `node --test dist/ultragoal/__tests__/artifacts.test.js dist/cli/__tests__/ultragoal.test.js`
- `npm run lint -- src/ultragoal/artifacts.ts src/ultragoal/__tests__/artifacts.test.ts src/cli/__tests__/ultragoal.test.ts`
- `npm run check:no-unused`
- `git diff --check upstream/dev...HEAD`

## Pre-publication review
- Ultragoal loop applied an ontology/Scholastic-style critique first: source markdown plan/checklist item/acceptance criterion/executable story/durable queue are distinct.
- Fresh OMX blocker review initially found an over-broad heuristic; fixed with heading-aware non-story filtering and repeated `1.` auto-numbering support.
- Final focused OMX recheck: `APPROVE`.

## Scope
- `src/ultragoal/artifacts.ts`
- `src/ultragoal/__tests__/artifacts.test.ts`
- `src/cli/__tests__/ultragoal.test.ts`

No new skill, agent, or runtime surface.
