### PR TITLE
Fix HUD autopilot session mirror fallback

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -751,6 +751,95 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('surfaces session-mirrored root autopilot state when the HUD session file has not been materialized yet', async () => {
+    await withTempRepo('omx-hud-root-mirror-autopilot-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-autopilot-root-mirror';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd }));
+      await writeFile(join(rootStateDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'autopilot',
+        phase: 'deep-interview',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(rootStateDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'deep-interview',
+        session_id: sessionId,
+      }));
+
+      const state = await readAllState(cwd);
+
+      assert.equal(state.autopilot?.active, true);
+      assert.equal(state.autopilot?.current_phase, 'deep-interview');
+    });
+  });
+
+  it('does not resurrect root terminal autopilot detail when session file is missing', async () => {
+    await withTempRepo('omx-hud-root-terminal-autopilot-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-autopilot-root-terminal';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd }));
+      await writeFile(join(rootStateDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'autopilot',
+        phase: 'deep-interview',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(rootStateDir, 'autopilot-state.json'), JSON.stringify({
+        active: false,
+        mode: 'autopilot',
+        current_phase: 'complete',
+        session_id: sessionId,
+        completed_at: '2026-05-30T00:00:00.000Z',
+      }));
+
+      const state = await readAllState(cwd);
+
+      assert.equal(state.autopilot, null);
+    });
+  });
+
+  it('does not surface root canonical workflow entries without current-session ownership', async () => {
+    await withTempRepo('omx-hud-root-stale-owner-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-current-hud';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd }));
+      await writeFile(join(rootStateDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'autopilot',
+        phase: 'deep-interview',
+        active_skills: [
+          { skill: 'autopilot', phase: 'deep-interview', active: true },
+          { skill: 'ralplan', phase: 'planning', active: true, session_id: 'sess-other-hud' },
+        ],
+      }));
+      await writeFile(join(rootStateDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'deep-interview',
+      }));
+      await writeFile(join(rootStateDir, 'ralplan-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'planning',
+      }));
+
+      const state = await readAllState(cwd);
+
+      assert.equal(state.autopilot, null);
+      assert.equal(state.ralplan, null);
+    });
+  });
+
   it('does not resurrect terminal autopilot from stale canonical skill-active phase', async () => {
     await withTempRepo('omx-hud-canonical-autopilot-terminal-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -45,13 +45,24 @@ async function readJsonFile<T>(path: string): Promise<T | null> {
   }
 }
 
+function rootModeStateBelongsToSession(state: unknown, sessionId: string): boolean {
+  if (!state || typeof state !== 'object') return false;
+  return sanitizeOptionalString((state as { session_id?: unknown }).session_id) === sessionId;
+}
+
 async function readSessionAwareModeState<T>(cwd: string, mode: string): Promise<T | null> {
   const candidates = await getReadScopedStatePaths(mode, cwd);
   const sessionId = await readCurrentSessionId(cwd);
 
   if (sessionId) {
     if (candidates.length === 0) return null;
-    return readJsonFile<T>(candidates[0]);
+    const sessionState = await readJsonFile<T>(candidates[0]);
+    if (sessionState) return sessionState;
+
+    const rootCandidate = candidates[1];
+    if (!rootCandidate) return null;
+    const rootState = await readJsonFile<T>(rootCandidate);
+    return rootModeStateBelongsToSession(rootState, sessionId) ? rootState : null;
   }
 
   for (const candidate of candidates) {
@@ -457,6 +468,8 @@ function shouldSurfaceCanonicalSkill(
   detail: { active?: boolean; current_phase?: string } | null,
   useCompatibilityFallback: boolean,
 ): boolean {
+  const canonicalPhase = canonicalPhaseForSkill(canonicalSkills, skill);
+  if (canonicalSkills.has(skill) && !detail && canonicalPhase) return true;
   if (!canonicalSkills.has(skill) && !useCompatibilityFallback) return false;
   return !isMissingTerminalOrInactiveDetail(detail);
 }

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -175,6 +175,73 @@ describe('skill-active state helpers', () => {
       const rootState = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
       assert.equal(rootState.initialized_mode, 'ralph');
       assert.equal(rootState.initialized_state_path, '.omx/state/sessions/old-session/ralph-state.json');
+    });
+  });
+
+  it('does not synthesize session root mirror fallback from top-level skill fields', async () => {
+    await withTempRepo('omx-skill-active-root-top-level-only-', async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        phase: 'deep-interview',
+        session_id: 'current-session',
+      }));
+
+      const sessionState = await readVisibleSkillActiveState(cwd, 'current-session');
+
+      assert.equal(sessionState, null);
+    });
+  });
+
+  it('sanitizes root mirror metadata when session skill-active file is missing', async () => {
+    await withTempRepo('omx-skill-active-root-mirror-sanitize-', async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        phase: 'deep-interview',
+        initialized_mode: 'ralph',
+        initialized_state_path: '.omx/state/sessions/stale-session/ralph-state.json',
+        owner_omx_session_id: 'stale-session',
+        owner_codex_session_id: 'stale-codex-session',
+        owner_codex_thread_id: 'stale-thread',
+        task_slug: 'stale-task',
+        context_snapshot_path: '.omx/context/stale.md',
+        session_id: 'stale-session',
+        active_skills: [{
+          skill: 'autopilot',
+          phase: 'deep-interview',
+          active: true,
+          session_id: 'current-session',
+          thread_id: 'current-thread',
+          turn_id: 'current-turn',
+        }],
+      }));
+
+      const sessionState = await readVisibleSkillActiveState(cwd, 'current-session') as Record<string, unknown> | null;
+
+      assert.ok(sessionState);
+      assert.equal(sessionState.skill, 'autopilot');
+      assert.equal(sessionState.phase, 'deep-interview');
+      assert.equal(sessionState.session_id, 'current-session');
+      assert.equal(sessionState.thread_id, 'current-thread');
+      assert.equal(sessionState.turn_id, 'current-turn');
+      assert.equal(sessionState.initialized_mode, undefined);
+      assert.equal(sessionState.initialized_state_path, undefined);
+      assert.equal(sessionState.owner_omx_session_id, undefined);
+      assert.equal(sessionState.owner_codex_session_id, undefined);
+      assert.equal(sessionState.owner_codex_thread_id, undefined);
+      assert.equal(sessionState.task_slug, undefined);
+      assert.equal(sessionState.context_snapshot_path, undefined);
+      assert.deepEqual(
+        listActiveSkills(sessionState).map(({ skill, phase, session_id }) => ({ skill, phase, session_id })),
+        [{ skill: 'autopilot', phase: 'deep-interview', session_id: 'current-session' }],
+      );
     });
   });
 

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -312,9 +312,42 @@ async function readVisibleSkillActiveStateFromPaths(
   if (sessionPath && existsSync(sessionPath)) {
     return readSkillActiveState(sessionPath);
   }
-  if (sessionPath) return null;
+
   if (!existsSync(rootPath)) return null;
-  return readSkillActiveState(rootPath);
+  const rootState = await readSkillActiveState(rootPath);
+  if (!sessionPath) return rootState;
+
+  const normalizedSessionId = sessionPath.replace(/\\/g, '/').match(/(?:^|\/)sessions\/([^/]+)\/skill-active-state\.json$/)?.[1];
+  if (!normalizedSessionId) return null;
+
+  let rawRootState: SkillActiveStateLike | null = null;
+  try {
+    rawRootState = JSON.parse(await readFile(rootPath, 'utf-8')) as SkillActiveStateLike;
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(rawRootState.active_skills)) return null;
+  const visibleRootEntries = rawRootState.active_skills
+    .map(normalizeSkillActiveEntry)
+    .filter((entry): entry is SkillActiveEntry => (
+      entry !== null && safeString(entry.session_id).trim() === normalizedSessionId
+    ));
+  if (visibleRootEntries.length === 0) return null;
+
+  const primaryEntry = visibleRootEntries[0];
+  return normalizeSkillActiveState({
+    version: rootState?.version,
+    active_skills: visibleRootEntries,
+    active: true,
+    skill: primaryEntry?.skill,
+    phase: primaryEntry?.phase ?? '',
+    activated_at: primaryEntry?.activated_at,
+    updated_at: primaryEntry?.updated_at,
+    session_id: primaryEntry?.session_id,
+    thread_id: primaryEntry?.thread_id,
+    turn_id: primaryEntry?.turn_id,
+  });
 }
 
 export function tracksCanonicalWorkflowSkill(mode: string): mode is CanonicalWorkflowSkill {


### PR DESCRIPTION
## Summary
- restore HUD visibility for active autopilot from session-owned root-mirrored `skill-active` state before the session file is materialized
- tighten the fallback so root entries are visible only when `active_skills[].session_id` exactly matches the current HUD session
- rebuild the fallback state from matching entry fields only, avoiding stale root top-level `initialized_*`, `owner_*`, task, or context metadata leakage
- add regression coverage for session-owned mirror visibility, stale/foreign owner suppression, terminal suppression, and metadata sanitization

Draft follow-up to closed #2630. This branch was recreated from current `upstream/dev` after #2628 landed; `upstream/dev...HEAD` contains only this HUD/skill-active fallback change and focused tests.

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/hud/__tests__/state.test.js dist/state/__tests__/skill-active.test.js dist/hooks/__tests__/keyword-detector.test.js`
- `git diff --check`

## Independent review carried over from #2630 iteration
- code-reviewer: APPROVE; 0 issues
- architect: CLEAR
