### PR TITLE
Verify plugin hook metadata during mirror sync

### DIFF
--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -5,6 +5,8 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const hookDir = dirname(fileURLToPath(import.meta.url));
+// sync-plugin-mirror verifies this stable marker; runtime behavior is tested separately.
+const OMX_PLUGIN_HOOK_LAUNCHER_CONTRACT_MARKER = 'omx-plugin-hook-launcher:v1';
 const MAX_WRAPPER_STDIN_BYTES = 1024 * 1024;
 const RAW_EVENT_SCAN_BYTES = 64 * 1024;
 const CODEX_HOOK_EVENT_NAMES = new Set([

--- a/plugins/oh-my-codex/hooks/hooks.json
+++ b/plugins/oh-my-codex/hooks/hooks.json
@@ -18,8 +18,7 @@
             "type": "command",
             "command": "node \"${PLUGIN_ROOT}/hooks/codex-native-hook.mjs\""
           }
-        ],
-        "matcher": "Bash"
+        ]
       }
     ],
     "PostToolUse": [

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -57,6 +57,7 @@ const pluginManifestPath = join(pluginRoot, '.codex-plugin', 'plugin.json');
 const pluginMcpPath = join(pluginRoot, '.mcp.json');
 const pluginAppsPath = join(pluginRoot, '.app.json');
 const pluginHooksPath = join(pluginRoot, 'hooks', 'hooks.json');
+const pluginHookLauncherPath = join(pluginRoot, 'hooks', 'codex-native-hook.mjs');
 const marketplacePath = join(root, '.agents', 'plugins', 'marketplace.json');
 const omxBin = join(root, 'dist', 'cli', 'omx.js');
 
@@ -115,6 +116,193 @@ async function writeOmxShim(binDir: string): Promise<void> {
     'utf-8',
   );
   await chmod(shimPath, 0o755);
+}
+
+async function createPluginMirrorFixtureRoot(): Promise<string> {
+  const fixtureRoot = await mkdtemp(join(tmpdir(), 'omx-plugin-mirror-fixture-'));
+  await Promise.all([
+    mkdir(join(fixtureRoot, 'plugins'), { recursive: true }),
+    mkdir(join(fixtureRoot, 'src', 'catalog'), { recursive: true }),
+  ]);
+  await Promise.all([
+    cp(join(root, 'package.json'), join(fixtureRoot, 'package.json')),
+    cp(join(root, 'plugins', pluginName), join(fixtureRoot, 'plugins', pluginName), { recursive: true }),
+    cp(join(root, 'skills'), join(fixtureRoot, 'skills'), { recursive: true }),
+    cp(join(root, 'src', 'catalog', 'manifest.json'), join(fixtureRoot, 'src', 'catalog', 'manifest.json')),
+  ]);
+  return fixtureRoot;
+}
+
+async function assertSyncPluginRepairsMissingHooksPointer(): Promise<void> {
+  const fixtureRoot = await createPluginMirrorFixtureRoot();
+  try {
+    const fixtureManifestPath = join(fixtureRoot, 'plugins', pluginName, '.codex-plugin', 'plugin.json');
+    const fixtureHooksPath = join(fixtureRoot, 'plugins', pluginName, 'hooks', 'hooks.json');
+    const originalManifest = await readFile(fixtureManifestPath, 'utf-8');
+    const manifest = JSON.parse(originalManifest) as PluginManifest;
+    delete manifest.hooks;
+    await writeFile(fixtureManifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+
+    const result = spawnSync(process.execPath, [join(root, 'dist', 'scripts', 'sync-plugin-mirror.js')], {
+      cwd: fixtureRoot,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        OMX_AUTO_UPDATE: '0',
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const repairedManifest = await readJson<PluginManifest>(fixtureManifestPath);
+    assert.equal(repairedManifest.hooks, './hooks/hooks.json');
+
+    const hooksManifest = await readJson<{ hooks?: Record<string, Array<{ matcher?: string }>> }>(fixtureHooksPath);
+    const preToolUseEntries = hooksManifest.hooks?.PreToolUse ?? [];
+    assert.notEqual(preToolUseEntries.length, 0, 'fixture sync should keep PreToolUse hook entries');
+    assert.deepEqual(
+      preToolUseEntries.map((entry) => entry.matcher).filter((matcher): matcher is string => typeof matcher === 'string'),
+      [],
+      'fixture sync must not reintroduce a Bash-only PreToolUse matcher',
+    );
+  } finally {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+async function assertSyncPluginCheckRejectsLauncherWithoutContract(): Promise<void> {
+  const fixtureRoot = await createPluginMirrorFixtureRoot();
+  try {
+    const fixtureHookLauncherPath = join(fixtureRoot, 'plugins', pluginName, 'hooks', 'codex-native-hook.mjs');
+    const launcher = await readFile(fixtureHookLauncherPath, 'utf-8');
+    await writeFile(
+      fixtureHookLauncherPath,
+      launcher.replace('omx-plugin-hook-launcher:v1', 'omx-plugin-hook-launcher:missing'),
+      'utf-8',
+    );
+
+    const result = spawnSync(process.execPath, [join(root, 'dist', 'scripts', 'sync-plugin-mirror.js'), '--check'], {
+      cwd: fixtureRoot,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        OMX_AUTO_UPDATE: '0',
+      },
+    });
+
+    assert.notEqual(result.status, 0, 'sync-plugin-mirror --check should reject launcher contract drift');
+    assert.match(result.stderr, /plugin_bundle_metadata_out_of_sync/);
+    assert.match(result.stderr, /kind=hook-launcher/);
+  } finally {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+async function assertPluginHookEventsAlignWithLauncher(): Promise<void> {
+  const hooksManifest = await readJson<{ hooks?: Record<string, unknown> }>(pluginHooksPath);
+  const launcher = await readFile(pluginHookLauncherPath, 'utf-8');
+  const eventSetMatch = launcher.match(/const CODEX_HOOK_EVENT_NAMES = new Set\(\[([\s\S]*?)\]\);/);
+  assert.ok(eventSetMatch, 'plugin hook launcher should declare a CODEX_HOOK_EVENT_NAMES set');
+  const launcherEvents = Array.from(eventSetMatch[1].matchAll(/'([^']+)'/g), (match) => match[1]).sort();
+  assert.deepEqual(
+    launcherEvents,
+    Object.keys(hooksManifest.hooks ?? {}).sort(),
+    'plugin hook launcher event allowlist must stay aligned with generated plugin hooks manifest',
+  );
+}
+
+async function assertPluginHookLaunchesPostCompactFromCache(): Promise<void> {
+  const cacheRoot = await mkdtemp(join(tmpdir(), 'omx-plugin-hook-cache-'));
+  const cachePluginRoot = join(cacheRoot, pluginName, 'local');
+  const shimDir = join(cacheRoot, 'bin');
+  await cp(pluginRoot, cachePluginRoot, { recursive: true });
+  await writeOmxShim(shimDir);
+
+  try {
+    const payload = JSON.stringify({
+      hook_event_name: 'PostCompact',
+      session_id: 'omx-plugin-hook-postcompact-smoke',
+      transcript_path: join(cacheRoot, 'missing-transcript.jsonl'),
+      cwd: cacheRoot,
+    });
+    const result = spawnSync(process.execPath, [join(cachePluginRoot, 'hooks', 'codex-native-hook.mjs')], {
+      cwd: cachePluginRoot,
+      encoding: 'utf-8',
+      input: payload,
+      env: {
+        ...process.env,
+        PATH: `${shimDir}${delimiter}${process.env.PATH || ''}`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        OMX_ROOT: join(cacheRoot, '.omx-root'),
+        OMX_SESSION_ID: 'omx-plugin-hook-postcompact-smoke',
+        OMX_SOURCE_CWD: cacheRoot,
+        OMX_STARTUP_CWD: cacheRoot,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(result.stdout, '', 'PostCompact plugin hook launcher should emit no stdout');
+    assert.doesNotMatch(result.stderr, /MODULE_NOT_FOUND|Cannot find module/);
+  } finally {
+    await rm(cacheRoot, { recursive: true, force: true });
+  }
+}
+
+async function assertPluginHookDelegatesPostCompactToPinnedCommand(): Promise<void> {
+  const cacheRoot = await mkdtemp(join(tmpdir(), 'omx-plugin-hook-delegate-'));
+  const cachePluginRoot = join(cacheRoot, pluginName, 'local');
+  const recorderPath = join(cacheRoot, 'record-hook.mjs');
+  const argsPath = join(cacheRoot, 'recorded-args.json');
+  const stdinPath = join(cacheRoot, 'recorded-stdin.json');
+  await cp(pluginRoot, cachePluginRoot, { recursive: true });
+  await writeFile(
+    recorderPath,
+    [
+      "import { writeFileSync } from 'node:fs';",
+      "const chunks = [];",
+      "for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));",
+      `writeFileSync(${JSON.stringify(argsPath)}, JSON.stringify(process.argv.slice(2)));`,
+      `writeFileSync(${JSON.stringify(stdinPath)}, Buffer.concat(chunks));`,
+      "",
+    ].join('\n'),
+    'utf-8',
+  );
+  await writeJson(join(cachePluginRoot, 'hooks', 'omx-command.json'), {
+    command: process.execPath,
+    argsPrefix: [recorderPath],
+  });
+
+  try {
+    const payload = JSON.stringify({
+      hook_event_name: 'PostCompact',
+      session_id: 'omx-plugin-hook-postcompact-delegate',
+      transcript_path: join(cacheRoot, 'missing-transcript.jsonl'),
+      cwd: cacheRoot,
+    });
+    const result = spawnSync(process.execPath, [join(cachePluginRoot, 'hooks', 'codex-native-hook.mjs')], {
+      cwd: cachePluginRoot,
+      encoding: 'utf-8',
+      input: payload,
+      env: {
+        ...process.env,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        OMX_ROOT: join(cacheRoot, '.omx-root'),
+        OMX_SESSION_ID: 'omx-plugin-hook-postcompact-delegate',
+        OMX_SOURCE_CWD: cacheRoot,
+        OMX_STARTUP_CWD: cacheRoot,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(result.stdout, '', 'PostCompact plugin hook launcher should emit no stdout when delegate is quiet');
+    assert.deepEqual(JSON.parse(await readFile(argsPath, 'utf-8')), ['codex-native-hook']);
+    assert.deepEqual(JSON.parse(await readFile(stdinPath, 'utf-8')), JSON.parse(payload));
+  } finally {
+    await rm(cacheRoot, { recursive: true, force: true });
+  }
 }
 
 async function assertPluginCacheLaunchable(entrypoint: string): Promise<void> {
@@ -205,11 +393,23 @@ describe('official Codex plugin layout', () => {
     assert.ok(manifest.interface?.developerName, 'expected developerName');
   });
 
+  it('repairs a missing plugin hooks manifest pointer during plugin sync', async () => {
+    await assertSyncPluginRepairsMissingHooksPointer();
+  });
+
+  it('rejects plugin hook launcher drift during plugin sync check', async () => {
+    await assertSyncPluginCheckRejectsLauncherWithoutContract();
+  });
+
+  it('keeps generated plugin hook events aligned with the launcher allowlist', async () => {
+    await assertPluginHookEventsAlignWithLauncher();
+  });
+
   it('ships plugin-scoped hooks and disabled-by-default MCP compatibility metadata', async () => {
     const [mcpManifest, appsManifest, hooksManifest] = await Promise.all([
       readJson<PluginMcpManifest>(pluginMcpPath),
       readJson<PluginAppsManifest>(pluginAppsPath),
-      readJson<{ hooks?: Record<string, Array<{ hooks?: Array<{ command?: string }> }>> }>(pluginHooksPath),
+      readJson<{ hooks?: Record<string, Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>> }>(pluginHooksPath),
     ]);
     const expectedPluginMcpManifest = buildOmxPluginMcpManifest();
 
@@ -225,6 +425,11 @@ describe('official Codex plugin layout', () => {
     assert.ok(
       hookCommands.every((command) => command === 'node "${PLUGIN_ROOT}/hooks/codex-native-hook.mjs"'),
       'plugin hooks should use Codex PLUGIN_ROOT instead of setup-owned .codex/hooks.json',
+    );
+    assert.equal(
+      hooksManifest.hooks?.PreToolUse?.some((entry) => typeof entry.matcher === 'string'),
+      false,
+      'plugin PreToolUse hooks must cover non-Bash tools just like setup-owned native hooks',
     );
     assert.deepEqual(mcpManifest, expectedPluginMcpManifest);
 
@@ -649,6 +854,14 @@ process.stdin.on('end', () => {
     }
   });
 
+  it('launches the plugin-scoped native hook for PostCompact from a cache-style plugin root', async () => {
+    await assertPluginHookLaunchesPostCompactFromCache();
+  });
+
+  it('delegates PostCompact plugin hook payloads to the pinned launcher command', async () => {
+    await assertPluginHookDelegatesPostCompactToPinnedCommand();
+  });
+
   it('does not stage setup-owned hook or runtime directories inside the plugin', async () => {
     const pluginEntries = await readdir(pluginRoot);
 
@@ -656,6 +869,7 @@ process.stdin.on('end', () => {
     assert.equal(pluginEntries.includes('.omx'), false, 'official plugin should not ship runtime hook directories');
     assert.equal(pluginEntries.includes('hooks.json'), false, 'official plugin hook metadata should stay under hooks/');
     assert.equal(pluginEntries.includes('hooks'), true, 'official plugin should ship plugin-scoped lifecycle hooks');
+    await stat(pluginHookLauncherPath);
   });
 
   it('registers the plugin in the repo marketplace with explicit source, policy, and category', async () => {

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -175,6 +175,8 @@ describe('package bin contract', () => {
     const pluginManifestEntry = results[0]?.files?.find((file) => file.path === 'plugins/oh-my-codex/.codex-plugin/plugin.json');
     const pluginMcpEntry = results[0]?.files?.find((file) => file.path === 'plugins/oh-my-codex/.mcp.json');
     const pluginAppsEntry = results[0]?.files?.find((file) => file.path === 'plugins/oh-my-codex/.app.json');
+    const pluginHooksManifestEntry = results[0]?.files?.find((file) => file.path === 'plugins/oh-my-codex/hooks/hooks.json');
+    const pluginHookLauncherEntry = results[0]?.files?.find((file) => file.path === 'plugins/oh-my-codex/hooks/codex-native-hook.mjs');
     const stateServerEntry = results[0]?.files?.find((file) => file.path === 'dist/mcp/state-server.js');
     const memoryServerEntry = results[0]?.files?.find((file) => file.path === 'dist/mcp/memory-server.js');
     const codeIntelServerEntry = results[0]?.files?.find((file) => file.path === 'dist/mcp/code-intel-server.js');
@@ -202,6 +204,8 @@ describe('package bin contract', () => {
     assert.ok(pluginManifestEntry, 'expected npm pack output to include plugins/oh-my-codex/.codex-plugin/plugin.json');
     assert.ok(pluginMcpEntry, 'expected npm pack output to include plugins/oh-my-codex/.mcp.json');
     assert.ok(pluginAppsEntry, 'expected npm pack output to include plugins/oh-my-codex/.app.json');
+    assert.ok(pluginHooksManifestEntry, 'expected npm pack output to include plugins/oh-my-codex/hooks/hooks.json');
+    assert.ok(pluginHookLauncherEntry, 'expected npm pack output to include plugins/oh-my-codex/hooks/codex-native-hook.mjs');
     assert.ok(stateServerEntry, 'expected npm pack output to include dist/mcp/state-server.js for omx mcp-serve');
     assert.ok(memoryServerEntry, 'expected npm pack output to include dist/mcp/memory-server.js for omx mcp-serve');
     assert.ok(codeIntelServerEntry, 'expected npm pack output to include dist/mcp/code-intel-server.js for omx mcp-serve');

--- a/src/scripts/sync-plugin-mirror.ts
+++ b/src/scripts/sync-plugin-mirror.ts
@@ -13,6 +13,7 @@ import {
 	assertSkillMirror,
 	compareSkillMirror,
 } from "../catalog/skill-mirror.js";
+import { MANAGED_HOOK_EVENTS } from "../config/codex-hooks.js";
 import { buildOmxPluginMcpManifest } from "../config/omx-first-party-mcp.js";
 
 export interface SyncPluginMirrorOptions {
@@ -56,6 +57,15 @@ const SETUP_OWNED_PLUGIN_MANIFEST_FIELDS = [
 	"agents",
 	"prompts",
 ] as const;
+const OMX_PLUGIN_HOOK_COMMAND =
+	'node "${PLUGIN_ROOT}/hooks/codex-native-hook.mjs"';
+const OMX_PLUGIN_HOOK_LAUNCHER_CONTRACT_MARKER =
+	"omx-plugin-hook-launcher:v1";
+// Plugin-scoped Codex hooks intentionally mirror the setup-managed lifecycle
+// roster today while using PLUGIN_ROOT-local launch commands. If plugin and
+// setup hook coverage diverge, split this alias into a plugin-owned roster.
+const PLUGIN_HOOK_EVENTS = MANAGED_HOOK_EVENTS;
+type PluginHookEventName = (typeof PLUGIN_HOOK_EVENTS)[number];
 
 async function readJsonFile<T>(path: string): Promise<T> {
 	return JSON.parse(await readFile(path, "utf-8")) as T;
@@ -63,6 +73,35 @@ async function readJsonFile<T>(path: string): Promise<T> {
 
 function stringifyJson(value: unknown): string {
 	return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function commandHook(timeout?: number): JsonValue {
+	return {
+		type: "command",
+		command: OMX_PLUGIN_HOOK_COMMAND,
+		...(typeof timeout === "number" ? { timeout } : {}),
+	};
+}
+
+function pluginHookEntry(eventName: PluginHookEventName): JsonValue {
+	const base = {
+		hooks: [commandHook(eventName === "Stop" ? 30 : undefined)],
+	};
+	if (eventName === "SessionStart") {
+		return { ...base, matcher: "startup|resume|clear" };
+	}
+	return base;
+}
+
+function buildOmxPluginHooksManifest(): JsonValue {
+	return {
+		hooks: Object.fromEntries(
+			PLUGIN_HOOK_EVENTS.map((eventName) => [
+				eventName,
+				[pluginHookEntry(eventName)],
+			]),
+		),
+	};
 }
 
 function assertDeepJsonEqual(
@@ -84,12 +123,36 @@ function assertDeepJsonEqual(
 	}
 }
 
+function assertPluginHookLauncherContractMarkerPresent(
+	path: string,
+	content: string,
+): void {
+	const requiredMarkers = [
+		OMX_PLUGIN_HOOK_LAUNCHER_CONTRACT_MARKER,
+	];
+	const missingMarkers = requiredMarkers.filter(
+		(marker) => !content.includes(marker),
+	);
+	if (missingMarkers.length > 0) {
+		throw new Error(
+			[
+				"plugin_bundle_metadata_out_of_sync",
+				"kind=hook-launcher",
+				`path=${path}`,
+				`missingMarkers=${JSON.stringify(missingMarkers)}`,
+			].join("\n"),
+		);
+	}
+}
+
 function getPluginPaths(root: string): {
 	pluginRoot: string;
 	pluginSkillsDir: string;
 	pluginMcpPath: string;
 	pluginAppsPath: string;
 	pluginManifestPath: string;
+	pluginHooksPath: string;
+	pluginHookLauncherPath: string;
 } {
 	const pluginRoot = join(root, "plugins", PLUGIN_NAME);
 	return {
@@ -98,6 +161,8 @@ function getPluginPaths(root: string): {
 		pluginMcpPath: join(pluginRoot, ".mcp.json"),
 		pluginAppsPath: join(pluginRoot, ".app.json"),
 		pluginManifestPath: join(pluginRoot, ".codex-plugin", "plugin.json"),
+		pluginHooksPath: join(pluginRoot, "hooks", "hooks.json"),
+		pluginHookLauncherPath: join(pluginRoot, "hooks", "codex-native-hook.mjs"),
 	};
 }
 
@@ -188,6 +253,7 @@ async function buildExpectedPluginManifest(
 		skills: "./skills/",
 		mcpServers: "./.mcp.json",
 		apps: "./.app.json",
+		hooks: "./hooks/hooks.json",
 	};
 }
 
@@ -237,16 +303,29 @@ async function assertPluginManifestPolicy(
 }
 
 async function assertPluginMetadata(root: string): Promise<void> {
-	const { pluginMcpPath, pluginAppsPath, pluginManifestPath } =
-		getPluginPaths(root);
-	const [actualMcp, actualApps, actualManifest] = await Promise.all([
-		readJsonFile<unknown>(pluginMcpPath),
-		readJsonFile<unknown>(pluginAppsPath),
-		readJsonFile<PluginManifest>(pluginManifestPath),
-	]);
+	const {
+		pluginMcpPath,
+		pluginAppsPath,
+		pluginManifestPath,
+		pluginHooksPath,
+		pluginHookLauncherPath,
+	} = getPluginPaths(root);
+	const [actualMcp, actualApps, actualManifest, actualHooks, actualHookLauncher] =
+		await Promise.all([
+			readJsonFile<unknown>(pluginMcpPath),
+			readJsonFile<unknown>(pluginAppsPath),
+			readJsonFile<PluginManifest>(pluginManifestPath),
+			readJsonFile<unknown>(pluginHooksPath),
+			readFile(pluginHookLauncherPath, "utf-8"),
+		]);
 
 	assertDeepJsonEqual(actualMcp, buildOmxPluginMcpManifest(), "mcp-manifest");
 	assertDeepJsonEqual(actualApps, { apps: {} }, "apps-manifest");
+	assertDeepJsonEqual(actualHooks, buildOmxPluginHooksManifest(), "hooks-manifest");
+	assertPluginHookLauncherContractMarkerPresent(
+		pluginHookLauncherPath,
+		actualHookLauncher,
+	);
 	await assertPluginManifestPolicy(root, actualManifest);
 }
 
@@ -254,11 +333,16 @@ async function writePluginMetadata(
 	root: string,
 	verbose = false,
 ): Promise<boolean> {
-	const { pluginMcpPath, pluginAppsPath, pluginManifestPath } =
-		getPluginPaths(root);
+	const {
+		pluginMcpPath,
+		pluginAppsPath,
+		pluginManifestPath,
+		pluginHooksPath,
+	} = getPluginPaths(root);
 	const expectedMcp = buildOmxPluginMcpManifest();
 	const expectedApps = { apps: {} };
 	const expectedManifest = await buildExpectedPluginManifest(root);
+	const expectedHooks = buildOmxPluginHooksManifest();
 	const writes = [
 		{
 			path: pluginMcpPath,
@@ -274,6 +358,11 @@ async function writePluginMetadata(
 			path: pluginManifestPath,
 			content: stringifyJson(expectedManifest),
 			label: "plugin manifest",
+		},
+		{
+			path: pluginHooksPath,
+			content: stringifyJson(expectedHooks),
+			label: "plugin hooks manifest",
 		},
 	];
 	let changed = false;


### PR DESCRIPTION
## Summary
- make `sync-plugin-mirror` keep the plugin `hooks` manifest pointer and `hooks/hooks.json` aligned with the managed native hook event list
- keep plugin `PreToolUse` coverage matcher-free, matching setup-owned native hooks so non-Bash implementation tools are not bypassed
- verify the plugin-scoped `hooks/codex-native-hook.mjs` launcher through a stable `omx-plugin-hook-launcher:v1` contract marker instead of implementation-detail marker checks
- make the plugin hook roster ownership explicit with a `PLUGIN_HOOK_EVENTS` contract alias, including guidance to split it if plugin/setup lifecycle coverage diverges
- assert the npm package includes both plugin hook assets: `plugins/oh-my-codex/hooks/hooks.json` and `plugins/oh-my-codex/hooks/codex-native-hook.mjs`
- add plugin-layout regressions for fixture-only sync repair, missing launcher contract rejection, launcher event allowlist alignment, matcher-free `PreToolUse`, cache-style `PostCompact` launch, and pinned-command `PostCompact` delegation

## Why
Codex can resolve `PreCompact` / `PostCompact` hooks from the plugin cache with:

```text
node "${PLUGIN_ROOT}/hooks/codex-native-hook.mjs"
```

If the cached plugin bundle is missing that launcher, the manifest no longer points at plugin-scoped hook metadata, or `PreToolUse` is accidentally narrowed to Bash only, compact/native hooks can fail before OMX runtime starts. This follow-up replaces #2647 with a clean `dev`-based branch containing only the plugin hook metadata/cache-safety fix.

## Review follow-up
- Removed the stale `PreToolUse` matcher so plugin native hooks preserve parity with setup-owned native hook coverage.
- Isolated the missing-hooks-pointer regression in a temp plugin mirror fixture so the test does not mutate the real checkout.
- Addressed Scholastic/architecture WATCH items by documenting the intentional shared lifecycle event roster, replacing implementation-detail launcher markers with a stable launcher contract marker, adding a negative `sync-plugin-mirror --check` fixture test for launcher drift, and adding package-boundary assertions for hook assets.
- Followed up on the later WATCH recommendations by making `PLUGIN_HOOK_EVENTS` an explicit plugin contract alias, testing generated hook events against the launcher allowlist, renaming the launcher check to contract-marker semantics, and proving `PostCompact` payload delegation to the pinned launcher command.

## Perimeter reduction
This revision intentionally avoids adding a generated TypeScript copy of `codex-native-hook.mjs`. The launcher remains the existing plugin asset; `sync-plugin-mirror` generates/checks plugin hook metadata and verifies the launcher contract marker/presence while runtime behavior is covered by cache/delegation tests.

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/codex-plugin-layout.test.js`
- `npm run test:plugin-boundaries:compiled`
- `npm run check:no-unused`
- `npm exec biome -- lint src/scripts/sync-plugin-mirror.ts src/cli/__tests__/codex-plugin-layout.test.ts src/cli/__tests__/package-bin-contract.test.ts plugins/oh-my-codex/hooks/codex-native-hook.mjs`
- `node dist/scripts/sync-plugin-mirror.js --check`
- `git diff --check origin/dev...HEAD`
- UltraQA: 9/9 adversarial plugin hook/cache scenarios passed before the final contract-hardening follow-up

## Re-review
- code-reviewer: APPROVE, no CRITICAL/HIGH/MEDIUM/LOW issues before final hardening follow-up
- architect/Scholastic: WATCH items were non-blocking and led to the final `PLUGIN_HOOK_EVENTS` + launcher delegation hardening in this revision
