### PR TITLE
Fix stale plugin hook cache refresh

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -916,6 +916,63 @@ OMX_LORE_COMMIT_GUARD = "truee"
 		}
 	});
 
+	it("warns when plugin-scoped hook cache launcher content is stale", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-hook-cache-stale-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await mkdir(codexDir, { recursive: true });
+			const cacheDir = await installPluginCacheFixture(codexDir);
+			await writeFile(
+				join(cacheDir, "hooks", "omx-command.json"),
+				`${JSON.stringify(
+					{
+						command: process.execPath,
+						argsPrefix: ["/tmp/stale-omx-worktree/dist/cli/omx.js"],
+					},
+					null,
+					2,
+				)}\n`,
+			);
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				`${JSON.stringify({ scope: "user", installMode: "plugin", mcpMode: "none" }, null, 2)}\n`,
+			);
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"plugin_hooks = true",
+					"goals = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "local"',
+					`source = ${JSON.stringify(repoRoot())}`,
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				new RegExp(
+					`\\[!!\\] Native hooks: plugin-scoped hooks are enabled, but cached plugin hook files or pinned hook launcher in ${cacheDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} do not match the packaged plugin; setup-owned hooks\\.json is intentionally absent at .*\\.codex[\\/]+hooks\\.json; run "omx setup --plugin --force" to refresh the plugin cache`,
+				),
+			);
+			assert.doesNotMatch(res.stdout, /plugin cache native hook coverage smoke passed/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("accepts plugin-scoped native hooks when hooks.json contains user-owned hooks", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-scoped-hooks-user-"));
 		try {

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -595,6 +595,40 @@ async function seedStalePluginDiscoveryCache(codexHomeDir: string): Promise<stri
 	return artifactPath;
 }
 
+
+async function seedSameVersionPluginCacheWithStaleHooks(codexHomeDir: string): Promise<string> {
+	const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+	await mkdir(dirname(cacheDir), { recursive: true });
+	await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
+		recursive: true,
+	});
+	await writeFile(
+		join(cacheDir, "hooks", "omx-command.json"),
+		JSON.stringify({ command: process.execPath, argsPrefix: [join(packageRoot, "dist", "cli", "omx.js")] }, null, 2) + "\n",
+	);
+	const hooksPath = join(cacheDir, "hooks", "hooks.json");
+	const hooks = JSON.parse(await readFile(hooksPath, "utf-8")) as { hooks?: { PreToolUse?: Array<Record<string, unknown>> } };
+	const preToolUse = hooks.hooks?.PreToolUse?.[0];
+	assert.ok(preToolUse, "expected packaged plugin PreToolUse hook fixture");
+	preToolUse.matcher = "Bash";
+	await writeFile(hooksPath, JSON.stringify(hooks, null, 2) + "\n");
+	return cacheDir;
+}
+
+
+async function seedSameVersionPluginCacheWithStaleLauncher(codexHomeDir: string): Promise<string> {
+	const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+	await mkdir(dirname(cacheDir), { recursive: true });
+	await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
+		recursive: true,
+	});
+	await writeFile(
+		join(cacheDir, "hooks", "omx-command.json"),
+		JSON.stringify({ command: "/stale/node", argsPrefix: ["/stale/omx.js"] }, null, 2) + "\n",
+	);
+	return cacheDir;
+}
+
 async function packagedPluginCacheDir(codexHomeDir: string): Promise<string> {
 	const manifest = JSON.parse(
 		await readFile(
@@ -1139,6 +1173,55 @@ describe("omx setup install mode behavior", () => {
 						existsSync(join(codexHomeDir, "skills", "old-only", "SKILL.md")),
 						false,
 					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("invalidates same-version plugin caches when hook file contents drift", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const cacheDir = await seedSameVersionPluginCacheWithStaleHooks(codexHomeDir);
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					const refreshedHooks = JSON.parse(
+						await readFile(join(cacheDir, "hooks", "hooks.json"), "utf-8"),
+					) as { hooks?: { PreToolUse?: Array<{ matcher?: unknown }> } };
+					assert.equal(refreshedHooks.hooks?.PreToolUse?.[0]?.matcher, undefined);
+					assert.match(output, /Invalidated 1 stale Codex plugin discovery cache entry/);
+					assert.match(output, /Installed local Codex plugin cache/);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("invalidates same-version plugin caches when the pinned hook launcher drifts", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const cacheDir = await seedSameVersionPluginCacheWithStaleLauncher(codexHomeDir);
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					const launcher = JSON.parse(
+						await readFile(join(cacheDir, "hooks", "omx-command.json"), "utf-8"),
+					) as { command?: string; argsPrefix?: string[] };
+					assert.equal(launcher.command, process.execPath);
+					assert.deepEqual(launcher.argsPrefix, [join(packageRoot, "dist", "cli", "omx.js")]);
+					assert.match(output, /Invalidated 1 stale Codex plugin discovery cache entry/);
+					assert.match(output, /Installed local Codex plugin cache/);
 				});
 			});
 		} finally {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -64,6 +64,7 @@ import {
 	discoverOmxPluginCacheDirs,
 	expectedPackagedOmxSkillNames,
 	packagedOmxPluginVersion,
+	pluginHookCacheMatchesPackaged,
 	readOmxPluginCacheState,
 	resolvePackagedOmxMarketplace,
 } from "./plugin-marketplace.js";
@@ -1183,6 +1184,15 @@ async function checkPluginScopedNativeHooks(
 					`plugin-scoped hooks are enabled, but expected plugin hook file is missing at ${expectedPath}; ${setupHooksPathDescription}; run "omx setup --plugin --force" to refresh the plugin cache`,
 			};
 		}
+	}
+
+	if (!(await pluginHookCacheMatchesPackaged(expectedCacheDir, packagedMarketplace))) {
+		return {
+			name: "Native hooks",
+			status: "warn",
+			message:
+				`plugin-scoped hooks are enabled, but cached plugin hook files or pinned hook launcher in ${expectedCacheDir} do not match the packaged plugin; ${setupHooksPathDescription}; run "omx setup --plugin --force" to refresh the plugin cache`,
+		};
 	}
 
 	let hookContent: string;

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -224,15 +224,79 @@ export async function hasExpectedOmxPluginCache(
 	const state = await readOmxPluginCacheState(
 		join(omxPluginCacheBase(codexHomeDir), version),
 	);
-	return (
-		state?.manifestVersion === version &&
-		state.skillsPointer === "./skills/" &&
-		state.hooksPointer === "./hooks/hooks.json" &&
-		state.hookLauncherPinned &&
-		existsSync(join(state.cacheDir, "hooks", "hooks.json")) &&
-		existsSync(join(state.cacheDir, "hooks", "codex-native-hook.mjs")) &&
-		JSON.stringify(state.skillNames) === JSON.stringify(expectedSkillNames)
+	if (
+		state?.manifestVersion !== version ||
+		state.skillsPointer !== "./skills/" ||
+		state.hooksPointer !== "./hooks/hooks.json" ||
+		!state.hookLauncherPinned ||
+		!existsSync(join(state.cacheDir, "hooks", "hooks.json")) ||
+		!existsSync(join(state.cacheDir, "hooks", "codex-native-hook.mjs")) ||
+		JSON.stringify(state.skillNames) !== JSON.stringify(expectedSkillNames)
+	) {
+		return false;
+	}
+
+	return pluginHookCacheMatchesPackaged(state.cacheDir, packagedMarketplace);
+}
+
+async function fileContentsEqual(leftPath: string, rightPath: string): Promise<boolean> {
+	try {
+		const [left, right] = await Promise.all([
+			readFile(leftPath),
+			readFile(rightPath),
+		]);
+		return left.equals(right);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Compares only plugin-scoped hook assets that Codex executes from the cache.
+ * Manifest pointers and skill lists are validated by callers before using this
+ * as a hook/launcher freshness predicate.
+ */
+export async function pluginHookCacheMatchesPackaged(
+	cacheDir: string,
+	packagedMarketplace: PackagedOmxMarketplace,
+): Promise<boolean> {
+	return await fileContentsEqual(
+		join(cacheDir, "hooks", "hooks.json"),
+		join(packagedMarketplace.pluginRoot, "hooks", "hooks.json"),
+	) && await fileContentsEqual(
+		join(cacheDir, "hooks", "codex-native-hook.mjs"),
+		join(packagedMarketplace.pluginRoot, "hooks", "codex-native-hook.mjs"),
+	) && await pinnedHookLauncherMatchesPackaged(
+		cacheDir,
+		packagedMarketplace,
 	);
+}
+
+function buildPinnedHookLauncherContent(
+	packagedMarketplace: PackagedOmxMarketplace,
+): string {
+	return `${JSON.stringify(
+		{
+			command: process.execPath,
+			argsPrefix: [join(packagedMarketplace.packageRoot, "dist", "cli", "omx.js")],
+		},
+		null,
+		2,
+	)}\n`;
+}
+
+async function pinnedHookLauncherMatchesPackaged(
+	cacheDir: string,
+	packagedMarketplace: PackagedOmxMarketplace,
+): Promise<boolean> {
+	try {
+		return await readFile(
+			join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE),
+			"utf-8",
+		) === buildPinnedHookLauncherContent(packagedMarketplace);
+	} catch {
+		return false;
+	}
 }
 
 async function writePinnedHookLauncher(
@@ -241,14 +305,7 @@ async function writePinnedHookLauncher(
 ): Promise<void> {
 	await writeFile(
 		join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE),
-		`${JSON.stringify(
-			{
-				command: process.execPath,
-				argsPrefix: [join(packagedMarketplace.packageRoot, "dist", "cli", "omx.js")],
-			},
-			null,
-			2,
-		)}\n`,
+		buildPinnedHookLauncherContent(packagedMarketplace),
 	);
 }
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -112,6 +112,7 @@ import {
 	upsertLocalOmxPluginEnablement,
 	upsertLocalOmxPluginMcpServerEnablement,
 	hasLocalOmxPluginMcpServerRegistrations,
+	pluginHookCacheMatchesPackaged,
 } from "./plugin-marketplace.js";
 import { resolveCodexHookFeatureSupportForCli } from "./codex-feature-probe.js";
 
@@ -1095,6 +1096,8 @@ async function refreshOmxPluginDiscoveryCache(
 		const hookFilesMissing = !existsSync(join(cacheDir, "hooks", "hooks.json"))
 			|| !existsSync(join(cacheDir, "hooks", "codex-native-hook.mjs"))
 			|| !existsSync(join(cacheDir, "hooks", "omx-command.json"));
+		const hookFilesChanged = !hookFilesMissing
+			&& !(await pluginHookCacheMatchesPackaged(cacheDir, packagedMarketplace));
 		const skillListChanged =
 			expectedSkillNames !== null &&
 			cachedSkillNames !== null &&
@@ -1105,6 +1108,7 @@ async function refreshOmxPluginDiscoveryCache(
 			!skillsPointerChanged &&
 			!hooksPointerChanged &&
 			!hookFilesMissing &&
+			!hookFilesChanged &&
 			!skillListChanged
 		) continue;
 
@@ -1124,6 +1128,7 @@ async function refreshOmxPluginDiscoveryCache(
 					? `hooks pointer ${manifest.hooks ?? "missing"} -> ./hooks/hooks.json`
 					: null,
 				hookFilesMissing ? "plugin hook files missing" : null,
+				hookFilesChanged ? "plugin hook files changed" : null,
 				skillListChanged ? "skill directory list changed" : null,
 			].filter(Boolean);
 			console.log(


### PR DESCRIPTION
## Summary
- invalidate same-version Codex plugin caches when packaged hook files or the generated pinned hook launcher drift
- make `omx doctor` reuse the same packaged hook/launcher freshness predicate so stale cache diagnostics are visible before smoke
- keep prompt-submit HUD creation scoped to the emitting pane instead of creating full-width panes in multipane windows
- skip prompt-submit HUD reconciliation during native-hook doctor smoke so smoke checks do not mutate user tmux layout

## Root cause
PR #2672 removed the packaged `PreToolUse.matcher = "Bash"`, but a local same-version plugin cache could keep the older `hooks/hooks.json` and `omx-command.json`. Codex loads hooks from the effective plugin cache, not directly from source, so non-Bash edit tools could bypass the PreToolUse Autopilot planning boundary until the cache was manually refreshed.

## Validation
- `npm run build`
- `node --test dist/cli/__tests__/doctor-warning-copy.test.js dist/cli/__tests__/setup-install-mode.test.js` — 92 pass / 0 fail
- `node --test dist/cli/__tests__/setup-install-mode.test.js dist/hud/__tests__/reconcile.test.js dist/scripts/__tests__/codex-native-hook.test.js` — 502 pass / 0 fail before the doctor follow-up; affected setup test re-run after follow-up
- `npm run check:no-unused`
- `npm run lint`
- `node dist/scripts/sync-plugin-mirror.js --check`
- `git diff --check`
- `npm install -g .`
- `omx setup --scope user --plugin --force`
- `omx doctor --verbose` — 17 passed / 0 warnings / 0 failed

## Installed-surface proof
- `/usr/bin/omx` resolves to `/home/tools/oh-my-codex.omx-worktrees/launch-fix-omx-observasation-hud-status/dist/cli/omx.js`
- effective cache `PreToolUse[0]` has no `matcher`
- source/cache `hooks.json` SHA256 match: `b84e3ea2225d21a769149dfb7883e3e8469374ec952af473f69f1dc36148e332`
- cached `hooks/omx-command.json` points at this worktree's `dist/cli/omx.js`
