### PR TITLE
Keep HUD late-gate replacements source-aware

### DIFF
--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -209,11 +209,46 @@ describe('renderHud – code-review', () => {
     const ctx = {
       ...emptyCtx(),
       autopilot: { active: true, current_phase: 'code-review' },
-      codeReview: { active: true, current_phase: 'autopilot' },
+      codeReview: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
     };
     const result = stripSgr(renderHud(ctx, 'focused'));
     assert.ok(result.includes('code-review:autopilot'));
     assert.equal(result.includes('autopilot:code-review'), false);
+  });
+
+  it('drops mismatched autopilot-derived late gate labels', () => {
+    const ctx = {
+      ...emptyCtx(),
+      autopilot: { active: true, current_phase: 'code-review' },
+      codeReview: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
+      ultraqa: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
+    };
+    const result = stripSgr(renderHud(ctx, 'focused'));
+    assert.ok(result.includes('code-review:autopilot'));
+    assert.equal(result.includes('qa:autopilot'), false);
+    assert.equal(result.includes('autopilot:code-review'), false);
+  });
+
+  it('keeps autopilot visible when only a mismatched derived late gate exists', () => {
+    const ctx = {
+      ...emptyCtx(),
+      autopilot: { active: true, current_phase: 'code-review' },
+      ultraqa: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
+    };
+    const result = stripSgr(renderHud(ctx, 'focused'));
+    assert.ok(result.includes('autopilot:code-review'));
+    assert.equal(result.includes('qa:autopilot'), false);
+  });
+
+  it('keeps canonical code-review distinct from an autopilot late phase', () => {
+    const ctx = {
+      ...emptyCtx(),
+      autopilot: { active: true, current_phase: 'code-review' },
+      codeReview: { active: true, current_phase: 'planning', source: 'canonical-skill' as const },
+    };
+    const result = stripSgr(renderHud(ctx, 'focused'));
+    assert.ok(result.includes('autopilot:code-review'));
+    assert.ok(result.includes('code-review:planning'));
   });
 });
 
@@ -230,7 +265,7 @@ describe('renderHud – ultraqa', () => {
     const ctx = {
       ...emptyCtx(),
       autopilot: { active: true, current_phase: 'ultraqa' },
-      ultraqa: { active: true, current_phase: 'autopilot' },
+      ultraqa: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
     };
     const result = stripSgr(renderHud(ctx, 'focused'));
     assert.ok(result.includes('qa:autopilot'));

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -5,6 +5,8 @@ import { existsSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, join, relative } from 'node:path';
+import { renderHud } from '../render.js';
+import { recordSkillActivation } from '../../hooks/keyword-detector.js';
 import {
   buildGitBranchLabel,
   readGitBranch,
@@ -38,6 +40,10 @@ async function withWindowsPlatform(run: () => Promise<void> | void): Promise<voi
       Object.defineProperty(process, 'platform', originalPlatform);
     }
   }
+}
+
+function stripSgr(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, '');
 }
 
 async function withTempRepo(prefix: string, run: (cwd: string) => Promise<void>): Promise<void> {
@@ -676,13 +682,35 @@ describe('readAllState canonical skill precedence', () => {
       await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
         active: true,
         skill: 'code-review',
-        phase: 'running',
+        phase: 'planning',
         session_id: sessionId,
-        active_skills: [{ skill: 'code-review', phase: 'running', active: true, session_id: sessionId }],
+        active_skills: [{ skill: 'code-review', phase: 'planning', active: true, session_id: sessionId }],
       }));
 
       const state = await readAllState(cwd);
-      assert.deepEqual(state.codeReview, { active: true, current_phase: 'running' });
+      assert.deepEqual(state.codeReview, { active: true, current_phase: 'planning', source: 'canonical-skill' });
+    });
+  });
+
+  it('surfaces real keyword-activated code-review phase in state and HUD', async () => {
+    await withTempRepo('omx-hud-keyword-code-review-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-code-review-keyword';
+      await mkdir(join(rootStateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+
+      await recordSkillActivation({
+        stateDir: rootStateDir,
+        sourceCwd: cwd,
+        text: '$code-review inspect HUD',
+        sessionId,
+        nowIso: '2026-06-01T00:00:00.000Z',
+      });
+
+      const state = await readAllState(cwd);
+      assert.deepEqual(state.codeReview, { active: true, current_phase: 'planning', source: 'canonical-skill' });
+      const rendered = stripSgr(renderHud(state, 'focused'));
+      assert.ok(rendered.includes('code-review:planning'));
     });
   });
 
@@ -707,7 +735,7 @@ describe('readAllState canonical skill precedence', () => {
       }));
 
       const codeReviewState = await readAllState(cwd);
-      assert.deepEqual(codeReviewState.codeReview, { active: true, current_phase: 'autopilot' });
+      assert.deepEqual(codeReviewState.codeReview, { active: true, current_phase: 'autopilot', source: 'autopilot' });
       assert.equal(codeReviewState.ultraqa, null);
 
       await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
@@ -717,7 +745,7 @@ describe('readAllState canonical skill precedence', () => {
       }));
       const ultraqaState = await readAllState(cwd);
       assert.equal(ultraqaState.codeReview, null);
-      assert.deepEqual(ultraqaState.ultraqa, { active: true, current_phase: 'autopilot' });
+      assert.deepEqual(ultraqaState.ultraqa, { active: true, current_phase: 'autopilot', source: 'autopilot' });
     });
   });
 

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -74,15 +74,34 @@ function renderUltrawork(ctx: HudRenderContext): string | null {
   return cyan('ultrawork');
 }
 
+function normalizeHudPhase(phase: string | undefined): string {
+  return (phase || '').toLowerCase().replace(/_/g, '-');
+}
+
 function isLateAutopilotHudPhase(phase: string): boolean {
-  const normalized = phase.toLowerCase().replace(/_/g, '-');
+  const normalized = normalizeHudPhase(phase);
   return normalized === 'code-review' || normalized === 'ultraqa';
+}
+
+function isAutopilotLateGateSource(ctx: HudRenderContext, stage: 'code-review' | 'ultraqa'): boolean {
+  return normalizeHudPhase(ctx.autopilot?.current_phase) === stage;
+}
+
+function hasAutopilotLateGateReplacement(ctx: HudRenderContext, phase: string): boolean {
+  const normalized = normalizeHudPhase(phase);
+  if (normalized === 'code-review') {
+    return ctx.codeReview?.source === 'autopilot' && isAutopilotLateGateSource(ctx, 'code-review');
+  }
+  if (normalized === 'ultraqa') {
+    return ctx.ultraqa?.source === 'autopilot' && isAutopilotLateGateSource(ctx, 'ultraqa');
+  }
+  return false;
 }
 
 function renderAutopilot(ctx: HudRenderContext): string | null {
   if (!ctx.autopilot) return null;
   const phase = sanitizeDynamicText(ctx.autopilot.current_phase || 'active') || 'active';
-  if (isLateAutopilotHudPhase(phase) && (ctx.codeReview || ctx.ultraqa)) return null;
+  if (isLateAutopilotHudPhase(phase) && hasAutopilotLateGateReplacement(ctx, phase)) return null;
   return yellow(`autopilot:${phase}`);
 }
 
@@ -113,12 +132,14 @@ function renderAutoresearch(ctx: HudRenderContext): string | null {
 
 function renderCodeReview(ctx: HudRenderContext): string | null {
   if (!ctx.codeReview) return null;
+  if (ctx.codeReview.source === 'autopilot' && !isAutopilotLateGateSource(ctx, 'code-review')) return null;
   const phase = sanitizeDynamicText(ctx.codeReview.current_phase || 'active') || 'active';
   return green(`code-review:${phase}`);
 }
 
 function renderUltraqa(ctx: HudRenderContext): string | null {
   if (!ctx.ultraqa) return null;
+  if (ctx.ultraqa.source === 'autopilot' && !isAutopilotLateGateSource(ctx, 'ultraqa')) return null;
   const phase = sanitizeDynamicText(ctx.ultraqa.current_phase || 'active') || 'active';
   return green(`qa:${phase}`);
 }

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -34,6 +34,7 @@ import type {
   SessionStateForHud,
   ResolvedHudConfig,
   HudGitDisplay,
+  LateGateHudSource,
 } from './types.js';
 import { DEFAULT_HUD_CONFIG } from './types.js';
 
@@ -498,12 +499,19 @@ function activeAutopilotPhase(autopilot: AutopilotStateForHud | null): string | 
   return sanitizeOptionalString(autopilot.current_phase)?.toLowerCase().replace(/_/g, '-');
 }
 
-function supervisedAutopilotStage<T extends { active?: boolean; current_phase?: string }>(
+function withLateGateSource<T extends { source?: LateGateHudSource }>(
+  state: T | null,
+  source: LateGateHudSource,
+): T | null {
+  return state ? { ...state, source } : null;
+}
+
+function supervisedAutopilotStage<T extends { active?: boolean; current_phase?: string; source?: LateGateHudSource }>(
   autopilot: AutopilotStateForHud | null,
   stage: string,
 ): T | null {
   return activeAutopilotPhase(autopilot) === stage
-    ? { active: true, current_phase: 'autopilot' } as T
+    ? { active: true, current_phase: 'autopilot', source: 'autopilot' } as T
     : null;
 }
 
@@ -571,10 +579,17 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     })()
     : null;
   const codeReview = shouldSurfaceCanonicalSkill(canonicalSkills, 'code-review', null)
-    ? mergePhase<CodeReviewStateForHud>(null, canonicalPhaseForSkill(canonicalSkills, 'code-review'))
+    ? withLateGateSource(
+      mergePhase<CodeReviewStateForHud>(null, canonicalPhaseForSkill(canonicalSkills, 'code-review')),
+      'canonical-skill',
+    )
     : supervisedAutopilotStage<CodeReviewStateForHud>(autopilot, 'code-review');
   const ultraqa = shouldSurfaceCanonicalSkill(canonicalSkills, 'ultraqa', ultraqaDetail)
-    ? mergePhase(ultraqaDetail?.active === true ? ultraqaDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ultraqa'))
+    ? (() => {
+      const detail = ultraqaDetail?.active === true ? ultraqaDetail : null;
+      const merged = mergePhase(detail, canonicalPhaseForSkill(canonicalSkills, 'ultraqa'));
+      return detail ? merged : withLateGateSource(merged, 'canonical-skill');
+    })()
     : supervisedAutopilotStage<UltraqaStateForHud>(autopilot, 'ultraqa');
   const canonicalTeamPhase = await readCanonicalTeamPhase(cwd, teamDetail?.active === true ? teamDetail : null);
   const team = shouldSurfaceCanonicalSkill(canonicalSkills, 'team', teamDetail)

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -67,16 +67,22 @@ export interface AutoresearchStateForHud {
   current_phase?: string;
 }
 
+export type LateGateHudSource = 'canonical-skill' | 'autopilot';
+
 /** Code-review state for HUD display */
 export interface CodeReviewStateForHud {
   active: boolean;
   current_phase?: string;
+  /** Authority that produced this HUD-only status. */
+  source?: LateGateHudSource;
 }
 
 /** Ultraqa state for HUD display */
 export interface UltraqaStateForHud {
   active: boolean;
   current_phase?: string;
+  /** Authority that produced this derived/fallback HUD status. */
+  source?: LateGateHudSource;
 }
 
 /** Team state for HUD display */


### PR DESCRIPTION
## Summary
- tags HUD late-gate projections with `source` provenance (`canonical-skill` vs `autopilot`)
- makes Autopilot late-phase suppression require a matching renderable Autopilot-derived replacement
- adds regressions for real `$code-review` activation, mismatched synthetic late-gate labels, and canonical-sibling coexistence

## Context
Follow-up to merged PR #2686. The post-merge code-review/Scholastic gates found one remaining WATCH/HIGH: a mismatched HUD-only late-gate object could suppress the authoritative `autopilot:code-review` / `autopilot:ultraqa` label. This keeps code-review HUD-only and does not add a tracked workflow state or MCP state mode.

## Verification
- `npm run build`
- clean-env `node --test dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js dist/hooks/__tests__/keyword-detector.test.js` — 297 pass
- `npm run check:no-unused`
- `npm run lint`
- `node dist/scripts/sync-plugin-mirror.js --check`
- `git diff --check`
- CLI HUD smoke: `code-review:planning`, `code-review:autopilot`, `qa:autopilot`
- code-reviewer: APPROVE
- architect: CLEAR
- Scholastic: PASS

## Notes
A broader clean `npm run test:node` attempt exposed unrelated existing failures in launch/notifications/openclaw/triage/team tests and was stopped after the scoped HUD gates passed.
