### PR TITLE
Fix Ultragoal HUD and Team pane duplication

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from '../reconcile.js';
+import { HUD_TMUX_HEIGHT_LINES } from '../constants.js';
 import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../tmux.js';
 
 describe('reconcileHudForPromptSubmit', () => {
@@ -89,9 +90,9 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.match(created[0]?.cmd || '', /exec .*\/repo\/dist\/cli\/omx\.js' hud --watch/);
     assert.match(created[0]?.cmd || '', /OMX_SESSION_ID='sess-a'/);
     assert.match(created[0]?.cmd || '', /OMX_TMUX_HUD_OWNER='1'/);
-    assert.equal(created[0]?.options?.heightLines, 3);
+    assert.equal(created[0]?.options?.heightLines, HUD_TMUX_HEIGHT_LINES);
     assert.equal(resized.length, 1);
-    assert.equal(resized[0]?.heightLines, 3);
+    assert.equal(resized[0]?.heightLines, HUD_TMUX_HEIGHT_LINES);
   });
 
   it('prefers an explicit session override when recreating HUD', async () => {
@@ -202,7 +203,7 @@ describe('reconcileHudForPromptSubmit', () => {
       createHudWatchPane: (_cwd, cmd, options) => {
         created.push({ cmd });
         assert.equal(options?.fullWidth, true);
-        assert.equal(options?.heightLines, 3);
+        assert.equal(options?.heightLines, HUD_TMUX_HEIGHT_LINES);
         return '%9';
       },
       resizeTmuxPane: () => true,
@@ -313,7 +314,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.status, 'resized');
     assert.equal(resized.length, 1);
     assert.equal(resized[0]?.paneId, '%2');
-    assert.equal(resized[0]?.heightLines, 3);
+    assert.equal(resized[0]?.heightLines, HUD_TMUX_HEIGHT_LINES);
   });
 
   it('resizes an existing owner-tagged same-leader HUD pane instead of creating a duplicate during prompt revive', async () => {
@@ -344,7 +345,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.status, 'resized');
     assert.equal(result.paneId, '%2');
     assert.deepEqual(created, []);
-    assert.deepEqual(resized, [{ paneId: '%2', heightLines: 3 }]);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
   });
 
 
@@ -370,7 +371,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.paneId, '%2');
     assert.equal(result.duplicateCount, 1);
     assert.deepEqual(killed, ['%3']);
-    assert.deepEqual(resized, [{ paneId: '%2', heightLines: 3 }]);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
     assert.deepEqual(created, []);
   });
 
@@ -402,7 +403,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.status, 'resized');
     assert.equal(result.paneId, '%2');
     assert.deepEqual(created, []);
-    assert.deepEqual(resized, [{ paneId: '%2', heightLines: 3 }]);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
   });
 
   it('registers client-resized hook scoped from the emitting pane after resizing an existing HUD pane', async () => {
@@ -429,7 +430,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(registered.length, 1);
     assert.equal(registered[0]?.hudPaneId, '%2');
     assert.equal(registered[0]?.currentPaneId, '%1');
-    assert.equal(registered[0]?.heightLines, 3);
+    assert.equal(registered[0]?.heightLines, HUD_TMUX_HEIGHT_LINES);
   });
 
   it('registers client-resized hook scoped from the emitting pane after creating a new HUD pane', async () => {
@@ -452,7 +453,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(registered.length, 1);
     assert.equal(registered[0]?.hudPaneId, '%9');
     assert.equal(registered[0]?.currentPaneId, '%1');
-    assert.equal(registered[0]?.heightLines, 3);
+    assert.equal(registered[0]?.heightLines, HUD_TMUX_HEIGHT_LINES);
   });
 
   it('unregisters existing hook before killing duplicates and re-registers for the new pane', async () => {

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -331,6 +331,74 @@ describe('renderHud – ultragoal', () => {
     assert.ok(result.includes('…'));
     assert.ok(!result.includes(longObjective));
   });
+
+  it('renders up to three ongoing ultragoal items alongside ralplan and ultraqa within the expanded HUD budget', () => {
+    const ctx = {
+      ...emptyCtx(),
+      ralplan: { active: true, current_phase: 'review' },
+      ultraqa: { active: true, current_phase: 'adversarial-e2e' },
+      ultragoal: {
+        active: true,
+        status: 'in_progress',
+        total: 5,
+        complete: 1,
+        pending: 3,
+        inProgress: 1,
+        failed: 0,
+        reviewBlocked: 0,
+        needsUserDecision: 0,
+        progressTotal: 5,
+        activeGoal: {
+          id: 'G002-active',
+          title: 'Active HUD status',
+          objective: 'show three active workflow statuses in the OMX HUD without clipping',
+          status: 'in_progress',
+          index: 2,
+        },
+        ongoingGoals: [
+          {
+            id: 'G002-active',
+            title: 'Active HUD status',
+            objective: 'show three active workflow statuses in the OMX HUD without clipping',
+            status: 'in_progress',
+            index: 2,
+          },
+          {
+            id: 'G003-next',
+            title: 'Next verification item',
+            objective: 'verify the HUD pane',
+            status: 'pending',
+            index: 3,
+          },
+          {
+            id: 'G004-qa',
+            title: 'Run UltraQA matrix',
+            objective: 'exercise adversarial scenarios',
+            status: 'pending',
+            index: 4,
+          },
+          {
+            id: 'G005-hidden',
+            title: 'Hidden fourth item',
+            objective: 'should not render',
+            status: 'pending',
+            index: 5,
+          },
+        ],
+      },
+    };
+
+    const result = stripSgr(renderHud(ctx, 'focused', { maxWidth: 260, maxLines: 6 }));
+
+    assert.ok(result.startsWith('[OMX]'));
+    assert.ok(result.includes('ralplan:review'));
+    assert.ok(result.includes('qa:adversarial-e2e'));
+    assert.ok(result.includes('G002-active: Active HUD status'));
+    assert.ok(result.includes('G003-next: Next verification item (pending)'));
+    assert.ok(result.includes('G004-qa: Run UltraQA matrix (pending)'));
+    assert.ok(!result.includes('G005-hidden'));
+    assert.ok(result.split('\n').length <= 6);
+  });
 });
 
 // ── Metrics – turns ───────────────────────────────────────────────────────────

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -271,7 +271,49 @@ describe('readUltragoalState', { concurrency: false }, () => {
           status: 'in_progress',
           index: 2,
         },
+        ongoingGoals: [
+          {
+            id: 'G002-hud-progress',
+            title: 'HUD progress display',
+            objective: 'show active ultragoal objective in OMX HUD',
+            status: 'in_progress',
+            index: 2,
+          },
+          {
+            id: 'G003-tests',
+            title: 'Tests',
+            objective: 'Validate the HUD display',
+            status: 'pending',
+            index: 3,
+          },
+        ],
       });
+    });
+  });
+
+  it('limits ultragoal ongoing HUD goals to three unresolved items with active goal first', async () => {
+    await withTempRepo('omx-hud-ultragoal-ongoing-', async (cwd) => {
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G004-active',
+        goals: [
+          { id: 'G001-done', title: 'Done', objective: 'Complete old work', status: 'complete' },
+          { id: 'G002-pending', title: 'Pending one', objective: 'Do pending one', status: 'pending' },
+          { id: 'G003-running', title: 'Running one', objective: 'Do running one', status: 'in_progress' },
+          { id: 'G004-active', title: 'Active selected', objective: 'Do active selected', status: 'in_progress' },
+          { id: 'G005-blocked', title: 'Blocked one', objective: 'Resolve blocker', status: 'review_blocked' },
+        ],
+      }));
+
+      const state = await readUltragoalState(cwd);
+
+      assert.deepEqual(state?.ongoingGoals?.map((goal) => goal.id), [
+        'G004-active',
+        'G003-running',
+        'G005-blocked',
+      ]);
     });
   });
 

--- a/src/hud/constants.ts
+++ b/src/hud/constants.ts
@@ -1,4 +1,4 @@
-export const HUD_TMUX_HEIGHT_LINES = 3;
+export const HUD_TMUX_HEIGHT_LINES = 6;
 export const HUD_TMUX_TEAM_HEIGHT_LINES = 3;
-export const HUD_TMUX_MAX_HEIGHT_LINES = 5;
+export const HUD_TMUX_MAX_HEIGHT_LINES = 6;
 export const HUD_RESIZE_RECONCILE_DELAY_SECONDS = 2;

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -322,7 +322,7 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
   const args = buildTmuxSplitArgs(cwd, omxBin, flags.preset, process.env.OMX_SESSION_ID, process.env.OMX_ROOT, currentPaneId);
 
   try {
-    // Split bottom pane, 4 lines tall, running omx hud --watch.
+    // Split bottom pane at the shared HUD height, running omx hud --watch.
     // execFileSync bypasses the shell – cwd and omxBin cannot inject commands.
     execFileSync('tmux', args, { stdio: 'inherit' });
     console.log('HUD launched in tmux pane below. Close with: Ctrl+C in that pane, or `tmux kill-pane -t bottom`');

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -138,12 +138,21 @@ function renderUltragoal(ctx: HudRenderContext): string | null {
   if (!Number.isFinite(total) || total <= 0 || !Number.isFinite(complete)) return null;
 
   const progress = `ultragoal ${complete}/${total}`;
-  const id = ctx.ultragoal.activeGoal?.id ? sanitizeDynamicText(ctx.ultragoal.activeGoal.id) : '';
-  const title = ctx.ultragoal.activeGoal?.title ? sanitizeDynamicText(ctx.ultragoal.activeGoal.title) : '';
-  const rawObjective = ctx.ultragoal.activeGoal?.objective ? sanitizeDynamicText(ctx.ultragoal.activeGoal.objective) : '';
+  const ongoingGoals = (ctx.ultragoal.ongoingGoals?.length ? ctx.ultragoal.ongoingGoals : ctx.ultragoal.activeGoal ? [ctx.ultragoal.activeGoal] : [])
+    .slice(0, 3)
+    .map((goal) => {
+      const id = goal.id ? sanitizeDynamicText(goal.id) : '';
+      const title = goal.title ? truncateDynamicText(sanitizeDynamicText(goal.title), 36) : '';
+      const status = goal.status ? sanitizeDynamicText(goal.status) : '';
+      const heading = [id, title].filter(Boolean).join(': ');
+      return status && status !== 'in_progress' ? `${heading} (${status})` : heading;
+    })
+    .filter(Boolean);
+  const activeGoal = ctx.ultragoal.activeGoal ?? ctx.ultragoal.ongoingGoals?.[0];
+  const rawObjective = activeGoal?.objective ? sanitizeDynamicText(activeGoal.objective) : '';
   const objective = rawObjective ? truncateDynamicText(rawObjective, 96) : '';
-  const heading = [id, title].filter(Boolean).join(': ');
-  const summary = heading ? `${progress} ▶ ${heading}` : progress;
+  const items = ongoingGoals.length > 0 ? ` ▶ ${ongoingGoals.join(' · ')}` : '';
+  const summary = `${progress}${items}`;
   return cyan(objective ? `${summary} · objective: ${objective}` : summary);
 }
 

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -175,6 +175,28 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
   );
   const activeIndex = activeGoal ? goals.findIndex((goal) => goal.id === activeGoal.id) : -1;
   const complete = isAggregateComplete(plan.aggregateCompletion) || unresolved_goals === 0;
+  const orderedOngoingGoals = goals
+    .map((goal, index) => ({ goal, index }))
+    .filter(({ goal }) => ULTRAGOAL_UNRESOLVED_STATUSES.has(goal.status))
+    .sort((a, b) => {
+      const aActive = activeGoal && a.goal.id === activeGoal.id ? 0 : 1;
+      const bActive = activeGoal && b.goal.id === activeGoal.id ? 0 : 1;
+      if (aActive !== bActive) return aActive - bActive;
+
+      const aRunning = ULTRAGOAL_ACTIVE_STATUSES.has(a.goal.status) ? 0 : 1;
+      const bRunning = ULTRAGOAL_ACTIVE_STATUSES.has(b.goal.status) ? 0 : 1;
+      if (aRunning !== bRunning) return aRunning - bRunning;
+
+      return a.index - b.index;
+    })
+    .slice(0, 3)
+    .map(({ goal, index }) => ({
+      id: goal.id,
+      title: goal.title,
+      objective: goal.objective,
+      status: goal.status,
+      index: index + 1,
+    }));
 
   return {
     active: !complete,
@@ -194,6 +216,7 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
       status: activeGoal.status,
       index: activeIndex + 1,
     } : undefined,
+    ongoingGoals: orderedOngoingGoals,
   };
 }
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -30,6 +30,7 @@ export interface UltragoalStateForHud {
   needsUserDecision: number;
   progressTotal: number;
   activeGoal?: UltragoalActiveGoalForHud;
+  ongoingGoals?: UltragoalActiveGoalForHud[];
 }
 
 /** Ultrawork state for HUD display */

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -24,6 +24,7 @@ import {
 import { writeSessionStart } from "../../hooks/session.js";
 import { resetTriageConfigCache } from "../../hooks/triage-config.js";
 import { executeStateOperation } from "../../state/operations.js";
+import { HUD_TMUX_HEIGHT_LINES } from "../../hud/constants.js";
 import { OMX_TMUX_HUD_OWNER_ENV } from "../../hud/reconcile.js";
 import { OMX_TMUX_HUD_LEADER_PANE_ENV } from "../../hud/tmux.js";
 import { readAllState } from "../../hud/state.js";
@@ -4153,8 +4154,8 @@ esac
       assert.equal(result.omxEventName, "keyword-detector");
       const tmuxCalls = await readFile(tmuxLog, "utf-8");
       assert.match(tmuxCalls, /list-panes -t %1 -F/);
-      assert.match(tmuxCalls, /split-window -v -l 3 -d -t %1 -c/);
-      assert.match(tmuxCalls, /resize-pane -t %9 -y 3/);
+      assert.match(tmuxCalls, new RegExp(`split-window -v -l ${HUD_TMUX_HEIGHT_LINES} -d -t %1 -c`));
+      assert.match(tmuxCalls, new RegExp(`resize-pane -t %9 -y ${HUD_TMUX_HEIGHT_LINES}`));
       assert.match(tmuxCalls, /dist\/cli\/omx\.js' hud --watch --preset=focused/);
       assert.doesNotMatch(tmuxCalls, /\/tmp\/codex-host-binary' hud --watch/);
     } finally {
@@ -4235,7 +4236,7 @@ esac
       assert.equal(result.omxEventName, "keyword-detector");
       const tmuxCalls = await readFile(tmuxLog, "utf-8");
       assert.match(tmuxCalls, /list-panes -t %1 -F/);
-      assert.match(tmuxCalls, /resize-pane -t %2 -y 3/);
+      assert.match(tmuxCalls, new RegExp(`resize-pane -t %2 -y ${HUD_TMUX_HEIGHT_LINES}`));
       assert.doesNotMatch(tmuxCalls, /split-window/);
       assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", canonicalSessionId, "ralplan-state.json")), true);
       assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", nativeSessionId, "ralplan-state.json")), false);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6119,6 +6119,7 @@ esac
           assert.match(tmuxLog, /run-shell -b sleep \d+; tmux resize-pane -t %44 -y \d+ >/);
           assert.match(tmuxLog, /run-shell tmux resize-pane -t %44 -y \d+ >/);
           assert.match(tmuxLog, /hud --watch/);
+          assert.match(tmuxLog, /OMX_TMUX_HUD_LEADER_PANE='%11'/);
           assert.match(tmuxLog, /select-pane -t %11/);
         },
       );

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -3296,7 +3296,7 @@ esac
           assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id omx-pane-scope/);
-          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER=1 .*hud --watch/);
+          assert.match(tmuxLog, /exec env OMX_SESSION_ID='omx-pane-scope' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
         },
       );
     } finally {
@@ -3874,7 +3874,7 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, new RegExp(escapeRegExp(launcherPath)));
           assert.doesNotMatch(tmuxLog, /'dist\/cli\/omx\.js' hud --watch/);
-          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER=1 .*hud --watch/);
+          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%11' .*hud --watch/);
         },
       );
     } finally {
@@ -3961,7 +3961,7 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(
             tmuxLog,
-            /exec env OMX_TMUX_HUD_OWNER=1 OMX_ROOT='\/tmp\/boxed root\/it'\\''s\/\$\(literal\)' .*hud --watch/,
+            /exec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%11' OMX_ROOT='\/tmp\/boxed root\/it'\\''s\/\$\(literal\)' .*hud --watch/,
           );
         },
       );

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -35,6 +35,7 @@ import { resolveOmxCliEntryPath } from '../utils/paths.js';
 const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
 import { OMX_TMUX_HUD_OWNER_ENV } from '../hud/reconcile.js';
+import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../hud/tmux.js';
 
 const OMX_INSTANCE_OPTION = '@omx_instance_id';
 const OMX_PANE_INSTANCE_OPTION = '@omx_pane_instance_id';
@@ -404,13 +405,20 @@ function shellQuoteSingle(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function formatHudEnvAssignments(env: NodeJS.ProcessEnv = process.env): string {
+function formatHudEnvAssignments(
+  env: NodeJS.ProcessEnv = process.env,
+  owner: { sessionId?: string | null; leaderPaneId?: string | null } = {},
+): string {
+  const sessionId = (owner.sessionId ?? '').trim();
+  const leaderPaneId = (owner.leaderPaneId ?? '').trim();
   const assignments = [
+    sessionId ? `OMX_SESSION_ID=${shellQuoteSingle(sessionId)}` : '',
     `${OMX_TMUX_HUD_OWNER_ENV}=1`,
+    leaderPaneId ? `${OMX_TMUX_HUD_LEADER_PANE_ENV}=${shellQuoteSingle(leaderPaneId)}` : '',
     ...(typeof env.OMX_ROOT === 'string' && env.OMX_ROOT.trim() !== ''
       ? [`OMX_ROOT=${shellQuoteSingle(env.OMX_ROOT)}`]
       : []),
-  ];
+  ].filter(Boolean);
   return assignments.join(' ');
 }
 
@@ -1283,7 +1291,7 @@ export function createTeamSession(
     let resizeHookName: string | null = null;
     let resizeHookTarget: string | null = null;
     if (canRecreateTeamHud && omxEntry) {
-      const hudCmd = `exec env ${formatHudEnvAssignments()} node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+      const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: instanceId, leaderPaneId })} node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
       const hudCwd = translatePathForMsys(cwd);
       const hudResult = runTmux([
         'split-window', '-v', '-f', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', teamTarget, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,
@@ -1411,7 +1419,7 @@ export function restoreStandaloneHudPane(
   const omxEntry = resolveOmxCliEntryPath();
   if (!omxEntry || omxEntry.trim() === '') return null;
 
-  const hudCmd = `exec env ${formatHudEnvAssignments()} ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+  const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { leaderPaneId: normalizedLeaderPaneId })} ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
   const hudCwd = translatePathForMsys(cwd);
   const hudResult = runTmux([
     'split-window',


### PR DESCRIPTION
## Summary
- expand the tmux HUD strip by 3 lines so Ultragoal/Ralplan/UltraQA status text no longer collapses
- render up to 3 ongoing Ultragoal items in the HUD
- tag Team-created/restored HUD panes with the leader pane owner so Ultragoal + Team prompt reconciliation reuses the existing HUD instead of duplicating it

## Verification
- `npm run build`
- `node --test --test-name-pattern "tags leader, worker, and HUD panes|restores standalone HUD panes with an absolute|restores standalone HUD panes with OMX_ROOT|shutdownTeam restores a standalone HUD pane" dist/team/__tests__/tmux-session.test.js dist/team/__tests__/runtime.test.js`
- `node --test dist/hud/__tests__/render.test.js dist/hud/__tests__/reconcile.test.js`
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_TEAM_STATE_ROOT -u TMUX -u TMUX_PANE node --test dist/hud/__tests__/state.test.js`
- `npm run lint`
- `npm run check:no-unused`

## Notes
A full `npm test` was not used as the completion gate because existing unrelated environment-sensitive failures were already observed in auth/doctor/dispatcher/run-test fixtures, plus ambient OMX runtime env can perturb HUD state tests unless sanitized.
