### PR TITLE
Keep HUD watch alive during transient authority failures

### DIFF
--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -465,6 +465,60 @@ describe('runWatchMode', () => {
     assert.ok(writes.some((chunk) => chunk.includes('frame')));
   });
 
+  it('keeps rendering when the authority tick fails after a frame', async () => {
+    const writes: string[] = [];
+    const errors: string[] = [];
+    let sigintHandler: (() => void) | undefined;
+    let timerTick: (() => void) | undefined;
+    let renderCount = 0;
+    let authorityCalls = 0;
+    const firstAuthorityAttempted = deferred();
+    const secondReadStarted = deferred();
+
+    const promise = runWatchMode('/tmp', WATCH_FLAGS, {
+      isTTY: true,
+      env: {},
+      readAllStateFn: async () => {
+        renderCount += 1;
+        if (renderCount === 2) secondReadStarted.resolve();
+        return emptyCtx();
+      },
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
+      renderHudFn: () => 'frame',
+      writeStdout: (text) => { writes.push(text); },
+      writeStderr: (text) => { errors.push(text); },
+      registerSigint: (handler) => { sigintHandler = handler; },
+      setIntervalFn: (handler) => {
+        timerTick = handler;
+        return ({}) as ReturnType<typeof setInterval>;
+      },
+      clearIntervalFn: () => {},
+      runAuthorityTickFn: async () => {
+        authorityCalls += 1;
+        if (authorityCalls === 1) {
+          firstAuthorityAttempted.resolve();
+          throw new Error('dist is rebuilding');
+        }
+      },
+    });
+
+    await withTimeout(firstAuthorityAttempted.promise, 'first authority tick should run');
+    await flush();
+    assert.equal(process.exitCode, undefined);
+    assert.ok(errors.some((line) => line.includes('HUD watch authority tick failed: dist is rebuilding')));
+
+    timerTick?.();
+    await withTimeout(secondReadStarted.promise, 'watch should render again after authority tick failure');
+    sigintHandler?.();
+    await promise;
+
+    assert.equal(renderCount, 2);
+    assert.equal(authorityCalls, 2);
+    assert.equal(process.exitCode, undefined);
+    assert.equal((writes.join('').match(/frame/g) ?? []).length, 2);
+    assert.ok(!errors.some((line) => line.includes('HUD watch render failed')));
+  });
+
   it('handles render failures gracefully and restores terminal state', async () => {
     const writes: string[] = [];
     const errors: string[] = [];

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -236,7 +236,12 @@ export async function runWatchMode(
         maxLines,
       });
       dependencies.writeStdout(line + '\x1b[K\x1b[J');
-      await dependencies.runAuthorityTickFn({ cwd: frameCwd });
+      try {
+        await dependencies.runAuthorityTickFn({ cwd: frameCwd });
+      } catch (authorityError) {
+        const message = authorityError instanceof Error ? authorityError.message : String(authorityError);
+        dependencies.writeStderr(`HUD watch authority tick failed: ${message}\n`);
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       dependencies.writeStderr(`HUD watch render failed: ${message}\n`);


### PR DESCRIPTION
## Summary
- keep HUD watch rendering alive when the auxiliary notification-authority heartbeat fails after a frame has rendered
- log authority tick failures separately from real render failures instead of closing the tmux HUD pane
- add a regression test that proves a failed authority tick does not set `process.exitCode` and the next frame still renders

## Why
During local rebuild/setup, `dist/` can be temporarily missing while an existing HUD watch pane is still running. If the authority helper fails in that window, the current render-failure path tears down the watch process and the tmux HUD pane disappears even though the HUD frame itself rendered correctly.

## Validation
- `npm run build`
- `npm run lint`
- `node --test dist/hud/__tests__/index.test.js dist/hud/__tests__/authority.test.js dist/hud/__tests__/resource-leak-watch.test.js`
- `git diff --check`
