### PR TITLE
fix: reap orphaned same-session HUD panes when the leader pane is gone

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -170,6 +170,45 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.paneId, '%9');
   });
 
+  it('reaps a same-session orphan whose recorded leader is itself another HUD pane', async () => {
+    // Review follow-up (#2682): when a HUD pane was mistakenly used as a leader, an
+    // orphan can name another HUD pane as its leader. That referenced HUD must not
+    // count as a live leader, or the orphan survives while the referenced HUD is
+    // reaped — leaving a dangling strip that still never matches the real pane.
+    const killed: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          // orphan whose recorded leader (%3) is itself another HUD pane
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%3' node omx hud --watch --preset=focused`,
+        },
+        {
+          // the referenced HUD %3, itself orphaned (its leader %21 is gone)
+          paneId: '%3',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%21' node omx hud --watch --preset=focused`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      resizeTmuxPane: () => true,
+      createHudWatchPane: () => '%9',
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    // Both HUD-led and dead-leader orphans are reaped; a single fresh HUD is created.
+    assert.deepEqual(killed.sort(), ['%2', '%3']);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%9');
+  });
+
   it('prefers an explicit session override when recreating HUD', async () => {
     const created: Array<{ cmd: string }> = [];
 

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -95,6 +95,81 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(resized[0]?.heightLines, HUD_TMUX_HEIGHT_LINES);
   });
 
+  it('reaps orphaned same-session HUD panes whose leader pane was destroyed, then recreates a single HUD', async () => {
+    // Regression for the "team mode leaves only stacked HUD strips" bug: the leader
+    // pane (%21) was destroyed but its owner-tagged HUD panes remained, all pointing
+    // at the dead leader id. They match neither findHudWatchPaneIds (leader mismatch)
+    // nor findLegacyFocusedHudWatchPaneIds (they carry owner metadata), so each prompt
+    // submit previously appended a fresh HUD instead of reclaiming the orphans.
+    const killed: string[] = [];
+    const created: Array<{ cmd: string; options?: { targetPaneId?: string } }> = [];
+
+    const orphan = (paneId: string) => ({
+      paneId,
+      currentCommand: 'node',
+      startCommand: `exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%21' node omx hud --watch --preset=focused`,
+    });
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%33', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        // %33 is the current (live) leader pane; %21 is gone from the window.
+        { paneId: '%33', currentCommand: 'codex', startCommand: 'codex' },
+        orphan('%34'),
+        orphan('%42'),
+        orphan('%47'),
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      resizeTmuxPane: () => true,
+      createHudWatchPane: (_cwd, cmd, options) => {
+        created.push({ cmd, options });
+        return '%50';
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    // All three dead-leader orphans are reaped, then exactly one fresh HUD is created.
+    assert.deepEqual(killed.sort(), ['%34', '%42', '%47']);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%50');
+    assert.equal(created.length, 1);
+    assert.equal(created[0]?.options?.targetPaneId, '%33');
+    assert.match(created[0]?.cmd || '', new RegExp(`${OMX_TMUX_HUD_LEADER_PANE_ENV}='%33'`));
+  });
+
+  it('does not reap an orphaned HUD pane that belongs to a different session', async () => {
+    // A HUD owned by another session's leader (which may live in a different tmux
+    // window we cannot see here) must survive even when that leader is absent.
+    const killed: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%4',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-b' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%5' node omx hud --watch`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      resizeTmuxPane: () => true,
+      createHudWatchPane: () => '%9',
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    // sess-b orphan is left untouched; this session simply creates its own HUD.
+    assert.deepEqual(killed, []);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%9');
+  });
+
   it('prefers an explicit session override when recreating HUD', async () => {
     const created: Array<{ cmd: string }> = [];
 

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -140,6 +140,38 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.match(created[0]?.cmd || '', new RegExp(`${OMX_TMUX_HUD_LEADER_PANE_ENV}='%33'`));
   });
 
+  it('reaps orphaned HUD panes tagged with an equivalent native session id', async () => {
+    // #2684 lets HUD dedupe treat the OMX owner id and Codex native session id as
+    // equivalent. Orphan reaping must use the same identity set so a canonical
+    // owner reconcile still reclaims dead-leader HUDs tagged with the native id.
+    const killed: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'codex-native-uuid', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      sessionId: 'omx-owner-abc',
+      sessionIds: ['omx-owner-abc', 'codex-native-uuid'],
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='codex-native-uuid' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%21' node omx hud --watch`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      resizeTmuxPane: () => true,
+      createHudWatchPane: () => '%9',
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.deepEqual(killed, ['%2']);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%9');
+  });
+
   it('does not reap an orphaned HUD pane that belongs to a different session', async () => {
     // A HUD owned by another session's leader (which may live in a different tmux
     // window we cannot see here) must survive even when that leader is absent.
@@ -579,6 +611,8 @@ describe('reconcileHudForPromptSubmit', () => {
           startCommand: `env OMX_SESSION_ID='codex-native-uuid' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
         },
         {
+          // Same equivalent session, but its recorded leader is itself a HUD pane;
+          // the orphan reaper should remove it before normal same-leader dedupe.
           paneId: '%4',
           currentCommand: 'node',
           startCommand: `env OMX_SESSION_ID='codex-native-uuid' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%4' node omx hud --watch`,
@@ -602,7 +636,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.status, 'replaced_duplicates');
     assert.equal(result.paneId, '%2');
     assert.equal(result.duplicateCount, 1);
-    assert.deepEqual(killed, ['%3']);
+    assert.deepEqual(killed, ['%4', '%3']);
     assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
     assert.deepEqual(created, []);
   });

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -6,8 +6,10 @@ import {
   createHudWatchPane,
   findLegacyFocusedHudWatchPaneIds,
   findHudWatchPaneIds,
+  isHudWatchPane,
   killTmuxPane,
   listCurrentWindowPanes,
+  readHudPaneOwner,
   registerHudResizeHook,
   unregisterHudResizeHook,
   resizeTmuxPane,
@@ -20,6 +22,54 @@ export const OMX_TMUX_HUD_OWNER_ENV = 'OMX_TMUX_HUD_OWNER';
 
 function isExplicitOmxOwnedTmuxEnv(env: NodeJS.ProcessEnv): boolean {
   return env[OMX_TMUX_HUD_OWNER_ENV] === '1';
+}
+
+/**
+ * Kill HUD watch panes that belong to the *current* session but whose owning
+ * leader pane is no longer alive in this window.
+ *
+ * When a leader pane is destroyed (e.g. during a `team` setup/teardown cycle that
+ * tears down the leader REPL pane), its owner-tagged HUD panes are left pointing at
+ * the dead leader id. They are matched by neither `findHudWatchPaneIds` — whose
+ * owner check requires the recorded leader to equal the current pane — nor
+ * `findLegacyFocusedHudWatchPaneIds`, which only adopts HUD panes that *lack* owner
+ * metadata. So the reconcile below sees "no HUD", recreates one, and repeats on
+ * every prompt submit until the window degenerates into a column of stacked HUD
+ * strips with no leader or worker panes left.
+ *
+ * The reap is intentionally scoped to the current session: HUD panes owned by other
+ * sessions (whose leader may legitimately live in a different tmux window we cannot
+ * see from this window's pane list) are never touched.
+ */
+function reapOrphanedSessionHudPanes(
+  panes: TmuxPaneSnapshot[],
+  opts: {
+    sessionId: string | undefined;
+    currentPaneId: string | undefined;
+    killPane: (paneId: string) => boolean;
+  },
+): string[] {
+  const { sessionId, currentPaneId, killPane } = opts;
+  if (!sessionId) return [];
+  // A recorded leader only counts as "live" if it exists in this window AND is not
+  // itself a HUD watcher. Without the HUD exclusion, an orphan whose recorded leader
+  // is *another HUD pane* would be preserved here; that referenced HUD could be
+  // reaped on a later iteration, leaving a dangling orphan that still never matches
+  // the real current pane — so the all-HUD-strip state is only partially cleaned.
+  const liveNonHudPaneIds = new Set(
+    panes.filter((pane) => !isHudWatchPane(pane)).map((pane) => pane.paneId),
+  );
+  const reaped: string[] = [];
+  for (const pane of panes) {
+    if (!isHudWatchPane(pane)) continue;
+    const owner = readHudPaneOwner(pane);
+    // Only reclaim HUDs that explicitly belong to this session and name a leader.
+    if (owner.sessionId !== sessionId || !owner.leaderPaneId) continue;
+    // Keep HUDs whose leader is the current pane or another live non-HUD leader pane.
+    if (owner.leaderPaneId === currentPaneId || liveNonHudPaneIds.has(owner.leaderPaneId)) continue;
+    if (killPane(pane.paneId)) reaped.push(pane.paneId);
+  }
+  return reaped;
 }
 
 export interface ReconcileHudForPromptSubmitResult {
@@ -129,7 +179,6 @@ export async function reconcileHudForPromptSubmit(
   const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
 
   const currentPaneId = env.TMUX_PANE?.trim();
-  const panes = listPanes(currentPaneId);
   const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
   const equivalentSessionIds = [
     resolvedSessionId,
@@ -138,6 +187,21 @@ export async function reconcileHudForPromptSubmit(
   ]
     .map((sessionId) => sessionId?.trim() ?? '')
     .filter((sessionId, index, sessionIds) => sessionId !== '' && sessionIds.indexOf(sessionId) === index);
+  let panes = listPanes(currentPaneId);
+
+  // Reclaim orphaned HUD panes left behind by a destroyed leader before deciding
+  // whether a HUD already exists; otherwise dead-leader HUDs accumulate one per
+  // prompt submit and the window fills with stacked HUD strips.
+  const reapedOrphanPaneIds = reapOrphanedSessionHudPanes(panes, {
+    sessionId: resolvedSessionId,
+    currentPaneId,
+    killPane,
+  });
+  if (reapedOrphanPaneIds.length > 0) {
+    const reapedPaneIdSet = new Set(reapedOrphanPaneIds);
+    panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
+  }
+
   const owner = {
     sessionId: resolvedSessionId,
     sessionIds: equivalentSessionIds,

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -45,12 +45,18 @@ function reapOrphanedSessionHudPanes(
   panes: TmuxPaneSnapshot[],
   opts: {
     sessionId: string | undefined;
+    sessionIds?: string[];
     currentPaneId: string | undefined;
     killPane: (paneId: string) => boolean;
   },
 ): string[] {
   const { sessionId, currentPaneId, killPane } = opts;
-  if (!sessionId) return [];
+  const sameSessionIds = new Set(
+    [sessionId, ...(opts.sessionIds ?? [])]
+      .map((candidate) => candidate?.trim() ?? '')
+      .filter((candidate) => candidate !== ''),
+  );
+  if (sameSessionIds.size === 0) return [];
   // A recorded leader only counts as "live" if it exists in this window AND is not
   // itself a HUD watcher. Without the HUD exclusion, an orphan whose recorded leader
   // is *another HUD pane* would be preserved here; that referenced HUD could be
@@ -64,7 +70,7 @@ function reapOrphanedSessionHudPanes(
     if (!isHudWatchPane(pane)) continue;
     const owner = readHudPaneOwner(pane);
     // Only reclaim HUDs that explicitly belong to this session and name a leader.
-    if (owner.sessionId !== sessionId || !owner.leaderPaneId) continue;
+    if (!owner.sessionId || !sameSessionIds.has(owner.sessionId) || !owner.leaderPaneId) continue;
     // Keep HUDs whose leader is the current pane or another live non-HUD leader pane.
     if (owner.leaderPaneId === currentPaneId || liveNonHudPaneIds.has(owner.leaderPaneId)) continue;
     if (killPane(pane.paneId)) reaped.push(pane.paneId);
@@ -194,6 +200,7 @@ export async function reconcileHudForPromptSubmit(
   // prompt submit and the window fills with stacked HUD strips.
   const reapedOrphanPaneIds = reapOrphanedSessionHudPanes(panes, {
     sessionId: resolvedSessionId,
+    sessionIds: equivalentSessionIds,
     currentPaneId,
     killPane,
   });


### PR DESCRIPTION
## Summary

> Targets `dev` per CONTRIBUTING.md (normal contribution).

In team mode, after several turns the tmux window could degenerate into **nothing
but stacked HUD strips** — the leader REPL pane and all worker (`codex`) panes
vanish and every remaining pane runs `omx hud --watch`. The HUD count grows over
time and is never reclaimed.

Forensics on a live affected session (`oh-my-codex@0.18.7`, tmux 3.4):

- N panes, **all** `omx hud --watch --preset=focused`; 0 leader REPL, 0 workers.
- Every HUD pane owner-tagged identically: `OMX_SESSION_ID='<redacted>'`,
  `OMX_TMUX_HUD_LEADER_PANE='%21'`.
- **Pane `%21` (the tagged leader) no longer exists in any tmux window** — the
  leader pane was destroyed, but its HUDs were never reaped and a new one kept
  appearing (pane ages staggered ~1 per turn).

**Root cause.** When a leader pane is destroyed (e.g. during a `team`
setup/teardown cycle that tears down the leader REPL pane), its owner-tagged HUD
panes are left pointing at the dead leader id. On `dev` they are adopted by
**neither** dedup path in `reconcileHudForPromptSubmit`:

- `findHudWatchPaneIds` — `hudPaneMatchesOwner` requires `leaderPaneMatches` once a
  pane carries a leader tag, and the dead `%21` ≠ the current leader pane; and
- `findLegacyFocusedHudWatchPaneIds` — only adopts HUD panes that **lack** owner
  metadata, so it skips these owner-tagged orphans.

So the reconcile concludes the window has zero HUDs and **creates another one** on
every prompt submit, without bound, until the window is all HUD strips.

## Changes

- `src/hud/reconcile.ts`: before the existence check, reap HUD watch panes that
  belong to the **current session** but whose owning leader pane is no longer alive
  in the window (`reapOrphanedSessionHudPanes`). The reap is deliberately
  session-scoped — HUD panes owned by other sessions, whose leader may legitimately
  live in a tmux window we cannot see from this window's pane list, are never
  touched (preserves existing multi-session isolation, incl. the
  *"does not resize, kill, or reuse another active leader session HUD"* test).
- `src/hud/__tests__/reconcile.test.ts`: two regressions — (1) three dead-leader
  same-session orphans are reaped and a single HUD is recreated under the live
  leader; (2) a different-session orphan is left untouched.

## Validation

- [x] `npm run build` (tsc clean)
- [x] `npm test` — `node --test dist/hud/__tests__/*` + `dist/team/__tests__/tmux-session.test.js` → **484 pass / 0 fail**
- [x] `npm run lint` (biome) clean on changed files
- [ ] `omx doctor` — n/a (no setup/config behavior change)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed — n/a (`src/hud/**` is not a doc-mapped refresh surface)
- [x] Backward-compatibility considered — reap is additive and session-scoped; no
  status/behavior change for the healthy single-HUD or cross-session cases

## Related

Closes #

---

### Recommended follow-ups (out of scope for this PR)

1. `chooseTeamLeaderPaneId` (`src/team/tmux-session.ts`) returns `preferredPaneId`
   even when every pane is a HUD watcher, so team setup can elect a HUD pane as the
   "leader." A fail-fast guard would prevent building the team layout around a HUD.
2. Audit the team teardown/rollback path (`collectShutdownPaneIds` /
   `teardownWorkerPanes` / `createTeamSession` rollback) so it never includes the
   leader pane id in its kill set — that destruction is what strands the HUDs.
