### PR TITLE
Scope HUD tmux splits to source panes

### DIFF
--- a/src/hud/__tests__/hud-tmux-injection.test.ts
+++ b/src/hud/__tests__/hud-tmux-injection.test.ts
@@ -235,7 +235,8 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
 
   it('tags tmux-launched HUD panes with the emitting leader pane', () => {
     const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', undefined, 'sess-managed', undefined, '%leader');
-    const cmd = args[6];
+    const cmd = args.at(-1) ?? '';
+    assert.deepEqual(args.slice(0, 7), ['split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES), '-t', '%leader', '-c']);
     assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%leader' ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
   });
 });

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -261,6 +261,28 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(created[0]?.options?.targetPaneId, '%leader');
   });
 
+  it('keeps prompt-submit HUD recreation scoped to the emitting pane in multi-pane windows', async () => {
+    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%right', OMX_SESSION_ID: 'sess-right', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%left', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%right', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%hud-right';
+      },
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'recreated');
+    assert.equal(created[0]?.options?.targetPaneId, '%right');
+    assert.notEqual(created[0]?.options?.fullWidth, true);
+  });
+
   it('collapses same-owner HUD panes that appear during the create race window', async () => {
     const killed: string[] = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -39,7 +39,7 @@ describe('reconcileHudForPromptSubmit', () => {
   });
 
   it('skips recreating a missing HUD in explicit OMX-owned tmux without a session id', async () => {
-    const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+    const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; targetPaneId?: string } }> = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
@@ -65,7 +65,7 @@ describe('reconcileHudForPromptSubmit', () => {
   });
 
   it('recreates a missing HUD in explicit OMX-owned tmux with a session id', async () => {
-    const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+    const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; targetPaneId?: string } }> = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
@@ -238,7 +238,7 @@ describe('reconcileHudForPromptSubmit', () => {
 
   it('targets the emitting pane window when listing and creating HUD panes', async () => {
     const listArgs: Array<string | undefined> = [];
-    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+    const created: Array<{ options?: { heightLines?: number; targetPaneId?: string } }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
       env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
@@ -262,7 +262,7 @@ describe('reconcileHudForPromptSubmit', () => {
   });
 
   it('keeps prompt-submit HUD recreation scoped to the emitting pane in multi-pane windows', async () => {
-    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+    const created: Array<{ options?: { heightLines?: number; targetPaneId?: string } }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
       env: { TMUX: '1', TMUX_PANE: '%right', OMX_SESSION_ID: 'sess-right', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
@@ -280,7 +280,7 @@ describe('reconcileHudForPromptSubmit', () => {
 
     assert.equal(result.status, 'recreated');
     assert.equal(created[0]?.options?.targetPaneId, '%right');
-    assert.notEqual(created[0]?.options?.fullWidth, true);
+    assert.equal(Object.hasOwn(created[0]?.options ?? {}, 'fullWidth'), false);
   });
 
   it('collapses same-owner HUD panes that appear during the create race window', async () => {

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -384,7 +384,16 @@ export function buildTmuxSplitArgs(
   const height = Number.isFinite(heightLines) && (heightLines ?? 0) > 0
     ? Math.floor(heightLines ?? HUD_TMUX_HEIGHT_LINES)
     : HUD_TMUX_HEIGHT_LINES;
-  return ['split-window', '-v', '-l', String(height), '-c', cwd, cmd];
+  return [
+    'split-window',
+    '-v',
+    '-l',
+    String(height),
+    ...(leaderPaneId ? ['-t', leaderPaneId] : []),
+    '-c',
+    cwd,
+    cmd,
+  ];
 }
 
 async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -6,7 +6,6 @@ import {
   createHudWatchPane,
   findLegacyFocusedHudWatchPaneIds,
   findHudWatchPaneIds,
-  isHudWatchPane,
   killTmuxPane,
   listCurrentWindowPanes,
   registerHudResizeHook,
@@ -44,7 +43,7 @@ export interface ReconcileHudForPromptSubmitDeps {
   createHudWatchPane?: (
     cwd: string,
     hudCmd: string,
-    options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string },
+    options?: { heightLines?: number; targetPaneId?: string },
   ) => string | null;
   killTmuxPane?: (paneId: string) => boolean;
   resizeTmuxPane?: (paneId: string, heightLines: number) => boolean;

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -139,7 +139,6 @@ export async function reconcileHudForPromptSubmit(
     ...findLegacyFocusedHudWatchPaneIds(panes, currentPaneId),
   ].filter((paneId, index, paneIds) => paneIds.indexOf(paneId) === index);
   const duplicateCount = Math.max(0, hudPaneIds.length - 1);
-  const nonHudPaneCount = panes.filter((pane) => !isHudWatchPane(pane)).length;
   const readHudConfigFn = deps.readHudConfig ?? readHudConfig;
   const hudConfig = await readHudConfigFn(cwd).catch(() => null);
   const readAllStateFn = deps.readAllState ?? readAllState;
@@ -204,7 +203,6 @@ export async function reconcileHudForPromptSubmit(
 
   const paneId = createPane(cwd, hudCmd, {
     heightLines: desiredHeight,
-    fullWidth: nonHudPaneCount > 1,
     targetPaneId: currentPaneId,
   });
   if (!paneId) {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5075,6 +5075,50 @@ esac
     }
   });
 
+  it("skips prompt-submit HUD reconciliation during doctor smoke validation", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-doctor-smoke-hud-"));
+    const originalTmux = process.env.TMUX;
+    const originalTmuxPane = process.env.TMUX_PANE;
+    const originalHudOwner = process.env[OMX_TMUX_HUD_OWNER_ENV];
+    const originalDoctorSmoke = process.env.OMX_NATIVE_HOOK_DOCTOR_SMOKE;
+    try {
+      process.env.TMUX = "1";
+      process.env.TMUX_PANE = "%1";
+      process.env[OMX_TMUX_HUD_OWNER_ENV] = "1";
+      process.env.OMX_NATIVE_HOOK_DOCTOR_SMOKE = "1";
+
+      let reconcileCalled = false;
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "omx-doctor-plugin-hook-smoke",
+          prompt: "$ralplan doctor plugin hook smoke test",
+        },
+        {
+          cwd,
+          reconcileHudForPromptSubmitFn: async () => {
+            reconcileCalled = true;
+            return { status: "recreated", paneId: "%9", desiredHeight: 3, duplicateCount: 0 };
+          },
+        },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(reconcileCalled, false);
+    } finally {
+      if (originalTmux === undefined) delete process.env.TMUX;
+      else process.env.TMUX = originalTmux;
+      if (originalTmuxPane === undefined) delete process.env.TMUX_PANE;
+      else process.env.TMUX_PANE = originalTmuxPane;
+      if (originalHudOwner === undefined) delete process.env[OMX_TMUX_HUD_OWNER_ENV];
+      else process.env[OMX_TMUX_HUD_OWNER_ENV] = originalHudOwner;
+      if (originalDoctorSmoke === undefined) delete process.env.OMX_NATIVE_HOOK_DOCTOR_SMOKE;
+      else process.env.OMX_NATIVE_HOOK_DOCTOR_SMOKE = originalDoctorSmoke;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("recreates a leader-only HUD pane when UserPromptSubmit revives with the canonical session id", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reuse-"));
     const originalTmux = process.env.TMUX;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4226,9 +4226,10 @@ export async function dispatchCodexNativeHook(
         triageAdditionalContext = null;
       }
     }
+    const skipHudReconcileForDoctorSmoke = process.env.OMX_NATIVE_HOOK_DOCTOR_SMOKE === "1";
     const skipHudReconcileForTeamWorkerPane = !isSubagentPromptSubmit
       && await isConfirmedTeamWorkerPromptSubmitPane(cwd).catch(() => false);
-    if (!skipHudReconcileForTeamWorkerPane) {
+    if (!skipHudReconcileForDoctorSmoke && !skipHudReconcileForTeamWorkerPane) {
       const reconcileHudForPromptSubmitFn = options.reconcileHudForPromptSubmitFn ?? reconcileHudForPromptSubmit;
       const hudSessionId = resolveHudReconcileSessionId(
         currentSessionState,


### PR DESCRIPTION
## Summary
- keep prompt-submit HUD recreation scoped to the emitting tmux pane instead of creating a full-window split in multi-pane windows
- target manual `omx hud --tmux` splits to the detected leader pane
- skip prompt-submit HUD reconciliation during `OMX_NATIVE_HOOK_DOCTOR_SMOKE=1` so doctor/plugin hook smoke checks cannot leave stale HUD panes in the user's tmux window

## Live evidence
Observed in tmux window `omx-0:launch-fix-autopolot-observation-6`:

- left source pane `%299` had a correct scoped HUD `%352`
- right source pane `%353` had lost its scoped HUD
- stale full-width bottom pane `%360` was running `omx.js hud --watch --preset=focused`
- `%360` had `OMX_SESSION_ID=omx-doctor-plugin-hook-smoke`, `OMX_TMUX_HUD_LEADER_PANE=%353`, and `OMX_ROOT=/tmp/omx-doctor-plugin-hook-WlBKCD/.omx-doctor-root`
- `%360` cwd was `/tmp/omx-doctor-plugin-hook-WlBKCD (deleted)`, so the status source was gone and the HUD showed stale `No active modes.`

Root cause: prompt-submit HUD reconciliation used `fullWidth: nonHudPaneCount > 1`, which maps to `tmux split-window -f`; in a vertically split window that creates a bottom pane across the entire window instead of under the emitting pane. Doctor smoke inherited tmux/HUD owner env and was allowed to run that reconciliation path.

## Validation
- `npm run build`
- `env -u ... node --test dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/hud-tmux-injection.test.js` — 55/55 pass
- `env -u ... node --test --test-name-pattern 'skips prompt-submit HUD reconciliation during doctor smoke validation|runs prompt-submit HUD reconciliation as a best-effort tmux-only side effect' dist/scripts/__tests__/codex-native-hook.test.js` — 2/2 pass
- `env -u ... node --test --test-name-pattern 'accepts plugin-scoped native hooks|doctor smoke-validates the installed native hook dist script by default' dist/cli/__tests__/doctor-warning-copy.test.js` — 3/3 pass
- tmux pane-count smoke around doctor tests: `pane-before=%299 %352 %353 %360`, `pane-after=%299 %352 %353 %360`
