### PR TITLE
Keep Ultragoal HUD active until goals finish

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -306,6 +306,37 @@ describe('readUltragoalState', { concurrency: false }, () => {
     });
   });
 
+  it('keeps HUD active when aggregate completion exists but repo-native ultragoal work is still running', async () => {
+    await withTempRepo('omx-hud-ultragoal-aggregate-active-', async (cwd) => {
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G002-running',
+        aggregateCompletion: {
+          status: 'complete',
+          completedAt: '2026-06-01T12:00:00.000Z',
+          evidence: 'task-scoped Codex aggregate completed before microgoal ledger reconciliation finished',
+        },
+        goals: [
+          { id: 'G001-done', title: 'Done', objective: 'Completed prior work', status: 'complete' },
+          { id: 'G002-running', title: 'Running', objective: 'Finish active repo-native work', status: 'in_progress' },
+          { id: 'G003-pending', title: 'Pending', objective: 'Finish follow-up work', status: 'pending' },
+        ],
+      }));
+
+      const state = await readUltragoalState(cwd);
+
+      assert.equal(state?.active, true);
+      assert.equal(state?.status, 'in_progress');
+      assert.equal(state?.activeGoal?.id, 'G002-running');
+      assert.equal(state?.complete, 1);
+      assert.equal(state?.inProgress, 1);
+      assert.equal(state?.pending, 1);
+      assert.deepEqual(state?.ongoingGoals?.map((goal) => goal.id), ['G002-running', 'G003-pending']);
+    });
+  });
+
   it('shows active ultragoal plus the next three pending goals', async () => {
     await withTempRepo('omx-hud-ultragoal-next-pending-', async (cwd) => {
       const ultragoalDir = join(cwd, '.omx', 'ultragoal');

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -138,11 +138,6 @@ function normalizeUltragoalGoal(raw: unknown): NormalizedUltragoalGoal | null {
   return { id, title, objective, status };
 }
 
-function isAggregateComplete(value: unknown): boolean {
-  if (!value || typeof value !== 'object') return false;
-  return (value as { status?: unknown }).status === 'complete';
-}
-
 export async function readUltragoalState(cwd: string): Promise<UltragoalStateForHud | null> {
   const plan = await readJsonFile<RawUltragoalPlan>(join(cwd, '.omx', 'ultragoal', 'goals.json'));
   if (!plan || typeof plan !== 'object' || !Array.isArray(plan.goals)) return null;
@@ -164,7 +159,7 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
     ?? goals.find((goal) => ULTRAGOAL_UNRESOLVED_STATUSES.has(goal.status))
   );
   const activeIndex = activeGoal ? goals.findIndex((goal) => goal.id === activeGoal.id) : -1;
-  const complete = isAggregateComplete(plan.aggregateCompletion) || unresolved_goals === 0;
+  const complete = unresolved_goals === 0;
   const toHudGoal = ({ goal, index }: { goal: NormalizedUltragoalGoal; index: number }) => ({
     id: goal.id,
     title: goal.title,


### PR DESCRIPTION
## Summary
- Keep the Ultragoal HUD in progress while any goal remains unresolved, even if aggregateCompletion says complete
- Surface active/pending unresolved goals instead of treating aggregate completion as terminal
- Add a regression covering aggregate complete with in-progress/pending repo-native goals

Closes #2698

## Tests
- npm run build
- node --test dist/hud/__tests__/state.test.js
- npm run lint
- git diff --check

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*