### PR TITLE
Seed Autopilot context snapshots on activation

### DIFF
--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -171,6 +171,49 @@ export interface DeepInterviewModeState {
   [key: string]: unknown;
 }
 
+function slugifyAutopilotTask(text: string): string {
+  const withoutWorkflow = text
+    .replace(/(?:^|\s)\$?(?:oh-my-codex:)?autopilot\b/gi, ' ')
+    .replace(/[^A-Za-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+  return (withoutWorkflow || 'autopilot-task').slice(0, 48).replace(/-+$/g, '') || 'autopilot-task';
+}
+
+function utcCompactTimestamp(nowIso: string): string {
+  return nowIso.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+async function ensureAutopilotContextSnapshot(
+  sourceCwd: string,
+  nowIso: string,
+  activationText: string,
+  existingPath?: unknown,
+): Promise<string> {
+  const existing = safeString(existingPath).trim();
+  if (existing) return existing;
+
+  const slug = slugifyAutopilotTask(activationText);
+  const contextDir = join(sourceCwd, '.omx', 'context');
+  await mkdir(contextDir, { recursive: true });
+  const relativePath = `.omx/context/${slug}-${utcCompactTimestamp(nowIso)}.md`;
+  const absolutePath = join(sourceCwd, relativePath);
+  const taskStatement = activationText.trim() || '$autopilot';
+  const body = [
+    `# Autopilot context: ${slug}`,
+    '',
+    `- task statement: ${taskStatement}`,
+    '- desired outcome: complete the requested Autopilot workflow correctly with durable gate evidence.',
+    '- known facts/evidence: Autopilot was activated from a UserPromptSubmit keyword.',
+    '- constraints: follow deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa; do not skip gates without persisted evidence.',
+    '- unknowns/open questions: to be resolved by the deep-interview gate.',
+    '- likely codebase touchpoints: to be discovered during pre-context intake and planning.',
+    '',
+  ].join('\n');
+  await writeFile(absolutePath, body, 'utf-8');
+  return relativePath;
+}
+
 function createDeepInterviewInputLock(nowIso: string, previous?: DeepInterviewInputLock): DeepInterviewInputLock {
   return {
     active: true,
@@ -367,6 +410,8 @@ async function persistStatefulSkillSeedState(
   nextSkill: SkillActiveState,
   nowIso: string,
   previousSkill: SkillActiveState | null,
+  activationText = '',
+  sourceCwd = dirname(dirname(stateDir)),
 ): Promise<SkillActiveState> {
   const config = STATEFUL_SKILL_SEED_CONFIG[nextSkill.skill as StatefulSkillMode];
   if (!config) return nextSkill;
@@ -436,11 +481,18 @@ async function persistStatefulSkillSeedState(
     const existingHandoffs = (existingState.handoff_artifacts && typeof existingState.handoff_artifacts === 'object')
       ? existingState.handoff_artifacts as Record<string, unknown>
       : {};
+    const contextSnapshotPath = await ensureAutopilotContextSnapshot(
+      sourceCwd,
+      nowIso,
+      activationText || safeString(nextSkill.keyword) || '$autopilot',
+      existingHandoffs.context_snapshot_path,
+    );
     baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
     baseState.state = {
       ...existingState,
       phase_cycle: Array.isArray(existingState.phase_cycle) ? existingState.phase_cycle : ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa'],
       handoff_artifacts: {
+        context_snapshot_path: contextSnapshotPath,
         deep_interview: null,
         ralplan: null,
         ralplan_consensus_gate: {
@@ -1097,6 +1149,8 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
           },
           nowIso,
           previous,
+          input.text,
+          sourceCwd,
         );
         if (requestedEntry.skill === workflowState.skill) {
           nextState = {
@@ -1187,7 +1241,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   };
 
   try {
-    const nextState = await persistStatefulSkillSeedState(input.stateDir, state, nowIso, previous);
+    const nextState = await persistStatefulSkillSeedState(input.stateDir, state, nowIso, previous, input.text, sourceCwd);
     nextState.active_skills = buildActiveSkills(nextState);
     await writeSkillActiveStateCopiesForStateDir(
       input.stateDir,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3400,6 +3400,16 @@ standardMaxRounds = 15
       assert.match(message, /Do not advance from deep-interview to ralplan merely because the first question was answered/);
       assert.match(message, /Planner output has been reviewed sequentially by Architect and then Critic/);
       assert.match(message, /do not hand off to Ultragoal or implementation until .*ralplan_architect_review.*ralplan_critic_review/);
+
+      const autopilotState = JSON.parse(await readFile(
+        join(cwd, ".omx", "state", "sessions", "sess-autopilot-ralplan-gate", "autopilot-state.json"),
+        "utf-8",
+      )) as { state?: { handoff_artifacts?: { context_snapshot_path?: string } } };
+      const snapshotPath = autopilotState.state?.handoff_artifacts?.context_snapshot_path || "";
+      assert.match(snapshotPath, /^\.omx\/context\/implement-issue-2430-\d{8}T\d{6}Z\.md$/);
+      const snapshot = await readFile(join(cwd, snapshotPath), "utf-8");
+      assert.match(snapshot, /task statement: \$autopilot implement issue #2430/);
+      assert.match(snapshot, /constraints: follow deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- observed prompt-side Autopilot activation in tmux/HUD/state and found the seeded state missing the required pre-context snapshot handoff
- create `.omx/context/<slug>-<timestamp>.md` during Autopilot seed-state initialization
- persist `state.handoff_artifacts.context_snapshot_path` while preserving existing handoffs on resume
- add regression coverage to the native hook Autopilot activation test

## Validation
- `npm run build`
- `node --test --test-name-pattern 'injects autopilot ralplan consensus gate guidance' dist/scripts/__tests__/codex-native-hook.test.js`

## Notes
- An earlier broad `npm test -- --runInBand src/scripts/__tests__/codex-native-hook.test.ts` invocation was not a valid targeted run for this repo script; it launched the full compiled suite while another build/test activity was present and exited non-zero. The focused build + regression test above passed cleanly.
