### PR TITLE
Keep native ralplan reviewers as subagent evidence

### DIFF
--- a/src/autopilot/ralplan-gate.ts
+++ b/src/autopilot/ralplan-gate.ts
@@ -76,5 +76,8 @@ export function canAdvanceAutopilotRalplanToUltragoal(
 export function buildAutopilotRalplanUltragoalGateError(
   decision: AutopilotRalplanUltragoalGateDecision,
 ): string {
-  return `Cannot transition ralplan -> ultragoal: ${decision.reason}.`;
+  const details = decision.evidence?.blockedDetails?.length
+    ? ` Details: ${decision.evidence.blockedDetails.join('; ')}.`
+    : '';
+  return `Cannot transition ralplan -> ultragoal: ${decision.reason}.${details}`;
 }

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -9,6 +9,7 @@ export interface RalplanConsensusGateEvidence {
   ralplan_critic_review: Record<string, unknown> | null;
   source: string | null;
   blockedReason: string | null;
+  blockedDetails?: string[];
 }
 
 export interface RalplanNativeSubagentConsensusOptions {
@@ -61,6 +62,10 @@ export function buildRalplanConsensusGateFromSources(
       ralplan_critic_review: nativeBlockedEvidence.ralplan_critic_review,
       source: nativeBlockedEvidence.source,
       blockedReason: 'native_subagent_consensus_evidence_missing',
+      blockedDetails: [
+        trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_architect_review, 'architect', options),
+        trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_critic_review, 'critic', options),
+      ].filter((detail): detail is string => Boolean(detail)),
     };
   }
 
@@ -273,9 +278,17 @@ function isTrackerBackedNativeReview(
   agentRole: 'architect' | 'critic',
   options: RalplanNativeSubagentConsensusOptions,
 ): boolean {
-  if (!review) return false;
-  if (review.agent_role !== agentRole) return false;
-  if (review.provenance_kind !== 'native_subagent') return false;
+  return trackerBackedNativeReviewProblem(review, agentRole, options) === null;
+}
+
+function trackerBackedNativeReviewProblem(
+  review: Record<string, unknown> | null,
+  agentRole: 'architect' | 'critic',
+  options: RalplanNativeSubagentConsensusOptions,
+): string | null {
+  if (!review) return `${agentRole} review is missing`;
+  if (review.agent_role !== agentRole) return `${agentRole} review has agent_role=${String(review.agent_role || 'missing')}`;
+  if (review.provenance_kind !== 'native_subagent') return `${agentRole} review has provenance_kind=${String(review.provenance_kind || 'missing')}`;
   const sessionId = typeof options.sessionId === 'string' && options.sessionId.trim()
     ? options.sessionId.trim()
     : typeof review.session_id === 'string'
@@ -285,14 +298,20 @@ function isTrackerBackedNativeReview(
   const threadId = typeof review.thread_id === 'string' ? review.thread_id.trim() : '';
   const artifactPath = typeof review.artifact_path === 'string' ? review.artifact_path.trim() : '';
   const trackerPath = typeof review.tracker_path === 'string' ? review.tracker_path.trim() : '';
-  if (!sessionId || !reviewSessionId || reviewSessionId !== sessionId) return false;
-  if (!threadId || !artifactPath || !trackerPath || !trackerPath.endsWith('subagent-tracking.json')) return false;
-  if (!options.cwd) return false;
+  if (!sessionId) return `${agentRole} review cannot resolve session_id`;
+  if (!reviewSessionId || reviewSessionId !== sessionId) return `${agentRole} review session_id=${reviewSessionId || 'missing'} does not match ${sessionId}`;
+  if (!threadId) return `${agentRole} review missing thread_id`;
+  if (!artifactPath) return `${agentRole} review missing artifact_path`;
+  if (!trackerPath || !trackerPath.endsWith('subagent-tracking.json')) return `${agentRole} review missing subagent-tracking.json tracker_path`;
+  if (!options.cwd) return `${agentRole} review cannot resolve cwd for tracker lookup`;
 
   const tracking = readJsonState(subagentTrackingPath(options.cwd));
   const session = asRecord(asRecord(tracking?.sessions)?.[sessionId]);
   const thread = asRecord(asRecord(session?.threads)?.[threadId]);
-  return thread?.kind === 'subagent';
+  if (!session) return `${agentRole} tracker session ${sessionId} is missing`;
+  if (!thread) return `${agentRole} tracker thread ${threadId} is missing`;
+  if (thread.kind !== 'subagent') return `${agentRole} tracker thread ${threadId} has kind=${String(thread.kind || 'missing')}`;
+  return null;
 }
 
 function validateLocalSessionId(sessionId: string): string[] {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1201,6 +1201,66 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("keeps a self-parented native role thread as subagent evidence", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-self-parented-subagent-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "omx-autopilot-session";
+      const nativeRoleThreadId = "codex-architect-thread";
+      await mkdir(join(stateDir, "sessions", canonicalSessionId), { recursive: true });
+      await writeSessionStart(cwd, canonicalSessionId, {
+        nativeSessionId: nativeRoleThreadId,
+      });
+
+      const transcriptPath = join(cwd, "architect-subagent-rollout.jsonl");
+      await writeFile(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: nativeRoleThreadId,
+            source: {
+              subagent: {
+                thread_spawn: {
+                  parent_thread_id: nativeRoleThreadId,
+                  depth: 1,
+                  agent_nickname: "Architect",
+                  agent_role: "architect",
+                },
+              },
+            },
+            agent_nickname: "Architect",
+            agent_role: "architect",
+          },
+        })}\n`,
+      );
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: nativeRoleThreadId,
+          transcript_path: transcriptPath,
+        },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+
+      const tracking = JSON.parse(
+        await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"),
+      ) as {
+        sessions?: Record<string, {
+          leader_thread_id?: string;
+          threads?: Record<string, { kind?: string; mode?: string }>;
+        }>;
+      };
+      assert.equal(tracking.sessions?.[canonicalSessionId]?.leader_thread_id, undefined);
+      assert.equal(tracking.sessions?.[canonicalSessionId]?.threads?.[nativeRoleThreadId]?.kind, "subagent");
+      assert.equal(tracking.sessions?.[canonicalSessionId]?.threads?.[nativeRoleThreadId]?.mode, "architect");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not attach a subagent SessionStart to an unrelated canonical leader", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-subagent-session-start-mismatch-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -248,18 +248,25 @@ async function recordNativeSubagentSessionStart(
   metadata: NativeSubagentSessionStartMetadata,
   transcriptPath: string,
 ): Promise<void> {
+  const parentThreadId = metadata.parentThreadId.trim();
+  const childThreadId = childSessionId.trim();
   const trackingSessionIds = [...new Set([
     canonicalSessionId.trim(),
-    metadata.parentThreadId.trim(),
+    parentThreadId,
   ].filter(Boolean))];
   for (const sessionId of trackingSessionIds) {
+    if (parentThreadId && parentThreadId !== childThreadId) {
+      await recordSubagentTurnForSession(cwd, {
+        sessionId,
+        threadId: parentThreadId,
+        kind: 'leader',
+      }).catch(() => {});
+    }
     await recordSubagentTurnForSession(cwd, {
       sessionId,
-      threadId: metadata.parentThreadId,
-    }).catch(() => {});
-    await recordSubagentTurnForSession(cwd, {
-      sessionId,
-      threadId: childSessionId,
+      threadId: childThreadId,
+      kind: 'subagent',
+      ...(parentThreadId && parentThreadId !== childThreadId ? { leaderThreadId: parentThreadId } : {}),
       mode: metadata.agentRole,
     }).catch(() => {});
   }

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -51,6 +51,34 @@ describe('subagents/tracker', () => {
     assert.deepEqual(drained?.activeSubagentThreadIds, []);
   });
 
+  it('can record an explicitly spawned subagent as subagent even when it is the first seen thread', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-ralplan',
+      threadId: 'thread-architect',
+      timestamp: '2026-05-28T17:59:43.270Z',
+      mode: 'architect',
+      kind: 'subagent',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-ralplan',
+      threadId: 'thread-critic',
+      timestamp: '2026-05-28T18:01:49.547Z',
+      mode: 'critic',
+      kind: 'subagent',
+    });
+
+    const summary = summarizeSubagentSession(state, 'sess-ralplan', {
+      now: '2026-05-28T18:02:00.000Z',
+      activeWindowMs: 120_000,
+    });
+
+    assert.equal(state.sessions['sess-ralplan']?.leader_thread_id, undefined);
+    assert.equal(state.sessions['sess-ralplan']?.threads['thread-architect']?.kind, 'subagent');
+    assert.equal(state.sessions['sess-ralplan']?.threads['thread-critic']?.kind, 'subagent');
+    assert.deepEqual(summary?.allSubagentThreadIds, ['thread-architect', 'thread-critic']);
+  });
+
   it('reconciles completed subagent threads before reporting active wait state', () => {
     let state = createSubagentTrackingState();
     state = recordSubagentTurn(state, {

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -37,6 +37,8 @@ export interface RecordSubagentTurnInput {
   turnId?: string;
   timestamp?: string;
   mode?: string;
+  kind?: 'leader' | 'subagent';
+  leaderThreadId?: string;
   completed?: boolean;
   completionSource?: string;
 }
@@ -164,11 +166,16 @@ export function recordSubagentTurn(
     threads: {},
   };
 
-  const leaderThreadId = existingSession.leader_thread_id || threadId;
+  const requestedKind = input.kind === 'leader' || input.kind === 'subagent' ? input.kind : undefined;
+  const requestedLeaderThreadId = input.leaderThreadId?.trim();
+  const leaderThreadId = existingSession.leader_thread_id
+    || requestedLeaderThreadId
+    || (requestedKind === 'subagent' ? undefined : threadId);
   const existingThread = existingSession.threads[threadId];
+  const kind = requestedKind ?? (threadId === leaderThreadId ? 'leader' : 'subagent');
   const nextThread: TrackedSubagentThread = {
     thread_id: threadId,
-    kind: threadId === leaderThreadId ? 'leader' : 'subagent',
+    kind,
     first_seen_at: existingThread?.first_seen_at ?? timestamp,
     last_seen_at: timestamp,
     turn_count: (existingThread?.turn_count ?? 0) + 1,
@@ -196,7 +203,7 @@ export function recordSubagentTurn(
 
   normalized.sessions[sessionId] = {
     session_id: sessionId,
-    leader_thread_id: leaderThreadId,
+    ...(leaderThreadId ? { leader_thread_id: leaderThreadId } : {}),
     updated_at: timestamp,
     threads,
   };


### PR DESCRIPTION
## Summary
- keep native role sessions recorded as subagent evidence even when the native transcript reports a self-parented/first-seen thread
- keep that subagent evidence stable across later generic notify turns or nested native parent/leader records, while still allowing explicit subagent evidence to repair a prior self-leader inference
- preserve the strict Autopilot `ralplan -> ultragoal` FSM gate and add blocked-detail diagnostics for failed tracker-backed evidence checks

## Run evidence
This PR is based on a real Autopilot run against the Hermes agent on `iqdoctor@str`, tmux `comfy:hermes-fix`:

- run root: `/data/iqdoctor/.omx-runs/run-20260528174608-8f08`
- OMX session: `omx-1779990369032-z5p6k6`
- observed failure: the real Architect native thread `019e6fbd-44e7-7911-945e-e26b71fd83d7` was first seen/self-parented and ended up tracked as `kind=leader`; Critic had real native evidence, but the strict gate correctly refused `ralplan -> ultragoal` because Architect was not tracker-backed as a subagent lane
- after correcting the evidence/tracker state in that run, Autopilot advanced and completed with clean review/QA evidence

The code change keeps that gate fail-closed and fixes the native tracking path instead of relaxing consensus requirements.

## Tests
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `npm run verify:native-agents`
- `npm run verify:plugin-bundle`
- `node --test dist/subagents/__tests__/tracker.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/state/__tests__/operations.test.js dist/ralplan/__tests__/runtime.test.js dist/autopilot/__tests__/fsm.test.js` (431 tests)
- temporary UltraQA harness covering:
  - self-parented first-seen native role + later notify/parent turns remains `subagent` and can advance the gate
  - leader-kind denial emits an actionable diagnostic
  - corrupt tracker state fails closed

Not run: full `npm test`; an earlier accidental full-suite attempt hit unrelated local environment/tmux failures outside this patch scope.
