### PR TITLE
Preserve unmanaged native agent TOMLs in plugin setup

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -2298,6 +2298,52 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("preserves unmanaged native agent TOMLs with obsolete skill_ref during plugin refresh", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy" });
+
+					const customAgentPath = join(
+						codexHomeDir,
+						"agents",
+						"custom-reviewer.toml",
+					);
+					const generatedAgentPath = join(
+						codexHomeDir,
+						"agents",
+						"ghost.toml",
+					);
+					const customAgentToml = [
+						'name = "custom-reviewer"',
+						'description = "user-managed reviewer"',
+						'skill_ref = "custom-reviewer"',
+						"",
+					].join("\n");
+					await writeFile(customAgentPath, customAgentToml);
+					await writeFile(
+						generatedAgentPath,
+						[
+							"# oh-my-codex agent: ghost",
+							'name = "ghost"',
+							'description = "obsolete generated reviewer"',
+							'skill_ref = "ghost"',
+							"",
+						].join("\n"),
+					);
+
+					await setup({ scope: "user", installMode: "plugin" });
+
+					assert.equal(await readFile(customAgentPath, "utf-8"), customAgentToml);
+					assert.equal(existsSync(generatedAgentPath), false);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("counts plugin cleanup skill directory backups in the setup summary", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -3136,6 +3136,16 @@ async function cleanupObsoleteNativeAgents(
 
 		if (!containsTomlKey(content, OBSOLETE_NATIVE_AGENT_FIELD)) continue;
 
+		const agentName = file.slice(0, -5);
+		if (!isGeneratedOmxNativeAgentToml(content, agentName)) {
+			if (options.verbose) {
+				console.log(
+					`  skipped stale obsolete native agent ${file}: not an OMX-generated native agent`,
+				);
+			}
+			continue;
+		}
+
 		if (await ensureBackup(fullPath, true, backupContext, options)) {
 			// backup created for pre-existing obsolete native agent config
 		}


### PR DESCRIPTION
## Summary
- follow up on the Codex review finding from #2516 after maintainer PR #2519 merged
- preserve user-managed `.codex/agents/*.toml` files that still contain the obsolete `skill_ref` field during plugin-mode setup refresh
- continue removing obsolete `skill_ref` TOMLs only when they are explicitly OMX-generated (`# oh-my-codex agent: <name>` marker)
- add regression coverage for both the unmanaged-preserved and generated-obsolete-removed cases

## Validation
- `npm run build`
- `node --test dist/cli/__tests__/setup-install-mode.test.js --test-name-pattern 'preserves unmanaged native agent TOMLs'`
- `node --test dist/cli/__tests__/setup-install-mode.test.js`
- `npm run check:no-unused`
- `git diff --check`

Related: #2516, #2519, #2517