### PR TITLE
fix: allow autopilot deep-interview questions

### DIFF
--- a/src/question/__tests__/policy.test.ts
+++ b/src/question/__tests__/policy.test.ts
@@ -129,6 +129,50 @@ describe('evaluateQuestionPolicy', { concurrency: false }, () => {
 });
 
 describe('evaluateQuestionPolicy autopilot deep-interview wait', { concurrency: false }, () => {
+  it('allows autopilot deep-interview phase to open the user question UI', { concurrency: false }, async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-auto-deep');
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+      mode: 'autopilot',
+      active: true,
+      current_phase: 'deep-interview',
+    }, null, 2));
+    await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+      active: true,
+      skill: 'autopilot',
+      phase: 'deep-interview',
+      active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: 'sess-auto-deep' }],
+      session_id: 'sess-auto-deep',
+    }, null, 2));
+
+    const allowedWithSource = await evaluateQuestionPolicy({
+      cwd,
+      explicitSessionId: 'sess-auto-deep',
+      questionSource: 'deep-interview',
+      env: { ...process.env, OMX_TEAM_WORKER: '' },
+    });
+    assert.equal(allowedWithSource.allowed, true);
+    assert.equal(allowedWithSource.fallbackAllowed, true);
+
+    const allowedWithoutSource = await evaluateQuestionPolicy({
+      cwd,
+      explicitSessionId: 'sess-auto-deep',
+      env: { ...process.env, OMX_TEAM_WORKER: '' },
+    });
+    assert.equal(allowedWithoutSource.allowed, true);
+    assert.equal(allowedWithoutSource.fallbackAllowed, true);
+
+    const unrelatedSource = await evaluateQuestionPolicy({
+      cwd,
+      explicitSessionId: 'sess-auto-deep',
+      questionSource: 'implementation',
+      env: { ...process.env, OMX_TEAM_WORKER: '' },
+    });
+    assert.equal(unrelatedSource.allowed, false);
+    assert.equal(unrelatedSource.code, 'active_execution_mode_blocked');
+  });
+
   it('allows only controlled autopilot deep-interview questions while preserving unrelated guards', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-auto');

--- a/src/question/autopilot-wait.ts
+++ b/src/question/autopilot-wait.ts
@@ -66,6 +66,15 @@ export async function readAutopilotDeepInterviewQuestionWaitState(
   };
 }
 
+export async function isAutopilotDeepInterviewPhase(
+  cwd: string,
+  sessionId?: string,
+): Promise<boolean> {
+  const state = await readAutopilotState(cwd, sessionId);
+  if (!state || safeString(state.mode) !== 'autopilot' || state.active !== true) return false;
+  return normalizePhase(state.current_phase) === 'deep-interview';
+}
+
 export async function markAutopilotDeepInterviewQuestionWaiting(
   cwd: string,
   sessionId: string | undefined,

--- a/src/question/policy.ts
+++ b/src/question/policy.ts
@@ -2,7 +2,7 @@ import { listNotifyCanonicalActiveTeams, type NotifyCanonicalActiveTeam } from '
 import { readCurrentSessionId } from '../mcp/state-paths.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import { readActiveWorkflowModes } from '../state/workflow-transition.js';
-import { readAutopilotDeepInterviewQuestionWaitState } from './autopilot-wait.js';
+import { isAutopilotDeepInterviewPhase, readAutopilotDeepInterviewQuestionWaitState } from './autopilot-wait.js';
 
 const BLOCKED_EXECUTION_SKILLS = new Set([
   'autopilot',
@@ -94,7 +94,11 @@ export async function evaluateQuestionPolicy(
       && onlyControlledAutopilotQuestionBlock(blocked)
       ? await readAutopilotDeepInterviewQuestionWaitState(options.cwd, sessionId)
       : null;
-    if (autopilotWait) {
+    const autopilotDeepInterviewPhase = (source === 'deep-interview' || source === '')
+      && onlyControlledAutopilotQuestionBlock(blocked)
+      ? await isAutopilotDeepInterviewPhase(options.cwd, sessionId)
+      : false;
+    if (autopilotWait || autopilotDeepInterviewPhase) {
       return {
         allowed: true,
         fallbackAllowed: true,


### PR DESCRIPTION
## Summary
- Allow `omx question` during the controlled `$autopilot` deep-interview phase so the workflow can ask the user instead of selecting a default and continuing execution.
- Keep the existing execution-mode guard for unrelated sources, team workers, active teams, and any additional active execution mode.
- Add policy regression coverage for active autopilot deep-interview questions, including source-less CLI input from the reported flow.

Fixes #2540.

## Rationale

The reported failure happens at the intended user-decision gate: autopilot is active in `deep-interview`, but `omx question` is rejected because `autopilot` is treated as a blocked execution mode. The agent then cannot show the question UI and may proceed with a conservative default, defeating the deep-interview gate.

This patch narrows the exception to the one phase where a user question is expected: active autopilot + `current_phase: deep-interview`, with only autopilot as the blocked mode. Other execution modes still block `omx question`.

## Scope notes
- Does not change renderer behavior or tmux pane-return validation.
- Does not allow team workers or active team sessions to ask questions.
- Does not allow questions during autopilot implementation/verification phases.

## Local checks
- `npm run build`
- `node --test dist/question/__tests__/policy.test.js dist/question/__tests__/deep-interview.test.js dist/cli/__tests__/question.test.js`
- `npm run lint -- src/question/policy.ts src/question/autopilot-wait.ts src/question/__tests__/policy.test.ts`
- `npm run check:no-unused`
- `git diff --check upstream/dev...HEAD`

## Fresh OMX review
A fresh tmux OMX code-review pass was run against this branch:
- verdict: APPROVE
- blocking findings: 0
- caveat: source-less `omx question` is intentionally allowed only while autopilot is in deep-interview; if stricter provenance is desired later, require `source: "deep-interview"` separately.
