### PR TITLE
Keep malformed Stop hook fallback schema-compatible

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -411,13 +411,34 @@ describe("codex native hook dispatch", () => {
     );
   });
 
-  it("emits deterministic JSON stdout when CLI stdin is malformed", () => {
+  it("emits schema-safe JSON stdout when CLI stdin is malformed", () => {
     const stdout = runNativeHookCli("{");
+
+    const output = parseSingleJsonStdout(stdout) as {
+      continue?: boolean;
+      stopReason?: string;
+      systemMessage?: string;
+      hookSpecificOutput?: unknown;
+    };
+
+    assert.equal(output.continue, false);
+    assert.equal(output.stopReason, "native_hook_stdin_parse_error");
+    assert.equal(output.hookSpecificOutput, undefined);
+    assert.match(
+      String(output.systemMessage ?? ""),
+      /stdin JSON parsing failed inside codex-native-hook:/,
+    );
+  });
+
+  it("emits Stop-schema-safe block JSON when malformed stdin still identifies Stop", () => {
+    const stdout = runNativeHookCli('{hook_event_name:"Stop",');
 
     const output = parseSingleJsonStdout(stdout) as {
       decision?: string;
       reason?: string;
-      hookSpecificOutput?: { hookEventName?: string; additionalContext?: string };
+      stopReason?: string;
+      systemMessage?: string;
+      hookSpecificOutput?: unknown;
     };
 
     assert.equal(output.decision, "block");
@@ -425,9 +446,10 @@ describe("codex native hook dispatch", () => {
       output.reason,
       "OMX native hook received malformed JSON input. Preserve runtime state, inspect the emitting hook payload yourself, and retry with valid JSON.",
     );
-    assert.equal(output.hookSpecificOutput?.hookEventName, "Unknown");
+    assert.equal(output.stopReason, "native_hook_stdin_parse_error");
+    assert.equal(output.hookSpecificOutput, undefined);
     assert.match(
-      String(output.hookSpecificOutput?.additionalContext ?? ""),
+      String(output.systemMessage ?? ""),
       /stdin JSON parsing failed inside codex-native-hook:/,
     );
   });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4045,6 +4045,7 @@ export async function dispatchCodexNativeHook(
 interface NativeHookCliReadResult {
   payload: CodexHookPayload;
   parseError: Error | null;
+  rawInput: string;
 }
 
 export function isCodexNativeHookMainModule(
@@ -4062,20 +4063,49 @@ async function readStdinJson(): Promise<NativeHookCliReadResult> {
   }
   const raw = Buffer.concat(chunks).toString("utf-8").trim();
   if (!raw) {
-    return { payload: {}, parseError: null };
+    return { payload: {}, parseError: null, rawInput: raw };
   }
 
   try {
     return {
       payload: safeObject(JSON.parse(raw)),
       parseError: null,
+      rawInput: raw,
     };
   } catch (error) {
     return {
       payload: {},
       parseError: error instanceof Error ? error : new Error(String(error)),
+      rawInput: raw,
     };
   }
+}
+
+function inferHookEventNameFromMalformedInput(raw: string): CodexHookEventName | null {
+  const match = raw.match(/(?:\"|['"])?hook[_-]?event[_-]?name(?:\"|['"])?\s*:\s*(?:\"|['"])?(SessionStart|PreToolUse|PostToolUse|UserPromptSubmit|PreCompact|PostCompact|Stop)\b/i);
+  const value = match?.[1];
+  if (!value) return null;
+  return readHookEventName({ hook_event_name: value });
+}
+
+function buildMalformedStdinHookOutput(parseError: Error, rawInput: string): Record<string, unknown> {
+  const reason =
+    "OMX native hook received malformed JSON input. Preserve runtime state, inspect the emitting hook payload yourself, and retry with valid JSON.";
+  const systemMessage =
+    `${reason} stdin JSON parsing failed inside codex-native-hook: ${parseError.message}.`;
+  if (inferHookEventNameFromMalformedInput(rawInput) === "Stop") {
+    return {
+      decision: "block",
+      reason,
+      stopReason: "native_hook_stdin_parse_error",
+      systemMessage,
+    };
+  }
+  return {
+    continue: false,
+    stopReason: "native_hook_stdin_parse_error",
+    systemMessage,
+  };
 }
 
 function writeNativeHookJsonStdout(output: Record<string, unknown>): void {
@@ -4129,18 +4159,10 @@ function buildStopDispatchFailureOutput(error: unknown): Record<string, unknown>
 }
 
 export async function runCodexNativeHookCli(): Promise<void> {
-  const { payload, parseError } = await readStdinJson();
+  const { payload, parseError, rawInput } = await readStdinJson();
   if (parseError) {
     await logNativeHookCliError(process.cwd(), "native_hook_stdin_parse_error", parseError);
-    writeNativeHookJsonStdout({
-      decision: "block",
-      reason: "OMX native hook received malformed JSON input. Preserve runtime state, inspect the emitting hook payload yourself, and retry with valid JSON.",
-      hookSpecificOutput: {
-        hookEventName: "Unknown",
-        additionalContext:
-          `stdin JSON parsing failed inside codex-native-hook: ${parseError.message}. Emit valid JSON from the native hook caller before retrying.`,
-      },
-    });
+    writeNativeHookJsonStdout(buildMalformedStdinHookOutput(parseError, rawInput));
     return;
   }
 


### PR DESCRIPTION
## Summary

Fixes #2580.

Keeps malformed stdin fallback output compatible with the Codex Stop hook schema. When malformed input still identifies `hook_event_name: Stop`, the hook now emits only Stop-accepted fields (`decision`, `reason`, `stopReason`, `systemMessage`) and omits `hookSpecificOutput`. Unknown malformed input uses a schema-safe generic fallback.

## Scope

- Base synced from `upstream/dev@f2315940`
- Branch: `strato-space:fix/stop-hook-malformed-json`
- Isolated change: 2 files only
  - `src/scripts/codex-native-hook.ts`
  - `src/scripts/__tests__/codex-native-hook.test.ts`

## Validation

```bash
npm run build
node --test --test-name-pattern "malformed|inactive Stop CLI" dist/scripts/__tests__/codex-native-hook.test.js
printf '{hook_event_name:"Stop",' | node dist/scripts/codex-native-hook.js
npm run lint
```

Manual malformed Stop input now returns valid Stop-schema-safe JSON with no `hookSpecificOutput`.
