### PR TITLE
Prepare 0.18.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project are documented in this file.
 
 ## [Unreleased]
+## [0.18.7] - 2026-05-29
+
+Patch release for the post-`0.18.6` runtime reliability train: duplicate HUD and question-renderer pane prevention, HUD ownership preservation across native tmux session replacement, Stop-hook duplicate suppression safety, Autopilot/ralplan gate hardening, Hermes MCP pane routing, and Team coordination protocol updates.
+
+### Changed
+
+- **HUD ownership is more durable** — native session replacement preserves HUD ownership metadata, attached tmux HUD rendering stays singleton, and HUD watch remains bound to its live tmux cwd.
+- **Planning and automation gates are stricter** — ralplan remains a planning-only boundary, Autopilot completion requires gate evidence, and command-style Autopilot invocations route through the intended path.
+- **Team coordination is documented and typed** — lightweight team coordination protocol docs, state, and tests landed for the worker runtime surface.
+
+### Fixed
+
+- **Duplicate HUD panes are prevented** — standalone HUD restore and attached tmux rendering reuse existing same-owner panes instead of spawning duplicates.
+- **Duplicate question/Stop UI paths are safer** — question renderer panes close after answers, duplicate renderer panes are prevented, and duplicate worker Stop nudges preserve recovery evidence.
+- **Hermes MCP and detached tmux behavior are safer** — Hermes MCP tmux bridge pane routing is fixed and detached tmux history growth is constrained.
+- **Gitignore handling is protected** — effective gitignore regression coverage was added for release-critical file discovery.
+
+### PRs
+
+- #2571, #2573, #2574, #2583, #2593, #2594, #2595, #2605, #2608, #2609, #2611
+
+### Issues
+
+- No separately closed GitHub issues were found for the `v0.18.6..HEAD` release range; the release scope is represented by the merged PR inventory above.
+
+### Verification
+
+- Release readiness evidence is tracked in `docs/qa/release-readiness-0.18.7.md`.
 
 ## [0.18.6] - 2026-05-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "omx-api"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -40,14 +40,14 @@ dependencies = [
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "omx-mux"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "omx-mux",
  "omx-runtime-core",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "fs2",
  "serde",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "omx-mux",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.18.6"
+version = "0.18.7"
 
 edition = "2021"
 rust-version = "1.73"

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,37 +1,38 @@
-# oh-my-codex 0.18.6
+# oh-my-codex 0.18.7
 
-`0.18.6` is a patch release after `0.18.5` for the Ultragoal/HUD rendering follow-up that landed on `dev`. It focuses on keeping the runtime HUD compact without hiding the active Ultragoal context: non-Ultragoal sessions stay at the smaller line budget, active Ultragoal sessions can use up to three lines, tmux panes are resized from the same policy, and the current Ultragoal receives a distinct accent.
+`0.18.7` is a patch release after `0.18.6` for the runtime reliability train that landed on `dev`. It focuses on preventing duplicate UI/HUD panes, preserving HUD ownership across native tmux session replacement, hardening question and Stop-hook duplicate suppression, and tightening planning/autopilot gates without changing published APIs.
 
 ## Highlights
 
-- **Ultragoal HUD line budget is adaptive** — the HUD keeps the compact default for ordinary sessions while allowing active Ultragoal state to use the larger, bounded display.
-- **tmux HUD pane sizing follows render policy** — pane reconcile and resize behavior now derives from the same Ultragoal-aware line-budget helper used by rendering.
-- **Current Ultragoal context is clearer** — the active Ultragoal is highlighted with a magenta accent, and compact HUD output drops lower-priority next-goal text to avoid mixed summaries.
-- **ANSI and watch-mode rendering are safer** — constrained-width truncation preserves ANSI styling, and watch mode avoids extra-row output.
-- **Regression coverage protects the HUD contract** — render, watch, reconcile, live tmux resize, and terminal row-budget tests cover the adaptive behavior.
+- **Duplicate HUD pane fixes are release-blocker covered** — attached tmux HUD rendering now reuses an existing same-owner HUD instead of splitting duplicates, standalone HUD restore reuses the correct pane, and native session replacement preserves HUD ownership metadata.
+- **Question and Stop-hook duplication is safer** — answered question renderer panes close correctly, duplicate question renderer panes are prevented, and duplicate worker Stop nudges preserve the evidence needed for recovery.
+- **Autopilot and ralplan gates are stricter** — Autopilot completion requires gate evidence, command-style Autopilot invocations route correctly, and ralplan remains a planning-only boundary.
+- **Team and MCP routing are more robust** — lightweight team coordination protocol docs/code landed, Hermes MCP tmux bridge pane routing was fixed, and detached tmux history growth is constrained.
+- **Regression coverage protects changed surfaces** — focused HUD duplicate/tmux suites and broader changed-surface tests cover the release-critical paths.
 
 ## Fixes / compatibility
 
-- Existing Ultragoal aggregate plans and HUD state files remain compatible; this release changes rendering and pane sizing behavior only.
+- Existing HUD state and Ultragoal state remain compatible; this release tightens pane ownership and dedupe behavior.
+- No compatibility-breaking CLI or package layout changes are intended.
 - No separately closed GitHub issues were found for this release window; the scope is represented by the merged PR inventory.
 
 ## Merged PR inventory
 
-#2555.
+#2571, #2573, #2574, #2583, #2593, #2594, #2595, #2605, #2608, #2609, #2611.
 
 ## Validation
 
-Release readiness evidence is recorded in `docs/qa/release-readiness-0.18.6.md`.
+Release readiness evidence is recorded in `docs/qa/release-readiness-0.18.7.md`.
 
 Local gates completed before tagging:
 
 - release workflow version-sync probe
 - `npm run build`
-- `node --test dist/hud/__tests__/render.test.js dist/hud/__tests__/index.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/hud-tmux-injection.test.js`
+- focused duplicate HUD/tmux regression suite
+- changed-surface compiled regression suite
 - `npm run lint`
 - `npm run check:no-unused`
 - `npm run verify:native-agents`
-- `npm run sync:plugin`
 - `npm run verify:plugin-bundle`
 - `node dist/scripts/generate-catalog-docs.js --check`
 - `git diff --check`
@@ -41,8 +42,8 @@ The GitHub release workflow remains the authoritative cross-platform native asse
 
 ## Contributors
 
-Thanks to the contributor who landed the `v0.18.5...v0.18.6` delta:
+Thanks to the contributor who landed the `v0.18.6...v0.18.7` delta:
 
-- [@Yeachan-Heo](https://github.com/Yeachan-Heo) — #2555
+- [@Yeachan-Heo](https://github.com/Yeachan-Heo)
 
-**Full Changelog**: [`v0.18.5...v0.18.6`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.18.5...v0.18.6)
+**Full Changelog**: [`v0.18.6...v0.18.7`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.18.6...v0.18.7)

--- a/docs/qa/release-readiness-0.18.7.md
+++ b/docs/qa/release-readiness-0.18.7.md
@@ -1,0 +1,84 @@
+# Release readiness: oh-my-codex 0.18.7
+
+## Range
+
+- Previous tag: `v0.18.6`.
+- Candidate branch during prep: `release/0.18.7` from `dev`.
+- Release tag to create after merge: `v0.18.7`.
+- Compare: `v0.18.6..HEAD` before tag, then `v0.18.6..v0.18.7` after tagging.
+- Release-prep branch target: `dev`.
+
+## Release scope
+
+`0.18.7` packages the post-`0.18.6` runtime reliability train:
+
+- Duplicate HUD pane prevention and HUD ownership preservation across attached tmux, standalone restore, and native tmux session replacement paths.
+- Duplicate question renderer pane prevention and answered-renderer cleanup.
+- Worker Stop-hook duplicate suppression with preserved recovery evidence.
+- Autopilot gate evidence, command-style routing, and deep-interview/question state hardening.
+- Ralplan planning-only boundary hardening.
+- Hermes MCP tmux bridge pane routing and detached tmux history growth fixes.
+- Lightweight Team coordination protocol state/docs/tests.
+- Effective gitignore regression protection.
+
+## Merged PR inventory
+
+- #2571 — route command-style Autopilot invocations.
+- #2573 — prevent duplicate question renderer panes.
+- #2574 — prevent duplicate worker Stop nudges.
+- #2583 — keep HUD watch bound to its live tmux cwd.
+- #2593 — keep attached tmux HUD rendering singleton.
+- #2594 — clean Autopilot gate evidence handling on current dev.
+- #2595 — update README Discord invite.
+- #2605 — protect ralplan as a planning-only boundary.
+- #2608 — fix duplicate standalone HUD pane restore.
+- #2609 — preserve HUD ownership across native session replacement.
+- #2611 — protect effective gitignore handling from regression.
+
+## Issue inventory
+
+- No separately closed GitHub issues were found for the `v0.18.6..HEAD` release range during local release prep.
+- The release scope is represented by the merged PR inventory above.
+
+## Local validation evidence
+
+Final gates for this cut:
+
+- [x] Release workflow version-sync probe — PASS (`package=0.18.7`, `workspace=0.18.7`, `tag=v0.18.7`): `node dist/scripts/check-version-sync.js --tag v0.18.7`.
+- [x] `npm run build` — PASS.
+- [x] Focused duplicate HUD/tmux regression suite — PASS (`633` pass / `0` fail): `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/index.test.js dist/cli/__tests__/index.test.js dist/team/__tests__/tmux-session.test.js dist/team/__tests__/runtime.test.js`.
+- [x] Changed-surface compiled regression suite — PASS (`1173` pass / `0` fail): question, hooks, Autopilot, ralplan, Team, state, MCP, native-hook, agents, pipeline, and mode-contract tests.
+- [x] `npm run lint` — PASS.
+- [x] `npm run check:no-unused` — PASS.
+- [x] `npm run verify:native-agents` — PASS.
+- [x] `npm run sync:plugin` — PASS; plugin manifest metadata synced to `0.18.7`.
+- [x] `npm run verify:plugin-bundle` — PASS.
+- [x] `node dist/scripts/generate-catalog-docs.js --check` — PASS.
+- [x] `git diff --check` — PASS.
+- [x] `npm pack --dry-run` — PASS (`oh-my-codex-0.18.7.tgz`).
+
+## Duplicate HUD release-blocker evidence
+
+The duplicate HUD blocker is covered by both implementation and tests:
+
+- `src/hud/tmux.ts` owner matching scopes HUD panes by `OMX_SESSION_ID` and `OMX_TMUX_HUD_LEADER_PANE`.
+- `src/hud/reconcile.ts` reuses/resizes a matching HUD pane and kills same-owner duplicates during prompt-submit reconciliation.
+- `src/hud/index.ts` reuses an existing HUD pane for `omx hud --tmux` instead of splitting duplicates.
+- `src/cli/index.ts` and `src/team/tmux-session.ts` preserve leader/HUD exclusion and ownership during launch, restore, and teardown flows.
+- Tests cover same-leader duplicate HUD pane cleanup, same-session reuse without `TMUX_PANE`, cross-leader isolation, native Windows HUD restore reuse, attached tmux singleton behavior, and resize-hook preservation.
+
+## CI / PR evidence
+
+- PR targeting `dev`: pending.
+- LGTM review: pending.
+- Merge to `dev`: pending.
+- Post-merge CI: pending.
+
+## No-publish / no-tag evidence before final tag
+
+- Do not create or push `v0.18.7` until this PR is merged and release gates are green.
+- No local `npm publish` command is intended; publication remains delegated to the release workflow after tag push.
+
+## Current readiness verdict
+
+Local release prep is ready for PR review and merge to `dev`. Do not create or push `v0.18.7` and do not claim publication until the PR is merged, post-merge CI is green, and the tag-triggered release workflow/npm publication are verified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.18.6",
+      "version": "0.18.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/oh-my-codex/.codex-plugin/plugin.json
+++ b/plugins/oh-my-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "author": {
     "name": "Yeachan Heo",


### PR DESCRIPTION
## Summary
- bump npm/Cargo/plugin metadata to 0.18.7
- add 0.18.7 changelog, release body, and readiness evidence
- document duplicate HUD regression coverage and release gates

## Verification
- node dist/scripts/check-version-sync.js --tag v0.18.7
- npm run build
- node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/index.test.js
- node --test dist/cli/__tests__/question.test.js dist/hooks/__tests__/keyword-detector.test.js dist/question/__tests__/renderer.test.js dist/autopilot/__tests__/fsm.test.js dist/ralplan/__tests__/runtime.test.js dist/team/__tests__/coordination-protocol.test.js dist/mcp/__tests__/hermes-bridge.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npm run lint
- npm run check:no-unused
- npm run verify:native-agents
- npm run verify:plugin-bundle
- node dist/scripts/generate-catalog-docs.js --check
- git diff --check
- npm pack --dry-run