### PR TITLE
Respect review subagent model and effort settings

### DIFF
--- a/plugins/oh-my-codex/skills/code-review/SKILL.md
+++ b/plugins/oh-my-codex/skills/code-review/SKILL.md
@@ -71,10 +71,11 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
 
 Do not self-review as a fallback. If the `code-reviewer` or `architect` agent path is missing, unavailable, skipped, or fails, emit a clear unavailable-review result and block approval until the independent lane evidence exists.
 
+Respect the user's current model and reasoning/effort selection when launching review lanes. Do not pass `model` or `reasoning_effort` overrides in the review-lane task calls unless the user explicitly asks for review-specific overrides; omitting them lets native subagents inherit the active session settings.
+
 ```
 task(
   agent_type="code-reviewer",
-  reasoning_effort="xhigh",
   prompt="CODE REVIEW TASK
 
 Review code changes for quality, security, and maintainability.
@@ -100,7 +101,6 @@ Output: Code review report with:
 
 task(
   agent_type="architect",
-  reasoning_effort="xhigh",
   prompt="ARCHITECTURE / DEVIL'S-ADVOCATE REVIEW TASK
 
 Review the same code changes from the architecture/tradeoff perspective.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -71,10 +71,11 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
 
 Do not self-review as a fallback. If the `code-reviewer` or `architect` agent path is missing, unavailable, skipped, or fails, emit a clear unavailable-review result and block approval until the independent lane evidence exists.
 
+Respect the user's current model and reasoning/effort selection when launching review lanes. Do not pass `model` or `reasoning_effort` overrides in the review-lane task calls unless the user explicitly asks for review-specific overrides; omitting them lets native subagents inherit the active session settings.
+
 ```
 task(
   agent_type="code-reviewer",
-  reasoning_effort="xhigh",
   prompt="CODE REVIEW TASK
 
 Review code changes for quality, security, and maintainability.
@@ -100,7 +101,6 @@ Output: Code review report with:
 
 task(
   agent_type="architect",
-  reasoning_effort="xhigh",
   prompt="ARCHITECTURE / DEVIL'S-ADVOCATE REVIEW TASK
 
 Review the same code changes from the architecture/tradeoff perspective.

--- a/src/hooks/__tests__/code-review-skill-contract.test.ts
+++ b/src/hooks/__tests__/code-review-skill-contract.test.ts
@@ -22,9 +22,13 @@ describe('code-review skill contract', () => {
     assert.match(codeReviewSkill, /do \*\*not\*\* substitute the current\/authoring lane/i);
   });
 
-  it('uses native task agent_type examples instead of legacy delegate role/tier syntax', () => {
-    assert.match(codeReviewSkill, /task\(\s*agent_type="code-reviewer",\s*reasoning_effort="xhigh"/s);
-    assert.match(codeReviewSkill, /task\(\s*agent_type="architect",\s*reasoning_effort="xhigh"/s);
+  it('uses native task agent_type examples without overriding user model or effort', () => {
+    assert.match(codeReviewSkill, /Respect the user's current model and reasoning\/effort selection/i);
+    assert.match(codeReviewSkill, /Do not pass `model` or `reasoning_effort` overrides/i);
+    assert.match(codeReviewSkill, /task\(\s*agent_type="code-reviewer",\s*prompt=/s);
+    assert.match(codeReviewSkill, /task\(\s*agent_type="architect",\s*prompt=/s);
+    assert.doesNotMatch(codeReviewSkill, /task\(\s*agent_type="code-reviewer",\s*(?:model=|reasoning_effort=)/s);
+    assert.doesNotMatch(codeReviewSkill, /task\(\s*agent_type="architect",\s*(?:model=|reasoning_effort=)/s);
     assert.doesNotMatch(codeReviewSkill, /delegate\(\s*role=/s);
     assert.doesNotMatch(codeReviewSkill, /tier="/);
   });


### PR DESCRIPTION
## Summary

Fixes review-lane subagent dispatch guidance so `$code-review` respects the user's active model and reasoning/effort selection instead of forcing review-specific defaults.

## Changes

- Remove hardcoded `reasoning_effort="xhigh"` from the `code-reviewer` and `architect` native task examples.
- Add explicit code-review skill guidance to avoid passing `model` or `reasoning_effort` overrides unless the user asks for review-specific overrides.
- Update the code-review skill contract test to assert inheritance wording and fail if review lanes reintroduce hardcoded model/effort overrides.
- Sync the plugin skill mirror.

## User-facing contract impact

This intentionally changes the documented `$code-review` review-lane contract: review subagents now inherit the active session model/effort by default instead of forcing `xhigh`. Owner confirmation before merge may be useful to acknowledge that behavior change, but it directly matches issue #2696.

## Validation

- [x] `npm run build`
- [x] `node dist/scripts/run-test-files.js dist/hooks/__tests__/code-review-skill-contract.test.js`
- [x] `npm run lint`
- [x] `npm run sync:plugin:check`
- [x] `npm run verify:plugin-bundle`
- [ ] `npm test` (not rerun; focused contract/build/lint/plugin checks passed)
- [ ] `omx doctor` (not run; setup/config behavior unchanged)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (skill contract and plugin mirror)
- [x] Backward-compatibility impact considered

## Related

Closes #2696

Co-authored-by: OmX <omx@oh-my-codex.dev>
