### PR TITLE
fix: compact ultragoal HUD summaries

### DIFF
--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -243,7 +243,7 @@ describe('renderHud – team', () => {
 // ── Ultragoal ────────────────────────────────────────────────────────────────
 
 describe('renderHud – ultragoal', () => {
-  it('renders active ultragoal progress and objective in English', () => {
+  it('renders active ultragoal progress and title in English', () => {
     const ctx = {
       ...emptyCtx(),
       ultragoal: {
@@ -271,7 +271,7 @@ describe('renderHud – ultragoal', () => {
     const result = stripSgr(renderHud(ctx, 'focused'));
 
     assert.ok(result.includes('ultragoal 2/5 ▶ G003-tests: HUD progress display'));
-    assert.ok(result.includes('objective: show active ultragoal objective in OMX HUD'));
+    assert.ok(!result.includes('objective: show active ultragoal objective in OMX HUD'));
     assert.ok(!result.includes('목표'));
   });
 
@@ -317,8 +317,8 @@ describe('renderHud – ultragoal', () => {
         needsUserDecision: 0,
         progressTotal: 1,
         activeGoal: {
-          id: 'G001-long',
-          title: 'Long objective',
+          id: '',
+          title: '',
           objective: longObjective,
           status: 'in_progress',
           index: 1,
@@ -330,6 +330,40 @@ describe('renderHud – ultragoal', () => {
     assert.ok(result.includes('objective: show active ultragoal objective in OMX HUD'));
     assert.ok(result.includes('…'));
     assert.ok(!result.includes(longObjective));
+  });
+
+  it('keeps long ultragoal title/objective summaries compact without duplicate ellipses', () => {
+    const repeatedText = 'Build example component with helper, install example package and app package on the target';
+    const ctx = {
+      ...emptyCtx(),
+      ultragoal: {
+        active: true,
+        status: 'in_progress',
+        total: 6,
+        complete: 0,
+        pending: 5,
+        inProgress: 1,
+        failed: 0,
+        reviewBlocked: 0,
+        needsUserDecision: 0,
+        progressTotal: 6,
+        activeGoal: {
+          id: 'G004-example-long-goal-id',
+          title: `${repeatedText}...`,
+          objective: `${repeatedText}, run diagnostics, and collect logs`,
+          status: 'in_progress',
+          index: 4,
+        },
+      },
+    };
+
+    const result = stripSgr(renderHud(ctx, 'focused', { maxWidth: 120, maxLines: 3 }));
+
+    assert.ok(result.includes('ultragoal 0/6 ▶ G004-example-long-goal-id: Build example component with helper…'));
+    assert.ok(!result.includes('objective:'));
+    assert.ok(!result.includes('...'));
+    assert.ok(!result.includes('……'));
+    assert.ok(result.split('\n').length <= 3);
   });
 
   it('renders up to three ongoing ultragoal items alongside ralplan and ultraqa within the expanded HUD budget', () => {

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -125,10 +125,14 @@ function renderTeam(ctx: HudRenderContext): string | null {
 }
 
 
+function normalizeTrailingEllipsis(value: string): string {
+  return value.replace(/(?:\.\.\.|…)+$/u, '…');
+}
+
 function truncateDynamicText(value: string, maxLength: number): string {
-  if (value.length <= maxLength) return value;
+  if (value.length <= maxLength) return normalizeTrailingEllipsis(value);
   if (maxLength <= 1) return '…';
-  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+  return normalizeTrailingEllipsis(`${value.slice(0, maxLength - 1).trimEnd()}…`);
 }
 
 function renderUltragoal(ctx: HudRenderContext): string | null {
@@ -150,10 +154,10 @@ function renderUltragoal(ctx: HudRenderContext): string | null {
     .filter(Boolean);
   const activeGoal = ctx.ultragoal.activeGoal ?? ctx.ultragoal.ongoingGoals?.[0];
   const rawObjective = activeGoal?.objective ? sanitizeDynamicText(activeGoal.objective) : '';
-  const objective = rawObjective ? truncateDynamicText(rawObjective, 96) : '';
+  const objective = ongoingGoals.length === 0 && rawObjective ? truncateDynamicText(rawObjective, 96) : '';
   const items = ongoingGoals.length > 0 ? ` ▶ ${ongoingGoals.join(' · ')}` : '';
   const summary = `${progress}${items}`;
-  return cyan(objective ? `${summary} · objective: ${objective}` : summary);
+  return cyan(objective ? `${summary} ▶ objective: ${objective}` : summary);
 }
 
 function renderTurns(ctx: HudRenderContext): string | null {


### PR DESCRIPTION
## Summary
- Keep focused/tmux HUD ultragoal output compact by showing the active goal title/summary without repeating the objective by default.
- Preserve objective fallback when there is no renderable goal summary.
- Normalize trailing `...` / `…` so already-truncated titles do not produce duplicate ellipses.

Fixes #2543.

## Rationale

The HUD currently composes `title · objective` as one large segment, then the wrapping layer may ellipsize through that boundary. Long ultragoal titles/objectives can render as noisy double truncation like `... an... · objective: ...`.

For the focused tmux HUD, the active goal title is the stable summary. Repeating the objective is usually redundant and makes the line harder to parse. This patch keeps the title path compact while preserving an objective-only fallback when no title/id summary can be rendered.

## Scope notes
- Does not change ultragoal state collection or goal ordering.
- Does not change generic HUD wrapping logic.
- Keeps up to three ongoing ultragoal items in the expanded HUD budget.

## Local checks
- `npm run build`
- `node --test dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js`
- `npm run lint -- src/hud/render.ts src/hud/__tests__/render.test.ts`
- `npm run check:no-unused`
- `git diff --check upstream/dev...HEAD`

## Review
Read-only review pass: APPROVE, blocking findings: 0.
