### PR TITLE
Clarify Autopilot continuation phase labels

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3365,6 +3365,76 @@ ${JSON.stringify({
     }
   });
 
+  it("labels boxed autopilot question-wait state by the nested previous phase", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-boxed-question-answer-"));
+    const cwd = join(root, "source");
+    const omxRoot = join(root, "box");
+    const sessionId = "sess-autopilot-boxed-question-answer";
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      await mkdir(cwd, { recursive: true });
+      process.env.OMX_ROOT = omxRoot;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      const sessionDir = join(getBaseStateDir(cwd), "sessions", sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        keyword: "$autopilot",
+        phase: "deep-interview",
+        initialized_mode: "autopilot",
+        initialized_state_path: `.omx/state/sessions/${sessionId}/autopilot-state.json`,
+        session_id: sessionId,
+        active_skills: [
+          { skill: "autopilot", phase: "deep-interview", active: true, session_id: sessionId },
+        ],
+      });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "waiting-for-user",
+        state: {
+          deep_interview_question: {
+            status: "waiting_for_user",
+            previous_phase: "deep-interview",
+          },
+        },
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-autopilot-boxed-question-answer",
+          turn_id: "turn-autopilot-boxed-question-answer",
+          prompt: "[omx question answered] boxed_state_answer",
+        },
+        { cwd },
+      );
+
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /continued active workflow skill "autopilot:deep-interview"/);
+      assert.match(message, /skill: autopilot:deep-interview activated/);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", sessionId, "autopilot-state.json")), false);
+    } finally {
+      if (typeof previousOmxRoot === "string") process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === "string") process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("keeps deep-interview bridge guidance on marked question answers with workflow-like tokens", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-question-answer-continuation-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3317,7 +3317,17 @@ ${JSON.stringify({
       await writeJson(join(sessionDir, "autopilot-state.json"), {
         active: true,
         mode: "autopilot",
-        current_phase: "deep-interview",
+        current_phase: "waiting-for-user",
+        deep_interview_question: {
+          status: "waiting_for_user",
+          previous_phase: "deep-interview",
+          question_id: "question-real-wait-shape",
+        },
+        state: {
+          handoff_artifacts: {
+            deep_interview: { status: "waiting_for_q2_answer" },
+          },
+        },
         started_at: "2026-04-19T00:00:00.000Z",
         updated_at: "2026-04-19T00:10:00.000Z",
         session_id: sessionId,
@@ -3340,7 +3350,8 @@ ${JSON.stringify({
       const message = String(
         (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
       );
-      assert.match(message, /continued active workflow skill "autopilot"/);
+      assert.match(message, /continued active workflow skill "autopilot:deep-interview"/);
+      assert.match(message, /skill: autopilot:deep-interview activated/);
       assert.match(message, /Autopilot protocol:/);
       assert.match(message, /structured question chain, not a one-question gate/);
       assert.match(message, /This turn is a marked omx question answer/);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3318,12 +3318,12 @@ ${JSON.stringify({
         active: true,
         mode: "autopilot",
         current_phase: "waiting-for-user",
-        deep_interview_question: {
-          status: "waiting_for_user",
-          previous_phase: "deep-interview",
-          question_id: "question-real-wait-shape",
-        },
         state: {
+          deep_interview_question: {
+            status: "waiting_for_user",
+            previous_phase: "deep-interview",
+            question_id: "question-real-wait-shape",
+          },
           handoff_artifacts: {
             deep_interview: { status: "waiting_for_q2_answer" },
           },

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1708,9 +1708,15 @@ function readInitializedModePhase(cwd: string, skillState?: SkillActiveState | n
     const currentPhase = safeString(state.current_phase).trim();
     if (!currentPhase) return null;
     if (mode === "autopilot" && currentPhase === "waiting-for-user") {
+      const nestedState = state.state && typeof state.state === "object"
+        ? state.state as Record<string, unknown>
+        : null;
+      const nestedDeepInterviewQuestion = nestedState?.deep_interview_question;
       const deepInterviewQuestion = state.deep_interview_question && typeof state.deep_interview_question === "object"
         ? state.deep_interview_question as Record<string, unknown>
-        : null;
+        : nestedDeepInterviewQuestion && typeof nestedDeepInterviewQuestion === "object"
+          ? nestedDeepInterviewQuestion as Record<string, unknown>
+          : null;
       if (deepInterviewQuestion) {
         const waitStatus = safeString(deepInterviewQuestion.status).trim();
         const previousPhase = safeString(deepInterviewQuestion.previous_phase).trim();

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1698,11 +1698,21 @@ function buildNativeOutsideTmuxTeamPromptBlockState(
   };
 }
 
+function resolveInitializedModeStatePath(cwd: string, statePath: string): string {
+  if (statePath.startsWith("/")) return statePath;
+  const normalized = statePath.replace(/\\/g, "/");
+  const statePrefix = ".omx/state/";
+  if (normalized.startsWith(statePrefix)) {
+    return join(getBaseStateDir(cwd), normalized.slice(statePrefix.length));
+  }
+  return resolve(cwd, statePath);
+}
+
 function readInitializedModePhase(cwd: string, skillState?: SkillActiveState | null): string | null {
   const mode = safeString(skillState?.initialized_mode).trim() || safeString(skillState?.skill).trim();
   const statePath = safeString(skillState?.initialized_state_path).trim();
   if (!mode || !statePath) return null;
-  const fullPath = resolve(cwd, statePath);
+  const fullPath = resolveInitializedModeStatePath(cwd, statePath);
   try {
     const state = JSON.parse(readFileSync(fullPath, "utf-8")) as Record<string, unknown>;
     const currentPhase = safeString(state.current_phase).trim();

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1698,8 +1698,59 @@ function buildNativeOutsideTmuxTeamPromptBlockState(
   };
 }
 
-function buildSkillStateCliInstruction(mode: string, statePath: string): string {
-  return `skill: ${mode} activated and initial state initialized at ${statePath}; use CLI-first state updates via \`omx state write/read/clear --input '<json>' --json\`; use omx_state MCP only when explicit MCP compatibility is enabled.`;
+function readInitializedModePhase(cwd: string, skillState?: SkillActiveState | null): string | null {
+  const mode = safeString(skillState?.initialized_mode).trim() || safeString(skillState?.skill).trim();
+  const statePath = safeString(skillState?.initialized_state_path).trim();
+  if (!mode || !statePath) return null;
+  const fullPath = resolve(cwd, statePath);
+  try {
+    const state = JSON.parse(readFileSync(fullPath, "utf-8")) as Record<string, unknown>;
+    const currentPhase = safeString(state.current_phase).trim();
+    if (!currentPhase) return null;
+    if (mode === "autopilot" && currentPhase === "waiting-for-user") {
+      const deepInterviewQuestion = state.deep_interview_question && typeof state.deep_interview_question === "object"
+        ? state.deep_interview_question as Record<string, unknown>
+        : null;
+      if (deepInterviewQuestion) {
+        const waitStatus = safeString(deepInterviewQuestion.status).trim();
+        const previousPhase = safeString(deepInterviewQuestion.previous_phase).trim();
+        if (/^(?:waiting_for_user|prompting|pending)$/.test(waitStatus) && previousPhase) return previousPhase;
+      }
+      const handoffArtifacts = state.state && typeof state.state === "object"
+        ? (state.state as Record<string, unknown>).handoff_artifacts
+        : null;
+      const deepInterview = handoffArtifacts && typeof handoffArtifacts === "object"
+        ? (handoffArtifacts as Record<string, unknown>).deep_interview
+        : null;
+      if (deepInterview && typeof deepInterview === "object") {
+        const deepStatus = safeString((deepInterview as Record<string, unknown>).status).trim();
+        if (/^(?:in_progress|waiting|waiting_for_|prompting)/.test(deepStatus)) return "deep-interview";
+      }
+    }
+    return currentPhase;
+  } catch {
+    return null;
+  }
+}
+
+function buildWorkflowSkillLabel(cwd: string, skillState?: SkillActiveState | null): string {
+  const skill = safeString(skillState?.skill).trim() || "unknown";
+  const initializedMode = safeString(skillState?.initialized_mode).trim();
+  if (initializedMode === "autopilot") {
+    const phase = readInitializedModePhase(cwd, skillState);
+    return phase ? `autopilot:${phase}` : "autopilot";
+  }
+  if (initializedMode && initializedMode !== skill) {
+    const phase = readInitializedModePhase(cwd, skillState);
+    return phase ? `${initializedMode}:${phase}` : initializedMode;
+  }
+  return skill;
+}
+
+function buildSkillStateCliInstruction(cwd: string, mode: string, statePath: string): string {
+  const phase = readInitializedModePhase(cwd, { initialized_mode: mode, initialized_state_path: statePath } as SkillActiveState);
+  const label = phase ? `${mode}:${phase}` : mode;
+  return `skill: ${label} activated and initial state initialized at ${statePath}; use CLI-first state updates via \`omx state write/read/clear --input '<json>' --json\`; use omx_state MCP only when explicit MCP compatibility is enabled.`;
 }
 
 function buildAutopilotPromptActivationNote(
@@ -1741,10 +1792,10 @@ function buildAdditionalContextMessage(
     const markedQuestionAnswer = /^\s*\[omx question answered\]/i.test(prompt);
     const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { markedQuestionAnswer });
     return [
-      `OMX native UserPromptSubmit continued active workflow skill "${continuedSkill}".`,
+      `OMX native UserPromptSubmit continued active workflow skill "${buildWorkflowSkillLabel(cwd, skillState)}".`,
       promptPriorityMessage,
       skillState?.initialized_mode && skillState.initialized_state_path
-        ? buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path)
+        ? buildSkillStateCliInstruction(cwd, skillState.initialized_mode, skillState.initialized_state_path)
         : null,
       deepInterviewPromptActivationNote,
       deepInterviewConfigPromptActivationNote,
@@ -1767,10 +1818,10 @@ function buildAdditionalContextMessage(
     const deepInterviewConfigPromptActivationNote = buildDeepInterviewConfigInstruction(cwd, skillState);
     const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { markedQuestionAnswer: true });
     return [
-      `OMX native UserPromptSubmit continued active workflow skill "${continuedSkill}"; workflow-like tokens inside the marked omx question answer are treated as answer text, not a new workflow activation.`,
+      `OMX native UserPromptSubmit continued active workflow skill "${buildWorkflowSkillLabel(cwd, skillState)}"; workflow-like tokens inside the marked omx question answer are treated as answer text, not a new workflow activation.`,
       promptPriorityMessage,
       skillState?.initialized_mode && skillState.initialized_state_path
-        ? buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path)
+        ? buildSkillStateCliInstruction(cwd, skillState.initialized_mode, skillState.initialized_state_path)
         : null,
       deepInterviewPromptActivationNote,
       deepInterviewConfigPromptActivationNote,
@@ -1829,7 +1880,7 @@ function buildAdditionalContextMessage(
       autopilotPromptActivationNote,
       deepInterviewConfigPromptActivationNote,
       skillState.initialized_mode && skillState.initialized_state_path
-        ? buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path)
+        ? buildSkillStateCliInstruction(cwd, skillState.initialized_mode, skillState.initialized_state_path)
         : null,
       teamDetected
         ? buildTeamRuntimeInstruction(cwd, payload)
@@ -1841,7 +1892,7 @@ function buildAdditionalContextMessage(
 
   if (teamDetected) {
     const initializedStateMessage = skillState?.initialized_mode && skillState.initialized_state_path
-      ? buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path)
+      ? buildSkillStateCliInstruction(cwd, skillState.initialized_mode, skillState.initialized_state_path)
       : null;
     return [
       detectedKeywordMessage,
@@ -1870,7 +1921,7 @@ function buildAdditionalContextMessage(
         ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
         : null,
       promptPriorityMessage,
-      buildSkillStateCliInstruction(skillState.initialized_mode, skillState.initialized_state_path),
+      buildSkillStateCliInstruction(cwd, skillState.initialized_mode, skillState.initialized_state_path),
       deepInterviewPromptActivationNote,
       deepInterviewConfigPromptActivationNote,
       ultraworkPromptActivationNote,


### PR DESCRIPTION
## Summary
- Reapplies #2563 on top of current `dev` after the original PR was closed as `BEHIND`.
- Keeps Autopilot continuation phase labeling aligned with the active workflow phase instead of stale question UI labels.
- Preserves the focused regression coverage from the original PR.

## Test Plan
- `npm run build`
- Attempted focused hook tests after build; local script invocation path needs adjustment in this repo snapshot. A broader `npm run test:node ...` invocation built successfully but ran the full suite and hit unrelated plugin/tmux-environment failures.

Supersedes #2563.
