### PR TITLE
feat: add auth slot hot-swap wrapper (#2484)

### DIFF
--- a/src/auth/__tests__/config-sessions.test.ts
+++ b/src/auth/__tests__/config-sessions.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readAuthConfig } from "../config.js";
+import { findLatestRolloutSession } from "../sessions.js";
+
+describe("auth config", () => {
+  it("merges project keys over user keys per absent key fallback", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-auth-config-home-"));
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-config-wd-"));
+    try {
+      await mkdir(join(home, ".omx"), { recursive: true });
+      await writeFile(join(home, ".omx", "config.toml"), '[omx.auth]\nrotation = "priority"\npriority = ["user"]\nquota_patterns = ["custom-quota"]\n');
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(join(wd, ".omx", "config.toml"), '[omx.auth]\npriority = ["project"]\n');
+      const config = await readAuthConfig(wd, home);
+      assert.equal(config.rotation, "priority");
+      assert.deepEqual(config.priority, ["project"]);
+      assert.deepEqual(config.quotaPatterns, ["custom-quota"]);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Codex rollout session heuristic", () => {
+  it("returns newest rollout id by mtime", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-auth-sessions-"));
+    try {
+      const dir = join(home, "sessions", "2026", "05", "24");
+      await mkdir(dir, { recursive: true });
+      const oldPath = join(dir, "rollout-old.jsonl");
+      const newPath = join(dir, "rollout-new.jsonl");
+      await writeFile(oldPath, "{}\n");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await writeFile(newPath, "{}\n");
+      const latest = await findLatestRolloutSession(home);
+      assert.equal(latest?.id, "new");
+      assert.equal(latest?.path, newPath);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/auth/__tests__/quota-rotation.test.ts
+++ b/src/auth/__tests__/quota-rotation.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isQuotaError } from "../quota-detector.js";
+import { buildRotationPlan, nextSlotAfter } from "../rotation.js";
+import { redactAuthSecrets } from "../redact.js";
+
+describe("quota detector", () => {
+  it("matches structured and stderr quota signals", () => {
+    assert.equal(isQuotaError({ structuredError: { status: 429, message: "too many requests" } }), true);
+    assert.equal(isQuotaError({ stderr: "Error: quota exceeded for this account" }), true);
+    assert.equal(isQuotaError({ stderr: "HTTP 429 rate limit" }), true);
+    assert.equal(isQuotaError({ stderr: "syntax error" }), false);
+  });
+});
+
+describe("auth rotation", () => {
+  const slots = ["a", "b", "c"].map((slot) => ({ slot, createdAt: "now", updatedAt: "now" }));
+
+  it("defaults to round-robin from the current slot", () => {
+    assert.deepEqual(buildRotationPlan(slots, { rotation: "round-robin", priority: [] }, "b").order, ["b", "c", "a"]);
+  });
+
+  it("supports priority order and exhausted skipping", () => {
+    const order = buildRotationPlan(slots, { rotation: "priority", priority: ["c", "a"] }, "b").order;
+    assert.deepEqual(order, ["c", "a", "b"]);
+    assert.equal(nextSlotAfter(order, "c", new Set(["c"])), "a");
+    assert.equal(nextSlotAfter(order, "a", new Set(["a", "b", "c"])), undefined);
+  });
+
+  it("manual mode does not plan automatic rotation", () => {
+    assert.deepEqual(buildRotationPlan(slots, { rotation: "manual", priority: [] }, "b").order, ["b"]);
+  });
+
+  it("redacts token-shaped values", () => {
+    const redacted = redactAuthSecrets('access_token:"secret-value" Bearer abc.def sk-test-secret123');
+    assert.doesNotMatch(redacted, /secret-value|abc\.def|sk-test-secret123/);
+  });
+});

--- a/src/auth/__tests__/redact.test.ts
+++ b/src/auth/__tests__/redact.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { redactAuthSecrets } from "../redact.js";
+
+describe("auth secret redaction", () => {
+  it("redacts JSON quoted OAuth token fields while preserving key names", () => {
+    const redacted = redactAuthSecrets(
+      '{"access_token":"sentinel-secret","refresh_token":"refresh-secret","id_token":"id-secret","safe":"visible"}',
+    );
+
+    assert.doesNotMatch(redacted, /sentinel-secret|refresh-secret|id-secret/);
+    assert.match(redacted, /"access_token"\s*:\s*"\[REDACTED\]"/);
+    assert.match(redacted, /"refresh_token"\s*:\s*"\[REDACTED\]"/);
+    assert.match(redacted, /"id_token"\s*:\s*"\[REDACTED\]"/);
+    assert.match(redacted, /"safe":"visible"/);
+  });
+
+  it("redacts JSON OAuth token fields with whitespace and escaped content", () => {
+    const redacted = redactAuthSecrets(
+      '{ "access_token" : "sentinel-\\"secret", "refresh_token" : "refresh-secret" }',
+    );
+
+    assert.doesNotMatch(redacted, /sentinel|refresh-secret/);
+    assert.match(redacted, /"access_token"\s*:\s*"\[REDACTED\]"/);
+    assert.match(redacted, /"refresh_token"\s*:\s*"\[REDACTED\]"/);
+  });
+});

--- a/src/auth/__tests__/storage.test.ts
+++ b/src/auth/__tests__/storage.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { atomicWriteFile, addSlotFromAuthFile, listSlots, readAuthMetadata, useSlot } from "../storage.js";
+import { resolveLiveAuthPath, resolveOmxAuthDir, resolveSlotPath, validateSlotName } from "../paths.js";
+
+async function tempHome(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "omx-auth-storage-"));
+}
+
+describe("auth slot storage", () => {
+  it("adds, lists, and uses auth slots without exposing blob contents", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, ".codex", "auth.json");
+      await mkdir(join(home, ".codex"), { recursive: true });
+      await writeFile(live, '{"access_token":"sentinel-secret"}\n');
+
+      await addSlotFromAuthFile("work", live, home, new Date("2026-05-24T00:00:00.000Z"));
+      const slots = await listSlots(home);
+      assert.deepEqual(slots.map((slot) => slot.slot), ["work"]);
+      assert.equal(await readFile(resolveSlotPath("work", home), "utf-8"), '{"access_token":"sentinel-secret"}\n');
+
+      await writeFile(live, '{"access_token":"other"}\n');
+      await useSlot("work", live, home, new Date("2026-05-24T01:00:00.000Z"));
+      assert.equal(await readFile(live, "utf-8"), '{"access_token":"sentinel-secret"}\n');
+      const metadata = await readAuthMetadata(home);
+      assert.equal(metadata.currentSlot, "work");
+      assert.equal(metadata.slots[0]?.lastUsedAt, "2026-05-24T01:00:00.000Z");
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("uses owner-only modes for auth directory and files", async () => {
+    if (process.platform === "win32") return;
+    const home = await tempHome();
+    try {
+      const live = join(home, ".codex", "auth.json");
+      await mkdir(join(home, ".codex"), { recursive: true });
+      await writeFile(live, "{}\n");
+      await addSlotFromAuthFile("personal", live, home);
+      const dirMode = (await stat(resolveOmxAuthDir(home))).mode & 0o777;
+      const slotMode = (await stat(resolveSlotPath("personal", home))).mode & 0o777;
+      assert.equal(dirMode, 0o700);
+      assert.equal(slotMode, 0o600);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects unsafe slot names", () => {
+    assert.throws(() => validateSlotName("../bad"), /invalid auth slot name/);
+    assert.throws(() => validateSlotName("bad/name"), /invalid auth slot name/);
+  });
+
+  it("rejects a symlinked auth directory", async () => {
+    if (process.platform === "win32") return;
+    const home = await tempHome();
+    const outside = await tempHome();
+    try {
+      await mkdir(join(home, ".omx"), { recursive: true });
+      await symlink(outside, join(home, ".omx", "auth"));
+      const live = join(home, ".codex", "auth.json");
+      await mkdir(join(home, ".codex"), { recursive: true });
+      await writeFile(live, "{}\n");
+      await assert.rejects(addSlotFromAuthFile("work", live, home), /auth directory must not be a symlink/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the original file when atomic write fails before rename", async () => {
+    const home = await tempHome();
+    try {
+      const target = join(home, ".codex", "auth.json");
+      await mkdir(join(home, ".codex"), { recursive: true });
+      await writeFile(target, "original\n");
+      await assert.rejects(
+        atomicWriteFile(target, "partial\n", {
+          beforeRename: () => {
+            throw new Error("simulated interrupt");
+          },
+        }),
+        /simulated interrupt/,
+      );
+      assert.equal(await readFile(target, "utf-8"), "original\n");
+      assert.equal(existsSync(`${target}.tmp`), false);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves CODEX_HOME, project-scope, and default auth paths", async () => {
+    const home = await tempHome();
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-project-"));
+    try {
+      assert.equal(resolveLiveAuthPath(wd, { CODEX_HOME: join(home, "custom") }, home), join(home, "custom", "auth.json"));
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(join(wd, ".omx", "setup-scope.json"), '{"scope":"project"}\n');
+      assert.equal(resolveLiveAuthPath(wd, {}, home), join(wd, ".codex", "auth.json"));
+      assert.equal(resolveLiveAuthPath(wd, { CODEX_HOME: "" }, home), join(wd, ".codex", "auth.json"));
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -1,0 +1,91 @@
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+import { parse as parseToml } from "@iarna/toml";
+
+export type AuthRotationMode = "round-robin" | "priority" | "manual";
+
+export interface AuthConfig {
+  rotation: AuthRotationMode;
+  priority: string[];
+  quotaPatterns: string[];
+  sources: string[];
+}
+
+const DEFAULT_AUTH_CONFIG: AuthConfig = {
+  rotation: "round-robin",
+  priority: [],
+  quotaPatterns: [],
+  sources: [],
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function extractAuthTable(parsed: unknown): Record<string, unknown> | undefined {
+  const root = asRecord(parsed);
+  const omx = asRecord(root?.omx);
+  return asRecord(omx?.auth);
+}
+
+function parseRotation(value: unknown): AuthRotationMode | undefined {
+  if (value === "round-robin" || value === "priority" || value === "manual") return value;
+  return undefined;
+}
+
+function parseStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "");
+}
+
+export async function readAuthConfig(
+  cwd = process.cwd(),
+  home = homedir(),
+): Promise<AuthConfig> {
+  const candidates = [
+    join(cwd, ".omx", "config.toml"),
+    join(cwd, "omx.toml"),
+    join(home, ".omx", "config.toml"),
+  ];
+  const merged: AuthConfig = { ...DEFAULT_AUTH_CONFIG, sources: [] };
+  const seen = { rotation: false, priority: false, quotaPatterns: false };
+
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    let table: Record<string, unknown> | undefined;
+    try {
+      table = extractAuthTable(parseToml(await readFile(path, "utf-8")));
+    } catch {
+      continue;
+    }
+    if (!table) continue;
+    merged.sources.push(path);
+    if (!seen.rotation) {
+      const rotation = parseRotation(table.rotation);
+      if (rotation) {
+        merged.rotation = rotation;
+        seen.rotation = true;
+      }
+    }
+    if (!seen.priority) {
+      const priority = parseStringArray(table.priority);
+      if (priority) {
+        merged.priority = priority;
+        seen.priority = true;
+      }
+    }
+    if (!seen.quotaPatterns) {
+      const patterns = parseStringArray(table.quota_patterns ?? table.quotaPatterns);
+      if (patterns) {
+        merged.quotaPatterns = patterns;
+        seen.quotaPatterns = true;
+      }
+    }
+  }
+
+  return merged;
+}

--- a/src/auth/hotswap.ts
+++ b/src/auth/hotswap.ts
@@ -1,0 +1,225 @@
+import { spawn } from "child_process";
+import { dirname } from "path";
+import { homedir } from "os";
+import { buildPlatformCommandSpec, classifySpawnError } from "../utils/platform-command.js";
+import { readAuthConfig } from "./config.js";
+import { isQuotaError } from "./quota-detector.js";
+import { redactAuthSecrets } from "./redact.js";
+import { buildRotationPlan, nextSlotAfter } from "./rotation.js";
+import { findLatestRolloutSession } from "./sessions.js";
+import { listSlots, markSlotQuota, readAuthMetadata, useSlot } from "./storage.js";
+
+export interface PreparedHotswapCodexHome {
+  codexHomeOverride?: string;
+  sqliteHomeOverride?: string;
+  projectLocalCodexHomeForCleanup?: string;
+  runtimeCodexHomeForCleanup?: string;
+}
+
+export interface HotswapLifecycle {
+  prepareCodexHomeForLaunch: (cwd: string, sessionId: string, env: NodeJS.ProcessEnv) => Promise<PreparedHotswapCodexHome>;
+  preLaunch: (
+    cwd: string,
+    sessionId: string,
+    notifyTempContract: unknown,
+    codexHomeOverride: string | undefined,
+    enableNotifyFallbackAuthority: boolean,
+    worktreeDirty: boolean,
+  ) => Promise<void>;
+  postLaunch: (
+    cwd: string,
+    sessionId: string,
+    codexHomeOverride: string | undefined,
+    enableNotifyFallbackAuthority: boolean,
+    projectLocalCodexHomeForCleanup?: string,
+  ) => Promise<void>;
+  cleanupRuntimeCodexHome: (runtimeCodexHome?: string, projectCodexHome?: string) => Promise<void>;
+  normalizeCodexLaunchArgs: (args: string[]) => string[];
+  injectModelInstructionsBypassArgs: (cwd: string, args: string[], env: NodeJS.ProcessEnv, defaultFilePath?: string) => string[];
+  sessionModelInstructionsPath: (cwd: string, sessionId: string) => string;
+  resolveOmxRootForLaunch: (cwd: string, env: NodeJS.ProcessEnv) => string | undefined;
+  resolveNotifyTempContract: (args: string[], env: NodeJS.ProcessEnv) => {
+    contract: unknown;
+    passthroughArgs: string[];
+  };
+}
+
+export interface HotswapOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  argv: string[];
+  lifecycle: HotswapLifecycle;
+}
+
+export interface CodexRunResult {
+  status: number;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+}
+
+export function stripHotswapArg(args: string[]): string[] {
+  return args.filter((arg) => arg !== "--hotswap");
+}
+
+async function runCodexDirect(
+  cwd: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<CodexRunResult> {
+  const spec = buildPlatformCommandSpec("codex", args, process.platform, env);
+  return await new Promise((resolve, reject) => {
+    const child = spawn(spec.command, spec.args, {
+      cwd,
+      env,
+      stdio: ["inherit", "inherit", "pipe"],
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
+    });
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const text = redactAuthSecrets(chunk.toString("utf-8"));
+      stderr += text;
+      process.stderr.write(text);
+    });
+    child.on("error", (error: NodeJS.ErrnoException) => {
+      const kind = classifySpawnError(error);
+      if (kind === "missing") {
+        reject(new Error("failed to launch codex: executable not found in PATH"));
+      } else if (kind === "blocked") {
+        reject(new Error(`failed to launch codex: executable is blocked (${error.code || "blocked"})`));
+      } else {
+        reject(error);
+      }
+    });
+    child.on("close", (status, signal) => {
+      resolve({ status: typeof status === "number" ? status : 1, signal, stderr });
+    });
+  });
+}
+
+export function buildResumeArgsWithPreservedFlags(originalArgs: string[], sessionId: string): string[] {
+  const preserved: string[] = [];
+  for (let index = 0; index < originalArgs.length; index++) {
+    const arg = originalArgs[index];
+    if (arg === "--") break;
+    if (arg === "-c" || arg === "--config" || arg === "--model" || arg === "-m") {
+      preserved.push(arg);
+      const value = originalArgs[index + 1];
+      if (value && !value.startsWith("-")) {
+        preserved.push(value);
+        index += 1;
+      }
+      continue;
+    }
+    if (
+      arg.startsWith("--config=") ||
+      arg.startsWith("--model=") ||
+      arg === "--dangerously-bypass-approvals-and-sandbox"
+    ) {
+      preserved.push(arg);
+    }
+  }
+  return ["resume", sessionId, ...preserved];
+}
+
+function codexHomeFromAuthPath(authPath: string): string {
+  return dirname(authPath);
+}
+
+function hotswapSessionId(): string {
+  return `omx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export async function runAuthHotswap(options: HotswapOptions): Promise<number> {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const home = options.home ?? homedir();
+  const lifecycle = options.lifecycle;
+  const rawArgs = stripHotswapArg(options.argv);
+  const notifyTempResult = lifecycle.resolveNotifyTempContract(rawArgs, env);
+  const normalizedArgs = lifecycle.normalizeCodexLaunchArgs(notifyTempResult.passthroughArgs.filter((arg) => arg !== "--direct" && arg !== "--tmux"));
+  const config = await readAuthConfig(cwd, home);
+  const slots = await listSlots(home);
+  if (slots.length === 0) {
+    process.stderr.write("[omx auth] no slots configured; run `omx auth add <slot>` first.\n");
+    return 1;
+  }
+
+  const sessionId = hotswapSessionId();
+  const prepared = await lifecycle.prepareCodexHomeForLaunch(cwd, sessionId, env);
+  const childCodexHome = prepared.codexHomeOverride || (env.CODEX_HOME && env.CODEX_HOME.trim()) || `${home}/.codex`;
+  const liveAuthPath = `${childCodexHome}/auth.json`;
+  const metadata = await readAuthMetadata(home);
+  const plan = buildRotationPlan(slots, config, metadata.currentSlot);
+  let currentSlot = plan.order[0];
+  if (!currentSlot) {
+    process.stderr.write("[omx auth] no slots configured; run `omx auth add <slot>` first.\n");
+    return 1;
+  }
+
+  const exhausted = new Set<string>();
+  let resumeArgs: string[] | null = null;
+  try {
+    await useSlot(currentSlot, liveAuthPath, home);
+    await lifecycle.preLaunch(cwd, sessionId, notifyTempResult.contract, prepared.codexHomeOverride, true, false);
+    const baseEnv: NodeJS.ProcessEnv = {
+      ...env,
+      ...(prepared.codexHomeOverride ? { CODEX_HOME: prepared.codexHomeOverride } : {}),
+      ...(prepared.sqliteHomeOverride ? { CODEX_SQLITE_HOME: prepared.sqliteHomeOverride } : {}),
+    };
+    const omxRoot = lifecycle.resolveOmxRootForLaunch(cwd, env);
+    if (omxRoot) baseEnv.OMX_ROOT = omxRoot;
+
+    for (let attempt = 0; attempt < plan.order.length; attempt++) {
+      const attemptArgs = lifecycle.injectModelInstructionsBypassArgs(
+        cwd,
+        resumeArgs ?? normalizedArgs,
+        baseEnv,
+        lifecycle.sessionModelInstructionsPath(cwd, sessionId),
+      );
+      process.stderr.write(`[omx auth] using slot ${currentSlot}\n`);
+      const result = await runCodexDirect(cwd, attemptArgs, baseEnv);
+      if (result.status === 0) return 0;
+      if (!isQuotaError({ status: result.status, signal: result.signal, stderr: result.stderr }, config)) {
+        return result.status || 1;
+      }
+
+      await markSlotQuota(currentSlot, home);
+      exhausted.add(currentSlot);
+      if (plan.mode === "manual") {
+        process.stderr.write(
+          `[omx auth] quota detected for slot ${currentSlot}; rotation=manual, run \`omx auth use <slot>\` to switch accounts.\n`,
+        );
+        return 1;
+      }
+
+      const next = nextSlotAfter(plan.order, currentSlot, exhausted);
+      if (!next) {
+        process.stderr.write(`[omx auth] all slots exhausted: ${[...exhausted].join(", ")}\n`);
+        return 1;
+      }
+      const latest = await findLatestRolloutSession(codexHomeFromAuthPath(liveAuthPath), home);
+      if (!latest) {
+        process.stderr.write("[omx auth] quota detected but no Codex rollout session was found to resume.\n");
+        return 1;
+      }
+      currentSlot = next;
+      await useSlot(currentSlot, liveAuthPath, home);
+      resumeArgs = buildResumeArgsWithPreservedFlags(normalizedArgs, latest.id);
+      process.stderr.write(`[omx auth] quota detected; rotating to slot ${currentSlot} and resuming ${latest.id}\n`);
+    }
+
+    process.stderr.write(`[omx auth] all slots exhausted: ${plan.order.join(", ")}\n`);
+    return 1;
+  } catch (err) {
+    process.stderr.write(`[omx auth] ${redactAuthSecrets(err)}\n`);
+    return 1;
+  } finally {
+    await lifecycle.postLaunch(cwd, sessionId, prepared.codexHomeOverride, true, prepared.projectLocalCodexHomeForCleanup).catch((err) => {
+      process.stderr.write(`[omx auth] postLaunch warning: ${redactAuthSecrets(err)}\n`);
+    });
+    await lifecycle.cleanupRuntimeCodexHome(prepared.runtimeCodexHomeForCleanup, prepared.projectLocalCodexHomeForCleanup).catch((err) => {
+      process.stderr.write(`[omx auth] cleanup warning: ${redactAuthSecrets(err)}\n`);
+    });
+  }
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,7 @@
+export * from "./config.js";
+export * from "./paths.js";
+export * from "./quota-detector.js";
+export * from "./redact.js";
+export * from "./rotation.js";
+export * from "./sessions.js";
+export * from "./storage.js";

--- a/src/auth/paths.ts
+++ b/src/auth/paths.ts
@@ -1,0 +1,86 @@
+import { homedir } from "os";
+import { basename, join, resolve } from "path";
+import { lstat, mkdir, stat } from "fs/promises";
+import { resolveCodexHomeForLaunch } from "../cli/codex-home.js";
+
+export const AUTH_DIR_MODE = 0o700;
+export const AUTH_FILE_MODE = 0o600;
+
+export function resolveOmxAuthDir(home = homedir()): string {
+  return join(home, ".omx", "auth");
+}
+
+export function resolveAuthMetadataPath(home = homedir()): string {
+  return join(resolveOmxAuthDir(home), "slots.json");
+}
+
+export function validateSlotName(slot: string): string {
+  const trimmed = slot.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(trimmed)) {
+    throw new Error(
+      "invalid auth slot name: use 1-64 letters, numbers, '.', '_' or '-' and start with a letter or number",
+    );
+  }
+  if (trimmed === "." || trimmed === ".." || basename(trimmed) !== trimmed) {
+    throw new Error("invalid auth slot name: path traversal is not allowed");
+  }
+  return trimmed;
+}
+
+export function resolveSlotPath(slot: string, home = homedir()): string {
+  const safeSlot = validateSlotName(slot);
+  const authDir = resolveOmxAuthDir(home);
+  const candidate = resolve(authDir, `${safeSlot}.json`);
+  const expected = join(resolve(authDir), `${safeSlot}.json`);
+  if (candidate !== expected) {
+    throw new Error("invalid auth slot path");
+  }
+  return candidate;
+}
+
+export function resolveDefaultCodexHome(home = homedir()): string {
+  return join(home, ".codex");
+}
+
+export function resolveLiveAuthPath(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): string {
+  const codexHome = resolveCodexHomeForLaunch(cwd, env) || resolveDefaultCodexHome(home);
+  return join(codexHome, "auth.json");
+}
+
+export async function ensurePrivateDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true, mode: AUTH_DIR_MODE });
+  const info = await lstat(dir);
+  if (info.isSymbolicLink()) throw new Error(`auth directory must not be a symlink: ${dir}`);
+  if (!info.isDirectory()) throw new Error(`auth path is not a directory: ${dir}`);
+  if (process.platform !== "win32") {
+    const { chmod } = await import("fs/promises");
+    await chmod(dir, AUTH_DIR_MODE).catch(() => undefined);
+  }
+}
+
+export async function assertReadableFile(path: string, label: string): Promise<void> {
+  try {
+    const info = await stat(path);
+    if (!info.isFile()) throw new Error(`${label} is not a file: ${path}`);
+  } catch (err) {
+    if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+      throw new Error(`${label} not found: ${path}`);
+    }
+    throw err;
+  }
+}
+
+export async function assertNoSymlink(path: string, label: string): Promise<void> {
+  try {
+    const { lstat } = await import("fs/promises");
+    const info = await lstat(path);
+    if (info.isSymbolicLink()) throw new Error(`${label} must not be a symlink: ${path}`);
+  } catch (err) {
+    if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") return;
+    throw err;
+  }
+}

--- a/src/auth/quota-detector.ts
+++ b/src/auth/quota-detector.ts
@@ -1,0 +1,46 @@
+import type { AuthConfig } from "./config.js";
+
+export interface CodexExitSignal {
+  status?: number | null;
+  signal?: NodeJS.Signals | null;
+  stderr?: string;
+  stdout?: string;
+  structuredError?: unknown;
+}
+
+const DEFAULT_PATTERNS = [
+  /\b429\b/i,
+  /\bquota\b/i,
+  /rate\s*limit(?:ed|s)?/i,
+  /too\s+many\s+requests/i,
+];
+
+function structuredText(value: unknown): string {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const status = record.status ?? record.statusCode ?? record.code ?? "";
+    const type = record.type ?? record.error ?? "";
+    const message = record.message ?? "";
+    return `${status} ${type} ${message}`;
+  }
+  return String(value);
+}
+
+export function isQuotaError(signal: CodexExitSignal, config?: Pick<AuthConfig, "quotaPatterns">): boolean {
+  const haystack = [
+    structuredText(signal.structuredError),
+    signal.stderr ?? "",
+    signal.stdout ?? "",
+  ].join("\n");
+  if (!haystack.trim()) return false;
+  if (DEFAULT_PATTERNS.some((pattern) => pattern.test(haystack))) return true;
+  return (config?.quotaPatterns ?? []).some((pattern) => {
+    try {
+      return new RegExp(pattern, "i").test(haystack);
+    } catch {
+      return haystack.toLowerCase().includes(pattern.toLowerCase());
+    }
+  });
+}

--- a/src/auth/redact.ts
+++ b/src/auth/redact.ts
@@ -1,4 +1,7 @@
+const JSON_OAUTH_TOKEN_FIELD_PATTERN = /(["'](?:access_token|refresh_token|id_token)["']\s*:\s*)(["'])(?:\\.|(?!\2)[^\\])*\2/gi;
+
 const SECRET_PATTERNS: RegExp[] = [
+  JSON_OAUTH_TOKEN_FIELD_PATTERN,
   /\b(?:access|refresh|id)_token\b\s*[:=]\s*["']?[^"'\s,}]+/gi,
   /\bbearer\s+[A-Za-z0-9._~+/=-]+/gi,
   /\bsk-[A-Za-z0-9_-]{8,}\b/g,
@@ -9,6 +12,9 @@ export function redactAuthSecrets(value: unknown): string {
   let text = value instanceof Error ? value.message : String(value);
   for (const pattern of SECRET_PATTERNS) {
     text = text.replace(pattern, (match) => {
+      if (pattern === JSON_OAUTH_TOKEN_FIELD_PATTERN) {
+        return match.replace(/(:\s*)(["']).*\2$/s, "$1$2[REDACTED]$2");
+      }
       const separator = match.match(/[:=]/)?.[0];
       if (separator) return `${match.slice(0, match.indexOf(separator) + 1)} [REDACTED]`;
       if (/^bearer\s/i.test(match)) return "Bearer [REDACTED]";

--- a/src/auth/redact.ts
+++ b/src/auth/redact.ts
@@ -1,0 +1,19 @@
+const SECRET_PATTERNS: RegExp[] = [
+  /\b(?:access|refresh|id)_token\b\s*[:=]\s*["']?[^"'\s,}]+/gi,
+  /\bbearer\s+[A-Za-z0-9._~+/=-]+/gi,
+  /\bsk-[A-Za-z0-9_-]{8,}\b/g,
+  /\b(?:session|auth|api)[_-]?token\b\s*[:=]\s*["']?[^"'\s,}]+/gi,
+];
+
+export function redactAuthSecrets(value: unknown): string {
+  let text = value instanceof Error ? value.message : String(value);
+  for (const pattern of SECRET_PATTERNS) {
+    text = text.replace(pattern, (match) => {
+      const separator = match.match(/[:=]/)?.[0];
+      if (separator) return `${match.slice(0, match.indexOf(separator) + 1)} [REDACTED]`;
+      if (/^bearer\s/i.test(match)) return "Bearer [REDACTED]";
+      return "[REDACTED]";
+    });
+  }
+  return text;
+}

--- a/src/auth/rotation.ts
+++ b/src/auth/rotation.ts
@@ -1,0 +1,34 @@
+import type { AuthConfig } from "./config.js";
+import type { AuthSlotRecord } from "./storage.js";
+
+export interface RotationPlan {
+  mode: AuthConfig["rotation"];
+  order: string[];
+}
+
+export function buildRotationPlan(
+  slots: AuthSlotRecord[],
+  config: Pick<AuthConfig, "rotation" | "priority">,
+  currentSlot?: string,
+): RotationPlan {
+  const available = slots.map((slot) => slot.slot).sort((a, b) => a.localeCompare(b));
+  if (config.rotation === "manual") return { mode: "manual", order: currentSlot ? [currentSlot] : available.slice(0, 1) };
+  if (config.rotation === "priority") {
+    const priority = config.priority.filter((slot) => available.includes(slot));
+    const rest = available.filter((slot) => !priority.includes(slot));
+    return { mode: "priority", order: [...priority, ...rest] };
+  }
+  if (!currentSlot || !available.includes(currentSlot)) return { mode: "round-robin", order: available };
+  const index = available.indexOf(currentSlot);
+  return { mode: "round-robin", order: [...available.slice(index), ...available.slice(0, index)] };
+}
+
+export function nextSlotAfter(order: string[], current: string | undefined, exhausted: Set<string>): string | undefined {
+  if (order.length === 0) return undefined;
+  const start = current && order.includes(current) ? order.indexOf(current) + 1 : 0;
+  for (let offset = 0; offset < order.length; offset++) {
+    const slot = order[(start + offset) % order.length];
+    if (!exhausted.has(slot)) return slot;
+  }
+  return undefined;
+}

--- a/src/auth/sessions.ts
+++ b/src/auth/sessions.ts
@@ -1,0 +1,63 @@
+import { existsSync } from "fs";
+import { readdir, stat, readFile } from "fs/promises";
+import { basename, join } from "path";
+import { resolveDefaultCodexHome } from "./paths.js";
+
+export interface LatestRolloutSession {
+  id: string;
+  path: string;
+  mtimeMs: number;
+}
+
+async function collectRollouts(dir: string, out: string[]): Promise<void> {
+  if (!existsSync(dir)) return;
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectRollouts(path, out);
+    } else if (entry.isFile() && /^rollout-.+\.jsonl$/.test(entry.name)) {
+      out.push(path);
+    }
+  }
+}
+
+export async function extractRolloutSessionId(path: string): Promise<string> {
+  const fileMatch = basename(path).match(/^rollout-(.+)\.jsonl$/);
+  if (fileMatch?.[1]) return fileMatch[1];
+  const firstLine = (await readFile(path, "utf-8")).split(/\r?\n/, 1)[0] ?? "";
+  try {
+    const parsed = JSON.parse(firstLine) as Record<string, unknown>;
+    const id = parsed.id ?? parsed.session_id ?? parsed.sessionId;
+    if (typeof id === "string" && id.trim()) return id.trim();
+  } catch {
+    // fall through to basename fallback
+  }
+  return basename(path, ".jsonl").replace(/^rollout-/, "");
+}
+
+/**
+ * Codex stores resumable conversations as rollout JSONL files under
+ * <CODEX_HOME>/sessions/YYYY/MM/DD/rollout-*.jsonl. Hotswap uses the newest
+ * rollout by mtime as the best available continuity heuristic after a quota
+ * exit, because upstream Codex does not currently expose the active resume id
+ * as a stable structured wrapper signal.
+ */
+export async function findLatestRolloutSession(
+  codexHome: string,
+  fallbackHome?: string,
+): Promise<LatestRolloutSession | null> {
+  const roots = [join(codexHome, "sessions")];
+  const fallback = fallbackHome ? join(resolveDefaultCodexHome(fallbackHome), "sessions") : undefined;
+  if (fallback && fallback !== roots[0]) roots.push(fallback);
+  const files: string[] = [];
+  for (const root of roots) await collectRollouts(root, files);
+  let latest: { path: string; mtimeMs: number } | null = null;
+  for (const path of files) {
+    const info = await stat(path).catch(() => null);
+    if (!info?.isFile()) continue;
+    if (!latest || info.mtimeMs > latest.mtimeMs) latest = { path, mtimeMs: info.mtimeMs };
+  }
+  if (!latest) return null;
+  return { id: await extractRolloutSessionId(latest.path), path: latest.path, mtimeMs: latest.mtimeMs };
+}

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -1,0 +1,164 @@
+import { randomBytes } from "crypto";
+import { dirname } from "path";
+import { readFile, rename, rm, writeFile, chmod } from "fs/promises";
+import { existsSync } from "fs";
+import {
+  AUTH_FILE_MODE,
+  assertNoSymlink,
+  assertReadableFile,
+  ensurePrivateDir,
+  resolveAuthMetadataPath,
+  resolveOmxAuthDir,
+  resolveSlotPath,
+  validateSlotName,
+} from "./paths.js";
+
+export interface AuthSlotRecord {
+  slot: string;
+  createdAt: string;
+  updatedAt: string;
+  lastUsedAt?: string;
+  lastQuotaAt?: string;
+  exhaustedAt?: string;
+}
+
+export interface AuthMetadata {
+  version: 1;
+  currentSlot?: string;
+  slots: AuthSlotRecord[];
+}
+
+export interface AtomicWriteOptions {
+  mode?: number;
+  beforeRename?: (tempPath: string) => void | Promise<void>;
+}
+
+export async function atomicWriteFile(
+  targetPath: string,
+  data: string | Buffer,
+  options: AtomicWriteOptions = {},
+): Promise<void> {
+  const dir = dirname(targetPath);
+  await ensurePrivateDir(dir);
+  await assertNoSymlink(targetPath, "auth target");
+  const tempPath = `${targetPath}.tmp-${process.pid}-${Date.now()}-${randomBytes(4).toString("hex")}`;
+  try {
+    await writeFile(tempPath, data, { mode: options.mode ?? AUTH_FILE_MODE });
+    if (process.platform !== "win32") await chmod(tempPath, options.mode ?? AUTH_FILE_MODE).catch(() => undefined);
+    await options.beforeRename?.(tempPath);
+    await rename(tempPath, targetPath);
+    if (process.platform !== "win32") await chmod(targetPath, options.mode ?? AUTH_FILE_MODE).catch(() => undefined);
+  } catch (err) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw err;
+  }
+}
+
+export function emptyMetadata(): AuthMetadata {
+  return { version: 1, slots: [] };
+}
+
+export async function readAuthMetadata(home?: string): Promise<AuthMetadata> {
+  const path = resolveAuthMetadataPath(home);
+  if (!existsSync(path)) return emptyMetadata();
+  const parsed = JSON.parse(await readFile(path, "utf-8")) as Partial<AuthMetadata>;
+  return {
+    version: 1,
+    currentSlot: typeof parsed.currentSlot === "string" ? parsed.currentSlot : undefined,
+    slots: Array.isArray(parsed.slots)
+      ? parsed.slots
+          .filter((slot): slot is AuthSlotRecord => Boolean(slot && typeof slot.slot === "string"))
+          .map((slot) => ({ ...slot, slot: validateSlotName(slot.slot) }))
+      : [],
+  };
+}
+
+export async function writeAuthMetadata(metadata: AuthMetadata, home?: string): Promise<void> {
+  const authDir = resolveOmxAuthDir(home);
+  await ensurePrivateDir(authDir);
+  await atomicWriteFile(resolveAuthMetadataPath(home), `${JSON.stringify(metadata, null, 2)}\n`, {
+    mode: AUTH_FILE_MODE,
+  });
+}
+
+function upsertSlotRecord(metadata: AuthMetadata, slot: string, nowIso: string): AuthSlotRecord {
+  const safeSlot = validateSlotName(slot);
+  const existing = metadata.slots.find((record) => record.slot === safeSlot);
+  if (existing) {
+    existing.updatedAt = nowIso;
+    return existing;
+  }
+  const record: AuthSlotRecord = { slot: safeSlot, createdAt: nowIso, updatedAt: nowIso };
+  metadata.slots.push(record);
+  metadata.slots.sort((a, b) => a.slot.localeCompare(b.slot));
+  return record;
+}
+
+export async function addSlotFromAuthFile(
+  slot: string,
+  liveAuthPath: string,
+  home?: string,
+  now = new Date(),
+): Promise<AuthSlotRecord> {
+  const safeSlot = validateSlotName(slot);
+  await assertReadableFile(liveAuthPath, "live Codex auth.json");
+  await ensurePrivateDir(resolveOmxAuthDir(home));
+  const data = await readFile(liveAuthPath);
+  const target = resolveSlotPath(safeSlot, home);
+  await atomicWriteFile(target, data, { mode: AUTH_FILE_MODE });
+  const metadata = await readAuthMetadata(home);
+  const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
+  await writeAuthMetadata(metadata, home);
+  return record;
+}
+
+export async function listSlots(home?: string): Promise<AuthSlotRecord[]> {
+  const metadata = await readAuthMetadata(home);
+  return metadata.slots.filter((slot) => existsSync(resolveSlotPath(slot.slot, home)));
+}
+
+export async function useSlot(
+  slot: string,
+  liveAuthPath: string,
+  home?: string,
+  now = new Date(),
+): Promise<AuthSlotRecord> {
+  const safeSlot = validateSlotName(slot);
+  const slotPath = resolveSlotPath(safeSlot, home);
+  await assertReadableFile(slotPath, `auth slot ${safeSlot}`);
+  await ensurePrivateDir(dirname(liveAuthPath));
+  await assertNoSymlink(liveAuthPath, "live Codex auth.json");
+  const data = await readFile(slotPath);
+  await atomicWriteFile(liveAuthPath, data, { mode: AUTH_FILE_MODE });
+  const metadata = await readAuthMetadata(home);
+  const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
+  record.lastUsedAt = now.toISOString();
+  delete record.exhaustedAt;
+  metadata.currentSlot = safeSlot;
+  await writeAuthMetadata(metadata, home);
+  return record;
+}
+
+export async function markSlotQuota(
+  slot: string,
+  home?: string,
+  now = new Date(),
+): Promise<AuthMetadata> {
+  const safeSlot = validateSlotName(slot);
+  const metadata = await readAuthMetadata(home);
+  const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
+  record.lastQuotaAt = now.toISOString();
+  record.exhaustedAt = now.toISOString();
+  await writeAuthMetadata(metadata, home);
+  return metadata;
+}
+
+export async function clearSlotExhaustion(slot: string, home?: string): Promise<void> {
+  const metadata = await readAuthMetadata(home);
+  const record = metadata.slots.find((entry) => entry.slot === validateSlotName(slot));
+  if (record) {
+    delete record.exhaustedAt;
+    await writeAuthMetadata(metadata, home);
+  }
+}
+

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -161,4 +161,3 @@ export async function clearSlotExhaustion(slot: string, home?: string): Promise<
     await writeAuthMetadata(metadata, home);
   }
 }
-

--- a/src/cli/__tests__/auth.test.ts
+++ b/src/cli/__tests__/auth.test.ts
@@ -1,0 +1,171 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function omxBin(): string {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  return join(testDir, "..", "..", "..", "dist", "cli", "omx.js");
+}
+
+function runOmx(cwd: string, argv: string[], env: Record<string, string> = {}) {
+  const result = spawnSync(process.execPath, [omxBin(), ...argv], {
+    cwd,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      HOME: env.HOME,
+      CODEX_HOME: env.CODEX_HOME ?? "",
+      NODE_OPTIONS: "",
+      OMX_AUTO_UPDATE: "0",
+      OMX_NOTIFY_FALLBACK: "0",
+      OMX_HOOK_DERIVED_SIGNALS: "0",
+      ...env,
+    },
+  });
+  return { status: result.status, stdout: result.stdout || "", stderr: result.stderr || "", error: result.error?.message || "" };
+}
+
+async function writeFakeCodex(binDir: string, script: string): Promise<string> {
+  await mkdir(binDir, { recursive: true });
+  const path = join(binDir, "codex");
+  await writeFile(path, script);
+  await chmod(path, 0o755);
+  return path;
+}
+
+describe("omx auth CLI", () => {
+  it("shows nested help and top-level hotswap help", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-help-"));
+    try {
+      const help = runOmx(wd, ["auth", "--help"], { HOME: wd });
+      assert.equal(help.status, 0, help.stderr);
+      assert.match(help.stdout, /omx auth add <slot>/);
+      const top = runOmx(wd, ["--help"], { HOME: wd });
+      assert.match(top.stdout, /--hotswap/);
+      assert.match(top.stdout, /omx auth/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("adds, lists, and uses slots through the compiled CLI without leaking tokens", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-cli-"));
+    try {
+      const home = join(wd, "home");
+      const codexHome = join(home, ".codex");
+      const bin = join(wd, "bin");
+      await mkdir(codexHome, { recursive: true });
+      await writeFakeCodex(bin, `#!/bin/sh\nif [ "$1" = "login" ]; then mkdir -p "$CODEX_HOME"; printf '{"access_token":"sentinel-secret"}\\n' > "$CODEX_HOME/auth.json"; exit 0; fi\necho unexpected "$@" >&2\nexit 2\n`);
+      const env = { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` };
+      const add = runOmx(wd, ["auth", "add", "work"], env);
+      assert.equal(add.status, 0, add.stderr);
+      assert.doesNotMatch(add.stdout + add.stderr, /sentinel-secret/);
+      const list = runOmx(wd, ["auth", "list", "--json"], env);
+      assert.equal(list.status, 0, list.stderr);
+      assert.match(list.stdout, /"slot": "work"/);
+      await writeFile(join(codexHome, "auth.json"), '{"access_token":"other"}\n');
+      const use = runOmx(wd, ["auth", "use", "work"], env);
+      assert.equal(use.status, 0, use.stderr);
+      assert.doesNotMatch(use.stdout + use.stderr, /sentinel-secret/);
+      assert.equal(await readFile(join(codexHome, "auth.json"), "utf-8"), '{"access_token":"sentinel-secret"}\n');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("adds project-scope slots from the same CODEX_HOME used by launch", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-project-add-"));
+    try {
+      const home = join(wd, "home");
+      const bin = join(wd, "bin");
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(join(wd, ".omx", "setup-scope.json"), '{"scope":"project"}\n');
+      await writeFakeCodex(bin, `#!/bin/sh
+if [ "$1" = "login" ]; then case "$CODEX_HOME" in ${JSON.stringify(`${wd}/.codex`)}) mkdir -p "$CODEX_HOME"; printf '{"access_token":"project-secret"}\n' > "$CODEX_HOME/auth.json"; exit 0;; *) echo "wrong CODEX_HOME=$CODEX_HOME" >&2; exit 4;; esac; fi
+echo unexpected "$@" >&2
+exit 2
+`);
+      const env = { HOME: home, PATH: `${bin}:/usr/bin:/bin` };
+      const add = runOmx(wd, ["auth", "add", "project"], env);
+      assert.equal(add.status, 0, add.stderr);
+      assert.doesNotMatch(add.stdout + add.stderr, /project-secret/);
+      assert.equal(await readFile(join(home, ".omx", "auth", "project.json"), "utf-8"), '{"access_token":"project-secret"}\n');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails soft when no slots are configured", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-noslots-"));
+    try {
+      const result = runOmx(wd, ["--hotswap", "--direct"], { HOME: join(wd, "home"), PATH: `/usr/bin:/bin` });
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /no slots configured/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("hotswaps on 429 and resumes the latest rollout with the next slot", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-hotswap-"));
+    try {
+      const home = join(wd, "home");
+      const codexHome = join(home, ".codex");
+      const authDir = join(home, ".omx", "auth");
+      const bin = join(wd, "bin");
+      const countFile = join(wd, "count");
+      const argvFile = join(wd, "argv.log");
+      await mkdir(authDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(authDir, "first.json"), '{"access_token":"first-secret"}\n');
+      await writeFile(join(authDir, "second.json"), '{"access_token":"second-secret"}\n');
+      await writeFile(join(authDir, "slots.json"), JSON.stringify({ version: 1, currentSlot: "first", slots: [
+        { slot: "first", createdAt: "now", updatedAt: "now" },
+        { slot: "second", createdAt: "now", updatedAt: "now" }
+      ] }, null, 2));
+      await writeFakeCodex(bin, `#!/bin/sh\ncount=0\n[ -f ${JSON.stringify(countFile)} ] && count=$(cat ${JSON.stringify(countFile)})\ncount=$((count+1))\nprintf '%s' "$count" > ${JSON.stringify(countFile)}\nprintf '%s\\n' "$*" >> ${JSON.stringify(argvFile)}\nif [ "$count" -eq 1 ]; then mkdir -p "$CODEX_HOME/sessions/2026/05/24"; printf '{}\\n' > "$CODEX_HOME/sessions/2026/05/24/rollout-session-123.jsonl"; echo 'HTTP 429 quota exceeded access_token=stderr-secret Bearer abc.def' >&2; exit 1; fi\ncase "$*" in *"resume session-123"*--model*"gpt-review"*) exit 0;; *) echo 'missing resume args or model flag' >&2; exit 3;; esac\n`);
+      const env = { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` };
+      const result = runOmx(wd, ["--hotswap", "--direct", "--model", "gpt-review"], env);
+      assert.equal(result.status, 0, result.stderr + result.stdout);
+      assert.match(result.stderr, /HTTP 429 quota exceeded/);
+      const argvLog = await readFile(argvFile, "utf-8");
+      assert.match(argvLog, /resume session-123/);
+      assert.match(argvLog, /--model gpt-review/);
+      assert.equal(await readFile(join(codexHome, "auth.json"), "utf-8"), '{"access_token":"second-secret"}\n');
+      assert.doesNotMatch(result.stderr + result.stdout, /first-secret|second-secret|stderr-secret|abc\.def/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("emits one clean error when all hotswap slots are exhausted", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-exhausted-"));
+    try {
+      const home = join(wd, "home");
+      const codexHome = join(home, ".codex");
+      const authDir = join(home, ".omx", "auth");
+      const bin = join(wd, "bin");
+      await mkdir(authDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(authDir, "first.json"), '{"access_token":"first-secret"}\n');
+      await writeFile(join(authDir, "second.json"), '{"access_token":"second-secret"}\n');
+      await writeFile(join(authDir, "slots.json"), JSON.stringify({ version: 1, currentSlot: "first", slots: [
+        { slot: "first", createdAt: "now", updatedAt: "now" },
+        { slot: "second", createdAt: "now", updatedAt: "now" }
+      ] }, null, 2));
+      await writeFakeCodex(bin, `#!/bin/sh\nmkdir -p "$CODEX_HOME/sessions/2026/05/24"\nprintf '{}\\n' > "$CODEX_HOME/sessions/2026/05/24/rollout-session-429.jsonl"\necho 'HTTP 429 quota exceeded' >&2\nexit 1\n`);
+      const result = runOmx(wd, ["--hotswap", "--direct"], { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` });
+      assert.equal(result.status, 1);
+      const matches = result.stderr.match(/all slots exhausted: first, second/g) ?? [];
+      assert.equal(matches.length, 1, result.stderr);
+      assert.doesNotMatch(result.stderr + result.stdout, /first-secret|second-secret/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -1,0 +1,93 @@
+import { dirname } from "path";
+import { spawnPlatformCommandSync, classifySpawnError } from "../utils/platform-command.js";
+import { readAuthConfig } from "../auth/config.js";
+import { resolveLiveAuthPath } from "../auth/paths.js";
+import { redactAuthSecrets } from "../auth/redact.js";
+import { addSlotFromAuthFile, listSlots, useSlot } from "../auth/storage.js";
+
+export const AUTH_HELP = `
+Usage:
+  omx auth add <slot>      Log in with Codex OAuth and store auth.json as a named slot
+  omx auth list [--json]   List registered auth slots and local quota metadata
+  omx auth use <slot>      Atomically switch live Codex auth.json to a slot
+  omx auth --help          Show this help
+
+Auth slots are stored under ~/.omx/auth/<slot>.json with owner-only permissions.
+`;
+
+function wantsJson(args: string[]): boolean {
+  return args.includes("--json");
+}
+
+function runCodexLogin(cwd: string, env: NodeJS.ProcessEnv): void {
+  const { result } = spawnPlatformCommandSync("codex", ["login"], {
+    cwd,
+    env,
+    stdio: "inherit",
+    encoding: "utf-8",
+  });
+  if (result.error) {
+    const error = result.error as NodeJS.ErrnoException;
+    const kind = classifySpawnError(error);
+    if (kind === "missing") throw new Error("failed to launch codex login: executable not found in PATH");
+    if (kind === "blocked") throw new Error(`failed to launch codex login: executable is blocked (${error.code || "blocked"})`);
+    throw error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`codex login exited with code ${result.status ?? 1}`);
+  }
+}
+
+export async function authCommand(args: string[], env: NodeJS.ProcessEnv = process.env): Promise<void> {
+  const command = args[0];
+  const cwd = process.cwd();
+  const home = env.HOME;
+  if (!command || command === "--help" || command === "-h" || command === "help") {
+    console.log(AUTH_HELP.trim());
+    return;
+  }
+
+  if (command === "add") {
+    const slot = args[1];
+    if (!slot) throw new Error("Usage: omx auth add <slot>");
+    const liveAuthPath = resolveLiveAuthPath(cwd, env, home);
+    runCodexLogin(cwd, { ...env, CODEX_HOME: dirname(liveAuthPath) });
+    const record = await addSlotFromAuthFile(slot, liveAuthPath, home);
+    console.log(`Added auth slot ${record.slot}`);
+    return;
+  }
+
+  if (command === "list") {
+    const slots = await listSlots(home);
+    const config = await readAuthConfig(cwd, home);
+    if (wantsJson(args)) {
+      console.log(JSON.stringify({ slots, config: { rotation: config.rotation, priority: config.priority } }, null, 2));
+      return;
+    }
+    if (slots.length === 0) {
+      console.log("No auth slots configured. Run `omx auth add <slot>` first.");
+      return;
+    }
+    for (const slot of slots) {
+      const quota = slot.exhaustedAt ? ` exhausted=${slot.exhaustedAt}` : slot.lastQuotaAt ? ` last-quota=${slot.lastQuotaAt}` : "";
+      const used = slot.lastUsedAt ? ` last-used=${slot.lastUsedAt}` : "";
+      console.log(`${slot.slot}${used}${quota}`);
+    }
+    return;
+  }
+
+  if (command === "use") {
+    const slot = args[1];
+    if (!slot) throw new Error("Usage: omx auth use <slot>");
+    const liveAuthPath = resolveLiveAuthPath(cwd, env, home);
+    const record = await useSlot(slot, liveAuthPath, home);
+    console.log(`Using auth slot ${record.slot}`);
+    return;
+  }
+
+  throw new Error(`Unknown auth command: ${command}\n${AUTH_HELP.trim()}`);
+}
+
+export function formatAuthError(err: unknown): string {
+  return redactAuthSecrets(err);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,6 +49,8 @@ import { mcpParityCommand } from "./mcp-parity.js";
 import { mcpServeCommand } from "./mcp-serve.js";
 import { adaptCommand } from "./adapt.js";
 import { listCommand } from "./list.js";
+import { authCommand } from "./auth.js";
+import { runAuthHotswap } from "../auth/hotswap.js";
 import {
   MADMAX_FLAG,
   CODEX_BYPASS_FLAG,
@@ -204,6 +206,7 @@ Usage:
   omx cleanup   Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
+  omx auth      Manage Codex OAuth auth slots (add|list|use)
   omx question  OMX-owned blocking question UI entrypoint for agent-invoked user questions
   omx adapt     Scaffold OMX-owned adapter foundations for persistent external targets
   omx resume    Resume a previous interactive Codex session
@@ -259,6 +262,7 @@ Options:
   --madmax-spark  spark model for workers + bypass approvals for leader and workers
                 (shorthand for: --spark --madmax)
   --notify-temp  Enable temporary notification routing for this run/session only
+  --hotswap     Run a direct Codex session that rotates auth slots on 429/quota and resumes
   --direct       Launch the interactive leader directly without OMX tmux/HUD management
   --tmux         Launch the interactive leader session in detached tmux
   --discord      Select Discord provider for temporary notification mode
@@ -355,6 +359,7 @@ type CliCommand =
   | "uninstall"
   | "doctor"
   | "cleanup"
+  | "auth"
   | "ask"
   | "question"
   | "adapt"
@@ -383,6 +388,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "ask",
   "question",
   "cleanup",
+  "auth",
   "adapt",
   "autoresearch",
   "autoresearch-goal",
@@ -836,7 +842,7 @@ export async function persistProjectLaunchRuntimeProjectTrustState(
   }
 }
 
-async function cleanupRuntimeCodexHome(
+export async function cleanupRuntimeCodexHome(
   runtimeCodexHomeForCleanup?: string,
   projectCodexHomeForPersistence?: string,
 ): Promise<void> {
@@ -1596,6 +1602,7 @@ export async function main(args: string[]): Promise<void> {
     "uninstall",
     "doctor",
     "cleanup",
+    "auth",
     "ask",
     "question",
     "autoresearch",
@@ -1643,7 +1650,11 @@ export async function main(args: string[]): Promise<void> {
   try {
     switch (command) {
       case "launch":
-        await launchWithHud(launchArgs);
+        if (launchArgs.includes("--hotswap")) {
+          await launchWithAuthHotswap(launchArgs);
+        } else {
+          await launchWithHud(launchArgs);
+        }
         break;
       case "resume":
         await launchWithHud(["resume", ...launchArgs]);
@@ -1699,6 +1710,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "cleanup":
         await cleanupCommand(args.slice(1));
+        break;
+      case "auth":
+        await authCommand(args.slice(1));
         break;
       case "autoresearch":
         await autoresearchCommand(args.slice(1));
@@ -1886,6 +1900,81 @@ async function reasoningCommand(args: string[]): Promise<void> {
   const updated = upsertTopLevelTomlString(existing, REASONING_KEY, mode);
   await writeFile(configPath, updated);
   console.log(`Set ${REASONING_KEY}="${mode}" in ${configPath}`);
+}
+
+export async function launchWithAuthHotswap(args: string[]): Promise<void> {
+  const launchCwd = process.cwd();
+  const parsedWorktree = parseWorktreeMode(args);
+  let cwd = launchCwd;
+  let worktreeDirty = false;
+  let ensuredLaunchWorktree: ReturnType<typeof ensureWorktree> | undefined;
+
+  if (parsedWorktree.mode.enabled) {
+    const planned = planWorktreeTarget({
+      cwd: launchCwd,
+      scope: "launch",
+      mode: parsedWorktree.mode,
+    });
+    const ensured = ensureWorktree(planned, { allowDirtyReuse: true });
+    ensuredLaunchWorktree = ensured;
+    if (ensured.enabled) {
+      cwd = ensured.worktreePath;
+      worktreeDirty = Boolean(ensured.dirty);
+      if (ensured.dirty) {
+        process.stderr.write(
+          `[omx] Caution: worktree at ${cwd} has uncommitted changes.\n` +
+          `  The hotswap session will launch as-is.\n`,
+        );
+      }
+      const depBootstrap = ensureReusableNodeModules(cwd);
+      if (depBootstrap.strategy === "symlink") {
+        console.log(`[omx] Reusing node_modules from ${depBootstrap.sourceNodeModulesPath}`);
+      } else if (depBootstrap.strategy === "missing" && depBootstrap.warning) {
+        console.warn(`[omx] ${depBootstrap.warning}`);
+      }
+    }
+  }
+  applyDisposableWorktreeOmxRootForLaunch(ensuredLaunchWorktree);
+
+  try {
+    await maybeCheckAndPromptUpdate(cwd);
+  } catch (err) {
+    logCliOperationFailure(err);
+  }
+  try {
+    await maybePromptGithubStar();
+  } catch (err) {
+    logCliOperationFailure(err);
+  }
+  try {
+    const configPath = resolveCodexConfigPathForLaunch(launchCwd, process.env);
+    const repaired = await repairConfigIfNeeded(
+      configPath,
+      getPackageRoot(),
+      await resolveLaunchConfigRepairOptions(launchCwd, configPath),
+    );
+    if (repaired) console.log("[omx] Repaired managed config.toml compatibility issue.");
+  } catch {
+    // Non-fatal: repair failure must not block launch
+  }
+
+  const status = await runAuthHotswap({
+    cwd,
+    argv: parsedWorktree.remainingArgs,
+    lifecycle: {
+      prepareCodexHomeForLaunch,
+      preLaunch: (launchPath, sessionId, notifyTempContract, codexHomeOverride, enableAuthority) =>
+        preLaunch(launchPath, sessionId, notifyTempContract as NotifyTempContract, codexHomeOverride, enableAuthority, worktreeDirty),
+      postLaunch,
+      cleanupRuntimeCodexHome,
+      normalizeCodexLaunchArgs,
+      injectModelInstructionsBypassArgs,
+      sessionModelInstructionsPath,
+      resolveOmxRootForLaunch,
+      resolveNotifyTempContract,
+    },
+  });
+  process.exitCode = status;
 }
 
 export async function launchWithHud(args: string[]): Promise<void> {
@@ -3768,7 +3857,7 @@ export async function reapPostLaunchOrphanedMcpProcesses(
  * OMX MCP processes without a live Codex ancestor are reaped so new launches
  * do not accumulate stale processes from prior crashed/closed sessions.
  */
-async function preLaunch(
+export async function preLaunch(
   cwd: string,
   sessionId: string,
   notifyTempContract?: NotifyTempContract,
@@ -4421,7 +4510,7 @@ function scheduleDetachedWindowsCodexLaunch(
  * postLaunch: Clean up after Codex exits.
  * Each step is independently fault-tolerant (try/catch per step).
  */
-async function postLaunch(
+export async function postLaunch(
   cwd: string,
   sessionId: string,
   codexHomeOverride?: string,


### PR DESCRIPTION
Closes #2484

## Summary
- Add `omx auth add/list/use` for private Codex OAuth slot storage under `~/.omx/auth` with owner-only permissions and safe slot-name validation.
- Add `omx --hotswap` direct-launch wrapper that strips the OMX-only flag before Codex, detects quota/429 failures from redacted stderr, rotates through configured slots, and resumes the latest rollout session.
- Reuse existing launch lifecycle preparation/cleanup so project-scope and runtime `CODEX_HOME` auth paths stay aligned, including a regression for project-scope `auth add`.
- Add focused storage, quota/rotation, session heuristic, and compiled CLI coverage with no token-output assertions.

## Tests
- `npm run build`
- `node --test dist/auth/__tests__/*.test.js dist/cli/__tests__/auth.test.js`
- `npm run check:no-unused`
- `npm run lint`
- `npm run sync:plugin:check`

## Caveats
- V1 implements the wrapper hot-swap path and slot UX; non-interactive OAuth renew is not included yet and remains delegated to upstream Codex OAuth/session behavior.
- Hotswap intentionally uses the direct Codex runner because detached tmux does not expose the child status/stderr needed for reliable quota detection.
- Live auth switching uses atomic temp-file copy + rename rather than symlink swapping to keep project/runtime `CODEX_HOME` cleanup deterministic and avoid symlink traversal risk.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
