### PR TITLE
Fix Hermes MCP tmux bridge pane routing

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -54,6 +54,7 @@ import {
   buildDetachedSessionBootstrapSteps,
   buildDetachedTmuxSessionName,
   buildDetachedSessionFinalizeSteps,
+  shouldAttachDetachedTmuxSession,
   buildDetachedSessionRollbackSteps,
   detectDetachedSessionWindowIndex,
   resolveNotifyTempContract,
@@ -3342,6 +3343,7 @@ exit 0
         `#!/bin/sh
 printf 'codex:%s\\n' "$*" >> "${logPath}"
 printf 'codex-pwd:%s\\n' "$(pwd)" >> "${logPath}"
+printf 'codex-bridge-env:%s\\n' "\${OMX_HERMES_MCP_BRIDGE-unset}" >> "${logPath}"
 exit 0
 `,
       );
@@ -3390,6 +3392,7 @@ exit 0
           ...process.env,
           PATH: `${fakeBin}:/usr/bin:/bin`,
           HOME: cwd,
+          OMX_HERMES_MCP_BRIDGE: "1",
         },
         stdio: "ignore",
       });
@@ -3400,6 +3403,7 @@ exit 0
         normalizeDarwinTmpPath(log),
         new RegExp(`codex-pwd:${escapeRegExp(normalizeDarwinTmpPath(cwd))}`),
       );
+      assert.match(log, /codex-bridge-env:unset/);
       assert.match(log, /tmux:display-message -p #\{socket_path\}/);
       assert.match(log, /tmux:show-options -sv extended-keys/);
       assert.match(log, /tmux:set-option -sq extended-keys always/);
@@ -4225,6 +4229,24 @@ exit 0
     assert.equal(attachIndex > scheduleIndex, true);
     assert.equal(names.includes("register-resize-hook"), true);
     assert.equal(names.includes("reconcile-hud-resize"), true);
+  });
+
+  it("buildDetachedSessionFinalizeSteps skips attach for Hermes MCP bridge launches", () => {
+    assert.equal(shouldAttachDetachedTmuxSession({ OMX_HERMES_MCP_BRIDGE: "1" }), false);
+    assert.equal(shouldAttachDetachedTmuxSession({}), true);
+
+    const steps = buildDetachedSessionFinalizeSteps(
+      "omx-demo",
+      "%12",
+      "3",
+      true,
+      false,
+      shouldAttachDetachedTmuxSession({ OMX_HERMES_MCP_BRIDGE: "1" }),
+    );
+
+    assert.equal(steps.some((step) => step.name === "attach-session"), false);
+    assert.equal(steps.some((step) => step.name === "register-resize-hook"), true);
+    assert.equal(steps.some((step) => step.name === "set-mouse"), true);
   });
 
   it("buildDetachedSessionFinalizeSteps uses quiet best-effort tmux resize commands", () => {

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -298,6 +298,75 @@ printf 'fake-codex:%s\n' "$*"
   });
 });
 
+describe('Hermes MCP tmux bridge launch', () => {
+  it('creates a detached tmux session without attach-session under OMX_HERMES_MCP_BRIDGE', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-hermes-bridge-'));
+    try {
+      const { env, tmuxLogPath } = await createLaunchFixture(
+        wd,
+        (logPath) => `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${logPath}"
+case "$1" in
+  -V|list-sessions)
+    printf 'tmux 3.4\n'
+    exit 0
+    ;;
+  has-session)
+    exit 1
+    ;;
+  new-session)
+    printf 'leader-pane\n'
+    exit 0
+    ;;
+  split-window)
+    printf 'hud-pane\n'
+    exit 0
+    ;;
+  display-message)
+    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\n'
+    else
+      printf '0\n'
+    fi
+    exit 0
+    ;;
+  show-options)
+    printf 'off\n'
+    exit 0
+    ;;
+  set-option|set-hook|kill-session|run-shell|resize-pane)
+    exit 0
+    ;;
+  attach-session)
+    printf 'attach must not be called for Hermes MCP bridge\n' >&2
+    exit 99
+    ;;
+esac
+exit 0
+`,
+      );
+
+      const result = runOmx(wd, ['--tmux', 'bridge prompt'], {
+        ...env,
+        OMX_HERMES_MCP_BRIDGE: '1',
+        TMUX: '',
+        TMUX_PANE: '',
+      });
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(tmuxLog, /tmux:new-session /);
+      assert.match(tmuxLog, /tmux:split-window /);
+      assert.doesNotMatch(tmuxLog, /tmux:attach-session/);
+      assert.doesNotMatch(result.stderr, /failed to attach detached tmux session/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('omx launcher when tmux is available', () => {
   it('reuses the same boxed madmax detached launch context instead of spawning duplicate tmux sessions', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-reuse-'));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2952,6 +2952,7 @@ function buildDetachedSessionLeaderCommand(
     "};",
     "trap omx_detached_session_cleanup 0 INT TERM HUP;",
     parentEnvSource,
+    "unset OMX_HERMES_MCP_BRIDGE;",
     "omx_codex_started_at=$(date +%s 2>/dev/null || printf 0);",
     `${codexCmd} <&3 &`,
     "omx_codex_pid=$!;",
@@ -3300,12 +3301,24 @@ async function readLaunchAppendInstructions(): Promise<string> {
   return (await readFile(appendixPath, "utf-8")).trim();
 }
 
+export function shouldAttachDetachedTmuxSession(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.OMX_HERMES_MCP_BRIDGE !== "1";
+}
+
+function stripHermesMcpBridgeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const { OMX_HERMES_MCP_BRIDGE: _bridge, ...rest } = env;
+  return rest;
+}
+
 export function buildDetachedSessionFinalizeSteps(
   sessionName: string,
   hudPaneId: string | null,
   hookWindowIndex: string | null,
   enableMouse: boolean,
   nativeWindows = false,
+  attachSession = true,
 ): DetachedSessionTmuxStep[] {
   const steps: DetachedSessionTmuxStep[] = [];
   if (!nativeWindows && hudPaneId && hookWindowIndex) {
@@ -3364,10 +3377,12 @@ export function buildDetachedSessionFinalizeSteps(
       args: [],
     });
   }
-  steps.push({
-    name: "attach-session",
-    args: ["attach-session", "-t", sessionName],
-  });
+  if (attachSession) {
+    steps.push({
+      name: "attach-session",
+      args: ["attach-session", "-t", sessionName],
+    });
+  }
   return steps;
 }
 
@@ -4026,7 +4041,7 @@ function runCodex(
     workerDefaultModel,
   );
   const codexBaseEnv = {
-    ...process.env,
+    ...stripHermesMcpBridgeEnv(process.env),
     ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
     ...(sqliteHomeOverride ? { [CODEX_SQLITE_HOME_ENV]: sqliteHomeOverride } : {}),
     ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
@@ -4158,6 +4173,12 @@ function runCodex(
         detachedTmuxSessionExists(activeRecord.tmux_session_name)
       ) {
         cleanupCurrentMadmaxReuseRunRoot(process.env, runsRoot);
+        if (!shouldAttachDetachedTmuxSession(process.env)) {
+          process.stderr.write(
+            `[omx] madmax detached launch already active for this context; reusing ${activeRecord.tmux_session_name} without attaching because this launch is a Hermes MCP bridge.\n`,
+          );
+          return { postLaunchHandledExternally: true };
+        }
         process.stderr.write(
           `[omx] madmax detached launch already active for this context; attaching ${activeRecord.tmux_session_name} instead of starting a duplicate.\n`,
         );
@@ -4177,10 +4198,24 @@ function runCodex(
         rmSync(activeRecordPath, { force: true });
       }
 
-      void writeSessionStart(cwd, sessionId, { tmuxSessionName: sessionName }).catch((err) => {
-        logCliOperationFailure(err);
-        // Non-fatal: managed tmux recovery can still use compatibility fallback.
-      });
+      let detachedSessionBindingWrite: Promise<unknown> = Promise.resolve();
+      const writeDetachedSessionBinding = (tmuxPaneId?: string | null) => {
+        detachedSessionBindingWrite = detachedSessionBindingWrite
+          .catch((err) => {
+            logCliOperationFailure(err);
+          })
+          .then(() =>
+            writeSessionStart(cwd, sessionId, {
+              tmuxSessionName: sessionName,
+              ...(tmuxPaneId ? { tmuxPaneId } : {}),
+            }),
+          );
+        void detachedSessionBindingWrite.catch((err) => {
+          logCliOperationFailure(err);
+          // Non-fatal: managed tmux recovery can still use compatibility fallback.
+        });
+      };
+      writeDetachedSessionBinding();
       let createdDetachedSession = false;
       let registeredHookTarget: string | null = null;
       let registeredHookName: string | null = null;
@@ -4235,7 +4270,8 @@ function runCodex(
                 tmux_session_name: sessionName,
               });
             }
-            parsePaneIdFromTmuxOutput(output || "");
+            const leaderPaneId = parsePaneIdFromTmuxOutput(output || "");
+            if (leaderPaneId) writeDetachedSessionBinding(leaderPaneId);
           }
           if (step.name === "split-and-capture-hud-pane") {
             const hudPaneId = parsePaneIdFromTmuxOutput(output || "");
@@ -4270,6 +4306,7 @@ function runCodex(
               hookWindowIndex,
               process.env.OMX_MOUSE !== "0",
               nativeWindows,
+              shouldAttachDetachedTmuxSession(process.env),
             );
             if (nativeWindows && detachedWindowsCodexCmd) {
               scheduleDetachedWindowsCodexLaunch(

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -275,6 +275,35 @@ describe('session lifecycle manager', () => {
     }
   });
 
+  it('preserves existing native and tmux bindings on same-session start updates', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-preserve-'));
+    try {
+      await writeSessionStart(cwd, 'omx-launch-1', {
+        nativeSessionId: 'codex-native-1',
+        tmuxSessionName: 'omx-detached-demo',
+      });
+
+      const withPane = await writeSessionStart(cwd, 'omx-launch-1', {
+        tmuxSessionName: 'omx-detached-demo',
+        tmuxPaneId: '%42',
+      });
+
+      assert.equal(withPane.native_session_id, 'codex-native-1');
+      assert.equal(withPane.tmux_session_name, 'omx-detached-demo');
+      assert.equal(withPane.tmux_pane_id, '%42');
+
+      const withoutPane = await writeSessionStart(cwd, 'omx-launch-1', {
+        tmuxSessionName: 'omx-detached-demo',
+      });
+
+      assert.equal(withoutPane.native_session_id, 'codex-native-1');
+      assert.equal(withoutPane.tmux_session_name, 'omx-detached-demo');
+      assert.equal(withoutPane.tmux_pane_id, '%42');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('lets an owner OMX launch session end the fresh native session it spawned', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-end-'));
     try {

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -27,6 +27,7 @@ export interface SessionState {
   pid_start_ticks?: number;
   pid_cmdline?: string;
   tmux_session_name?: string;
+  tmux_pane_id?: string;
 }
 
 const SESSION_FILE = 'session.json';
@@ -169,6 +170,7 @@ interface SessionStartOptions {
   nativeSessionSwitchedAt?: string;
   ownerOmxSessionId?: string;
   tmuxSessionName?: string;
+  tmuxPaneId?: string;
 }
 
 function defaultIsPidAlive(pid: number): boolean {
@@ -236,6 +238,7 @@ function createSessionState(
     ownerOmxSessionId?: string;
     startedAt?: string;
     tmuxSessionName?: string;
+    tmuxPaneId?: string;
   } = {},
 ): SessionState {
   const nowIso = options.nowIso ?? new Date().toISOString();
@@ -244,6 +247,9 @@ function createSessionState(
     : undefined;
   const tmuxSessionName = typeof options.tmuxSessionName === 'string' && options.tmuxSessionName.trim()
     ? options.tmuxSessionName.trim()
+    : undefined;
+  const tmuxPaneId = typeof options.tmuxPaneId === 'string' && options.tmuxPaneId.trim()
+    ? options.tmuxPaneId.trim()
     : undefined;
   const previousNativeSessionId =
     typeof options.previousNativeSessionId === 'string' && options.previousNativeSessionId.trim()
@@ -271,6 +277,7 @@ function createSessionState(
     pid_start_ticks: linuxIdentity?.startTicks,
     pid_cmdline: linuxIdentity?.cmdline ?? undefined,
     ...(tmuxSessionName ? { tmux_session_name: tmuxSessionName } : {}),
+    ...(tmuxPaneId ? { tmux_pane_id: tmuxPaneId } : {}),
   };
 }
 
@@ -318,6 +325,8 @@ export async function writeSessionStart(
 ): Promise<SessionState> {
   const stateDir = omxStateDir(cwd);
   await mkdir(stateDir, { recursive: true });
+  const existing = await readSessionState(cwd);
+  const sameSession = existing?.session_id === sessionId;
   const pid = Number.isInteger(options.pid) && options.pid && options.pid > 0
     ? options.pid
     : process.pid;
@@ -326,11 +335,12 @@ export async function writeSessionStart(
     ? readLinuxProcessIdentity(pid)
     : null;
   const state = createSessionState(cwd, sessionId, pid, platform, linuxIdentity, {
-    nativeSessionId: options.nativeSessionId,
-    previousNativeSessionId: options.previousNativeSessionId,
-    nativeSessionSwitchedAt: options.nativeSessionSwitchedAt,
-    ownerOmxSessionId: options.ownerOmxSessionId,
-    tmuxSessionName: options.tmuxSessionName,
+    nativeSessionId: options.nativeSessionId ?? (sameSession ? existing?.native_session_id : undefined),
+    previousNativeSessionId: options.previousNativeSessionId ?? (sameSession ? existing?.previous_native_session_id : undefined),
+    nativeSessionSwitchedAt: options.nativeSessionSwitchedAt ?? (sameSession ? existing?.native_session_switched_at : undefined),
+    ownerOmxSessionId: options.ownerOmxSessionId ?? (sameSession ? existing?.owner_omx_session_id : undefined),
+    tmuxSessionName: options.tmuxSessionName ?? (sameSession ? existing?.tmux_session_name : undefined),
+    tmuxPaneId: options.tmuxPaneId ?? (sameSession ? existing?.tmux_pane_id : undefined),
   });
 
   await writeFile(sessionPath(cwd), JSON.stringify(state, null, 2));
@@ -426,6 +436,7 @@ export async function reconcileNativeSessionStart(
     ownerOmxSessionId: existing.owner_omx_session_id,
     startedAt: existing.started_at,
     tmuxSessionName: existing.tmux_session_name,
+    tmuxPaneId: existing.tmux_pane_id,
   });
 
   await writeFile(sessionPath(cwd), JSON.stringify(state, null, 2));

--- a/src/mcp/__tests__/hermes-bridge.test.ts
+++ b/src/mcp/__tests__/hermes-bridge.test.ts
@@ -272,6 +272,222 @@ describe("Hermes MCP bridge core", () => {
     }
   });
 
+  it("routes selected prompts to a bound tmux session when no active exec queue accepts input", async () => {
+    const cwd = await tempWorkspace("omx-hermes-tmux-prompt-");
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(join(cwd, ".omx", "state", "session.json"), JSON.stringify({
+        session_id: "sess-tmux",
+        native_session_id: "native-tmux",
+        started_at: "2026-05-11T00:00:00.000Z",
+        cwd,
+        pid: 12345,
+        tmux_session_name: "omx-detached-demo",
+        tmux_pane_id: "%42",
+      }));
+      const tmuxCalls: string[][] = [];
+
+      const result = await hermesSendPrompt(
+        { workingDirectory: cwd, session_id: "native-tmux", prompt: "continue\nwith care", allow_mutation: true },
+        {
+          injectExecFollowup: async () => {
+            throw new Error("job_not_input_accepting:no_active_exec_session");
+          },
+          execTmuxFileSync: (args) => {
+            tmuxCalls.push(args);
+            if (args[0] === "show-options") return "sess-tmux\n";
+            if (args[0] === "display-message") return "omx-detached-demo\n";
+            return "";
+          },
+        },
+      );
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.data, {
+        session_id: "sess-tmux",
+        tmux_session_name: "omx-detached-demo",
+        target: "%42",
+        transport: "tmux_send_keys",
+      });
+      assert.deepEqual(tmuxCalls, [
+        ["has-session", "-t", "omx-detached-demo"],
+        ["show-options", "-qv", "-t", "omx-detached-demo", "@omx_instance_id"],
+        ["display-message", "-p", "-t", "%42", "#{session_name}"],
+        ["send-keys", "-t", "%42", "-l", "--", "continue with care"],
+        ["send-keys", "-t", "%42", "C-m"],
+        ["send-keys", "-t", "%42", "C-m"],
+      ]);
+      assert.equal(tmuxCalls.some((args) => args.includes("attach-session")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns prompt_not_accepted when tmux pane delivery fails", async () => {
+    const cwd = await tempWorkspace("omx-hermes-tmux-prompt-fail-");
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(join(cwd, ".omx", "state", "session.json"), JSON.stringify({
+        session_id: "sess-tmux",
+        started_at: "2026-05-11T00:00:00.000Z",
+        cwd,
+        pid: 12345,
+        tmux_session_name: "omx-detached-demo",
+        tmux_pane_id: "%42",
+      }));
+
+      const result = await hermesSendPrompt(
+        { workingDirectory: cwd, session_id: "sess-tmux", prompt: "continue", allow_mutation: true },
+        {
+          injectExecFollowup: async () => {
+            throw new Error("job_not_input_accepting:no_active_exec_session");
+          },
+          execTmuxFileSync: (args) => {
+            if (args[0] === "show-options") return "sess-tmux\n";
+            if (args[0] === "display-message") return "omx-detached-demo\n";
+            if (args[0] === "send-keys") throw new Error("pane closed");
+            return "";
+          },
+        },
+      );
+
+      assert.equal(result.ok, false);
+      assert.equal(result.code, "prompt_not_accepted");
+      assert.match(result.error ?? "", /unsupported_session_kind:tmux_prompt_delivery_failed:omx-detached-demo:%42:tmux_send_failed/);
+      assert.doesNotMatch(result.error ?? "", /pane closed/);
+      assert.doesNotMatch(result.error ?? "", /continue/);
+      assert.doesNotMatch(result.error ?? "", /invalid_input/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects tmux prompt delivery when the stored target is not a pane id", async () => {
+    const cwd = await tempWorkspace("omx-hermes-tmux-invalid-pane-");
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(join(cwd, ".omx", "state", "session.json"), JSON.stringify({
+        session_id: "sess-tmux",
+        started_at: "2026-05-11T00:00:00.000Z",
+        cwd,
+        pid: 12345,
+        tmux_session_name: "omx-detached-demo",
+        tmux_pane_id: "omx-detached-demo",
+      }));
+      const tmuxCalls: string[][] = [];
+
+      const result = await hermesSendPrompt(
+        { workingDirectory: cwd, session_id: "sess-tmux", prompt: "continue", allow_mutation: true },
+        {
+          injectExecFollowup: async () => {
+            throw new Error("job_not_input_accepting:no_active_exec_session");
+          },
+          execTmuxFileSync: (args) => {
+            tmuxCalls.push(args);
+            return "";
+          },
+        },
+      );
+
+      assert.equal(result.ok, false);
+      assert.equal(result.code, "prompt_not_accepted");
+      assert.match(result.error ?? "", /unsupported_session_kind:invalid_tmux_pane_binding:omx-detached-demo/);
+      assert.deepEqual(tmuxCalls, []);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects tmux prompt delivery when the stored pane is not in the bound session", async () => {
+    const cwd = await tempWorkspace("omx-hermes-tmux-pane-mismatch-");
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(join(cwd, ".omx", "state", "session.json"), JSON.stringify({
+        session_id: "sess-tmux",
+        started_at: "2026-05-11T00:00:00.000Z",
+        cwd,
+        pid: 12345,
+        tmux_session_name: "omx-detached-demo",
+        tmux_pane_id: "%42",
+      }));
+
+      const result = await hermesSendPrompt(
+        { workingDirectory: cwd, session_id: "sess-tmux", prompt: "continue", allow_mutation: true },
+        {
+          injectExecFollowup: async () => {
+            throw new Error("job_not_input_accepting:no_active_exec_session");
+          },
+          execTmuxFileSync: (args) => {
+            if (args[0] === "show-options") return "sess-tmux\n";
+            if (args[0] === "display-message") return "other-session\n";
+            return "";
+          },
+        },
+      );
+
+      assert.equal(result.ok, false);
+      assert.equal(result.code, "prompt_not_accepted");
+      assert.match(result.error ?? "", /unsupported_session_kind:tmux_prompt_delivery_failed:omx-detached-demo:%42:pane_session_mismatch:%42:other-session/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects tmux prompt delivery when the tmux instance tag does not match session state", async () => {
+    const cwd = await tempWorkspace("omx-hermes-tmux-instance-mismatch-");
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(join(cwd, ".omx", "state", "session.json"), JSON.stringify({
+        session_id: "sess-tmux",
+        started_at: "2026-05-11T00:00:00.000Z",
+        cwd,
+        pid: 12345,
+        tmux_session_name: "omx-detached-demo",
+        tmux_pane_id: "%42",
+      }));
+
+      const result = await hermesSendPrompt(
+        { workingDirectory: cwd, session_id: "sess-tmux", prompt: "continue", allow_mutation: true },
+        {
+          injectExecFollowup: async () => {
+            throw new Error("job_not_input_accepting:no_active_exec_session");
+          },
+          execTmuxFileSync: (args) => {
+            if (args[0] === "show-options") return "other-session\n";
+            return "";
+          },
+        },
+      );
+
+      assert.equal(result.ok, false);
+      assert.equal(result.code, "prompt_not_accepted");
+      assert.match(result.error ?? "", /unsupported_session_kind:tmux_prompt_delivery_failed:omx-detached-demo:%42:tmux_instance_mismatch:omx-detached-demo:other-session/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a clear unsupported-session-kind diagnostic when no exec or tmux binding can accept prompts", async () => {
+    const cwd = await tempWorkspace("omx-hermes-no-prompt-binding-");
+    try {
+      const result = await hermesSendPrompt(
+        { workingDirectory: cwd, session_id: "sess-missing", prompt: "continue", allow_mutation: true },
+        {
+          injectExecFollowup: async () => {
+            throw new Error("job_not_input_accepting:no_active_exec_session");
+          },
+        },
+      );
+
+      assert.equal(result.ok, false);
+      assert.equal(result.code, "prompt_not_accepted");
+      assert.match(result.error ?? "", /unsupported_session_kind:no_active_exec_session_or_tmux_binding:sess-missing/);
+      assert.doesNotMatch(result.error ?? "", /job_not_input_accepting:no_active_exec_session/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("queues selected prompts through the audited exec follow-up contract", async () => {
     const result = await hermesSendPrompt(
       { session_id: "sess-a", prompt: "continue", actor: "hermes-test", allow_mutation: true },
@@ -300,24 +516,25 @@ describe("Hermes MCP bridge core", () => {
   it("starts sessions in tmux worktree mode and requires mutation opt-in", async () => {
     const cwd = await tempWorkspace("omx-hermes-start-");
     try {
-      let observed: { command: string; args: string[]; cwd?: string } | null = null;
+      const observed: Array<{ command: string; args: string[]; cwd?: string; env?: NodeJS.ProcessEnv }> = [];
       const result = await hermesStartSession(
         { workingDirectory: cwd, prompt: "$ralph fix it", worktreeName: "pkg/demo", allow_mutation: true },
         {
           resolveOmxCliEntryPath: () => "/opt/omx/dist/cli/omx.js",
-          spawnProcess: ((command: string, args: string[], options: { cwd?: string }) => {
-            observed = { command, args, cwd: options.cwd };
+          spawnProcess: ((command: string, args: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv }) => {
+            observed.push({ command, args, cwd: options.cwd, env: options.env });
             return { pid: 4242, unref() {} };
           }) as never,
         },
       );
 
       assert.equal(result.ok, true);
-      assert.deepEqual(observed, {
-        command: "/opt/omx/dist/cli/omx.js",
-        args: ["--tmux", "--worktree=pkg/demo", "$ralph fix it"],
-        cwd,
-      });
+      assert.equal(observed[0]?.command, "/opt/omx/dist/cli/omx.js");
+      assert.deepEqual(observed[0]?.args, ["--tmux", "--worktree=pkg/demo", "$ralph fix it"]);
+      assert.equal(observed[0]?.cwd, cwd);
+      assert.equal(observed[0]?.env?.OMX_HERMES_MCP_BRIDGE, "1");
+      assert.equal(observed[0]?.env?.TMUX, undefined);
+      assert.equal(observed[0]?.env?.TMUX_PANE, undefined);
       assert.equal(result.data?.pid, 4242);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/mcp/hermes-bridge.ts
+++ b/src/mcp/hermes-bridge.ts
@@ -1,9 +1,9 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, open, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { injectExecFollowup } from "../exec/followup.js";
-import { isSessionStateUsable, readUsableSessionState, type SessionState } from "../hooks/session.js";
+import { isSessionStateUsable, readSessionState, readUsableSessionState, type SessionState } from "../hooks/session.js";
 import { readQuestionEvents } from "../question/events.js";
 import {
   listQuestionRecords,
@@ -20,6 +20,8 @@ import {
   validateSessionId,
 } from "./state-paths.js";
 import { resolveOmxCliEntryPath } from "../utils/paths.js";
+import { buildSendPaneArgvs } from "../notifications/tmux-detector.js";
+import { resolveTmuxBinaryForPlatform } from "../utils/platform-command.js";
 import { safeJsonParse } from "../utils/safe-json.js";
 
 export type HermesBridgeFailureCode =
@@ -88,12 +90,20 @@ export interface HermesQuestionSummary {
   error?: QuestionRecord["error"];
 }
 
+export interface HermesTmuxPromptResult {
+  session_id: string;
+  tmux_session_name: string;
+  target: string;
+  transport: "tmux_send_keys";
+}
+
 export interface HermesBridgeDeps {
   now?: () => Date;
   spawnProcess?: typeof spawn;
   resolveOmxCliEntryPath?: typeof resolveOmxCliEntryPath;
   readUsableSessionState?: typeof readUsableSessionState;
   injectExecFollowup?: typeof injectExecFollowup;
+  execTmuxFileSync?: (args: string[]) => string | Buffer | void;
 }
 
 const SAFE_ARTIFACT_PREFIXES = [
@@ -107,6 +117,7 @@ const DEFAULT_ARTIFACT_MAX_BYTES = 128_000;
 const DEFAULT_TAIL_LINES = 80;
 const MAX_TAIL_LINES = 500;
 const MAX_TAIL_READ_BYTES = 256_000;
+const OMX_INSTANCE_OPTION = "@omx_instance_id";
 
 function jsonResult<T extends Record<string, unknown>>(data: T): HermesBridgeResult<T> {
   return { ok: true, data };
@@ -158,6 +169,70 @@ function optionalBoolean(value: unknown): boolean | undefined {
 function optionalString(value: unknown): string | undefined {
   const normalized = typeof value === "string" ? value.trim() : "";
   return normalized || undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sessionMatchesRequested(state: SessionState, sessionId: string): boolean {
+  return state.session_id === sessionId || state.native_session_id === sessionId;
+}
+
+function isTmuxPaneId(value: string): boolean {
+  return /^%\d+$/.test(value);
+}
+
+function defaultExecTmuxFileSync(args: string[]): string | Buffer | void {
+  return execFileSync(resolveTmuxBinaryForPlatform() || "tmux", args, {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: process.platform === "win32",
+  });
+}
+
+async function sendPromptToBoundTmuxSession(
+  cwd: string,
+  sessionId: string,
+  prompt: string,
+  deps: HermesBridgeDeps,
+): Promise<HermesTmuxPromptResult | null> {
+  const rawSession = await readSessionState(cwd);
+  if (!rawSession || !sessionMatchesRequested(rawSession, sessionId)) return null;
+  const tmuxSessionName = optionalString(rawSession.tmux_session_name);
+  const tmuxPaneId = optionalString(rawSession.tmux_pane_id);
+  if (!tmuxSessionName || !tmuxPaneId) return null;
+  if (!isTmuxPaneId(tmuxPaneId)) {
+    throw new Error(`unsupported_session_kind:invalid_tmux_pane_binding:${tmuxSessionName}`);
+  }
+
+  const execTmux = deps.execTmuxFileSync ?? defaultExecTmuxFileSync;
+  try {
+    execTmux(["has-session", "-t", tmuxSessionName]);
+    const instanceId = String(execTmux(["show-options", "-qv", "-t", tmuxSessionName, OMX_INSTANCE_OPTION]) ?? "").trim();
+    if (instanceId !== rawSession.session_id) {
+      throw new Error(`tmux_instance_mismatch:${tmuxSessionName}:${instanceId || "missing"}`);
+    }
+    const paneSession = String(execTmux(["display-message", "-p", "-t", tmuxPaneId, "#{session_name}"]) ?? "").trim();
+    if (paneSession !== tmuxSessionName) {
+      throw new Error(`pane_session_mismatch:${tmuxPaneId}:${paneSession || "missing"}`);
+    }
+    for (const argv of buildSendPaneArgvs(tmuxPaneId, prompt, true)) {
+      execTmux(argv);
+    }
+  } catch (error) {
+    const message = errorMessage(error);
+    const reason = message.startsWith("tmux_instance_mismatch") || message.startsWith("pane_session_mismatch")
+      ? message
+      : "tmux_send_failed";
+    throw new Error(`unsupported_session_kind:tmux_prompt_delivery_failed:${tmuxSessionName}:${tmuxPaneId}:${reason}`);
+  }
+  return {
+    session_id: rawSession.session_id,
+    tmux_session_name: tmuxSessionName,
+    target: tmuxPaneId,
+    transport: "tmux_send_keys",
+  };
 }
 
 function projectQuestion(record: QuestionRecord): HermesQuestionSummary {
@@ -352,7 +427,7 @@ export async function hermesSubmitQuestionAnswer(
 export async function hermesSendPrompt(
   args: Record<string, unknown>,
   deps: HermesBridgeDeps = {},
-): Promise<HermesBridgeResult<{ followup_id: string; session_id: string; queue_path: string }>> {
+): Promise<HermesBridgeResult<{ followup_id?: string; session_id: string; queue_path?: string; transport?: string; tmux_session_name?: string; target?: string }>> {
   try {
     requireMutation(args);
     const cwd = resolveWorkingDirectoryForState(normalizeString(args.workingDirectory, "workingDirectory"));
@@ -361,14 +436,29 @@ export async function hermesSendPrompt(
     const prompt = normalizeString(args.prompt, "prompt", { required: true })!;
     const actor = normalizeString(args.actor, "actor") ?? "hermes-mcp";
     const inject = deps.injectExecFollowup ?? injectExecFollowup;
-    const result = await inject({ cwd, sessionId, prompt, actor });
-    return jsonResult({
-      followup_id: result.queued.id,
-      session_id: result.queued.session_id,
-      queue_path: result.queuePath,
-    });
+    try {
+      const result = await inject({ cwd, sessionId, prompt, actor });
+      return jsonResult({
+        followup_id: result.queued.id,
+        session_id: result.queued.session_id,
+        queue_path: result.queuePath,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.startsWith("job_not_input_accepting")) throw error;
+
+      const tmuxResult = await sendPromptToBoundTmuxSession(cwd, sessionId, prompt, deps);
+      if (tmuxResult) return jsonResult({ ...tmuxResult });
+
+      return failure(
+        "prompt_not_accepted",
+        `unsupported_session_kind:no_active_exec_session_or_tmux_binding:${sessionId}. ` +
+          "hermes_send_prompt supports active exec follow-up queues and OMX-managed tmux sessions with live tmux_session_name and tmux_pane_id bindings.",
+      );
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith("unsupported_session_kind")) return failure("prompt_not_accepted", message);
     if (message.startsWith("job_not_input_accepting")) return failure("prompt_not_accepted", message);
     if (message.includes("allow_mutation")) return failure("mutation_not_allowed", message);
     return failure("invalid_input", message);
@@ -389,11 +479,12 @@ export async function hermesStartSession(
     }
     const command = (deps.resolveOmxCliEntryPath ?? resolveOmxCliEntryPath)({ cwd }) ?? "omx";
     const launchArgs = ["--tmux", worktreeName ? `--worktree=${worktreeName}` : "--worktree", prompt];
+    const { TMUX: _tmux, TMUX_PANE: _tmuxPane, ...bridgeEnv } = process.env;
     const child = (deps.spawnProcess ?? spawn)(command, launchArgs, {
       cwd,
       detached: true,
       stdio: "ignore",
-      env: { ...process.env, OMX_HERMES_MCP_BRIDGE: "1" },
+      env: { ...bridgeEnv, OMX_HERMES_MCP_BRIDGE: "1" },
     }) as ChildProcess;
     child.unref();
     if (!child.pid) return failure("command_failed", "OMX session launcher did not report a pid");


### PR DESCRIPTION
## Summary
- Fix Hermes MCP tmux bridge launches so they create detached tmux sessions without attaching from non-TTY bridge calls.
- Persist and preserve the detached leader pane binding, then route Hermes prompt fallback only to a verified `%pane` target.
- Strip/unset `OMX_HERMES_MCP_BRIDGE` before Codex child execution and sanitize tmux prompt delivery failures.

Fixes #2576.

## Validation
- `npm run build`
- `npm run check:no-unused`
- `npm run lint -- src/cli/index.ts src/hooks/session.ts src/mcp/hermes-bridge.ts src/cli/__tests__/index.test.ts src/cli/__tests__/launch-fallback.test.ts src/hooks/__tests__/session.test.ts src/mcp/__tests__/hermes-bridge.test.ts`
- `env -u OMX_ROOT -u OMX_STATE_ROOT node --test dist/mcp/__tests__/hermes-bridge.test.js dist/hooks/__tests__/session.test.js dist/cli/__tests__/launch-fallback.test.js` (68/68)
- `node --test --test-name-pattern "buildDetachedSessionFinalizeSteps skips attach for Hermes MCP bridge launches|detached leader command preserves cwd and cleanup without shell-quote breakage" dist/cli/__tests__/index.test.js` (2/2)
- `git diff --check`
- Independent final review: code-reviewer APPROVE; architect CLEAR.

## Notes
- A broader combined `dist/cli/__tests__/index.test.js` run still has unrelated pre-existing failures in postLaunch cleanup and tmux extended-key lease cases; the new Hermes-specific index cases pass by name.
