### PR TITLE
Keep HUD watch bound to live tmux cwd

### DIFF
--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
-import { hudCommand, runWatchMode } from '../index.js';
+import { hudCommand, resolveHudWatchCwd, runWatchMode } from '../index.js';
 import { renderHud } from '../render.js';
 import { OMX_TMUX_HUD_OWNER_ENV } from '../reconcile.js';
 import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../tmux.js';
@@ -62,6 +62,68 @@ afterEach(() => {
 });
 
 describe('runWatchMode', () => {
+  it('resolves a live cwd when the HUD launch path was reused by another run', () => {
+    const resolved = resolveHudWatchCwd('/home/tools/calc', {
+      getCwd: () => '/home/tools/calc',
+      readProcCwd: () => '/home/tools/calc.noninteractive-aborted-20260527T233204Z',
+      realpath: (path) => {
+        if (path === '/home/tools/calc') return '/dev/inode/new-calc-run';
+        if (path === '/home/tools/calc.noninteractive-aborted-20260527T233204Z') {
+          return '/dev/inode/old-aborted-run';
+        }
+        return path;
+      },
+    });
+
+    assert.equal(resolved, '/home/tools/calc.noninteractive-aborted-20260527T233204Z');
+  });
+
+  it('keeps the launch cwd when live and launch paths resolve to the same directory', () => {
+    const resolved = resolveHudWatchCwd('/workspace/link', {
+      getCwd: () => '/workspace/link',
+      readProcCwd: () => '/workspace/real',
+      realpath: () => '/dev/inode/same-project',
+    });
+
+    assert.equal(resolved, '/workspace/link');
+  });
+
+  it('reads HUD state from the resolved live cwd on every watch frame', async () => {
+    const seenConfigCwds: string[] = [];
+    const seenStateCwds: string[] = [];
+    const seenAuthorityCwds: string[] = [];
+    let sigintHandler: (() => void) | undefined;
+
+    const promise = runWatchMode('/home/tools/calc', WATCH_FLAGS, {
+      isTTY: true,
+      env: {},
+      resolveWatchCwdFn: () => '/home/tools/calc.noninteractive-aborted-20260527T233204Z',
+      readHudConfigFn: async (cwd) => {
+        seenConfigCwds.push(cwd);
+        return { preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } };
+      },
+      readAllStateFn: async (cwd) => {
+        seenStateCwds.push(cwd);
+        return emptyCtx();
+      },
+      renderHudFn: () => 'frame',
+      runAuthorityTickFn: async ({ cwd }) => { seenAuthorityCwds.push(cwd); },
+      writeStdout: () => {},
+      writeStderr: () => {},
+      registerSigint: (handler) => { sigintHandler = handler; },
+      setIntervalFn: () => ({}) as ReturnType<typeof setInterval>,
+      clearIntervalFn: () => {},
+    });
+
+    await flush();
+    sigintHandler?.();
+    await promise;
+
+    assert.deepEqual(seenConfigCwds, ['/home/tools/calc.noninteractive-aborted-20260527T233204Z']);
+    assert.deepEqual(seenStateCwds, ['/home/tools/calc.noninteractive-aborted-20260527T233204Z']);
+    assert.deepEqual(seenAuthorityCwds, ['/home/tools/calc.noninteractive-aborted-20260527T233204Z']);
+  });
+
   it('restores cursor and clears interval on SIGINT', async () => {
     const writes: string[] = [];
     let sigintHandler: (() => void) | undefined;

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -10,6 +10,7 @@
  */
 
 import { execFileSync } from 'child_process';
+import { readlinkSync, realpathSync } from 'node:fs';
 import { readAllState, readHudConfig } from './state.js';
 import { getHudRenderMaxLines, renderHud } from './render.js';
 import type { HudFlags, HudPreset, HudRenderContext, ResolvedHudConfig } from './types.js';
@@ -68,6 +69,7 @@ export async function watchRenderLoop(
 interface RunWatchModeDependencies {
   isTTY: boolean;
   env: NodeJS.ProcessEnv;
+  resolveWatchCwdFn: (launchCwd: string) => string;
   readAllStateFn: (cwd: string, config?: ResolvedHudConfig) => Promise<HudRenderContext>;
   readHudConfigFn: (cwd: string) => Promise<ResolvedHudConfig>;
   renderHudFn: (ctx: HudRenderContext, preset: HudPreset, options?: { maxWidth?: number; maxLines?: number }) => string;
@@ -79,6 +81,56 @@ interface RunWatchModeDependencies {
   registerSigint: (handler: () => void) => void | (() => void);
   setIntervalFn: (handler: () => void, intervalMs: number) => ReturnType<typeof setInterval>;
   clearIntervalFn: (timer: ReturnType<typeof setInterval>) => void;
+}
+
+export interface ResolveHudWatchCwdDependencies {
+  getCwd?: () => string;
+  realpath?: (path: string) => string;
+  readProcCwd?: () => string | null | undefined;
+}
+
+function safeCallString(fn: () => string | null | undefined): string | null {
+  try {
+    const value = fn();
+    return typeof value === 'string' && value.trim() ? value.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultProcCwd(): string | null {
+  if (process.platform === 'win32') return null;
+  return safeCallString(() => readlinkSync('/proc/self/cwd'));
+}
+
+/**
+ * Resolve the cwd a long-running HUD watch should read on this frame.
+ *
+ * tmux launches HUD with both a real cwd and a shell PWD string. If that
+ * directory is later renamed and the original pathname is reused by a fresh
+ * OMX run, the old HUD process can keep reading the reused launch path and
+ * display the new run's state. Compare the launch path to the process' live
+ * cwd inode/path each tick; when they diverge, follow the live cwd instead of
+ * the stale launch path.
+ */
+export function resolveHudWatchCwd(
+  launchCwd: string,
+  deps: ResolveHudWatchCwdDependencies = {},
+): string {
+  const getCwd = deps.getCwd ?? (() => process.cwd());
+  const realpath = deps.realpath ?? ((path: string) => realpathSync.native(path));
+  const readProcCwd = deps.readProcCwd ?? defaultProcCwd;
+
+  const launchPath = launchCwd.trim() || safeCallString(getCwd) || launchCwd;
+  const livePath = safeCallString(readProcCwd) || safeCallString(getCwd);
+  if (!livePath) return launchPath;
+
+  const launchReal = safeCallString(() => realpath(launchPath));
+  const liveReal = safeCallString(() => realpath(livePath));
+  if (launchReal && liveReal && launchReal !== liveReal) return livePath;
+  if (!launchReal && liveReal) return livePath;
+  if (launchReal && !liveReal && livePath !== launchPath) return livePath;
+  return launchPath;
 }
 
 function reconcileRunningHudPaneHeight(
@@ -107,6 +159,7 @@ export async function runWatchMode(
   const dependencies: RunWatchModeDependencies = {
     isTTY: deps.isTTY ?? Boolean(process.stdout.isTTY),
     env: deps.env ?? process.env,
+    resolveWatchCwdFn: deps.resolveWatchCwdFn ?? ((launchCwd) => resolveHudWatchCwd(launchCwd)),
     readAllStateFn: deps.readAllStateFn ?? readAllState,
     readHudConfigFn: deps.readHudConfigFn ?? readHudConfig,
     renderHudFn: deps.renderHudFn ?? renderHud,
@@ -169,8 +222,9 @@ export async function runWatchMode(
       } else {
         dependencies.writeStdout('\x1b[H');
       }
-      const config = await dependencies.readHudConfigFn(cwd);
-      const ctx = await dependencies.readAllStateFn(cwd, config);
+      const frameCwd = dependencies.resolveWatchCwdFn(cwd);
+      const config = await dependencies.readHudConfigFn(frameCwd);
+      const ctx = await dependencies.readAllStateFn(frameCwd, config);
       const preset = flags.preset ?? config.preset;
       const maxLines = getHudRenderMaxLines(ctx);
       if (maxLines !== lastDesiredHeight) {
@@ -182,7 +236,7 @@ export async function runWatchMode(
         maxLines,
       });
       dependencies.writeStdout(line + '\x1b[K\x1b[J');
-      await dependencies.runAuthorityTickFn({ cwd });
+      await dependencies.runAuthorityTickFn({ cwd: frameCwd });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       dependencies.writeStderr(`HUD watch render failed: ${message}\n`);


### PR DESCRIPTION
## Summary

Fixes a tmux HUD state leak shape where an old `omx hud --watch` process keeps reading the pathname captured at launch after its live cwd has been renamed and that pathname is reused by a new OMX run.

The watch loop now resolves the HUD cwd per frame: if the launch path and the process live cwd resolve to different real directories, HUD reads config/state and runs authority ticks against the live cwd.

Closes #2582.

## Tests

- `npm run build`
- `node --test dist/hud/__tests__/index.test.js dist/hud/__tests__/hud-tmux-injection.test.js dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js`
- `npm run lint`
- `git diff --check`
