### PR TITLE
Guard hook payload intake size

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -34,6 +34,7 @@ import { WIKI_SCHEMA_VERSION } from "../../wiki/types.js";
 import { createUltragoalPlan, readUltragoalPlan } from "../../ultragoal/artifacts.js";
 import { getBaseStateDir } from "../../state/paths.js";
 import { maybeNudgeLeaderForAllowedWorkerStop } from "../notify-hook/team-worker-stop.js";
+import { MAX_NATIVE_STDIN_JSON_BYTES } from "../hook-payload-guard.js";
 
 function nativeHookScriptPath(): string {
   return join(process.cwd(), "dist", "scripts", "codex-native-hook.js");
@@ -467,6 +468,48 @@ describe("codex native hook dispatch", () => {
       const output = parseSingleJsonStdout(stdout);
 
       assert.deepEqual(output, {});
+      assert.equal(existsSync(join(cwd, ".omx", "state")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty JSON for oversized Stop stdin without parsing or creating inactive state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-"));
+    try {
+      const oversizedStop = JSON.stringify({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-cli-stop-oversized",
+        transcript: "x".repeat(MAX_NATIVE_STDIN_JSON_BYTES + 1),
+      });
+
+      const stdout = runNativeHookCli(oversizedStop, { cwd });
+      assert.deepEqual(parseSingleJsonStdout(stdout), {});
+      assert.equal(existsSync(join(cwd, ".omx", "state")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for oversized non-Stop stdin before parsing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-nonstop-oversized-"));
+    try {
+      const oversizedPrompt = JSON.stringify({
+        hook_event_name: "UserPromptSubmit",
+        cwd,
+        session_id: "sess-cli-prompt-oversized",
+        prompt: "x".repeat(MAX_NATIVE_STDIN_JSON_BYTES + 1),
+      });
+
+      const output = parseSingleJsonStdout(runNativeHookCli(oversizedPrompt, { cwd })) as {
+        continue?: boolean;
+        stopReason?: string;
+        systemMessage?: string;
+      };
+      assert.equal(output.continue, false);
+      assert.equal(output.stopReason, "native_hook_stdin_oversized");
+      assert.match(String(output.systemMessage ?? ""), /rejected oversized stdin JSON before parsing/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -109,6 +109,10 @@ import {
   isFinalHandoffDocumentRefreshCandidate,
 } from "../document-refresh/enforcer.js";
 import { buildExecFollowupStopOutput } from "../exec/followup.js";
+import {
+  MAX_NATIVE_STDIN_JSON_BYTES,
+  extractRawCodexHookEventName,
+} from "./hook-payload-guard.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -3941,6 +3945,14 @@ export async function dispatchCodexNativeHook(
 ): Promise<NativeHookDispatchResult> {
   const hookEventName = readHookEventName(payload);
   const cwd = options.cwd ?? (safeString(payload.cwd).trim() || process.cwd());
+  if (hookEventName === "Stop" && !hasNativeStopRuntimeSurface(cwd)) {
+    return {
+      hookEventName,
+      omxEventName: mapCodexHookEventToOmxEvent(hookEventName),
+      skillState: null,
+      outputJson: null,
+    };
+  }
   // Native hooks must use the same authoritative runtime state root as HUD/MCP
   // when boxed/team roots are active; do not bypass it with cwd/.omx/state.
   const stateDir = getBaseStateDir(cwd);
@@ -4237,10 +4249,31 @@ export async function dispatchCodexNativeHook(
   };
 }
 
+function hasNativeStopRuntimeSurface(cwd: string): boolean {
+  if (existsSync(join(cwd, ".omx"))) return true;
+  if (findGitLayout(cwd)) return true;
+  const omxRoot = safeString(process.env.OMX_ROOT).trim();
+  if (omxRoot && existsSync(join(omxRoot, ".omx"))) return true;
+  const stateRoot = safeString(process.env.OMX_STATE_ROOT).trim();
+  if (stateRoot && existsSync(stateRoot)) return true;
+  return [
+    process.env.OMX_SESSION_ID,
+    process.env.OMX_TEAM_INTERNAL_WORKER,
+    process.env.OMX_TEAM_WORKER,
+    process.env.OMX_TEAM_STATE_ROOT,
+    process.env.OMX_TEAM_LEADER_CWD,
+    process.env.OMX_NOTIFY_HOOK_TRUSTED_MANAGED_CWD,
+    process.env.OMX_TMUX_HUD_OWNER,
+    process.env.OMX_TMUX_HUD_LEADER_PANE,
+  ].some((value) => safeString(value).trim() !== "");
+}
+
 interface NativeHookCliReadResult {
   payload: CodexHookPayload;
   parseError: Error | null;
   rawInput: string;
+  oversized: boolean;
+  rawHookEventName: CodexHookEventName | null;
 }
 
 export function isCodexNativeHookMainModule(
@@ -4253,12 +4286,33 @@ export function isCodexNativeHookMainModule(
 
 async function readStdinJson(): Promise<NativeHookCliReadResult> {
   const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let oversized = false;
   for await (const chunk of process.stdin) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_NATIVE_STDIN_JSON_BYTES) {
+      const remaining = Math.max(0, MAX_NATIVE_STDIN_JSON_BYTES - (totalBytes - buffer.byteLength));
+      if (remaining > 0) chunks.push(Buffer.from(buffer.subarray(0, remaining)));
+      oversized = true;
+      process.stdin.destroy();
+      break;
+    }
+    chunks.push(buffer);
   }
   const raw = Buffer.concat(chunks).toString("utf-8").trim();
+  const rawHookEventName = extractRawCodexHookEventName(raw);
+  if (oversized) {
+    return {
+      payload: {},
+      parseError: null,
+      rawInput: raw,
+      oversized: true,
+      rawHookEventName,
+    };
+  }
   if (!raw) {
-    return { payload: {}, parseError: null, rawInput: raw };
+    return { payload: {}, parseError: null, rawInput: raw, oversized: false, rawHookEventName };
   }
 
   try {
@@ -4266,12 +4320,16 @@ async function readStdinJson(): Promise<NativeHookCliReadResult> {
       payload: safeObject(JSON.parse(raw)),
       parseError: null,
       rawInput: raw,
+      oversized: false,
+      rawHookEventName,
     };
   } catch (error) {
     return {
       payload: {},
       parseError: error instanceof Error ? error : new Error(String(error)),
       rawInput: raw,
+      oversized: false,
+      rawHookEventName,
     };
   }
 }
@@ -4299,6 +4357,17 @@ function buildMalformedStdinHookOutput(parseError: Error, rawInput: string): Rec
   return {
     continue: false,
     stopReason: "native_hook_stdin_parse_error",
+    systemMessage,
+  };
+}
+
+function buildOversizedStdinHookOutput(rawHookEventName: CodexHookEventName | null): Record<string, unknown> {
+  if (rawHookEventName === "Stop") return {};
+  const systemMessage =
+    `OMX native hook rejected oversized stdin JSON before parsing; maxBytes=${MAX_NATIVE_STDIN_JSON_BYTES}.`;
+  return {
+    continue: false,
+    stopReason: "native_hook_stdin_oversized",
     systemMessage,
   };
 }
@@ -4354,7 +4423,11 @@ function buildStopDispatchFailureOutput(error: unknown): Record<string, unknown>
 }
 
 export async function runCodexNativeHookCli(): Promise<void> {
-  const { payload, parseError, rawInput } = await readStdinJson();
+  const { payload, parseError, rawInput, oversized, rawHookEventName } = await readStdinJson();
+  if (oversized) {
+    writeNativeHookJsonStdout(buildOversizedStdinHookOutput(rawHookEventName));
+    return;
+  }
   if (parseError) {
     await logNativeHookCliError(process.cwd(), "native_hook_stdin_parse_error", parseError);
     writeNativeHookJsonStdout(buildMalformedStdinHookOutput(parseError, rawInput));

--- a/src/scripts/hook-payload-guard.ts
+++ b/src/scripts/hook-payload-guard.ts
@@ -1,0 +1,113 @@
+export const MAX_NOTIFY_ARGV_JSON_BYTES = 64 * 1024;
+export const MAX_NATIVE_STDIN_JSON_BYTES = 1024 * 1024;
+export const RAW_JSON_FIELD_SCAN_BYTES = 64 * 1024;
+
+export const CODEX_HOOK_EVENT_NAMES = [
+  "SessionStart",
+  "PreToolUse",
+  "PostToolUse",
+  "UserPromptSubmit",
+  "PreCompact",
+  "PostCompact",
+  "Stop",
+] as const;
+
+export type RawCodexHookEventName = typeof CODEX_HOOK_EVENT_NAMES[number];
+
+export function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf-8");
+}
+
+function skipJsonWhitespace(raw: string, index: number): number {
+  while (index < raw.length && /\s/.test(raw[index] ?? "")) index += 1;
+  return index;
+}
+
+function readJsonStringLiteral(raw: string, quoteIndex: number): { value: string; endIndex: number } | null {
+  if (raw[quoteIndex] !== '"') return null;
+  let value = "";
+  for (let index = quoteIndex + 1; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (char === '"') return { value, endIndex: index + 1 };
+    if (char !== "\\") {
+      value += char;
+      continue;
+    }
+
+    index += 1;
+    if (index >= raw.length) return null;
+    const escaped = raw[index];
+    switch (escaped) {
+      case '"':
+      case "\\":
+      case "/":
+        value += escaped;
+        break;
+      case "b":
+        value += "\b";
+        break;
+      case "f":
+        value += "\f";
+        break;
+      case "n":
+        value += "\n";
+        break;
+      case "r":
+        value += "\r";
+        break;
+      case "t":
+        value += "\t";
+        break;
+      case "u": {
+        const hex = raw.slice(index + 1, index + 5);
+        if (!/^[0-9a-fA-F]{4}$/.test(hex)) return null;
+        value += String.fromCharCode(Number.parseInt(hex, 16));
+        index += 4;
+        break;
+      }
+      default:
+        return null;
+    }
+  }
+  return null;
+}
+
+export function extractRawJsonStringField(rawInput: string, fieldNames: readonly string[]): string | null {
+  const raw = rawInput.slice(0, RAW_JSON_FIELD_SCAN_BYTES);
+  const wanted = new Set(fieldNames);
+  let depth = 0;
+  let index = 0;
+
+  while (index < raw.length) {
+    const char = raw[index];
+    if (char === '"') {
+      const key = readJsonStringLiteral(raw, index);
+      if (!key) return null;
+      index = key.endIndex;
+      const afterKey = skipJsonWhitespace(raw, index);
+      if (depth === 1 && raw[afterKey] === ":" && wanted.has(key.value)) {
+        const valueStart = skipJsonWhitespace(raw, afterKey + 1);
+        const value = readJsonStringLiteral(raw, valueStart);
+        return value?.value ?? null;
+      }
+      continue;
+    }
+    if (char === "{") depth += 1;
+    else if (char === "}") depth = Math.max(0, depth - 1);
+    index += 1;
+  }
+
+  return null;
+}
+
+export function extractRawCodexHookEventName(rawInput: string): RawCodexHookEventName | null {
+  const raw = extractRawJsonStringField(rawInput, [
+    "hook_event_name",
+    "hookEventName",
+    "event",
+    "name",
+  ]);
+  return CODEX_HOOK_EVENT_NAMES.includes(raw as RawCodexHookEventName)
+    ? raw as RawCodexHookEventName
+    : null;
+}

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -68,6 +68,11 @@ import {
 } from './notify-hook/team-worker.js';
 import { DEFAULT_MARKER } from './tmux-hook-engine.js';
 import { sameFilePath } from '../utils/paths.js';
+import {
+  MAX_NOTIFY_ARGV_JSON_BYTES,
+  extractRawJsonStringField,
+  utf8ByteLength,
+} from './hook-payload-guard.js';
 
 const RALPH_ACTIVE_PROGRESS_PHASES = new Set([
   'start',
@@ -283,6 +288,9 @@ function isNotifyFallbackTaskCompletePayload(payload: Record<string, unknown>): 
 async function main() {
   const rawPayload = process.argv[process.argv.length - 1];
   if (!rawPayload || rawPayload.startsWith('-')) {
+    process.exit(0);
+  }
+  if (utf8ByteLength(rawPayload) > MAX_NOTIFY_ARGV_JSON_BYTES) {
     process.exit(0);
   }
 
@@ -909,8 +917,12 @@ async function logFatalNotifyHookError(err: unknown): Promise<void> {
   try {
     const rawPayload = process.argv[process.argv.length - 1];
     if (rawPayload && !rawPayload.startsWith('-')) {
-      const payload = JSON.parse(rawPayload) as Record<string, unknown>;
-      cwd = safeString(payload.cwd || payload['cwd'] || cwd) || cwd;
+      if (utf8ByteLength(rawPayload) <= MAX_NOTIFY_ARGV_JSON_BYTES) {
+        const payload = JSON.parse(rawPayload) as Record<string, unknown>;
+        cwd = safeString(payload.cwd || payload['cwd'] || cwd) || cwd;
+      } else {
+        cwd = extractRawJsonStringField(rawPayload, ['cwd']) || cwd;
+      }
     }
   } catch {
     // Keep notification hook failures silent in Codex TUI surfaces.

--- a/src/scripts/notify-hook/__tests__/payload-guard.test.ts
+++ b/src/scripts/notify-hook/__tests__/payload-guard.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { MAX_NOTIFY_ARGV_JSON_BYTES } from '../../hook-payload-guard.js';
+
+function notifyHookScriptPath(): string {
+  return join(process.cwd(), 'dist', 'scripts', 'notify-hook.js');
+}
+
+describe('notify-hook raw payload guard', () => {
+  it('ignores oversized argv JSON before parsing or writing hook state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-notify-hook-oversized-'));
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'setup-scope.json'), '{}', 'utf-8');
+      const payload = JSON.stringify({
+        cwd,
+        type: 'agent-turn-complete',
+        session_id: 'sess-notify-oversized',
+        turn_id: 'turn-notify-oversized',
+        input_messages: ['hello'],
+        last_assistant_message: 'x'.repeat(MAX_NOTIFY_ARGV_JSON_BYTES + 1),
+      });
+
+      execFileSync(process.execPath, [notifyHookScriptPath(), payload], {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: process.env,
+      });
+
+      assert.equal(existsSync(join(cwd, '.omx', 'logs')), false);
+      assert.equal(existsSync(join(cwd, '.omx', 'state')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared bounded raw hook payload guard for native stdin and notify argv payloads
- fail closed for oversized native non-Stop payloads while allowing oversized Stop payloads to return `{}` without full JSON parsing
- skip inactive native Stop processing when there is no OMX/git/runtime surface, avoiding `.omx/state` creation
- add regressions for oversized native Stop/UserPromptSubmit stdin and oversized notify-hook argv payloads

Fixes #2614.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 dist/scripts/__tests__/codex-native-hook.test.js dist/scripts/notify-hook/__tests__/payload-guard.test.js dist/hooks/__tests__/notify-hook-modules.test.js`
- `npm run test:recent-bug-regressions:compiled`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
