### PR TITLE
Close answered question renderer panes

### DIFF
--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import {
+  closeQuestionRenderer,
   computeAdaptiveQuestionPaneHeight,
   formatQuestionAnswerForInjection,
   formatQuestionAnswersForInjection,
@@ -110,6 +111,41 @@ describe('resolveQuestionRendererStrategy', () => {
       resolveQuestionRendererStrategy({} as NodeJS.ProcessEnv, undefined),
       'unsupported',
     );
+  });
+});
+
+
+describe('question renderer cleanup', () => {
+  it('kills tmux pane renderers by target pane id', () => {
+    const calls: string[][] = [];
+    const closed = closeQuestionRenderer({
+      renderer: 'tmux-pane',
+      target: '%42',
+      launched_at: '2026-05-11T00:00:00.000Z',
+    }, (args) => {
+      calls.push(args);
+      return '';
+    });
+
+    assert.equal(closed, true);
+    assert.deepEqual(calls, [['kill-pane', '-t', '%42']]);
+  });
+
+  it('ignores invalid, noop, and Windows process renderers during cleanup', () => {
+    const calls: string[][] = [];
+    assert.equal(closeQuestionRenderer(undefined, (args) => { calls.push(args); return ''; }), false);
+    assert.equal(closeQuestionRenderer({
+      renderer: 'tmux-session',
+      target: 'test-noop-renderer',
+      launched_at: '2026-05-11T00:00:00.000Z',
+    }, (args) => { calls.push(args); return ''; }), false);
+    assert.equal(closeQuestionRenderer({
+      renderer: 'windows-console',
+      target: 'pid:1234',
+      pid: 1234,
+      launched_at: '2026-05-11T00:00:00.000Z',
+    }, (args) => { calls.push(args); return ''; }), false);
+    assert.deepEqual(calls, []);
   });
 });
 

--- a/src/question/__tests__/state.test.ts
+++ b/src/question/__tests__/state.test.ts
@@ -70,6 +70,51 @@ describe('question state', () => {
     assert.equal(event?.state?.timeout_ms, 1234);
   });
 
+  it('closes the renderer pane after accepting an answer so stale question panes do not remain visible', async () => {
+    const cwd = await makeRepo();
+    const { record, recordPath } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-close-renderer');
+
+    await markQuestionPrompting(recordPath, {
+      renderer: 'tmux-pane',
+      target: '%42',
+      launched_at: '2026-05-11T00:00:00.000Z',
+      return_target: '%11',
+      return_transport: 'tmux-send-keys',
+    });
+
+    const injected: Array<{ paneId: string; value: string | string[] }> = [];
+    const closed: string[] = [];
+    const answered = await markQuestionAnswered(recordPath, {
+      kind: 'option',
+      value: 'a',
+      selected_labels: ['A'],
+      selected_values: ['a'],
+    }, {
+      injectAnswersToPane: (paneId, answers) => {
+        injected.push({ paneId, value: answers[0]!.answer.value });
+        return true;
+      },
+      closeQuestionRenderer: (renderer) => {
+        if (renderer?.target) closed.push(renderer.target);
+        return true;
+      },
+    });
+
+    assert.equal(answered.status, 'answered');
+    assert.deepEqual(injected, [{ paneId: '%11', value: 'a' }]);
+    assert.deepEqual(closed, ['%42']);
+    const loaded = await readQuestionRecord(recordPath);
+    assert.equal(loaded?.renderer?.target, '%42');
+    assert.equal(loaded?.status, 'answered');
+    assert.equal(record.status, 'pending');
+  });
+
   it('submits bounded answers by id and rejects duplicate stale or unknown submissions', async () => {
     const cwd = await makeRepo();
     const { record } = await createQuestionRecord(cwd, {
@@ -450,7 +495,7 @@ describe('question state', () => {
     assert.match(loaded?.error?.message || '', /pane %42 disappeared immediately after launch/);
   });
 
-  it('does not regress an already answered record back to prompting when renderer metadata arrives late', async () => {
+  it('closes late renderer metadata without regressing an already answered record back to prompting', async () => {
     const cwd = await makeRepo();
     const { recordPath } = await createQuestionRecord(cwd, {
       question: 'Pick one',
@@ -466,18 +511,65 @@ describe('question state', () => {
       selected_labels: ['A'],
       selected_values: ['a'],
     });
+    const closed: string[] = [];
     await markQuestionPrompting(recordPath, {
       renderer: 'tmux-pane',
       target: '%42',
       launched_at: '2026-04-19T00:00:00.000Z',
       return_target: '%11',
       return_transport: 'tmux-send-keys',
+    }, {
+      closeQuestionRenderer: (renderer) => {
+        if (renderer?.target) closed.push(renderer.target);
+        return true;
+      },
     });
 
     const loaded = await readQuestionRecord(recordPath);
     assert.equal(loaded?.status, 'answered');
     assert.equal(loaded?.answer?.value, 'a');
-    assert.equal(loaded?.renderer?.return_target, '%11');
+    assert.equal(loaded?.renderer, undefined);
+    assert.deepEqual(closed, ['%42']);
+  });
+
+  it('still closes the renderer when return-pane injection throws after persisting the answer', async () => {
+    const cwd = await makeRepo();
+    const { recordPath } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-close-after-inject-failure');
+    await markQuestionPrompting(recordPath, {
+      renderer: 'tmux-pane',
+      target: '%42',
+      launched_at: '2026-05-14T00:00:00.000Z',
+      return_target: '%11',
+      return_transport: 'tmux-send-keys',
+    });
+
+    const closed: string[] = [];
+    await assert.rejects(
+      () => markQuestionAnswered(recordPath, {
+        kind: 'option',
+        value: 'a',
+        selected_labels: ['A'],
+        selected_values: ['a'],
+      }, {
+        injectAnswersToPane: () => { throw new Error('inject failed'); },
+        closeQuestionRenderer: (renderer) => {
+          if (renderer?.target) closed.push(renderer.target);
+          return true;
+        },
+      }),
+      /inject failed/,
+    );
+
+    const loaded = await readQuestionRecord(recordPath);
+    assert.equal(loaded?.status, 'answered');
+    assert.equal(loaded?.answer?.value, 'a');
+    assert.deepEqual(closed, ['%42']);
   });
 
   it('injects answered text to the persisted renderer return pane', async () => {
@@ -511,6 +603,7 @@ describe('question state', () => {
           injected.push({ paneId, values: answers.map((entry) => entry.answer.value) });
           return true;
         },
+        closeQuestionRenderer: () => true,
       },
     );
 
@@ -549,6 +642,7 @@ describe('question state', () => {
           injected = true;
           return true;
         },
+        closeQuestionRenderer: () => true,
       },
     );
 

--- a/src/question/__tests__/ui.test.ts
+++ b/src/question/__tests__/ui.test.ts
@@ -305,6 +305,7 @@ describe('question ui arrow navigation', () => {
           injected.push({ paneId, value: answers[0]!.answer.value });
           return true;
         },
+        closeQuestionRenderer: () => true,
       });
 
       setTimeout(() => {
@@ -361,6 +362,7 @@ describe('question ui arrow navigation', () => {
           injected.push({ paneId, value: answers[0]!.answer.value });
           return true;
         },
+        closeQuestionRenderer: () => true,
       });
 
       setTimeout(() => {
@@ -407,6 +409,7 @@ describe('question ui arrow navigation', () => {
           injected.push({ paneId, value: answers[0]!.answer.value });
           return true;
         },
+        closeQuestionRenderer: () => true,
       });
 
       setTimeout(() => {
@@ -561,6 +564,7 @@ describe('question ui batch wizard', () => {
           injected.push({ paneId, values: answers.map((entry) => entry.answer.value) });
           return true;
         },
+        closeQuestionRenderer: () => true,
       });
 
       setTimeout(() => {

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -376,6 +376,29 @@ export function isQuestionRendererAlive(
   return true;
 }
 
+export function closeQuestionRenderer(
+  renderer: QuestionRendererState | undefined,
+  execTmux: ExecTmuxSync = defaultExecTmux,
+): boolean {
+  if (!renderer) return false;
+  try {
+    if (renderer.renderer === 'tmux-pane' && isPaneId(renderer.target)) {
+      execTmux(['kill-pane', '-t', renderer.target]);
+      return true;
+    }
+    if (renderer.renderer === 'tmux-session' && renderer.target !== 'test-noop-renderer' && safeString(renderer.target).trim()) {
+      execTmux(['kill-session', '-t', renderer.target]);
+      return true;
+    }
+    if (renderer.renderer === 'windows-console') {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
 export function formatQuestionAnswerForInjection(answer: QuestionAnswer): string {
   const prefix = '[omx question answered]';
   if (answer.kind === 'other') {

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -5,7 +5,10 @@ import { getStateDir } from '../mcp/state-paths.js';
 import { writeAtomic } from '../team/state.js';
 import { sleep } from '../utils/sleep.js';
 import { appendQuestionAnsweredEventOnce, appendQuestionEvent, normalizeSubmittedAnswers, resolveQuestionRunId } from './events.js';
-import { injectQuestionAnswersToPane as defaultInjectQuestionAnswersToPane } from './renderer.js';
+import {
+  closeQuestionRenderer as defaultCloseQuestionRenderer,
+  injectQuestionAnswersToPane as defaultInjectQuestionAnswersToPane,
+} from './renderer.js';
 import { getNormalizedQuestionType, isMultiAnswerableQuestion, normalizeQuestionInput } from './types.js';
 import type {
   NormalizedQuestionItem,
@@ -26,6 +29,8 @@ export type InjectQuestionAnswersToPane = (
   paneId: string,
   answers: QuestionAnswerEntry[],
 ) => boolean;
+
+export type CloseQuestionRenderer = (renderer: QuestionRendererState | undefined) => boolean;
 
 export type QuestionSubmitFailureCode =
   | 'question_unknown'
@@ -121,19 +126,40 @@ export async function updateQuestionRecord(
 export async function markQuestionPrompting(
   recordPath: string,
   renderer: QuestionRendererState,
+  options: { closeQuestionRenderer?: CloseQuestionRenderer } = {},
 ): Promise<QuestionRecord> {
-  return updateQuestionRecord(recordPath, (record) => ({
-    ...record,
-    status: isTerminalQuestionStatus(record.status) ? record.status : 'prompting',
-    updated_at: new Date().toISOString(),
-    renderer,
-  }));
+  return await withQuestionSubmitLock(recordPath, async () => {
+    let rendererToClose: QuestionRendererState | undefined;
+    const updated = await updateQuestionRecord(recordPath, (record) => {
+      if (isTerminalQuestionStatus(record.status)) {
+        rendererToClose = renderer;
+        return record;
+      }
+      return {
+        ...record,
+        status: 'prompting',
+        updated_at: new Date().toISOString(),
+        renderer,
+      };
+    });
+    if (rendererToClose) maybeCloseQuestionRenderer(rendererToClose, options.closeQuestionRenderer);
+    return updated;
+  });
 }
 
 export async function markQuestionAnswered(
   recordPath: string,
   answerOrAnswers: QuestionAnswer | QuestionAnswerEntry[],
-  options: { injectAnswersToPane?: InjectQuestionAnswersToPane } = {},
+  options: { injectAnswersToPane?: InjectQuestionAnswersToPane; closeQuestionRenderer?: CloseQuestionRenderer } = {},
+): Promise<QuestionRecord> {
+  const updated = await withQuestionSubmitLock(recordPath, () => persistQuestionAnswered(recordPath, answerOrAnswers));
+  runAnsweredQuestionSideEffects(updated, options);
+  return updated;
+}
+
+async function persistQuestionAnswered(
+  recordPath: string,
+  answerOrAnswers: QuestionAnswer | QuestionAnswerEntry[],
 ): Promise<QuestionRecord> {
   const updated = await updateQuestionRecord(recordPath, (record) => {
     const answers = Array.isArray(answerOrAnswers)
@@ -149,8 +175,22 @@ export async function markQuestionAnswered(
       error: undefined,
     };
   });
-  maybeInjectQuestionAnswersToReturnPane(updated, options.injectAnswersToPane);
   return updated;
+}
+
+function runAnsweredQuestionSideEffects(
+  record: QuestionRecord,
+  options: { injectAnswersToPane?: InjectQuestionAnswersToPane; closeQuestionRenderer?: CloseQuestionRenderer } = {},
+): void {
+  let injectError: unknown;
+  try {
+    maybeInjectQuestionAnswersToReturnPane(record, options.injectAnswersToPane);
+  } catch (error) {
+    injectError = error;
+  } finally {
+    maybeCloseQuestionRenderer(record.renderer, options.closeQuestionRenderer);
+  }
+  if (injectError) throw injectError;
 }
 
 function maybeInjectQuestionAnswersToReturnPane(
@@ -162,6 +202,13 @@ function maybeInjectQuestionAnswersToReturnPane(
   if (typeof returnTarget !== 'string' || !/^%\d+$/.test(returnTarget.trim())) return false;
   if (!record.answers?.length) return false;
   return injectAnswersToPane(returnTarget.trim(), record.answers);
+}
+
+function maybeCloseQuestionRenderer(
+  renderer: QuestionRendererState | undefined,
+  closeQuestionRenderer: CloseQuestionRenderer = defaultCloseQuestionRenderer,
+): boolean {
+  return closeQuestionRenderer(renderer);
 }
 
 function isValidQuestionId(questionId: string): boolean {
@@ -396,7 +443,7 @@ export async function submitQuestionAnswerById(
   cwd: string,
   questionId: string,
   answerPayload: unknown,
-  options: { sessionId?: string; runId?: string; injectAnswersToPane?: InjectQuestionAnswersToPane } = {},
+  options: { sessionId?: string; runId?: string; injectAnswersToPane?: InjectQuestionAnswersToPane; closeQuestionRenderer?: CloseQuestionRenderer } = {},
 ): Promise<{ recordPath: string; record: QuestionRecord }> {
   const normalizedQuestionId = questionId.trim();
   if (!isValidQuestionId(normalizedQuestionId)) {
@@ -404,7 +451,7 @@ export async function submitQuestionAnswerById(
   }
 
   const recordPath = getQuestionRecordPath(cwd, normalizedQuestionId, options.sessionId);
-  return await withQuestionSubmitLock(recordPath, async () => {
+  const result = await withQuestionSubmitLock(recordPath, async () => {
     const current = await readQuestionRecord(recordPath);
     if (!current) throw new QuestionSubmitError('question_unknown', `Unknown question id: ${normalizedQuestionId}`);
     if (current.status !== 'pending' && current.status !== 'prompting') {
@@ -421,12 +468,12 @@ export async function submitQuestionAnswerById(
     } catch (error) {
       throw new QuestionSubmitError('question_invalid_answer', error instanceof Error ? error.message : String(error));
     }
-    const record = await markQuestionAnswered(recordPath, answers, {
-      injectAnswersToPane: options.injectAnswersToPane,
-    });
+    const record = await persistQuestionAnswered(recordPath, answers);
     await appendQuestionAnsweredEventOnce(cwd, record, { recordPath, runId: options.runId });
     return { recordPath, record };
   });
+  runAnsweredQuestionSideEffects(result.record, options);
+  return result;
 }
 
 export async function markQuestionTerminalError(

--- a/src/question/ui.ts
+++ b/src/question/ui.ts
@@ -24,6 +24,7 @@ interface QuestionUiDeps {
   output?: QuestionUiOutput;
   env?: NodeJS.ProcessEnv;
   injectAnswersToPane?: (paneId: string, answers: QuestionAnswerEntry[]) => boolean;
+  closeQuestionRenderer?: (renderer: QuestionRecord['renderer']) => boolean;
 }
 
 interface InteractiveSelectionState {
@@ -519,6 +520,7 @@ export async function runQuestionUi(recordPath: string, deps: QuestionUiDeps = {
     }
     await markQuestionAnswered(recordPath, answers, {
       injectAnswersToPane: deps.injectAnswersToPane,
+      closeQuestionRenderer: deps.closeQuestionRenderer,
     });
   } catch (error) {
     await markQuestionTerminalError(recordPath, 'error', 'question_ui_failed', error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
## Summary
- close answered tmux question renderer panes after answer persistence so stale Q panes do not remain visible when the next question opens
- serialize prompting/answer transitions through the question submit lock to prevent stale renderer metadata from overwriting terminal answers
- keep renderer/injection side effects outside the submit lock and skip unsafe Windows PID cleanup

## Diagnostics
Live `ccbot-master` showed Q1 answered pane `%210` staying visible while Q2 opened in `%211`. The persisted Q1 record was already `answered` with `renderer.target=%210`; Q2 was `prompting` with `renderer.target=%211`, so the layout bug was lifecycle cleanup, not prompt routing.

## Review
Ran an OMX code review in a dedicated tmux pane. It initially blocked on:
- stale prompting-vs-answered race
- unsafe Windows PID cleanup
- self-kill before submit-lock release

This PR addresses those blockers; final blocker-only re-review returned `APPROVE`.

## Tests
- `npm run build`
- `node --test dist/question/__tests__/state.test.js dist/question/__tests__/renderer.test.js dist/question/__tests__/ui.test.js dist/question/__tests__/deep-interview.test.js`
- `npm run lint -- src/question/renderer.ts src/question/state.ts src/question/ui.ts src/question/__tests__/state.test.ts src/question/__tests__/renderer.test.ts src/question/__tests__/ui.test.ts`
- `npm run check:no-unused`
- `git diff --check origin/dev...HEAD`
