### PR TITLE
Fix duplicate standalone HUD status pane

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -3832,6 +3832,58 @@ esac
     }
   });
 
+  it('reuses an existing standalone HUD pane across repeated restore calls', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-reuse-hud-'));
+
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-reuse-standalone-hud-',
+        (logPath) => {
+          const statePath = `${logPath}.state`;
+          return `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  list-panes)
+    printf '%%11\\tzsh\\tzsh\\n'
+    if [ -f "${statePath}" ]; then
+      printf "%%44\\tnode\\texec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%11' /node /omx.js hud --watch\\n"
+    fi
+    exit 0
+    ;;
+  split-window)
+    : > "${statePath}"
+    echo "%44"
+    exit 0
+    ;;
+  run-shell|select-pane|resize-pane|set-hook|kill-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`;
+        },
+        async ({ logPath }) => {
+          const firstPaneId = restoreStandaloneHudPane('%11', cwd);
+          const secondPaneId = restoreStandaloneHudPane('%11', cwd);
+
+          assert.equal(firstPaneId, '%44');
+          assert.equal(secondPaneId, '%44');
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          const splitCount = (tmuxLog.match(/(^|\n)split-window /g) ?? []).length;
+          assert.equal(splitCount, 1);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
+          assert.match(tmuxLog, /list-panes -t %11 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('restores standalone HUD panes with an absolute OMX entry path after cwd drift', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-relative-hud-'));
     const startupCwd = await mkdtemp(join(tmpdir(), 'omx-standalone-relative-start-'));

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -35,7 +35,7 @@ import { resolveOmxCliEntryPath } from '../utils/paths.js';
 const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
 import { OMX_TMUX_HUD_OWNER_ENV } from '../hud/reconcile.js';
-import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../hud/tmux.js';
+import { findHudWatchPaneIds, OMX_TMUX_HUD_LEADER_PANE_ENV } from '../hud/tmux.js';
 
 const OMX_INSTANCE_OPTION = '@omx_instance_id';
 const OMX_PANE_INSTANCE_OPTION = '@omx_pane_instance_id';
@@ -317,6 +317,10 @@ function findHudPaneIds(target: string, leaderPaneId: string): string[] {
     .filter((pane) => pane.paneId !== leaderPaneId)
     .filter((pane) => isHudWatchPane(pane))
     .map((pane) => pane.paneId);
+}
+
+function findOwnedHudPaneIds(target: string, leaderPaneId: string): string[] {
+  return findHudWatchPaneIds(listPanes(target), leaderPaneId, { leaderPaneId });
 }
 
 const MAX_FRACTIONAL_SLEEP_MS = 60_000;
@@ -1418,6 +1422,24 @@ export function restoreStandaloneHudPane(
 
   const omxEntry = resolveOmxCliEntryPath();
   if (!omxEntry || omxEntry.trim() === '') return null;
+
+  const [existingHudPaneId, ...duplicateHudPaneIds] = findOwnedHudPaneIds(
+    normalizedLeaderPaneId,
+    normalizedLeaderPaneId,
+  );
+  for (const paneId of duplicateHudPaneIds) {
+    runTmux(['kill-pane', '-t', paneId]);
+  }
+  if (existingHudPaneId) {
+    if (isNativeWindows()) {
+      runTmux(buildHudResizeArgs(existingHudPaneId));
+    } else {
+      runTmux(buildScheduleDelayedHudResizeArgs(existingHudPaneId));
+      runTmux(buildReconcileHudResizeArgs(existingHudPaneId));
+    }
+    runTmux(['select-pane', '-t', normalizedLeaderPaneId]);
+    return existingHudPaneId;
+  }
 
   const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { leaderPaneId: normalizedLeaderPaneId })} ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
   const hudCwd = translatePathForMsys(cwd);


### PR DESCRIPTION
## Summary
- Reuse an existing standalone OMX-owned HUD/status pane during restore instead of splitting a duplicate pane.
- Clean up extra same-leader owned HUD panes before reusing the keeper pane.
- Add a regression proving repeated standalone HUD restore calls create only one bottom status pane.

Fixes #2607.

## Verification
- `npm ci`
- `npm run build`
- `npm run lint`
- `node --test dist/team/__tests__/tmux-session.test.js dist/hud/__tests__/index.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js` — 344 pass / 0 fail
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
