### PR TITLE
fix: keep ultragoal focused on approved implementation sequences

### DIFF
--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -234,6 +234,56 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('prefers approved implementation sequence over consensus/supporting bullets', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: [
+          '# Ralplan Final',
+          '',
+          '## Consensus status',
+          '',
+          '- Planning artifacts:',
+          '  - PRD: `.omx/plans/prd.md`',
+          '  - Test spec: `.omx/plans/test-spec.md`',
+          '- Critic review: APPROVE; no required revisions.',
+          '',
+          '## Binding decision',
+          '',
+          'P0 blocks new live generation.',
+          '',
+          '## Approved implementation sequence',
+          '',
+          '1. `a7a.2` — tracked VariantL_one fixtures / clean-clone reproducibility.',
+          '2. `a7a.4` — robust Cinematic Telegram wrapper and normalized evidence.',
+          '3. `a7a.1` — fail-closed required Comfy Telegram delivery gate.',
+          '4. `a7a.3` — VariantL_one post-live completion gate.',
+          '5. P0 readiness docs/update: live generation remains blocked until P0 passes or is explicitly waived.',
+          '',
+          '## Principles',
+          '',
+          '1. Required live-output delivery evidence is a completion invariant.',
+          '2. Runtime proof evidence is not a source fixture.',
+          '',
+          '## Available agent types / staffing guidance',
+          '',
+          '- Executor, medium reasoning: fixture/reproducibility and gate implementation.',
+          '- Test-engineer, medium reasoning: regression fixtures.',
+        ].join('\n'),
+        force: true,
+      });
+
+      const titles = plan.goals.map((goal) => goal.title);
+      assert.equal(titles.length, 5);
+      assert.deepEqual(titles.slice(0, 4), [
+        '`a7a.2` — tracked VariantL_one fixtures / clean-clone reproducibility.',
+        '`a7a.4` — robust Cinematic Telegram wrapper and normalized evidence.',
+        '`a7a.1` — fail-closed required Comfy Telegram delivery gate.',
+        '`a7a.3` — VariantL_one post-live completion gate.',
+      ]);
+      assert.match(titles[4] ?? '', /^P0 readiness docs\/update: live generation remains blocked until P0 pa/);
+    });
+  });
+
   it('recognizes singular story headings when choosing goals over preface bullets', async () => {
     await withTempRepo(async (cwd) => {
       const plan = await createUltragoalPlan(cwd, {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -315,7 +315,7 @@ function sectionLooksNonStory(section: string | undefined): boolean {
 }
 
 function sectionLooksStory(section: string | undefined): boolean {
-  return /^(?:story|stories|goals?|milestones?|p\d+)$/.test(section ?? '');
+  return /^(?:story|stories|goals?|milestones?|p\d+|approved\s+implementation\s+sequence|implementation\s+sequence)$/.test(section ?? '');
 }
 
 function parseMarkdownListItems(lines: readonly string[]): MarkdownListItem[] {


### PR DESCRIPTION
## Summary
- Treat `Approved implementation sequence` / `Implementation sequence` headings as Ultragoal story sections.
- Prevent ralplan final handoffs from expanding consensus/supporting bullets into dozens of microgoals when an approved execution sequence is present.
- Add a regression fixture matching the observed ralplan final shape: consensus metadata + approved sequence + principles/staffing notes should produce only the approved sequence goals.

## Why
In a live 0.18.4 session, `$ultragoal .omx/plans/ralplan-final-a7a-p0-cinematic-stabilization.md` produced 38 goals from a five-item approved sequence because the parser did not treat `## Approved implementation sequence` as a story-bearing section. The agent had to manually rewrite a compact brief. The earlier checklist/plain-label fixes are present in 0.18.4, but they do not cover this ralplan-final heading shape.

## Tests
- `npm run build`
- `node --test dist/ultragoal/__tests__/artifacts.test.js`
- `npm run lint -- src/ultragoal/artifacts.ts src/ultragoal/__tests__/artifacts.test.ts`
- `npm run check:no-unused`
- `git diff --check upstream/dev...HEAD`

## Review
- Read-only review pass: parser/test change is appropriate; no code-level blockers. Initial review noted only that the fix needed to be committed before PR publication; commit `f5b43723` now contains it.
