### PR TITLE
Mirror oversized Stop semantics in plugin hook

### DIFF
--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const hookDir = dirname(fileURLToPath(import.meta.url));
@@ -71,9 +71,9 @@ function readJsonStringLiteral(raw, quoteIndex) {
   return null;
 }
 
-function extractTopLevelHookEventName(rawInput) {
+function extractTopLevelStringField(rawInput, fieldNames) {
   const raw = rawInput.slice(0, RAW_EVENT_SCAN_BYTES);
-  const wanted = new Set(['hook_event_name', 'hookEventName', 'event', 'name']);
+  const wanted = new Set(fieldNames);
   let depth = 0;
   let index = 0;
 
@@ -87,8 +87,7 @@ function extractTopLevelHookEventName(rawInput) {
       if (depth === 1 && raw[afterKey] === ':' && wanted.has(key.value)) {
         const valueStart = skipJsonWhitespace(raw, afterKey + 1);
         const value = readJsonStringLiteral(raw, valueStart);
-        const eventName = value?.value ?? null;
-        return CODEX_HOOK_EVENT_NAMES.has(eventName) ? eventName : null;
+        return value?.value ?? null;
       }
       continue;
     }
@@ -98,6 +97,11 @@ function extractTopLevelHookEventName(rawInput) {
   }
 
   return null;
+}
+
+function extractTopLevelHookEventName(rawInput) {
+  const eventName = extractTopLevelStringField(rawInput, ['hook_event_name', 'hookEventName', 'event', 'name']);
+  return CODEX_HOOK_EVENT_NAMES.has(eventName) ? eventName : null;
 }
 
 function detectStopHookInput(input) {
@@ -177,6 +181,98 @@ function readConfiguredLauncher() {
   return readPinnedLauncher() ?? { command: 'omx', argsPrefix: [] };
 }
 
+function readJsonFile(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function isTerminalOutcome(value) {
+  return ['finish', 'finished', 'complete', 'completed', 'done', 'blocked', 'blocked-on-user', 'blocked_on_user', 'failed', 'fail', 'error', 'cancelled', 'canceled', 'cancel', 'aborted', 'abort', 'userinterlude', 'user-interlude', 'interrupted', 'interrupt', 'askuserquestion', 'ask-user-question', 'askuser', 'question'].includes(String(value ?? '').trim().toLowerCase());
+}
+
+function isTerminalRunStateForMode(state, mode) {
+  if (!state) return false;
+  const runMode = String(state.mode ?? '').trim();
+  if (runMode && runMode !== mode) return false;
+  return isTerminalOutcome(state.outcome)
+    || isTerminalOutcome(state.run_outcome)
+    || isTerminalOutcome(state.lifecycle_outcome)
+    || isTerminalOutcome(state.terminal_outcome);
+}
+
+function canonicalPath(path) {
+  const absolute = resolve(path);
+  if (!existsSync(absolute)) return absolute;
+  try {
+    return typeof realpathSync.native === 'function' ? realpathSync.native(absolute) : realpathSync(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+function sameFilePath(leftPath, rightPath) {
+  return canonicalPath(leftPath) === canonicalPath(rightPath);
+}
+
+function isSessionStateAuthoritativeForCwd(state, cwd) {
+  if (!isSafeSessionId(state?.session_id)) return false;
+  const sessionCwd = typeof state.cwd === 'string' ? state.cwd.trim() : '';
+  return !sessionCwd || sameFilePath(sessionCwd, cwd);
+}
+
+function listAuthoritativeStateBaseDirs(cwd) {
+  if (process.env.OMX_TEAM_STATE_ROOT?.trim()) return [process.env.OMX_TEAM_STATE_ROOT.trim()];
+  if (process.env.OMX_ROOT?.trim()) return [join(process.env.OMX_ROOT.trim(), '.omx', 'state')];
+  if (process.env.OMX_STATE_ROOT?.trim()) return [join(process.env.OMX_STATE_ROOT.trim(), '.omx', 'state')];
+  return [join(cwd, '.omx', 'state')];
+}
+
+function isSafeSessionId(sessionId) {
+  return typeof sessionId === 'string' && /^[A-Za-z0-9_-]{1,64}$/.test(sessionId.trim());
+}
+
+function readCurrentSessionId(stateBaseDirs, cwd) {
+  for (const stateDir of stateBaseDirs) {
+    const session = readJsonFile(join(stateDir, 'session.json'));
+    if (isSessionStateAuthoritativeForCwd(session, cwd)) return session.session_id.trim();
+  }
+  const envSessionId = process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID;
+  return isSafeSessionId(envSessionId) ? envSessionId.trim() : null;
+}
+
+function shouldContinueAutopilotState(state) {
+  if (state?.active !== true) return false;
+  return !(isTerminalOutcome(state.current_phase)
+    || isTerminalOutcome(state.run_outcome)
+    || isTerminalOutcome(state.lifecycle_outcome)
+    || isTerminalOutcome(state.terminal_outcome)
+    || isTerminalOutcome(state.outcome)
+    || (typeof state.completed_at === 'string' && state.completed_at.trim() !== ''));
+}
+
+function hasActiveAutopilotStateForOversizedStop(input) {
+  const text = input.toString('utf8');
+  const cwd = extractTopLevelStringField(text, ['cwd']) || process.cwd();
+  const stateBaseDirs = listAuthoritativeStateBaseDirs(cwd);
+  const sessionId = readCurrentSessionId(stateBaseDirs, cwd);
+  if (!isSafeSessionId(sessionId)) return false;
+
+  const sessionDir = join(stateBaseDirs[0], 'sessions', sessionId.trim());
+  const terminalRunState = readJsonFile(join(sessionDir, 'run-state.json'));
+  if (isTerminalRunStateForMode(terminalRunState, 'autopilot')) return false;
+
+  const sessionState = readJsonFile(join(sessionDir, 'autopilot-state.json'));
+  return shouldContinueAutopilotState(sessionState);
+}
+
+function writeJsonNoop() {
+  process.stdout.write(`${JSON.stringify({})}\n`);
+  process.exitCode = 0;
+}
+
 async function main() {
   const { input, oversized, totalBytes } = await readBoundedStdin();
   const isStop = detectStopHookInput(input);
@@ -184,8 +280,12 @@ async function main() {
   if (oversized) {
     const message = `plugin hook stdin exceeded ${MAX_WRAPPER_STDIN_BYTES} bytes before launcher delegation; totalBytes>${totalBytes}`;
     if (isStop) {
-      console.error(`[oh-my-codex] ${message}`);
-      writeStopFallback('plugin_stop_hook_stdin_oversized', message);
+      if (hasActiveAutopilotStateForOversizedStop(input)) {
+        console.error(`[oh-my-codex] ${message}`);
+        writeStopFallback('plugin_stop_hook_stdin_oversized_active_workflow', message);
+        return;
+      }
+      writeJsonNoop();
       return;
     }
     console.error(`[oh-my-codex] ${message}`);

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { chmod, cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { delimiter, join, relative, sep } from 'node:path';
+import { delimiter, dirname, join, relative, sep } from 'node:path';
 import { buildMergedConfig } from '../../config/generator.js';
 import type { CatalogManifest } from '../../catalog/schema.js';
 import { getSetupInstallableSkillNames } from '../../catalog/installable.js';
@@ -74,6 +74,11 @@ type PluginAppsManifest = {
 
 async function readJson<T>(path: string): Promise<T> {
   return JSON.parse(await readFile(path, 'utf-8')) as T;
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(value, null, 2), 'utf-8');
 }
 
 function escapeRegex(value: string): string {
@@ -158,17 +163,25 @@ async function withPluginCacheCopy<T>(run: (cachePluginRoot: string, cacheRoot: 
   }
 }
 
+function pluginHookEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of ['OMX_TEAM_STATE_ROOT', 'OMX_ROOT', 'OMX_STATE_ROOT', 'OMX_SESSION_ID', 'CODEX_SESSION_ID']) {
+    delete env[key];
+  }
+  return { ...env, ...overrides };
+}
+
 function runPluginNativeHook(
   cachePluginRoot: string,
   input: string,
-  env: NodeJS.ProcessEnv = process.env,
+  env: NodeJS.ProcessEnv = {},
 ) {
   return spawnSync(process.execPath, [join(cachePluginRoot, 'hooks', 'codex-native-hook.mjs')], {
     cwd: cachePluginRoot,
     input,
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
-    env,
+    env: pluginHookEnv(env),
   });
 }
 
@@ -252,7 +265,6 @@ describe('official Codex plugin layout', () => {
         cachePluginRoot,
         JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-missing-command-stop' }),
         {
-          ...process.env,
           OMX_NATIVE_HOOK_COMMAND: join(cacheRoot, 'bin', 'missing-omx-command'),
         },
       );
@@ -270,7 +282,6 @@ describe('official Codex plugin layout', () => {
         cachePluginRoot,
         JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-false-command-stop' }),
         {
-          ...process.env,
           OMX_NATIVE_HOOK_COMMAND: process.platform === 'win32' ? 'cmd.exe /c exit 1' : '/bin/false',
         },
       );
@@ -295,7 +306,7 @@ describe('official Codex plugin layout', () => {
       const result = runPluginNativeHook(
         cachePluginRoot,
         JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-empty-ok-stop' }),
-        { ...process.env, OMX_NATIVE_HOOK_COMMAND: commandPath },
+        { OMX_NATIVE_HOOK_COMMAND: commandPath },
       );
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
@@ -318,7 +329,7 @@ describe('official Codex plugin layout', () => {
       const result = runPluginNativeHook(
         cachePluginRoot,
         JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-partial-stop' }),
-        { ...process.env, OMX_NATIVE_HOOK_COMMAND: commandPath },
+        { OMX_NATIVE_HOOK_COMMAND: commandPath },
       );
 
       assert.equal(result.status, 2, result.stderr || result.stdout);
@@ -398,15 +409,151 @@ describe('official Codex plugin layout', () => {
     });
   });
 
-  it('fails oversized plugin Stop stdin with one schema-safe JSON object', async () => {
+  it('allows oversized plugin Stop stdin when no active workflow state is present', async () => {
     await withPluginCacheCopy(async (cachePluginRoot) => {
       const oversizedStop = `{"hook_event_name":"Stop","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+    });
+  });
+
+  it('blocks oversized plugin Stop stdin when current session autopilot state is active', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      const sessionId = 'sess-plugin-oversized-active';
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'sessions', sessionId, 'autopilot-state.json'), {
+        active: true,
+        current_phase: 'execution',
+      });
+      const oversizedStop = `{"hook_event_name":"Stop","cwd":"${cachePluginRoot}","session_id":"${sessionId}","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
+      const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
       const output = parseSingleJsonStdout(result.stdout);
       assert.equal(output.decision, 'block');
-      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized');
+      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_active_workflow');
+    });
+  });
+
+  it('does not let unrelated terminal run-state suppress active plugin Autopilot oversized Stop blocking', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      const sessionId = 'sess-plugin-oversized-unrelated-terminal';
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'sessions', sessionId, 'autopilot-state.json'), {
+        active: true,
+        current_phase: 'execution',
+      });
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'sessions', sessionId, 'run-state.json'), {
+        mode: 'ralph',
+        active: false,
+        outcome: 'finish',
+      });
+      const oversizedStop = `{"hook_event_name":"Stop","cwd":"${cachePluginRoot}","session_id":"${sessionId}","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
+      const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_active_workflow');
+    });
+  });
+
+  it('allows oversized plugin Stop stdin when terminal Autopilot run-state shadows stale active state', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      const sessionId = 'sess-plugin-oversized-terminal-autopilot';
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'sessions', sessionId, 'autopilot-state.json'), {
+        active: true,
+        current_phase: 'execution',
+      });
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'sessions', sessionId, 'run-state.json'), {
+        mode: 'autopilot',
+        active: false,
+        outcome: 'blocked_on_user',
+      });
+      const oversizedStop = `{"hook_event_name":"Stop","cwd":"${cachePluginRoot}","session_id":"${sessionId}","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
+      const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+    });
+  });
+
+  it('detects active plugin Autopilot state for oversized Stop under OMX_ROOT', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const sessionId = 'sess-plugin-oversized-omx-root';
+      const omxRoot = join(cacheRoot, 'boxed-root');
+      await writeJson(join(omxRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
+      await writeJson(join(omxRoot, '.omx', 'state', 'sessions', sessionId, 'autopilot-state.json'), {
+        active: true,
+        current_phase: 'execution',
+      });
+      const oversizedStop = `{"hook_event_name":"Stop","cwd":"${cachePluginRoot}","session_id":"${sessionId}","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
+      const result = runPluginNativeHook(cachePluginRoot, oversizedStop, { OMX_ROOT: omxRoot });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_active_workflow');
+    });
+  });
+
+  it('lets terminal OMX_ROOT Autopilot state override stale cwd active state for oversized Stop', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const sessionId = 'sess-plugin-oversized-omx-root-terminal';
+      const omxRoot = join(cacheRoot, 'boxed-root-terminal');
+      await writeJson(join(omxRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
+      await writeJson(join(omxRoot, '.omx', 'state', 'sessions', sessionId, 'run-state.json'), {
+        mode: 'autopilot',
+        outcome: 'blocked_on_user',
+      });
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'sessions', sessionId, 'autopilot-state.json'), {
+        active: true,
+        current_phase: 'execution',
+      });
+      const oversizedStop = `{"hook_event_name":"Stop","cwd":"${cachePluginRoot}","session_id":"${sessionId}","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
+      const result = runPluginNativeHook(cachePluginRoot, oversizedStop, { OMX_ROOT: omxRoot });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+    });
+  });
+
+  it('allows oversized plugin Stop when Autopilot state is active but terminal by phase', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot) => {
+      const sessionId = 'sess-plugin-oversized-terminal-phase';
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'sessions', sessionId, 'autopilot-state.json'), {
+        active: true,
+        current_phase: 'complete',
+      });
+      const oversizedStop = `{"hook_event_name":"Stop","cwd":"${cachePluginRoot}","session_id":"${sessionId}","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
+      const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+    });
+  });
+
+  it('ignores stale plugin session state whose cwd does not match oversized Stop cwd', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const sessionId = 'sess-plugin-oversized-stale-cwd';
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), {
+        session_id: sessionId,
+        cwd: join(cacheRoot, 'different-cwd'),
+      });
+      await writeJson(join(cachePluginRoot, '.omx', 'state', 'sessions', sessionId, 'autopilot-state.json'), {
+        active: true,
+        current_phase: 'execution',
+      });
+      const oversizedStop = `{"hook_event_name":"Stop","cwd":"${cachePluginRoot}","session_id":"${sessionId}","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
+      const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
     });
   });
 
@@ -450,7 +597,6 @@ process.stdin.on('end', () => {
         payload: 'keep these bytes unchanged',
       });
       const result = runPluginNativeHook(cachePluginRoot, input, {
-        ...process.env,
         OMX_NATIVE_HOOK_COMMAND: launcherPath,
         CAPTURE_PATH: capturePath,
       });


### PR DESCRIPTION
## Summary
- mirror the already-merged core oversized Stop semantics (#2618) into the plugin-scoped Codex native hook wrapper
- allow oversized plugin Stop stdin to return `{}` when no current active workflow state exists, preserving the privacy/no-parse boundary
- block oversized plugin Stop stdin only when the current plugin session has active Autopilot state, including OMX_ROOT-based state lookup and terminal run-state stale-state suppression

## Why
#2661 merged the plugin Stop launcher JSON fallback before this follow-up landed. This keeps the follow-up separate from #2666, which is native-agent recursion guard work, and aligns plugin wrapper behavior with the core hook's session-scoped oversized Stop handling.

## Validation
- `npm run build`
- `node --test dist/cli/__tests__/codex-plugin-layout.test.js --test-name-pattern="oversized plugin Stop|plugin Stop stdin"` — 25/25 pass
- `npm run check:no-unused`
- `npx biome lint src/cli/__tests__/codex-plugin-layout.test.ts plugins/oh-my-codex/hooks/codex-native-hook.mjs`
- `git diff --check`
- `node --check plugins/oh-my-codex/hooks/codex-native-hook.mjs`

## Related
- Follow-up split from merged #2661
- Mirrors core behavior from #2618
- Separate from native-agent recursion guard #2666
