### PR TITLE
Fix project-local Codex trust sync relaunch regression

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, utimesSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, utimesSync } from "node:fs";
 import { chmod, lstat, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { once } from "node:events";
+import TOML from "@iarna/toml";
 import {
   HELP,
   normalizeCodexLaunchArgs,
@@ -97,6 +98,10 @@ function normalizeDarwinTmpPath(value: string): string {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function countMatches(text: string, pattern: RegExp): number {
+  return text.match(pattern)?.length ?? 0;
 }
 
 function expectedLowComplexityModel(codexHomeOverride?: string): string {
@@ -2260,12 +2265,21 @@ describe("project launch scope helpers", () => {
         /model_availability_nux/,
         "NUX counters must not leak into durable project config.toml",
       );
+      const projectHookTrustHeader =
+        `[hooks.state."${join(projectCodexHome, "hooks.json")}:pre_tool_use:0:0"]`;
       assert.ok(
-        persistedProjectConfig.includes(
-          `[hooks.state."${join(projectCodexHome, "hooks.json")}:pre_tool_use:0:0"]`,
-        ),
+        persistedProjectConfig.includes(projectHookTrustHeader),
         "setup-owned project hook trust state must remain intact",
       );
+      assert.equal(
+        countMatches(
+          persistedProjectConfig,
+          new RegExp(`^${escapeRegExp(projectHookTrustHeader)}$`, "gm"),
+        ),
+        1,
+        "runtime trust sync must not duplicate setup-owned hook trust state",
+      );
+      assert.doesNotThrow(() => TOML.parse(persistedProjectConfig));
 
       // 3. On a subsequent launch, the runtime mirror carries the persisted
       //    project trust state forward — so Codex finds the workspace as
@@ -2281,7 +2295,88 @@ describe("project launch scope helpers", () => {
         nextRuntimeConfig.includes(`[projects."${wd}"]`),
         "next launch must inherit the persisted workspace trust entry",
       );
+      assert.equal(
+        countMatches(
+          nextRuntimeConfig,
+          new RegExp(`^${escapeRegExp(projectHookTrustHeader)}$`, "gm"),
+        ),
+        1,
+        "next runtime config must remain parseable without duplicate hook trust tables",
+      );
+      assert.doesNotThrow(() => TOML.parse(nextRuntimeConfig));
       assert.equal(existsSync(join(nextRuntimeCodexHome, "hooks.json")), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs duplicate project hook trust state before relaunching project-scope Codex home (GH #2401)", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-issue-2401-relaunch-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      const projectConfigPath = join(projectCodexHome, "config.toml");
+      const projectHooksPath = join(projectCodexHome, "hooks.json");
+      const projectHookTrustHeader =
+        `[hooks.state."${projectHooksPath}:post_compact:0:0"]`;
+      const escapedProjectHookTrustHeader = escapeRegExp(projectHookTrustHeader);
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await mkdir(projectCodexHome, { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      await writeFile(projectHooksPath, '{"hooks":{}}\n');
+      await writeFile(
+        projectConfigPath,
+        [
+          'model = "gpt-5.5"',
+          "",
+          "[features]",
+          "hooks = true",
+          "",
+          "# OMX-owned Codex hook trust state",
+          "# Trusts only setup-managed native hook wrappers.",
+          projectHookTrustHeader,
+          'trusted_hash = "sha256:setup-owned"',
+          "# End OMX-owned Codex hook trust state",
+          "",
+          "# OMX-synced Codex project trust state (from runtime CODEX_HOME)",
+          `[projects."${wd}"]`,
+          'trust_level = "trusted"',
+          "",
+          projectHookTrustHeader,
+          'trusted_hash = "sha256:setup-owned"',
+          "",
+          "# End OMX-synced Codex project trust state",
+          "",
+        ].join("\n"),
+      );
+
+      assert.throws(() => TOML.parse(readFileSync(projectConfigPath, "utf-8")));
+
+      await prepareCodexHomeForLaunch(wd, "session-relaunch", {});
+
+      const repairedProjectConfig = await readFile(projectConfigPath, "utf-8");
+      const runtimeConfig = await readFile(
+        join(runtimeCodexHomePath(wd, "session-relaunch"), "config.toml"),
+        "utf-8",
+      );
+
+      assert.doesNotThrow(() => TOML.parse(repairedProjectConfig));
+      assert.doesNotThrow(() => TOML.parse(runtimeConfig));
+      assert.equal(
+        countMatches(
+          repairedProjectConfig,
+          new RegExp(`^${escapedProjectHookTrustHeader}$`, "gm"),
+        ),
+        1,
+      );
+      assert.equal(
+        countMatches(runtimeConfig, new RegExp(`^${escapedProjectHookTrustHeader}$`, "gm")),
+        1,
+      );
+      assert.ok(runtimeConfig.includes(`[projects."${wd}"]`));
+      assert.ok(repairedProjectConfig.includes(`[projects."${wd}"]`));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -124,7 +124,7 @@ import {
 } from "../team/tmux-session.js";
 import { getPackageRoot } from "../utils/package.js";
 import { codexConfigPath, omxRoot, rememberOmxLaunchContext, resolveOmxEntryPath } from "../utils/paths.js";
-import { cleanCodexModelAvailabilityNuxIfNeeded, extractSharedMcpRegistryServersFromConfig, repairConfigIfNeeded, syncProjectScopeTrustStateFromRuntime } from "../config/generator.js";
+import { cleanCodexModelAvailabilityNuxIfNeeded, extractSharedMcpRegistryServersFromConfig, repairConfigIfNeeded, repairProjectScopeTrustStateForLaunch, syncProjectScopeTrustStateFromRuntime } from "../config/generator.js";
 import type { UnifiedMcpRegistryServer } from "../config/mcp-registry.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
@@ -775,7 +775,16 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
     const source = join(projectCodexHome, entry.name);
     const destination = join(runtimeCodexHome, entry.name);
     if (entry.name === "config.toml") {
-      await copyFile(source, destination);
+      const projectHooksPath = join(projectCodexHome, "hooks.json");
+      const projectConfig = await readFile(source, "utf-8");
+      const launchConfig = repairProjectScopeTrustStateForLaunch(
+        projectConfig,
+        projectHooksPath,
+      );
+      if (launchConfig !== projectConfig) {
+        await writeFile(source, launchConfig, "utf-8");
+      }
+      await writeFile(destination, launchConfig, "utf-8");
       continue;
     }
     await linkOrCopyCodexHomeEntry(source, destination);

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -816,6 +816,30 @@ const OMX_PROJECT_TRUST_START_MARKER =
 const OMX_PROJECT_TRUST_END_MARKER =
   "# End OMX-synced Codex project trust state";
 
+function extractMarkerBlockContent(
+  config: string,
+  startMarker: string,
+  endMarker: string,
+): string | undefined {
+  const lines = config.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() !== startMarker) continue;
+
+    const nextEndIdx = lines.findIndex(
+      (line, index) => index > i && line.trim() === endMarker,
+    );
+    const nextStartIdx = lines.findIndex(
+      (line, index) => index > i && line.trim() === startMarker,
+    );
+    if (nextEndIdx === -1 || (nextStartIdx !== -1 && nextStartIdx < nextEndIdx)) {
+      return undefined;
+    }
+
+    return lines.slice(i + 1, nextEndIdx).join("\n").trim();
+  }
+  return undefined;
+}
+
 function stripMarkerBlock(
   config: string,
   startMarker: string,
@@ -866,6 +890,48 @@ function safeParseToml(content: string): Record<string, unknown> | undefined {
   }
 }
 
+function collectProjectHookTrustStateKeys(config: string): Set<string> {
+  const keys = new Set<string>();
+  const parsed = safeParseToml(config);
+  const hooksTable = isPlainTomlRecord(parsed) ? parsed.hooks : undefined;
+  const hooksState = isPlainTomlRecord(hooksTable) ? hooksTable.state : undefined;
+  if (!isPlainTomlRecord(hooksState)) return keys;
+  for (const [key, entry] of Object.entries(hooksState)) {
+    if (!isPlainTomlRecord(entry)) continue;
+    keys.add(key);
+  }
+  return keys;
+}
+
+/**
+ * Repairs project configs from the 0.18.3 relaunch regression where a
+ * project-synced trust block could duplicate setup-owned hook trust tables and
+ * make the next runtime CODEX_HOME config.toml invalid before Codex started.
+ */
+export function repairProjectScopeTrustStateForLaunch(
+  projectConfig: string,
+  projectHooksPath: string,
+): string {
+  const syncedTrustBlock = extractMarkerBlockContent(
+    projectConfig,
+    OMX_PROJECT_TRUST_START_MARKER,
+    OMX_PROJECT_TRUST_END_MARKER,
+  );
+  if (!syncedTrustBlock) return projectConfig;
+
+  const stripped = stripMarkerBlock(
+    projectConfig,
+    OMX_PROJECT_TRUST_START_MARKER,
+    OMX_PROJECT_TRUST_END_MARKER,
+  );
+  const repaired = syncProjectScopeTrustStateFromRuntime(
+    stripped,
+    syncedTrustBlock,
+    projectHooksPath,
+  );
+  return repaired === stripped ? projectConfig : repaired;
+}
+
 /**
  * Project-scope launches mirror the durable project config.toml into an
  * ephemeral runtime CODEX_HOME. Codex writes its workspace-trust ledger and
@@ -887,6 +953,12 @@ export function syncProjectScopeTrustStateFromRuntime(
   const parsed = safeParseToml(runtimeConfig);
   if (!parsed) return projectConfig;
 
+  const stripped = stripMarkerBlock(
+    projectConfig,
+    OMX_PROJECT_TRUST_START_MARKER,
+    OMX_PROJECT_TRUST_END_MARKER,
+  );
+  const existingHookTrustStateKeys = collectProjectHookTrustStateKeys(stripped);
   const trustBlockLines: string[] = [];
 
   const projectsTable = parsed.projects;
@@ -914,6 +986,7 @@ export function syncProjectScopeTrustStateFromRuntime(
     )) {
       if (!isPlainTomlRecord(entry)) continue;
       if (!stateKey.startsWith(`${projectHooksPath}:`)) continue;
+      if (existingHookTrustStateKeys.has(stateKey)) continue;
       const trusted = entry.trusted_hash;
       if (typeof trusted !== "string" || trusted.length === 0) continue;
       trustBlockLines.push(
@@ -923,12 +996,6 @@ export function syncProjectScopeTrustStateFromRuntime(
       );
     }
   }
-
-  const stripped = stripMarkerBlock(
-    projectConfig,
-    OMX_PROJECT_TRUST_START_MARKER,
-    OMX_PROJECT_TRUST_END_MARKER,
-  );
 
   if (trustBlockLines.length === 0) {
     return stripped.length === 0 ? "" : `${stripped}\n`;


### PR DESCRIPTION
## Summary
- Fixes the reopened project-local relaunch path that could duplicate setup-owned `hooks.state` trust tables into the OMX-synced project trust block.
- Repairs already-corrupted project `.codex/config.toml` before creating the next runtime `CODEX_HOME` mirror so Codex no longer exits on duplicate TOML keys after second login/relaunch.
- Keeps `auth.json` opaque: no parsing/logging of auth secrets; auth copy-back remains file-level only.

Closes #2401

## Verification
- `npm run build`
- `npm run check:no-unused`
- `node --test --test-reporter=spec --test-name-pattern='project launch scope helpers|project-scope launch registers native hooks|repairs duplicate project hook trust|persists project-scope Codex auth|keeps setup-owned hook trust' dist/cli/__tests__/index.test.js`
- `node --test --test-reporter=spec dist/auth/__tests__/storage.test.js dist/auth/__tests__/config-sessions.test.js dist/cli/__tests__/doctor-warning-copy.test.js dist/cli/__tests__/setup-scope.test.js`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
