### PR TITLE
fix: reap orphaned same-session HUD panes when the leader pane is gone

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -296,6 +296,80 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(killed, ['%3']);
   });
 
+  it('reaps orphaned same-session HUD panes whose leader pane was destroyed, then recreates a single HUD', async () => {
+    // Regression for the "team mode leaves only stacked HUD strips" bug: the leader
+    // pane (%21) was destroyed but its HUD panes remained, all tagged with the dead
+    // leader id. Each prompt submit previously failed the owner match and appended a
+    // new HUD instead of reclaiming the orphans.
+    const killed: string[] = [];
+    const created: Array<{ cmd: string; options?: { targetPaneId?: string } }> = [];
+
+    const orphan = (paneId: string) => ({
+      paneId,
+      currentCommand: 'node',
+      startCommand: `exec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%21' node omx hud --watch --preset=focused`,
+    });
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%33', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        // %33 is the current (live) leader pane; %21 is gone from the window.
+        { paneId: '%33', currentCommand: 'codex', startCommand: 'codex' },
+        orphan('%34'),
+        orphan('%42'),
+        orphan('%47'),
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      resizeTmuxPane: () => true,
+      createHudWatchPane: (_cwd, cmd, options) => {
+        created.push({ cmd, options });
+        return '%50';
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    // All three dead-leader orphans are reaped, then exactly one fresh HUD is created.
+    assert.deepEqual(killed.sort(), ['%34', '%42', '%47']);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%50');
+    assert.equal(created.length, 1);
+    assert.equal(created[0]?.options?.targetPaneId, '%33');
+    assert.match(created[0]?.cmd || '', new RegExp(`${OMX_TMUX_HUD_LEADER_PANE_ENV}='%33'`));
+  });
+
+  it('does not reap an orphaned HUD pane that belongs to a different session', async () => {
+    // A HUD owned by another session's leader (which may live in a different tmux
+    // window we cannot see here) must survive even when that leader is absent.
+    const killed: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%4',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-b' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%5' node omx hud --watch`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      resizeTmuxPane: () => true,
+      createHudWatchPane: () => '%9',
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    // sess-b orphan is left untouched; this session simply creates its own HUD.
+    assert.deepEqual(killed, []);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%9');
+  });
+
   it('deduplicates same-leader node HUD panes while preserving active ultragoal height despite empty mode state', async () => {
     const killed: string[] = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -8,6 +8,7 @@ import {
   isHudWatchPane,
   killTmuxPane,
   listCurrentWindowPanes,
+  readHudPaneOwner,
   registerHudResizeHook,
   unregisterHudResizeHook,
   resizeTmuxPane,
@@ -19,6 +20,46 @@ export const OMX_TMUX_HUD_OWNER_ENV = 'OMX_TMUX_HUD_OWNER';
 
 function isExplicitOmxOwnedTmuxEnv(env: NodeJS.ProcessEnv): boolean {
   return env[OMX_TMUX_HUD_OWNER_ENV] === '1';
+}
+
+/**
+ * Kill HUD watch panes that belong to the *current* session but whose owning
+ * leader pane is no longer alive in this window.
+ *
+ * Without this, a destroyed leader pane (e.g. when a `team` setup/teardown cycle
+ * tears down the leader REPL pane) leaves its HUD panes orphaned. The owner match
+ * used below (`findHudWatchPaneIds` with `leaderPaneId: currentPaneId`) keys on the
+ * *current* leader pane id, so those orphans — still tagged with the dead leader id
+ * — never match. The reconcile then treats the window as having zero HUDs and
+ * appends a fresh one on every prompt submit, until the window degenerates into a
+ * column of stacked HUD strips with no leader or worker panes left.
+ *
+ * The reap is intentionally scoped to the current session: HUD panes owned by other
+ * sessions (whose leader may legitimately live in a different tmux window we cannot
+ * see from this window's pane list) are never touched.
+ */
+function reapOrphanedSessionHudPanes(
+  panes: TmuxPaneSnapshot[],
+  opts: {
+    sessionId: string | undefined;
+    currentPaneId: string | undefined;
+    killPane: (paneId: string) => boolean;
+  },
+): string[] {
+  const { sessionId, currentPaneId, killPane } = opts;
+  if (!sessionId) return [];
+  const livePaneIds = new Set(panes.map((pane) => pane.paneId));
+  const reaped: string[] = [];
+  for (const pane of panes) {
+    if (!isHudWatchPane(pane)) continue;
+    const owner = readHudPaneOwner(pane);
+    // Only reclaim HUDs that explicitly belong to this session and name a leader.
+    if (owner.sessionId !== sessionId || !owner.leaderPaneId) continue;
+    // Keep HUDs whose leader is the current pane or otherwise still alive here.
+    if (owner.leaderPaneId === currentPaneId || livePaneIds.has(owner.leaderPaneId)) continue;
+    if (killPane(pane.paneId)) reaped.push(pane.paneId);
+  }
+  return reaped;
 }
 
 export interface ReconcileHudForPromptSubmitResult {
@@ -107,8 +148,21 @@ export async function reconcileHudForPromptSubmit(
   const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
 
   const currentPaneId = env.TMUX_PANE?.trim();
-  const panes = listPanes(currentPaneId);
   const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
+  let panes = listPanes(currentPaneId);
+
+  // Reclaim orphaned HUD panes from a destroyed leader before deciding whether a
+  // HUD already exists; otherwise dead-leader HUDs accumulate one per prompt submit.
+  const reapedOrphanPaneIds = reapOrphanedSessionHudPanes(panes, {
+    sessionId: resolvedSessionId,
+    currentPaneId,
+    killPane,
+  });
+  if (reapedOrphanPaneIds.length > 0) {
+    const reapedPaneIdSet = new Set(reapedOrphanPaneIds);
+    panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
+  }
+
   const hudPaneIds = findHudWatchPaneIds(panes, currentPaneId, {
     sessionId: resolvedSessionId,
     leaderPaneId: currentPaneId,


### PR DESCRIPTION
## Summary

> Targets `dev` per CONTRIBUTING.md (normal contribution).

In team mode, after several turns the tmux window could degenerate into **nothing
but stacked HUD strips** — the leader REPL pane and all worker (`codex`) panes
vanish and every remaining pane runs `omx hud --watch`. The HUD count grows over
time and is never reclaimed.

Forensics on a live affected session (`oh-my-codex@0.18.7`, tmux 3.4):

- N panes, **all** `omx hud --watch --preset=focused`; 0 leader REPL, 0 workers.
- Every HUD pane owner-tagged identically: `OMX_SESSION_ID='<redacted>'`,
  `OMX_TMUX_HUD_LEADER_PANE='%21'`.
- **Pane `%21` (the tagged leader) no longer exists in any tmux window** — the
  leader pane was destroyed, but its HUDs were never reaped and a new one kept
  appearing (pane ages staggered ~1 per turn).

**Root cause.** When a leader pane is destroyed (e.g. during a `team`
setup/teardown cycle that tears down the leader REPL pane), its owner-tagged HUD
panes are left pointing at the dead leader id. On `dev` they are adopted by
**neither** dedup path in `reconcileHudForPromptSubmit`:

- `findHudWatchPaneIds` — `hudPaneMatchesOwner` requires `leaderPaneMatches` once a
  pane carries a leader tag, and the dead `%21` ≠ the current leader pane; and
- `findLegacyFocusedHudWatchPaneIds` — only adopts HUD panes that **lack** owner
  metadata, so it skips these owner-tagged orphans.

So the reconcile concludes the window has zero HUDs and **creates another one** on
every prompt submit, without bound, until the window is all HUD strips.

## Changes

- `src/hud/reconcile.ts`: before the existence check, reap HUD watch panes that
  belong to the **current session** but whose owning leader pane is no longer alive
  in the window (`reapOrphanedSessionHudPanes`). The reap is deliberately
  session-scoped — HUD panes owned by other sessions, whose leader may legitimately
  live in a tmux window we cannot see from this window's pane list, are never
  touched (preserves existing multi-session isolation, incl. the
  *"does not resize, kill, or reuse another active leader session HUD"* test).
- `src/hud/__tests__/reconcile.test.ts`: two regressions — (1) three dead-leader
  same-session orphans are reaped and a single HUD is recreated under the live
  leader; (2) a different-session orphan is left untouched.

## Validation

- [x] `npm run build` (tsc clean)
- [x] `npm test` — `node --test dist/hud/__tests__/*` + `dist/team/__tests__/tmux-session.test.js` → **484 pass / 0 fail**
- [x] `npm run lint` (biome) clean on changed files
- [ ] `omx doctor` — n/a (no setup/config behavior change)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed — n/a (`src/hud/**` is not a doc-mapped refresh surface)
- [x] Backward-compatibility considered — reap is additive and session-scoped; no
  status/behavior change for the healthy single-HUD or cross-session cases

## Related

Closes #

---

### Recommended follow-ups (out of scope for this PR)

1. `chooseTeamLeaderPaneId` (`src/team/tmux-session.ts`) returns `preferredPaneId`
   even when every pane is a HUD watcher, so team setup can elect a HUD pane as the
   "leader." A fail-fast guard would prevent building the team layout around a HUD.
2. Audit the team teardown/rollback path (`collectShutdownPaneIds` /
   `teardownWorkerPanes` / `createTeamSession` rollback) so it never includes the
   leader pane id in its kill set — that destruction is what strands the HUDs.
