### PR TITLE
fix: keep explore prompt syntax visible in runtime guidance (#2494)

### DIFF
--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -296,6 +296,17 @@ describe('parseExploreArgs', () => {
     assert.throws(() => parseExploreArgs(['--bogus']), /Unknown argument/);
   });
 
+  it('rejects positional prompt text with a corrective --prompt hint', () => {
+    assert.throws(
+      () => parseExploreArgs(['find package.json']),
+      /Positional prompt text is not supported\. Use: omx explore --prompt "find package\.json"/,
+    );
+    assert.throws(
+      () => parseExploreArgs(['find', 'package.json']),
+      /Positional prompt text is not supported\. Use: omx explore --prompt "find package\.json"/,
+    );
+  });
+
   it('rejects duplicate prompt sources', () => {
     assert.throws(() => parseExploreArgs(['--prompt', 'find auth', '--prompt-file', 'prompt.md']), /Choose exactly one/);
   });
@@ -306,6 +317,22 @@ describe('parseExploreArgs', () => {
 
   it('rejects missing prompt value', () => {
     assert.throws(() => parseExploreArgs(['--prompt']), /Missing text after --prompt/);
+  });
+});
+
+describe('exploreCommand help', () => {
+  it('prints explore-specific usage for --help', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-help-'));
+    try {
+      const result = await runExploreCommandForTest(wd, ['--help']);
+      assert.equal(result.exitCode, 0);
+      assert.match(result.stdout, /Usage: omx explore --prompt "<prompt>"/);
+      assert.match(result.stdout, /omx explore --prompt-file <file>/);
+      assert.match(result.stdout, /Never use positional prompt text/i);
+      assert.equal(result.stderr, '');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1598,6 +1598,7 @@ describe("commandOwnsLocalHelp", () => {
       "question",
       "autoresearch",
       "deepinit",
+      "explore",
       "hooks",
       "hud",
       "ralph",

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -28,6 +28,7 @@ describe('nested help routing', () => {
     [['ask', '--help'], /Usage:\s*omx ask <claude\|gemini> <question or task>/i],
     [['question', '--help'], /omx question - OMX-owned blocking user question entrypoint/i],
     [['autoresearch', '--help'], /hard-deprecated legacy command surface[\s\S]*\$autoresearch/i],
+    [['explore', '--help'], /Usage:\s*omx explore --prompt "<prompt>"/i],
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
     [['state', '--help'], /Usage:\s*omx state <read\|write\|clear\|list-active\|get-status>/i],

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -31,6 +31,8 @@ import { runProcessTreeWithTimeout } from '../runtime/process-tree.js';
 export const EXPLORE_USAGE = [
   'Usage: omx explore --prompt "<prompt>"',
   '   or: omx explore --prompt-file <file>',
+  '',
+  'Never use positional prompt text. Use: omx explore --prompt "find package.json"',
 ].join('\n');
 
 const PROMPT_FLAG = '--prompt';
@@ -483,6 +485,10 @@ function exploreUsageError(reason: string): Error {
   return new Error(`${reason}\n${EXPLORE_USAGE}`);
 }
 
+function isHelpArg(token: string): boolean {
+  return token === '--help' || token === '-h';
+}
+
 function appendPromptValue(current: string | undefined, value: string, reason: string): string {
   const trimmed = value.trim();
   if (!trimmed) throw exploreUsageError(reason);
@@ -546,6 +552,9 @@ export function parseExploreArgs(args: readonly string[]): ParsedExploreArgs {
     if (token.startsWith(`${PROMPT_FILE_FLAG}=`)) {
       promptFile = appendPromptFileValue(promptFile, token.slice(`${PROMPT_FILE_FLAG}=`.length), 'Missing path after --prompt-file=.');
       continue;
+    }
+    if (!token.startsWith('-')) {
+      throw exploreUsageError(`Positional prompt text is not supported. Use: omx explore --prompt "${args.slice(i).join(' ')}"`);
     }
     throw exploreUsageError(`Unknown argument: ${token}`);
   }
@@ -685,6 +694,10 @@ export async function loadExplorePrompt(parsed: ParsedExploreArgs): Promise<stri
 export async function exploreCommand(args: string[]): Promise<void> {
   if (process.env[EXPLORE_ACTIVE_ENV] === '1') {
     throw new Error('[explore] refusing to launch nested omx explore from an active explore run.');
+  }
+  if (args.some(isHelpArg)) {
+    process.stdout.write(`${EXPLORE_USAGE}\n`);
+    return;
   }
   const parsed = parseExploreArgs(args);
   const prompt = await loadExplorePrompt(parsed);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -384,6 +384,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "question",
   "cleanup",
   "adapt",
+  "explore",
   "autoresearch",
   "autoresearch-goal",
   "agents",

--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -89,6 +89,8 @@ describe("generateOverlay", () => {
         defaultOverlay,
         /\*\*Explore Command Preference:\*\*/,
       );
+      assert.match(defaultOverlay, /Syntax: omx explore --prompt "<prompt>" or omx explore --prompt-file <file>/);
+      assert.match(defaultOverlay, /Never use omx explore "<prompt>"/);
       assert.match(defaultOverlay, /default-on; opt out/i);
       assert.match(defaultOverlay, /omx explore` FIRST before attempting full code analysis/i);
 

--- a/src/hooks/__tests__/explore-routing.test.ts
+++ b/src/hooks/__tests__/explore-routing.test.ts
@@ -36,6 +36,9 @@ describe('explore-routing', () => {
 
   it('builds advisory guidance whenever routing is not explicitly disabled', () => {
     const guidance = buildExploreRoutingGuidance({});
+    assert.ok(
+      guidance.startsWith('Syntax: omx explore --prompt "<prompt>" or omx explore --prompt-file <file>. Never use omx explore "<prompt>".'),
+    );
     assert.match(guidance, /USE_OMX_EXPLORE_CMD/);
     assert.match(guidance, /default-on; opt out/i);
     assert.match(guidance, /agents SHOULD treat `omx explore` as the default first stop/i);

--- a/src/hooks/explore-routing.ts
+++ b/src/hooks/explore-routing.ts
@@ -34,6 +34,7 @@ export function isSimpleExplorationPrompt(text: string): boolean {
 export function buildExploreRoutingGuidance(env: NodeJS.ProcessEnv = process.env): string {
   if (!isExploreCommandRoutingEnabled(env)) return '';
   return [
+    'Syntax: omx explore --prompt "<prompt>" or omx explore --prompt-file <file>. Never use omx explore "<prompt>".',
     `**Explore Command Preference:** enabled via \`${OMX_EXPLORE_CMD_ENV}\` (default-on; opt out with \`0\`, \`false\`, \`no\`, or \`off\`)`,
     '- Advisory steering only: agents SHOULD treat `omx explore` as the default first stop for direct inspection and SHOULD reserve `omx sparkshell` for qualifying read-only shell-native tasks.',
     '- For simple file/symbol lookups, use `omx explore` FIRST before attempting full code analysis.',


### PR DESCRIPTION
Closes #2494

## Summary
- Put the valid `omx explore --prompt` / `--prompt-file` syntax at the first line of runtime explore guidance so truncation keeps it visible.
- Route `omx explore --help` to explore-specific usage instead of global help.
- Keep positional prompt text rejected, but replace the generic unknown-argument error with an explicit corrective `--prompt` hint.
- Added regressions for guidance ordering, overlay inclusion, explore-local help, nested help routing, and positional prompt diagnostics.

## Tests
- `npm run build`
- `npm run lint -- src/hooks/explore-routing.ts src/hooks/__tests__/explore-routing.test.ts src/hooks/__tests__/agents-overlay.test.ts src/cli/explore.ts src/cli/index.ts src/cli/__tests__/explore.test.ts src/cli/__tests__/index.test.ts src/cli/__tests__/nested-help-routing.test.ts`
- `npm run check:no-unused`
- `npm run test:explore`
- `node --test --test-name-pattern "adds advisory explore routing guidance" dist/hooks/__tests__/agents-overlay.test.js`
- `node --test --test-name-pattern "commandOwnsLocalHelp" dist/cli/__tests__/index.test.js`
- `node --test dist/cli/__tests__/nested-help-routing.test.js`
- `npm run sync:plugin:check`
- Manual: `node dist/cli/omx.js explore --help`
- Manual: `node dist/cli/omx.js explore find package.json`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
