### PR TITLE
Fix HUD autopilot session mirror fallback

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -751,6 +751,36 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('surfaces session-mirrored root autopilot state when the HUD session file has not been materialized yet', async () => {
+    await withTempRepo('omx-hud-root-mirror-autopilot-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-autopilot-root-mirror';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd }));
+      await writeFile(join(rootStateDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'autopilot',
+        phase: 'deep-interview',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(rootStateDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'deep-interview',
+        session_id: sessionId,
+      }));
+
+      const state = await readAllState(cwd);
+
+      assert.deepEqual(state.autopilot, {
+        active: true,
+        current_phase: 'deep-interview',
+      });
+    });
+  });
+
   it('does not resurrect terminal autopilot from stale canonical skill-active phase', async () => {
     await withTempRepo('omx-hud-canonical-autopilot-terminal-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -457,6 +457,8 @@ function shouldSurfaceCanonicalSkill(
   detail: { active?: boolean; current_phase?: string } | null,
   useCompatibilityFallback: boolean,
 ): boolean {
+  const canonicalPhase = canonicalPhaseForSkill(canonicalSkills, skill);
+  if (canonicalSkills.has(skill) && !detail && canonicalPhase) return true;
   if (!canonicalSkills.has(skill) && !useCompatibilityFallback) return false;
   return !isMissingTerminalOrInactiveDetail(detail);
 }

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -312,9 +312,23 @@ async function readVisibleSkillActiveStateFromPaths(
   if (sessionPath && existsSync(sessionPath)) {
     return readSkillActiveState(sessionPath);
   }
-  if (sessionPath) return null;
+
   if (!existsSync(rootPath)) return null;
-  return readSkillActiveState(rootPath);
+  const rootState = await readSkillActiveState(rootPath);
+  if (!sessionPath) return rootState;
+
+  const normalizedSessionId = sessionPath.replace(/\\/g, '/').match(/(?:^|\/)sessions\/([^/]+)\/skill-active-state\.json$/)?.[1];
+  const visibleRootEntries = filterRootEntriesForSession(listActiveSkills(rootState ?? {}), normalizedSessionId);
+  if (visibleRootEntries.length === 0) return null;
+
+  return normalizeSkillActiveState({
+    ...(rootState ?? {}),
+    active_skills: visibleRootEntries,
+    active: true,
+    skill: visibleRootEntries[0]?.skill,
+    phase: visibleRootEntries[0]?.phase ?? '',
+    session_id: visibleRootEntries[0]?.session_id,
+  });
 }
 
 export function tracksCanonicalWorkflowSkill(mode: string): mode is CanonicalWorkflowSkill {


### PR DESCRIPTION
## Summary
- restore HUD visibility for active autopilot when canonical skill-active state is mirrored at root but the session skill-active file is not materialized yet
- allow HUD to render canonical workflow phase from skill-active state without resurrecting terminal mode detail
- add regression coverage for session-mirrored root autopilot state

This is a minimal branch recreated from current `upstream/dev` after #2624 was closed for targeting `main` and carrying unrelated branch delta.

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/hud/__tests__/state.test.js dist/hooks/__tests__/keyword-detector.test.js`
- `git diff --check`
