### PR TITLE
Clarify Autopilot task-seed provenance

### DIFF
--- a/plugins/oh-my-codex/skills/autopilot/SKILL.md
+++ b/plugins/oh-my-codex/skills/autopilot/SKILL.md
@@ -68,12 +68,14 @@ Before Phase `deep-interview` or `ralplan` starts or resumes:
 1. Derive a task slug from the request.
 2. Reuse the latest relevant `.omx/context/{slug}-*.md` snapshot when available.
 3. If none exists, create `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) with:
-   - task statement
+   - activation prompt / task seed
+   - original task status (`activation-prompt`, `legacy-unverified`, or `unavailable`)
    - desired outcome
    - known facts/evidence
    - constraints
    - unknowns/open questions
    - likely codebase touchpoints
+   - a scope note that the seed is the Autopilot activation prompt, not guaranteed prior conversation context
 4. If brownfield facts are missing, run `explore` first before or during `$deep-interview` (`$deep-interview --quick <task>` remains acceptable for bounded low-ambiguity intake); do not skip the clarification gate merely because the task sounds actionable.
 5. Carry the snapshot path in Autopilot state and all handoff artifacts.
 </Pre-context Intake>

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -68,12 +68,14 @@ Before Phase `deep-interview` or `ralplan` starts or resumes:
 1. Derive a task slug from the request.
 2. Reuse the latest relevant `.omx/context/{slug}-*.md` snapshot when available.
 3. If none exists, create `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) with:
-   - task statement
+   - activation prompt / task seed
+   - original task status (`activation-prompt`, `legacy-unverified`, or `unavailable`)
    - desired outcome
    - known facts/evidence
    - constraints
    - unknowns/open questions
    - likely codebase touchpoints
+   - a scope note that the seed is the Autopilot activation prompt, not guaranteed prior conversation context
 4. If brownfield facts are missing, run `explore` first before or during `$deep-interview` (`$deep-interview --quick <task>` remains acceptable for bounded low-ambiguity intake); do not skip the clarification gate merely because the task sounds actionable.
 5. Carry the snapshot path in Autopilot state and all handoff artifacts.
 </Pre-context Intake>

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -42,6 +42,7 @@ interface TestAutopilotModeState {
       context_snapshot?: {
         path?: string;
         kind?: string;
+        original_task_status?: string;
         recovery?: { status?: string; reason?: string };
       };
     };
@@ -108,8 +109,8 @@ async function assertAutopilotRecoverySnapshot(
   const recoverySnapshot = await readFile(join(cwd, snapshotPath), 'utf-8');
   assert.match(recoverySnapshot, /recovery status: degraded/);
   assert.match(recoverySnapshot, new RegExp(`recovery reason: ${expectedReason}`));
-  assert.match(recoverySnapshot, /do not treat the continuation input as the task statement/);
-  assert.doesNotMatch(recoverySnapshot, /task statement: continue/);
+  assert.match(recoverySnapshot, /do not treat the continuation input as the task seed/);
+  assert.doesNotMatch(recoverySnapshot, /task seed: continue/);
   return snapshotPath;
 }
 
@@ -711,6 +712,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
         context_snapshot: {
           path: '.omx/context/please-run-and-keep-going-20260225T000000Z.md',
           kind: 'canonical',
+          original_task_status: 'activation-prompt',
         },
         deep_interview: null,
         ralplan: null,
@@ -731,7 +733,8 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.state.qa_verdict, null);
       assert.equal(modeState.state.return_to_ralplan_reason, null);
       const snapshot = await readFile(join(cwd, '.omx', 'context', 'please-run-and-keep-going-20260225T000000Z.md'), 'utf-8');
-      assert.match(snapshot, /task statement: please run \$autopilot and keep going/);
+      assert.match(snapshot, /activation prompt \/ task seed: please run \$autopilot and keep going/);
+      assert.match(snapshot, /scope note: this seed captures the Autopilot activation prompt/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -760,6 +763,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.deepEqual(modeState.state?.handoff_artifacts?.context_snapshot, {
         path: '.omx/context/legacy-task-20260529T000000Z.md',
         kind: 'legacy',
+        original_task_status: 'legacy-unverified',
       });
       assert.equal(existsSync(join(cwd, '.omx', 'context', 'continue-20260530T000000Z.md')), false);
     } finally {
@@ -984,10 +988,11 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.deepEqual(modeState.state?.handoff_artifacts?.context_snapshot, {
         path: '.omx/context/implement-the-real-task-20260530T000000Z.md',
         kind: 'canonical',
+        original_task_status: 'activation-prompt',
       });
       assert.equal(modeState.state?.context_snapshot_recovery, undefined);
       const snapshot = await readFile(join(cwd, '.omx', 'context', 'implement-the-real-task-20260530T000000Z.md'), 'utf-8');
-      assert.match(snapshot, /task statement: \$autopilot implement the real task/);
+      assert.match(snapshot, /activation prompt \/ task seed: \$autopilot implement the real task/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1156,6 +1161,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
         context_snapshot: {
           path: '.omx/context/investigate-the-next-issue-20260530T000000Z.md',
           kind: 'canonical',
+          original_task_status: 'activation-prompt',
         },
         deep_interview: null,
         ralplan: null,

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -283,6 +283,7 @@ async function findReusableAutopilotContextSnapshotPath(
 interface AutopilotContextSnapshotResult {
   path: string;
   kind: AutopilotContextSnapshotKind;
+  original_task_status?: 'activation-prompt' | 'legacy-unverified' | 'unavailable';
   recovery?: Record<string, unknown>;
 }
 
@@ -348,7 +349,11 @@ async function ensureAutopilotContextSnapshot(
 ): Promise<AutopilotContextSnapshotResult> {
   if (existingSnapshot) {
     if (isSafeAutopilotContextSnapshotPath(existingSnapshot.path)) {
-      return { path: existingSnapshot.path, kind: existingSnapshot.kind };
+      return {
+        path: existingSnapshot.path,
+        kind: existingSnapshot.kind,
+        original_task_status: existingSnapshot.kind === 'legacy' ? 'legacy-unverified' : 'activation-prompt',
+      };
     }
     throw new Error(`Unsafe Autopilot context snapshot path: ${existingSnapshot.path}`);
   }
@@ -364,7 +369,8 @@ async function ensureAutopilotContextSnapshot(
       `- recovery reason: ${reason}`,
       `- reason detail: ${AUTOPILOT_CONTEXT_RECOVERY_REASON_MESSAGES[reason]}`,
       `- continuation input: ${continuationInput}`,
-      '- original task statement: unavailable; do not treat the continuation input as the task statement.',
+      '- original task status: unavailable',
+      '- original task seed: unavailable; do not treat the continuation input as the task seed.',
       '- required follow-up: re-establish or confirm the intended task context before downstream handoff.',
       '',
     ].join('\n');
@@ -372,6 +378,7 @@ async function ensureAutopilotContextSnapshot(
     return {
       path,
       kind: 'recovery',
+      original_task_status: 'unavailable',
       recovery: {
         status: 'degraded',
         reason,
@@ -382,11 +389,13 @@ async function ensureAutopilotContextSnapshot(
   }
 
   const slug = slugifyAutopilotTask(activationText);
-  const taskStatement = activationText.trim() || '$autopilot';
+  const taskSeed = activationText.trim() || '$autopilot';
   const body = [
-    `# Autopilot context: ${slug}`,
+    `# Autopilot task seed: ${slug}`,
     '',
-    `- task statement: ${taskStatement}`,
+    `- activation prompt / task seed: ${taskSeed}`,
+    '- original task status: activation-prompt',
+    '- scope note: this seed captures the Autopilot activation prompt and is not guaranteed to include prior conversation context.',
     '- desired outcome: complete the requested Autopilot workflow correctly with durable gate evidence.',
     '- known facts/evidence: Autopilot was activated from a UserPromptSubmit keyword.',
     '- constraints: follow deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa; do not skip gates without persisted evidence.',
@@ -394,7 +403,11 @@ async function ensureAutopilotContextSnapshot(
     '- likely codebase touchpoints: to be discovered during pre-context intake and planning.',
     '',
   ].join('\n');
-  return { path: await writeUniqueAutopilotContextSnapshot(sourceCwd, slug, nowIso, body), kind: 'canonical' };
+  return {
+    path: await writeUniqueAutopilotContextSnapshot(sourceCwd, slug, nowIso, body),
+    kind: 'canonical',
+    original_task_status: 'activation-prompt',
+  };
 }
 
 function createDeepInterviewInputLock(nowIso: string, previous?: DeepInterviewInputLock): DeepInterviewInputLock {
@@ -735,6 +748,7 @@ async function persistStatefulSkillSeedState(
         context_snapshot: {
           path: contextSnapshotPath,
           kind: contextSnapshot.kind,
+          ...(contextSnapshot.original_task_status ? { original_task_status: contextSnapshot.original_task_status } : {}),
           ...(contextSnapshot.recovery ? { recovery: contextSnapshot.recovery } : {}),
         },
       },

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3497,7 +3497,8 @@ standardMaxRounds = 15
       const snapshotPath = autopilotState.state?.handoff_artifacts?.context_snapshot_path ?? "";
       assert.match(snapshotPath, /^\.omx\/context\/implement-issue-2430-\d{8}T\d{6}Z\.md$/);
       const snapshot = await readFile(join(cwd, snapshotPath), "utf-8");
-      assert.match(snapshot, /task statement: \$autopilot implement issue #2430/);
+      assert.match(snapshot, /activation prompt \/ task seed: \$autopilot implement issue #2430/);
+      assert.match(snapshot, /scope note: this seed captures the Autopilot activation prompt/);
       assert.match(snapshot, /constraints: follow deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa/);
     } finally {
       await rm(cwd, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- clarify Autopilot canonical snapshot wording as an activation prompt / task seed, not full prior conversation context
- persist `context_snapshot.original_task_status` for canonical (`activation-prompt`), legacy (`legacy-unverified`), and recovery (`unavailable`) snapshot paths
- update recovery artifacts/tests so continuation input cannot be confused with an original task seed
- update the Autopilot skill contract plus plugin mirror so packaged guidance matches the new task-seed provenance fields
- keep the merged #2670 safety behavior while narrowing the provenance contract for downstream readers

## Validation
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npx biome lint src/hooks/keyword-detector.ts src/hooks/__tests__/keyword-detector.test.ts src/scripts/__tests__/codex-native-hook.test.ts`
- `git diff --check`
- `npm run verify:plugin-bundle`
- stale contract grep: no `task statement` wording remains in `skills/autopilot` or `plugins/oh-my-codex/skills/autopilot`
- `$oh-my-codex:code-review`: code-reviewer APPROVE, architect WATCH only for future schema centralization, Scholastic PASS
- `$oh-my-codex:ultraqa`: adversarial harness passed twice across activation prompt provenance, repeated continuation, malformed state, path spoofing, dirty sentinel, cancel/resume, timeout, misleading success, and trusted safe canonical descriptor

## Notes
- Follow-up to merged #2670.
- Addresses the automated review finding about keeping the documented snapshot contract aligned with the new task-seed wording.
- Does not push to or modify `dev`/`main` directly.
