### PR TITLE
Harden native hook diagnostics

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -431,6 +431,32 @@ describe("codex native hook dispatch", () => {
     );
   });
 
+  it("logs a bounded raw stdin prefix when CLI stdin is malformed", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-malformed-log-prefix-"));
+    try {
+      const malformed = '{hook_event_name:"PostToolUse", tool_name:"Bash",';
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: malformed,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stderr, "");
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.stopReason, "native_hook_stdin_parse_error");
+
+      const log = await readFile(join(cwd, ".omx", "logs", `native-hook-${new Date().toISOString().split("T")[0]}.jsonl`), "utf-8");
+      const entry = JSON.parse(log.trim()) as Record<string, unknown>;
+      assert.equal(entry.type, "native_hook_stdin_parse_error");
+      assert.equal(entry.raw_input_length, Buffer.byteLength(malformed, "utf-8"));
+      assert.equal(entry.raw_input_prefix, malformed);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("emits Stop-schema-safe block JSON when malformed stdin still identifies Stop", () => {
     const stdout = runNativeHookCli('{hook_event_name:"Stop",');
 
@@ -7752,6 +7778,50 @@ exit 0
       assert.equal(attention?.leader_session_id, canonicalSessionId);
     } finally {
       process.chdir(previousCwd);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block ordinary non-zero grep output in PostToolUse", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-grep-nonzero-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-grep-nonzero",
+          tool_input: { command: "grep -R missing-pattern src | head -20" },
+          tool_response: "{\"exit_code\":1,\"stdout\":\"src/example.ts:TODO\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block ordinary non-zero diagnostic output in PostToolUse", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-diagnostic-nonzero-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-diagnostic-nonzero",
+          tool_input: { command: "find src -name nope -print" },
+          tool_response: "{\"exit_code\":1,\"stdout\":\"searched 10 files\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -431,10 +431,11 @@ describe("codex native hook dispatch", () => {
     );
   });
 
-  it("logs a bounded raw stdin prefix when CLI stdin is malformed", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-malformed-log-prefix-"));
+  it("redacts unterminated prompt-like malformed stdin fields", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-malformed-unterminated-"));
     try {
-      const malformed = '{hook_event_name:"PostToolUse", tool_name:"Bash",';
+      const privatePrompt = "PRIVATE_UNTERMINATED_PROMPT";
+      const malformed = `{hook_event_name:"PostToolUse", prompt:"${privatePrompt}`;
       const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
         cwd,
         input: malformed,
@@ -449,9 +450,42 @@ describe("codex native hook dispatch", () => {
 
       const log = await readFile(join(cwd, ".omx", "logs", `native-hook-${new Date().toISOString().split("T")[0]}.jsonl`), "utf-8");
       const entry = JSON.parse(log.trim()) as Record<string, unknown>;
+      const prefix = String(entry.raw_input_prefix ?? "");
+      assert.doesNotMatch(prefix, new RegExp(privatePrompt));
+      assert.match(prefix, /prompt:"\[REDACTED\]"/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("logs a bounded redacted raw stdin prefix when CLI stdin is malformed", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-malformed-log-prefix-"));
+    try {
+      const secret = "sk-test-secret123456";
+      const promptText = "summarize private launch notes";
+      const malformed = `{hook_event_name:"PostToolUse", access_token:"${secret}", prompt:"${promptText}", text:"${promptText}", bad:"${"x".repeat(400)}"}${String.fromCharCode(10, 0, 7)}`;
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: malformed,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stderr, "");
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.stopReason, "native_hook_stdin_parse_error");
+
+      const log = await readFile(join(cwd, ".omx", "logs", `native-hook-${new Date().toISOString().split("T")[0]}.jsonl`), "utf-8");
+      const entry = JSON.parse(log.trim()) as Record<string, unknown>;
+      const prefix = String(entry.raw_input_prefix ?? "");
       assert.equal(entry.type, "native_hook_stdin_parse_error");
       assert.equal(entry.raw_input_length, Buffer.byteLength(malformed, "utf-8"));
-      assert.equal(entry.raw_input_prefix, malformed);
+      assert.ok(prefix.length <= 240, `prefix should be bounded, got ${prefix.length}`);
+      assert.doesNotMatch(prefix, /[\u0000-\u001f\u007f-\u009f]/);
+      assert.doesNotMatch(prefix, new RegExp(secret));
+      assert.doesNotMatch(prefix, new RegExp(promptText));
+      assert.match(prefix, /\[REDACTED\]/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -7881,6 +7915,81 @@ exit 0
             "The Bash output appears informative despite the non-zero exit code. Review and report the output before retrying instead of assuming the command simply failed.",
         },
       });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("treats wrapped gh pr checks output as reviewable", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-gh-wrapped-"));
+    try {
+      for (const command of [
+        "GH_PAGER=cat gh pr checks",
+        "env GH_TOKEN=ghp_testtoken gh pr checks",
+        "/usr/bin/gh pr checks",
+        "gh --repo owner/repo pr checks",
+        "echo a; gh pr checks",
+        "cd repo && gh pr checks",
+      ]) {
+        const result = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "PostToolUse",
+            cwd,
+            tool_name: "Bash",
+            tool_use_id: `tool-useful-${command}`,
+            tool_input: { command },
+            tool_response: "{\"exit_code\":8,\"stdout\":\"build pending\",\"stderr\":\"\"}",
+          },
+          { cwd },
+        );
+
+        assert.equal(result.omxEventName, "post-tool-use");
+        assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block", command);
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat heredoc gh pr checks text as a reviewable command", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-gh-heredoc-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-heredoc-gh-checks",
+          tool_input: { command: "cat <<'EOF'\ngh pr checks\nEOF\nfalse" },
+          tool_response: "{\"exit_code\":1,\"stdout\":\"gh pr checks\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat echoed gh pr checks text as a reviewable command", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-gh-echo-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-echo-gh-checks",
+          tool_input: { command: "echo gh pr checks" },
+          tool_response: "{\"exit_code\":1,\"stdout\":\"gh pr checks\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4425,11 +4425,20 @@ function writeNativeHookJsonStdout(output: Record<string, unknown>): void {
   process.stdout.write(`${JSON.stringify(output)}\n`);
 }
 
+function buildRawInputLogFields(rawInput: string): Record<string, unknown> {
+  if (!rawInput) return {};
+  return {
+    raw_input_length: Buffer.byteLength(rawInput, "utf-8"),
+    raw_input_prefix: rawInput.replace(/[\u0000-\u001f\u007f-\u009f]/g, "").slice(0, 240),
+  };
+}
+
 async function logNativeHookCliError(
   cwd: string,
   type: string,
   error: unknown,
   payload: CodexHookPayload = {},
+  details: Record<string, unknown> = {},
 ): Promise<void> {
   const logsDir = join(cwd || process.cwd(), ".omx", "logs");
   await mkdir(logsDir, { recursive: true }).catch(() => {});
@@ -4444,6 +4453,7 @@ async function logNativeHookCliError(
       thread_id: readPayloadThreadId(payload) || undefined,
       turn_id: readPayloadTurnId(payload) || undefined,
       error: error instanceof Error ? error.message : String(error),
+      ...details,
     }) + "\n",
   ).catch(() => {});
 }
@@ -4478,7 +4488,13 @@ export async function runCodexNativeHookCli(): Promise<void> {
     return;
   }
   if (parseError) {
-    await logNativeHookCliError(process.cwd(), "native_hook_stdin_parse_error", parseError);
+    await logNativeHookCliError(
+      process.cwd(),
+      "native_hook_stdin_parse_error",
+      parseError,
+      {},
+      buildRawInputLogFields(rawInput),
+    );
     writeNativeHookJsonStdout(buildMalformedStdinHookOutput(parseError, rawInput));
     return;
   }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4,6 +4,7 @@ import { appendFile, mkdir, readFile, readdir, stat, writeFile } from "fs/promis
 import { extname, join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
 import { readModeStateForActiveDecision, readModeStateForSession, updateModeState } from "../modes/base.js";
+import { redactAuthSecrets } from "../auth/redact.js";
 import {
   SKILL_ACTIVE_STATE_FILE,
   extractSessionIdFromInitializedStatePath,
@@ -4425,11 +4426,29 @@ function writeNativeHookJsonStdout(output: Record<string, unknown>): void {
   process.stdout.write(`${JSON.stringify(output)}\n`);
 }
 
+function redactMalformedHookPreview(rawInput: string): string {
+  const withoutControls = rawInput.replace(/[\u0000-\u001f\u007f-\u009f]/g, "");
+  const withoutAuthSecrets = redactAuthSecrets(withoutControls);
+  return withoutAuthSecrets
+    .replace(
+      /(["']?(?:prompt|user_prompt|input|text)["']?\s*:\s*)(["'])(?:\\.|(?!\2)[^\\])*\2/gi,
+      "$1$2[REDACTED]$2",
+    )
+    .replace(
+      /(["']?(?:prompt|user_prompt|input|text)["']?\s*:\s*)(["'])(?:\\.|[^\\])*$/gi,
+      "$1$2[REDACTED]$2",
+    )
+    .replace(
+      /(["']?(?:prompt|user_prompt|input|text)["']?\s*:\s*)(?!["'])[^,}]*/gi,
+      "$1[REDACTED]",
+    );
+}
+
 function buildRawInputLogFields(rawInput: string): Record<string, unknown> {
   if (!rawInput) return {};
   return {
     raw_input_length: Buffer.byteLength(rawInput, "utf-8"),
-    raw_input_prefix: rawInput.replace(/[\u0000-\u001f\u007f-\u009f]/g, "").slice(0, 240),
+    raw_input_prefix: redactMalformedHookPreview(rawInput).slice(0, 240),
   };
 }
 

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -1223,8 +1223,83 @@ function hasActionableBashHardFailure(normalized: NormalizedPostToolUsePayload):
   return containsHardFailure(`${normalized.stderrText}\n${normalized.stdoutText}`);
 }
 
+function isShellEnvAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token);
+}
+
+function shellCommandBasename(token: string): string {
+  const normalized = token.replace(/\\/g, "/");
+  return (normalized.split("/").pop() || normalized).toLowerCase();
+}
+
+function skipEnvWrapper(tokens: string[]): number {
+  let index = 0;
+  while (isShellEnvAssignment(tokens[index] || "")) index += 1;
+  if (tokens[index] !== "env") return index;
+
+  index += 1;
+  while (index < tokens.length) {
+    const token = tokens[index] || "";
+    if (isShellEnvAssignment(token)) {
+      index += 1;
+      continue;
+    }
+    if (token === "-i" || token === "--ignore-environment") {
+      index += 1;
+      continue;
+    }
+    if (token === "-u" || token === "--unset") {
+      index += 2;
+      continue;
+    }
+    if (token.startsWith("-u") && token.length > 2) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function skipGhGlobalOptions(tokens: string[], startIndex: number): number {
+  let index = startIndex;
+  const optionsWithValue = new Set(["--repo", "-R", "--hostname", "--config-dir"]);
+  while (index < tokens.length) {
+    const token = tokens[index] || "";
+    if (optionsWithValue.has(token)) {
+      index += 2;
+      continue;
+    }
+    if (/^(?:--repo|--hostname|--config-dir)=/.test(token)) {
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-") && token !== "-") {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function isReviewableGhPrChecksTokens(tokens: string[]): boolean {
+  const commandIndex = skipEnvWrapper(tokens);
+  const basename = shellCommandBasename(tokens[commandIndex] || "");
+  if (basename !== "gh" && basename !== "gh.exe") return false;
+  const subcommandIndex = skipGhGlobalOptions(tokens, commandIndex + 1);
+  return tokens[subcommandIndex] === "pr" && tokens[subcommandIndex + 1] === "checks";
+}
+
 function isReviewableNonZeroBashCommand(command: string): boolean {
-  return /(?:^|[;&|]\s*)gh\s+pr\s+checks(?:\s|$)/.test(command);
+  const boundaryTokens = tokenizeShellCommandWithBoundaries(removeHereDocBodies(command));
+  if (!boundaryTokens) return false;
+  for (let commandStart = 0; commandStart < boundaryTokens.length; commandStart = nextCommandStart(boundaryTokens, commandStart)) {
+    const commandEnd = nextCommandStart(boundaryTokens, commandStart);
+    const commandTokens = boundaryTokens.slice(commandStart, commandEnd).map((candidate) => candidate.value);
+    if (isReviewableGhPrChecksTokens(commandTokens)) return true;
+  }
+  return false;
 }
 
 export function buildNativePostToolUseOutput(

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -1223,6 +1223,10 @@ function hasActionableBashHardFailure(normalized: NormalizedPostToolUsePayload):
   return containsHardFailure(`${normalized.stderrText}\n${normalized.stdoutText}`);
 }
 
+function isReviewableNonZeroBashCommand(command: string): boolean {
+  return /(?:^|[;&|]\s*)gh\s+pr\s+checks(?:\s|$)/.test(command);
+}
+
 export function buildNativePostToolUseOutput(
   payload: CodexHookPayload,
 ): Record<string, unknown> | null {
@@ -1264,6 +1268,7 @@ export function buildNativePostToolUseOutput(
     && normalized.exitCode !== 0
     && combined.length > 0
     && !containsHardFailure(combined)
+    && isReviewableNonZeroBashCommand(normalized.normalizedCommand)
   ) {
     return {
       decision: "block",


### PR DESCRIPTION
## Summary

- keep ordinary non-zero Bash diagnostics (for example grep/find no-match output) from being escalated by the PostToolUse hook;
- preserve review blocking for `gh pr checks` non-zero output using boundary-aware command detection, including env wrappers, path-qualified gh, global options, and chained commands;
- add bounded malformed-stdin diagnostics that strip control characters and redact auth secrets plus prompt-like fields, including unterminated malformed values.

## Validation

- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js --test-name-pattern 'malformed|unterminated|ordinary non-zero|gh pr checks style|wrapped gh pr checks|echoed gh pr checks|heredoc gh pr checks|stderr-only informative'` — 397 pass / 0 fail
- `npm run check:no-unused`
- `npx --no-install biome lint src/scripts/codex-native-hook.ts src/scripts/codex-native-pre-post.ts src/scripts/__tests__/codex-native-hook.test.ts`
- UltraQA adversarial harness — 13/13 pass

## Review notes

This replaces closed PR #2629 after its follow-up review findings were addressed in `5367636d`.
