### PR TITLE
fix: reuse existing HUD during UserPromptSubmit revive (#2488)

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -316,6 +316,37 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(resized[0]?.heightLines, 3);
   });
 
+  it('resizes an existing owner-tagged same-leader HUD pane instead of creating a duplicate during prompt revive', async () => {
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    const created: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-canonical', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+        },
+      ],
+      createHudWatchPane: () => {
+        created.push('create');
+        return '%9';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'resized');
+    assert.equal(result.paneId, '%2');
+    assert.deepEqual(created, []);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: 3 }]);
+  });
+
   it('resizes an existing single HUD pane even without a fresh session id', async () => {
     const resized: Array<{ paneId: string; heightLines: number }> = [];
     const created: string[] = [];

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -169,7 +169,30 @@ describe('HUD pane ownership helpers', () => {
     );
 
     assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), ['%2', '%3']);
-    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'new-session', leaderPaneId: '%1' }), ['%3']);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'new-session', leaderPaneId: '%1' }), ['%2', '%3']);
+  });
+
+  it('matches owner-tagged same-leader HUD panes even when the current revive has only a canonical session id', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        `%2\tnode\texec env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-canonical', leaderPaneId: '%1' }), ['%2']);
+  });
+
+  it('does not owner-match a different live leader just because the session id matches', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        '%3\tcodex\tcodex',
+        `%4\tnode\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%3' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), []);
   });
 
   it('does not owner-match untagged HUD panes when an owner scope is requested', () => {

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -80,14 +80,26 @@ export function readHudPaneOwner(pane: TmuxPaneSnapshot): HudPaneOwner {
 
 export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner = {}): boolean {
   if (!isHudWatchPane(pane)) return false;
-  const wantsSession = typeof owner.sessionId === 'string' && owner.sessionId.trim() !== '';
-  const wantsLeaderPane = typeof owner.leaderPaneId === 'string' && owner.leaderPaneId.trim() !== '';
+  const wantedSessionId = typeof owner.sessionId === 'string' ? owner.sessionId.trim() : '';
+  const wantedLeaderPaneId = typeof owner.leaderPaneId === 'string' ? owner.leaderPaneId.trim() : '';
+  const wantsSession = wantedSessionId !== '';
+  const wantsLeaderPane = wantedLeaderPaneId !== '';
   if (!wantsSession && !wantsLeaderPane) return true;
+
   const paneOwner = readHudPaneOwner(pane);
-  if (wantsSession && paneOwner.sessionId !== owner.sessionId?.trim()) return false;
-  if (wantsSession && wantsLeaderPane && !paneOwner.leaderPaneId) return true;
-  if (wantsLeaderPane && paneOwner.leaderPaneId !== owner.leaderPaneId?.trim()) return false;
-  return true;
+  const sessionMatches = wantsSession && paneOwner.sessionId === wantedSessionId;
+  const leaderPaneMatches = wantsLeaderPane && paneOwner.leaderPaneId === wantedLeaderPaneId;
+
+  if (wantsSession && wantsLeaderPane) {
+    // Prompt-submit revive may know the canonical session id even when an
+    // existing launch-path HUD was only tagged with its leader pane. Treat
+    // either owner identity as the same HUD so reconciliation can resize/reuse
+    // it instead of creating a duplicate, while keeping other live leaders in
+    // the same tmux window isolated when their leader tag differs.
+    return leaderPaneMatches || (sessionMatches && !paneOwner.leaderPaneId);
+  }
+  if (wantsSession) return sessionMatches;
+  return leaderPaneMatches;
 }
 
 export function findHudWatchPaneIds(

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -25,6 +25,7 @@ import { writeSessionStart } from "../../hooks/session.js";
 import { resetTriageConfigCache } from "../../hooks/triage-config.js";
 import { executeStateOperation } from "../../state/operations.js";
 import { OMX_TMUX_HUD_OWNER_ENV } from "../../hud/reconcile.js";
+import { OMX_TMUX_HUD_LEADER_PANE_ENV } from "../../hud/tmux.js";
 import { readAllState } from "../../hud/state.js";
 import { renderHud } from "../../hud/render.js";
 import { getLegacyWikiDir, serializePage, writePage } from "../../wiki/storage.js";
@@ -3929,6 +3930,78 @@ esac
       }
       process.env.PATH = originalPath;
       process.argv = originalArgv;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses an existing owner-tagged HUD pane when UserPromptSubmit revives with the canonical session id", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reuse-"));
+    const originalTmux = process.env.TMUX;
+    const originalTmuxPane = process.env.TMUX_PANE;
+    const originalPath = process.env.PATH;
+    const originalHudOwner = process.env[OMX_TMUX_HUD_OWNER_ENV];
+    try {
+      process.env.TMUX = "1";
+      process.env.TMUX_PANE = "%1";
+      process.env[OMX_TMUX_HUD_OWNER_ENV] = "1";
+      const canonicalSessionId = "omx-canonical-hud-reuse";
+      const nativeSessionId = "codex-native-hud-reuse";
+      await mkdir(join(cwd, ".omx", "state", "sessions", canonicalSessionId), { recursive: true });
+      await writeSessionStart(cwd, canonicalSessionId);
+
+      const binDir = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reuse-bin-"));
+      const tmuxLog = join(cwd, "tmux.log");
+      await writeFile(
+        join(binDir, "tmux"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> ${JSON.stringify(tmuxLog)}
+case "$1" in
+  list-panes)
+    printf '%%1\tcodex\tcodex\n'
+    printf '%%2\tnode\texec env OMX_TMUX_HUD_OWNER='"'"'1'"'"' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='"'"'%%1'"'"' /node /omx.js hud --watch\n'
+    ;;
+  display-message)
+    printf '80\t24\n'
+    ;;
+  resize-pane)
+    ;;
+  split-window)
+    printf '%%9\n'
+    ;;
+esac
+`,
+      );
+      await chmod(join(binDir, "tmux"), 0o755);
+      process.env.PATH = `${binDir}:${originalPath}`;
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: nativeSessionId,
+          thread_id: "thread-hud-reuse",
+          turn_id: "turn-hud-reuse",
+          prompt: "$ralplan prepare plan",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      const tmuxCalls = await readFile(tmuxLog, "utf-8");
+      assert.match(tmuxCalls, /list-panes -t %1 -F/);
+      assert.match(tmuxCalls, /resize-pane -t %2 -y 3/);
+      assert.doesNotMatch(tmuxCalls, /split-window/);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", canonicalSessionId, "ralplan-state.json")), true);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", nativeSessionId, "ralplan-state.json")), false);
+    } finally {
+      if (originalTmux === undefined) delete process.env.TMUX;
+      else process.env.TMUX = originalTmux;
+      if (originalTmuxPane === undefined) delete process.env.TMUX_PANE;
+      else process.env.TMUX_PANE = originalTmuxPane;
+      if (originalHudOwner === undefined) delete process.env[OMX_TMUX_HUD_OWNER_ENV];
+      else process.env[OMX_TMUX_HUD_OWNER_ENV] = originalHudOwner;
+      process.env.PATH = originalPath;
       await rm(cwd, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Closes #2488

## Summary
- PR #2489 fixed the `omx --madmax` launch-path dead-leader HUD reaper, but the UserPromptSubmit hook HUD revive/reconcile path could still create a duplicate HUD pane.
- Owner-confirmed diagnosis from #omx-dev message 1508141095236665474: the UserPromptSubmit hook path that revives HUD ignored an already-existing HUD and started a new HUD pane.
- Root cause: prompt-submit reconciliation supplied both canonical `OMX_SESSION_ID` and current leader pane as the desired owner, while an existing launch-path HUD pane may only be leader-tagged (or legacy session-tagged). The strict owner matcher rejected that existing pane before reconciliation, so the create/split path ran.

## Fix
- Updated HUD owner matching to treat a HUD pane as matching when both desired owner identifiers are present and either:
  - the existing HUD has the same leader pane owner, or
  - the existing HUD is a legacy same-session HUD without a leader tag.
- Preserved neighbor isolation by not matching a different live leader just because the session id is the same.
- Added UserPromptSubmit regression coverage showing an existing owner-tagged HUD pane is resized/reused and no second split/create is made.

## Tests
- `npm run build`
- `npm run lint -- src/scripts/ src/hud/`
- `npm run check:no-unused`
- `npm run sync:plugin:check`
- `node --test --test-name-pattern 'reuses an existing owner-tagged HUD pane|resizes an existing owner-tagged same-leader|matches owner-tagged same-leader|does not owner-match a different live leader' dist/scripts/__tests__/codex-native-hook.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/tmux.test.js`

## Verification note
- The requested full command `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/tmux.test.js` was run and the new HUD tests passed, but the command still fails in unrelated pre-existing deep-interview config assertions in `codex-native-hook.test.js`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
