### PR TITLE
Optimize CI lanes for GJC evidence artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,17 @@ jobs:
               || path === 'dist-workspace.toml';
           }
 
+          function isGjcPlanningEvidence(path) {
+            return /^\.gjc\/(plans|ultragoal|quality-gates?|planning-evidence)\//.test(path)
+              || /^\.gjc\/[^/]+\/(quality-gates?|planning-evidence)\//.test(path)
+              || /^\.gjc\/[^/]+\/(prd|test-spec|plan|quality-gate)[^/]*\.(md|json|jsonl|txt)$/.test(path);
+          }
+
+          function isGjcRuntimeAffecting(path) {
+            return /^\.gjc\/(runtime|state|sessions|team|hooks|notifications)\//.test(path)
+              || /^\.gjc\/(config|settings|policy)\.(json|toml|ya?ml)$/.test(path);
+          }
+
           const paths = lines.flatMap(pathsFromNameStatus);
           if (paths.length === 0 && !out.full_suite) {
             out.full_suite = true;
@@ -160,13 +171,21 @@ jobs:
             if (isRust(path)) out.rust_changed = true;
             if (isNative(path)) out.native_changed = true;
             if (isSharedConfig(path)) out.shared_config_changed = true;
+            if (isGjcRuntimeAffecting(path)) out.ts_changed = true;
           }
 
           const allDocs = paths.length > 0 && paths.every(isDocs);
           out.docs_only = allDocs;
+          const allGjcPlanningEvidence = paths.length > 0 && paths.every(isGjcPlanningEvidence);
+          const gjcRuntimePaths = paths.filter(isGjcRuntimeAffecting);
+          if (!out.full_suite && allGjcPlanningEvidence) {
+            out.reason = 'gjc planning/evidence artifacts only';
+          } else if (!out.full_suite && gjcRuntimePaths.length > 0) {
+            out.reason = `gjc runtime-affecting artifact(s): ${gjcRuntimePaths.join(', ')}`;
+          }
 
           // Fail closed for shared config, workflow, version, lockfile, native packaging, or ambiguous repo assets.
-          const known = (path) => isDocs(path) || isTs(path) || isRust(path) || isNative(path) || isSharedConfig(path);
+          const known = (path) => isDocs(path) || isTs(path) || isRust(path) || isNative(path) || isSharedConfig(path) || isGjcPlanningEvidence(path) || isGjcRuntimeAffecting(path);
           const unknown = paths.filter((path) => !known(path));
           if (out.shared_config_changed || unknown.length > 0) {
             out.full_suite = true;
@@ -550,6 +569,8 @@ jobs:
           set -euo pipefail
 
           failures=0
+          failing_active_gates=()
+          unexpected_inactive_gates=()
           bool_any() {
             for value in "$@"; do
               [[ "$value" == "true" ]] && return 0
@@ -564,11 +585,13 @@ jobs:
             if [[ "$active" == "true" ]]; then
               if [[ "$result" != "success" ]]; then
                 echo "::error::$name must succeed when active, got $result"
+                failing_active_gates+=("$name=$result")
                 failures=$((failures + 1))
               fi
             else
               if [[ "$result" != "success" && "$result" != "skipped" ]]; then
                 echo "::error::$name inactive lane should be success or skipped, got $result"
+                unexpected_inactive_gates+=("$name=$result")
                 failures=$((failures + 1))
               fi
             fi
@@ -620,6 +643,13 @@ jobs:
           check_job build "$BUILD_RESULT" "$build_active"
 
           if (( failures > 0 )); then
+            if (( ${#failing_active_gates[@]} > 0 )); then
+              echo "::error::Actual failing active CI gate(s): ${failing_active_gates[*]}"
+            fi
+            if (( ${#unexpected_inactive_gates[@]} > 0 )); then
+              echo "::error::Unexpected inactive CI gate result(s): ${unexpected_inactive_gates[*]}"
+            fi
+            echo "::error::Lane-selection reason: ${REASON:-unknown}; full_suite=${FULL_SUITE:-unknown}"
             echo "::error::$failures CI status requirement(s) failed"
             exit 1
           fi

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 
 function readCiWorkflow(): string {
   const workflowPath = join(process.cwd(), '.github', 'workflows', 'ci.yml');
@@ -22,6 +24,44 @@ function jobBlock(workflow: string, jobName: string): string {
 
 function assertJobIf(workflow: string, jobName: string, expected: RegExp): void {
   assert.match(jobBlock(workflow, jobName), expected, `${jobName} should have the expected lane predicate`);
+}
+
+function classifyChangedPaths(paths: string[]): Record<string, string> {
+  const workflow = readCiWorkflow();
+  const changesJob = jobBlock(workflow, 'changes');
+  const match = changesJob.match(/node <<'NODE'\n(?<script>[\s\S]*?)\n\s+NODE/);
+  assert.ok(match?.groups?.script, 'missing inline changed-path classifier script');
+
+  const cwd = mkdtempSync(join(tmpdir(), 'omx-ci-classifier-'));
+  const outputPath = join(cwd, 'github-output.txt');
+  try {
+    writeFileSync(
+      join(cwd, 'changed-files.tsv'),
+      paths.map((path) => `M\t${path}`).join('\n'),
+    );
+    execFileSync(process.execPath, ['-e', match.groups.script], {
+      cwd,
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputPath,
+        full_suite: 'false',
+        reason: 'targeted',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return Object.fromEntries(
+      readFileSync(outputPath, 'utf-8')
+        .trim()
+        .split(/\n/)
+        .filter(Boolean)
+        .map((line) => {
+          const index = line.indexOf('=');
+          return [line.slice(0, index), line.slice(index + 1)];
+        }),
+    );
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
 }
 
 describe('CI Rust gates', () => {
@@ -70,7 +110,65 @@ describe('CI Rust gates', () => {
     assert.match(changesJob, /function isSharedConfig\(path\)/);
     assert.match(changesJob, /\^\\\.github\\\//);
     assert.match(changesJob, /package\(-lock\)\?\\\.json/);
+    assert.match(changesJob, /function isGjcPlanningEvidence\(path\)/);
+    assert.match(changesJob, /function isGjcRuntimeAffecting\(path\)/);
     assert.match(changesJob, /const unknown = paths\.filter/);
+  });
+
+  it('keeps benign .gjc planning and quality evidence artifacts out of full-suite CI', () => {
+    const result = classifyChangedPaths([
+      '.gjc/plans/prd-issue-2663.md',
+      '.gjc/ultragoal/ledger.jsonl',
+      '.gjc/quality-gates/final-quality-gate.json',
+      '.gjc/session-1/planning-evidence/test-spec.json',
+    ]);
+
+    assert.equal(result.full_suite, 'false');
+    assert.equal(result.ts_changed, 'false');
+    assert.equal(result.shared_config_changed, 'false');
+    assert.equal(result.reason, 'gjc planning/evidence artifacts only');
+  });
+
+  it('routes runtime-affecting .gjc artifacts to the focused TypeScript/runtime gate without full-suite fallback', () => {
+    const result = classifyChangedPaths(['.gjc/runtime/session-state.json']);
+
+    assert.equal(result.full_suite, 'false');
+    assert.equal(result.ts_changed, 'true');
+    assert.equal(result.shared_config_changed, 'false');
+    assert.match(result.reason, /gjc runtime-affecting artifact/);
+  });
+
+  it('keeps unknown .gjc paths fail-closed while preserving normal TS/config behavior', () => {
+    const unknownGjc = classifyChangedPaths(['.gjc/random/output.bin']);
+    assert.deepEqual(
+      {
+        full_suite: unknownGjc.full_suite,
+        reason: unknownGjc.reason,
+      },
+      {
+        full_suite: 'true',
+        reason: 'unclassified path(s): .gjc/random/output.bin',
+      },
+    );
+
+    const sourceChange = classifyChangedPaths(['src/verification/ci-status.ts']);
+    assert.equal(sourceChange.full_suite, 'false');
+    assert.equal(sourceChange.ts_changed, 'true');
+
+    const workflowChange = classifyChangedPaths(['.github/workflows/ci.yml']);
+    assert.equal(workflowChange.full_suite, 'true');
+    assert.equal(workflowChange.shared_config_changed, 'true');
+    assert.equal(workflowChange.reason, 'shared config, workflow, manifest, lockfile, or packaging change');
+  });
+
+  it('reports lane-selection reason and actual failing gates in CI status output', () => {
+    const statusJob = jobBlock(readCiWorkflow(), 'ci-status');
+
+    assert.match(statusJob, /CI lane reason: \$\{REASON:-unknown\}/);
+    assert.match(statusJob, /failing_active_gates=\(\)/);
+    assert.match(statusJob, /failing_active_gates\+=\("\$name=\$result"\)/);
+    assert.match(statusJob, /Actual failing active CI gate\(s\):/);
+    assert.match(statusJob, /Lane-selection reason: \$\{REASON:-unknown\}; full_suite=\$\{FULL_SUITE:-unknown\}/);
   });
 
   it('gates expensive jobs by lane while preserving full-suite fail-closed behavior', () => {


### PR DESCRIPTION
## Summary
- classify benign .gjc planning, ultragoal, and quality-gate evidence artifacts without forcing FULL_SUITE/team-state coverage
- route runtime-affecting .gjc artifacts into the focused TS/runtime gate while unknown .gjc paths stay fail-closed
- make ci-status report lane-selection reason plus actual failing active gates

Fixes #2663

## Verification
- npm run build
- node --test dist/verification/__tests__/ci-rust-gates.test.js
- npm run lint

## Notes
- Full GitHub Actions matrix has not completed locally; PR CI will cover it.