### PR TITLE
Fix duplicate worker Stop nudges

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -33,6 +33,7 @@ import { getLegacyWikiDir, serializePage, writePage } from "../../wiki/storage.j
 import { WIKI_SCHEMA_VERSION } from "../../wiki/types.js";
 import { createUltragoalPlan, readUltragoalPlan } from "../../ultragoal/artifacts.js";
 import { getBaseStateDir } from "../../state/paths.js";
+import { maybeNudgeLeaderForAllowedWorkerStop } from "../notify-hook/team-worker-stop.js";
 
 function nativeHookScriptPath(): string {
   return join(process.cwd(), "dist", "scripts", "codex-native-hook.js");
@@ -136,8 +137,12 @@ async function withLoreGuardConfig<T>(
 
 function buildWorkerStopFakeTmux(
   tmuxLogPath: string,
-  options: { failSend?: boolean; busyLeader?: boolean } = {},
+  options: { failSend?: boolean; busyLeader?: boolean; captureText?: string; sendDelayMs?: number; removePathOnSend?: string } = {},
 ): string {
+  const rawCaptureText = options.captureText ?? (options.busyLeader ? "• Working… (esc to interrupt)" : "› ready");
+  const captureText = `'${rawCaptureText.replace(/'/g, "'\"'\"'")}'`;
+  const sendDelaySeconds = Math.max(0, options.sendDelayMs ?? 0) / 1000;
+  const removePathOnSend = options.removePathOnSend ? `'${options.removePathOnSend.replace(/'/g, "'\"'\"'")}'` : "";
   return `#!/usr/bin/env bash
 set -eu
 echo "$@" >> "${tmuxLogPath}"
@@ -165,10 +170,12 @@ if [[ "$cmd" == "display-message" ]]; then
   exit 0
 fi
 if [[ "$cmd" == "capture-pane" ]]; then
-  ${options.busyLeader ? 'echo "• Working… (esc to interrupt)"' : 'echo "› ready"'}
+  printf '%s\\n' ${captureText}
   exit 0
 fi
 if [[ "$cmd" == "send-keys" ]]; then
+  ${sendDelaySeconds > 0 ? `sleep ${sendDelaySeconds}` : ""}
+  ${removePathOnSend ? `rm -rf ${removePathOnSend}` : ""}
   ${options.failSend ? "exit 1" : "exit 0"}
 fi
 exit 0
@@ -8174,6 +8181,219 @@ exit 0
       else delete process.env.OMX_TEAM_WORKER;
       if (typeof prevTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
       else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof prevPath === "string") process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("dedupes allowed worker Stop leader nudges across workers in the same team window", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-team-dedupe-"));
+    const prevPath = process.env.PATH;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const logsDir = join(cwd, ".omx", "logs");
+      const teamName = "worker-stop-team-dedupe";
+      const teamDir = join(stateDir, "team", teamName);
+      const fakeBinDir = join(cwd, "fake-bin");
+      const tmuxLogPath = join(cwd, "tmux.log");
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, "tmux"), buildWorkerStopFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, "tmux"), 0o755);
+      await writeJson(join(teamDir, "manifest.v2.json"), {
+        name: teamName,
+        tmux_session: "omx-team-worker-stop",
+        leader_pane_id: "%42",
+        workers: [
+          { name: "worker-1", index: 1, pane_id: "%10" },
+          { name: "worker-2", index: 2, pane_id: "%11" },
+        ],
+      });
+      process.env.PATH = `${fakeBinDir}:${prevPath || ""}`;
+
+      const first = await maybeNudgeLeaderForAllowedWorkerStop({
+        stateDir,
+        logsDir,
+        workerContext: { teamName, workerName: "worker-1" },
+      });
+      const second = await maybeNudgeLeaderForAllowedWorkerStop({
+        stateDir,
+        logsDir,
+        workerContext: { teamName, workerName: "worker-2" },
+      });
+
+      assert.equal(first.result, "sent");
+      assert.equal(second.result, "suppressed_team_cooldown");
+      const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+      const stopNudges = tmuxLog.match(/send-keys -t %42 -l \[OMX\] worker-\d+ native Stop allowed/g) || [];
+      assert.equal(stopNudges.length, 1, "same-team workers should share one leader nudge cooldown window");
+      const teamNudgeState = JSON.parse(await readFile(join(teamDir, "worker-stop-nudge.json"), "utf-8"));
+      assert.equal(teamNudgeState.worker, "worker-1");
+      assert.equal(teamNudgeState.delivery, "sent");
+    } finally {
+      if (typeof prevPath === "string") process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes concurrent allowed worker Stop leader nudges with a team lock", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-concurrent-dedupe-"));
+    const prevPath = process.env.PATH;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const logsDir = join(cwd, ".omx", "logs");
+      const teamName = "worker-stop-concurrent";
+      const teamDir = join(stateDir, "team", teamName);
+      const fakeBinDir = join(cwd, "fake-bin");
+      const tmuxLogPath = join(cwd, "tmux.log");
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, "tmux"), buildWorkerStopFakeTmux(tmuxLogPath, { sendDelayMs: 100 }));
+      await chmod(join(fakeBinDir, "tmux"), 0o755);
+      await writeJson(join(teamDir, "manifest.v2.json"), {
+        name: teamName,
+        tmux_session: "omx-team-worker-stop",
+        leader_pane_id: "%42",
+        workers: [
+          { name: "worker-1", index: 1, pane_id: "%10" },
+          { name: "worker-2", index: 2, pane_id: "%11" },
+        ],
+      });
+      process.env.PATH = `${fakeBinDir}:${prevPath || ""}`;
+
+      const results = await Promise.all([
+        maybeNudgeLeaderForAllowedWorkerStop({
+          stateDir,
+          logsDir,
+          workerContext: { teamName, workerName: "worker-1" },
+        }),
+        maybeNudgeLeaderForAllowedWorkerStop({
+          stateDir,
+          logsDir,
+          workerContext: { teamName, workerName: "worker-2" },
+        }),
+      ]);
+
+      assert.equal(results.filter((result) => result.result === "sent").length, 1);
+      assert.equal(results.filter((result) => result.result === "suppressed_team_lock_held").length, 1);
+      const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+      const stopNudges = tmuxLog.match(/send-keys -t %42 -l \[OMX\] worker-\d+ native Stop allowed/g) || [];
+      assert.equal(stopNudges.length, 1, "concurrent same-team workers should emit only one leader nudge");
+      assert.equal(existsSync(join(teamDir, "worker-stop-nudge.lock")), false);
+    } finally {
+      if (typeof prevPath === "string") process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("skips worker Stop leader nudge when team state is missing or shut down", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-missing-team-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const logsDir = join(cwd, ".omx", "logs");
+      const result = await maybeNudgeLeaderForAllowedWorkerStop({
+        stateDir,
+        logsDir,
+        workerContext: { teamName: "removed-team", workerName: "worker-1" },
+      });
+
+      assert.equal(result.result, "team_state_gone_or_shutdown");
+      assert.equal(existsSync(join(stateDir, "team", "removed-team", "worker-stop-nudge.json")), false);
+
+      await writeJson(join(stateDir, "team", "shutdown-team", "shutdown.json"), {
+        started_at: new Date().toISOString(),
+      });
+      const shutdownResult = await maybeNudgeLeaderForAllowedWorkerStop({
+        stateDir,
+        logsDir,
+        workerContext: { teamName: "shutdown-team", workerName: "worker-1" },
+      });
+      assert.equal(shutdownResult.result, "team_state_gone_or_shutdown");
+      assert.equal(existsSync(join(stateDir, "team", "shutdown-team", "worker-stop-nudge.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not duplicate a queued same-team worker Stop nudge already visible in the leader queue", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-queue-dedupe-"));
+    const prevPath = process.env.PATH;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const logsDir = join(cwd, ".omx", "logs");
+      const teamName = "queued-stop-dedupe";
+      const teamDir = join(stateDir, "team", teamName);
+      const fakeBinDir = join(cwd, "fake-bin");
+      const tmuxLogPath = join(cwd, "tmux.log");
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        join(fakeBinDir, "tmux"),
+        buildWorkerStopFakeTmux(tmuxLogPath, {
+          busyLeader: true,
+          captureText:
+            `[OMX] worker-1 native Stop allowed. Run \`omx team status ${teamName}\`, read worker messages/results, then assign next task, reconcile completion, or shut down. [OMX_TMUX_INJECT]\n`
+            + "• Working… (esc to interrupt)",
+        }),
+      );
+      await chmod(join(fakeBinDir, "tmux"), 0o755);
+      await writeJson(join(teamDir, "manifest.v2.json"), {
+        name: teamName,
+        tmux_session: "omx-team-worker-stop",
+        leader_pane_id: "%42",
+        workers: [{ name: "worker-2", index: 2, pane_id: "%11" }],
+      });
+      process.env.PATH = `${fakeBinDir}:${prevPath || ""}`;
+
+      const result = await maybeNudgeLeaderForAllowedWorkerStop({
+        stateDir,
+        logsDir,
+        workerContext: { teamName, workerName: "worker-2" },
+      });
+
+      assert.equal(result.result, "suppressed_duplicate_queue");
+      const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-2 native Stop allowed/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 Tab/);
+    } finally {
+      if (typeof prevPath === "string") process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not recreate team state when teardown removes it during worker Stop delivery", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-teardown-race-"));
+    const prevPath = process.env.PATH;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const logsDir = join(cwd, ".omx", "logs");
+      const teamName = "worker-stop-teardown-race";
+      const teamDir = join(stateDir, "team", teamName);
+      const fakeBinDir = join(cwd, "fake-bin");
+      const tmuxLogPath = join(cwd, "tmux.log");
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeJson(join(teamDir, "manifest.v2.json"), {
+        name: teamName,
+        tmux_session: "omx-team-worker-stop",
+        leader_pane_id: "%42",
+        workers: [{ name: "worker-1", index: 1, pane_id: "%10" }],
+      });
+      await writeFile(join(fakeBinDir, "tmux"), buildWorkerStopFakeTmux(tmuxLogPath, { removePathOnSend: teamDir }));
+      await chmod(join(fakeBinDir, "tmux"), 0o755);
+      process.env.PATH = `${fakeBinDir}:${prevPath || ""}`;
+
+      const result = await maybeNudgeLeaderForAllowedWorkerStop({
+        stateDir,
+        logsDir,
+        workerContext: { teamName, workerName: "worker-1" },
+      });
+
+      assert.equal(result.result, "sent");
+      assert.equal(existsSync(teamDir), false, "worker Stop delivery must not recreate removed team state");
+      const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+      assert.match(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-1 native Stop allowed/);
+    } finally {
       if (typeof prevPath === "string") process.env.PATH = prevPath;
       else delete process.env.PATH;
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/notify-hook/team-worker-stop.ts
+++ b/src/scripts/notify-hook/team-worker-stop.ts
@@ -6,11 +6,12 @@
  * It must not depend on idle/heartbeat freshness or inferred progress stalls.
  */
 
-import { appendFile, mkdir, rename, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { appendFile, mkdir, rename, rm, stat, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { DEFAULT_MARKER, paneHasActiveTask } from '../tmux-hook-engine.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
-import { safeString, asNumber } from './utils.js';
+import { safeString, asNumber, isTerminalPhase } from './utils.js';
 import { readJsonIfExists } from './state-io.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, queuePaneInput, sendPaneInput } from './team-tmux-guard.js';
@@ -21,6 +22,80 @@ const STOP_NUDGE_COOLDOWN_MS = 30_000;
 const SOURCE_TYPE = 'worker_stop';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
+const TEAM_SHUTDOWN_NO_INJECTION_REASON = 'team_state_gone_or_shutdown';
+const TEAM_LOCK_HELD_REASON = 'suppressed_team_lock_held';
+
+function escapeRegExp(value) {
+  return safeString(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function teamStopNudgeAlreadyQueued(paneCapture, teamName) {
+  const capture = safeString(paneCapture);
+  const normalizedTeamName = safeString(teamName).trim();
+  if (!capture || !normalizedTeamName) return false;
+  const teamPattern = escapeRegExp(normalizedTeamName);
+  const stopNudgePattern = new RegExp(
+    `\\[OMX\\]\\s+worker-\\d+\\s+native Stop allowed\\.[\\s\\S]*?omx team status ${teamPattern}(?:\\s|\`|,|\\.)`,
+    'i',
+  );
+  return stopNudgePattern.test(capture);
+}
+
+async function teamStateAllowsWorkerStopNudge(stateDir, teamName) {
+  const teamDir = join(stateDir, 'team', teamName);
+  if (!existsSync(teamDir)) return false;
+  if (existsSync(join(teamDir, 'shutdown.json'))) return false;
+
+  const phase = await readJsonIfExists(join(teamDir, 'phase.json'), null);
+  const currentPhase = safeString(phase?.current_phase || phase?.phase || '').trim();
+  if (currentPhase && isTerminalPhase(currentPhase)) return false;
+
+  return true;
+}
+
+async function acquireTeamStopNudgeLock(teamDir, nowMs, cooldownMs) {
+  const lockDir = join(teamDir, 'worker-stop-nudge.lock');
+  const staleAfterMs = Math.max(cooldownMs, 30_000);
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await mkdir(lockDir);
+      await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+        pid: process.pid,
+        acquired_at_ms: nowMs,
+        acquired_at: new Date(nowMs).toISOString(),
+      }, null, 2)).catch(() => {});
+      return { acquired: true, lockDir };
+    } catch (error) {
+      if (error?.code === 'ENOENT') return { acquired: false, reason: TEAM_SHUTDOWN_NO_INJECTION_REASON };
+      if (error?.code !== 'EEXIST') return { acquired: false, reason: TEAM_LOCK_HELD_REASON };
+
+      try {
+        const lockStat = await stat(lockDir);
+        if ((nowMs - lockStat.mtimeMs) >= staleAfterMs) {
+          await rm(lockDir, { recursive: true, force: true });
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      return { acquired: false, reason: TEAM_LOCK_HELD_REASON };
+    }
+  }
+
+  return { acquired: false, reason: TEAM_LOCK_HELD_REASON };
+}
+
+async function releaseTeamStopNudgeLock(lockDir) {
+  if (!lockDir) return;
+  await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+}
+
+async function writeStopNudgeStateIfTeamExists(teamDir, statePath, state) {
+  if (!existsSync(teamDir)) return false;
+  await writeStopNudgeState(statePath, state);
+  return true;
+}
 
 function resolveWorkerStopCooldownMs() {
   const raw = safeString(process.env.OMX_TEAM_WORKER_STOP_COOLDOWN_MS || '');
@@ -119,21 +194,13 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
   const { teamName, workerName } = workerContext || {};
   if (!teamName || !workerName || !stateDir) return { ok: false, result: 'unresolved' };
 
-  const workerDir = join(stateDir, 'team', teamName, 'workers', workerName);
+  const teamDir = join(stateDir, 'team', teamName);
+  const workerDir = join(teamDir, 'workers', workerName);
   const statePath = join(workerDir, 'worker-stop-nudge.json');
+  const teamStatePath = join(teamDir, 'worker-stop-nudge.json');
   const nowMs = Date.now();
   const nowIso = new Date(nowMs).toISOString();
-  const existing = (await readJsonIfExists(statePath, null)) || {};
-  const lastNotifiedMs = asNumber(existing.last_notified_at_ms) ?? 0;
   const cooldownMs = resolveWorkerStopCooldownMs();
-  if ((nowMs - lastNotifiedMs) < cooldownMs) {
-    return { ok: true, result: 'suppressed_cooldown' };
-  }
-
-  const teamInfo = await readTeamWorkersForIdleCheck(stateDir, teamName);
-  if (!teamInfo) return { ok: false, result: 'unresolved' };
-  const { tmuxSession, leaderPaneId } = teamInfo;
-  const tmuxTarget = await resolveCanonicalLeaderPaneId(leaderPaneId);
   const nextState = {
     last_notified_at_ms: nowMs,
     last_notified_at: nowIso,
@@ -141,8 +208,44 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     worker: workerName,
     source_type: SOURCE_TYPE,
   };
+  let tmuxSession = '';
+  let leaderPaneId = '';
+
+  if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+    return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
+  }
+
+  const lock = await acquireTeamStopNudgeLock(teamDir, nowMs, cooldownMs);
+  if (!lock.acquired) {
+    return { ok: true, result: lock.reason || TEAM_LOCK_HELD_REASON };
+  }
+
+  try {
+    if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+      return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
+    }
+
+  const teamExisting = (await readJsonIfExists(teamStatePath, null)) || {};
+  const teamLastNotifiedMs = asNumber(teamExisting.last_notified_at_ms) ?? 0;
+  if ((nowMs - teamLastNotifiedMs) < cooldownMs) {
+    return { ok: true, result: 'suppressed_team_cooldown' };
+  }
+
+  const existing = (await readJsonIfExists(statePath, null)) || {};
+  const lastNotifiedMs = asNumber(existing.last_notified_at_ms) ?? 0;
+  if ((nowMs - lastNotifiedMs) < cooldownMs) {
+    return { ok: true, result: 'suppressed_cooldown' };
+  }
+
+  const teamInfo = await readTeamWorkersForIdleCheck(stateDir, teamName);
+  if (!teamInfo) return { ok: false, result: 'unresolved' };
+  ({ tmuxSession, leaderPaneId } = teamInfo);
+  const tmuxTarget = await resolveCanonicalLeaderPaneId(leaderPaneId);
 
   if (!tmuxTarget) {
+    if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+      return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
+    }
     await recordDeferred({
       stateDir,
       logsDir,
@@ -164,6 +267,9 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     requireIdle: false,
   });
   if (!paneGuard.ok) {
+    if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+      return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
+    }
     await recordDeferred({
       stateDir,
       logsDir,
@@ -179,12 +285,19 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     return { ok: true, result: 'deferred' };
   }
 
+  if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+    return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
+  }
+
+  if (teamStopNudgeAlreadyQueued(paneGuard.paneCapture, teamName)) {
+    return { ok: true, result: 'suppressed_duplicate_queue' };
+  }
+
   const prompt =
     `[OMX] ${workerName} native Stop allowed. `
     + `Run \`omx team status ${teamName}\`, read worker messages/results, then assign next task, reconcile completion, or shut down. `
     + DEFAULT_MARKER;
 
-  try {
     const leaderHasActiveTask = paneHasActiveTask(paneGuard.paneCapture);
     let deliveryMode = 'sent';
     if (leaderHasActiveTask) {
@@ -204,22 +317,28 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
       if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
     }
 
-    await writeStopNudgeState(statePath, {
+    const deliveryState = {
       ...nextState,
       delivery: deliveryMode,
       leader_pane_id: leaderPaneId || null,
       tmux_target: tmuxTarget,
-    });
-    await appendWorkerStopEvent(stateDir, teamName, {
-      event_id: `worker-stop-nudge-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
-      team: teamName,
-      type: 'worker_stop_leader_nudge',
-      worker: workerName,
-      to_worker: 'leader-fixed',
-      delivery: deliveryMode,
-      created_at: nowIso,
-      source_type: SOURCE_TYPE,
-    });
+    };
+    const wroteWorkerState = await writeStopNudgeStateIfTeamExists(teamDir, statePath, deliveryState).catch(() => false);
+    const wroteTeamState = wroteWorkerState
+      ? await writeStopNudgeStateIfTeamExists(teamDir, teamStatePath, deliveryState).catch(() => false)
+      : false;
+    if (wroteTeamState) {
+      await appendWorkerStopEvent(stateDir, teamName, {
+        event_id: `worker-stop-nudge-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+        team: teamName,
+        type: 'worker_stop_leader_nudge',
+        worker: workerName,
+        to_worker: 'leader-fixed',
+        delivery: deliveryMode,
+        created_at: nowIso,
+        source_type: SOURCE_TYPE,
+      });
+    }
     await logTmuxHookEvent(logsDir, {
       timestamp: nowIso,
       type: 'worker_stop_leader_nudge',
@@ -241,6 +360,9 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     }).catch(() => {});
     return { ok: true, result: deliveryMode };
   } catch (err) {
+    if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+      return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
+    }
     await recordDeferred({
       stateDir,
       logsDir,
@@ -253,5 +375,7 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
       leaderPaneId,
     });
     return { ok: true, result: 'deferred' };
+  } finally {
+    await releaseTeamStopNudgeLock(lock.lockDir);
   }
 }


### PR DESCRIPTION
## Summary
- Deduplicate allowed worker Stop leader nudges at the team level.
- Add a short team lock so concurrent workers cannot send duplicate Stop nudges.
- Avoid recreating removed team state during teardown races.

## Verification
- `npm run build`
- `node --test --test-name-pattern 'worker Stop|Stop leader nudge|allowed worker Stop' dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`
- `git diff --check`
- `npm run check:no-unused`

Fixes #2559

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
