### PR TITLE
Deprecate omx explore

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ If `Shift+Enter` still submits instead of inserting a newline inside an OMX-mana
 Examples:
 
 ```bash
+# Deprecated compatibility only; prefer normal Codex repository inspection for new lookups
 omx explore --prompt "find where team state is written"
 omx sparkshell git status
 omx sparkshell --tmux-pane %12 --tail-lines 400

--- a/docs/wiki-feature.md
+++ b/docs/wiki-feature.md
@@ -21,7 +21,7 @@ OMX Wiki is a compiled markdown knowledge layer for agents.
 ## Retrieval model
 
 - Wiki pages are queried first when useful
-- `omx explore` can inject wiki-first context before broader repository search
+- `omx explore` is deprecated and compatibility-only; prefer the wiki workflow plus normal Codex repository inspection before broader repository search
 - repository search remains the fallback when wiki evidence is weak or missing
 
 ## Lifecycle model

--- a/plugins/oh-my-codex/skills/deep-interview/SKILL.md
+++ b/plugins/oh-my-codex/skills/deep-interview/SKILL.md
@@ -47,7 +47,7 @@ If no flag is provided, use **Standard**.
 - Do not rotate to a new clarity dimension just for coverage when the current answer is still vague; stay on the same thread until one layer deeper, one assumption clearer, or one boundary tighter
 - Before crystallizing, complete at least one explicit pressure pass that revisits an earlier answer with a deeper, assumption-focused, or tradeoff-focused follow-up
 - Gather codebase facts via `explore` before asking user about internals
-- When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only brownfield fact gathering; keep prompts narrow and concrete, and keep ambiguous or non-shell-only investigation on the richer normal path and fall back normally if `omx explore` is unavailable.
+- `omx explore` is deprecated. Use normal repository inspection tools/subagents for simple read-only brownfield fact gathering; use `omx sparkshell` only for explicit shell-native read-only evidence, and keep ambiguous or non-shell-only investigation on the richer normal path.
 - Always run a preflight context intake before the first interview question
 - If initial context is oversized or would exceed the prompt budget, do not paste or forward the raw payload into interview prompts; request and record a prompt-safe initial-context summary first
 - The oversized initial-context summary gate is blocking: wait for the concise summary before ambiguity scoring, crystallizing artifacts, or any downstream execution handoff

--- a/plugins/oh-my-codex/skills/plan/SKILL.md
+++ b/plugins/oh-my-codex/skills/plan/SKILL.md
@@ -30,7 +30,7 @@ Jumping into code without understanding requirements leads to rework, scope cree
 - Auto-detect interview vs direct mode based on request specificity
 - Ask one question at a time during interviews -- never batch multiple interview rounds into one question form
 - Gather codebase facts via `explore` agent before asking the user about them
-- When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups during planning; keep prompts narrow and concrete, and keep prompt-heavy or ambiguous planning work on the richer normal path and fall back normally if `omx explore` is unavailable.
+- `omx explore` is deprecated. Use normal repository inspection tools/subagents for simple read-only repository lookups during planning; use `omx sparkshell` only for explicit shell-native read-only evidence, and keep prompt-heavy or ambiguous planning work on the richer normal path.
 - Plans must meet quality standards: 80%+ claims cite file/line, 90%+ criteria are testable
 - Implementation step count must be right-sized to task scope; avoid defaulting to exactly five steps when the work is clearly smaller or larger
 - Consensus mode outputs the final plan by default; add `--interactive` to enable execution handoff

--- a/plugins/oh-my-codex/skills/ralph/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralph/SKILL.md
@@ -50,7 +50,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
      - unknowns/open questions
      - likely codebase touchpoints
    - If an existing relevant snapshot is available, reuse it and record the path in Ralph state.
-   - If request ambiguity is high, gather brownfield facts first. When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups with narrow, concrete prompts; otherwise use the richer normal explore path. Then run `$deep-interview --quick <task>` to close critical gaps.
+   - If request ambiguity is high, gather brownfield facts first. `omx explore` is deprecated; use normal repository inspection tools/subagents for simple read-only repository lookups and `omx sparkshell` only for explicit shell-native read-only evidence. Then run `$deep-interview --quick <task>` to close critical gaps.
    - Do not begin Ralph execution work (delegation, implementation, or verification loops) until snapshot grounding exists. If forced to proceed quickly, note explicit risk tradeoffs.
 1. **Review progress**: Check TODO list and any prior iteration state
 2. **Continue from where you left off**: Pick up incomplete tasks

--- a/plugins/oh-my-codex/skills/ralplan/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralplan/SKILL.md
@@ -102,7 +102,7 @@ Before consensus planning or execution handoff, ensure a grounded context snapsh
    - constraints
    - unknowns/open questions
    - likely codebase touchpoints
-4. If ambiguity remains high, gather brownfield facts first. When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups with narrow, concrete prompts; otherwise use the richer normal explore path. Then run `$deep-interview --quick <task>` before continuing.
+4. If ambiguity remains high, gather brownfield facts first. `omx explore` is deprecated; use normal repository inspection tools/subagents for simple read-only repository lookups and `omx sparkshell` only for explicit shell-native read-only evidence. Then run `$deep-interview --quick <task>` before continuing.
 5. If the plan depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, use `$best-practice-research` as the bounded evidence wrapper and auto-delegate `researcher` for the official/upstream lookup before finalizing the planning handoff so execution does not start from repo-local recall alone.
 6. If a prior `$autoresearch` or `$autoresearch-goal` run exists, treat its approved artifact as evidence for the plan. Do not include Autoresearch as a final architecture or runtime component unless the user explicitly requested ongoing research automation; otherwise synthesize the evidence into the `$ralplan` ADR, risks, and verification steps.
 

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -27,7 +27,7 @@ Explore just enough context, implement the smallest correct change, verify it wi
 <ask_gate>
 - Explore first, ask last; choose the safest reasonable interpretation when one exists.
 - Ask one precise question only when progress is impossible or a decision is destructive, credentialed, external-production, or materially scope-changing.
-- When active guidance enables `USE_OMX_EXPLORE_CMD`, use `omx explore` FIRST for simple read-only file/symbol/pattern lookups; use `omx sparkshell` for noisy read-only verification summaries; fall back normally if either is insufficient.
+- `omx explore` is deprecated. Use normal repository inspection tools/subagents for simple file/symbol/pattern lookups; use `omx sparkshell` only for explicit shell-native read-only or noisy verification summaries.
 </ask_gate>
 
 <!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:START -->

--- a/prompts/explore-harness.md
+++ b/prompts/explore-harness.md
@@ -14,8 +14,8 @@ Your job is to inspect the current repository and return a concise markdown summ
 - Treat unavailable tools as unavailable. Do not assume LSP, ast-grep, MCP, web search, images, or structured Read/Glob tools exist here.
 - Keep file/path arguments inside the current repository. Do not intentionally inspect `..` paths or unrelated absolute paths.
 - This harness is for simple read-only repository lookup tasks after `omx explore` has already been selected; it is not the richer normal path.
-- Prefer `omx explore --prompt ...` with narrow, concrete lookup goals; if the ask is broad, multi-part, or needs synthesis beyond simple repository inspection, report the limitation so the caller can fall back to the richer normal path.
-- Prefer `omx explore --prompt ...` for short one-off asks and `omx explore --prompt-file ...` when the brief is longer or reusable.
+- `omx explore --prompt ...` is deprecated and compatibility-only. If the ask is broad, multi-part, or needs synthesis beyond simple repository inspection, report the limitation so the caller can use the richer normal path.
+- Existing `omx explore --prompt ...` and `omx explore --prompt-file ...` callers remain supported temporarily, but new guidance should point to normal repository inspection or `omx sparkshell` for explicit shell-native read-only commands.
 - Prefer direct read-only inspection first; for qualifying read-only shell-native tasks where command-native execution or long output is the better fit, it is acceptable to use `omx sparkshell <allowlisted command...>` as a backend and then continue with a markdown answer.
 - If the user clearly needs non-shell-only tooling or the harness cannot answer safely, report the limitation so the caller can fall back to the richer normal path.
 - Return markdown only.

--- a/prompts/explore.md
+++ b/prompts/explore.md
@@ -16,7 +16,7 @@ Return complete, actionable repository facts: where things live, how they connec
 - ALL paths are absolute in results.
 - Own repo-local facts only; route external docs to `researcher`, and if the caller needs a dependency recommendation, report that handoff upward to `dependency-expert`.
 - For all usages of a symbol, use the best local search/reference tools first; report if a richer semantic pass is needed.
-- When active guidance enables `USE_OMX_EXPLORE_CMD`, `omx explore --prompt ...` is the preferred low-cost path for simple read-only lookups. This prompt handles ambiguous, relationship-heavy, or non-shell-only investigations; if the harness is incomplete, continue on this richer normal path.
+- `omx explore --prompt ...` is deprecated and compatibility-only. Use this richer normal path for simple read-only lookups, ambiguous investigations, relationship-heavy analysis, or non-shell-only work; use `omx sparkshell` only for explicit shell-native read-only evidence.
 </scope_guard>
 
 <ask_gate>

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -45,7 +45,7 @@ Leave execution with a right-sized, evidence-grounded plan: scope, steps, accept
 <execution_loop>
 1. Inspect the repository before asking about code facts.
 2. Classify the task as simple, refactor, feature, or broad initiative.
-3. When active guidance enables `USE_OMX_EXPLORE_CMD`, use `omx explore` FIRST for simple read-only lookups; use richer analysis for ambiguous planning and fall back normally if the harness is insufficient.
+3. `omx explore` is deprecated. Use normal repository inspection tools/subagents for simple read-only lookups; use richer analysis for ambiguous planning and `omx sparkshell` only for explicit shell-native read-only evidence.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:START -->
 3) If correctness depends on repository inspection, prompt review, official docs, or other evidence, keep using those sources until the plan is grounded; stop once the requirements, affected resources, validation commands, failure behavior, and material open questions are traceable.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:END -->

--- a/prompts/sisyphus-lite.md
+++ b/prompts/sisyphus-lite.md
@@ -22,7 +22,7 @@ Default: explore first, ask last.
 - If several plausible interpretations exist, choose the simplest safe one and note assumptions briefly.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - Ask only when progress is truly impossible.
-- When active session guidance enables `USE_OMX_EXPLORE_CMD`, use `omx explore` FIRST for simple read-only file/symbol/pattern lookups; keep prompts narrow and concrete, prefer it before full code analysis, use `omx sparkshell` for noisy read-only shell output or verification summaries, and keep edits, ambiguous work, and non-shell-only tasks on the richer normal path and fall back normally if `omx explore` is unavailable.
+- `omx explore` is deprecated. Use normal repository inspection tools/subagents for simple read-only file/symbol/pattern lookups, use `omx sparkshell` for explicit shell-native read-only output or verification summaries, and keep edits, ambiguous work, and non-shell-only tasks on the richer normal path.
 
 - Do not claim completion without fresh verification output.
 - Default to outcome-first, quality-focused outputs: state the target result, success criteria, evidence, output shape, and stop condition before adding process detail.

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -47,7 +47,7 @@ If no flag is provided, use **Standard**.
 - Do not rotate to a new clarity dimension just for coverage when the current answer is still vague; stay on the same thread until one layer deeper, one assumption clearer, or one boundary tighter
 - Before crystallizing, complete at least one explicit pressure pass that revisits an earlier answer with a deeper, assumption-focused, or tradeoff-focused follow-up
 - Gather codebase facts via `explore` before asking user about internals
-- When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only brownfield fact gathering; keep prompts narrow and concrete, and keep ambiguous or non-shell-only investigation on the richer normal path and fall back normally if `omx explore` is unavailable.
+- `omx explore` is deprecated. Use normal repository inspection tools/subagents for simple read-only brownfield fact gathering; use `omx sparkshell` only for explicit shell-native read-only evidence, and keep ambiguous or non-shell-only investigation on the richer normal path.
 - Always run a preflight context intake before the first interview question
 - If initial context is oversized or would exceed the prompt budget, do not paste or forward the raw payload into interview prompts; request and record a prompt-safe initial-context summary first
 - The oversized initial-context summary gate is blocking: wait for the concise summary before ambiguity scoring, crystallizing artifacts, or any downstream execution handoff

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -30,7 +30,7 @@ Jumping into code without understanding requirements leads to rework, scope cree
 - Auto-detect interview vs direct mode based on request specificity
 - Ask one question at a time during interviews -- never batch multiple interview rounds into one question form
 - Gather codebase facts via `explore` agent before asking the user about them
-- When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups during planning; keep prompts narrow and concrete, and keep prompt-heavy or ambiguous planning work on the richer normal path and fall back normally if `omx explore` is unavailable.
+- `omx explore` is deprecated. Use normal repository inspection tools/subagents for simple read-only repository lookups during planning; use `omx sparkshell` only for explicit shell-native read-only evidence, and keep prompt-heavy or ambiguous planning work on the richer normal path.
 - Plans must meet quality standards: 80%+ claims cite file/line, 90%+ criteria are testable
 - Implementation step count must be right-sized to task scope; avoid defaulting to exactly five steps when the work is clearly smaller or larger
 - Consensus mode outputs the final plan by default; add `--interactive` to enable execution handoff

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -50,7 +50,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
      - unknowns/open questions
      - likely codebase touchpoints
    - If an existing relevant snapshot is available, reuse it and record the path in Ralph state.
-   - If request ambiguity is high, gather brownfield facts first. When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups with narrow, concrete prompts; otherwise use the richer normal explore path. Then run `$deep-interview --quick <task>` to close critical gaps.
+   - If request ambiguity is high, gather brownfield facts first. `omx explore` is deprecated; use normal repository inspection tools/subagents for simple read-only repository lookups and `omx sparkshell` only for explicit shell-native read-only evidence. Then run `$deep-interview --quick <task>` to close critical gaps.
    - Do not begin Ralph execution work (delegation, implementation, or verification loops) until snapshot grounding exists. If forced to proceed quickly, note explicit risk tradeoffs.
 1. **Review progress**: Check TODO list and any prior iteration state
 2. **Continue from where you left off**: Pick up incomplete tasks

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -102,7 +102,7 @@ Before consensus planning or execution handoff, ensure a grounded context snapsh
    - constraints
    - unknowns/open questions
    - likely codebase touchpoints
-4. If ambiguity remains high, gather brownfield facts first. When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups with narrow, concrete prompts; otherwise use the richer normal explore path. Then run `$deep-interview --quick <task>` before continuing.
+4. If ambiguity remains high, gather brownfield facts first. `omx explore` is deprecated; use normal repository inspection tools/subagents for simple read-only repository lookups and `omx sparkshell` only for explicit shell-native read-only evidence. Then run `$deep-interview --quick <task>` before continuing.
 5. If the plan depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, use `$best-practice-research` as the bounded evidence wrapper and auto-delegate `researcher` for the official/upstream lookup before finalizing the planning handoff so execution does not start from repo-local recall alone.
 6. If a prior `$autoresearch` or `$autoresearch-goal` run exists, treat its approved artifact as evidence for the plan. Do not include Autoresearch as a final architecture or runtime component unless the user explicitly requested ongoing research automation; otherwise synthesize the evidence into the `$ralplan` ADR, risks, and verification steps.
 

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -637,7 +637,7 @@ enabled = true
 		});
 	});
 
-	it("warns when explore routing is explicitly disabled in config.toml", async () => {
+	it("passes when deprecated explore routing is explicitly disabled by environment/config", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-explore-routing-"));
 		try {
 			const home = join(wd, "home");
@@ -654,12 +654,13 @@ USE_OMX_EXPLORE_CMD = "off"
 			const res = runOmx(wd, ["doctor"], {
 				HOME: home,
 				CODEX_HOME: join(home, ".codex"),
+				USE_OMX_EXPLORE_CMD: "off",
 			});
 			if (shouldSkipForSpawnPermissions(res.error)) return;
 			assert.equal(res.status, 0, res.stderr || res.stdout);
 			assert.match(
 				res.stdout,
-				/Explore routing: disabled in config\.toml; set USE_OMX_EXPLORE_CMD = "1" under \[shell_environment_policy\.set\] to restore default explore-first routing/,
+				/Explore routing: deprecated compatibility routing disabled by environment override \(recommended\)/,
 			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -12,6 +12,7 @@ import {
   buildExploreHarnessArgs,
   buildExplorePromptWithWikiContext,
   exploreCommand,
+  EXPLORE_DEPRECATION_NOTICE,
   EXPLORE_USAGE,
   loadExplorePrompt,
   packagedExploreHarnessBinaryName,
@@ -329,6 +330,7 @@ describe('exploreCommand help', () => {
       assert.match(result.stdout, /Usage: omx explore --prompt "<prompt>"/);
       assert.match(result.stdout, /omx explore --prompt-file <file>/);
       assert.match(result.stdout, /Never use positional prompt text/i);
+      assert.match(result.stdout, /DEPRECATED: `omx explore` is deprecated/i);
       assert.equal(result.stderr, '');
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -824,7 +826,7 @@ describe('exploreCommand', () => {
       assert.equal(result.exitCode, 0);
       assert.match(result.stdout, /local fast-path used \(text lookup\)/);
       assert.match(result.stdout, /src\/auth\.ts:1/);
-      assert.equal(result.stderr, '');
+      assert.equal(result.stderr, `${EXPLORE_DEPRECATION_NOTICE}\n`);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -848,7 +850,7 @@ describe('exploreCommand', () => {
       assert.match(result.stdout, /# Demo README/);
       assert.match(result.stdout, /This content must be visible\./);
       assert.doesNotMatch(result.stdout.trim(), /^.*README\.md \(\d+ bytes\)$/);
-      assert.equal(result.stderr, '');
+      assert.equal(result.stderr, `${EXPLORE_DEPRECATION_NOTICE}\n`);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -869,7 +871,7 @@ describe('exploreCommand', () => {
       assert.equal(result.exitCode, 0);
       assert.match(result.stdout, /# Demo README/);
       assert.match(result.stdout, /\[truncated: file exceeds local fast-path limit/);
-      assert.equal(result.stderr, '');
+      assert.equal(result.stderr, `${EXPLORE_DEPRECATION_NOTICE}\n`);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -914,7 +916,7 @@ describe('exploreCommand', () => {
       assert.equal(result.exitCode, 0);
       assert.match(result.stdout, /harness-fallback/);
       assert.doesNotMatch(result.stdout, /local fast-path used \(text lookup\)/);
-      assert.equal(result.stderr, '');
+      assert.equal(result.stderr, `${EXPLORE_DEPRECATION_NOTICE}\n`);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -988,7 +990,7 @@ describe('exploreCommand', () => {
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.equal(result.stdout, '# Answer\n- routed via sparkshell\n');
-      assert.equal(result.stderr, '');
+      assert.equal(result.stderr, `${EXPLORE_DEPRECATION_NOTICE}\n`);
       const captured = (await readFile(capturePath, 'utf-8')).trim().split('\n');
       assert.deepEqual(captured, ['git', 'log', '--oneline']);
     } finally {
@@ -1091,7 +1093,7 @@ describe('exploreCommand', () => {
         process.stderr.write = originalStderr;
       }
 
-      assert.equal(stderrChunks.join(''), '');
+      assert.equal(stderrChunks.join(''), `${EXPLORE_DEPRECATION_NOTICE}\n`);
       assert.equal(stdoutChunks.join(''), '# Files\n- demo\n');
       const captured = (await readFile(capturePath, 'utf-8')).trim().split('\n');
       assert.ok(captured.includes('--prompt'));

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -233,7 +233,7 @@ describe("omx setup scope behavior", () => {
       assert.match(configToml, /^max_depth = 2$/m);
       assert.doesNotMatch(configToml, /^\[env\]$/m);
       assert.match(configToml, /^\[shell_environment_policy\.set\]$/m);
-      assert.match(configToml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
+      assert.match(configToml, /^USE_OMX_EXPLORE_CMD = "0"$/m);
       assert.match(configToml, /^hooks = true$/m);
       assert.match(configToml, /^goals = true$/m);
       assert.match(

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -462,10 +462,10 @@ describe('omx sparkshell', () => {
       if (shouldSkipForSpawnPermissions(result.error)) return;
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stdout, /omx explore\s+Default read-only exploration entrypoint \(may adaptively use sparkshell backend\)/);
+      assert.match(result.stdout, /omx explore\s+DEPRECATED compatibility command; use normal repo inspection or omx sparkshell/);
       assert.match(result.stdout, /omx sparkshell <command> \[args\.\.\.\]/);
       assert.match(result.stdout, /omx sparkshell --tmux-pane <pane-id> \[--tail-lines <100-1000>\]/);
-      assert.match(result.stdout, /adaptive backend for qualifying read-only explore tasks/i);
+      assert.match(result.stdout, /explicit tmux-pane summarization/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -906,15 +906,20 @@ async function checkModelContextRecommendation(
 
 async function checkExploreRouting(configPath: string): Promise<Check> {
 	const envValue = process.env[OMX_EXPLORE_CMD_ENV];
-	if (
-		typeof envValue === "string" &&
-		!isExploreCommandRoutingEnabled(process.env)
-	) {
+	if (typeof envValue === "string") {
+		if (isExploreCommandRoutingEnabled(process.env)) {
+			return {
+				name: "Explore routing",
+				status: "warn",
+				message:
+					"deprecated compatibility routing enabled by environment override; remove USE_OMX_EXPLORE_CMD or set it to 0 and use normal Codex repo inspection or omx sparkshell instead",
+			};
+		}
 		return {
 			name: "Explore routing",
-			status: "warn",
+			status: "pass",
 			message:
-				"disabled by environment override; enable with USE_OMX_EXPLORE_CMD=1 (or remove the explicit opt-out)",
+				"deprecated compatibility routing disabled by environment override (recommended)",
 		};
 	}
 
@@ -922,7 +927,7 @@ async function checkExploreRouting(configPath: string): Promise<Check> {
 		return {
 			name: "Explore routing",
 			status: "pass",
-			message: "enabled by default (config.toml not found yet)",
+			message: "deprecated by default (config.toml not found yet)",
 		};
 	}
 
@@ -936,24 +941,28 @@ async function checkExploreRouting(configPath: string): Promise<Check> {
 			parsed?.shell_environment_policy?.set?.USE_OMX_EXPLORE_CMD ??
 			parsed?.env?.USE_OMX_EXPLORE_CMD;
 
-		if (
-			typeof configuredValue === "string" &&
-			!isExploreCommandRoutingEnabled({
+		if (typeof configuredValue === "string") {
+			if (isExploreCommandRoutingEnabled({
 				USE_OMX_EXPLORE_CMD: configuredValue,
-			})
-		) {
+			})) {
+				return {
+					name: "Explore routing",
+					status: "warn",
+					message:
+						'deprecated compatibility routing enabled in config.toml; set USE_OMX_EXPLORE_CMD = "0" under [shell_environment_policy.set] and use normal Codex repo inspection or omx sparkshell instead',
+				};
+			}
 			return {
 				name: "Explore routing",
-				status: "warn",
-				message:
-					'disabled in config.toml; set USE_OMX_EXPLORE_CMD = "1" under [shell_environment_policy.set] to restore default explore-first routing',
+				status: "pass",
+				message: "deprecated compatibility routing disabled in config.toml (recommended)",
 			};
 		}
 
 		return {
 			name: "Explore routing",
 			status: "pass",
-			message: "enabled by default",
+			message: "deprecated by default",
 		};
 	} catch {
 		return {

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -28,10 +28,14 @@ import { hasReadableWiki, queryWiki } from '../wiki/index.js';
 import { resolveCodexHomeForLaunch } from './codex-home.js';
 import { runProcessTreeWithTimeout } from '../runtime/process-tree.js';
 
+export const EXPLORE_DEPRECATION_NOTICE = 'DEPRECATED: `omx explore` is deprecated. Use the normal Codex repository tools/subagents for repo inspection, or `omx sparkshell` for explicit shell-native read-only commands.';
+
 export const EXPLORE_USAGE = [
+  EXPLORE_DEPRECATION_NOTICE,
   'Usage: omx explore --prompt "<prompt>"',
   '   or: omx explore --prompt-file <file>',
   '',
+  'Compatibility only: existing callers may still use --prompt/--prompt-file temporarily.',
   'Never use positional prompt text. Use: omx explore --prompt "find package.json"',
 ].join('\n');
 
@@ -692,6 +696,9 @@ export async function loadExplorePrompt(parsed: ParsedExploreArgs): Promise<stri
 }
 
 export async function exploreCommand(args: string[]): Promise<void> {
+  if (!args.includes('--help') && !args.includes('-h')) {
+    process.stderr.write(`${EXPLORE_DEPRECATION_NOTICE}\n`);
+  }
   if (process.env[EXPLORE_ACTIVE_ENV] === '1') {
     throw new Error('[explore] refusing to launch nested omx explore from an active explore run.');
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -210,7 +210,7 @@ Usage:
   omx question  OMX-owned blocking question UI entrypoint for agent-invoked user questions
   omx adapt     Scaffold OMX-owned adapter foundations for persistent external targets
   omx resume    Resume a previous interactive Codex session
-  omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
+  omx explore   DEPRECATED compatibility command; use normal repo inspection or omx sparkshell
   omx api       Run native omx-api localhost gateway commands (serve|status|stop|generate)
   omx session   Search prior local session transcripts and history artifacts
   omx agents-init [path]

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -10,7 +10,7 @@ Resolved setup scope: user
   [!!] Config: config.toml exists but no OMX entries yet (expected before first setup; run "omx setup --force" once)
   [OK] Native hooks: hooks.json not found yet (expected before first setup)
   [OK] Native hook dist smoke: installed dist/scripts/codex-native-hook.js parsed and accepted a minimal UserPromptSubmit payload
-  [OK] Explore routing: enabled by default
+  [OK] Explore routing: deprecated by default
   [OK] Lore commit guard: disabled by default
   [!!] Prompts: prompts directory not found
   [!!] Skills: skills directory not found

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -98,7 +98,7 @@ function assertSingleOmxBlock(
     "[shell_environment_policy.set] should appear once",
   );
   assert.equal(
-    count(toml, /^USE_OMX_EXPLORE_CMD = "1"$/gm),
+    count(toml, /^USE_OMX_EXPLORE_CMD = "0"$/gm),
     1,
     "USE_OMX_EXPLORE_CMD should appear once",
   );
@@ -678,15 +678,15 @@ describe("config generator idempotency (#384)", () => {
     assert.doesNotMatch(toml, /^\[tui\]$/m);
     assert.doesNotMatch(toml, /^\[mcp_servers\.omx_state\]$/m);
     assert.match(toml, /^\[shell_environment_policy\.set\]$/m);
-    assert.match(toml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
+    assert.match(toml, /^USE_OMX_EXPLORE_CMD = "0"$/m);
   });
 
-  it('seeds USE_OMX_EXPLORE_CMD=1 into generated config by default', () => {
+  it('seeds USE_OMX_EXPLORE_CMD=0 into generated config by default', () => {
     const toml = buildMergedConfig('', '/tmp/omx');
 
     assert.doesNotMatch(toml, /^\[env\]$/m);
     assert.match(toml, /^\[shell_environment_policy\.set\]$/m);
-    assert.match(toml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
+    assert.match(toml, /^USE_OMX_EXPLORE_CMD = "0"$/m);
   });
 
   it('migrates existing [env] keys and explicit explore routing opt-outs', () => {
@@ -724,7 +724,7 @@ describe("config generator idempotency (#384)", () => {
       /FOO = """first line\n  second line\nthird line"""/,
     );
     assert.match(toml, /BAR = \[\n  "one",\n  "two",\n\]/);
-    assert.match(toml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
+    assert.match(toml, /^USE_OMX_EXPLORE_CMD = "0"$/m);
     assert.doesNotThrow(() => TOML.parse(toml));
   });
 

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -108,7 +108,7 @@ const SHARED_MCP_REGISTRY_END_MARKER =
   "# End oh-my-codex shared MCP registry sync";
 const OMX_AGENTS_MAX_THREADS = 6;
 const OMX_AGENTS_MAX_DEPTH = 2;
-const OMX_EXPLORE_ROUTING_DEFAULT = "1";
+const OMX_EXPLORE_ROUTING_DEFAULT = "0";
 const OMX_EXPLORE_CMD_ENV = "USE_OMX_EXPLORE_CMD";
 const DEFAULT_LAUNCHER_MCP_STARTUP_TIMEOUT_SEC = 15;
 const STATUS_LINE_FOCUSED_FIELDS: readonly string[] = [
@@ -2333,7 +2333,7 @@ function getOmxTablesBlock(
  * Layout:
  *   1. OMX top-level keys (notify, model_reasoning_effort, developer_instructions)
  *   2. [features] with multi_agent + child_agents_md + hooks + goals
- *   3. [shell_environment_policy.set] with defaulted explore-routing opt-in
+ *   3. [shell_environment_policy.set] with defaulted deprecated explore-routing opt-out
  *   4. … user sections …
  *   5. OMX [table] sections (mcp_servers, tui)
  */

--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -77,7 +77,7 @@ describe("generateOverlay", () => {
     assert.doesNotMatch(defaultOverlay, /\*\*Orchestration Mode:\*\* team/);
   });
 
-  it("adds advisory explore routing guidance by default and hides it only on explicit opt-out", async () => {
+  it("adds deprecation guidance for explore routing by default and on explicit compatibility opt-in", async () => {
     const previous = process.env.USE_OMX_EXPLORE_CMD;
     try {
       delete process.env.USE_OMX_EXPLORE_CMD;
@@ -85,21 +85,18 @@ describe("generateOverlay", () => {
         tempDir,
         "explore-routing-default",
       );
-      assert.match(
-        defaultOverlay,
-        /\*\*Explore Command Preference:\*\*/,
-      );
-      assert.match(defaultOverlay, /Syntax: omx explore --prompt "<prompt>" or omx explore --prompt-file <file>/);
-      assert.match(defaultOverlay, /Never use omx explore "<prompt>"/);
-      assert.match(defaultOverlay, /default-on; opt out/i);
-      assert.match(defaultOverlay, /omx explore` FIRST before attempting full code analysis/i);
+      assert.match(defaultOverlay, /\*\*Explore Command Deprecated:\*\*/);
+      assert.match(defaultOverlay, /MUST NOT be recommended/i);
+      assert.match(defaultOverlay, /normal Codex repository inspection/i);
+      assert.match(defaultOverlay, /Compatibility routing is not enabled/i);
 
-      process.env.USE_OMX_EXPLORE_CMD = "off";
-      const disabledOverlay = await generateOverlay(
+      process.env.USE_OMX_EXPLORE_CMD = "1";
+      const enabledOverlay = await generateOverlay(
         tempDir,
-        "explore-routing-off",
+        "explore-routing-enabled",
       );
-      assert.doesNotMatch(disabledOverlay, /\*\*Explore Command Preference:\*\*/);
+      assert.match(enabledOverlay, /compatibility routing is explicitly enabled/i);
+      assert.match(enabledOverlay, /still prefer the replacement path/i);
     } finally {
       if (typeof previous === "string")
         process.env.USE_OMX_EXPLORE_CMD = previous;

--- a/src/hooks/__tests__/explore-routing.test.ts
+++ b/src/hooks/__tests__/explore-routing.test.ts
@@ -7,8 +7,8 @@ import {
 } from '../explore-routing.js';
 
 describe('explore-routing', () => {
-  it('defaults USE_OMX_EXPLORE_CMD to enabled and only disables explicit opt-out values', () => {
-    assert.equal(isExploreCommandRoutingEnabled({}), true);
+  it('defaults USE_OMX_EXPLORE_CMD to disabled compatibility mode and honors explicit values', () => {
+    assert.equal(isExploreCommandRoutingEnabled({}), false);
     assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: '1' }), true);
     assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: 'true' }), true);
     assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: 'yes' }), true);
@@ -34,20 +34,15 @@ describe('explore-routing', () => {
     assert.equal(isSimpleExplorationPrompt('investigate everything in this repo'), false);
   });
 
-  it('builds advisory guidance whenever routing is not explicitly disabled', () => {
+  it('builds deprecation guidance and never recommends explore for new work', () => {
     const guidance = buildExploreRoutingGuidance({});
-    assert.ok(
-      guidance.startsWith('Syntax: omx explore --prompt "<prompt>" or omx explore --prompt-file <file>. Never use omx explore "<prompt>".'),
-    );
+    assert.ok(guidance.startsWith('**Explore Command Deprecated:**'));
     assert.match(guidance, /USE_OMX_EXPLORE_CMD/);
-    assert.match(guidance, /default-on; opt out/i);
-    assert.match(guidance, /agents SHOULD treat `omx explore` as the default first stop/i);
-    assert.match(guidance, /use `omx explore` FIRST before attempting full code analysis/i);
-    assert.match(guidance, /Explore examples:/);
-    assert.match(guidance, /SparkShell examples:/);
-    assert.match(guidance, /--prompt-file/);
-    assert.match(guidance, /shell-only allowlisted read-only path/i);
-    assert.match(guidance, /gracefully fall back to the normal path/i);
-    assert.equal(buildExploreRoutingGuidance({ USE_OMX_EXPLORE_CMD: 'off' }), '');
+    assert.match(guidance, /compatibility-only/i);
+    assert.match(guidance, /MUST NOT be recommended/i);
+    assert.match(guidance, /normal Codex repository inspection/i);
+    assert.match(guidance, /omx sparkshell -- <command>/);
+    assert.match(guidance, /do not route simple lookups to `omx explore`/i);
+    assert.match(buildExploreRoutingGuidance({ USE_OMX_EXPLORE_CMD: '1' }), /explicitly enabled.*still prefer the replacement path/is);
   });
 });

--- a/src/hooks/__tests__/explore-sparkshell-guidance-contract.test.ts
+++ b/src/hooks/__tests__/explore-sparkshell-guidance-contract.test.ts
@@ -10,13 +10,12 @@ function expectPatterns(path: string, patterns: RegExp[]): void {
 }
 
 describe('explore + sparkshell guidance contract', () => {
-  it('keeps AGENTS root and template aligned on conditional explore routing and opt-in sparkshell guidance', () => {
+  it('keeps AGENTS root and template aligned on deprecated explore routing and opt-in sparkshell guidance', () => {
     const patterns = [
       /USE_OMX_EXPLORE_CMD/i,
-      /SHOULD treat `omx explore`|strongly prefer `omx explore`/i,
-      /--prompt/i,
-      /shell-only, allowlisted, read-only path|shell-only allowlisted read-only path/i,
-      /gracefully fall back to the normal path/i,
+      /`omx explore` is deprecated/i,
+      /MUST NOT be recommended|does not make `omx explore` preferred/i,
+      /normal Codex repository inspection/i,
       /omx sparkshell --tmux-pane/i,
       /explicit opt-?in/i,
       /When to use what/i,
@@ -29,19 +28,19 @@ describe('explore + sparkshell guidance contract', () => {
 
   it('keeps explore surfaces explicit about richer-path fallback', () => {
     expectPatterns('prompts/explore.md', [
-      /USE_OMX_EXPLORE_CMD/i,
-      /preferred low-cost path/i,
-      /continue on this richer normal path/i,
+      /`omx explore --prompt \.\.\.` is deprecated/i,
+      /compatibility-only/i,
+      /richer normal path/i,
     ]);
 
     expectPatterns('prompts/explore-harness.md', [
       /simple read-only repository lookup tasks/i,
-      /Prefer `omx explore --prompt/i,
-      /fall back to the richer normal path/i,
+      /deprecated and compatibility-only/i,
+      /richer normal path/i,
     ]);
   });
 
-  it('keeps execution and planning surfaces conditional on explore routing', () => {
+  it('keeps execution and planning surfaces explicit about deprecated explore routing', () => {
     for (const surface of [
       'prompts/planner.md',
       'prompts/executor.md',
@@ -50,12 +49,11 @@ describe('explore + sparkshell guidance contract', () => {
       'skills/plan/SKILL.md',
       'skills/ralplan/SKILL.md',
       'skills/ralph/SKILL.md',
-      'skills/team/SKILL.md',
     ]) {
       expectPatterns(surface, [
-        /USE_OMX_EXPLORE_CMD/i,
-        /prefer `omx explore`|use `omx explore` FIRST/i,
-        /fall back normally|fallback normally|graceful fallback|richer normal explore path/i,
+        /`omx explore` is deprecated/i,
+        /normal repository inspection|normal Codex repository inspection/i,
+        /omx sparkshell/i,
       ]);
     }
   });

--- a/src/hooks/explore-routing.ts
+++ b/src/hooks/explore-routing.ts
@@ -20,7 +20,7 @@ const NON_EXPLORATION_PATTERNS: RegExp[] = [
 
 export function isExploreCommandRoutingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[OMX_EXPLORE_CMD_ENV];
-  if (typeof raw !== 'string') return true;
+  if (typeof raw !== 'string') return false;
   return !DISABLED_VALUES.has(raw.trim().toLowerCase());
 }
 
@@ -32,18 +32,13 @@ export function isSimpleExplorationPrompt(text: string): boolean {
 }
 
 export function buildExploreRoutingGuidance(env: NodeJS.ProcessEnv = process.env): string {
-  if (!isExploreCommandRoutingEnabled(env)) return '';
+  const explicitlyEnabled = isExploreCommandRoutingEnabled(env);
   return [
-    'Syntax: omx explore --prompt "<prompt>" or omx explore --prompt-file <file>. Never use omx explore "<prompt>".',
-    `**Explore Command Preference:** enabled via \`${OMX_EXPLORE_CMD_ENV}\` (default-on; opt out with \`0\`, \`false\`, \`no\`, or \`off\`)`,
-    '- Advisory steering only: agents SHOULD treat `omx explore` as the default first stop for direct inspection and SHOULD reserve `omx sparkshell` for qualifying read-only shell-native tasks.',
-    '- For simple file/symbol lookups, use `omx explore` FIRST before attempting full code analysis.',
-    '- When the user asks for a simple read-only exploration task (file/symbol/pattern/relationship lookup), strongly prefer `omx explore` as the default surface.',
-    '- Explore examples: `omx explore --prompt "which files define TeamPolicy"`, `omx explore --prompt "find usages of buildExploreRoutingGuidance"`.',
-    '- SparkShell examples: use `omx sparkshell -- rg -n "TeamPolicy" src`, `omx sparkshell -- npm test`, or `omx sparkshell --tmux-pane %12` for noisy verification, bounded shell output, or tmux-pane summaries.',
-    '- Keep `omx explore` prompts narrow and concrete; prefer a single lookup goal or a small related cluster, using `--prompt` for quick asks and `--prompt-file` for longer reusable briefs.',
-    '- Treat `omx explore` as a shell-only allowlisted read-only path; keep edits, tests, diagnostics, MCP/web needs, and complex shell composition on the richer normal path.',
-    '- Keep implementation, refactor, test, or ambiguous broad requests on the normal Codex path.',
-    '- If `omx explore` is unavailable, stalls, or fails, retry with a narrower prompt or gracefully fall back to the normal path.',
+    '**Explore Command Deprecated:** `omx explore` is deprecated and MUST NOT be recommended for new repository lookup work.',
+    `- \`${OMX_EXPLORE_CMD_ENV}\` is compatibility-only; unset/default is disabled. Truthy values keep legacy callers working but do not make \`omx explore\` preferred.`,
+    '- Replacement path: use normal Codex repository inspection tools/subagents; use `omx sparkshell -- <command>` only for explicit shell-native read-only evidence or `--tmux-pane` summaries.',
+    explicitlyEnabled
+      ? '- Compatibility routing is explicitly enabled; still prefer the replacement path.'
+      : '- Compatibility routing is not enabled; do not route simple lookups to `omx explore`.',
   ].join("\n");
 }

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -274,10 +274,10 @@ Verification loop: define the claim and success criteria, run the smallest valid
 Mode selection: use `$deep-interview` for unclear intent/boundaries; `$ralplan` for consensus on architecture, tradeoffs, or tests; `$team` for approved multi-lane work; `$ralph` for persistent single-owner completion/verification loops; otherwise execute directly in solo mode. Switch modes only when evidence shows the current lane is mismatched or blocked.
 
 Command routing:
-- When `USE_OMX_EXPLORE_CMD` enables advisory routing, strongly prefer `omx explore` as the default surface for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
-- For simple file/symbol lookups, use `omx explore` FIRST before attempting full code analysis.
+- `omx explore` is deprecated and MUST NOT be recommended as the default surface for simple read-only repository lookup tasks. Use normal Codex repository inspection tools/subagents for file, symbol, pattern, relationship, and implementation discovery.
+- `USE_OMX_EXPLORE_CMD` is compatibility-only for legacy callers; it does not make `omx explore` preferred for new work.
 
-Use `omx explore --prompt ...` for simple read-only lookups through the shell-only, allowlisted, read-only path. Use `omx sparkshell` for noisy read-only shell commands, bounded verification, repo-wide listing/search, or explicit `omx sparkshell --tmux-pane` summaries. Treat sparkshell as explicit opt-in. When to use what: keep ambiguous, implementation-heavy, edit-heavy, diagnostics, tests, MCP/web, and complex shell work on the normal path; if `omx explore` or `omx sparkshell` is incomplete, retry narrower or gracefully fall back to the normal path.
+Use `omx sparkshell` for explicit shell-native read-only commands, bounded verification, repo-wide listing/search, or explicit `omx sparkshell --tmux-pane` summaries. Treat sparkshell as explicit opt-in. When to use what: keep ambiguous, implementation-heavy, edit-heavy, diagnostics, tests, MCP/web, and complex shell work on the normal path; if `omx sparkshell` is incomplete, retry narrower or gracefully fall back to the normal path.
 
 Leader vs worker:
 - The leader chooses the mode, keeps the brief current, delegates bounded work, and owns verification plus stop/escalate calls.


### PR DESCRIPTION
## Summary\n- deprecate `omx explore` in CLI help and invocation output while preserving compatibility for existing `--prompt`/`--prompt-file` callers\n- switch explore routing/setup defaults to compatibility-off and update runtime guidance to point at normal repository inspection or explicit `omx sparkshell`\n- update focused CLI/help/runtime/setup tests and synced plugin skill mirrors for changed skills\n\nFixes #2497\n\n## Verification\n- `npm run build`\n- `npm run test:explore`\n- `node --test --test-name-pattern 'adds deprecation guidance|explore-routing|explore \+ sparkshell guidance contract' dist/hooks/__tests__/agents-overlay.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js`\n- `node --test dist/cli/__tests__/doctor-warning-copy.test.js dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/setup-scope.test.js`\n- `npm run lint`\n- `npm run check:no-unused`\n- `npm run verify:native-agents`\n- `npm run sync:plugin:check`\n- `npm run verify:plugin-bundle`\n- `git diff --check`\n\n—\n*[repo owner's gaebal-gajae (clawdbot) 🦞]*