### PR TITLE
Fix ultragoal status when Codex goal DB is unavailable

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -103,6 +103,55 @@ describe('cli/ultragoal', () => {
     });
   });
 
+  it('reports artifact-backed completion when Codex goal DB schema is unavailable', async () => {
+    await withCwd(async (cwd) => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+      const goals = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { codexObjective: string };
+
+      const checkpoint = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first-milestone',
+        '--status', 'complete',
+        '--evidence', 'tests passed',
+        '--codex-goal-json', JSON.stringify({ goal: { objective: goals.codexObjective, status: 'complete' } }),
+        '--quality-gate-json', cleanQualityGate(),
+      ]));
+      assert.equal(checkpoint.exitCode, undefined);
+
+      const status = await capture(() => ultragoalCommand([
+        'status',
+        '--codex-goal-json',
+        JSON.stringify({ error: 'SqliteError: no such table: thread_goals' }),
+        '--json',
+      ]));
+      assert.equal(status.exitCode, undefined);
+      const parsed = JSON.parse(status.stdout.join('\n')) as {
+        summary: { complete: number; aggregateComplete: boolean; artifactComplete: boolean };
+        codexGoalFallback?: { status: string; reason: string; message: string };
+        reconciliation?: { ok: boolean; warnings: string[]; snapshot: { unavailableReason?: string } };
+      };
+      assert.equal(parsed.summary.complete, 1);
+      assert.equal(parsed.summary.aggregateComplete, false);
+      assert.equal(parsed.summary.artifactComplete, true);
+      assert.equal(parsed.codexGoalFallback?.status, 'codex_goal_reconciliation_unavailable');
+      assert.equal(parsed.codexGoalFallback?.reason, 'db_schema_context_error');
+      assert.match(parsed.codexGoalFallback?.message ?? '', /artifact-backed Ultragoal status remains available/);
+      assert.equal(parsed.reconciliation?.ok, true);
+      assert.equal(parsed.reconciliation?.snapshot.unavailableReason, 'db_schema_context_error');
+
+      const human = await capture(() => ultragoalCommand([
+        'status',
+        '--codex-goal-json',
+        JSON.stringify({ error: 'SQL error: no such table: thread_goals' }),
+      ]));
+      const output = human.stdout.join('\n');
+      assert.match(output, /ultragoal artifact goals: complete/);
+      assert.match(output, /codex goal fallback: Codex goal DB\/schema\/context is unavailable/);
+      assert.match(output, /codex goal warning: .*no such table: thread_goals/);
+    });
+  });
+
   it('labels aggregate product completion separately from microgoal bookkeeping status', async () => {
     await withCwd(async () => {
       const taskObjective = 'Fix ultragoal task-scoped goal reconciliation.';
@@ -400,6 +449,17 @@ describe('cli/ultragoal', () => {
       assert.match(mismatch.stderr.join('\n'), /--status blocked/);
       assert.match(mismatch.stderr.join('\n'), /Codex goal context/);
       assert.doesNotMatch(mismatch.stderr.join('\n'), /fresh (?:Codex )?(?:thread|session)s?/i);
+
+      const unavailable = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first-milestone',
+        '--status', 'complete',
+        '--evidence', 'tests passed',
+        '--codex-goal-json', '{"error":"SqliteError: no such table: thread_goals"}',
+      ]));
+      assert.equal(unavailable.exitCode, 1);
+      assert.match(unavailable.stderr.join('\n'), /DB\/schema\/context error/);
+      assert.match(unavailable.stderr.join('\n'), /strict completion reconciliation can be proven/);
     });
   });
 

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -134,6 +134,10 @@ function printStatus(plan: Awaited<ReturnType<typeof readUltragoalPlan>>): void 
   if (summary.aggregateComplete) {
     console.log('ultragoal aggregate product: complete');
     console.log(`microgoal ledger bookkeeping (progress-only): ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked, ${summary.needsUserDecision} needs-user-decision`);
+  } else if (summary.artifactComplete) {
+    console.log('ultragoal artifact goals: complete');
+    console.log(`codex goal reconciliation: not recorded in OMX aggregateCompletion; status is artifact-backed until a fresh Codex goal snapshot is available.`);
+    console.log(`microgoal ledger: ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked, ${summary.needsUserDecision} needs-user-decision`);
   } else {
     console.log(`ultragoal: ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked, ${summary.needsUserDecision} needs-user-decision`);
   }
@@ -327,17 +331,25 @@ export async function ultragoalCommand(args: string[]): Promise<void> {
       const expectedObjective = plan.codexGoalMode === 'aggregate'
         ? plan.codexObjective
         : activeGoal?.objective;
-      const reconciliation = activeGoal
+      const reconciliation = activeGoal || snapshot
         ? reconcileCodexGoalSnapshot(snapshot, {
-          expectedObjective: expectedObjective ?? activeGoal.objective,
+          expectedObjective: expectedObjective ?? plan.codexObjective ?? '',
           acceptedObjectives: plan.codexGoalMode === 'aggregate' ? plan.codexObjectiveAliases : undefined,
-          allowedStatuses: plan.codexGoalMode === 'aggregate' ? ['active'] : ['active', 'complete'],
+          allowedStatuses: activeGoal && plan.codexGoalMode === 'aggregate' ? ['active'] : ['active', 'complete'],
           requireSnapshot: false,
         })
         : null;
-      if (json) printJson({ plan, summary: summarizeUltragoalPlan(plan), reconciliation });
+      const codexGoalFallback = reconciliation?.snapshot.unavailableReason === 'db_schema_context_error'
+        ? {
+          status: 'codex_goal_reconciliation_unavailable',
+          reason: reconciliation.snapshot.unavailableReason,
+          message: 'Codex goal DB/schema/context is unavailable; artifact-backed Ultragoal status remains available, but strict Codex goal completion reconciliation is deferred.',
+        }
+        : undefined;
+      if (json) printJson({ plan, summary: summarizeUltragoalPlan(plan), reconciliation, codexGoalFallback });
       else {
         printStatus(plan);
+        if (codexGoalFallback) console.log(`codex goal fallback: ${codexGoalFallback.message}`);
         if (reconciliation && !reconciliation.ok) console.log(`codex goal warning: ${formatCodexGoalReconciliation(reconciliation)}`);
         else if (reconciliation?.warnings.length) console.log(`codex goal warning: ${formatCodexGoalReconciliation(reconciliation)}`);
       }

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -760,7 +760,7 @@ export async function createUltragoalPlan(cwd: string, options: CreateUltragoalO
   });
 }
 
-export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; needsUserDecision: number; superseded: number; steeringBlocked: number; aggregateComplete: boolean; activeGoalId?: string } {
+export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; needsUserDecision: number; superseded: number; steeringBlocked: number; aggregateComplete: boolean; artifactComplete: boolean; activeGoalId?: string } {
   return {
     total: plan.goals.length,
     pending: plan.goals.filter((goal) => goal.status === 'pending').length,
@@ -772,6 +772,7 @@ export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pe
     superseded: plan.goals.filter((goal) => goal.steeringStatus === 'superseded').length,
     steeringBlocked: plan.goals.filter((goal) => goal.steeringStatus === 'blocked').length,
     aggregateComplete: plan.aggregateCompletion?.status === 'complete',
+    artifactComplete: isUltragoalDone(plan),
     activeGoalId: plan.activeGoalId,
   };
 }


### PR DESCRIPTION
## Summary
- Fixes #2530.
- Adds artifact-backed Ultragoal completion status (`artifactComplete`) so completed OMX stories are reported separately from Codex aggregate reconciliation.
- Classifies unavailable Codex goal DB/schema snapshots (including `no such table: thread_goals`) as a clear fallback status in `omx ultragoal status` without weakening strict checkpoint completion.
- Adds regression coverage for status JSON/human output and confirms unavailable goal snapshots cannot prove completion checkpoints.

## Validation
- `npm run build`
- `node --test dist/goal-workflows/__tests__/codex-goal-snapshot.test.js dist/cli/__tests__/ultragoal.test.js`
- `npm run check:no-unused`
- `git diff --check`

## Release blocker verdict
This should block 0.18.4 until merged: #2530 makes final quality-gated Ultragoal runs look incomplete/unreliable when Codex goal tooling lacks the `thread_goals` schema. This PR keeps strict Codex reconciliation semantics while giving operators a clear artifact-backed fallback status.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
