### PR TITLE
Fix ultragoal Stop recovery loop for completed aggregate goals

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2383,6 +2383,38 @@ standardMaxRounds = 15
     }
   });
 
+  it("does not repeat ultragoal Stop recovery after a safe completed-aggregate microgoal blocker is recorded", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-aggregate-blocked-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
+        version: 1,
+        codexGoalMode: "aggregate",
+        activeGoalId: "G001-demo",
+        goals: [{
+          id: "G001-demo",
+          status: "in_progress",
+          objective: "Demo goal",
+          failureReason: "aggregate Codex goal already complete and unreconcilable while repo-native .omx/ultragoal/goals.json still has an in-progress microgoal; stop the recovery loop",
+        }],
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-ultragoal-aggregate-blocked-stop",
+        thread_id: "thread-ultragoal-aggregate-blocked-stop",
+        stop_hook_active: true,
+        last_assistant_message: "Goal complete.",
+      }, { cwd });
+
+      assert.notEqual(result.outputJson?.decision, "block");
+      assert.notEqual(result.outputJson?.stopReason, "ultragoal_codex_goal_snapshot_required");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /omx ultragoal checkpoint --goal-id G001-demo --status complete/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
 
   it("does not block ultragoal Stop after task-scoped reconciliation finishes exploded bookkeeping", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-reconciled-stop-"));

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2099,6 +2099,18 @@ function reportsBlockedPerformanceGoalObjectiveMismatch(state: unknown): boolean
   return /objective mismatch/i.test(evidence);
 }
 
+function reportsBlockedUltragoalCompletedAggregateMicrogoalLoop(goal: Record<string, unknown>): boolean {
+  const evidence = [
+    safeString(goal.failureReason),
+    safeString(goal.blockedReason),
+    safeString(goal.evidence),
+  ].join(" ");
+  return /aggregate codex goal/i.test(evidence)
+    && /\bcomplete(?:d)?\b/i.test(evidence)
+    && /microgoal/i.test(evidence)
+    && /\b(?:unreconcilable|mismatch|loop|already complete|already completed|blocks?)\b/i.test(evidence);
+}
+
 async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Promise<{ workflow: string; command: string; remediation?: string } | null> {
   const ultragoal = await readJsonIfExists(join(cwd, ".omx", "ultragoal", "goals.json"));
   const aggregateCompletion = safeObject(ultragoal?.aggregateCompletion);
@@ -2107,6 +2119,9 @@ async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Pro
   const activeUltragoal = aggregateProductComplete
     ? undefined
     : ultragoals.find((goal) => safeString(goal.status) === "in_progress" || safeString(goal.id) === safeString(ultragoal?.activeGoalId));
+  if (activeUltragoal && reportsBlockedUltragoalCompletedAggregateMicrogoalLoop(activeUltragoal)) {
+    return null;
+  }
   if (activeUltragoal) {
     const goalId = safeString(activeUltragoal.id) || "<goal-id>";
     return {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -1347,6 +1347,36 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('records a safe blocker when the aggregate Codex goal is already complete while a microgoal remains in progress', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        codexGoalMode: 'aggregate',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+          { title: 'Second', objective: 'Complete second milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      const evidence = 'aggregate Codex goal already complete and unreconcilable while repo-native .omx/ultragoal/goals.json still has an in-progress microgoal; stop the recovery loop';
+      const plan = await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'blocked',
+        evidence,
+        codexGoal: { goal: { objective: ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE, status: 'complete' } },
+      });
+
+      assert.equal(plan.goals[0]?.status, 'in_progress');
+      assert.equal(plan.activeGoalId, first.goal!.id);
+      assert.match(plan.goals[0]?.failureReason ?? '', /aggregate Codex goal already complete/);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"goal_blocked"/);
+      assert.match(ledger, /safe-recovery blocker/);
+      assert.match(ledger, /impossible checkpoint loop/);
+    });
+  });
+
   it('rejects blocked checkpoints for active or same-objective Codex goals', async () => {
     await withTempRepo(async (cwd) => {
       await createUltragoalPlan(cwd, {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -489,6 +489,29 @@ function buildUnavailableCodexGoalRemediation(goal: UltragoalItem): string {
   ].join(' ');
 }
 
+function evidenceDescribesCompletedAggregateMicrogoalLoop(evidence: string | undefined): boolean {
+  const normalized = normalizeObjective(evidence ?? '').toLowerCase();
+  return normalized.includes('aggregate codex goal')
+    && /\bcomplete(?:d)?\b/.test(normalized)
+    && normalized.includes('microgoal')
+    && /\b(?:unreconcilable|mismatch|loop|already complete|already completed|blocks?)\b/.test(normalized);
+}
+
+function isSafeCompletedAggregateBlockerSnapshot(
+  plan: UltragoalPlan,
+  goal: UltragoalItem,
+  snapshot: ReturnType<typeof parseCodexGoalSnapshot>,
+  evidence: string | undefined,
+): boolean {
+  if (codexGoalMode(plan) !== 'aggregate') return false;
+  if (goal.status !== 'in_progress' || plan.activeGoalId !== goal.id) return false;
+  if (snapshot?.status !== 'complete' || !snapshot.objective) return false;
+  if (!evidenceDescribesCompletedAggregateMicrogoalLoop(evidence)) return false;
+  const actual = normalizeObjective(snapshot.objective);
+  return [expectedCodexObjective(plan, goal), ...compatibleCodexObjectives(plan)]
+    .some((objective) => normalizeObjective(objective) === actual);
+}
+
 function codexGoalMode(plan: UltragoalPlan): UltragoalCodexGoalMode {
   return plan.codexGoalMode ?? 'per_story';
 }
@@ -1240,10 +1263,14 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     if (!snapshot.objective) {
       throw new UltragoalError('Blocked ultragoal checkpoint Codex snapshot is missing objective text.');
     }
-    if (normalizeObjective(snapshot.objective) === normalizeObjective(expectedCodexObjective(plan, goal))) {
-      throw new UltragoalError('Blocked ultragoal checkpoint is only for a different completed legacy Codex goal; complete this ultragoal with --status complete after its audit passes.');
+    const safeCompletedAggregateBlocker = isSafeCompletedAggregateBlockerSnapshot(plan, goal, snapshot, options.evidence);
+    const blockedSnapshotMatchesExpected = [expectedCodexObjective(plan, goal), ...compatibleCodexObjectives(plan)]
+      .some((objective) => normalizeObjective(objective) === normalizeObjective(snapshot.objective ?? ''));
+    if (!safeCompletedAggregateBlocker && blockedSnapshotMatchesExpected) {
+      throw new UltragoalError('Blocked ultragoal checkpoint is only for a different completed legacy Codex goal unless an aggregate Codex goal is already complete and unreconcilable while the active repo-native microgoal remains in progress.');
     }
     goal.updatedAt = now;
+    if (safeCompletedAggregateBlocker) goal.failureReason = assertNonEmpty(options.evidence, '--evidence');
     plan.activeGoalId = goal.id;
     plan.updatedAt = now;
     await writePlan(cwd, plan);
@@ -1254,6 +1281,9 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       status: goal.status,
       evidence: options.evidence,
       codexGoal: options.codexGoal,
+      message: safeCompletedAggregateBlocker
+        ? 'Completed aggregate Codex goal is already terminal while the repo-native microgoal remains in progress; recorded a non-terminal safe-recovery blocker to avoid repeating an impossible checkpoint loop.'
+        : undefined,
     });
     return plan;
   }


### PR DESCRIPTION
## Summary
- allow a narrowly-scoped non-terminal blocked checkpoint when a completed aggregate Codex goal is unreconcilable with an in-progress repo-native microgoal
- keep same-objective blocked checkpoint rejection for normal/per-story cases
- stop native Stop reconciliation from repeating the impossible complete checkpoint after that safe blocker is recorded

Fixes #2505

## Tests
- npm run build
- node --test dist/ultragoal/__tests__/artifacts.test.js
- node --test --test-name-pattern "ultragoal Stop|goal completion|goal snapshot|performance-goal reconciliation" dist/scripts/__tests__/codex-native-hook.test.js

## Notes
- A full codex-native-hook test run was not used as final evidence because unrelated deep-interview config override tests failed in this worktree; the focused Stop/goal reconciliation slice passed.