### PR TITLE
Reap deleted-cwd HUD watch panes

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2846,7 +2846,7 @@ describe("tmux HUD pane helpers", () => {
       "-t",
       "%leader",
       "-F",
-      "#{pane_id}\t#{pane_current_command}\t#{pane_start_command}",
+      "#{pane_id}\t#{pane_current_command}\t#{pane_start_command}\t#{pane_current_path}",
     ]);
   });
 

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -146,6 +146,13 @@ describe('HUD pane ownership helpers', () => {
     });
   });
 
+  it('preserves tab-containing start commands when reading the optional cwd column', () => {
+    const [pane] = parseTmuxPaneSnapshot('%9\tnode\tnode\t/omx.js hud --watch\t/tmp/repo');
+
+    assert.equal(pane?.startCommand, 'node\t/omx.js hud --watch');
+    assert.equal(pane?.currentPath, '/tmp/repo');
+  });
+
   it('keeps independent leaders in one tmux window from matching each other HUD panes', () => {
     const panes = parseTmuxPaneSnapshot(
       [
@@ -233,7 +240,7 @@ describe('HUD pane ownership helpers', () => {
 
     assert.deepEqual(listCurrentWindowHudPaneIds(undefined, execTmuxSync, { sessionId: 'sess-a' }), ['%2']);
     assert.deepEqual(calls, [
-      ['list-panes', '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}'],
+      ['list-panes', '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}\t#{pane_current_path}'],
     ]);
   });
 
@@ -330,6 +337,26 @@ describe('dead HUD pane reaper', () => {
     });
 
     assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+  });
+
+  it('kills untagged HUD panes whose tmux cwd has been deleted', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        '%2\tnode\tnode /tmp/bin/omx.js hud --watch\t/tmp/omx-doctor-native-hook-dist-QLbHN0 (deleted)',
+      ].join('\n'),
+    );
+    const killed: string[] = [];
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+    });
+
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
   });
 
   it('does not touch non-HUD panes', () => {

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -6,6 +6,7 @@ export interface TmuxPaneSnapshot {
   paneId: string;
   currentCommand: string;
   startCommand: string;
+  currentPath?: string;
 }
 
 export const OMX_TMUX_HUD_LEADER_PANE_ENV = 'OMX_TMUX_HUD_LEADER_PANE';
@@ -34,11 +35,17 @@ export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const [paneId = '', currentCommand = '', ...startCommandParts] = line.split('\t');
+      const parts = line.split('\t');
+      const [paneId = '', currentCommand = ''] = parts;
+      const hasCurrentPathColumn = parts.length >= 4;
+      const currentPath = hasCurrentPathColumn ? (parts.at(-1) ?? '') : '';
+      const startCommandParts = hasCurrentPathColumn ? parts.slice(2, -1) : parts.slice(2);
+      const trimmedCurrentPath = currentPath.trim();
       return {
         paneId: paneId.trim(),
         currentCommand: currentCommand.trim(),
         startCommand: startCommandParts.join('\t').trim(),
+        ...(trimmedCurrentPath ? { currentPath: trimmedCurrentPath } : {}),
       };
     })
     .filter((pane) => pane.paneId.startsWith('%'));
@@ -113,6 +120,10 @@ export function findHudWatchPaneIds(
     .map((pane) => pane.paneId);
 }
 
+function isDeletedTmuxPanePath(path: string | undefined): boolean {
+  return /(?:^|\s)\(deleted\)\s*$/.test(path ?? '');
+}
+
 export function reapDeadHudPanes(
   panes: TmuxPaneSnapshot[],
   opts: {
@@ -131,7 +142,11 @@ export function reapDeadHudPanes(
 
     const leaderPaneId = readHudPaneOwner(pane).leaderPaneId;
     if (!leaderPaneId) {
-      preserved.push(pane.paneId);
+      if (isDeletedTmuxPanePath(pane.currentPath) && killPane(pane.paneId)) {
+        reaped.push(pane.paneId);
+      } else {
+        preserved.push(pane.paneId);
+      }
       continue;
     }
 
@@ -278,7 +293,7 @@ export function listCurrentWindowPanes(
         'list-panes',
         ...(currentPaneId ? ['-t', currentPaneId] : []),
         '-F',
-        '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}',
+        '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}\t#{pane_current_path}',
       ]),
     );
   } catch {


### PR DESCRIPTION
## Summary
- reap ownerless HUD watch panes when tmux reports their cwd as deleted
- keep normal legacy/untagged HUD panes preserved unless `pane_current_path` ends with `(deleted)`
- include `pane_current_path` in the shared tmux pane snapshot without losing tab-containing start commands

## Local evidence
Observed the same stale-pane class in two windows:
- `omx-0:1` (`codex`): orphan HUD `%122`, cwd `/tmp/omx-doctor-native-hook-dist-gykQDo (deleted)`, no `OMX_TMUX_HUD_LEADER_PANE`, alongside live owner-tagged HUD `%104` for leader `%103`.
- `omx-0:5` (`fix/ultagoal-cleanup-in-autopilot`): orphan HUD `%123`, cwd `/tmp/omx-doctor-native-hook-dist-QLbHN0 (deleted)`, no `OMX_TMUX_HUD_LEADER_PANE`, alongside live owner-tagged HUD `%130` for leader `%115`.

This fills a gap left by earlier duplicate-HUD cleanup: same-leader/standalone duplicates were handled, but deleted-cwd ownerless doctor-smoke HUD panes were still intentionally preserved as generic legacy panes.

This is separate from #2630, which is about HUD state mirror fallback rather than tmux pane lifecycle cleanup.

## Validation
- `npm run build`
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js` (46 pass)
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
