### PR TITLE
Block oversized Stop for active autopilot sessions

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -492,6 +492,83 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("blocks oversized Stop stdin when current session autopilot is active", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-active-"));
+    try {
+      await writeActiveAutopilotSession(cwd, "sess-cli-stop-oversized-active");
+      const oversizedStop = JSON.stringify({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "native-session-hidden-by-oversized-payload",
+        transcript: "x".repeat(MAX_NATIVE_STDIN_JSON_BYTES + 1),
+      });
+
+      const output = parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })) as {
+        decision?: string;
+        stopReason?: string;
+        systemMessage?: string;
+      };
+      assert.equal(output.decision, "block");
+      assert.equal(output.stopReason, "native_stop_stdin_oversized_active_workflow");
+      assert.match(String(output.systemMessage ?? ""), /active current-session workflow state/);
+      assert.equal(existsSync(join(cwd, ".omx", "logs")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block oversized Stop stdin for unrelated root autopilot state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-stale-root-"));
+    try {
+      await writeJson(join(cwd, ".omx", "state", "session.json"), {
+        session_id: "sess-current-without-active-autopilot",
+        cwd,
+      });
+      await writeJson(join(cwd, ".omx", "state", "autopilot-state.json"), {
+        active: true,
+        current_phase: "execution",
+      });
+      const oversizedStop = JSON.stringify({
+        hook_event_name: "Stop",
+        cwd,
+        transcript: "x".repeat(MAX_NATIVE_STDIN_JSON_BYTES + 1),
+      });
+
+      assert.deepEqual(parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })), {});
+      assert.equal(existsSync(join(cwd, ".omx", "logs")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block oversized Stop stdin when terminal run-state shadows stale autopilot state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-terminal-run-"));
+    try {
+      const sessionId = "sess-cli-stop-oversized-terminal-run";
+      await writeActiveAutopilotSession(cwd, sessionId);
+      await writeJson(join(cwd, ".omx", "state", "sessions", sessionId, "run-state.json"), {
+        version: 1,
+        active: false,
+        mode: "autopilot",
+        outcome: "finish",
+        lifecycle_outcome: "finished",
+        current_phase: "complete",
+        completed_at: "2026-05-20T11:00:00.000Z",
+        updated_at: "2026-05-20T11:00:00.000Z",
+      });
+      const oversizedStop = JSON.stringify({
+        hook_event_name: "Stop",
+        cwd,
+        transcript: "x".repeat(MAX_NATIVE_STDIN_JSON_BYTES + 1),
+      });
+
+      assert.deepEqual(parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })), {});
+      assert.equal(existsSync(join(cwd, ".omx", "logs")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed for oversized non-Stop stdin before parsing", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-nonstop-oversized-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4361,8 +4361,36 @@ function buildMalformedStdinHookOutput(parseError: Error, rawInput: string): Rec
   };
 }
 
-function buildOversizedStdinHookOutput(rawHookEventName: CodexHookEventName | null): Record<string, unknown> {
-  if (rawHookEventName === "Stop") return {};
+async function buildOversizedStopActiveWorkflowOutput(cwd: string): Promise<Record<string, unknown> | null> {
+  const currentSession = await readUsableSessionState(cwd);
+  const currentSessionId = safeString(currentSession?.session_id).trim()
+    || safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID).trim();
+  if (!currentSessionId) return null;
+
+  if (await readCanonicalTerminalRunStateForStop(cwd, currentSessionId, "autopilot")) return null;
+
+  const autopilotState = await readModeStateForActiveDecision("autopilot", currentSessionId, cwd);
+  if (!autopilotState || !shouldContinueRun(autopilotState)) return null;
+
+  const phase = formatPhase(autopilotState.current_phase);
+  const reason =
+    `OMX native Stop received oversized stdin before parsing while the current session has active OMX autopilot state (phase: ${phase}); continue once with a compact response or reduce hook payload size so normal Stop gates can run.`;
+  return {
+    decision: "block",
+    reason,
+    stopReason: "native_stop_stdin_oversized_active_workflow",
+    systemMessage:
+      "OMX native Stop rejected oversized stdin before parsing; active current-session workflow state is present, so Stop is blocked instead of silently allowing termination.",
+  };
+}
+
+async function buildOversizedStdinHookOutput(
+  rawHookEventName: CodexHookEventName | null,
+  cwd: string,
+): Promise<Record<string, unknown>> {
+  if (rawHookEventName === "Stop") {
+    return await buildOversizedStopActiveWorkflowOutput(cwd) ?? {};
+  }
   const systemMessage =
     `OMX native hook rejected oversized stdin JSON before parsing; maxBytes=${MAX_NATIVE_STDIN_JSON_BYTES}.`;
   return {
@@ -4425,7 +4453,7 @@ function buildStopDispatchFailureOutput(error: unknown): Record<string, unknown>
 export async function runCodexNativeHookCli(): Promise<void> {
   const { payload, parseError, rawInput, oversized, rawHookEventName } = await readStdinJson();
   if (oversized) {
-    writeNativeHookJsonStdout(buildOversizedStdinHookOutput(rawHookEventName));
+    writeNativeHookJsonStdout(await buildOversizedStdinHookOutput(rawHookEventName, process.cwd()));
     return;
   }
   if (parseError) {


### PR DESCRIPTION
## Summary
- keep #2615's oversized payload privacy boundary: no full parse, no payload-derived previews, no notify changes, and no `.omx/logs` writes
- change only native oversized `Stop` semantics for the current session: if session-scoped Autopilot is still active, return a content-free block instead of `{}`
- preserve existing behavior for inactive/no-session oversized `Stop`, stale root Autopilot state, terminal run-state, and oversized non-Stop events

## Why
`{}` is safe from a parsing/privacy perspective, but for a Codex `Stop` hook it is also an allow-stop result. When the current session has active Autopilot state, that can bypass the normal Stop gate and allow premature termination. This PR keeps content fail-closed while preserving the continuation gate for the current authoritative session only.

## Scope
This is intentionally v1-scoped to session-scoped Autopilot because that is the concrete risk discussed after #2617. It does not claim general oversized observability and does not broaden into root/compatibility state.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 dist/scripts/__tests__/codex-native-hook.test.js --test-name-pattern="oversized Stop|oversized non-Stop"`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- code-review subagent: APPROVE / CLEAR
