### PR TITLE
Fix autopilot deep-interview question UI gating

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -144,6 +144,107 @@ describe('omx question CLI', () => {
     assert.equal(payload.prompt.type, 'multi-answerable');
   });
 
+  it('bridges active autopilot deep-interview questions into waiting-for-user state until answered', async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-q');
+    const autopilotPath = join(sessionDir, 'autopilot-state.json');
+    await writeFile(autopilotPath, JSON.stringify({
+      mode: 'autopilot',
+      active: true,
+      current_phase: 'deep-interview',
+      run_outcome: 'interviewing',
+      lifecycle_outcome: 'running',
+      session_id: 'sess-q',
+    }, null, 2));
+    await writeFile(join(sessionDir, 'deep-interview-state.json'), JSON.stringify({
+      mode: 'deep-interview',
+      active: true,
+      current_phase: 'intent-first',
+      session_id: 'sess-q',
+    }, null, 2));
+    await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+      active: true,
+      skill: 'autopilot',
+      phase: 'deep-interview',
+      session_id: 'sess-q',
+      active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: 'sess-q' }],
+    }, null, 2));
+
+    const input = JSON.stringify({
+      question: 'Which provenance rule?',
+      options: [{ label: 'Exact page mapping', value: 'exact-page' }],
+      allow_other: false,
+      source: 'deep-interview',
+      session_id: 'sess-q',
+    });
+
+    const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
+      cwd,
+      env: makeQuestionCliEnv(cwd, {
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        OMX_QUESTION_TEST_RENDERER: 'noop',
+      }),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+    child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+    const closePromise = new Promise<number | null>((resolve) => child.on('close', resolve));
+
+    const questionsDir = join(sessionDir, 'questions');
+    const recordFile = await waitForQuestionRecordFile(questionsDir, () => `stderr=${stderr}; stdout=${stdout}`);
+    const recordPath = join(questionsDir, recordFile);
+
+    let record = null;
+    for (let attempt = 0; attempt < 250; attempt += 1) {
+      record = await readQuestionRecord(recordPath);
+      if (record?.status === 'prompting') break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    assert.equal(record?.status, 'prompting', `expected prompting question record, stderr=${stderr}`);
+
+    const waitingAutopilot = JSON.parse(await readFile(autopilotPath, 'utf-8')) as {
+      current_phase?: string;
+      run_outcome?: string;
+      lifecycle_outcome?: string;
+      state?: { deep_interview_question?: { status?: string; previous_phase?: string } };
+    };
+    assert.equal(waitingAutopilot.current_phase, 'waiting-for-user');
+    assert.equal(waitingAutopilot.run_outcome, 'blocked_on_user');
+    assert.equal(waitingAutopilot.lifecycle_outcome, 'askuserQuestion');
+    assert.equal(waitingAutopilot.state?.deep_interview_question?.status, 'waiting_for_user');
+    assert.equal(waitingAutopilot.state?.deep_interview_question?.previous_phase, 'deep-interview');
+
+    await markQuestionAnswered(recordPath, {
+      kind: 'option',
+      value: 'exact-page',
+      selected_labels: ['Exact page mapping'],
+      selected_values: ['exact-page'],
+    });
+
+    const exitCode = await closePromise;
+    assert.equal(exitCode, 0, stderr || stdout);
+
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.answer.value, 'exact-page');
+
+    const finalAutopilot = JSON.parse(await readFile(autopilotPath, 'utf-8')) as {
+      current_phase?: string;
+      run_outcome?: string;
+      lifecycle_outcome?: string;
+      state?: { deep_interview_question?: { status?: string } };
+    };
+    assert.equal(finalAutopilot.current_phase, 'deep-interview');
+    assert.equal(finalAutopilot.run_outcome, 'interviewing');
+    assert.equal(finalAutopilot.lifecycle_outcome, 'running');
+    assert.equal(finalAutopilot.state?.deep_interview_question?.status, 'satisfied');
+  });
+
   it('omits legacy prompt and answer projections for batch payloads', async () => {
     const cwd = await makeRepo();
     const input = JSON.stringify({

--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -1,6 +1,17 @@
 import { evaluateQuestionPolicy } from '../question/policy.js';
 import { appendQuestionAnsweredEventOnce, appendQuestionEvent } from '../question/events.js';
 import {
+  clearDeepInterviewQuestionObligation,
+  createDeepInterviewQuestionObligation,
+  satisfyDeepInterviewQuestionObligation,
+  updateDeepInterviewQuestionEnforcement,
+  type DeepInterviewQuestionEnforcementState,
+} from '../question/deep-interview.js';
+import {
+  markAutopilotDeepInterviewQuestionWaiting,
+  resolveAutopilotDeepInterviewQuestionWaiting,
+} from '../question/autopilot-wait.js';
+import {
   createQuestionRecord,
   markQuestionTerminalError,
   markQuestionPrompting,
@@ -172,6 +183,35 @@ function createJsonSafeInlineQuestionOutput(): { isTTY?: boolean; write(chunk: s
   };
 }
 
+function isDeepInterviewQuestionSource(source: unknown): boolean {
+  return typeof source === 'string' && source.trim() === 'deep-interview';
+}
+
+async function finalizeDirectDeepInterviewObligation(
+  cwd: string,
+  sessionId: string | undefined,
+  obligation: DeepInterviewQuestionEnforcementState | null,
+  outcome: { status: 'satisfied'; questionId: string } | { status: 'cleared' },
+): Promise<void> {
+  if (!obligation) return;
+  await updateDeepInterviewQuestionEnforcement(
+    cwd,
+    sessionId,
+    (current) => {
+      if (current?.obligation_id !== obligation.obligation_id) return current;
+      return outcome.status === 'satisfied'
+        ? satisfyDeepInterviewQuestionObligation(current, outcome.questionId)
+        : clearDeepInterviewQuestionObligation(current, 'error');
+    },
+  );
+  await resolveAutopilotDeepInterviewQuestionWaiting(
+    cwd,
+    sessionId,
+    obligation.obligation_id,
+    outcome.status,
+  );
+}
+
 export async function questionCommand(args: string[]): Promise<void> {
   const parsed = parseQuestionArgs(args);
   if (parsed.help || args.length === 0) {
@@ -252,6 +292,21 @@ export async function questionCommand(args: string[]): Promise<void> {
     return;
   }
 
+  let directDeepInterviewObligation: DeepInterviewQuestionEnforcementState | null = null;
+  if (isDeepInterviewQuestionSource(input.source) && policy.sessionId) {
+    directDeepInterviewObligation = createDeepInterviewQuestionObligation();
+    await updateDeepInterviewQuestionEnforcement(
+      cwd,
+      policy.sessionId,
+      () => directDeepInterviewObligation ?? undefined,
+    );
+    await markAutopilotDeepInterviewQuestionWaiting(
+      cwd,
+      policy.sessionId,
+      directDeepInterviewObligation,
+    );
+  }
+
   const waitTimeoutMs = parseQuestionWaitTimeoutMs();
   const { record, recordPath } = await createQuestionRecord(cwd, input, policy.sessionId, new Date(), {
     emitEvent: true,
@@ -291,6 +346,12 @@ export async function questionCommand(args: string[]): Promise<void> {
       recordPath,
       timeoutMs: waitTimeoutMs,
     });
+    await finalizeDirectDeepInterviewObligation(
+      cwd,
+      policy.sessionId,
+      directDeepInterviewObligation,
+      { status: 'cleared' },
+    );
     printJson({
       ok: false,
       question_id: record.question_id,
@@ -311,6 +372,12 @@ export async function questionCommand(args: string[]): Promise<void> {
         timeoutMs: waitTimeoutMs,
       });
     }
+    await finalizeDirectDeepInterviewObligation(
+      cwd,
+      policy.sessionId,
+      directDeepInterviewObligation,
+      { status: 'cleared' },
+    );
     printJson({
       ok: false,
       question_id: finalRecord.question_id,
@@ -327,6 +394,12 @@ export async function questionCommand(args: string[]): Promise<void> {
     recordPath,
     timeoutMs: waitTimeoutMs,
   });
+  await finalizeDirectDeepInterviewObligation(
+    cwd,
+    policy.sessionId,
+    directDeepInterviewObligation,
+    { status: 'satisfied', questionId: finalRecord.question_id },
+  );
 
   const isSingleQuestion = (finalRecord.questions?.length ?? 0) === 1;
   printJson({

--- a/src/question/__tests__/policy.test.ts
+++ b/src/question/__tests__/policy.test.ts
@@ -129,6 +129,41 @@ describe('evaluateQuestionPolicy', { concurrency: false }, () => {
 });
 
 describe('evaluateQuestionPolicy autopilot deep-interview wait', { concurrency: false }, () => {
+  it('allows a deep-interview question to start while autopilot is in its deep-interview phase', { concurrency: false }, async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-auto-start');
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+      mode: 'autopilot',
+      active: true,
+      current_phase: 'deep-interview',
+    }, null, 2));
+    await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+      active: true,
+      skill: 'autopilot',
+      phase: 'deep-interview',
+      active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: 'sess-auto-start' }],
+      session_id: 'sess-auto-start',
+    }, null, 2));
+
+    const allowed = await evaluateQuestionPolicy({
+      cwd,
+      explicitSessionId: 'sess-auto-start',
+      questionSource: 'deep-interview',
+      env: { ...process.env, OMX_TEAM_WORKER: '' },
+    });
+    assert.equal(allowed.allowed, true);
+
+    const unrelatedSource = await evaluateQuestionPolicy({
+      cwd,
+      explicitSessionId: 'sess-auto-start',
+      questionSource: 'implementation',
+      env: { ...process.env, OMX_TEAM_WORKER: '' },
+    });
+    assert.equal(unrelatedSource.allowed, false);
+    assert.equal(unrelatedSource.code, 'active_execution_mode_blocked');
+  });
+
   it('allows only controlled autopilot deep-interview questions while preserving unrelated guards', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-auto');

--- a/src/question/autopilot-wait.ts
+++ b/src/question/autopilot-wait.ts
@@ -66,6 +66,15 @@ export async function readAutopilotDeepInterviewQuestionWaitState(
   };
 }
 
+export async function canStartAutopilotDeepInterviewQuestion(
+  cwd: string,
+  sessionId?: string,
+): Promise<boolean> {
+  const state = await readAutopilotState(cwd, sessionId);
+  if (!state || safeString(state.mode) !== 'autopilot' || state.active !== true) return false;
+  return normalizePhase(state.current_phase) === 'deep-interview';
+}
+
 export async function markAutopilotDeepInterviewQuestionWaiting(
   cwd: string,
   sessionId: string | undefined,

--- a/src/question/policy.ts
+++ b/src/question/policy.ts
@@ -2,7 +2,10 @@ import { listNotifyCanonicalActiveTeams, type NotifyCanonicalActiveTeam } from '
 import { readCurrentSessionId } from '../mcp/state-paths.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import { readActiveWorkflowModes } from '../state/workflow-transition.js';
-import { readAutopilotDeepInterviewQuestionWaitState } from './autopilot-wait.js';
+import {
+  canStartAutopilotDeepInterviewQuestion,
+  readAutopilotDeepInterviewQuestionWaitState,
+} from './autopilot-wait.js';
 
 const BLOCKED_EXECUTION_SKILLS = new Set([
   'autopilot',
@@ -90,19 +93,24 @@ export async function evaluateQuestionPolicy(
 
   if (blocked.length > 0) {
     const source = safeString(options.questionSource).trim();
-    const autopilotWait = source === 'deep-interview'
-      && onlyControlledAutopilotQuestionBlock(blocked)
-      ? await readAutopilotDeepInterviewQuestionWaitState(options.cwd, sessionId)
-      : null;
-    if (autopilotWait) {
-      return {
-        allowed: true,
-        fallbackAllowed: true,
+    if (source === 'deep-interview' && onlyControlledAutopilotQuestionBlock(blocked)) {
+      const autopilotWait = await readAutopilotDeepInterviewQuestionWaitState(
+        options.cwd,
         sessionId,
-        activeModes,
-        activeSkills,
-        activeTeams,
-      };
+      );
+      const canStartAutopilotQuestion = autopilotWait
+        ? true
+        : await canStartAutopilotDeepInterviewQuestion(options.cwd, sessionId);
+      if (canStartAutopilotQuestion) {
+        return {
+          allowed: true,
+          fallbackAllowed: true,
+          sessionId,
+          activeModes,
+          activeSkills,
+          activeTeams,
+        };
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary

Fixes #2540 by preserving the intended autopilot intake sequence when deep-interview reaches a user decision point. Direct `omx question --input ... source:"deep-interview"` calls are now allowed only while autopilot is in its deep-interview/waiting-for-user path, then the CLI records a waiting-for-user bridge until the question is answered or errors.

## Changes

- Allow the question policy to start a controlled deep-interview question while active autopilot is still in `deep-interview`.
- Mark autopilot as `waiting-for-user`/`askuserQuestion` during direct deep-interview `omx question` CLI calls, then restore/resolve the prior phase after answer or error.
- Add focused regressions for the direct CLI path, policy guard, and existing Stop-hook wait behavior.
- Preserve existing tmux return-pane safety; this does not loosen PreToolUse bridge checks.

## Validation

- [x] `npm run build`
- [x] `node --test dist/question/__tests__/policy.test.js dist/cli/__tests__/question.test.js dist/question/__tests__/deep-interview.test.js`
- [x] `node --test --test-name-pattern 'native Stop autopilot deep-interview wait|does not force continued execution while autopilot is waiting on a deep-interview omx question' dist/scripts/__tests__/codex-native-hook.test.js`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [ ] `npm test` (not run; focused issue regression plus build/lint/no-unused were run)
- [ ] `omx doctor` (not setup/config behavior)

Note: I also tried the broader `dist/scripts/__tests__/codex-native-hook.test.js`; unrelated deep-interview config override fixture assertions fail in this checkout before the issue-specific tests.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed (N/A)
- [x] Backward-compatibility impact considered

## Related

Closes #2540
