### PR TITLE
Scope HUD resize hooks by leader pane

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -665,7 +665,7 @@ describe('reconcileHudForPromptSubmit', () => {
   });
 
   it('registers client-resized hook scoped from the emitting pane after resizing an existing HUD pane', async () => {
-    const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
+    const registered: Array<{ hudPaneId: string; leaderPaneId: string | undefined; heightLines: number }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
       env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
@@ -678,8 +678,8 @@ describe('reconcileHudForPromptSubmit', () => {
         },
       ],
       resizeTmuxPane: () => true,
-      registerHudResizeHook: (hudPaneId, currentPaneId, heightLines) => {
-        registered.push({ hudPaneId, currentPaneId, heightLines });
+      registerHudResizeHook: (hudPaneId, leaderPaneId, heightLines) => {
+        registered.push({ hudPaneId, leaderPaneId, heightLines });
         return true;
       },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
@@ -687,12 +687,12 @@ describe('reconcileHudForPromptSubmit', () => {
 
     assert.equal(registered.length, 1);
     assert.equal(registered[0]?.hudPaneId, '%2');
-    assert.equal(registered[0]?.currentPaneId, '%1');
+    assert.equal(registered[0]?.leaderPaneId, '%1');
     assert.equal(registered[0]?.heightLines, HUD_TMUX_HEIGHT_LINES);
   });
 
   it('registers client-resized hook scoped from the emitting pane after creating a new HUD pane', async () => {
-    const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
+    const registered: Array<{ hudPaneId: string; leaderPaneId: string | undefined; heightLines: number }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
       env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
@@ -701,8 +701,8 @@ describe('reconcileHudForPromptSubmit', () => {
       ],
       createHudWatchPane: () => '%9',
       resizeTmuxPane: () => true,
-      registerHudResizeHook: (hudPaneId, currentPaneId, heightLines) => {
-        registered.push({ hudPaneId, currentPaneId, heightLines });
+      registerHudResizeHook: (hudPaneId, leaderPaneId, heightLines) => {
+        registered.push({ hudPaneId, leaderPaneId, heightLines });
         return true;
       },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
@@ -710,13 +710,13 @@ describe('reconcileHudForPromptSubmit', () => {
 
     assert.equal(registered.length, 1);
     assert.equal(registered[0]?.hudPaneId, '%9');
-    assert.equal(registered[0]?.currentPaneId, '%1');
+    assert.equal(registered[0]?.leaderPaneId, '%1');
     assert.equal(registered[0]?.heightLines, HUD_TMUX_HEIGHT_LINES);
   });
 
   it('keeps the resize hook on the reused duplicate keeper pane', async () => {
     const unregistered: Array<string | undefined> = [];
-    const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined }> = [];
+    const registered: Array<{ hudPaneId: string; leaderPaneId: string | undefined }> = [];
 
     await reconcileHudForPromptSubmit('/repo', {
       env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
@@ -728,14 +728,14 @@ describe('reconcileHudForPromptSubmit', () => {
       killTmuxPane: () => true,
       createHudWatchPane: () => '%9',
       resizeTmuxPane: () => true,
-      unregisterHudResizeHook: (currentPaneId) => { unregistered.push(currentPaneId); return true; },
-      registerHudResizeHook: (hudPaneId, currentPaneId) => { registered.push({ hudPaneId, currentPaneId }); return true; },
+      unregisterHudResizeHook: (leaderPaneId) => { unregistered.push(leaderPaneId); return true; },
+      registerHudResizeHook: (hudPaneId, leaderPaneId) => { registered.push({ hudPaneId, leaderPaneId }); return true; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
     assert.deepEqual(unregistered, []);
     assert.equal(registered.length, 1);
     assert.equal(registered[0]?.hudPaneId, '%2');
-    assert.equal(registered[0]?.currentPaneId, '%1');
+    assert.equal(registered[0]?.leaderPaneId, '%1');
   });
 });

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -48,6 +48,12 @@ describe('HUD resize hook helpers', () => {
     });
   });
 
+  it('rejects malformed tmux ids in hook context output', () => {
+    assert.equal(parseHudResizeHookContext('$7; touch /tmp/owned\t@3\n', '%1'), null);
+    assert.equal(parseHudResizeHookContext('$7\t@3$(touch /tmp/owned)\n', '%1'), null);
+    assert.equal(parseHudResizeHookContext('$7\t@3\n', '%1; touch /tmp/owned'), null);
+  });
+
   it('registers a client-resized hook at session scope with exact HUD pane targeting', () => {
     const calls: string[][] = [];
 
@@ -60,17 +66,17 @@ describe('HUD resize hook helpers', () => {
     const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
     assert.equal(result, true);
     assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
-    assert.deepEqual(calls[1], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-    assert.equal(calls[2]?.[0], 'set-hook');
-    assert.equal(calls[2]?.[1], '-t');
-    assert.equal(calls[2]?.[2], '$7');
-    assert.equal(calls[2]?.[3], hookSlot);
-    assert.match(calls[2]?.[4] ?? '', /^run-shell -b /);
-    assert.match(calls[2]?.[4] ?? '', /resize-pane/);
-    assert.match(calls[2]?.[4] ?? '', /set-hook/);
-    assert.doesNotMatch(calls[2]?.[4] ?? '', /'-w'/);
-    assert.match(calls[2]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
-    assert.match(calls[2]?.[4] ?? '', new RegExp(hookSlot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.equal(calls[1]?.[0], 'set-hook');
+    assert.equal(calls[1]?.[1], '-t');
+    assert.equal(calls[1]?.[2], '$7');
+    assert.equal(calls[1]?.[3], hookSlot);
+    assert.match(calls[1]?.[4] ?? '', /^run-shell -b /);
+    assert.match(calls[1]?.[4] ?? '', /resize-pane/);
+    assert.match(calls[1]?.[4] ?? '', /set-hook/);
+    assert.doesNotMatch(calls[1]?.[4] ?? '', /'-w'/);
+    assert.match(calls[1]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
+    assert.match(calls[1]?.[4] ?? '', new RegExp(hookSlot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.deepEqual(calls[2], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
   });
 
   it('unregisters the same per-window hook slot', () => {
@@ -106,8 +112,8 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%9', '%1', 3, execFor('@3')), true);
     assert.equal(registerHudResizeHook('%10', '%2', 3, execFor('@4')), true);
 
-    const firstSlot = registered[1]?.[3];
-    const secondSlot = registered[3]?.[3];
+    const firstSlot = registered[0]?.[3];
+    const secondSlot = registered[2]?.[3];
     assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
     assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
     assert.notEqual(firstSlot, secondSlot);
@@ -124,8 +130,8 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
     assert.equal(registerHudResizeHook('%10', '%2', 3, execTmuxSync), true);
 
-    const firstSlot = registered[1]?.[3];
-    const secondSlot = registered[3]?.[3];
+    const firstSlot = registered[0]?.[3];
+    const secondSlot = registered[2]?.[3];
     assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
     assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
     assert.notEqual(firstSlot, secondSlot);
@@ -142,7 +148,40 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
     assert.equal(registerHudResizeHook('%10', '%1', 3, execTmuxSync), true);
 
-    assert.equal(registered[1]?.[3], registered[3]?.[3]);
+    assert.equal(registered[0]?.[3], registered[2]?.[3]);
+  });
+
+  it('does not unregister the legacy hook when installing the leader-scoped hook fails', () => {
+    const calls: string[][] = [];
+
+    const result = registerHudResizeHook('%9', '%1', 3, (args) => {
+      calls.push(args);
+      if (args[0] === 'display-message') return '$7\t@3\n';
+      if (args[0] === 'set-hook' && args[1] === '-t') throw new Error('transient tmux failure');
+      return '';
+    });
+
+    assert.equal(result, false);
+    assert.deepEqual(calls.map((args) => args.slice(0, 2)), [
+      ['display-message', '-p'],
+      ['set-hook', '-t'],
+    ]);
+  });
+
+  it('keeps registration successful when legacy cleanup fails after installing the leader-scoped hook', () => {
+    const calls: string[][] = [];
+
+    const result = registerHudResizeHook('%9', '%1', 3, (args) => {
+      calls.push(args);
+      if (args[0] === 'display-message') return '$7\t@3\n';
+      if (args[0] === 'set-hook' && args[1] === '-u') throw new Error('stale legacy cleanup failure');
+      return '';
+    });
+
+    assert.equal(result, true);
+    assert.equal(calls[1]?.[0], 'set-hook');
+    assert.equal(calls[1]?.[1], '-t');
+    assert.deepEqual(calls[2], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
   });
 
   it('unregisters only the leader-scoped hook slot for the selected leader', () => {

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -23,12 +23,12 @@ import {
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS } from '../constants.js';
 
 describe('HUD resize hook helpers', () => {
-  it('builds a deterministic hook name from the tmux session and window identity', () => {
-    assert.equal(buildHudResizeHookName('$7', '@3'), 'omx_hud_resize_7_3');
+  it('builds a deterministic hook name from the tmux session, window, and leader identity', () => {
+    assert.equal(buildHudResizeHookName('$7', '@3', '%1'), 'omx_hud_resize_7_3_1');
   });
 
   it('builds a bounded numeric client-resized slot', () => {
-    const slot = buildHudResizeHookSlot('omx_hud_resize_7_3');
+    const slot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
     assert.match(slot, /^client-resized\[\d+\]$/);
 
     const index = Number.parseInt(slot.replace(/^client-resized\[|\]$/g, ''), 10);
@@ -37,13 +37,14 @@ describe('HUD resize hook helpers', () => {
   });
 
   it('parses hook context from tmux display-message output', () => {
-    const context = parseHudResizeHookContext('$7\t@3\n');
+    const context = parseHudResizeHookContext('$7\t@3\n', '%1');
 
     assert.deepEqual(context, {
       sessionId: '$7',
       windowId: '@3',
-      hookName: 'omx_hud_resize_7_3',
-      hookSlot: buildHudResizeHookSlot('omx_hud_resize_7_3'),
+      leaderPaneId: '%1',
+      hookName: 'omx_hud_resize_7_3_1',
+      hookSlot: buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
     });
   });
 
@@ -56,19 +57,20 @@ describe('HUD resize hook helpers', () => {
       return '';
     });
 
-    const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3');
+    const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
     assert.equal(result, true);
     assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
-    assert.equal(calls[1]?.[0], 'set-hook');
-    assert.equal(calls[1]?.[1], '-t');
-    assert.equal(calls[1]?.[2], '$7');
-    assert.equal(calls[1]?.[3], hookSlot);
-    assert.match(calls[1]?.[4] ?? '', /^run-shell -b /);
-    assert.match(calls[1]?.[4] ?? '', /resize-pane/);
-    assert.match(calls[1]?.[4] ?? '', /set-hook/);
-    assert.doesNotMatch(calls[1]?.[4] ?? '', /'-w'/);
-    assert.match(calls[1]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
-    assert.match(calls[1]?.[4] ?? '', new RegExp(hookSlot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.deepEqual(calls[1], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
+    assert.equal(calls[2]?.[0], 'set-hook');
+    assert.equal(calls[2]?.[1], '-t');
+    assert.equal(calls[2]?.[2], '$7');
+    assert.equal(calls[2]?.[3], hookSlot);
+    assert.match(calls[2]?.[4] ?? '', /^run-shell -b /);
+    assert.match(calls[2]?.[4] ?? '', /resize-pane/);
+    assert.match(calls[2]?.[4] ?? '', /set-hook/);
+    assert.doesNotMatch(calls[2]?.[4] ?? '', /'-w'/);
+    assert.match(calls[2]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
+    assert.match(calls[2]?.[4] ?? '', new RegExp(hookSlot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   });
 
   it('unregisters the same per-window hook slot', () => {
@@ -82,12 +84,13 @@ describe('HUD resize hook helpers', () => {
 
     assert.equal(result, true);
     assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
-    assert.deepEqual(calls[1], [
+    assert.deepEqual(calls[1], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
+    assert.deepEqual(calls[2], [
       'set-hook',
       '-u',
       '-t',
       '$7',
-      buildHudResizeHookSlot('omx_hud_resize_7_3'),
+      buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
     ]);
   });
 
@@ -103,14 +106,32 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%9', '%1', 3, execFor('@3')), true);
     assert.equal(registerHudResizeHook('%10', '%2', 3, execFor('@4')), true);
 
-    const firstSlot = registered[0]?.[3];
-    const secondSlot = registered[1]?.[3];
+    const firstSlot = registered[1]?.[3];
+    const secondSlot = registered[3]?.[3];
     assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
     assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
     assert.notEqual(firstSlot, secondSlot);
   });
 
-  it('reuses the same hook slot when a HUD pane is recreated in the same window', () => {
+  it('uses distinct hook slots for different leaders in the same session window', () => {
+    const registered: string[][] = [];
+    const execTmuxSync = (args: string[]) => {
+      if (args[0] === 'display-message') return '$7\t@3\n';
+      registered.push(args);
+      return '';
+    };
+
+    assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
+    assert.equal(registerHudResizeHook('%10', '%2', 3, execTmuxSync), true);
+
+    const firstSlot = registered[1]?.[3];
+    const secondSlot = registered[3]?.[3];
+    assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
+    assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
+    assert.notEqual(firstSlot, secondSlot);
+  });
+
+  it('reuses the same hook slot when a HUD pane is recreated for the same leader', () => {
     const registered: string[][] = [];
     const execTmuxSync = (args: string[]) => {
       if (args[0] === 'display-message') return '$7\t@3\n';
@@ -121,7 +142,27 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
     assert.equal(registerHudResizeHook('%10', '%1', 3, execTmuxSync), true);
 
-    assert.equal(registered[0]?.[3], registered[1]?.[3]);
+    assert.equal(registered[1]?.[3], registered[3]?.[3]);
+  });
+
+  it('unregisters only the leader-scoped hook slot for the selected leader', () => {
+    const unregistered: string[][] = [];
+    const execTmuxSync = (args: string[]) => {
+      if (args[0] === 'display-message') return '$7\t@3\n';
+      unregistered.push(args);
+      return '';
+    };
+
+    assert.equal(unregisterHudResizeHook('%2', execTmuxSync), true);
+
+    assert.deepEqual(unregistered[0], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
+    assert.deepEqual(unregistered[1], [
+      'set-hook',
+      '-u',
+      '-t',
+      '$7',
+      buildHudResizeHookSlot('omx_hud_resize_7_3_2'),
+    ]);
   });
 });
 

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -75,7 +75,7 @@ interface RunWatchModeDependencies {
   renderHudFn: (ctx: HudRenderContext, preset: HudPreset, options?: { maxWidth?: number; maxLines?: number }) => string;
   runAuthorityTickFn: (options: { cwd: string }) => Promise<void>;
   resizeTmuxPaneFn: (paneId: string, heightLines: number) => boolean;
-  registerHudResizeHookFn: (hudPaneId: string, currentPaneId: string | undefined, heightLines: number) => boolean;
+  registerHudResizeHookFn: (hudPaneId: string, leaderPaneId: string | undefined, heightLines: number) => boolean;
   writeStdout: (text: string) => void;
   writeStderr: (text: string) => void;
   registerSigint: (handler: () => void) => void | (() => void);
@@ -402,11 +402,12 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
   }
   const envPaneId = process.env.TMUX_PANE?.trim();
   const currentPaneId = envPaneId || readActiveTmuxPaneId() || undefined;
+  const leaderPaneId = currentPaneId;
   const sessionId = process.env.OMX_SESSION_ID?.trim() || undefined;
-  const existingHudPaneIds = currentPaneId || sessionId
-    ? listCurrentWindowHudPaneIds(currentPaneId, undefined, {
+  const existingHudPaneIds = leaderPaneId || sessionId
+    ? listCurrentWindowHudPaneIds(leaderPaneId, undefined, {
         sessionId,
-        leaderPaneId: currentPaneId,
+        leaderPaneId,
       })
     : [];
   if (existingHudPaneIds.length >= 1) {
@@ -418,7 +419,7 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
     const ctx = await readAllState(cwd, config);
     const desiredHeight = getHudRenderMaxLines(ctx);
     resizeTmuxPane(keeperPaneId, desiredHeight);
-    if (currentPaneId) registerHudResizeHook(keeperPaneId, currentPaneId, desiredHeight);
+    if (leaderPaneId) registerHudResizeHook(keeperPaneId, leaderPaneId, desiredHeight);
     console.log(duplicatePaneIds.length > 0
       ? 'HUD already running in tmux pane. Removed duplicate HUD panes and reused existing HUD pane.'
       : 'HUD already running in tmux pane. Reused existing HUD pane.');

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -50,18 +50,18 @@ export interface ReconcileHudForPromptSubmitDeps {
   readHudConfig?: typeof readHudConfig;
   readAllState?: typeof readAllState;
   resolveOmxCliEntryPath?: typeof resolveOmxCliEntryPath;
-  registerHudResizeHook?: (hudPaneId: string, currentPaneId: string | undefined, heightLines: number) => boolean;
-  unregisterHudResizeHook?: (currentPaneId: string | undefined) => boolean;
+  registerHudResizeHook?: (hudPaneId: string, leaderPaneId: string | undefined, heightLines: number) => boolean;
+  unregisterHudResizeHook?: (leaderPaneId: string | undefined) => boolean;
 }
 
 function ensureHudResizeHook(
   hudPaneId: string,
-  currentPaneId: string | undefined,
+  leaderPaneId: string | undefined,
   desiredHeight: number,
   deps: ReconcileHudForPromptSubmitDeps,
 ): void {
   try {
-    (deps.registerHudResizeHook ?? registerHudResizeHook)(hudPaneId, currentPaneId, desiredHeight);
+    (deps.registerHudResizeHook ?? registerHudResizeHook)(hudPaneId, leaderPaneId, desiredHeight);
   } catch {
     // Non-critical — hook registration failure does not break HUD lifecycle.
   }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -217,7 +217,16 @@ function normalizeTmuxHookToken(value: string): string {
   return normalized || 'unknown';
 }
 
-export function buildHudResizeHookName(sessionId: string, windowId: string): string {
+export function buildHudResizeHookName(sessionId: string, windowId: string, leaderPaneId: string): string {
+  return [
+    'omx_hud_resize',
+    normalizeTmuxHookToken(sessionId),
+    normalizeTmuxHookToken(windowId),
+    normalizeTmuxHookToken(leaderPaneId),
+  ].join('_');
+}
+
+function buildLegacyHudResizeHookName(sessionId: string, windowId: string): string {
   return [
     'omx_hud_resize',
     normalizeTmuxHookToken(sessionId),
@@ -236,20 +245,23 @@ export function buildHudResizeHookSlot(hookName: string): string {
 export interface HudResizeHookContext {
   sessionId: string;
   windowId: string;
+  leaderPaneId: string;
   hookName: string;
   hookSlot: string;
 }
 
-export function parseHudResizeHookContext(output: string): HudResizeHookContext | null {
+export function parseHudResizeHookContext(output: string, leaderPaneId: string): HudResizeHookContext | null {
   const [sessionId = '', windowId = ''] = output
     .split('\n')[0]
     ?.split('\t')
     .map((part) => part.trim()) ?? [];
-  if (!sessionId || !windowId) return null;
-  const hookName = buildHudResizeHookName(sessionId, windowId);
+  const normalizedLeaderPaneId = leaderPaneId.trim();
+  if (!sessionId || !windowId || !normalizedLeaderPaneId.startsWith('%')) return null;
+  const hookName = buildHudResizeHookName(sessionId, windowId, normalizedLeaderPaneId);
   return {
     sessionId,
     windowId,
+    leaderPaneId: normalizedLeaderPaneId,
     hookName,
     hookSlot: buildHudResizeHookSlot(hookName),
   };
@@ -269,6 +281,7 @@ export function readHudResizeHookContext(
         currentPaneId,
         '#{session_id}\t#{window_id}',
       ]),
+      currentPaneId,
     );
   } catch {
     return null;
@@ -289,6 +302,20 @@ function buildHudResizeHookCommand(
   const unregister = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-t', context.sessionId, context.hookSlot]);
   const resizeOrUnregister = `${resize} >/dev/null 2>&1 || ${unregister} >/dev/null 2>&1 || true`;
   return `${resizeOrUnregister}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeOrUnregister}`;
+}
+
+function unregisterLegacyHudResizeHook(
+  context: HudResizeHookContext,
+  execTmuxSync: TmuxExecSync,
+): void {
+  const legacyHookSlot = buildHudResizeHookSlot(buildLegacyHudResizeHookName(context.sessionId, context.windowId));
+  if (legacyHookSlot === context.hookSlot) return;
+  try {
+    execTmuxSync(['set-hook', '-u', '-t', context.sessionId, legacyHookSlot]);
+  } catch {
+    // Best-effort migration cleanup: failure should not prevent the new
+    // leader-scoped hook from being registered or unregistered.
+  }
 }
 
 function buildEnvPrefix(env: Record<string, string | undefined>): string {
@@ -458,6 +485,7 @@ export function registerHudResizeHook(
   const height = String(Math.max(1, Math.floor(heightLines)));
   const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, context));
   try {
+    unregisterLegacyHudResizeHook(context, execTmuxSync);
     execTmuxSync(['set-hook', '-t', context.sessionId, context.hookSlot, `run-shell -b ${resizeCmd}`]);
     return true;
   } catch {
@@ -472,6 +500,7 @@ export function unregisterHudResizeHook(
   const context = readHudResizeHookContext(currentPaneId, execTmuxSync);
   if (!context) return false;
   try {
+    unregisterLegacyHudResizeHook(context, execTmuxSync);
     execTmuxSync(['set-hook', '-u', '-t', context.sessionId, context.hookSlot]);
     return true;
   } catch {

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -217,6 +217,18 @@ function normalizeTmuxHookToken(value: string): string {
   return normalized || 'unknown';
 }
 
+function isTmuxSessionId(value: string): boolean {
+  return /^\$\d+$/.test(value);
+}
+
+function isTmuxWindowId(value: string): boolean {
+  return /^@\d+$/.test(value);
+}
+
+function isTmuxPaneId(value: string): boolean {
+  return /^%\d+$/.test(value);
+}
+
 export function buildHudResizeHookName(sessionId: string, windowId: string, leaderPaneId: string): string {
   return [
     'omx_hud_resize',
@@ -256,7 +268,7 @@ export function parseHudResizeHookContext(output: string, leaderPaneId: string):
     ?.split('\t')
     .map((part) => part.trim()) ?? [];
   const normalizedLeaderPaneId = leaderPaneId.trim();
-  if (!sessionId || !windowId || !normalizedLeaderPaneId.startsWith('%')) return null;
+  if (!isTmuxSessionId(sessionId) || !isTmuxWindowId(windowId) || !isTmuxPaneId(normalizedLeaderPaneId)) return null;
   const hookName = buildHudResizeHookName(sessionId, windowId, normalizedLeaderPaneId);
   return {
     sessionId,
@@ -268,20 +280,20 @@ export function parseHudResizeHookContext(output: string, leaderPaneId: string):
 }
 
 export function readHudResizeHookContext(
-  currentPaneId: string | undefined,
+  leaderPaneId: string | undefined,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): HudResizeHookContext | null {
-  if (!currentPaneId?.startsWith('%')) return null;
+  if (!leaderPaneId || !isTmuxPaneId(leaderPaneId)) return null;
   try {
     return parseHudResizeHookContext(
       execTmuxSync([
         'display-message',
         '-p',
         '-t',
-        currentPaneId,
+        leaderPaneId,
         '#{session_id}\t#{window_id}',
       ]),
-      currentPaneId,
+      leaderPaneId,
     );
   } catch {
     return null;
@@ -474,19 +486,19 @@ export function resizeTmuxPane(
 
 export function registerHudResizeHook(
   hudPaneId: string,
-  currentPaneId: string | undefined,
+  leaderPaneId: string | undefined,
   heightLines: number,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): boolean {
   if (!hudPaneId.startsWith('%')) return false;
-  const context = readHudResizeHookContext(currentPaneId, execTmuxSync);
+  const context = readHudResizeHookContext(leaderPaneId, execTmuxSync);
   if (!context) return false;
   const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
   const height = String(Math.max(1, Math.floor(heightLines)));
   const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, context));
   try {
-    unregisterLegacyHudResizeHook(context, execTmuxSync);
     execTmuxSync(['set-hook', '-t', context.sessionId, context.hookSlot, `run-shell -b ${resizeCmd}`]);
+    unregisterLegacyHudResizeHook(context, execTmuxSync);
     return true;
   } catch {
     return false;
@@ -494,10 +506,10 @@ export function registerHudResizeHook(
 }
 
 export function unregisterHudResizeHook(
-  currentPaneId: string | undefined,
+  leaderPaneId: string | undefined,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): boolean {
-  const context = readHudResizeHookContext(currentPaneId, execTmuxSync);
+  const context = readHudResizeHookContext(leaderPaneId, execTmuxSync);
   if (!context) return false;
   try {
     unregisterLegacyHudResizeHook(context, execTmuxSync);


### PR DESCRIPTION
## Summary
- scope HUD tmux resize hook names by `sessionId + windowId + leaderPaneId`
- keep recreated HUD panes under the same leader on the same hook slot
- allow different Codex leaders in one tmux window to keep independent HUD resize hooks

## Why this fix appeared
During live tmux dogfooding, the window was intentionally arranged as a 2x2 layout:

- left: supervisor Codex + supervisor HUD
- right: worker Codex + worker HUD

After restoration, the two HUD panes were `%307` and `%308`, but tmux showed only one `client-resized[...]` hook, targeting the last registered HUD (`%308`). The old hook identity was based on session + tmux window, so registering the worker HUD overwrote the supervisor HUD's resize hook.

That treated tmux window layout as the owner. The actual HUD owner is the Codex/OMX leader pane. This fix makes the resize hook identity leader-scoped while keeping the hook stable across HUD pane recreation.

## Verification
- `npm run build`
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/index.test.js` — 74 passing
