### PR TITLE
Require independent ultragoal review evidence

### DIFF
--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -56,7 +56,7 @@ For intermediate stories, do **not** call `update_goal`; checkpoint the OMX stor
 omx ultragoal checkpoint --goal-id G001-example --status complete --evidence "npm test passed; docs updated" --codex-goal-json ./get-goal.json
 ```
 
-For the final story, run the whole-run audit plus the mandatory final `ai-slop-cleaner`, post-cleaner verification, and `$code-review` gate. If review is clean (`APPROVE` + `CLEAR`), call `update_goal({status: "complete"})`, call `get_goal` again, and checkpoint with the fresh complete aggregate snapshot plus `--quality-gate-json`. If review is non-clean, do not call `update_goal`; use `omx ultragoal record-review-blockers` to append a durable blocker-resolution story and continue.
+For the final story, run the whole-run audit plus the mandatory final `ai-slop-cleaner`, post-cleaner verification, and independent `$code-review` gate. If review is clean (`APPROVE` + `CLEAR` with distinct `code-reviewer` and `architect` subagent evidence), call `update_goal({status: "complete"})`, call `get_goal` again, and checkpoint with the fresh complete aggregate snapshot plus `--quality-gate-json`. If review is non-clean or independent delegation is unavailable, do not call `update_goal`; use `omx ultragoal record-review-blockers` to append a durable blocker-resolution story and continue.
 
 Failure handling:
 
@@ -132,7 +132,7 @@ The final ultragoal story is not complete until the active agent has run the fin
 1. Run targeted verification for the story.
 2. Run `ai-slop-cleaner` on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
 3. Rerun verification after the cleaner pass.
-4. Run `$code-review`. Clean means `codeReview.recommendation: "APPROVE"` and `codeReview.architectStatus: "CLEAR"`; `COMMENT`, `WATCH`, `REQUEST CHANGES`, and `BLOCK` are non-clean. If the approved plan already used Scholastic for ontology-heavy review, carry that advisory evidence into the quality gate; non-clean Scholastic findings should be treated as blocker evidence rather than a completion claim.
+4. Run `$code-review` through the independent review path. Clean means `codeReview.recommendation: "APPROVE"`, `codeReview.architectStatus: "CLEAR"`, and `codeReview.independentReview` contains distinct completed `code-reviewer` and `architect` subagent evidence. `COMMENT`, `WATCH`, `REQUEST CHANGES`, `BLOCK`, missing subagent evidence, unavailable delegation, and same-lane/self-review are non-clean. If the approved plan already used Scholastic for ontology-heavy review, carry that advisory evidence into the quality gate; non-clean Scholastic findings should be treated as blocker evidence rather than a completion claim.
 5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
 
    ```sh
@@ -153,7 +153,15 @@ The final ultragoal story is not complete until the active agent has run the fin
 {
   "aiSlopCleaner": { "status": "passed", "evidence": "cleaner report" },
   "verification": { "status": "passed", "commands": ["npm test"], "evidence": "post-cleaner verification" },
-  "codeReview": { "recommendation": "APPROVE", "architectStatus": "CLEAR", "evidence": "final review synthesis" }
+  "codeReview": {
+    "recommendation": "APPROVE",
+    "architectStatus": "CLEAR",
+    "evidence": "final review synthesis",
+    "independentReview": {
+      "codeReviewer": { "agentRole": "code-reviewer", "evidence": "code-reviewer subagent APPROVE evidence" },
+      "architect": { "agentRole": "architect", "evidence": "architect subagent CLEAR evidence" }
+    }
+  }
 }
 ```
 

--- a/plugins/oh-my-codex/skills/code-review/SKILL.md
+++ b/plugins/oh-my-codex/skills/code-review/SKILL.md
@@ -32,6 +32,7 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
    - **`code-reviewer` lane** - owns spec compliance, security, code quality, performance, and maintainability findings
    - **`architect` lane** - owns the devil's-advocate / design-tradeoff perspective
    - Both lanes run in parallel and produce distinct outputs before final synthesis
+   - If either lane cannot be launched or does not return evidence, report `independent review unavailable`; do **not** substitute the current/authoring lane, and do **not** approve or mark the review merge-ready.
 
 3. **Review Categories**
    - **Security** - Hardcoded secrets, injection risks, XSS, CSRF
@@ -58,6 +59,7 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
 
 7. **Final Synthesis**
    - Combine the `code-reviewer` recommendation and the architect status into one final verdict
+   - Approval requires explicit evidence from both independent lanes; missing or failed delegation is a blocking unavailable-review state, not an approval fallback
    - Deterministic merge gating rules:
      - If architect status is **BLOCK**, final recommendation is **REQUEST CHANGES**
      - Else if `code-reviewer` recommendation is **REQUEST CHANGES**, final recommendation is **REQUEST CHANGES**
@@ -66,6 +68,8 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
    - The final report must make architect blockers impossible to miss
 
 ## Agent Delegation
+
+Do not self-review as a fallback. If the `code-reviewer` or `architect` agent path is missing, unavailable, skipped, or fails, emit a clear unavailable-review result and block approval until the independent lane evidence exists.
 
 ```
 delegate(
@@ -126,7 +130,7 @@ The code-reviewer agent SHOULD consult Codex for cross-validation.
 1. **Form your OWN review FIRST** - Complete the review independently
 2. **Consult for validation** - Cross-check findings with Codex
 3. **Critically evaluate** - Never blindly adopt external findings
-4. **Graceful fallback** - Never block if tools unavailable
+4. **Graceful optional consultation fallback** - Never block because optional external consultation tools are unavailable; this does not waive the required independent `code-reviewer` and `architect` lanes
 
 ### When to Consult
 - Security-sensitive code changes
@@ -141,7 +145,7 @@ The code-reviewer agent SHOULD consult Codex for cross-validation.
 - Small, isolated changes
 
 ### Tool Usage
-Prefer native `code-reviewer` agent consultation or CLI-backed `ask_codex` surfaces when available. Optional MCP compatibility ask tools may be used only when already enabled. If consultation tools are unavailable, fall back to the `code-reviewer` agent.
+Prefer native `code-reviewer` agent consultation or CLI-backed `ask_codex` surfaces when available. Optional MCP compatibility ask tools may be used only when already enabled. If optional external consultation tools are unavailable, continue with the required independent `code-reviewer` and `architect` lanes; do not replace those lanes with self-review.
 
 **Note:** Codex calls can take up to 1 hour. Consider the review timeline before consulting.
 
@@ -246,8 +250,8 @@ The `architect` lane checks:
 
 ## Approval Criteria
 
-**APPROVE** - `code-reviewer` returns APPROVE and architect status is `CLEAR`
-**REQUEST CHANGES** - `code-reviewer` returns REQUEST CHANGES or architect status is `BLOCK`
+**APPROVE** - `code-reviewer` returns APPROVE, architect status is `CLEAR`, and both independent lanes returned evidence
+**REQUEST CHANGES** - `code-reviewer` returns REQUEST CHANGES, architect status is `BLOCK`, or required independent review delegation is unavailable/skipped/failed
 **COMMENT** - `code-reviewer` returns COMMENT with architect status `CLEAR`, architect status is `WATCH`, or only LOW/MEDIUM improvements remain
 
 

--- a/plugins/oh-my-codex/skills/ultragoal/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultragoal/SKILL.md
@@ -94,7 +94,7 @@ The final ultragoal story is not complete until the active agent has run the fin
 1. Run targeted verification for the story.
 2. Run `ai-slop-cleaner` on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
 3. Rerun verification after the cleaner pass.
-4. Run `$code-review`. Clean means `codeReview.recommendation: "APPROVE"` and `codeReview.architectStatus: "CLEAR"`; `COMMENT`, `WATCH`, `REQUEST CHANGES`, and `BLOCK` are non-clean.
+4. Run `$code-review` through the independent review path. Clean means `codeReview.recommendation: "APPROVE"`, `codeReview.architectStatus: "CLEAR"`, and `codeReview.independentReview` contains distinct completed `code-reviewer` and `architect` subagent evidence. `COMMENT`, `WATCH`, `REQUEST CHANGES`, `BLOCK`, missing subagent evidence, unavailable delegation, and same-lane/self-review are non-clean.
 5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
 
    ```sh
@@ -115,7 +115,15 @@ The final ultragoal story is not complete until the active agent has run the fin
 {
   "aiSlopCleaner": { "status": "passed", "evidence": "cleaner report" },
   "verification": { "status": "passed", "commands": ["npm test"], "evidence": "post-cleaner verification" },
-  "codeReview": { "recommendation": "APPROVE", "architectStatus": "CLEAR", "evidence": "final review synthesis" }
+  "codeReview": {
+    "recommendation": "APPROVE",
+    "architectStatus": "CLEAR",
+    "evidence": "final review synthesis",
+    "independentReview": {
+      "codeReviewer": { "agentRole": "code-reviewer", "evidence": "code-reviewer subagent APPROVE evidence" },
+      "architect": { "agentRole": "architect", "evidence": "architect subagent CLEAR evidence" }
+    }
+  }
 }
 ```
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -32,6 +32,7 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
    - **`code-reviewer` lane** - owns spec compliance, security, code quality, performance, and maintainability findings
    - **`architect` lane** - owns the devil's-advocate / design-tradeoff perspective
    - Both lanes run in parallel and produce distinct outputs before final synthesis
+   - If either lane cannot be launched or does not return evidence, report `independent review unavailable`; do **not** substitute the current/authoring lane, and do **not** approve or mark the review merge-ready.
 
 3. **Review Categories**
    - **Security** - Hardcoded secrets, injection risks, XSS, CSRF
@@ -58,6 +59,7 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
 
 7. **Final Synthesis**
    - Combine the `code-reviewer` recommendation and the architect status into one final verdict
+   - Approval requires explicit evidence from both independent lanes; missing or failed delegation is a blocking unavailable-review state, not an approval fallback
    - Deterministic merge gating rules:
      - If architect status is **BLOCK**, final recommendation is **REQUEST CHANGES**
      - Else if `code-reviewer` recommendation is **REQUEST CHANGES**, final recommendation is **REQUEST CHANGES**
@@ -66,6 +68,8 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
    - The final report must make architect blockers impossible to miss
 
 ## Agent Delegation
+
+Do not self-review as a fallback. If the `code-reviewer` or `architect` agent path is missing, unavailable, skipped, or fails, emit a clear unavailable-review result and block approval until the independent lane evidence exists.
 
 ```
 delegate(
@@ -126,7 +130,7 @@ The code-reviewer agent SHOULD consult Codex for cross-validation.
 1. **Form your OWN review FIRST** - Complete the review independently
 2. **Consult for validation** - Cross-check findings with Codex
 3. **Critically evaluate** - Never blindly adopt external findings
-4. **Graceful fallback** - Never block if tools unavailable
+4. **Graceful optional consultation fallback** - Never block because optional external consultation tools are unavailable; this does not waive the required independent `code-reviewer` and `architect` lanes
 
 ### When to Consult
 - Security-sensitive code changes
@@ -141,7 +145,7 @@ The code-reviewer agent SHOULD consult Codex for cross-validation.
 - Small, isolated changes
 
 ### Tool Usage
-Prefer native `code-reviewer` agent consultation or CLI-backed `ask_codex` surfaces when available. Optional MCP compatibility ask tools may be used only when already enabled. If consultation tools are unavailable, fall back to the `code-reviewer` agent.
+Prefer native `code-reviewer` agent consultation or CLI-backed `ask_codex` surfaces when available. Optional MCP compatibility ask tools may be used only when already enabled. If optional external consultation tools are unavailable, continue with the required independent `code-reviewer` and `architect` lanes; do not replace those lanes with self-review.
 
 **Note:** Codex calls can take up to 1 hour. Consider the review timeline before consulting.
 
@@ -246,8 +250,8 @@ The `architect` lane checks:
 
 ## Approval Criteria
 
-**APPROVE** - `code-reviewer` returns APPROVE and architect status is `CLEAR`
-**REQUEST CHANGES** - `code-reviewer` returns REQUEST CHANGES or architect status is `BLOCK`
+**APPROVE** - `code-reviewer` returns APPROVE, architect status is `CLEAR`, and both independent lanes returned evidence
+**REQUEST CHANGES** - `code-reviewer` returns REQUEST CHANGES, architect status is `BLOCK`, or required independent review delegation is unavailable/skipped/failed
 **COMMENT** - `code-reviewer` returns COMMENT with architect status `CLEAR`, architect status is `WATCH`, or only LOW/MEDIUM improvements remain
 
 

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -94,7 +94,7 @@ The final ultragoal story is not complete until the active agent has run the fin
 1. Run targeted verification for the story.
 2. Run `ai-slop-cleaner` on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
 3. Rerun verification after the cleaner pass.
-4. Run `$code-review`. Clean means `codeReview.recommendation: "APPROVE"` and `codeReview.architectStatus: "CLEAR"`; `COMMENT`, `WATCH`, `REQUEST CHANGES`, and `BLOCK` are non-clean.
+4. Run `$code-review` through the independent review path. Clean means `codeReview.recommendation: "APPROVE"`, `codeReview.architectStatus: "CLEAR"`, and `codeReview.independentReview` contains distinct completed `code-reviewer` and `architect` subagent evidence. `COMMENT`, `WATCH`, `REQUEST CHANGES`, `BLOCK`, missing subagent evidence, unavailable delegation, and same-lane/self-review are non-clean.
 5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
 
    ```sh
@@ -115,7 +115,15 @@ The final ultragoal story is not complete until the active agent has run the fin
 {
   "aiSlopCleaner": { "status": "passed", "evidence": "cleaner report" },
   "verification": { "status": "passed", "commands": ["npm test"], "evidence": "post-cleaner verification" },
-  "codeReview": { "recommendation": "APPROVE", "architectStatus": "CLEAR", "evidence": "final review synthesis" }
+  "codeReview": {
+    "recommendation": "APPROVE",
+    "architectStatus": "CLEAR",
+    "evidence": "final review synthesis",
+    "independentReview": {
+      "codeReviewer": { "agentRole": "code-reviewer", "evidence": "code-reviewer subagent APPROVE evidence" },
+      "architect": { "agentRole": "architect", "evidence": "architect subagent CLEAR evidence" }
+    }
+  }
 }
 ```
 

--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -21,7 +21,15 @@ function cleanQualityGate(): string {
   return JSON.stringify({
     aiSlopCleaner: { status: 'passed', evidence: 'ai-slop-cleaner passed' },
     verification: { status: 'passed', commands: ['npm test'], evidence: 'tests passed after cleaner' },
-    codeReview: { recommendation: 'APPROVE', architectStatus: 'CLEAR', evidence: '$code-review APPROVE + CLEAR' },
+    codeReview: {
+      recommendation: 'APPROVE',
+      architectStatus: 'CLEAR',
+      evidence: '$code-review APPROVE + CLEAR',
+      independentReview: {
+        codeReviewer: { agentRole: 'code-reviewer', evidence: 'code-reviewer subagent returned APPROVE' },
+        architect: { agentRole: 'architect', evidence: 'architect subagent returned CLEAR' },
+      },
+    },
   });
 }
 

--- a/src/hooks/__tests__/code-review-skill-contract.test.ts
+++ b/src/hooks/__tests__/code-review-skill-contract.test.ts
@@ -16,6 +16,8 @@ describe('code-review skill contract', () => {
     assert.match(codeReviewSkill, /Both lanes run in parallel/i);
     assert.match(codeReviewSkill, /`code-reviewer` lane/i);
     assert.match(codeReviewSkill, /`architect` lane/i);
+    assert.match(codeReviewSkill, /If either lane cannot be launched or does not return evidence/i);
+    assert.match(codeReviewSkill, /do \*\*not\*\* substitute the current\/authoring lane/i);
   });
 
   it('frames architect as the devil’s-advocate lane with deterministic blocker status', () => {
@@ -30,12 +32,20 @@ describe('code-review skill contract', () => {
   it('requires final synthesis across both lanes', () => {
     assert.match(codeReviewSkill, /Final Synthesis/i);
     assert.match(codeReviewSkill, /Combine the `code-reviewer` recommendation and the architect status/i);
+    assert.match(codeReviewSkill, /Approval requires explicit evidence from both independent lanes/i);
+    assert.match(codeReviewSkill, /missing or failed delegation is a blocking unavailable-review state/i);
     assert.match(codeReviewSkill, /final report must make architect blockers impossible to miss/i);
   });
 
+  it('forbids self-review fallback approval when delegation is unavailable', () => {
+    assert.match(codeReviewSkill, /Do not self-review as a fallback/i);
+    assert.match(codeReviewSkill, /missing, unavailable, skipped, or fails/i);
+    assert.match(codeReviewSkill, /block approval until the independent lane evidence exists/i);
+  });
+
   it('keeps approval criteria aligned with the deterministic synthesis contract', () => {
-    assert.match(codeReviewSkill, /\*\*APPROVE\*\* - `code-reviewer` returns APPROVE and architect status is `CLEAR`/i);
-    assert.match(codeReviewSkill, /\*\*REQUEST CHANGES\*\* - `code-reviewer` returns REQUEST CHANGES or architect status is `BLOCK`/i);
+    assert.match(codeReviewSkill, /\*\*APPROVE\*\* - `code-reviewer` returns APPROVE, architect status is `CLEAR`, and both independent lanes returned evidence/i);
+    assert.match(codeReviewSkill, /\*\*REQUEST CHANGES\*\* - `code-reviewer` returns REQUEST CHANGES, architect status is `BLOCK`, or required independent review delegation is unavailable\/skipped\/failed/i);
     assert.match(codeReviewSkill, /\*\*COMMENT\*\* - `code-reviewer` returns COMMENT with architect status `CLEAR`, architect status is `WATCH`, or only LOW\/MEDIUM improvements remain/i);
   });
 

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -35,7 +35,15 @@ function cleanQualityGate(): object {
   return {
     aiSlopCleaner: { status: 'passed', evidence: 'ai-slop-cleaner ran on changed files' },
     verification: { status: 'passed', commands: ['npm test'], evidence: 'tests passed after cleaner' },
-    codeReview: { recommendation: 'APPROVE', architectStatus: 'CLEAR', evidence: '$code-review approved with CLEAR architecture' },
+    codeReview: {
+      recommendation: 'APPROVE',
+      architectStatus: 'CLEAR',
+      evidence: '$code-review approved with CLEAR architecture',
+      independentReview: {
+        codeReviewer: { agentRole: 'code-reviewer', evidence: 'code-reviewer subagent returned APPROVE' },
+        architect: { agentRole: 'architect', evidence: 'architect subagent returned CLEAR' },
+      },
+    },
   };
 }
 
@@ -271,6 +279,34 @@ describe('ultragoal artifacts', () => {
       assert.doesNotMatch(instruction, /fresh (?:Codex )?(?:thread|session)s?/i);
       assert.doesNotMatch(instruction, /\.\.\/\.\.\/codex/);
       assert.doesNotMatch(instruction, /`codex\s+goal\b/i);
+    });
+  });
+
+  it('emits final-story handoffs that block missing independent review before update_goal', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const aggregateInstruction = buildCodexGoalInstruction(started.goal!, started.plan);
+
+      assert.match(aggregateInstruction, /independentReview evidence from both code-reviewer and architect subagents/);
+      assert.match(aggregateInstruction, /independent delegation is unavailable\/skipped\/failed, do not call update_goal/);
+      assert.match(aggregateInstruction, /APPROVE \+ CLEAR \+ independent code-reviewer and architect subagent evidence/);
+
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        codexGoalMode: 'per_story',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+        force: true,
+      });
+      const perStory = await startNextUltragoal(cwd);
+      const perStoryInstruction = buildCodexGoalInstruction(perStory.goal!, perStory.plan);
+
+      assert.match(perStoryInstruction, /independentReview evidence from both code-reviewer and architect subagents/);
+      assert.match(perStoryInstruction, /independent delegation is unavailable\/skipped\/failed, do not call update_goal/);
+      assert.match(perStoryInstruction, /APPROVE \+ CLEAR \+ independent code-reviewer and architect subagent evidence/);
     });
   });
 
@@ -770,6 +806,67 @@ describe('ultragoal artifacts', () => {
           },
         }),
         /aiSlopCleaner\.status="passed"/,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            codeReview: {
+              recommendation: 'APPROVE',
+              architectStatus: 'CLEAR',
+              evidence: 'same execution lane self-reviewed and approved without spawning review subagents',
+            },
+          },
+        }),
+        /independent review unavailable|self-approving/i,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            codeReview: {
+              recommendation: 'APPROVE',
+              architectStatus: 'CLEAR',
+              evidence: 'authoring lane claimed it was merge-ready',
+              independentReview: {
+                codeReviewer: { agentRole: 'executor', evidence: 'authoring lane approved its own change' },
+                architect: { agentRole: 'architect', evidence: 'architect subagent returned CLEAR' },
+              },
+            },
+          },
+        }),
+        /independent code-reviewer subagent|self-review/i,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            codeReview: {
+              recommendation: 'APPROVE',
+              architectStatus: 'CLEAR',
+              evidence: 'code-review path skipped architect delegation',
+              independentReview: {
+                codeReviewer: { agentRole: 'code-reviewer', evidence: 'code-reviewer subagent returned APPROVE' },
+              },
+            },
+          },
+        }),
+        /missing codeReview\.independentReview\.architect/i,
       );
 
       await checkpointUltragoal(cwd, {

--- a/src/ultragoal/__tests__/docs-contract.test.ts
+++ b/src/ultragoal/__tests__/docs-contract.test.ts
@@ -66,6 +66,11 @@ describe('ultragoal docs contract', () => {
       assert.match(doc, /passed\/no-op report/);
       assert.match(doc, /post-cleaner verification/i);
       assert.match(doc, /\$code-review/);
+      assert.match(doc, /independent review path/i);
+      assert.match(doc, /codeReview\.independentReview/);
+      assert.match(doc, /code-reviewer/);
+      assert.match(doc, /architect/);
+      assert.match(doc, /same-lane\/self-review/i);
       assert.match(doc, /record-review-blockers/);
       assert.match(doc, /review_blocked/);
       assert.match(doc, /quality-gate-json/);

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -240,6 +240,16 @@ export interface UltragoalQualityGate {
     recommendation: 'APPROVE';
     architectStatus: 'CLEAR';
     evidence: string;
+    independentReview: {
+      codeReviewer: {
+        agentRole: 'code-reviewer';
+        evidence: string;
+      };
+      architect: {
+        agentRole: 'architect';
+        evidence: string;
+      };
+    };
   };
 }
 
@@ -1191,6 +1201,26 @@ function validateQualityGate(value: unknown): UltragoalQualityGate {
     throw new UltragoalError('Final code-review must be clean: codeReview.architectStatus must be CLEAR; use record-review-blockers for WATCH or BLOCK.');
   }
   assertNonEmpty(review.evidence, 'codeReview.evidence');
+  const independentReview = (review as Partial<UltragoalQualityGate['codeReview']>).independentReview;
+  if (!independentReview || typeof independentReview !== 'object') {
+    throw new UltragoalError('Final code-review independent review unavailable: codeReview.independentReview must include completed code-reviewer and architect subagent evidence; use record-review-blockers instead of self-approving.');
+  }
+  const codeReviewer = independentReview.codeReviewer;
+  if (!codeReviewer || typeof codeReviewer !== 'object') {
+    throw new UltragoalError('Final code-review independent review unavailable: missing codeReview.independentReview.codeReviewer evidence from the code-reviewer subagent.');
+  }
+  if (codeReviewer.agentRole !== 'code-reviewer') {
+    throw new UltragoalError('Final code-review must use an independent code-reviewer subagent; self-review or default/authoring-lane review cannot approve the ultragoal gate.');
+  }
+  assertNonEmpty(codeReviewer.evidence, 'codeReview.independentReview.codeReviewer.evidence');
+  const architect = independentReview.architect;
+  if (!architect || typeof architect !== 'object') {
+    throw new UltragoalError('Final code-review independent review unavailable: missing codeReview.independentReview.architect evidence from the architect subagent.');
+  }
+  if (architect.agentRole !== 'architect') {
+    throw new UltragoalError('Final code-review must use an independent architect subagent; self-review or default/authoring-lane review cannot approve the ultragoal gate.');
+  }
+  assertNonEmpty(architect.evidence, 'codeReview.independentReview.architect.evidence');
   return gate as UltragoalQualityGate;
 }
 
@@ -1505,7 +1535,10 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
       ? '- Final mandatory quality gate: run ai-slop-cleaner on changed files even when it is a no-op, rerun verification, then run $code-review.'
       : '- This is not the final ultragoal story; do not run the final ai-slop-cleaner/$code-review gate yet.',
     finalStory
-      ? '- If final $code-review is not APPROVE with architect status CLEAR, do not call update_goal. Record blockers with:'
+      ? '- Final $code-review is clean only when it is APPROVE with architect status CLEAR and includes independentReview evidence from both code-reviewer and architect subagents.'
+      : null,
+    finalStory
+      ? '- If final $code-review is non-clean, missing independentReview evidence, or independent delegation is unavailable/skipped/failed, do not call update_goal. Record blockers with:'
       : '- After the goal is actually complete, call update_goal({status: "complete"}), call get_goal again for a fresh completion snapshot, then checkpoint the ledger with:',
     finalStory
       ? `  omx ultragoal record-review-blockers --goal-id ${goal.id} --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json "<active get_goal JSON or path>"`
@@ -1514,7 +1547,7 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
       ? '- In legacy per-story mode, the blocker story may require an available Codex goal context because this story remains an active incomplete Codex goal; do not claim it is complete.'
       : null,
     finalStory
-      ? '- If final $code-review is clean (APPROVE + CLEAR), call update_goal({status: "complete"}), call get_goal again, then checkpoint with --quality-gate-json:'
+      ? '- If final $code-review is clean (APPROVE + CLEAR + independent code-reviewer and architect subagent evidence), call update_goal({status: "complete"}), call get_goal again, then checkpoint with --quality-gate-json:'
       : null,
     finalStory
       ? `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh complete get_goal JSON or path>" --quality-gate-json "<quality gate JSON or path>"`
@@ -1550,13 +1583,16 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
       ? '- This is the final pending story: run the mandatory final ai-slop-cleaner pass, rerun verification, and run $code-review before any update_goal call.'
       : '- This is not the final story: do not call update_goal yet; the aggregate Codex goal must remain active while later OMX stories remain.',
     finalStory
-      ? '- If final $code-review is not APPROVE with architect status CLEAR, do not call update_goal. Record durable blocker work first:'
+      ? '- Final $code-review is clean only when it is APPROVE with architect status CLEAR and includes independentReview evidence from both code-reviewer and architect subagents.'
+      : null,
+    finalStory
+      ? '- If final $code-review is non-clean, missing independentReview evidence, or independent delegation is unavailable/skipped/failed, do not call update_goal. Record durable blocker work first:'
       : null,
     finalStory
       ? `  omx ultragoal record-review-blockers --goal-id ${goal.id} --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json "<active get_goal JSON or path>"`
       : null,
     finalStory
-      ? '- If final $code-review is clean (APPROVE + CLEAR), call update_goal({status: "complete"}), call get_goal again for a fresh complete snapshot, then checkpoint with --quality-gate-json.'
+      ? '- If final $code-review is clean (APPROVE + CLEAR + independent code-reviewer and architect subagent evidence), call update_goal({status: "complete"}), call get_goal again for a fresh complete snapshot, then checkpoint with --quality-gate-json.'
       : null,
     `- Checkpoint this OMX story with a fresh get_goal snapshot whose objective matches the aggregate payload and whose status is ${checkpointStatus}:`,
     finalStory


### PR DESCRIPTION
## Summary
- require final ultragoal quality gates to include independent `code-reviewer` and `architect` review evidence
- update generated final-story handoffs so missing/unavailable review delegation blocks before `update_goal`
- lock the code-review/ultragoal skill docs and plugin mirrors against self-review fallback approval

## Tests
- `npm run build`
- `node --test dist/ultragoal/__tests__/artifacts.test.js dist/ultragoal/__tests__/docs-contract.test.js dist/hooks/__tests__/code-review-skill-contract.test.js dist/cli/__tests__/ultragoal.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `npm run verify:plugin-bundle`
- independent code-reviewer re-review: APPROVE
- independent architect re-review: CLEAR

Fixes #2534
