### PR TITLE
Respect effective gitignore for OMX setup ignores

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -211,6 +211,30 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("creates .gitignore without .omx/ when global Git excludes already ignore it", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-global-ignore-"));
+    const excludesFile = join(wd, "global-ignore");
+    try {
+      const initResult = spawnSync("git", ["init", "-q"], { cwd: wd });
+      assert.equal(initResult.status, 0);
+      await writeFile(excludesFile, ".omx/\n");
+      const configResult = spawnSync(
+        "git",
+        ["config", "core.excludesfile", excludesFile],
+        { cwd: wd },
+      );
+      assert.equal(configResult.status, 0);
+
+      await runSetupInTempDir(wd, { scope: "project" });
+
+      const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
+      assert.equal(gitignore, EXPECTED_PROJECT_GITIGNORE_WITHOUT_OMX);
+      assert.equal(gitignore.match(/^\.omx\/$/gm)?.length ?? 0, 0);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("ignores project-local config while keeping .codex agents, skills, and prompts trackable", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {


### PR DESCRIPTION
## Summary
- add setup regression coverage for `.omx/` ignored through `core.excludesfile`
- preserve the existing narrow effective-ignore guard that skips project `.gitignore` mutation when Git already ignores `.omx/`
- keep startup/setup behavior boundaries unchanged

Closes #2610

## Validation
- npm run build
- npm run lint
- npm run check:no-unused
- node --test dist/cli/__tests__/setup-refresh.test.js dist/scripts/__tests__/codex-native-hook.test.js
- git diff --check

## Review
- code-reviewer: APPROVE
- architect: CLEAR
