### PR TITLE
Reap deleted-cwd HUD watch panes

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2846,7 +2846,7 @@ describe("tmux HUD pane helpers", () => {
       "-t",
       "%leader",
       "-F",
-      "#{pane_id}\t#{pane_current_command}\t#{pane_start_command}",
+      "#{pane_id}\x1f#{pane_current_command}\x1f#{pane_start_command}\x1f#{pane_current_path}",
     ]);
   });
 

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -1,5 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   buildHudResizeHookName,
   buildHudResizeHookSlot,
@@ -146,6 +149,13 @@ describe('HUD pane ownership helpers', () => {
     });
   });
 
+  it('preserves tab-containing start commands when reading the optional cwd column', () => {
+    const [pane] = parseTmuxPaneSnapshot('%9\tnode\tnode\t/omx.js hud --watch\t/tmp/repo');
+
+    assert.equal(pane?.startCommand, 'node\t/omx.js hud --watch');
+    assert.equal(pane?.currentPath, '/tmp/repo');
+  });
+
   it('keeps independent leaders in one tmux window from matching each other HUD panes', () => {
     const panes = parseTmuxPaneSnapshot(
       [
@@ -233,7 +243,7 @@ describe('HUD pane ownership helpers', () => {
 
     assert.deepEqual(listCurrentWindowHudPaneIds(undefined, execTmuxSync, { sessionId: 'sess-a' }), ['%2']);
     assert.deepEqual(calls, [
-      ['list-panes', '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}'],
+      ['list-panes', '-F', '#{pane_id}\x1f#{pane_current_command}\x1f#{pane_start_command}\x1f#{pane_current_path}'],
     ]);
   });
 
@@ -330,6 +340,104 @@ describe('dead HUD pane reaper', () => {
     });
 
     assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+  });
+
+  it('kills untagged HUD panes whose tmux cwd has been deleted', () => {
+    const deletedPath = join(tmpdir(), `omx-doctor-native-hook-dist-${process.pid}-${Date.now()} (deleted)`);
+    rmSync(deletedPath, { recursive: true, force: true });
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        `%2\tnode\tnode /tmp/bin/omx.js hud --watch\t${deletedPath}`,
+      ].join('\n'),
+    );
+    const killed: string[] = [];
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+    });
+
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+  });
+
+  it('kills deleted-cwd HUD panes even when an old owner tag points at a live leader', () => {
+    const deletedPath = join(tmpdir(), `omx-doctor-plugin-hook-${process.pid}-${Date.now()} (deleted)`);
+    rmSync(deletedPath, { recursive: true, force: true });
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        `%2\tnode\texec env OMX_SESSION_ID='doctor-smoke' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch\t${deletedPath}`,
+      ].join('\n'),
+    );
+    const killed: string[] = [];
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+    });
+
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+  });
+
+  it('preserves HUD panes in an existing cwd whose name ends with the deleted marker text', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'omx-live-cwd-'));
+    const liveDeletedSuffixPath = join(parent, 'live (deleted)');
+    mkdirSync(liveDeletedSuffixPath);
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        `%2\tnode\texec env OMX_SESSION_ID='live' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch\t${liveDeletedSuffixPath}`,
+      ].join('\n'),
+    );
+
+    try {
+      const result = reapDeadHudPanes(panes, {
+        killPane: () => {
+          throw new Error('live cwd with literal marker suffix should not be killed');
+        },
+      });
+
+      assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves live deleted-marker cwd paths containing tabs from the tmux list separator', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'omx-tab-live-cwd-'));
+    const liveDeletedSuffixPath = join(parent, 'left\tlive (deleted)');
+    mkdirSync(liveDeletedSuffixPath);
+    const separator = '\x1f';
+    const panes = parseTmuxPaneSnapshot(
+      [
+        ['%1', 'codex', 'codex', '/repo'].join(separator),
+        [
+          '%2',
+          'node',
+          `exec env OMX_SESSION_ID='live' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+          liveDeletedSuffixPath,
+        ].join(separator),
+      ].join('\n'),
+    );
+
+    try {
+      const result = reapDeadHudPanes(panes, {
+        killPane: () => {
+          throw new Error('live tab cwd with literal marker suffix should not be killed');
+        },
+      });
+
+      assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
   });
 
   it('does not touch non-HUD panes', () => {

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 
@@ -6,10 +7,12 @@ export interface TmuxPaneSnapshot {
   paneId: string;
   currentCommand: string;
   startCommand: string;
+  currentPath?: string;
 }
 
 export const OMX_TMUX_HUD_LEADER_PANE_ENV = 'OMX_TMUX_HUD_LEADER_PANE';
 const OMX_TMUX_HUD_OWNER_ENV = 'OMX_TMUX_HUD_OWNER';
+export const TMUX_PANE_FIELD_SEPARATOR = '\x1f';
 
 export interface HudPaneOwner {
   sessionId?: string;
@@ -34,11 +37,18 @@ export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const [paneId = '', currentCommand = '', ...startCommandParts] = line.split('\t');
+      const fieldSeparator = line.includes(TMUX_PANE_FIELD_SEPARATOR) ? TMUX_PANE_FIELD_SEPARATOR : '\t';
+      const parts = line.split(fieldSeparator);
+      const [paneId = '', currentCommand = ''] = parts;
+      const hasCurrentPathColumn = parts.length >= 4;
+      const currentPath = hasCurrentPathColumn ? (parts.at(-1) ?? '') : '';
+      const startCommandParts = hasCurrentPathColumn ? parts.slice(2, -1) : parts.slice(2);
+      const trimmedCurrentPath = currentPath.trim();
       return {
         paneId: paneId.trim(),
         currentCommand: currentCommand.trim(),
         startCommand: startCommandParts.join('\t').trim(),
+        ...(trimmedCurrentPath ? { currentPath: trimmedCurrentPath } : {}),
       };
     })
     .filter((pane) => pane.paneId.startsWith('%'));
@@ -113,6 +123,11 @@ export function findHudWatchPaneIds(
     .map((pane) => pane.paneId);
 }
 
+function isDeletedTmuxPanePath(path: string | undefined): boolean {
+  const currentPath = path?.trim();
+  return Boolean(currentPath && /(?:^|\s)\(deleted\)\s*$/.test(currentPath) && !existsSync(currentPath));
+}
+
 export function reapDeadHudPanes(
   panes: TmuxPaneSnapshot[],
   opts: {
@@ -128,6 +143,11 @@ export function reapDeadHudPanes(
 
   for (const pane of panes) {
     if (!isHudWatchPane(pane)) continue;
+
+    if (isDeletedTmuxPanePath(pane.currentPath) && killPane(pane.paneId)) {
+      reaped.push(pane.paneId);
+      continue;
+    }
 
     const leaderPaneId = readHudPaneOwner(pane).leaderPaneId;
     if (!leaderPaneId) {
@@ -278,7 +298,7 @@ export function listCurrentWindowPanes(
         'list-panes',
         ...(currentPaneId ? ['-t', currentPaneId] : []),
         '-F',
-        '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}',
+        `#{pane_id}${TMUX_PANE_FIELD_SEPARATOR}#{pane_current_command}${TMUX_PANE_FIELD_SEPARATOR}#{pane_start_command}${TMUX_PANE_FIELD_SEPARATOR}#{pane_current_path}`,
       ]),
     );
   } catch {


### PR DESCRIPTION
## Summary
- recreate #2631 from current `upstream/dev` after #2628 landed, preserving the merged Autopilot child-supervision changes
- reap HUD watch panes whose tmux cwd is already deleted, including stale doctor-smoke panes with old owner tags
- avoid false positives by preserving existing cwd paths whose literal names end with `(deleted)` and by using a non-tab tmux list separator for new pane snapshots
- keep normal live owner-tagged HUD panes and non-deleted legacy untagged HUD panes preserved

## Local evidence
Observed stale HUD panes in live tmux windows:
- `omx-0:1` and `omx-0:5`: ownerless `omx-doctor-native-hook-dist-*` HUD panes with cwd ending in `(deleted)`.
- `omx-0:4` (`omx-posttooluse-hook`): stale `omx-doctor-plugin-hook-*` HUD pane with cwd ending in `(deleted)` and an old `OMX_TMUX_HUD_LEADER_PANE` tag pointing at a live leader.

Review follow-up tightened the safety boundary:
- exact cwd paths that exist on disk are preserved even if their literal name ends with ` (deleted)`
- new tmux snapshots use `\x1f` as field separator so tabs inside `pane_start_command` or `pane_current_path` do not make the cwd check ambiguous

This is separate from #2630, which handles HUD state mirror fallback rather than tmux pane lifecycle cleanup.

## Diff scope
Current `upstream/dev..HEAD` contains only:
- `src/hud/tmux.ts`
- `src/hud/__tests__/tmux.test.ts`
- `src/cli/__tests__/index.test.ts`

## Validation
- `npm run build`
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js` (49 pass)
- `npm run check:no-unused`
- `npm run lint`
- `git diff --check`

