### PR TITLE
Support state operation help

### DIFF
--- a/src/cli/__tests__/state.test.ts
+++ b/src/cli/__tests__/state.test.ts
@@ -13,6 +13,31 @@ describe('stateCommand', () => {
     assert.match(out.join('\n'), /Usage: omx state/);
   });
 
+
+  it('prints help for operation-level help forms without executing state operations', async () => {
+    const operations = ['read', 'write', 'clear', 'list-active', 'get-status'];
+    const helpForms = ['--help', '-h', 'help'];
+
+    for (const operation of operations) {
+      for (const helpForm of helpForms) {
+        const out: string[] = [];
+        let executed = false;
+        await stateCommand([operation, helpForm], {
+          stdout: (line) => out.push(line),
+          stderr: () => undefined,
+          execute: async () => {
+            executed = true;
+            return { payload: { error: 'should not execute' }, isError: true };
+          },
+        });
+
+        assert.equal(executed, false, `${operation} ${helpForm} should not execute state operation`);
+        assert.match(out.join('\n'), /Usage: omx state/);
+        assert.doesNotMatch(out.join('\n'), /Unknown state argument/);
+      }
+    }
+  });
+
   it('emits a frozen compact JSON envelope when --json is set', async () => {
     const out: string[] = [];
     await stateCommand(['read', '--input', '{"mode":"ralph"}', '--json'], {

--- a/src/cli/state.ts
+++ b/src/cli/state.ts
@@ -16,6 +16,10 @@ export interface StateCommandDependencies {
   execute?: typeof executeStateOperation;
 }
 
+function isHelpArg(arg: string | undefined): boolean {
+  return arg === '--help' || arg === '-h' || arg === 'help';
+}
+
 function parseStateInput(input: string | undefined): Record<string, unknown> {
   if (!input) return {};
   let parsed: unknown;
@@ -39,7 +43,7 @@ export async function stateCommand(
   const execute = deps.execute ?? executeStateOperation;
 
   const subcommand = args[0];
-  if (!subcommand || subcommand === '--help' || subcommand === '-h' || subcommand === 'help') {
+  if (!subcommand || isHelpArg(subcommand)) {
     stdout(STATE_HELP);
     return;
   }
@@ -47,6 +51,11 @@ export async function stateCommand(
   const operation = STATE_OPERATION_MAP[subcommand];
   if (!operation) {
     throw new Error(`Unknown state subcommand: ${subcommand}\n${STATE_HELP}`);
+  }
+
+  if (isHelpArg(args[1])) {
+    stdout(STATE_HELP);
+    return;
   }
 
   let inputValue: string | undefined;


### PR DESCRIPTION
Closes #2645.

## Summary
- Route `omx state <operation> --help`, `-h`, and `help` to the existing state usage output before normal argument validation.
- Add regression coverage for read/write/clear/list-active/get-status across all requested help forms.

## Tests
- `npm run build`
- `node --test dist/cli/__tests__/state.test.js dist/cli/__tests__/nested-help-routing.test.js`
- `npm run lint`
- `npm run check:no-unused`
- Direct smoke: `node dist/cli/omx.js state <op> <help-form>` for all requested operation/help-form combinations

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
