### PR TITLE
fix: preserve team-mode diff gutter on wrapped multi-line hunks (#2487)

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -3125,6 +3125,97 @@ esac
 });
 
 describe('createTeamSession tmux instance tagging', () => {
+  it('redraws the leader pane after team layout changes so wrapped diff hunks repaint with gutters', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-redraw-leader-'));
+    const prevTmux = process.env.TMUX;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-redraw-leader-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *)
+        printf "%%1\\n"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  set-option|resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell|send-keys)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+        `,
+        async ({ logPath }) => {
+          const fakeBinDir = join(logPath, '..');
+          const geminiPath = join(fakeBinDir, 'gemini');
+          await writeFile(geminiPath, '#!/bin/sh\nexit 0\n');
+          await chmod(geminiPath, 0o755);
+
+          process.env.TMUX = 'leader-session,stub,0';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+
+          createTeamSession('Diff Gutter Redraw', 1, cwd);
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /select-layout -t leader:0 main-vertical/);
+          assert.match(tmuxLog, /set-window-option -t leader:0 main-pane-width 60/);
+          assert.match(tmuxLog, /split-window -v -f -l 3 -t leader:0 -d -P -F #\{pane_id\}/);
+          assert.match(
+            tmuxLog,
+            /send-keys -t %1 C-l/,
+            'leader Codex pane must repaint after team splits/resizes so tmux does not auto-wrap diff continuation rows without the line-number gutter',
+          );
+        },
+      );
+    } finally {
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('tags leader, worker, and HUD panes with pane-scoped instance ownership', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-pane-tags-'));
     const prevTmux = process.env.TMUX;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -604,6 +604,12 @@ export function buildReconcileHudResizeArgs(
   return ['run-shell', buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)))];
 }
 
+function redrawLeaderPaneAfterTeamLayout(leaderPaneId: string): void {
+  const target = leaderPaneId.trim();
+  if (!target.startsWith('%')) return;
+  runTmux(['send-keys', '-t', target, 'C-l']);
+}
+
 const ZSH_CANDIDATE_PATHS = ['/bin/zsh', '/usr/bin/zsh', '/usr/local/bin/zsh', '/opt/local/bin/zsh', '/opt/homebrew/bin/zsh'];
 const BASH_CANDIDATE_PATHS = ['/bin/bash', '/usr/bin/bash'];
 
@@ -1355,6 +1361,7 @@ export function createTeamSession(
     }
 
     runTmux(['select-pane', '-t', leaderPaneId]);
+    redrawLeaderPaneAfterTeamLayout(leaderPaneId);
     sleepSeconds(0.5);
 
     // Enable mouse scrolling so agent output panes can be scrolled with the


### PR DESCRIPTION
Closes #2487.

## Screenshot evidence

Owner screenshot evidence from Sigrid Jin in `#omx-dev`, message id `1508124829361111041`, showed the team-mode main agent pane corrupting a diff hunk:

- rows 36/37 rendered with the line-number gutter and `+` marker intact;
- rows 38/39 lost the line-number column entirely;
- the trailing token `ivered");` rendered in an isolated dark box at an unexpected column with no `+` sign and no line number;
- rendering resumed at `40 +});`;
- small stray `2` glyphs appeared at the right edge of the pane.

## Data path / root cause

The main agent pane is the existing Codex leader tmux pane selected by `src/team/tmux-session.ts:createTeamSession`.

Data path:

1. Codex/agent TUI writes directly to the leader tmux pane.
2. Codex owns diff/code hunk rendering and the line-number gutter.
3. OMX team mode mutates geometry around that renderer: worker splits, `main-vertical`, `main-pane-width`, full-width bottom HUD split, HUD height reconciliation, then focus returns to the leader pane.
4. Before this patch, OMX did not force the fullscreen leader TUI to repaint after those split/layout/HUD changes.

That leaves a team-owned stale-render window: if a diff hunk is already visible while the leader pane narrows, tmux can physically auto-wrap stale rows instead of Codex repainting rows for the new pane width. Those terminal continuation rows are not Codex diff rows, so they lack the line-number gutter and `+` marker. This matches the observed 38/39 gutter loss and the misplaced wrapped `ivered");` fragment.

## Fix

After final team layout/HUD resize and after reselecting the leader pane, `createTeamSession` now sends a best-effort `C-l` to the leader pane. This prompts the fullscreen Codex TUI to repaint against the final pane geometry, preventing stale tmux auto-wrap continuation rows from masquerading as diff hunk rows.

The change is intentionally scoped to `src/team/tmux-session.ts` and its regression test.

## Repro test

Added `src/team/__tests__/tmux-session.test.ts` coverage:

- `redraws the leader pane after team layout changes so wrapped diff hunks repaint with gutters`

The test simulates team worker split, `main-pane-width` narrowing, and full-width HUD split creation, then asserts the leader pane receives `send-keys -t %1 C-l` after the layout changes.

Failure on dev/current pre-fix behavior:

- `node --test dist/team/__tests__/tmux-session.test.js --test-name-pattern 'redraws the leader pane after team layout changes'` failed because the tmux command log lacked `send-keys -t %1 C-l`.

Pass after fix:

- `node --test dist/team/__tests__/tmux-session.test.js` passes (`192` tests).

## Stray `2` glyphs

I did not find evidence that the diff gutter loss comes from HUD overlay writes into the leader pane. The HUD runs in a separate tmux pane and resize commands target the HUD pane id. The stray right-edge `2` glyphs are most consistent with stale terminal cells after rapid layout/HUD resize; the same leader repaint should clear stale cells in the leader pane.

If right-edge HUD artifacts persist after this repaint fix, they should be tracked as a separate HUD/tmux overlay follow-up because direct `src/hud/` changes were explicitly out of scope for #2487.

## Verification

- `npm run build`
- `npm run lint -- src/team/tmux-session.ts src/team/__tests__/tmux-session.test.ts`
- `npm run check:no-unused`
- `node --test dist/team/__tests__/tmux-session.test.js`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
