### PR TITLE
Prevent quoted team syntax from blocking native inspection

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4440,6 +4440,30 @@ exit 0
     }
   });
 
+  it("allows read-only inspection commands that mention omx team syntax from Codex App/native outside tmux", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-team-readonly-mention-"));
+    try {
+      const mentionedCommand = ["omx", "team"].join(" ");
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          source: "codex-app",
+          session_id: "sess-team-readonly-mention",
+          tool_name: "Bash",
+          tool_use_id: "tool-team-readonly-mention",
+          tool_input: { command: `rg -n "${mentionedCommand}|multi-agent" ~/.codex/AGENTS.md ~/.codex/skills` },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("preserves direct CLI outside-tmux omx team Bash behavior", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-team-cli-outside-"));
     try {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -1119,7 +1119,7 @@ function commandInvokesOmxTeam(command: string): boolean {
     if ((token === 'omx' || token === 'omx.js') && tokens[index + 1] === 'team') return true;
     if ((token === 'node' || token === 'node.exe') && /(?:^|\/)omx\.js$/.test(tokens[index + 1] || '') && tokens[index + 2] === 'team') return true;
   }
-  return /\bomx\s+team\b/i.test(command) || /\bomx\.js['"]?\s+team\b/i.test(command);
+  return false;
 }
 
 function commandInvokesOmxHud(command: string): boolean {
@@ -1130,7 +1130,7 @@ function commandInvokesOmxHud(command: string): boolean {
     if ((token === 'omx' || token === 'omx.js') && tokens[index + 1] === 'hud') return true;
     if ((token === 'node' || token === 'node.exe') && /(?:^|\/)omx\.js$/.test(tokens[index + 1] || '') && tokens[index + 2] === 'hud') return true;
   }
-  return /\bomx\s+hud\b/i.test(command) || /\bomx\.js['"]?\s+hud\b/i.test(command);
+  return false;
 }
 
 function buildNativeOmxHudPreToolUseEnforcementOutput(


### PR DESCRIPTION
## Summary
- Keep Codex App/native outside-tmux guards for real `omx team` and `omx hud` runtime launches token-based.
- Remove broad whole-command regex fallbacks that also matched quoted search/documentation text.
- Add a regression test for read-only inspections that mention `omx team` syntax.

## Verification
- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js` (352/352 passing)

## Context
This fixes false-positive PreToolUse blocks such as read-only `rg` searches over AGENTS/skills that mention team syntax while preserving the existing native outside-tmux block for actual tmux runtime launches.