### PR TITLE
Clarify clean-context for code-review subagents

### DIFF
--- a/plugins/oh-my-codex/skills/code-review/SKILL.md
+++ b/plugins/oh-my-codex/skills/code-review/SKILL.md
@@ -31,7 +31,7 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
 2. **Launch Parallel Review Lanes**
    - **`code-reviewer` lane** - owns spec compliance, security, code quality, performance, and maintainability findings
    - **`architect` lane** - owns the devil's-advocate / design-tradeoff perspective
-   - Both lanes run in parallel and produce distinct outputs before final synthesis
+   - Both lanes run in parallel on a clean context with explicit scope and artifacts, and produce distinct outputs before final synthesis
    - If either lane cannot be launched or does not return evidence, report `independent review unavailable`; do **not** substitute the current/authoring lane, and do **not** approve or mark the review merge-ready.
 
 3. **Review Categories**

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -31,7 +31,7 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
 2. **Launch Parallel Review Lanes**
    - **`code-reviewer` lane** - owns spec compliance, security, code quality, performance, and maintainability findings
    - **`architect` lane** - owns the devil's-advocate / design-tradeoff perspective
-   - Both lanes run in parallel and produce distinct outputs before final synthesis
+   - Both lanes run in parallel on a clean context with explicit scope and artifacts, and produce distinct outputs before final synthesis
    - If either lane cannot be launched or does not return evidence, report `independent review unavailable`; do **not** substitute the current/authoring lane, and do **not** approve or mark the review merge-ready.
 
 3. **Review Categories**

--- a/src/hooks/__tests__/code-review-skill-contract.test.ts
+++ b/src/hooks/__tests__/code-review-skill-contract.test.ts
@@ -14,6 +14,8 @@ describe('code-review skill contract', () => {
   it('requires parallel code-reviewer and architect lanes', () => {
     assert.match(codeReviewSkill, /`code-reviewer` and `architect` agents in parallel/i);
     assert.match(codeReviewSkill, /Both lanes run in parallel/i);
+    assert.match(codeReviewSkill, /clean context/i);
+    assert.match(codeReviewSkill, /explicit scope and artifacts/i);
     assert.match(codeReviewSkill, /`code-reviewer` lane/i);
     assert.match(codeReviewSkill, /`architect` lane/i);
     assert.match(codeReviewSkill, /If either lane cannot be launched or does not return evidence/i);


### PR DESCRIPTION
## Summary
- Clarify that code-review subagents run on a clean context with explicit scope and artifacts.
- Mirror the same wording in the plugin skill copy.
- Lock the expectation with a contract test.

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/code-review-skill-contract.test.js`
- `npm run verify:plugin-bundle`
- `npm run test:plugin-boundaries:compiled`

## Notes
- The patch is intentionally narrow: it only updates the code-review skill text and its contract test.
- Broader repo/runtime regressions I observed elsewhere are unrelated to this change.
