### PR TITLE
Keep Autopilot ralplan write guards phase-aware

### DIFF
--- a/src/autopilot/__tests__/fsm.test.ts
+++ b/src/autopilot/__tests__/fsm.test.ts
@@ -16,6 +16,9 @@ describe('autopilot supervisor FSM helpers', () => {
     assert.equal(normalizeAutopilotPhase('ralph'), 'ralph');
     assert.equal(normalizeAutopilotPhase('completed'), 'complete');
     assert.equal(normalizeAutopilotPhase('planning'), 'ralplan');
+    assert.equal(normalizeAutopilotPhase('replan'), 'ralplan');
+    assert.equal(normalizeAutopilotPhase('autopilot:ralplan'), 'ralplan');
+    assert.equal(normalizeAutopilotPhase('autopilot:replan'), 'ralplan');
   });
 
   it('derives child-stage labels only from Autopilot supervisor state', () => {

--- a/src/autopilot/fsm.ts
+++ b/src/autopilot/fsm.ts
@@ -28,9 +28,9 @@ function safeObject(value: unknown): Record<string, unknown> {
 }
 
 function normalizePhaseText(value: unknown): string {
-  const normalized = safeString(value).toLowerCase().replace(/_/g, '-');
+  const normalized = safeString(value).toLowerCase().replace(/_/g, '-').replace(/^autopilot:/, '');
   if (normalized === 'completed') return 'complete';
-  if (normalized === 'planning') return 'ralplan';
+  if (normalized === 'planning' || normalized === 'replan') return 'ralplan';
   return normalized;
 }
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13932,6 +13932,136 @@ exit 0
     }
   });
 
+  it("blocks implementation writes when Autopilot ralplan is visible only in skill-active phase", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-skill-ralplan-pretool-block-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-autopilot-skill-ralplan-pretool-block";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "autopilot:ralplan",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "autopilot:ralplan", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "planning",
+        session_id: sessionId,
+        state: {
+          handoff_artifacts: {
+            ralplan_consensus_gate: { required: true, complete: false },
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-autopilot-skill-ralplan-pretool-block",
+          tool_name: "Edit",
+          tool_input: { file_path: "src/runtime.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Autopilot planning is active .*implementation\/write tools are blocked/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores stale Autopilot ralplan skill mirrors after detail state leaves planning", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-stale-ralplan-mirror-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-autopilot-stale-ralplan-mirror";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "autopilot:ralplan",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "autopilot:ralplan", active: true, session_id: sessionId }],
+      });
+
+      for (const phase of ["ultragoal", "code-review", "completing", "complete"]) {
+        await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+          active: true,
+          mode: "autopilot",
+          current_phase: phase,
+          session_id: sessionId,
+        });
+
+        const result = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            session_id: sessionId,
+            thread_id: "thread-autopilot-stale-ralplan-mirror",
+            tool_name: "Edit",
+            tool_input: { file_path: "src/runtime.ts" },
+          },
+          { cwd },
+        );
+
+        assert.equal(result.omxEventName, "pre-tool-use");
+        assert.equal(result.outputJson, null, `stale skill-active ralplan mirror must not block when Autopilot detail phase is ${phase}`);
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows explicit blank Autopilot detail phase to use a ralplan skill mirror", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-blank-phase-mirror-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-autopilot-blank-phase-mirror";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "autopilot:ralplan",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "autopilot:ralplan", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-autopilot-blank-phase-mirror",
+          tool_name: "Edit",
+          tool_input: { file_path: "src/runtime.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Autopilot planning is active .*implementation\/write tools are blocked/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block implementation writes from Autopilot ralplan detail state without canonical skill state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-ralplan-no-canonical-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -83,6 +83,7 @@ import {
   onSessionStart as buildWikiSessionStartContext,
 } from "../wiki/lifecycle.js";
 import { readAutoresearchCompletionStatus, readAutoresearchModeStateForActiveDecision } from "../autoresearch/skill-validation.js";
+import { normalizeAutopilotPhase } from "../autopilot/fsm.js";
 import { readRunState } from "../runtime/run-state.js";
 import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
 import { getRunContinuationSnapshot, shouldContinueRun } from "../runtime/run-loop.js";
@@ -2592,12 +2593,12 @@ function isActiveRalplanPhase(state: Record<string, unknown> | null): boolean {
   return true;
 }
 
-function isActiveAutopilotRalplanPhase(state: Record<string, unknown> | null): boolean {
-  if (!state || state.active !== true) return false;
-  const mode = safeString(state.mode).trim();
-  if (mode && mode !== "autopilot") return false;
-  const phase = safeString(state.current_phase ?? state.currentPhase).trim().toLowerCase();
-  return phase === "ralplan" || phase === "replan" || phase === "autopilot:replan";
+function isAutopilotRalplanLikePhase(phase: string): boolean {
+  return normalizeAutopilotPhase(phase) === "ralplan";
+}
+
+function canAutopilotSkillMirrorSupplyRalplanPhase(phase: string): boolean {
+  return phase === "" || normalizeAutopilotPhase(phase) === "ralplan";
 }
 
 function hasExplicitExecutionHandoffSkill(
@@ -2733,7 +2734,9 @@ async function readActiveRalplanStateForPreToolUse(
   const autopilotState = sessionId
     ? await readStopSessionPinnedState("autopilot-state.json", cwd, sessionId, stateDir)
     : await readJsonIfExists(join(stateDir, "autopilot-state.json"));
-  if (!isActiveAutopilotRalplanPhase(autopilotState) || !autopilotState) return null;
+  if (!autopilotState || autopilotState.active !== true) return null;
+  const autopilotMode = safeString(autopilotState.mode).trim();
+  if (autopilotMode && autopilotMode !== "autopilot") return null;
   if (!modeStateMatchesSkillStopContext(autopilotState, cwd, sessionId)) return null;
   const terminalAutopilotRunState = await readCanonicalTerminalRunStateForStop(cwd, sessionId, "autopilot");
   if (terminalAutopilotRunState) return null;
@@ -2742,6 +2745,15 @@ async function readActiveRalplanStateForPreToolUse(
     entry.skill === "autopilot"
     && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
   ));
+  if (!hasActiveAutopilotSkill) return null;
+  const autopilotStatePhase = safeString(autopilotState.current_phase ?? autopilotState.currentPhase).trim().toLowerCase();
+  if (!canAutopilotSkillMirrorSupplyRalplanPhase(autopilotStatePhase)) return null;
+  const hasRalplanScopedAutopilotSkill = listActiveSkills(canonicalState).some((entry) => (
+    entry.skill === "autopilot"
+    && isAutopilotRalplanLikePhase(safeString(entry.phase).trim().toLowerCase())
+    && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
+  ));
+  if (!isAutopilotRalplanLikePhase(autopilotStatePhase) && !hasRalplanScopedAutopilotSkill) return null;
   return hasActiveAutopilotSkill ? autopilotState : null;
 }
 


### PR DESCRIPTION
## Summary

- Treat `autopilot:ralplan` from canonical `skill-active-state.json` as a ralplan-like PreToolUse boundary, even when `autopilot-state.json` still carries a generic `current_phase: "planning"`.
- Keep the existing terminal run-state escape hatch so completed Autopilot runs do not keep blocking later implementation work.
- Add a regression test for the split-state shape observed in tmux: visible phase `autopilot:ralplan` + detail phase `planning` must block implementation edits.

## Root cause

The current guard only keyed Autopilot planning write blocking on `autopilot-state.current_phase` values like `ralplan`/`replan`. In the observed tmux run, the visible runtime phase was `autopilot:ralplan`, but that phase lived in skill-active state while the detail state still looked like generic planning. That split let an implementation `Edit` begin during the planning gate.

## Validation

- `npm run build`
- `node --test --test-name-pattern 'blocks implementation writes while Autopilot is supervising ralplan without handoff|blocks implementation writes when Autopilot ralplan is visible only in skill-active phase|does not block implementation writes from Autopilot ralplan detail state without canonical skill state|allows implementation writes when terminal Autopilot run-state shadows stale supervised ralplan state' dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- Code review subagent: APPROVE / CLEAR

## Related

- Follow-up to issue #2674 / PR #2675 runtime evidence.
