### PR TITLE
Fix HUD pane detection with escaped tmux separators

### DIFF
--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -149,6 +149,41 @@ describe('HUD pane ownership helpers', () => {
     });
   });
 
+  it('splits tmux octal-escaped control separators from live list-panes output', () => {
+    const escapedSeparator = '\\037';
+    const panes = parseTmuxPaneSnapshot(
+      [
+        ['%140', 'node', '', '/home/tools/oh-my-codex'].join(escapedSeparator),
+        [
+          '%202',
+          'node',
+          `"exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%140' OMX_ROOT='/tmp/run' '/usr/bin/node' '/repo/dist/cli/omx.js' hud --watch --preset=focused"`,
+          '/home/tools/oh-my-codex.omx-worktrees/launch-fix-default-subagent-fix',
+        ].join(escapedSeparator),
+      ].join('\n'),
+    );
+
+    assert.equal(panes.length, 2);
+    assert.equal(panes[0]?.paneId, '%140');
+    assert.equal(panes[0]?.currentCommand, 'node');
+    assert.equal(panes[0]?.startCommand, '');
+    assert.equal(panes[0]?.currentPath, '/home/tools/oh-my-codex');
+    assert.equal(panes[1]?.paneId, '%202');
+    assert.equal(panes[1]?.currentCommand, 'node');
+    assert.equal(
+      panes[1]?.currentPath,
+      '/home/tools/oh-my-codex.omx-worktrees/launch-fix-default-subagent-fix',
+    );
+    assert.deepEqual(readHudPaneOwner(panes[1]!), {
+      sessionId: 'sess-a',
+      leaderPaneId: '%140',
+    });
+    assert.deepEqual(
+      findHudWatchPaneIds(panes, '%140', { sessionId: 'sess-a', leaderPaneId: '%140' }),
+      ['%202'],
+    );
+  });
+
   it('preserves tab-containing start commands when reading the optional cwd column', () => {
     const [pane] = parseTmuxPaneSnapshot('%9\tnode\tnode\t/omx.js hud --watch\t/tmp/repo');
 

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -11,6 +11,7 @@ import {
   hudPaneMatchesOwner,
   listCurrentWindowHudPaneIds,
   OMX_TMUX_HUD_LEADER_PANE_ENV,
+  TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE,
   parseTmuxPaneSnapshot,
   readActiveTmuxPaneId,
   readHudPaneOwner,
@@ -150,7 +151,7 @@ describe('HUD pane ownership helpers', () => {
   });
 
   it('splits tmux octal-escaped control separators from live list-panes output', () => {
-    const escapedSeparator = '\\037';
+    const escapedSeparator = TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE;
     const panes = parseTmuxPaneSnapshot(
       [
         ['%140', 'node', '', '/home/tools/oh-my-codex'].join(escapedSeparator),

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -13,6 +13,7 @@ export interface TmuxPaneSnapshot {
 export const OMX_TMUX_HUD_LEADER_PANE_ENV = 'OMX_TMUX_HUD_LEADER_PANE';
 const OMX_TMUX_HUD_OWNER_ENV = 'OMX_TMUX_HUD_OWNER';
 export const TMUX_PANE_FIELD_SEPARATOR = '\x1f';
+const TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE = '\\037';
 
 export interface HudPaneOwner {
   sessionId?: string;
@@ -37,7 +38,11 @@ export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const fieldSeparator = line.includes(TMUX_PANE_FIELD_SEPARATOR) ? TMUX_PANE_FIELD_SEPARATOR : '\t';
+      const fieldSeparator = line.includes(TMUX_PANE_FIELD_SEPARATOR)
+        ? TMUX_PANE_FIELD_SEPARATOR
+        : line.includes(TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE)
+          ? TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE
+          : '\t';
       const parts = line.split(fieldSeparator);
       const [paneId = '', currentCommand = ''] = parts;
       const hasCurrentPathColumn = parts.length >= 4;

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -13,7 +13,7 @@ export interface TmuxPaneSnapshot {
 export const OMX_TMUX_HUD_LEADER_PANE_ENV = 'OMX_TMUX_HUD_LEADER_PANE';
 const OMX_TMUX_HUD_OWNER_ENV = 'OMX_TMUX_HUD_OWNER';
 export const TMUX_PANE_FIELD_SEPARATOR = '\x1f';
-const TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE = '\\037';
+export const TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE = '\\037';
 
 export interface HudPaneOwner {
   sessionId?: string;


### PR DESCRIPTION
## Summary
- fix HUD tmux pane snapshot parsing when tmux renders the control separator as literal `\037`
- keep owner-tagged HUD panes discoverable so prompt-submit reconcile can reuse/dedupe instead of splitting a new HUD pane
- add a live-shaped regression test covering owner parse and `findHudWatchPaneIds`

## Validation
- `npm run build` (passed earlier in Autopilot after the change)
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js`
- `git diff --check`

## Notes
- Live dogfood evidence: `omx-0:fix/default-subagent-fix` had one leader plus seven `omx hud --watch` panes because owner metadata was hidden behind literal `\037` field separators.
- I did not manually kill existing duplicate live HUD panes in this PR.
