### PR TITLE
fix: accept shared skill roots without duplicate names

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -804,6 +804,33 @@ OMX_LORE_COMMIT_GUARD = "truee"
 		}
 	});
 
+	it("passes when shared skill root exists without duplicate skill names", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-shared-skills-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			const canonicalPlan = join(codexDir, "skills", "plan");
+			const legacyShared = join(home, ".agents", "skills", "shared-context");
+			await mkdir(canonicalPlan, { recursive: true });
+			await mkdir(legacyShared, { recursive: true });
+			await writeFile(join(canonicalPlan, "SKILL.md"), "# canonical plan\n");
+			await writeFile(join(legacyShared, "SKILL.md"), "# shared context\n");
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/\[OK\] Legacy skill roots: shared ~\/\.agents\/skills exists \(1 skills\) alongside canonical .*\.codex[\\/]+skills; no duplicate skill names detected/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("warns when canonical and legacy skill roots overlap", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-skill-overlap-"));
 		try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1621,8 +1621,8 @@ async function checkLegacySkillRootOverlap(): Promise<Check> {
 	if (overlap.overlappingSkillNames.length === 0) {
 		return {
 			name: "Legacy skill roots",
-			status: "warn",
-			message: `legacy ~/.agents/skills still exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}; remove or archive it if Codex shows duplicate entries`,
+			status: "pass",
+			message: `shared ~/.agents/skills exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}; no duplicate skill names detected`,
 		};
 	}
 


### PR DESCRIPTION
## Summary
- Treat a shared `~/.agents/skills` root as healthy when it has no skill-name overlap with the canonical Codex skill root.
- Keep the existing warning only for actual duplicate skill names across the two roots.
- Add a doctor regression test for the no-overlap shared-skills case.

## Scope notes
This is intentionally narrow:
- changes only the `omx doctor` legacy/current skill-root overlap status for the no-overlap case
- preserves the existing warning when duplicate skill names exist across the roots
- does not change setup/uninstall migration copy or skill-root discovery semantics

## Local checks
- `npm run build`
- `node --test dist/cli/__tests__/doctor-warning-copy.test.js`
- `npm run lint -- src/cli/doctor.ts src/cli/__tests__/doctor-warning-copy.test.ts`
- `npm run check:no-unused`
- `git diff --check upstream/dev...HEAD`
- `npm run verify:native-agents && npm run verify:plugin-bundle`

## Fresh OMX review
A fresh tmux OMX code-review pass was run against this branch after opening the PR:
- verdict: APPROVE
- blocking findings: 0
- caveat: `omx setup` still has older cleanup-oriented wording for no-overlap legacy roots, but this PR is scoped to doctor behavior and preserves warnings for actual duplicates.
