### PR TITLE
Fix detached tmux history growth

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -77,6 +77,7 @@ import {
   withTmuxExtendedKeys,
   serializeDetachedSessionParentEnv,
   CODEX_SQLITE_HOME_ENV,
+  DETACHED_TMUX_HISTORY_LIMIT,
 } from "../index.js";
 import { mergeConfig, repairConfigIfNeeded } from "../../config/generator.js";
 import { ensureReusableNodeModules } from "../../utils/repo-deps.js";
@@ -4221,6 +4222,9 @@ exit 0
       "%12",
       "3",
       true,
+      false,
+      true,
+      "%leader",
     );
     const names = steps.map((step) => step.name);
     const attachedIndex = names.indexOf("register-client-attached-reconcile");
@@ -4232,6 +4236,15 @@ exit 0
     assert.equal(attachIndex > scheduleIndex, true);
     assert.equal(names.includes("register-resize-hook"), true);
     assert.equal(names.includes("reconcile-hud-resize"), true);
+    assert.equal(DETACHED_TMUX_HISTORY_LIMIT, 500);
+    const historyHook = steps.find((step) => step.name === "register-detached-history-prune-hook");
+    assert.ok(historyHook);
+    assert.deepEqual(historyHook.args.slice(0, 3), ["set-hook", "-t", "omx-demo"]);
+    assert.match(historyHook.args[3] || "", /^client-detached\[[0-9]+\]$/);
+    assert.equal(
+      historyHook.args[4],
+      "if-shell -F '#{==:#{session_attached},0}' 'clear-history -t %leader'",
+    );
   });
 
   it("buildDetachedSessionFinalizeSteps skips attach for Hermes MCP bridge launches", () => {

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
+import { DETACHED_TMUX_HISTORY_LIMIT } from '../index.js';
 
 const CLI_SPAWN_TIMEOUT_MS = 15_000;
 
@@ -315,7 +316,7 @@ case "$1" in
     exit 1
     ;;
   new-session)
-    printf 'leader-pane\n'
+    printf '%%12\n'
     exit 0
     ;;
   split-window)
@@ -373,6 +374,7 @@ describe('omx launcher when tmux is available', () => {
     try {
       const runs = join(wd, 'runs');
       const activeMarker = join(wd, 'active-session');
+      const instanceMarker = join(wd, 'active-instance');
       const { env, tmuxLogPath } = await createLaunchFixture(
         wd,
         (logPath) => `#!/bin/sh
@@ -387,8 +389,12 @@ case "$1" in
     exit $?
     ;;
   new-session)
-    printf '%s\n' "$*" > "${activeMarker}"
-    printf 'leader-pane\n'
+    prev=''
+    for arg in "$@"; do
+      if [ "$prev" = '-s' ]; then printf '%s\n' "$arg" > "${activeMarker}"; fi
+      prev="$arg"
+    done
+    printf '%%12\n'
     exit 0
     ;;
   split-window)
@@ -398,6 +404,8 @@ case "$1" in
   display-message)
     if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
       printf '/tmp/tmux-test.sock\n'
+    elif [ "$2" = '-p' ] && [ "$5" = '#{session_name}' ]; then
+      cat "${activeMarker}"
     elif [ "$2" = '-p' ] && [ "$5" = '#{session_attached}' ]; then
       printf '1\n'
     else
@@ -406,10 +414,20 @@ case "$1" in
     exit 0
     ;;
   show-options)
+    if [ "$5" = '@omx_instance_id' ]; then
+      cat "${instanceMarker}"
+      exit 0
+    fi
     printf 'off\n'
     exit 0
     ;;
-  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane)
+  set-option)
+    if [ "$4" = '@omx_instance_id' ]; then
+      printf '%s\n' "$5" > "${instanceMarker}"
+    fi
+    exit 0
+    ;;
+  set-hook|attach-session|kill-session|run-shell|resize-pane)
     exit 0
     ;;
 esac
@@ -447,6 +465,95 @@ exit 0
         'utf-8',
       );
       assert.match(activeRecords, /"tmux_session_name"/);
+      assert.match(activeRecords, /"session_id"/);
+      assert.match(activeRecords, /"tmux_pane_id": "%12"/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not mutate a stale active-detached tmux session without OMX ownership proof', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-stale-active-'));
+    try {
+      const runs = join(wd, 'runs');
+      const activeDir = join(runs, 'active-detached');
+      await mkdir(activeDir, { recursive: true });
+      await writeFile(
+        join(activeDir, 'boxed-context-under-test.json'),
+        `${JSON.stringify({
+          version: 1,
+          context_key: 'boxed-context-under-test',
+          created_at: new Date().toISOString(),
+          source_cwd: wd,
+          argv: ['--madmax', '--tmux'],
+          run_dir: wd,
+          tmux_session_name: 'user-owned-session',
+          session_id: 'expected-omx-session-id',
+          tmux_pane_id: '%99',
+        })}\n`,
+      );
+      const { env, tmuxLogPath } = await createLaunchFixture(
+        wd,
+        (logPath) => `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${logPath}"
+case "$1" in
+  -V)
+    printf 'tmux 3.4\n'
+    exit 0
+    ;;
+  has-session)
+    exit 0
+    ;;
+  new-session)
+    printf '%%12\n'
+    exit 0
+    ;;
+  split-window)
+    printf 'hud-pane\n'
+    exit 0
+    ;;
+  display-message)
+    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\n'
+    elif [ "$2" = '-p' ] && [ "$5" = '#{session_name}' ]; then
+      printf 'user-owned-session\n'
+    else
+      printf '0\n'
+    fi
+    exit 0
+    ;;
+  show-options)
+    if [ "$5" = '@omx_instance_id' ]; then
+      printf 'different-session-id\n'
+      exit 0
+    fi
+    printf 'off\n'
+    exit 0
+    ;;
+  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane)
+    exit 0
+    ;;
+esac
+exit 0
+`,
+      );
+
+      const result = runOmx(wd, ['--madmax', '--tmux'], {
+        ...env,
+        OMX_RUNS_DIR: runs,
+        OMXBOX_ACTIVE: '1',
+        OMX_MADMAX_DETACHED_CONTEXT: 'boxed-context-under-test',
+        OMX_LAUNCH_POLICY: 'direct',
+        TMUX: '',
+        TMUX_PANE: '',
+      });
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /tmux:set-option .* -t user-owned-session .*history-limit/);
+      assert.doesNotMatch(tmuxLog, /tmux:clear-history .*user-owned-session|tmux:clear-history .*%99/);
+      assert.match(tmuxLog, /tmux:new-session /);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -463,7 +570,7 @@ printf 'tmux:%s\n' "$*" >> "${logPath}"
 case "$1" in
   -V) printf 'tmux 3.4\n'; exit 0 ;;
   has-session) exit 1 ;;
-  new-session) printf 'leader-pane\n'; exit 0 ;;
+  new-session) printf '%%12\n'; exit 0 ;;
   split-window) printf 'hud-pane\n'; exit 0 ;;
   display-message) if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then printf '/tmp/tmux-test.sock\n'; else printf '0\n'; fi; exit 0 ;;
   show-options) printf 'off\n'; exit 0 ;;
@@ -525,7 +632,7 @@ printf 'tmux:%s\n' "$*" >> "${logPath}"
 case "$1" in
   -V) printf 'tmux 3.4\n'; exit 0 ;;
   has-session) exit 1 ;;
-  new-session) printf 'leader-pane\n'; exit 0 ;;
+  new-session) printf '%%12\n'; exit 0 ;;
   split-window) printf 'hud-pane\n'; exit 0 ;;
   display-message) if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then printf '/tmp/tmux-test.sock\n'; else printf '0\n'; fi; exit 0 ;;
   show-options) printf 'off\n'; exit 0 ;;
@@ -582,7 +689,7 @@ case "$1" in
     exit 0
     ;;
   new-session)
-    printf 'leader-pane\\n'
+    printf '%%12\n'
     exit 0
     ;;
   split-window)
@@ -628,7 +735,15 @@ exit 0
       if (shouldSkipForSpawnPermissions(result.error)) return;
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /tmux:show-options -gv history-limit/);
+      assert.doesNotMatch(tmuxLog, /tmux:set-option -g[q ]+history-limit/);
       assert.match(tmuxLog, /tmux:new-session .* -s /);
+      assert.match(tmuxLog, new RegExp(`tmux:set-option -q -t .* history-limit ${DETACHED_TMUX_HISTORY_LIMIT}`));
+      assert.match(tmuxLog, new RegExp(`tmux:set-option -pq -t %12 history-limit ${DETACHED_TMUX_HISTORY_LIMIT}`));
+      assert.match(
+        tmuxLog,
+        /tmux:set-hook -t .* client-detached\[[0-9]+\] if-shell -F '#\{==:#\{session_attached\},0\}' 'clear-history -t %12'/,
+      );
       assert.match(tmuxLog, new RegExp(`tmux:split-window -v -l ${HUD_TMUX_HEIGHT_LINES} .* -t `));
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
     } finally {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -880,6 +880,96 @@ function execTmuxFileSync(
   }) as string;
 }
 
+export const DETACHED_TMUX_HISTORY_LIMIT = 500;
+const TMUX_HOOK_INDEX_MAX = 1_000_000;
+
+function setDetachedTmuxSessionHistoryLimit(
+  sessionName: string,
+  leaderPaneId?: string | null,
+): void {
+  const boundedHistoryLimit = String(DETACHED_TMUX_HISTORY_LIMIT);
+  try {
+    execTmuxFileSync(
+      ["set-option", "-q", "-t", sessionName, "history-limit", boundedHistoryLimit],
+      { stdio: "ignore" },
+    );
+  } catch (err) {
+    logCliOperationFailure(err);
+  }
+  if (!leaderPaneId) return;
+  try {
+    execTmuxFileSync(
+      ["set-option", "-pq", "-t", leaderPaneId, "history-limit", boundedHistoryLimit],
+      { stdio: "ignore" },
+    );
+  } catch (err) {
+    logCliOperationFailure(err);
+  }
+}
+
+function clearDetachedTmuxSessionHistoryIfUnattached(
+  sessionName: string,
+  leaderPaneId: string,
+): void {
+  try {
+    const attached = execTmuxFileSync(
+      ["display-message", "-p", "-t", sessionName, "#{session_attached}"],
+      {
+        stdio: ["ignore", "pipe", "ignore"],
+        encoding: "utf-8",
+      },
+    ).trim();
+    if (attached !== "0") return;
+    execTmuxFileSync(["clear-history", "-t", leaderPaneId], {
+      stdio: "ignore",
+    });
+  } catch (err) {
+    logCliOperationFailure(err);
+  }
+}
+
+function readTmuxSessionInstanceId(sessionName: string): string | null {
+  try {
+    return execTmuxFileSync(
+      ["show-options", "-qv", "-t", sessionName, OMX_INSTANCE_OPTION],
+      {
+        stdio: ["ignore", "pipe", "ignore"],
+        encoding: "utf-8",
+      },
+    ).trim();
+  } catch {
+    return null;
+  }
+}
+
+function tmuxPaneBelongsToSession(paneId: string, sessionName: string): boolean {
+  try {
+    const paneSessionName = execTmuxFileSync(
+      ["display-message", "-p", "-t", paneId, "#{session_name}"],
+      {
+        stdio: ["ignore", "pipe", "ignore"],
+        encoding: "utf-8",
+      },
+    ).trim();
+    return paneSessionName === sessionName;
+  } catch {
+    return false;
+  }
+}
+
+function buildDetachedHistoryPruneHookCommand(leaderPaneId: string): string {
+  return `if-shell -F '#{==:#{session_attached},0}' 'clear-history -t ${leaderPaneId}'`;
+}
+
+function buildDetachedHistoryPruneHookSlot(sessionName: string, leaderPaneId: string): string {
+  const key = `${sessionName}:${leaderPaneId}:omx-history-prune`;
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) - hash + key.charCodeAt(i)) | 0;
+  }
+  return `client-detached[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
+}
+
 function hasErrnoCode(error: unknown, code: string): boolean {
   return Boolean(
     error &&
@@ -1292,6 +1382,8 @@ interface MadmaxDetachedActiveRecord {
   argv: string[];
   run_dir: string;
   tmux_session_name: string;
+  session_id?: string;
+  tmux_pane_id?: string;
 }
 
 function resolveMadmaxRunsRoot(env: NodeJS.ProcessEnv = process.env): string {
@@ -1399,10 +1491,23 @@ function readMadmaxDetachedActiveRecord(
       argv: [...parsed.argv],
       run_dir: parsed.run_dir,
       tmux_session_name: parsed.tmux_session_name,
+      ...(typeof parsed.session_id === "string" ? { session_id: parsed.session_id } : {}),
+      ...(typeof parsed.tmux_pane_id === "string" ? { tmux_pane_id: parsed.tmux_pane_id } : {}),
     };
   } catch {
     return null;
   }
+}
+
+function isReusableMadmaxDetachedActiveRecord(
+  record: MadmaxDetachedActiveRecord,
+): boolean {
+  if (!detachedTmuxSessionExists(record.tmux_session_name)) return false;
+  if (!record.session_id || !record.tmux_pane_id) return false;
+  if (readTmuxSessionInstanceId(record.tmux_session_name) !== record.session_id) {
+    return false;
+  }
+  return tmuxPaneBelongsToSession(record.tmux_pane_id, record.tmux_session_name);
 }
 
 function detachedTmuxSessionExists(sessionName: string): boolean {
@@ -3330,8 +3435,22 @@ export function buildDetachedSessionFinalizeSteps(
   enableMouse: boolean,
   nativeWindows = false,
   attachSession = true,
+  leaderPaneId: string | null = null,
 ): DetachedSessionTmuxStep[] {
   const steps: DetachedSessionTmuxStep[] = [];
+  if (!nativeWindows && leaderPaneId) {
+    steps.push({
+      name: "register-detached-history-prune-hook",
+      args: [
+        "set-hook",
+        "-t",
+        sessionName,
+        buildDetachedHistoryPruneHookSlot(sessionName, leaderPaneId),
+        buildDetachedHistoryPruneHookCommand(leaderPaneId),
+      ],
+    });
+  }
+
   if (!nativeWindows && hudPaneId && hookWindowIndex) {
     const hookTarget = buildResizeHookTarget(sessionName, hookWindowIndex);
     const hookName = buildResizeHookName(
@@ -4195,10 +4314,18 @@ function runCodex(
       if (
         activeRecord &&
         activeRecord.context_key === contextKey &&
-        detachedTmuxSessionExists(activeRecord.tmux_session_name)
+        isReusableMadmaxDetachedActiveRecord(activeRecord)
       ) {
         cleanupCurrentMadmaxReuseRunRoot(process.env, runsRoot);
+        setDetachedTmuxSessionHistoryLimit(
+          activeRecord.tmux_session_name,
+          activeRecord.tmux_pane_id!,
+        );
         if (!shouldAttachDetachedTmuxSession(process.env)) {
+          clearDetachedTmuxSessionHistoryIfUnattached(
+            activeRecord.tmux_session_name,
+            activeRecord.tmux_pane_id!,
+          );
           process.stderr.write(
             `[omx] madmax detached launch already active for this context; reusing ${activeRecord.tmux_session_name} without attaching because this launch is a Hermes MCP bridge.\n`,
           );
@@ -4246,6 +4373,7 @@ function runCodex(
       let registeredHookName: string | null = null;
       let registeredClientAttachedHookName: string | null = null;
       let detachedParentEnvFilePath: string | undefined;
+      let detachedLeaderPaneId: string | null = null;
       try {
         // This path is the user-shell interactive launch: OMX creates a tmux
         // session and immediately attaches the user's terminal to it. If a tmux
@@ -4284,19 +4412,25 @@ function runCodex(
           });
           if (step.name === "new-session") {
             createdDetachedSession = true;
-            if (activeRecordPath && contextKey) {
-              writeMadmaxDetachedActiveRecord(activeRecordPath, {
-                version: 1,
-                context_key: contextKey,
-                created_at: new Date().toISOString(),
-                source_cwd: process.env.OMX_SOURCE_CWD || cwd,
-                argv: args,
-                run_dir: process.env.OMX_ROOT || cwd,
-                tmux_session_name: sessionName,
-              });
-            }
             const leaderPaneId = parsePaneIdFromTmuxOutput(output || "");
-            if (leaderPaneId) writeDetachedSessionBinding(leaderPaneId);
+            if (leaderPaneId) {
+              detachedLeaderPaneId = leaderPaneId;
+              setDetachedTmuxSessionHistoryLimit(sessionName, leaderPaneId);
+              if (activeRecordPath && contextKey) {
+                writeMadmaxDetachedActiveRecord(activeRecordPath, {
+                  version: 1,
+                  context_key: contextKey,
+                  created_at: new Date().toISOString(),
+                  source_cwd: process.env.OMX_SOURCE_CWD || cwd,
+                  argv: args,
+                  run_dir: process.env.OMX_ROOT || cwd,
+                  tmux_session_name: sessionName,
+                  session_id: sessionId,
+                  tmux_pane_id: leaderPaneId,
+                });
+              }
+              writeDetachedSessionBinding(leaderPaneId);
+            }
           }
           if (step.name === "split-and-capture-hud-pane") {
             const hudPaneId = parsePaneIdFromTmuxOutput(output || "");
@@ -4332,6 +4466,7 @@ function runCodex(
               process.env.OMX_MOUSE !== "0",
               nativeWindows,
               shouldAttachDetachedTmuxSession(process.env),
+              detachedLeaderPaneId,
             );
             if (nativeWindows && detachedWindowsCodexCmd) {
               scheduleDetachedWindowsCodexLaunch(


### PR DESCRIPTION
## Summary
- bound history for OMX-managed detached tmux sessions/panes
- clear detached leader pane history only through session-scoped hooks or ownership-verified reuse
- record session/pane ownership and add stale active-record regression coverage

Closes #2597

## Validation
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js
- npm run lint
- git diff --check
- independent code-reviewer: APPROVE
- independent architect: CLEAR

## Notes
- Raw `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js` exposed pre-existing test concurrency assumptions; repo runner passed 273/273.