### PR TITLE
Fix HUD dedupe across native session IDs

### DIFF
--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -20,6 +20,7 @@ export interface SessionState {
   previous_native_session_id?: string;
   native_session_switched_at?: string;
   owner_omx_session_id?: string;
+  owner_codex_session_id?: string;
   started_at: string;
   cwd: string;
   pid: number;

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -362,7 +362,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(resized, [{ paneId: '%8', heightLines: HUD_TMUX_HEIGHT_LINES }]);
   });
 
-  it('reports failure when the post-create keeper cannot be resized', async () => {
+  it('kills post-create duplicate HUD panes even when the keeper cannot be resized', async () => {
     const killed: string[] = [];
     const registered: string[] = [];
     let listCount = 0;
@@ -394,9 +394,9 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     assert.equal(result.status, 'failed');
-    assert.equal(result.paneId, null);
+    assert.equal(result.paneId, '%9');
     assert.equal(result.duplicateCount, 1);
-    assert.deepEqual(killed, []);
+    assert.deepEqual(killed, ['%8']);
     assert.deepEqual(registered, []);
   });
 
@@ -438,6 +438,56 @@ describe('reconcileHudForPromptSubmit', () => {
 
     assert.equal(result.status, 'replaced_duplicates');
     assert.equal(result.paneId, '%2');
+    assert.deepEqual(killed, ['%3']);
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+    assert.deepEqual(created, []);
+  });
+
+  it('deduplicates same-leader HUD panes tagged with equivalent owner and canonical session ids', async () => {
+    const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    const created: Array<{ cmd: string }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'codex-native-uuid', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      sessionId: 'omx-owner-abc',
+      sessionIds: ['omx-owner-abc', 'codex-native-uuid'],
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='omx-owner-abc' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+        {
+          paneId: '%3',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='codex-native-uuid' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+        {
+          paneId: '%4',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='codex-native-uuid' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%4' node omx hud --watch`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, cmd) => {
+        created.push({ cmd });
+        return '%9';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.paneId, '%2');
+    assert.equal(result.duplicateCount, 1);
     assert.deepEqual(killed, ['%3']);
     assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
     assert.deepEqual(created, []);
@@ -531,7 +581,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(resized, [{ paneId: '%9', heightLines: HUD_TMUX_HEIGHT_LINES }]);
   });
 
-  it('does not kill existing duplicate HUD panes when the keeper cannot be resized', async () => {
+  it('kills existing duplicate HUD panes even when the keeper cannot be resized', async () => {
     const killed: string[] = [];
     const registered: string[] = [];
 
@@ -557,9 +607,9 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     assert.equal(result.status, 'failed');
-    assert.equal(result.paneId, null);
+    assert.equal(result.paneId, '%8');
     assert.equal(result.duplicateCount, 1);
-    assert.deepEqual(killed, []);
+    assert.deepEqual(killed, ['%9']);
     assert.deepEqual(registered, []);
   });
 

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -380,6 +380,27 @@ describe('HUD pane ownership helpers', () => {
     assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2']);
   });
 
+  it('matches equivalent owner and canonical session ids for the same leader', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        `%2\tnode\texec env OMX_SESSION_ID='omx-owner-abc' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+        `%3\tnode\texec env OMX_SESSION_ID='codex-native-uuid' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+        `%4\tnode\texec env OMX_SESSION_ID='other-session' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
+        `%5\tnode\texec env OMX_SESSION_ID='codex-native-uuid' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%5' /node /omx.js hud --watch`,
+      ].join('\n'),
+    );
+
+    assert.deepEqual(
+      findHudWatchPaneIds(panes, '%1', {
+        sessionId: 'omx-owner-abc',
+        sessionIds: ['omx-owner-abc', 'codex-native-uuid'],
+        leaderPaneId: '%1',
+      }),
+      ['%2', '%3'],
+    );
+  });
+
   it('finds one same-session HUD pane when TMUX_PANE is unavailable', () => {
     const calls: string[][] = [];
     const execTmuxSync = (args: string[]) => {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -11,6 +11,7 @@ import {
   registerHudResizeHook,
   unregisterHudResizeHook,
   resizeTmuxPane,
+  type HudPaneOwner,
   type TmuxPaneSnapshot,
 } from './tmux.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
@@ -39,6 +40,7 @@ export interface ReconcileHudForPromptSubmitResult {
 export interface ReconcileHudForPromptSubmitDeps {
   env?: NodeJS.ProcessEnv;
   sessionId?: string;
+  sessionIds?: string[];
   listCurrentWindowPanes?: (currentPaneId?: string) => TmuxPaneSnapshot[];
   createHudWatchPane?: (
     cwd: string,
@@ -70,7 +72,7 @@ function ensureHudResizeHook(
 function planOwnedHudPaneDedupe(
   panes: TmuxPaneSnapshot[],
   currentPaneId: string | undefined,
-  owner: { sessionId?: string; leaderPaneId?: string },
+  owner: HudPaneOwner,
   preferredPaneId: string,
 ): { paneId: string; duplicatePaneIds: string[] } {
   const ownedPaneIds = [
@@ -129,8 +131,16 @@ export async function reconcileHudForPromptSubmit(
   const currentPaneId = env.TMUX_PANE?.trim();
   const panes = listPanes(currentPaneId);
   const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
+  const equivalentSessionIds = [
+    resolvedSessionId,
+    env.OMX_SESSION_ID?.trim(),
+    ...(deps.sessionIds ?? []),
+  ]
+    .map((sessionId) => sessionId?.trim() ?? '')
+    .filter((sessionId, index, sessionIds) => sessionId !== '' && sessionIds.indexOf(sessionId) === index);
   const owner = {
     sessionId: resolvedSessionId,
+    sessionIds: equivalentSessionIds,
     leaderPaneId: currentPaneId,
   };
   const hudPaneIds = [
@@ -164,16 +174,16 @@ export async function reconcileHudForPromptSubmit(
   if (hudPaneIds.length > 1) {
     const [keeperPaneId, ...extraPaneIds] = hudPaneIds;
     const resized = resizePane(keeperPaneId, desiredHeight);
+    for (const paneId of extraPaneIds) {
+      killPane(paneId);
+    }
     if (!resized) {
       return {
         status: 'failed',
-        paneId: null,
+        paneId: keeperPaneId,
         desiredHeight,
         duplicateCount,
       };
-    }
-    for (const paneId of extraPaneIds) {
-      killPane(paneId);
     }
     ensureHudResizeHook(keeperPaneId, currentPaneId, desiredHeight, deps);
     return {
@@ -224,16 +234,16 @@ export async function reconcileHudForPromptSubmit(
     paneId,
   );
   const resized = resizePane(postCreate.paneId, desiredHeight);
+  for (const duplicatePaneId of postCreate.duplicatePaneIds) {
+    killPane(duplicatePaneId);
+  }
   if (!resized) {
     return {
       status: 'failed',
-      paneId: null,
+      paneId: postCreate.paneId,
       desiredHeight,
       duplicateCount: postCreate.duplicatePaneIds.length,
     };
-  }
-  for (const duplicatePaneId of postCreate.duplicatePaneIds) {
-    killPane(duplicatePaneId);
   }
   ensureHudResizeHook(postCreate.paneId, currentPaneId, desiredHeight, deps);
 

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -17,6 +17,7 @@ export const TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE = '\\037';
 
 export interface HudPaneOwner {
   sessionId?: string;
+  sessionIds?: string[];
   leaderPaneId?: string;
 }
 export type HudRuntimeRootSource = 'team-env' | 'omx-root-env' | 'omx-state-root-env' | 'cwd-default';
@@ -151,14 +152,19 @@ export function findLegacyFocusedHudWatchPaneIds(
 
 export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner = {}): boolean {
   if (!isHudWatchPane(pane)) return false;
-  const wantedSessionId = typeof owner.sessionId === 'string' ? owner.sessionId.trim() : '';
+  const wantedSessionIds = [
+    typeof owner.sessionId === 'string' ? owner.sessionId.trim() : '',
+    ...(Array.isArray(owner.sessionIds) ? owner.sessionIds : []),
+  ]
+    .map((sessionId) => sessionId.trim())
+    .filter((sessionId, index, sessionIds) => sessionId !== '' && sessionIds.indexOf(sessionId) === index);
   const wantedLeaderPaneId = typeof owner.leaderPaneId === 'string' ? owner.leaderPaneId.trim() : '';
-  const wantsSession = wantedSessionId !== '';
+  const wantsSession = wantedSessionIds.length > 0;
   const wantsLeaderPane = wantedLeaderPaneId !== '';
   if (!wantsSession && !wantsLeaderPane) return true;
 
   const paneOwner = readHudPaneOwner(pane);
-  const sessionMatches = wantsSession && paneOwner.sessionId === wantedSessionId;
+  const sessionMatches = wantsSession && wantedSessionIds.includes(paneOwner.sessionId ?? '');
   const leaderPaneMatches = wantsLeaderPane && paneOwner.leaderPaneId === wantedLeaderPaneId;
 
   if (wantsSession && wantsLeaderPane) {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1633,7 +1633,7 @@ describe("codex native hook dispatch", () => {
       assert.equal(sessionState.previous_native_session_id, oldNativeSessionId);
       assert.equal(sessionState.owner_omx_session_id, ownerSessionId);
 
-      let reconcileCall: { cwd: string; sessionId?: string } | null = null;
+      let reconcileCall: { cwd: string; sessionId?: string; sessionIds?: string[] } | null = null;
       const promptResult = await dispatchCodexNativeHook(
         {
           hook_event_name: "UserPromptSubmit",
@@ -1646,14 +1646,18 @@ describe("codex native hook dispatch", () => {
         {
           cwd,
           reconcileHudForPromptSubmitFn: async (hookCwd, deps = {}) => {
-            reconcileCall = { cwd: hookCwd, sessionId: deps.sessionId };
+            reconcileCall = { cwd: hookCwd, sessionId: deps.sessionId, sessionIds: deps.sessionIds };
             return { status: "recreated", paneId: "%9", desiredHeight: 3, duplicateCount: 0 };
           },
         },
       );
 
       assert.equal(promptResult.omxEventName, "keyword-detector");
-      assert.deepEqual(reconcileCall, { cwd, sessionId: ownerSessionId });
+      assert.deepEqual(reconcileCall, {
+        cwd,
+        sessionId: ownerSessionId,
+        sessionIds: [ownerSessionId, nativeSessionId],
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1674,7 +1678,7 @@ describe("codex native hook dispatch", () => {
         sessionState.owner_omx_session_id = invalidOwnerSessionId;
         await writeJson(sessionStatePath, sessionState);
 
-        let reconcileCall: { cwd: string; sessionId?: string } | null = null;
+        let reconcileCall: { cwd: string; sessionId?: string; sessionIds?: string[] } | null = null;
         const promptResult = await dispatchCodexNativeHook(
           {
             hook_event_name: "UserPromptSubmit",
@@ -1687,14 +1691,18 @@ describe("codex native hook dispatch", () => {
           {
             cwd,
             reconcileHudForPromptSubmitFn: async (hookCwd, deps = {}) => {
-              reconcileCall = { cwd: hookCwd, sessionId: deps.sessionId };
+              reconcileCall = { cwd: hookCwd, sessionId: deps.sessionId, sessionIds: deps.sessionIds };
               return { status: "recreated", paneId: "%9", desiredHeight: 3, duplicateCount: 0 };
             },
           },
         );
 
         assert.equal(promptResult.omxEventName, "keyword-detector");
-        assert.deepEqual(reconcileCall, { cwd, sessionId: canonicalSessionId });
+        assert.deepEqual(reconcileCall, {
+          cwd,
+          sessionId: canonicalSessionId,
+          sessionIds: [canonicalSessionId, nativeSessionId],
+        });
       } finally {
         await rm(cwd, { recursive: true, force: true });
       }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -190,6 +190,25 @@ function resolveHudReconcileSessionId(
   return canonicalSessionId || sessionIdForState || undefined;
 }
 
+function resolveHudReconcileSessionIds(
+  currentSessionState: SessionState | null,
+  canonicalSessionId: string | null,
+  sessionIdForState: string | null,
+  nativeSessionId: string | null,
+): string[] {
+  const ownerOmxSessionId = safeString(currentSessionState?.owner_omx_session_id).trim();
+  return uniqueNonEmpty([
+    resolveHudReconcileSessionId(currentSessionState, canonicalSessionId, sessionIdForState),
+    canonicalSessionId ?? undefined,
+    sessionIdForState ?? undefined,
+    nativeSessionId ?? undefined,
+    safeString(currentSessionState?.session_id),
+    safeString(currentSessionState?.native_session_id),
+    OMX_OWNER_SESSION_ID_PATTERN.test(ownerOmxSessionId) ? ownerOmxSessionId : undefined,
+    safeString(currentSessionState?.owner_codex_session_id),
+  ]);
+}
+
 function safeContextSnippet(value: unknown, maxLength = 300): string {
   const text = safeString(value).replace(/\s+/g, " ").trim();
   if (text.length <= maxLength) return text;
@@ -4236,7 +4255,13 @@ export async function dispatchCodexNativeHook(
         canonicalSessionId,
         sessionIdForState,
       );
-      await reconcileHudForPromptSubmitFn(cwd, { sessionId: hudSessionId }).catch(() => {});
+      const hudSessionIds = resolveHudReconcileSessionIds(
+        currentSessionState,
+        canonicalSessionId,
+        sessionIdForState,
+        nativeSessionId,
+      );
+      await reconcileHudForPromptSubmitFn(cwd, { sessionId: hudSessionId, sessionIds: hudSessionIds }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
## Summary
- Match HUD panes across equivalent OMX owner and Codex native session ids while preserving leader-pane scoping.
- Pass canonical/native/owner ids from native prompt-submit HUD reconciliation.
- Kill duplicate HUD panes even when the keeper resize fails.

## Tests
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `env -u OMX_ROOT -u OMX_SESSION_ID -u OMX_SOURCE_CWD -u OMX_STARTUP_CWD -u OMX_ENTRY_PATH -u OMX_TMUX_HUD_OWNER -u TMUX -u TMUX_PANE node --test dist/team/__tests__/runtime-cli.test.js dist/team/__tests__/tmux-session.test.js dist/team/__tests__/worker-runtime-identity.test.js`

Fixes #2683
Related: #2679, #2680, #2682

— OmX
