### PR TITLE
fix: preserve tagged HUD panes during cleanup

### DIFF
--- a/src/compat/__tests__/doctor-contract.test.ts
+++ b/src/compat/__tests__/doctor-contract.test.ts
@@ -42,10 +42,14 @@ function resolveCompatTarget(): { command: string; argsPrefix: string[] } {
 
 function runCompatTarget(cwd: string, argv: string[], envOverrides: Record<string, string> = {}): CompatRunResult {
   const target = resolveCompatTarget();
+  const env = { ...process.env, ...envOverrides };
+  if (!Object.hasOwn(envOverrides, 'USE_OMX_EXPLORE_CMD')) {
+    delete env.USE_OMX_EXPLORE_CMD;
+  }
   const result = spawnSync(target.command, [...target.argsPrefix, ...argv], {
     cwd,
     encoding: 'utf-8',
-    env: { ...process.env, ...envOverrides },
+    env,
   });
   return { status: result.status, stdout: result.stdout || '', stderr: result.stderr || '', error: result.error?.message };
 }

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -380,6 +380,18 @@ describe('HUD pane ownership helpers', () => {
     assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2']);
   });
 
+  it('prefers leader-tagged HUD panes over legacy same-session panes during duplicate cleanup', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        "%2\tnode\texec env OMX_SESSION_ID='sess-a' /node /omx.js hud --watch",
+        `%3\tnode\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%3', '%2']);
+  });
+
   it('finds one same-session HUD pane when TMUX_PANE is unavailable', () => {
     const calls: string[][] = [];
     const execTmuxSync = (args: string[]) => {

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -174,9 +174,16 @@ export function findHudWatchPaneIds(
   currentPaneId?: string,
   owner: HudPaneOwner = {},
 ): string[] {
+  const wantedLeaderPaneId = typeof owner.leaderPaneId === 'string' ? owner.leaderPaneId.trim() : '';
   return panes
     .filter((pane) => pane.paneId !== currentPaneId)
     .filter((pane) => hudPaneMatchesOwner(pane, owner))
+    .sort((a, b) => {
+      if (!wantedLeaderPaneId) return 0;
+      const aLeaderMatches = readHudPaneOwner(a).leaderPaneId === wantedLeaderPaneId;
+      const bLeaderMatches = readHudPaneOwner(b).leaderPaneId === wantedLeaderPaneId;
+      return Number(bLeaderMatches) - Number(aLeaderMatches);
+    })
     .map((pane) => pane.paneId);
 }
 


### PR DESCRIPTION
## Summary
- Prefer exact leader-tagged HUD watch panes over legacy same-session panes during duplicate cleanup.
- Add a regression for mixed owner metadata so reconciliation preserves the stronger owner tag.
- Isolate the compat doctor contract test from ambient `USE_OMX_EXPLORE_CMD` unless a case explicitly opts in.

## Validation
- `npm run build`
- `USE_OMX_EXPLORE_CMD=1 node --test dist/compat/__tests__/doctor-contract.test.js`
- `USE_OMX_EXPLORE_CMD=1 node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js`
- `npm run lint`
- `npm test`

Fixes #2679
