### PR TITLE
Keep Autopilot child phases supervised

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -2415,6 +2415,54 @@ deepMaxRounds = 21
     }
   });
 
+  it('ignores stale root child mode state during session-scoped Autopilot child reconciliation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-child-session-root-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-child-session-root';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'deep-interview',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'ultragoal-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'ultragoal',
+          current_phase: 'executing',
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$deep-interview continue scoped interview',
+        sessionId,
+        nowIso: '2026-05-30T00:05:00.000Z',
+      });
+
+      assert.equal(result?.skill, 'autopilot');
+      assert.equal(result?.supervised_child_skill, 'deep-interview');
+      assert.equal(result?.transition_error, undefined);
+      const rootUltragoal = JSON.parse(
+        await readFile(join(stateDir, 'ultragoal-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string };
+      assert.equal(rootUltragoal.active, true);
+      assert.equal(rootUltragoal.current_phase, 'executing');
+      assert.equal(existsSync(join(stateDir, 'sessions', sessionId, 'deep-interview-state.json')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('records ultragoal as a prompt skill with first-class mode state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ultragoal-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -2258,6 +2258,65 @@ deepMaxRounds = 21
     }
   });
 
+  it('keeps tracked Autopilot child keywords supervised and completes stale child mode state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-child-ultraqa-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-child-ultraqa';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'ultraqa',
+          activated_at: '2026-05-30T00:00:00.000Z',
+          updated_at: '2026-05-30T00:01:00.000Z',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', phase: 'ultraqa', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'ultragoal-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'ultragoal',
+          current_phase: 'planning',
+          session_id: sessionId,
+          started_at: '2026-05-29T23:00:00.000Z',
+          updated_at: '2026-05-29T23:05:00.000Z',
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ultraqa run adversarial checks',
+        sessionId,
+        threadId: 'thread-autopilot-child-ultraqa',
+        turnId: 'turn-autopilot-child-ultraqa',
+        nowIso: '2026-05-30T00:02:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      assert.equal(result.phase, 'ultraqa');
+      assert.equal(result.supervised_child_skill, 'ultraqa');
+      assert.equal(result.transition_error, undefined);
+      assert.equal(existsSync(join(stateDir, 'sessions', sessionId, 'ultraqa-state.json')), false);
+      const ultragoal = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'ultragoal-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string; auto_completed_reason?: string };
+      assert.equal(ultragoal.active, false);
+      assert.equal(ultragoal.current_phase, 'completed');
+      assert.match(ultragoal.auto_completed_reason || '', /mode transiting: ultragoal -> ultraqa/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('records ultragoal as a prompt skill with first-class mode state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ultragoal-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -2317,6 +2317,104 @@ deepMaxRounds = 21
     }
   });
 
+  it('denies supervised Autopilot child rollback without clearing stale execution state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-child-rollback-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-child-rollback';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'ultragoal',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', phase: 'ultragoal', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'ultragoal-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'ultragoal',
+          current_phase: 'executing',
+          session_id: sessionId,
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$deep-interview go back and re-plan',
+        sessionId,
+        nowIso: '2026-05-30T00:03:00.000Z',
+      });
+
+      assert.equal(result?.skill, 'autopilot');
+      assert.match(String(result?.transition_error), /Execution-to-planning rollback auto-complete is not allowed/i);
+      assert.equal(result?.supervised_child_skill, undefined);
+      assert.equal(existsSync(join(stateDir, 'sessions', sessionId, 'deep-interview-state.json')), false);
+      const ultragoal = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'ultragoal-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string };
+      assert.equal(ultragoal.active, true);
+      assert.equal(ultragoal.current_phase, 'executing');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces supervised Autopilot deep-interview to ralplan gate failures', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-child-gate-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-child-gate';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'deep-interview',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'deep-interview-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'deep-interview',
+          current_phase: 'intent-first',
+          session_id: sessionId,
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan continue without interview completion evidence',
+        sessionId,
+        nowIso: '2026-05-30T00:04:00.000Z',
+      });
+
+      assert.equal(result?.skill, 'autopilot');
+      assert.match(String(result?.transition_error), /missing deep-interview completion\/skip gate/i);
+      assert.equal(result?.supervised_child_skill, undefined);
+      assert.equal(existsSync(join(stateDir, 'sessions', sessionId, 'ralplan-state.json')), false);
+      const deepInterview = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'deep-interview-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string };
+      assert.equal(deepInterview.active, true);
+      assert.equal(deepInterview.current_phase, 'intent-first');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('records ultragoal as a prompt skill with first-class mode state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ultragoal-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -31,7 +31,10 @@ import {
   type DownstreamAuthority,
   type TrackedWorkflowMode,
 } from '../state/workflow-transition.js';
-import { reconcileWorkflowTransition } from '../state/workflow-transition-reconcile.js';
+import {
+  completeWorkflowModeState,
+  reconcileWorkflowTransition,
+} from '../state/workflow-transition-reconcile.js';
 import {
   clearDeepInterviewQuestionObligation,
   type DeepInterviewQuestionEnforcementState,
@@ -758,7 +761,41 @@ function shouldReusePreviousSkillForContinuation(
 }
 
 function isAutopilotSupervisedChildSkill(skill: string): boolean {
-  return skill === 'code-review';
+  return skill === 'code-review'
+    || skill === 'ultraqa'
+    || skill === 'ralplan'
+    || skill === 'ultragoal'
+    || skill === 'deep-interview';
+}
+
+const AUTOPILOT_SUPERVISED_TRACKED_CHILD_SKILLS: TrackedWorkflowMode[] = [
+  'deep-interview',
+  'ralplan',
+  'ultragoal',
+  'ultraqa',
+];
+
+async function completeAutopilotSupervisedChildModeStates(
+  cwd: string,
+  stateDir: string,
+  sessionId: string | undefined,
+  childSkill: string,
+  nowIso: string,
+): Promise<void> {
+  if (!isTrackedWorkflowMode(childSkill)) return;
+
+  for (const mode of AUTOPILOT_SUPERVISED_TRACKED_CHILD_SKILLS) {
+    if (mode === childSkill) continue;
+    const { absolutePath } = resolveSeedStateFilePath(stateDir, mode as StatefulSkillMode, sessionId);
+    const existing = await readJsonStateIfExists(absolutePath);
+    if (!existing || existing.active !== true || safeString(existing.mode).trim() !== mode) continue;
+    await completeWorkflowModeState(cwd, mode, childSkill, {
+      baseStateDir: stateDir,
+      sessionId,
+      nowIso,
+      source: 'autopilot-supervised-child',
+    });
+  }
 }
 
 function isDeepInterviewRuntimeConfig(value: unknown): value is DeepInterviewRuntimeConfig {
@@ -950,6 +987,45 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     ? reusableDeepInterviewConfig ?? resolveDeepInterviewRuntimeConfig({ cwd: sourceCwd, text: input.text })
     : null;
 
+  if (previous?.active === true && previous.skill === 'autopilot' && isAutopilotSupervisedChildSkill(match.skill)) {
+    const nextState: SkillActiveState = {
+      ...previous,
+      version: 1,
+      active: true,
+      updated_at: nowIso,
+      source: 'keyword-detector',
+      session_id: input.sessionId ?? previous.session_id,
+      thread_id: input.threadId ?? previous.thread_id,
+      turn_id: input.turnId ?? previous.turn_id,
+      active_skills: listActiveSkills(previous).map((entry) => (
+        entry.skill === 'autopilot'
+          ? {
+              ...entry,
+              active: true,
+              updated_at: nowIso,
+              session_id: input.sessionId ?? entry.session_id,
+              thread_id: input.threadId ?? entry.thread_id,
+              turn_id: input.turnId ?? entry.turn_id,
+            }
+          : entry
+      )),
+      supervised_child_keyword: match.keyword,
+      supervised_child_skill: match.skill,
+    };
+    try {
+      await completeAutopilotSupervisedChildModeStates(sourceCwd, input.stateDir, input.sessionId ?? previous.session_id, match.skill, nowIso);
+      await writeSkillActiveStateCopiesForStateDir(
+        input.stateDir,
+        nextState,
+        input.sessionId,
+        selectRootSkillStateCopy(previousRoot, nextState, input.sessionId),
+      );
+    } catch (error) {
+      console.warn('[omx] warning: failed to persist keyword activation state', error);
+    }
+    return nextState;
+  }
+
   if (isTrackedWorkflowMatch) {
     let nextWorkflowEntries = previousWorkflowEntries.map((entry) => ({ ...entry }));
     const transitionMessages: string[] = [];
@@ -1120,44 +1196,6 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     }
 
     return workflowState;
-  }
-
-  if (previous?.active === true && previous.skill === 'autopilot' && isAutopilotSupervisedChildSkill(match.skill)) {
-    const nextState: SkillActiveState = {
-      ...previous,
-      version: 1,
-      active: true,
-      updated_at: nowIso,
-      source: 'keyword-detector',
-      session_id: input.sessionId ?? previous.session_id,
-      thread_id: input.threadId ?? previous.thread_id,
-      turn_id: input.turnId ?? previous.turn_id,
-      active_skills: listActiveSkills(previous).map((entry) => (
-        entry.skill === 'autopilot'
-          ? {
-              ...entry,
-              active: true,
-              updated_at: nowIso,
-              session_id: input.sessionId ?? entry.session_id,
-              thread_id: input.threadId ?? entry.thread_id,
-              turn_id: input.turnId ?? entry.turn_id,
-            }
-          : entry
-      )),
-      supervised_child_keyword: match.keyword,
-      supervised_child_skill: match.skill,
-    };
-    try {
-      await writeSkillActiveStateCopiesForStateDir(
-        input.stateDir,
-        nextState,
-        input.sessionId,
-        selectRootSkillStateCopy(previousRoot, nextState, input.sessionId),
-      );
-    } catch (error) {
-      console.warn('[omx] warning: failed to persist keyword activation state', error);
-    }
-    return nextState;
   }
 
   const state: SkillActiveState = {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -785,7 +785,6 @@ async function reconcileAutopilotSupervisedChildModeStates(
   for (const mode of AUTOPILOT_SUPERVISED_TRACKED_CHILD_SKILLS) {
     const candidatePaths = [
       resolveSeedStateFilePath(stateDir, mode as StatefulSkillMode, sessionId).absolutePath,
-      ...(sessionId?.trim() ? [resolveSeedStateFilePath(stateDir, mode as StatefulSkillMode, undefined).absolutePath] : []),
     ];
     for (const candidatePath of candidatePaths) {
       const existing = await readJsonStateIfExists(candidatePath);

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -31,10 +31,7 @@ import {
   type DownstreamAuthority,
   type TrackedWorkflowMode,
 } from '../state/workflow-transition.js';
-import {
-  completeWorkflowModeState,
-  reconcileWorkflowTransition,
-} from '../state/workflow-transition-reconcile.js';
+import { reconcileWorkflowTransition } from '../state/workflow-transition-reconcile.js';
 import {
   clearDeepInterviewQuestionObligation,
   type DeepInterviewQuestionEnforcementState,
@@ -775,27 +772,38 @@ const AUTOPILOT_SUPERVISED_TRACKED_CHILD_SKILLS: TrackedWorkflowMode[] = [
   'ultraqa',
 ];
 
-async function completeAutopilotSupervisedChildModeStates(
+async function reconcileAutopilotSupervisedChildModeStates(
   cwd: string,
   stateDir: string,
   sessionId: string | undefined,
   childSkill: string,
   nowIso: string,
-): Promise<void> {
-  if (!isTrackedWorkflowMode(childSkill)) return;
+): Promise<string[]> {
+  if (!isTrackedWorkflowMode(childSkill)) return [];
 
+  const activeChildModes: TrackedWorkflowMode[] = [];
   for (const mode of AUTOPILOT_SUPERVISED_TRACKED_CHILD_SKILLS) {
-    if (mode === childSkill) continue;
-    const { absolutePath } = resolveSeedStateFilePath(stateDir, mode as StatefulSkillMode, sessionId);
-    const existing = await readJsonStateIfExists(absolutePath);
-    if (!existing || existing.active !== true || safeString(existing.mode).trim() !== mode) continue;
-    await completeWorkflowModeState(cwd, mode, childSkill, {
-      baseStateDir: stateDir,
-      sessionId,
-      nowIso,
-      source: 'autopilot-supervised-child',
-    });
+    const candidatePaths = [
+      resolveSeedStateFilePath(stateDir, mode as StatefulSkillMode, sessionId).absolutePath,
+      ...(sessionId?.trim() ? [resolveSeedStateFilePath(stateDir, mode as StatefulSkillMode, undefined).absolutePath] : []),
+    ];
+    for (const candidatePath of candidatePaths) {
+      const existing = await readJsonStateIfExists(candidatePath);
+      if (!existing || existing.active !== true || safeString(existing.mode).trim() !== mode) continue;
+      activeChildModes.push(mode);
+      break;
+    }
   }
+
+  const transition = await reconcileWorkflowTransition(cwd, childSkill, {
+    action: 'activate',
+    baseStateDir: stateDir,
+    currentModes: activeChildModes,
+    nowIso,
+    sessionId,
+    source: 'autopilot-supervised-child',
+  });
+  return transition.completedPaths;
 }
 
 function isDeepInterviewRuntimeConfig(value: unknown): value is DeepInterviewRuntimeConfig {
@@ -1013,7 +1021,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       supervised_child_skill: match.skill,
     };
     try {
-      await completeAutopilotSupervisedChildModeStates(sourceCwd, input.stateDir, input.sessionId ?? previous.session_id, match.skill, nowIso);
+      await reconcileAutopilotSupervisedChildModeStates(sourceCwd, input.stateDir, input.sessionId ?? previous.session_id, match.skill, nowIso);
       await writeSkillActiveStateCopiesForStateDir(
         input.stateDir,
         nextState,
@@ -1021,7 +1029,18 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         selectRootSkillStateCopy(previousRoot, nextState, input.sessionId),
       );
     } catch (error) {
-      console.warn('[omx] warning: failed to persist keyword activation state', error);
+      return {
+        ...previous,
+        version: 1,
+        active: true,
+        updated_at: nowIso,
+        source: 'keyword-detector',
+        session_id: input.sessionId ?? previous.session_id,
+        thread_id: input.threadId ?? previous.thread_id,
+        turn_id: input.turnId ?? previous.turn_id,
+        active_skills: listActiveSkills(previous),
+        transition_error: error instanceof Error ? error.message : String(error),
+      };
     }
     return nextState;
   }

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -188,6 +188,28 @@ async function completeSourceModeState(
   return completedPaths;
 }
 
+export async function completeWorkflowModeState(
+  cwd: string,
+  sourceMode: TrackedWorkflowMode,
+  destinationMode: TrackedWorkflowMode,
+  options: {
+    sessionId?: string;
+    nowIso?: string;
+    source?: string;
+    baseStateDir?: string;
+  } = {},
+): Promise<string[]> {
+  return completeSourceModeState(
+    cwd,
+    options.baseStateDir,
+    sourceMode,
+    destinationMode,
+    options.sessionId,
+    options.nowIso ?? new Date().toISOString(),
+    options.source ?? 'workflow-transition',
+  );
+}
+
 export async function reconcileWorkflowTransition(
   cwd: string,
   requestedMode: TrackedWorkflowMode,

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -142,6 +142,7 @@ const AUTO_COMPLETE_TRANSITIONS = new Set([
   'ralplan->ralph',
   'ralplan->autopilot',
   'ralplan->autoresearch',
+  'ultragoal->ultraqa',
 ]);
 
 const EVIDENCE_GATED_AUTO_COMPLETE_TRANSITIONS = new Set([


### PR DESCRIPTION
## Summary
- follow up #2623 by keeping Autopilot as the visible supervisor when tracked child phase keywords (`deep-interview`, `ralplan`, `ultragoal`, `ultraqa`) appear inside an active Autopilot run
- complete stale supervised child mode state through the shared workflow-transition reconciliation path instead of bespoke JSON rewriting
- add regression coverage for stale `ultragoal-state.json` no longer blocking an Autopilot `ultraqa` child handoff

## Validation
- `npm run build && node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js` — 541 pass, 0 fail
- previous PR validation on this branch: `npm run lint`; `npm run check:no-unused`; `git diff --check`

## Notes
- #2627 is closed and cannot be reopened; this is the active clean follow-up PR against current `dev`.
- I verified the open follow-up PR already contains the intended patch tree; no extra push was needed for `followup/autopilot-child-supervision`.