### PR TITLE
Fix duplicate HUD pane spawn convergence

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3130,11 +3130,11 @@ describe("detached tmux new-session sequencing", () => {
     const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\)\s*: \[\];/,
+      /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\)\s*: \[\];/,
     );
     assert.doesNotMatch(
       source,
-      /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\);/,
+      /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\);/,
     );
   });
 
@@ -3142,7 +3142,7 @@ describe("detached tmux new-session sequencing", () => {
     const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\)\s*: \[\];/,
+      /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\)\s*: \[\];/,
     );
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4068,7 +4068,7 @@ function runCodex(
     });
 
     const staleHudPaneIds = currentPaneId
-      ? listHudWatchPaneIdsInCurrentWindow(currentPaneId, { leaderPaneId: currentPaneId })
+      ? listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId })
       : [];
     for (const paneId of staleHudPaneIds) {
       killTmuxPane(paneId);
@@ -4122,7 +4122,7 @@ function runCodex(
       });
     } finally {
       const cleanupPaneIds = buildHudPaneCleanupTargets(
-        listHudWatchPaneIdsInCurrentWindow(currentPaneId),
+        listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId }),
         hudPaneId,
         currentPaneId,
       );

--- a/src/hud/__tests__/hud-tmux-injection.test.ts
+++ b/src/hud/__tests__/hud-tmux-injection.test.ts
@@ -101,7 +101,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
       'split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES),
       // split height should come from shared HUD constants
       '-c', '/home/user/project',
-      `exec ${runtimePrefix} '/usr/local/bin/omx.js' hud --watch`,
+      `exec env OMX_TMUX_HUD_OWNER=1 ${runtimePrefix} '/usr/local/bin/omx.js' hud --watch`,
     ]);
   });
 
@@ -141,7 +141,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
       cmd.includes("'\\''"),
       `Expected escaped single quote in: ${cmd}`,
     );
-    assert.equal(cmd, `exec ${runtimePrefix} '/tmp/it'\\''s/omx.js' hud --watch`);
+    assert.equal(cmd, `exec env OMX_TMUX_HUD_OWNER=1 ${runtimePrefix} '/tmp/it'\\''s/omx.js' hud --watch`);
   });
 
   it('omxBin with $() is neutralised by single-quote wrapping', () => {
@@ -150,7 +150,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     const cmd = args[6];
 
     // Inside single quotes, $() is literal.
-    assert.equal(cmd, `exec ${runtimePrefix} '/tmp/$(id)/omx.js' hud --watch`);
+    assert.equal(cmd, `exec env OMX_TMUX_HUD_OWNER=1 ${runtimePrefix} '/tmp/$(id)/omx.js' hud --watch`);
   });
 
   it('omxBin with backticks is neutralised by single-quote wrapping', () => {
@@ -158,7 +158,7 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     const args = buildTmuxSplitArgs('/home/user', maliciousOmx);
     const cmd = args[6];
 
-    assert.equal(cmd, `exec ${runtimePrefix} '/tmp/\`whoami\`/omx.js' hud --watch`);
+    assert.equal(cmd, `exec env OMX_TMUX_HUD_OWNER=1 ${runtimePrefix} '/tmp/\`whoami\`/omx.js' hud --watch`);
   });
 
   it("omxBin with ';command' breakout attempt is neutralised", () => {
@@ -170,10 +170,10 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     // quotes escaped as '\''.  In a POSIX shell the result is a single word;
     // the semicolons never act as command separators.
     //
-    // Raw expected value: exec node '/tmp/x'\'';touch /tmp/pwned;echo '\''/omx.js' hud --watch
+    // Raw expected value: exec node '/tmp/x'\\'';touch /tmp/pwned;echo '\\''/omx.js' hud --watch
     assert.equal(
       cmd,
-      `exec ${runtimePrefix} '/tmp/x'\\'';touch /tmp/pwned;echo '\\''/omx.js' hud --watch`,
+      `exec env OMX_TMUX_HUD_OWNER=1 ${runtimePrefix} '/tmp/x'\\'';touch /tmp/pwned;echo '\\''/omx.js' hud --watch`,
     );
 
     // Both original single quotes are escaped (two '\'' sequences).
@@ -201,14 +201,14 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
       'minimal;touch /tmp/pwned',
     );
     const cmd = args[6];
-    assert.equal(cmd, `exec ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
+    assert.equal(cmd, `exec env OMX_TMUX_HUD_OWNER=1 ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
     assert.ok(!cmd.includes('--preset='));
   });
 
   it('prepends OMX_SESSION_ID when provided', () => {
     const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', 'focused', 'sess-managed');
     const cmd = args[6];
-    assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=focused`);
+    assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' OMX_TMUX_HUD_OWNER=1 ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=focused`);
   });
 
   it('forwards OMX_ROOT with OMX_SESSION_ID using shell-safe quoting', () => {
@@ -222,15 +222,21 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     const cmd = args[6];
     assert.equal(
       cmd,
-      `exec env OMX_SESSION_ID='sess managed' OMX_ROOT='/tmp/boxed root/it'\\''s/$(literal)' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=focused`,
+      `exec env OMX_SESSION_ID='sess managed' OMX_TMUX_HUD_OWNER=1 OMX_ROOT='/tmp/boxed root/it'\\''s/$(literal)' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=focused`,
     );
   });
 
   it('omits OMX_ROOT when unset while preserving existing OMX_SESSION_ID behavior', () => {
     const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', undefined, 'sess-managed');
     const cmd = args[6];
-    assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
+    assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' OMX_TMUX_HUD_OWNER=1 ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
     assert.doesNotMatch(cmd, /OMX_ROOT=/);
+  });
+
+  it('tags tmux-launched HUD panes with the emitting leader pane', () => {
+    const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', undefined, 'sess-managed', undefined, '%leader');
+    const cmd = args[6];
+    assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%leader' ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
   });
 });
 

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -347,6 +347,33 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(resized, [{ paneId: '%2', heightLines: 3 }]);
   });
 
+
+  it('deduplicates same-leader HUD panes without creating a new pane when session id is unavailable', async () => {
+    const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    const created: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%2', currentCommand: 'node', startCommand: `env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch` },
+        { paneId: '%3', currentCommand: 'node', startCommand: `env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch` },
+      ],
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
+      createHudWatchPane: () => { created.push('create'); return '%9'; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.paneId, '%2');
+    assert.equal(result.duplicateCount, 1);
+    assert.deepEqual(killed, ['%3']);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: 3 }]);
+    assert.deepEqual(created, []);
+  });
+
   it('resizes an existing single HUD pane even without a fresh session id', async () => {
     const resized: Array<{ paneId: string; heightLines: number }> = [];
     const created: string[] = [];

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -17,6 +17,14 @@ import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_MAX_HEIGHT_LINES } from './constants.js
 import { sleep } from '../utils/sleep.js';
 import { runHudAuthorityTick } from './authority.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
+import {
+  killTmuxPane,
+  listCurrentWindowHudPaneIds,
+  OMX_TMUX_HUD_LEADER_PANE_ENV,
+  registerHudResizeHook,
+  resizeTmuxPane,
+} from './tmux.js';
+import { OMX_TMUX_HUD_OWNER_ENV } from './reconcile.js';
 
 export const HUD_USAGE = [
   'Usage:',
@@ -263,14 +271,18 @@ export function buildTmuxSplitArgs(
   preset?: string,
   sessionId?: string,
   omxRoot?: string,
+  leaderPaneId?: string,
 ): string[] {
   // Defense-in-depth: keep preset constrained even if this helper is reused.
   const safePreset = parseHudPreset(preset);
   const presetArg = safePreset ? ` --preset=${safePreset}` : '';
   const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
   const safeOmxRoot = typeof omxRoot === 'string' ? omxRoot : '';
+  const safeLeaderPaneId = typeof leaderPaneId === 'string' ? leaderPaneId.trim() : '';
   const envAssignments = [
     safeSessionId ? `OMX_SESSION_ID=${shellEscape(safeSessionId)}` : '',
+    `${OMX_TMUX_HUD_OWNER_ENV}=1`,
+    safeLeaderPaneId ? `${OMX_TMUX_HUD_LEADER_PANE_ENV}=${shellEscape(safeLeaderPaneId)}` : '',
     safeOmxRoot.trim() ? `OMX_ROOT=${shellEscape(safeOmxRoot)}` : '',
   ].filter(Boolean);
   const envPrefix = envAssignments.length > 0 ? `env ${envAssignments.join(' ')} ` : '';
@@ -290,7 +302,24 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
     console.error('Failed to resolve OMX launcher path for tmux HUD startup.');
     process.exit(1);
   }
-  const args = buildTmuxSplitArgs(cwd, omxBin, flags.preset, process.env.OMX_SESSION_ID, process.env.OMX_ROOT);
+  const currentPaneId = process.env.TMUX_PANE?.trim();
+  const existingHudPaneIds = currentPaneId
+    ? listCurrentWindowHudPaneIds(currentPaneId, undefined, {
+        sessionId: process.env.OMX_SESSION_ID,
+        leaderPaneId: currentPaneId,
+      })
+    : [];
+  if (existingHudPaneIds.length === 1) {
+    resizeTmuxPane(existingHudPaneIds[0], HUD_TMUX_HEIGHT_LINES);
+    if (currentPaneId) registerHudResizeHook(existingHudPaneIds[0], currentPaneId, HUD_TMUX_HEIGHT_LINES);
+    console.log('HUD already running in tmux pane. Reused existing HUD pane.');
+    return;
+  }
+  for (const paneId of existingHudPaneIds) {
+    killTmuxPane(paneId);
+  }
+
+  const args = buildTmuxSplitArgs(cwd, omxBin, flags.preset, process.env.OMX_SESSION_ID, process.env.OMX_ROOT, currentPaneId);
 
   try {
     // Split bottom pane, 4 lines tall, running omx hud --watch.

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -131,6 +131,21 @@ export async function reconcileHudForPromptSubmit(
     };
   }
 
+  if (hudPaneIds.length > 1 && !resolvedSessionId) {
+    const [keeperPaneId, ...extraPaneIds] = hudPaneIds;
+    for (const paneId of extraPaneIds) {
+      killPane(paneId);
+    }
+    const resized = resizePane(keeperPaneId, desiredHeight);
+    if (resized) ensureHudResizeHook(keeperPaneId, currentPaneId, desiredHeight, deps);
+    return {
+      status: resized ? 'replaced_duplicates' : 'failed',
+      paneId: resized ? keeperPaneId : null,
+      desiredHeight,
+      duplicateCount,
+    };
+  }
+
   if (!resolvedSessionId) {
     return {
       status: 'skipped_no_session_id',


### PR DESCRIPTION
## Summary
- Fixes #2523.
- Tags `omx hud --tmux` launch panes with OMX HUD owner + leader pane identity so later launch/reconcile/revive paths can find the same HUD.
- Reuses/resizes an existing launch HUD instead of blindly splitting another pane; duplicate launch panes are killed before creating a replacement.
- Expands prompt-submit reconcile so same-leader duplicates still converge to one pane even when a fresh session id is unavailable.
- Makes inside-tmux `omx` launch cleanup match by session + leader, preserving same-leader cross-session cleanup while also catching same-session legacy HUD panes without leader tags.

## Validation
- `npm run build`
- `npm run check:no-unused`
- `npm run lint`
- `node --test dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/tmux.test.js dist/hud/__tests__/hud-tmux-injection.test.js`
- `node --test --test-name-pattern "runCodex (coalesces|skips|builds|registers)" dist/cli/__tests__/index.test.js`

## Notes
A full unfiltered `dist/cli/__tests__/index.test.js` run was not used as completion evidence because this worktree has unrelated environment-sensitive cleanup/lease failures; the HUD-focused and launch-source tests above pass.
