### PR TITLE
Fix team worker startup compatibility for tmux worktrees

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1658,7 +1658,7 @@ esac
           assert.equal(runtime.config.hud_pane_id, '%3');
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /display-message -p #S:#I #{pane_id}/);
+          assert.match(tmuxLog, /display-message -p #\{session_name\}:#\{window_index\} #\{pane_id\}/);
           assert.match(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
 
           if (teamNameForCleanup) {

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -63,6 +63,11 @@ function buildContextPackOutcome(relativePackPath: string): string {
   ].join('\n');
 }
 
+
+function workerStartupScriptPath(cwd: string, teamName: string, workerName: string): string {
+  return join(cwd, '.omx', 'state', 'team', teamName, 'runtime', `${workerName}-startup.sh`);
+}
+
 type ContextPackRole = 'scope' | 'build' | 'verify';
 
 type ScaleUpApprovedBindingState =
@@ -1236,10 +1241,15 @@ describe('scaleUp', () => {
       if (!result.ok) return;
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /CODEX_HOME=.*\.codex/);
-      assert.match(tmuxLog, /model_reasoning_effort="xhigh"/);
-      assert.match(tmuxLog, /--model/);
-      assert.match(tmuxLog, /project-standard-model/);
+      const startupScript = await readFile(
+        workerStartupScriptPath(cwd, 'scale-up-project-reasoning', 'worker-2'),
+        'utf-8',
+      );
+      assert.match(tmuxLog, /worker-2-startup\.sh/);
+      assert.match(startupScript, /CODEX_HOME=.*\.codex/);
+      assert.match(startupScript, /model_reasoning_effort="xhigh"/);
+      assert.match(startupScript, /--model/);
+      assert.match(startupScript, /project-standard-model/);
 
       const workerAgents = await readFile(join(cwd, '.omx', 'state', 'team', 'scale-up-project-reasoning', 'workers', 'worker-2', 'AGENTS.md'), 'utf-8');
       assert.match(workerAgents, /You are operating as the \*\*writer\*\* role/);

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -19,6 +19,8 @@ import {
   buildUnregisterClientAttachedReconcileArgs,
   buildUnregisterResizeHookArgs,
   buildWorkerStartupCommand,
+  trustWorkerMiseConfigIfAvailable,
+  writeWorkerStartupScriptCommand,
   shouldSourceTeamWorkerShellRc,
   buildHudPaneTarget,
   chooseTeamLeaderPaneId,
@@ -27,6 +29,7 @@ import {
   isMsysOrGitBash,
   isNativeWindows,
   isTmuxAvailable,
+  isWorkerPaneOpen,
   restoreStandaloneHudPane,
   translatePathForMsys,
   isWsl2,
@@ -1188,6 +1191,99 @@ describe('buildWorkerStartupCommand', () => {
       else delete process.env.SHELL;
       if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
       else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('does not use startup scripts on win32/MSYS so existing tmux path translation remains in force', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const prevMsystem = process.env.MSYSTEM;
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      process.env.MSYSTEM = 'MINGW64';
+      assert.equal(
+        writeWorkerStartupScriptCommand(
+          'alpha',
+          1,
+          ['--model', 'gpt-5'],
+          'C:\\repo',
+          { OMX_TEAM_STATE_ROOT: 'C:\\repo\\.omx\\state' },
+        ),
+        null,
+      );
+    } finally {
+      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
+      else delete process.env.MSYSTEM;
+    }
+  });
+
+  it('writes a short worker startup script under team runtime state when available', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-worker-startup-script-'));
+    const stateRoot = join(wd, '.omx', 'state');
+    const prevShell = process.env.SHELL;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.SHELL = '/bin/bash';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const cmd = writeWorkerStartupScriptCommand(
+        'alpha',
+        1,
+        ['--model', 'gpt-5'],
+        wd,
+        {
+          OMX_TEAM_STATE_ROOT: stateRoot,
+          OMX_TEAM_LEADER_CWD: wd,
+        },
+        'gemini',
+      );
+      assert.equal(cmd, `exec /bin/sh '${stateRoot}/team/alpha/runtime/worker-1-startup.sh'`);
+      const script = await readFile(join(stateRoot, 'team', 'alpha', 'runtime', 'worker-1-startup.sh'), 'utf-8');
+      assert.match(script, /^#!\/bin\/sh/m);
+      assert.match(script, new RegExp(`cd '${wd.replace(/'/g, `'\\\\''`)}'`));
+      assert.match(script, /export OMX_TEAM_STATE_ROOT=/);
+      assert.match(script, /exec '\/bin\/bash' -c /);
+      assert.doesNotMatch(cmd ?? '', /OMX_TEAM_STATE_ROOT=/, 'tmux command should point at script instead of inlining env');
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('trusts worktree .mise.toml before worker launch when mise is available', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-worker-mise-trust-'));
+    const fakeBin = join(wd, 'bin');
+    const logPath = join(wd, 'mise.log');
+    const previousPath = process.env.PATH;
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(wd, '.mise.toml'), '[tools]\nnode = "latest"\n');
+      await writeFile(
+        join(fakeBin, 'mise'),
+        `#!/bin/sh\nprintf '%s\\n' "$*" >> '${logPath}'\nexit 0\n`,
+      );
+      await chmod(join(fakeBin, 'mise'), 0o755);
+      process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+      assert.equal(trustWorkerMiseConfigIfAvailable(wd), true);
+      assert.match(await readFile(logPath, 'utf-8'), new RegExp(`trust --yes ${wd.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}\\/\\.mise\\.toml`));
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails soft when .mise.toml exists but mise is unavailable', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-worker-mise-missing-'));
+    try {
+      await writeFile(join(wd, '.mise.toml'), '[tools]\nnode = "latest"\n');
+      withEmptyPath(() => {
+        assert.equal(trustWorkerMiseConfigIfAvailable(wd), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
     }
   });
 
@@ -3426,6 +3522,90 @@ esac
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('degrades HUD run-shell resize failures to warnings during team startup', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-runshell-fallback-'));
+    const prevTmux = process.env.TMUX;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevWarn = console.warn;
+    const warnings: string[] = [];
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-runshell-fallback-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*) echo "120" ;;
+      *) echo "leader:0 %1" ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"*) printf "%%1\\tnode\\t'codex'\\n" ;;
+      *) printf "%%1\\n" ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*) echo "%2" ;;
+      *) echo "%3" ;;
+    esac
+    exit 0
+    ;;
+  run-shell)
+    echo "Unsupported tmux compatibility command: run-shell" >&2
+    exit 1
+    ;;
+  set-option|resize-pane|select-layout|set-window-option|select-pane|set-hook|send-keys)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          const fakeBinDir = join(logPath, '..');
+          const geminiPath = join(fakeBinDir, 'gemini');
+          await writeFile(geminiPath, '#!/bin/sh\nexit 0\n');
+          await chmod(geminiPath, 0o755);
+
+          process.env.TMUX = 'leader-session,stub,0';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+          console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
+
+          const session = createTeamSession('Run Shell Fallback', 1, cwd);
+          assert.equal(session.hudPaneId, '%3');
+          assert.match(warnings.join('\n'), /HUD resize/);
+          assert.match(warnings.join('\n'), /Unsupported tmux compatibility command: run-shell/);
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /run-shell -b sleep/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %3/);
+        },
+      );
+    } finally {
+      console.warn = prevWarn;
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('native Windows HUD reconciliation', () => {
@@ -3513,7 +3693,7 @@ esac
           assert.equal(session.hudPaneId, '%3');
 
           const tmuxLog = await readFile(logPath, 'utf-8');
-          assert.match(tmuxLog, /display-message -p #S:#I #{pane_id}/);
+          assert.match(tmuxLog, /display-message -p #\{session_name\}:#\{window_index\} #\{pane_id\}/);
           assert.match(tmuxLog, /powershell\.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand/);
           assert.doesNotMatch(tmuxLog, /\/bin\/sh -lc/);
           assert.match(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
@@ -4103,6 +4283,37 @@ describe('isWorkerAlive', () => {
     withEmptyPath(() => {
       assert.equal(isWorkerAlive('omx-team-x', 1), false);
     });
+  });
+
+  it('treats an existing non-dead pane id as live even when pane_pid is unavailable', async () => {
+    await withMockTmuxFixture(
+      'omx-pane-id-liveness-',
+      (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    if [ "$2" = "-a" ]; then
+      printf "%%77 0 \\n%%88 1 \\n"
+      exit 0
+    fi
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`,
+      async () => {
+        assert.equal(isWorkerAlive('ignored-session', 1, '%77'), true);
+        assert.equal(isWorkerPaneOpen('ignored-session', 1, '%77'), true);
+        assert.equal(isWorkerAlive('ignored-session', 2, '%88'), false);
+      },
+    );
   });
 });
 

--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -274,8 +274,13 @@ process.on('SIGTERM', () => process.exit(0));
       assert.doesNotMatch(workerAgents, /Sisyphus-lite/);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /gpt-5\.3-codex-spark/);
-      assert.match(tmuxLog, /model_reasoning_effort.*low/);
+      assert.match(tmuxLog, /runtime\/worker-2-startup\.sh/);
+      const startupScript = await readFile(
+        join(cwd, '.omx', 'state', 'team', 'low-role-scale', 'runtime', 'worker-2-startup.sh'),
+        'utf-8',
+      );
+      assert.match(startupScript, /gpt-5\.3-codex-spark/);
+      assert.match(startupScript, /model_reasoning_effort.*low/);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -22,6 +22,8 @@ import {
   getWorkerPanePid,
   teardownWorkerPanes,
   buildWorkerStartupCommand,
+  trustWorkerMiseConfigIfAvailable,
+  writeWorkerStartupScriptCommand,
   resolveTeamWorkerCliPlan,
 } from './tmux-session.js';
 import { execFileSync, spawnSync } from 'child_process';
@@ -467,7 +469,17 @@ export async function scaleUp(
         }
         extraEnv.OMX_TEAM_WORKTREE_DETACHED = workerWorkspace.detached ? '1' : '0';
       }
-      const cmd = buildWorkerStartupCommand(
+      trustWorkerMiseConfigIfAvailable(workerCwd);
+      const cmd = writeWorkerStartupScriptCommand(
+        sanitized,
+        workerIndex,
+        workerLaunchArgs,
+        workerCwd,
+        extraEnv,
+        workerCliPlan[i],
+        undefined,
+        runtimeRole,
+      ) ?? buildWorkerStartupCommand(
         sanitized,
         workerIndex,
         workerLaunchArgs,

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1,8 +1,8 @@
 import { spawnSync, execFile } from 'child_process';
 import { promisify } from 'util';
-import { existsSync, readFileSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
-import { isAbsolute, join, resolve } from 'path';
+import { dirname, isAbsolute, join, resolve } from 'path';
 import {
   CODEX_BYPASS_FLAG,
   CLAUDE_SKIP_PERMISSIONS_FLAG,
@@ -101,6 +101,7 @@ const TMUX_COPY_MODE_STYLE_OPTIONS = [
 const TMUX_PANE_STABILITY_POLL_MS = 60;
 const TMUX_PANE_STABILITY_POLLS_REQUIRED = 2;
 const TMUX_PANE_STABILITY_TIMEOUT_MS = 750;
+const OMX_TEAM_STATE_ROOT_ENV = 'OMX_TEAM_STATE_ROOT';
 
 export type TeamWorkerCli = 'codex' | 'claude' | 'gemini';
 type TeamWorkerCliMode = 'auto' | TeamWorkerCli;
@@ -197,8 +198,8 @@ export function mitigateCopyModeUnderlineArtifacts(sessionTarget: string): boole
 export function hasCurrentTmuxClientContext(): boolean {
   const tmuxPaneTarget = process.env.TMUX_PANE?.trim();
   const displayArgs = tmuxPaneTarget
-    ? ['display-message', '-p', '-t', tmuxPaneTarget, '#S:#I #{pane_id}']
-    : ['display-message', '-p', '#S:#I #{pane_id}'];
+    ? ['display-message', '-p', '-t', tmuxPaneTarget, '#{session_name}:#{window_index} #{pane_id}']
+    : ['display-message', '-p', '#{session_name}:#{window_index} #{pane_id}'];
   const context = runTmux(displayArgs);
   if (!context.ok) return false;
   const [sessionAndWindow = '', detectedLeaderPaneId = ''] = context.stdout.split(' ');
@@ -377,6 +378,10 @@ async function captureVisiblePaneAsync(target: string): Promise<string> {
 }
 
 async function isWorkerAliveAsync(sessionName: string, workerIndex: number, workerPaneId?: string): Promise<boolean> {
+  if (workerPaneId?.startsWith('%')) {
+    const paneStatus = await readPaneLivenessByIdAsync(workerPaneId);
+    if (paneStatus !== null) return paneStatus;
+  }
   const result = await runTmuxAsync([
     'list-panes',
     '-t', paneTarget(sessionName, workerIndex, workerPaneId),
@@ -403,6 +408,49 @@ async function isWorkerAliveAsync(sessionName: string, workerIndex: number, work
   } catch {
     return false;
   }
+}
+
+function parsePaneLivenessLine(line: string, allowMissingPid: boolean): boolean | null {
+  const parts = line.trim().split(/\s+/);
+  if (parts.length < 1 || parts[0] === '') return null;
+  const paneDead = parts[0];
+  const pid = Number.parseInt(parts[1] ?? '', 10);
+
+  if (paneDead === '1') return false;
+  if (!Number.isFinite(pid)) return allowMissingPid ? true : false;
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return allowMissingPid;
+  }
+}
+
+function readPaneLivenessById(paneId: string): boolean | null {
+  const result = runTmux(['list-panes', '-a', '-F', '#{pane_id} #{pane_dead} #{pane_pid}']);
+  if (!result.ok) return null;
+  for (const line of result.stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [id = '', ...rest] = trimmed.split(/\s+/);
+    if (id !== paneId) continue;
+    return parsePaneLivenessLine(rest.join(' '), true);
+  }
+  return null;
+}
+
+async function readPaneLivenessByIdAsync(paneId: string): Promise<boolean | null> {
+  const result = await runTmuxAsync(['list-panes', '-a', '-F', '#{pane_id} #{pane_dead} #{pane_pid}']);
+  if (!result.ok) return null;
+  for (const line of result.stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [id = '', ...rest] = trimmed.split(/\s+/);
+    if (id !== paneId) continue;
+    return parsePaneLivenessLine(rest.join(' '), true);
+  }
+  return null;
 }
 
 function shellQuoteSingle(value: string): string {
@@ -830,6 +878,20 @@ function commandExists(binary: string): boolean {
   return true;
 }
 
+export function trustWorkerMiseConfigIfAvailable(workerCwd: string): boolean {
+  const miseConfigPath = join(workerCwd, '.mise.toml');
+  if (!existsSync(miseConfigPath)) return false;
+  if (!commandExists('mise')) return false;
+
+  const { result } = spawnPlatformCommandSync('mise', ['trust', '--yes', miseConfigPath], { encoding: 'utf-8' });
+  if (result.error || result.status !== 0) {
+    const reason = result.error?.message || String(result.stderr || '').trim() || `mise exited ${result.status}`;
+    console.warn(`[omx] mise trust failed for team worker config ${miseConfigPath}: ${reason}; continuing.`);
+    return false;
+  }
+  return true;
+}
+
 /**
  * Resolve the absolute path of a binary from the leader's current environment.
  * Returns the absolute path or the bare command name as fallback.
@@ -1020,6 +1082,88 @@ export function buildWorkerStartupCommand(
   return `env ${envParts.map(shellQuoteSingle).join(' ')} ${shellQuoteSingle(launchSpec.shell)} -c ${shellQuoteSingle(inner)}`;
 }
 
+function assertShellEnvKey(key: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+    throw new Error(`invalid worker startup env key: ${key}`);
+  }
+}
+
+function buildWorkerStartupScriptContent(
+  processSpec: WorkerProcessLaunchSpec,
+  startupEnv: Record<string, string>,
+  startupArgs: string[],
+  cwd: string,
+  extraEnv: Record<string, string>,
+): string {
+  const resolvedLeaderNodePath = processSpec.env[OMX_LEADER_NODE_PATH_ENV]?.trim() || resolveLeaderNodePath();
+  const leaderNodeDir = /[\\/]/.test(resolvedLeaderNodePath)
+    ? resolvedLeaderNodePath.replace(/[\\/][^\\/]+$/, '')
+    : '';
+  const launchSpec = buildWorkerLaunchSpec(process.env.SHELL);
+  const pathPrefix = leaderNodeDir ? `export PATH=${shellQuoteSingle(leaderNodeDir)}:$PATH\n` : '';
+  const quotedArgs = startupArgs.map(shellQuoteSingle).join(' ');
+  const quotedCommand = shellQuoteSingle(processSpec.command);
+  const cliInvocation = quotedArgs.length > 0 ? `exec ${quotedCommand} ${quotedArgs}` : `exec ${quotedCommand}`;
+  const rcPrefix = shouldSourceTeamWorkerShellRc({ ...process.env, ...extraEnv }) && launchSpec.rcFile
+    ? `if [ -f ${launchSpec.rcFile} ]; then . ${launchSpec.rcFile}; fi\n`
+    : '';
+  const envExports = Object.entries(startupEnv)
+    .map(([key, value]) => {
+      assertShellEnvKey(key);
+      return `export ${key}=${shellQuoteSingle(value)}`;
+    })
+    .join('\n');
+
+  return [
+    '#!/bin/sh',
+    'set -eu',
+    `cd ${shellQuoteSingle(cwd)}`,
+    envExports,
+    `exec ${shellQuoteSingle(launchSpec.shell)} -c ${shellQuoteSingle(`${rcPrefix}${pathPrefix}${cliInvocation}`)}`,
+    '',
+  ].filter((line) => line !== '').join('\n');
+}
+
+export function writeWorkerStartupScriptCommand(
+  teamName: string,
+  workerIndex: number,
+  launchArgs: string[] = [],
+  cwd: string = process.cwd(),
+  extraEnv: Record<string, string> = {},
+  workerCliOverride?: TeamWorkerCli,
+  initialPrompt?: string,
+  workerRole?: string,
+): string | null {
+  if (process.platform === 'win32') return null;
+  const stateRoot = extraEnv[OMX_TEAM_STATE_ROOT_ENV]?.trim();
+  if (!stateRoot) return null;
+
+  const processSpec = buildWorkerProcessLaunchSpec(
+    teamName,
+    workerIndex,
+    launchArgs,
+    cwd,
+    extraEnv,
+    workerCliOverride,
+    initialPrompt,
+    workerRole,
+  );
+  const startupEnv = {
+    ...readTmuxWorkerAmbientEnv(process.env),
+    ...processSpec.env,
+  };
+  const startupArgs = [...processSpec.args];
+  if (processSpec.workerCli === 'codex') {
+    appendTeamWorkerMcpDisableOverrides(startupArgs, { ...process.env, ...extraEnv });
+  }
+
+  const scriptPath = join(stateRoot, 'team', teamName, 'runtime', `worker-${workerIndex}-startup.sh`);
+  mkdirSync(dirname(scriptPath), { recursive: true });
+  writeFileSync(scriptPath, buildWorkerStartupScriptContent(processSpec, startupEnv, startupArgs, cwd, extraEnv), 'utf-8');
+  chmodSync(scriptPath, 0o700);
+  return `exec /bin/sh ${shellQuoteSingle(scriptPath)}`;
+}
+
 export function buildWorkerProcessLaunchSpec(
   teamName: string,
   workerIndex: number,
@@ -1188,8 +1332,8 @@ export function createTeamSession(
   try {
     const tmuxPaneTarget = process.env.TMUX_PANE;
     const displayArgs = tmuxPaneTarget
-      ? ['display-message', '-p', '-t', tmuxPaneTarget, '#S:#I #{pane_id}']
-      : ['display-message', '-p', '#S:#I #{pane_id}'];
+      ? ['display-message', '-p', '-t', tmuxPaneTarget, '#{session_name}:#{window_index} #{pane_id}']
+      : ['display-message', '-p', '#{session_name}:#{window_index} #{pane_id}'];
     const context = runTmux(displayArgs);
     if (!context.ok) {
       const paneHint = tmuxPaneTarget ? ` (TMUX_PANE=${tmuxPaneTarget})` : '';
@@ -1231,7 +1375,17 @@ export function createTeamSession(
       const tmuxWorkerCwd = translatePathForMsys(workerCwd);
       const workerEnv = startup.env || {};
       const launchArgsForWorker = startup.launchArgs || workerLaunchArgs;
-      const cmd = buildWorkerStartupCommand(
+      trustWorkerMiseConfigIfAvailable(workerCwd);
+      const cmd = writeWorkerStartupScriptCommand(
+        safeTeamName,
+        i,
+        launchArgsForWorker,
+        workerCwd,
+        workerEnv,
+        workerCliPlan[i - 1],
+        startup.initialPrompt,
+        startup.workerRole,
+      ) ?? buildWorkerStartupCommand(
         safeTeamName,
         i,
         launchArgsForWorker,
@@ -1348,10 +1502,6 @@ export function createTeamSession(
             );
             if (registerClientAttachedHook.ok) {
               registeredClientAttachedHook = { name: clientAttachedHookName, target: hookTarget };
-            } else if (registerHook.ok) {
-              throw new Error(
-                `failed to register client-attached reconcile hook ${clientAttachedHookName}: ${registerClientAttachedHook.stderr}`,
-              );
             } else {
               console.warn(
                 `[omx] tmux client-attached resize fallback unavailable for ${hookTarget} `
@@ -1361,11 +1511,11 @@ export function createTeamSession(
 
             const delayed = runTmux(buildScheduleDelayedHudResizeArgs(hudPaneId));
             if (!delayed.ok) {
-              throw new Error(`failed to schedule delayed HUD resize: ${delayed.stderr}`);
+              console.warn(`[omx] tmux delayed HUD resize unavailable for ${hudPaneId}: ${delayed.stderr}; continuing.`);
             }
             const reconcile = runTmux(buildReconcileHudResizeArgs(hudPaneId));
             if (!reconcile.ok) {
-              throw new Error(`failed to reconcile HUD resize: ${reconcile.stderr}`);
+              console.warn(`[omx] tmux HUD resize reconcile unavailable for ${hudPaneId}: ${reconcile.stderr}; continuing.`);
             }
           }
         }
@@ -2091,6 +2241,10 @@ export function getWorkerPanePid(sessionName: string, workerIndex: number, worke
 
 // Check if worker's tmux pane has a running process
 export function isWorkerAlive(sessionName: string, workerIndex: number, workerPaneId?: string): boolean {
+  if (workerPaneId?.startsWith('%')) {
+    const paneStatus = readPaneLivenessById(workerPaneId);
+    if (paneStatus !== null) return paneStatus;
+  }
   const result = runTmux([
     'list-panes',
     '-t', paneTarget(sessionName, workerIndex, workerPaneId),
@@ -2120,6 +2274,10 @@ export function isWorkerAlive(sessionName: string, workerIndex: number, workerPa
 }
 
 export function isWorkerPaneOpen(sessionName: string, workerIndex: number, workerPaneId?: string): boolean {
+  if (workerPaneId?.startsWith('%')) {
+    const paneStatus = readPaneLivenessById(workerPaneId);
+    if (paneStatus !== null) return paneStatus;
+  }
   const result = runTmux([
     'list-panes',
     '-t', paneTarget(sessionName, workerIndex, workerPaneId),


### PR DESCRIPTION
## Summary

Fixes #2638.

This is a narrow team-runtime compatibility patch for tmux/cmux + mise/direnv worktree startup and pane liveness:

- writes POSIX worker startup commands to generated scripts under team runtime state so tmux panes receive a short `exec /bin/sh .../worker-N-startup.sh` command instead of a long inline env/shell command;
- keeps win32/MSYS on the existing inline path so established path translation behavior is preserved;
- trusts worker worktree `.mise.toml` with `mise trust --yes` when `mise` is available and fails soft with warning otherwise;
- expands tmux target discovery with `#{session_name}:#{window_index}` instead of literal-style `#S:#I`;
- degrades unsupported optional HUD `run-shell` resize operations to warnings instead of aborting team startup;
- treats a known pane id as live when `#{pane_id}` exists and `pane_dead` is false, even if `pane_pid` is missing/unusable.

## Validation

- `npm run build`
- `env -u OMX_TEAM_STATE_ROOT timeout 40s node --test dist/team/__tests__/tmux-session.test.js`
- `env -u OMX_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_MADMAX_DETACHED_CONTEXT -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD -u OMX_ENTRY_PATH timeout 30s node --test --test-name-pattern 'scaleUp preserves low-complexity assigned roles' dist/team/__tests__/worker-runtime-identity.test.js`
- `env -u OMX_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_MADMAX_DETACHED_CONTEXT -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD -u OMX_ENTRY_PATH timeout 30s node --test --test-name-pattern 'preserves leader/HUD layout by avoiding tiled relayout during scale-up|provisions detached worktrees for scaled-up workers|provisions named worktrees for scaled-up workers' dist/team/__tests__/scaling.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

## Notes

A combined `worker-runtime-identity.test.js + scaling.test.js` run was intentionally not repeated because it can hang/cascade under ambient OMX runtime env. Focused reruns with ambient OMX env cleared passed and cover the changed scale-up path.
