### PR TITLE
Allow Autopilot deep-interview to wait on omx question

### DIFF
--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -235,7 +235,11 @@ export async function questionCommand(args: string[]): Promise<void> {
 
   const input = normalizeQuestionInput(rawInput);
   const cwd = process.cwd();
-  const policy = await evaluateQuestionPolicy({ cwd, explicitSessionId: input.session_id });
+  const policy = await evaluateQuestionPolicy({
+    cwd,
+    explicitSessionId: input.session_id,
+    questionSource: input.source,
+  });
   if (!policy.allowed) {
     printJson({
       ok: false,

--- a/src/question/__tests__/deep-interview.test.ts
+++ b/src/question/__tests__/deep-interview.test.ts
@@ -2,18 +2,25 @@ import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, it } from 'node:test';
+import { after, describe, it } from 'node:test';
 import { OmxQuestionError, type OmxQuestionProcessRunner } from '../client.js';
+import { readAutopilotDeepInterviewQuestionWaitState } from '../autopilot-wait.js';
 import {
   reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords,
   runDeepInterviewQuestion,
 } from '../deep-interview.js';
 
 const tempDirs: string[] = [];
+const originalOmxRoot = process.env.OMX_ROOT;
+const originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+const originalOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
 
 async function makeRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-question-'));
   tempDirs.push(cwd);
+  process.env.OMX_ROOT = cwd;
+  delete process.env.OMX_STATE_ROOT;
+  delete process.env.OMX_TEAM_STATE_ROOT;
   await mkdir(join(cwd, '.omx', 'state', 'sessions', 'sess-di'), { recursive: true });
   await writeFile(
     join(cwd, '.omx', 'state', 'session.json'),
@@ -33,12 +40,18 @@ async function makeRepo(): Promise<string> {
   return cwd;
 }
 
-afterEach(async () => {
+after(async () => {
+  if (originalOmxRoot === undefined) delete process.env.OMX_ROOT;
+  else process.env.OMX_ROOT = originalOmxRoot;
+  if (originalOmxStateRoot === undefined) delete process.env.OMX_STATE_ROOT;
+  else process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+  if (originalOmxTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+  else process.env.OMX_TEAM_STATE_ROOT = originalOmxTeamStateRoot;
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
-describe('runDeepInterviewQuestion', () => {
-  it('tracks a pending obligation before omx question returns and satisfies it afterward', async () => {
+describe('runDeepInterviewQuestion', { concurrency: false }, () => {
+  it('tracks a pending obligation before omx question returns and satisfies it afterward', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const statePath = join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'deep-interview-state.json');
     let inFlightQuestionStatus = '';
@@ -82,6 +95,7 @@ describe('runDeepInterviewQuestion', () => {
 
     const result = await runDeepInterviewQuestion(
       {
+        session_id: 'sess-di',
         question: 'What should happen next?',
         options: [{ label: 'Launch', value: 'launch' }],
         allow_other: false,
@@ -116,13 +130,14 @@ describe('runDeepInterviewQuestion', () => {
     assert.equal(finalState.run_outcome, undefined);
   });
 
-  it('clears the pending obligation when omx question fails after being attempted', async () => {
+  it('clears the pending obligation when omx question fails after being attempted', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const statePath = join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'deep-interview-state.json');
 
     await assert.rejects(
       runDeepInterviewQuestion(
         {
+          session_id: 'sess-di',
           question: 'What should happen next?',
           options: [{ label: 'Launch', value: 'launch' }],
           allow_other: false,
@@ -168,13 +183,14 @@ describe('runDeepInterviewQuestion', () => {
     assert.equal(finalState.run_outcome, undefined);
   });
 
-  it('clears the pending obligation when question renderer launch fails', async () => {
+  it('clears the pending obligation when question renderer launch fails', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const statePath = join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'deep-interview-state.json');
 
     await assert.rejects(
       runDeepInterviewQuestion(
         {
+          session_id: 'sess-di',
           question: 'What should happen next?',
           options: [{ label: 'Launch', value: 'launch' }],
           allow_other: false,
@@ -220,7 +236,7 @@ describe('runDeepInterviewQuestion', () => {
     assert.equal(finalState.run_outcome, undefined);
   });
 
-  it('reconciles a pending obligation from an already-answered same-session question record', async () => {
+  it('reconciles a pending obligation from an already-answered same-session question record', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const statePath = join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'deep-interview-state.json');
     const questionsDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'questions');
@@ -297,5 +313,75 @@ describe('runDeepInterviewQuestion', () => {
     assert.equal(finalState.question_enforcement?.satisfied_at, '2026-04-19T00:00:21.000Z');
     assert.equal(finalState.lifecycle_outcome, undefined);
     assert.equal(finalState.run_outcome, undefined);
+  });
+});
+
+describe('runDeepInterviewQuestion autopilot wait bridge', { concurrency: false }, () => {
+  it('persists readable autopilot waiting-for-user state while omx question is in flight and restores it after answer', { concurrency: false }, async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di');
+    const autopilotPath = join(sessionDir, 'autopilot-state.json');
+    await writeFile(autopilotPath, JSON.stringify({
+      active: true,
+      mode: 'autopilot',
+      current_phase: 'deep-interview',
+      started_at: '2026-04-19T00:00:00.000Z',
+      updated_at: '2026-04-19T00:00:00.000Z',
+      session_id: 'sess-di',
+      state: { deep_interview_gate: { status: 'required' } },
+    }, null, 2));
+
+    let observedWait = false;
+    const runner: OmxQuestionProcessRunner = async () => {
+      const waitState = await readAutopilotDeepInterviewQuestionWaitState(cwd, 'sess-di');
+      assert.ok(waitState);
+      assert.equal(waitState.previousPhase, 'deep-interview');
+      const autopilotState = JSON.parse(await readFile(autopilotPath, 'utf-8')) as {
+        active?: boolean;
+        current_phase?: string;
+        run_outcome?: string;
+        lifecycle_outcome?: string;
+        state?: { deep_interview_question?: { status?: string; obligation_id?: string } };
+      };
+      assert.equal(autopilotState.active, true);
+      assert.equal(autopilotState.current_phase, 'waiting-for-user');
+      assert.equal(autopilotState.run_outcome, 'blocked_on_user');
+      assert.equal(autopilotState.lifecycle_outcome, 'askuserQuestion');
+      assert.equal(autopilotState.state?.deep_interview_question?.status, 'waiting_for_user');
+      assert.ok(autopilotState.state?.deep_interview_question?.obligation_id);
+      observedWait = true;
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          ok: true,
+          question_id: 'question-autopilot-1',
+          session_id: 'sess-di',
+          questions: [{ id: 'q-1', question: 'Clarify?', options: [], allow_other: true, other_label: 'Other', type: 'single-answerable', multi_select: false, source: 'deep-interview' }],
+          answers: [{ question_id: 'q-1', index: 0, answer: { kind: 'freeform', value: 'answer' } }],
+          answer: { kind: 'freeform', value: 'answer' },
+        }),
+        stderr: '',
+      };
+    };
+
+    await runDeepInterviewQuestion(
+      { session_id: 'sess-di', question: 'Clarify?', allow_other: true },
+      { cwd, argv1: '/repo/dist/cli/omx.js', runner },
+    );
+
+    assert.equal(observedWait, true);
+    assert.equal(await readAutopilotDeepInterviewQuestionWaitState(cwd, 'sess-di'), null);
+    const finalAutopilot = JSON.parse(await readFile(autopilotPath, 'utf-8')) as {
+      active?: boolean;
+      current_phase?: string;
+      run_outcome?: string;
+      lifecycle_outcome?: string;
+      state?: { deep_interview_question?: { status?: string } };
+    };
+    assert.equal(finalAutopilot.active, true);
+    assert.equal(finalAutopilot.current_phase, 'deep-interview');
+    assert.equal(finalAutopilot.run_outcome, undefined);
+    assert.equal(finalAutopilot.lifecycle_outcome, undefined);
+    assert.equal(finalAutopilot.state?.deep_interview_question?.status, 'satisfied');
   });
 });

--- a/src/question/__tests__/policy.test.ts
+++ b/src/question/__tests__/policy.test.ts
@@ -2,31 +2,43 @@ import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, it } from 'node:test';
+import { after, describe, it } from 'node:test';
 import { evaluateQuestionPolicy } from '../policy.js';
 
 const tempDirs: string[] = [];
+const originalOmxRoot = process.env.OMX_ROOT;
+const originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+const originalOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
 
 async function makeRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-question-policy-'));
   tempDirs.push(cwd);
+  process.env.OMX_ROOT = cwd;
+  delete process.env.OMX_STATE_ROOT;
+  delete process.env.OMX_TEAM_STATE_ROOT;
   await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
   return cwd;
 }
 
-afterEach(async () => {
+after(async () => {
+  if (originalOmxRoot === undefined) delete process.env.OMX_ROOT;
+  else process.env.OMX_ROOT = originalOmxRoot;
+  if (originalOmxStateRoot === undefined) delete process.env.OMX_STATE_ROOT;
+  else process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+  if (originalOmxTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+  else process.env.OMX_TEAM_STATE_ROOT = originalOmxTeamStateRoot;
   await Promise.all(tempDirs.splice(0).map((dir) => import('node:fs/promises').then(({ rm }) => rm(dir, { recursive: true, force: true }))));
 });
 
-describe('evaluateQuestionPolicy', () => {
-  it('allows non-team leader sessions with no blocked modes', async () => {
+describe('evaluateQuestionPolicy', { concurrency: false }, () => {
+  it('allows non-team leader sessions with no blocked modes', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess-1' }));
     const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-1', env: { ...process.env, OMX_TEAM_WORKER: '' } });
     assert.equal(result.allowed, true);
   });
 
-  it('blocks worker contexts immediately', async () => {
+  it('blocks worker contexts immediately', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-1', env: { ...process.env, OMX_TEAM_WORKER: 'demo/worker-1' } });
     assert.equal(result.allowed, false);
@@ -34,7 +46,7 @@ describe('evaluateQuestionPolicy', () => {
     assert.equal(result.fallbackAllowed, false);
   });
 
-  it('blocks canonical active team ownership for the current session', async () => {
+  it('blocks canonical active team ownership for the current session', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const teamRoot = join(cwd, '.omx', 'state', 'team', 'alpha');
     await mkdir(teamRoot, { recursive: true });
@@ -58,24 +70,26 @@ describe('evaluateQuestionPolicy', () => {
       resize_hook_target: null,
     }));
     await writeFile(join(teamRoot, 'phase.json'), JSON.stringify({ current_phase: 'team-exec', max_fix_attempts: 3, current_fix_attempt: 0, transitions: [], updated_at: new Date().toISOString() }));
+    await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess-team' }));
     const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-team', env: { ...process.env, OMX_TEAM_WORKER: '' } });
     assert.equal(result.allowed, false);
     assert.equal(result.code, 'team_blocked');
     assert.equal(result.fallbackAllowed, false);
   });
 
-  it('blocks active execution-like workflows for the current session', async () => {
+  it('blocks active execution-like workflows for the current session', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-ralph');
     await mkdir(sessionDir, { recursive: true });
     await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({ mode: 'ralph', active: true }));
+    await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess-ralph' }));
     const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-ralph', env: { ...process.env, OMX_TEAM_WORKER: '' } });
     assert.equal(result.allowed, false);
     assert.equal(result.code, 'active_execution_mode_blocked');
     assert.equal(result.fallbackAllowed, false);
   });
 
-  it('does not falsely block from another session team state', async () => {
+  it('does not falsely block from another session team state', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const teamRoot = join(cwd, '.omx', 'state', 'team', 'beta');
     await mkdir(teamRoot, { recursive: true });
@@ -103,7 +117,7 @@ describe('evaluateQuestionPolicy', () => {
     assert.equal(result.allowed, true);
   });
 
-  it('allows deep-interview state when no execution-like workflow is active', async () => {
+  it('allows deep-interview state when no execution-like workflow is active', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di');
     await mkdir(sessionDir, { recursive: true });
@@ -111,5 +125,63 @@ describe('evaluateQuestionPolicy', () => {
     const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-di', env: { ...process.env, OMX_TEAM_WORKER: '' } });
     assert.equal(result.allowed, true);
     assert.equal(result.fallbackAllowed, true);
+  });
+});
+
+describe('evaluateQuestionPolicy autopilot deep-interview wait', { concurrency: false }, () => {
+  it('allows only controlled autopilot deep-interview questions while preserving unrelated guards', { concurrency: false }, async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-auto');
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+      mode: 'autopilot',
+      active: true,
+      current_phase: 'waiting-for-user',
+      run_outcome: 'blocked_on_user',
+      lifecycle_outcome: 'askuserQuestion',
+      state: {
+        deep_interview_question: {
+          status: 'waiting_for_user',
+          source: 'omx-question',
+          obligation_id: 'obligation-1',
+          previous_phase: 'deep-interview',
+        },
+      },
+    }, null, 2));
+    await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+      active: true,
+      skill: 'autopilot',
+      phase: 'deep-interview',
+      active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: 'sess-auto' }],
+      session_id: 'sess-auto',
+    }, null, 2));
+
+    await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess-auto' }));
+    const allowed = await evaluateQuestionPolicy({
+      cwd,
+      explicitSessionId: 'sess-auto',
+      questionSource: 'deep-interview',
+      env: { ...process.env, OMX_TEAM_WORKER: '' },
+    });
+    assert.equal(allowed.allowed, true);
+
+    const unrelatedSource = await evaluateQuestionPolicy({
+      cwd,
+      explicitSessionId: 'sess-auto',
+      questionSource: 'implementation',
+      env: { ...process.env, OMX_TEAM_WORKER: '' },
+    });
+    assert.equal(unrelatedSource.allowed, false);
+    assert.equal(unrelatedSource.code, 'active_execution_mode_blocked');
+
+    await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({ mode: 'ralph', active: true }));
+    const unrelatedMode = await evaluateQuestionPolicy({
+      cwd,
+      explicitSessionId: 'sess-auto',
+      questionSource: 'deep-interview',
+      env: { ...process.env, OMX_TEAM_WORKER: '' },
+    });
+    assert.equal(unrelatedMode.allowed, false);
+    assert.equal(unrelatedMode.code, 'active_execution_mode_blocked');
   });
 });

--- a/src/question/autopilot-wait.ts
+++ b/src/question/autopilot-wait.ts
@@ -1,0 +1,156 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { getStateFilePath } from '../mcp/state-paths.js';
+import type { DeepInterviewQuestionEnforcementState } from './deep-interview.js';
+
+const AUTOPILOT_STATE_FILE = 'autopilot-state.json';
+
+export interface AutopilotDeepInterviewQuestionWaitState {
+  obligationId: string;
+  previousPhase: string;
+  requestedAt?: string;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function safeObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : {};
+}
+
+function normalizePhase(value: unknown): string {
+  return safeString(value).toLowerCase().replace(/_/g, '-');
+}
+
+async function readAutopilotState(cwd: string, sessionId?: string): Promise<Record<string, unknown> | null> {
+  const statePath = getStateFilePath(AUTOPILOT_STATE_FILE, cwd, sessionId);
+  try {
+    return JSON.parse(await readFile(statePath, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+async function writeAutopilotState(cwd: string, sessionId: string | undefined, state: Record<string, unknown>): Promise<void> {
+  const statePath = getStateFilePath(AUTOPILOT_STATE_FILE, cwd, sessionId);
+  await mkdir(dirname(statePath), { recursive: true });
+  await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+export async function readAutopilotDeepInterviewQuestionWaitState(
+  cwd: string,
+  sessionId?: string,
+): Promise<AutopilotDeepInterviewQuestionWaitState | null> {
+  const state = await readAutopilotState(cwd, sessionId);
+  if (!state || safeString(state.mode) !== 'autopilot') return null;
+
+  const nestedState = safeObject(state.state);
+  const wait = safeObject(nestedState.deep_interview_question);
+  const obligationId = safeString(wait.obligation_id);
+  if (!obligationId) return null;
+  if (safeString(wait.status) !== 'waiting_for_user') return null;
+  if (safeString(wait.source) !== 'omx-question') return null;
+
+  const phase = normalizePhase(state.current_phase);
+  const runOutcome = safeString(state.run_outcome);
+  const lifecycleOutcome = safeString(state.lifecycle_outcome);
+  if (phase !== 'waiting-for-user') return null;
+  if (runOutcome && runOutcome !== 'blocked_on_user') return null;
+  if (lifecycleOutcome && lifecycleOutcome !== 'askuserQuestion') return null;
+
+  return {
+    obligationId,
+    previousPhase: safeString(wait.previous_phase) || 'deep-interview',
+    requestedAt: safeString(wait.requested_at) || undefined,
+  };
+}
+
+export async function markAutopilotDeepInterviewQuestionWaiting(
+  cwd: string,
+  sessionId: string | undefined,
+  obligation: DeepInterviewQuestionEnforcementState,
+): Promise<boolean> {
+  if (!safeString(sessionId)) return false;
+  const state = await readAutopilotState(cwd, sessionId);
+  if (!state || safeString(state.mode) !== 'autopilot' || state.active !== true) return false;
+
+  const currentPhase = safeString(state.current_phase) || 'deep-interview';
+  if (normalizePhase(currentPhase) !== 'deep-interview') return false;
+
+  const nestedState = safeObject(state.state);
+  const wait = {
+    status: 'waiting_for_user',
+    source: 'omx-question',
+    obligation_id: obligation.obligation_id,
+    previous_phase: currentPhase,
+    previous_run_outcome: state.run_outcome ?? null,
+    previous_lifecycle_outcome: state.lifecycle_outcome ?? null,
+    requested_at: obligation.requested_at,
+    updated_at: new Date().toISOString(),
+  };
+
+  const nextState = {
+    ...state,
+    active: true,
+    current_phase: 'waiting-for-user',
+    run_outcome: 'blocked_on_user',
+    lifecycle_outcome: 'askuserQuestion',
+    updated_at: new Date().toISOString(),
+    state: {
+      ...nestedState,
+      deep_interview_question: wait,
+    },
+  };
+
+  await writeAutopilotState(cwd, sessionId, nextState);
+  return true;
+}
+
+export async function resolveAutopilotDeepInterviewQuestionWaiting(
+  cwd: string,
+  sessionId: string | undefined,
+  obligationId: string,
+  status: 'satisfied' | 'cleared',
+): Promise<boolean> {
+  if (!safeString(sessionId) || !safeString(obligationId)) return false;
+  const state = await readAutopilotState(cwd, sessionId);
+  if (!state || safeString(state.mode) !== 'autopilot') return false;
+
+  const nestedState = safeObject(state.state);
+  const wait = safeObject(nestedState.deep_interview_question);
+  if (safeString(wait.obligation_id) !== obligationId) return false;
+  if (safeString(wait.status) !== 'waiting_for_user') return false;
+
+  const previousRunOutcome = wait.previous_run_outcome;
+  const previousLifecycleOutcome = wait.previous_lifecycle_outcome;
+  const nextState: Record<string, unknown> = {
+    ...state,
+    active: true,
+    current_phase: safeString(wait.previous_phase) || 'deep-interview',
+    updated_at: new Date().toISOString(),
+    state: {
+      ...nestedState,
+      deep_interview_question: {
+        ...wait,
+        status,
+        resolved_at: new Date().toISOString(),
+      },
+    },
+  };
+
+  if (typeof previousRunOutcome === 'string' && previousRunOutcome.trim()) {
+    nextState.run_outcome = previousRunOutcome;
+  } else {
+    delete nextState.run_outcome;
+  }
+
+  if (typeof previousLifecycleOutcome === 'string' && previousLifecycleOutcome.trim()) {
+    nextState.lifecycle_outcome = previousLifecycleOutcome;
+  } else {
+    delete nextState.lifecycle_outcome;
+  }
+
+  await writeAutopilotState(cwd, sessionId, nextState);
+  return true;
+}

--- a/src/question/deep-interview.ts
+++ b/src/question/deep-interview.ts
@@ -14,6 +14,10 @@ import {
 import type { TerminalLifecycleOutcome } from '../runtime/terminal-lifecycle.js';
 import type { QuestionInput, QuestionRecord } from './types.js';
 import type { DownstreamAuthority } from '../state/workflow-transition.js';
+import {
+  markAutopilotDeepInterviewQuestionWaiting,
+  resolveAutopilotDeepInterviewQuestionWaiting,
+} from './autopilot-wait.js';
 
 const DEEP_INTERVIEW_STATE_FILE = 'deep-interview-state.json';
 
@@ -275,6 +279,7 @@ export async function runDeepInterviewQuestion(
     sessionId,
     () => obligation,
   );
+  await markAutopilotDeepInterviewQuestionWaiting(cwd, sessionId, obligation);
 
   try {
     const result = await runOmxQuestion(
@@ -295,6 +300,12 @@ export async function runDeepInterviewQuestion(
           : current
       ),
     );
+    await resolveAutopilotDeepInterviewQuestionWaiting(
+      cwd,
+      sessionId,
+      obligation.obligation_id,
+      'satisfied',
+    );
 
     return result;
   } catch (error) {
@@ -306,6 +317,12 @@ export async function runDeepInterviewQuestion(
           ? clearDeepInterviewQuestionObligation(current, 'error')
           : current
       ),
+    );
+    await resolveAutopilotDeepInterviewQuestionWaiting(
+      cwd,
+      sessionId,
+      obligation.obligation_id,
+      'cleared',
     );
     throw error;
   }

--- a/src/question/policy.ts
+++ b/src/question/policy.ts
@@ -2,6 +2,7 @@ import { listNotifyCanonicalActiveTeams, type NotifyCanonicalActiveTeam } from '
 import { readCurrentSessionId } from '../mcp/state-paths.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import { readActiveWorkflowModes } from '../state/workflow-transition.js';
+import { readAutopilotDeepInterviewQuestionWaitState } from './autopilot-wait.js';
 
 const BLOCKED_EXECUTION_SKILLS = new Set([
   'autopilot',
@@ -27,6 +28,7 @@ export interface EvaluateQuestionPolicyOptions {
   cwd: string;
   explicitSessionId?: string;
   env?: NodeJS.ProcessEnv;
+  questionSource?: string;
 }
 
 function safeString(value: unknown): string {
@@ -35,6 +37,10 @@ function safeString(value: unknown): string {
 
 function hasWorkerContext(env: NodeJS.ProcessEnv): boolean {
   return safeString(env.OMX_TEAM_WORKER).trim() !== '';
+}
+
+function onlyControlledAutopilotQuestionBlock(blocked: string[]): boolean {
+  return blocked.length > 0 && blocked.every((entry) => entry === 'autopilot');
 }
 
 export async function evaluateQuestionPolicy(
@@ -83,6 +89,22 @@ export async function evaluateQuestionPolicy(
   const blocked = [...new Set([...blockedModes, ...blockedSkills])];
 
   if (blocked.length > 0) {
+    const source = safeString(options.questionSource).trim();
+    const autopilotWait = source === 'deep-interview'
+      && onlyControlledAutopilotQuestionBlock(blocked)
+      ? await readAutopilotDeepInterviewQuestionWaitState(options.cwd, sessionId)
+      : null;
+    if (autopilotWait) {
+      return {
+        allowed: true,
+        fallbackAllowed: true,
+        sessionId,
+        activeModes,
+        activeSkills,
+        activeTeams,
+      };
+    }
+
     return {
       allowed: false,
       sessionId,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -14110,3 +14110,62 @@ describe("codex native hook triage integration", () => {
     }
   });
 });
+
+describe('native Stop autopilot deep-interview wait', () => {
+  it('does not force continued execution while autopilot is waiting on a deep-interview omx question', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-native-hook-autopilot-question-wait-'));
+    try {
+      const sessionId = 'sess-autopilot-wait';
+      const sessionDir = join(cwd, '.omx', 'state', 'sessions', sessionId);
+      await writeJson(join(cwd, '.omx', 'state', 'session.json'), { session_id: sessionId });
+      await writeJson(join(sessionDir, 'autopilot-state.json'), {
+        mode: 'autopilot',
+        active: true,
+        current_phase: 'waiting-for-user',
+        run_outcome: 'blocked_on_user',
+        lifecycle_outcome: 'askuserQuestion',
+        session_id: sessionId,
+        state: {
+          deep_interview_question: {
+            status: 'waiting_for_user',
+            source: 'omx-question',
+            obligation_id: 'obligation-stop-1',
+            previous_phase: 'deep-interview',
+          },
+        },
+      });
+      await writeJson(join(sessionDir, 'deep-interview-state.json'), {
+        mode: 'deep-interview',
+        active: false,
+        current_phase: 'intent-first',
+        lifecycle_outcome: 'askuserQuestion',
+        run_outcome: 'blocked_on_user',
+        session_id: sessionId,
+        question_enforcement: {
+          obligation_id: 'obligation-stop-1',
+          source: 'omx-question',
+          status: 'pending',
+          lifecycle_outcome: 'askuserQuestion',
+          requested_at: '2026-04-19T00:00:00.000Z',
+        },
+      });
+      await writeJson(join(sessionDir, 'skill-active-state.json'), {
+        active: true,
+        skill: 'autopilot',
+        phase: 'deep-interview',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: 'Stop',
+        session_id: sessionId,
+        thread_id: 'thread-autopilot-wait',
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -101,6 +101,7 @@ import {
   isPendingDeepInterviewQuestionEnforcement,
   reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords,
 } from "../question/deep-interview.js";
+import { readAutopilotDeepInterviewQuestionWaitState } from "../question/autopilot-wait.js";
 import {
   buildDocumentRefreshAdvisoryOutput,
   evaluateFinalHandoffDocumentRefresh,
@@ -2055,6 +2056,9 @@ async function buildModeBasedStopOutput(
   if (await readCanonicalTerminalRunStateForStop(cwd, sessionId, mode)) {
     return null;
   }
+  if (mode === "autopilot" && await readAutopilotDeepInterviewQuestionWaitState(cwd, sessionId)) {
+    return null;
+  }
   const state = await readModeStateForActiveDecision(mode, sessionId?.trim() || undefined, cwd);
   if (!state || !shouldContinueRun(state)) return null;
   const phase = formatPhase(state.current_phase);
@@ -2869,6 +2873,9 @@ async function buildDeepInterviewQuestionStopOutput(
   threadId: string,
 ): Promise<{ output: Record<string, unknown>; obligationId: string } | null> {
   await reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords(cwd, sessionId);
+  if (await readAutopilotDeepInterviewQuestionWaitState(cwd, sessionId)) {
+    return null;
+  }
   const modeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId, stateDir);
   if (!modeState) return null;
 


### PR DESCRIPTION
## Summary
- Add a controlled Autopilot deep-interview waiting state while `runDeepInterviewQuestion` launches `omx question`.
- Allow `omx question` only for `source=deep-interview` when the sole active execution blocker is that controlled Autopilot wait state.
- Teach Stop handling to allow the session to pause while Autopilot is waiting on the operator instead of forcing assumed-answer progress.

## Tests
- `npm run build`
- `node --test dist/question/__tests__/deep-interview.test.js --test-concurrency=1`
- `node --test dist/question/__tests__/policy.test.js --test-concurrency=1`
- `node --test --test-name-pattern "native Stop autopilot deep-interview wait" dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`
- `npm run check:no-unused`
