### PR TITLE
Clarify native ralplan tracker diagnostics

### DIFF
--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -305,11 +305,12 @@ function trackerBackedNativeReviewProblem(
   if (!trackerPath || !trackerPath.endsWith('subagent-tracking.json')) return `${agentRole} review missing subagent-tracking.json tracker_path`;
   if (!options.cwd) return `${agentRole} review cannot resolve cwd for tracker lookup`;
 
-  const tracking = readJsonState(subagentTrackingPath(options.cwd));
+  const expectedTrackerPath = subagentTrackingPath(options.cwd);
+  const tracking = readJsonState(expectedTrackerPath);
   const session = asRecord(asRecord(tracking?.sessions)?.[sessionId]);
   const thread = asRecord(asRecord(session?.threads)?.[threadId]);
-  if (!session) return `${agentRole} tracker session ${sessionId} is missing`;
-  if (!thread) return `${agentRole} tracker thread ${threadId} is missing`;
+  if (!session) return `${agentRole} tracker session ${sessionId} is missing in ${expectedTrackerPath}; only reviews recorded in OMX subagent-tracking.json count as native lanes`;
+  if (!thread) return `${agentRole} tracker thread ${threadId} is missing in ${expectedTrackerPath}; external/collab subagent reviews are not tracker-backed native lanes`;
   const leaderThreadId = typeof session.leader_thread_id === 'string' ? session.leader_thread_id.trim() : '';
   if (leaderThreadId && leaderThreadId === threadId) return `${agentRole} tracker thread ${threadId} is the session leader`;
   if (thread.kind !== 'subagent') return `${agentRole} tracker thread ${threadId} has kind=${String(thread.kind || 'missing')}`;

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1521,6 +1521,50 @@ describe('state operations directory initialization', () => {
   });
 
 
+  it('explains when native ralplan reviews are not present in subagent tracking', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ralplan-native-missing-tracker-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ralplan-native-missing-tracker';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'ralplan',
+            state: {
+              handoff_artifacts: {
+                ralplan: {
+                  plan_path: '.omx/plans/prd.md',
+                  test_spec_path: '.omx/plans/test-spec.md',
+                },
+                ralplan_consensus_gate: ralplanConsensusGate(sessionId, 'native_subagent'),
+              },
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: true,
+          current_phase: 'ultragoal',
+        });
+
+        assert.equal(response.isError, true);
+        const error = String((response.payload as { error?: string }).error || '');
+        assert.match(error, /subagent-tracking\.json/);
+        assert.match(error, /only reviews recorded in OMX subagent-tracking\.json count as native lanes/i);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+
   it('denies Autopilot ralplan to ultragoal self-write when native reviews reuse one subagent thread', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ralplan-same-thread-deny-'));
     try {


### PR DESCRIPTION
## Summary
- make strict Autopilot ralplan consensus gate failures more actionable when native review evidence is not present in `subagent-tracking.json`
- include the actual tracker path checked in missing-session/thread diagnostics
- clarify that external/collab subagent reviews are not tracker-backed OMX native lanes

## Investigation
This came from a real Autopilot run where Architect/Critic review content existed, but `omx state write` correctly refused the ralplan -> ultragoal/complete transition. The reviews were produced by the external collab subagent tool, not by OMX-tracked native subagent lanes, so they were not recorded under the current session in `.omx/state/subagent-tracking.json`.

The gate behavior is intentionally strict and should stay strict. The problem was the operator-facing diagnosis: the error only said the tracker session/thread was missing, without showing which tracker was checked or explaining that non-OMX/collab reviews do not satisfy the native-lane requirement.

## Validation
- `npm run build`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_SESSION_ID node --test --test-concurrency=1 dist/state/__tests__/operations.test.js --test-name-pattern="native ralplan reviews are not present"`
- `node --test --test-concurrency=1 dist/ralplan/__tests__/runtime.test.js --test-name-pattern="consensus|native"`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
