### PR TITLE
Resolve worker Stop nudge merge blockers

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -137,12 +137,22 @@ async function withLoreGuardConfig<T>(
 
 function buildWorkerStopFakeTmux(
   tmuxLogPath: string,
-  options: { failSend?: boolean; busyLeader?: boolean; captureText?: string; sendDelayMs?: number; removePathOnSend?: string } = {},
+  options: {
+    failSend?: boolean;
+    busyLeader?: boolean;
+    captureText?: string;
+    currentCommand?: string;
+    sendDelayMs?: number;
+    removePathOnSend?: string;
+    removePathOnCapture?: string;
+  } = {},
 ): string {
   const rawCaptureText = options.captureText ?? (options.busyLeader ? "• Working… (esc to interrupt)" : "› ready");
   const captureText = `'${rawCaptureText.replace(/'/g, "'\"'\"'")}'`;
+  const currentCommand = `'${(options.currentCommand ?? "codex").replace(/'/g, "'\"'\"'")}'`;
   const sendDelaySeconds = Math.max(0, options.sendDelayMs ?? 0) / 1000;
   const removePathOnSend = options.removePathOnSend ? `'${options.removePathOnSend.replace(/'/g, "'\"'\"'")}'` : "";
+  const removePathOnCapture = options.removePathOnCapture ? `'${options.removePathOnCapture.replace(/'/g, "'\"'\"'")}'` : "";
   return `#!/usr/bin/env bash
 set -eu
 echo "$@" >> "${tmuxLogPath}"
@@ -163,13 +173,14 @@ if [[ "$cmd" == "display-message" ]]; then
     "#{pane_id}") echo "%42" ;;
     "#{pane_current_path}") pwd ;;
     "#{pane_start_command}") echo "codex" ;;
-    "#{pane_current_command}") echo "codex" ;;
+    "#{pane_current_command}") printf '%s\\n' ${currentCommand} ;;
     "#S") echo "omx-team-worker-stop" ;;
     *) ;;
   esac
   exit 0
 fi
 if [[ "$cmd" == "capture-pane" ]]; then
+  ${removePathOnCapture ? `rm -rf ${removePathOnCapture}` : ""}
   printf '%s\\n' ${captureText}
   exit 0
 fi
@@ -8316,7 +8327,7 @@ exit 0
     }
   });
 
-  it("does not duplicate a queued same-team worker Stop nudge already visible in the leader queue", async () => {
+  it("does not treat old visible worker Stop transcript as pending queue state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-queue-dedupe-"));
     const prevPath = process.env.PATH;
     try {
@@ -8351,10 +8362,62 @@ exit 0
         workerContext: { teamName, workerName: "worker-2" },
       });
 
-      assert.equal(result.result, "suppressed_duplicate_queue");
+      assert.equal(result.result, "queued");
       const tmuxLog = await readFile(tmuxLogPath, "utf-8");
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-2 native Stop allowed/);
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 Tab/);
+      assert.match(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-2 native Stop allowed/);
+      assert.match(tmuxLog, /send-keys -t %42 Tab/);
+      const teamNudgeState = JSON.parse(await readFile(join(teamDir, "worker-stop-nudge.json"), "utf-8"));
+      assert.equal(teamNudgeState.worker, "worker-2");
+      assert.equal(teamNudgeState.delivery, "queued");
+    } finally {
+      if (typeof prevPath === "string") process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("reports deferred when non-teardown persistence failure prevents worker Stop nudge cooldown state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-persist-fail-"));
+    const prevPath = process.env.PATH;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const logsDir = join(cwd, ".omx", "logs");
+      const teamName = "worker-stop-persist-fail";
+      const teamDir = join(stateDir, "team", teamName);
+      const fakeBinDir = join(cwd, "fake-bin");
+      const tmuxLogPath = join(cwd, "tmux.log");
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeJson(join(teamDir, "manifest.v2.json"), {
+        name: teamName,
+        tmux_session: "omx-team-worker-stop",
+        leader_pane_id: "%42",
+        workers: [{ name: "worker-1", index: 1, pane_id: "%10" }],
+      });
+      await writeFile(join(teamDir, "workers"), "not a directory");
+      await writeFile(join(fakeBinDir, "tmux"), buildWorkerStopFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, "tmux"), 0o755);
+      process.env.PATH = `${fakeBinDir}:${prevPath || ""}`;
+
+      const result = await maybeNudgeLeaderForAllowedWorkerStop({
+        stateDir,
+        logsDir,
+        workerContext: { teamName, workerName: "worker-1" },
+      });
+
+      assert.equal(result.result, "deferred");
+      assert.equal(existsSync(join(teamDir, "worker-stop-nudge.json")), false);
+      assert.equal(existsSync(join(teamDir, "workers", "worker-1", "worker-stop-nudge.json")), false);
+      const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+      assert.match(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-1 native Stop allowed/);
+      const deliveryLogPath = join(logsDir, `team-delivery-${new Date().toISOString().split("T")[0]}.jsonl`);
+      const deliveryEvents = (await readFile(deliveryLogPath, "utf-8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      const deferredEvent = deliveryEvents.find((event) => event.event === "nudge_triggered" && event.result === "deferred");
+      assert.equal(deferredEvent?.team, teamName);
+      assert.equal(deferredEvent?.from_worker, "worker-1");
+      assert.match(String(deferredEvent?.reason || ""), /EEXIST|ENOTDIR|not a directory|file already exists/);
     } finally {
       if (typeof prevPath === "string") process.env.PATH = prevPath;
       else delete process.env.PATH;
@@ -8393,6 +8456,51 @@ exit 0
       assert.equal(existsSync(teamDir), false, "worker Stop delivery must not recreate removed team state");
       const tmuxLog = await readFile(tmuxLogPath, "utf-8");
       assert.match(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-1 native Stop allowed/);
+    } finally {
+      if (typeof prevPath === "string") process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not recreate team state when teardown removes it before deferred worker Stop recording", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-deferred-teardown-"));
+    const prevPath = process.env.PATH;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const logsDir = join(cwd, ".omx", "logs");
+      const teamName = "worker-stop-deferred-teardown";
+      const teamDir = join(stateDir, "team", teamName);
+      const fakeBinDir = join(cwd, "fake-bin");
+      const tmuxLogPath = join(cwd, "tmux.log");
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeJson(join(teamDir, "manifest.v2.json"), {
+        name: teamName,
+        tmux_session: "omx-team-worker-stop",
+        leader_pane_id: "%42",
+        workers: [{ name: "worker-1", index: 1, pane_id: "%10" }],
+      });
+      await writeFile(
+        join(fakeBinDir, "tmux"),
+        buildWorkerStopFakeTmux(tmuxLogPath, {
+          currentCommand: "bash",
+          captureText: "$ ",
+          removePathOnCapture: teamDir,
+        }),
+      );
+      await chmod(join(fakeBinDir, "tmux"), 0o755);
+      process.env.PATH = `${fakeBinDir}:${prevPath || ""}`;
+
+      const result = await maybeNudgeLeaderForAllowedWorkerStop({
+        stateDir,
+        logsDir,
+        workerContext: { teamName, workerName: "worker-1" },
+      });
+
+      assert.equal(result.result, "team_state_gone_or_shutdown");
+      assert.equal(existsSync(teamDir), false, "deferred worker Stop recording must not recreate removed team state");
+      const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-1 native Stop allowed/);
     } finally {
       if (typeof prevPath === "string") process.env.PATH = prevPath;
       else delete process.env.PATH;

--- a/src/scripts/notify-hook/team-worker-stop.ts
+++ b/src/scripts/notify-hook/team-worker-stop.ts
@@ -8,7 +8,7 @@
 
 import { existsSync } from 'fs';
 import { appendFile, mkdir, rename, rm, stat, writeFile } from 'fs/promises';
-import { dirname, join } from 'path';
+import { dirname, join, relative } from 'path';
 import { DEFAULT_MARKER, paneHasActiveTask } from '../tmux-hook-engine.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
 import { safeString, asNumber, isTerminalPhase } from './utils.js';
@@ -24,22 +24,6 @@ const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injectio
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 const TEAM_SHUTDOWN_NO_INJECTION_REASON = 'team_state_gone_or_shutdown';
 const TEAM_LOCK_HELD_REASON = 'suppressed_team_lock_held';
-
-function escapeRegExp(value) {
-  return safeString(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function teamStopNudgeAlreadyQueued(paneCapture, teamName) {
-  const capture = safeString(paneCapture);
-  const normalizedTeamName = safeString(teamName).trim();
-  if (!capture || !normalizedTeamName) return false;
-  const teamPattern = escapeRegExp(normalizedTeamName);
-  const stopNudgePattern = new RegExp(
-    `\\[OMX\\]\\s+worker-\\d+\\s+native Stop allowed\\.[\\s\\S]*?omx team status ${teamPattern}(?:\\s|\`|,|\\.)`,
-    'i',
-  );
-  return stopNudgePattern.test(capture);
-}
 
 async function teamStateAllowsWorkerStopNudge(stateDir, teamName) {
   const teamDir = join(stateDir, 'team', teamName);
@@ -91,10 +75,56 @@ async function releaseTeamStopNudgeLock(lockDir) {
   await rm(lockDir, { recursive: true, force: true }).catch(() => {});
 }
 
-async function writeStopNudgeStateIfTeamExists(teamDir, statePath, state) {
+async function ensureDirectoryUnderExistingTeam(teamDir, targetDir) {
   if (!existsSync(teamDir)) return false;
-  await writeStopNudgeState(statePath, state);
-  return true;
+  const rel = relative(teamDir, targetDir);
+  if (!rel) return true;
+  if (rel.startsWith('..')) throw new Error('state_path_outside_team_dir');
+
+  let current = teamDir;
+  for (const segment of rel.split(/[\\/]+/).filter(Boolean)) {
+    if (!existsSync(teamDir)) return false;
+    current = join(current, segment);
+    try {
+      await mkdir(current);
+    } catch (error) {
+      if (error?.code === 'ENOENT' && !existsSync(teamDir)) return false;
+      if (error?.code !== 'EEXIST') throw error;
+      const currentStat = await stat(current);
+      if (!currentStat.isDirectory()) throw error;
+    }
+  }
+  return existsSync(teamDir);
+}
+
+async function writeStopNudgeStateIfTeamExists(teamDir, statePath, state) {
+  const stateDir = dirname(statePath);
+  const ready = await ensureDirectoryUnderExistingTeam(teamDir, stateDir);
+  if (!ready) return false;
+  try {
+    const tmpPath = `${statePath}.tmp.${process.pid}`;
+    await writeFile(tmpPath, JSON.stringify(state, null, 2));
+    await rename(tmpPath, statePath);
+  } catch (error) {
+    if (error?.code === 'ENOENT' && !existsSync(teamDir)) return false;
+    throw error;
+  }
+  return existsSync(teamDir);
+}
+
+async function appendWorkerStopEventIfTeamExists(stateDir, teamName, event) {
+  const teamDir = join(stateDir, 'team', teamName);
+  const eventsDir = join(teamDir, 'events');
+  const ready = await ensureDirectoryUnderExistingTeam(teamDir, eventsDir);
+  if (!ready) return false;
+  const eventsPath = join(eventsDir, 'events.ndjson');
+  try {
+    await appendFile(eventsPath, JSON.stringify(event) + '\n');
+  } catch (error) {
+    if (error?.code === 'ENOENT' && !existsSync(teamDir)) return false;
+    throw error;
+  }
+  return existsSync(teamDir);
 }
 
 function resolveWorkerStopCooldownMs() {
@@ -117,20 +147,6 @@ async function resolveCanonicalLeaderPaneId(leaderPaneId) {
   return normalizedLeaderPaneId;
 }
 
-async function appendWorkerStopEvent(stateDir, teamName, event) {
-  const eventsDir = join(stateDir, 'team', teamName, 'events');
-  const eventsPath = join(eventsDir, 'events.ndjson');
-  await mkdir(eventsDir, { recursive: true }).catch(() => {});
-  await appendFile(eventsPath, JSON.stringify(event) + '\n').catch(() => {});
-}
-
-async function writeStopNudgeState(statePath, state) {
-  await mkdir(dirname(statePath), { recursive: true }).catch(() => {});
-  const tmpPath = `${statePath}.tmp.${process.pid}`;
-  await writeFile(tmpPath, JSON.stringify(state, null, 2));
-  await rename(tmpPath, statePath);
-}
-
 async function recordDeferred({
   stateDir,
   logsDir,
@@ -144,23 +160,26 @@ async function recordDeferred({
   paneCurrentCommand = '',
 }) {
   const nowIso = nextState.last_notified_at;
-  await writeStopNudgeState(statePath, {
+  const teamDir = join(stateDir, 'team', teamName);
+  const wroteState = await writeStopNudgeStateIfTeamExists(teamDir, statePath, {
     ...nextState,
     delivery: 'deferred',
     reason,
     pane_current_command: paneCurrentCommand || null,
   }).catch(() => {});
-  await appendWorkerStopEvent(stateDir, teamName, {
-    event_id: `worker-stop-deferred-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
-    team: teamName,
-    type: 'worker_stop_leader_nudge',
-    worker: workerName,
-    to_worker: 'leader-fixed',
-    delivery: 'deferred',
-    reason,
-    created_at: nowIso,
-    source_type: SOURCE_TYPE,
-  });
+  if (wroteState) {
+    await appendWorkerStopEventIfTeamExists(stateDir, teamName, {
+      event_id: `worker-stop-deferred-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+      team: teamName,
+      type: 'worker_stop_leader_nudge',
+      worker: workerName,
+      to_worker: 'leader-fixed',
+      delivery: 'deferred',
+      reason,
+      created_at: nowIso,
+      source_type: SOURCE_TYPE,
+    }).catch(() => {});
+  }
   await logTmuxHookEvent(logsDir, {
     timestamp: nowIso,
     type: 'leader_notification_deferred',
@@ -289,10 +308,6 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
   }
 
-  if (teamStopNudgeAlreadyQueued(paneGuard.paneCapture, teamName)) {
-    return { ok: true, result: 'suppressed_duplicate_queue' };
-  }
-
   const prompt =
     `[OMX] ${workerName} native Stop allowed. `
     + `Run \`omx team status ${teamName}\`, read worker messages/results, then assign next task, reconcile completion, or shut down. `
@@ -323,12 +338,12 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
       leader_pane_id: leaderPaneId || null,
       tmux_target: tmuxTarget,
     };
-    const wroteWorkerState = await writeStopNudgeStateIfTeamExists(teamDir, statePath, deliveryState).catch(() => false);
+    const wroteWorkerState = await writeStopNudgeStateIfTeamExists(teamDir, statePath, deliveryState);
     const wroteTeamState = wroteWorkerState
-      ? await writeStopNudgeStateIfTeamExists(teamDir, teamStatePath, deliveryState).catch(() => false)
+      ? await writeStopNudgeStateIfTeamExists(teamDir, teamStatePath, deliveryState)
       : false;
     if (wroteTeamState) {
-      await appendWorkerStopEvent(stateDir, teamName, {
+      await appendWorkerStopEventIfTeamExists(stateDir, teamName, {
         event_id: `worker-stop-nudge-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
         team: teamName,
         type: 'worker_stop_leader_nudge',
@@ -337,7 +352,7 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
         delivery: deliveryMode,
         created_at: nowIso,
         source_type: SOURCE_TYPE,
-      });
+      }).catch(() => {});
     }
     await logTmuxHookEvent(logsDir, {
       timestamp: nowIso,
@@ -363,6 +378,8 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
       return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
     }
+    // Worker Stop is already allowed before this helper runs; nudge failures are
+    // surfaced as deferred operational evidence instead of re-blocking Stop.
     await recordDeferred({
       stateDir,
       logsDir,


### PR DESCRIPTION
## Summary
- remove transcript-history-based worker Stop nudge suppression so old visible prompts cannot suppress later valid Stop nudges
- make worker/team cooldown persistence failures surface as deferred operational evidence instead of clean sent/queued success
- keep deferred worker Stop recording teardown-aware so removed team state is not recreated

## Verification
- `npm run build`
- `node --test --test-name-pattern 'worker Stop|Stop leader nudge|allowed worker Stop' dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint -- src/scripts/notify-hook/team-worker-stop.ts src/scripts/__tests__/codex-native-hook.test.ts`
- `npm run check:no-unused`
- `git diff --check`
- independent code-reviewer: APPROVE
- independent architect: CLEAR

Follow-up for PR #2574 merge-gate blockers.
