### PR TITLE
fix: harden Team and Ultragoal coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ These are useful, but they are not the main onboarding path.
 
 Use the team runtime when you specifically need durable tmux/worktree coordination, not as the default way to begin using OMX. In Codex App or plain outside-tmux sessions, treat `omx team` as a tmux-runtime shell surface rather than a directly available in-app workflow; launch OMX CLI from shell first if you actually want team execution.
 
+When Team runs inside an Ultragoal story, Ultragoal remains leader-owned state: workers report checkpoint-ready evidence upward instead of mutating `.omx/ultragoal` directly. Team startup tolerates stale or malformed Ultragoal artifacts for unrelated work, but explicitly Ultragoal-linked Team launches stay fail-closed. Team startup also writes `.omx/state/team/<team-name>/preflight-context.json` so large Team runs can be resumed after compaction with the original task, worker split, Ultragoal context, and verification checklist.
+
+For very small atomic work, Team may cap implicit fanout to one worker and print an over-orchestration warning; pass an explicit worker count only when the extra coordination cost is intentional.
+
 ```bash
 omx team 3:executor "fix the failing tests with verification"
 omx team status <team-name>

--- a/src/cli/__tests__/team-decompose.test.ts
+++ b/src/cli/__tests__/team-decompose.test.ts
@@ -119,12 +119,17 @@ describe('decomposeTaskString', () => {
   });
 
   it('keeps explicit worker-count small tasks conservative only when count is implicit', () => {
-    const implicitTasks = decomposeTaskString('fix typo in README', 3, 'executor', false, false);
-    assert.equal(implicitTasks.length, 1);
-    assert.equal(implicitTasks[0].owner, 'worker-1');
+    const implicitPlan = buildTeamExecutionPlan('fix typo in README', 3, 'executor', false, false);
+    assert.equal(implicitPlan.workerCount, 1);
+    assert.equal(implicitPlan.tasks.length, 1);
+    assert.equal(implicitPlan.tasks[0].owner, 'worker-1');
+    assert.equal(implicitPlan.overOrchestrationNotice?.code, 'team_over_orchestration_warning');
+    assert.match(implicitPlan.overOrchestrationNotice?.message ?? '', /solo execution path/i);
 
-    const explicitTasks = decomposeTaskString('fix typo in README', 3, 'executor', false, true);
-    assert.equal(explicitTasks.length, 3);
+    const explicitPlan = buildTeamExecutionPlan('fix typo in README', 3, 'executor', false, true);
+    assert.equal(explicitPlan.workerCount, 3);
+    assert.equal(explicitPlan.tasks.length, 3);
+    assert.equal(explicitPlan.overOrchestrationNotice?.code, 'explicit_team_override_acknowledged');
   });
 
   it('keeps medium-sized coupled implementation prompts single-lane by default', () => {

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -2908,6 +2908,20 @@ describe('teamCommand status', () => {
       await writeFile(testSpecPath, '# Ultragoal JSON status test spec\n');
       const hint = readApprovedExecutionLaunchHint(wd, 'team', { prdPath, task });
       assert.ok(hint);
+      await mkdir(join(wd, '.omx', 'ultragoal'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'ultragoal', 'goals.json'),
+        `${JSON.stringify({
+          version: 1,
+          activeGoalId: 'G001-team-runtime-bridge',
+          codexGoalMode: 'aggregate',
+          goals: [{
+            id: 'G001-team-runtime-bridge',
+            title: 'Team runtime bridge',
+            status: 'in_progress',
+          }],
+        })}\n`,
+      );
       await writePersistedApprovedTeamExecutionBinding(
         'ultragoal-json-team',
         wd,
@@ -3012,6 +3026,20 @@ describe('teamCommand status', () => {
       await writeFile(testSpecPath, '# Ultragoal text status test spec\n');
       const hint = readApprovedExecutionLaunchHint(wd, 'team', { prdPath, task });
       assert.ok(hint);
+      await mkdir(join(wd, '.omx', 'ultragoal'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'ultragoal', 'goals.json'),
+        `${JSON.stringify({
+          version: 1,
+          activeGoalId: 'G001-team-runtime-bridge',
+          codexGoalMode: 'aggregate',
+          goals: [{
+            id: 'G001-team-runtime-bridge',
+            title: 'Team runtime bridge',
+            status: 'in_progress',
+          }],
+        })}\n`,
+      );
       await writePersistedApprovedTeamExecutionBinding(
         'ultragoal-text-team',
         wd,

--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -51,6 +52,74 @@ async function capture(run: () => Promise<void>): Promise<{ stdout: string[]; st
 }
 
 describe('cli/ultragoal', () => {
+  it('refuses mutating ultragoal commands from Team worker environments', async () => {
+    const mutators: string[][] = [
+      ['create-goals', '--brief', 'worker must not create'],
+      ['create', '--brief', 'worker must not create'],
+      ['add-goal', '--title', 'Worker goal', '--objective', 'Do not add'],
+      ['steer', '--kind', 'add_subgoal', '--title', 'Worker steer', '--objective', 'Do not steer', '--evidence', 'worker evidence', '--rationale', 'worker rationale'],
+      ['record-review-blockers', '--goal-id', 'G001-first', '--title', 'Blocker', '--objective', 'Do not record', '--evidence', 'worker evidence', '--codex-goal-json', JSON.stringify({ goal: { objective: 'x', status: 'active' } })],
+      ['complete-goals'],
+      ['complete'],
+      ['next'],
+      ['start-next'],
+      ['checkpoint', '--goal-id', 'G001-first', '--status', 'complete', '--evidence', 'worker evidence'],
+    ];
+    const envCases: Array<[string, string]> = [
+      ['OMX_TEAM_WORKER', 'display-team/worker-1'],
+      ['OMX_TEAM_INTERNAL_WORKER', 'internal-team/worker-1'],
+    ];
+
+    for (const [envName, envValue] of envCases) {
+      for (const args of mutators) {
+        await withCwd(async (cwd) => {
+          const previousPublic = process.env.OMX_TEAM_WORKER;
+          const previousInternal = process.env.OMX_TEAM_INTERNAL_WORKER;
+          delete process.env.OMX_TEAM_WORKER;
+          delete process.env.OMX_TEAM_INTERNAL_WORKER;
+          process.env[envName] = envValue;
+          try {
+            const result = await capture(() => ultragoalCommand(args));
+            assert.equal(result.exitCode, 1, `${envName} should block ${args[0]}`);
+            assert.match(result.stderr.join('\n'), /leader-owned/i);
+            assert.match(result.stderr.join('\n'), /report checkpoint evidence upward/i);
+            assert.equal(existsSync(join(cwd, '.omx/ultragoal/goals.json')), false);
+            assert.equal(existsSync(join(cwd, '.omx/ultragoal/ledger.jsonl')), false);
+          } finally {
+            if (typeof previousPublic === 'string') process.env.OMX_TEAM_WORKER = previousPublic;
+            else delete process.env.OMX_TEAM_WORKER;
+            if (typeof previousInternal === 'string') process.env.OMX_TEAM_INTERNAL_WORKER = previousInternal;
+            else delete process.env.OMX_TEAM_INTERNAL_WORKER;
+          }
+        });
+      }
+    }
+  });
+
+  it('allows ultragoal help and status from Team worker environments', async () => {
+    await withCwd(async () => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));
+      const previousPublic = process.env.OMX_TEAM_WORKER;
+      const previousInternal = process.env.OMX_TEAM_INTERNAL_WORKER;
+      process.env.OMX_TEAM_WORKER = 'display-team/worker-1';
+      process.env.OMX_TEAM_INTERNAL_WORKER = 'internal-team/worker-1';
+      try {
+        const help = await capture(() => ultragoalCommand(['help']));
+        assert.equal(help.exitCode, undefined);
+        assert.match(help.stdout.join('\n'), /omx ultragoal/);
+
+        const status = await capture(() => ultragoalCommand(['status']));
+        assert.equal(status.exitCode, undefined);
+        assert.match(status.stdout.join('\n'), /ultragoal:/);
+      } finally {
+        if (typeof previousPublic === 'string') process.env.OMX_TEAM_WORKER = previousPublic;
+        else delete process.env.OMX_TEAM_WORKER;
+        if (typeof previousInternal === 'string') process.env.OMX_TEAM_INTERNAL_WORKER = previousInternal;
+        else delete process.env.OMX_TEAM_INTERNAL_WORKER;
+      }
+    });
+  });
+
   it('prints help with artifact and goal-mode constraints', async () => {
     assert.match(ULTRAGOAL_HELP, /create-goals/);
     assert.match(ULTRAGOAL_HELP, /complete-goals/);

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -39,6 +39,7 @@ import {
 } from '../team/approved-execution.js';
 import {
   buildUltragoalCheckpointGuidance,
+  reconcilePersistedTeamUltragoalContext,
   readPersistedTeamUltragoalContext,
   renderUltragoalCheckpointGuidanceText,
 } from '../team/ultragoal-context.js';
@@ -975,6 +976,10 @@ interface DecompositionPlan {
 export interface TeamExecutionPlan {
   workerCount: number;
   tasks: Array<{ subject: string; description: string; owner: string; role?: string }>;
+  overOrchestrationNotice?: {
+    code: 'team_over_orchestration_warning' | 'explicit_team_override_acknowledged';
+    message: string;
+  };
 }
 
 function resolveImplicitTeamFallbackRole(agentType: string, explicitAgentType: boolean): string {
@@ -1031,6 +1036,7 @@ export function buildTeamExecutionPlan(
   explicitWorkerCount = false,
 ): TeamExecutionPlan {
   const plan = splitTaskString(task);
+  const taskSize = classifyTaskSize(task).size;
   const effectiveWorkerCount = resolveTeamFanoutLimit(
     task,
     workerCount,
@@ -1039,6 +1045,19 @@ export function buildTeamExecutionPlan(
     plan,
   );
   const fallbackRole = resolveImplicitTeamFallbackRole(agentType, explicitAgentType);
+  const overOrchestrationNotice = plan.strategy === 'atomic' && taskSize === 'small'
+    ? explicitWorkerCount && workerCount > 1
+      ? {
+        code: 'explicit_team_override_acknowledged' as const,
+        message: 'Small atomic task is using Team fanout because the worker count was explicit.',
+      }
+      : workerCount > 1 && effectiveWorkerCount === 1
+        ? {
+          code: 'team_over_orchestration_warning' as const,
+          message: 'Small atomic task is capped to one Team worker; consider a solo execution path for lower overhead.',
+        }
+        : undefined
+    : undefined;
 
   let subtasks = plan.subtasks;
   const usedAspectSubtasks = subtasks.length <= 1 && effectiveWorkerCount > 1;
@@ -1069,6 +1088,7 @@ export function buildTeamExecutionPlan(
   return {
     workerCount: effectiveWorkerCount,
     tasks,
+    ...(overOrchestrationNotice ? { overOrchestrationNotice } : {}),
   };
 }
 
@@ -1482,9 +1502,27 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
       config?.leader_cwd ?? cwd,
       config?.team_state_root ?? undefined,
     );
-    const ultragoalCheckpointGuidance = ultragoalContext
-      ? buildUltragoalCheckpointGuidance(ultragoalContext)
+    const ultragoalReconciliation = await reconcilePersistedTeamUltragoalContext(
+      config?.leader_cwd ?? cwd,
+      ultragoalContext,
+    );
+    const currentUltragoalContext = ultragoalReconciliation.status === 'valid'
+      ? ultragoalReconciliation.context
       : null;
+    const ultragoalCheckpointGuidance = currentUltragoalContext
+      ? buildUltragoalCheckpointGuidance(currentUltragoalContext)
+      : null;
+    const ultragoalContextWarning = ultragoalReconciliation.warning
+      ? {
+        status: ultragoalReconciliation.status,
+        message: ultragoalReconciliation.warning.message,
+      }
+      : ultragoalContext
+        ? {
+          status: ultragoalReconciliation.status,
+          message: `Persisted Ultragoal context is not currently valid (${ultragoalReconciliation.status}); checkpoint guidance suppressed.`,
+        }
+        : null;
     if (wantsJson) {
       console.log(JSON.stringify({
         ...buildJsonBase(),
@@ -1511,6 +1549,9 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
         },
         performance: snapshot.performance ?? null,
         panes: paneStatus,
+        ...(ultragoalContextWarning
+          ? { ultragoal_context_warning: ultragoalContextWarning }
+          : {}),
         ...(ultragoalCheckpointGuidance
           ? { ultragoal_checkpoint_guidance: ultragoalCheckpointGuidance }
           : {}),
@@ -1534,7 +1575,10 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
         `monitor_perf_ms: total=${snapshot.performance.total_ms} list=${snapshot.performance.list_tasks_ms} workers=${snapshot.performance.worker_scan_ms} mailbox=${snapshot.performance.mailbox_delivery_ms}`
       );
     }
-    for (const line of renderUltragoalCheckpointGuidanceText(ultragoalContext)) {
+    if (ultragoalContextWarning) {
+      console.log(`ultragoal_context_warning: ${ultragoalContextWarning.message}`);
+    }
+    for (const line of renderUltragoalCheckpointGuidanceText(currentUltragoalContext)) {
       console.log(line);
     }
     renderTeamPaneStatus(paneStatus, modelInspect, tailLines);
@@ -1722,5 +1766,8 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
   );
 
   await ensureTeamModeState({ ...effectiveParsed, teamName: runtime.teamName, displayName: runtime.config.display_name ?? effectiveParsed.displayName }, tasks);
+  if (executionPlan.overOrchestrationNotice) {
+    console.log(`${executionPlan.overOrchestrationNotice.code}: ${executionPlan.overOrchestrationNotice.message}`);
+  }
   await renderStartSummary(runtime, staffingPlan);
 }

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -288,6 +288,36 @@ function printSteerResult(proposal: UltragoalSteeringProposal, result: CliSteerR
   printStatus(result.plan);
 }
 
+const ULTRAGOAL_MUTATING_COMMANDS = new Set([
+  'create',
+  'create-goals',
+  'add-goal',
+  'steer',
+  'record-review-blockers',
+  'complete',
+  'complete-goals',
+  'next',
+  'start-next',
+  'checkpoint',
+]);
+
+function readTeamWorkerIdentity(env: NodeJS.ProcessEnv = process.env): string | null {
+  const publicIdentity = typeof env.OMX_TEAM_WORKER === 'string' ? env.OMX_TEAM_WORKER.trim() : '';
+  if (publicIdentity) return publicIdentity;
+  const internalIdentity = typeof env.OMX_TEAM_INTERNAL_WORKER === 'string' ? env.OMX_TEAM_INTERNAL_WORKER.trim() : '';
+  return internalIdentity || null;
+}
+
+function assertUltragoalMutationAllowedFromCurrentProcess(command: string): void {
+  if (!ULTRAGOAL_MUTATING_COMMANDS.has(command)) return;
+  const workerIdentity = readTeamWorkerIdentity();
+  if (!workerIdentity) return;
+  throw new UltragoalError(
+    `Refusing mutating ultragoal command "${command}" from Team worker ${workerIdentity}. `
+    + 'Ultragoal state is leader-owned; workers must report checkpoint evidence upward instead of mutating .omx/ultragoal.',
+  );
+}
+
 export async function ultragoalCommand(args: string[]): Promise<void> {
   const command = args[0] ?? 'help';
   const rest = args.slice(1);
@@ -299,6 +329,8 @@ export async function ultragoalCommand(args: string[]): Promise<void> {
       console.log(ULTRAGOAL_HELP);
       return;
     }
+
+    assertUltragoalMutationAllowedFromCurrentProcess(command);
 
     if (command === 'create' || command === 'create-goals') {
       const briefFile = readValue(rest, '--brief-file');

--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -62,6 +62,7 @@ describe("generateOverlay", () => {
     assert.ok(overlay.includes("<!-- OMX:RUNTIME:END -->"));
     assert.ok(overlay.includes("test-session-1"));
     assert.ok(overlay.includes("Compaction Protocol"));
+    assert.ok(overlay.includes("preflight-context.json"));
   });
 
   it("injects mandatory native subagent agent_type routing guidance", async () => {

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -326,7 +326,8 @@ function getCompactionInstructions(): string {
     "Before context compaction, preserve critical state:",
     "1. Write progress checkpoint via `omx state write --input '<json>' --json`",
     "2. Save key decisions via `omx notepad write-working --input '<json>' --json`",
-    "3. If context is >80% full, proactively checkpoint state",
+    "3. Before large Team work near compaction, reload `.omx/state/team/<team>/preflight-context.json`",
+    "4. If context is >80% full, proactively checkpoint state",
   ].join("\n");
 }
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6677,6 +6677,22 @@ esac
         existsSync(join(teamStateRoot, 'team', runtime.teamName, 'ultragoal-context.json')),
         false,
       );
+      const preflight = JSON.parse(await readFile(
+        join(teamStateRoot, 'team', runtime.teamName, 'preflight-context.json'),
+        'utf-8',
+      )) as {
+        schema_version: number;
+        task: string;
+        ultragoal: { status: string; active_goal_id: string | null };
+        prohibitions: string[];
+        resume_instructions: string[];
+      };
+      assert.equal(preflight.schema_version, 1);
+      assert.match(preflight.task, /completed Ultragoal artifacts/);
+      assert.equal(preflight.ultragoal.status, 'missing');
+      assert.equal(preflight.ultragoal.active_goal_id, null);
+      assert.ok(preflight.prohibitions.includes('workers_must_not_mutate_ultragoal'));
+      assert.ok(preflight.resume_instructions.some((line) => /preflight-context\.json/.test(line)));
       const inbox = await readFile(
         join(teamStateRoot, 'team', runtime.teamName, 'workers', 'worker-1', 'inbox.md'),
         'utf-8',
@@ -6687,6 +6703,87 @@ esac
       if (runtime) {
         await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
       }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam tolerates malformed Ultragoal artifacts for unrelated Team startup', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-ultragoal-malformed-optional-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(cwd, '.omx', 'ultragoal'), { recursive: true });
+    await writeFile(join(cwd, '.omx', 'ultragoal', 'goals.json'), '{not-json');
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withPromptModeCodexEnv(binDir, {}, () =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-ultragoal-malformed-optional',
+            'malformed Ultragoal artifacts must not block unrelated team startup',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            cwd,
+          ),
+        ),
+      );
+
+      const teamStateRoot = runtime.config.team_state_root ?? join(cwd, '.omx', 'state');
+      const preflight = JSON.parse(await readFile(
+        join(teamStateRoot, 'team', runtime.teamName, 'preflight-context.json'),
+        'utf-8',
+      )) as { ultragoal: { status: string; warning: string | null } };
+      assert.equal(preflight.ultragoal.status, 'malformed');
+      assert.match(preflight.ultragoal.warning ?? '', /malformed_goals_json/);
+      const inbox = await readFile(
+        join(teamStateRoot, 'team', runtime.teamName, 'workers', 'worker-1', 'inbox.md'),
+        'utf-8',
+      );
+      assert.doesNotMatch(inbox, /Leader-owned Ultragoal context/);
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam fails closed for malformed artifacts when explicitly linked to an Ultragoal goal', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-ultragoal-malformed-strict-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(cwd, '.omx', 'ultragoal'), { recursive: true });
+    await writeFile(join(cwd, '.omx', 'ultragoal', 'goals.json'), '{not-json');
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `setTimeout(() => {}, 5000);`,
+    );
+
+    try {
+      await assert.rejects(
+        () => withPromptModeCodexEnv(binDir, {}, () =>
+          withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-ultragoal-malformed-strict',
+              'Execute Ultragoal goal G001-malformed-story with Team',
+              'executor',
+              1,
+              [{ subject: 's', description: 'd', owner: 'worker-1' }],
+              cwd,
+            ),
+          ),
+        ),
+        /invalid_ultragoal_team_context:malformed_goals_json/,
+      );
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', 'team-ultragoal-malformed-strict')), false);
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -27,8 +27,10 @@ import { composeRoleInstructionsForRole } from "../../agents/native-config.js";
 import { buildTeamWorkerGoalInstruction } from "../goal-workflow.js";
 import {
   normalizeUltragoalTeamContext,
+  reconcilePersistedTeamUltragoalContext,
   renderLeaderOwnedUltragoalContextSection,
   resolveLeaderOwnedUltragoalContext,
+  resolveLeaderOwnedUltragoalContextOutcome,
 } from "../ultragoal-context.js";
 import type { TeamTask } from "../state.js";
 
@@ -460,6 +462,66 @@ describe("worker bootstrap", () => {
         () => resolveLeaderOwnedUltragoalContext(wd),
         /invalid_ultragoal_team_context:malformed_goals_json/,
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves invalid Ultragoal artifacts as optional warnings for unrelated Team startup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-team-ultragoal-optional-"));
+    try {
+      await mkdir(join(wd, ".omx", "ultragoal"), { recursive: true });
+      await writeFile(join(wd, ".omx", "ultragoal", "goals.json"), "{bad json\n");
+
+      const outcome = await resolveLeaderOwnedUltragoalContextOutcome(wd);
+
+      assert.equal(outcome.status, "malformed");
+      assert.equal(outcome.context, null);
+      assert.match(outcome.warning?.message ?? "", /malformed_goals_json/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("reconciles persisted Ultragoal context against current active goals", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-team-ultragoal-reconcile-"));
+    try {
+      await mkdir(join(wd, ".omx", "ultragoal"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "ultragoal", "goals.json"),
+        `${JSON.stringify({
+          version: 1,
+          activeGoalId: "G002-current",
+          codexGoalMode: "aggregate",
+          goals: [{
+            id: "G002-current",
+            title: "Current story",
+            status: "in_progress",
+          }],
+        })}\n`,
+      );
+
+      const stale = await reconcilePersistedTeamUltragoalContext(wd, {
+        kind: "leader_owned_ultragoal_context",
+        goalsPath: ".omx/ultragoal/goals.json",
+        ledgerPath: ".omx/ultragoal/ledger.jsonl",
+        activeGoalId: "G001-old",
+        codexGoalMode: "aggregate",
+        checkpointPolicy: "fresh_leader_get_goal_required",
+      });
+      assert.equal(stale.status, "mismatched");
+      assert.equal(stale.context, null);
+
+      const valid = await reconcilePersistedTeamUltragoalContext(wd, {
+        kind: "leader_owned_ultragoal_context",
+        goalsPath: ".omx/ultragoal/goals.json",
+        ledgerPath: ".omx/ultragoal/ledger.jsonl",
+        activeGoalId: "G002-current",
+        codexGoalMode: "aggregate",
+        checkpointPolicy: "fresh_leader_get_goal_required",
+      });
+      assert.equal(valid.status, "valid");
+      assert.equal(valid.context?.activeGoalId, "G002-current");
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/team/repo-aware-decomposition.ts
+++ b/src/team/repo-aware-decomposition.ts
@@ -64,6 +64,10 @@ export interface RepoAwareTeamExecutionPlan {
   workerCount: number;
   tasks: RepoAwareTask[];
   metadata?: TeamDecompositionMetadata;
+  overOrchestrationNotice?: {
+    code: 'team_over_orchestration_warning' | 'explicit_team_override_acknowledged';
+    message: string;
+  };
 }
 
 const DEFAULT_MAX_WORKERS = 20;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -146,6 +146,7 @@ import {
   readPersistedTeamUltragoalContext,
   renderLeaderOwnedUltragoalContextSection,
   resolveLeaderOwnedUltragoalContext,
+  resolveLeaderOwnedUltragoalContextOutcome,
   writePersistedTeamUltragoalContext,
 } from './ultragoal-context.js';
 import {
@@ -1384,6 +1385,81 @@ function resolveEffectiveTeamWorktreeMode(
   return { enabled: false };
 }
 
+function isExplicitUltragoalLinkedTeam(task: string, approvedExecution: unknown, selectedApprovedExecutionHint: unknown): boolean {
+  const approvedHaystack = [
+    JSON.stringify(approvedExecution ?? {}),
+    JSON.stringify(selectedApprovedExecutionHint ?? {}),
+  ].join('\n');
+  if (/(?:ultragoal|\.omx\/ultragoal)/i.test(approvedHaystack)) return true;
+  return /(?:\.omx\/ultragoal|ultragoal\s+(?:goal|plan|checkpoint)|goal\s+G\d{3}|\bG\d{3}[-\w]*\b)/i.test(task);
+}
+
+async function writeTeamPreflightContextPacket(params: {
+  teamName: string;
+  displayName: string;
+  teamStateRoot: string;
+  leaderCwd: string;
+  task: string;
+  workerCount: number;
+  workerBootstrapPlans: Array<{
+    workerName: string;
+    workerRole: string;
+    workerTasks: TeamTask[];
+  }>;
+  approvedExecution: ApprovedTeamExecutionBinding | null;
+  ultragoalOutcome: {
+    status: string;
+    context?: { activeGoalId?: string; activeGoalTitle?: string } | null;
+    warning?: { message?: string } | null;
+  };
+}): Promise<string> {
+  const packetPath = join(params.teamStateRoot, 'team', params.teamName, 'preflight-context.json');
+  const packet = {
+    schema_version: 1,
+    created_at: new Date().toISOString(),
+    team_id: params.teamName,
+    display_name: params.displayName,
+    leader_cwd: params.leaderCwd,
+    task: params.task,
+    worker_count: params.workerCount,
+    worker_allocation: params.workerBootstrapPlans.map((plan) => ({
+      worker: plan.workerName,
+      role: plan.workerRole,
+      task_ids: plan.workerTasks.map((task) => task.id),
+      task_subjects: plan.workerTasks.map((task) => task.subject),
+    })),
+    approved_execution: params.approvedExecution
+      ? {
+        prd_path: params.approvedExecution.prd_path,
+        task: params.approvedExecution.task,
+      }
+      : null,
+    ultragoal: {
+      status: params.ultragoalOutcome.status,
+      active_goal_id: params.ultragoalOutcome.context?.activeGoalId ?? null,
+      active_goal_title: params.ultragoalOutcome.context?.activeGoalTitle ?? null,
+      warning: params.ultragoalOutcome.warning?.message ?? null,
+    },
+    verification_checklist: [
+      'collect worker evidence before leader checkpoint',
+      'run targeted verification for changed files',
+      'leader performs any Ultragoal checkpoint from fresh get_goal evidence',
+    ],
+    prohibitions: [
+      'workers_must_not_mutate_ultragoal',
+      'workers_must_not_checkpoint_ultragoal',
+    ],
+    resume_instructions: [
+      `After compaction, reload ${packetPath}`,
+      'Verify the active Ultragoal goal still matches this packet before checkpointing.',
+      'Resume Team monitoring with omx team status before dispatching follow-up work.',
+    ],
+  };
+  await mkdir(dirname(packetPath), { recursive: true });
+  await writeFile(packetPath, `${JSON.stringify(packet, null, 2)}\n`, 'utf-8');
+  return packetPath;
+}
+
 const MODEL_INSTRUCTIONS_FILE_ENV = 'OMX_MODEL_INSTRUCTIONS_FILE';
 const TEAM_STATE_ROOT_ENV = 'OMX_TEAM_STATE_ROOT';
 const TEAM_LEADER_CWD_ENV = 'OMX_TEAM_LEADER_CWD';
@@ -2377,7 +2453,21 @@ export async function startTeam(
   const approvedExecution = selectedApprovedExecutionHint
     ? buildApprovedTeamExecutionBinding(selectedApprovedExecutionHint)
     : null;
-  const ultragoalContext = await resolveLeaderOwnedUltragoalContext(leaderCwd);
+  const explicitUltragoalLinkedTeam = isExplicitUltragoalLinkedTeam(
+    task,
+    requestedApprovedExecution ?? approvedExecution,
+    selectedApprovedExecutionHint,
+  );
+  const strictUltragoalContext = explicitUltragoalLinkedTeam
+    ? await resolveLeaderOwnedUltragoalContext(leaderCwd)
+    : undefined;
+  const ultragoalOutcome = explicitUltragoalLinkedTeam
+    ? {
+      status: strictUltragoalContext ? 'valid' as const : 'missing' as const,
+      context: strictUltragoalContext ?? null,
+    }
+    : await resolveLeaderOwnedUltragoalContextOutcome(leaderCwd);
+  const ultragoalContext = ultragoalOutcome.status === 'valid' ? ultragoalOutcome.context : null;
   const approvedContextSection = joinContextSections(
     buildApprovedTeamHandoffSection(selectedApprovedExecutionHint),
     renderLeaderOwnedUltragoalContextSection(ultragoalContext),
@@ -2743,6 +2833,17 @@ export async function startTeam(
     };
 
     // 6. Create worker runtime (interactive tmux panes or prompt-mode child processes)
+    await writeTeamPreflightContextPacket({
+      teamName: sanitized,
+      displayName,
+      teamStateRoot,
+      leaderCwd,
+      task,
+      workerCount,
+      workerBootstrapPlans,
+      approvedExecution,
+      ultragoalOutcome,
+    });
     await cleanupTeamWorkerLaunchOrphanedMcpProcesses({
       cleanup: options.cleanupLaunchOrphanedMcpProcesses,
       writeWarning: options.writeCleanupWarning,

--- a/src/team/ultragoal-context.ts
+++ b/src/team/ultragoal-context.ts
@@ -32,6 +32,25 @@ export interface UltragoalCheckpointGuidance {
   };
 }
 
+export type UltragoalContextResolutionStatus =
+  | 'valid'
+  | 'missing'
+  | 'malformed'
+  | 'completed'
+  | 'mismatched'
+  | 'stale';
+
+export interface UltragoalContextWarning {
+  code: UltragoalContextResolutionStatus;
+  message: string;
+}
+
+export interface UltragoalContextResolution {
+  status: UltragoalContextResolutionStatus;
+  context: UltragoalTeamContext | null;
+  warning?: UltragoalContextWarning;
+}
+
 const ULTRAGOAL_GOAL_ID_SAFE_PATTERN = /^G\d{3}[-\w]*$/;
 
 export function isSafeUltragoalGoalId(value: string): boolean {
@@ -92,32 +111,46 @@ export function normalizeUltragoalTeamContext(value: unknown): UltragoalTeamCont
 }
 
 export async function resolveLeaderOwnedUltragoalContext(cwd: string): Promise<UltragoalTeamContext | null> {
+  const outcome = await resolveLeaderOwnedUltragoalContextOutcome(cwd);
+  if (outcome.status === 'valid') return outcome.context;
+  if (outcome.status === 'missing') return null;
+  throw new Error(`invalid_ultragoal_team_context:${outcome.warning?.message ?? outcome.status}`);
+}
+
+function warning(code: UltragoalContextResolutionStatus, message: string): UltragoalContextResolution {
+  return { status: code, context: null, warning: { code, message } };
+}
+
+export async function resolveLeaderOwnedUltragoalContextOutcome(cwd: string): Promise<UltragoalContextResolution> {
   const goalsJsonPath = join(cwd, '.omx', 'ultragoal', 'goals.json');
-  if (!existsSync(goalsJsonPath)) return null;
+  if (!existsSync(goalsJsonPath)) return { status: 'missing', context: null };
 
   try {
     const parsed = JSON.parse(await readFile(goalsJsonPath, 'utf-8')) as Record<string, unknown>;
     const activeGoalId = typeof parsed.activeGoalId === 'string' ? parsed.activeGoalId.trim() : '';
     if (activeGoalId === '') {
-      return null;
+      return { status: 'missing', context: null };
     }
     if (!isSafeUltragoalGoalId(activeGoalId)) {
-      throw new InvalidUltragoalTeamContextError(`unsafe_active_goal_id:${activeGoalId}`);
+      return warning('malformed', `unsafe_active_goal_id:${activeGoalId}`);
     }
     const goals = Array.isArray(parsed.goals) ? parsed.goals : [];
     const activeGoal = goals.find((goal) =>
       goal && typeof goal === 'object' && (goal as Record<string, unknown>).id === activeGoalId,
     ) as Record<string, unknown> | undefined;
     if (!activeGoal) {
-      throw new InvalidUltragoalTeamContextError(`active_goal_not_found:${activeGoalId}`);
+      return warning('mismatched', `active_goal_not_found:${activeGoalId}`);
     }
     if (activeGoal.status !== 'in_progress') {
-      throw new InvalidUltragoalTeamContextError(`active_goal_not_in_progress:${activeGoalId}`);
+      return warning(
+        activeGoal.status === 'complete' ? 'completed' : 'stale',
+        `active_goal_not_in_progress:${activeGoalId}`,
+      );
     }
     const activeGoalTitle = typeof activeGoal?.title === 'string' && activeGoal.title.trim() !== ''
       ? activeGoal.title.trim()
       : undefined;
-    return {
+    const context: UltragoalTeamContext = {
       kind: 'leader_owned_ultragoal_context',
       goalsPath: '.omx/ultragoal/goals.json',
       ledgerPath: '.omx/ultragoal/ledger.jsonl',
@@ -126,12 +159,30 @@ export async function resolveLeaderOwnedUltragoalContext(cwd: string): Promise<U
       codexGoalMode: resolvePlanCodexGoalMode(parsed.codexGoalMode),
       checkpointPolicy: 'fresh_leader_get_goal_required',
     };
+    return { status: 'valid', context };
   } catch (error) {
     if (error instanceof InvalidUltragoalTeamContextError) {
-      throw new Error(`invalid_ultragoal_team_context:${error.message}`);
+      return warning('malformed', error.message);
     }
-    throw new Error(`invalid_ultragoal_team_context:malformed_goals_json`);
+    return warning('malformed', 'malformed_goals_json');
   }
+}
+
+export async function reconcilePersistedTeamUltragoalContext(
+  cwd: string,
+  persisted: UltragoalTeamContext | null | undefined,
+): Promise<UltragoalContextResolution> {
+  const normalized = normalizeUltragoalTeamContext(persisted);
+  if (!normalized) return { status: 'missing', context: null };
+  const current = await resolveLeaderOwnedUltragoalContextOutcome(cwd);
+  if (current.status !== 'valid' || !current.context) return current;
+  if (current.context.activeGoalId !== normalized.activeGoalId) {
+    return warning(
+      'mismatched',
+      `persisted_goal_mismatch:${normalized.activeGoalId}:current:${current.context.activeGoalId}`,
+    );
+  }
+  return current;
 }
 
 export async function writePersistedTeamUltragoalContext(


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Hardens the combined Team + Ultragoal workflow so Team can run inside or near Ultragoal plans without letting workers mutate leader-owned goal state, showing stale checkpoint guidance, or losing launch context across compaction.

## Changes

- Block mutating `omx ultragoal` commands from Team worker environments while keeping `help` and `status` available.
- Split Team Ultragoal context resolution into strict vs optional outcomes:
  - unrelated Team launches tolerate stale/malformed Ultragoal artifacts with warning metadata,
  - explicitly Ultragoal-linked launches remain fail-closed.
- Reconcile `omx team status` Ultragoal checkpoint guidance against current `.omx/ultragoal/goals.json` before rendering it.
- Add small atomic Team over-orchestration notices for implicit fanout caps and explicit override acknowledgement.
- Write `.omx/state/team/<team>/preflight-context.json` before worker dispatch with task, worker allocation, Ultragoal status, prohibitions, and resume instructions.
- Update README Team runtime guidance for Team + Ultragoal ownership, preflight resume packets, and small-task warnings.

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `git diff --check`
- [x] `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_SESSION_ID node --test dist/cli/__tests__/ultragoal.test.js dist/cli/__tests__/team-decompose.test.js dist/team/__tests__/worker-bootstrap.test.js dist/hooks/__tests__/agents-overlay.test.js dist/cli/__tests__/team.test.js`
- [x] `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_SESSION_ID node --test --test-name-pattern "Ultragoal artifacts|Ultragoal goal" dist/team/__tests__/runtime.test.js`

Note: full `npm test` was not run for this draft PR. A broader `test:recent-bug-regressions:compiled` run before the final cleanup exposed pre-existing/unrelated failures in `codex-native-hook.test.js` stderr warning expectations and `sendWorkerMessage` hook-preferred mailbox cases; the targeted Team + Ultragoal coverage above is green.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
