### PR TITLE
Prevent HUD fallback authority respawn storms

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -4582,7 +4582,7 @@ exit 0
   it('keeps the detached helper alive after the hidden bootstrap exits', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-bootstrap-survival-'));
     const readyPath = join(wd, 'helper-ready.json');
-    const helperScriptPath = join(wd, 'helper-survival.js');
+    const helperScriptPath = join(wd, 'helper-survival.cjs');
 
     try {
       await writeFile(helperScriptPath, `

--- a/src/hud/__tests__/authority.test.ts
+++ b/src/hud/__tests__/authority.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -71,50 +71,476 @@ describe('runHudAuthorityTick', () => {
   });
 
   it('invokes fallback watcher in authority-only mode with HUD env', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-env-'));
     const calls: Array<{
       nodePath: string;
       args: string[];
       options: { cwd: string; env: NodeJS.ProcessEnv; timeoutMs: number };
     }> = [];
 
-    await runHudAuthorityTick(
-      {
-        cwd: '/tmp/project',
-        nodePath: '/node',
-        packageRoot: '/pkg',
-        pollMs: 75,
-        timeoutMs: 4321,
-        env: { CUSTOM_ENV: '1' },
-      },
-      {
-        runProcess: async (
-          nodePath: string,
-          args: string[],
-          options: { cwd: string; env: NodeJS.ProcessEnv; timeoutMs: number },
-        ) => {
-          calls.push({ nodePath, args, options });
+    try {
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          pollMs: 75,
+          timeoutMs: 4321,
+          env: { CUSTOM_ENV: '1' },
         },
-      },
-    );
+        {
+          runProcess: async (
+            nodePath: string,
+            args: string[],
+            options: { cwd: string; env: NodeJS.ProcessEnv; timeoutMs: number },
+          ) => {
+            calls.push({ nodePath, args, options });
+          },
+        },
+      );
 
-    assert.equal(calls.length, 1);
-    const call = calls[0]!;
-    assert.equal(call.nodePath, '/node');
-    assert.deepEqual(call.args, [
-      '/pkg/dist/scripts/notify-fallback-watcher.js',
-      '--once',
-      '--authority-only',
-      '--cwd',
-      '/tmp/project',
-      '--notify-script',
-      '/pkg/dist/scripts/notify-hook.js',
-      '--poll-ms',
-      '75',
-    ]);
-    assert.equal(call.options.cwd, '/tmp/project');
-    assert.equal(call.options.timeoutMs, 4321);
-    assert.equal(call.options.env.OMX_HUD_AUTHORITY, '1');
-    assert.equal(call.options.env.CUSTOM_ENV, '1');
+      assert.equal(calls.length, 1);
+      const call = calls[0]!;
+      assert.equal(call.nodePath, '/node');
+      assert.deepEqual(call.args, [
+        '/pkg/dist/scripts/notify-fallback-watcher.js',
+        '--once',
+        '--authority-only',
+        '--cwd',
+        cwd,
+        '--notify-script',
+        '/pkg/dist/scripts/notify-hook.js',
+        '--poll-ms',
+        '75',
+      ]);
+      assert.equal(call.options.cwd, cwd);
+      assert.equal(call.options.timeoutMs, 4321);
+      assert.equal(call.options.env.OMX_HUD_AUTHORITY, '1');
+      assert.equal(call.options.env.OMX_HUD_AUTHORITY_MIN_INTERVAL_MS, '5000');
+      assert.equal(call.options.env.OMX_HUD_AUTHORITY_JITTER_MS, '250');
+      assert.equal(call.options.env.CUSTOM_ENV, '1');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rate-limits repeated HUD authority watcher spawns and records diagnostics', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-rate-limit-'));
+    const calls: Array<string[]> = [];
+    try {
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 1_000,
+          random: () => 0,
+          runProcess: async (_nodePath, args) => {
+            calls.push(args);
+          },
+        },
+      );
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 2_000,
+          random: () => 0,
+          runProcess: async (_nodePath, args) => {
+            calls.push(args);
+          },
+        },
+      );
+
+      assert.equal(calls.length, 1, 'second HUD frame should not respawn an authority-only child');
+      const state = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'notify-fallback-authority-state.json'), 'utf-8'));
+      assert.equal(state.last_status, 'skipped');
+      assert.equal(state.last_reason, 'rate_limited');
+      assert.equal(state.skip_count, 1);
+      assert.equal(state.last_spawn_at, new Date(1_000).toISOString());
+      assert.equal(state.next_allowed_at, new Date(6_000).toISOString());
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows HUD authority watcher spawn after the rate-limit window elapses', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-rate-limit-elapsed-'));
+    let calls = 0;
+    try {
+      for (const now of [1_000, 7_000]) {
+        await runHudAuthorityTick(
+          {
+            cwd,
+            nodePath: '/node',
+            packageRoot: '/pkg',
+            minIntervalMs: 5_000,
+            jitterMs: 0,
+          },
+          {
+            nowMs: () => now,
+            random: () => 0,
+            runProcess: async () => {
+              calls += 1;
+            },
+          },
+        );
+      }
+
+      assert.equal(calls, 2);
+      const state = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'notify-fallback-authority-state.json'), 'utf-8'));
+      assert.equal(state.last_status, 'spawned');
+      assert.equal(state.last_spawn_at, new Date(7_000).toISOString());
+      assert.equal(state.next_allowed_at, new Date(12_000).toISOString());
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves cooldown when a contender observes the rate limit only after taking the lock', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-race-'));
+    const statePath = join(cwd, '.omx', 'state', 'notify-fallback-authority-state.json');
+    let calls = 0;
+    try {
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 1_000,
+          random: () => 0,
+          runProcess: async () => {
+            calls += 1;
+          },
+        },
+      );
+      const spawnedState = JSON.parse(await readFile(statePath, 'utf-8'));
+      await writeFile(statePath, JSON.stringify({ ...spawnedState, next_allowed_at: new Date(0).toISOString() }, null, 2));
+
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 2_000,
+          random: () => 0,
+          onLockAcquired: async () => {
+            await writeFile(statePath, JSON.stringify(spawnedState, null, 2));
+          },
+          runProcess: async () => {
+            calls += 1;
+          },
+        },
+      );
+
+      assert.equal(calls, 1, 'contender should re-check cooldown after locking and skip spawning');
+      const state = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(state.last_status, 'skipped');
+      assert.equal(state.last_reason, 'rate_limited_after_lock');
+      assert.equal(state.next_allowed_at, new Date(6_000).toISOString());
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not let a lock loser overwrite canonical cooldown diagnostics', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-lock-loser-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const statePath = join(stateDir, 'notify-fallback-authority-state.json');
+    const ownerPath = join(stateDir, 'notify-fallback-authority-owner.json');
+    const lockPath = join(stateDir, 'notify-fallback-authority.lock');
+    const canonicalState = {
+      owner: 'hud',
+      pid: process.pid,
+      cwd,
+      heartbeat_at: new Date(1_000).toISOString(),
+      last_spawn_at: new Date(1_000).toISOString(),
+      next_allowed_at: new Date(6_000).toISOString(),
+      cooldown_ms: 5_000,
+      jitter_ms: 0,
+      skip_count: 0,
+      last_status: 'spawned',
+      last_reason: 'spawned',
+    };
+    try {
+      mkdirSync(stateDir, { recursive: true });
+      mkdirSync(lockPath);
+      await writeFile(statePath, JSON.stringify(canonicalState, null, 2));
+
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 7_000,
+          random: () => 0,
+          runProcess: async () => {
+            assert.fail('lock loser must not spawn');
+          },
+        },
+      );
+
+      const state = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(state.last_status, 'spawned');
+      assert.equal(state.next_allowed_at, canonicalState.next_allowed_at);
+      const owner = JSON.parse(await readFile(ownerPath, 'utf-8'));
+      assert.equal(owner.last_status, 'locked');
+      assert.equal(owner.last_reason, 'spawn_lock_active');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not release a lock that was replaced by a newer owner', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-token-release-'));
+    const lockPath = join(cwd, '.omx', 'state', 'notify-fallback-authority.lock');
+    let calls = 0;
+    try {
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 1_000,
+          random: () => 0,
+          onLockAcquired: async () => {
+            await rm(lockPath, { recursive: true, force: true });
+            await mkdir(lockPath, { recursive: true });
+            await writeFile(join(lockPath, 'owner.json'), JSON.stringify({ token: 'newer-owner' }, null, 2));
+          },
+          runProcess: async () => {
+            calls += 1;
+          },
+        },
+      );
+
+      assert.equal(calls, 1);
+      assert.equal(existsSync(lockPath), true, 'stale releaser must not remove a newer lock owner');
+      const owner = JSON.parse(await readFile(join(lockPath, 'owner.json'), 'utf-8'));
+      assert.equal(owner.token, 'newer-owner');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reaps a stale authority lock before acquiring a fresh lock', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-stale-lock-'));
+    const lockPath = join(cwd, '.omx', 'state', 'notify-fallback-authority.lock');
+    let calls = 0;
+    try {
+      await mkdir(lockPath, { recursive: true });
+      await writeFile(join(lockPath, 'owner.json'), JSON.stringify({ token: 'stale-owner' }, null, 2));
+      const staleDate = new Date(1_000);
+      await utimes(lockPath, staleDate, staleDate);
+
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+          timeoutMs: 1_000,
+        },
+        {
+          nowMs: () => 10_000,
+          random: () => 0,
+          runProcess: async () => {
+            calls += 1;
+          },
+        },
+      );
+
+      assert.equal(calls, 1);
+      assert.equal(existsSync(lockPath), false, 'fresh authority lock should be released after successful spawn');
+      const state = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'notify-fallback-authority-state.json'), 'utf-8'));
+      assert.equal(state.last_status, 'spawned');
+      assert.equal(state.next_allowed_at, new Date(15_000).toISOString());
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed before spawning when the rate-limit state cannot be persisted', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-persist-failure-'));
+    let calls = 0;
+    try {
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 1_000,
+          random: () => 0,
+          onLockAcquired: async () => {
+            await rm(join(cwd, '.omx', 'state'), { recursive: true, force: true });
+            await writeFile(join(cwd, '.omx', 'state'), 'not a directory');
+          },
+          runProcess: async () => {
+            calls += 1;
+          },
+        },
+      ).then(
+        () => assert.fail('expected persistence failure'),
+        (error) => assert.match(String(error), /failed to persist HUD authority rate-limit state/),
+      );
+
+      assert.equal(calls, 0, 'authority child should not spawn without durable rate-limit state');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed without spawning when the authority state is unreadable', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-invalid-state-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const statePath = join(stateDir, 'notify-fallback-authority-state.json');
+    let calls = 0;
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(statePath, '{not valid json');
+
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 1_000,
+          random: () => 0,
+          runProcess: async () => {
+            calls += 1;
+          },
+        },
+      );
+
+      assert.equal(calls, 0, 'authority child should not spawn when cooldown state cannot be trusted');
+      const state = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(state.last_status, 'failed');
+      assert.equal(state.last_reason, 'invalid_authority_state');
+      assert.equal(state.next_allowed_at, new Date(6_000).toISOString());
+      assert.match(state.last_error, /failed to read HUD authority state/);
+
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 2_000,
+          random: () => 0,
+          runProcess: async () => {
+            calls += 1;
+          },
+        },
+      );
+
+      assert.equal(calls, 0, 'repaired invalid-state diagnostic should still enforce cooldown on the next tick');
+      const skippedState = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(skippedState.last_status, 'skipped');
+      assert.equal(skippedState.last_reason, 'rate_limited');
+      assert.equal(skippedState.next_allowed_at, new Date(6_000).toISOString());
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed without spawning when the authority state has an invalid shape', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-invalid-shape-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const statePath = join(stateDir, 'notify-fallback-authority-state.json');
+    let calls = 0;
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(statePath, JSON.stringify({}));
+
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 1_000,
+          random: () => 0,
+          runProcess: async () => {
+            calls += 1;
+          },
+        },
+      );
+
+      assert.equal(calls, 0, 'authority child should not spawn when parsed state shape cannot be trusted');
+      const state = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(state.last_status, 'failed');
+      assert.equal(state.last_reason, 'invalid_authority_state');
+      assert.equal(state.next_allowed_at, new Date(6_000).toISOString());
+      assert.match(state.last_error, /authority state owner must be hud/);
+
+      await writeFile(statePath, JSON.stringify({ ...state, next_allowed_at: 'not-a-date' }));
+
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot: '/pkg',
+          minIntervalMs: 5_000,
+          jitterMs: 0,
+        },
+        {
+          nowMs: () => 2_000,
+          random: () => 0,
+          runProcess: async () => {
+            calls += 1;
+          },
+        },
+      );
+
+      assert.equal(calls, 0, 'authority child should not spawn when next_allowed_at is malformed');
+      const repairedState = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(repairedState.last_status, 'failed');
+      assert.equal(repairedState.last_reason, 'invalid_authority_state');
+      assert.equal(repairedState.next_allowed_at, new Date(7_000).toISOString());
+      assert.match(repairedState.last_error, /next_allowed_at must be a valid ISO timestamp/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('surfaces authority child stderr on failure', async () => {

--- a/src/hud/authority.ts
+++ b/src/hud/authority.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { getPackageRoot } from '../utils/package.js';
 
 export interface RunHudAuthorityTickOptions {
@@ -11,6 +12,8 @@ export interface RunHudAuthorityTickOptions {
   pollMs?: number;
   timeoutMs?: number;
   env?: NodeJS.ProcessEnv;
+  minIntervalMs?: number;
+  jitterMs?: number;
 }
 
 export interface RunHudAuthorityTickDeps {
@@ -23,6 +26,39 @@ export interface RunHudAuthorityTickDeps {
       timeoutMs: number;
     },
   ) => Promise<void> | void;
+  nowMs?: () => number;
+  random?: () => number;
+  onLockAcquired?: () => Promise<void> | void;
+}
+
+interface HudAuthorityState {
+  owner: 'hud';
+  pid: number;
+  cwd: string;
+  heartbeat_at: string;
+  last_spawn_at?: string;
+  last_skip_at?: string;
+  next_allowed_at?: string;
+  cooldown_ms: number;
+  jitter_ms: number;
+  skip_count: number;
+  last_status: 'spawned' | 'skipped' | 'failed' | 'locked';
+  last_reason: string;
+  last_error?: string;
+}
+
+interface AuthorityLock {
+  path: string;
+  token: string;
+}
+
+class AuthorityStateReadError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly cause: unknown,
+  ) {
+    super(`failed to read HUD authority state: ${cause instanceof Error ? cause.message : String(cause)}`);
+  }
 }
 
 function isDeletedCwdMarkerPath(path: string): boolean {
@@ -63,6 +99,231 @@ async function defaultRunProcess(
   }
 }
 
+function asPositiveNumber(value: string | number | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function asNonNegativeNumber(value: string | number | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function parseIsoMs(value: unknown): number | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+function isAuthorityStatus(value: unknown): value is HudAuthorityState['last_status'] {
+  return value === 'spawned' || value === 'skipped' || value === 'failed' || value === 'locked';
+}
+
+function validateAuthorityState(value: unknown): HudAuthorityState {
+  if (typeof value !== 'object' || value === null) {
+    throw new Error('authority state must be an object');
+  }
+  const state = value as Partial<HudAuthorityState>;
+  if (state.owner !== 'hud') throw new Error('authority state owner must be hud');
+  if (typeof state.pid !== 'number' || !Number.isInteger(state.pid) || state.pid <= 0) {
+    throw new Error('authority state pid must be a positive integer');
+  }
+  if (typeof state.cwd !== 'string' || !state.cwd) throw new Error('authority state cwd must be a non-empty string');
+  if (parseIsoMs(state.heartbeat_at) === null) throw new Error('authority state heartbeat_at must be a valid ISO timestamp');
+  if (parseIsoMs(state.next_allowed_at) === null) throw new Error('authority state next_allowed_at must be a valid ISO timestamp');
+  if (typeof state.cooldown_ms !== 'number' || !Number.isFinite(state.cooldown_ms) || state.cooldown_ms < 0) {
+    throw new Error('authority state cooldown_ms must be a non-negative number');
+  }
+  if (typeof state.jitter_ms !== 'number' || !Number.isFinite(state.jitter_ms) || state.jitter_ms < 0) {
+    throw new Error('authority state jitter_ms must be a non-negative number');
+  }
+  if (typeof state.skip_count !== 'number' || !Number.isInteger(state.skip_count) || state.skip_count < 0) {
+    throw new Error('authority state skip_count must be a non-negative integer');
+  }
+  if (!isAuthorityStatus(state.last_status)) throw new Error('authority state last_status is invalid');
+  if (typeof state.last_reason !== 'string' || !state.last_reason) {
+    throw new Error('authority state last_reason must be a non-empty string');
+  }
+  return state as HudAuthorityState;
+}
+
+async function readAuthorityState(path: string): Promise<HudAuthorityState | null> {
+  try {
+    return validateAuthorityState(JSON.parse(await readFile(path, 'utf-8')));
+  } catch (error) {
+    if (isNotFoundError(error)) return null;
+    throw new AuthorityStateReadError(path, error);
+  }
+}
+
+async function writeAuthorityState(path: string, state: HudAuthorityState): Promise<boolean> {
+  const tempPath = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+  try {
+    await mkdir(dirname(path), { recursive: true }).catch(() => {});
+    await writeFile(tempPath, JSON.stringify(state, null, 2));
+    await rename(tempPath, path);
+    return true;
+  } catch {
+    await rm(tempPath, { force: true }).catch(() => {});
+    return false;
+  }
+}
+
+async function writeAuthorityStateUnlessNewerCooldown(path: string, state: HudAuthorityState): Promise<boolean> {
+  const currentState = await readAuthorityState(path).catch(() => null);
+  const currentNextAllowedMs = parseIsoMs(currentState?.next_allowed_at);
+  const candidateNextAllowedMs = parseIsoMs(state.next_allowed_at);
+  if (currentNextAllowedMs !== null && candidateNextAllowedMs !== null && currentNextAllowedMs > candidateNextAllowedMs) {
+    return true;
+  }
+  return writeAuthorityState(path, state);
+}
+
+async function tryCreateAuthorityLock(lockPath: string, nowMs: number): Promise<AuthorityLock | null> {
+  const token = randomUUID();
+  let createdDir = false;
+  try {
+    await mkdir(lockPath, { recursive: false });
+    createdDir = true;
+    await writeFile(join(lockPath, 'owner.json'), JSON.stringify({
+      token,
+      pid: process.pid,
+      acquired_at: new Date(nowMs).toISOString(),
+    }, null, 2));
+    return { path: lockPath, token };
+  } catch {
+    if (createdDir) await rm(lockPath, { recursive: true, force: true }).catch(() => {});
+    return null;
+  }
+}
+
+async function readAuthorityLockOwner(lockPath: string): Promise<{ token?: unknown } | null> {
+  return readFile(join(lockPath, 'owner.json'), 'utf-8')
+    .then((content) => JSON.parse(content) as { token?: unknown })
+    .catch(() => null);
+}
+
+async function restoreMovedLock(fromPath: string, toPath: string): Promise<void> {
+  const restored = await rename(fromPath, toPath).then(() => true).catch(() => false);
+  if (!restored) await rm(fromPath, { recursive: true, force: true }).catch(() => {});
+}
+
+async function acquireAuthorityLock(lockPath: string, staleMs: number, nowMs: number): Promise<AuthorityLock | null> {
+  const created = await tryCreateAuthorityLock(lockPath, nowMs);
+  if (created) return created;
+
+  const observedOwner = await readAuthorityLockOwner(lockPath);
+  const lockStat = await stat(lockPath).catch(() => null);
+  if (!lockStat || nowMs - lockStat.mtimeMs <= staleMs) return null;
+
+  const reapPath = `${lockPath}.stale.${process.pid}.${nowMs}.${randomUUID()}`;
+  try {
+    await rename(lockPath, reapPath);
+  } catch {
+    return null;
+  }
+
+  const reapedOwner = await readAuthorityLockOwner(reapPath);
+  const reapedStat = await stat(reapPath).catch(() => null);
+  const reapedObservedLock = observedOwner?.token === reapedOwner?.token
+    && reapedStat?.mtimeMs === lockStat.mtimeMs
+    && nowMs - reapedStat.mtimeMs > staleMs;
+
+  if (!reapedObservedLock) {
+    await restoreMovedLock(reapPath, lockPath);
+    return null;
+  }
+
+  await rm(reapPath, { recursive: true, force: true }).catch(() => {});
+  return tryCreateAuthorityLock(lockPath, nowMs);
+}
+
+async function releaseAuthorityLock(lock: AuthorityLock): Promise<void> {
+  const releasePath = `${lock.path}.release.${process.pid}.${Date.now()}.${lock.token}`;
+  try {
+    await rename(lock.path, releasePath);
+  } catch {
+    return;
+  }
+
+  const releaseOwner = await readAuthorityLockOwner(releasePath);
+  if (releaseOwner?.token === lock.token) {
+    await rm(releasePath, { recursive: true, force: true }).catch(() => {});
+    return;
+  }
+
+  await restoreMovedLock(releasePath, lock.path);
+}
+
+function buildAuthorityState(
+  cwd: string,
+  nowMs: number,
+  cooldownMs: number,
+  jitterMs: number,
+  overrides: Partial<HudAuthorityState>,
+): HudAuthorityState {
+  return {
+    owner: 'hud',
+    pid: process.pid,
+    cwd,
+    heartbeat_at: new Date(nowMs).toISOString(),
+    cooldown_ms: cooldownMs,
+    jitter_ms: jitterMs,
+    skip_count: 0,
+    last_status: 'spawned',
+    last_reason: 'spawned',
+    ...overrides,
+  };
+}
+
+async function writeRateLimitSkipState(
+  path: string,
+  ownerPath: string,
+  cwd: string,
+  nowMs: number,
+  cooldownMs: number,
+  fallbackJitterMs: number,
+  previousState: HudAuthorityState,
+  reason: 'rate_limited' | 'rate_limited_after_lock',
+): Promise<void> {
+  const skippedState = buildAuthorityState(cwd, nowMs, cooldownMs, previousState.jitter_ms ?? fallbackJitterMs, {
+    last_spawn_at: previousState.last_spawn_at,
+    last_skip_at: new Date(nowMs).toISOString(),
+    next_allowed_at: previousState.next_allowed_at,
+    skip_count: (previousState.skip_count ?? 0) + 1,
+    last_status: 'skipped',
+    last_reason: reason,
+    last_error: previousState.last_error,
+  });
+  await writeAuthorityState(ownerPath, skippedState);
+  await writeAuthorityStateUnlessNewerCooldown(path, skippedState);
+}
+
+async function writeInvalidStateDiagnostic(
+  path: string,
+  ownerPath: string,
+  cwd: string,
+  nowMs: number,
+  cooldownMs: number,
+  jitterMs: number,
+  error: unknown,
+): Promise<boolean> {
+  const failedState = buildAuthorityState(cwd, nowMs, cooldownMs, jitterMs, {
+    last_skip_at: new Date(nowMs).toISOString(),
+    next_allowed_at: new Date(nowMs + cooldownMs + jitterMs).toISOString(),
+    last_status: 'failed',
+    last_reason: 'invalid_authority_state',
+    last_error: error instanceof Error ? error.message : String(error),
+  });
+  const ownerWritten = await writeAuthorityState(ownerPath, failedState);
+  const stateWritten = await writeAuthorityState(path, failedState);
+  return ownerWritten || stateWritten;
+}
+
 export async function runHudAuthorityTick(
   options: RunHudAuthorityTickOptions,
   deps: RunHudAuthorityTickDeps = {},
@@ -73,40 +334,155 @@ export async function runHudAuthorityTick(
   const packageRoot = options.packageRoot ?? getPackageRoot();
   const pollMs = Math.max(1, options.pollMs ?? 75);
   const timeoutMs = Math.max(100, options.timeoutMs ?? 5_000);
+  const minIntervalMs = Math.max(
+    250,
+    asPositiveNumber(
+      options.minIntervalMs ?? options.env?.OMX_HUD_AUTHORITY_MIN_INTERVAL_MS ?? process.env.OMX_HUD_AUTHORITY_MIN_INTERVAL_MS,
+      5_000,
+    ),
+  );
+  const jitterMaxMs = Math.max(
+    0,
+    asNonNegativeNumber(
+      options.jitterMs ?? options.env?.OMX_HUD_AUTHORITY_JITTER_MS ?? process.env.OMX_HUD_AUTHORITY_JITTER_MS,
+      250,
+    ),
+  );
+  const nowMs = deps.nowMs?.() ?? Date.now();
+  const random = deps.random ?? Math.random;
+  const jitterMs = jitterMaxMs > 0 ? Math.floor(random() * (jitterMaxMs + 1)) : 0;
   const watcherScript = join(packageRoot, 'dist', 'scripts', 'notify-fallback-watcher.js');
   const notifyScript = join(packageRoot, 'dist', 'scripts', 'notify-hook.js');
-  const authorityOwnerPath = join(cwd, '.omx', 'state', 'notify-fallback-authority-owner.json');
+  const authorityStateDir = join(cwd, '.omx', 'state');
+  const authorityOwnerPath = join(authorityStateDir, 'notify-fallback-authority-owner.json');
+  const authorityStatePath = join(authorityStateDir, 'notify-fallback-authority-state.json');
+  const authorityLockPath = join(authorityStateDir, 'notify-fallback-authority.lock');
   const runProcess = deps.runProcess ?? defaultRunProcess;
 
-  await mkdir(join(cwd, '.omx', 'state'), { recursive: true }).catch(() => {});
-  await writeFile(authorityOwnerPath, JSON.stringify({
-    owner: 'hud',
-    pid: process.pid,
-    cwd,
-    heartbeat_at: new Date().toISOString(),
-  }, null, 2)).catch(() => {});
+  await mkdir(authorityStateDir, { recursive: true }).catch(() => {});
 
-  await runProcess(
-    nodePath,
-    [
-      watcherScript,
-      '--once',
-      '--authority-only',
-      '--cwd',
+  let previousState: HudAuthorityState | null;
+  try {
+    previousState = await readAuthorityState(authorityStatePath);
+  } catch (error) {
+    if (!(await writeInvalidStateDiagnostic(authorityStatePath, authorityOwnerPath, cwd, nowMs, minIntervalMs, jitterMs, error))) {
+      throw new Error('failed to persist HUD authority invalid-state diagnostic');
+    }
+    return;
+  }
+  const previousNextAllowedMs = parseIsoMs(previousState?.next_allowed_at);
+  if (previousState && previousNextAllowedMs !== null && nowMs < previousNextAllowedMs) {
+    await writeRateLimitSkipState(
+      authorityStatePath,
+      authorityOwnerPath,
       cwd,
-      '--notify-script',
-      notifyScript,
-      '--poll-ms',
-      String(pollMs),
-    ],
-    {
+      nowMs,
+      minIntervalMs,
+      jitterMs,
+      previousState,
+      'rate_limited',
+    );
+    return;
+  }
+
+  const lock = await acquireAuthorityLock(authorityLockPath, timeoutMs + minIntervalMs, nowMs);
+  if (!lock) {
+    const latestState = await readAuthorityState(authorityStatePath).catch(() => null);
+    const diagnosticState = latestState ?? previousState;
+    const lockedState = buildAuthorityState(cwd, nowMs, minIntervalMs, diagnosticState?.jitter_ms ?? jitterMs, {
+      last_spawn_at: diagnosticState?.last_spawn_at,
+      last_skip_at: new Date(nowMs).toISOString(),
+      next_allowed_at: diagnosticState?.next_allowed_at,
+      skip_count: (diagnosticState?.skip_count ?? 0) + 1,
+      last_status: 'locked',
+      last_reason: 'spawn_lock_active',
+      last_error: diagnosticState?.last_error,
+    });
+    await writeAuthorityState(authorityOwnerPath, lockedState);
+    return;
+  }
+
+  await deps.onLockAcquired?.();
+
+  let lockedState: HudAuthorityState | null;
+  try {
+    lockedState = await readAuthorityState(authorityStatePath);
+  } catch (error) {
+    const diagnosticWritten = await writeInvalidStateDiagnostic(authorityStatePath, authorityOwnerPath, cwd, nowMs, minIntervalMs, jitterMs, error);
+    await releaseAuthorityLock(lock);
+    if (!diagnosticWritten) throw new Error('failed to persist HUD authority rate-limit state');
+    return;
+  }
+  const lockedNextAllowedMs = parseIsoMs(lockedState?.next_allowed_at);
+  if (lockedState && lockedNextAllowedMs !== null && nowMs < lockedNextAllowedMs) {
+    await writeRateLimitSkipState(
+      authorityStatePath,
+      authorityOwnerPath,
       cwd,
-      env: {
-        ...process.env,
-        ...(options.env ?? {}),
-        OMX_HUD_AUTHORITY: '1',
+      nowMs,
+      minIntervalMs,
+      jitterMs,
+      lockedState,
+      'rate_limited_after_lock',
+    );
+    await releaseAuthorityLock(lock);
+    return;
+  }
+
+  const nextAllowedAt = new Date(nowMs + minIntervalMs + jitterMs).toISOString();
+  const spawnedState = buildAuthorityState(cwd, nowMs, minIntervalMs, jitterMs, {
+    last_spawn_at: new Date(nowMs).toISOString(),
+    next_allowed_at: nextAllowedAt,
+    skip_count: previousState?.skip_count ?? 0,
+    last_status: 'spawned',
+    last_reason: 'spawned',
+  });
+  await writeAuthorityState(authorityOwnerPath, spawnedState);
+  if (!(await writeAuthorityState(authorityStatePath, spawnedState))) {
+    await releaseAuthorityLock(lock);
+    throw new Error('failed to persist HUD authority rate-limit state');
+  }
+
+  try {
+    await runProcess(
+      nodePath,
+      [
+        watcherScript,
+        '--once',
+        '--authority-only',
+        '--cwd',
+        cwd,
+        '--notify-script',
+        notifyScript,
+        '--poll-ms',
+        String(pollMs),
+      ],
+      {
+        cwd,
+        env: {
+          ...process.env,
+          ...(options.env ?? {}),
+          OMX_HUD_AUTHORITY: '1',
+          OMX_HUD_AUTHORITY_MIN_INTERVAL_MS: String(minIntervalMs),
+          OMX_HUD_AUTHORITY_JITTER_MS: String(jitterMaxMs),
+        },
+        timeoutMs,
       },
-      timeoutMs,
-    },
-  );
+    );
+  } catch (error) {
+    const failedAt = deps.nowMs?.() ?? Date.now();
+    const failedState = buildAuthorityState(cwd, failedAt, minIntervalMs, jitterMs, {
+      last_spawn_at: spawnedState.last_spawn_at,
+      next_allowed_at: nextAllowedAt,
+      skip_count: previousState?.skip_count ?? 0,
+      last_status: 'failed',
+      last_reason: 'child_failed',
+      last_error: error instanceof Error ? error.message : String(error),
+    });
+    await writeAuthorityState(authorityOwnerPath, failedState);
+    await writeAuthorityState(authorityStatePath, failedState);
+    throw error;
+  } finally {
+    await releaseAuthorityLock(lock);
+  }
 }


### PR DESCRIPTION
## Summary
- add persisted cooldown/jitter state and a spawn lock around HUD authority-only fallback watcher launches
- re-check cooldown under the lock and fail closed if pre-spawn rate-limit state cannot be persisted
- preserve existing long-lived fallback watcher parent-pid/singleton contracts and fix the detached-helper test fixture for ESM package mode

Fixes #2659

## Validation
- `npm run build`
- `node --test dist/hud/__tests__/authority.test.js dist/hud/__tests__/index.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js`
- `npm run check:no-unused`
- `npm run lint`
- `git diff --check`

## Review evidence
- code-reviewer: APPROVE after prior lock/state blockers were fixed
- architect: CLEAR after atomic writes and under-lock cooldown recheck
