### PR TITLE
Deduplicate legacy focused HUD panes on prompt revive

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -336,6 +336,67 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(created, []);
   });
 
+  it('reuses and deduplicates legacy unowned focused HUD watch panes before recreating', async () => {
+    const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    const created: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%2', currentCommand: 'node', startCommand: 'node /tmp/bin/omx.js hud --watch --preset=focused' },
+        { paneId: '%3', currentCommand: 'node', startCommand: 'node /tmp/bin/omx.js hud --watch --preset=focused' },
+        { paneId: '%4', currentCommand: 'node', startCommand: 'node /tmp/bin/omx.js hud --watch --preset=minimal' },
+        { paneId: '%5', currentCommand: 'node', startCommand: 'node /tmp/bin/omx.js hud --tmux --preset=focused' },
+      ],
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      createHudWatchPane: () => { created.push('create'); return '%9'; },
+      resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.paneId, '%2');
+    assert.equal(result.duplicateCount, 1);
+    assert.deepEqual(killed, ['%3']);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+    assert.deepEqual(created, []);
+  });
+
+  it('deduplicates legacy focused panes that appear during the prompt-submit create race', async () => {
+    const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    let listCount = 0;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-race', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => {
+        listCount += 1;
+        if (listCount === 1) return [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }];
+        return [
+          { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+          { paneId: '%8', currentCommand: 'node', startCommand: 'node /tmp/bin/omx.js hud --watch --preset=focused' },
+          {
+            paneId: '%9',
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='sess-race' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch --preset=focused`,
+          },
+        ];
+      },
+      createHudWatchPane: () => '%9',
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.paneId, '%9');
+    assert.equal(result.duplicateCount, 1);
+    assert.deepEqual(killed, ['%8']);
+    assert.deepEqual(resized, [{ paneId: '%9', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+  });
+
   it('does not kill existing duplicate HUD panes when the keeper cannot be resized', async () => {
     const killed: string[] = [];
     const registered: string[] = [];

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -364,6 +364,33 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(created, []);
   });
 
+  it('treats an extra legacy focused pane as stale when an owned HUD already exists', async () => {
+    const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch --preset=focused`,
+        },
+        { paneId: '%3', currentCommand: 'node', startCommand: 'node /tmp/bin/omx.js hud --watch --preset=focused' },
+      ],
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.paneId, '%2');
+    assert.equal(result.duplicateCount, 1);
+    assert.deepEqual(killed, ['%3']);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+  });
+
   it('deduplicates legacy focused panes that appear during the prompt-submit create race', async () => {
     const killed: string[] = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -7,6 +7,7 @@ import {
   buildHudResizeHookName,
   buildHudResizeHookSlot,
   buildHudWatchCommand,
+  findLegacyFocusedHudWatchPaneIds,
   findHudWatchPaneIds,
   hudPaneMatchesOwner,
   listCurrentWindowHudPaneIds,
@@ -333,6 +334,21 @@ describe('HUD pane ownership helpers', () => {
 
     assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), []);
     assert.deepEqual(findHudWatchPaneIds(panes, '%1'), ['%2']);
+  });
+
+  it('separately detects legacy focused watch panes for automatic reconciliation only', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        '%2\tnode\tnode /tmp/bin/omx.js hud --watch --preset=focused',
+        '%3\tnode\tnode /tmp/bin/omx.js hud --watch --preset=minimal',
+        `%4\tnode\texec env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch --preset=focused`,
+        '%5\tnode\tnode /tmp/bin/omx.js hud --tmux --preset=focused',
+        `%6\tnode\t/bin/zsh -c 'exec '\\''node'\\'' '\\''/tmp/bin/omx.js'\\'' '\\''hud'\\'' '\\''--watch'\\'' '\\''--preset=focused'\\'''`,
+      ].join('\n'),
+    );
+
+    assert.deepEqual(findLegacyFocusedHudWatchPaneIds(panes, '%1'), ['%2', '%6']);
   });
 
   it('matches session-owned legacy HUD panes without leader tags for same-session cleanup', () => {

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -345,6 +345,9 @@ describe('HUD pane ownership helpers', () => {
         `%4\tnode\texec env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch --preset=focused`,
         '%5\tnode\tnode /tmp/bin/omx.js hud --tmux --preset=focused',
         `%6\tnode\t/bin/zsh -c 'exec '\\''node'\\'' '\\''/tmp/bin/omx.js'\\'' '\\''hud'\\'' '\\''--watch'\\'' '\\''--preset=focused'\\'''`,
+        '%7\tnode\tnode /tmp/bin/custom-hud.js hud --watch --preset=focused',
+        '%8\tnode\tnode /tmp/omx-pr2664/custom-hud.js hud --watch --preset=focused',
+        '%9\tnode\tnode /tmp/bin/omx.js hud --tmux --watch --preset=focused',
       ].join('\n'),
     );
 

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -4,6 +4,7 @@ import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import {
   buildHudWatchCommand,
   createHudWatchPane,
+  findLegacyFocusedHudWatchPaneIds,
   findHudWatchPaneIds,
   isHudWatchPane,
   killTmuxPane,
@@ -73,7 +74,10 @@ function planOwnedHudPaneDedupe(
   owner: { sessionId?: string; leaderPaneId?: string },
   preferredPaneId: string,
 ): { paneId: string; duplicatePaneIds: string[] } {
-  const ownedPaneIds = findHudWatchPaneIds(panes, currentPaneId, owner);
+  const ownedPaneIds = [
+    ...findHudWatchPaneIds(panes, currentPaneId, owner),
+    ...findLegacyFocusedHudWatchPaneIds(panes, currentPaneId),
+  ].filter((paneId, index, paneIds) => paneIds.indexOf(paneId) === index);
   const keeperPaneId = ownedPaneIds.includes(preferredPaneId)
     ? preferredPaneId
     : (ownedPaneIds[0] ?? preferredPaneId);
@@ -130,7 +134,10 @@ export async function reconcileHudForPromptSubmit(
     sessionId: resolvedSessionId,
     leaderPaneId: currentPaneId,
   };
-  const hudPaneIds = findHudWatchPaneIds(panes, currentPaneId, owner);
+  const hudPaneIds = [
+    ...findHudWatchPaneIds(panes, currentPaneId, owner),
+    ...findLegacyFocusedHudWatchPaneIds(panes, currentPaneId),
+  ].filter((paneId, index, paneIds) => paneIds.indexOf(paneId) === index);
   const duplicateCount = Math.max(0, hudPaneIds.length - 1);
   const nonHudPaneCount = panes.filter((pane) => !isHudWatchPane(pane)).length;
   const readHudConfigFn = deps.readHudConfig ?? readHudConfig;

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -101,10 +101,19 @@ function hasHudPaneOwnerMetadata(pane: TmuxPaneSnapshot): boolean {
     || Boolean(owner.sessionId || owner.leaderPaneId);
 }
 
+function hasOmxCliToken(command: string): boolean {
+  return /(?:^|[\s'"])(?:[^\s'"]*\/)?omx(?:\.js)?(?=$|[\s'"])/.test(command);
+}
+
 function isLegacyFocusedHudWatchPane(pane: TmuxPaneSnapshot): boolean {
+  // Migration-only heuristic for prompt-submit auto-HUD reconciliation: older
+  // focused auto-HUD panes lacked owner metadata, so keep this deliberately
+  // narrower than general HUD ownership/reaping.
   if (!isHudWatchPane(pane) || hasHudPaneOwnerMetadata(pane)) return false;
   const command = `${pane.startCommand} ${pane.currentCommand}`;
-  return /(?:^|[\s'"])--preset=focused(?:[\s'"]|$)/.test(command);
+  return hasOmxCliToken(command)
+    && !/(?:^|[\s'"])--tmux(?:[\s'"]|$)/.test(command)
+    && /(?:^|[\s'"])--preset=focused(?:[\s'"]|$)/.test(command);
 }
 
 export function findLegacyFocusedHudWatchPaneIds(

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -101,6 +101,22 @@ function hasHudPaneOwnerMetadata(pane: TmuxPaneSnapshot): boolean {
     || Boolean(owner.sessionId || owner.leaderPaneId);
 }
 
+function isLegacyFocusedHudWatchPane(pane: TmuxPaneSnapshot): boolean {
+  if (!isHudWatchPane(pane) || hasHudPaneOwnerMetadata(pane)) return false;
+  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  return /(?:^|[\s'"])--preset=focused(?:[\s'"]|$)/.test(command);
+}
+
+export function findLegacyFocusedHudWatchPaneIds(
+  panes: TmuxPaneSnapshot[],
+  currentPaneId?: string,
+): string[] {
+  return panes
+    .filter((pane) => pane.paneId !== currentPaneId)
+    .filter((pane) => isLegacyFocusedHudWatchPane(pane))
+    .map((pane) => pane.paneId);
+}
+
 export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner = {}): boolean {
   if (!isHudWatchPane(pane)) return false;
   const wantedSessionId = typeof owner.sessionId === 'string' ? owner.sessionId.trim() : '';


### PR DESCRIPTION
## Summary
- Adds automatic prompt-submit HUD reconciliation for legacy unowned `omx hud --watch --preset=focused` panes reported in #2662.
- Reuses one focused legacy watcher and kills extras before creating a new pane, including the post-create race window.
- Keeps owner-scoped reconciliation intact and leaves manual non-watch/`--tmux` command detection out of the legacy auto-HUD path.

## PR #2652 overlap
PR #2652 strengthens session-authoritative HUD state and owner metadata propagation, but it does not fully cover #2662's observed legacy unowned `--preset=focused` watcher panes. This PR is the narrow compatibility/dedupe layer for already-created unowned focused watchers.

Closes #2662.

## Verification
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node --test dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/tmux.test.js dist/hud/__tests__/hud-tmux-injection.test.js dist/scripts/__tests__/codex-native-hook.test.js` — 503 passing
- `git diff --check`

## Note
A broader `dist/cli/__tests__/index.test.js` run was attempted and hit pre-existing unrelated origin/dev cleanup/extended-keys lease failures in this workspace; the HUD/tmux/reconcile/native-hook focused suites above passed after this change.
