### PR TITLE
Prevent HUD doctor panes from materializing deleted cwd

### DIFF
--- a/src/hud/__tests__/authority.test.ts
+++ b/src/hud/__tests__/authority.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -22,6 +22,51 @@ describe('runHudAuthorityTick', () => {
       assert.ok(typeof lease.heartbeat_at === 'string' && lease.heartbeat_at.length > 0);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not materialize authority state under a deleted cwd marker path', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'omx-hud-authority-deleted-marker-'));
+    const deletedMarkerCwd = join(parent, 'doctor-smoke (deleted)');
+    try {
+      let invoked = false;
+      await runHudAuthorityTick(
+        { cwd: deletedMarkerCwd, nodePath: '/node', packageRoot: '/pkg' },
+        {
+          runProcess: async () => {
+            invoked = true;
+          },
+        },
+      );
+
+      assert.equal(invoked, false);
+      assert.equal(existsSync(join(deletedMarkerCwd, '.omx', 'state')), false);
+      assert.equal(existsSync(deletedMarkerCwd), false);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('writes authority state under a real existing cwd that literally ends with the marker text', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'omx-hud-authority-live-marker-'));
+    const liveMarkerCwd = join(parent, 'real workspace (deleted)');
+    mkdirSync(liveMarkerCwd);
+    try {
+      let invoked = false;
+      await runHudAuthorityTick(
+        { cwd: liveMarkerCwd, nodePath: '/node', packageRoot: '/pkg' },
+        {
+          runProcess: async () => {
+            invoked = true;
+          },
+        },
+      );
+
+      assert.equal(invoked, true);
+      const lease = JSON.parse(readFileSync(join(liveMarkerCwd, '.omx', 'state', 'notify-fallback-authority-owner.json'), 'utf-8'));
+      assert.equal(lease.cwd, liveMarkerCwd);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
     }
   });
 

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -115,6 +115,21 @@ describe('runWatchMode', () => {
     assert.equal(resolved, '/tmp/live workspace (deleted)');
   });
 
+  it('follows a live literal deleted-marker cwd when process cwd is an alias to the same directory', () => {
+    const resolved = resolveHudWatchCwd('/tmp/stale-launch', {
+      getCwd: () => '/tmp/link-to-live',
+      readProcCwd: () => '/tmp/live workspace (deleted)',
+      realpath: (path) => {
+        if (path === '/tmp/stale-launch') return '/dev/inode/stale-launch';
+        if (path === '/tmp/link-to-live') return '/dev/inode/live-literal-marker';
+        if (path === '/tmp/live workspace (deleted)') return '/dev/inode/live-literal-marker';
+        return path;
+      },
+    });
+
+    assert.equal(resolved, '/tmp/live workspace (deleted)');
+  });
+
   it('reads HUD state from the resolved live cwd on every watch frame', async () => {
     const seenConfigCwds: string[] = [];
     const seenStateCwds: string[] = [];

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -88,6 +88,33 @@ describe('runWatchMode', () => {
     assert.equal(resolved, '/workspace/link');
   });
 
+  it('does not select a proc deleted-cwd marker over the safer launch cwd', () => {
+    const resolved = resolveHudWatchCwd('/tmp/omx-doctor-plugin-hook-smoke', {
+      getCwd: () => '/tmp/omx-doctor-plugin-hook-smoke',
+      readProcCwd: () => '/tmp/omx-doctor-plugin-hook-smoke (deleted)',
+      realpath: (path) => {
+        if (path === '/tmp/omx-doctor-plugin-hook-smoke') return '/dev/inode/reused-safe-path';
+        throw new Error(`deleted marker path should not be resolved: ${path}`);
+      },
+    });
+
+    assert.equal(resolved, '/tmp/omx-doctor-plugin-hook-smoke');
+  });
+
+  it('follows a live cwd whose literal name ends with the deleted marker text', () => {
+    const resolved = resolveHudWatchCwd('/tmp/stale-launch', {
+      getCwd: () => '/tmp/live workspace (deleted)',
+      readProcCwd: () => '/tmp/live workspace (deleted)',
+      realpath: (path) => {
+        if (path === '/tmp/stale-launch') return '/dev/inode/stale-launch';
+        if (path === '/tmp/live workspace (deleted)') return '/dev/inode/live-literal-marker';
+        return path;
+      },
+    });
+
+    assert.equal(resolved, '/tmp/live workspace (deleted)');
+  });
+
   it('reads HUD state from the resolved live cwd on every watch frame', async () => {
     const seenConfigCwds: string[] = [];
     const seenStateCwds: string[] = [];

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -422,6 +422,33 @@ describe('dead HUD pane reaper', () => {
     assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
   });
 
+  it('kills doctor-smoke HUD panes even if a literal deleted-marker cwd was materialized', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'omx-doctor-plugin-hook-live-marker-'));
+    const materializedDeletedPath = join(parent, 'smoke (deleted)');
+    mkdirSync(materializedDeletedPath);
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex\t/repo',
+        `%2\tnode\texec env OMX_SESSION_ID='omx-doctor-plugin-hook-smoke' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch\t${materializedDeletedPath}`,
+      ].join('\n'),
+    );
+    const killed: string[] = [];
+
+    try {
+      const result = reapDeadHudPanes(panes, {
+        killPane: (paneId) => {
+          killed.push(paneId);
+          return true;
+        },
+      });
+
+      assert.deepEqual(killed, ['%2']);
+      assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
   it('preserves non-doctor deleted-cwd HUD panes while their leader is still live', () => {
     const deletedPath = join(tmpdir(), `omx-live-leader-deleted-cwd-${process.pid}-${Date.now()} (deleted)`);
     rmSync(deletedPath, { recursive: true, force: true });

--- a/src/hud/authority.ts
+++ b/src/hud/authority.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getPackageRoot } from '../utils/package.js';
@@ -22,6 +23,11 @@ export interface RunHudAuthorityTickDeps {
       timeoutMs: number;
     },
   ) => Promise<void> | void;
+}
+
+function isDeletedCwdMarkerPath(path: string): boolean {
+  const currentPath = path.trim();
+  return /(?:^|\s)\(deleted\)\s*$/.test(currentPath) && !existsSync(currentPath);
 }
 
 async function defaultRunProcess(
@@ -62,6 +68,7 @@ export async function runHudAuthorityTick(
   deps: RunHudAuthorityTickDeps = {},
 ): Promise<void> {
   const cwd = options.cwd;
+  if (isDeletedCwdMarkerPath(cwd)) return;
   const nodePath = options.nodePath ?? process.execPath;
   const packageRoot = options.packageRoot ?? getPackageRoot();
   const pollMs = Math.max(1, options.pollMs ?? 75);

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -129,8 +129,11 @@ export function resolveHudWatchCwd(
   const launchPath = launchCwd.trim() || processCwd || launchCwd;
   const livePath = safeCallString(readProcCwd) || processCwd;
   if (!livePath) return launchPath;
-  if (isDeletedCwdMarkerText(livePath) && !isDeletedCwdMarkerText(launchPath) && processCwd !== livePath) {
-    return launchPath;
+  const liveMarkerMayBeProcDeleted = isDeletedCwdMarkerText(livePath) && !isDeletedCwdMarkerText(launchPath) && processCwd !== livePath;
+  if (liveMarkerMayBeProcDeleted) {
+    const processReal = processCwd ? safeCallString(() => realpath(processCwd)) : null;
+    const markerReal = safeCallString(() => realpath(livePath));
+    if (!processReal || !markerReal || processReal !== markerReal) return launchPath;
   }
 
   const launchReal = safeCallString(() => realpath(launchPath));

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -103,6 +103,10 @@ function defaultProcCwd(): string | null {
   return safeCallString(() => readlinkSync('/proc/self/cwd'));
 }
 
+function isDeletedCwdMarkerText(path: string | null): boolean {
+  return Boolean(path && /(?:^|\s)\(deleted\)\s*$/.test(path.trim()));
+}
+
 /**
  * Resolve the cwd a long-running HUD watch should read on this frame.
  *
@@ -121,9 +125,13 @@ export function resolveHudWatchCwd(
   const realpath = deps.realpath ?? ((path: string) => realpathSync.native(path));
   const readProcCwd = deps.readProcCwd ?? defaultProcCwd;
 
-  const launchPath = launchCwd.trim() || safeCallString(getCwd) || launchCwd;
-  const livePath = safeCallString(readProcCwd) || safeCallString(getCwd);
+  const processCwd = safeCallString(getCwd);
+  const launchPath = launchCwd.trim() || processCwd || launchCwd;
+  const livePath = safeCallString(readProcCwd) || processCwd;
   if (!livePath) return launchPath;
+  if (isDeletedCwdMarkerText(livePath) && !isDeletedCwdMarkerText(launchPath) && processCwd !== livePath) {
+    return launchPath;
+  }
 
   const launchReal = safeCallString(() => realpath(launchPath));
   const liveReal = safeCallString(() => realpath(livePath));

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -141,6 +141,11 @@ function isDeletedTmuxPanePath(path: string | undefined): boolean {
   return Boolean(currentPath && /(?:^|\s)\(deleted\)\s*$/.test(currentPath) && !existsSync(currentPath));
 }
 
+function hasDeletedTmuxPaneMarker(path: string | undefined): boolean {
+  const currentPath = path?.trim();
+  return Boolean(currentPath && /(?:^|\s)\(deleted\)\s*$/.test(currentPath));
+}
+
 function isDoctorSmokeSessionId(sessionId: string | undefined): boolean {
   return /^(?:doctor-smoke|omx-doctor-[a-z0-9-]+-smoke)$/i.test(sessionId ?? '');
 }
@@ -149,9 +154,10 @@ function shouldReapDeletedCwdHudPane(pane: TmuxPaneSnapshot, isLivePane: (paneId
   // A deleted tmux launch cwd is not enough to prove a HUD is dead: watch mode can
   // keep serving from a resolved live cwd. Reap only explicit doctor smoke panes or
   // owner-tagged panes whose leader is gone.
-  if (!hasHudPaneOwnerMetadata(pane) || !isDeletedTmuxPanePath(pane.currentPath)) return false;
+  if (!hasHudPaneOwnerMetadata(pane) || !hasDeletedTmuxPaneMarker(pane.currentPath)) return false;
   const owner = readHudPaneOwner(pane);
   if (isDoctorSmokeSessionId(owner.sessionId)) return true;
+  if (!isDeletedTmuxPanePath(pane.currentPath)) return false;
   return !owner.leaderPaneId || !isLivePane(owner.leaderPaneId);
 }
 


### PR DESCRIPTION
## Summary
- prevent HUD authority ticks from materializing `.omx/state` under Linux deleted-cwd marker paths ending in ` (deleted)`
- keep HUD watch cwd resolution from preferring a proc deleted-cwd marker over a safer launch cwd
- keep doctor-smoke HUD panes reapable even if a literal `(deleted)` marker directory already exists

## Why this fix appeared
During live dogfooding in tmux window `omx-0:2`, a stale HUD pane `%304` remained after an `omx doctor` / plugin hook smoke run:

- `OMX_SESSION_ID=omx-doctor-plugin-hook-smoke`
- `OMX_TMUX_HUD_LEADER_PANE=%124`
- `cwd=/tmp/omx-doctor-plugin-hook-ic80SJ (deleted)`
- command: `omx hud --watch --preset=focused`

The previous deleted-cwd reaper intended to remove stale doctor-smoke HUD panes, but this pane was preserved because the HUD authority tick had created a real literal directory named `... (deleted)`. That collapsed two different categories:

- Linux `/proc/self/cwd` deleted marker presentation: not a durable workspace root
- real user directory literally ending in `(deleted)`: durable filesystem artifact

This fix pins the no-materialization invariant at the write boundary (`runHudAuthorityTick`) and keeps doctor-smoke marker panes reapable.

## Verification
- `npm run build`
- `node --test dist/hud/__tests__/authority.test.js dist/hud/__tests__/index.test.js dist/hud/__tests__/tmux.test.js` — 56 passing
