### PR TITLE
Close Autopilot gate review follow-ups

### DIFF
--- a/src/autopilot/__tests__/fsm.test.ts
+++ b/src/autopilot/__tests__/fsm.test.ts
@@ -15,7 +15,7 @@ describe('autopilot supervisor FSM helpers', () => {
     assert.equal(normalizeAutopilotPhase('team'), 'team');
     assert.equal(normalizeAutopilotPhase('ralph'), 'ralph');
     assert.equal(normalizeAutopilotPhase('completed'), 'complete');
-    assert.equal(normalizeAutopilotPhase('planning'), null);
+    assert.equal(normalizeAutopilotPhase('planning'), 'ralplan');
   });
 
   it('derives child-stage labels only from Autopilot supervisor state', () => {
@@ -60,6 +60,11 @@ describe('autopilot supervisor FSM helpers', () => {
       active: true,
       current_phase: 'ralph',
     }), 'autopilot:ralph');
+    assert.equal(deriveAutopilotStageLabel({
+      mode: 'autopilot',
+      active: true,
+      current_phase: 'planning',
+    }), 'autopilot:ralplan');
   });
 
   it('does not derive standalone workflow states as Autopilot stage labels', () => {

--- a/src/autopilot/deep-interview-gate.ts
+++ b/src/autopilot/deep-interview-gate.ts
@@ -190,13 +190,35 @@ function collectQuestionEnforcementsFromStates(
   }
   return enforcements;
 }
+
+function questionEnforcementKey(enforcement: DeepInterviewQuestionEnforcementState): string | null {
+  const obligationId = safeString(enforcement.obligation_id);
+  if (obligationId) return `obligation:${obligationId}`;
+  const questionId = safeString(enforcement.question_id);
+  if (questionId) return `question:${questionId}`;
+  return null;
+}
+
 function collectResultingQuestionEnforcements(
   input: AutopilotDeepInterviewRalplanGateInput,
   deepState: JsonObject | null,
 ): DeepInterviewQuestionEnforcementState[] {
-  return collectQuestionEnforcementsFromStates(input.nextState
-    ? [input.nextState, deepState]
-    : [input.currentState, deepState]);
+  if (!input.nextState) return collectQuestionEnforcementsFromStates([input.currentState, deepState]);
+
+  const resulting = collectQuestionEnforcementsFromStates([input.nextState, deepState]);
+  const resultingKeys = new Set(
+    resulting
+      .map((enforcement) => questionEnforcementKey(enforcement))
+      .filter((key): key is string => Boolean(key)),
+  );
+
+  for (const current of collectQuestionEnforcementsFromStates([input.currentState])) {
+    const key = questionEnforcementKey(current);
+    if (key && resultingKeys.has(key)) continue;
+    resulting.push(current);
+  }
+
+  return resulting;
 }
 
 function hasPendingQuestion(enforcements: readonly DeepInterviewQuestionEnforcementState[]): boolean {

--- a/src/autopilot/deep-interview-gate.ts
+++ b/src/autopilot/deep-interview-gate.ts
@@ -59,7 +59,7 @@ function questionEnforcement(state: JsonObject | null | undefined): DeepIntervie
 function autopilotQuestionEnforcement(
   state: JsonObject | null | undefined,
 ): DeepInterviewQuestionEnforcementState | undefined {
-  const wait = safeObject(nestedState(state)?.deep_interview_question);
+  const wait = safeObject(state?.deep_interview_question) ?? safeObject(nestedState(state)?.deep_interview_question);
   if (!wait) return undefined;
   if (safeString(wait.source) !== 'omx-question') return undefined;
   const obligationId = safeString(wait.obligation_id);
@@ -178,18 +178,25 @@ function isSkipGate(gate: JsonObject, sessionId?: string): boolean {
     && sessionMatches;
 }
 
-function collectQuestionEnforcements(
-  input: AutopilotDeepInterviewRalplanGateInput,
-  deepState: JsonObject | null,
+function collectQuestionEnforcementsFromStates(
+  states: Array<JsonObject | null | undefined>,
 ): DeepInterviewQuestionEnforcementState[] {
   const enforcements: DeepInterviewQuestionEnforcementState[] = [];
-  for (const state of allCandidateStates(input, deepState)) {
+  for (const state of states) {
     const standalone = questionEnforcement(state);
     if (standalone) enforcements.push(standalone);
     const autopilotWait = autopilotQuestionEnforcement(state);
     if (autopilotWait) enforcements.push(autopilotWait);
   }
   return enforcements;
+}
+function collectResultingQuestionEnforcements(
+  input: AutopilotDeepInterviewRalplanGateInput,
+  deepState: JsonObject | null,
+): DeepInterviewQuestionEnforcementState[] {
+  return collectQuestionEnforcementsFromStates(input.nextState
+    ? [input.nextState, deepState]
+    : [input.currentState, deepState]);
 }
 
 function hasPendingQuestion(enforcements: readonly DeepInterviewQuestionEnforcementState[]): boolean {
@@ -244,7 +251,7 @@ export async function canAdvanceAutopilotDeepInterviewToRalplan(
   input: AutopilotDeepInterviewRalplanGateInput,
 ): Promise<AutopilotDeepInterviewRalplanGateDecision> {
   const deepState = await readDeepInterviewState(input);
-  const enforcements = collectQuestionEnforcements(input, deepState);
+  const enforcements = collectResultingQuestionEnforcements(input, deepState);
   if (hasPendingQuestion(enforcements)) {
     return {
       allowed: false,

--- a/src/autopilot/fsm.ts
+++ b/src/autopilot/fsm.ts
@@ -29,7 +29,9 @@ function safeObject(value: unknown): Record<string, unknown> {
 
 function normalizePhaseText(value: unknown): string {
   const normalized = safeString(value).toLowerCase().replace(/_/g, '-');
-  return normalized === 'completed' ? 'complete' : normalized;
+  if (normalized === 'completed') return 'complete';
+  if (normalized === 'planning') return 'ralplan';
+  return normalized;
 }
 
 export function isAutopilotChildPhase(value: unknown): value is AutopilotChildPhase {

--- a/src/question/__tests__/state.test.ts
+++ b/src/question/__tests__/state.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, it } from 'node:test';
 import {
   createQuestionRecord,
   getQuestionRecordPath,
+  getQuestionRecordPathForStateDir,
   markQuestionAnswered,
   markQuestionPrompting,
   markQuestionTerminalError,
@@ -43,6 +44,15 @@ describe('question state', () => {
     const loaded = await readQuestionRecord(recordPath);
     assert.equal(loaded?.question, 'Pick one');
     assert.equal(loaded?.type, 'single-answerable');
+  });
+
+  it('resolves session-scoped question records under the questions namespace for state roots', async () => {
+    const stateDir = join('/tmp', 'omx-state-root');
+
+    assert.equal(
+      getQuestionRecordPathForStateDir(stateDir, 'question-1', 'sess-1'),
+      join(stateDir, 'sessions', 'sess-1', 'questions', 'question-1.json'),
+    );
   });
 
   it('emits a structured creation event with correlation metadata', async () => {

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -56,7 +56,8 @@ export function getQuestionStateDir(cwd: string, sessionId?: string): string {
 }
 
 export function getQuestionStateDirForStateDir(stateDir: string, sessionId?: string): string {
-  return join(sessionId ? join(stateDir, 'sessions', sessionId) : stateDir, QUESTION_NAMESPACE);
+  const scopedStateDir = sessionId ? join(stateDir, 'sessions', sessionId) : stateDir;
+  return join(scopedStateDir, QUESTION_NAMESPACE);
 }
 
 export function getQuestionRecordPath(cwd: string, questionId: string, sessionId?: string): string {

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -908,6 +908,66 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('denies Autopilot handoff when the next state omits a still-pending deep-interview question', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-omitted-question-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-omitted-question-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'waiting-for-user',
+            run_outcome: 'blocked_on_user',
+            lifecycle_outcome: 'askuserQuestion',
+            state: {
+              deep_interview_question: {
+                status: 'waiting_for_user',
+                source: 'omx-question',
+                obligation_id: 'obligation-omitted',
+                previous_phase: 'deep-interview',
+                requested_at: '2026-05-28T00:00:00.000Z',
+              },
+              deep_interview_gate: {
+                status: 'required',
+                rationale: 'Question still needs an answer.',
+              },
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: true,
+          current_phase: 'ralplan',
+          state: {
+            deep_interview_gate: {
+              status: 'complete',
+              rationale: 'Replacement state must not erase an unanswered question obligation.',
+            },
+            handoff_artifacts: {
+              deep_interview: { summary: 'Ready for planning.' },
+            },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /question obligation is still pending/i);
+        const state = JSON.parse(
+          await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8'),
+        ) as Record<string, unknown>;
+        assert.equal(state.current_phase, 'waiting-for-user');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('ignores stale standalone deep-interview question state for Autopilot supervisor handoff', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ignore-standalone-di-'));
     try {

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1017,6 +1017,80 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('allows Autopilot handoff when next state satisfies a previously pending question', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-next-question-satisfied-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-next-question-satisfied';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        const questionId = 'question-next-satisfied';
+        await mkdir(join(sessionDir, 'questions'), { recursive: true });
+        await writeFile(
+          join(sessionDir, 'questions', `${questionId}.json`),
+          JSON.stringify({
+            kind: 'omx.question/v1',
+            question_id: questionId,
+            session_id: sessionId,
+            source: 'deep-interview',
+            status: 'answered',
+            answer: 'lowercase ascii slug',
+            answers: [{ question_id: 'q-1', index: 0, answer: 'lowercase ascii slug' }],
+          }, null, 2),
+        );
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'deep-interview',
+            state: {
+              deep_interview_question: {
+                obligation_id: 'obligation-next-satisfied',
+                source: 'omx-question',
+                status: 'waiting_for_user',
+                requested_at: '2026-05-28T00:00:00.000Z',
+              },
+              deep_interview_gate: { status: 'required' },
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: true,
+          current_phase: 'ralplan',
+          state: {
+            deep_interview_question: {
+              obligation_id: 'obligation-next-satisfied',
+              source: 'omx-question',
+              status: 'satisfied',
+              requested_at: '2026-05-28T00:00:00.000Z',
+              question_id: questionId,
+              satisfied_at: '2026-05-28T00:01:00.000Z',
+            },
+            deep_interview_gate: {
+              status: 'complete',
+              rationale: 'The answered question resolves the CLI output policy.',
+            },
+            handoff_artifacts: {
+              deep_interview: { summary: 'Ready for ralplan after answered question.' },
+            },
+          },
+        });
+
+        assert.equal(response.isError, undefined);
+        const state = JSON.parse(
+          await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8'),
+        ) as Record<string, unknown>;
+        assert.equal(state.current_phase, 'ralplan');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('allows Autopilot deep-interview to ralplan self-write with explicit user-authorized skip evidence', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-child-phase-skip-'));
     try {
@@ -1270,6 +1344,42 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('denies legacy Autopilot planning to ultragoal without ralplan consensus evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-legacy-planning-gate-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-legacy-planning-gate';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'planning',
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: true,
+          current_phase: 'ultragoal',
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /ralplan consensus/i);
+        const state = JSON.parse(
+          await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8'),
+        ) as Record<string, unknown>;
+        assert.equal(state.current_phase, 'planning');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('allows Autopilot ralplan to ultragoal self-write with tracker-backed native consensus evidence', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ralplan-native-allow-'));
     try {
@@ -1309,6 +1419,51 @@ describe('state operations directory initialization', () => {
           await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8'),
         ) as Record<string, unknown>;
         assert.equal(state.current_phase, 'ultragoal');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when canonical deep-interview is active but mode state is missing', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-missing-deep-interview-state-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-missing-deep-interview-state';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'skill-active-state.json'),
+          JSON.stringify({
+            version: 1,
+            active: true,
+            skill: 'deep-interview',
+            session_id: sessionId,
+            active_skills: [{
+              skill: 'deep-interview',
+              active: true,
+              phase: 'intent-first',
+              session_id: sessionId,
+            }],
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'ralplan',
+          active: true,
+          current_phase: 'planning',
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /missing deep-interview completion\/skip gate/i);
+        assert.equal(existsSync(join(sessionDir, 'ralplan-state.json')), false);
+        const canonical = JSON.parse(
+          await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8'),
+        ) as { active_skills?: Array<{ skill: string; active?: boolean }> };
+        assert.equal(canonical.active_skills?.[0]?.skill, 'deep-interview');
+        assert.equal(canonical.active_skills?.[0]?.active, true);
       });
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -117,7 +117,10 @@ async function completeSourceModeState(
   const completedPaths: string[] = [];
 
   for (const candidatePath of candidatePaths) {
-    const existing = await readJsonIfExists(candidatePath);
+    const existing = await readJsonIfExists(candidatePath, {
+      mode: sourceMode,
+      throwOnParseError: true,
+    });
     if (!existing || existing.active !== true) continue;
     if (sourceMode === 'deep-interview' && destinationMode === 'ralplan') {
       const gate = await canAdvanceAutopilotDeepInterviewToRalplan({
@@ -159,6 +162,16 @@ async function completeSourceModeState(
     await mkdir(dirname(candidatePath), { recursive: true });
     await writeFile(candidatePath, JSON.stringify(nextState, null, 2));
     completedPaths.push(candidatePath);
+  }
+
+  if (sourceMode === 'deep-interview' && destinationMode === 'ralplan' && completedPaths.length === 0) {
+    const gate = await canAdvanceAutopilotDeepInterviewToRalplan({
+      cwd,
+      sessionId,
+      baseStateDir,
+      deepInterviewState: null,
+    });
+    throw new Error(buildAutopilotDeepInterviewRalplanGateError(gate));
   }
 
   await syncCanonicalSkillStateForMode({


### PR DESCRIPTION
Follow-up against #2588 to address the current Code Review comments without broadening the maintainer PR.

Covers:
- P1: normalize legacy Autopilot `current_phase: \"planning\"` as the supervised `ralplan` phase so ralplan -> ultragoal still requires consensus evidence.
- P1: fail closed when canonical `deep-interview` is active but `deep-interview-state.json` is missing, instead of deactivating the skill state during `deep-interview -> ralplan` reconciliation.
- P2: evaluate pending deep-interview question obligations from the resulting state, allowing the same `state_write` to provide satisfied question evidence.

Validation:
- `npm run build`
- `npm run lint`
- `NODE_OPTIONS='' TMPDIR=/tmp node --test --test-reporter=tap dist/autopilot/__tests__/fsm.test.js dist/state/__tests__/operations.test.js`
- clean-env rerun of the same focused tests
- `git diff --check`

Related: #2588, #2586.