### PR TITLE
Show HUD late-gate status

### DIFF
--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -29,6 +29,7 @@ function emptyCtx(): HudRenderContext {
     ralplan: null,
     deepInterview: null,
     autoresearch: null,
+    codeReview: null,
     ultraqa: null,
     team: null,
     metrics: null,
@@ -195,6 +196,27 @@ describe('renderHud – autoresearch', () => {
   });
 });
 
+// ── Code review ───────────────────────────────────────────────────────────────
+
+describe('renderHud – code-review', () => {
+  it('renders code-review with the current phase', () => {
+    const ctx = { ...emptyCtx(), codeReview: { active: true, current_phase: 'running' } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${GREEN}code-review:running${RESET}`));
+  });
+
+  it('suppresses duplicate late autopilot code-review status', () => {
+    const ctx = {
+      ...emptyCtx(),
+      autopilot: { active: true, current_phase: 'code-review' },
+      codeReview: { active: true, current_phase: 'autopilot' },
+    };
+    const result = stripSgr(renderHud(ctx, 'focused'));
+    assert.ok(result.includes('code-review:autopilot'));
+    assert.equal(result.includes('autopilot:code-review'), false);
+  });
+});
+
 // ── Ultraqa ───────────────────────────────────────────────────────────────────
 
 describe('renderHud – ultraqa', () => {
@@ -202,6 +224,17 @@ describe('renderHud – ultraqa', () => {
     const ctx = { ...emptyCtx(), ultraqa: { active: true, current_phase: 'diagnose' } };
     const result = renderHud(ctx, 'focused');
     assert.ok(result.includes(`${GREEN}qa:diagnose${RESET}`));
+  });
+
+  it('suppresses duplicate late autopilot ultraqa status', () => {
+    const ctx = {
+      ...emptyCtx(),
+      autopilot: { active: true, current_phase: 'ultraqa' },
+      ultraqa: { active: true, current_phase: 'autopilot' },
+    };
+    const result = stripSgr(renderHud(ctx, 'focused'));
+    assert.ok(result.includes('qa:autopilot'));
+    assert.equal(result.includes('autopilot:ultraqa'), false);
   });
 });
 

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -666,6 +666,90 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('surfaces code-review from canonical skill-active without detail state', async () => {
+    await withTempRepo('omx-hud-canonical-code-review-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-code-review';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'code-review',
+        phase: 'running',
+        session_id: sessionId,
+        active_skills: [{ skill: 'code-review', phase: 'running', active: true, session_id: sessionId }],
+      }));
+
+      const state = await readAllState(cwd);
+      assert.deepEqual(state.codeReview, { active: true, current_phase: 'running' });
+    });
+  });
+
+  it('derives late-gate HUD statuses from active Autopilot child phases', async () => {
+    await withTempRepo('omx-hud-autopilot-late-gates-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-autopilot-late';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'autopilot',
+        phase: 'code-review',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'code-review', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'code-review',
+      }));
+
+      const codeReviewState = await readAllState(cwd);
+      assert.deepEqual(codeReviewState.codeReview, { active: true, current_phase: 'autopilot' });
+      assert.equal(codeReviewState.ultraqa, null);
+
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'ultraqa',
+      }));
+      const ultraqaState = await readAllState(cwd);
+      assert.equal(ultraqaState.codeReview, null);
+      assert.deepEqual(ultraqaState.ultraqa, { active: true, current_phase: 'autopilot' });
+    });
+  });
+
+  it('suppresses stale root late-gate detail without session authority', async () => {
+    await withTempRepo('omx-hud-late-gate-stale-root-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-late-gate-stale';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(rootStateDir, 'code-review-state.json'), JSON.stringify({ active: true, current_phase: 'stale-root' }));
+      await writeFile(join(rootStateDir, 'ultraqa-state.json'), JSON.stringify({ active: true, current_phase: 'stale-root' }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'autopilot',
+        phase: 'ralplan',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'ralplan', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'ralplan',
+      }));
+
+      const state = await readAllState(cwd);
+      assert.equal(state.codeReview, null);
+      assert.equal(state.ultraqa, null);
+      assert.deepEqual(state.autopilot, { active: true, mode: 'autopilot', current_phase: 'ralplan' });
+    });
+  });
+
   it('surfaces approved combined workflow state from canonical multi-skill data', async () => {
     await withTempRepo('omx-hud-canonical-combined-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -74,9 +74,15 @@ function renderUltrawork(ctx: HudRenderContext): string | null {
   return cyan('ultrawork');
 }
 
+function isLateAutopilotHudPhase(phase: string): boolean {
+  const normalized = phase.toLowerCase().replace(/_/g, '-');
+  return normalized === 'code-review' || normalized === 'ultraqa';
+}
+
 function renderAutopilot(ctx: HudRenderContext): string | null {
   if (!ctx.autopilot) return null;
   const phase = sanitizeDynamicText(ctx.autopilot.current_phase || 'active') || 'active';
+  if (isLateAutopilotHudPhase(phase) && (ctx.codeReview || ctx.ultraqa)) return null;
   return yellow(`autopilot:${phase}`);
 }
 
@@ -103,6 +109,12 @@ function renderAutoresearch(ctx: HudRenderContext): string | null {
   if (!ctx.autoresearch) return null;
   const phase = sanitizeDynamicText(ctx.autoresearch.current_phase || 'active') || 'active';
   return cyan(`research:${phase}`);
+}
+
+function renderCodeReview(ctx: HudRenderContext): string | null {
+  if (!ctx.codeReview) return null;
+  const phase = sanitizeDynamicText(ctx.codeReview.current_phase || 'active') || 'active';
+  return green(`code-review:${phase}`);
 }
 
 function renderUltraqa(ctx: HudRenderContext): string | null {
@@ -256,6 +268,7 @@ const MINIMAL_ELEMENTS: ElementRenderer[] = [
   renderRalplan,
   renderDeepInterview,
   renderAutoresearch,
+  renderCodeReview,
   renderUltraqa,
   renderExecutionSummary,
   renderTurns,
@@ -269,6 +282,7 @@ const FOCUSED_ELEMENTS: ElementRenderer[] = [
   renderRalplan,
   renderDeepInterview,
   renderAutoresearch,
+  renderCodeReview,
   renderUltraqa,
   renderExecutionSummary,
   renderTurns,
@@ -286,6 +300,7 @@ const FULL_ELEMENTS: ElementRenderer[] = [
   renderRalplan,
   renderDeepInterview,
   renderAutoresearch,
+  renderCodeReview,
   renderUltraqa,
   renderExecutionSummary,
   renderTurns,

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -24,6 +24,7 @@ import type {
   RalplanStateForHud,
   DeepInterviewStateForHud,
   AutoresearchStateForHud,
+  CodeReviewStateForHud,
   UltraqaStateForHud,
   TeamStateForHud,
   HudMetrics,
@@ -492,6 +493,20 @@ function mergeTeamPhase(
   return { active: true, current_phase: canonicalPhase };
 }
 
+function activeAutopilotPhase(autopilot: AutopilotStateForHud | null): string | undefined {
+  if (autopilot?.active !== true) return undefined;
+  return sanitizeOptionalString(autopilot.current_phase)?.toLowerCase().replace(/_/g, '-');
+}
+
+function supervisedAutopilotStage<T extends { active?: boolean; current_phase?: string }>(
+  autopilot: AutopilotStateForHud | null,
+  stage: string,
+): T | null {
+  return activeAutopilotPhase(autopilot) === stage
+    ? { active: true, current_phase: 'autopilot' } as T
+    : null;
+}
+
 /** Read all state files and build the full render context */
 export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFAULT_HUD_CONFIG): Promise<HudRenderContext> {
   const version = readVersion();
@@ -555,9 +570,12 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
       return merged;
     })()
     : null;
+  const codeReview = shouldSurfaceCanonicalSkill(canonicalSkills, 'code-review', null)
+    ? mergePhase<CodeReviewStateForHud>(null, canonicalPhaseForSkill(canonicalSkills, 'code-review'))
+    : supervisedAutopilotStage<CodeReviewStateForHud>(autopilot, 'code-review');
   const ultraqa = shouldSurfaceCanonicalSkill(canonicalSkills, 'ultraqa', ultraqaDetail)
     ? mergePhase(ultraqaDetail?.active === true ? ultraqaDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ultraqa'))
-    : null;
+    : supervisedAutopilotStage<UltraqaStateForHud>(autopilot, 'ultraqa');
   const canonicalTeamPhase = await readCanonicalTeamPhase(cwd, teamDetail?.active === true ? teamDetail : null);
   const team = shouldSurfaceCanonicalSkill(canonicalSkills, 'team', teamDetail)
     ? mergeTeamPhase(
@@ -591,6 +609,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     ralplan,
     deepInterview,
     autoresearch,
+    codeReview,
     ultraqa,
     team,
     metrics,

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -67,6 +67,12 @@ export interface AutoresearchStateForHud {
   current_phase?: string;
 }
 
+/** Code-review state for HUD display */
+export interface CodeReviewStateForHud {
+  active: boolean;
+  current_phase?: string;
+}
+
 /** Ultraqa state for HUD display */
 export interface UltraqaStateForHud {
   active: boolean;
@@ -117,6 +123,7 @@ export interface HudRenderContext {
   ralplan: RalplanStateForHud | null;
   deepInterview: DeepInterviewStateForHud | null;
   autoresearch: AutoresearchStateForHud | null;
+  codeReview?: CodeReviewStateForHud | null;
   ultraqa: UltraqaStateForHud | null;
   team: TeamStateForHud | null;
   metrics: HudMetrics | null;


### PR DESCRIPTION
## Summary
- Add a HUD-only `codeReview` render context and `code-review:<phase>` token.
- Derive `code-review:autopilot` / `qa:autopilot` from supervised Autopilot late phases without making `code-review` a workflow state mode.
- Suppress duplicate parent `autopilot:code-review` / `autopilot:ultraqa` tokens and add stale-root/session-authority regressions.

## Verification
- `npm run build`
- clean-env `node --test dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js` (127 pass)
- `npm run check:no-unused`
- `npm run lint`
- `node dist/scripts/sync-plugin-mirror.js --check`
- `git diff --check`
- CLI HUD smoke: `code-review:running`, `code-review:autopilot`, `qa:autopilot`; no duplicate late Autopilot parent token

## Review / QA
- code-reviewer: APPROVE, findings none
- architect: CLEAR, findings none after removing code-review state API exposure
- UltraQA: PASS, findings none
