### PR TITLE
Show next ultragoal items in HUD

### DIFF
--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -180,6 +180,13 @@ describe('runWatchMode', () => {
             status: 'in_progress',
             index: 2,
           },
+          nextGoals: [{
+            id: 'G003-next',
+            title: 'Next team checkpoint',
+            objective: 'keep combined team ultragoal compact',
+            status: 'pending',
+            index: 3,
+          }],
         },
       }),
       readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
@@ -199,6 +206,8 @@ describe('runWatchMode', () => {
     assert.equal((plain.match(/team:2 workers/g) ?? []).length, 1);
     assert.equal((plain.match(/ultragoal 1\/3/g) ?? []).length, 1);
     assert.ok(plain.includes('ultragoal 1/3 + team:2 workers'));
+    assert.ok(plain.includes('G002-team: Team HUD summary'));
+    assert.ok(plain.includes('G003-next: Next team checkpoint (pending)'));
   });
 
   it('runs authority tick after each rendered frame', async () => {

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -400,7 +400,7 @@ describe('renderHud – ultragoal', () => {
     assert.ok(result.split('\n').length <= 3);
   });
 
-  it('renders up to three ongoing ultragoal items alongside ralplan and ultraqa within the expanded HUD budget', () => {
+  it('renders active ultragoal plus up to three next pending items alongside ralplan and ultraqa when space allows', () => {
     const ctx = {
       ...emptyCtx(),
       ralplan: { active: true, current_phase: 'review' },
@@ -423,14 +423,7 @@ describe('renderHud – ultragoal', () => {
           status: 'in_progress',
           index: 2,
         },
-        ongoingGoals: [
-          {
-            id: 'G002-active',
-            title: 'Active HUD status',
-            objective: 'show three active workflow statuses in the OMX HUD without clipping',
-            status: 'in_progress',
-            index: 2,
-          },
+        nextGoals: [
           {
             id: 'G003-next',
             title: 'Next verification item',
@@ -446,9 +439,9 @@ describe('renderHud – ultragoal', () => {
             index: 4,
           },
           {
-            id: 'G005-hidden',
-            title: 'Hidden fourth item',
-            objective: 'should not render',
+            id: 'G005-docs',
+            title: 'Document compact summary',
+            objective: 'document behavior',
             status: 'pending',
             index: 5,
           },
@@ -464,8 +457,47 @@ describe('renderHud – ultragoal', () => {
     assert.ok(result.includes('G002-active: Active HUD status'));
     assert.ok(result.includes('G003-next: Next verification item (pending)'));
     assert.ok(result.includes('G004-qa: Run UltraQA matrix (pending)'));
-    assert.ok(!result.includes('G005-hidden'));
+    assert.ok(result.includes('G005-docs: Document compact summary (pending)'));
     assert.ok(result.split('\n').length <= 6);
+  });
+
+  it('renders fewer pending ultragoal items without empty separators', () => {
+    const ctx = {
+      ...emptyCtx(),
+      ultragoal: {
+        active: true,
+        status: 'in_progress',
+        total: 2,
+        complete: 0,
+        pending: 1,
+        inProgress: 1,
+        failed: 0,
+        reviewBlocked: 0,
+        needsUserDecision: 0,
+        progressTotal: 2,
+        activeGoal: {
+          id: 'G001-active',
+          title: 'Active HUD work',
+          objective: 'keep active summary compact',
+          status: 'in_progress',
+          index: 1,
+        },
+        nextGoals: [{
+          id: 'G002-next',
+          title: 'Only next item',
+          objective: 'handle fewer pending goals',
+          status: 'pending',
+          index: 2,
+        }],
+      },
+    };
+
+    const result = stripSgr(renderHud(ctx, 'focused', { maxWidth: 180, maxLines: 3 }));
+
+    assert.ok(result.includes('G001-active: Active HUD work'));
+    assert.ok(result.includes('G002-next: Only next item (pending)'));
+    assert.ok(!result.includes(' ·  · '));
+    assert.ok(!result.includes('objective:'));
   });
 });
 

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -287,12 +287,21 @@ describe('readUltragoalState', { concurrency: false }, () => {
             index: 3,
           },
         ],
+        nextGoals: [
+          {
+            id: 'G003-tests',
+            title: 'Tests',
+            objective: 'Validate the HUD display',
+            status: 'pending',
+            index: 3,
+          },
+        ],
       });
     });
   });
 
-  it('limits ultragoal ongoing HUD goals to three unresolved items with active goal first', async () => {
-    await withTempRepo('omx-hud-ultragoal-ongoing-', async (cwd) => {
+  it('shows active ultragoal plus the next three pending goals', async () => {
+    await withTempRepo('omx-hud-ultragoal-next-pending-', async (cwd) => {
       const ultragoalDir = join(cwd, '.omx', 'ultragoal');
       await mkdir(ultragoalDir, { recursive: true });
       await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
@@ -300,10 +309,14 @@ describe('readUltragoalState', { concurrency: false }, () => {
         activeGoalId: 'G004-active',
         goals: [
           { id: 'G001-done', title: 'Done', objective: 'Complete old work', status: 'complete' },
-          { id: 'G002-pending', title: 'Pending one', objective: 'Do pending one', status: 'pending' },
+          { id: 'G002-previous-pending', title: 'Previous pending', objective: 'Do previous pending', status: 'pending' },
           { id: 'G003-running', title: 'Running one', objective: 'Do running one', status: 'in_progress' },
           { id: 'G004-active', title: 'Active selected', objective: 'Do active selected', status: 'in_progress' },
-          { id: 'G005-blocked', title: 'Blocked one', objective: 'Resolve blocker', status: 'review_blocked' },
+          { id: 'G005-pending', title: 'Pending two', objective: 'Do pending two', status: 'pending' },
+          { id: 'G006-blocked', title: 'Blocked one', objective: 'Resolve blocker', status: 'review_blocked' },
+          { id: 'G007-pending', title: 'Pending three', objective: 'Do pending three', status: 'pending' },
+          { id: 'G008-pending', title: 'Pending four', objective: 'Do pending four', status: 'pending' },
+          { id: 'G009-pending', title: 'Hidden pending five', objective: 'Do pending five', status: 'pending' },
         ],
       }));
 
@@ -311,9 +324,36 @@ describe('readUltragoalState', { concurrency: false }, () => {
 
       assert.deepEqual(state?.ongoingGoals?.map((goal) => goal.id), [
         'G004-active',
-        'G003-running',
-        'G005-blocked',
+        'G005-pending',
+        'G007-pending',
+        'G008-pending',
       ]);
+      assert.deepEqual(state?.nextGoals?.map((goal) => goal.id), [
+        'G005-pending',
+        'G007-pending',
+        'G008-pending',
+      ]);
+    });
+  });
+
+  it('handles fewer than three pending ultragoal goals gracefully', async () => {
+    await withTempRepo('omx-hud-ultragoal-fewer-pending-', async (cwd) => {
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G002-active',
+        goals: [
+          { id: 'G001-done', title: 'Done', objective: 'Complete old work', status: 'complete' },
+          { id: 'G002-active', title: 'Active selected', objective: 'Do active selected', status: 'in_progress' },
+          { id: 'G003-pending', title: 'Only pending', objective: 'Do only pending', status: 'pending' },
+        ],
+      }));
+
+      const state = await readUltragoalState(cwd);
+
+      assert.deepEqual(state?.ongoingGoals?.map((goal) => goal.id), ['G002-active', 'G003-pending']);
+      assert.deepEqual(state?.nextGoals?.map((goal) => goal.id), ['G003-pending']);
     });
   });
 

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -147,8 +147,12 @@ function renderUltragoal(ctx: HudRenderContext): string | null {
 
   const teamSummary = formatTeamSummary(ctx);
   const progress = `ultragoal ${complete}/${total}${teamSummary ? ` + ${teamSummary}` : ''}`;
-  const ongoingGoals = (ctx.ultragoal.ongoingGoals?.length ? ctx.ultragoal.ongoingGoals : ctx.ultragoal.activeGoal ? [ctx.ultragoal.activeGoal] : [])
-    .slice(0, 3)
+  const activeGoal = ctx.ultragoal.activeGoal ?? ctx.ultragoal.ongoingGoals?.[0];
+  const nextGoals = ctx.ultragoal.nextGoals ?? ctx.ultragoal.ongoingGoals?.filter((goal) => goal.id !== activeGoal?.id).slice(0, 3) ?? [];
+  const ongoingGoals = [
+    ...(activeGoal ? [activeGoal] : []),
+    ...nextGoals.slice(0, 3),
+  ]
     .map((goal) => {
       const id = goal.id ? sanitizeDynamicText(goal.id) : '';
       const title = goal.title ? truncateDynamicText(sanitizeDynamicText(goal.title), 36) : '';
@@ -157,7 +161,6 @@ function renderUltragoal(ctx: HudRenderContext): string | null {
       return status && status !== 'in_progress' ? `${heading} (${status})` : heading;
     })
     .filter(Boolean);
-  const activeGoal = ctx.ultragoal.activeGoal ?? ctx.ultragoal.ongoingGoals?.[0];
   const rawObjective = activeGoal?.objective ? sanitizeDynamicText(activeGoal.objective) : '';
   const objective = ongoingGoals.length === 0 && rawObjective ? truncateDynamicText(rawObjective, 96) : '';
   const items = ongoingGoals.length > 0 ? ` ▶ ${ongoingGoals.join(' · ')}` : '';

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -175,28 +175,22 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
   );
   const activeIndex = activeGoal ? goals.findIndex((goal) => goal.id === activeGoal.id) : -1;
   const complete = isAggregateComplete(plan.aggregateCompletion) || unresolved_goals === 0;
-  const orderedOngoingGoals = goals
+  const toHudGoal = ({ goal, index }: { goal: NormalizedUltragoalGoal; index: number }) => ({
+    id: goal.id,
+    title: goal.title,
+    objective: goal.objective,
+    status: goal.status,
+    index: index + 1,
+  });
+  const nextPendingGoals = goals
     .map((goal, index) => ({ goal, index }))
-    .filter(({ goal }) => ULTRAGOAL_UNRESOLVED_STATUSES.has(goal.status))
-    .sort((a, b) => {
-      const aActive = activeGoal && a.goal.id === activeGoal.id ? 0 : 1;
-      const bActive = activeGoal && b.goal.id === activeGoal.id ? 0 : 1;
-      if (aActive !== bActive) return aActive - bActive;
-
-      const aRunning = ULTRAGOAL_ACTIVE_STATUSES.has(a.goal.status) ? 0 : 1;
-      const bRunning = ULTRAGOAL_ACTIVE_STATUSES.has(b.goal.status) ? 0 : 1;
-      if (aRunning !== bRunning) return aRunning - bRunning;
-
-      return a.index - b.index;
-    })
+    .filter(({ goal, index }) => index > activeIndex && goal.status === 'pending' && goal.id !== activeGoal?.id)
     .slice(0, 3)
-    .map(({ goal, index }) => ({
-      id: goal.id,
-      title: goal.title,
-      objective: goal.objective,
-      status: goal.status,
-      index: index + 1,
-    }));
+    .map(toHudGoal);
+  const orderedOngoingGoals = [
+    ...(activeGoal && activeIndex >= 0 ? [toHudGoal({ goal: activeGoal, index: activeIndex })] : []),
+    ...nextPendingGoals,
+  ];
 
   return {
     active: !complete,
@@ -217,6 +211,7 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
       index: activeIndex + 1,
     } : undefined,
     ongoingGoals: orderedOngoingGoals,
+    nextGoals: nextPendingGoals,
   };
 }
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -31,6 +31,7 @@ export interface UltragoalStateForHud {
   progressTotal: number;
   activeGoal?: UltragoalActiveGoalForHud;
   ongoingGoals?: UltragoalActiveGoalForHud[];
+  nextGoals?: UltragoalActiveGoalForHud[];
 }
 
 /** Ultrawork state for HUD display */


### PR DESCRIPTION
## Summary
- show the active ultragoal HUD item plus up to three next pending items
- keep the existing compact active summary without title/objective duplication
- preserve combined ultragoal + team rendering as one non-duplicated summary

Fixes #2552

## Verification
- `npm run build`
- `env -u OMX_SESSION_ID -u OMX_TEAM_STATE_ROOT -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/hud/__tests__/state.test.js dist/hud/__tests__/render.test.js dist/hud/__tests__/index.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

## Review gates
- code-reviewer: APPROVE
- architect: CLEAR
