### PR TITLE
Fix duplicated HUD summary for ultragoal team state

### DIFF
--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
 import { hudCommand, runWatchMode } from '../index.js';
+import { renderHud } from '../render.js';
 import type { HudFlags, HudRenderContext } from '../types.js';
 
 const WATCH_FLAGS: HudFlags = {
@@ -150,6 +151,55 @@ describe('runWatchMode', () => {
     assert.equal(callCount, 2, 'multiple overlapping ticks should collapse to one queued rerender');
   });
 
+
+  it('renders combined ultragoal and team state as one stable watch frame', async () => {
+    const writes: string[] = [];
+    let sigintHandler: (() => void) | undefined;
+
+    const promise = runWatchMode('/tmp', WATCH_FLAGS, {
+      isTTY: true,
+      env: {},
+      readAllStateFn: async () => ({
+        ...emptyCtx(),
+        team: { active: true, agent_count: 2, team_name: 'hud-fix' },
+        ultragoal: {
+          active: true,
+          status: 'in_progress',
+          total: 3,
+          complete: 1,
+          pending: 1,
+          inProgress: 1,
+          failed: 0,
+          reviewBlocked: 0,
+          needsUserDecision: 0,
+          progressTotal: 3,
+          activeGoal: {
+            id: 'G002-team',
+            title: 'Team HUD summary',
+            objective: 'avoid duplicated focused tmux HUD content',
+            status: 'in_progress',
+            index: 2,
+          },
+        },
+      }),
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
+      renderHudFn: renderHud,
+      writeStdout: (text) => { writes.push(text); },
+      writeStderr: () => {},
+      registerSigint: (handler) => { sigintHandler = handler; },
+      setIntervalFn: () => ({}) as ReturnType<typeof setInterval>,
+      clearIntervalFn: () => {},
+    });
+
+    await flush();
+    sigintHandler?.();
+    await promise;
+
+    const plain = writes.join('').replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+    assert.equal((plain.match(/team:2 workers/g) ?? []).length, 1);
+    assert.equal((plain.match(/ultragoal 1\/3/g) ?? []).length, 1);
+    assert.ok(plain.includes('ultragoal 1/3 + team:2 workers'));
+  });
 
   it('runs authority tick after each rendered frame', async () => {
     const writes: string[] = [];

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -280,6 +280,40 @@ describe('renderHud – ultragoal', () => {
     assert.ok(!result.includes('ultragoal'));
   });
 
+  it('combines active ultragoal and team into one non-duplicated focused summary', () => {
+    const ctx = {
+      ...emptyCtx(),
+      team: { active: true, agent_count: 4, team_name: 'hud-fix' },
+      ultragoal: {
+        active: true,
+        status: 'in_progress',
+        total: 4,
+        complete: 1,
+        pending: 2,
+        inProgress: 1,
+        failed: 0,
+        reviewBlocked: 0,
+        needsUserDecision: 0,
+        progressTotal: 4,
+        activeGoal: {
+          id: 'G002-team-hud',
+          title: 'Fix combined HUD rendering',
+          objective: 'avoid duplicate ultragoal and team HUD summaries',
+          status: 'in_progress',
+          index: 2,
+        },
+      },
+    };
+
+    const result = stripSgr(renderHud(ctx, 'focused', { maxWidth: 220, maxLines: 3 }));
+
+    assert.equal((result.match(/team:4 workers/g) ?? []).length, 1);
+    assert.equal((result.match(/ultragoal 1\/4/g) ?? []).length, 1);
+    assert.ok(result.includes('ultragoal 1/4 + team:4 workers ▶ G002-team-hud: Fix combined HUD rendering'));
+    assert.ok(!result.includes(' | team:4 workers | ultragoal'));
+    assert.ok(result.split('\n').length <= 3);
+  });
+
   it('omits completed ultragoal plans instead of showing stale progress', () => {
     const ctx = {
       ...emptyCtx(),

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -664,6 +664,53 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('collects active ultragoal plan with canonical team state for combined rendering', async () => {
+    await withTempRepo('omx-hud-ultragoal-team-combined-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-ultragoal-team';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(sessionDir, { recursive: true });
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'ultragoal',
+        phase: 'running',
+        session_id: sessionId,
+        active_skills: [
+          { skill: 'ultragoal', phase: 'running', active: true, session_id: sessionId },
+          { skill: 'team', phase: 'team-exec', active: true, session_id: sessionId },
+        ],
+      }));
+      await writeFile(join(sessionDir, 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'hud-fix',
+        agent_count: 3,
+      }));
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G002-team-hud',
+        goals: [
+          { id: 'G001-inspect', title: 'Inspect HUD', objective: 'Inspect combined state', status: 'complete' },
+          { id: 'G002-team-hud', title: 'Patch team HUD', objective: 'Fix duplicate team and ultragoal summaries', status: 'in_progress' },
+        ],
+      }));
+
+      const state = await readAllState(cwd);
+
+      assert.deepEqual(state.team, {
+        active: true,
+        team_name: 'hud-fix',
+        agent_count: 3,
+        current_phase: 'team-exec',
+      });
+      assert.equal(state.ultragoal?.active, true);
+      assert.equal(state.ultragoal?.activeGoal?.id, 'G002-team-hud');
+      assert.equal(state.ultragoal?.complete, 1);
+    });
+  });
+
   it('does not resurrect terminal autopilot from stale canonical skill-active phase', async () => {
     await withTempRepo('omx-hud-canonical-autopilot-terminal-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -111,19 +111,23 @@ function renderUltraqa(ctx: HudRenderContext): string | null {
   return green(`qa:${phase}`);
 }
 
-function renderTeam(ctx: HudRenderContext): string | null {
+function formatTeamSummary(ctx: HudRenderContext): string | null {
   if (!ctx.team) return null;
   const count = ctx.team.agent_count;
   const name = ctx.team.team_name ? sanitizeDynamicText(ctx.team.team_name) : '';
   if (count !== undefined && count > 0) {
-    return green(`team:${count} workers`);
+    return `team:${count} workers`;
   }
   if (name) {
-    return green(`team:${name}`);
+    return `team:${name}`;
   }
-  return green('team');
+  return 'team';
 }
 
+function renderTeam(ctx: HudRenderContext): string | null {
+  const summary = formatTeamSummary(ctx);
+  return summary ? green(summary) : null;
+}
 
 function normalizeTrailingEllipsis(value: string): string {
   return value.replace(/(?:\.\.\.|…)+$/u, '…');
@@ -141,7 +145,8 @@ function renderUltragoal(ctx: HudRenderContext): string | null {
   const complete = ctx.ultragoal.complete;
   if (!Number.isFinite(total) || total <= 0 || !Number.isFinite(complete)) return null;
 
-  const progress = `ultragoal ${complete}/${total}`;
+  const teamSummary = formatTeamSummary(ctx);
+  const progress = `ultragoal ${complete}/${total}${teamSummary ? ` + ${teamSummary}` : ''}`;
   const ongoingGoals = (ctx.ultragoal.ongoingGoals?.length ? ctx.ultragoal.ongoingGoals : ctx.ultragoal.activeGoal ? [ctx.ultragoal.activeGoal] : [])
     .slice(0, 3)
     .map((goal) => {
@@ -158,6 +163,12 @@ function renderUltragoal(ctx: HudRenderContext): string | null {
   const items = ongoingGoals.length > 0 ? ` ▶ ${ongoingGoals.join(' · ')}` : '';
   const summary = `${progress}${items}`;
   return cyan(objective ? `${summary} ▶ objective: ${objective}` : summary);
+}
+
+
+function renderExecutionSummary(ctx: HudRenderContext): string | null {
+  if (ctx.ultragoal?.active) return renderUltragoal(ctx);
+  return renderTeam(ctx);
 }
 
 function renderTurns(ctx: HudRenderContext): string | null {
@@ -233,8 +244,7 @@ const MINIMAL_ELEMENTS: ElementRenderer[] = [
   renderDeepInterview,
   renderAutoresearch,
   renderUltraqa,
-  renderTeam,
-  renderUltragoal,
+  renderExecutionSummary,
   renderTurns,
 ];
 
@@ -247,8 +257,7 @@ const FOCUSED_ELEMENTS: ElementRenderer[] = [
   renderDeepInterview,
   renderAutoresearch,
   renderUltraqa,
-  renderTeam,
-  renderUltragoal,
+  renderExecutionSummary,
   renderTurns,
   renderTokens,
   renderQuota,
@@ -265,8 +274,7 @@ const FULL_ELEMENTS: ElementRenderer[] = [
   renderDeepInterview,
   renderAutoresearch,
   renderUltraqa,
-  renderTeam,
-  renderUltragoal,
+  renderExecutionSummary,
   renderTurns,
   renderTokens,
   renderQuota,


### PR DESCRIPTION
## Summary
- Combine active ultragoal + team HUD metadata into one execution summary segment.
- Preserve existing team-only and ultragoal-only rendering paths.
- Add render/state/watch regression coverage for the combined ultragoal + team case.

Fixes #2551.

## Validation
- `npm run build`
- `env -u OMX_SESSION_ID -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT node --test dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js dist/hud/__tests__/index.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- code-reviewer: APPROVE
- architect: CLEAR

## Scope notes
- Production change is limited to HUD rendering composition.
- No team or ultragoal lifecycle semantics changed.
- #2552 next-goals visualization is intentionally out of scope.
