### PR TITLE
Surface HUD authority tick failures

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -647,6 +647,173 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+
+  it('fully resets terminal Autopilot mode state when reactivated', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-terminal-reset-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-terminal-reset';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        keyword: '$autopilot',
+        phase: 'complete',
+        activated_at: '2026-05-29T00:00:00.000Z',
+        updated_at: '2026-05-29T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', active: true, phase: 'complete', session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'complete',
+        started_at: '2026-05-29T00:00:00.000Z',
+        completed_at: '2026-05-29T00:10:00.000Z',
+        iteration: 10,
+        max_iterations: 10,
+        review_cycle: 3,
+        lifecycle_outcome: 'finished',
+        run_outcome: 'finish',
+        handoff_artifacts: {
+          code_review: { verdict: 'APPROVE / CLEAR' },
+          ultraqa: { verdict: 'pass' },
+        },
+        state: {
+          handoff_artifacts: {
+            ralplan_consensus_gate: { complete: false },
+            code_review: { verdict: 'stale' },
+          },
+        },
+      }, null, 2));
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$autopilot investigate the next issue',
+        sessionId,
+        threadId: 'thread-reactivated',
+        turnId: 'turn-reactivated',
+        nowIso: '2026-05-30T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      assert.equal(result.phase, 'deep-interview');
+      assert.equal(result.activated_at, '2026-05-30T00:00:00.000Z');
+      assert.equal(result.active_skills?.[0]?.phase, 'deep-interview');
+      assert.equal(result.active_skills?.[0]?.activated_at, '2026-05-30T00:00:00.000Z');
+      const skillState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), 'utf-8')) as {
+        phase?: string;
+        activated_at?: string;
+        active_skills?: Array<{ phase?: string; activated_at?: string }>;
+      };
+      assert.equal(skillState.phase, 'deep-interview');
+      assert.equal(skillState.activated_at, '2026-05-30T00:00:00.000Z');
+      assert.equal(skillState.active_skills?.[0]?.phase, 'deep-interview');
+      assert.equal(skillState.active_skills?.[0]?.activated_at, '2026-05-30T00:00:00.000Z');
+      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
+        active?: boolean;
+        current_phase?: string;
+        started_at?: string;
+        completed_at?: string;
+        iteration?: number;
+        max_iterations?: number;
+        review_cycle?: number;
+        lifecycle_outcome?: string;
+        run_outcome?: string;
+        handoff_artifacts?: Record<string, unknown>;
+        state?: { handoff_artifacts?: Record<string, unknown> };
+      };
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'deep-interview');
+      assert.equal(modeState.started_at, '2026-05-30T00:00:00.000Z');
+      assert.equal(modeState.completed_at, undefined);
+      assert.equal(modeState.iteration, 1);
+      assert.equal(modeState.max_iterations, 10);
+      assert.equal(modeState.review_cycle, 0);
+      assert.equal(modeState.lifecycle_outcome, undefined);
+      assert.equal(modeState.run_outcome, undefined);
+      assert.equal(modeState.handoff_artifacts, undefined);
+      assert.deepEqual(modeState.state?.handoff_artifacts, {
+        deep_interview: null,
+        ralplan: null,
+        ralplan_consensus_gate: {
+          required: true,
+          sequence: ['architect-review', 'critic-review'],
+          planning_artifacts_are_not_consensus: true,
+          required_review_roles: ['architect', 'critic'],
+          ralplan_architect_review: null,
+          ralplan_critic_review: null,
+          complete: false,
+        },
+        ultragoal: null,
+        code_review: null,
+        ultraqa: null,
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('resets stopped Autopilot mode state when reactivated', async () => {
+    for (const phase of ['stopped', 'user-stopped']) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-keyword-autopilot-${phase}-reset-`));
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionId = `sess-autopilot-${phase}-reset`;
+      try {
+        await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+        await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase,
+          activated_at: '2026-05-29T00:00:00.000Z',
+          updated_at: '2026-05-29T00:00:00.000Z',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', active: true, phase, session_id: sessionId }],
+        }, null, 2));
+        await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: phase,
+          started_at: '2026-05-29T00:00:00.000Z',
+          completed_at: '2026-05-29T00:10:00.000Z',
+          iteration: 10,
+          max_iterations: 10,
+          review_cycle: 3,
+          state: { handoff_artifacts: { code_review: { verdict: 'stale' } } },
+        }, null, 2));
+
+        const result = await recordSkillActivation({
+          stateDir,
+          text: '$autopilot new task after stop',
+          sessionId,
+          nowIso: '2026-05-30T00:00:00.000Z',
+        });
+
+        assert.ok(result);
+        assert.equal(result.phase, 'deep-interview');
+        assert.equal(result.activated_at, '2026-05-30T00:00:00.000Z');
+        const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
+          current_phase?: string;
+          iteration?: number;
+          review_cycle?: number;
+          state?: { handoff_artifacts?: { code_review?: unknown } };
+        };
+        assert.equal(modeState.current_phase, 'deep-interview');
+        assert.equal(modeState.iteration, 1);
+        assert.equal(modeState.review_cycle, 0);
+        assert.equal(modeState.state?.handoff_artifacts?.code_review, null);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
   it('adds approved workflow overlaps without deleting the existing canonical state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-overlap-'));
     const stateDir = join(cwd, '.omx', 'state');
@@ -2408,6 +2575,178 @@ deepMaxRounds = 21
       assert.equal(existsSync(join(stateDir, 'sessions', 'sess-autopilot-bare', 'ralph-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('preserves active Autopilot question-wait state on bare continuation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-question-wait-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-question-wait';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'waiting-for-user',
+          activated_at: '2026-04-19T00:00:00.000Z',
+          updated_at: '2026-04-19T00:10:00.000Z',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [
+            {
+              skill: 'autopilot',
+              phase: 'waiting-for-user',
+              active: true,
+              activated_at: '2026-04-19T00:00:00.000Z',
+              updated_at: '2026-04-19T00:10:00.000Z',
+              session_id: sessionId,
+            },
+          ],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'autopilot-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: 'waiting-for-user',
+          started_at: '2026-04-19T00:00:00.000Z',
+          updated_at: '2026-04-19T00:10:00.000Z',
+          session_id: sessionId,
+          iteration: 4,
+          max_iterations: 10,
+          review_cycle: 2,
+          run_outcome: 'blocked_on_user',
+          lifecycle_outcome: 'askuserQuestion',
+          state: {
+            deep_interview_question: {
+              status: 'waiting_for_user',
+              obligation_id: 'obligation-question-wait',
+              previous_phase: 'deep-interview',
+            },
+          },
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '\\ keep going now',
+        sessionId,
+        nowIso: '2026-04-19T00:15:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8'),
+      ) as {
+        current_phase?: string;
+        iteration?: number;
+        max_iterations?: number;
+        review_cycle?: number;
+        lifecycle_outcome?: string;
+        state?: { deep_interview_question?: { obligation_id?: string; status?: string } };
+      };
+      assert.equal(modeState.current_phase, 'waiting-for-user');
+      assert.equal(modeState.iteration, 4);
+      assert.equal(modeState.max_iterations, 10);
+      assert.equal(modeState.review_cycle, 2);
+      assert.equal(modeState.lifecycle_outcome, 'askuserQuestion');
+      assert.equal(modeState.state?.deep_interview_question?.status, 'waiting_for_user');
+      assert.equal(modeState.state?.deep_interview_question?.obligation_id, 'obligation-question-wait');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('resets terminal Ralph blocked_on_user state when reactivated', async () => {
+    const cases = [
+      { name: 'phase', phase: 'blocked_on_user', run_outcome: undefined },
+      { name: 'outcome', phase: 'executing', run_outcome: 'blocked_on_user' },
+    ];
+
+    for (const testCase of cases) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-keyword-state-ralph-terminal-${testCase.name}-reactivation-`));
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionId = `sess-ralph-terminal-${testCase.name}`;
+      try {
+        await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+        await writeFile(
+          join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+          JSON.stringify({
+            version: 1,
+            active: true,
+            skill: 'ralph',
+            keyword: '$ralph',
+            phase: testCase.phase,
+            activated_at: '2026-04-19T00:00:00.000Z',
+            updated_at: '2026-04-19T00:10:00.000Z',
+            source: 'keyword-detector',
+            session_id: sessionId,
+            active_skills: [
+              {
+                skill: 'ralph',
+                phase: testCase.phase,
+                active: true,
+                activated_at: '2026-04-19T00:00:00.000Z',
+                updated_at: '2026-04-19T00:10:00.000Z',
+                session_id: sessionId,
+              },
+            ],
+          }, null, 2),
+        );
+        await writeFile(
+          join(stateDir, 'sessions', sessionId, 'ralph-state.json'),
+          JSON.stringify({
+            active: false,
+            mode: 'ralph',
+            current_phase: testCase.phase,
+            started_at: '2026-04-19T00:00:00.000Z',
+            completed_at: '2026-04-19T00:10:00.000Z',
+            iteration: 50,
+            max_iterations: 50,
+            ...(testCase.run_outcome ? { run_outcome: testCase.run_outcome } : {}),
+          }, null, 2),
+        );
+
+        const result = await recordSkillActivation({
+          stateDir,
+          text: '\\ keep going now',
+          sessionId,
+          nowIso: '2026-04-19T00:15:00.000Z',
+        });
+
+        assert.ok(result);
+        assert.equal(result.skill, 'ralph');
+        assert.equal(result.phase, 'planning');
+        assert.equal(result.activated_at, '2026-04-19T00:15:00.000Z');
+        assert.equal(result.active_skills?.[0]?.phase, 'planning');
+        assert.equal(result.active_skills?.[0]?.activated_at, '2026-04-19T00:15:00.000Z');
+        const modeState = JSON.parse(
+          await readFile(join(stateDir, 'sessions', sessionId, 'ralph-state.json'), 'utf-8'),
+        ) as {
+          active?: boolean;
+          current_phase?: string;
+          started_at?: string;
+          completed_at?: string;
+          iteration?: number;
+          max_iterations?: number;
+        };
+        assert.equal(modeState.active, true);
+        assert.equal(modeState.current_phase, 'starting');
+        assert.equal(modeState.started_at, '2026-04-19T00:15:00.000Z');
+        assert.equal(modeState.completed_at, undefined);
+        assert.equal(modeState.iteration, 0);
+        assert.equal(modeState.max_iterations, 50);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
     }
   });
 

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -3570,6 +3570,79 @@ exit 0
     }
   });
 
+  it('prints notify script missing errors to stderr for authority-only ticks', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-authority-missing-script-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-authority-missing-home-'));
+    const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const missingNotifyHook = join(wd, 'dist', 'scripts', 'missing-notify-hook.js');
+    try {
+      const run = spawnSync(
+        process.execPath,
+        [
+          watcherScript,
+          '--once',
+          '--authority-only',
+          '--cwd',
+          wd,
+          '--notify-script',
+          missingNotifyHook,
+          '--poll-ms',
+          '50',
+        ],
+        {
+          cwd: wd,
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({ HOME: tempHome }),
+        },
+      );
+
+      assert.equal(run.status, 1);
+      assert.match(run.stderr, /notify-fallback-watcher: notify script missing:/);
+      assert.match(run.stderr, /missing-notify-hook\.js/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('prints fatal watcher errors to stderr for authority-only ticks', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-authority-fatal-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-authority-fatal-home-'));
+    const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+    try {
+      const run = spawnSync(
+        process.execPath,
+        [
+          watcherScript,
+          '--once',
+          '--authority-only',
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+        ],
+        {
+          cwd: wd,
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            HOME: tempHome,
+            NODE_ENV: 'test',
+            OMX_NOTIFY_FALLBACK_TEST_FATAL: '1',
+          }),
+        },
+      );
+
+      assert.equal(run.status, 1);
+      assert.match(run.stderr, /notify-fallback-watcher: fatal: test fatal notify fallback failure/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
 
   it('ignores stale session-scoped Ralph state when the current session identity is stale', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-stale-session-ralph-'));

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -41,6 +41,7 @@ import {
   resolveDeepInterviewRuntimeConfig,
   type DeepInterviewRuntimeConfig,
 } from '../config/deep-interview.js';
+import { inferTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -345,6 +346,22 @@ function resolveSeedStateFilePath(
   };
 }
 
+function isResettableTerminalModeState(state: Record<string, unknown> | null, expectedMode: string): boolean {
+  if (!state || safeString(state.mode).trim() !== expectedMode) return false;
+
+  const phase = safeString(state.current_phase).trim().toLowerCase().replace(/_/g, '-');
+  const terminalPhases = expectedMode === 'ralph'
+    ? ['blocked-on-user', 'complete', 'completed', 'failed', 'cancelled', 'canceled', 'stopped', 'user-stopped']
+    : ['complete', 'completed', 'failed', 'cancelled', 'canceled', 'stopped', 'user-stopped'];
+  if (terminalPhases.includes(phase)) return true;
+
+  const lifecycleOutcome = inferTerminalLifecycleOutcome(state, { includeQuestionEnforcement: false });
+  return lifecycleOutcome === 'finished'
+    || lifecycleOutcome === 'failed'
+    || lifecycleOutcome === 'userinterlude'
+    || (expectedMode === 'ralph' && lifecycleOutcome === 'blocked');
+}
+
 async function persistStatefulSkillSeedState(
   stateDir: string,
   nextSkill: SkillActiveState,
@@ -364,13 +381,16 @@ async function persistStatefulSkillSeedState(
   const sameActiveSkill = previousSkill?.skill === nextSkill.skill && previousSkill.active;
   const existingModeMatches = safeString(existingModeState?.mode).trim() === config.mode;
   const existingPhase = safeString(existingModeState?.current_phase).trim();
+  const existingModeTerminal = existingModeMatches
+    && isResettableTerminalModeState(existingModeState as Record<string, unknown>, config.mode);
   const preserveExistingModeState = existingModeMatches
     && existingPhase !== ''
+    && !existingModeTerminal
     && (
       sameActiveSkill
       || (config.mode === 'team' && existingModeState?.active === true)
     );
-  const startedAt = previousSkill?.skill === nextSkill.skill && previousSkill.active
+  const startedAt = previousSkill?.skill === nextSkill.skill && previousSkill.active && !existingModeTerminal
     ? safeString(existingModeState?.started_at).trim() || previousSkill.activated_at || nowIso
     : preserveExistingModeState
       ? safeString(existingModeState?.started_at).trim() || nowIso
@@ -399,8 +419,9 @@ async function persistStatefulSkillSeedState(
   if (config.includeIteration) {
     const defaultIteration = config.mode === 'autopilot' ? 1 : 0;
     const defaultMaxIterations = config.mode === 'autopilot' ? 10 : 50;
-    baseState.iteration = typeof existingModeState?.iteration === 'number' ? existingModeState.iteration : defaultIteration;
-    baseState.max_iterations = typeof existingModeState?.max_iterations === 'number' ? existingModeState.max_iterations : defaultMaxIterations;
+    const reusableModeState = preserveExistingModeState ? existingModeState : null;
+    baseState.iteration = typeof reusableModeState?.iteration === 'number' ? reusableModeState.iteration : defaultIteration;
+    baseState.max_iterations = typeof reusableModeState?.max_iterations === 'number' ? reusableModeState.max_iterations : defaultMaxIterations;
   }
 
   if (config.mode === 'deep-interview') {
@@ -408,13 +429,14 @@ async function persistStatefulSkillSeedState(
   }
 
   if (config.mode === 'autopilot') {
-    const existingState = (existingModeState?.state && typeof existingModeState.state === 'object')
-      ? existingModeState.state as Record<string, unknown>
+    const reusableModeState = preserveExistingModeState ? existingModeState : null;
+    const existingState = (reusableModeState?.state && typeof reusableModeState.state === 'object')
+      ? reusableModeState.state as Record<string, unknown>
       : {};
     const existingHandoffs = (existingState.handoff_artifacts && typeof existingState.handoff_artifacts === 'object')
       ? existingState.handoff_artifacts as Record<string, unknown>
       : {};
-    baseState.review_cycle = typeof existingModeState?.review_cycle === 'number' ? existingModeState.review_cycle : 0;
+    baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
     baseState.state = {
       ...existingState,
       phase_cycle: Array.isArray(existingState.phase_cycle) ? existingState.phase_cycle : ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa'],
@@ -870,7 +892,19 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   const sameSkill = previous?.active === true && previous.skill === match.skill;
   const sameKeyword = previous?.keyword?.toLowerCase() === match.keyword.toLowerCase();
   const sameSkillContinuation = sameSkill && shouldReusePreviousSkillForContinuation(input.text, previous);
-  const preserveActivatedAt = sameSkill && (sameKeyword || sameSkillContinuation);
+  const matchedSeedConfig = STATEFUL_SKILL_SEED_CONFIG[match.skill as StatefulSkillMode];
+  const matchedModeState = matchedSeedConfig
+    ? await readJsonStateIfExists(resolveSeedStateFilePath(
+      input.stateDir,
+      matchedSeedConfig.mode,
+      input.sessionId,
+      matchedSeedConfig.scope,
+    ).absolutePath)
+    : null;
+  const matchedModeTerminal = matchedSeedConfig
+    ? isResettableTerminalModeState(matchedModeState as Record<string, unknown> | null, matchedSeedConfig.mode)
+    : false;
+  const preserveActivatedAt = sameSkill && !matchedModeTerminal && (sameKeyword || sameSkillContinuation);
   const previousEntries = listActiveSkills(previous ?? {});
   const previousWorkflowEntries = previousEntries.filter((entry) => (
     isTrackedWorkflowMode(entry.skill)
@@ -989,7 +1023,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 
       const existingEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
       if (existingEntry) {
-        existingEntry.phase = requestedMode === match.skill && !sameSkill
+        existingEntry.phase = requestedMode === match.skill && (!sameSkill || matchedModeTerminal)
           ? initialWorkflowPhaseForMode(requestedMode)
           : existingEntry.phase;
         existingEntry.active = true;

--- a/src/hud/__tests__/authority.test.ts
+++ b/src/hud/__tests__/authority.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -69,5 +70,47 @@ describe('runHudAuthorityTick', () => {
     assert.equal(call.options.timeoutMs, 4321);
     assert.equal(call.options.env.OMX_HUD_AUTHORITY, '1');
     assert.equal(call.options.env.CUSTOM_ENV, '1');
+  });
+
+  it('surfaces authority child stderr on failure', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-hud-authority-failure-'));
+    try {
+      mkdirSync(join(cwd, 'dist', 'scripts'), { recursive: true });
+      const failingScript = join(cwd, 'dist', 'scripts', 'notify-fallback-watcher.js');
+      writeFileSync(failingScript, "console.error('notify script missing during rebuild'); process.exit(1);\n");
+
+      await assert.rejects(
+        runHudAuthorityTick({
+          cwd,
+          nodePath: process.execPath,
+          packageRoot: cwd,
+          timeoutMs: 1000,
+        }),
+        /notify script missing during rebuild/,
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces nonzero authority child status when the child is silent', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-hud-authority-silent-failure-'));
+    try {
+      mkdirSync(join(cwd, 'dist', 'scripts'), { recursive: true });
+      const failingScript = join(cwd, 'dist', 'scripts', 'notify-fallback-watcher.js');
+      writeFileSync(failingScript, 'process.exit(1);\n');
+
+      await assert.rejects(
+        runHudAuthorityTick({
+          cwd,
+          nodePath: process.execPath,
+          packageRoot: cwd,
+          timeoutMs: 1000,
+        }),
+        /hud authority tick failed with status 1/,
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/hud/authority.ts
+++ b/src/hud/authority.ts
@@ -37,12 +37,23 @@ async function defaultRunProcess(
     cwd: options.cwd,
     env: options.env,
     encoding: 'utf-8',
-    stdio: 'ignore',
+    stdio: ['ignore', 'pipe', 'pipe'],
     timeout: options.timeoutMs,
     windowsHide: true,
   });
   if (result.status !== 0) {
-    throw new Error((result.stderr || result.stdout || '').trim() || `hud authority tick failed with status ${result.status ?? 'unknown'}`);
+    const output = [result.error?.message, result.stderr, result.stdout]
+      .map((value) => value?.trim() ?? '')
+      .filter(Boolean)
+      .join('\n')
+      .trim();
+    const suffix = result.signal
+      ? `signal ${result.signal}`
+      : `status ${result.status ?? 'unknown'}`;
+    throw new Error(output ? `hud authority tick failed with ${suffix}: ${output}` : `hud authority tick failed with ${suffix}`);
+  }
+  if (result.error) {
+    throw new Error(`hud authority tick failed: ${result.error.message}`);
   }
 }
 

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -1963,10 +1963,15 @@ function shutdown(signal: string): void {
 }
 
 async function main(): Promise<void> {
+  if (process.env.NODE_ENV === 'test' && process.env.OMX_NOTIFY_FALLBACK_TEST_FATAL === '1') {
+    throw new Error('test fatal notify fallback failure');
+  }
   await mkdir(logsDir, { recursive: true }).catch(() => {});
   await mkdir(stateDir, { recursive: true }).catch(() => {});
   if (!existsSync(notifyScript)) {
+    const reason = `notify script missing: ${notifyScript}`;
     await eventLog({ type: 'watcher_error', reason: 'notify_script_missing', notify_script: notifyScript });
+    process.stderr.write(`notify-fallback-watcher: ${reason}\n`);
     process.exit(1);
   }
 
@@ -2006,10 +2011,12 @@ async function main(): Promise<void> {
 
 main().catch(async (err) => {
   await mkdir(dirname(logPath), { recursive: true }).catch(() => {});
+  const message = err instanceof Error ? err.message : safeString(err);
   await eventLog({
     type: 'watcher_error',
     reason: 'fatal',
-    error: err instanceof Error ? err.message : safeString(err),
+    error: message,
   });
+  process.stderr.write(`notify-fallback-watcher: fatal: ${message || 'unknown error'}\n`);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- surface HUD authority tick child watcher failures with status/signal plus stderr/stdout details
- print notify-fallback watcher missing-script and fatal errors to stderr before exiting
- add regressions for stderr, silent nonzero, missing notify-script, and fatal authority-only paths

## Validation
- npm run build
- node --test dist/hud/__tests__/authority.test.js dist/hud/__tests__/index.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js --test-name-pattern='authority|notify script missing|fatal watcher|keeps rendering when the authority tick fails'
- npm run lint
- npm run check:no-unused
- git diff --check

## Notes
- HUD watch still keeps rendering after authority tick failures; the change makes failures actionable instead of generic `status 1` bling.
