### PR TITLE
Bound native tool hook waits

### DIFF
--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -246,7 +246,7 @@ describe("codex hooks helpers", () => {
         {
           async: false,
           command,
-          timeout: 600,
+          timeout: 10,
           type: "command",
         },
       ],
@@ -285,7 +285,7 @@ describe("codex hooks helpers", () => {
         {
           async: false,
           command,
-          timeout: 600,
+          timeout: 10,
           type: "command",
         },
       ],

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -69,6 +69,8 @@ const CODEX_HOOK_EVENT_LABELS: Record<ManagedHookEventName, string> = {
   Stop: "stop",
 };
 
+const FAST_NATIVE_HOOK_TIMEOUT_SECONDS = 10;
+
 function isPlainObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -230,10 +232,14 @@ export function buildManagedCodexHooksConfig(
         }),
       ],
       PreToolUse: [
-        buildCommandHook(command),
+        buildCommandHook(command, {
+          timeout: FAST_NATIVE_HOOK_TIMEOUT_SECONDS,
+        }),
       ],
       PostToolUse: [
-        buildCommandHook(command),
+        buildCommandHook(command, {
+          timeout: FAST_NATIVE_HOOK_TIMEOUT_SECONDS,
+        }),
       ],
       UserPromptSubmit: [
         buildCommandHook(command),

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -306,6 +306,7 @@ describe("codex native hook config", () => {
       String(preToolUse.hooks?.[0]?.command || ""),
       /codex-native-hook\.js"?$/,
     );
+    assert.equal(preToolUse.hooks?.[0]?.timeout, 10);
     assert.equal(preToolUse.hooks?.[0]?.statusMessage, undefined);
 
     const postToolUse = config.hooks.PostToolUse[0] as {
@@ -317,6 +318,7 @@ describe("codex native hook config", () => {
       String(postToolUse.hooks?.[0]?.command || ""),
       /codex-native-hook\.js"?$/,
     );
+    assert.equal(postToolUse.hooks?.[0]?.timeout, 10);
     assert.equal(postToolUse.hooks?.[0]?.statusMessage, undefined);
 
     const userPromptSubmit = config.hooks.UserPromptSubmit[0] as {


### PR DESCRIPTION
## Summary

- Add explicit 10-second timeouts to generated native PreToolUse and PostToolUse hooks.
- Keep the existing longer Stop hook timeout unchanged.
- Update hook trust hash tests and native hook config shape tests so the bounded timeout is preserved.

## Why

PreToolUse and PostToolUse gate every tool call. When generated without an explicit short timeout, a rare slow hook path can leave Codex stuck at the hook status line, e.g. `Running PreToolUse hook` or `Running PostToolUse hook`.

## Verification

- `npm run build`
- `node --test dist/config/__tests__/codex-hooks.test.js dist/scripts/__tests__/codex-native-hook.test.js` (375/375 passing)
