### PR TITLE
Keep fork PR CI from self-hosted skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,7 @@ concurrency:
 jobs:
   changes:
     name: Detect CI lanes
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 10
     outputs:
       full_suite: ${{ steps.classify.outputs.full_suite }}
@@ -214,7 +213,7 @@ jobs:
 
   docs-check:
     name: Docs Check
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 10
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.docs_changed == 'true' }}
@@ -225,7 +224,7 @@ jobs:
 
   rustfmt:
     name: Rust Format
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 20
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
@@ -241,7 +240,7 @@ jobs:
 
   clippy:
     name: Rust Clippy
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 30
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
@@ -265,7 +264,7 @@ jobs:
 
   rust-tests:
     name: Rust Tests + Coverage Signal
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 45
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
@@ -312,7 +311,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 20
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -327,7 +326,7 @@ jobs:
 
   typecheck:
     name: Typecheck
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 25
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -343,7 +342,7 @@ jobs:
 
   build-dist:
     name: Build dist artifact
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 25
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -364,7 +363,7 @@ jobs:
 
   test:
     name: Test (Node ${{ matrix.node-version }} / ${{ matrix.lane }})
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 60
     needs: [changes, build-dist]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -467,7 +466,7 @@ jobs:
 
   coverage-team-critical:
     name: Coverage Gate (Team Critical)
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 45
     needs: [changes, build-dist]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -517,7 +516,7 @@ jobs:
 
   ralph-persistence-gate:
     name: Ralph Persistence Gate
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 30
     needs: [changes, build-dist]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -538,7 +537,7 @@ jobs:
 
   build:
     name: Build (Full Source Build)
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 45
     needs: [changes, build-dist]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -573,7 +572,7 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
     timeout-minutes: 10
     needs: [changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, test, coverage-team-critical, ralph-persistence-gate, build]
     steps:

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -65,6 +65,17 @@ function classifyChangedPaths(paths: string[]): Record<string, string> {
 }
 
 describe('CI Rust gates', () => {
+
+  it('runs fork pull-request CI on GitHub-hosted runners instead of skipping lane detection', () => {
+    const workflow = readCiWorkflow();
+    const changesJob = jobBlock(workflow, 'changes');
+
+    assert.doesNotMatch(changesJob, /head\.repo\.full_name == github\.repository/);
+    assert.doesNotMatch(changesJob, /^\s+if:\s*github\.event_name != 'pull_request'/m);
+    assert.match(workflow, /head\.repo\.full_name != github\.repository && 'ubuntu-latest' \|\| 'gajae-layofflabs-2'/);
+    assert.match(jobBlock(workflow, 'ci-status'), /head\.repo\.full_name != github\.repository && 'ubuntu-latest' \|\| 'gajae-layofflabs-2'/);
+  });
+
   it('detects changed-file lanes once and exposes fail-closed outputs for targeted CI', () => {
     const workflow = readCiWorkflow();
     const changesJob = jobBlock(workflow, 'changes');


### PR DESCRIPTION
## Summary
- route fork `pull_request` CI jobs to `ubuntu-latest` instead of skipping lane detection on self-hosted runners
- keep same-repo/trusted branch CI on `gajae-layofflabs-2`
- add a workflow contract test covering fork PR lane detection and CI Status runner fallback

## Validation
- npm ci
- npm run build
- npm run lint
- npm run check:no-unused
- git diff --check
- npx js-yaml .github/workflows/ci.yml
- node --test dist/verification/__tests__/ci-rust-gates.test.js

## PR #2692 diagnosis
Run 26745805018 is not transient: `Detect CI lanes` was skipped by the fork self-hosted guard, leaving empty outputs. `CI Status` has `if: always()` and `needs: [changes, ...]`, then requires `changes` to succeed, so it failed on `changes=skipped`. PR #2692 changed skill docs plus hook contract tests; lane detection should have selected full suite if it had run.