### PR TITLE
Reset terminal autopilot state on reactivation

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -647,6 +647,84 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+
+  it('resets Autopilot mode state when reactivated after a terminal phase', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-terminal-reset-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-autopilot-terminal-reset';
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        keyword: '$autopilot',
+        phase: 'complete',
+        activated_at: '2026-05-29T00:00:00.000Z',
+        updated_at: '2026-05-29T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', active: true, phase: 'complete', session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'complete',
+        completed_at: '2026-05-29T00:00:00.000Z',
+        handoff_artifacts: {
+          code_review: { verdict: 'APPROVE / CLEAR' },
+          ultraqa: { verdict: 'pass' },
+        },
+        state: {
+          handoff_artifacts: {
+            ralplan_consensus_gate: { complete: false },
+            code_review: { verdict: 'stale' },
+          },
+        },
+      }, null, 2));
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$autopilot investigate the next issue',
+        sessionId,
+        threadId: 'thread-reactivated',
+        turnId: 'turn-reactivated',
+        nowIso: '2026-05-30T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
+        active?: boolean;
+        current_phase?: string;
+        completed_at?: string;
+        handoff_artifacts?: Record<string, unknown>;
+        state?: { handoff_artifacts?: Record<string, unknown> };
+      };
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'deep-interview');
+      assert.equal(modeState.completed_at, undefined);
+      assert.equal(modeState.handoff_artifacts, undefined);
+      assert.deepEqual(modeState.state?.handoff_artifacts, {
+        deep_interview: null,
+        ralplan: null,
+        ralplan_consensus_gate: {
+          required: true,
+          sequence: ['architect-review', 'critic-review'],
+          planning_artifacts_are_not_consensus: true,
+          required_review_roles: ['architect', 'critic'],
+          ralplan_architect_review: null,
+          ralplan_critic_review: null,
+          complete: false,
+        },
+        ultragoal: null,
+        code_review: null,
+        ultraqa: null,
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('adds approved workflow overlaps without deleting the existing canonical state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-overlap-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -364,8 +364,11 @@ async function persistStatefulSkillSeedState(
   const sameActiveSkill = previousSkill?.skill === nextSkill.skill && previousSkill.active;
   const existingModeMatches = safeString(existingModeState?.mode).trim() === config.mode;
   const existingPhase = safeString(existingModeState?.current_phase).trim();
+  const existingPhaseNormalized = existingPhase.toLowerCase().replace(/_/g, '-');
+  const existingModeTerminal = ['complete', 'completed', 'failed', 'cancelled', 'canceled'].includes(existingPhaseNormalized);
   const preserveExistingModeState = existingModeMatches
     && existingPhase !== ''
+    && !existingModeTerminal
     && (
       sameActiveSkill
       || (config.mode === 'team' && existingModeState?.active === true)
@@ -408,13 +411,14 @@ async function persistStatefulSkillSeedState(
   }
 
   if (config.mode === 'autopilot') {
-    const existingState = (existingModeState?.state && typeof existingModeState.state === 'object')
-      ? existingModeState.state as Record<string, unknown>
+    const reusableModeState = preserveExistingModeState ? existingModeState : null;
+    const existingState = (reusableModeState?.state && typeof reusableModeState.state === 'object')
+      ? reusableModeState.state as Record<string, unknown>
       : {};
     const existingHandoffs = (existingState.handoff_artifacts && typeof existingState.handoff_artifacts === 'object')
       ? existingState.handoff_artifacts as Record<string, unknown>
       : {};
-    baseState.review_cycle = typeof existingModeState?.review_cycle === 'number' ? existingModeState.review_cycle : 0;
+    baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
     baseState.state = {
       ...existingState,
       phase_cycle: Array.isArray(existingState.phase_cycle) ? existingState.phase_cycle : ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa'],


### PR DESCRIPTION
## Summary
- reset Autopilot mode state when `$autopilot` is invoked again after a terminal phase
- avoid preserving stale `current_phase: complete` / completed handoff artifacts during a new activation
- add a regression test for reactivating Autopilot after terminal state with stale top-level and nested handoffs

## Investigation
Disk evidence from the real run showed two separate issues:

1. `omx state write` correctly refused my synthetic ralplan consensus because the reviews were not present in OMX `subagent-tracking.json` for the current session. That is addressed separately by #2619 with clearer diagnostics.
2. A later `$autopilot` activation reused a terminal `autopilot-state.json`: it became `active: true` while still carrying `current_phase: complete` and stale handoff evidence. That is a real reactivation bug fixed here.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 dist/hooks/__tests__/keyword-detector.test.js --test-name-pattern="resets Autopilot mode state"`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
