### PR TITLE
Harden UltraQA temporary harness guidance

### DIFF
--- a/plugins/oh-my-codex/skills/ultraqa/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultraqa/SKILL.md
@@ -58,6 +58,15 @@ The matrix must include normal-path coverage plus adversarial dynamic e2e scenar
 - Validate exit codes and output semantics; do not trust success-looking text alone.
 - Do not delete, rewrite, or mask unrelated user work. Capture dirty-worktree evidence before and after generated harness work.
 
+### Temporary Harness Generation Guardrails
+
+Generated harnesses are part of the QA evidence chain; until setup succeeds, they are evidence about the harness apparatus, not product behavior.
+
+- **Use absolute repo imports for built artifacts.** When a harness runs from `/tmp` or another scratch directory but imports repository code, resolve the repository root explicitly from the verified repo cwd and import built modules with an absolute path or `pathToFileURL(join(repoRoot, "dist", ...)).href`. Never rely on `./dist/...` from the harness file's temporary directory.
+- **Use a safe file writer for JS/TS harness bodies.** Prefer a small Node/Python writer or another non-interpolating file-write mechanism for harness source that contains backticks, `${...}`, shell metacharacters, or prompt-injection strings. If a shell heredoc is unavoidable, quote the delimiter and verify the written file before execution; do not use interpolating heredocs for JavaScript assertions.
+- **Sanitize OMX runtime env for isolated probes.** When the scenario creates a temporary repo/state tree or intentionally checks local isolation, run the probe with `OMX_ROOT` and `OMX_STATE_ROOT` unset (for example `env -u OMX_ROOT -u OMX_STATE_ROOT ...`) so ambient boxed runtime state cannot redirect reads/writes away from the scenario fixture.
+- **Classify harness setup failures separately.** If a generated harness fails before exercising product behavior because of import paths, shell interpolation, environment leakage, or fixture construction, record it as harness debris, fix the harness, and rerun the scenario before declaring a product defect.
+
 ## Cycle Workflow
 
 ### Cycle N (Max 5)

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -58,6 +58,15 @@ The matrix must include normal-path coverage plus adversarial dynamic e2e scenar
 - Validate exit codes and output semantics; do not trust success-looking text alone.
 - Do not delete, rewrite, or mask unrelated user work. Capture dirty-worktree evidence before and after generated harness work.
 
+### Temporary Harness Generation Guardrails
+
+Generated harnesses are part of the QA evidence chain; until setup succeeds, they are evidence about the harness apparatus, not product behavior.
+
+- **Use absolute repo imports for built artifacts.** When a harness runs from `/tmp` or another scratch directory but imports repository code, resolve the repository root explicitly from the verified repo cwd and import built modules with an absolute path or `pathToFileURL(join(repoRoot, "dist", ...)).href`. Never rely on `./dist/...` from the harness file's temporary directory.
+- **Use a safe file writer for JS/TS harness bodies.** Prefer a small Node/Python writer or another non-interpolating file-write mechanism for harness source that contains backticks, `${...}`, shell metacharacters, or prompt-injection strings. If a shell heredoc is unavoidable, quote the delimiter and verify the written file before execution; do not use interpolating heredocs for JavaScript assertions.
+- **Sanitize OMX runtime env for isolated probes.** When the scenario creates a temporary repo/state tree or intentionally checks local isolation, run the probe with `OMX_ROOT` and `OMX_STATE_ROOT` unset (for example `env -u OMX_ROOT -u OMX_STATE_ROOT ...`) so ambient boxed runtime state cannot redirect reads/writes away from the scenario fixture.
+- **Classify harness setup failures separately.** If a generated harness fails before exercising product behavior because of import paths, shell interpolation, environment leakage, or fixture construction, record it as harness debris, fix the harness, and rerun the scenario before declaring a product defect.
+
 ## Cycle Workflow
 
 ### Cycle N (Max 5)

--- a/src/hooks/__tests__/skill-guidance-contract.test.ts
+++ b/src/hooks/__tests__/skill-guidance-contract.test.ts
@@ -56,6 +56,54 @@ describe('execution-heavy skill guidance contract', () => {
     }
   });
 
+  it('ultraqa harness guardrail patterns require intended semantics and reject inverted phrasing', () => {
+    const ultraqa = SKILL_CONTRACTS.find((contract) => contract.id === 'ultraqa');
+    assert.ok(ultraqa, 'ultraqa contract must exist');
+
+    const findPattern = (needle: string): RegExp => {
+      const pattern = ultraqa.requiredPatterns.find((candidate) => candidate.source.includes(needle));
+      assert.ok(pattern, `missing ultraqa guardrail pattern containing: ${needle}`);
+      return pattern;
+    };
+
+    const absoluteImports = findPattern('Use absolute repo imports');
+    assert.match(
+      'Use absolute repo imports and pathToFileURL(join(repoRoot, "dist", ...)).href. Never rely on ./dist from /tmp.',
+      absoluteImports,
+    );
+    assert.doesNotMatch(
+      'Absolute repo imports are forbidden. Rely on ./dist paths from /tmp harnesses.',
+      absoluteImports,
+    );
+
+    const safeWriter = findPattern('Use a safe file writer');
+    assert.match(
+      'Use a safe file writer with a non-interpolating file-write mechanism and do not use interpolating heredocs.',
+      safeWriter,
+    );
+    assert.doesNotMatch(
+      'Use interpolating heredocs for JavaScript assertions instead of a safe writer.',
+      safeWriter,
+    );
+
+    const sanitizedEnv = findPattern('Sanitize OMX runtime env for isolated probes');
+    assert.match(
+      'Sanitize OMX runtime env for isolated probes: keep OMX_ROOT and OMX_STATE_ROOT unset and run env -u OMX_ROOT -u OMX_STATE_ROOT.',
+      sanitizedEnv,
+    );
+    assert.doesNotMatch(
+      'Keep OMX_ROOT and OMX_STATE_ROOT set for isolated probes; avoid env -u OMX_ROOT -u OMX_STATE_ROOT.',
+      sanitizedEnv,
+    );
+
+    const harnessDebris = findPattern('Classify harness setup failures separately');
+    assert.match(
+      'Classify harness setup failures separately: record it as harness debris, fix the harness, and rerun the scenario before declaring a product defect.',
+      harnessDebris,
+    );
+    assert.doesNotMatch('Harness debris noted.', harnessDebris);
+  });
+
   it('ultrawork guidance stays OMX-native and avoids upstream-only runtime taxonomy', () => {
     const content = loadSurface('skills/ultrawork/SKILL.md');
     assert.doesNotMatch(content, /@opencode-ai\/plugin|bun:sqlite|\.sisyphus/i);

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -102,12 +102,18 @@ const SKILL_PATTERNS = [
   rx('user says `continue`'),
 ];
 
+// Textual guidance contract only: these patterns prevent prompt-surface drift;
+// they do not enforce runtime harness behavior.
 const ULTRAQA_SKILL_PATTERNS = [
   ...SKILL_PATTERNS,
   rx('adversarial dynamic e2e'),
   rx('not satisfied by a shallow build/lint/typecheck/test checklist|build/lint/typecheck/test.*not sufficient'),
   rx('malicious/hostile user behavior|hostile user modeling|User/attacker model'),
   rx('temporary tests.*harnesses|temporary harnesses'),
+  rx('Use absolute repo imports[^\\n]*pathToFileURL\\(join\\(repoRoot, \"dist\", \\.\\.\\.\\)\\)\\.href[^\\n]*Never rely on[^\\n]*\\./dist'),
+  rx('Use a safe file writer[^\\n]*non-interpolating file-write mechanism[^\\n]*do not use interpolating heredocs'),
+  rx('Sanitize OMX runtime env for isolated probes[^\\n]*OMX_ROOT[^\\n]*OMX_STATE_ROOT[^\\n]*unset[^\\n]*env -u OMX_ROOT -u OMX_STATE_ROOT'),
+  rx('Classify harness setup failures separately[^\\n]*record it as harness debris[^\\n]*fix the harness[^\\n]*rerun the scenario[^\\n]*before declaring a product defect'),
   rx('malformed input'),
   rx('repeated interruptions'),
   rx('prompt injection'),


### PR DESCRIPTION
## Summary
- Add explicit UltraQA temporary harness guardrails for absolute repo imports from temp dirs.
- Require safe non-interpolating harness writers instead of unsafe shell heredocs for JS/TS bodies.
- Require isolated probes to unset `OMX_ROOT` and `OMX_STATE_ROOT` and classify pre-product harness setup failures as harness debris.
- Extend prompt guidance contracts so these guardrails stay in both canonical and plugin skill mirrors.

## Validation
- `node` custom guardrail contract check: canonical/plugin mirror equality and required patterns pass.
- `npx biome lint src/hooks/prompt-guidance-contract.ts`: pass.
- `git diff --check`: pass.
- `node /home/tools/oh-my-codex/dist/scripts/sync-plugin-mirror.js --check`: pass.
- `timeout 180s npm run build`: timed out under host-wide concurrent `tsc` contention; no TypeScript error output before timeout.

## Notes
This is a follow-up to observed UltraQA harness debris where generated probes imported `./dist/...` relative to `/tmp`, shell heredoc expansion stripped JS literals, and ambient `OMX_ROOT` redirected isolated state.