### PR TITLE
Guard native hook subagent trust against leader spoofing

### DIFF
--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { subagentTrackingPath } from '../../subagents/tracker.js';
+import {
+  buildAutopilotRalplanUltragoalGateError,
+  canAdvanceAutopilotRalplanToUltragoal,
+} from '../ralplan-gate.js';
+
+describe('autopilot ralplan gate', () => {
+  it('rejects native review evidence from the session leader even when malformed tracking marks it as subagent', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-leader-spoof-'));
+    const sessionId = 'sess-autopilot-leader-spoof';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-05-28T18:34:51.000Z',
+            threads: {
+              'thread-leader': {
+                thread_id: 'thread-leader',
+                kind: 'subagent',
+                first_seen_at: '2026-05-28T18:34:51.000Z',
+                last_seen_at: '2026-05-28T18:34:51.000Z',
+                turn_count: 2,
+              },
+              'thread-critic': {
+                thread_id: 'thread-critic',
+                kind: 'subagent',
+                first_seen_at: '2026-05-28T18:35:10.000Z',
+                last_seen_at: '2026-05-28T18:35:10.000Z',
+                turn_count: 1,
+              },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-leader',
+              artifact_path: '.omx/artifacts/architect.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-05-28T18:34:51.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic',
+              artifact_path: '.omx/artifacts/critic.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-05-28T18:35:10.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /architect tracker thread thread-leader is the session leader/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/autopilot/ralplan-gate.ts
+++ b/src/autopilot/ralplan-gate.ts
@@ -76,5 +76,8 @@ export function canAdvanceAutopilotRalplanToUltragoal(
 export function buildAutopilotRalplanUltragoalGateError(
   decision: AutopilotRalplanUltragoalGateDecision,
 ): string {
-  return `Cannot transition ralplan -> ultragoal: ${decision.reason}.`;
+  const details = decision.evidence?.blockedDetails?.length
+    ? ` Details: ${decision.evidence.blockedDetails.join('; ')}.`
+    : '';
+  return `Cannot transition ralplan -> ultragoal: ${decision.reason}.${details}`;
 }

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -9,6 +9,7 @@ export interface RalplanConsensusGateEvidence {
   ralplan_critic_review: Record<string, unknown> | null;
   source: string | null;
   blockedReason: string | null;
+  blockedDetails?: string[];
 }
 
 export interface RalplanNativeSubagentConsensusOptions {
@@ -61,6 +62,10 @@ export function buildRalplanConsensusGateFromSources(
       ralplan_critic_review: nativeBlockedEvidence.ralplan_critic_review,
       source: nativeBlockedEvidence.source,
       blockedReason: 'native_subagent_consensus_evidence_missing',
+      blockedDetails: [
+        trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_architect_review, 'architect', options),
+        trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_critic_review, 'critic', options),
+      ].filter((detail): detail is string => Boolean(detail)),
     };
   }
 
@@ -273,9 +278,17 @@ function isTrackerBackedNativeReview(
   agentRole: 'architect' | 'critic',
   options: RalplanNativeSubagentConsensusOptions,
 ): boolean {
-  if (!review) return false;
-  if (review.agent_role !== agentRole) return false;
-  if (review.provenance_kind !== 'native_subagent') return false;
+  return trackerBackedNativeReviewProblem(review, agentRole, options) === null;
+}
+
+function trackerBackedNativeReviewProblem(
+  review: Record<string, unknown> | null,
+  agentRole: 'architect' | 'critic',
+  options: RalplanNativeSubagentConsensusOptions,
+): string | null {
+  if (!review) return `${agentRole} review is missing`;
+  if (review.agent_role !== agentRole) return `${agentRole} review has agent_role=${String(review.agent_role || 'missing')}`;
+  if (review.provenance_kind !== 'native_subagent') return `${agentRole} review has provenance_kind=${String(review.provenance_kind || 'missing')}`;
   const sessionId = typeof options.sessionId === 'string' && options.sessionId.trim()
     ? options.sessionId.trim()
     : typeof review.session_id === 'string'
@@ -285,14 +298,22 @@ function isTrackerBackedNativeReview(
   const threadId = typeof review.thread_id === 'string' ? review.thread_id.trim() : '';
   const artifactPath = typeof review.artifact_path === 'string' ? review.artifact_path.trim() : '';
   const trackerPath = typeof review.tracker_path === 'string' ? review.tracker_path.trim() : '';
-  if (!sessionId || !reviewSessionId || reviewSessionId !== sessionId) return false;
-  if (!threadId || !artifactPath || !trackerPath || !trackerPath.endsWith('subagent-tracking.json')) return false;
-  if (!options.cwd) return false;
+  if (!sessionId) return `${agentRole} review cannot resolve session_id`;
+  if (!reviewSessionId || reviewSessionId !== sessionId) return `${agentRole} review session_id=${reviewSessionId || 'missing'} does not match ${sessionId}`;
+  if (!threadId) return `${agentRole} review missing thread_id`;
+  if (!artifactPath) return `${agentRole} review missing artifact_path`;
+  if (!trackerPath || !trackerPath.endsWith('subagent-tracking.json')) return `${agentRole} review missing subagent-tracking.json tracker_path`;
+  if (!options.cwd) return `${agentRole} review cannot resolve cwd for tracker lookup`;
 
   const tracking = readJsonState(subagentTrackingPath(options.cwd));
   const session = asRecord(asRecord(tracking?.sessions)?.[sessionId]);
   const thread = asRecord(asRecord(session?.threads)?.[threadId]);
-  return thread?.kind === 'subagent';
+  if (!session) return `${agentRole} tracker session ${sessionId} is missing`;
+  if (!thread) return `${agentRole} tracker thread ${threadId} is missing`;
+  const leaderThreadId = typeof session.leader_thread_id === 'string' ? session.leader_thread_id.trim() : '';
+  if (leaderThreadId && leaderThreadId === threadId) return `${agentRole} tracker thread ${threadId} is the session leader`;
+  if (thread.kind !== 'subagent') return `${agentRole} tracker thread ${threadId} has kind=${String(thread.kind || 'missing')}`;
+  return null;
 }
 
 function validateLocalSessionId(sessionId: string): string[] {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1201,6 +1201,66 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("keeps a self-parented native role thread as subagent evidence", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-self-parented-subagent-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "omx-autopilot-session";
+      const nativeRoleThreadId = "codex-architect-thread";
+      await mkdir(join(stateDir, "sessions", canonicalSessionId), { recursive: true });
+      await writeSessionStart(cwd, canonicalSessionId, {
+        nativeSessionId: nativeRoleThreadId,
+      });
+
+      const transcriptPath = join(cwd, "architect-subagent-rollout.jsonl");
+      await writeFile(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: nativeRoleThreadId,
+            source: {
+              subagent: {
+                thread_spawn: {
+                  parent_thread_id: nativeRoleThreadId,
+                  depth: 1,
+                  agent_nickname: "Architect",
+                  agent_role: "architect",
+                },
+              },
+            },
+            agent_nickname: "Architect",
+            agent_role: "architect",
+          },
+        })}\n`,
+      );
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: nativeRoleThreadId,
+          transcript_path: transcriptPath,
+        },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+
+      const tracking = JSON.parse(
+        await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"),
+      ) as {
+        sessions?: Record<string, {
+          leader_thread_id?: string;
+          threads?: Record<string, { kind?: string; mode?: string }>;
+        }>;
+      };
+      assert.equal(tracking.sessions?.[canonicalSessionId]?.leader_thread_id, undefined);
+      assert.equal(tracking.sessions?.[canonicalSessionId]?.threads?.[nativeRoleThreadId]?.kind, "subagent");
+      assert.equal(tracking.sessions?.[canonicalSessionId]?.threads?.[nativeRoleThreadId]?.mode, "architect");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not attach a subagent SessionStart to an unrelated canonical leader", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-subagent-session-start-mismatch-"));
     try {
@@ -2711,6 +2771,61 @@ standardMaxRounds = 15
       assert.equal(existsSync(join(stateDir, "sessions", canonicalSessionId, "skill-active-state.json")), false);
       assert.equal(existsSync(join(stateDir, "sessions", canonicalSessionId, "ralplan-state.json")), false);
       assert.equal(existsSync(join(stateDir, "sessions", childNativeSessionId, "ralplan-state.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat a corrupt leader kind=subagent tracker entry as native subagent prompt scope", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-corrupt-leader-subagent-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "sess-corrupt-leader";
+      const leaderNativeSessionId = "native-corrupt-leader";
+      const nowIso = new Date().toISOString();
+
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: canonicalSessionId,
+        native_session_id: leaderNativeSessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [canonicalSessionId]: {
+            session_id: canonicalSessionId,
+            leader_thread_id: leaderNativeSessionId,
+            updated_at: nowIso,
+            threads: {
+              [leaderNativeSessionId]: {
+                thread_id: leaderNativeSessionId,
+                kind: "subagent",
+                first_seen_at: nowIso,
+                last_seen_at: nowIso,
+                turn_count: 2,
+              },
+            },
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: leaderNativeSessionId,
+          thread_id: leaderNativeSessionId,
+          turn_id: "turn-corrupt-leader",
+          prompt: "$autopilot continue this review blocker fix",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "autopilot");
+      assert.equal(
+        existsSync(join(stateDir, "sessions", canonicalSessionId, "autopilot-state.json")),
+        true,
+      );
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -14,6 +14,7 @@ import {
   type SkillActiveStateLike,
 } from "../state/skill-active.js";
 import {
+  isTrustedSubagentThread,
   readSubagentSessionSummary,
   readSubagentTrackingState,
   recordSubagentTurnForSession,
@@ -248,18 +249,25 @@ async function recordNativeSubagentSessionStart(
   metadata: NativeSubagentSessionStartMetadata,
   transcriptPath: string,
 ): Promise<void> {
+  const parentThreadId = metadata.parentThreadId.trim();
+  const childThreadId = childSessionId.trim();
   const trackingSessionIds = [...new Set([
     canonicalSessionId.trim(),
-    metadata.parentThreadId.trim(),
+    parentThreadId,
   ].filter(Boolean))];
   for (const sessionId of trackingSessionIds) {
+    if (parentThreadId && parentThreadId !== childThreadId) {
+      await recordSubagentTurnForSession(cwd, {
+        sessionId,
+        threadId: parentThreadId,
+        kind: 'leader',
+      }).catch(() => {});
+    }
     await recordSubagentTurnForSession(cwd, {
       sessionId,
-      threadId: metadata.parentThreadId,
-    }).catch(() => {});
-    await recordSubagentTurnForSession(cwd, {
-      sessionId,
-      threadId: childSessionId,
+      threadId: childThreadId,
+      kind: 'subagent',
+      ...(parentThreadId && parentThreadId !== childThreadId ? { leaderThreadId: parentThreadId } : {}),
       mode: metadata.agentRole,
     }).catch(() => {});
   }
@@ -326,7 +334,7 @@ async function isNativeSubagentHook(
   if (!trackingState) return false;
 
   return Object.values(trackingState.sessions).some((session) => (
-    candidateIds.some((id) => session.threads[id]?.kind === "subagent")
+    candidateIds.some((id) => isTrustedSubagentThread(session, id))
   ));
 }
 

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -51,6 +51,131 @@ describe('subagents/tracker', () => {
     assert.deepEqual(drained?.activeSubagentThreadIds, []);
   });
 
+  it('can record an explicitly spawned subagent as subagent even when it is the first seen thread', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-ralplan',
+      threadId: 'thread-architect',
+      timestamp: '2026-05-28T17:59:43.270Z',
+      mode: 'architect',
+      kind: 'subagent',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-ralplan',
+      threadId: 'thread-critic',
+      timestamp: '2026-05-28T18:01:49.547Z',
+      mode: 'critic',
+      kind: 'subagent',
+    });
+
+    const summary = summarizeSubagentSession(state, 'sess-ralplan', {
+      now: '2026-05-28T18:02:00.000Z',
+      activeWindowMs: 120_000,
+    });
+
+    assert.equal(state.sessions['sess-ralplan']?.leader_thread_id, undefined);
+    assert.equal(state.sessions['sess-ralplan']?.threads['thread-architect']?.kind, 'subagent');
+    assert.equal(state.sessions['sess-ralplan']?.threads['thread-critic']?.kind, 'subagent');
+    assert.deepEqual(summary?.allSubagentThreadIds, ['thread-architect', 'thread-critic']);
+  });
+
+  it('keeps an explicitly spawned first-seen subagent as subagent after a generic follow-up turn', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-ralplan',
+      threadId: 'thread-architect',
+      timestamp: '2026-05-28T17:59:43.270Z',
+      mode: 'architect',
+      kind: 'subagent',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-ralplan',
+      threadId: 'thread-architect',
+      turnId: 'turn-after-session-start',
+      timestamp: '2026-05-28T18:00:05.000Z',
+      mode: 'architect',
+    });
+
+    assert.equal(state.sessions['sess-ralplan']?.leader_thread_id, undefined);
+    assert.equal(state.sessions['sess-ralplan']?.threads['thread-architect']?.kind, 'subagent');
+    assert.equal(state.sessions['sess-ralplan']?.threads['thread-architect']?.turn_count, 2);
+    assert.equal(state.sessions['sess-ralplan']?.threads['thread-architect']?.last_turn_id, 'turn-after-session-start');
+  });
+
+  it('does not promote existing subagent evidence when the same thread later acts as a parent', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-ralplan',
+      threadId: 'thread-architect',
+      timestamp: '2026-05-28T17:59:43.270Z',
+      mode: 'architect',
+      kind: 'subagent',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-ralplan',
+      threadId: 'thread-architect',
+      timestamp: '2026-05-28T18:00:10.000Z',
+      mode: 'architect',
+      kind: 'leader',
+    });
+
+    assert.equal(state.sessions['sess-ralplan']?.leader_thread_id, undefined);
+    assert.equal(state.sessions['sess-ralplan']?.threads['thread-architect']?.kind, 'subagent');
+  });
+
+  it('does not downgrade a known leader when later native metadata claims the same thread as subagent', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-ralplan',
+      threadId: 'thread-leader',
+      timestamp: '2026-05-28T17:59:40.000Z',
+      mode: 'ralplan',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-ralplan',
+      threadId: 'thread-leader',
+      timestamp: '2026-05-28T17:59:43.270Z',
+      mode: 'architect',
+      kind: 'subagent',
+    });
+
+    assert.equal(state.sessions['sess-ralplan']?.leader_thread_id, 'thread-leader');
+    assert.equal(state.sessions['sess-ralplan']?.threads['thread-leader']?.kind, 'leader');
+  });
+
+  it('excludes a corrupt leader thread from trusted subagent summaries even when kind is subagent', () => {
+    const state = createSubagentTrackingState();
+    state.sessions['sess-corrupt'] = {
+      session_id: 'sess-corrupt',
+      leader_thread_id: 'thread-leader',
+      updated_at: '2026-05-28T19:04:17.000Z',
+      threads: {
+        'thread-leader': {
+          thread_id: 'thread-leader',
+          kind: 'subagent',
+          first_seen_at: '2026-05-28T19:04:17.000Z',
+          last_seen_at: '2026-05-28T19:04:17.000Z',
+          turn_count: 2,
+        },
+        'thread-child': {
+          thread_id: 'thread-child',
+          kind: 'subagent',
+          first_seen_at: '2026-05-28T19:04:18.000Z',
+          last_seen_at: '2026-05-28T19:04:18.000Z',
+          turn_count: 1,
+        },
+      },
+    };
+
+    const summary = summarizeSubagentSession(state, 'sess-corrupt', {
+      now: '2026-05-28T19:04:19.000Z',
+      activeWindowMs: 120_000,
+    });
+
+    assert.deepEqual(summary?.allSubagentThreadIds, ['thread-child']);
+    assert.deepEqual(summary?.activeSubagentThreadIds, ['thread-child']);
+  });
+
   it('reconciles completed subagent threads before reporting active wait state', () => {
     let state = createSubagentTrackingState();
     state = recordSubagentTurn(state, {

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -37,6 +37,8 @@ export interface RecordSubagentTurnInput {
   turnId?: string;
   timestamp?: string;
   mode?: string;
+  kind?: 'leader' | 'subagent';
+  leaderThreadId?: string;
   completed?: boolean;
   completionSource?: string;
 }
@@ -59,6 +61,17 @@ export function createSubagentTrackingState(): SubagentTrackingState {
     schemaVersion: SUBAGENT_TRACKING_SCHEMA_VERSION,
     sessions: {},
   };
+}
+
+export function isTrustedSubagentThread(
+  session: TrackedSubagentSession | null | undefined,
+  threadId: string,
+): boolean {
+  const normalizedThreadId = threadId.trim();
+  if (!session || !normalizedThreadId) return false;
+  const leaderThreadId = session.leader_thread_id?.trim();
+  if (leaderThreadId && leaderThreadId === normalizedThreadId) return false;
+  return session.threads[normalizedThreadId]?.kind === 'subagent';
 }
 
 export function normalizeSubagentTrackingState(input: unknown): SubagentTrackingState {
@@ -164,11 +177,29 @@ export function recordSubagentTurn(
     threads: {},
   };
 
-  const leaderThreadId = existingSession.leader_thread_id || threadId;
+  const requestedKind = input.kind === 'leader' || input.kind === 'subagent' ? input.kind : undefined;
+  const requestedLeaderThreadId = input.leaderThreadId?.trim();
   const existingThread = existingSession.threads[threadId];
+  const existingKind = existingThread?.kind === 'leader' || existingThread?.kind === 'subagent'
+    ? existingThread.kind
+    : undefined;
+  const existingLeaderThreadId = existingSession.leader_thread_id?.trim();
+  const preserveExistingSubagent = existingKind === 'subagent' && requestedKind !== 'subagent';
+  const preserveKnownLeader = requestedKind === 'subagent'
+    && (existingKind === 'leader' || existingLeaderThreadId === threadId);
+  const leaderThreadId = preserveKnownLeader
+    ? existingLeaderThreadId || threadId
+    : existingLeaderThreadId
+      || requestedLeaderThreadId
+      || (requestedKind === 'subagent' || preserveExistingSubagent ? undefined : threadId);
+  const kind = preserveKnownLeader
+    ? 'leader'
+    : requestedKind === 'leader' && existingKind === 'subagent'
+      ? 'subagent'
+      : requestedKind ?? (threadId === leaderThreadId ? 'leader' : existingKind ?? 'subagent');
   const nextThread: TrackedSubagentThread = {
     thread_id: threadId,
-    kind: threadId === leaderThreadId ? 'leader' : 'subagent',
+    kind,
     first_seen_at: existingThread?.first_seen_at ?? timestamp,
     last_seen_at: timestamp,
     turn_count: (existingThread?.turn_count ?? 0) + 1,
@@ -196,7 +227,7 @@ export function recordSubagentTurn(
 
   normalized.sessions[sessionId] = {
     session_id: sessionId,
-    leader_thread_id: leaderThreadId,
+    ...(leaderThreadId ? { leader_thread_id: leaderThreadId } : {}),
     updated_at: timestamp,
     threads,
   };
@@ -227,7 +258,7 @@ export function summarizeSubagentSession(
       : Date.now();
 
   const allThreadIds = Object.keys(session.threads).sort();
-  const allSubagentThreadIds = allThreadIds.filter((threadId) => session.threads[threadId]?.kind === 'subagent');
+  const allSubagentThreadIds = allThreadIds.filter((threadId) => isTrustedSubagentThread(session, threadId));
   const activeSubagentThreadIds = allSubagentThreadIds.filter((threadId) => {
     const thread = session.threads[threadId];
     if (!thread) return false;


### PR DESCRIPTION
## Summary

Clean replacement for the closed #2600, on top of current `upstream/dev`.

This addresses the remaining review blocker: native hook classification could still trust a corrupt tracker entry where the leader thread was recorded as `kind: "subagent"`. The fix centralizes subagent trust on the same authority boundary used by the ralplan gate:

- `thread.kind === "subagent"` is descriptive tracker metadata only.
- `leader_thread_id` is the authoritative session identity boundary.
- Trusted subagent evidence must satisfy both: `kind === "subagent"` and `thread_id !== leader_thread_id`.

## Changes

- Add `isTrustedSubagentThread(session, threadId)` in `src/subagents/tracker.ts`.
- Use that predicate for `summarizeSubagentSession()` so corrupt leader entries are not surfaced as subagent evidence.
- Use the same predicate in the native hook global fallback path.
- Keep ralplan/autopilot consensus fail-closed when review evidence comes from the session leader, even if tracking is malformed.
- Add regressions for:
  - corrupt leader-as-subagent excluded from tracker summaries,
  - corrupt leader prompt still activating workflow keywords instead of being suppressed as subagent scope,
  - real child subagent prompt still suppressed/literalized,
  - ralplan native evidence rejecting leader-thread spoofing.

## Scholastic review

Ontology-first review result: **WATCH, not BLOCK**.

The category mistake in the prior patch was treating descriptive `thread.kind` as if it were authoritative identity. This PR repairs that by making `leader_thread_id` the normative boundary and using `thread.kind` only as a secondary predicate.

Remaining architectural watch item: native-hook fallback still uses a workspace-global tracker index with sticky subagent classification. That is intentionally conservative for anti-spoofing and child-prompt suppression, but a future tightening could add session-scoped reconciliation or trust TTLs. It is not a merge blocker for this fix.

## Validation

Passed locally:

```text
git diff --check
npm run build
node --test dist/subagents/__tests__/tracker.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/autopilot/__tests__/ralplan-gate.test.js dist/ralplan/__tests__/runtime.test.js dist/autopilot/__tests__/fsm.test.js
npm run lint
npm run check:no-unused
npm run verify:native-agents
npm run verify:plugin-bundle
node --test dist/state/__tests__/operations.test.js dist/pipeline/__tests__/stages.test.js
```

Targeted node suite result: `tests 396`, `pass 396`, `fail 0`.
State/pipeline suite result: `tests 111`, `pass 111`, `fail 0`.

Additional review evidence:

- Code-review subagent: **APPROVE**, 0 issues.
- Scholastic/architecture subagent: **WATCH**, no blocker.
