### PR TITLE
Add Antigravity ACPX advisor provider

### DIFF
--- a/plugins/oh-my-codex/skills/ask/SKILL.md
+++ b/plugins/oh-my-codex/skills/ask/SKILL.md
@@ -12,14 +12,17 @@ Use a locally installed external advisor CLI for focused questions, reviews, bra
 ```bash
 $ask claude <question or task>
 $ask gemini <question or task>
+$ask antigravity <question or task>
 omx ask claude "<question or task>"
 omx ask gemini "<question or task>"
+omx ask antigravity "<question or task>"
 ```
 
 ## Backend selection
 
 - Use `claude` when the user asks for Claude, Anthropic, or the previous `$ask-claude` behavior.
 - Use `gemini` when the user asks for Gemini or the previous `$ask-gemini` behavior.
+- Use `antigravity` when the user asks for Antigravity/agy review through ACPX + agy-acp.
 - If no backend is specified, choose the installed backend that best matches the user request; if neither is clearly available, explain that a local CLI is required.
 
 ## Local CLI commands
@@ -36,7 +39,19 @@ Gemini:
 ```bash
 omx ask gemini "{{ARGUMENTS}}"
 gemini -p "{{ARGUMENTS}}"
+
+Antigravity:
+```bash
+omx ask antigravity "{{ARGUMENTS}}"
+OMX_ANTIGRAVITY_MODEL_TIER=low omx ask antigravity "{{ARGUMENTS}}"
+OMX_ANTIGRAVITY_MODEL_TIER=medium omx ask antigravity "{{ARGUMENTS}}"
+OMX_ANTIGRAVITY_MODEL_TIER=high omx ask antigravity "{{ARGUMENTS}}"
+OMX_ANTIGRAVITY_MODEL=low omx ask antigravity "{{ARGUMENTS}}"
+OMX_ANTIGRAVITY_MODEL='gemini-3.5-flash (high)' omx ask antigravity "{{ARGUMENTS}}"
 ```
+
+Antigravity model note: `agy` 1.0.2 has no documented hard `--model` CLI flag. `omx ask antigravity` defaults to requested model setting `gemini-3.5-flash (medium)`, infers `low|medium|high` model tier from task wording, and accepts `OMX_ANTIGRAVITY_MODEL`, `OMX_ANTIGRAVITY_MODEL_TIER`, `OMX_ANTIGRAVITY_MODEL_SETTING`, or `OMX_ANTIGRAVITY_PROFILE` as routing hints. Low/medium/high is treated as the model setting, not a separate effort knob. If a future `agy` adds hard model flags, pass them via `AGY_EXTRA_ARGS`. Antigravity defaults to long-running review timeouts (`AGY_TIMEOUT_SECONDS=900`, `OMX_ANTIGRAVITY_ACPX_TIMEOUT_SECONDS=960`) to avoid killing full frontend audits early; override these env vars for shorter or longer lanes.
+
 
 If needed, adapt to the user's installed CLI variant while keeping local execution as the default path. Do not silently switch to an MCP or remote provider when the local binary is missing.
 

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -12,14 +12,17 @@ Use a locally installed external advisor CLI for focused questions, reviews, bra
 ```bash
 $ask claude <question or task>
 $ask gemini <question or task>
+$ask antigravity <question or task>
 omx ask claude "<question or task>"
 omx ask gemini "<question or task>"
+omx ask antigravity "<question or task>"
 ```
 
 ## Backend selection
 
 - Use `claude` when the user asks for Claude, Anthropic, or the previous `$ask-claude` behavior.
 - Use `gemini` when the user asks for Gemini or the previous `$ask-gemini` behavior.
+- Use `antigravity` when the user asks for Antigravity/agy review through ACPX + agy-acp.
 - If no backend is specified, choose the installed backend that best matches the user request; if neither is clearly available, explain that a local CLI is required.
 
 ## Local CLI commands
@@ -36,7 +39,19 @@ Gemini:
 ```bash
 omx ask gemini "{{ARGUMENTS}}"
 gemini -p "{{ARGUMENTS}}"
+
+Antigravity:
+```bash
+omx ask antigravity "{{ARGUMENTS}}"
+OMX_ANTIGRAVITY_MODEL_TIER=low omx ask antigravity "{{ARGUMENTS}}"
+OMX_ANTIGRAVITY_MODEL_TIER=medium omx ask antigravity "{{ARGUMENTS}}"
+OMX_ANTIGRAVITY_MODEL_TIER=high omx ask antigravity "{{ARGUMENTS}}"
+OMX_ANTIGRAVITY_MODEL=low omx ask antigravity "{{ARGUMENTS}}"
+OMX_ANTIGRAVITY_MODEL='gemini-3.5-flash (high)' omx ask antigravity "{{ARGUMENTS}}"
 ```
+
+Antigravity model note: `agy` 1.0.2 has no documented hard `--model` CLI flag. `omx ask antigravity` defaults to requested model setting `gemini-3.5-flash (medium)`, infers `low|medium|high` model tier from task wording, and accepts `OMX_ANTIGRAVITY_MODEL`, `OMX_ANTIGRAVITY_MODEL_TIER`, `OMX_ANTIGRAVITY_MODEL_SETTING`, or `OMX_ANTIGRAVITY_PROFILE` as routing hints. Low/medium/high is treated as the model setting, not a separate effort knob. If a future `agy` adds hard model flags, pass them via `AGY_EXTRA_ARGS`. Antigravity defaults to long-running review timeouts (`AGY_TIMEOUT_SECONDS=900`, `OMX_ANTIGRAVITY_ACPX_TIMEOUT_SECONDS=960`) to avoid killing full frontend audits early; override these env vars for shorter or longer lanes.
+
 
 If needed, adapt to the user's installed CLI variant while keeping local execution as the default path. Do not silently switch to an MCP or remote provider when the local binary is missing.
 

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -77,6 +77,13 @@ describe('parseAskArgs', () => {
     });
   });
 
+  it('parses antigravity provider prompt form', () => {
+    assert.deepEqual(parseAskArgs(['antigravity', 'review', 'frontend']), {
+      provider: 'antigravity',
+      prompt: 'review frontend',
+    });
+  });
+
   it('parses --agent-prompt with positional task text', () => {
     assert.deepEqual(parseAskArgs(['claude', '--agent-prompt', 'executor', 'review', 'this']), {
       provider: 'claude',
@@ -218,6 +225,102 @@ describe('omx ask', () => {
       const geminiArtifactPath = geminiRes.stdout.trim();
       const geminiArtifact = await readFile(geminiArtifactPath, 'utf-8');
       assert.match(geminiArtifact, /GEMINI_PROMPT_OK:gemini-long-flag/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('routes antigravity through persistent ACPX session with Gemini Flash model tier metadata', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-ask-antigravity-'));
+    try {
+      const fakeBin = join(wd, 'bin');
+      const fakeAdapter = join(wd, 'tools', 'agy-acp', 'target', 'release', 'agy-acp.exe');
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(dirname(fakeAdapter), { recursive: true });
+      await writeFile(fakeAdapter, '#!/bin/sh\necho fake-adapter\n');
+      await chmod(fakeAdapter, 0o755);
+
+      await writeFile(
+        join(fakeBin, 'acpx'),
+        [
+          '#!/bin/sh',
+          'if [ "$1" = "--version" ]; then echo "fake-acpx"; exit 0; fi',
+          'case "$*" in',
+          '  *" sessions ensure --name antigravity"*) echo "SESSION_ENSURED"; exit 0 ;;',
+          '  *" prompt -s antigravity -- "*)',
+          '    last=""',
+          '    for arg in "$@"; do last="$arg"; done',
+          '    printf "ACPX_PROMPT_OK:%s" "$last"',
+          '    exit 0',
+          '    ;;',
+          'esac',
+          'echo "unexpected args:$*" 1>&2',
+          'exit 5',
+          '',
+        ].join('\n'),
+      );
+      await chmod(join(fakeBin, 'acpx'), 0o755);
+
+      const res = runOmx(wd, ['ask', 'antigravity', 'quick', 'frontend', 'check'], {
+        PATH: `${fakeBin}:${process.env.PATH || ''}`,
+        OMX_ANTIGRAVITY_MODEL_TIER: 'low',
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      const artifact = await readFile(res.stdout.trim(), 'utf-8');
+      assert.match(artifact, /Requested model setting: gemini-3\.5-flash \(low\)/);
+      assert.match(artifact, /ACPX_PROMPT_OK:[\s\S]*quick frontend check/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('infers antigravity model tier from raw user task instead of injected agent prompt text', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-ask-antigravity-tier-'));
+    try {
+      const fakeBin = join(wd, 'bin');
+      const fakeAdapter = join(wd, 'tools', 'agy-acp', 'target', 'release', 'agy-acp');
+      const codexHome = join(wd, '.codex-home');
+      const promptsDir = join(codexHome, 'prompts');
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(dirname(fakeAdapter), { recursive: true });
+      await mkdir(promptsDir, { recursive: true });
+      await writeFile(fakeAdapter, '#!/bin/sh\necho fake-adapter\n');
+      await chmod(fakeAdapter, 0o755);
+      await writeFile(join(promptsDir, 'architect.md'), 'High security architecture review boilerplate.');
+
+      await writeFile(
+        join(fakeBin, 'acpx'),
+        [
+          '#!/bin/sh',
+          'if [ "$1" = "--version" ]; then echo "fake-acpx"; exit 0; fi',
+          'case "$*" in',
+          '  *" sessions ensure --name antigravity"*) exit 0 ;;',
+          '  *" prompt -s antigravity -- "*)',
+          '    last=""',
+          '    for arg in "$@"; do last="$arg"; done',
+          '    printf "ACPX_PROMPT_OK:%s" "$last"',
+          '    exit 0',
+          '    ;;',
+          'esac',
+          'echo "unexpected args:$*" 1>&2',
+          'exit 5',
+          '',
+        ].join('\n'),
+      );
+      await chmod(join(fakeBin, 'acpx'), 0o755);
+
+      const res = runOmx(wd, ['ask', 'antigravity', '--agent-prompt', 'architect', 'quick', 'check'], {
+        PATH: `${fakeBin}:${process.env.PATH || ''}`,
+        CODEX_HOME: codexHome,
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      const artifact = await readFile(res.stdout.trim(), 'utf-8');
+      assert.match(artifact, /Requested model setting: gemini-3\.5-flash \(low\)/);
+      assert.match(artifact, /High security architecture review boilerplate/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -25,7 +25,7 @@ function runOmx(cwd: string, argv: string[]) {
 describe('nested help routing', () => {
   for (const [argv, expectedUsage] of [
     [['adapt', '--help'], /Usage:\s*omx adapt <target> <probe\|status\|init\|envelope\|doctor>/i],
-    [['ask', '--help'], /Usage:\s*omx ask <claude\|gemini> <question or task>/i],
+    [['ask', '--help'], /Usage:\s*omx ask <claude\|gemini\|antigravity> <question or task>/i],
     [['question', '--help'], /omx question - OMX-owned blocking user question entrypoint/i],
     [['autoresearch', '--help'], /hard-deprecated legacy command surface[\s\S]*\$autoresearch/i],
     [['explore', '--help'], /Usage:\s*omx explore --prompt "<prompt>"/i],

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -7,15 +7,15 @@ import { getPackageRoot } from '../utils/package.js';
 import { codexPromptsDir } from '../utils/paths.js';
 
 export const ASK_USAGE = [
-  'Usage: omx ask <claude|gemini> <question or task>',
-  '   or: omx ask <claude|gemini> -p "<prompt>"',
+  'Usage: omx ask <claude|gemini|antigravity> <question or task>',
+  '   or: omx ask <claude|gemini|antigravity> -p "<prompt>"',
   '   or: omx ask claude --print "<prompt>"',
   '   or: omx ask gemini --prompt "<prompt>"',
-  '   or: omx ask <claude|gemini> --agent-prompt <role> "<prompt>"',
-  '   or: omx ask <claude|gemini> --agent-prompt=<role> --prompt "<prompt>"',
+  '   or: omx ask <claude|gemini|antigravity> --agent-prompt <role> "<prompt>"',
+  '   or: omx ask <claude|gemini|antigravity> --agent-prompt=<role> --prompt "<prompt>"',
 ].join('\n');
 
-const ASK_PROVIDERS = ['claude', 'gemini'] as const;
+const ASK_PROVIDERS = ['claude', 'gemini', 'antigravity'] as const;
 type AskProvider = typeof ASK_PROVIDERS[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 const ASK_ADVISOR_SCRIPT_ENV = 'OMX_ASK_ADVISOR_SCRIPT';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -205,7 +205,7 @@ Usage:
   omx list      List packaged OMX skills and native agent prompts (--json)
   omx cleanup   Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories
   omx doctor --team  Check team/swarm runtime health diagnostics
-  omx ask       Ask local provider CLI (claude|gemini) and write artifact output
+  omx ask       Ask local provider CLI (claude|gemini|antigravity) and write artifact output
   omx auth      Manage Codex OAuth auth slots (add|list|use)
   omx question  OMX-owned blocking question UI entrypoint for agent-invoked user questions
   omx adapt     Scaffold OMX-owned adapter foundations for persistent external targets

--- a/src/compat/fixtures/help.stdout.txt
+++ b/src/compat/fixtures/help.stdout.txt
@@ -10,7 +10,7 @@ Usage:
   omx doctor    Check installation health
   omx cleanup   Kill orphaned OMX MCP server processes from prior sessions
   omx doctor --team  Check team/swarm runtime health diagnostics
-  omx ask       Ask local provider CLI (claude|gemini) and write artifact output
+  omx ask       Ask local provider CLI (claude|gemini|antigravity) and write artifact output
   omx autoresearch [DEPRECATED] Use $autoresearch; direct CLI launch removed
   omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
   omx session   Search prior local session transcripts and history artifacts

--- a/src/scripts/run-provider-advisor.ts
+++ b/src/scripts/run-provider-advisor.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
+import { existsSync } from 'fs';
 import { mkdir, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { dirname, isAbsolute, join, resolve } from 'path';
 import process from 'process';
 import { spawnSync } from 'child_process';
 import { CLAUDE_SKIP_PERMISSIONS_FLAG } from '../cli/constants.js';
@@ -8,6 +9,7 @@ import { CLAUDE_SKIP_PERMISSIONS_FLAG } from '../cli/constants.js';
 const PROVIDER_BINARIES: Record<string, string> = {
   claude: 'claude',
   gemini: 'gemini',
+  antigravity: 'acpx',
 };
 const ASK_ORIGINAL_TASK_ENV = 'OMX_ASK_ORIGINAL_TASK';
 const ISSUE_WORK_PROMPT_PATTERNS = [
@@ -17,7 +19,7 @@ const ISSUE_WORK_PROMPT_PATTERNS = [
 ];
 
 function usage(): void {
-  console.error('Usage: omx ask <claude|gemini> "<prompt>"');
+  console.error('Usage: omx ask <claude|gemini|antigravity> "<prompt>"');
   console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|gemini> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
@@ -61,6 +63,120 @@ function parseArgs(argv: string[]): { provider: string; prompt: string } {
   return { provider, prompt: rest.join(' ').trim() };
 }
 
+
+function findUp(start: string, relativePath: string): string | null {
+  let current = resolve(start);
+  while (true) {
+    const candidate = join(current, relativePath);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function resolveAntigravityAcpAgent(cwd = process.cwd()): string {
+  const override = process.env.OMX_ANTIGRAVITY_ACP_AGENT?.trim();
+  if (override) return isAbsolute(override) ? override : resolve(cwd, override);
+
+  const executableNames = process.platform === 'win32' ? ['agy-acp.exe', 'agy-acp'] : ['agy-acp', 'agy-acp.exe'];
+  for (const executableName of executableNames) {
+    const release = findUp(cwd, `tools/agy-acp/target/release/${executableName}`);
+    if (release) return release;
+
+    const debug = findUp(cwd, `tools/agy-acp/target/debug/${executableName}`);
+    if (debug) return debug;
+  }
+
+  return resolve(cwd, `tools/agy-acp/target/release/${executableNames[0]}`);
+}
+
+function resolveAntigravitySessionName() {
+  return process.env.OMX_ANTIGRAVITY_SESSION?.trim() || 'antigravity';
+}
+
+function normalizeAntigravityModelTier(value?: string): 'low' | 'medium' | 'high' | '' {
+  const normalized = (value || '').trim().toLowerCase();
+  if (normalized === 'med') return 'medium';
+  if (normalized === 'low' || normalized === 'medium' || normalized === 'high') return normalized;
+  return '';
+}
+
+function inferAntigravityModelTier(prompt: string, originalTask = prompt): 'low' | 'medium' | 'high' {
+  const modelAsTier = normalizeAntigravityModelTier(process.env.OMX_ANTIGRAVITY_MODEL);
+  const explicit = modelAsTier
+    || normalizeAntigravityModelTier(process.env.OMX_ANTIGRAVITY_MODEL_TIER)
+    || normalizeAntigravityModelTier(process.env.OMX_ANTIGRAVITY_MODEL_SETTING)
+    || normalizeAntigravityModelTier(process.env.OMX_ANTIGRAVITY_PROFILE)
+    || normalizeAntigravityModelTier(process.env.OMX_ANTIGRAVITY_EFFORT);
+  if (explicit) return explicit;
+
+  const text = originalTask.toLowerCase();
+  if (/\b(high|deep|thorough|audit|architecture|critical|security|root cause|complex|hard|comprehensive)\b/.test(text)) {
+    return 'high';
+  }
+  if (/\b(low|quick|fast|simple|small|trivial|light|brief)\b/.test(text)) {
+    return 'low';
+  }
+  return 'medium';
+}
+
+function resolveAntigravityBaseModel(): string {
+  const requested = process.env.OMX_ANTIGRAVITY_MODEL?.trim();
+  if (requested && !normalizeAntigravityModelTier(requested)) return requested;
+  return 'gemini-3.5-flash';
+}
+
+function buildAntigravityModelSelection(prompt: string, originalTask = prompt): string {
+  const model = resolveAntigravityBaseModel();
+  const tier = inferAntigravityModelTier(prompt, originalTask);
+  if (/\b(low|medium|med|high)\b/i.test(model)) return model;
+  return `${model} (${tier})`;
+}
+
+function buildAntigravityPrompt(prompt: string, originalTask = prompt): string {
+  const modelSelection = buildAntigravityModelSelection(prompt, originalTask);
+  return [
+    '<omx_antigravity_routing>',
+    `Requested model setting: ${modelSelection}`,
+    'Low/medium/high is part of the model selection, not a separate reasoning-effort knob.',
+    'Use this exact model selection in Antigravity if the model selector or runtime exposes it.',
+    'If hard model selection is unavailable in the current agy CLI session, continue with the closest available Gemini 3.5 Flash model and say if the actual selected model is visible.',
+    '</omx_antigravity_routing>',
+    '',
+    prompt,
+  ].join('\n');
+}
+
+function resolveAntigravityAcpBaseArgs() {
+  const agent = resolveAntigravityAcpAgent();
+  if (!existsSync(agent)) {
+    console.error('[ask-antigravity] Missing agy-acp adapter binary. Build it with: cd tools/agy-acp && cargo build --release');
+    console.error(`[ask-antigravity] Expected adapter: ${agent}`);
+    process.exit(1);
+  }
+  if (!process.env.AGY_BIN?.trim()) {
+    const defaultAgy = join(process.env.HOME || '', '.local', 'bin', 'agy');
+    if (existsSync(defaultAgy)) process.env.AGY_BIN = defaultAgy;
+  }
+  if (!process.env.AGY_TIMEOUT_SECONDS?.trim()) {
+    process.env.AGY_TIMEOUT_SECONDS = '900';
+  }
+  if (!process.env.AGY_OUTPUT_MODE?.trim()) {
+    process.env.AGY_OUTPUT_MODE = 'cumulative-delta';
+  }
+  const timeout = process.env.OMX_ANTIGRAVITY_ACPX_TIMEOUT_SECONDS?.trim() || '960';
+  return ['--agent', agent, '--cwd', process.cwd(), '--timeout', timeout, '--format', 'text'];
+}
+
+function buildAntigravityEnsureSessionArgs() {
+  return [...resolveAntigravityAcpBaseArgs(), 'sessions', 'ensure', '--name', resolveAntigravitySessionName()];
+}
+
+function buildAntigravityLaunchArgs(prompt: string, originalTask = prompt) {
+  return [...resolveAntigravityAcpBaseArgs(), 'prompt', '-s', resolveAntigravitySessionName(), '--', buildAntigravityPrompt(prompt, originalTask)];
+}
+
 function ensureBinary(binary: string): void {
   const probe = spawnSync(binary, ['--version'], {
     stdio: 'ignore',
@@ -84,6 +200,10 @@ function shouldUseClaudeIssuePermissionsBypass(provider: string, prompt: string)
 }
 
 function buildProviderLaunchArgs(provider: string, prompt: string, originalTask: string): string[] {
+  if (provider === 'antigravity') {
+    return buildAntigravityLaunchArgs(prompt, originalTask);
+  }
+
   const promptArgs = provider === 'claude'
     ? ['-p', '--', prompt]
     : ['-p', prompt];
@@ -175,6 +295,23 @@ async function main(): Promise<void> {
 
   ensureBinary(binary);
 
+  if (provider === 'antigravity') {
+    const ensureRun = spawnSync(binary, buildAntigravityEnsureSessionArgs(), {
+      encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
+      windowsHide: true,
+    });
+    if (ensureRun.error) {
+      console.error(`[ask-antigravity] ${ensureRun.error.message}`);
+      process.exit(1);
+    }
+    if (typeof ensureRun.status === 'number' && ensureRun.status !== 0) {
+      const ensureOutput = [ensureRun.stdout || '', ensureRun.stderr || ''].filter(Boolean).join('\n\n');
+      console.error(ensureOutput || `[ask-antigravity] failed to ensure session ${resolveAntigravitySessionName()}`);
+      process.exit(ensureRun.status);
+    }
+  }
+
   const launchArgs = buildProviderLaunchArgs(provider, prompt, originalTask);
 
   const run = spawnSync(binary, launchArgs, {
@@ -191,7 +328,7 @@ async function main(): Promise<void> {
   const artifactPath = await writeArtifact({
     provider,
     originalTask,
-    finalPrompt: prompt,
+    finalPrompt: provider === 'antigravity' ? buildAntigravityPrompt(prompt, originalTask) : prompt,
     rawOutput,
     exitCode,
   });


### PR DESCRIPTION
## Summary
- add `antigravity` as an `omx ask` provider alongside Claude/Gemini
- route Antigravity through ACPX + `agy-acp` with persistent named sessions
- add Gemini 3.5 Flash low/medium/high model-tier routing metadata
- document Antigravity usage in ask skill docs and plugin mirror

## Notes
`agy` 1.0.2 does not expose a documented hard `--model` flag, so low/medium/high are sent as model-setting metadata and can be paired with persistent session names. If AG CLI later exposes hard model args, they can pass through via `AGY_EXTRA_ARGS`.

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/ask.test.js dist/cli/__tests__/nested-help-routing.test.js`
- `npm run lint -- src/cli/ask.ts src/scripts/run-provider-advisor.ts src/cli/__tests__/ask.test.ts src/cli/__tests__/nested-help-routing.test.ts`
- `npm run verify:plugin-bundle`
