### PR TITLE
Make Team mode disableable

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -35,6 +35,7 @@ import {
   resolveSetupInstallModeArg,
   resolveSetupMcpModeArg,
   resolveSetupScopeArg,
+  resolveSetupTeamModeArg,
   resolveLaunchConfigRepairOptions,
   readPersistedSetupPreferences,
   readPersistedSetupScope,
@@ -1861,6 +1862,41 @@ describe("resolveSetupMcpModeArg", () => {
   });
 });
 
+describe("resolveSetupTeamModeArg", () => {
+  it("maps explicit setup Team mode flags", () => {
+    assert.equal(resolveSetupTeamModeArg(["--dry-run"]), undefined);
+    assert.equal(resolveSetupTeamModeArg(["--disable-team"]), "disabled");
+    assert.equal(resolveSetupTeamModeArg(["--no-team"]), "disabled");
+    assert.equal(resolveSetupTeamModeArg(["--enable-team"]), "enabled");
+    assert.equal(resolveSetupTeamModeArg(["--team"]), "enabled");
+    assert.equal(resolveSetupTeamModeArg(["--team-mode", "disabled"]), "disabled");
+    assert.equal(resolveSetupTeamModeArg(["--team-mode=enabled"]), "enabled");
+    assert.equal(
+      resolveSetupTeamModeArg(["--scope", "project", "--team-mode", "disabled"]),
+      "disabled",
+    );
+  });
+
+  it("rejects invalid or conflicting setup Team mode flags", () => {
+    assert.throws(
+      () => resolveSetupTeamModeArg(["--team-mode"]),
+      /Missing setup Team mode value after --team-mode/,
+    );
+    assert.throws(
+      () => resolveSetupTeamModeArg(["--team-mode", "minimal"]),
+      /Invalid setup Team mode: minimal/,
+    );
+    assert.throws(
+      () => resolveSetupTeamModeArg(["--disable-team", "--enable-team"]),
+      /Conflicting setup Team mode flags/,
+    );
+    assert.throws(
+      () => resolveSetupTeamModeArg(["--team-mode=enabled", "--no-team"]),
+      /Conflicting setup Team mode flags/,
+    );
+  });
+});
+
 describe("resolveSetupScopeArg", () => {
   it("returns undefined when scope is omitted", () => {
     assert.equal(resolveSetupScopeArg(["--dry-run"]), undefined);
@@ -1917,6 +1953,23 @@ describe("project launch scope helpers", () => {
       assert.deepEqual(readPersistedSetupPreferences(wd), {
         scope: "user",
         installMode: "plugin",
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("reads persisted setup Team mode when present", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project", teamMode: "disabled" }),
+      );
+      assert.deepEqual(readPersistedSetupPreferences(wd), {
+        scope: "project",
+        teamMode: "disabled",
       });
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -869,6 +869,41 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("omits Team plugin skills and native team executor when plugin mode disables Team", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-no-team-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						teamMode: "disabled",
+					});
+				});
+
+				const pkg = JSON.parse(
+					await readFile(join(packageRoot, "package.json"), "utf-8"),
+				) as { version: string };
+				const cacheSkillsDir = join(
+					codexHomeDir,
+					"plugins",
+					"cache",
+					"oh-my-codex-local",
+					"oh-my-codex",
+					pkg.version,
+					"skills",
+				);
+				assert.equal(existsSync(join(cacheSkillsDir, "team", "SKILL.md")), false);
+				assert.equal(existsSync(join(cacheSkillsDir, "worker", "SKILL.md")), false);
+				assert.equal(existsSync(join(cacheSkillsDir, "ralph", "SKILL.md")), true);
+				assert.equal(existsSync(join(codexHomeDir, "agents", "team-executor.toml")), false);
+				assert.equal(existsSync(join(codexHomeDir, "agents", "executor.toml")), true);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("keeps legacy-mode next steps describing native agent TOML output", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -184,6 +184,9 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       }
       assert.equal(existsSync(join(wd, ".codex", "skills", "team", "SKILL.md")), false);
       assert.equal(existsSync(join(wd, ".codex", "skills", "worker", "SKILL.md")), false);
+      assert.equal(existsSync(join(wd, ".codex", "prompts", "team-executor.md")), false);
+      assert.equal(existsSync(join(wd, ".codex", "agents", "team-executor.toml")), false);
+      assert.equal(existsSync(join(wd, ".codex", "agents", "executor.toml")), true);
 
       const persisted = JSON.parse(
         await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
@@ -197,6 +200,36 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       assert.doesNotMatch(agents, /\bteam-executor\b/);
       assert.match(agents, /\$ralph/);
       assert.match(agents, /autopilot/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("removes managed Team guidance and role files when Team mode is disabled on refresh", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-disable-team-"));
+    try {
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        installMode: "legacy",
+        teamMode: "enabled",
+      });
+      assert.equal(existsSync(join(wd, ".codex", "prompts", "team-executor.md")), true);
+      assert.equal(existsSync(join(wd, ".codex", "agents", "team-executor.toml")), true);
+      assert.match(await readFile(join(wd, "AGENTS.md"), "utf-8"), /\$team/);
+
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        installMode: "legacy",
+        teamMode: "disabled",
+      });
+
+      assert.equal(existsSync(join(wd, ".codex", "prompts", "team-executor.md")), false);
+      assert.equal(existsSync(join(wd, ".codex", "agents", "team-executor.toml")), false);
+      const agents = await readFile(join(wd, "AGENTS.md"), "utf-8");
+      assert.doesNotMatch(agents, /\$team/);
+      assert.doesNotMatch(agents, /<team_(?:compositions|pipeline|model_resolution)>/);
+      assert.doesNotMatch(agents, /\bteam-executor\b/);
+      assert.match(agents, /\$ralph/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -159,6 +159,49 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("omits Team skills and generated guidance when Team mode is disabled", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-no-team-"));
+    try {
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        installMode: "legacy",
+        teamMode: "disabled",
+      });
+
+      for (const skillName of [
+        "autopilot",
+        "ralplan",
+        "ralph",
+        "ultragoal",
+        "code-review",
+        "ultraqa",
+      ]) {
+        assert.equal(
+          existsSync(join(wd, ".codex", "skills", skillName, "SKILL.md")),
+          true,
+          `expected disabled Team setup to preserve ${skillName}`,
+        );
+      }
+      assert.equal(existsSync(join(wd, ".codex", "skills", "team", "SKILL.md")), false);
+      assert.equal(existsSync(join(wd, ".codex", "skills", "worker", "SKILL.md")), false);
+
+      const persisted = JSON.parse(
+        await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+      ) as { teamMode?: string };
+      assert.equal(persisted.teamMode, "disabled");
+
+      const agents = await readFile(join(wd, "AGENTS.md"), "utf-8");
+      assert.doesNotMatch(agents, /\$team/);
+      assert.doesNotMatch(agents, /<team_(?:compositions|pipeline|model_resolution)>/);
+      assert.doesNotMatch(agents, /\bTeam mode\b/);
+      assert.doesNotMatch(agents, /\bteam-executor\b/);
+      assert.match(agents, /\$ralph/);
+      assert.match(agents, /autopilot/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("appends missing OMX project ignore rules to an existing project .gitignore without duplicating them", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -786,7 +786,7 @@ describe('runDeferredGlobalUpdate', () => {
       await mkdir(join(cwd, '.omx'), { recursive: true });
       await writeFile(
         join(cwd, '.omx', 'setup-scope.json'),
-        JSON.stringify({ scope: 'user', installMode: 'plugin', mcpMode: 'none' }, null, 2),
+        JSON.stringify({ scope: 'user', installMode: 'plugin', mcpMode: 'none', teamMode: 'disabled' }, null, 2),
       );
 
       const result = runDeferredGlobalUpdate(
@@ -806,7 +806,7 @@ describe('runDeferredGlobalUpdate', () => {
 
       assert.equal(result.ok, true);
       assert.equal(calls.length, 1);
-      assert.match(calls[0].args[1], /'omx' 'setup' '--scope' 'user' '--plugin' '--mcp' 'none'/);
+      assert.match(calls[0].args[1], /'omx' 'setup' '--scope' 'user' '--plugin' '--mcp' 'none' '--disable-team'/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -821,7 +821,7 @@ describe('runDeferredGlobalUpdate', () => {
       const setupScopePath = join(cwd, '.omx', 'setup-scope.json');
       await writeFile(
         setupScopePath,
-        JSON.stringify({ scope: 'user', installMode: 'plugin', mcpMode: 'none' }, null, 2),
+        JSON.stringify({ scope: 'user', installMode: 'plugin', mcpMode: 'none', teamMode: 'disabled' }, null, 2),
       );
 
       const result = runDeferredGlobalUpdate(
@@ -846,7 +846,7 @@ describe('runDeferredGlobalUpdate', () => {
 
       assert.equal(result.ok, true);
       assert.equal(calls.length, 1);
-      assert.match(calls[0].args[1], /'omx' 'setup' '--scope' 'user' '--plugin' '--mcp' 'none'/);
+      assert.match(calls[0].args[1], /'omx' 'setup' '--scope' 'user' '--plugin' '--mcp' 'none' '--disable-team'/);
       assert.doesNotMatch(calls[0].args[1], /compat/);
       assert.doesNotMatch(calls[0].args[1], /legacy/);
     } finally {
@@ -938,7 +938,7 @@ describe('post-update setup refresh handoff', () => {
       await mkdir(join(cwd, '.omx'), { recursive: true });
       await writeFile(
         join(cwd, '.omx', 'setup-scope.json'),
-        JSON.stringify({ scope: 'user', installMode: 'plugin', mcpMode: 'none' }, null, 2),
+        JSON.stringify({ scope: 'user', installMode: 'plugin', mcpMode: 'none', teamMode: 'disabled' }, null, 2),
       );
 
       const result = spawnInstalledSetupRefresh(
@@ -959,6 +959,7 @@ describe('post-update setup refresh handoff', () => {
         '--plugin',
         '--mcp',
         'none',
+        '--disable-team',
       ]);
       assert.deepEqual(resolveSetupRefreshArgs(cwd), [
         'setup',
@@ -967,6 +968,7 @@ describe('post-update setup refresh handoff', () => {
         '--plugin',
         '--mcp',
         'none',
+        '--disable-team',
       ]);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,9 +13,11 @@ import {
   setup,
   SETUP_MCP_MODES,
   SETUP_SCOPES,
+  SETUP_TEAM_MODES,
   type SetupInstallMode,
   type SetupMcpMode,
   type SetupScope,
+  type SetupTeamMode,
 } from "./setup.js";
 import { uninstall } from "./uninstall.js";
 import { version } from "./version.js";
@@ -287,6 +289,11 @@ Options:
                 Explicit setup MCP mode (default: none; compat enables first-party MCP compatibility and shared registry sync)
   --no-mcp      Alias for --mcp=none
   --with-mcp    Alias for --mcp=compat
+  --disable-team
+                Disable Team skill/context generation for setup (default remains enabled)
+  --enable-team Re-enable Team skill/context generation for setup
+  --team-mode <enabled|disabled>
+                Explicit Team setup mode
   --keep-config Skip config.toml cleanup during uninstall
   --purge       Remove .omx/ cache directory during uninstall
   --verbose     Show detailed output
@@ -549,6 +556,54 @@ export function resolveSetupScopeArg(args: string[]): SetupScope | undefined {
   throw new Error(
     `Invalid setup scope: ${value}. Expected one of: ${SETUP_SCOPES.join(", ")}`,
   );
+}
+
+export function resolveSetupTeamModeArg(args: string[]): SetupTeamMode | undefined {
+  let value: SetupTeamMode | undefined;
+  const setValue = (next: SetupTeamMode, source: string): void => {
+    if (value && value !== next) {
+      throw new Error(
+        `Conflicting setup Team mode flags: ${source} selects ${next}, but another flag already selected ${value}`,
+      );
+    }
+    value = next;
+  };
+  const parseValue = (next: string): SetupTeamMode => {
+    if (!SETUP_TEAM_MODES.includes(next as SetupTeamMode)) {
+      throw new Error(
+        `Invalid setup Team mode: ${next}. Expected one of: enabled, disabled`,
+      );
+    }
+    return next as SetupTeamMode;
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--disable-team" || arg === "--no-team") {
+      setValue("disabled", arg);
+      continue;
+    }
+    if (arg === "--enable-team" || arg === "--team") {
+      setValue("enabled", arg);
+      continue;
+    }
+    if (arg === "--team-mode") {
+      const next = args[index + 1];
+      if (!next || next.startsWith("-")) {
+        throw new Error(
+          `Missing setup Team mode value after --team-mode. Expected one of: enabled, disabled`,
+        );
+      }
+      setValue(parseValue(next), arg);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--team-mode=")) {
+      setValue(parseValue(arg.slice("--team-mode=".length)), "--team-mode");
+    }
+  }
+
+  return value;
 }
 
 export function resolveCliInvocation(args: string[]): ResolvedCliInvocation {
@@ -1785,6 +1840,7 @@ export async function main(args: string[]): Promise<void> {
           scope: resolveSetupScopeArg(args.slice(1)),
           installMode: resolveSetupInstallModeArg(args.slice(1)),
           mcpMode: resolveSetupMcpModeArg(args.slice(1)),
+          teamMode: resolveSetupTeamModeArg(args.slice(1)),
         });
         break;
       case "update":

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 import { cp, readdir, readFile, rm, writeFile } from "fs/promises";
 import { join, resolve } from "path";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
+import { teamModeEnabled, type SetupTeamMode } from "../config/team-mode.js";
 
 export const OMX_LOCAL_MARKETPLACE_NAME = "oh-my-codex-local";
 export const OMX_PLUGIN_NAME = "oh-my-codex";
@@ -30,6 +31,7 @@ interface PluginManifest {
 }
 
 const OMX_PLUGIN_HOOK_LAUNCHER_FILE = "omx-command.json";
+const TEAM_MODE_PLUGIN_SKILL_NAMES = new Set(["team", "worker"]);
 
 export async function resolvePackagedOmxMarketplace(
 	packageRoot: string,
@@ -114,8 +116,13 @@ export async function packagedOmxPluginVersion(
 
 export async function expectedPackagedOmxSkillNames(
 	packagedMarketplace: PackagedOmxMarketplace,
+	options: { teamMode?: SetupTeamMode } = {},
 ): Promise<string[] | null> {
-	return listChildDirectoryNames(join(packagedMarketplace.pluginRoot, "skills"));
+	const skillNames = await listChildDirectoryNames(join(packagedMarketplace.pluginRoot, "skills"));
+	if (!skillNames) return null;
+	return skillNames.filter((name) => (
+		teamModeEnabled(options.teamMode) || !TEAM_MODE_PLUGIN_SKILL_NAMES.has(name)
+	));
 }
 
 export function omxPluginCacheBase(codexHomeDir: string): string {
@@ -207,10 +214,11 @@ export async function readOmxPluginCacheState(
 export async function hasExpectedOmxPluginCache(
 	codexHomeDir: string,
 	packagedMarketplace: PackagedOmxMarketplace,
+	options: { teamMode?: SetupTeamMode } = {},
 ): Promise<boolean> {
 	const [version, expectedSkillNames] = await Promise.all([
 		packagedOmxPluginVersion(packagedMarketplace),
-		expectedPackagedOmxSkillNames(packagedMarketplace),
+		expectedPackagedOmxSkillNames(packagedMarketplace, options),
 	]);
 	if (!version || !expectedSkillNames) return false;
 	const state = await readOmxPluginCacheState(
@@ -244,6 +252,16 @@ async function writePinnedHookLauncher(
 	);
 }
 
+async function applyTeamModeToPluginCache(
+	cacheDir: string,
+	teamMode: SetupTeamMode | undefined,
+): Promise<void> {
+	if (teamModeEnabled(teamMode)) return;
+	for (const skillName of TEAM_MODE_PLUGIN_SKILL_NAMES) {
+		await rm(join(cacheDir, "skills", skillName), { recursive: true, force: true });
+	}
+}
+
 export interface OmxPluginCacheMaterializeResult {
 	status: "unavailable" | "unchanged" | "materialized";
 	cacheDir?: string;
@@ -253,18 +271,19 @@ export interface OmxPluginCacheMaterializeResult {
 export async function materializePackagedOmxPluginCache(
 	codexHomeDir: string,
 	packagedMarketplace: PackagedOmxMarketplace | null,
-	options: { dryRun?: boolean } = {},
+	options: { dryRun?: boolean; teamMode?: SetupTeamMode } = {},
 ): Promise<OmxPluginCacheMaterializeResult> {
 	if (!packagedMarketplace) return { status: "unavailable" };
 	const version = await packagedOmxPluginVersion(packagedMarketplace);
 	if (!version) return { status: "unavailable" };
 	const cacheDir = join(omxPluginCacheBase(codexHomeDir), version);
-	if (await hasExpectedOmxPluginCache(codexHomeDir, packagedMarketplace)) {
+	if (await hasExpectedOmxPluginCache(codexHomeDir, packagedMarketplace, options)) {
 		return { status: "unchanged", cacheDir, version };
 	}
 	if (!options.dryRun) {
 		await rm(cacheDir, { recursive: true, force: true });
 		await cp(packagedMarketplace.pluginRoot, cacheDir, { recursive: true });
+		await applyTeamModeToPluginCache(cacheDir, options.teamMode);
 		await writePinnedHookLauncher(cacheDir, packagedMarketplace);
 	}
 	return { status: "materialized", cacheDir, version };

--- a/src/cli/setup-preferences.ts
+++ b/src/cli/setup-preferences.ts
@@ -1,6 +1,10 @@
 import { existsSync, readFileSync } from "fs";
 import { readFile } from "fs/promises";
 import { join } from "path";
+import {
+	isSetupTeamMode,
+	type SetupTeamMode,
+} from "../config/team-mode.js";
 
 export const SETUP_SCOPES = ["user", "project"] as const;
 export type SetupScope = (typeof SETUP_SCOPES)[number];
@@ -15,6 +19,7 @@ export interface PersistedSetupScope {
 	scope: SetupScope;
 	installMode?: SetupInstallMode;
 	mcpMode?: SetupMcpMode;
+	teamMode?: SetupTeamMode;
 }
 
 export type PartialPersistedSetupScope = Partial<PersistedSetupScope>;
@@ -47,6 +52,7 @@ function parsePersistedSetupPreferences(
 		scope: unknown;
 		installMode: unknown;
 		mcpMode: unknown;
+		teamMode: unknown;
 	}>;
 	const persisted: PartialPersistedSetupScope = {};
 
@@ -70,6 +76,10 @@ function parsePersistedSetupPreferences(
 
 	if (typeof parsed.mcpMode === "string" && isSetupMcpMode(parsed.mcpMode)) {
 		persisted.mcpMode = parsed.mcpMode;
+	}
+
+	if (typeof parsed.teamMode === "string" && isSetupTeamMode(parsed.teamMode)) {
+		persisted.teamMode = parsed.teamMode;
 	}
 
 	return Object.keys(persisted).length > 0 ? persisted : undefined;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -81,6 +81,10 @@ import { getCatalogHeadlineCounts } from "./catalog-contract.js";
 import { tryReadCatalogManifest } from "../catalog/reader.js";
 import { DEFAULT_FRONTIER_MODEL } from "../config/models.js";
 import {
+	teamModeEnabled,
+	type SetupTeamMode,
+} from "../config/team-mode.js";
+import {
 	addGeneratedAgentsMarker,
 	hasOmxAgentsContract,
 	hasOmxManagedAgentsSections,
@@ -146,6 +150,7 @@ interface SetupOptions {
 	dryRun?: boolean;
 	installMode?: SetupInstallMode;
 	mcpMode?: SetupMcpMode;
+	teamMode?: SetupTeamMode;
 	scope?: SetupScope;
 	verbose?: boolean;
 	agentsOverwritePrompt?: (destinationPath: string) => Promise<boolean>;
@@ -173,6 +178,7 @@ interface SetupOptions {
 }
 
 export { SETUP_INSTALL_MODES, SETUP_MCP_MODES, SETUP_SCOPES };
+export { SETUP_TEAM_MODES, type SetupTeamMode } from "../config/team-mode.js";
 export type { SetupInstallMode, SetupMcpMode, SetupScope };
 
 export interface ScopeDirectories {
@@ -236,6 +242,8 @@ const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".codex/"] as const;
 const SETUP_ONLY_INSTALLABLE_SKILLS = new Set(["wiki"]);
 const DEFAULT_SETUP_MCP_MODE: SetupMcpMode = "none";
 const HARD_DEPRECATED_SKILL_NAMES = new Set(["web-clone"]);
+const TEAM_MODE_SKILL_NAMES = new Set(["team", "worker"]);
+const TEAM_MODE_NATIVE_AGENT_NAMES = new Set(["team-executor"]);
 
 function isCatalogInstallableStatus(status: string | undefined): boolean {
 	return status === "active" || status === "internal";
@@ -276,6 +284,61 @@ function applyPluginModeWordingToAgentsTemplate(
 	return scopedContent.replace(
 		/Role prompts under `prompts\/\*\.md` are narrower execution surfaces\. They must follow this file, not override it\.\nWhen OMX is installed, load the installed prompt\/skill\/agent surfaces from [^\n]+active\)\./,
 		`Registered Codex plugin marketplace surfaces supply OMX workflows and plugin-scoped companion resources when the plugin is installed. Native agent roles are installed as setup-owned Codex agent TOML files in plugin mode so agent_type routing works. They must follow this file, not override it.\nUser-installed skills may still live under ${userSkillPath}.`,
+		);
+}
+
+function stripNamedXmlSection(content: string, sectionName: string): string {
+	return content.replace(
+		new RegExp(`\\n?<${sectionName}>[\\s\\S]*?<\\/${sectionName}>\\n?`, "g"),
+		"\n",
+	);
+}
+
+function applyTeamModeToAgentsTemplate(content: string, teamMode: SetupTeamMode): string {
+	if (teamModeEnabled(teamMode)) return content;
+
+	let next = content;
+	for (const section of ["team_compositions", "team_pipeline", "team_model_resolution"]) {
+		next = stripNamedXmlSection(next, section);
+	}
+
+	return next
+		.replace(/\(\+ \$team if needed\)/g, "")
+		.replace(/- `\$team` when[^\n]*\n/g, "")
+		.replace(/,?\s*`team`,?/g, "")
+		.replace(/\s*\|\s*`\$team ".*?"`\s*\|.*\|\n/g, "\n")
+		.replace(/,?\s*`\$team`/g, "")
+		.replace(/`\$team`,?\s*/g, "")
+		.replace(/\/?\s*`team`\/`swarm`/g, "`swarm`")
+		.split("\n")
+		.filter((line) => {
+			const normalized = line.toLowerCase();
+			if (normalized.includes("team mode")) return false;
+			if (normalized.includes("team runtime")) return false;
+			if (normalized.includes("team orchestration")) return false;
+			if (normalized.includes("team/swarm")) return false;
+			if (normalized.includes("team pipeline")) return false;
+			if (normalized.includes("runtime/team")) return false;
+			if (normalized.includes("team overlays")) return false;
+			if (normalized.includes("team pane")) return false;
+			if (normalized.startsWith("- teams may ")) return false;
+			if (normalized.includes("outside active `team`")) return false;
+			if (normalized.includes("reserve `worker`")) return false;
+			if (normalized.includes("worker` is a team-runtime")) return false;
+			if (normalized.includes("team-plan")) return false;
+			if (normalized.includes("omx team")) return false;
+			return true;
+		})
+		.join("\n")
+		.replace(/\n{3,}/g, "\n\n");
+}
+
+function getAgentsModelTableDefinitionsForTeamMode(teamMode: SetupTeamMode) {
+	if (teamModeEnabled(teamMode)) return AGENT_DEFINITIONS;
+	return Object.fromEntries(
+		Object.entries(AGENT_DEFINITIONS).filter(
+			([name]) => !TEAM_MODE_NATIVE_AGENT_NAMES.has(name),
+		),
 	);
 }
 
@@ -680,7 +743,7 @@ async function promptForFirstPartyMcpRemoval(
 function hasPersistedSetupPreferences(
 	preferences: Partial<PersistedSetupScope> | undefined,
 ): preferences is Partial<PersistedSetupScope> {
-	return Boolean(preferences?.scope || preferences?.installMode);
+	return Boolean(preferences?.scope || preferences?.installMode || preferences?.teamMode);
 }
 
 function formatPersistedSetupPreferenceSummary(
@@ -690,6 +753,7 @@ function formatPersistedSetupPreferenceSummary(
 		`scope=${preferences.scope ?? "not recorded"}`,
 		`installMode=${preferences.installMode ?? "not recorded"}`,
 		`mcpMode=${preferences.mcpMode ?? "not recorded"}`,
+		`teamMode=${preferences.teamMode ?? "enabled"}`,
 	].join(", ");
 }
 
@@ -1715,6 +1779,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		dryRun = false,
 		installMode: requestedInstallMode,
 		mcpMode: requestedMcpMode,
+		teamMode: requestedTeamMode,
 		scope: requestedScope,
 		verbose = false,
 		setupScopePrompt,
@@ -1747,9 +1812,14 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		Boolean(persistedPreferences?.mcpMode) &&
 		(!persistedPreferences?.scope ||
 			persistedPreferences.scope === effectiveScopeForInstallMode);
+	const wouldUsePersistedTeamMode =
+		!requestedTeamMode &&
+		Boolean(persistedPreferences?.teamMode) &&
+		(!persistedPreferences?.scope ||
+			persistedPreferences.scope === effectiveScopeForInstallMode);
 	const shouldReviewPersistedSetup =
 		hasPersistedSetupPreferences(persistedPreferences) &&
-		(wouldUsePersistedScope || wouldUsePersistedInstallMode || wouldUsePersistedMcpMode) &&
+		(wouldUsePersistedScope || wouldUsePersistedInstallMode || wouldUsePersistedMcpMode || wouldUsePersistedTeamMode) &&
 		(typeof persistedSetupReviewPrompt === "function" ||
 			(process.stdin.isTTY && process.stdout.isTTY));
 	if (shouldReviewPersistedSetup) {
@@ -1781,6 +1851,16 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		persistedReviewDecision,
 		persistedPreferences,
 	);
+	const resolvedTeamMode: SetupTeamMode =
+		requestedTeamMode
+		?? (
+			persistedReviewDecision !== "reset" &&
+			(!persistedPreferences?.scope || persistedPreferences.scope === resolvedScope.scope)
+				? persistedPreferences?.teamMode
+				: undefined
+		)
+		?? "enabled";
+	const isTeamModeEnabled = teamModeEnabled(resolvedTeamMode);
 	const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
 	const existingConfigForMcpMigration = existsSync(scopeDirs.codexConfigFile)
 		? await readFile(scopeDirs.codexConfigFile, "utf-8")
@@ -1855,6 +1935,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	console.log(
 		`Using setup MCP mode: ${resolvedMcpMode.mcpMode}${mcpModeSourceMessage}\n`,
 	);
+	console.log(`Using setup Team mode: ${resolvedTeamMode}\n`);
 	if (shouldOfferFirstPartyMcpRemoval) {
 		if (removeFirstPartyMcpRegistrations) {
 			console.log(
@@ -1895,6 +1976,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	const setupPreferencesToPersist: PersistedSetupScope = {
 		scope: resolvedScope.scope,
 		mcpMode: resolvedMcpMode.mcpMode,
+		teamMode: resolvedTeamMode,
 		...(resolvedInstallMode &&
 		(resolvedScope.scope === "user" ||
 			resolvedInstallMode.installMode === "plugin")
@@ -2018,6 +2100,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 					force,
 					dryRun,
 					verbose,
+					teamMode: resolvedTeamMode,
 				},
 			);
 		}
@@ -2318,14 +2401,18 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		);
 	}
 
-	// Step 5.5: Verify team CLI interop surface is available.
+	// Step 5.5: Verify team CLI interop surface is available when Team is enabled.
 	console.log("[5.5/8] Verifying Team CLI API interop...");
-	const teamToolsCheck = await verifyTeamCliApiInterop(pkgRoot);
-	if (teamToolsCheck.ok) {
-		console.log("  omx team api command detected (CLI-first interop ready)");
+	if (isTeamModeEnabled) {
+		const teamToolsCheck = await verifyTeamCliApiInterop(pkgRoot);
+		if (teamToolsCheck.ok) {
+			console.log("  omx team api command detected (CLI-first interop ready)");
+		} else {
+			console.log(`  WARNING: ${teamToolsCheck.message}`);
+			console.log("  Run `npm run build` and then re-run `omx setup`.");
+		}
 	} else {
-		console.log(`  WARNING: ${teamToolsCheck.message}`);
-		console.log("  Run `npm run build` and then re-run `omx setup`.");
+		console.log("  Skipped because Team mode is disabled for this setup.");
 	}
 	console.log();
 
@@ -2354,14 +2441,20 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 						codexHomeOverride: scopeDirs.codexHomeDir,
 					},
 				);
+				const modelTableDefinitions =
+					getAgentsModelTableDefinitionsForTeamMode(resolvedTeamMode);
 				const rewritten = upsertAgentsModelTable(
 					addGeneratedAgentsMarker(
-						applyPluginModeWordingToAgentsTemplate(
-							content,
-							resolvedScope.scope,
+						applyTeamModeToAgentsTemplate(
+							applyPluginModeWordingToAgentsTemplate(
+								content,
+								resolvedScope.scope,
+							),
+							resolvedTeamMode,
 						),
 					),
 					modelTableContext,
+					modelTableDefinitions,
 				);
 				const result = await syncManagedAgentsContent(
 					rewritten,
@@ -2424,11 +2517,17 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			const modelTableContext = resolveAgentsModelTableContext(resolvedConfig, {
 				codexHomeOverride: scopeDirs.codexHomeDir,
 			});
+			const modelTableDefinitions =
+				getAgentsModelTableDefinitionsForTeamMode(resolvedTeamMode);
 			const rewritten = upsertAgentsModelTable(
 				addGeneratedAgentsMarker(
-					applyScopePathRewritesToAgentsTemplate(content, resolvedScope.scope),
+					applyTeamModeToAgentsTemplate(
+						applyScopePathRewritesToAgentsTemplate(content, resolvedScope.scope),
+						resolvedTeamMode,
+					),
 				),
 				modelTableContext,
+				modelTableDefinitions,
 			);
 			let changed = true;
 			let canApplyManagedModelRefresh = false;
@@ -2456,6 +2555,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 						managedRefreshContent = upsertAgentsModelTable(
 							existing,
 							modelTableContext,
+							modelTableDefinitions,
 						);
 						canApplyManagedModelRefresh = managedRefreshContent !== existing;
 					}
@@ -3202,6 +3302,13 @@ export async function installSkills(
 	for (const entry of entries) {
 		if (!entry.isDirectory()) continue;
 		staleCandidateSkillNames.add(entry.name);
+		if (!teamModeEnabled(options.teamMode) && TEAM_MODE_SKILL_NAMES.has(entry.name)) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				console.log(`  skipped ${entry.name}/ (Team mode disabled)`);
+			}
+			continue;
+		}
 		const status = skillStatusByName?.get(entry.name);
 		if (skillStatusByName && !isSetupInstallableSkill(entry.name, status)) {
 			summary.skipped += 1;
@@ -3271,9 +3378,10 @@ export async function installSkills(
 	if (manifest && existsSync(dstDir)) {
 		for (const staleSkill of staleCandidateSkillNames) {
 			const status = skillStatusByName?.get(staleSkill);
-			if (isSetupInstallableSkill(staleSkill, status)) continue;
+			const disabledTeamSkill = !teamModeEnabled(options.teamMode) && TEAM_MODE_SKILL_NAMES.has(staleSkill);
+			if (isSetupInstallableSkill(staleSkill, status) && !disabledTeamSkill) continue;
 			const hardDeprecated = HARD_DEPRECATED_SKILL_NAMES.has(staleSkill);
-			if (!options.force && !hardDeprecated) continue;
+			if (!options.force && !hardDeprecated && !disabledTeamSkill) continue;
 
 			const staleSkillDir = join(dstDir, staleSkill);
 			if (!existsSync(staleSkillDir)) continue;
@@ -3287,7 +3395,9 @@ export async function installSkills(
 					? "would remove stale skill"
 					: "removed stale skill";
 				const label = status ?? "unlisted";
-				const reason = hardDeprecated ? ", hard-deprecated" : "";
+				const reason = disabledTeamSkill
+					? ", Team mode disabled"
+					: hardDeprecated ? ", hard-deprecated" : "";
 				console.log(`  ${prefix} ${staleSkill}/ (status: ${label}${reason})`);
 			}
 		}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -243,6 +243,7 @@ const SETUP_ONLY_INSTALLABLE_SKILLS = new Set(["wiki"]);
 const DEFAULT_SETUP_MCP_MODE: SetupMcpMode = "none";
 const HARD_DEPRECATED_SKILL_NAMES = new Set(["web-clone"]);
 const TEAM_MODE_SKILL_NAMES = new Set(["team", "worker"]);
+const TEAM_MODE_PROMPT_NAMES = new Set(["team-executor"]);
 const TEAM_MODE_NATIVE_AGENT_NAMES = new Set(["team-executor"]);
 
 function isCatalogInstallableStatus(status: string | undefined): boolean {
@@ -2034,7 +2035,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				promptsSrc,
 				promptsDst,
 				backupContext,
-				{ force, dryRun, verbose },
+				{ force, dryRun, verbose, teamMode: resolvedTeamMode },
 			);
 			const cleanedLegacyPromptShims = await cleanupLegacySkillPromptShims(
 				promptsSrc,
@@ -2128,6 +2129,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				dryRun,
 				verbose,
 				preserveUnmanagedObsoleteNativeAgents: true,
+				teamMode: resolvedTeamMode,
 			},
 		);
 		console.log(
@@ -2142,6 +2144,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				force,
 				dryRun,
 				verbose,
+				teamMode: resolvedTeamMode,
 			},
 		);
 		console.log(
@@ -2269,7 +2272,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		const pluginCacheMaterialize = await materializePackagedOmxPluginCache(
 			scopeDirs.codexHomeDir,
 			packagedMarketplace,
-			{ dryRun },
+			{ dryRun, teamMode: resolvedTeamMode },
 		);
 		if (pluginCacheMaterialize.status === "materialized") {
 			console.log(
@@ -2534,6 +2537,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			);
 			let changed = true;
 			let canApplyManagedModelRefresh = false;
+			let canApplyManagedRefreshDuringActiveSession = false;
 			let managedRefreshContent = "";
 			let canApplyManagedAgentsMerge = false;
 			let mergedAgentsContent = "";
@@ -2555,12 +2559,21 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 					canApplyManagedAgentsMerge = mergedAgentsContent !== existing;
 				} else {
 					if (hasOmxManagedAgentsSections(existing)) {
-						managedRefreshContent = upsertAgentsModelTable(
-							existing,
-							modelTableContext,
-							modelTableDefinitions,
-						);
+						const existingIsGeneratedAgentsMd = isOmxGeneratedAgentsMd(existing);
+						managedRefreshContent = teamModeEnabled(resolvedTeamMode)
+							? upsertAgentsModelTable(
+									existing,
+									modelTableContext,
+									modelTableDefinitions,
+								)
+							: existingIsGeneratedAgentsMd
+								? rewritten
+								: upsertManagedAgentsBlock(existing, rewritten);
 						canApplyManagedModelRefresh = managedRefreshContent !== existing;
+						canApplyManagedRefreshDuringActiveSession =
+							canApplyManagedModelRefresh &&
+							!teamModeEnabled(resolvedTeamMode) &&
+							existingIsGeneratedAgentsMd;
 					}
 				}
 			}
@@ -2569,7 +2582,8 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				resolvedScope.scope === "project" &&
 				sessionIsActive &&
 				agentsMdExists &&
-				(changed || canApplyManagedAgentsMerge || canApplyManagedModelRefresh)
+				(changed || canApplyManagedAgentsMerge || canApplyManagedModelRefresh) &&
+				!canApplyManagedRefreshDuringActiveSession
 			) {
 				summary.agentsMd.skipped += 1;
 				console.log(
@@ -2987,6 +3001,13 @@ async function installPrompts(
 	for (const file of files) {
 		if (!file.endsWith(".md")) continue;
 		const promptName = file.slice(0, -3);
+		if (!teamModeEnabled(options.teamMode) && TEAM_MODE_PROMPT_NAMES.has(promptName)) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				console.log(`  skipped ${file} (Team mode disabled)`);
+			}
+			continue;
+		}
 
 		const status = agentStatusByName?.get(promptName);
 		if (manifest && !isSetupPromptAssetName(promptName, manifest)) {
@@ -3012,13 +3033,15 @@ async function installPrompts(
 		);
 	}
 
-	if (options.force && manifest && existsSync(dstDir)) {
+	if (manifest && existsSync(dstDir)) {
 		const installedFiles = await readdir(dstDir);
 		for (const file of installedFiles) {
 			if (!file.endsWith(".md")) continue;
 			const promptName = file.slice(0, -3);
 			const status = agentStatusByName?.get(promptName);
-			if (isSetupPromptAssetName(promptName, manifest)) continue;
+			const disabledTeamPrompt = !teamModeEnabled(options.teamMode) && TEAM_MODE_PROMPT_NAMES.has(promptName);
+			if (isSetupPromptAssetName(promptName, manifest) && !disabledTeamPrompt) continue;
+			if (!options.force && !disabledTeamPrompt) continue;
 
 			const stalePromptPath = join(dstDir, file);
 			if (!existsSync(stalePromptPath)) continue;
@@ -3035,7 +3058,8 @@ async function installPrompts(
 					? "would remove stale prompt"
 					: "removed stale prompt";
 				const label = status ?? "unlisted";
-				console.log(`  ${prefix} ${file} (status: ${label})`);
+				const reason = disabledTeamPrompt ? ", Team mode disabled" : "";
+				console.log(`  ${prefix} ${file} (status: ${label}${reason})`);
 			}
 		}
 	}
@@ -3115,6 +3139,7 @@ async function refreshNativeAgentConfigs(
 	backupContext: SetupBackupContext,
 	options: Pick<SetupOptions, "dryRun" | "verbose" | "force"> & {
 		preserveUnmanagedObsoleteNativeAgents?: boolean;
+		teamMode?: SetupTeamMode;
 	},
 ): Promise<SetupCategorySummary> {
 	const summary = createEmptyCategorySummary();
@@ -3137,6 +3162,13 @@ async function refreshNativeAgentConfigs(
 
 	for (const name of nativeAgentNames) {
 		staleCandidateNativeAgentNames.add(name);
+		if (!teamModeEnabled(options.teamMode) && TEAM_MODE_NATIVE_AGENT_NAMES.has(name)) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				console.log(`  skipped native agent ${name}.toml (Team mode disabled)`);
+			}
+			continue;
+		}
 		const agent = AGENT_DEFINITIONS[name];
 		if (!agent) {
 			if (options.verbose) {
@@ -3183,13 +3215,15 @@ async function refreshNativeAgentConfigs(
 		summary.removed += generatedCleanup.removed;
 	}
 
-	if (options.force && manifest && existsSync(agentsDir)) {
+	if (manifest && existsSync(agentsDir)) {
 		const installedFiles = await readdir(agentsDir);
 		for (const file of installedFiles) {
 			if (!file.endsWith(".toml")) continue;
 			const agentName = file.slice(0, -5);
 			const agentStatus = agentStatusByName?.get(agentName);
-			if (isNativeAgentInstallableStatus(agentStatus)) continue;
+			const disabledTeamAgent = !teamModeEnabled(options.teamMode) && TEAM_MODE_NATIVE_AGENT_NAMES.has(agentName);
+			if (isNativeAgentInstallableStatus(agentStatus) && !disabledTeamAgent) continue;
+			if (!options.force && !disabledTeamAgent) continue;
 			if (
 				!staleCandidateNativeAgentNames.has(agentName) &&
 				agentStatus === undefined
@@ -3211,7 +3245,8 @@ async function refreshNativeAgentConfigs(
 					? "would remove stale native agent"
 					: "removed stale native agent";
 				const label = agentStatus ?? "unlisted";
-				console.log(`  ${prefix} ${file} (status: ${label})`);
+				const reason = disabledTeamAgent ? ", Team mode disabled" : "";
+				console.log(`  ${prefix} ${file} (status: ${label}${reason})`);
 			}
 		}
 	}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -749,12 +749,13 @@ function hasPersistedSetupPreferences(
 function formatPersistedSetupPreferenceSummary(
 	preferences: Partial<PersistedSetupScope>,
 ): string {
-	return [
+	const summary = [
 		`scope=${preferences.scope ?? "not recorded"}`,
 		`installMode=${preferences.installMode ?? "not recorded"}`,
 		`mcpMode=${preferences.mcpMode ?? "not recorded"}`,
-		`teamMode=${preferences.teamMode ?? "enabled"}`,
-	].join(", ");
+	];
+	if (preferences.teamMode) summary.push(`teamMode=${preferences.teamMode}`);
+	return summary.join(", ");
 }
 
 async function promptForPersistedSetupReview(
@@ -1976,7 +1977,9 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	const setupPreferencesToPersist: PersistedSetupScope = {
 		scope: resolvedScope.scope,
 		mcpMode: resolvedMcpMode.mcpMode,
-		teamMode: resolvedTeamMode,
+		...(requestedTeamMode || persistedPreferences?.teamMode || resolvedTeamMode === "disabled"
+			? { teamMode: resolvedTeamMode }
+			: {}),
 		...(resolvedInstallMode &&
 		(resolvedScope.scope === "user" ||
 			resolvedInstallMode.installMode === "plugin")

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -165,6 +165,11 @@ export function resolveSetupRefreshArgs(cwd: string): string[] {
   if (preferences?.mcpMode) {
     args.push('--mcp', preferences.mcpMode);
   }
+  if (preferences?.teamMode === 'disabled') {
+    args.push('--disable-team');
+  } else if (preferences?.teamMode === 'enabled') {
+    args.push('--enable-team');
+  }
   return args;
 }
 

--- a/src/config/team-mode.ts
+++ b/src/config/team-mode.ts
@@ -1,0 +1,106 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { codexHome } from "../utils/paths.js";
+
+export const SETUP_TEAM_MODES = ["enabled", "disabled"] as const;
+export type SetupTeamMode = (typeof SETUP_TEAM_MODES)[number];
+
+export interface TeamModeConfig {
+	enabled: boolean;
+	status: "enabled" | "disabled" | "defaulted" | "invalid";
+	source: "default" | "env" | "setup" | "file" | "invalid";
+	path?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function booleanFromNestedConfig(parsed: unknown): boolean | undefined {
+	if (!isRecord(parsed)) return undefined;
+
+	const topLevel = parsed.teamMode;
+	if (topLevel === "enabled") return true;
+	if (topLevel === "disabled") return false;
+	if (isRecord(topLevel) && typeof topLevel.enabled === "boolean") {
+		return topLevel.enabled;
+	}
+
+	const orchestration = parsed.orchestration;
+	if (isRecord(orchestration)) {
+		const team = orchestration.team;
+		if (isRecord(team) && typeof team.enabled === "boolean") {
+			return team.enabled;
+		}
+	}
+
+	const features = parsed.features;
+	if (isRecord(features)) {
+		const team = features.team;
+		if (isRecord(team) && typeof team.enabled === "boolean") {
+			return team.enabled;
+		}
+		if (typeof team === "boolean") return team;
+	}
+
+	return undefined;
+}
+
+function readJson(path: string): unknown {
+	return JSON.parse(readFileSync(path, "utf-8")) as unknown;
+}
+
+function readBooleanFromJson(path: string): boolean | undefined {
+	if (!existsSync(path)) return undefined;
+	return booleanFromNestedConfig(readJson(path));
+}
+
+export function isSetupTeamMode(value: string): value is SetupTeamMode {
+	return SETUP_TEAM_MODES.includes(value as SetupTeamMode);
+}
+
+export function teamModeEnabled(mode: SetupTeamMode | undefined): boolean {
+	return mode !== "disabled";
+}
+
+export function readTeamModeConfig(cwd = process.cwd()): TeamModeConfig {
+	const env = process.env.OMX_TEAM_MODE?.trim().toLowerCase();
+	if (env === "enabled" || env === "1" || env === "true") {
+		return { enabled: true, status: "enabled", source: "env" };
+	}
+	if (env === "disabled" || env === "0" || env === "false") {
+		return { enabled: false, status: "disabled", source: "env" };
+	}
+
+	const setupPath = join(cwd, ".omx", "setup-scope.json");
+	try {
+		const enabled = readBooleanFromJson(setupPath);
+		if (enabled !== undefined) {
+			return {
+				enabled,
+				status: enabled ? "enabled" : "disabled",
+				source: "setup",
+				path: setupPath,
+			};
+		}
+	} catch {
+		return { enabled: true, status: "invalid", source: "invalid", path: setupPath };
+	}
+
+	const userConfigPath = join(codexHome(), ".omx-config.json");
+	try {
+		const enabled = readBooleanFromJson(userConfigPath);
+		if (enabled !== undefined) {
+			return {
+				enabled,
+				status: enabled ? "enabled" : "disabled",
+				source: "file",
+				path: userConfigPath,
+			};
+		}
+	} catch {
+		return { enabled: true, status: "invalid", source: "invalid", path: userConfigPath };
+	}
+
+	return { enabled: true, status: "defaulted", source: "default" };
+}

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1459,6 +1459,36 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('ignores disabled Team when selecting the primary workflow', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-disabled-primary-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'setup-scope.json'),
+        JSON.stringify({ scope: 'project', teamMode: 'disabled' }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$team $ralph ship this fix',
+        sessionId: 'sess-team-disabled-primary',
+        nowIso: '2026-04-10T01:00:00.000Z',
+      });
+
+      assert.equal(result?.skill, 'ralph');
+      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['ralph']);
+      assert.equal(existsSync(join(stateDir, 'team-state.json')), false);
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-team-disabled-primary', 'ralph-state.json')),
+        true,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('filters deferred team handoffs when persisted Team mode is disabled', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-disabled-deferred-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1430,6 +1430,66 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('does not activate team state when persisted Team mode is disabled', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-disabled-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'setup-scope.json'),
+        JSON.stringify({ scope: 'project', teamMode: 'disabled' }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$team coordinate the hotfix',
+        sessionId: 'sess-team-disabled',
+        nowIso: '2026-04-08T00:00:00.000Z',
+      });
+
+      assert.equal(result, null);
+      assert.equal(existsSync(join(stateDir, 'team-state.json')), false);
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-team-disabled', SKILL_ACTIVE_STATE_FILE)),
+        false,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('filters deferred team handoffs when persisted Team mode is disabled', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-disabled-deferred-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'setup-scope.json'),
+        JSON.stringify({ scope: 'project', teamMode: 'disabled' }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan $team $ralph ship this fix',
+        sessionId: 'sess-team-disabled-deferred',
+        nowIso: '2026-04-10T00:00:00.000Z',
+      });
+
+      assert.equal(result?.skill, 'ralplan');
+      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['ralplan']);
+      assert.deepEqual(result?.deferred_skills, ['ralph']);
+      assert.equal(existsSync(join(stateDir, 'team-state.json')), false);
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-team-disabled-deferred', 'team-state.json')),
+        false,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves active team root state when $team is re-entered from prompt routing', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-preserve-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -725,6 +725,15 @@ export function detectPrimaryKeyword(text: string): KeywordMatch | null {
   return matches.length > 0 ? matches[0] : null;
 }
 
+function filterMatchesForTeamMode(matches: KeywordMatch[], teamEnabled: boolean): KeywordMatch[] {
+  return teamEnabled ? matches : matches.filter((entry) => entry.skill !== 'team');
+}
+
+function detectPrimaryKeywordForTeamMode(text: string, teamEnabled: boolean): KeywordMatch | null {
+  const matches = filterMatchesForTeamMode(detectKeywords(text), teamEnabled);
+  return matches[0] ?? null;
+}
+
 function isActiveSkillContinuationPrompt(text: string): boolean {
   const normalized = text.trim();
   if (!normalized) return false;
@@ -894,20 +903,17 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   const previousRoot = await readExistingSkillState(rootStatePath);
   const previousSession = sessionStatePath ? await readExistingSkillState(sessionStatePath) : null;
   const previous = input.sessionId ? previousSession : previousRoot;
+  const teamMode = readTeamModeConfig(sourceCwd);
   const match = resolveContinuationKeywordMatch(
     input.text,
     previous,
-    detectPrimaryKeyword(input.text),
+    detectPrimaryKeywordForTeamMode(input.text, teamMode.enabled),
   );
   if (!match) return null;
-  const teamMode = readTeamModeConfig(sourceCwd);
-  if (!teamMode.enabled && match.skill === 'team') {
-    return null;
-  }
 
   const nowIso = input.nowIso ?? new Date().toISOString();
   const hadDeepInterviewLock = previous?.skill === 'deep-interview' && previous?.input_lock?.active === true;
-  const matches = detectKeywords(input.text);
+  const matches = filterMatchesForTeamMode(detectKeywords(input.text), teamMode.enabled);
   const hasCancelIntent = matches.some((entry) => entry.skill === 'cancel');
 
   if (hasCancelIntent && hadDeepInterviewLock) {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -18,6 +18,7 @@ import { isApprovedExecutionFollowupShortcut, type FollowupMode } from '../team/
 import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts.js';
 import { hasDurableRalplanConsensusEvidenceForCwd } from '../ralplan/consensus-gate.js';
 import { KEYWORD_TRIGGER_DEFINITIONS, compareKeywordMatches } from './keyword-registry.js';
+import { readTeamModeConfig } from '../config/team-mode.js';
 import {
   SKILL_ACTIVE_STATE_FILE,
   listActiveSkills,
@@ -899,6 +900,10 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     detectPrimaryKeyword(input.text),
   );
   if (!match) return null;
+  const teamMode = readTeamModeConfig(sourceCwd);
+  if (!teamMode.enabled && match.skill === 'team') {
+    return null;
+  }
 
   const nowIso = input.nowIso ?? new Date().toISOString();
   const hadDeepInterviewLock = previous?.skill === 'deep-interview' && previous?.input_lock?.active === true;
@@ -974,6 +979,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   const workflowMatches: TrackedWorkflowMode[] = isTrackedWorkflowMatch && !markedQuestionAnswerContinuation
     ? parseExplicitSkillInvocations(normalizedInputText).matches
       .map((entry) => entry.skill)
+      .filter((skill) => teamMode.enabled || skill !== 'team')
       .filter(isTrackedWorkflowMode)
     : [];
   const resolvedWorkflowRequest = isTrackedWorkflowMatch

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -15268,6 +15268,45 @@ describe("codex native hook triage integration", () => {
     }
   });
 
+  it("ignores disabled $team before outside-tmux Team blocking so later workflows can activate", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-disabled-team-primary-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeJson(join(cwd, ".omx", "setup-scope.json"), {
+        scope: "project",
+        teamMode: "disabled",
+      });
+      await writeSessionStart(cwd, "sess-disabled-team-primary");
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-disabled-team-primary",
+          thread_id: "thread-disabled-team-primary",
+          turn_id: "turn-disabled-team-primary",
+          prompt: "$team $ralph fix this",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.skillState?.skill, "ralph");
+      assert.equal(result.skillState?.transition_error, undefined);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "team-state.json")), false);
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "sessions", "sess-disabled-team-primary", "ralph-state.json")),
+        true,
+      );
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /detected workflow keyword "\$ralph" -> ralph/);
+      assert.doesNotMatch(additionalContext, /Codex App\/native outside-tmux sessions cannot activate/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("makes bare autopilot command activation observable in state and prompt guidance", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-autopilot-bare-observable-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -15233,6 +15233,41 @@ describe("codex native hook triage integration", () => {
     }
   });
 
+  it("omits Team handoff guidance from autopilot prompt context when Team mode is disabled", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-autopilot-observable-no-team-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeJson(join(cwd, ".omx", "setup-scope.json"), {
+        scope: "project",
+        teamMode: "disabled",
+      });
+      await writeSessionStart(cwd, "sess-autopilot-observable-no-team");
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-autopilot-observable-no-team",
+          thread_id: "thread-autopilot-observable-no-team",
+          turn_id: "turn-autopilot-observable-no-team",
+          prompt: "$autopilot implement issue #2430",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.skillState?.skill, "autopilot");
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /detected workflow keyword "\$autopilot" -> autopilot/);
+      assert.match(additionalContext, /\$deep-interview -> \$ralplan -> \$ultragoal -> \$code-review -> \$ultraqa/);
+      assert.doesNotMatch(additionalContext, /\$team/);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "team-state.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("makes bare autopilot command activation observable in state and prompt guidance", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-autopilot-bare-observable-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3324,8 +3324,10 @@ async function maybeBuildOrdinaryStopNoProgressOutput(
   stateDir: string,
   canonicalSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
-  const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
-  if (!stopHookActive) return null;
+  const lastAssistantMessage = safeString(
+    payload.last_assistant_message ?? payload.lastAssistantMessage,
+  ).trim();
+  if (!lastAssistantMessage) return null;
 
   const statePath = join(stateDir, NATIVE_STOP_STATE_FILE);
   const state = await readJsonIfExists(statePath) ?? {};

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -48,6 +48,7 @@ import {
   type SkillActiveState,
 } from "../hooks/keyword-detector.js";
 import { buildDeepInterviewConfigInstruction } from "../hooks/deep-interview-config-instruction.js";
+import { readTeamModeConfig } from "../config/team-mode.js";
 import {
   detectNativeStopStallPattern,
   loadAutoNudgeConfig,
@@ -1765,11 +1766,14 @@ function buildSkillStateCliInstruction(mode: string, statePath: string): string 
 
 function buildAutopilotPromptActivationNote(
   skillState?: SkillActiveState | null,
-  options: { markedQuestionAnswer?: boolean } = {},
+  options: { markedQuestionAnswer?: boolean; cwd?: string } = {},
 ): string | null {
   if (skillState?.initialized_mode !== "autopilot") return null;
+  const teamHandoff = readTeamModeConfig(options.cwd).enabled
+    ? " (+ $team if needed)"
+    : "";
   return [
-    "Autopilot protocol: the durable default chain is $deep-interview -> $ralplan -> $ultragoal (+ $team if needed) -> $code-review -> $ultraqa (deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa).",
+    `Autopilot protocol: the durable default chain is $deep-interview -> $ralplan -> $ultragoal${teamHandoff} -> $code-review -> $ultraqa (deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa).`,
     "Start/resume at current_phase=deep-interview unless the task is clear and bounded; if deep-interview is intentionally skipped, persist and state an explicit deep_interview_gate.skip_reason before moving to ralplan.",
     "Deep-interview is a structured question chain, not a one-question gate: after an omx question answer, re-score ambiguity against the active threshold, treat max_rounds as a cap, and crystallize once ambiguity is at or below threshold and readiness gates pass.",
     options.markedQuestionAnswer
@@ -1782,6 +1786,12 @@ function buildAutopilotPromptActivationNote(
   ].filter(Boolean).join(" ");
 }
 
+function formatExecutionHandoffList(cwd: string): string {
+  return readTeamModeConfig(cwd).enabled
+    ? "`$ultragoal`, `$team`, or `$ralph`"
+    : "`$ultragoal` or `$ralph`";
+}
+
 function buildAdditionalContextMessage(
   prompt: string,
   skillState?: SkillActiveState | null,
@@ -1790,8 +1800,9 @@ function buildAdditionalContextMessage(
 ): string | null {
   if (!prompt) return null;
   const promptPriorityMessage = buildPromptPriorityMessage(prompt);
-  const matches = detectKeywords(prompt);
-  const match = detectPrimaryKeyword(prompt);
+  const teamMode = readTeamModeConfig(cwd);
+  const matches = detectKeywords(prompt).filter((entry) => teamMode.enabled || entry.skill !== "team");
+  const match = matches[0] ?? null;
   if (!match) {
     const continuedSkill = safeString(skillState?.skill).trim();
     if (!continuedSkill) return promptPriorityMessage;
@@ -1800,7 +1811,7 @@ function buildAdditionalContextMessage(
       : null;
     const deepInterviewConfigPromptActivationNote = buildDeepInterviewConfigInstruction(cwd, skillState);
     const markedQuestionAnswer = /^\s*\[omx question answered\]/i.test(prompt);
-    const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { markedQuestionAnswer });
+    const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { markedQuestionAnswer, cwd });
     return [
       `OMX native UserPromptSubmit continued active workflow skill "${continuedSkill}".`,
       promptPriorityMessage,
@@ -1826,7 +1837,7 @@ function buildAdditionalContextMessage(
       ? buildDeepInterviewQuestionBridgeInstruction(cwd, payload)
       : null;
     const deepInterviewConfigPromptActivationNote = buildDeepInterviewConfigInstruction(cwd, skillState);
-    const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { markedQuestionAnswer: true });
+    const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { markedQuestionAnswer: true, cwd });
     return [
       `OMX native UserPromptSubmit continued active workflow skill "${continuedSkill}"; workflow-like tokens inside the marked omx question answer are treated as answer text, not a new workflow activation.`,
       promptPriorityMessage,
@@ -1859,7 +1870,7 @@ function buildAdditionalContextMessage(
   const ultragoalPromptActivationNote = match.skill === "ultragoal"
     ? "Ultragoal protocol: use `omx ultragoal create-goals` / `complete-goals` / `checkpoint` for `.omx/ultragoal` artifacts, then use Codex goal model tools only from the active agent handoff (`get_goal`, `create_goal`, `update_goal`) and never overwrite a different active Codex goal. Ultragoal does not call `/goal clear`; for multiple sequential ultragoal runs in one Codex session/thread, manually clear the completed Codex goal in the UI before creating the next aggregate goal."
     : null;
-  const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState);
+  const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { cwd });
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;
     if (matches.length <= 1 || activeSkills.length <= 1) return skillState.transition_message;
@@ -2761,7 +2772,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
         `${planningModeDescription}. `
         + "Write only planning artifacts under `.omx/context/`, `.omx/plans/`, `.omx/specs/`, or required `.omx/state/` files. "
         + "Do not edit implementation files or run implementation-focused writes from planning phases. "
-        + "To execute, first process an explicit handoff such as `$ultragoal`, `$team`, or `$ralph`, which must emit terminal planning state before implementation begins.",
+        + `To execute, first process an explicit handoff such as ${formatExecutionHandoffList(cwd)}, which must emit terminal planning state before implementation begins.`,
     },
   };
 }
@@ -2798,7 +2809,7 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       additionalContext:
-        "Deep-interview is requirements/spec mode. Treat detailed user answers as interview/spec material, not implicit implementation authorization. You may write only deep-interview artifacts under `.omx/context/`, `.omx/interviews/`, `.omx/specs/`, or required `.omx/state/` files. To implement, first ask for or process an explicit transition such as `$ralplan`, `$autopilot`, `$ralph`, `$team`, or `$ultragoal`.",
+        `Deep-interview is requirements/spec mode. Treat detailed user answers as interview/spec material, not implicit implementation authorization. You may write only deep-interview artifacts under \`.omx/context/\`, \`.omx/interviews/\`, \`.omx/specs/\`, or required \`.omx/state/\` files. To implement, first ask for or process an explicit transition such as \`$ralplan\`, \`$autopilot\`, ${formatExecutionHandoffList(cwd)}.`,
     },
   };
 }
@@ -3057,6 +3068,7 @@ async function reconcileStaleRootSkillActiveStateForStop(
 function buildRalplanContinuationStatus(
   blocker: { phase: string; latestPlanPath?: string; planningComplete?: boolean; runOutcome?: string },
   activeSubagentCount: number,
+  cwd: string,
 ): { reason: string; systemMessage: string; stopReasonSuffix: string } {
   const phase = blocker.phase || "planning";
   const artifact = blocker.latestPlanPath
@@ -3092,7 +3104,7 @@ function buildRalplanContinuationStatus(
   }
 
   const completeHint = blocker.planningComplete
-    ? " The planning artifacts are present; if consensus is approved, emit terminal ralplan complete/approved handoff state and stop planning. Implementation must wait for an explicit $ultragoal, $team, or $ralph handoff."
+    ? ` The planning artifacts are present; if consensus is approved, emit terminal ralplan complete/approved handoff state and stop planning. Implementation must wait for an explicit ${formatExecutionHandoffList(cwd).replaceAll("`", "")} handoff.`
     : "";
 
   return {
@@ -3312,6 +3324,9 @@ async function maybeBuildOrdinaryStopNoProgressOutput(
   stateDir: string,
   canonicalSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
+  const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
+  if (!stopHookActive) return null;
+
   const statePath = join(stateDir, NATIVE_STOP_STATE_FILE);
   const state = await readJsonIfExists(statePath) ?? {};
   const sessions = safeObject(state.sessions);
@@ -3342,9 +3357,6 @@ async function maybeBuildOrdinaryStopNoProgressOutput(
   };
   await mkdir(stateDir, { recursive: true });
   await writeFile(statePath, JSON.stringify({ ...state, sessions }, null, 2));
-
-  const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
-  if (!stopHookActive) return null;
 
   const maxRepeats = parseBoundedPositiveInteger(
     process.env.OMX_NATIVE_STOP_NO_PROGRESS_MAX_REPEATS,
@@ -3550,7 +3562,7 @@ async function buildSkillStopOutput(
   const activeSubagentCount = subagentSummary?.activeSubagentThreadIds.length ?? 0;
 
   if (blocker.skill === "ralplan") {
-    const status = buildRalplanContinuationStatus(blocker, activeSubagentCount);
+    const status = buildRalplanContinuationStatus(blocker, activeSubagentCount, cwd);
     return {
       decision: "block",
       reason: status.reason,
@@ -4008,7 +4020,9 @@ export async function dispatchCodexNativeHook(
   // Native hooks must use the same authoritative runtime state root as HUD/MCP
   // when boxed/team roots are active; do not bypass it with cwd/.omx/state.
   const stateDir = getBaseStateDir(cwd);
-  await mkdir(stateDir, { recursive: true });
+  if (hookEventName !== "Stop") {
+    await mkdir(stateDir, { recursive: true });
+  }
 
   const omxEventName = mapCodexHookEventToOmxEvent(hookEventName);
   let skillState: SkillActiveState | null = null;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1731,6 +1731,7 @@ function buildNativeOutsideTmuxTeamPromptBlockState(
   threadId?: string,
   turnId?: string,
 ): SkillActiveState | null {
+  if (!readTeamModeConfig(cwd).enabled) return null;
   const match = detectPrimaryKeyword(prompt);
   if (match?.skill !== "team") return null;
 


### PR DESCRIPTION
## Summary
- add a Team-mode preference/config helper with Team enabled by default
- allow setup/update paths to preserve or write the Team-mode preference
- suppress Team-specific guidance/state prompts when Team mode is disabled

Fixes #2653.

## Validation
- npm run build
- node --test dist/hooks/__tests__/keyword-detector.test.js
- CODEX_HOME=$(mktemp -d) node --test dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/update.test.js
- npm run lint
- direct inactive Stop CLI reproduction: exit 0, stdout {}, no .omx/state side effect

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*