### PR TITLE
Keep Autopilot question waits single-owner

### DIFF
--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import { questionCommand } from '../question.js';
+import { AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV } from '../../question/autopilot-wait.js';
 import { markQuestionAnswered, readQuestionRecord } from '../../question/state.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -245,6 +246,115 @@ describe('omx question CLI', () => {
     assert.equal(finalAutopilot.state?.deep_interview_question?.status, 'satisfied');
     assert.equal(finalAutopilot.state?.deep_interview_question?.question_id, record?.question_id);
     assert.ok(finalAutopilot.state?.deep_interview_question?.satisfied_at);
+  });
+
+  it('allows the owning spawned deep-interview question after Autopilot records the wait', async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-q');
+    const questionsDir = join(sessionDir, 'questions');
+    const autopilotPath = join(sessionDir, 'autopilot-state.json');
+    const obligationId = 'obligation-owner';
+    await writeFile(autopilotPath, JSON.stringify({
+      mode: 'autopilot',
+      active: true,
+      current_phase: 'waiting-for-user',
+      run_outcome: 'blocked_on_user',
+      lifecycle_outcome: 'askuserQuestion',
+      session_id: 'sess-q',
+      state: {
+        deep_interview_question: {
+          status: 'waiting_for_user',
+          source: 'omx-question',
+          obligation_id: obligationId,
+          previous_phase: 'deep-interview',
+          previous_run_outcome: 'interviewing',
+          previous_lifecycle_outcome: 'running',
+          requested_at: '2026-04-19T00:00:00.000Z',
+        },
+      },
+    }, null, 2));
+    await writeFile(join(sessionDir, 'deep-interview-state.json'), JSON.stringify({
+      mode: 'deep-interview',
+      active: false,
+      current_phase: 'intent-first',
+      session_id: 'sess-q',
+      question_enforcement: {
+        obligation_id: obligationId,
+        source: 'omx-question',
+        status: 'pending',
+        lifecycle_outcome: 'askuserQuestion',
+        requested_at: '2026-04-19T00:00:00.000Z',
+      },
+    }, null, 2));
+    await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+      active: true,
+      skill: 'autopilot',
+      phase: 'deep-interview',
+      session_id: 'sess-q',
+      active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: 'sess-q' }],
+    }, null, 2));
+
+    const input = JSON.stringify({
+      question: 'Which filename policy?',
+      options: [{ label: 'Lowercase kebab', value: 'kebab' }],
+      allow_other: false,
+      source: 'deep-interview',
+      session_id: 'sess-q',
+    });
+
+    const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
+      cwd,
+      env: makeQuestionCliEnv(cwd, {
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        OMX_QUESTION_TEST_RENDERER: 'noop',
+        [AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV]: obligationId,
+      }),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+    child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+    const closePromise = new Promise<number | null>((resolve) => child.on('close', resolve));
+
+    const recordFile = await waitForQuestionRecordFile(questionsDir, () => `stderr=${stderr}; stdout=${stdout}`);
+    const recordPath = join(questionsDir, recordFile);
+    let record = null;
+    for (let attempt = 0; attempt < 250; attempt += 1) {
+      record = await readQuestionRecord(recordPath);
+      if (record?.status === 'prompting') break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    assert.equal(record?.status, 'prompting', `expected owner question to prompt, stderr=${stderr}; stdout=${stdout}`);
+
+    await markQuestionAnswered(recordPath, {
+      kind: 'option',
+      value: 'kebab',
+      selected_labels: ['Lowercase kebab'],
+      selected_values: ['kebab'],
+    });
+
+    const exitCode = await closePromise;
+    assert.equal(exitCode, 0, stderr || stdout);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.answer.value, 'kebab');
+
+    const finalAutopilot = JSON.parse(await readFile(autopilotPath, 'utf-8')) as {
+      current_phase?: string;
+      run_outcome?: string;
+      lifecycle_outcome?: string;
+      state?: { deep_interview_question?: { status?: string; obligation_id?: string; question_id?: string } };
+    };
+    assert.equal(finalAutopilot.current_phase, 'deep-interview');
+    assert.equal(finalAutopilot.run_outcome, 'interviewing');
+    assert.equal(finalAutopilot.lifecycle_outcome, 'running');
+    assert.equal(finalAutopilot.state?.deep_interview_question?.status, 'satisfied');
+    assert.equal(finalAutopilot.state?.deep_interview_question?.obligation_id, obligationId);
+    assert.equal(finalAutopilot.state?.deep_interview_question?.question_id, record?.question_id);
   });
 
   it('omits legacy prompt and answer projections for batch payloads', async () => {

--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -325,15 +325,29 @@ export async function questionCommand(args: string[]): Promise<void> {
     );
     if (!directDeepInterviewObligation) {
       directDeepInterviewObligation = createDeepInterviewQuestionObligation();
+      const autopilotWaitStarted = await markAutopilotDeepInterviewQuestionWaiting(
+        cwd,
+        policy.sessionId,
+        directDeepInterviewObligation,
+      );
+      if (!autopilotWaitStarted) {
+        const conflictingWait = await readAutopilotDeepInterviewQuestionWaitState(cwd, policy.sessionId);
+        if (conflictingWait) {
+          printJson({
+            ok: false,
+            error: {
+              code: 'active_execution_mode_blocked',
+              message: 'Autopilot already has a pending deep-interview question.',
+            },
+          }, parsed.json);
+          process.exitCode = 1;
+          return;
+        }
+      }
       await updateDeepInterviewQuestionEnforcement(
         cwd,
         policy.sessionId,
         () => directDeepInterviewObligation ?? undefined,
-      );
-      await markAutopilotDeepInterviewQuestionWaiting(
-        cwd,
-        policy.sessionId,
-        directDeepInterviewObligation,
       );
     }
   }

--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -8,7 +8,9 @@ import {
   type DeepInterviewQuestionEnforcementState,
 } from '../question/deep-interview.js';
 import {
+  AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV,
   markAutopilotDeepInterviewQuestionWaiting,
+  readAutopilotDeepInterviewQuestionWaitState,
   resolveAutopilotDeepInterviewQuestionWaiting,
 } from '../question/autopilot-wait.js';
 import {
@@ -187,6 +189,26 @@ function isDeepInterviewQuestionSource(source: unknown): boolean {
   return typeof source === 'string' && source.trim() === 'deep-interview';
 }
 
+async function readOwningAutopilotDeepInterviewObligation(
+  cwd: string,
+  sessionId: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<DeepInterviewQuestionEnforcementState | null> {
+  const ownerObligationId = String(env[AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV] ?? '').trim();
+  if (!ownerObligationId || !sessionId) return null;
+
+  const waitState = await readAutopilotDeepInterviewQuestionWaitState(cwd, sessionId);
+  if (waitState?.obligationId !== ownerObligationId) return null;
+
+  return {
+    obligation_id: waitState.obligationId,
+    source: 'omx-question',
+    status: 'pending',
+    lifecycle_outcome: 'askuserQuestion',
+    requested_at: waitState.requestedAt ?? new Date().toISOString(),
+  };
+}
+
 async function finalizeDirectDeepInterviewObligation(
   cwd: string,
   sessionId: string | undefined,
@@ -297,17 +319,23 @@ export async function questionCommand(args: string[]): Promise<void> {
 
   let directDeepInterviewObligation: DeepInterviewQuestionEnforcementState | null = null;
   if (isDeepInterviewQuestionSource(input.source) && policy.sessionId) {
-    directDeepInterviewObligation = createDeepInterviewQuestionObligation();
-    await updateDeepInterviewQuestionEnforcement(
+    directDeepInterviewObligation = await readOwningAutopilotDeepInterviewObligation(
       cwd,
       policy.sessionId,
-      () => directDeepInterviewObligation ?? undefined,
     );
-    await markAutopilotDeepInterviewQuestionWaiting(
-      cwd,
-      policy.sessionId,
-      directDeepInterviewObligation,
-    );
+    if (!directDeepInterviewObligation) {
+      directDeepInterviewObligation = createDeepInterviewQuestionObligation();
+      await updateDeepInterviewQuestionEnforcement(
+        cwd,
+        policy.sessionId,
+        () => directDeepInterviewObligation ?? undefined,
+      );
+      await markAutopilotDeepInterviewQuestionWaiting(
+        cwd,
+        policy.sessionId,
+        directDeepInterviewObligation,
+      );
+    }
   }
 
   const waitTimeoutMs = parseQuestionWaitTimeoutMs();

--- a/src/question/__tests__/deep-interview.test.ts
+++ b/src/question/__tests__/deep-interview.test.ts
@@ -359,6 +359,66 @@ describe('runDeepInterviewQuestion autopilot wait bridge', { concurrency: false 
     assert.equal(autopilotState.state?.deep_interview_question?.requested_at, '2026-04-19T00:00:00.000Z');
   });
 
+  it('fails terminally instead of replacing another pending Autopilot question owner', { concurrency: false }, async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di');
+    const autopilotPath = join(sessionDir, 'autopilot-state.json');
+    const deepInterviewPath = join(sessionDir, 'deep-interview-state.json');
+    await writeFile(autopilotPath, JSON.stringify({
+      active: true,
+      mode: 'autopilot',
+      current_phase: 'waiting-for-user',
+      run_outcome: 'blocked_on_user',
+      lifecycle_outcome: 'askuserQuestion',
+      session_id: 'sess-di',
+      state: {
+        deep_interview_question: {
+          status: 'waiting_for_user',
+          source: 'omx-question',
+          obligation_id: 'obligation-original',
+          previous_phase: 'deep-interview',
+          requested_at: '2026-04-19T00:00:00.000Z',
+        },
+      },
+    }, null, 2));
+    await writeFile(deepInterviewPath, JSON.stringify({
+      active: false,
+      mode: 'deep-interview',
+      session_id: 'sess-di',
+      question_enforcement: {
+        obligation_id: 'obligation-original',
+        source: 'omx-question',
+        status: 'pending',
+        lifecycle_outcome: 'askuserQuestion',
+        requested_at: '2026-04-19T00:00:00.000Z',
+      },
+    }, null, 2));
+
+    let runnerCalled = false;
+    await assert.rejects(
+      runDeepInterviewQuestion(
+        { session_id: 'sess-di', question: 'Clarify?', allow_other: true },
+        {
+          cwd,
+          argv1: '/repo/dist/cli/omx.js',
+          runner: async () => {
+            runnerCalled = true;
+            return { code: 1, stdout: '', stderr: '' };
+          },
+        },
+      ),
+      (error: unknown) => error instanceof OmxQuestionError
+        && error.code === 'active_execution_mode_blocked',
+    );
+
+    assert.equal(runnerCalled, false);
+    const deepInterviewState = JSON.parse(await readFile(deepInterviewPath, 'utf-8')) as {
+      question_enforcement?: { obligation_id?: string; status?: string };
+    };
+    assert.equal(deepInterviewState.question_enforcement?.obligation_id, 'obligation-original');
+    assert.equal(deepInterviewState.question_enforcement?.status, 'pending');
+  });
+
   it('persists readable autopilot waiting-for-user state while omx question is in flight and restores it after answer', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di');

--- a/src/question/__tests__/deep-interview.test.ts
+++ b/src/question/__tests__/deep-interview.test.ts
@@ -359,6 +359,56 @@ describe('runDeepInterviewQuestion autopilot wait bridge', { concurrency: false 
     assert.equal(autopilotState.state?.deep_interview_question?.requested_at, '2026-04-19T00:00:00.000Z');
   });
 
+  it('serializes concurrent Autopilot deep-interview question ownership claims', { concurrency: false }, async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di');
+    const autopilotPath = join(sessionDir, 'autopilot-state.json');
+    await writeFile(autopilotPath, JSON.stringify({
+      active: true,
+      mode: 'autopilot',
+      current_phase: 'deep-interview',
+      session_id: 'sess-di',
+      state: { deep_interview_gate: { status: 'required' } },
+    }, null, 2));
+
+    const obligations = Array.from({ length: 24 }, (_, index) => ({
+      obligation_id: `obligation-${index}`,
+      source: 'omx-question' as const,
+      status: 'pending' as const,
+      lifecycle_outcome: 'askuserQuestion' as const,
+      requested_at: `2026-04-19T00:00:${String(index).padStart(2, '0')}.000Z`,
+    }));
+
+    const results = await Promise.all(
+      obligations.map((obligation) => markAutopilotDeepInterviewQuestionWaiting(
+        cwd,
+        'sess-di',
+        obligation,
+      )),
+    );
+
+    assert.equal(results.filter(Boolean).length, 1);
+    const winningObligationIds = obligations
+      .filter((_, index) => results[index])
+      .map((obligation) => obligation.obligation_id);
+    assert.equal(winningObligationIds.length, 1);
+
+    const autopilotState = JSON.parse(await readFile(autopilotPath, 'utf-8')) as {
+      current_phase?: string;
+      run_outcome?: string;
+      lifecycle_outcome?: string;
+      state?: { deep_interview_question?: { obligation_id?: string; status?: string } };
+    };
+    assert.equal(autopilotState.current_phase, 'waiting-for-user');
+    assert.equal(autopilotState.run_outcome, 'blocked_on_user');
+    assert.equal(autopilotState.lifecycle_outcome, 'askuserQuestion');
+    assert.equal(autopilotState.state?.deep_interview_question?.status, 'waiting_for_user');
+    assert.equal(
+      autopilotState.state?.deep_interview_question?.obligation_id,
+      winningObligationIds[0],
+    );
+  });
+
   it('fails terminally instead of replacing another pending Autopilot question owner', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di');

--- a/src/question/__tests__/deep-interview.test.ts
+++ b/src/question/__tests__/deep-interview.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, describe, it } from 'node:test';
 import { OmxQuestionError, type OmxQuestionProcessRunner } from '../client.js';
-import { readAutopilotDeepInterviewQuestionWaitState } from '../autopilot-wait.js';
+import {
+  markAutopilotDeepInterviewQuestionWaiting,
+  readAutopilotDeepInterviewQuestionWaitState,
+} from '../autopilot-wait.js';
 import {
   reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords,
   runDeepInterviewQuestion,
@@ -317,6 +320,44 @@ describe('runDeepInterviewQuestion', { concurrency: false }, () => {
 });
 
 describe('runDeepInterviewQuestion autopilot wait bridge', { concurrency: false }, () => {
+  it('does not overwrite an already pending Autopilot deep-interview question', { concurrency: false }, async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di');
+    const autopilotPath = join(sessionDir, 'autopilot-state.json');
+    await writeFile(autopilotPath, JSON.stringify({
+      active: true,
+      mode: 'autopilot',
+      current_phase: 'waiting-for-user',
+      run_outcome: 'blocked_on_user',
+      lifecycle_outcome: 'askuserQuestion',
+      session_id: 'sess-di',
+      state: {
+        deep_interview_question: {
+          status: 'waiting_for_user',
+          source: 'omx-question',
+          obligation_id: 'obligation-original',
+          previous_phase: 'deep-interview',
+          requested_at: '2026-04-19T00:00:00.000Z',
+        },
+      },
+    }, null, 2));
+
+    const started = await markAutopilotDeepInterviewQuestionWaiting(cwd, 'sess-di', {
+      obligation_id: 'obligation-new',
+      source: 'omx-question',
+      status: 'pending',
+      lifecycle_outcome: 'askuserQuestion',
+      requested_at: '2026-04-19T00:01:00.000Z',
+    });
+
+    assert.equal(started, false);
+    const autopilotState = JSON.parse(await readFile(autopilotPath, 'utf-8')) as {
+      state?: { deep_interview_question?: { obligation_id?: string; requested_at?: string } };
+    };
+    assert.equal(autopilotState.state?.deep_interview_question?.obligation_id, 'obligation-original');
+    assert.equal(autopilotState.state?.deep_interview_question?.requested_at, '2026-04-19T00:00:00.000Z');
+  });
+
   it('persists readable autopilot waiting-for-user state while omx question is in flight and restores it after answer', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di');

--- a/src/question/__tests__/deep-interview.test.ts
+++ b/src/question/__tests__/deep-interview.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { after, describe, it } from 'node:test';
 import { OmxQuestionError, type OmxQuestionProcessRunner } from '../client.js';
 import {
+  AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV,
   markAutopilotDeepInterviewQuestionWaiting,
   readAutopilotDeepInterviewQuestionWaitState,
 } from '../autopilot-wait.js';
@@ -373,10 +374,14 @@ describe('runDeepInterviewQuestion autopilot wait bridge', { concurrency: false 
     }, null, 2));
 
     let observedWait = false;
-    const runner: OmxQuestionProcessRunner = async () => {
+    const runner: OmxQuestionProcessRunner = async (_command, _args, runnerOptions) => {
       const waitState = await readAutopilotDeepInterviewQuestionWaitState(cwd, 'sess-di');
       assert.ok(waitState);
       assert.equal(waitState.previousPhase, 'deep-interview');
+      assert.equal(
+        runnerOptions.env[AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV],
+        waitState.obligationId,
+      );
       const autopilotState = JSON.parse(await readFile(autopilotPath, 'utf-8')) as {
         active?: boolean;
         current_phase?: string;

--- a/src/question/__tests__/policy.test.ts
+++ b/src/question/__tests__/policy.test.ts
@@ -164,7 +164,7 @@ describe('evaluateQuestionPolicy autopilot deep-interview wait', { concurrency: 
     assert.equal(unrelatedSource.code, 'active_execution_mode_blocked');
   });
 
-  it('allows only controlled autopilot deep-interview questions while preserving unrelated guards', { concurrency: false }, async () => {
+  it('blocks duplicate deep-interview questions while autopilot is already waiting', { concurrency: false }, async () => {
     const cwd = await makeRepo();
     const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-auto');
     await mkdir(sessionDir, { recursive: true });
@@ -192,13 +192,14 @@ describe('evaluateQuestionPolicy autopilot deep-interview wait', { concurrency: 
     }, null, 2));
 
     await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess-auto' }));
-    const allowed = await evaluateQuestionPolicy({
+    const duplicateQuestion = await evaluateQuestionPolicy({
       cwd,
       explicitSessionId: 'sess-auto',
       questionSource: 'deep-interview',
       env: { ...process.env, OMX_TEAM_WORKER: '' },
     });
-    assert.equal(allowed.allowed, true);
+    assert.equal(duplicateQuestion.allowed, false);
+    assert.equal(duplicateQuestion.code, 'active_execution_mode_blocked');
 
     const unrelatedSource = await evaluateQuestionPolicy({
       cwd,

--- a/src/question/__tests__/policy.test.ts
+++ b/src/question/__tests__/policy.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, describe, it } from 'node:test';
+import { AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV } from '../autopilot-wait.js';
 import { evaluateQuestionPolicy } from '../policy.js';
 
 const tempDirs: string[] = [];
@@ -200,6 +201,31 @@ describe('evaluateQuestionPolicy autopilot deep-interview wait', { concurrency: 
     });
     assert.equal(duplicateQuestion.allowed, false);
     assert.equal(duplicateQuestion.code, 'active_execution_mode_blocked');
+
+    const owningQuestion = await evaluateQuestionPolicy({
+      cwd,
+      explicitSessionId: 'sess-auto',
+      questionSource: 'deep-interview',
+      env: {
+        ...process.env,
+        OMX_TEAM_WORKER: '',
+        [AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV]: 'obligation-1',
+      },
+    });
+    assert.equal(owningQuestion.allowed, true);
+
+    const wrongOwnerQuestion = await evaluateQuestionPolicy({
+      cwd,
+      explicitSessionId: 'sess-auto',
+      questionSource: 'deep-interview',
+      env: {
+        ...process.env,
+        OMX_TEAM_WORKER: '',
+        [AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV]: 'obligation-other',
+      },
+    });
+    assert.equal(wrongOwnerQuestion.allowed, false);
+    assert.equal(wrongOwnerQuestion.code, 'active_execution_mode_blocked');
 
     const unrelatedSource = await evaluateQuestionPolicy({
       cwd,

--- a/src/question/autopilot-wait.ts
+++ b/src/question/autopilot-wait.ts
@@ -9,6 +9,8 @@ import { getStateFilePath } from '../mcp/state-paths.js';
 import type { DeepInterviewQuestionEnforcementState } from './deep-interview.js';
 
 const AUTOPILOT_STATE_FILE = 'autopilot-state.json';
+export const AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV =
+  'OMX_AUTOPILOT_DEEP_INTERVIEW_QUESTION_OBLIGATION_ID';
 
 export interface AutopilotDeepInterviewQuestionWaitState {
   obligationId: string;
@@ -77,11 +79,17 @@ export async function readAutopilotDeepInterviewQuestionWaitState(
 export async function canStartAutopilotDeepInterviewQuestion(
   cwd: string,
   sessionId?: string,
+  options: { ownerObligationId?: string } = {},
 ): Promise<boolean> {
   const state = await readAutopilotState(cwd, sessionId);
   if (!isAutopilotSupervisingChild(state, 'deep-interview')) return false;
   const nestedState = safeObject(state?.state);
-  return !isPendingAutopilotQuestionWait(safeObject(nestedState.deep_interview_question));
+  const wait = safeObject(nestedState.deep_interview_question);
+  if (!isPendingAutopilotQuestionWait(wait)) return true;
+
+  const ownerObligationId = safeString(options.ownerObligationId);
+  return ownerObligationId.length > 0
+    && safeString(wait.obligation_id) === ownerObligationId;
 }
 
 export async function markAutopilotDeepInterviewQuestionWaiting(

--- a/src/question/autopilot-wait.ts
+++ b/src/question/autopilot-wait.ts
@@ -1,14 +1,17 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import {
   deriveAutopilotChildPhase,
   isAutopilotSupervisingChild,
   normalizeAutopilotPhase,
 } from '../autopilot/fsm.js';
 import { getStateFilePath } from '../mcp/state-paths.js';
+import { sleep } from '../utils/sleep.js';
 import type { DeepInterviewQuestionEnforcementState } from './deep-interview.js';
 
 const AUTOPILOT_STATE_FILE = 'autopilot-state.json';
+const AUTOPILOT_QUESTION_WAIT_LOCK_STALE_MS = 30_000;
+const AUTOPILOT_QUESTION_WAIT_LOCK_TIMEOUT_MS = 10_000;
 export const AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV =
   'OMX_AUTOPILOT_DEEP_INTERVIEW_QUESTION_OBLIGATION_ID';
 
@@ -45,6 +48,66 @@ async function writeAutopilotState(cwd: string, sessionId: string | undefined, s
   const statePath = getStateFilePath(AUTOPILOT_STATE_FILE, cwd, sessionId);
   await mkdir(dirname(statePath), { recursive: true });
   await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function lockOwnerToken(): string {
+  return `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+}
+
+async function maybeRecoverStaleAutopilotQuestionWaitLock(lockDir: string): Promise<boolean> {
+  try {
+    const info = await stat(lockDir);
+    if (Date.now() - info.mtimeMs > AUTOPILOT_QUESTION_WAIT_LOCK_STALE_MS) {
+      await rm(lockDir, { recursive: true, force: true });
+      return true;
+    }
+  } catch {
+  }
+  return false;
+}
+
+async function withAutopilotQuestionWaitLock<T>(
+  cwd: string,
+  sessionId: string,
+  fn: () => Promise<T>,
+  onTimeout: () => Promise<T> | T,
+): Promise<T> {
+  const statePath = getStateFilePath(AUTOPILOT_STATE_FILE, cwd, sessionId);
+  const lockDir = `${statePath}.deep-interview-question.lock`;
+  const ownerPath = join(lockDir, 'owner');
+  const ownerToken = lockOwnerToken();
+  const deadline = Date.now() + AUTOPILOT_QUESTION_WAIT_LOCK_TIMEOUT_MS;
+  await mkdir(dirname(lockDir), { recursive: true });
+  while (true) {
+    try {
+      await mkdir(lockDir);
+      try {
+        await writeFile(ownerPath, ownerToken, 'utf8');
+      } catch (error) {
+        await rm(lockDir, { recursive: true, force: true });
+        throw error;
+      }
+      break;
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code !== 'EEXIST') throw error;
+      if (await maybeRecoverStaleAutopilotQuestionWaitLock(lockDir)) continue;
+      if (Date.now() > deadline) return await onTimeout();
+      await sleep(25);
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    try {
+      const currentOwner = await readFile(ownerPath, 'utf8');
+      if (currentOwner.trim() === ownerToken) {
+        await rm(lockDir, { recursive: true, force: true });
+      }
+    } catch {
+    }
+  }
 }
 
 export async function readAutopilotDeepInterviewQuestionWaitState(
@@ -97,42 +160,50 @@ export async function markAutopilotDeepInterviewQuestionWaiting(
   sessionId: string | undefined,
   obligation: DeepInterviewQuestionEnforcementState,
 ): Promise<boolean> {
-  if (!safeString(sessionId)) return false;
-  const state = await readAutopilotState(cwd, sessionId);
-  if (!state || safeString(state.mode) !== 'autopilot' || state.active !== true) return false;
+  const normalizedSessionId = safeString(sessionId);
+  if (!normalizedSessionId) return false;
+  return await withAutopilotQuestionWaitLock(
+    cwd,
+    normalizedSessionId,
+    async () => {
+      const state = await readAutopilotState(cwd, normalizedSessionId);
+      if (!state || safeString(state.mode) !== 'autopilot' || state.active !== true) return false;
 
-  if (!isAutopilotSupervisingChild(state, 'deep-interview')) return false;
-  const currentPhase = normalizeAutopilotPhase(state.current_phase) || 'deep-interview';
+      if (!isAutopilotSupervisingChild(state, 'deep-interview')) return false;
+      const currentPhase = normalizeAutopilotPhase(state.current_phase) || 'deep-interview';
 
-  const nestedState = safeObject(state.state);
-  if (isPendingAutopilotQuestionWait(safeObject(nestedState.deep_interview_question))) return false;
+      const nestedState = safeObject(state.state);
+      if (isPendingAutopilotQuestionWait(safeObject(nestedState.deep_interview_question))) return false;
 
-  const wait = {
-    status: 'waiting_for_user',
-    source: 'omx-question',
-    obligation_id: obligation.obligation_id,
-    previous_phase: currentPhase,
-    previous_run_outcome: state.run_outcome ?? null,
-    previous_lifecycle_outcome: state.lifecycle_outcome ?? null,
-    requested_at: obligation.requested_at,
-    updated_at: new Date().toISOString(),
-  };
+      const wait = {
+        status: 'waiting_for_user',
+        source: 'omx-question',
+        obligation_id: obligation.obligation_id,
+        previous_phase: currentPhase,
+        previous_run_outcome: state.run_outcome ?? null,
+        previous_lifecycle_outcome: state.lifecycle_outcome ?? null,
+        requested_at: obligation.requested_at,
+        updated_at: new Date().toISOString(),
+      };
 
-  const nextState = {
-    ...state,
-    active: true,
-    current_phase: 'waiting-for-user',
-    run_outcome: 'blocked_on_user',
-    lifecycle_outcome: 'askuserQuestion',
-    updated_at: new Date().toISOString(),
-    state: {
-      ...nestedState,
-      deep_interview_question: wait,
+      const nextState = {
+        ...state,
+        active: true,
+        current_phase: 'waiting-for-user',
+        run_outcome: 'blocked_on_user',
+        lifecycle_outcome: 'askuserQuestion',
+        updated_at: new Date().toISOString(),
+        state: {
+          ...nestedState,
+          deep_interview_question: wait,
+        },
+      };
+
+      await writeAutopilotState(cwd, normalizedSessionId, nextState);
+      return true;
     },
-  };
-
-  await writeAutopilotState(cwd, sessionId, nextState);
-  return true;
+    () => false,
+  );
 }
 
 export async function resolveAutopilotDeepInterviewQuestionWaiting(

--- a/src/question/autopilot-wait.ts
+++ b/src/question/autopilot-wait.ts
@@ -24,6 +24,12 @@ function safeObject(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' ? value as Record<string, unknown> : {};
 }
 
+function isPendingAutopilotQuestionWait(wait: Record<string, unknown>): boolean {
+  return safeString(wait.status) === 'waiting_for_user'
+    && safeString(wait.source) === 'omx-question'
+    && safeString(wait.obligation_id).length > 0;
+}
+
 async function readAutopilotState(cwd: string, sessionId?: string): Promise<Record<string, unknown> | null> {
   const statePath = getStateFilePath(AUTOPILOT_STATE_FILE, cwd, sessionId);
   try {
@@ -50,8 +56,7 @@ export async function readAutopilotDeepInterviewQuestionWaitState(
   const wait = safeObject(nestedState.deep_interview_question);
   const obligationId = safeString(wait.obligation_id);
   if (!obligationId) return null;
-  if (safeString(wait.status) !== 'waiting_for_user') return null;
-  if (safeString(wait.source) !== 'omx-question') return null;
+  if (!isPendingAutopilotQuestionWait(wait)) return null;
 
   const phase = normalizeAutopilotPhase(state.current_phase);
   const runOutcome = safeString(state.run_outcome);
@@ -74,7 +79,9 @@ export async function canStartAutopilotDeepInterviewQuestion(
   sessionId?: string,
 ): Promise<boolean> {
   const state = await readAutopilotState(cwd, sessionId);
-  return isAutopilotSupervisingChild(state, 'deep-interview');
+  if (!isAutopilotSupervisingChild(state, 'deep-interview')) return false;
+  const nestedState = safeObject(state?.state);
+  return !isPendingAutopilotQuestionWait(safeObject(nestedState.deep_interview_question));
 }
 
 export async function markAutopilotDeepInterviewQuestionWaiting(
@@ -90,6 +97,8 @@ export async function markAutopilotDeepInterviewQuestionWaiting(
   const currentPhase = normalizeAutopilotPhase(state.current_phase) || 'deep-interview';
 
   const nestedState = safeObject(state.state);
+  if (isPendingAutopilotQuestionWait(safeObject(nestedState.deep_interview_question))) return false;
+
   const wait = {
     status: 'waiting_for_user',
     source: 'omx-question',

--- a/src/question/deep-interview.ts
+++ b/src/question/deep-interview.ts
@@ -285,12 +285,19 @@ export async function runDeepInterviewQuestion(
     );
   }
 
+  const autopilotWaitStarted = await markAutopilotDeepInterviewQuestionWaiting(cwd, sessionId, obligation);
+  if (!autopilotWaitStarted && await readAutopilotDeepInterviewQuestionWaitState(cwd, sessionId)) {
+    throw new OmxQuestionError(
+      'active_execution_mode_blocked',
+      'Autopilot already has a pending deep-interview question.',
+    );
+  }
+
   await updateDeepInterviewQuestionEnforcement(
     cwd,
     sessionId,
     () => obligation,
   );
-  const autopilotWaitStarted = await markAutopilotDeepInterviewQuestionWaiting(cwd, sessionId, obligation);
 
   try {
     const result = await runOmxQuestion(

--- a/src/question/deep-interview.ts
+++ b/src/question/deep-interview.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { getStateFilePath, readCurrentSessionId } from '../mcp/state-paths.js';
 import {
+  OmxQuestionError,
   runOmxQuestion,
   type OmxQuestionClientOptions,
   type OmxQuestionSuccessPayload,
@@ -15,7 +16,9 @@ import type { TerminalLifecycleOutcome } from '../runtime/terminal-lifecycle.js'
 import type { QuestionInput, QuestionRecord } from './types.js';
 import type { DownstreamAuthority } from '../state/workflow-transition.js';
 import {
+  AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV,
   markAutopilotDeepInterviewQuestionWaiting,
+  readAutopilotDeepInterviewQuestionWaitState,
   resolveAutopilotDeepInterviewQuestionWaiting,
 } from './autopilot-wait.js';
 
@@ -273,13 +276,21 @@ export async function runDeepInterviewQuestion(
   const cwd = options.cwd ?? process.cwd();
   const sessionId = safeString(input.session_id).trim() || await readCurrentSessionId(cwd);
   const obligation = createDeepInterviewQuestionObligation();
+  const existingAutopilotWait = await readAutopilotDeepInterviewQuestionWaitState(cwd, sessionId);
+
+  if (existingAutopilotWait) {
+    throw new OmxQuestionError(
+      'active_execution_mode_blocked',
+      'Autopilot already has a pending deep-interview question.',
+    );
+  }
 
   await updateDeepInterviewQuestionEnforcement(
     cwd,
     sessionId,
     () => obligation,
   );
-  await markAutopilotDeepInterviewQuestionWaiting(cwd, sessionId, obligation);
+  const autopilotWaitStarted = await markAutopilotDeepInterviewQuestionWaiting(cwd, sessionId, obligation);
 
   try {
     const result = await runOmxQuestion(
@@ -288,7 +299,15 @@ export async function runDeepInterviewQuestion(
         source: input.source ?? 'deep-interview',
         ...(sessionId ? { session_id: sessionId } : {}),
       },
-      options,
+      autopilotWaitStarted
+        ? {
+            ...options,
+            env: {
+              ...(options.env ?? process.env),
+              [AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV]: obligation.obligation_id,
+            },
+          }
+        : options,
     );
 
     await updateDeepInterviewQuestionEnforcement(

--- a/src/question/policy.ts
+++ b/src/question/policy.ts
@@ -2,7 +2,10 @@ import { listNotifyCanonicalActiveTeams, type NotifyCanonicalActiveTeam } from '
 import { readCurrentSessionId } from '../mcp/state-paths.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import { readActiveWorkflowModes } from '../state/workflow-transition.js';
-import { canStartAutopilotDeepInterviewQuestion } from './autopilot-wait.js';
+import {
+  AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV,
+  canStartAutopilotDeepInterviewQuestion,
+} from './autopilot-wait.js';
 
 const BLOCKED_EXECUTION_SKILLS = new Set([
   'autopilot',
@@ -91,7 +94,11 @@ export async function evaluateQuestionPolicy(
   if (blocked.length > 0) {
     const source = safeString(options.questionSource).trim();
     if (source === 'deep-interview' && onlyControlledAutopilotQuestionBlock(blocked)) {
-      const canStartAutopilotQuestion = await canStartAutopilotDeepInterviewQuestion(options.cwd, sessionId);
+      const canStartAutopilotQuestion = await canStartAutopilotDeepInterviewQuestion(
+        options.cwd,
+        sessionId,
+        { ownerObligationId: env[AUTOPILOT_DEEP_INTERVIEW_QUESTION_OWNER_ENV] },
+      );
       if (canStartAutopilotQuestion) {
         return {
           allowed: true,

--- a/src/question/policy.ts
+++ b/src/question/policy.ts
@@ -2,10 +2,7 @@ import { listNotifyCanonicalActiveTeams, type NotifyCanonicalActiveTeam } from '
 import { readCurrentSessionId } from '../mcp/state-paths.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import { readActiveWorkflowModes } from '../state/workflow-transition.js';
-import {
-  canStartAutopilotDeepInterviewQuestion,
-  readAutopilotDeepInterviewQuestionWaitState,
-} from './autopilot-wait.js';
+import { canStartAutopilotDeepInterviewQuestion } from './autopilot-wait.js';
 
 const BLOCKED_EXECUTION_SKILLS = new Set([
   'autopilot',
@@ -94,13 +91,7 @@ export async function evaluateQuestionPolicy(
   if (blocked.length > 0) {
     const source = safeString(options.questionSource).trim();
     if (source === 'deep-interview' && onlyControlledAutopilotQuestionBlock(blocked)) {
-      const autopilotWait = await readAutopilotDeepInterviewQuestionWaitState(
-        options.cwd,
-        sessionId,
-      );
-      const canStartAutopilotQuestion = autopilotWait
-        ? true
-        : await canStartAutopilotDeepInterviewQuestion(options.cwd, sessionId);
+      const canStartAutopilotQuestion = await canStartAutopilotDeepInterviewQuestion(options.cwd, sessionId);
       if (canStartAutopilotQuestion) {
         return {
           allowed: true,

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -756,6 +756,21 @@ exit 1
       const t = await createTask('team-owner-write-fail', { subject: 'a', description: 'd', status: 'pending' }, cwd);
 
       previousUmask = process.umask(0o222);
+      const probeDir = join(cwd, 'claim-lock-permission-probe');
+      await mkdir(probeDir);
+      try {
+        await writeFile(join(probeDir, 'owner'), 'probe');
+        // Root and some permissive filesystems can still write through the
+        // umask-created non-writable directory, so this failure mode cannot be
+        // exercised deterministically in that environment.
+        return;
+      } catch {
+        // Expected on normal non-root POSIX filesystems; continue with the
+        // claim-lock cleanup assertion below.
+      } finally {
+        await rm(probeDir, { recursive: true, force: true });
+      }
+
       await assert.rejects(
         () => claimTask('team-owner-write-fail', t.id, 'worker-1', t.version ?? 1, cwd),
         /(EACCES|EPERM|permission denied)/i,


### PR DESCRIPTION
Follow-up for current #2588 head `343778e3ab`.

Addresses:
- Code Review P2: prevent duplicate deep-interview `omx question` launches from overwriting an existing Autopilot `waiting-for-user` question obligation.
- CI failure in `Test (Node 20 / team-state-runtime)`: root/permissive environments can write through the umask-based permission probe, so the claim-lock cleanup regression now first checks whether that permission failure can be exercised deterministically.

Validation:
- `npm run build`
- `npm run lint`
- `node --test dist/team/__tests__/state.test.js dist/question/__tests__/policy.test.js dist/question/__tests__/deep-interview.test.js dist/cli/__tests__/question.test.js` (104 pass)
- clean-env rerun of the same tests (104 pass)
- `git diff --check`

Not run: full GitHub CI matrix on this follow-up branch.