### PR TITLE
Keep native executor lanes leaf-only

### DIFF
--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -248,19 +248,23 @@ describe("agents/native-config", () => {
     assert.match(teamExecutorToml, /<native_subagent_leaf_guard>/);
   });
 
-  it("does not apply the leaf guard to roles with explicit native delegation contracts", () => {
+  it("keeps executor native agents as leaf implementation lanes", () => {
     const executorToml = generateAgentToml(
       AGENT_DEFINITIONS.executor,
       "executor prompt",
     );
+
+    assert.match(executorToml, /<native_subagent_leaf_guard>/);
+    assert.doesNotMatch(executorToml, /native_subagent_delegation: allowed/);
+  });
+
+  it("does not apply the leaf guard to roles with explicit native delegation contracts", () => {
     const metisToml = generateAgentToml(
       AGENT_DEFINITIONS["prometheus-strict-metis"],
       "metis prompt",
     );
 
-    assert.doesNotMatch(executorToml, /<native_subagent_leaf_guard>/);
     assert.doesNotMatch(metisToml, /<native_subagent_leaf_guard>/);
-    assert.match(executorToml, /native_subagent_delegation: allowed/);
     assert.match(metisToml, /native_subagent_delegation: allowed/);
   });
 

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -8,6 +8,7 @@ import { AGENT_DEFINITIONS } from "../definitions.js";
 import type { AgentDefinition } from "../definitions.js";
 import type { CatalogManifest } from "../../catalog/schema.js";
 import {
+  composeRoleInstructionsForRole,
   generateAgentToml,
   installNativeAgentConfigs,
 } from "../native-config.js";
@@ -195,6 +196,89 @@ describe("agents/native-config", () => {
     assert.match(exactMiniToml, /resolved_model: gpt-5\.4-mini/);
     assert.doesNotMatch(frontierToml, /exact gpt-5\.4-mini model/);
     assert.doesNotMatch(tunedToml, /exact gpt-5\.4-mini model/);
+  });
+
+  it("adds a leaf guard after delegation guidance in generated native agent instructions", () => {
+    const codeReviewerToml = generateAgentToml(
+      AGENT_DEFINITIONS["code-reviewer"],
+      "code-reviewer prompt",
+    );
+
+    assert.match(codeReviewerToml, /<native_subagent_leaf_guard>/);
+    assert.match(codeReviewerToml, /do not call Task, spawn_agent, or native child agents/);
+    assert.match(codeReviewerToml, /report missing specialist coverage to the leader/);
+
+    const postureDelegationIndex = codeReviewerToml.indexOf(
+      "Default to delegation and orchestration when specialists exist.",
+    );
+    const modelDelegationIndex = codeReviewerToml.indexOf("precise delegation.");
+    const guardIndex = codeReviewerToml.indexOf("<native_subagent_leaf_guard>");
+    const metadataIndex = codeReviewerToml.indexOf("## OMX Agent Metadata");
+
+    assert.ok(postureDelegationIndex >= 0, "frontier posture delegation text should exist");
+    assert.ok(modelDelegationIndex >= 0, "frontier model delegation text should exist");
+    assert.ok(guardIndex > postureDelegationIndex, "leaf guard should override posture delegation text");
+    assert.ok(guardIndex > modelDelegationIndex, "leaf guard should override model delegation text");
+    assert.ok(metadataIndex > guardIndex, "metadata should remain final non-policy bookkeeping");
+
+    const architectToml = generateAgentToml(
+      AGENT_DEFINITIONS.architect,
+      "architect prompt",
+    );
+    const exactMiniIndex = architectToml.indexOf(
+      "strict execution order: inspect -> plan -> act -> verify",
+    );
+    const architectGuardIndex = architectToml.indexOf("<native_subagent_leaf_guard>");
+    const architectMetadataIndex = architectToml.indexOf("## OMX Agent Metadata");
+
+    assert.ok(exactMiniIndex >= 0, "architect should exercise the exact-model overlay path");
+    assert.ok(
+      architectGuardIndex > exactMiniIndex,
+      "leaf guard should override exact-model overlay guidance",
+    );
+    assert.ok(
+      architectMetadataIndex > architectGuardIndex,
+      "metadata should remain final non-policy bookkeeping for exact-model roles",
+    );
+
+    const teamExecutorToml = generateAgentToml(
+      AGENT_DEFINITIONS["team-executor"],
+      "team-executor prompt",
+    );
+    assert.match(teamExecutorToml, /<native_subagent_leaf_guard>/);
+  });
+
+  it("does not apply the leaf guard to roles with explicit native delegation contracts", () => {
+    const executorToml = generateAgentToml(
+      AGENT_DEFINITIONS.executor,
+      "executor prompt",
+    );
+    const metisToml = generateAgentToml(
+      AGENT_DEFINITIONS["prometheus-strict-metis"],
+      "metis prompt",
+    );
+
+    assert.doesNotMatch(executorToml, /<native_subagent_leaf_guard>/);
+    assert.doesNotMatch(metisToml, /<native_subagent_leaf_guard>/);
+    assert.match(executorToml, /native_subagent_delegation: allowed/);
+    assert.match(metisToml, /native_subagent_delegation: allowed/);
+  });
+
+  it("keeps native-only leaf guards out of non-native role composition", () => {
+    const writerInstructions = composeRoleInstructionsForRole(
+      "writer",
+      "writer prompt",
+      "gpt-5.5",
+    );
+    const unknownInstructions = composeRoleInstructionsForRole(
+      "does-not-exist",
+      "plain prompt",
+      "gpt-5.5",
+    );
+
+    assert.doesNotMatch(writerInstructions, /<native_subagent_leaf_guard>/);
+    assert.doesNotMatch(writerInstructions, /native_subagent_delegation: allowed/);
+    assert.doesNotMatch(unknownInstructions, /<native_subagent_leaf_guard>/);
   });
 
   it("installs only catalog-installable agents and skips existing files without force", async () => {

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -15,6 +15,12 @@ export interface AgentDefinition {
   routingRole: 'leader' | 'specialist' | 'executor';
   /** Tool access pattern */
   tools: 'read-only' | 'analysis' | 'execution' | 'data';
+  /**
+   * Whether a generated native-agent role may dispatch child native subagents.
+   * Omitted means the role is a leaf lane and must report missing specialist
+   * coverage upward to its leader instead of spawning grandchildren.
+   */
+  nativeSubagentDelegation?: 'allowed';
   /** Category for grouping */
   category: 'build' | 'review' | 'domain' | 'product' | 'coordination';
 }
@@ -27,6 +33,7 @@ const EXECUTOR_AGENT: AgentDefinition = {
   modelClass: 'standard',
   routingRole: 'executor',
   tools: 'execution',
+  nativeSubagentDelegation: 'allowed',
   category: 'build',
 };
 
@@ -325,6 +332,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
     modelClass: 'frontier',
     routingRole: 'leader',
     tools: 'analysis',
+    nativeSubagentDelegation: 'allowed',
     category: 'coordination',
   },
   'prometheus-strict-momus': {

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -18,7 +18,9 @@ export interface AgentDefinition {
   /**
    * Whether a generated native-agent role may dispatch child native subagents.
    * Omitted means the role is a leaf lane and must report missing specialist
-   * coverage upward to its leader instead of spawning grandchildren.
+   * coverage upward to its leader instead of spawning grandchildren. This is
+   * enforced by generated native developer instructions plus verifier checks;
+   * add a runtime tool-capability gate here if native TOML gains one later.
    */
   nativeSubagentDelegation?: 'allowed';
   /** Category for grouping */
@@ -33,7 +35,6 @@ const EXECUTOR_AGENT: AgentDefinition = {
   modelClass: 'standard',
   routingRole: 'executor',
   tools: 'execution',
-  nativeSubagentDelegation: 'allowed',
   category: 'build',
 };
 

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -103,6 +103,15 @@ const EXACT_MINI_MODEL_OVERLAY = [
   "</exact_model_guidance>",
 ].join("\n");
 
+const NATIVE_SUBAGENT_LEAF_GUARD = [
+  "<native_subagent_leaf_guard>",
+  "",
+  "Leaf native subagent: do not call Task, spawn_agent, or native child agents.",
+  "Use local tools; report missing specialist coverage to the leader.",
+  "",
+  "</native_subagent_leaf_guard>",
+].join("\n");
+
 export interface GeneratedNativeAgentConfig {
   name: string;
   description: string;
@@ -123,6 +132,11 @@ interface RoleInstructionMetadata {
   posture: AgentDefinition["posture"];
   modelClass: AgentDefinition["modelClass"];
   routingRole: AgentDefinition["routingRole"];
+  nativeSubagentDelegation?: AgentDefinition["nativeSubagentDelegation"];
+}
+
+interface ComposeRoleInstructionsOptions {
+  nativeAgent?: boolean;
 }
 
 function readConfigTomlContent(
@@ -187,6 +201,7 @@ export function composeRoleInstructions(
   promptContent: string,
   metadata: RoleInstructionMetadata | null,
   resolvedModel?: string,
+  options: ComposeRoleInstructionsOptions = {},
 ): string {
   const instructions = stripFrontmatter(promptContent);
   const parts = [instructions];
@@ -204,6 +219,10 @@ export function composeRoleInstructions(
     parts.push("", EXACT_MINI_MODEL_OVERLAY);
   }
 
+  if (options.nativeAgent === true && metadata?.nativeSubagentDelegation !== "allowed") {
+    parts.push("", NATIVE_SUBAGENT_LEAF_GUARD);
+  }
+
   const metadataLines = [];
   if (metadata) {
     metadataLines.push(
@@ -213,6 +232,9 @@ export function composeRoleInstructions(
       `- model_class: ${metadata.modelClass}`,
       `- routing_role: ${metadata.routingRole}`,
     );
+    if (options.nativeAgent === true && metadata.nativeSubagentDelegation) {
+      metadataLines.push(`- native_subagent_delegation: ${metadata.nativeSubagentDelegation}`);
+    }
   }
   if (resolvedModel) {
     if (metadataLines.length === 0) {
@@ -241,6 +263,7 @@ export function composeRoleInstructionsForRole(
           posture: agent.posture,
           modelClass: agent.modelClass,
           routingRole: agent.routingRole,
+          nativeSubagentDelegation: agent.nativeSubagentDelegation,
         }
       : null,
     resolvedModel,
@@ -315,7 +338,12 @@ export function generateAgentToml(
   return generateStandaloneAgentToml({
     name: agent.name,
     description: agent.description,
-    developerInstructions: composeRoleInstructions(promptContent, agent, resolvedModel),
+    developerInstructions: composeRoleInstructions(
+      promptContent,
+      agent,
+      resolvedModel,
+      { nativeAgent: true },
+    ),
     model: resolvedModel,
     modelProvider: resolvedModelProvider,
     reasoningEffort: getAgentReasoningOverride(agent.name, options.codexHomeOverride)

--- a/src/scripts/__tests__/verify-native-agents.test.ts
+++ b/src/scripts/__tests__/verify-native-agents.test.ts
@@ -85,8 +85,13 @@ describe("verify-native-agents", () => {
       await writeFile(
         join(root, "prompts", "executor.md"),
         [
-          "Executor prompt discussing <native_subagent_leaf_guard> as prose.",
+          "Executor prompt discussing generated guard markers as prose.",
+          "</posture_overlay>",
+          "</model_class_guidance>",
+          "</exact_model_guidance>",
+          "<native_subagent_leaf_guard>",
           "- Do not treat this prompt text as a generated guard.",
+          "</native_subagent_leaf_guard>",
         ].join("\n"),
       );
       await writeFile(

--- a/src/scripts/__tests__/verify-native-agents.test.ts
+++ b/src/scripts/__tests__/verify-native-agents.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 import type { AgentDefinition } from "../../agents/definitions.js";
 import {
@@ -57,6 +60,73 @@ describe("verify-native-agents", () => {
     });
 
     assert.deepEqual(result.installableAgentNames, ["executor"]);
+  });
+
+  it("validates explicit native-subagent delegation metadata", async () => {
+    const result = await verifyNativeAgents({
+      manifest: manifest([{ name: "executor", category: "build", status: "active" }]),
+      definitions: {
+        executor: {
+          ...definition,
+          nativeSubagentDelegation: "allowed",
+        },
+      },
+      promptNames: new Set(["executor"]),
+      pluginManifest: {},
+    });
+
+    assert.deepEqual(result.installableAgentNames, ["executor"]);
+  });
+
+  it("does not accept prompt-body sentinel text as generated delegation metadata", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-verify-native-spoof-"));
+    try {
+      await mkdir(join(root, "prompts"), { recursive: true });
+      await writeFile(
+        join(root, "prompts", "executor.md"),
+        [
+          "Executor prompt discussing <native_subagent_leaf_guard> as prose.",
+          "- Do not treat this prompt text as a generated guard.",
+        ].join("\n"),
+      );
+      await writeFile(
+        join(root, "prompts", "writer.md"),
+        [
+          "Writer prompt discussing generated metadata as prose.",
+          "- native_subagent_delegation: allowed",
+        ].join("\n"),
+      );
+
+      const result = await verifyNativeAgents({
+        root,
+        manifest: manifest([
+          { name: "executor", category: "build", status: "active" },
+          { name: "writer", category: "domain", status: "active" },
+        ]),
+        definitions: {
+          executor: {
+            ...definition,
+            nativeSubagentDelegation: "allowed",
+          },
+          writer: {
+            ...definition,
+            name: "writer",
+            description: "Documentation writer",
+            reasoningEffort: "high",
+            posture: "fast-lane",
+            modelClass: "standard",
+            routingRole: "specialist",
+            tools: "execution",
+            category: "domain",
+          },
+        },
+        pluginManifest: {},
+      });
+
+      assert.deepEqual(result.installableAgentNames, ["executor", "writer"]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("fails when an installable catalog agent lacks a definition", async () => {

--- a/src/scripts/verify-native-agents.ts
+++ b/src/scripts/verify-native-agents.ts
@@ -116,17 +116,81 @@ function assertTomlStructure(
     });
   }
 
+  const metadataHeading = "## OMX Agent Metadata";
+  const metadataIndex = instructions.lastIndexOf(metadataHeading);
+  if (metadataIndex < 0) {
+    throw errorBlock("native_agent_toml_invalid", {
+      agent: agentName,
+      field: "developer_instructions",
+      missing: metadataHeading,
+    });
+  }
+  const metadataLines = new Set(
+    instructions
+      .slice(metadataIndex)
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+
   for (const expected of [
     `- role: ${agentName}`,
     `- posture: ${agent.posture}`,
     `- model_class: ${agent.modelClass}`,
     `- routing_role: ${agent.routingRole}`,
   ]) {
-    if (!instructions.includes(expected)) {
+    if (!metadataLines.has(expected)) {
       throw errorBlock("native_agent_toml_invalid", {
         agent: agentName,
         field: "developer_instructions",
         missing: expected,
+      });
+    }
+  }
+
+  const leafGuard = "<native_subagent_leaf_guard>";
+  const leafGuardEnd = "</native_subagent_leaf_guard>";
+  const allowedDelegation = "- native_subagent_delegation: allowed";
+  const latestGeneratedPolicyIndex = Math.max(
+    instructions.indexOf("</posture_overlay>"),
+    instructions.indexOf("</model_class_guidance>"),
+    instructions.indexOf("</exact_model_guidance>"),
+  );
+  const leafGuardIndex = instructions.lastIndexOf(leafGuard);
+  const leafGuardEndIndex = instructions.lastIndexOf(leafGuardEnd);
+  const hasGeneratedLeafGuard = leafGuardIndex > latestGeneratedPolicyIndex
+    && leafGuardEndIndex > leafGuardIndex
+    && leafGuardEndIndex < metadataIndex;
+  if (agent.nativeSubagentDelegation === "allowed") {
+    if (!metadataLines.has(allowedDelegation)) {
+      throw errorBlock("native_agent_toml_invalid", {
+        agent: agentName,
+        field: "developer_instructions",
+        missing: allowedDelegation,
+      });
+    }
+    if (hasGeneratedLeafGuard) {
+      throw errorBlock("native_agent_toml_invalid", {
+        agent: agentName,
+        field: "developer_instructions",
+        unexpected: leafGuard,
+        message: "delegation-allowed agents must not receive the leaf-only guard",
+      });
+    }
+  } else {
+    if (!hasGeneratedLeafGuard) {
+      throw errorBlock("native_agent_toml_invalid", {
+        agent: agentName,
+        field: "developer_instructions",
+        missing: leafGuard,
+        message: "leaf native agents must receive the anti-recursion guard",
+      });
+    }
+    if (metadataLines.has(allowedDelegation)) {
+      throw errorBlock("native_agent_toml_invalid", {
+        agent: agentName,
+        field: "developer_instructions",
+        unexpected: allowedDelegation,
       });
     }
   }

--- a/src/scripts/verify-native-agents.ts
+++ b/src/scripts/verify-native-agents.ts
@@ -152,9 +152,9 @@ function assertTomlStructure(
   const leafGuardEnd = "</native_subagent_leaf_guard>";
   const allowedDelegation = "- native_subagent_delegation: allowed";
   const latestGeneratedPolicyIndex = Math.max(
-    instructions.indexOf("</posture_overlay>"),
-    instructions.indexOf("</model_class_guidance>"),
-    instructions.indexOf("</exact_model_guidance>"),
+    instructions.lastIndexOf("</posture_overlay>", metadataIndex),
+    instructions.lastIndexOf("</model_class_guidance>", metadataIndex),
+    instructions.lastIndexOf("</exact_model_guidance>", metadataIndex),
   );
   const leafGuardIndex = instructions.lastIndexOf(leafGuard);
   const leafGuardEndIndex = instructions.lastIndexOf(leafGuardEnd);


### PR DESCRIPTION
## Summary
- applies the CI repair for the native subagent recursion guard work from #2658
- keeps executor/team lanes leaf-only unless explicitly allowed to delegate
- preserves the generated native-agent guard/allowlist contract with updated regression coverage

## Validation
- npm run build
- npm run verify:native-agents
- npm run verify:plugin-bundle
- npm run lint
- CI-style Node 20 focused team/state runtime suite via dist/scripts/run-test-files.js

Supersedes #2658 because the original fork branch could not be pushed to from maintainer automation.