### PR TITLE
fix: ignore plain-label ultragoal checklist sections

### DIFF
--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -117,6 +117,125 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('derives story goals without queuing nested criteria or plain-label checklist items', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '### Stories',
+          '  1. Ship parser fix',
+          '     - Preserve parent story objective detail',
+          '  2. Add coverage',
+          '',
+          'Acceptance criteria:',
+          '  - Parent stories only',
+          '',
+          'Verification checklist:',
+          '  1. Run tests',
+          '  2. Run lint',
+        ].join('\n'),
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), ['Ship parser fix', 'Add coverage']);
+      assert.match(plan.goals[0]?.objective ?? '', /Preserve parent story objective detail/);
+      assert.doesNotMatch(plan.goals[1]?.objective ?? '', /Run tests|Run lint|Parent stories only/);
+    });
+  });
+
+  it('does not fall back to checklist bullets when a brief has only non-story sections', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: '### Verification checklist:\n- Run tests\n- Run lint\n\nAcceptance criteria:\n- Parent stories only',
+      });
+
+      assert.equal(plan.goals.length, 1);
+      assert.equal(plan.goals[0]?.title, '### Verification checklist:');
+      assert.doesNotMatch(plan.goals[0]?.id ?? '', /run-tests|run-lint|parent-stories/);
+    });
+  });
+
+  it('keeps later sibling stories after an indented plain-label note', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: '1. Story A\n   Notes:\n   - Keep as detail\n2. Story B',
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), ['Story A', 'Story B']);
+      assert.match(plan.goals[0]?.objective ?? '', /Keep as detail/);
+    });
+  });
+
+  it('prefers story-section goals over preface bullets', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: '- Context\n\n### Stories\n  1. Ship parser fix\n  2. Add coverage',
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), ['Ship parser fix', 'Add coverage']);
+    });
+  });
+
+  it('prefers indented markdown story headings over preface bullets', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: '- Context\n\n  ### Stories\n    1. Ship parser fix\n    2. Add coverage',
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), ['Ship parser fix', 'Add coverage']);
+    });
+  });
+
+  it('keeps sibling stories after an indented ATX note heading', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: '1. Story A\n   ### Notes\n   - Keep as detail\n2. Story B',
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), ['Story A', 'Story B']);
+      assert.match(plan.goals[0]?.objective ?? '', /Keep as detail/);
+    });
+  });
+
+  it('keeps sibling stories after a blank before an indented ATX note heading', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: '1. Story A\n\n   ### Notes\n   - Keep as detail\n2. Story B',
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), ['Story A', 'Story B']);
+      assert.match(plan.goals[0]?.objective ?? '', /Keep as detail/);
+    });
+  });
+
+  it('resumes unlabeled top-level story bullets after a non-story section break', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: 'Acceptance criteria:\n- keep API stable\n\n- Ship parser fix\n- Add coverage',
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), ['Ship parser fix', 'Add coverage']);
+    });
+  });
+
+  it('deduplicates derived list goals', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: '- Ship parser fix\n- Ship parser fix\n- Add coverage',
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), ['Ship parser fix', 'Add coverage']);
+    });
+  });
+
+  it('recognizes singular story headings when choosing goals over preface bullets', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: '- Context\n\n### Story\n  1. Ship parser fix\n  2. Add coverage',
+      });
+
+      assert.deepEqual(plan.goals.map((goal) => goal.title), ['Ship parser fix', 'Add coverage']);
+    });
+  });
+
   it('starts one story at a time and emits an aggregate Codex goal handoff by default', async () => {
     await withTempRepo(async (cwd) => {
       await createUltragoalPlan(cwd, {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -273,6 +273,95 @@ function cleanLine(line: string): string {
   return line.replace(/^\s*(?:[-*+]\s+|\d+[.)]\s+)/, '').trim();
 }
 
+interface MarkdownListItem {
+  lineIndex: number;
+  indent: number;
+  text: string;
+  section?: string;
+}
+
+function lineIndentWidth(line: string): number {
+  return (line.match(/^(\s*)/)?.[1] ?? '').replace(/\t/g, '  ').length;
+}
+
+function normalizeSectionLabel(value: string): string | undefined {
+  if (/^\s*(?:[-*+]\s+|\d+[.)]\s+)/.test(value)) return undefined;
+  const atx = /^#{1,6}\s+(.+?)\s*#*\s*$/.exec(value)?.[1];
+  const plain = /^([^\s].{1,100}):\s*$/.exec(value)?.[1];
+  return (atx ?? plain)?.replace(/[`*_~]/g, '').replace(/:$/, '').trim().toLowerCase();
+}
+
+function normalizeIndentedAtxStorySectionLabel(value: string): string | undefined {
+  const atx = /^\s{1,3}#{1,6}\s+(.+?)\s*#*\s*$/.exec(value)?.[1]
+    ?.replace(/[`*_~]/g, '')
+    .replace(/:$/, '')
+    .trim()
+    .toLowerCase();
+  return sectionLooksStory(atx) ? atx : undefined;
+}
+
+function sectionLooksNonStory(section: string | undefined): boolean {
+  return /^(?:acceptance\s+criteria|verification(?:\s+checklist)?|validation(?:\s+checklist)?|checklist|evidence|constraints?|risks?|immediate\s+next\s+actions?|next\s+actions?|follow-?ups?|notes?)$/.test(section ?? '');
+}
+
+function sectionLooksStory(section: string | undefined): boolean {
+  return /^(?:story|stories|goals?|milestones?|p\d+)$/.test(section ?? '');
+}
+
+function parseMarkdownListItems(lines: readonly string[]): MarkdownListItem[] {
+  const items: MarkdownListItem[] = [];
+  let section: string | undefined;
+  let resetNonStorySection = false;
+  let afterBlank = false;
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex] ?? '';
+    if (!line.trim()) {
+      resetNonStorySection ||= sectionLooksNonStory(section);
+      afterBlank = true;
+      continue;
+    }
+    const nextSection = normalizeSectionLabel(line)
+      ?? (afterBlank ? normalizeIndentedAtxStorySectionLabel(line) : undefined);
+    if (nextSection) {
+      section = nextSection;
+      resetNonStorySection = false;
+    }
+    afterBlank = false;
+    const match = /^(\s*)([-*+]|\d+[.)])\s+(.+)$/.exec(line);
+    if (!match) continue;
+    const indent = match[1].replace(/\t/g, '  ').length;
+    if (resetNonStorySection && indent === 0) section = undefined;
+    resetNonStorySection = false;
+    const text = cleanLine(line);
+    if (!text || text.length > 1200) continue;
+    items.push({ lineIndex, indent, text, section });
+  }
+  return items;
+}
+
+function selectedItemObjective(parent: MarkdownListItem, lines: readonly string[], nextParentLineIndex?: number): string {
+  const parts = [parent.text];
+  for (let lineIndex = parent.lineIndex + 1; lineIndex < (nextParentLineIndex ?? lines.length); lineIndex += 1) {
+    const line = lines[lineIndex] ?? '';
+    const indent = lineIndentWidth(line);
+    if (indent <= parent.indent && sectionLooksNonStory(normalizeSectionLabel(line))) break;
+    if (/^\s*(?:[-*+]\s+|\d+[.)]\s+)/.test(line) && indent <= parent.indent) break;
+    if (indent <= parent.indent || !line.trim()) continue;
+    const nested = cleanLine(line);
+    if (nested && nested.length <= 1200) parts.push(nested);
+  }
+  return parts.join('\n');
+}
+
+function topLevelStoryItems(items: readonly MarkdownListItem[]): MarkdownListItem[] {
+  const storyItems = items.filter((item) => !sectionLooksNonStory(item.section));
+  if (storyItems.length === 0) return [];
+  const storySectionItems = storyItems.filter((item) => sectionLooksStory(item.section));
+  const candidates = storySectionItems.length > 0 ? storySectionItems : storyItems;
+  const minIndent = Math.min(...candidates.map((item) => item.indent));
+  return candidates.filter((item) => item.indent === minIndent);
+}
+
 function normalizeObjective(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
 }
@@ -492,21 +581,28 @@ function titleFromObjective(objective: string, fallback: string): string {
 
 export function deriveGoalCandidates(brief: string): Array<{ title: string; objective: string }> {
   const lines = brief.split(/\r?\n/);
-  const bulletGoals = lines
+  const parsedItems = parseMarkdownListItems(lines);
+  const parentItems = topLevelStoryItems(parsedItems);
+  const listGoals = parentItems
+    .map((item, index) => selectedItemObjective(item, lines, parentItems[index + 1]?.lineIndex))
+    .filter((objective, index, all) => all.findIndex((candidate) => candidate === objective) === index);
+  const bulletGoals = (listGoals.length > 0 || parsedItems.length > 0 ? listGoals : lines
     .map((line) => ({ original: line, cleaned: cleanLine(line) }))
     .filter(({ cleaned }) => cleaned.length > 0 && cleaned.length <= 1200)
     .filter(({ original, cleaned }, index, all) => (
       /^\s*(?:[-*+]\s+|\d+[.)]\s+)/.test(original)
       && all.findIndex((candidate) => candidate.cleaned === cleaned) === index
     ))
-    .map(({ cleaned }) => cleaned);
+    .map(({ cleaned }) => cleaned));
 
   const objectives = bulletGoals.length > 0
     ? bulletGoals
-    : brief
-      .split(/\n\s*\n/)
-      .map((paragraph) => paragraph.trim())
-      .filter((paragraph) => paragraph.length > 0 && !paragraph.startsWith('#'));
+    : parsedItems.length > 0
+      ? [brief.trim() || 'Complete the requested project objective.']
+      : brief
+        .split(/\n\s*\n/)
+        .map((paragraph) => paragraph.trim())
+        .filter((paragraph) => paragraph.length > 0 && !paragraph.startsWith('#'));
 
   const selected = objectives.length > 0 ? objectives : [brief.trim() || 'Complete the requested project objective.'];
   return selected.map((objective, index) => ({


### PR DESCRIPTION
## Summary
- Fix automatic `deriveGoalCandidates()` so nested markdown plans produce story-level Ultragoal queue entries instead of checklist-level microgoals.
- Prefer top-level story list items, fold nested bullets/details into the parent objective, and ignore non-story checklist/verification/validation sections.
- Recognize plain-label non-story sections such as `Acceptance criteria:` and `Verification checklist:` before selecting parent items, so their checklist bullets are not queued as separate goals.
- Preserve explicit `--goal` precedence and simple flat top-level bullet behavior.

## Evidence / root cause
`omx ultragoal create-goals` previously flattened every markdown bullet/numbered line at any indentation depth into a durable goal. In a real MediaGen/Comfy run, that produced 74 autogenerated goals before manual normalization to 12 executable stories.

PR #2490 narrowed the extractor toward story-level goals, but the final review found a remaining gap: plain-label plan sections like `Verification checklist:` / `Acceptance criteria:` were not carried into candidate selection, so list items under those labels could still become durable parent goals. This focused replacement fixes that gap without bringing over the broader churn from #2490.

Fixes #2500.
Replaces #2490.

## Scope notes
This is intentionally narrow:
- Touched only `src/ultragoal/artifacts.ts` and `src/ultragoal/__tests__/artifacts.test.ts`.
- No new CLI surface, workflow, skill, or runtime behavior outside automatic brief-to-goal extraction.
- Keeps bare explicit list briefs working as before.
- Keeps nested plain labels/ATX headings inside a selected story as objective detail without letting them reclassify later sibling stories.
- Supports valid indented Markdown story headings after section breaks (for example `  ### Stories`).
- Deduplicates repeated derived list objectives, preserving the previous flat-list behavior.
- Prefers explicit story sections (`Story` / `Stories`) over preface/context bullets, so a preface line cannot collapse an indented story list into one broad goal.
- Resumes unlabeled top-level story bullets after a non-story section break instead of keeping stale checklist context forever.

## Local checks
- `npm run build`
- `node --test dist/ultragoal/__tests__/artifacts.test.js dist/cli/__tests__/ultragoal.test.js`
- `npm run lint -- src/ultragoal/artifacts.ts src/ultragoal/__tests__/artifacts.test.ts`
- `npm run check:no-unused`
- `git diff --check upstream/dev...HEAD`

## Pre-publication review
Fresh tmux OMX code-review pass against this branch:
- verdict: APPROVE
- blocking findings: 0
- evidence: focused diff, artifact tests passed, manual parser checks covered bare lists, mixed story/checklist sections, nested story detail, and all-non-story plain/ATX sections.



