### PR TITLE
Fix HUD duplicate pane race after prompt revive

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -223,6 +223,38 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(resized, [{ paneId: '%9', heightLines: HUD_TMUX_HEIGHT_LINES }]);
   });
 
+  it('keeps an observed same-owner HUD when the returned create pane is absent from the post-create scan', async () => {
+    const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    let listCount = 0;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-race', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => {
+        listCount += 1;
+        if (listCount === 1) return [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }];
+        return [
+          { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+          {
+            paneId: '%8',
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='sess-race' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+          },
+        ];
+      },
+      createHudWatchPane: () => '%9',
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%8');
+    assert.equal(result.duplicateCount, 0);
+    assert.deepEqual(killed, []);
+    assert.deepEqual(resized, [{ paneId: '%8', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+  });
+
   it('reports failure when the post-create keeper cannot be resized', async () => {
     const killed: string[] = [];
     const registered: string[] = [];

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -172,8 +172,93 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     assert.equal(result.status, 'recreated');
-    assert.deepEqual(listArgs, ['%leader']);
+    assert.deepEqual(listArgs, ['%leader', '%leader']);
     assert.equal(created[0]?.options?.targetPaneId, '%leader');
+  });
+
+  it('collapses same-owner HUD panes that appear during the create race window', async () => {
+    const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    let listCount = 0;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-race', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => {
+        listCount += 1;
+        if (listCount === 1) {
+          return [
+            { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+          ];
+        }
+        return [
+          { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+          {
+            paneId: '%8',
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='sess-race' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+          },
+          {
+            paneId: '%9',
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='sess-race' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch --preset=focused`,
+          },
+        ];
+      },
+      createHudWatchPane: () => '%9',
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.paneId, '%9');
+    assert.equal(result.duplicateCount, 1);
+    assert.deepEqual(killed, ['%8']);
+    assert.deepEqual(resized, [{ paneId: '%9', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+  });
+
+  it('reports failure when the post-create keeper cannot be resized', async () => {
+    const killed: string[] = [];
+    const registered: string[] = [];
+    let listCount = 0;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-race', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => {
+        listCount += 1;
+        if (listCount === 1) return [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }];
+        return [
+          { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+          {
+            paneId: '%8',
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='sess-race' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+          },
+          {
+            paneId: '%9',
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='sess-race' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+          },
+        ];
+      },
+      createHudWatchPane: () => '%9',
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      resizeTmuxPane: () => false,
+      registerHudResizeHook: (paneId) => { registered.push(paneId); return true; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, null);
+    assert.equal(result.duplicateCount, 1);
+    assert.deepEqual(killed, []);
+    assert.deepEqual(registered, []);
   });
 
   it('kills duplicate HUD panes and reuses one existing pane', async () => {
@@ -217,6 +302,38 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(killed, ['%3']);
     assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
     assert.deepEqual(created, []);
+  });
+
+  it('does not kill existing duplicate HUD panes when the keeper cannot be resized', async () => {
+    const killed: string[] = [];
+    const registered: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%8',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+        {
+          paneId: '%9',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+      ],
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      resizeTmuxPane: () => false,
+      registerHudResizeHook: (paneId) => { registered.push(paneId); return true; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, null);
+    assert.equal(result.duplicateCount, 1);
+    assert.deepEqual(killed, []);
+    assert.deepEqual(registered, []);
   });
 
   it('does not resize, kill, or reuse another active leader session HUD in the same tmux window', async () => {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -67,6 +67,23 @@ function ensureHudResizeHook(
   }
 }
 
+function planOwnedHudPaneDedupe(
+  panes: TmuxPaneSnapshot[],
+  currentPaneId: string | undefined,
+  owner: { sessionId?: string; leaderPaneId?: string },
+  keepPaneId: string,
+): { paneId: string; duplicatePaneIds: string[] } {
+  const ownedPaneIds = findHudWatchPaneIds(panes, currentPaneId, owner);
+  const paneIds = ownedPaneIds.includes(keepPaneId)
+    ? ownedPaneIds
+    : [...ownedPaneIds, keepPaneId];
+  const keeperPaneId = paneIds.includes(keepPaneId) ? keepPaneId : (paneIds[0] ?? keepPaneId);
+  return {
+    paneId: keeperPaneId,
+    duplicatePaneIds: paneIds.filter((paneId) => paneId !== keeperPaneId),
+  };
+}
+
 export async function reconcileHudForPromptSubmit(
   cwd: string,
   deps: ReconcileHudForPromptSubmitDeps = {},
@@ -109,10 +126,11 @@ export async function reconcileHudForPromptSubmit(
   const currentPaneId = env.TMUX_PANE?.trim();
   const panes = listPanes(currentPaneId);
   const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
-  const hudPaneIds = findHudWatchPaneIds(panes, currentPaneId, {
+  const owner = {
     sessionId: resolvedSessionId,
     leaderPaneId: currentPaneId,
-  });
+  };
+  const hudPaneIds = findHudWatchPaneIds(panes, currentPaneId, owner);
   const duplicateCount = Math.max(0, hudPaneIds.length - 1);
   const nonHudPaneCount = panes.filter((pane) => !isHudWatchPane(pane)).length;
   const readHudConfigFn = deps.readHudConfig ?? readHudConfig;
@@ -136,14 +154,22 @@ export async function reconcileHudForPromptSubmit(
 
   if (hudPaneIds.length > 1) {
     const [keeperPaneId, ...extraPaneIds] = hudPaneIds;
+    const resized = resizePane(keeperPaneId, desiredHeight);
+    if (!resized) {
+      return {
+        status: 'failed',
+        paneId: null,
+        desiredHeight,
+        duplicateCount,
+      };
+    }
     for (const paneId of extraPaneIds) {
       killPane(paneId);
     }
-    const resized = resizePane(keeperPaneId, desiredHeight);
-    if (resized) ensureHudResizeHook(keeperPaneId, currentPaneId, desiredHeight, deps);
+    ensureHudResizeHook(keeperPaneId, currentPaneId, desiredHeight, deps);
     return {
-      status: resized ? 'replaced_duplicates' : 'failed',
-      paneId: resized ? keeperPaneId : null,
+      status: 'replaced_duplicates',
+      paneId: keeperPaneId,
       desiredHeight,
       duplicateCount,
     };
@@ -179,13 +205,34 @@ export async function reconcileHudForPromptSubmit(
     };
   }
 
-  resizePane(paneId, desiredHeight);
-  ensureHudResizeHook(paneId, currentPaneId, desiredHeight, deps);
+  // A launch-path restore and prompt-submit reconciliation can both observe
+  // "no HUD" before either split-window has materialized. Re-scan after create
+  // and collapse same-owner panes so the second creator cleans up the race
+  // instead of leaving a duplicate HUD in the user window.
+  const postCreate = planOwnedHudPaneDedupe(
+    listPanes(currentPaneId),
+    currentPaneId,
+    owner,
+    paneId,
+  );
+  const resized = resizePane(postCreate.paneId, desiredHeight);
+  if (!resized) {
+    return {
+      status: 'failed',
+      paneId: null,
+      desiredHeight,
+      duplicateCount: postCreate.duplicatePaneIds.length,
+    };
+  }
+  for (const duplicatePaneId of postCreate.duplicatePaneIds) {
+    killPane(duplicatePaneId);
+  }
+  ensureHudResizeHook(postCreate.paneId, currentPaneId, desiredHeight, deps);
 
   return {
-    status: hudPaneIds.length > 1 ? 'replaced_duplicates' : 'recreated',
-    paneId,
+    status: postCreate.duplicatePaneIds.length > 0 || hudPaneIds.length > 1 ? 'replaced_duplicates' : 'recreated',
+    paneId: postCreate.paneId,
     desiredHeight,
-    duplicateCount,
+    duplicateCount: postCreate.duplicatePaneIds.length,
   };
 }

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -71,16 +71,16 @@ function planOwnedHudPaneDedupe(
   panes: TmuxPaneSnapshot[],
   currentPaneId: string | undefined,
   owner: { sessionId?: string; leaderPaneId?: string },
-  keepPaneId: string,
+  preferredPaneId: string,
 ): { paneId: string; duplicatePaneIds: string[] } {
   const ownedPaneIds = findHudWatchPaneIds(panes, currentPaneId, owner);
-  const paneIds = ownedPaneIds.includes(keepPaneId)
-    ? ownedPaneIds
-    : [...ownedPaneIds, keepPaneId];
-  const keeperPaneId = paneIds.includes(keepPaneId) ? keepPaneId : (paneIds[0] ?? keepPaneId);
+  const keeperPaneId = ownedPaneIds.includes(preferredPaneId)
+    ? preferredPaneId
+    : (ownedPaneIds[0] ?? preferredPaneId);
+
   return {
     paneId: keeperPaneId,
-    duplicatePaneIds: paneIds.filter((paneId) => paneId !== keeperPaneId),
+    duplicatePaneIds: ownedPaneIds.filter((paneId) => paneId !== keeperPaneId),
   };
 }
 


### PR DESCRIPTION
## Summary
- fix prompt-submit HUD reconciliation to re-scan the tmux window after creating a HUD pane
- collapse same-owner panes created by concurrent launch/reconcile paths so one leader/session keeps one HUD
- add a regression for the dogfooded race shape observed after #2642

## Research / reproduction
- PR #2642 is merged into `dev` and fixed escaped tmux separators in `src/hud/tmux.ts`.
- Live tmux evidence still showed two owner-matched HUD panes in `omx-0:3:UltraQA harness generator`:
  - `%272` launch-path HUD for `OMX_SESSION_ID=omx-1780138878869-lumggh`, leader `%179`
  - `%273` prompt-submit HUD for the same session/leader
- That points to a create race: both paths can observe no HUD before either split is visible.

## Tests
- `npm run build && node --test dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/tmux.test.js`
