### PR TITLE
fix: narrow doctor shared skill root warnings

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -804,6 +804,33 @@ OMX_LORE_COMMIT_GUARD = "truee"
 		}
 	});
 
+	it("passes when shared skill root exists without duplicate skill names", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-shared-skills-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			const canonicalPlan = join(codexDir, "skills", "plan");
+			const legacyShared = join(home, ".agents", "skills", "shared-context");
+			await mkdir(canonicalPlan, { recursive: true });
+			await mkdir(legacyShared, { recursive: true });
+			await writeFile(join(canonicalPlan, "SKILL.md"), "# canonical plan\n");
+			await writeFile(join(legacyShared, "SKILL.md"), "# shared context\n");
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/\[OK\] Legacy skill roots: shared ~\/\.agents\/skills exists \(1 skills\) alongside canonical .*\.codex[\\/]+skills; no duplicate skill names detected/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("warns when canonical and legacy skill roots overlap", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-skill-overlap-"));
 		try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1621,8 +1621,8 @@ async function checkLegacySkillRootOverlap(): Promise<Check> {
 	if (overlap.overlappingSkillNames.length === 0) {
 		return {
 			name: "Legacy skill roots",
-			status: "warn",
-			message: `legacy ~/.agents/skills still exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}; remove or archive it if Codex shows duplicate entries`,
+			status: "pass",
+			message: `shared ~/.agents/skills exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}; no duplicate skill names detected`,
 		};
 	}
 


### PR DESCRIPTION
## Summary
- Make `omx doctor` treat a distinct shared `~/.agents/skills` root as healthy when it has no duplicate skill names against the active canonical Codex skill root.
- Keep the warning for the actionable case: overlapping skill names, with stronger wording already preserved when `SKILL.md` content differs.
- Add regression coverage for the no-overlap shared-root case.

Fixes #2536.

## Rationale

`omx doctor` should warn on active-runtime ambiguity, not on the mere existence of user-owned shared configuration.

In multi-agent setups, `~/.agents/skills` can be a valid shared library used by Codex, Hermes, and other agents. If that root has no skill-name overlap with the active canonical Codex skill root, there is no duplicate skill resolution problem for doctor to report. Warning anyway turns a healthy shared library into a false positive and nudges users to remove configuration that is outside this OMX setup's ownership.

This keeps the contract narrow:
- OK: shared root exists, no duplicate skill names.
- WARN: duplicate skill names across active discovery roots.
- Existing symlink-to-canonical-root behavior remains OK.

## Scope notes
- Only changes `omx doctor` warning/pass classification for the no-overlap shared-root case.
- Does not change skill discovery, setup/uninstall behavior, or duplicate detection.
- Does not suppress real duplicate warnings.

## Local checks
- `npm run build`
- `node --test dist/cli/__tests__/doctor-warning-copy.test.js`
- `npm run lint -- src/cli/doctor.ts src/cli/__tests__/doctor-warning-copy.test.ts`
- `npm run check:no-unused`
- `git diff --check upstream/dev...HEAD`
