### PR TITLE
Fix duplicate HUD panes in attached tmux

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3127,12 +3127,15 @@ describe("detached tmux new-session sequencing", () => {
     assert.doesNotMatch(argsText, /fake-provider-key/);
   });
 
-  it("runCodex coalesces stale same-leader HUD panes across session ids", async () => {
+  it("runCodex coalesces stale same-leader HUD panes across session ids and reuses a keeper", async () => {
     const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
       /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\)\s*: \[\];/,
     );
+    assert.match(source, /const \[keeperHudPaneId, \.\.\.duplicateHudPaneIds\] = staleHudPaneIds;/);
+    assert.match(source, /for \(const paneId of duplicateHudPaneIds\) \{\s*killTmuxPane\(paneId\);\s*\}/);
+    assert.match(source, /if \(keeperHudPaneId\) \{\s*hudPaneId = keeperHudPaneId;/);
     assert.doesNotMatch(
       source,
       /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\);/,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -128,6 +128,7 @@ import { cleanCodexModelAvailabilityNuxIfNeeded, extractSharedMcpRegistryServers
 import type { UnifiedMcpRegistryServer } from "../config/mcp-registry.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
+import { readUltragoalState } from "../hud/state.js";
 import { OMX_TMUX_HUD_OWNER_ENV } from "../hud/reconcile.js";
 import {
   createHudWatchPane as createSharedHudWatchPane,
@@ -138,6 +139,7 @@ import {
   parsePaneIdFromTmuxOutput,
   reapDeadHudPanes,
   registerHudResizeHook,
+  resizeTmuxPane,
 } from "../hud/tmux.js";
 
 export { parseTmuxPaneSnapshot, isHudWatchPane, findHudWatchPaneIds } from "../hud/tmux.js";
@@ -1844,7 +1846,12 @@ async function showStatus(): Promise<void> {
   try {
     const refs = await listModeStateFilesWithScopePreference(cwd);
     const states = refs.map((ref) => ref.path);
+    const ultragoalState = await readUltragoalState(cwd).catch(() => null);
     if (states.length === 0) {
+      if (ultragoalState?.active) {
+        console.log(`ultragoal: ACTIVE (phase: ${ultragoalState.status})`);
+        return;
+      }
       console.log("No active modes.");
       return;
     }
@@ -1859,9 +1866,13 @@ async function showStatus(): Promise<void> {
       }
       const file = basename(path);
       const mode = file.replace("-state.json", "");
+      if (mode === "ultragoal" && ultragoalState?.active) continue;
       console.log(
         `${mode}: ${state.active === true ? "ACTIVE" : "inactive"} (phase: ${String(state.current_phase || "n/a")})`,
       );
+    }
+    if (ultragoalState?.active) {
+      console.log(`ultragoal: ACTIVE (phase: ${ultragoalState.status})`);
     }
   } catch (err) {
     logCliOperationFailure(err);
@@ -4085,22 +4096,36 @@ function runCodex(
     const staleHudPaneIds = currentPaneId
       ? listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId })
       : [];
-    for (const paneId of staleHudPaneIds) {
+
+    let hudPaneId: string | null = null;
+    const [keeperHudPaneId, ...duplicateHudPaneIds] = staleHudPaneIds;
+    for (const paneId of duplicateHudPaneIds) {
       killTmuxPane(paneId);
     }
 
-    let hudPaneId: string | null = null;
-    try {
-      hudPaneId = createHudWatchPane(cwd, hudCmd, {
-        heightLines: HUD_TMUX_HEIGHT_LINES,
-        targetPaneId: currentPaneId,
-      });
-      if (hudPaneId && currentPaneId) {
-        registerHudResizeHook(hudPaneId, currentPaneId, HUD_TMUX_HEIGHT_LINES);
+    if (keeperHudPaneId) {
+      hudPaneId = keeperHudPaneId;
+      try {
+        resizeTmuxPane(hudPaneId, HUD_TMUX_HEIGHT_LINES);
+        if (currentPaneId) {
+          registerHudResizeHook(hudPaneId, currentPaneId, HUD_TMUX_HEIGHT_LINES);
+        }
+      } catch (err) {
+        logCliOperationFailure(err);
       }
-    } catch (err) {
-      logCliOperationFailure(err);
-      // HUD split failed, continue without it
+    } else {
+      try {
+        hudPaneId = createHudWatchPane(cwd, hudCmd, {
+          heightLines: HUD_TMUX_HEIGHT_LINES,
+          targetPaneId: currentPaneId,
+        });
+        if (hudPaneId && currentPaneId) {
+          registerHudResizeHook(hudPaneId, currentPaneId, HUD_TMUX_HEIGHT_LINES);
+        }
+      } catch (err) {
+        logCliOperationFailure(err);
+        // HUD split failed, continue without it
+      }
     }
 
     // Enable mouse scrolling at session start so scroll works before team

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -547,6 +547,67 @@ describe('runWatchMode', () => {
 });
 
 describe('hudCommand --tmux', () => {
+  it('removes duplicate same-leader HUD panes and reuses one when launched with --tmux', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'omx-hud-tmux-duplicate-test-'));
+    const logPath = join(tmp, 'tmux.log');
+    const fakeBin = join(tmp, 'bin');
+    await mkdir(fakeBin);
+    const tmuxPath = join(fakeBin, 'tmux');
+    await writeFile(tmuxPath, `#!/usr/bin/env bash
+printf '%s\n' "$*" >> ${JSON.stringify(logPath)}
+if [[ "$1" == "display-message" && "$*" == *'#{session_id}'* ]]; then
+  printf '$7\t@3\n'
+  exit 0
+fi
+if [[ "$1" == "list-panes" ]]; then
+  printf '%s\n' '%1	zsh	zsh'
+  printf '%s\n' "%2	node	exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch"
+  printf '%s\n' "%3	node	exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch"
+  exit 0
+fi
+if [[ "$1" == "resize-pane" || "$1" == "set-hook" || "$1" == "kill-pane" ]]; then
+  exit 0
+fi
+if [[ "$1" == "split-window" ]]; then
+  echo '%9'
+  exit 0
+fi
+exit 0
+`);
+    await chmod(tmuxPath, 0o755);
+
+    const previousEnv = {
+      PATH: process.env.PATH,
+      TMUX: process.env.TMUX,
+      TMUX_PANE: process.env.TMUX_PANE,
+      OMX_SESSION_ID: process.env.OMX_SESSION_ID,
+    };
+    const previousLog = console.log;
+    const logs: string[] = [];
+    try {
+      process.env.PATH = `${fakeBin}${delimiter}${process.env.PATH ?? ''}`;
+      process.env.TMUX = '/tmp/tmux-1000/default,12345,0';
+      process.env.TMUX_PANE = '%1';
+      process.env.OMX_SESSION_ID = 'sess-a';
+      console.log = (message?: unknown) => { logs.push(String(message ?? '')); };
+
+      await hudCommand(['--tmux']);
+
+      const tmuxLog = await readFile(logPath, 'utf8');
+      assert.match(tmuxLog, /list-panes -t %1 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}/);
+      assert.match(tmuxLog, /kill-pane -t %3/);
+      assert.match(tmuxLog, /resize-pane -t %2 -y \d+/);
+      assert.doesNotMatch(tmuxLog, /split-window/);
+      assert.ok(logs.some((line) => line.includes('Removed duplicate HUD panes and reused existing HUD pane')));
+    } finally {
+      console.log = previousLog;
+      for (const [key, value] of Object.entries(previousEnv)) {
+        if (typeof value === 'string') process.env[key] = value;
+        else delete process.env[key];
+      }
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
   it('reuses a same-session HUD pane when TMUX_PANE is empty instead of splitting a duplicate', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'omx-hud-tmux-test-'));
     const logPath = join(tmp, 'tmux.log');

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -176,8 +176,9 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(created[0]?.options?.targetPaneId, '%leader');
   });
 
-  it('kills duplicate HUD panes and recreates one full-width pane', async () => {
+  it('kills duplicate HUD panes and reuses one existing pane', async () => {
     const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
     const created: Array<{ cmd: string }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
@@ -200,20 +201,22 @@ describe('reconcileHudForPromptSubmit', () => {
         killed.push(paneId);
         return true;
       },
-      createHudWatchPane: (_cwd, cmd, options) => {
+      createHudWatchPane: (_cwd, cmd) => {
         created.push({ cmd });
-        assert.equal(options?.fullWidth, true);
-        assert.equal(options?.heightLines, HUD_TMUX_HEIGHT_LINES);
         return '%9';
       },
-      resizeTmuxPane: () => true,
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
     assert.equal(result.status, 'replaced_duplicates');
-    assert.deepEqual(killed, ['%2', '%3']);
-    assert.match(created[0]?.cmd || '', /OMX_SESSION_ID='sess-a'/);
-    assert.match(created[0]?.cmd || '', /OMX_TMUX_HUD_OWNER='1'/);
+    assert.equal(result.paneId, '%2');
+    assert.deepEqual(killed, ['%3']);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+    assert.deepEqual(created, []);
   });
 
   it('does not resize, kill, or reuse another active leader session HUD in the same tmux window', async () => {
@@ -289,7 +292,62 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     assert.equal(result.status, 'replaced_duplicates');
-    assert.deepEqual(killed, ['%2', '%3']);
+    assert.equal(result.paneId, '%2');
+    assert.deepEqual(killed, ['%3']);
+  });
+
+  it('deduplicates same-leader node HUD panes while preserving active ultragoal height despite empty mode state', async () => {
+    const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    const created: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'zsh', startCommand: 'zsh' },
+        { paneId: '%2', currentCommand: 'node', startCommand: `exec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch` },
+        { paneId: '%3', currentCommand: 'node', startCommand: `exec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch` },
+      ],
+      readHudConfig: async () => ({ preset: 'focused', git: { display: 'branch' }, statusLine: { preset: 'focused' } }),
+      readAllState: async () => ({
+        version: null,
+        gitBranch: null,
+        ralph: null,
+        ultragoal: {
+          active: true,
+          status: 'in_progress',
+          total: 1,
+          complete: 0,
+          pending: 0,
+          inProgress: 1,
+          failed: 0,
+          reviewBlocked: 0,
+          needsUserDecision: 0,
+          progressTotal: 1,
+        },
+        ultrawork: null,
+        autopilot: null,
+        ralplan: null,
+        deepInterview: null,
+        autoresearch: null,
+        ultraqa: null,
+        team: null,
+        metrics: null,
+        hudNotify: null,
+        session: null,
+      }),
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
+      createHudWatchPane: () => { created.push('create'); return '%9'; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.paneId, '%2');
+    assert.equal(result.duplicateCount, 1);
+    assert.deepEqual(killed, ['%3']);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_ULTRAGOAL_HEIGHT_LINES }]);
+    assert.deepEqual(created, []);
   });
 
   it('resizes an existing single HUD pane instead of recreating it', async () => {
@@ -507,7 +565,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(registered[0]?.heightLines, HUD_TMUX_HEIGHT_LINES);
   });
 
-  it('unregisters existing hook before killing duplicates and re-registers for the new pane', async () => {
+  it('keeps the resize hook on the reused duplicate keeper pane', async () => {
     const unregistered: Array<string | undefined> = [];
     const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined }> = [];
 
@@ -526,10 +584,9 @@ describe('reconcileHudForPromptSubmit', () => {
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
-    assert.equal(unregistered.length, 1);
-    assert.equal(unregistered[0], '%1');
+    assert.deepEqual(unregistered, []);
     assert.equal(registered.length, 1);
-    assert.equal(registered[0]?.hudPaneId, '%9');
+    assert.equal(registered[0]?.hudPaneId, '%2');
     assert.equal(registered[0]?.currentPaneId, '%1');
   });
 });

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -398,17 +398,20 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
         leaderPaneId: currentPaneId,
       })
     : [];
-  if (existingHudPaneIds.length === 1) {
+  if (existingHudPaneIds.length >= 1) {
+    const [keeperPaneId, ...duplicatePaneIds] = existingHudPaneIds;
+    for (const paneId of duplicatePaneIds) {
+      killTmuxPane(paneId);
+    }
     const config = await readHudConfig(cwd);
     const ctx = await readAllState(cwd, config);
     const desiredHeight = getHudRenderMaxLines(ctx);
-    resizeTmuxPane(existingHudPaneIds[0], desiredHeight);
-    if (currentPaneId) registerHudResizeHook(existingHudPaneIds[0], currentPaneId, desiredHeight);
-    console.log('HUD already running in tmux pane. Reused existing HUD pane.');
+    resizeTmuxPane(keeperPaneId, desiredHeight);
+    if (currentPaneId) registerHudResizeHook(keeperPaneId, currentPaneId, desiredHeight);
+    console.log(duplicatePaneIds.length > 0
+      ? 'HUD already running in tmux pane. Removed duplicate HUD panes and reused existing HUD pane.'
+      : 'HUD already running in tmux pane. Reused existing HUD pane.');
     return;
-  }
-  for (const paneId of existingHudPaneIds) {
-    killTmuxPane(paneId);
   }
 
   const config = await readHudConfig(cwd);

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -134,7 +134,7 @@ export async function reconcileHudForPromptSubmit(
     };
   }
 
-  if (hudPaneIds.length > 1 && !resolvedSessionId) {
+  if (hudPaneIds.length > 1) {
     const [keeperPaneId, ...extraPaneIds] = hudPaneIds;
     for (const paneId of extraPaneIds) {
       killPane(paneId);

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -123,6 +123,86 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('surfaces active ultragoal artifacts in list-active without mode state files', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ultragoal-artifact-'));
+    try {
+      await mkdir(join(wd, '.omx', 'ultragoal'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'ultragoal', 'goals.json'),
+        JSON.stringify({
+          activeGoalId: 'G001',
+          goals: [{
+            id: 'G001',
+            title: 'Fix duplicate HUD panes',
+            objective: 'Keep one HUD renderer per leader.',
+            status: 'in_progress',
+          }],
+        }, null, 2),
+      );
+
+      const activeResponse = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(activeResponse.payload, { active_modes: ['ultragoal'] });
+
+      const statusResponse = await executeStateOperation('state_get_status', {
+        workingDirectory: wd,
+        mode: 'ultragoal',
+      });
+      const statuses = (statusResponse.payload as {
+        statuses?: Record<string, { active?: boolean; phase?: string; path?: string; source?: string }>;
+      }).statuses || {};
+      assert.equal(statuses.ultragoal?.active, true);
+      assert.equal(statuses.ultragoal?.phase, 'in_progress');
+      assert.equal(statuses.ultragoal?.path, join(wd, '.omx', 'ultragoal', 'goals.json'));
+      assert.equal(statuses.ultragoal?.source, 'ultragoal-artifacts');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers active ultragoal artifacts over stale inactive mode state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ultragoal-stale-state-'));
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'ultragoal'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'ultragoal-state.json'),
+        JSON.stringify({ active: false, current_phase: 'cleared' }, null, 2),
+      );
+      await writeFile(
+        join(wd, '.omx', 'ultragoal', 'goals.json'),
+        JSON.stringify({
+          activeGoalId: 'G001',
+          goals: [{
+            id: 'G001',
+            title: 'Fix duplicate HUD panes',
+            objective: 'Keep one HUD renderer per leader.',
+            status: 'in_progress',
+          }],
+        }, null, 2),
+      );
+
+      const activeResponse = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(activeResponse.payload, { active_modes: ['ultragoal'] });
+
+      const statusResponse = await executeStateOperation('state_get_status', {
+        workingDirectory: wd,
+        mode: 'ultragoal',
+      });
+      const statuses = (statusResponse.payload as {
+        statuses?: Record<string, { active?: boolean; phase?: string; source?: string }>;
+      }).statuses || {};
+      assert.equal(statuses.ultragoal?.active, true);
+      assert.equal(statuses.ultragoal?.phase, 'in_progress');
+      assert.equal(statuses.ultragoal?.source, 'ultragoal-artifacts');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('does not treat root fallback as active for explicit session list-active decisions', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-active-scope-'));
     try {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -20,6 +20,7 @@ import { evaluateRalphCompletionAuditEvidence } from '../ralph/completion-audit.
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
+import { readUltragoalState } from '../hud/state.js';
 import {
   SKILL_ACTIVE_STATE_MODE,
   readSkillActiveState,
@@ -170,6 +171,19 @@ export async function listStateStatuses(
       } catch {
         statuses[currentMode] = { error: 'malformed state file' };
       }
+    }
+  }
+
+  if (!mode || mode === 'ultragoal') {
+    const ultragoal = await readUltragoalState(cwd).catch(() => null);
+    if (ultragoal && (ultragoal.active || (mode === 'ultragoal' && !seenModes.has('ultragoal')))) {
+      statuses.ultragoal = {
+        active: ultragoal.active,
+        phase: ultragoal.status,
+        path: join(cwd, '.omx', 'ultragoal', 'goals.json'),
+        data: ultragoal,
+        source: 'ultragoal-artifacts',
+      };
     }
   }
 


### PR DESCRIPTION
## Summary
- Reuse one existing same-leader HUD pane in attached tmux launch/relaunch/reconcile paths and kill duplicate node HUD panes instead of creating another renderer.
- Preserve leader/session/window ownership scoping while resizing and re-registering the keeper HUD pane.
- Align `omx status` and `omx state list-active --json` with active Ultragoal artifacts when mode state is missing or stale.

Closes #2591.

## Tests
- `npm run build`
- `npm run lint`
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_STATE_ROOT -u TMUX -u TMUX_PANE node --test dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/index.test.js dist/state/__tests__/operations.test.js`
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_STATE_ROOT -u TMUX -u TMUX_PANE node --test --test-name-pattern='HUD|hud|duplicate|restore a standalone HUD|relaunch re-creates HUD|preserves leader/HUD layout' dist/team/__tests__/tmux-session.test.js dist/team/__tests__/runtime.test.js`
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_STATE_ROOT -u TMUX -u TMUX_PANE npm run test:team:cross-rebase-smoke:compiled`
- Manual smoke: stale inactive `ultragoal-state.json` + active `.omx/ultragoal/goals.json` makes `omx status` and `omx state list-active --json` report Ultragoal active.

## Notes
- Full `npm test` was attempted in the attached OMX env and failed in pre-existing deep-interview config expectations unrelated to this HUD change; focused isolated checks above pass.