### PR TITLE
Preserve plugin setup mode during update refresh

### DIFF
--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -10,6 +10,7 @@ import {
   readUserInstallStamp,
   resolveAutoUpdateMode,
   resolveInstalledCliEntry,
+  resolveSetupRefreshArgs,
   runDeferredGlobalUpdate,
   runImmediateUpdate,
   shouldCheckForUpdates,
@@ -775,6 +776,40 @@ describe('runDeferredGlobalUpdate', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('preserves plugin setup delivery mode for deferred post-update refreshes', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deferred-update-plugin-'));
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'setup-scope.json'),
+        JSON.stringify({ scope: 'user', installMode: 'plugin', mcpMode: 'none' }, null, 2),
+      );
+
+      const result = runDeferredGlobalUpdate(
+        cwd,
+        ((command, args) => {
+          calls.push({ command, args: args as string[] });
+          return {
+            once() {
+              return this;
+            },
+            unref() {},
+          } as unknown as ReturnType<typeof import('node:child_process').spawn>;
+        }) as typeof import('node:child_process').spawn,
+        'linux',
+        12345,
+      );
+
+      assert.equal(result.ok, true);
+      assert.equal(calls.length, 1);
+      assert.match(calls[0].args[1], /omx setup --scope user --plugin --mcp none/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('post-update setup refresh handoff', () => {
@@ -837,5 +872,72 @@ describe('post-update setup refresh handoff', () => {
 
     assert.equal(result.ok, true);
     assert.equal(receivedTimeout, undefined);
+  });
+
+  it('passes persisted plugin setup choices to the updated CLI refresh', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-plugin-refresh-'));
+    const received: Array<{ command: string; args: string[] }> = [];
+
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'setup-scope.json'),
+        JSON.stringify({ scope: 'user', installMode: 'plugin', mcpMode: 'none' }, null, 2),
+      );
+
+      const result = spawnInstalledSetupRefresh(
+        '/tmp/omx.js',
+        cwd,
+        ((command, args) => {
+          received.push({ command, args: args as string[] });
+          return { status: 0, error: undefined };
+        }) as typeof import('node:child_process').spawnSync,
+      );
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(received[0]?.args, [
+        '/tmp/omx.js',
+        'setup',
+        '--scope',
+        'user',
+        '--plugin',
+        '--mcp',
+        'none',
+      ]);
+      assert.deepEqual(resolveSetupRefreshArgs(cwd), [
+        'setup',
+        '--scope',
+        'user',
+        '--plugin',
+        '--mcp',
+        'none',
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('migrates legacy project-local scope when building update setup refresh args', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-plugin-legacy-scope-'));
+
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'setup-scope.json'),
+        JSON.stringify({ scope: 'project-local', installMode: 'plugin', mcpMode: 'none' }, null, 2),
+      );
+
+      assert.deepEqual(resolveSetupRefreshArgs(cwd), [
+        'setup',
+        '--scope',
+        'project',
+        '--plugin',
+        '--mcp',
+        'none',
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -10,6 +10,7 @@ import {
   readUserInstallStamp,
   resolveAutoUpdateMode,
   resolveInstalledCliEntry,
+  formatDeferredSetupCommand,
   resolveSetupRefreshArgs,
   runDeferredGlobalUpdate,
   runImmediateUpdate,
@@ -771,7 +772,7 @@ describe('runDeferredGlobalUpdate', () => {
       assert.equal((calls[0].options.env as NodeJS.ProcessEnv | undefined)?.OMX_DEFERRED_UPDATE_LOG, result.logPath);
       assert.match(calls[0].args[4], /Get-Process -Id \$parentPid/);
       assert.match(calls[0].args[4], /npm install -g oh-my-codex@latest/);
-      assert.match(calls[0].args[4], /omx setup/);
+      assert.match(calls[0].args[4], /& 'omx' 'setup'/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -805,10 +806,65 @@ describe('runDeferredGlobalUpdate', () => {
 
       assert.equal(result.ok, true);
       assert.equal(calls.length, 1);
-      assert.match(calls[0].args[1], /omx setup --scope user --plugin --mcp none/);
+      assert.match(calls[0].args[1], /'omx' 'setup' '--scope' 'user' '--plugin' '--mcp' 'none'/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it('snapshots deferred setup refresh args when scheduling the detached updater', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deferred-update-snapshot-'));
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      const setupScopePath = join(cwd, '.omx', 'setup-scope.json');
+      await writeFile(
+        setupScopePath,
+        JSON.stringify({ scope: 'user', installMode: 'plugin', mcpMode: 'none' }, null, 2),
+      );
+
+      const result = runDeferredGlobalUpdate(
+        cwd,
+        ((command, args) => {
+          calls.push({ command, args: args as string[] });
+          return {
+            once() {
+              return this;
+            },
+            unref() {},
+          } as unknown as ReturnType<typeof import('node:child_process').spawn>;
+        }) as typeof import('node:child_process').spawn,
+        'linux',
+        12345,
+      );
+
+      await writeFile(
+        setupScopePath,
+        JSON.stringify({ scope: 'project', installMode: 'legacy', mcpMode: 'compat' }, null, 2),
+      );
+
+      assert.equal(result.ok, true);
+      assert.equal(calls.length, 1);
+      assert.match(calls[0].args[1], /'omx' 'setup' '--scope' 'user' '--plugin' '--mcp' 'none'/);
+      assert.doesNotMatch(calls[0].args[1], /compat/);
+      assert.doesNotMatch(calls[0].args[1], /legacy/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('quotes deferred setup command arguments at the shell boundary', () => {
+    const args = ['setup', '--scope', 'user project', '--mcp', "none'; echo pwned #", '--flag', ''];
+
+    assert.equal(
+      formatDeferredSetupCommand('linux', 'omx tool', args),
+      "'omx tool' 'setup' '--scope' 'user project' '--mcp' 'none'\\''; echo pwned #' '--flag' ''",
+    );
+    assert.equal(
+      formatDeferredSetupCommand('win32', 'omx tool', args),
+      "& 'omx tool' 'setup' '--scope' 'user project' '--mcp' 'none''; echo pwned #' '--flag' ''",
+    );
   });
 });
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -13,6 +13,7 @@ import { spawn, spawnSync } from 'child_process';
 import { createInterface } from 'readline/promises';
 import { getPackageRoot } from '../utils/package.js';
 import { omxUserInstallStampPath } from '../utils/paths.js';
+import { readPersistedSetupPreferencesSync } from './setup-preferences.js';
 
 export interface UpdateState {
   last_checked_at: string;
@@ -149,6 +150,24 @@ function runGlobalUpdate(): RunGlobalUpdateResult {
   return { ok: true, stderr: '' };
 }
 
+
+export function resolveSetupRefreshArgs(cwd: string): string[] {
+  const preferences = readPersistedSetupPreferencesSync(cwd);
+  const args = ['setup'];
+  if (preferences?.scope) {
+    args.push('--scope', preferences.scope);
+  }
+  if (preferences?.installMode === 'plugin') {
+    args.push('--plugin');
+  } else if (preferences?.installMode === 'legacy') {
+    args.push('--legacy');
+  }
+  if (preferences?.mcpMode) {
+    args.push('--mcp', preferences.mcpMode);
+  }
+  return args;
+}
+
 function formatUpdateLogPath(date = new Date()): string {
   return `update-${date.toISOString().replace(/[:.]/g, '-')}.log`;
 }
@@ -160,6 +179,8 @@ export function runDeferredGlobalUpdate(
   parentPid = process.pid,
 ): RunDeferredUpdateResult {
   const logPath = join(cwd, '.omx', 'logs', formatUpdateLogPath());
+  const setupArgs = resolveSetupRefreshArgs(cwd);
+  const setupCommand = ['omx', ...setupArgs].join(' ');
 
   try {
     mkdirSync(dirname(logPath), { recursive: true });
@@ -183,7 +204,7 @@ export function runDeferredGlobalUpdate(
             '$parentPid = [int]$env:OMX_DEFERRED_UPDATE_PARENT_PID',
             'while (Get-Process -Id $parentPid -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 1 }',
             'npm install -g oh-my-codex@latest *>> $log',
-            'if ($LASTEXITCODE -eq 0) { omx setup *>> $log }',
+            `if ($LASTEXITCODE -eq 0) { ${setupCommand} *>> $log }`,
           ].join('; '),
         ]
       : [
@@ -191,7 +212,7 @@ export function runDeferredGlobalUpdate(
           [
             'while kill -0 "$OMX_DEFERRED_UPDATE_PARENT_PID" 2>/dev/null; do sleep 1; done',
             'npm install -g oh-my-codex@latest >> "$OMX_DEFERRED_UPDATE_LOG" 2>&1',
-            'if [ "$?" -eq 0 ]; then omx setup >> "$OMX_DEFERRED_UPDATE_LOG" 2>&1; fi',
+            `if [ "$?" -eq 0 ]; then ${setupCommand} >> "$OMX_DEFERRED_UPDATE_LOG" 2>&1; fi`,
           ].join('; '),
         ];
 
@@ -383,7 +404,7 @@ export function spawnInstalledSetupRefresh(
   cwd: string,
   spawnProcess: SpawnSyncLike = spawnSync,
 ): RunSetupRefreshResult {
-  const result = spawnProcess(process.execPath, [cliEntry, 'setup'], {
+  const result = spawnProcess(process.execPath, [cliEntry, ...resolveSetupRefreshArgs(cwd)], {
     cwd,
     env: process.env,
     stdio: 'inherit',

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -168,6 +168,27 @@ export function resolveSetupRefreshArgs(cwd: string): string[] {
   return args;
 }
 
+function quotePosixShellArg(value: string): string {
+  if (value === '') return "''";
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function quotePowerShellArg(value: string): string {
+  return `'${value.replace(/'/g, `''`)}'`;
+}
+
+export function formatDeferredSetupCommand(
+  platform: NodeJS.Platform,
+  command: string,
+  args: string[],
+): string {
+  const argv = [command, ...args];
+  if (platform === 'win32') {
+    return `& ${argv.map(quotePowerShellArg).join(' ')}`;
+  }
+  return argv.map(quotePosixShellArg).join(' ');
+}
+
 function formatUpdateLogPath(date = new Date()): string {
   return `update-${date.toISOString().replace(/[:.]/g, '-')}.log`;
 }
@@ -179,8 +200,11 @@ export function runDeferredGlobalUpdate(
   parentPid = process.pid,
 ): RunDeferredUpdateResult {
   const logPath = join(cwd, '.omx', 'logs', formatUpdateLogPath());
+  // Snapshot the current setup delivery mode when the update is scheduled.
+  // The detached process runs after this CLI exits, so the refresh should replay
+  // the setup mode that was active when the user accepted/scheduled the update.
   const setupArgs = resolveSetupRefreshArgs(cwd);
-  const setupCommand = ['omx', ...setupArgs].join(' ');
+  const setupCommand = formatDeferredSetupCommand(platform, 'omx', setupArgs);
 
   try {
     mkdirSync(dirname(logPath), { recursive: true });


### PR DESCRIPTION
## Summary
- carry persisted `.omx/setup-scope.json` setup choices into post-update setup refreshes
- preserve `--plugin` / `--legacy`, `--scope`, and `--mcp` during immediate and deferred `omx update` handoffs
- add update tests covering plugin-mode refresh args for both inline and deferred update paths

## Research / reproduction
- `omx doctor` warnings reported a missing/stale plugin cache manifest after update/install even though the user had selected plugin delivery mode.
- The update handoff ran the newly installed CLI as plain `omx setup`, which can lose the selected delivery mode in update contexts.
- Passing the persisted setup choices makes plugin-mode update refresh materialize the Codex plugin cache instead of leaving doctor to recommend `omx setup --plugin --force`.

## Tests
- `npm run build && node --test dist/cli/__tests__/update.test.js dist/cli/__tests__/setup-refresh.test.js`
