### PR TITLE
Prevent Autopilot terminal turn replay reactivation

### DIFF
--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -1952,6 +1952,160 @@ exit 0
     });
   });
 
+  it('does not reactivate completed autopilot from canonical terminal replay wording', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      const terminalCompletedAt = '2026-05-31T20:24:39.005Z';
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+      await writeJson(join(sessionStateDir, 'autopilot-state.json'), {
+        mode: 'autopilot',
+        active: false,
+        current_phase: 'complete',
+        completed_at: terminalCompletedAt,
+        thread_id: 'thread-autopilot-complete',
+        turn_id: 'turn-autopilot-complete',
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(join(cwd, 'tmux.log')));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        type: 'agent-turn-complete',
+        'thread-id': 'thread-autopilot-complete',
+        'turn-id': 'turn-autopilot-complete',
+        'input-messages': ['autopilot mode'],
+        'last-assistant-message': 'Autopilot completed successfully.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const autopilotState = JSON.parse(await readFile(join(sessionStateDir, 'autopilot-state.json'), 'utf-8')) as {
+        active: boolean;
+        current_phase: string;
+        completed_at?: string;
+      };
+      assert.equal(autopilotState.active, false);
+      assert.equal(autopilotState.current_phase, 'complete');
+      assert.equal(autopilotState.completed_at, terminalCompletedAt);
+    });
+  });
+
+  it('does not reactivate completed autopilot from registry-alias terminal replay', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      const terminalCompletedAt = '2026-05-31T20:24:39.005Z';
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+      await writeJson(join(sessionStateDir, 'autopilot-state.json'), {
+        mode: 'autopilot',
+        active: false,
+        current_phase: 'complete',
+        completed_at: terminalCompletedAt,
+        thread_id: 'thread-autopilot-complete',
+        turn_id: 'turn-autopilot-complete',
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(join(cwd, 'tmux.log')));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        type: 'agent-turn-complete',
+        'thread-id': 'thread-autopilot-complete',
+        'turn-id': 'turn-autopilot-complete',
+        'input-messages': ['build me a terminal replay regression guard'],
+        'last-assistant-message': 'Autopilot complete. Regression guard shipped.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const autopilotState = JSON.parse(await readFile(join(sessionStateDir, 'autopilot-state.json'), 'utf-8')) as {
+        active: boolean;
+        current_phase: string;
+        completed_at?: string;
+      };
+      assert.equal(autopilotState.active, false);
+      assert.equal(autopilotState.current_phase, 'complete');
+      assert.equal(autopilotState.completed_at, terminalCompletedAt);
+    });
+  });
+
+  it('allows a later autopilot prompt after completed autopilot state', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+      await writeJson(join(sessionStateDir, 'autopilot-state.json'), {
+        mode: 'autopilot',
+        active: false,
+        current_phase: 'complete',
+        completed_at: '2026-05-31T20:24:39.005Z',
+        thread_id: 'thread-autopilot-complete',
+        turn_id: 'turn-autopilot-complete',
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(join(cwd, 'tmux.log')));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        type: 'agent-turn-complete',
+        'thread-id': 'thread-autopilot-complete',
+        'turn-id': 'turn-later-autopilot-start',
+        'input-messages': ['$autopilot .omx/specs/next-task.md'],
+        'last-assistant-message': 'Autopilot complete replay text from a different turn should not suppress this activation.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const autopilotState = JSON.parse(await readFile(join(sessionStateDir, 'autopilot-state.json'), 'utf-8')) as {
+        active: boolean;
+        current_phase: string;
+        completed_at?: string;
+        turn_id?: string;
+      };
+      assert.equal(autopilotState.active, true);
+      assert.equal(autopilotState.current_phase, 'deep-interview');
+      assert.equal(autopilotState.completed_at, undefined);
+      assert.equal(autopilotState.turn_id, 'turn-later-autopilot-start');
+    });
+  });
+
   it('writes skill-active-state.json when keyword activation is detected', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -1869,6 +1869,89 @@ exit 0
     });
   });
 
+  it('does not reactivate completed autopilot from terminal turn replay', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      const terminalCompletedAt = '2026-05-31T20:24:39.005Z';
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+      await writeJson(join(sessionStateDir, 'autopilot-state.json'), {
+        mode: 'autopilot',
+        active: false,
+        current_phase: 'complete',
+        completed_at: terminalCompletedAt,
+        stop_reason: 'completed',
+        session_id: 'sess-managed',
+        thread_id: 'thread-autopilot-complete',
+        turn_id: 'turn-autopilot-complete',
+        iteration: 7,
+        max_iterations: 10,
+        review_cycle: 1,
+      });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
+        version: 1,
+        active: false,
+        skill: 'autopilot',
+        keyword: '$autopilot',
+        phase: 'completing',
+        activated_at: '2026-05-31T19:28:04.651Z',
+        updated_at: terminalCompletedAt,
+        source: 'keyword-detector',
+        session_id: 'sess-managed',
+        thread_id: 'thread-autopilot-complete',
+        turn_id: 'turn-autopilot-complete',
+        active_skills: [],
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(join(cwd, 'tmux.log')));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        type: 'agent-turn-complete',
+        'thread-id': 'thread-autopilot-complete',
+        'turn-id': 'turn-autopilot-complete',
+        'input-messages': ['$autopilot .omx/specs/hermes-intake-librarian-subagent-mcp.md'],
+        'last-assistant-message': 'Autopilot complete. Committed:\n- 93302d4b2 enable profile-scoped MCP delegation without leaking tools',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const autopilotState = JSON.parse(await readFile(join(sessionStateDir, 'autopilot-state.json'), 'utf-8')) as {
+        active: boolean;
+        current_phase: string;
+        completed_at?: string;
+        started_at?: string;
+        iteration?: number;
+      };
+      assert.equal(autopilotState.active, false);
+      assert.equal(autopilotState.current_phase, 'complete');
+      assert.equal(autopilotState.completed_at, terminalCompletedAt);
+      assert.equal(autopilotState.started_at, undefined);
+      assert.equal(autopilotState.iteration, 7);
+
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        phase: string;
+        active_skills?: unknown[];
+      };
+      assert.equal(skillState.active, false);
+      assert.equal(skillState.phase, 'completing');
+      assert.equal(skillState.active_skills?.length ?? 0, 0);
+    });
+  });
+
   it('writes skill-active-state.json when keyword activation is detected', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -267,7 +267,8 @@ function isExplicitAutopilotActivationText(text: string): boolean {
   return /(?:^|[^\w])\$autopilot\b/i.test(text)
     || /^\s*\/autopilot\b/i.test(text)
     || /^\s*(?:please\s+)?autopilot(?:\s+(?:this|mode|workflow|skill|loop|now))?\s*[.!]?\s*$/i.test(text)
-    || /\b(?:use|run|start|enable|launch|invoke|activate|resume|continue)\s+(?:the\s+)?autopilot(?:\s+(?:mode|workflow|skill|loop|now))?\s*[.!]?\s*$/i.test(text);
+    || /\b(?:use|run|start|enable|launch|invoke|activate|resume|continue)\s+(?:the\s+)?autopilot(?:\s+(?:mode|workflow|skill|loop|now))?\s*[.!]?\s*$/i.test(text)
+    || /\bautopilot\s+(?:mode|workflow|skill|loop)\b/i.test(text);
 }
 
 function looksLikeAutopilotTerminalHandoff(text: string): boolean {
@@ -288,7 +289,25 @@ function isTerminalModeStateObject(value: unknown, mode: string): boolean {
     || safeString(state.completed_at || state.completedAt).trim() !== '';
 }
 
-async function hasTerminalAutopilotStateForNotifyTurn(stateDir: string, sessionId: string): Promise<boolean> {
+function terminalStateMatchesNotifyTurn(state: Record<string, unknown>, payload: Record<string, unknown>): boolean {
+  const payloadTurnId = safeString(payload['turn-id'] || payload.turn_id || '').trim();
+  const stateTurnId = safeString(state.turn_id || state.turnId || '').trim();
+  const payloadThreadId = safeString(payload['thread-id'] || payload.thread_id || '').trim();
+  const stateThreadId = safeString(state.thread_id || state.threadId || '').trim();
+
+  if (payloadTurnId || stateTurnId) {
+    if (!payloadTurnId || !stateTurnId || payloadTurnId !== stateTurnId) return false;
+    return !payloadThreadId || !stateThreadId || payloadThreadId === stateThreadId;
+  }
+
+  return Boolean(payloadThreadId && stateThreadId && payloadThreadId === stateThreadId);
+}
+
+async function hasTerminalAutopilotStateForNotifyTurn(
+  stateDir: string,
+  sessionId: string,
+  payload: Record<string, unknown>,
+): Promise<boolean> {
   const state = await readScopedJsonIfExists(
     stateDir,
     'autopilot-state.json',
@@ -296,22 +315,23 @@ async function hasTerminalAutopilotStateForNotifyTurn(stateDir: string, sessionI
     null,
     { includeRootFallback: true },
   );
-  return isTerminalModeStateObject(state, 'autopilot');
+  return isTerminalModeStateObject(state, 'autopilot')
+    && terminalStateMatchesNotifyTurn(state as Record<string, unknown>, payload);
 }
 
 async function shouldSuppressAutopilotTerminalReplayActivation(
   stateDir: string,
   payload: Record<string, unknown>,
-  latestUserInput: string,
+  isAutopilotActivation: boolean,
   sessionId: string,
 ): Promise<boolean> {
   if (!isTurnCompletePayload(payload) && !isNotifyFallbackTaskCompletePayload(payload)) return false;
-  if (!isExplicitAutopilotActivationText(latestUserInput)) return false;
+  if (!isAutopilotActivation) return false;
 
   const lastAssistantMessage = safeString(payload['last-assistant-message'] || payload.last_assistant_message || '');
   if (!looksLikeAutopilotTerminalHandoff(lastAssistantMessage) && !isNotifyFallbackTaskCompletePayload(payload)) return false;
 
-  return hasTerminalAutopilotStateForNotifyTurn(stateDir, sessionId);
+  return hasTerminalAutopilotStateForNotifyTurn(stateDir, sessionId, payload);
 }
 
 function buildIdleNotificationFingerprint(payload: Record<string, unknown>): string {
@@ -693,13 +713,16 @@ async function main() {
 
   // 4.45. Skill activation tracking: update skill-active-state.json before any nudge logic.
   try {
-    const { recordSkillActivation } = await import('../hooks/keyword-detector.js');
+    const { detectKeywords, recordSkillActivation } = await import('../hooks/keyword-detector.js');
     if (latestUserInput) {
       const activationSessionId = getEffectiveSessionId();
+      const isAutopilotActivation = detectKeywords(latestUserInput)
+        .some((match) => match.skill === 'autopilot')
+        || isExplicitAutopilotActivationText(latestUserInput);
       const suppressTerminalReplay = await shouldSuppressAutopilotTerminalReplayActivation(
         stateDir,
         payload,
-        latestUserInput,
+        isAutopilotActivation,
         activationSessionId,
       );
       if (!suppressTerminalReplay) {

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -262,6 +262,58 @@ function classifyIdleNotificationPhase(message: unknown): 'idle' | 'progress' | 
   return 'idle';
 }
 
+
+function isExplicitAutopilotActivationText(text: string): boolean {
+  return /(?:^|[^\w])\$autopilot\b/i.test(text)
+    || /^\s*\/autopilot\b/i.test(text)
+    || /^\s*(?:please\s+)?autopilot(?:\s+(?:this|mode|workflow|skill|loop|now))?\s*[.!]?\s*$/i.test(text)
+    || /\b(?:use|run|start|enable|launch|invoke|activate|resume|continue)\s+(?:the\s+)?autopilot(?:\s+(?:mode|workflow|skill|loop|now))?\s*[.!]?\s*$/i.test(text);
+}
+
+function looksLikeAutopilotTerminalHandoff(text: string): boolean {
+  return /\bAutopilot complete\b/i.test(text)
+    || /\btask_complete\b/i.test(text)
+    || /\bautopilot\b[\s\S]{0,120}\b(?:complete|completed|finished)\b/i.test(text);
+}
+
+function isTerminalModeStateObject(value: unknown, mode: string): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const state = value as Record<string, unknown>;
+  if (safeString(state.mode).trim() !== mode) return false;
+  if (state.active === true) return false;
+  const phase = safeString(state.current_phase || state.currentPhase).trim().toLowerCase().replace(/_/g, '-');
+  if (['complete', 'completed', 'failed', 'cancelled', 'canceled', 'stopped', 'user-stopped'].includes(phase)) return true;
+  const outcome = safeString(state.run_outcome || state.outcome || state.lifecycle_outcome || state.terminal_outcome).trim().toLowerCase();
+  return ['finish', 'finished', 'complete', 'completed', 'failed', 'cancelled', 'canceled'].includes(outcome)
+    || safeString(state.completed_at || state.completedAt).trim() !== '';
+}
+
+async function hasTerminalAutopilotStateForNotifyTurn(stateDir: string, sessionId: string): Promise<boolean> {
+  const state = await readScopedJsonIfExists(
+    stateDir,
+    'autopilot-state.json',
+    sessionId || undefined,
+    null,
+    { includeRootFallback: true },
+  );
+  return isTerminalModeStateObject(state, 'autopilot');
+}
+
+async function shouldSuppressAutopilotTerminalReplayActivation(
+  stateDir: string,
+  payload: Record<string, unknown>,
+  latestUserInput: string,
+  sessionId: string,
+): Promise<boolean> {
+  if (!isTurnCompletePayload(payload) && !isNotifyFallbackTaskCompletePayload(payload)) return false;
+  if (!isExplicitAutopilotActivationText(latestUserInput)) return false;
+
+  const lastAssistantMessage = safeString(payload['last-assistant-message'] || payload.last_assistant_message || '');
+  if (!looksLikeAutopilotTerminalHandoff(lastAssistantMessage) && !isNotifyFallbackTaskCompletePayload(payload)) return false;
+
+  return hasTerminalAutopilotStateForNotifyTurn(stateDir, sessionId);
+}
+
 function buildIdleNotificationFingerprint(payload: Record<string, unknown>): string {
   const lastAssistantMessage = safeString(payload['last-assistant-message'] || payload.last_assistant_message || '');
   const summary = summarizeIdleNotificationMessage(lastAssistantMessage);
@@ -643,14 +695,23 @@ async function main() {
   try {
     const { recordSkillActivation } = await import('../hooks/keyword-detector.js');
     if (latestUserInput) {
+      const activationSessionId = getEffectiveSessionId();
+      const suppressTerminalReplay = await shouldSuppressAutopilotTerminalReplayActivation(
+        stateDir,
+        payload,
+        latestUserInput,
+        activationSessionId,
+      );
+      if (!suppressTerminalReplay) {
         await recordSkillActivation({
           stateDir,
           sourceCwd: cwd,
           text: latestUserInput,
-          sessionId: getEffectiveSessionId(),
+          sessionId: activationSessionId,
           threadId: payloadThreadId,
           turnId: safeString(payload['turn-id'] || payload.turn_id || ''),
         });
+      }
     }
   } catch {
     // Non-fatal: keyword detector module may not be built yet


### PR DESCRIPTION
## Summary
- Fixes #2674.
- Suppresses notify `agent-turn-complete` / fallback task-complete keyword activation when the payload replays the original explicit `$autopilot` input, the assistant output is terminal (`Autopilot complete` / task_complete), and the visible Autopilot mode state is already terminal.
- Adds a regression that preserves `autopilot-state.json` as inactive/complete instead of rewriting it to active/deep-interview.

## Root cause
The notify turn-complete hook re-read `input-messages` after completion and called `recordSkillActivation`. For the completed Autopilot turn, that payload still contained the original `$autopilot ...` prompt, so the keyword detector treated it as a fresh activation and re-seeded `autopilot-state.json` at `active: true` / `current_phase: deep-interview`.

## Verification
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node --test dist/hooks/__tests__/notify-hook-auto-nudge.test.js`
- `node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js`

## Not tested
- Live macOS Hermes/Codex notify replay.

No merge requested.
