### PR TITLE
Keep hook diagnostics from blocking reviews

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -431,6 +431,32 @@ describe("codex native hook dispatch", () => {
     );
   });
 
+  it("logs a bounded raw stdin prefix when CLI stdin is malformed", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-malformed-log-prefix-"));
+    try {
+      const malformed = '{hook_event_name:"PostToolUse", tool_name:"Bash",';
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: malformed,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stderr, "");
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.stopReason, "native_hook_stdin_parse_error");
+
+      const log = await readFile(join(cwd, ".omx", "logs", `native-hook-${new Date().toISOString().split("T")[0]}.jsonl`), "utf-8");
+      const entry = JSON.parse(log.trim()) as Record<string, unknown>;
+      assert.equal(entry.type, "native_hook_stdin_parse_error");
+      assert.equal(entry.raw_input_length, Buffer.byteLength(malformed, "utf-8"));
+      assert.equal(entry.raw_input_prefix, malformed);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("emits Stop-schema-safe block JSON when malformed stdin still identifies Stop", () => {
     const stdout = runNativeHookCli('{hook_event_name:"Stop",');
 
@@ -7752,6 +7778,50 @@ exit 0
       assert.equal(attention?.leader_session_id, canonicalSessionId);
     } finally {
       process.chdir(previousCwd);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block ordinary non-zero grep output in PostToolUse", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-grep-nonzero-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-grep-nonzero",
+          tool_input: { command: "grep -R missing-pattern src | head -20" },
+          tool_response: "{\"exit_code\":1,\"stdout\":\"src/example.ts:TODO\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block ordinary non-zero diagnostic output in PostToolUse", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-diagnostic-nonzero-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-diagnostic-nonzero",
+          tool_input: { command: "find src -name nope -print" },
+          tool_response: "{\"exit_code\":1,\"stdout\":\"searched 10 files\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4425,11 +4425,20 @@ function writeNativeHookJsonStdout(output: Record<string, unknown>): void {
   process.stdout.write(`${JSON.stringify(output)}\n`);
 }
 
+function buildRawInputLogFields(rawInput: string): Record<string, unknown> {
+  if (!rawInput) return {};
+  return {
+    raw_input_length: Buffer.byteLength(rawInput, "utf-8"),
+    raw_input_prefix: rawInput.replace(/[\u0000-\u001f\u007f-\u009f]/g, "").slice(0, 240),
+  };
+}
+
 async function logNativeHookCliError(
   cwd: string,
   type: string,
   error: unknown,
   payload: CodexHookPayload = {},
+  details: Record<string, unknown> = {},
 ): Promise<void> {
   const logsDir = join(cwd || process.cwd(), ".omx", "logs");
   await mkdir(logsDir, { recursive: true }).catch(() => {});
@@ -4444,6 +4453,7 @@ async function logNativeHookCliError(
       thread_id: readPayloadThreadId(payload) || undefined,
       turn_id: readPayloadTurnId(payload) || undefined,
       error: error instanceof Error ? error.message : String(error),
+      ...details,
     }) + "\n",
   ).catch(() => {});
 }
@@ -4478,7 +4488,13 @@ export async function runCodexNativeHookCli(): Promise<void> {
     return;
   }
   if (parseError) {
-    await logNativeHookCliError(process.cwd(), "native_hook_stdin_parse_error", parseError);
+    await logNativeHookCliError(
+      process.cwd(),
+      "native_hook_stdin_parse_error",
+      parseError,
+      {},
+      buildRawInputLogFields(rawInput),
+    );
     writeNativeHookJsonStdout(buildMalformedStdinHookOutput(parseError, rawInput));
     return;
   }

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -1223,6 +1223,10 @@ function hasActionableBashHardFailure(normalized: NormalizedPostToolUsePayload):
   return containsHardFailure(`${normalized.stderrText}\n${normalized.stdoutText}`);
 }
 
+function isReviewableNonZeroBashCommand(command: string): boolean {
+  return /(?:^|[;&|]\s*)gh\s+pr\s+checks(?:\s|$)/.test(command);
+}
+
 export function buildNativePostToolUseOutput(
   payload: CodexHookPayload,
 ): Record<string, unknown> | null {
@@ -1264,6 +1268,7 @@ export function buildNativePostToolUseOutput(
     && normalized.exitCode !== 0
     && combined.length > 0
     && !containsHardFailure(combined)
+    && isReviewableNonZeroBashCommand(normalized.normalizedCommand)
   ) {
     return {
       decision: "block",


### PR DESCRIPTION
## Summary
- Recreated the hook diagnostics fix as a minimal branch on current upstream/dev.
- Added bounded malformed-stdin diagnostics (`raw_input_length`, sanitized `raw_input_prefix`) to native hook parse-error logs.
- Narrowed PostToolUse review-blocking for non-zero Bash output to the intentional `gh pr checks` surface so ordinary grep/find diagnostics stay silent.

## Addresses prior review
This replaces closed PR #2626's stale branch shape. The diff is limited to:
- `src/scripts/codex-native-hook.ts`
- `src/scripts/codex-native-pre-post.ts`
- `src/scripts/__tests__/codex-native-hook.test.ts`

It does not carry the unrelated Autopilot child-keyword or stale notify-fallback/HUD hunks from the old branch.

## Tests
- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js --test-name-pattern 'malformed|ordinary non-zero|gh pr checks style|stderr-only informative'`
- `npm run check:no-unused`
- `npx --no-install biome lint src/scripts/codex-native-hook.ts src/scripts/codex-native-pre-post.ts src/scripts/__tests__/codex-native-hook.test.ts`
