### PR TITLE
Protect ralplan as a planning-only boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ Most users should think of OMX as **better task routing + better workflow + bett
 2. `$ralplan` — turn that clarified scope into an approved architecture and implementation plan.
 3. `$ultragoal` — make the approved plan durable as sequential Codex goals with `.omx/ultragoal` ledger checkpoints.
 
+`$ralplan` stops at planning artifacts and a durable consensus handoff. Code changes require an explicit execution lane (`$ultragoal`, `$team`, or an intentional `$ralph` fallback); ralplan does not implement directly.
+
 Inside an Ultragoal story, use `$team` only when that story benefits from coordinated parallel execution. Use `$ralph` as an intentional alternate completion loop when you do not need a durable multi-goal ledger.
 
 ## Common in-session surfaces

--- a/plugins/oh-my-codex/skills/ralplan/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralplan/SKILL.md
@@ -64,6 +64,18 @@ The consensus workflow:
 
 > **Important:** Steps 3 and 4 MUST run sequentially as role-specific subagents. Do NOT issue both agent calls in the same parallel batch. Always await the subsequent `Architect` result before invoking the subsequent `Critic`; only a completed, role-specific `Critic` approval can satisfy the durable gate.
 
+## Planning/Execution Boundary
+
+`$ralplan` is a planning mode. While ralplan is active and no explicit execution handoff is active, implementation-focused write tools are out of scope. Ralplan may inspect the repository and may write only planning artifacts such as `.omx/context/`, `.omx/plans/`, `.omx/specs/`, and required `.omx/state/` records.
+
+The canonical flow is:
+
+```
+$ralplan -> durable consensus artifact -> explicit execution lane -> $ultragoal | $team | $ralph
+```
+
+Before any execution lane begins, ralplan must emit terminal planning state (complete, paused, failed, or waiting for input) and the durable handoff record below. Do not continue from consensus planning into direct code edits in the same ralplan session.
+
 ## Durable Consensus Handoff Contract
 
 Ralplan is not complete, skippable, or ready for execution merely because `.omx/plans/prd-*.md` and `.omx/plans/test-spec-*.md` exist. Those files are planning artifacts, not consensus evidence.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -64,6 +64,18 @@ The consensus workflow:
 
 > **Important:** Steps 3 and 4 MUST run sequentially as role-specific subagents. Do NOT issue both agent calls in the same parallel batch. Always await the subsequent `Architect` result before invoking the subsequent `Critic`; only a completed, role-specific `Critic` approval can satisfy the durable gate.
 
+## Planning/Execution Boundary
+
+`$ralplan` is a planning mode. While ralplan is active and no explicit execution handoff is active, implementation-focused write tools are out of scope. Ralplan may inspect the repository and may write only planning artifacts such as `.omx/context/`, `.omx/plans/`, `.omx/specs/`, and required `.omx/state/` records.
+
+The canonical flow is:
+
+```
+$ralplan -> durable consensus artifact -> explicit execution lane -> $ultragoal | $team | $ralph
+```
+
+Before any execution lane begins, ralplan must emit terminal planning state (complete, paused, failed, or waiting for input) and the durable handoff record below. Do not continue from consensus planning into direct code edits in the same ralplan session.
+
 ## Durable Consensus Handoff Contract
 
 Ralplan is not complete, skippable, or ready for execution merely because `.omx/plans/prd-*.md` and `.omx/plans/test-spec-*.md` exist. Those files are planning artifacts, not consensus evidence.

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1348,6 +1348,71 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('emits terminal ralplan state before explicit ultragoal execution handoff', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-ralplan-ultragoal-handoff-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(stateDir, 'sessions', 'sess-ralplan-ultragoal'), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-ralplan-ultragoal', SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'ralplan',
+          keyword: '$ralplan',
+          phase: 'planning',
+          session_id: 'sess-ralplan-ultragoal',
+          active_skills: [{ skill: 'ralplan', phase: 'planning', active: true, session_id: 'sess-ralplan-ultragoal' }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-ralplan-ultragoal', 'ralplan-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'ralplan',
+          current_phase: 'complete',
+          planning_complete: true,
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', approved: true },
+            ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', approved: true },
+          },
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$ultragoal execute the approved ralplan',
+        sessionId: 'sess-ralplan-ultragoal',
+        nowIso: '2026-04-10T00:20:00.000Z',
+      });
+
+      assert.equal(result?.transition_error, undefined);
+      assert.equal(result?.skill, 'ultragoal');
+      assert.equal(result?.transition_message, 'mode transiting: ralplan -> ultragoal');
+      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['ultragoal']);
+
+      const ralplan = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-ralplan-ultragoal', 'ralplan-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string; completed_at?: string; auto_completed_reason?: string };
+      assert.equal(ralplan.active, false);
+      assert.equal(ralplan.current_phase, 'completed');
+      assert.equal(ralplan.auto_completed_reason, 'mode transiting: ralplan -> ultragoal');
+      assert.ok(ralplan.completed_at);
+
+      const ultragoal = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-ralplan-ultragoal', 'ultragoal-state.json'), 'utf-8'),
+      ) as { active?: boolean; mode?: string; current_phase?: string };
+      assert.equal(ultragoal.active, true);
+      assert.equal(ultragoal.mode, 'ultragoal');
+      assert.equal(ultragoal.current_phase, 'planning');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('keeps root team state out of the session-scoped Ralph canonical state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-ralph-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -12941,6 +12941,221 @@ exit 0
     }
   });
 
+  it("blocks implementation writes while ralplan is active without execution handoff", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-pretool-block-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-ralplan-pretool-block";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{ skill: "ralplan", phase: "planning", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "critic-review",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-pretool-block",
+          tool_name: "Edit",
+          tool_input: { file_path: "src/runtime.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Ralplan is active .*implementation\/write tools are blocked/i);
+      assert.match(
+        String((result.outputJson?.hookSpecificOutput as { additionalContext?: string } | undefined)?.additionalContext ?? ""),
+        /\$ultragoal.*\$team.*\$ralph/i,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows ralplan planning artifact writes without execution handoff", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-pretool-artifact-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-ralplan-pretool-artifact";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{ skill: "ralplan", phase: "planning", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-pretool-artifact",
+          tool_name: "Write",
+          tool_input: { file_path: ".omx/plans/prd-issue-2603.md" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks bash implementation writes while ralplan is active without execution handoff", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-pretool-bash-block-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-ralplan-pretool-bash-block";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{ skill: "ralplan", phase: "planning", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-pretool-bash-block",
+          tool_name: "Bash",
+          tool_input: { command: "cat <<'EOF' > src/runtime.ts\nimplementation\nEOF" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Ralplan is active .*implementation\/write tools are blocked/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows bash planning artifact writes while ralplan is active without execution handoff", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-pretool-bash-artifact-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-ralplan-pretool-bash-artifact";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{ skill: "ralplan", phase: "planning", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-pretool-bash-artifact",
+          tool_name: "Bash",
+          tool_input: { command: "cat <<'EOF' > .omx/plans/prd-issue-2603.md\nplanning\nEOF" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows implementation writes when an explicit execution handoff is active", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-pretool-handoff-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-ralplan-pretool-handoff";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ultragoal",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [
+          { skill: "ralplan", phase: "planning", active: true, session_id: sessionId },
+          { skill: "ultragoal", phase: "planning", active: true, session_id: sessionId },
+        ],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "complete",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-pretool-handoff",
+          tool_name: "Edit",
+          tool_input: { file_path: "src/runtime.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block Stop from root team state without team_name when no session is known", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-team-no-session-no-name-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2434,12 +2434,32 @@ const DEEP_INTERVIEW_ALLOWED_WRITE_PREFIXES = [
   ".omx/state",
 ] as const;
 
-const DEEP_INTERVIEW_IMPLEMENTATION_TOOL_NAMES = new Set([
+const RALPLAN_ALLOWED_WRITE_PREFIXES = [
+  ".omx/context",
+  ".omx/plans",
+  ".omx/specs",
+  ".omx/state",
+] as const;
+
+const PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES = new Set([
   "Write",
   "Edit",
   "MultiEdit",
+  "NotebookEdit",
   "apply_patch",
   "ApplyPatch",
+]);
+
+const DEEP_INTERVIEW_IMPLEMENTATION_TOOL_NAMES = PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES;
+
+const RALPLAN_EXECUTION_HANDOFF_SKILLS = new Set([
+  "autopilot",
+  "autoresearch",
+  "ralph",
+  "team",
+  "ultragoal",
+  "ultrawork",
+  "ultraqa",
 ]);
 
 function isActiveDeepInterviewPhase(state: Record<string, unknown> | null): boolean {
@@ -2451,7 +2471,31 @@ function isActiveDeepInterviewPhase(state: Record<string, unknown> | null): bool
   return true;
 }
 
-function isAllowedDeepInterviewArtifactPath(cwd: string, rawPath: string): boolean {
+function isActiveRalplanPhase(state: Record<string, unknown> | null): boolean {
+  if (!state || state.active !== true) return false;
+  const mode = safeString(state.mode).trim();
+  if (mode && mode !== "ralplan") return false;
+  const phase = safeString(state.current_phase ?? state.currentPhase).trim().toLowerCase();
+  if (phase && (TERMINAL_MODE_PHASES.has(phase) || phase === "completing")) return false;
+  return true;
+}
+
+function hasExplicitExecutionHandoffSkill(
+  state: SkillActiveStateLike | null,
+  sessionId: string,
+  threadId: string,
+): boolean {
+  return listActiveSkills(state ?? {}).some((entry) => (
+    RALPLAN_EXECUTION_HANDOFF_SKILLS.has(entry.skill)
+    && matchesSkillStopContext(entry, state ?? {}, sessionId, threadId)
+  ));
+}
+
+function isAllowedPlanningArtifactPath(
+  cwd: string,
+  rawPath: string,
+  allowedPrefixes: readonly string[],
+): boolean {
   const trimmed = rawPath.trim().replace(/^['"]|['"]$/g, "");
   if (!trimmed || trimmed.includes("\0")) return false;
   let relativePath: string;
@@ -2462,9 +2506,17 @@ function isAllowedDeepInterviewArtifactPath(cwd: string, rawPath: string): boole
     return false;
   }
   if (!relativePath || relativePath.startsWith("..") || relativePath.startsWith("/")) return false;
-  return DEEP_INTERVIEW_ALLOWED_WRITE_PREFIXES.some((prefix) => (
+  return allowedPrefixes.some((prefix) => (
     relativePath === prefix || relativePath.startsWith(`${prefix}/`)
   ));
+}
+
+function isAllowedDeepInterviewArtifactPath(cwd: string, rawPath: string): boolean {
+  return isAllowedPlanningArtifactPath(cwd, rawPath, DEEP_INTERVIEW_ALLOWED_WRITE_PREFIXES);
+}
+
+function isAllowedRalplanArtifactPath(cwd: string, rawPath: string): boolean {
+  return isAllowedPlanningArtifactPath(cwd, rawPath, RALPLAN_ALLOWED_WRITE_PREFIXES);
 }
 
 function readPreToolUseCommand(payload: CodexHookPayload): string {
@@ -2534,6 +2586,73 @@ async function readActiveDeepInterviewStateForPreToolUse(
     && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
   ));
   return hasActiveDeepInterviewSkill ? modeState : null;
+}
+
+async function readActiveRalplanStateForPreToolUse(
+  cwd: string,
+  stateDir: string,
+  sessionId: string,
+  threadId: string,
+): Promise<Record<string, unknown> | null> {
+  const modeState = sessionId
+    ? await readStopSessionPinnedState("ralplan-state.json", cwd, sessionId, stateDir)
+    : await readJsonIfExists(join(stateDir, "ralplan-state.json"));
+  if (!isActiveRalplanPhase(modeState) || !modeState) return null;
+  if (!modeStateMatchesSkillStopContext(modeState, cwd, sessionId)) return null;
+
+  const canonicalState = sessionId
+    ? await readVisibleSkillActiveStateForStateDir(stateDir, sessionId)
+    : await readSkillActiveState(join(stateDir, SKILL_ACTIVE_STATE_FILE));
+  if (hasExplicitExecutionHandoffSkill(canonicalState, sessionId, threadId)) return null;
+  if (!canonicalState) return modeState;
+  const hasActiveRalplanSkill = listActiveSkills(canonicalState).some((entry) => (
+    entry.skill === "ralplan"
+    && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
+  ));
+  return hasActiveRalplanSkill ? modeState : null;
+}
+
+function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
+  if (!commandHasDeepInterviewWriteIntent(command)) return true;
+  if (/\bomx\s+(?:state\s+(?:write|read|clear)|question)\b/.test(command)) return true;
+  const targets = extractDeepInterviewCommandWriteTargets(command);
+  return targets.length > 0 && targets.every((target) => isAllowedRalplanArtifactPath(cwd, target));
+}
+
+async function buildRalplanPreToolUseBoundaryOutput(
+  payload: CodexHookPayload,
+  cwd: string,
+  stateDir: string,
+): Promise<Record<string, unknown> | null> {
+  const sessionId = readPayloadSessionId(payload);
+  const threadId = readPayloadThreadId(payload);
+  const activeState = await readActiveRalplanStateForPreToolUse(cwd, stateDir, sessionId, threadId);
+  if (!activeState) return null;
+
+  const toolName = safeString(payload.tool_name).trim();
+  const command = readPreToolUseCommand(payload);
+  const pathCandidates = readPreToolUsePathCandidates(payload);
+  let blocked = false;
+
+  if (toolName === "Bash") {
+    blocked = !isAllowedRalplanBashWrite(cwd, command);
+  } else if (PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES.has(toolName)) {
+    blocked = pathCandidates.length === 0
+      || !pathCandidates.every((candidate) => isAllowedRalplanArtifactPath(cwd, candidate));
+  }
+
+  if (!blocked) return null;
+
+  const phase = formatPhase(activeState.current_phase ?? activeState.currentPhase, "planning");
+  return {
+    decision: "block",
+    reason: `Ralplan is active (phase: ${phase}); implementation/write tools are blocked until an explicit execution handoff workflow is activated.`,
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext:
+        "Ralplan is consensus-planning mode. Write only planning artifacts under `.omx/context/`, `.omx/plans/`, `.omx/specs/`, or required `.omx/state/` files. Do not edit implementation files or run implementation-focused writes from ralplan. To execute, first process an explicit handoff such as `$ultragoal`, `$team`, or `$ralph`, which must emit terminal ralplan state before implementation begins.",
+    },
+  };
 }
 
 async function buildDeepInterviewPreToolUseBoundaryOutput(
@@ -2861,15 +2980,15 @@ function buildRalplanContinuationStatus(
   }
 
   const completeHint = blocker.planningComplete
-    ? " The planning artifacts are present; if consensus is approved, emit the final complete/approved handoff instead of stopping here."
+    ? " The planning artifacts are present; if consensus is approved, emit terminal ralplan complete/approved handoff state and stop planning. Implementation must wait for an explicit $ultragoal, $team, or $ralph handoff."
     : "";
 
   return {
     reason:
-      `Status: continue_from_artifact — ralplan is still active (phase: ${phase}) and has not emitted a terminal complete/paused/waiting status. Continue from the current ralplan artifact, resolve any review ambiguity conservatively or ask the user if needed, and proceed to the next planning/review step before stopping.${artifact}${completeHint}`,
+      `Status: continue_from_artifact — ralplan is still active (phase: ${phase}) and has not emitted a terminal complete/paused/waiting status. Continue from the current ralplan artifact, resolve any review ambiguity conservatively or ask the user if needed, and proceed to the next planning/review step before stopping; do not begin implementation from ralplan.${artifact}${completeHint}`,
     stopReasonSuffix: "continue_artifact",
     systemMessage:
-      `OMX ralplan status: continue_from_artifact at phase ${phase}; continue from the current ralplan artifact and finish by stating whether ralplan is complete, paused for review, waiting for input, or still continuing.`,
+      `OMX ralplan status: continue_from_artifact at phase ${phase}; continue from the current ralplan artifact and finish by stating whether ralplan is complete, paused for review, waiting for input, or still continuing; do not begin implementation from ralplan.`,
   };
 }
 
@@ -4021,6 +4140,7 @@ export async function dispatchCodexNativeHook(
     }
   } else if (hookEventName === "PreToolUse") {
     outputJson = await buildDeepInterviewPreToolUseBoundaryOutput(payload, cwd, stateDir)
+      ?? await buildRalplanPreToolUseBoundaryOutput(payload, cwd, stateDir)
       ?? buildNativePreToolUseOutput(payload);
   } else if (hookEventName === "PostToolUse") {
     if (detectMcpTransportFailure(payload)) {

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -105,6 +105,13 @@ describe('workflow transition rules', () => {
     assert.deepEqual(ralplanToRalph.autoCompleteModes, ['ralplan']);
     assert.deepEqual(ralplanToRalph.resultingModes, ['ultrawork', 'ralph']);
 
+    const ralplanToUltragoal = evaluateWorkflowTransition(['ralplan'], 'ultragoal');
+    assert.equal(ralplanToUltragoal.allowed, true);
+    assert.equal(ralplanToUltragoal.kind, 'auto-complete');
+    assert.deepEqual(ralplanToUltragoal.autoCompleteModes, ['ralplan']);
+    assert.deepEqual(ralplanToUltragoal.resultingModes, ['ultragoal']);
+    assert.equal(ralplanToUltragoal.transitionMessage, 'mode transiting: ralplan -> ultragoal');
+
     const ralplanToAutoresearch = evaluateWorkflowTransition(['ralplan'], 'autoresearch');
     assert.equal(ralplanToAutoresearch.allowed, true);
     assert.equal(ralplanToAutoresearch.kind, 'auto-complete');

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -138,6 +138,7 @@ const AUTO_COMPLETE_TRANSITIONS = new Set([
   'deep-interview->ultragoal',
   'deep-interview->ultrawork',
   'ralplan->team',
+  'ralplan->ultragoal',
   'ralplan->ralph',
   'ralplan->autopilot',
   'ralplan->autoresearch',


### PR DESCRIPTION
## Summary
- Enforce `$ralplan` as planning-only in the native PreToolUse boundary unless an explicit execution handoff workflow is active.
- Auto-complete terminal ralplan state when handing off to `$ultragoal`, matching existing execution-lane transitions.
- Tighten docs/skill guidance so Stop continuation and handoff copy do not drift into implementation.

Fixes #2603.

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/keyword-detector.test.js dist/state/__tests__/workflow-transition.test.js dist/hooks/__tests__/autopilot-skill-contract.test.js dist/ralplan/__tests__/runtime.test.js`
- `npm run verify:plugin-bundle`
- `git diff --check`

OmX co-authored-by: OpenAI Codex
