### PR TITLE
Prevent duplicate question renderer panes

### DIFF
--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -9,9 +9,11 @@ import {
   formatQuestionAnswerForInjection,
   formatQuestionAnswersForInjection,
   injectQuestionAnswerToPane,
+  findLiveQuestionsForSession,
   injectQuestionAnswersToPane,
   launchQuestionRenderer,
   resolveQuestionRendererStrategy,
+  supersedeLiveQuestionsForSession,
 } from '../renderer.js';
 import { buildSendPaneArgvs } from '../../notifications/tmux-detector.js';
 
@@ -878,5 +880,161 @@ describe('question answer injection', () => {
     assert.equal(ok, true);
     assert.deepEqual(calls, buildSendPaneArgvs('%11', '[omx question answered] first: a; second: d', true));
     assert.deepEqual(sleeps, [120, 100]);
+  });
+});
+
+
+describe('question renderer in-flight dedupe', () => {
+  function writeQuestionRecord(path: string, overrides: Record<string, unknown>): void {
+    writeFileSync(path, JSON.stringify({
+      kind: 'omx.question/v1',
+      question_id: 'question-default',
+      session_id: 'sess-dedupe',
+      created_at: '2026-05-27T00:00:00.000Z',
+      updated_at: '2026-05-27T00:00:00.000Z',
+      status: 'prompting',
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: false,
+      other_label: 'Other',
+      multi_select: false,
+      type: 'single-answerable',
+      questions: [{
+        id: 'q-1',
+        question: 'Pick one',
+        options: [{ label: 'A', value: 'a' }],
+        allow_other: false,
+        other_label: 'Other',
+        multi_select: false,
+        type: 'single-answerable',
+      }],
+      renderer: {
+        renderer: 'tmux-pane',
+        target: '%41',
+        launched_at: '2026-05-27T00:00:00.000Z',
+      },
+      ...overrides,
+    }, null, 2));
+  }
+
+  it('finds only live prompting question renderers for the same session', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-question-dedupe-find-'));
+    try {
+      const dir = join(cwd, '.omx', 'state', 'sessions', 'sess-dedupe', 'questions');
+      mkdirSync(dir, { recursive: true });
+      writeQuestionRecord(join(dir, 'question-live.json'), {
+        question_id: 'question-live',
+        created_at: '2026-05-27T00:00:01.000Z',
+        renderer: { renderer: 'tmux-pane', target: '%41', launched_at: '2026-05-27T00:00:01.000Z' },
+      });
+      writeQuestionRecord(join(dir, 'question-dead.json'), {
+        question_id: 'question-dead',
+        created_at: '2026-05-27T00:00:02.000Z',
+        renderer: { renderer: 'tmux-pane', target: '%42', launched_at: '2026-05-27T00:00:02.000Z' },
+      });
+      writeQuestionRecord(join(dir, 'question-answered.json'), {
+        question_id: 'question-answered',
+        status: 'answered',
+        created_at: '2026-05-27T00:00:03.000Z',
+        renderer: { renderer: 'tmux-pane', target: '%43', launched_at: '2026-05-27T00:00:03.000Z' },
+      });
+
+      const live = findLiveQuestionsForSession(cwd, 'sess-dedupe', (args) => {
+        if (args[0] === 'list-panes' && args[2] === '%41') return '0\t%41\n';
+        if (args[0] === 'list-panes' && args[2] === '%42') throw new Error('missing pane');
+        if (args[0] === 'list-panes' && args[2] === '%43') return '0\t%43\n';
+        return '';
+      });
+
+      assert.deepEqual(live.map((item) => item.record.question_id), ['question-live']);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('marks prior live prompting panes superseded and kills them before a new tmux split', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-question-dedupe-launch-'));
+    try {
+      const dir = join(cwd, '.omx', 'state', 'sessions', 'sess-dedupe', 'questions');
+      mkdirSync(dir, { recursive: true });
+      const priorPath = join(dir, 'question-prior.json');
+      const nextPath = join(dir, 'question-next.json');
+      writeQuestionRecord(priorPath, {
+        question_id: 'question-prior',
+        renderer: {
+          renderer: 'tmux-pane',
+          target: '%41',
+          launched_at: '2026-05-27T00:00:00.000Z',
+        },
+      });
+      writeQuestionRecord(nextPath, {
+        question_id: 'question-next',
+        status: 'pending',
+        renderer: undefined,
+      });
+
+      const calls: string[][] = [];
+      const result = launchQuestionRenderer({
+        cwd,
+        recordPath: nextPath,
+        sessionId: 'sess-dedupe',
+        nowIso: '2026-05-27T00:01:00.000Z',
+        env: { TMUX: '/tmp/tmux-demo', TMUX_PANE: '%11' } as NodeJS.ProcessEnv,
+      }, {
+        strategy: 'inside-tmux',
+        execTmux: (args) => {
+          calls.push(args);
+          if (args[0] === 'display-message' && args.includes('#{session_attached}')) return '1\n';
+          if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
+          if (args[0] === 'list-panes' && args[2] === '%41') return '0\t%41\n';
+          if (args[0] === 'kill-pane') return '';
+          if (args[0] === 'split-window') return '%44\n';
+          if (args[0] === 'list-panes' && args[2] === '%44') return '0\t%44\n';
+          return '';
+        },
+        sleepSync: () => {},
+      });
+
+      assert.equal(result.target, '%44');
+      const prior = JSON.parse(readFileSync(priorPath, 'utf-8')) as { status: string; error?: { code?: string }; updated_at?: string };
+      assert.equal(prior.status, 'superseded');
+      assert.equal(prior.error?.code, 'question_superseded');
+      assert.equal(prior.updated_at, '2026-05-27T00:01:00.000Z');
+      const killIndex = calls.findIndex((call) => call.join(' ') === 'kill-pane -t %41');
+      const splitIndex = calls.findIndex((call) => call[0] === 'split-window');
+      assert.ok(killIndex >= 0);
+      assert.ok(splitIndex > killIndex);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not supersede answered records when launching a replacement renderer', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-question-dedupe-answered-'));
+    try {
+      const dir = join(cwd, '.omx', 'state', 'sessions', 'sess-dedupe', 'questions');
+      mkdirSync(dir, { recursive: true });
+      const answeredPath = join(dir, 'question-answered.json');
+      writeQuestionRecord(answeredPath, {
+        question_id: 'question-answered',
+        status: 'answered',
+        renderer: {
+          renderer: 'tmux-pane',
+          target: '%41',
+          launched_at: '2026-05-27T00:00:00.000Z',
+        },
+      });
+
+      const superseded = supersedeLiveQuestionsForSession(cwd, 'sess-dedupe', (args) => {
+        if (args[0] === 'list-panes') return '0\t%41\n';
+        throw new Error(`unexpected tmux call: ${args.join(' ')}`);
+      });
+
+      assert.deepEqual(superseded, []);
+      const answered = JSON.parse(readFileSync(answeredPath, 'utf-8')) as { status: string };
+      assert.equal(answered.status, 'answered');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -1,13 +1,13 @@
 import { execFileSync, spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { basename } from 'node:path';
+import { existsSync, readdirSync, renameSync, writeFileSync, readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
 import { stdin as processStdin, stdout as processStdout } from 'node:process';
 import { parsePaneIdFromTmuxOutput } from '../hud/tmux.js';
 import { buildSendPaneArgvs } from '../notifications/tmux-detector.js';
 import { sleepSync } from '../utils/sleep.js';
 import { sanitizeReplyInput } from '../notifications/reply-listener.js';
 import { getCurrentTmuxPaneId } from '../notifications/tmux.js';
-import { getStatePath } from '../mcp/state-paths.js';
+import { getStateDir, getStatePath } from '../mcp/state-paths.js';
 import { TRACKED_WORKFLOW_MODES } from '../state/workflow-transition.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
@@ -463,6 +463,78 @@ export function injectQuestionAnswersToPane(
   return true;
 }
 
+
+export interface LiveQuestionRecord {
+  recordPath: string;
+  record: QuestionRecord;
+}
+
+function getQuestionStateDirForRenderer(cwd: string, sessionId?: string): string {
+  return join(getStateDir(cwd, sessionId), 'questions');
+}
+
+function isQuestionRecord(value: unknown): value is QuestionRecord {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && (value as { kind?: unknown }).kind === 'omx.question/v1'
+      && typeof (value as { question_id?: unknown }).question_id === 'string',
+  );
+}
+
+function writeQuestionRecordSync(recordPath: string, record: QuestionRecord): void {
+  const tempPath = `${recordPath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(record, null, 2)}\n`, 'utf-8');
+  renameSync(tempPath, recordPath);
+}
+
+export function findLiveQuestionsForSession(
+  cwd: string,
+  sessionId: string | undefined,
+  execTmux: ExecTmuxSync = defaultExecTmux,
+  options: { excludeRecordPath?: string } = {},
+): LiveQuestionRecord[] {
+  const questionsDir = getQuestionStateDirForRenderer(cwd, sessionId);
+  if (!existsSync(questionsDir)) return [];
+  const live: LiveQuestionRecord[] = [];
+  const excludeRecordPath = options.excludeRecordPath;
+  for (const entry of readdirSync(questionsDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const recordPath = join(questionsDir, entry.name);
+    if (excludeRecordPath && recordPath === excludeRecordPath) continue;
+    const record = readJsonFileIfExists(recordPath);
+    if (!isQuestionRecord(record)) continue;
+    if (record.status !== 'prompting') continue;
+    if (!isQuestionRendererAlive(record.renderer, execTmux)) continue;
+    live.push({ recordPath, record });
+  }
+  return live.sort((left, right) => left.record.created_at.localeCompare(right.record.created_at));
+}
+
+export function supersedeLiveQuestionsForSession(
+  cwd: string,
+  sessionId: string | undefined,
+  execTmux: ExecTmuxSync = defaultExecTmux,
+  options: { excludeRecordPath?: string; nowIso?: string } = {},
+): LiveQuestionRecord[] {
+  const live = findLiveQuestionsForSession(cwd, sessionId, execTmux, options);
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  for (const item of live) {
+    writeQuestionRecordSync(item.recordPath, {
+      ...item.record,
+      status: 'superseded',
+      updated_at: nowIso,
+      error: {
+        code: 'question_superseded',
+        message: 'Question was superseded by a newer omx question launch for the same session.',
+        at: nowIso,
+      },
+    });
+    closeQuestionRenderer(item.record.renderer, execTmux);
+  }
+  return live;
+}
+
 export function launchQuestionRenderer(
   options: LaunchQuestionRendererOptions,
   deps: {
@@ -513,6 +585,11 @@ export function launchQuestionRenderer(
         'omx question cannot open a visible renderer because this tmux session has no attached client. Run omx question from an attached tmux pane.',
       );
     }
+
+    supersedeLiveQuestionsForSession(options.cwd, options.sessionId, execTmux, {
+      excludeRecordPath: options.recordPath,
+      nowIso: launchedAt,
+    });
 
     const sizingTarget = returnTarget || safeString(env.TMUX_PANE).trim() || undefined;
     const availableHeight = resolveAvailablePaneHeight(execTmux, sizingTarget);
@@ -579,6 +656,10 @@ export function launchQuestionRenderer(
   }
 
   if (strategy === 'detached-tmux') {
+    supersedeLiveQuestionsForSession(options.cwd, options.sessionId, execTmux, {
+      excludeRecordPath: options.recordPath,
+      nowIso: launchedAt,
+    });
     const baseName = basename(options.recordPath, '.json').replace(/[^A-Za-z0-9_-]+/g, '-').slice(0, 32) || 'question';
     const sessionName = `omx-question-${baseName}`;
     const output = execTmux([

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -495,7 +495,7 @@ export async function markQuestionTerminalError(
 }
 
 export function isTerminalQuestionStatus(status: QuestionStatus): boolean {
-  return status === 'answered' || status === 'aborted' || status === 'error';
+  return status === 'answered' || status === 'aborted' || status === 'error' || status === 'superseded';
 }
 
 export async function waitForQuestionTerminalState(

--- a/src/question/types.ts
+++ b/src/question/types.ts
@@ -53,7 +53,7 @@ export interface QuestionAnswerEntry {
 
 export type QuestionRendererKind = 'tmux-pane' | 'tmux-session' | 'inline-tty' | 'windows-console';
 
-export type QuestionStatus = 'pending' | 'prompting' | 'answered' | 'aborted' | 'error';
+export type QuestionStatus = 'pending' | 'prompting' | 'answered' | 'aborted' | 'error' | 'superseded';
 
 export interface QuestionRendererState {
   renderer: QuestionRendererKind;


### PR DESCRIPTION
## Summary
- supersede any live prompting `omx question` renderer records for the same session before opening a new inside-tmux pane
- mark superseded records as terminal and close only their persisted renderer pane metadata
- add renderer coverage for live prompting dedupe, dead-pane no-op, answered no-op, and different-session isolation

## Tests
- `npm run build`
- `node --test dist/question/__tests__/renderer.test.js dist/question/__tests__/state.test.js dist/question/__tests__/ui.test.js`
- `npm run lint`
- `git diff --check`
- `npm run check:no-unused`

Closes #2572
