### PR TITLE
Summarize oversized notify logs without payload views

### DIFF
--- a/src/scripts/hook-payload-guard.ts
+++ b/src/scripts/hook-payload-guard.ts
@@ -111,3 +111,177 @@ export function extractRawCodexHookEventName(rawInput: string): RawCodexHookEven
     ? raw as RawCodexHookEventName
     : null;
 }
+
+export const MAX_NOTIFY_COMPACT_SCAN_BYTES = 2 * 1024 * 1024;
+export const MAX_NOTIFY_RETAINED_TEXT_BYTES = 16 * 1024;
+
+export interface OversizedNotifyLogSummary {
+  cwd: string;
+  type: string;
+  threadId: string;
+  turnId: string;
+  latestInputText: string;
+  inputMessageCount: number | null;
+  inputMessageCountPartial: boolean;
+  inputMessagesTruncated: boolean;
+  outputPreview: string;
+  rawPayloadBytes: number;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (utf8ByteLength(value) <= maxBytes) return value;
+  return Buffer.from(value, "utf-8").subarray(0, maxBytes).toString("utf-8").replace(/\uFFFD$/u, "");
+}
+
+function skipJsonValue(raw: string, index: number): number {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let cursor = index; cursor < raw.length; cursor += 1) {
+    const char = raw[cursor];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === "{" || char === "[") depth += 1;
+    else if (char === "}" || char === "]") {
+      if (depth === 0) return cursor;
+      depth -= 1;
+    } else if (char === "," && depth === 0) {
+      return cursor + 1;
+    }
+  }
+  return raw.length;
+}
+
+function readInputMessagesSummary(raw: string, arrayStart: number): {
+  endIndex: number;
+  latest: string;
+  count: number;
+  partial: boolean;
+  truncated: boolean;
+} {
+  let index = skipJsonWhitespace(raw, arrayStart);
+  if (raw[index] !== "[") return { endIndex: index, latest: "", count: 0, partial: false, truncated: true };
+  index += 1;
+  let count = 0;
+  let latest = "";
+  let partial = true;
+  let truncated = false;
+  while (index < raw.length) {
+    index = skipJsonWhitespace(raw, index);
+    const char = raw[index];
+    if (char === "]") {
+      partial = false;
+      index += 1;
+      break;
+    }
+    if (char === '"') {
+      const item = readJsonStringLiteral(raw, index);
+      if (!item) {
+        truncated = true;
+        break;
+      }
+      count += 1;
+      const retained = truncateUtf8(item.value, MAX_NOTIFY_RETAINED_TEXT_BYTES);
+      latest = retained;
+      truncated = truncated || retained !== item.value;
+      index = skipJsonWhitespace(raw, item.endIndex);
+      if (raw[index] === ",") index += 1;
+      continue;
+    }
+    truncated = true;
+    index = skipJsonValue(raw, index);
+  }
+  return { endIndex: index, latest, count, partial, truncated: truncated || partial };
+}
+
+export function extractOversizedNotifyLogSummary(rawPayload: string): OversizedNotifyLogSummary {
+  const rawPayloadBytes = utf8ByteLength(rawPayload);
+  const scanBuffer = Buffer.from(rawPayload, "utf-8").subarray(0, MAX_NOTIFY_COMPACT_SCAN_BYTES);
+  const raw = scanBuffer.toString("utf-8");
+  const summary: OversizedNotifyLogSummary = {
+    cwd: "",
+    type: "",
+    threadId: "",
+    turnId: "",
+    latestInputText: "",
+    inputMessageCount: null,
+    inputMessageCountPartial: rawPayloadBytes > scanBuffer.byteLength,
+    inputMessagesTruncated: rawPayloadBytes > MAX_NOTIFY_ARGV_JSON_BYTES,
+    outputPreview: "",
+    rawPayloadBytes,
+  };
+
+  let depth = 0;
+  let index = 0;
+  while (index < raw.length) {
+    const char = raw[index];
+    if (char === '"') {
+      const key = readJsonStringLiteral(raw, index);
+      if (!key) break;
+      index = key.endIndex;
+      const afterKey = skipJsonWhitespace(raw, index);
+      if (depth !== 1 || raw[afterKey] !== ":") continue;
+      const valueStart = skipJsonWhitespace(raw, afterKey + 1);
+      switch (key.value) {
+        case "cwd":
+        case "type": {
+          const value = readJsonStringLiteral(raw, valueStart);
+          if (value) {
+            summary[key.value] = truncateUtf8(value.value, MAX_NOTIFY_RETAINED_TEXT_BYTES);
+            index = value.endIndex;
+          }
+          break;
+        }
+        case "thread-id":
+        case "thread_id": {
+          const value = readJsonStringLiteral(raw, valueStart);
+          if (value) {
+            summary.threadId = truncateUtf8(value.value, MAX_NOTIFY_RETAINED_TEXT_BYTES);
+            index = value.endIndex;
+          }
+          break;
+        }
+        case "turn-id":
+        case "turn_id": {
+          const value = readJsonStringLiteral(raw, valueStart);
+          if (value) {
+            summary.turnId = truncateUtf8(value.value, MAX_NOTIFY_RETAINED_TEXT_BYTES);
+            index = value.endIndex;
+          }
+          break;
+        }
+        case "last-assistant-message":
+        case "last_assistant_message": {
+          const value = readJsonStringLiteral(raw, valueStart);
+          if (value) {
+            summary.outputPreview = truncateUtf8(value.value, MAX_NOTIFY_RETAINED_TEXT_BYTES);
+            index = value.endIndex;
+          }
+          break;
+        }
+        case "input-messages":
+        case "input_messages": {
+          const input = readInputMessagesSummary(raw, valueStart);
+          summary.latestInputText = input.latest;
+          summary.inputMessageCount = input.count;
+          summary.inputMessageCountPartial = input.partial || rawPayloadBytes > scanBuffer.byteLength;
+          summary.inputMessagesTruncated = input.truncated || rawPayloadBytes > MAX_NOTIFY_ARGV_JSON_BYTES;
+          index = input.endIndex;
+          break;
+        }
+        default:
+          index = skipJsonValue(raw, valueStart);
+      }
+      continue;
+    }
+    if (char === "{") depth += 1;
+    else if (char === "}") depth = Math.max(0, depth - 1);
+    index += 1;
+  }
+  return summary;
+}

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -70,6 +70,7 @@ import { DEFAULT_MARKER } from './tmux-hook-engine.js';
 import { sameFilePath } from '../utils/paths.js';
 import {
   MAX_NOTIFY_ARGV_JSON_BYTES,
+  extractOversizedNotifyLogSummary,
   extractRawJsonStringField,
   utf8ByteLength,
 } from './hook-payload-guard.js';
@@ -291,6 +292,27 @@ async function main() {
     process.exit(0);
   }
   if (utf8ByteLength(rawPayload) > MAX_NOTIFY_ARGV_JSON_BYTES) {
+    const compact = extractOversizedNotifyLogSummary(rawPayload);
+    const compactCwd = compact.cwd || process.cwd();
+    if (!compact.cwd || !(await isOmxManagedCwd(compactCwd))) {
+      process.exit(0);
+    }
+    const logsDir = join(compactCwd, '.omx', 'logs');
+    await mkdir(logsDir, { recursive: true }).catch(() => {});
+    const logFile = join(logsDir, `turns-${new Date().toISOString().split('T')[0]}.jsonl`);
+    await appendFile(logFile, JSON.stringify({
+      timestamp: new Date().toISOString(),
+      type: compact.type || 'agent-turn-complete',
+      thread_id: compact.threadId || undefined,
+      turn_id: compact.turnId || undefined,
+      input_preview: compact.latestInputText.slice(0, 200),
+      input_message_count: compact.inputMessageCount,
+      input_message_count_partial: compact.inputMessageCountPartial,
+      input_messages_truncated: compact.inputMessagesTruncated,
+      output_preview: compact.outputPreview.slice(0, 200),
+      payload_compacted: true,
+      raw_payload_bytes: compact.rawPayloadBytes,
+    }) + '\n').catch(() => {});
     process.exit(0);
   }
 

--- a/src/scripts/notify-hook/__tests__/payload-guard.test.ts
+++ b/src/scripts/notify-hook/__tests__/payload-guard.test.ts
@@ -1,18 +1,45 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import { MAX_NOTIFY_ARGV_JSON_BYTES } from '../../hook-payload-guard.js';
+import {
+  MAX_NOTIFY_ARGV_JSON_BYTES,
+  extractOversizedNotifyLogSummary,
+} from '../../hook-payload-guard.js';
 
 function notifyHookScriptPath(): string {
   return join(process.cwd(), 'dist', 'scripts', 'notify-hook.js');
 }
 
 describe('notify-hook raw payload guard', () => {
-  it('ignores oversized argv JSON before parsing or writing hook state', async () => {
+  it('extracts an oversized notify log summary without retaining the full array', () => {
+    const raw = JSON.stringify({
+      cwd: '/tmp/project',
+      type: 'agent-turn-complete',
+      'thread-id': 'thread-1',
+      'turn-id': 'turn-1',
+      input_messages: ['first', 'middle'.repeat(20000), 'latest compact input'],
+      last_assistant_message: 'assistant'.repeat(20000),
+    });
+
+    const view = extractOversizedNotifyLogSummary(raw);
+    assert.equal(view.cwd, '/tmp/project');
+    assert.equal(view.threadId, 'thread-1');
+    assert.equal(view.turnId, 'turn-1');
+    assert.equal(view.latestInputText, 'latest compact input');
+    assert.equal(view.inputMessageCount, 3);
+    assert.equal(view.inputMessagesTruncated, true);
+    assert.equal('client' in view, false);
+    assert.equal('mode' in view, false);
+    assert.equal('producerSource' in view, false);
+    assert.equal('projectName' in view, false);
+    assert.equal('input_messages' in view, false);
+  });
+
+  it('logs a compact oversized managed payload summary without writing hook state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-notify-hook-oversized-'));
     try {
       await mkdir(join(cwd, '.omx'), { recursive: true });
@@ -22,6 +49,48 @@ describe('notify-hook raw payload guard', () => {
         type: 'agent-turn-complete',
         session_id: 'sess-notify-oversized',
         turn_id: 'turn-notify-oversized',
+        client: 'codex-tui',
+        mode: 'autopilot',
+        source: 'notify-fallback-watcher',
+        project_name: 'secret-project',
+        input_messages: ['hello', 'latest oversized input'.repeat(30)],
+        last_assistant_message: 'y'.repeat(500),
+        padding: 'z'.repeat(MAX_NOTIFY_ARGV_JSON_BYTES + 1),
+      });
+
+      execFileSync(process.execPath, [notifyHookScriptPath(), payload], {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: process.env,
+      });
+
+      const logPath = join(cwd, '.omx', 'logs', `turns-${new Date().toISOString().split('T')[0]}.jsonl`);
+      assert.equal(existsSync(logPath), true);
+      const entry = JSON.parse(readFileSync(logPath, 'utf-8').trim());
+      assert.equal(entry.payload_compacted, true);
+      assert.equal(entry.turn_id, 'turn-notify-oversized');
+      assert.equal(entry.input_preview.length, 200);
+      assert.equal(entry.output_preview.length, 200);
+      assert.equal(entry.input_message_count, 2);
+      assert.equal(entry.input_messages_truncated, true);
+      assert.equal('client' in entry, false);
+      assert.equal('mode' in entry, false);
+      assert.equal('source' in entry, false);
+      assert.equal('project_name' in entry, false);
+      assert.equal('session_id' in entry, false);
+      assert.equal('input_messages' in entry, false);
+      assert.equal('raw_payload_bytes_scanned' in entry, false);
+      assert.equal(existsSync(join(cwd, '.omx', 'state')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores oversized payloads when cwd is missing without creating local state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-notify-hook-oversized-missing-cwd-'));
+    try {
+      const payload = JSON.stringify({
+        type: 'agent-turn-complete',
         input_messages: ['hello'],
         last_assistant_message: 'x'.repeat(MAX_NOTIFY_ARGV_JSON_BYTES + 1),
       });
@@ -32,8 +101,7 @@ describe('notify-hook raw payload guard', () => {
         env: process.env,
       });
 
-      assert.equal(existsSync(join(cwd, '.omx', 'logs')), false);
-      assert.equal(existsSync(join(cwd, '.omx', 'state')), false);
+      assert.equal(existsSync(join(cwd, '.omx')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- refine the merged #2615 notify guard so oversized legacy notify payloads still leave a bounded local turn-log hint instead of disappearing completely
- replace the earlier broad compact payload view with a narrow `extractOversizedNotifyLogSummary` helper for the oversized path only
- persist only normal turn-log-equivalent fields for managed OMX directories: capped input/output previews, input count/truncation flags, turn/thread/type, and payload size
- keep the oversized path side-effect-minimal: no full `JSON.parse`, no synthetic `input_messages`, no state writes, no native/derived event dispatch, and no fallback completion inference

## Context
#2615 correctly added the raw payload guard for #2614. This follow-up keeps that safety boundary, but preserves a small amount of useful notify evidence when Codex legacy notify payloads are oversized because of historical `input_messages` or assistant text bloat.

The producer-side Codex issue is tracked at:
- https://github.com/openai/codex/issues/25141

## Why this version is smaller
After RALPLAN + Scholastic review, the patch was narrowed from a “compact payload view” abstraction to a log-summary extractor. The net simplification removed payload-view metadata that the oversized branch must not semantically own (`client`, `mode`, `source`, `project_name`, `session_id`, scan-byte metadata, fallback-complete inference, full arrays).

## Validation
- `npm run build`
- `node --test --test-concurrency=1 dist/scripts/notify-hook/__tests__/payload-guard.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
