### PR TITLE
Reap deleted-cwd HUD watch panes

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2846,7 +2846,7 @@ describe("tmux HUD pane helpers", () => {
       "-t",
       "%leader",
       "-F",
-      "#{pane_id}\t#{pane_current_command}\t#{pane_start_command}",
+      "#{pane_id}\x1f#{pane_current_command}\x1f#{pane_start_command}\x1f#{pane_current_path}",
     ]);
   });
 

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -594,7 +594,7 @@ exit 0
       await hudCommand(['--tmux']);
 
       const tmuxLog = await readFile(logPath, 'utf8');
-      assert.match(tmuxLog, /list-panes -t %1 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}/);
+      assert.match(tmuxLog, /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}/);
       assert.match(tmuxLog, /kill-pane -t %3/);
       assert.match(tmuxLog, /resize-pane -t %2 -y \d+/);
       assert.doesNotMatch(tmuxLog, /split-window/);
@@ -659,7 +659,7 @@ exit 0
 
       const tmuxLog = await readFile(logPath, 'utf8');
       assert.match(tmuxLog, /display-message -p #\{pane_id\}/);
-      assert.match(tmuxLog, /list-panes -t %1 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}/);
+      assert.match(tmuxLog, /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}/);
       assert.match(tmuxLog, /resize-pane -t %2 -y \d+/);
       assert.doesNotMatch(tmuxLog, /split-window/);
       assert.ok(logs.some((line) => line.includes('Reused existing HUD pane')));

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -1,5 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   buildHudResizeHookName,
   buildHudResizeHookSlot,
@@ -146,6 +149,13 @@ describe('HUD pane ownership helpers', () => {
     });
   });
 
+  it('preserves tab-containing start commands when reading the optional cwd column', () => {
+    const [pane] = parseTmuxPaneSnapshot('%9\tnode\tnode\t/omx.js hud --watch\t/tmp/repo');
+
+    assert.equal(pane?.startCommand, 'node\t/omx.js hud --watch');
+    assert.equal(pane?.currentPath, '/tmp/repo');
+  });
+
   it('keeps independent leaders in one tmux window from matching each other HUD panes', () => {
     const panes = parseTmuxPaneSnapshot(
       [
@@ -233,7 +243,7 @@ describe('HUD pane ownership helpers', () => {
 
     assert.deepEqual(listCurrentWindowHudPaneIds(undefined, execTmuxSync, { sessionId: 'sess-a' }), ['%2']);
     assert.deepEqual(calls, [
-      ['list-panes', '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}'],
+      ['list-panes', '-F', '#{pane_id}\x1f#{pane_current_command}\x1f#{pane_start_command}\x1f#{pane_current_path}'],
     ]);
   });
 
@@ -326,6 +336,164 @@ describe('dead HUD pane reaper', () => {
     const result = reapDeadHudPanes(panes, {
       killPane: () => {
         throw new Error('legacy untagged HUD should not be killed');
+      },
+    });
+
+    assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+  });
+
+  it('kills untagged HUD panes whose tmux cwd has been deleted', () => {
+    const deletedPath = join(tmpdir(), `omx-doctor-native-hook-dist-${process.pid}-${Date.now()} (deleted)`);
+    rmSync(deletedPath, { recursive: true, force: true });
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        `%2\tnode\texec env OMX_TMUX_HUD_OWNER='1' /tmp/bin/omx.js hud --watch\t${deletedPath}`,
+      ].join('\n'),
+    );
+    const killed: string[] = [];
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+    });
+
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+  });
+
+  it('kills deleted-cwd doctor-smoke HUD panes even when an old owner tag points at a live leader', () => {
+    const deletedPath = join(tmpdir(), `omx-doctor-plugin-hook-${process.pid}-${Date.now()} (deleted)`);
+    rmSync(deletedPath, { recursive: true, force: true });
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        `%2\tnode\texec env OMX_SESSION_ID='doctor-smoke' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch\t${deletedPath}`,
+      ].join('\n'),
+    );
+    const killed: string[] = [];
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+    });
+
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+  });
+
+  it('preserves non-doctor deleted-cwd HUD panes while their leader is still live', () => {
+    const deletedPath = join(tmpdir(), `omx-live-leader-deleted-cwd-${process.pid}-${Date.now()} (deleted)`);
+    rmSync(deletedPath, { recursive: true, force: true });
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        `%2\tnode\texec env OMX_SESSION_ID='sess-live' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch\t${deletedPath}`,
+      ].join('\n'),
+    );
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: () => {
+        throw new Error('live leader HUD with stale launch cwd should not be killed');
+      },
+    });
+
+    assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+  });
+
+  it('kills deleted-cwd HUD panes when their owner leader is no longer live', () => {
+    const deletedPath = join(tmpdir(), `omx-dead-leader-deleted-cwd-${process.pid}-${Date.now()} (deleted)`);
+    rmSync(deletedPath, { recursive: true, force: true });
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        `%2\tnode\texec env OMX_SESSION_ID='sess-stale' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%9' /node /omx.js hud --watch\t${deletedPath}`,
+      ].join('\n'),
+    );
+    const killed: string[] = [];
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+    });
+
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+  });
+
+  it('preserves HUD panes in an existing cwd whose name ends with the deleted marker text', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'omx-live-cwd-'));
+    const liveDeletedSuffixPath = join(parent, 'live (deleted)');
+    mkdirSync(liveDeletedSuffixPath);
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        `%2\tnode\texec env OMX_SESSION_ID='live' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch\t${liveDeletedSuffixPath}`,
+      ].join('\n'),
+    );
+
+    try {
+      const result = reapDeadHudPanes(panes, {
+        killPane: () => {
+          throw new Error('live cwd with literal marker suffix should not be killed');
+        },
+      });
+
+      assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves live deleted-marker cwd paths containing tabs from the tmux list separator', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'omx-tab-live-cwd-'));
+    const liveDeletedSuffixPath = join(parent, 'left\tlive (deleted)');
+    mkdirSync(liveDeletedSuffixPath);
+    const separator = '\x1f';
+    const panes = parseTmuxPaneSnapshot(
+      [
+        ['%1', 'codex', 'codex', '/repo'].join(separator),
+        [
+          '%2',
+          'node',
+          `exec env OMX_SESSION_ID='live' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+          liveDeletedSuffixPath,
+        ].join(separator),
+      ].join('\n'),
+    );
+
+    try {
+      const result = reapDeadHudPanes(panes, {
+        killPane: () => {
+          throw new Error('live tab cwd with literal marker suffix should not be killed');
+        },
+      });
+
+      assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves deleted-cwd panes with misleading HUD text but no OMX owner metadata', () => {
+    const deletedPath = join(tmpdir(), `omx-misleading-hud-text-${process.pid}-${Date.now()} (deleted)`);
+    rmSync(deletedPath, { recursive: true, force: true });
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        `%2\tnode\tSUCCESS but not an OMX pane: hud --watch\t${deletedPath}`,
+      ].join('\n'),
+    );
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: () => {
+        throw new Error('misleading non-OMX HUD text should not be killed');
       },
     });
 

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 
@@ -6,10 +7,12 @@ export interface TmuxPaneSnapshot {
   paneId: string;
   currentCommand: string;
   startCommand: string;
+  currentPath?: string;
 }
 
 export const OMX_TMUX_HUD_LEADER_PANE_ENV = 'OMX_TMUX_HUD_LEADER_PANE';
 const OMX_TMUX_HUD_OWNER_ENV = 'OMX_TMUX_HUD_OWNER';
+export const TMUX_PANE_FIELD_SEPARATOR = '\x1f';
 
 export interface HudPaneOwner {
   sessionId?: string;
@@ -34,11 +37,18 @@ export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const [paneId = '', currentCommand = '', ...startCommandParts] = line.split('\t');
+      const fieldSeparator = line.includes(TMUX_PANE_FIELD_SEPARATOR) ? TMUX_PANE_FIELD_SEPARATOR : '\t';
+      const parts = line.split(fieldSeparator);
+      const [paneId = '', currentCommand = ''] = parts;
+      const hasCurrentPathColumn = parts.length >= 4;
+      const currentPath = hasCurrentPathColumn ? (parts.at(-1) ?? '') : '';
+      const startCommandParts = hasCurrentPathColumn ? parts.slice(2, -1) : parts.slice(2);
+      const trimmedCurrentPath = currentPath.trim();
       return {
         paneId: paneId.trim(),
         currentCommand: currentCommand.trim(),
         startCommand: startCommandParts.join('\t').trim(),
+        ...(trimmedCurrentPath ? { currentPath: trimmedCurrentPath } : {}),
       };
     })
     .filter((pane) => pane.paneId.startsWith('%'));
@@ -78,6 +88,14 @@ export function readHudPaneOwner(pane: TmuxPaneSnapshot): HudPaneOwner {
   };
 }
 
+
+function hasHudPaneOwnerMetadata(pane: TmuxPaneSnapshot): boolean {
+  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  const owner = readHudPaneOwner(pane);
+  return parseShellEnvAssignment(command, OMX_TMUX_HUD_OWNER_ENV) === '1'
+    || Boolean(owner.sessionId || owner.leaderPaneId);
+}
+
 export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner = {}): boolean {
   if (!isHudWatchPane(pane)) return false;
   const wantedSessionId = typeof owner.sessionId === 'string' ? owner.sessionId.trim() : '';
@@ -113,6 +131,25 @@ export function findHudWatchPaneIds(
     .map((pane) => pane.paneId);
 }
 
+function isDeletedTmuxPanePath(path: string | undefined): boolean {
+  const currentPath = path?.trim();
+  return Boolean(currentPath && /(?:^|\s)\(deleted\)\s*$/.test(currentPath) && !existsSync(currentPath));
+}
+
+function isDoctorSmokeSessionId(sessionId: string | undefined): boolean {
+  return /^(?:doctor-smoke|omx-doctor-[a-z0-9-]+-smoke)$/i.test(sessionId ?? '');
+}
+
+function shouldReapDeletedCwdHudPane(pane: TmuxPaneSnapshot, isLivePane: (paneId: string) => boolean): boolean {
+  // A deleted tmux launch cwd is not enough to prove a HUD is dead: watch mode can
+  // keep serving from a resolved live cwd. Reap only explicit doctor smoke panes or
+  // owner-tagged panes whose leader is gone.
+  if (!hasHudPaneOwnerMetadata(pane) || !isDeletedTmuxPanePath(pane.currentPath)) return false;
+  const owner = readHudPaneOwner(pane);
+  if (isDoctorSmokeSessionId(owner.sessionId)) return true;
+  return !owner.leaderPaneId || !isLivePane(owner.leaderPaneId);
+}
+
 export function reapDeadHudPanes(
   panes: TmuxPaneSnapshot[],
   opts: {
@@ -128,6 +165,11 @@ export function reapDeadHudPanes(
 
   for (const pane of panes) {
     if (!isHudWatchPane(pane)) continue;
+
+    if (shouldReapDeletedCwdHudPane(pane, isLivePane) && killPane(pane.paneId)) {
+      reaped.push(pane.paneId);
+      continue;
+    }
 
     const leaderPaneId = readHudPaneOwner(pane).leaderPaneId;
     if (!leaderPaneId) {
@@ -278,7 +320,7 @@ export function listCurrentWindowPanes(
         'list-panes',
         ...(currentPaneId ? ['-t', currentPaneId] : []),
         '-F',
-        '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}',
+        `#{pane_id}${TMUX_PANE_FIELD_SEPARATOR}#{pane_current_command}${TMUX_PANE_FIELD_SEPARATOR}#{pane_start_command}${TMUX_PANE_FIELD_SEPARATOR}#{pane_current_path}`,
       ]),
     );
   } catch {


### PR DESCRIPTION
## Summary
- clean replacement for closed #2635, after UltraQA found the CI failure in the `hooks-notify-platform` lane
- reap OMX-owned HUD watch panes whose tmux cwd is already deleted, including stale doctor-smoke panes with old owner tags
- avoid false positives by preserving existing cwd paths whose literal names end with `(deleted)` and by using a non-tab tmux list separator for new pane snapshots
- require OMX HUD owner metadata before deleted-cwd reaping so misleading non-OMX `hud --watch` text is preserved
- update the standalone `hudCommand --tmux` tests that caused #2635's CI failure after the separator change

## Why this replaces #2635
#2635 was closed because CI failed in `Test (Node 20 / hooks-notify-platform)`. The failing assertions were in `src/hud/__tests__/index.test.ts`: they still expected the old tab-delimited `list-panes -F` format. This branch updates those assertions and reruns the focused HUD surface locally.

## Safety boundary
Deleted-cwd reaping now requires all of these:
1. the pane matches the HUD watch shape
2. the pane has OMX HUD owner metadata (`OMX_TMUX_HUD_OWNER=1`, `OMX_SESSION_ID`, or `OMX_TMUX_HUD_LEADER_PANE`)
3. `pane_current_path` ends with `(deleted)`
4. that exact parsed cwd does not exist on disk

## Diff scope
Current `upstream/dev..HEAD` contains only:
- `src/hud/tmux.ts`
- `src/hud/__tests__/tmux.test.ts`
- `src/hud/__tests__/index.test.ts`
- `src/cli/__tests__/index.test.ts`

## Validation
- `npm run build`
- `node --test dist/hud/__tests__/index.test.js dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js` (65 pass)
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js` (49 pass)
- `npm run check:no-unused`
- `npm run lint`
- `git diff --check`
- UltraQA adversarial harness: live tab-containing cwd named `... (deleted)` preserved; stale OMX-owned deleted cwd reaped; misleading non-OMX `hud --watch` text preserved; temp harness cleaned up

## CI note
I also inspected the closed #2635 failing GitHub job. The only reported failures were the two stale `hudCommand --tmux` assertions updated in this PR.
