### PR TITLE
Seed and harden Autopilot context snapshots

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -624,6 +624,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
         rationale: 'Autopilot starts at the deep-interview gate by default; clear bounded tasks may skip only with an explicit persisted skip reason.',
       });
       assert.deepEqual(modeState.state.handoff_artifacts, {
+        context_snapshot_path: '.omx/context/please-run-and-keep-going-20260225T000000Z.md',
         deep_interview: null,
         ralplan: null,
         ralplan_consensus_gate: {
@@ -642,11 +643,104 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.state.review_verdict, null);
       assert.equal(modeState.state.qa_verdict, null);
       assert.equal(modeState.state.return_to_ralplan_reason, null);
+      const snapshot = await readFile(join(cwd, '.omx', 'context', 'please-run-and-keep-going-20260225T000000Z.md'), 'utf-8');
+      assert.match(snapshot, /task statement: please run \$autopilot and keep going/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
+
+
+  it('migrates legacy Autopilot context snapshot paths into handoff artifacts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-legacy-context-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-legacy-context';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        keyword: '$autopilot',
+        phase: 'deep-interview',
+        activated_at: '2026-05-29T00:00:00.000Z',
+        updated_at: '2026-05-29T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', active: true, phase: 'deep-interview', session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'deep-interview',
+        started_at: '2026-05-29T00:00:00.000Z',
+        context_snapshot_path: '.omx/context/legacy-task-20260529T000000Z.md',
+        state: { handoff_artifacts: { deep_interview: null } },
+      }, null, 2));
+
+      await recordSkillActivation({
+        stateDir,
+        text: 'continue',
+        sessionId,
+        threadId: 'thread-legacy',
+        turnId: 'turn-legacy',
+        nowIso: '2026-05-30T00:00:00.000Z',
+      });
+
+      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
+        state?: { handoff_artifacts?: { context_snapshot_path?: string } };
+      };
+      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/legacy-task-20260529T000000Z.md');
+      assert.equal(existsSync(join(cwd, '.omx', 'context', 'continue-20260530T000000Z.md')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unsafe legacy Autopilot context snapshot paths without writing outside .omx/context', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-unsafe-context-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-unsafe-context';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        keyword: '$autopilot',
+        phase: 'deep-interview',
+        activated_at: '2026-05-29T00:00:00.000Z',
+        updated_at: '2026-05-29T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', active: true, phase: 'deep-interview', session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'deep-interview',
+        started_at: '2026-05-29T00:00:00.000Z',
+        state: { handoff_artifacts: { context_snapshot_path: '.omx/context/../../escape.md' } },
+      }, null, 2));
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'continue',
+        sessionId,
+        threadId: 'thread-unsafe',
+        turnId: 'turn-unsafe',
+        nowIso: '2026-05-30T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(existsSync(join(cwd, '.omx', 'escape.md')), false);
+      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
+        state?: { handoff_artifacts?: { context_snapshot_path?: string } };
+      };
+      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/continue-20260530T000000Z.md');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 
   it('fully resets terminal Autopilot mode state when reactivated', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-terminal-reset-'));
@@ -736,6 +830,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.run_outcome, undefined);
       assert.equal(modeState.handoff_artifacts, undefined);
       assert.deepEqual(modeState.state?.handoff_artifacts, {
+        context_snapshot_path: '.omx/context/investigate-the-next-issue-20260530T000000Z.md',
         deep_interview: null,
         ralplan: null,
         ralplan_consensus_gate: {

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -810,8 +810,9 @@ describe('keyword detector skill-active-state lifecycle', () => {
     const expectedReasons = {
       'missing-current-phase': 'nonpreservable-autopilot-mode-state-missing-current-phase',
       'malformed-json': 'malformed-autopilot-mode-state',
+      'array-json': 'malformed-autopilot-mode-state',
     } as const;
-    for (const fixture of ['missing-current-phase', 'malformed-json'] as const) {
+    for (const fixture of ['missing-current-phase', 'malformed-json', 'array-json'] as const) {
       const cwd = await mkdtemp(join(tmpdir(), `omx-keyword-autopilot-corrupt-continuation-${fixture}-`));
       const stateDir = join(cwd, '.omx', 'state');
       const sessionId = `sess-autopilot-corrupt-continuation-${fixture}`;
@@ -825,8 +826,10 @@ describe('keyword detector skill-active-state lifecycle', () => {
             started_at: AUTOPILOT_TEST_STARTED_AT,
             state: { handoff_artifacts: {} },
           }, null, 2));
-        } else {
+        } else if (fixture === 'malformed-json') {
           await writeFile(modeStatePath, '{ "active": true, "mode": "autopilot",');
+        } else {
+          await writeFile(modeStatePath, '[]');
         }
 
         await continueAutopilotTestState(stateDir, cwd, sessionId, fixture);
@@ -874,6 +877,77 @@ describe('keyword detector skill-active-state lifecycle', () => {
     } finally {
       await rm(cwd, { recursive: true, force: true });
       await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects typed canonical Autopilot recovery snapshot candidates during reuse', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-typed-recovery-context-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-typed-recovery-context';
+    try {
+      await mkdir(join(cwd, '.omx', 'context'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'context', 'autopilot-recovery-20260529T000000Z.md'), '# stale degraded recovery');
+      await writeActiveAutopilotSkillState(stateDir, sessionId);
+      await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'ralplan',
+        started_at: AUTOPILOT_TEST_STARTED_AT,
+        state: {
+          handoff_artifacts: {
+            context_snapshot: {
+              path: '.omx/context/autopilot-recovery-20260529T000000Z.md',
+              kind: 'canonical',
+            },
+          },
+        },
+      }, null, 2));
+
+      await continueAutopilotTestState(stateDir, cwd, sessionId, 'typed-recovery');
+
+      await assertAutopilotRecoverySnapshot(
+        cwd,
+        await readAutopilotModeState(stateDir, sessionId),
+        '.omx/context/autopilot-recovery-20260530T000000Z.md',
+        'missing-or-unsafe-legacy-context-snapshot',
+      );
+      assert.equal(existsSync(join(cwd, '.omx', 'context', 'autopilot-recovery-20260529T000000Z.md')), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects oversized Autopilot context snapshot candidates during reuse', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-oversized-context-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-oversized-context';
+    try {
+      await mkdir(join(cwd, '.omx', 'context'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'context', 'oversized-legacy-20260529T000000Z.md'), 'x'.repeat((1024 * 1024) + 1));
+      await writeActiveAutopilotSkillState(stateDir, sessionId);
+      await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'ralplan',
+        started_at: AUTOPILOT_TEST_STARTED_AT,
+        state: {
+          handoff_artifacts: {
+            context_snapshot_path: '.omx/context/oversized-legacy-20260529T000000Z.md',
+          },
+        },
+      }, null, 2));
+
+      await continueAutopilotTestState(stateDir, cwd, sessionId, 'oversized-context');
+
+      await assertAutopilotRecoverySnapshot(
+        cwd,
+        await readAutopilotModeState(stateDir, sessionId),
+        '.omx/context/autopilot-recovery-20260530T000000Z.md',
+        'missing-or-unsafe-legacy-context-snapshot',
+      );
+      assert.equal(existsSync(join(cwd, '.omx', 'context', 'oversized-legacy-20260529T000000Z.md')), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
     }
   });
 

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -750,6 +750,64 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('does not snapshot bare continuation text when active Autopilot mode state is corrupt', async () => {
+    for (const fixture of ['missing-current-phase', 'malformed-json'] as const) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-keyword-autopilot-corrupt-continuation-${fixture}-`));
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionId = `sess-autopilot-corrupt-continuation-${fixture}`;
+      try {
+        await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+        await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'ralplan',
+          activated_at: '2026-05-29T00:00:00.000Z',
+          updated_at: '2026-05-29T00:10:00.000Z',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', active: true, phase: 'ralplan', session_id: sessionId }],
+        }, null, 2));
+        const modeStatePath = join(stateDir, 'sessions', sessionId, 'autopilot-state.json');
+        if (fixture === 'missing-current-phase') {
+          await writeFile(modeStatePath, JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            started_at: '2026-05-29T00:00:00.000Z',
+            state: { handoff_artifacts: {} },
+          }, null, 2));
+        } else {
+          await writeFile(modeStatePath, '{ "active": true, "mode": "autopilot",');
+        }
+
+        await recordSkillActivation({
+          stateDir,
+          sourceCwd: cwd,
+          text: 'continue',
+          sessionId,
+          threadId: `thread-${fixture}`,
+          turnId: `turn-${fixture}`,
+          nowIso: '2026-05-30T00:00:00.000Z',
+        });
+
+        assert.equal(existsSync(join(cwd, '.omx', 'context', 'continue-20260530T000000Z.md')), false);
+        const modeState = JSON.parse(await readFile(modeStatePath, 'utf-8')) as {
+          state?: { handoff_artifacts?: { context_snapshot_path?: string }; context_snapshot_recovery?: { status?: string; reason?: string } };
+        };
+        const snapshotPath = modeState.state?.handoff_artifacts?.context_snapshot_path ?? '';
+        assert.match(snapshotPath, /^\.omx\/context\/autopilot-recovery-20260530T000000Z(?:-\d+)?\.md$/);
+        assert.equal(modeState.state?.context_snapshot_recovery?.status, 'degraded');
+        assert.equal(modeState.state?.context_snapshot_recovery?.reason, 'missing-or-unsafe-legacy-context-snapshot');
+        const recoverySnapshot = await readFile(join(cwd, snapshotPath), 'utf-8');
+        assert.match(recoverySnapshot, /recovery status: degraded/);
+        assert.match(recoverySnapshot, /do not treat the continuation input as the task statement/);
+        assert.doesNotMatch(recoverySnapshot, /task statement: continue/);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
   it('does not follow symlinked Autopilot context directories when writing snapshots', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-symlink-context-'));
     const outside = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-symlink-outside-'));

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -732,8 +732,10 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.ok(result);
       assert.equal(existsSync(join(cwd, '.omx', 'escape.md')), false);
       const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
+        context_snapshot_path?: string;
         state?: { handoff_artifacts?: { context_snapshot_path?: string } };
       };
+      assert.equal(modeState.context_snapshot_path, undefined);
       assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/continue-20260530T000000Z.md');
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -2782,10 +2784,11 @@ deepMaxRounds = 21
       assert.equal(result.transition_error, undefined);
       const modeState = JSON.parse(
         await readFile(join(stateDir, 'sessions', 'sess-autopilot', 'autopilot-state.json'), 'utf-8'),
-      ) as { current_phase: string; started_at: string; state?: { context_snapshot_path?: string } };
+      ) as { current_phase: string; started_at: string; state?: { context_snapshot_path?: string; handoff_artifacts?: { context_snapshot_path?: string } } };
       assert.equal(modeState.current_phase, 'code-review');
       assert.equal(modeState.started_at, '2026-02-25T00:00:00.000Z');
-      assert.equal(modeState.state?.context_snapshot_path, '.omx/context/existing.md');
+      assert.equal(modeState.state?.context_snapshot_path, undefined);
+      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/existing.md');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -3004,9 +3007,10 @@ deepMaxRounds = 21
       assert.equal(result.transition_error, undefined);
       const modeState = JSON.parse(
         await readFile(join(stateDir, 'sessions', 'sess-autopilot-bare', 'autopilot-state.json'), 'utf-8'),
-      ) as { current_phase: string; state?: { context_snapshot_path?: string } };
+      ) as { current_phase: string; state?: { context_snapshot_path?: string; handoff_artifacts?: { context_snapshot_path?: string } } };
       assert.equal(modeState.current_phase, 'code-review');
-      assert.equal(modeState.state?.context_snapshot_path, '.omx/context/autopilot.md');
+      assert.equal(modeState.state?.context_snapshot_path, undefined);
+      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/autopilot.md');
       assert.equal(existsSync(join(stateDir, 'sessions', 'sess-autopilot-bare', 'ralph-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -625,6 +625,10 @@ describe('keyword detector skill-active-state lifecycle', () => {
       });
       assert.deepEqual(modeState.state.handoff_artifacts, {
         context_snapshot_path: '.omx/context/please-run-and-keep-going-20260225T000000Z.md',
+        context_snapshot: {
+          path: '.omx/context/please-run-and-keep-going-20260225T000000Z.md',
+          kind: 'canonical',
+        },
         deep_interview: null,
         ralplan: null,
         ralplan_consensus_gate: {
@@ -687,9 +691,13 @@ describe('keyword detector skill-active-state lifecycle', () => {
       });
 
       const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
-        state?: { handoff_artifacts?: { context_snapshot_path?: string } };
+        state?: { handoff_artifacts?: { context_snapshot_path?: string; context_snapshot?: { path?: string; kind?: string } } };
       };
       assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/legacy-task-20260529T000000Z.md');
+      assert.deepEqual(modeState.state?.handoff_artifacts?.context_snapshot, {
+        path: '.omx/context/legacy-task-20260529T000000Z.md',
+        kind: 'legacy',
+      });
       assert.equal(existsSync(join(cwd, '.omx', 'context', 'continue-20260530T000000Z.md')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -735,14 +743,23 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(existsSync(join(cwd, '.omx', 'escape.md')), false);
       const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
         context_snapshot_path?: string;
-        state?: { handoff_artifacts?: { context_snapshot_path?: string }; context_snapshot_recovery?: { status?: string; reason?: string } };
+        state?: {
+          handoff_artifacts?: {
+            context_snapshot_path?: string;
+            context_snapshot?: { path?: string; kind?: string; recovery?: { status?: string; reason?: string } };
+          };
+          context_snapshot_recovery?: { status?: string; reason?: string };
+        };
       };
       assert.equal(modeState.context_snapshot_path, undefined);
       assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/autopilot-recovery-20260530T000000Z.md');
+      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.kind, 'recovery');
+      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.recovery?.reason, 'missing-or-unsafe-legacy-context-snapshot');
       assert.equal(modeState.state?.context_snapshot_recovery?.status, 'degraded');
       assert.equal(modeState.state?.context_snapshot_recovery?.reason, 'missing-or-unsafe-legacy-context-snapshot');
       const recoverySnapshot = await readFile(join(cwd, '.omx', 'context', 'autopilot-recovery-20260530T000000Z.md'), 'utf-8');
       assert.match(recoverySnapshot, /recovery status: degraded/);
+      assert.match(recoverySnapshot, /recovery reason: missing-or-unsafe-legacy-context-snapshot/);
       assert.match(recoverySnapshot, /do not treat the continuation input as the task statement/);
       assert.doesNotMatch(recoverySnapshot, /task statement: continue/);
     } finally {
@@ -751,6 +768,10 @@ describe('keyword detector skill-active-state lifecycle', () => {
   });
 
   it('does not snapshot bare continuation text when active Autopilot mode state is corrupt', async () => {
+    const expectedReasons = {
+      'missing-current-phase': 'nonpreservable-autopilot-mode-state-missing-current-phase',
+      'malformed-json': 'malformed-autopilot-mode-state',
+    } as const;
     for (const fixture of ['missing-current-phase', 'malformed-json'] as const) {
       const cwd = await mkdtemp(join(tmpdir(), `omx-keyword-autopilot-corrupt-continuation-${fixture}-`));
       const stateDir = join(cwd, '.omx', 'state');
@@ -792,19 +813,155 @@ describe('keyword detector skill-active-state lifecycle', () => {
 
         assert.equal(existsSync(join(cwd, '.omx', 'context', 'continue-20260530T000000Z.md')), false);
         const modeState = JSON.parse(await readFile(modeStatePath, 'utf-8')) as {
-          state?: { handoff_artifacts?: { context_snapshot_path?: string }; context_snapshot_recovery?: { status?: string; reason?: string } };
+          state?: {
+            handoff_artifacts?: {
+              context_snapshot_path?: string;
+              context_snapshot?: { path?: string; kind?: string; recovery?: { status?: string; reason?: string } };
+            };
+            context_snapshot_recovery?: { status?: string; reason?: string };
+          };
         };
         const snapshotPath = modeState.state?.handoff_artifacts?.context_snapshot_path ?? '';
         assert.match(snapshotPath, /^\.omx\/context\/autopilot-recovery-20260530T000000Z(?:-\d+)?\.md$/);
+        assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.kind, 'recovery');
+        assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.recovery?.reason, expectedReasons[fixture]);
         assert.equal(modeState.state?.context_snapshot_recovery?.status, 'degraded');
-        assert.equal(modeState.state?.context_snapshot_recovery?.reason, 'missing-or-unsafe-legacy-context-snapshot');
+        assert.equal(modeState.state?.context_snapshot_recovery?.reason, expectedReasons[fixture]);
         const recoverySnapshot = await readFile(join(cwd, snapshotPath), 'utf-8');
         assert.match(recoverySnapshot, /recovery status: degraded/);
+        assert.match(recoverySnapshot, new RegExp(`recovery reason: ${expectedReasons[fixture]}`));
         assert.match(recoverySnapshot, /do not treat the continuation input as the task statement/);
         assert.doesNotMatch(recoverySnapshot, /task statement: continue/);
       } finally {
         await rm(cwd, { recursive: true, force: true });
       }
+    }
+  });
+
+  it('rejects nested symlink Autopilot context snapshot candidates during reuse', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-nested-symlink-context-'));
+    const outside = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-nested-symlink-outside-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-nested-symlink-context';
+    try {
+      await mkdir(join(cwd, '.omx', 'context'), { recursive: true });
+      await symlink(outside, join(cwd, '.omx', 'context', 'link'));
+      await writeFile(join(outside, 'exfil.md'), '# outside context');
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        keyword: '$autopilot',
+        phase: 'ralplan',
+        activated_at: '2026-05-29T00:00:00.000Z',
+        updated_at: '2026-05-29T00:10:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', active: true, phase: 'ralplan', session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'ralplan',
+        started_at: '2026-05-29T00:00:00.000Z',
+        state: { handoff_artifacts: { context_snapshot_path: '.omx/context/link/exfil.md' } },
+      }, null, 2));
+
+      await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: 'continue',
+        sessionId,
+        threadId: 'thread-nested-symlink',
+        turnId: 'turn-nested-symlink',
+        nowIso: '2026-05-30T00:00:00.000Z',
+      });
+
+      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
+        state?: {
+          handoff_artifacts?: {
+            context_snapshot_path?: string;
+            context_snapshot?: { path?: string; kind?: string; recovery?: { reason?: string } };
+          };
+          context_snapshot_recovery?: { status?: string; reason?: string };
+        };
+      };
+      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/autopilot-recovery-20260530T000000Z.md');
+      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.kind, 'recovery');
+      assert.equal(modeState.state?.context_snapshot_recovery?.reason, 'missing-or-unsafe-legacy-context-snapshot');
+      assert.equal(existsSync(join(outside, 'exfil.md')), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('does not promote degraded recovery snapshots to canonical context on reactivation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-recovery-reactivation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-recovery-reactivation';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await mkdir(join(cwd, '.omx', 'context'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'context', 'autopilot-recovery-20260529T000000Z.md'), '# degraded recovery');
+      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        keyword: '$autopilot',
+        phase: 'complete',
+        activated_at: '2026-05-29T00:00:00.000Z',
+        updated_at: '2026-05-29T00:10:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', active: true, phase: 'complete', session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'complete',
+        completed_at: '2026-05-29T00:10:00.000Z',
+        state: {
+          handoff_artifacts: {
+            context_snapshot_path: '.omx/context/autopilot-recovery-20260529T000000Z.md',
+            context_snapshot: {
+              path: '.omx/context/autopilot-recovery-20260529T000000Z.md',
+              kind: 'recovery',
+              recovery: { status: 'degraded', reason: 'missing-or-unsafe-legacy-context-snapshot' },
+            },
+          },
+          context_snapshot_recovery: { status: 'degraded', reason: 'missing-or-unsafe-legacy-context-snapshot' },
+        },
+      }, null, 2));
+
+      await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$autopilot implement the real task',
+        sessionId,
+        threadId: 'thread-recovery-reactivation',
+        turnId: 'turn-recovery-reactivation',
+        nowIso: '2026-05-30T00:00:00.000Z',
+      });
+
+      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
+        state?: {
+          handoff_artifacts?: {
+            context_snapshot_path?: string;
+            context_snapshot?: { path?: string; kind?: string };
+          };
+          context_snapshot_recovery?: unknown;
+        };
+      };
+      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/implement-the-real-task-20260530T000000Z.md');
+      assert.deepEqual(modeState.state?.handoff_artifacts?.context_snapshot, {
+        path: '.omx/context/implement-the-real-task-20260530T000000Z.md',
+        kind: 'canonical',
+      });
+      assert.equal(modeState.state?.context_snapshot_recovery, undefined);
+      const snapshot = await readFile(join(cwd, '.omx', 'context', 'implement-the-real-task-20260530T000000Z.md'), 'utf-8');
+      assert.match(snapshot, /task statement: \$autopilot implement the real task/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
     }
   });
 
@@ -968,6 +1125,10 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.handoff_artifacts, undefined);
       assert.deepEqual(modeState.state?.handoff_artifacts, {
         context_snapshot_path: '.omx/context/investigate-the-next-issue-20260530T000000Z.md',
+        context_snapshot: {
+          path: '.omx/context/investigate-the-next-issue-20260530T000000Z.md',
+          kind: 'canonical',
+        },
         deep_interview: null,
         ralplan: null,
         ralplan_consensus_gate: {

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -674,6 +674,8 @@ describe('keyword detector skill-active-state lifecycle', () => {
         context_snapshot_path: '.omx/context/legacy-task-20260529T000000Z.md',
         state: { handoff_artifacts: { deep_interview: null } },
       }, null, 2));
+      await mkdir(join(cwd, '.omx', 'context'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'context', 'legacy-task-20260529T000000Z.md'), '# legacy task');
 
       await recordSkillActivation({
         stateDir,
@@ -733,10 +735,87 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(existsSync(join(cwd, '.omx', 'escape.md')), false);
       const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
         context_snapshot_path?: string;
-        state?: { handoff_artifacts?: { context_snapshot_path?: string } };
+        state?: { handoff_artifacts?: { context_snapshot_path?: string }; context_snapshot_recovery?: { status?: string; reason?: string } };
       };
       assert.equal(modeState.context_snapshot_path, undefined);
-      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/continue-20260530T000000Z.md');
+      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/autopilot-recovery-20260530T000000Z.md');
+      assert.equal(modeState.state?.context_snapshot_recovery?.status, 'degraded');
+      assert.equal(modeState.state?.context_snapshot_recovery?.reason, 'missing-or-unsafe-legacy-context-snapshot');
+      const recoverySnapshot = await readFile(join(cwd, '.omx', 'context', 'autopilot-recovery-20260530T000000Z.md'), 'utf-8');
+      assert.match(recoverySnapshot, /recovery status: degraded/);
+      assert.match(recoverySnapshot, /do not treat the continuation input as the task statement/);
+      assert.doesNotMatch(recoverySnapshot, /task statement: continue/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not follow symlinked Autopilot context directories when writing snapshots', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-symlink-context-'));
+    const outside = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-symlink-outside-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await symlink(outside, join(cwd, '.omx', 'context'));
+      await mkdir(stateDir, { recursive: true });
+
+      const warnings: unknown[][] = [];
+      mock.method(console, 'warn', (...args: unknown[]) => {
+        warnings.push(args);
+      });
+      await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$autopilot symlink escape',
+        sessionId: 'sess-autopilot-symlink-context',
+        threadId: 'thread-symlink-context',
+        turnId: 'turn-symlink-context',
+        nowIso: '2026-05-30T00:00:00.000Z',
+      });
+
+      assert.equal(warnings.length, 1);
+      assert.match(String(warnings[0][1]), /symbolic link/);
+      assert.equal(existsSync(join(outside, 'symlink-escape-20260530T000000Z.md')), false);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-autopilot-symlink-context', 'autopilot-state.json')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('allocates unique Autopilot context snapshot paths for same-second matching slugs', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-context-collision-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$autopilot same task',
+        sessionId: 'sess-autopilot-collision-a',
+        threadId: 'thread-collision',
+        turnId: 'turn-collision-a',
+        nowIso: '2026-05-30T00:00:00.000Z',
+      });
+      await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$autopilot same task',
+        sessionId: 'sess-autopilot-collision-b',
+        threadId: 'thread-collision',
+        turnId: 'turn-collision-b',
+        nowIso: '2026-05-30T00:00:00.000Z',
+      });
+
+      const first = JSON.parse(await readFile(join(stateDir, 'sessions', 'sess-autopilot-collision-a', 'autopilot-state.json'), 'utf-8')) as {
+        state?: { handoff_artifacts?: { context_snapshot_path?: string } };
+      };
+      const second = JSON.parse(await readFile(join(stateDir, 'sessions', 'sess-autopilot-collision-b', 'autopilot-state.json'), 'utf-8')) as {
+        state?: { handoff_artifacts?: { context_snapshot_path?: string } };
+      };
+      assert.equal(first.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/same-task-20260530T000000Z.md');
+      assert.equal(second.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/same-task-20260530T000000Z-2.md');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -2770,6 +2849,8 @@ deepMaxRounds = 21
           state: { context_snapshot_path: '.omx/context/existing.md' },
         }),
       );
+      await mkdir(join(cwd, '.omx', 'context'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'context', 'existing.md'), '# existing context');
 
       const result = await recordSkillActivation({
         stateDir,
@@ -2993,6 +3074,8 @@ deepMaxRounds = 21
           state: { context_snapshot_path: '.omx/context/autopilot.md' },
         }, null, 2),
       );
+      await mkdir(join(cwd, '.omx', 'context'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'context', 'autopilot.md'), '# autopilot context');
 
       const result = await recordSkillActivation({
         stateDir,

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -719,7 +719,8 @@ describe('keyword detector skill-active-state lifecycle', () => {
         mode: 'autopilot',
         current_phase: 'deep-interview',
         started_at: '2026-05-29T00:00:00.000Z',
-        state: { handoff_artifacts: { context_snapshot_path: '.omx/context/../../escape.md' } },
+        context_snapshot_path: '.omx/context/../../escape.md',
+        state: { handoff_artifacts: { deep_interview: null } },
       }, null, 2));
 
       const result = await recordSkillActivation({

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -649,9 +649,6 @@ describe('keyword detector skill-active-state lifecycle', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
-
-
-
   it('migrates legacy Autopilot context snapshot paths into handoff artifacts', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-legacy-context-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -30,6 +30,89 @@ async function withIsolatedHome<T>(prefix: string, run: (homeDir: string) => Pro
   }
 }
 
+const AUTOPILOT_TEST_NOW = '2026-05-30T00:00:00.000Z';
+const AUTOPILOT_TEST_STARTED_AT = '2026-05-29T00:00:00.000Z';
+const AUTOPILOT_TEST_UPDATED_AT = '2026-05-29T00:10:00.000Z';
+
+interface TestAutopilotModeState {
+  context_snapshot_path?: string;
+  state?: {
+    handoff_artifacts?: {
+      context_snapshot_path?: string;
+      context_snapshot?: {
+        path?: string;
+        kind?: string;
+        recovery?: { status?: string; reason?: string };
+      };
+    };
+    context_snapshot_recovery?: { status?: string; reason?: string } | unknown;
+  };
+}
+
+async function writeActiveAutopilotSkillState(
+  stateDir: string,
+  sessionId: string,
+  phase = 'ralplan',
+): Promise<void> {
+  await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+  await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+    version: 1,
+    active: true,
+    skill: 'autopilot',
+    keyword: '$autopilot',
+    phase,
+    activated_at: AUTOPILOT_TEST_STARTED_AT,
+    updated_at: AUTOPILOT_TEST_UPDATED_AT,
+    session_id: sessionId,
+    active_skills: [{ skill: 'autopilot', active: true, phase, session_id: sessionId }],
+  }, null, 2));
+}
+
+async function readAutopilotModeState(stateDir: string, sessionId: string): Promise<TestAutopilotModeState> {
+  return JSON.parse(
+    await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8'),
+  ) as TestAutopilotModeState;
+}
+
+async function continueAutopilotTestState(
+  stateDir: string,
+  cwd: string,
+  sessionId: string,
+  suffix: string,
+  text = 'continue',
+): Promise<void> {
+  await recordSkillActivation({
+    stateDir,
+    sourceCwd: cwd,
+    text,
+    sessionId,
+    threadId: `thread-${suffix}`,
+    turnId: `turn-${suffix}`,
+    nowIso: AUTOPILOT_TEST_NOW,
+  });
+}
+
+async function assertAutopilotRecoverySnapshot(
+  cwd: string,
+  modeState: TestAutopilotModeState,
+  expectedPath: string | RegExp,
+  expectedReason: string,
+): Promise<string> {
+  const snapshotPath = modeState.state?.handoff_artifacts?.context_snapshot_path ?? '';
+  if (typeof expectedPath === 'string') assert.equal(snapshotPath, expectedPath);
+  else assert.match(snapshotPath, expectedPath);
+  assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.kind, 'recovery');
+  assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.recovery?.reason, expectedReason);
+  assert.equal((modeState.state?.context_snapshot_recovery as { status?: string; reason?: string } | undefined)?.status, 'degraded');
+  assert.equal((modeState.state?.context_snapshot_recovery as { status?: string; reason?: string } | undefined)?.reason, expectedReason);
+  const recoverySnapshot = await readFile(join(cwd, snapshotPath), 'utf-8');
+  assert.match(recoverySnapshot, /recovery status: degraded/);
+  assert.match(recoverySnapshot, new RegExp(`recovery reason: ${expectedReason}`));
+  assert.match(recoverySnapshot, /do not treat the continuation input as the task statement/);
+  assert.doesNotMatch(recoverySnapshot, /task statement: continue/);
+  return snapshotPath;
+}
+
 describe('keyword detector team compatibility', () => {
   it('keeps explicit $skill order in detectKeywords results (left-to-right)', () => {
     const matches = detectKeywords('$analyze $ultraqa $code-review now');
@@ -658,41 +741,21 @@ describe('keyword detector skill-active-state lifecycle', () => {
     const stateDir = join(cwd, '.omx', 'state');
     const sessionId = 'sess-autopilot-legacy-context';
     try {
-      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
-      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
-        version: 1,
-        active: true,
-        skill: 'autopilot',
-        keyword: '$autopilot',
-        phase: 'deep-interview',
-        activated_at: '2026-05-29T00:00:00.000Z',
-        updated_at: '2026-05-29T00:00:00.000Z',
-        session_id: sessionId,
-        active_skills: [{ skill: 'autopilot', active: true, phase: 'deep-interview', session_id: sessionId }],
-      }, null, 2));
+      await writeActiveAutopilotSkillState(stateDir, sessionId, 'deep-interview');
       await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
         active: true,
         mode: 'autopilot',
         current_phase: 'deep-interview',
-        started_at: '2026-05-29T00:00:00.000Z',
+        started_at: AUTOPILOT_TEST_STARTED_AT,
         context_snapshot_path: '.omx/context/legacy-task-20260529T000000Z.md',
         state: { handoff_artifacts: { deep_interview: null } },
       }, null, 2));
       await mkdir(join(cwd, '.omx', 'context'), { recursive: true });
       await writeFile(join(cwd, '.omx', 'context', 'legacy-task-20260529T000000Z.md'), '# legacy task');
 
-      await recordSkillActivation({
-        stateDir,
-        text: 'continue',
-        sessionId,
-        threadId: 'thread-legacy',
-        turnId: 'turn-legacy',
-        nowIso: '2026-05-30T00:00:00.000Z',
-      });
+      await continueAutopilotTestState(stateDir, cwd, sessionId, 'legacy');
 
-      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
-        state?: { handoff_artifacts?: { context_snapshot_path?: string; context_snapshot?: { path?: string; kind?: string } } };
-      };
+      const modeState = await readAutopilotModeState(stateDir, sessionId);
       assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/legacy-task-20260529T000000Z.md');
       assert.deepEqual(modeState.state?.handoff_artifacts?.context_snapshot, {
         path: '.omx/context/legacy-task-20260529T000000Z.md',
@@ -709,23 +772,12 @@ describe('keyword detector skill-active-state lifecycle', () => {
     const stateDir = join(cwd, '.omx', 'state');
     const sessionId = 'sess-autopilot-unsafe-context';
     try {
-      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
-      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
-        version: 1,
-        active: true,
-        skill: 'autopilot',
-        keyword: '$autopilot',
-        phase: 'deep-interview',
-        activated_at: '2026-05-29T00:00:00.000Z',
-        updated_at: '2026-05-29T00:00:00.000Z',
-        session_id: sessionId,
-        active_skills: [{ skill: 'autopilot', active: true, phase: 'deep-interview', session_id: sessionId }],
-      }, null, 2));
+      await writeActiveAutopilotSkillState(stateDir, sessionId, 'deep-interview');
       await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
         active: true,
         mode: 'autopilot',
         current_phase: 'deep-interview',
-        started_at: '2026-05-29T00:00:00.000Z',
+        started_at: AUTOPILOT_TEST_STARTED_AT,
         context_snapshot_path: '.omx/context/../../escape.md',
         state: { handoff_artifacts: { deep_interview: null } },
       }, null, 2));
@@ -741,27 +793,14 @@ describe('keyword detector skill-active-state lifecycle', () => {
 
       assert.ok(result);
       assert.equal(existsSync(join(cwd, '.omx', 'escape.md')), false);
-      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
-        context_snapshot_path?: string;
-        state?: {
-          handoff_artifacts?: {
-            context_snapshot_path?: string;
-            context_snapshot?: { path?: string; kind?: string; recovery?: { status?: string; reason?: string } };
-          };
-          context_snapshot_recovery?: { status?: string; reason?: string };
-        };
-      };
+      const modeState = await readAutopilotModeState(stateDir, sessionId);
       assert.equal(modeState.context_snapshot_path, undefined);
-      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/autopilot-recovery-20260530T000000Z.md');
-      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.kind, 'recovery');
-      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.recovery?.reason, 'missing-or-unsafe-legacy-context-snapshot');
-      assert.equal(modeState.state?.context_snapshot_recovery?.status, 'degraded');
-      assert.equal(modeState.state?.context_snapshot_recovery?.reason, 'missing-or-unsafe-legacy-context-snapshot');
-      const recoverySnapshot = await readFile(join(cwd, '.omx', 'context', 'autopilot-recovery-20260530T000000Z.md'), 'utf-8');
-      assert.match(recoverySnapshot, /recovery status: degraded/);
-      assert.match(recoverySnapshot, /recovery reason: missing-or-unsafe-legacy-context-snapshot/);
-      assert.match(recoverySnapshot, /do not treat the continuation input as the task statement/);
-      assert.doesNotMatch(recoverySnapshot, /task statement: continue/);
+      await assertAutopilotRecoverySnapshot(
+        cwd,
+        modeState,
+        '.omx/context/autopilot-recovery-20260530T000000Z.md',
+        'missing-or-unsafe-legacy-context-snapshot',
+      );
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -777,61 +816,28 @@ describe('keyword detector skill-active-state lifecycle', () => {
       const stateDir = join(cwd, '.omx', 'state');
       const sessionId = `sess-autopilot-corrupt-continuation-${fixture}`;
       try {
-        await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
-        await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
-          version: 1,
-          active: true,
-          skill: 'autopilot',
-          keyword: '$autopilot',
-          phase: 'ralplan',
-          activated_at: '2026-05-29T00:00:00.000Z',
-          updated_at: '2026-05-29T00:10:00.000Z',
-          session_id: sessionId,
-          active_skills: [{ skill: 'autopilot', active: true, phase: 'ralplan', session_id: sessionId }],
-        }, null, 2));
+        await writeActiveAutopilotSkillState(stateDir, sessionId);
         const modeStatePath = join(stateDir, 'sessions', sessionId, 'autopilot-state.json');
         if (fixture === 'missing-current-phase') {
           await writeFile(modeStatePath, JSON.stringify({
             active: true,
             mode: 'autopilot',
-            started_at: '2026-05-29T00:00:00.000Z',
+            started_at: AUTOPILOT_TEST_STARTED_AT,
             state: { handoff_artifacts: {} },
           }, null, 2));
         } else {
           await writeFile(modeStatePath, '{ "active": true, "mode": "autopilot",');
         }
 
-        await recordSkillActivation({
-          stateDir,
-          sourceCwd: cwd,
-          text: 'continue',
-          sessionId,
-          threadId: `thread-${fixture}`,
-          turnId: `turn-${fixture}`,
-          nowIso: '2026-05-30T00:00:00.000Z',
-        });
+        await continueAutopilotTestState(stateDir, cwd, sessionId, fixture);
 
         assert.equal(existsSync(join(cwd, '.omx', 'context', 'continue-20260530T000000Z.md')), false);
-        const modeState = JSON.parse(await readFile(modeStatePath, 'utf-8')) as {
-          state?: {
-            handoff_artifacts?: {
-              context_snapshot_path?: string;
-              context_snapshot?: { path?: string; kind?: string; recovery?: { status?: string; reason?: string } };
-            };
-            context_snapshot_recovery?: { status?: string; reason?: string };
-          };
-        };
-        const snapshotPath = modeState.state?.handoff_artifacts?.context_snapshot_path ?? '';
-        assert.match(snapshotPath, /^\.omx\/context\/autopilot-recovery-20260530T000000Z(?:-\d+)?\.md$/);
-        assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.kind, 'recovery');
-        assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.recovery?.reason, expectedReasons[fixture]);
-        assert.equal(modeState.state?.context_snapshot_recovery?.status, 'degraded');
-        assert.equal(modeState.state?.context_snapshot_recovery?.reason, expectedReasons[fixture]);
-        const recoverySnapshot = await readFile(join(cwd, snapshotPath), 'utf-8');
-        assert.match(recoverySnapshot, /recovery status: degraded/);
-        assert.match(recoverySnapshot, new RegExp(`recovery reason: ${expectedReasons[fixture]}`));
-        assert.match(recoverySnapshot, /do not treat the continuation input as the task statement/);
-        assert.doesNotMatch(recoverySnapshot, /task statement: continue/);
+        await assertAutopilotRecoverySnapshot(
+          cwd,
+          JSON.parse(await readFile(modeStatePath, 'utf-8')) as TestAutopilotModeState,
+          /^\.omx\/context\/autopilot-recovery-20260530T000000Z(?:-\d+)?\.md$/,
+          expectedReasons[fixture],
+        );
       } finally {
         await rm(cwd, { recursive: true, force: true });
       }
@@ -847,48 +853,23 @@ describe('keyword detector skill-active-state lifecycle', () => {
       await mkdir(join(cwd, '.omx', 'context'), { recursive: true });
       await symlink(outside, join(cwd, '.omx', 'context', 'link'));
       await writeFile(join(outside, 'exfil.md'), '# outside context');
-      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
-      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
-        version: 1,
-        active: true,
-        skill: 'autopilot',
-        keyword: '$autopilot',
-        phase: 'ralplan',
-        activated_at: '2026-05-29T00:00:00.000Z',
-        updated_at: '2026-05-29T00:10:00.000Z',
-        session_id: sessionId,
-        active_skills: [{ skill: 'autopilot', active: true, phase: 'ralplan', session_id: sessionId }],
-      }, null, 2));
+      await writeActiveAutopilotSkillState(stateDir, sessionId);
       await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
         active: true,
         mode: 'autopilot',
         current_phase: 'ralplan',
-        started_at: '2026-05-29T00:00:00.000Z',
+        started_at: AUTOPILOT_TEST_STARTED_AT,
         state: { handoff_artifacts: { context_snapshot_path: '.omx/context/link/exfil.md' } },
       }, null, 2));
 
-      await recordSkillActivation({
-        stateDir,
-        sourceCwd: cwd,
-        text: 'continue',
-        sessionId,
-        threadId: 'thread-nested-symlink',
-        turnId: 'turn-nested-symlink',
-        nowIso: '2026-05-30T00:00:00.000Z',
-      });
+      await continueAutopilotTestState(stateDir, cwd, sessionId, 'nested-symlink');
 
-      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
-        state?: {
-          handoff_artifacts?: {
-            context_snapshot_path?: string;
-            context_snapshot?: { path?: string; kind?: string; recovery?: { reason?: string } };
-          };
-          context_snapshot_recovery?: { status?: string; reason?: string };
-        };
-      };
-      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/autopilot-recovery-20260530T000000Z.md');
-      assert.equal(modeState.state?.handoff_artifacts?.context_snapshot?.kind, 'recovery');
-      assert.equal(modeState.state?.context_snapshot_recovery?.reason, 'missing-or-unsafe-legacy-context-snapshot');
+      await assertAutopilotRecoverySnapshot(
+        cwd,
+        await readAutopilotModeState(stateDir, sessionId),
+        '.omx/context/autopilot-recovery-20260530T000000Z.md',
+        'missing-or-unsafe-legacy-context-snapshot',
+      );
       assert.equal(existsSync(join(outside, 'exfil.md')), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -901,25 +882,14 @@ describe('keyword detector skill-active-state lifecycle', () => {
     const stateDir = join(cwd, '.omx', 'state');
     const sessionId = 'sess-autopilot-recovery-reactivation';
     try {
-      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
       await mkdir(join(cwd, '.omx', 'context'), { recursive: true });
       await writeFile(join(cwd, '.omx', 'context', 'autopilot-recovery-20260529T000000Z.md'), '# degraded recovery');
-      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
-        version: 1,
-        active: true,
-        skill: 'autopilot',
-        keyword: '$autopilot',
-        phase: 'complete',
-        activated_at: '2026-05-29T00:00:00.000Z',
-        updated_at: '2026-05-29T00:10:00.000Z',
-        session_id: sessionId,
-        active_skills: [{ skill: 'autopilot', active: true, phase: 'complete', session_id: sessionId }],
-      }, null, 2));
+      await writeActiveAutopilotSkillState(stateDir, sessionId, 'complete');
       await writeFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), JSON.stringify({
         active: true,
         mode: 'autopilot',
         current_phase: 'complete',
-        completed_at: '2026-05-29T00:10:00.000Z',
+        completed_at: AUTOPILOT_TEST_UPDATED_AT,
         state: {
           handoff_artifacts: {
             context_snapshot_path: '.omx/context/autopilot-recovery-20260529T000000Z.md',
@@ -933,25 +903,9 @@ describe('keyword detector skill-active-state lifecycle', () => {
         },
       }, null, 2));
 
-      await recordSkillActivation({
-        stateDir,
-        sourceCwd: cwd,
-        text: '$autopilot implement the real task',
-        sessionId,
-        threadId: 'thread-recovery-reactivation',
-        turnId: 'turn-recovery-reactivation',
-        nowIso: '2026-05-30T00:00:00.000Z',
-      });
+      await continueAutopilotTestState(stateDir, cwd, sessionId, 'recovery-reactivation', '$autopilot implement the real task');
 
-      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8')) as {
-        state?: {
-          handoff_artifacts?: {
-            context_snapshot_path?: string;
-            context_snapshot?: { path?: string; kind?: string };
-          };
-          context_snapshot_recovery?: unknown;
-        };
-      };
+      const modeState = await readAutopilotModeState(stateDir, sessionId);
       assert.equal(modeState.state?.handoff_artifacts?.context_snapshot_path, '.omx/context/implement-the-real-task-20260530T000000Z.md');
       assert.deepEqual(modeState.state?.handoff_artifacts?.context_snapshot, {
         path: '.omx/context/implement-the-real-task-20260530T000000Z.md',

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -193,20 +193,28 @@ function utcCompactTimestamp(nowIso: string): string {
 
 function isSafeAutopilotContextSnapshotPath(value: unknown): value is string {
   const path = safeString(value).trim();
+  const contextPrefix = '.omx/context/';
+  const snapshotName = path.startsWith(contextPrefix) ? path.slice(contextPrefix.length) : '';
   return path.startsWith('.omx/context/')
     && path.endsWith('.md')
     && !isAbsolute(path)
     && !path.split('/').includes('..')
-    && !path.includes('\\');
+    && !path.includes('\\')
+    && snapshotName !== ''
+    && !snapshotName.includes('/');
 }
 
 async function isReadableAutopilotContextSnapshotPath(sourceCwd: string, value: unknown): Promise<boolean> {
   if (!isSafeAutopilotContextSnapshotPath(value)) return false;
-  await ensureSafeAutopilotContextDir(sourceCwd);
+  const contextDir = await ensureSafeAutopilotContextDir(sourceCwd);
   const absolutePath = join(sourceCwd, value);
   try {
     const snapshotStat = await lstat(absolutePath);
     if (!snapshotStat.isFile() || snapshotStat.isSymbolicLink()) return false;
+    const contextRealPath = await realpath(contextDir);
+    const snapshotRealPath = await realpath(absolutePath);
+    const relativeToContext = relative(contextRealPath, snapshotRealPath);
+    if (relativeToContext === '' || relativeToContext.startsWith('..') || isAbsolute(relativeToContext)) return false;
     await readFile(absolutePath, 'utf-8');
     return true;
   } catch {
@@ -214,21 +222,68 @@ async function isReadableAutopilotContextSnapshotPath(sourceCwd: string, value: 
   }
 }
 
+type AutopilotContextSnapshotKind = 'canonical' | 'legacy' | 'recovery';
+
+type AutopilotContextRecoveryReason =
+  | 'missing-or-unsafe-legacy-context-snapshot'
+  | 'missing-autopilot-mode-state'
+  | 'malformed-autopilot-mode-state'
+  | 'nonpreservable-autopilot-mode-state-missing-current-phase';
+
+interface AutopilotContextSnapshotDescriptor {
+  path: string;
+  kind: AutopilotContextSnapshotKind;
+  recovery?: Record<string, unknown>;
+}
+
+interface AutopilotContextSnapshotCandidate {
+  value: unknown;
+  kind?: AutopilotContextSnapshotKind;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function normalizeAutopilotContextSnapshotCandidate(candidate: AutopilotContextSnapshotCandidate): AutopilotContextSnapshotDescriptor | null {
+  if (isRecord(candidate.value)) {
+    const path = safeString(candidate.value.path).trim();
+    const kind = safeString(candidate.value.kind).trim() as AutopilotContextSnapshotKind;
+    if (!path || !['canonical', 'legacy', 'recovery'].includes(kind)) return null;
+    if (kind === 'recovery') return null;
+    return { path, kind };
+  }
+
+  const path = safeString(candidate.value).trim();
+  if (!path) return null;
+  if (path.startsWith('.omx/context/autopilot-recovery-')) return null;
+  return { path, kind: candidate.kind ?? 'legacy' };
+}
+
 async function findReusableAutopilotContextSnapshotPath(
   sourceCwd: string,
-  candidates: unknown[],
-): Promise<string | undefined> {
+  candidates: AutopilotContextSnapshotCandidate[],
+): Promise<AutopilotContextSnapshotDescriptor | undefined> {
   for (const candidate of candidates) {
-    if (!isSafeAutopilotContextSnapshotPath(candidate)) continue;
-    if (await isReadableAutopilotContextSnapshotPath(sourceCwd, candidate)) return candidate;
+    const normalized = normalizeAutopilotContextSnapshotCandidate(candidate);
+    if (!normalized || !isSafeAutopilotContextSnapshotPath(normalized.path)) continue;
+    if (await isReadableAutopilotContextSnapshotPath(sourceCwd, normalized.path)) return normalized;
   }
   return undefined;
 }
 
 interface AutopilotContextSnapshotResult {
   path: string;
+  kind: AutopilotContextSnapshotKind;
   recovery?: Record<string, unknown>;
 }
+
+const AUTOPILOT_CONTEXT_RECOVERY_REASON_MESSAGES: Record<AutopilotContextRecoveryReason, string> = {
+  'missing-or-unsafe-legacy-context-snapshot': 'no safe legacy Autopilot context snapshot path was available during continuation.',
+  'missing-autopilot-mode-state': 'active Autopilot skill state existed but no matching Autopilot mode state was available during continuation.',
+  'malformed-autopilot-mode-state': 'active Autopilot mode state could not be parsed during continuation.',
+  'nonpreservable-autopilot-mode-state-missing-current-phase': 'active Autopilot mode state was missing current_phase during continuation.',
+};
 
 async function ensureSafeAutopilotContextDir(sourceCwd: string): Promise<string> {
   const rootRealPath = await realpath(sourceCwd);
@@ -280,23 +335,26 @@ async function ensureAutopilotContextSnapshot(
   sourceCwd: string,
   nowIso: string,
   activationText: string,
-  existingPath?: unknown,
-  options: { allowTaskSnapshotCreation?: boolean } = {},
+  existingSnapshot?: AutopilotContextSnapshotDescriptor,
+  options: { allowTaskSnapshotCreation?: boolean; recoveryReason?: AutopilotContextRecoveryReason } = {},
 ): Promise<AutopilotContextSnapshotResult> {
-  const existing = safeString(existingPath).trim();
-  if (existing) {
-    if (isSafeAutopilotContextSnapshotPath(existing)) return { path: existing };
-    throw new Error(`Unsafe Autopilot context snapshot path: ${existing}`);
+  if (existingSnapshot) {
+    if (isSafeAutopilotContextSnapshotPath(existingSnapshot.path)) {
+      return { path: existingSnapshot.path, kind: existingSnapshot.kind };
+    }
+    throw new Error(`Unsafe Autopilot context snapshot path: ${existingSnapshot.path}`);
   }
 
   if (options.allowTaskSnapshotCreation === false) {
     const slug = 'autopilot-recovery';
     const continuationInput = activationText.trim() || '<empty>';
+    const reason = options.recoveryReason ?? 'missing-or-unsafe-legacy-context-snapshot';
     const body = [
       '# Autopilot context recovery',
       '',
       '- recovery status: degraded',
-      '- reason: no safe legacy Autopilot context snapshot path was available during continuation.',
+      `- recovery reason: ${reason}`,
+      `- reason detail: ${AUTOPILOT_CONTEXT_RECOVERY_REASON_MESSAGES[reason]}`,
       `- continuation input: ${continuationInput}`,
       '- original task statement: unavailable; do not treat the continuation input as the task statement.',
       '- required follow-up: re-establish or confirm the intended task context before downstream handoff.',
@@ -305,9 +363,10 @@ async function ensureAutopilotContextSnapshot(
     const path = await writeUniqueAutopilotContextSnapshot(sourceCwd, slug, nowIso, body);
     return {
       path,
+      kind: 'recovery',
       recovery: {
         status: 'degraded',
-        reason: 'missing-or-unsafe-legacy-context-snapshot',
+        reason,
         recovered_at: nowIso,
         source: 'keyword-detector',
       },
@@ -327,7 +386,7 @@ async function ensureAutopilotContextSnapshot(
     '- likely codebase touchpoints: to be discovered during pre-context intake and planning.',
     '',
   ].join('\n');
-  return { path: await writeUniqueAutopilotContextSnapshot(sourceCwd, slug, nowIso, body) };
+  return { path: await writeUniqueAutopilotContextSnapshot(sourceCwd, slug, nowIso, body), kind: 'canonical' };
 }
 
 function createDeepInterviewInputLock(nowIso: string, previous?: DeepInterviewInputLock): DeepInterviewInputLock {
@@ -395,11 +454,21 @@ async function readExistingDeepInterviewState(statePath: string): Promise<DeepIn
 }
 
 async function readJsonStateIfExists(path: string): Promise<Record<string, unknown> | null> {
+  return (await readJsonStateWithStatus(path)).state;
+}
+
+async function readJsonStateWithStatus(path: string): Promise<{
+  state: Record<string, unknown> | null;
+  status: 'ok' | 'missing' | 'malformed';
+}> {
   try {
     const raw = await readFile(path, 'utf-8');
-    return JSON.parse(raw) as Record<string, unknown>;
-  } catch {
-    return null;
+    return { state: JSON.parse(raw) as Record<string, unknown>, status: 'ok' };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { state: null, status: 'missing' };
+    }
+    return { state: null, status: 'malformed' };
   }
 }
 
@@ -539,7 +608,8 @@ async function persistStatefulSkillSeedState(
     nextSkill.session_id,
     config.scope,
   );
-  const existingModeState = await readJsonStateIfExists(absolutePath);
+  const existingModeStateResult = await readJsonStateWithStatus(absolutePath);
+  const existingModeState = existingModeStateResult.state;
   const sameActiveSkill = previousSkill?.skill === nextSkill.skill && previousSkill.active;
   const existingModeMatches = safeString(existingModeState?.mode).trim() === config.mode;
   const existingPhase = safeString(existingModeState?.current_phase).trim();
@@ -603,17 +673,31 @@ async function persistStatefulSkillSeedState(
     const existingHandoffs = (existingState.handoff_artifacts && typeof existingState.handoff_artifacts === 'object')
       ? existingState.handoff_artifacts as Record<string, unknown>
       : {};
+    let recoveryReason: AutopilotContextRecoveryReason = 'missing-or-unsafe-legacy-context-snapshot';
+    if (options.activeContinuation === true && !preserveExistingModeState) {
+      if (existingModeStateResult.status === 'missing') {
+        recoveryReason = 'missing-autopilot-mode-state';
+      } else if (existingModeStateResult.status === 'malformed') {
+        recoveryReason = 'malformed-autopilot-mode-state';
+      } else if (existingModeMatches && existingPhase === '') {
+        recoveryReason = 'nonpreservable-autopilot-mode-state-missing-current-phase';
+      }
+    }
     const existingContextSnapshotPath = await findReusableAutopilotContextSnapshotPath(sourceCwd, [
-      existingHandoffs.context_snapshot_path,
-      legacyStateContextSnapshotPath,
-      reusableModeState?.context_snapshot_path,
+      { value: existingHandoffs.context_snapshot },
+      { value: existingHandoffs.context_snapshot_path, kind: 'legacy' },
+      { value: legacyStateContextSnapshotPath, kind: 'legacy' },
+      { value: reusableModeState?.context_snapshot_path, kind: 'legacy' },
     ]);
     const contextSnapshot = await ensureAutopilotContextSnapshot(
       sourceCwd,
       nowIso,
       activationText || safeString(nextSkill.keyword) || '$autopilot',
       existingContextSnapshotPath,
-      { allowTaskSnapshotCreation: !(preserveExistingModeState || options.activeContinuation === true) },
+      {
+        allowTaskSnapshotCreation: !(preserveExistingModeState || options.activeContinuation === true),
+        recoveryReason,
+      },
     );
     const contextSnapshotPath = contextSnapshot.path;
     baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
@@ -638,6 +722,11 @@ async function persistStatefulSkillSeedState(
         ultraqa: null,
         ...existingHandoffs,
         context_snapshot_path: contextSnapshotPath,
+        context_snapshot: {
+          path: contextSnapshotPath,
+          kind: contextSnapshot.kind,
+          ...(contextSnapshot.recovery ? { recovery: contextSnapshot.recovery } : {}),
+        },
       },
       review_verdict: Object.prototype.hasOwnProperty.call(existingState, 'review_verdict')
         ? existingState.review_verdict

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -528,6 +528,7 @@ async function persistStatefulSkillSeedState(
   previousSkill: SkillActiveState | null,
   activationText: string,
   sourceCwd: string,
+  options: { activeContinuation?: boolean } = {},
 ): Promise<SkillActiveState> {
   const config = STATEFUL_SKILL_SEED_CONFIG[nextSkill.skill as StatefulSkillMode];
   if (!config) return nextSkill;
@@ -612,7 +613,7 @@ async function persistStatefulSkillSeedState(
       nowIso,
       activationText || safeString(nextSkill.keyword) || '$autopilot',
       existingContextSnapshotPath,
-      { allowTaskSnapshotCreation: !preserveExistingModeState },
+      { allowTaskSnapshotCreation: !(preserveExistingModeState || options.activeContinuation === true) },
     );
     const contextSnapshotPath = contextSnapshot.path;
     baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
@@ -1386,6 +1387,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
           previous,
           input.text,
           sourceCwd,
+          { activeContinuation: requestedEntry.skill === 'autopilot' && sameSkillContinuation },
         );
         if (requestedEntry.skill === workflowState.skill) {
           nextState = {
@@ -1438,7 +1440,15 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   };
 
   try {
-    const nextState = await persistStatefulSkillSeedState(input.stateDir, state, nowIso, previous, input.text, sourceCwd);
+    const nextState = await persistStatefulSkillSeedState(
+      input.stateDir,
+      state,
+      nowIso,
+      previous,
+      input.text,
+      sourceCwd,
+      { activeContinuation: match.skill === 'autopilot' && sameSkillContinuation },
+    );
     nextState.active_skills = buildActiveSkills(nextState);
     await writeSkillActiveStateCopiesForStateDir(
       input.stateDir,

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -173,12 +173,14 @@ export interface DeepInterviewModeState {
 }
 
 function slugifyAutopilotTask(text: string): string {
-  const withoutWorkflow = text
+  const slug = text
     .replace(/(?:^|\s)\$?(?:oh-my-codex:)?autopilot\b/gi, ' ')
     .replace(/[^A-Za-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-    .toLowerCase();
-  return (withoutWorkflow || 'autopilot-task').slice(0, 48).replace(/-+$/g, '') || 'autopilot-task';
+    .toLowerCase()
+    .slice(0, 48)
+    .replace(/-+$/g, '');
+  return slug || 'autopilot-task';
 }
 
 function utcCompactTimestamp(nowIso: string): string {
@@ -427,8 +429,8 @@ async function persistStatefulSkillSeedState(
   nextSkill: SkillActiveState,
   nowIso: string,
   previousSkill: SkillActiveState | null,
-  activationText = '',
-  sourceCwd = dirname(dirname(stateDir)),
+  activationText: string,
+  sourceCwd: string,
 ): Promise<SkillActiveState> {
   const config = STATEFUL_SKILL_SEED_CONFIG[nextSkill.skill as StatefulSkillMode];
   if (!config) return nextSkill;

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -172,6 +172,49 @@ export interface DeepInterviewModeState {
   [key: string]: unknown;
 }
 
+function slugifyAutopilotTask(text: string): string {
+  const withoutWorkflow = text
+    .replace(/(?:^|\s)\$?(?:oh-my-codex:)?autopilot\b/gi, ' ')
+    .replace(/[^A-Za-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+  return (withoutWorkflow || 'autopilot-task').slice(0, 48).replace(/-+$/g, '') || 'autopilot-task';
+}
+
+function utcCompactTimestamp(nowIso: string): string {
+  return nowIso.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+async function ensureAutopilotContextSnapshot(
+  sourceCwd: string,
+  nowIso: string,
+  activationText: string,
+  existingPath?: unknown,
+): Promise<string> {
+  const existing = safeString(existingPath).trim();
+  if (existing) return existing;
+
+  const slug = slugifyAutopilotTask(activationText);
+  const contextDir = join(sourceCwd, '.omx', 'context');
+  await mkdir(contextDir, { recursive: true });
+  const relativePath = `.omx/context/${slug}-${utcCompactTimestamp(nowIso)}.md`;
+  const absolutePath = join(sourceCwd, relativePath);
+  const taskStatement = activationText.trim() || '$autopilot';
+  const body = [
+    `# Autopilot context: ${slug}`,
+    '',
+    `- task statement: ${taskStatement}`,
+    '- desired outcome: complete the requested Autopilot workflow correctly with durable gate evidence.',
+    '- known facts/evidence: Autopilot was activated from a UserPromptSubmit keyword.',
+    '- constraints: follow deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa; do not skip gates without persisted evidence.',
+    '- unknowns/open questions: to be resolved by the deep-interview gate.',
+    '- likely codebase touchpoints: to be discovered during pre-context intake and planning.',
+    '',
+  ].join('\n');
+  await writeFile(absolutePath, body, 'utf-8');
+  return relativePath;
+}
+
 function createDeepInterviewInputLock(nowIso: string, previous?: DeepInterviewInputLock): DeepInterviewInputLock {
   return {
     active: true,
@@ -368,6 +411,8 @@ async function persistStatefulSkillSeedState(
   nextSkill: SkillActiveState,
   nowIso: string,
   previousSkill: SkillActiveState | null,
+  activationText = '',
+  sourceCwd = dirname(dirname(stateDir)),
 ): Promise<SkillActiveState> {
   const config = STATEFUL_SKILL_SEED_CONFIG[nextSkill.skill as StatefulSkillMode];
   if (!config) return nextSkill;
@@ -437,11 +482,18 @@ async function persistStatefulSkillSeedState(
     const existingHandoffs = (existingState.handoff_artifacts && typeof existingState.handoff_artifacts === 'object')
       ? existingState.handoff_artifacts as Record<string, unknown>
       : {};
+    const contextSnapshotPath = await ensureAutopilotContextSnapshot(
+      sourceCwd,
+      nowIso,
+      activationText || safeString(nextSkill.keyword) || '$autopilot',
+      existingHandoffs.context_snapshot_path,
+    );
     baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
     baseState.state = {
       ...existingState,
       phase_cycle: Array.isArray(existingState.phase_cycle) ? existingState.phase_cycle : ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa'],
       handoff_artifacts: {
+        context_snapshot_path: contextSnapshotPath,
         deep_interview: null,
         ralplan: null,
         ralplan_consensus_gate: {
@@ -1203,6 +1255,8 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
           },
           nowIso,
           previous,
+          input.text,
+          sourceCwd,
         );
         if (requestedEntry.skill === workflowState.skill) {
           nextState = {
@@ -1255,7 +1309,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   };
 
   try {
-    const nextState = await persistStatefulSkillSeedState(input.stateDir, state, nowIso, previous);
+    const nextState = await persistStatefulSkillSeedState(input.stateDir, state, nowIso, previous, input.text, sourceCwd);
     nextState.active_skills = buildActiveSkills(nextState);
     await writeSkillActiveStateCopiesForStateDir(
       input.stateDir,

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -498,13 +498,15 @@ async function persistStatefulSkillSeedState(
     const existingHandoffs = (existingState.handoff_artifacts && typeof existingState.handoff_artifacts === 'object')
       ? existingState.handoff_artifacts as Record<string, unknown>
       : {};
+    const existingContextSnapshotPath = [
+      existingHandoffs.context_snapshot_path,
+      reusableModeState?.context_snapshot_path,
+    ].find(isSafeAutopilotContextSnapshotPath);
     const contextSnapshotPath = await ensureAutopilotContextSnapshot(
       sourceCwd,
       nowIso,
       activationText || safeString(nextSkill.keyword) || '$autopilot',
-      isSafeAutopilotContextSnapshotPath(existingHandoffs.context_snapshot_path)
-        ? existingHandoffs.context_snapshot_path
-        : reusableModeState?.context_snapshot_path,
+      existingContextSnapshotPath,
     );
     baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
     baseState.state = {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -10,9 +10,9 @@
  * rather than the full keyword/state table.
  */
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
 import { withModeRuntimeContext } from '../state/mode-state-context.js';
-import { dirname, isAbsolute, join } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { classifyTaskSize, isHeavyMode, type TaskSizeResult, type TaskSizeThresholds } from './task-size-detector.js';
 import { isApprovedExecutionFollowupShortcut, type FollowupMode } from '../team/followup-planner.js';
 import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts.js';
@@ -200,23 +200,121 @@ function isSafeAutopilotContextSnapshotPath(value: unknown): value is string {
     && !path.includes('\\');
 }
 
+async function isReadableAutopilotContextSnapshotPath(sourceCwd: string, value: unknown): Promise<boolean> {
+  if (!isSafeAutopilotContextSnapshotPath(value)) return false;
+  await ensureSafeAutopilotContextDir(sourceCwd);
+  const absolutePath = join(sourceCwd, value);
+  try {
+    const snapshotStat = await lstat(absolutePath);
+    if (!snapshotStat.isFile() || snapshotStat.isSymbolicLink()) return false;
+    await readFile(absolutePath, 'utf-8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findReusableAutopilotContextSnapshotPath(
+  sourceCwd: string,
+  candidates: unknown[],
+): Promise<string | undefined> {
+  for (const candidate of candidates) {
+    if (!isSafeAutopilotContextSnapshotPath(candidate)) continue;
+    if (await isReadableAutopilotContextSnapshotPath(sourceCwd, candidate)) return candidate;
+  }
+  return undefined;
+}
+
+interface AutopilotContextSnapshotResult {
+  path: string;
+  recovery?: Record<string, unknown>;
+}
+
+async function ensureSafeAutopilotContextDir(sourceCwd: string): Promise<string> {
+  const rootRealPath = await realpath(sourceCwd);
+  const omxDir = join(sourceCwd, '.omx');
+  await mkdir(omxDir, { recursive: true });
+  if ((await lstat(omxDir)).isSymbolicLink()) {
+    throw new Error('Unsafe Autopilot context directory: .omx is a symbolic link');
+  }
+
+  const contextDir = join(omxDir, 'context');
+  await mkdir(contextDir, { recursive: true });
+  if ((await lstat(contextDir)).isSymbolicLink()) {
+    throw new Error('Unsafe Autopilot context directory: .omx/context is a symbolic link');
+  }
+
+  const contextRealPath = await realpath(contextDir);
+  const relativeToRoot = relative(rootRealPath, contextRealPath);
+  if (relativeToRoot === '' || relativeToRoot.startsWith('..') || isAbsolute(relativeToRoot)) {
+    throw new Error('Unsafe Autopilot context directory: resolved path escapes repository root');
+  }
+  return contextDir;
+}
+
+async function writeUniqueAutopilotContextSnapshot(
+  sourceCwd: string,
+  slug: string,
+  nowIso: string,
+  body: string,
+): Promise<string> {
+  const contextDir = await ensureSafeAutopilotContextDir(sourceCwd);
+  const timestamp = utcCompactTimestamp(nowIso);
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const suffix = attempt === 0 ? '' : `-${attempt + 1}`;
+    const filename = `${slug}-${timestamp}${suffix}.md`;
+    const relativePath = `.omx/context/${filename}`;
+    const absolutePath = resolve(contextDir, filename);
+    try {
+      await writeFile(absolutePath, body, { encoding: 'utf-8', flag: 'wx' });
+      return relativePath;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') continue;
+      throw error;
+    }
+  }
+  throw new Error(`Unable to allocate unique Autopilot context snapshot for ${slug}`);
+}
+
 async function ensureAutopilotContextSnapshot(
   sourceCwd: string,
   nowIso: string,
   activationText: string,
   existingPath?: unknown,
-): Promise<string> {
+  options: { allowTaskSnapshotCreation?: boolean } = {},
+): Promise<AutopilotContextSnapshotResult> {
   const existing = safeString(existingPath).trim();
   if (existing) {
-    if (isSafeAutopilotContextSnapshotPath(existing)) return existing;
+    if (isSafeAutopilotContextSnapshotPath(existing)) return { path: existing };
     throw new Error(`Unsafe Autopilot context snapshot path: ${existing}`);
   }
 
+  if (options.allowTaskSnapshotCreation === false) {
+    const slug = 'autopilot-recovery';
+    const continuationInput = activationText.trim() || '<empty>';
+    const body = [
+      '# Autopilot context recovery',
+      '',
+      '- recovery status: degraded',
+      '- reason: no safe legacy Autopilot context snapshot path was available during continuation.',
+      `- continuation input: ${continuationInput}`,
+      '- original task statement: unavailable; do not treat the continuation input as the task statement.',
+      '- required follow-up: re-establish or confirm the intended task context before downstream handoff.',
+      '',
+    ].join('\n');
+    const path = await writeUniqueAutopilotContextSnapshot(sourceCwd, slug, nowIso, body);
+    return {
+      path,
+      recovery: {
+        status: 'degraded',
+        reason: 'missing-or-unsafe-legacy-context-snapshot',
+        recovered_at: nowIso,
+        source: 'keyword-detector',
+      },
+    };
+  }
+
   const slug = slugifyAutopilotTask(activationText);
-  const contextDir = join(sourceCwd, '.omx', 'context');
-  await mkdir(contextDir, { recursive: true });
-  const relativePath = `.omx/context/${slug}-${utcCompactTimestamp(nowIso)}.md`;
-  const absolutePath = join(sourceCwd, relativePath);
   const taskStatement = activationText.trim() || '$autopilot';
   const body = [
     `# Autopilot context: ${slug}`,
@@ -229,8 +327,7 @@ async function ensureAutopilotContextSnapshot(
     '- likely codebase touchpoints: to be discovered during pre-context intake and planning.',
     '',
   ].join('\n');
-  await writeFile(absolutePath, body, 'utf-8');
-  return relativePath;
+  return { path: await writeUniqueAutopilotContextSnapshot(sourceCwd, slug, nowIso, body) };
 }
 
 function createDeepInterviewInputLock(nowIso: string, previous?: DeepInterviewInputLock): DeepInterviewInputLock {
@@ -497,21 +594,27 @@ async function persistStatefulSkillSeedState(
     const existingStateRaw = (reusableModeState?.state && typeof reusableModeState.state === 'object')
       ? reusableModeState.state as Record<string, unknown>
       : {};
-    const { context_snapshot_path: legacyStateContextSnapshotPath, ...existingState } = existingStateRaw;
+    const {
+      context_snapshot_path: legacyStateContextSnapshotPath,
+      context_snapshot_recovery: _legacyContextSnapshotRecovery,
+      ...existingState
+    } = existingStateRaw;
     const existingHandoffs = (existingState.handoff_artifacts && typeof existingState.handoff_artifacts === 'object')
       ? existingState.handoff_artifacts as Record<string, unknown>
       : {};
-    const existingContextSnapshotPath = [
+    const existingContextSnapshotPath = await findReusableAutopilotContextSnapshotPath(sourceCwd, [
       existingHandoffs.context_snapshot_path,
       legacyStateContextSnapshotPath,
       reusableModeState?.context_snapshot_path,
-    ].find(isSafeAutopilotContextSnapshotPath);
-    const contextSnapshotPath = await ensureAutopilotContextSnapshot(
+    ]);
+    const contextSnapshot = await ensureAutopilotContextSnapshot(
       sourceCwd,
       nowIso,
       activationText || safeString(nextSkill.keyword) || '$autopilot',
       existingContextSnapshotPath,
+      { allowTaskSnapshotCreation: !preserveExistingModeState },
     );
+    const contextSnapshotPath = contextSnapshot.path;
     baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
     delete baseState.context_snapshot_path;
     baseState.state = {
@@ -544,6 +647,7 @@ async function persistStatefulSkillSeedState(
       return_to_ralplan_reason: Object.prototype.hasOwnProperty.call(existingState, 'return_to_ralplan_reason')
         ? existingState.return_to_ralplan_reason
         : null,
+      ...(contextSnapshot.recovery ? { context_snapshot_recovery: contextSnapshot.recovery } : {}),
       deep_interview_gate: (existingState.deep_interview_gate && typeof existingState.deep_interview_gate === 'object')
         ? existingState.deep_interview_gate
         : {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -10,7 +10,8 @@
  * rather than the full keyword/state table.
  */
 
-import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { access, lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
 import { withModeRuntimeContext } from '../state/mode-state-context.js';
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { classifyTaskSize, isHeavyMode, type TaskSizeResult, type TaskSizeThresholds } from './task-size-detector.js';
@@ -204,6 +205,12 @@ function isSafeAutopilotContextSnapshotPath(value: unknown): value is string {
     && !snapshotName.includes('/');
 }
 
+function isAutopilotRecoverySnapshotPath(path: string): boolean {
+  return path.startsWith('.omx/context/autopilot-recovery-');
+}
+
+const MAX_REUSABLE_AUTOPILOT_CONTEXT_SNAPSHOT_BYTES = 1024 * 1024;
+
 async function isReadableAutopilotContextSnapshotPath(sourceCwd: string, value: unknown): Promise<boolean> {
   if (!isSafeAutopilotContextSnapshotPath(value)) return false;
   const contextDir = await ensureSafeAutopilotContextDir(sourceCwd);
@@ -211,11 +218,12 @@ async function isReadableAutopilotContextSnapshotPath(sourceCwd: string, value: 
   try {
     const snapshotStat = await lstat(absolutePath);
     if (!snapshotStat.isFile() || snapshotStat.isSymbolicLink()) return false;
+    if (snapshotStat.size > MAX_REUSABLE_AUTOPILOT_CONTEXT_SNAPSHOT_BYTES) return false;
     const contextRealPath = await realpath(contextDir);
     const snapshotRealPath = await realpath(absolutePath);
     const relativeToContext = relative(contextRealPath, snapshotRealPath);
     if (relativeToContext === '' || relativeToContext.startsWith('..') || isAbsolute(relativeToContext)) return false;
-    await readFile(absolutePath, 'utf-8');
+    await access(absolutePath, fsConstants.R_OK);
     return true;
   } catch {
     return false;
@@ -250,13 +258,13 @@ function normalizeAutopilotContextSnapshotCandidate(candidate: AutopilotContextS
     const path = safeString(candidate.value.path).trim();
     const kind = safeString(candidate.value.kind).trim() as AutopilotContextSnapshotKind;
     if (!path || !['canonical', 'legacy', 'recovery'].includes(kind)) return null;
-    if (kind === 'recovery') return null;
+    if (kind === 'recovery' || isAutopilotRecoverySnapshotPath(path)) return null;
     return { path, kind };
   }
 
   const path = safeString(candidate.value).trim();
   if (!path) return null;
-  if (path.startsWith('.omx/context/autopilot-recovery-')) return null;
+  if (isAutopilotRecoverySnapshotPath(path)) return null;
   return { path, kind: candidate.kind ?? 'legacy' };
 }
 
@@ -266,7 +274,7 @@ async function findReusableAutopilotContextSnapshotPath(
 ): Promise<AutopilotContextSnapshotDescriptor | undefined> {
   for (const candidate of candidates) {
     const normalized = normalizeAutopilotContextSnapshotCandidate(candidate);
-    if (!normalized || !isSafeAutopilotContextSnapshotPath(normalized.path)) continue;
+    if (!normalized || isAutopilotRecoverySnapshotPath(normalized.path) || !isSafeAutopilotContextSnapshotPath(normalized.path)) continue;
     if (await isReadableAutopilotContextSnapshotPath(sourceCwd, normalized.path)) return normalized;
   }
   return undefined;
@@ -463,7 +471,9 @@ async function readJsonStateWithStatus(path: string): Promise<{
 }> {
   try {
     const raw = await readFile(path, 'utf-8');
-    return { state: JSON.parse(raw) as Record<string, unknown>, status: 'ok' };
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) return { state: null, status: 'malformed' };
+    return { state: parsed, status: 'ok' };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return { state: null, status: 'missing' };

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -494,14 +494,16 @@ async function persistStatefulSkillSeedState(
 
   if (config.mode === 'autopilot') {
     const reusableModeState = preserveExistingModeState ? existingModeState : null;
-    const existingState = (reusableModeState?.state && typeof reusableModeState.state === 'object')
+    const existingStateRaw = (reusableModeState?.state && typeof reusableModeState.state === 'object')
       ? reusableModeState.state as Record<string, unknown>
       : {};
+    const { context_snapshot_path: legacyStateContextSnapshotPath, ...existingState } = existingStateRaw;
     const existingHandoffs = (existingState.handoff_artifacts && typeof existingState.handoff_artifacts === 'object')
       ? existingState.handoff_artifacts as Record<string, unknown>
       : {};
     const existingContextSnapshotPath = [
       existingHandoffs.context_snapshot_path,
+      legacyStateContextSnapshotPath,
       reusableModeState?.context_snapshot_path,
     ].find(isSafeAutopilotContextSnapshotPath);
     const contextSnapshotPath = await ensureAutopilotContextSnapshot(
@@ -511,6 +513,7 @@ async function persistStatefulSkillSeedState(
       existingContextSnapshotPath,
     );
     baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
+    delete baseState.context_snapshot_path;
     baseState.state = {
       ...existingState,
       phase_cycle: Array.isArray(existingState.phase_cycle) ? existingState.phase_cycle : ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa'],

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -12,7 +12,7 @@
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { withModeRuntimeContext } from '../state/mode-state-context.js';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 import { classifyTaskSize, isHeavyMode, type TaskSizeResult, type TaskSizeThresholds } from './task-size-detector.js';
 import { isApprovedExecutionFollowupShortcut, type FollowupMode } from '../team/followup-planner.js';
 import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts.js';
@@ -182,7 +182,20 @@ function slugifyAutopilotTask(text: string): string {
 }
 
 function utcCompactTimestamp(nowIso: string): string {
-  return nowIso.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+  const parsed = new Date(nowIso);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid Autopilot context timestamp: ${nowIso}`);
+  }
+  return parsed.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function isSafeAutopilotContextSnapshotPath(value: unknown): value is string {
+  const path = safeString(value).trim();
+  return path.startsWith('.omx/context/')
+    && path.endsWith('.md')
+    && !isAbsolute(path)
+    && !path.split('/').includes('..')
+    && !path.includes('\\');
 }
 
 async function ensureAutopilotContextSnapshot(
@@ -192,7 +205,10 @@ async function ensureAutopilotContextSnapshot(
   existingPath?: unknown,
 ): Promise<string> {
   const existing = safeString(existingPath).trim();
-  if (existing) return existing;
+  if (existing) {
+    if (isSafeAutopilotContextSnapshotPath(existing)) return existing;
+    throw new Error(`Unsafe Autopilot context snapshot path: ${existing}`);
+  }
 
   const slug = slugifyAutopilotTask(activationText);
   const contextDir = join(sourceCwd, '.omx', 'context');
@@ -486,14 +502,15 @@ async function persistStatefulSkillSeedState(
       sourceCwd,
       nowIso,
       activationText || safeString(nextSkill.keyword) || '$autopilot',
-      existingHandoffs.context_snapshot_path,
+      isSafeAutopilotContextSnapshotPath(existingHandoffs.context_snapshot_path)
+        ? existingHandoffs.context_snapshot_path
+        : reusableModeState?.context_snapshot_path,
     );
     baseState.review_cycle = typeof reusableModeState?.review_cycle === 'number' ? reusableModeState.review_cycle : 0;
     baseState.state = {
       ...existingState,
       phase_cycle: Array.isArray(existingState.phase_cycle) ? existingState.phase_cycle : ['deep-interview', 'ralplan', 'ultragoal', 'code-review', 'ultraqa'],
       handoff_artifacts: {
-        context_snapshot_path: contextSnapshotPath,
         deep_interview: null,
         ralplan: null,
         ralplan_consensus_gate: {
@@ -509,6 +526,7 @@ async function persistStatefulSkillSeedState(
         code_review: null,
         ultraqa: null,
         ...existingHandoffs,
+        context_snapshot_path: contextSnapshotPath,
       },
       review_verdict: Object.prototype.hasOwnProperty.call(existingState, 'review_verdict')
         ? existingState.review_verdict

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3489,6 +3489,16 @@ standardMaxRounds = 15
       assert.match(message, /Do not advance from deep-interview to ralplan merely because the first question was answered/);
       assert.match(message, /Planner output has been reviewed sequentially by Architect and then Critic/);
       assert.match(message, /do not hand off to Ultragoal or implementation until .*ralplan_architect_review.*ralplan_critic_review/);
+
+      const autopilotState = JSON.parse(await readFile(
+        join(cwd, ".omx", "state", "sessions", "sess-autopilot-ralplan-gate", "autopilot-state.json"),
+        "utf-8",
+      )) as { state?: { handoff_artifacts?: { context_snapshot_path?: string } } };
+      const snapshotPath = autopilotState.state?.handoff_artifacts?.context_snapshot_path || "";
+      assert.match(snapshotPath, /^\.omx\/context\/implement-issue-2430-\d{8}T\d{6}Z\.md$/);
+      const snapshot = await readFile(join(cwd, snapshotPath), "utf-8");
+      assert.match(snapshot, /task statement: \$autopilot implement issue #2430/);
+      assert.match(snapshot, /constraints: follow deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3494,7 +3494,7 @@ standardMaxRounds = 15
         join(cwd, ".omx", "state", "sessions", "sess-autopilot-ralplan-gate", "autopilot-state.json"),
         "utf-8",
       )) as { state?: { handoff_artifacts?: { context_snapshot_path?: string } } };
-      const snapshotPath = autopilotState.state?.handoff_artifacts?.context_snapshot_path || "";
+      const snapshotPath = autopilotState.state?.handoff_artifacts?.context_snapshot_path ?? "";
       assert.match(snapshotPath, /^\.omx\/context\/implement-issue-2430-\d{8}T\d{6}Z\.md$/);
       const snapshot = await readFile(join(cwd, snapshotPath), "utf-8");
       assert.match(snapshot, /task statement: \$autopilot implement issue #2430/);


### PR DESCRIPTION
## Summary
- observed prompt-side Autopilot activation in tmux/HUD/state and found the seeded state missing the required pre-context snapshot handoff
- create `.omx/context/<slug>-<timestamp>.md` during Autopilot seed-state initialization
- persist `state.handoff_artifacts.context_snapshot_path` while preserving existing handoffs on resume
- add regression coverage to the native hook Autopilot activation test

## Validation
- `npm run build`
- `node --test --test-name-pattern 'injects autopilot ralplan consensus gate guidance' dist/scripts/__tests__/codex-native-hook.test.js`

## Notes
- An earlier broad `npm test -- --runInBand src/scripts/__tests__/codex-native-hook.test.ts` invocation was not a valid targeted run for this repo script; it launched the full compiled suite while another build/test activity was present and exited non-zero. The focused build + regression test above passed cleanly.
