### PR TITLE
Fix plugin Stop hook launcher JSON fallback

### DIFF
--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -5,6 +5,152 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const hookDir = dirname(fileURLToPath(import.meta.url));
+const MAX_WRAPPER_STDIN_BYTES = 1024 * 1024;
+const RAW_EVENT_SCAN_BYTES = 64 * 1024;
+const CODEX_HOOK_EVENT_NAMES = new Set([
+  'SessionStart',
+  'PreToolUse',
+  'PostToolUse',
+  'UserPromptSubmit',
+  'PreCompact',
+  'PostCompact',
+  'Stop',
+]);
+
+function skipJsonWhitespace(raw, index) {
+  while (index < raw.length && /\s/.test(raw[index] ?? '')) index += 1;
+  return index;
+}
+
+function readJsonStringLiteral(raw, quoteIndex) {
+  if (raw[quoteIndex] !== '"') return null;
+  let value = '';
+  for (let index = quoteIndex + 1; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (char === '"') return { value, endIndex: index + 1 };
+    if (char !== '\\') {
+      value += char;
+      continue;
+    }
+
+    index += 1;
+    if (index >= raw.length) return null;
+    const escaped = raw[index];
+    switch (escaped) {
+      case '"':
+      case '\\':
+      case '/':
+        value += escaped;
+        break;
+      case 'b':
+        value += '\b';
+        break;
+      case 'f':
+        value += '\f';
+        break;
+      case 'n':
+        value += '\n';
+        break;
+      case 'r':
+        value += '\r';
+        break;
+      case 't':
+        value += '\t';
+        break;
+      case 'u': {
+        const hex = raw.slice(index + 1, index + 5);
+        if (!/^[0-9a-fA-F]{4}$/.test(hex)) return null;
+        value += String.fromCharCode(Number.parseInt(hex, 16));
+        index += 4;
+        break;
+      }
+      default:
+        return null;
+    }
+  }
+  return null;
+}
+
+function extractTopLevelHookEventName(rawInput) {
+  const raw = rawInput.slice(0, RAW_EVENT_SCAN_BYTES);
+  const wanted = new Set(['hook_event_name', 'hookEventName', 'event', 'name']);
+  let depth = 0;
+  let index = 0;
+
+  while (index < raw.length) {
+    const char = raw[index];
+    if (char === '"') {
+      const key = readJsonStringLiteral(raw, index);
+      if (!key) return null;
+      index = key.endIndex;
+      const afterKey = skipJsonWhitespace(raw, index);
+      if (depth === 1 && raw[afterKey] === ':' && wanted.has(key.value)) {
+        const valueStart = skipJsonWhitespace(raw, afterKey + 1);
+        const value = readJsonStringLiteral(raw, valueStart);
+        const eventName = value?.value ?? null;
+        return CODEX_HOOK_EVENT_NAMES.has(eventName) ? eventName : null;
+      }
+      continue;
+    }
+    if (char === '{') depth += 1;
+    else if (char === '}') depth = Math.max(0, depth - 1);
+    index += 1;
+  }
+
+  return null;
+}
+
+function detectStopHookInput(input) {
+  const text = input.toString('utf8');
+  try {
+    const parsed = JSON.parse(text);
+    const eventName = parsed?.hook_event_name ?? parsed?.hookEventName ?? parsed?.event ?? parsed?.name;
+    return eventName === 'Stop';
+  } catch {
+    return extractTopLevelHookEventName(text) === 'Stop';
+  }
+}
+
+async function readBoundedStdin() {
+  const chunks = [];
+  let totalBytes = 0;
+  for await (const rawChunk of process.stdin) {
+    const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk);
+    totalBytes += chunk.length;
+    if (totalBytes > MAX_WRAPPER_STDIN_BYTES) {
+      const remaining = MAX_WRAPPER_STDIN_BYTES - Buffer.concat(chunks).length;
+      if (remaining > 0) chunks.push(chunk.subarray(0, remaining));
+      return { input: Buffer.concat(chunks), oversized: true, totalBytes };
+    }
+    chunks.push(chunk);
+  }
+  return { input: Buffer.concat(chunks), oversized: false, totalBytes };
+}
+
+function stopFallbackOutput(stopReason, detail) {
+  const reason = 'OMX plugin Stop hook launcher failed before valid native Stop JSON could be produced. Continue once, preserve runtime state, inspect hook launcher diagnostics, and retry.';
+  return {
+    decision: 'block',
+    reason,
+    stopReason,
+    systemMessage: detail ? `${reason} Failure: ${detail}` : reason,
+  };
+}
+
+function writeStopFallback(stopReason, detail) {
+  process.stdout.write(`${JSON.stringify(stopFallbackOutput(stopReason, detail))}\n`);
+  process.exitCode = 0;
+}
+
+function failLauncher(error, isStop, stopReason = 'plugin_stop_hook_launcher_failure') {
+  const detail = error instanceof Error ? error.message : String(error);
+  console.error(`[oh-my-codex] ${detail}`);
+  if (isStop) {
+    writeStopFallback(stopReason, detail);
+    return;
+  }
+  process.exitCode = 1;
+}
 
 function readPinnedLauncher() {
   const launcherPath = join(hookDir, 'omx-command.json');
@@ -20,8 +166,7 @@ function readPinnedLauncher() {
     return { command: raw.command, argsPrefix };
   } catch (error) {
     if (error?.code === 'ENOENT') return null;
-    console.error(`[oh-my-codex] invalid plugin hook launcher ${launcherPath}: ${error.message}`);
-    process.exit(1);
+    throw new Error(`invalid plugin hook launcher ${launcherPath}: ${error.message}`);
   }
 }
 
@@ -32,25 +177,91 @@ function readConfiguredLauncher() {
   return readPinnedLauncher() ?? { command: 'omx', argsPrefix: [] };
 }
 
-const { command, argsPrefix } = readConfiguredLauncher();
-const child = spawn(command, [...argsPrefix, 'codex-native-hook'], {
-  stdio: ['pipe', 'pipe', 'pipe'],
-  env: process.env,
-  shell: process.platform === 'win32',
-});
+async function main() {
+  const { input, oversized, totalBytes } = await readBoundedStdin();
+  const isStop = detectStopHookInput(input);
 
-process.stdin.pipe(child.stdin);
-child.stdout.pipe(process.stdout);
-child.stderr.pipe(process.stderr);
-child.on('error', (error) => {
-  console.error(`[oh-my-codex] failed to launch ${command} codex-native-hook: ${error.message}`);
-  process.exitCode = 1;
-});
-child.on('exit', (code, signal) => {
-  if (signal) {
-    console.error(`[oh-my-codex] codex-native-hook terminated by ${signal}`);
+  if (oversized) {
+    const message = `plugin hook stdin exceeded ${MAX_WRAPPER_STDIN_BYTES} bytes before launcher delegation; totalBytes>${totalBytes}`;
+    if (isStop) {
+      console.error(`[oh-my-codex] ${message}`);
+      writeStopFallback('plugin_stop_hook_stdin_oversized', message);
+      return;
+    }
+    console.error(`[oh-my-codex] ${message}`);
     process.exitCode = 1;
     return;
   }
-  process.exitCode = code ?? 0;
+
+  let launcher;
+  try {
+    launcher = readConfiguredLauncher();
+  } catch (error) {
+    failLauncher(error, isStop);
+    return;
+  }
+
+  const { command, argsPrefix } = launcher;
+  const child = spawn(command, [...argsPrefix, 'codex-native-hook'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: process.env,
+    shell: process.platform === 'win32',
+  });
+
+  let stdoutBytes = 0;
+  let childSpawnError = null;
+  let childStdinError = null;
+
+  child.stdout.on('data', (chunk) => {
+    stdoutBytes += Buffer.byteLength(chunk);
+    process.stdout.write(chunk);
+  });
+  child.stderr.pipe(process.stderr);
+  child.stdin.on('error', (error) => {
+    childStdinError = error;
+  });
+  child.on('error', (error) => {
+    childSpawnError = error;
+  });
+  child.on('close', (code, signal) => {
+    if (isStop && stdoutBytes === 0) {
+      if (childSpawnError) {
+        writeStopFallback('plugin_stop_hook_launcher_spawn_error', `failed to launch ${command} codex-native-hook: ${childSpawnError.message}`);
+        return;
+      }
+      if (signal) {
+        writeStopFallback('plugin_stop_hook_launcher_signal', `codex-native-hook terminated by ${signal}`);
+        return;
+      }
+      if (code && code !== 0) {
+        if (childStdinError) {
+          writeStopFallback('plugin_stop_hook_launcher_stdin_error', `codex-native-hook stdin failed: ${childStdinError.message}`);
+          return;
+        }
+        writeStopFallback('plugin_stop_hook_launcher_exit', `codex-native-hook exited with code ${code}`);
+        return;
+      }
+      writeStopFallback('plugin_stop_hook_launcher_empty_stdout', 'codex-native-hook exited successfully without producing Stop hook JSON');
+      return;
+    }
+
+    if (childSpawnError) {
+      console.error(`[oh-my-codex] failed to launch ${command} codex-native-hook: ${childSpawnError.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    if (signal) {
+      console.error(`[oh-my-codex] codex-native-hook terminated by ${signal}`);
+      process.exitCode = 1;
+      return;
+    }
+    process.exitCode = code ?? 0;
+  });
+
+  child.stdin.end(input);
+}
+
+main().catch((error) => {
+  console.error(`[oh-my-codex] plugin hook launcher failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
 });

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -140,6 +140,38 @@ async function assertPluginCacheLaunchable(entrypoint: string): Promise<void> {
   }
 }
 
+function parseSingleJsonStdout(stdout: string): Record<string, unknown> {
+  const trimmed = stdout.trim();
+  assert.notEqual(trimmed, '');
+  assert.equal(trimmed.split('\n').length, 1);
+  return JSON.parse(trimmed) as Record<string, unknown>;
+}
+
+async function withPluginCacheCopy<T>(run: (cachePluginRoot: string, cacheRoot: string) => Promise<T>): Promise<T> {
+  const cacheRoot = await mkdtemp(join(tmpdir(), 'omx-plugin-hook-cache-'));
+  const cachePluginRoot = join(cacheRoot, pluginName, 'local');
+  await cp(pluginRoot, cachePluginRoot, { recursive: true });
+  try {
+    return await run(cachePluginRoot, cacheRoot);
+  } finally {
+    await rm(cacheRoot, { recursive: true, force: true });
+  }
+}
+
+function runPluginNativeHook(
+  cachePluginRoot: string,
+  input: string,
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  return spawnSync(process.execPath, [join(cachePluginRoot, 'hooks', 'codex-native-hook.mjs')], {
+    cwd: cachePluginRoot,
+    input,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env,
+  });
+}
+
 describe('official Codex plugin layout', () => {
   it('defines a plugin manifest under a plugin root and keeps .codex-plugin limited to plugin.json', async () => {
     const pkg = await readJson<PackageJson>(join(root, 'package.json'));
@@ -195,6 +227,238 @@ describe('official Codex plugin layout', () => {
       assert.equal(OMX_FIRST_PARTY_MCP_PLUGIN_TARGETS.includes(target ?? ''), true, `${serverName} should use a stable public OMX MCP target`);
       assert.equal(target?.endsWith('-server.js'), false, `${serverName} should not expose internal dist filenames in plugin metadata`);
     }
+  });
+
+  it('emits Stop JSON when the plugin hook pinned launcher is invalid', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      await writeFile(join(cachePluginRoot, 'hooks', 'omx-command.json'), '{"command":', 'utf-8');
+
+      const result = runPluginNativeHook(cachePluginRoot, JSON.stringify({
+        hook_event_name: 'Stop',
+        session_id: 'sess-plugin-invalid-launcher-stop',
+      }));
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /invalid plugin hook launcher/);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_launcher_failure');
+    });
+  });
+
+  it('emits Stop JSON when the plugin hook command cannot spawn', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-missing-command-stop' }),
+        {
+          ...process.env,
+          OMX_NATIVE_HOOK_COMMAND: join(cacheRoot, 'bin', 'missing-omx-command'),
+        },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_launcher_spawn_error');
+    });
+  });
+
+  it('emits Stop JSON when the launched plugin hook command exits before producing stdout', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-false-command-stop' }),
+        {
+          ...process.env,
+          OMX_NATIVE_HOOK_COMMAND: process.platform === 'win32' ? 'cmd.exe /c exit 1' : '/bin/false',
+        },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.match(String(output.stopReason ?? ''), /plugin_stop_hook_launcher_(?:exit|stdin_error)/);
+    });
+  });
+
+  it('emits Stop JSON when the launched plugin hook command exits successfully without stdout', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'empty-ok.cmd' : 'empty-ok.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, '@echo off\r\nexit /b 0\r\n', 'utf-8');
+      } else {
+        await writeFile(commandPath, '#!/bin/sh\nexit 0\n', 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-empty-ok-stop' }),
+        { ...process.env, OMX_NATIVE_HOOK_COMMAND: commandPath },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_launcher_empty_stdout');
+    });
+  });
+
+  it('does not append fallback Stop JSON after partial child stdout', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'partial.cmd' : 'partial.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, '@echo off\r\n<nul set /p=PARTIAL\r\nexit /b 2\r\n', 'utf-8');
+      } else {
+        await writeFile(commandPath, '#!/bin/sh\nprintf PARTIAL\nexit 2\n', 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-partial-stop' }),
+        { ...process.env, OMX_NATIVE_HOOK_COMMAND: commandPath },
+      );
+
+      assert.equal(result.status, 2, result.stderr || result.stdout);
+      assert.equal(result.stdout, 'PARTIAL');
+      assert.doesNotMatch(result.stdout, /plugin_stop_hook_launcher/);
+    });
+  });
+
+  it('emits Stop JSON for malformed Stop-looking stdin before invalid launcher failure', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      await writeFile(join(cachePluginRoot, 'hooks', 'omx-command.json'), '{"command":', 'utf-8');
+
+      const result = runPluginNativeHook(cachePluginRoot, '{"hook_event_name":"Stop",');
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_launcher_failure');
+    });
+  });
+
+  it('emits Stop JSON for the core-supported name alias before invalid launcher failure', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      await writeFile(join(cachePluginRoot, 'hooks', 'omx-command.json'), '{"command":', 'utf-8');
+
+      const result = runPluginNativeHook(cachePluginRoot, '{"name":"Stop",');
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_launcher_failure');
+    });
+  });
+
+  it('keeps non-Stop plugin hook launcher failures fail-closed without Stop JSON', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      await writeFile(join(cachePluginRoot, 'hooks', 'omx-command.json'), '{"command":', 'utf-8');
+
+      const result = runPluginNativeHook(cachePluginRoot, JSON.stringify({
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'hello',
+      }));
+
+      assert.equal(result.status, 1);
+      assert.equal(result.stdout, '');
+      assert.match(result.stderr, /invalid plugin hook launcher/);
+    });
+  });
+
+  it('does not classify valid non-Stop plugin JSON with nested Stop text as Stop', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      await writeFile(join(cachePluginRoot, 'hooks', 'omx-command.json'), '{"command":', 'utf-8');
+
+      const result = runPluginNativeHook(cachePluginRoot, JSON.stringify({
+        hook_event_name: 'PreToolUse',
+        tool_input: { name: 'Stop' },
+      }));
+
+      assert.equal(result.status, 1);
+      assert.equal(result.stdout, '');
+      assert.match(result.stderr, /invalid plugin hook launcher/);
+    });
+  });
+
+  it('does not classify malformed non-Stop plugin JSON with nested Stop text as Stop', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      await writeFile(join(cachePluginRoot, 'hooks', 'omx-command.json'), '{"command":', 'utf-8');
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        '{"hook_event_name":"PreToolUse","tool_input":{"name":"Stop"},',
+      );
+
+      assert.equal(result.status, 1);
+      assert.equal(result.stdout, '');
+      assert.match(result.stderr, /invalid plugin hook launcher/);
+    });
+  });
+
+  it('fails oversized plugin Stop stdin with one schema-safe JSON object', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      const oversizedStop = `{"hook_event_name":"Stop","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
+      const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized');
+    });
+  });
+
+  it('fails oversized non-Stop plugin stdin without Stop JSON', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      const result = runPluginNativeHook(cachePluginRoot, 'x'.repeat(1024 * 1024 + 1));
+
+      assert.equal(result.status, 1);
+      assert.equal(result.stdout, '');
+      assert.match(result.stderr, /plugin hook stdin exceeded/);
+    });
+  });
+
+  it('forwards under-cap plugin hook stdin bytes unchanged to the delegated command', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const capturePath = join(cacheRoot, 'captured-stdin.json');
+      const commandPath = join(cacheRoot, 'capture-hook.mjs');
+      const launcherPath = join(cacheRoot, process.platform === 'win32' ? 'capture-hook.cmd' : 'capture-hook.sh');
+      await writeFile(
+        commandPath,
+        `import { writeFileSync } from 'node:fs';
+const chunks = [];
+process.stdin.on('data', (chunk) => chunks.push(chunk));
+process.stdin.on('end', () => {
+  writeFileSync(process.env.CAPTURE_PATH, Buffer.concat(chunks));
+  process.stdout.write('{}\\n');
+});
+`,
+        'utf-8',
+      );
+      if (process.platform === 'win32') {
+        await writeFile(launcherPath, `@echo off\r\n"${process.execPath}" "${commandPath}" %*\r\n`, 'utf-8');
+      } else {
+        await writeFile(launcherPath, `#!/bin/sh\nexec "${process.execPath}" "${commandPath}" "$@"\n`, 'utf-8');
+        await chmod(launcherPath, 0o755);
+      }
+
+      const input = JSON.stringify({
+        hook_event_name: 'Stop',
+        session_id: 'sess-plugin-forward-stdin',
+        payload: 'keep these bytes unchanged',
+      });
+      const result = runPluginNativeHook(cachePluginRoot, input, {
+        ...process.env,
+        OMX_NATIVE_HOOK_COMMAND: launcherPath,
+        CAPTURE_PATH: capturePath,
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+      assert.equal(await readFile(capturePath, 'utf-8'), input);
+    });
   });
 
   it('keeps plugin MCP metadata aligned with the explicit compat setup-managed MCP roster', async () => {


### PR DESCRIPTION
## Summary
- harden the plugin-scoped Codex native hook wrapper so Stop-hook launcher failures emit one valid block JSON object instead of leaving Codex with invalid/empty stdout
- bound wrapper stdin before delegation and detect Stop from the same top-level event aliases used by the core hook path
- add regression coverage for invalid pinned launchers, spawn failures, child nonzero/empty/partial stdout, malformed Stop stdin, nested non-Stop false positives, oversized input, and byte-for-byte forwarding

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/codex-plugin-layout.test.js` — 21/21 pass
- `node --test dist/scripts/__tests__/codex-native-hook.test.js` — 411/411 pass
- `npm run check:no-unused`
- `npm run verify:plugin-bundle`
- `npx biome lint src/cli/__tests__/codex-plugin-layout.test.ts plugins/oh-my-codex/hooks/codex-native-hook.mjs`
- `git diff --check`
- `node --check plugins/oh-my-codex/hooks/codex-native-hook.mjs`
## Related PRs
- Related investigation / original native-subagent recursion report: #2658
- Maintainer-owned replacement for the native executor leaf-only fix: #2666
