### PR TITLE
Keep hook diagnostics from blocking autopilot

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -2211,6 +2211,53 @@ deepMaxRounds = 21
     }
   });
 
+  it('keeps Autopilot visible when a supervised code-review child keyword appears', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-child-code-review-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-child-code-review';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'ralplan',
+          activated_at: '2026-05-30T00:00:00.000Z',
+          updated_at: '2026-05-30T00:01:00.000Z',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', phase: 'ralplan', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'CODE REVIEW the current diff before continuing',
+        sessionId,
+        threadId: 'thread-autopilot-child-code-review',
+        turnId: 'turn-autopilot-child-code-review',
+        nowIso: '2026-05-30T00:02:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      assert.equal(result.phase, 'ralplan');
+      assert.equal(result.supervised_child_skill, 'code-review');
+      const persisted = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { skill?: string; phase?: string; active_skills?: Array<{ skill?: string }> };
+      assert.equal(persisted.skill, 'autopilot');
+      assert.equal(persisted.phase, 'ralplan');
+      assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['autopilot']);
+      assert.equal(existsSync(join(stateDir, 'sessions', sessionId, 'code-review-state.json')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('records ultragoal as a prompt skill with first-class mode state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ultragoal-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -757,6 +757,14 @@ function shouldReusePreviousSkillForContinuation(
     || ((previousSkill === 'autopilot' || previousSkill === 'deep-interview') && isOmxQuestionAnsweredPrompt(text));
 }
 
+function isAutopilotSupervisedChildSkill(skill: string): boolean {
+  return skill === 'code-review'
+    || skill === 'ultraqa'
+    || skill === 'ralplan'
+    || skill === 'ultragoal'
+    || skill === 'deep-interview';
+}
+
 function isDeepInterviewRuntimeConfig(value: unknown): value is DeepInterviewRuntimeConfig {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const candidate = value as Partial<DeepInterviewRuntimeConfig>;
@@ -1116,6 +1124,44 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     }
 
     return workflowState;
+  }
+
+  if (previous?.active === true && previous.skill === 'autopilot' && isAutopilotSupervisedChildSkill(match.skill)) {
+    const nextState: SkillActiveState = {
+      ...previous,
+      version: 1,
+      active: true,
+      updated_at: nowIso,
+      source: 'keyword-detector',
+      session_id: input.sessionId ?? previous.session_id,
+      thread_id: input.threadId ?? previous.thread_id,
+      turn_id: input.turnId ?? previous.turn_id,
+      active_skills: listActiveSkills(previous).map((entry) => (
+        entry.skill === 'autopilot'
+          ? {
+              ...entry,
+              active: true,
+              updated_at: nowIso,
+              session_id: input.sessionId ?? entry.session_id,
+              thread_id: input.threadId ?? entry.thread_id,
+              turn_id: input.turnId ?? entry.turn_id,
+            }
+          : entry
+      )),
+      supervised_child_keyword: match.keyword,
+      supervised_child_skill: match.skill,
+    };
+    try {
+      await writeSkillActiveStateCopiesForStateDir(
+        input.stateDir,
+        nextState,
+        input.sessionId,
+        selectRootSkillStateCopy(previousRoot, nextState, input.sessionId),
+      );
+    } catch (error) {
+      console.warn('[omx] warning: failed to persist keyword activation state', error);
+    }
+    return nextState;
   }
 
   const state: SkillActiveState = {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13612,6 +13612,93 @@ exit 0
     }
   });
 
+  it("blocks implementation writes while Autopilot is supervising ralplan without handoff", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-ralplan-pretool-block-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-autopilot-ralplan-pretool-block";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "ralplan",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "ralplan", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ralplan",
+        session_id: sessionId,
+        state: {
+          handoff_artifacts: {
+            ralplan_consensus_gate: { required: true, complete: false },
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-autopilot-ralplan-pretool-block",
+          tool_name: "Edit",
+          tool_input: { file_path: "src/runtime.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Ralplan is active .*implementation\/write tools are blocked/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks bash implementation writes while Autopilot is supervising ralplan without handoff", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-ralplan-pretool-bash-block-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-autopilot-ralplan-pretool-bash-block";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "ralplan",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "ralplan", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ralplan",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-autopilot-ralplan-pretool-bash-block",
+          tool_name: "Bash",
+          tool_input: { command: "cat <<'EOF' > src/runtime.ts\nimplementation\nEOF" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Ralplan is active .*implementation\/write tools are blocked/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("allows ralplan planning artifact writes without execution handoff", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-pretool-artifact-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -431,6 +431,32 @@ describe("codex native hook dispatch", () => {
     );
   });
 
+  it("logs a bounded raw stdin prefix when CLI stdin is malformed", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-malformed-log-prefix-"));
+    try {
+      const malformed = '{hook_event_name:"PostToolUse", tool_name:"Bash",';
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: malformed,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stderr, "");
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.stopReason, "native_hook_stdin_parse_error");
+
+      const log = await readFile(join(cwd, ".omx", "logs", `native-hook-${new Date().toISOString().split("T")[0]}.jsonl`), "utf-8");
+      const entry = JSON.parse(log.trim()) as Record<string, unknown>;
+      assert.equal(entry.type, "native_hook_stdin_parse_error");
+      assert.equal(entry.raw_input_length, Buffer.byteLength(malformed, "utf-8"));
+      assert.equal(entry.raw_input_prefix, malformed);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("emits Stop-schema-safe block JSON when malformed stdin still identifies Stop", () => {
     const stdout = runNativeHookCli('{hook_event_name:"Stop",');
 
@@ -7756,6 +7782,51 @@ exit 0
     }
   });
 
+
+  it("does not block ordinary non-zero grep output in PostToolUse", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-grep-nonzero-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-grep-nonzero",
+          tool_input: { command: "grep -R missing-pattern src | head -20" },
+          tool_response: "{\"exit_code\":1,\"stdout\":\"src/example.ts:TODO\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block ordinary non-zero diagnostic output in PostToolUse", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-diagnostic-nonzero-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-diagnostic-nonzero",
+          tool_input: { command: "find src -name nope -print" },
+          tool_response: "{\"exit_code\":1,\"stdout\":\"searched 10 files\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("treats stderr-only informative non-zero output as reviewable instead of a generic failure", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-informative-stderr-"));
     try {
@@ -13607,6 +13678,55 @@ exit 0
         String((result.outputJson?.hookSpecificOutput as { additionalContext?: string } | undefined)?.additionalContext ?? ""),
         /\$ultragoal.*\$team.*\$ralph/i,
       );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("allows read-only Bash diagnostics while Autopilot is supervising ralplan", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-ralplan-readonly-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-autopilot-ralplan-readonly";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "ralplan",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "ralplan", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ralplan",
+        session_id: sessionId,
+      });
+
+      for (const command of [
+        "pwd",
+        "git diff -- src/scripts/codex-native-pre-post.ts",
+        "grep -R PostToolUse src/scripts | head -20",
+        "find src -name '*hook*' -maxdepth 3 -print",
+        "omx state read --input '{\"mode\":\"autopilot\"}' --json",
+      ]) {
+        const result = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            session_id: sessionId,
+            thread_id: "thread-autopilot-ralplan-readonly",
+            tool_name: "Bash",
+            tool_input: { command },
+          },
+          { cwd },
+        );
+
+        assert.equal(result.omxEventName, "pre-tool-use");
+        assert.equal(result.outputJson, null, command);
+      }
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4423,11 +4423,20 @@ function writeNativeHookJsonStdout(output: Record<string, unknown>): void {
   process.stdout.write(`${JSON.stringify(output)}\n`);
 }
 
+function buildRawInputLogFields(rawInput: string): Record<string, unknown> {
+  if (!rawInput) return {};
+  return {
+    raw_input_length: Buffer.byteLength(rawInput, "utf-8"),
+    raw_input_prefix: rawInput.replace(/[\u0000-\u001f\u007f-\u009f]/g, "").slice(0, 240),
+  };
+}
+
 async function logNativeHookCliError(
   cwd: string,
   type: string,
   error: unknown,
   payload: CodexHookPayload = {},
+  details: Record<string, unknown> = {},
 ): Promise<void> {
   const logsDir = join(cwd || process.cwd(), ".omx", "logs");
   await mkdir(logsDir, { recursive: true }).catch(() => {});
@@ -4442,6 +4451,7 @@ async function logNativeHookCliError(
       thread_id: readPayloadThreadId(payload) || undefined,
       turn_id: readPayloadTurnId(payload) || undefined,
       error: error instanceof Error ? error.message : String(error),
+      ...details,
     }) + "\n",
   ).catch(() => {});
 }
@@ -4476,7 +4486,13 @@ export async function runCodexNativeHookCli(): Promise<void> {
     return;
   }
   if (parseError) {
-    await logNativeHookCliError(process.cwd(), "native_hook_stdin_parse_error", parseError);
+    await logNativeHookCliError(
+      process.cwd(),
+      "native_hook_stdin_parse_error",
+      parseError,
+      {},
+      buildRawInputLogFields(rawInput),
+    );
     writeNativeHookJsonStdout(buildMalformedStdinHookOutput(parseError, rawInput));
     return;
   }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2540,6 +2540,14 @@ function isActiveRalplanPhase(state: Record<string, unknown> | null): boolean {
   return true;
 }
 
+function isActiveAutopilotRalplanPhase(state: Record<string, unknown> | null): boolean {
+  if (!state || state.active !== true) return false;
+  const mode = safeString(state.mode).trim();
+  if (mode && mode !== "autopilot") return false;
+  const phase = safeString(state.current_phase ?? state.currentPhase).trim().toLowerCase();
+  return phase === "ralplan";
+}
+
 function hasExplicitExecutionHandoffSkill(
   state: SkillActiveStateLike | null,
   sessionId: string,
@@ -2657,19 +2665,30 @@ async function readActiveRalplanStateForPreToolUse(
   const modeState = sessionId
     ? await readStopSessionPinnedState("ralplan-state.json", cwd, sessionId, stateDir)
     : await readJsonIfExists(join(stateDir, "ralplan-state.json"));
-  if (!isActiveRalplanPhase(modeState) || !modeState) return null;
-  if (!modeStateMatchesSkillStopContext(modeState, cwd, sessionId)) return null;
-
   const canonicalState = sessionId
     ? await readVisibleSkillActiveStateForStateDir(stateDir, sessionId)
     : await readSkillActiveState(join(stateDir, SKILL_ACTIVE_STATE_FILE));
-  if (hasExplicitExecutionHandoffSkill(canonicalState, sessionId, threadId)) return null;
-  if (!canonicalState) return modeState;
-  const hasActiveRalplanSkill = listActiveSkills(canonicalState).some((entry) => (
-    entry.skill === "ralplan"
+  if (isActiveRalplanPhase(modeState) && modeState && modeStateMatchesSkillStopContext(modeState, cwd, sessionId)) {
+    if (hasExplicitExecutionHandoffSkill(canonicalState, sessionId, threadId)) return null;
+    if (!canonicalState) return modeState;
+    const hasActiveRalplanSkill = listActiveSkills(canonicalState).some((entry) => (
+      entry.skill === "ralplan"
+      && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
+    ));
+    if (hasActiveRalplanSkill) return modeState;
+  }
+
+  const autopilotState = sessionId
+    ? await readStopSessionPinnedState("autopilot-state.json", cwd, sessionId, stateDir)
+    : await readJsonIfExists(join(stateDir, "autopilot-state.json"));
+  if (!isActiveAutopilotRalplanPhase(autopilotState) || !autopilotState) return null;
+  if (!modeStateMatchesSkillStopContext(autopilotState, cwd, sessionId)) return null;
+  if (!canonicalState) return autopilotState;
+  const hasActiveAutopilotSkill = listActiveSkills(canonicalState).some((entry) => (
+    entry.skill === "autopilot"
     && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
   ));
-  return hasActiveRalplanSkill ? modeState : null;
+  return hasActiveAutopilotSkill ? autopilotState : null;
 }
 
 function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -1223,6 +1223,10 @@ function hasActionableBashHardFailure(normalized: NormalizedPostToolUsePayload):
   return containsHardFailure(`${normalized.stderrText}\n${normalized.stdoutText}`);
 }
 
+function isReviewableNonZeroBashCommand(command: string): boolean {
+  return /(?:^|[;&|]\s*)gh\s+pr\s+checks(?:\s|$)/.test(command);
+}
+
 export function buildNativePostToolUseOutput(
   payload: CodexHookPayload,
 ): Record<string, unknown> | null {
@@ -1264,6 +1268,7 @@ export function buildNativePostToolUseOutput(
     && normalized.exitCode !== 0
     && combined.length > 0
     && !containsHardFailure(combined)
+    && isReviewableNonZeroBashCommand(normalized.normalizedCommand)
   ) {
     return {
       decision: "block",


### PR DESCRIPTION
## Summary
- Allow read-only Autopilot ralplan diagnostics (pwd, git diff, grep, find, omx state read) to pass PreToolUse without block output while preserving implementation-write blocks before consensus handoff.
- Narrow the PostToolUse informative non-zero Bash block to the known gh pr checks review surface.
- Add regressions for ordinary non-zero grep/find-style diagnostics so they no longer surface as repeated PostToolUse hook failures.

## Root cause
The hook failure storm was not a HUD render crash: native hooks report block decisions as hook failures in Codex. Two broad hook gates could make normal diagnosis look broken:
1. Autopilot-supervised ralplan needed explicit coverage proving read-only diagnostics are not treated as implementation writes.
2. PostToolUse treated any non-zero Bash command with useful output as review-blocking, so harmless diagnostic/search commands could produce repeated PostToolUse hook failed messages.

## Tests
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js --test-name-pattern 'Autopilot is supervising ralplan|read-only Bash diagnostics|ordinary non-zero|gh pr checks style|stderr-only informative' (392 pass / 0 fail in targeted compiled run)
- npm run check:no-unused
- npx --no-install biome lint src/scripts/codex-native-pre-post.ts src/scripts/__tests__/codex-native-hook.test.ts
- Native hook smoke: PostToolUse grep-style exit_code=1 exits 0 with empty stdout/stderr

## Notes
This branch also contains the preceding Autopilot ralplan supervision boundary commit (1b0505ed) because this worktree was branched from that in-progress fix branch.
