### PR TITLE
Fix HUD convergence without TMUX_PANE

### DIFF
--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { runWatchMode } from '../index.js';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { hudCommand, runWatchMode } from '../index.js';
 import type { HudFlags, HudRenderContext } from '../types.js';
 
 const WATCH_FLAGS: HudFlags = {
@@ -199,5 +202,72 @@ describe('runWatchMode', () => {
     assert.equal(process.exitCode, 1);
     assert.ok(errors.some((line) => line.includes('HUD watch render failed: boom')));
     assert.ok(writes.some((chunk) => chunk.includes('\x1b[?25h\x1b[2J\x1b[H')));
+  });
+});
+
+describe('hudCommand --tmux', () => {
+  it('reuses a same-session HUD pane when TMUX_PANE is empty instead of splitting a duplicate', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'omx-hud-tmux-test-'));
+    const logPath = join(tmp, 'tmux.log');
+    const fakeBin = join(tmp, 'bin');
+    await mkdir(fakeBin);
+    const tmuxPath = join(fakeBin, 'tmux');
+    await writeFile(tmuxPath, `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}
+if [[ "$1" == "display-message" && "$*" == *'#{pane_id}'* ]]; then
+  echo '%1'
+  exit 0
+fi
+if [[ "$1" == "display-message" && "$*" == *'#{session_id}'* ]]; then
+  printf '$7\\t@3\\n'
+  exit 0
+fi
+if [[ "$1" == "list-panes" ]]; then
+  printf '%s\\n' '%1	codex	codex'
+  printf '%s\\n' "%2	node	exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch"
+  exit 0
+fi
+if [[ "$1" == "resize-pane" || "$1" == "set-hook" ]]; then
+  exit 0
+fi
+if [[ "$1" == "split-window" ]]; then
+  echo '%9'
+  exit 0
+fi
+exit 0
+`);
+    await chmod(tmuxPath, 0o755);
+
+    const previousEnv = {
+      PATH: process.env.PATH,
+      TMUX: process.env.TMUX,
+      TMUX_PANE: process.env.TMUX_PANE,
+      OMX_SESSION_ID: process.env.OMX_SESSION_ID,
+    };
+    const previousLog = console.log;
+    const logs: string[] = [];
+    try {
+      process.env.PATH = `${fakeBin}${delimiter}${process.env.PATH ?? ''}`;
+      process.env.TMUX = '/tmp/tmux-1000/default,12345,0';
+      process.env.TMUX_PANE = '';
+      process.env.OMX_SESSION_ID = 'sess-a';
+      console.log = (message?: unknown) => { logs.push(String(message ?? '')); };
+
+      await hudCommand(['--tmux']);
+
+      const tmuxLog = await readFile(logPath, 'utf8');
+      assert.match(tmuxLog, /display-message -p #\{pane_id\}/);
+      assert.match(tmuxLog, /list-panes -t %1 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}/);
+      assert.match(tmuxLog, /resize-pane -t %2 -y \d+/);
+      assert.doesNotMatch(tmuxLog, /split-window/);
+      assert.ok(logs.some((line) => line.includes('Reused existing HUD pane')));
+    } finally {
+      console.log = previousLog;
+      for (const [key, value] of Object.entries(previousEnv)) {
+        if (typeof value === 'string') process.env[key] = value;
+        else delete process.env[key];
+      }
+      await rm(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -6,8 +6,10 @@ import {
   buildHudWatchCommand,
   findHudWatchPaneIds,
   hudPaneMatchesOwner,
+  listCurrentWindowHudPaneIds,
   OMX_TMUX_HUD_LEADER_PANE_ENV,
   parseTmuxPaneSnapshot,
+  readActiveTmuxPaneId,
   readHudPaneOwner,
   reapDeadHudPanes,
   parseHudResizeHookContext,
@@ -217,6 +219,45 @@ describe('HUD pane ownership helpers', () => {
     );
 
     assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2']);
+  });
+
+  it('finds one same-session HUD pane when TMUX_PANE is unavailable', () => {
+    const calls: string[][] = [];
+    const execTmuxSync = (args: string[]) => {
+      calls.push(args);
+      return [
+        '%1\tcodex\tcodex',
+        `%2\tnode\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+      ].join('\n');
+    };
+
+    assert.deepEqual(listCurrentWindowHudPaneIds(undefined, execTmuxSync, { sessionId: 'sess-a' }), ['%2']);
+    assert.deepEqual(calls, [
+      ['list-panes', '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}'],
+    ]);
+  });
+
+  it('keeps active-pane fallback isolated from a different same-session leader HUD', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        '%3\tcodex\tcodex',
+        `%4\tnode\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%3' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), []);
+  });
+
+  it('resolves the active tmux pane as a TMUX_PANE fallback', () => {
+    const calls: string[][] = [];
+    const paneId = readActiveTmuxPaneId((args) => {
+      calls.push(args);
+      return '%7\n';
+    });
+
+    assert.equal(paneId, '%7');
+    assert.deepEqual(calls, [['display-message', '-p', '#{pane_id}']]);
   });
 
   it('tags reconciled HUD watch commands with the leader pane owner', () => {

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -21,6 +21,7 @@ import {
   killTmuxPane,
   listCurrentWindowHudPaneIds,
   OMX_TMUX_HUD_LEADER_PANE_ENV,
+  readActiveTmuxPaneId,
   registerHudResizeHook,
   resizeTmuxPane,
 } from './tmux.js';
@@ -302,10 +303,12 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
     console.error('Failed to resolve OMX launcher path for tmux HUD startup.');
     process.exit(1);
   }
-  const currentPaneId = process.env.TMUX_PANE?.trim();
-  const existingHudPaneIds = currentPaneId
+  const envPaneId = process.env.TMUX_PANE?.trim();
+  const currentPaneId = envPaneId || readActiveTmuxPaneId() || undefined;
+  const sessionId = process.env.OMX_SESSION_ID?.trim() || undefined;
+  const existingHudPaneIds = currentPaneId || sessionId
     ? listCurrentWindowHudPaneIds(currentPaneId, undefined, {
-        sessionId: process.env.OMX_SESSION_ID,
+        sessionId,
         leaderPaneId: currentPaneId,
       })
     : [];

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -286,6 +286,16 @@ export function listCurrentWindowPanes(
   }
 }
 
+export function readActiveTmuxPaneId(
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): string | null {
+  try {
+    return parsePaneIdFromTmuxOutput(execTmuxSync(['display-message', '-p', '#{pane_id}']));
+  } catch {
+    return null;
+  }
+}
+
 export function listCurrentWindowHudPaneIds(
   currentPaneId?: string,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,


### PR DESCRIPTION
## Summary
- Resolve the active tmux pane when `TMUX_PANE` is empty so `omx hud --tmux` can reach existing HUD lookup/reuse.
- Allow same-session HUD lookup when `OMX_SESSION_ID` is available, while preserving leader-pane isolation whenever a pane identity is resolvable.
- Add launch-path and ownership regression tests for empty `TMUX_PANE` convergence and same-session/different-leader isolation.

Fixes #2538

## Tests
- `npm run build`
- `node --test dist/hud/__tests__/index.test.js dist/hud/__tests__/tmux.test.js dist/hud/__tests__/hud-tmux-injection.test.js dist/hud/__tests__/reconcile.test.js`
- `npm run lint`
- `npm run check:no-unused`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*