### PR TITLE
Fix plugin-only obsolete native agent preservation

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -2298,6 +2298,52 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("preserves unmanaged native agent TOMLs with obsolete skill_ref during plugin refresh", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy" });
+
+					const customAgentPath = join(
+						codexHomeDir,
+						"agents",
+						"custom-reviewer.toml",
+					);
+					const generatedAgentPath = join(
+						codexHomeDir,
+						"agents",
+						"ghost.toml",
+					);
+					const customAgentToml = [
+						'name = "custom-reviewer"',
+						'description = "user-managed reviewer"',
+						'skill_ref = "custom-reviewer"',
+						"",
+					].join("\n");
+					await writeFile(customAgentPath, customAgentToml);
+					await writeFile(
+						generatedAgentPath,
+						[
+							"# oh-my-codex agent: ghost",
+							'name = "ghost"',
+							'description = "obsolete generated reviewer"',
+							'skill_ref = "ghost"',
+							"",
+						].join("\n"),
+					);
+
+					await setup({ scope: "user", installMode: "plugin" });
+
+					assert.equal(await readFile(customAgentPath, "utf-8"), customAgentToml);
+					assert.equal(existsSync(generatedAgentPath), false);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("counts plugin cleanup skill directory backups in the setup summary", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -3136,6 +3136,16 @@ async function cleanupObsoleteNativeAgents(
 
 		if (!containsTomlKey(content, OBSOLETE_NATIVE_AGENT_FIELD)) continue;
 
+		const agentName = file.slice(0, -5);
+		if (!isGeneratedOmxNativeAgentToml(content, agentName)) {
+			if (options.verbose) {
+				console.log(
+					`  skipped stale obsolete native agent ${file}: not an OMX-generated native agent`,
+				);
+			}
+			continue;
+		}
+
 		if (await ensureBackup(fullPath, true, backupContext, options)) {
 			// backup created for pre-existing obsolete native agent config
 		}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -2041,6 +2041,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				force,
 				dryRun,
 				verbose,
+				preserveUnmanagedObsoleteNativeAgents: true,
 			},
 		);
 		console.log(
@@ -3009,7 +3010,9 @@ async function refreshNativeAgentConfigs(
 	pkgRoot: string,
 	agentsDir: string,
 	backupContext: SetupBackupContext,
-	options: Pick<SetupOptions, "dryRun" | "verbose" | "force">,
+	options: Pick<SetupOptions, "dryRun" | "verbose" | "force"> & {
+		preserveUnmanagedObsoleteNativeAgents?: boolean;
+	},
 ): Promise<SetupCategorySummary> {
 	const summary = createEmptyCategorySummary();
 
@@ -3116,7 +3119,9 @@ async function refreshNativeAgentConfigs(
 async function cleanupObsoleteNativeAgents(
 	agentsDir: string,
 	backupContext: SetupBackupContext,
-	options: Pick<SetupOptions, "dryRun" | "verbose">,
+	options: Pick<SetupOptions, "dryRun" | "verbose"> & {
+		preserveUnmanagedObsoleteNativeAgents?: boolean;
+	},
 ): Promise<number> {
 	if (!existsSync(agentsDir)) return 0;
 
@@ -3137,7 +3142,10 @@ async function cleanupObsoleteNativeAgents(
 		if (!containsTomlKey(content, OBSOLETE_NATIVE_AGENT_FIELD)) continue;
 
 		const agentName = file.slice(0, -5);
-		if (!isGeneratedOmxNativeAgentToml(content, agentName)) {
+		if (
+			options.preserveUnmanagedObsoleteNativeAgents &&
+			!isGeneratedOmxNativeAgentToml(content, agentName)
+		) {
 			if (options.verbose) {
 				console.log(
 					`  skipped stale obsolete native agent ${file}: not an OMX-generated native agent`,


### PR DESCRIPTION
Supersedes #2520 because maintainer push to `strato-space:fix/preserve-unmanaged-plugin-agent-tomls` is denied by GitHub 403 even though the PR has maintainer edits enabled.

## Summary
- Keep plugin-mode preservation for unmanaged `.codex/agents/*.toml` files that still contain obsolete `skill_ref`.
- Keep normal/legacy setup cleanup for stale obsolete bridge/native-agent TOMLs.
- Preserve generated obsolete TOML removal in plugin refreshes by only skipping unmanaged TOMLs when plugin mode opts in.

## Validation
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/cli/__tests__/setup-prompts-overwrite.test.js`
- `node --test dist/cli/__tests__/setup-install-mode.test.js`
- `git diff --check`

Do not merge until CI is green and an independent OMX review verdict is available.
