### PR TITLE
Reset terminal workflow state on reactivation

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -647,6 +647,173 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+
+  it('fully resets terminal Autopilot mode state when reactivated', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-terminal-reset-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-terminal-reset';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        keyword: '$autopilot',
+        phase: 'complete',
+        activated_at: '2026-05-29T00:00:00.000Z',
+        updated_at: '2026-05-29T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', active: true, phase: 'complete', session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'complete',
+        started_at: '2026-05-29T00:00:00.000Z',
+        completed_at: '2026-05-29T00:10:00.000Z',
+        iteration: 10,
+        max_iterations: 10,
+        review_cycle: 3,
+        lifecycle_outcome: 'finished',
+        run_outcome: 'finish',
+        handoff_artifacts: {
+          code_review: { verdict: 'APPROVE / CLEAR' },
+          ultraqa: { verdict: 'pass' },
+        },
+        state: {
+          handoff_artifacts: {
+            ralplan_consensus_gate: { complete: false },
+            code_review: { verdict: 'stale' },
+          },
+        },
+      }, null, 2));
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$autopilot investigate the next issue',
+        sessionId,
+        threadId: 'thread-reactivated',
+        turnId: 'turn-reactivated',
+        nowIso: '2026-05-30T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      assert.equal(result.phase, 'deep-interview');
+      assert.equal(result.activated_at, '2026-05-30T00:00:00.000Z');
+      assert.equal(result.active_skills?.[0]?.phase, 'deep-interview');
+      assert.equal(result.active_skills?.[0]?.activated_at, '2026-05-30T00:00:00.000Z');
+      const skillState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), 'utf-8')) as {
+        phase?: string;
+        activated_at?: string;
+        active_skills?: Array<{ phase?: string; activated_at?: string }>;
+      };
+      assert.equal(skillState.phase, 'deep-interview');
+      assert.equal(skillState.activated_at, '2026-05-30T00:00:00.000Z');
+      assert.equal(skillState.active_skills?.[0]?.phase, 'deep-interview');
+      assert.equal(skillState.active_skills?.[0]?.activated_at, '2026-05-30T00:00:00.000Z');
+      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
+        active?: boolean;
+        current_phase?: string;
+        started_at?: string;
+        completed_at?: string;
+        iteration?: number;
+        max_iterations?: number;
+        review_cycle?: number;
+        lifecycle_outcome?: string;
+        run_outcome?: string;
+        handoff_artifacts?: Record<string, unknown>;
+        state?: { handoff_artifacts?: Record<string, unknown> };
+      };
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'deep-interview');
+      assert.equal(modeState.started_at, '2026-05-30T00:00:00.000Z');
+      assert.equal(modeState.completed_at, undefined);
+      assert.equal(modeState.iteration, 1);
+      assert.equal(modeState.max_iterations, 10);
+      assert.equal(modeState.review_cycle, 0);
+      assert.equal(modeState.lifecycle_outcome, undefined);
+      assert.equal(modeState.run_outcome, undefined);
+      assert.equal(modeState.handoff_artifacts, undefined);
+      assert.deepEqual(modeState.state?.handoff_artifacts, {
+        deep_interview: null,
+        ralplan: null,
+        ralplan_consensus_gate: {
+          required: true,
+          sequence: ['architect-review', 'critic-review'],
+          planning_artifacts_are_not_consensus: true,
+          required_review_roles: ['architect', 'critic'],
+          ralplan_architect_review: null,
+          ralplan_critic_review: null,
+          complete: false,
+        },
+        ultragoal: null,
+        code_review: null,
+        ultraqa: null,
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('resets stopped Autopilot mode state when reactivated', async () => {
+    for (const phase of ['stopped', 'user-stopped']) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-keyword-autopilot-${phase}-reset-`));
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionId = `sess-autopilot-${phase}-reset`;
+      try {
+        await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+        await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase,
+          activated_at: '2026-05-29T00:00:00.000Z',
+          updated_at: '2026-05-29T00:00:00.000Z',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', active: true, phase, session_id: sessionId }],
+        }, null, 2));
+        await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: phase,
+          started_at: '2026-05-29T00:00:00.000Z',
+          completed_at: '2026-05-29T00:10:00.000Z',
+          iteration: 10,
+          max_iterations: 10,
+          review_cycle: 3,
+          state: { handoff_artifacts: { code_review: { verdict: 'stale' } } },
+        }, null, 2));
+
+        const result = await recordSkillActivation({
+          stateDir,
+          text: '$autopilot new task after stop',
+          sessionId,
+          nowIso: '2026-05-30T00:00:00.000Z',
+        });
+
+        assert.ok(result);
+        assert.equal(result.phase, 'deep-interview');
+        assert.equal(result.activated_at, '2026-05-30T00:00:00.000Z');
+        const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
+          current_phase?: string;
+          iteration?: number;
+          review_cycle?: number;
+          state?: { handoff_artifacts?: { code_review?: unknown } };
+        };
+        assert.equal(modeState.current_phase, 'deep-interview');
+        assert.equal(modeState.iteration, 1);
+        assert.equal(modeState.review_cycle, 0);
+        assert.equal(modeState.state?.handoff_artifacts?.code_review, null);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
   it('adds approved workflow overlaps without deleting the existing canonical state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-overlap-'));
     const stateDir = join(cwd, '.omx', 'state');
@@ -2408,6 +2575,178 @@ deepMaxRounds = 21
       assert.equal(existsSync(join(stateDir, 'sessions', 'sess-autopilot-bare', 'ralph-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('preserves active Autopilot question-wait state on bare continuation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-question-wait-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-question-wait';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'waiting-for-user',
+          activated_at: '2026-04-19T00:00:00.000Z',
+          updated_at: '2026-04-19T00:10:00.000Z',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [
+            {
+              skill: 'autopilot',
+              phase: 'waiting-for-user',
+              active: true,
+              activated_at: '2026-04-19T00:00:00.000Z',
+              updated_at: '2026-04-19T00:10:00.000Z',
+              session_id: sessionId,
+            },
+          ],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'autopilot-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: 'waiting-for-user',
+          started_at: '2026-04-19T00:00:00.000Z',
+          updated_at: '2026-04-19T00:10:00.000Z',
+          session_id: sessionId,
+          iteration: 4,
+          max_iterations: 10,
+          review_cycle: 2,
+          run_outcome: 'blocked_on_user',
+          lifecycle_outcome: 'askuserQuestion',
+          state: {
+            deep_interview_question: {
+              status: 'waiting_for_user',
+              obligation_id: 'obligation-question-wait',
+              previous_phase: 'deep-interview',
+            },
+          },
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '\\ keep going now',
+        sessionId,
+        nowIso: '2026-04-19T00:15:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8'),
+      ) as {
+        current_phase?: string;
+        iteration?: number;
+        max_iterations?: number;
+        review_cycle?: number;
+        lifecycle_outcome?: string;
+        state?: { deep_interview_question?: { obligation_id?: string; status?: string } };
+      };
+      assert.equal(modeState.current_phase, 'waiting-for-user');
+      assert.equal(modeState.iteration, 4);
+      assert.equal(modeState.max_iterations, 10);
+      assert.equal(modeState.review_cycle, 2);
+      assert.equal(modeState.lifecycle_outcome, 'askuserQuestion');
+      assert.equal(modeState.state?.deep_interview_question?.status, 'waiting_for_user');
+      assert.equal(modeState.state?.deep_interview_question?.obligation_id, 'obligation-question-wait');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('resets terminal Ralph blocked_on_user state when reactivated', async () => {
+    const cases = [
+      { name: 'phase', phase: 'blocked_on_user', run_outcome: undefined },
+      { name: 'outcome', phase: 'executing', run_outcome: 'blocked_on_user' },
+    ];
+
+    for (const testCase of cases) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-keyword-state-ralph-terminal-${testCase.name}-reactivation-`));
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionId = `sess-ralph-terminal-${testCase.name}`;
+      try {
+        await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+        await writeFile(
+          join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+          JSON.stringify({
+            version: 1,
+            active: true,
+            skill: 'ralph',
+            keyword: '$ralph',
+            phase: testCase.phase,
+            activated_at: '2026-04-19T00:00:00.000Z',
+            updated_at: '2026-04-19T00:10:00.000Z',
+            source: 'keyword-detector',
+            session_id: sessionId,
+            active_skills: [
+              {
+                skill: 'ralph',
+                phase: testCase.phase,
+                active: true,
+                activated_at: '2026-04-19T00:00:00.000Z',
+                updated_at: '2026-04-19T00:10:00.000Z',
+                session_id: sessionId,
+              },
+            ],
+          }, null, 2),
+        );
+        await writeFile(
+          join(stateDir, 'sessions', sessionId, 'ralph-state.json'),
+          JSON.stringify({
+            active: false,
+            mode: 'ralph',
+            current_phase: testCase.phase,
+            started_at: '2026-04-19T00:00:00.000Z',
+            completed_at: '2026-04-19T00:10:00.000Z',
+            iteration: 50,
+            max_iterations: 50,
+            ...(testCase.run_outcome ? { run_outcome: testCase.run_outcome } : {}),
+          }, null, 2),
+        );
+
+        const result = await recordSkillActivation({
+          stateDir,
+          text: '\\ keep going now',
+          sessionId,
+          nowIso: '2026-04-19T00:15:00.000Z',
+        });
+
+        assert.ok(result);
+        assert.equal(result.skill, 'ralph');
+        assert.equal(result.phase, 'planning');
+        assert.equal(result.activated_at, '2026-04-19T00:15:00.000Z');
+        assert.equal(result.active_skills?.[0]?.phase, 'planning');
+        assert.equal(result.active_skills?.[0]?.activated_at, '2026-04-19T00:15:00.000Z');
+        const modeState = JSON.parse(
+          await readFile(join(stateDir, 'sessions', sessionId, 'ralph-state.json'), 'utf-8'),
+        ) as {
+          active?: boolean;
+          current_phase?: string;
+          started_at?: string;
+          completed_at?: string;
+          iteration?: number;
+          max_iterations?: number;
+        };
+        assert.equal(modeState.active, true);
+        assert.equal(modeState.current_phase, 'starting');
+        assert.equal(modeState.started_at, '2026-04-19T00:15:00.000Z');
+        assert.equal(modeState.completed_at, undefined);
+        assert.equal(modeState.iteration, 0);
+        assert.equal(modeState.max_iterations, 50);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
     }
   });
 

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -41,6 +41,7 @@ import {
   resolveDeepInterviewRuntimeConfig,
   type DeepInterviewRuntimeConfig,
 } from '../config/deep-interview.js';
+import { inferTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -345,6 +346,22 @@ function resolveSeedStateFilePath(
   };
 }
 
+function isResettableTerminalModeState(state: Record<string, unknown> | null, expectedMode: string): boolean {
+  if (!state || safeString(state.mode).trim() !== expectedMode) return false;
+
+  const phase = safeString(state.current_phase).trim().toLowerCase().replace(/_/g, '-');
+  const terminalPhases = expectedMode === 'ralph'
+    ? ['blocked-on-user', 'complete', 'completed', 'failed', 'cancelled', 'canceled', 'stopped', 'user-stopped']
+    : ['complete', 'completed', 'failed', 'cancelled', 'canceled', 'stopped', 'user-stopped'];
+  if (terminalPhases.includes(phase)) return true;
+
+  const lifecycleOutcome = inferTerminalLifecycleOutcome(state, { includeQuestionEnforcement: false });
+  return lifecycleOutcome === 'finished'
+    || lifecycleOutcome === 'failed'
+    || lifecycleOutcome === 'userinterlude'
+    || (expectedMode === 'ralph' && lifecycleOutcome === 'blocked');
+}
+
 async function persistStatefulSkillSeedState(
   stateDir: string,
   nextSkill: SkillActiveState,
@@ -364,13 +381,16 @@ async function persistStatefulSkillSeedState(
   const sameActiveSkill = previousSkill?.skill === nextSkill.skill && previousSkill.active;
   const existingModeMatches = safeString(existingModeState?.mode).trim() === config.mode;
   const existingPhase = safeString(existingModeState?.current_phase).trim();
+  const existingModeTerminal = existingModeMatches
+    && isResettableTerminalModeState(existingModeState as Record<string, unknown>, config.mode);
   const preserveExistingModeState = existingModeMatches
     && existingPhase !== ''
+    && !existingModeTerminal
     && (
       sameActiveSkill
       || (config.mode === 'team' && existingModeState?.active === true)
     );
-  const startedAt = previousSkill?.skill === nextSkill.skill && previousSkill.active
+  const startedAt = previousSkill?.skill === nextSkill.skill && previousSkill.active && !existingModeTerminal
     ? safeString(existingModeState?.started_at).trim() || previousSkill.activated_at || nowIso
     : preserveExistingModeState
       ? safeString(existingModeState?.started_at).trim() || nowIso
@@ -399,8 +419,9 @@ async function persistStatefulSkillSeedState(
   if (config.includeIteration) {
     const defaultIteration = config.mode === 'autopilot' ? 1 : 0;
     const defaultMaxIterations = config.mode === 'autopilot' ? 10 : 50;
-    baseState.iteration = typeof existingModeState?.iteration === 'number' ? existingModeState.iteration : defaultIteration;
-    baseState.max_iterations = typeof existingModeState?.max_iterations === 'number' ? existingModeState.max_iterations : defaultMaxIterations;
+    const reusableModeState = preserveExistingModeState ? existingModeState : null;
+    baseState.iteration = typeof reusableModeState?.iteration === 'number' ? reusableModeState.iteration : defaultIteration;
+    baseState.max_iterations = typeof reusableModeState?.max_iterations === 'number' ? reusableModeState.max_iterations : defaultMaxIterations;
   }
 
   if (config.mode === 'deep-interview') {
@@ -408,13 +429,14 @@ async function persistStatefulSkillSeedState(
   }
 
   if (config.mode === 'autopilot') {
-    const existingState = (existingModeState?.state && typeof existingModeState.state === 'object')
-      ? existingModeState.state as Record<string, unknown>
+    const reusableModeState = preserveExistingModeState ? existingModeState : null;
+    const existingState = (reusableModeState?.state && typeof reusableModeState.state === 'object')
+      ? reusableModeState.state as Record<string, unknown>
       : {};
     const existingHandoffs = (existingState.handoff_artifacts && typeof existingState.handoff_artifacts === 'object')
       ? existingState.handoff_artifacts as Record<string, unknown>
       : {};
-    baseState.review_cycle = typeof existingModeState?.review_cycle === 'number' ? existingModeState.review_cycle : 0;
+    baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
     baseState.state = {
       ...existingState,
       phase_cycle: Array.isArray(existingState.phase_cycle) ? existingState.phase_cycle : ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa'],
@@ -870,7 +892,19 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   const sameSkill = previous?.active === true && previous.skill === match.skill;
   const sameKeyword = previous?.keyword?.toLowerCase() === match.keyword.toLowerCase();
   const sameSkillContinuation = sameSkill && shouldReusePreviousSkillForContinuation(input.text, previous);
-  const preserveActivatedAt = sameSkill && (sameKeyword || sameSkillContinuation);
+  const matchedSeedConfig = STATEFUL_SKILL_SEED_CONFIG[match.skill as StatefulSkillMode];
+  const matchedModeState = matchedSeedConfig
+    ? await readJsonStateIfExists(resolveSeedStateFilePath(
+      input.stateDir,
+      matchedSeedConfig.mode,
+      input.sessionId,
+      matchedSeedConfig.scope,
+    ).absolutePath)
+    : null;
+  const matchedModeTerminal = matchedSeedConfig
+    ? isResettableTerminalModeState(matchedModeState as Record<string, unknown> | null, matchedSeedConfig.mode)
+    : false;
+  const preserveActivatedAt = sameSkill && !matchedModeTerminal && (sameKeyword || sameSkillContinuation);
   const previousEntries = listActiveSkills(previous ?? {});
   const previousWorkflowEntries = previousEntries.filter((entry) => (
     isTrackedWorkflowMode(entry.skill)
@@ -989,7 +1023,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 
       const existingEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
       if (existingEntry) {
-        existingEntry.phase = requestedMode === match.skill && !sameSkill
+        existingEntry.phase = requestedMode === match.skill && (!sameSkill || matchedModeTerminal)
           ? initialWorkflowPhaseForMode(requestedMode)
           : existingEntry.phase;
         existingEntry.active = true;


### PR DESCRIPTION
## Summary
- reset terminal stateful workflow reactivation instead of preserving stale same-skill runtime state
- keep Autopilot `askuserQuestion` / `waiting-for-user` as suspended continuation, not resettable terminal state
- handle stopped/user-stopped Autopilot and Ralph `blocked_on_user` terminal cases, including outcome-only legacy Ralph state

## Context
Follow-up replacement for the closed #2620, based on the review findings there. The fix keeps the original Autopilot terminal reactivation goal but makes the lifecycle boundary explicit across both runtime mode state and the `skill-active-state.json` mirror.

## Validation
- `npm run build`
- `node --test --test-concurrency=1 dist/hooks/__tests__/keyword-detector.test.js --test-name-pattern="terminal Autopilot|stopped Autopilot|question-wait|terminal Ralph"`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

## Review evidence
- code-reviewer: APPROVE, 0 findings
- architect: CLEAR
- Scholastic gate: APPROVE
