### PR TITLE
Keep deep-interview question review screens visible in short tmux panes

### DIFF
--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -205,6 +205,123 @@ describe('question window topology selection', () => {
 
     assert.ok(estimateQuestionRenderFootprint(record, 20) > estimateQuestionRenderFootprint(record, 80));
   });
+
+  it('sizes multi-question records from the largest visible screen rather than summing every question', () => {
+    const longQuestion = {
+      id: 'q-2',
+      question: 'x'.repeat(220),
+      options: [{
+        label: 'Only option',
+        value: 'only',
+        description: 'y'.repeat(180),
+      }],
+      allow_other: false,
+      multi_select: false,
+      type: 'single-answerable',
+    };
+    const shortQuestion = {
+      id: 'q-1',
+      question: 'Short question?',
+      options: [{
+        label: 'Only option',
+        value: 'only',
+        description: 'Short description.',
+      }],
+      allow_other: false,
+      multi_select: false,
+      type: 'single-answerable',
+    };
+    const shared = {
+      kind: 'omx.question/v1',
+      question_id: 'question-1',
+      created_at: '2026-05-01T10:08:52.523Z',
+      updated_at: '2026-05-01T10:08:52.523Z',
+      status: 'pending',
+      allow_other: false,
+      multi_select: false,
+      type: 'single-answerable',
+      source: 'deep-interview',
+    };
+    const multiQuestionRecord = {
+      ...shared,
+      questions: [shortQuestion, longQuestion],
+    } as any;
+    const shortRecord = {
+      ...shared,
+      questions: [shortQuestion],
+    } as any;
+    const longRecord = {
+      ...shared,
+      questions: [longQuestion],
+    } as any;
+
+    const multiFootprint = estimateQuestionRenderFootprint(multiQuestionRecord, 20);
+    const shortFootprint = estimateQuestionRenderFootprint(shortRecord, 20);
+    const longFootprint = estimateQuestionRenderFootprint(longRecord, 20);
+
+    assert.ok(multiFootprint >= longFootprint);
+    assert.ok(multiFootprint < shortFootprint + longFootprint);
+  });
+
+  it('includes the review screen when sizing multi-question records', () => {
+    const shortQuestion = {
+      id: 'q-1',
+      question: 'First short question?',
+      options: [{
+        label: 'Only option',
+        value: 'only',
+        description: 'Short description.',
+      }],
+      allow_other: false,
+      multi_select: false,
+      type: 'single-answerable',
+    };
+    const shortSecondQuestion = {
+      id: 'q-2',
+      question: 'Second short question?',
+      options: [{
+        label: 'Only option',
+        value: 'only',
+        description: 'Short description.',
+      }],
+      allow_other: false,
+      multi_select: false,
+      type: 'single-answerable',
+    };
+    const shortThirdQuestion = {
+      id: 'q-3',
+      question: 'Third short question?',
+      options: [{
+        label: 'Only option',
+        value: 'only',
+        description: 'Short description.',
+      }],
+      allow_other: false,
+      multi_select: false,
+      type: 'single-answerable',
+    };
+    const shared = {
+      kind: 'omx.question/v1',
+      question_id: 'question-1',
+      created_at: '2026-05-01T10:08:52.523Z',
+      updated_at: '2026-05-01T10:08:52.523Z',
+      status: 'pending',
+      allow_other: false,
+      multi_select: false,
+      type: 'single-answerable',
+      source: 'deep-interview',
+    };
+    const singleScreenRecord = {
+      ...shared,
+      questions: [shortQuestion],
+    } as any;
+    const reviewScreenRecord = {
+      ...shared,
+      questions: [shortQuestion, shortSecondQuestion, shortThirdQuestion],
+    } as any;
+
+    assert.ok(estimateQuestionRenderFootprint(reviewScreenRecord, 80) > estimateQuestionRenderFootprint(singleScreenRecord, 80));
+  });
 });
 
 describe('launchQuestionRenderer', () => {
@@ -438,6 +555,82 @@ describe('launchQuestionRenderer', () => {
       const targetIndex = newWindowCall.indexOf('-t');
       assert.notEqual(targetIndex, -1);
       assert.deepEqual(newWindowCall.slice(targetIndex, targetIndex + 2), ['-t', '%11']);
+      assert.equal(calls.some((call) => call[0] === 'split-window'), false);
+    } finally {
+      rmSync(cwd, { recursive: true });
+    }
+  });
+
+  it('falls back to the default tmux width when the width probe fails', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-question-renderer-width-fallback-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state', 'sessions', 's1', 'questions');
+      mkdirSync(stateDir, { recursive: true });
+      const recordPath = join(stateDir, 'question-1.json');
+      writeFileSync(recordPath, JSON.stringify({
+        kind: 'omx.question/v1',
+        question_id: 'question-1',
+        created_at: '2026-05-01T10:08:52.523Z',
+        updated_at: '2026-05-01T10:08:52.523Z',
+        status: 'pending',
+        question: 'x'.repeat(2000),
+        options: [{
+          label: 'Only option',
+          value: 'only',
+          description: 'y'.repeat(1000),
+        }],
+        allow_other: false,
+        multi_select: false,
+        type: 'single-answerable',
+        source: 'deep-interview',
+        questions: [{
+          id: 'q-1',
+          question: 'x'.repeat(2000),
+          options: [{
+            label: 'Only option',
+            value: 'only',
+            description: 'y'.repeat(1000),
+          }],
+          allow_other: false,
+          multi_select: false,
+          type: 'single-answerable',
+        }],
+      }, null, 2));
+
+      const calls: string[][] = [];
+      const result = launchQuestionRenderer(
+        {
+          cwd,
+          recordPath,
+          sessionId: 's1',
+          env: { TMUX: '/tmp/tmux-demo', TMUX_PANE: '%11' } as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'inside-tmux',
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'display-message' && args.includes('#{session_attached}')) return '1\n';
+            if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '20\n';
+            if (args[0] === 'display-message' && args.includes('#{pane_width}') && args.includes('-t')) throw new Error('width query failed');
+            if (args[0] === 'display-message' && args.includes('#{pane_width}') && !args.includes('-t')) return '3\n';
+            if (args[0] === 'new-window') return '%88\n';
+            if (args[0] === 'list-panes' && args[2] === '%88') return '0\t%88\n';
+            return '';
+          },
+          sleepSync: () => {},
+        },
+      );
+
+      assert.equal(result.renderer, 'tmux-pane');
+      assert.equal(result.target, '%88');
+      assert.equal(result.return_target, '%11');
+      assert.equal(result.return_transport, 'tmux-send-keys');
+      const newWindowCall = calls.find((call) => call[0] === 'new-window');
+      assert.ok(newWindowCall);
+      const targetIndex = newWindowCall.indexOf('-t');
+      assert.notEqual(targetIndex, -1);
+      assert.deepEqual(newWindowCall.slice(targetIndex, targetIndex + 2), ['-t', '%11']);
+      assert.equal(calls.some((call) => call[0] === 'display-message' && call.includes('#{pane_width}') && !call.includes('-t')), false);
       assert.equal(calls.some((call) => call[0] === 'split-window'), false);
     } finally {
       rmSync(cwd, { recursive: true });

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -322,6 +322,35 @@ describe('question window topology selection', () => {
 
     assert.ok(estimateQuestionRenderFootprint(reviewScreenRecord, 80) > estimateQuestionRenderFootprint(singleScreenRecord, 80));
   });
+
+  it('sizes review screens from selected answers when multi-select summaries wrap', () => {
+    const questions = Array.from({ length: 5 }, (_, index) => ({
+      id: `q-${index + 1}`,
+      question: `Question ${index + 1}?`,
+      options: [
+        { label: 'Alpha option', value: 'alpha' },
+        { label: 'Beta option', value: 'beta' },
+        { label: 'Gamma option', value: 'gamma' },
+      ],
+      allow_other: false,
+      multi_select: true,
+      type: 'multi-answerable',
+    }));
+    const record = {
+      kind: 'omx.question/v1',
+      question_id: 'question-1',
+      created_at: '2026-05-01T10:08:52.523Z',
+      updated_at: '2026-05-01T10:08:52.523Z',
+      status: 'pending',
+      allow_other: false,
+      multi_select: true,
+      type: 'multi-answerable',
+      source: 'deep-interview',
+      questions,
+    } as any;
+
+    assert.equal(shouldOpenQuestionInNewWindow(20, estimateQuestionRenderFootprint(record, 20)), true);
+  });
 });
 
 describe('launchQuestionRenderer', () => {

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -214,7 +214,8 @@ describe('launchQuestionRenderer', () => {
         strategy: 'inside-tmux',
         execTmux: (args) => {
           calls.push(args);
-          if (args[0] === 'display-message') return '1\n';
+          if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
+            if (args[0] === 'display-message') return '1\n';
           if (args[0] === 'split-window') return '%42\n';
           if (args[0] === 'list-panes') return '0\t%42\n';
           return '';
@@ -249,6 +250,77 @@ describe('launchQuestionRenderer', () => {
     assert.ok(calls.some((call) => call.join(' ') === 'list-panes -t %42 -F #{pane_dead}\t#{pane_id}'));
   });
 
+  it('opens a new tmux window when the current pane is too short for the question frame', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-question-renderer-new-window-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state', 'sessions', 's1', 'questions');
+      mkdirSync(stateDir, { recursive: true });
+      const recordPath = join(stateDir, 'question-1.json');
+      writeFileSync(recordPath, JSON.stringify({
+        kind: 'omx.question/v1',
+        question_id: 'question-1',
+        created_at: '2026-05-01T10:08:52.523Z',
+        updated_at: '2026-05-01T10:08:52.523Z',
+        status: 'pending',
+        question: 'Round 1 | Target: definition-boundary | Ambiguity: 42%\n\nСамая важная неоднозначность: что именно считать системной метрикой скорости для TTS / Image / Voice, чтобы прогресс-бар и карточки не врали оператору?',
+        options: [
+          { label: 'Stage timings', value: 'stage-timings', description: 'Считать отдельно реальные этапы: TTS synthesis, image/still generation, voice/video final generation; для каждого нужны stage timestamps/metadata.' },
+          { label: 'Wall-clock by artifact', value: 'wall-clock-by-artifact', description: 'Брать общий wall-clock от createdAt до completed и нормализовать по типу результата: 1 image / N sec, 1s video / N sec.' },
+          { label: 'Hybrid recommended', value: 'hybrid', description: 'Сначала использовать wall-clock fallback, но добавлять stage timings для новых генераций, когда этапы можно инструментировать.' },
+        ],
+        allow_other: true,
+        other_label: 'Other',
+        multi_select: false,
+        type: 'single-answerable',
+        questions: [{
+          id: 'q-1',
+          question: 'Round 1 | Target: definition-boundary | Ambiguity: 42%\n\nСамая важная неоднозначность: что именно считать системной метрикой скорости для TTS / Image / Voice, чтобы прогресс-бар и карточки не врали оператору?',
+          options: [
+            { label: 'Stage timings', value: 'stage-timings', description: 'Считать отдельно реальные этапы: TTS synthesis, image/still generation, voice/video final generation; для каждого нужны stage timestamps/metadata.' },
+            { label: 'Wall-clock by artifact', value: 'wall-clock-by-artifact', description: 'Брать общий wall-clock от createdAt до completed и нормализовать по типу результата: 1 image / N sec, 1s video / N sec.' },
+            { label: 'Hybrid recommended', value: 'hybrid', description: 'Сначала использовать wall-clock fallback, но добавлять stage timings для новых генераций, когда этапы можно инструментировать.' },
+          ],
+          allow_other: true,
+          other_label: 'Other',
+          multi_select: false,
+          type: 'single-answerable',
+        }],
+        source: 'deep-interview',
+      }, null, 2));
+
+      const calls: string[][] = [];
+      const result = launchQuestionRenderer(
+        {
+          cwd,
+          recordPath,
+          sessionId: 's1',
+          env: { TMUX: '/tmp/tmux-demo', TMUX_PANE: '%11' } as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'inside-tmux',
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'display-message' && args.includes('#{session_attached}')) return '1\n';
+            if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '5\n';
+            if (args[0] === 'new-window') return '%42\n';
+            if (args[0] === 'list-panes' && args[2] === '%42') return '0\t%42\n';
+            return '';
+          },
+          sleepSync: () => {},
+        },
+      );
+
+      assert.equal(result.renderer, 'tmux-pane');
+      assert.equal(result.target, '%42');
+      assert.equal(result.return_target, '%11');
+      assert.equal(result.return_transport, 'tmux-send-keys');
+      assert.equal(calls.some((call) => call[0] === 'new-window'), true);
+      assert.equal(calls.some((call) => call[0] === 'split-window'), false);
+    } finally {
+      rmSync(cwd, { recursive: true });
+    }
+  });
+
   it('targets the explicit leader pane even when the caller is already inside tmux', () => {
     const calls: string[][] = [];
     const result = launchQuestionRenderer(
@@ -267,7 +339,7 @@ describe('launchQuestionRenderer', () => {
         execTmux: (args) => {
           calls.push(args);
           if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
-          if (args[0] === 'display-message') return '1\n';
+            if (args[0] === 'display-message') return '1\n';
           if (args[0] === 'split-window') return '%45\n';
           if (args[0] === 'list-panes') return '0\t%45\n';
           return '';
@@ -457,6 +529,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
             if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%42\n';
             throw new Error("can't find pane: %42");
@@ -532,6 +605,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
             if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%77\n';
             if (args[0] === 'list-panes') return '0\t%77\n';
@@ -579,6 +653,7 @@ describe('launchQuestionRenderer', () => {
         {
           strategy: 'inside-tmux',
           execTmux: (args) => {
+            if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
             if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%77\n';
             if (args[0] === 'list-panes') return '0\t%77\n';
@@ -607,7 +682,8 @@ describe('launchQuestionRenderer', () => {
         strategy: 'inside-tmux',
         execTmux: (args) => {
           calls.push(args);
-          if (args[0] === 'display-message') return '1\n';
+          if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
+            if (args[0] === 'display-message') return '1\n';
           if (args[0] === 'split-window') return '%77\n';
           if (args[0] === 'list-panes') return '0\t%77\n';
           return '';
@@ -649,6 +725,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
             if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') {
               process.env.TMUX_PANE = '%201';
@@ -755,6 +832,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
             if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%42\n';
             if (args[0] === 'list-panes') return '0\t%42\n';

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -464,6 +464,7 @@ describe('launchQuestionRenderer', () => {
             calls.push(args);
             if (args[0] === 'display-message' && args.includes('#{session_attached}')) return '1\n';
             if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '5\n';
+            if (args[0] === 'display-message' && args.includes('#{session_id}')) return '$1\n';
             if (args[0] === 'new-window') return '%42\n';
             if (args[0] === 'list-panes' && args[2] === '%42') return '0\t%42\n';
             return '';
@@ -480,8 +481,9 @@ describe('launchQuestionRenderer', () => {
       assert.ok(newWindowCall);
       const targetIndex = newWindowCall.indexOf('-t');
       assert.notEqual(targetIndex, -1);
-      assert.deepEqual(newWindowCall.slice(targetIndex, targetIndex + 2), ['-t', '%11']);
+      assert.deepEqual(newWindowCall.slice(targetIndex, targetIndex + 2), ['-t', '$1']);
       assert.equal(calls.some((call) => call[0] === 'split-window'), false);
+      assert.equal(calls.some((call) => call[0] === 'display-message' && call.includes('#{session_id}')), true);
     } finally {
       rmSync(cwd, { recursive: true });
     }
@@ -538,6 +540,7 @@ describe('launchQuestionRenderer', () => {
             if (args[0] === 'display-message' && args.includes('#{session_attached}')) return '1\n';
             if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '20\n';
             if (args[0] === 'display-message' && args.includes('#{pane_width}')) return '20\n';
+            if (args[0] === 'display-message' && args.includes('#{session_id}')) return '$1\n';
             if (args[0] === 'new-window') return '%99\n';
             if (args[0] === 'list-panes' && args[2] === '%99') return '0\t%99\n';
             return '';
@@ -554,7 +557,7 @@ describe('launchQuestionRenderer', () => {
       assert.ok(newWindowCall);
       const targetIndex = newWindowCall.indexOf('-t');
       assert.notEqual(targetIndex, -1);
-      assert.deepEqual(newWindowCall.slice(targetIndex, targetIndex + 2), ['-t', '%11']);
+      assert.deepEqual(newWindowCall.slice(targetIndex, targetIndex + 2), ['-t', '$1']);
       assert.equal(calls.some((call) => call[0] === 'split-window'), false);
     } finally {
       rmSync(cwd, { recursive: true });
@@ -613,6 +616,7 @@ describe('launchQuestionRenderer', () => {
             if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '20\n';
             if (args[0] === 'display-message' && args.includes('#{pane_width}') && args.includes('-t')) throw new Error('width query failed');
             if (args[0] === 'display-message' && args.includes('#{pane_width}') && !args.includes('-t')) return '3\n';
+            if (args[0] === 'display-message' && args.includes('#{session_id}')) return '$1\n';
             if (args[0] === 'new-window') return '%88\n';
             if (args[0] === 'list-panes' && args[2] === '%88') return '0\t%88\n';
             return '';
@@ -629,7 +633,8 @@ describe('launchQuestionRenderer', () => {
       assert.ok(newWindowCall);
       const targetIndex = newWindowCall.indexOf('-t');
       assert.notEqual(targetIndex, -1);
-      assert.deepEqual(newWindowCall.slice(targetIndex, targetIndex + 2), ['-t', '%11']);
+      assert.deepEqual(newWindowCall.slice(targetIndex, targetIndex + 2), ['-t', '$1']);
+      assert.equal(calls.some((call) => call[0] === 'display-message' && call.includes('#{pane_height}')), false);
       assert.equal(calls.some((call) => call[0] === 'display-message' && call.includes('#{pane_width}') && !call.includes('-t')), false);
       assert.equal(calls.some((call) => call[0] === 'split-window'), false);
     } finally {
@@ -714,13 +719,15 @@ describe('launchQuestionRenderer', () => {
         nowIso: '2026-04-19T00:00:00.000Z',
         env: { OMX_QUESTION_RETURN_PANE: '%77' } as NodeJS.ProcessEnv,
       },
-      {
-        execTmux: (args) => {
-          calls.push(args);
-          if (args[0] === 'split-window') return '%78\n';
-          if (args[0] === 'list-panes') return '0\t%78\n';
-          return '';
-        },
+        {
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
+            if (args[0] === 'display-message' && args.includes('#{pane_width}')) return '80\n';
+            if (args[0] === 'split-window') return '%78\n';
+            if (args[0] === 'list-panes') return '0\t%78\n';
+            return '';
+          },
         sleepSync: () => {},
       },
     );
@@ -808,6 +815,8 @@ describe('launchQuestionRenderer', () => {
         {
           execTmux: (args) => {
             calls.push(args);
+            if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
+            if (args[0] === 'display-message' && args.includes('#{pane_width}')) return '80\n';
             if (args[0] === 'split-window') return '%92\n';
             if (args[0] === 'list-panes') return '0\t%92\n';
             return '';
@@ -922,6 +931,7 @@ describe('launchQuestionRenderer', () => {
           execTmux: (args) => {
             calls.push(args);
             if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
+            if (args[0] === 'display-message' && args.includes('#{pane_width}')) return '80\n';
             if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%77\n';
             if (args[0] === 'list-panes') return '0\t%77\n';
@@ -970,6 +980,7 @@ describe('launchQuestionRenderer', () => {
           strategy: 'inside-tmux',
           execTmux: (args) => {
             if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
+            if (args[0] === 'display-message' && args.includes('#{pane_width}')) return '80\n';
             if (args[0] === 'display-message') return '1\n';
             if (args[0] === 'split-window') return '%77\n';
             if (args[0] === 'list-panes') return '0\t%77\n';
@@ -1380,6 +1391,7 @@ describe('question renderer in-flight dedupe', () => {
           calls.push(args);
           if (args[0] === 'display-message' && args.includes('#{session_attached}')) return '1\n';
           if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
+          if (args[0] === 'display-message' && args.includes('#{pane_width}')) return '80\n';
           if (args[0] === 'list-panes' && args[2] === '%41') return '0\t%41\n';
           if (args[0] === 'kill-pane') return '';
           if (args[0] === 'split-window') return '%44\n';

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -13,6 +13,8 @@ import {
   injectQuestionAnswersToPane,
   launchQuestionRenderer,
   resolveQuestionRendererStrategy,
+  estimateQuestionRenderFootprint,
+  shouldOpenQuestionInNewWindow,
   supersedeLiveQuestionsForSession,
 } from '../renderer.js';
 import { buildSendPaneArgvs } from '../../notifications/tmux-detector.js';
@@ -159,6 +161,49 @@ describe('adaptive question pane sizing', () => {
     assert.equal(computeAdaptiveQuestionPaneHeight(20, 50), 18);
     assert.equal(computeAdaptiveQuestionPaneHeight(Number.NaN, 10), 24);
     assert.equal(computeAdaptiveQuestionPaneHeight(9, 20), 7);
+  });
+});
+
+describe('question window topology selection', () => {
+  it('switches to a new tmux window only after the split height budget is exceeded', () => {
+    assert.equal(shouldOpenQuestionInNewWindow(20, 18), false);
+    assert.equal(shouldOpenQuestionInNewWindow(20, 19), true);
+    assert.equal(shouldOpenQuestionInNewWindow(5, 3), false);
+    assert.equal(shouldOpenQuestionInNewWindow(5, 4), true);
+  });
+
+  it('counts wrapped question text more conservatively in narrow panes', () => {
+    const record = {
+      kind: 'omx.question/v1',
+      question_id: 'question-1',
+      created_at: '2026-05-01T10:08:52.523Z',
+      updated_at: '2026-05-01T10:08:52.523Z',
+      status: 'pending',
+      question: 'x'.repeat(180),
+      options: [{
+        label: 'Only option',
+        value: 'only',
+        description: 'y'.repeat(140),
+      }],
+      allow_other: false,
+      multi_select: false,
+      type: 'single-answerable',
+      source: 'deep-interview',
+      questions: [{
+        id: 'q-1',
+        question: 'x'.repeat(180),
+        options: [{
+          label: 'Only option',
+          value: 'only',
+          description: 'y'.repeat(140),
+        }],
+        allow_other: false,
+        multi_select: false,
+        type: 'single-answerable',
+      }],
+    } as any;
+
+    assert.ok(estimateQuestionRenderFootprint(record, 20) > estimateQuestionRenderFootprint(record, 80));
   });
 });
 
@@ -314,7 +359,85 @@ describe('launchQuestionRenderer', () => {
       assert.equal(result.target, '%42');
       assert.equal(result.return_target, '%11');
       assert.equal(result.return_transport, 'tmux-send-keys');
-      assert.equal(calls.some((call) => call[0] === 'new-window'), true);
+      const newWindowCall = calls.find((call) => call[0] === 'new-window');
+      assert.ok(newWindowCall);
+      const targetIndex = newWindowCall.indexOf('-t');
+      assert.notEqual(targetIndex, -1);
+      assert.deepEqual(newWindowCall.slice(targetIndex, targetIndex + 2), ['-t', '%11']);
+      assert.equal(calls.some((call) => call[0] === 'split-window'), false);
+    } finally {
+      rmSync(cwd, { recursive: true });
+    }
+  });
+
+  it('opens a new tmux window when wrapped content would exceed the split budget in a narrow pane', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-question-renderer-wrapped-window-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state', 'sessions', 's1', 'questions');
+      mkdirSync(stateDir, { recursive: true });
+      const recordPath = join(stateDir, 'question-1.json');
+      writeFileSync(recordPath, JSON.stringify({
+        kind: 'omx.question/v1',
+        question_id: 'question-1',
+        created_at: '2026-05-01T10:08:52.523Z',
+        updated_at: '2026-05-01T10:08:52.523Z',
+        status: 'pending',
+        question: 'x'.repeat(220),
+        options: [{
+          label: 'Only option',
+          value: 'only',
+          description: 'y'.repeat(180),
+        }],
+        allow_other: false,
+        multi_select: false,
+        type: 'single-answerable',
+        source: 'deep-interview',
+        questions: [{
+          id: 'q-1',
+          question: 'x'.repeat(220),
+          options: [{
+            label: 'Only option',
+            value: 'only',
+            description: 'y'.repeat(180),
+          }],
+          allow_other: false,
+          multi_select: false,
+          type: 'single-answerable',
+        }],
+      }, null, 2));
+
+      const calls: string[][] = [];
+      const result = launchQuestionRenderer(
+        {
+          cwd,
+          recordPath,
+          sessionId: 's1',
+          env: { TMUX: '/tmp/tmux-demo', TMUX_PANE: '%11' } as NodeJS.ProcessEnv,
+        },
+        {
+          strategy: 'inside-tmux',
+          execTmux: (args) => {
+            calls.push(args);
+            if (args[0] === 'display-message' && args.includes('#{session_attached}')) return '1\n';
+            if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '20\n';
+            if (args[0] === 'display-message' && args.includes('#{pane_width}')) return '20\n';
+            if (args[0] === 'new-window') return '%99\n';
+            if (args[0] === 'list-panes' && args[2] === '%99') return '0\t%99\n';
+            return '';
+          },
+          sleepSync: () => {},
+        },
+      );
+
+      assert.equal(result.renderer, 'tmux-pane');
+      assert.equal(result.target, '%99');
+      assert.equal(result.return_target, '%11');
+      assert.equal(result.return_transport, 'tmux-send-keys');
+      const newWindowCall = calls.find((call) => call[0] === 'new-window');
+      assert.ok(newWindowCall);
+      const targetIndex = newWindowCall.indexOf('-t');
+      assert.notEqual(targetIndex, -1);
+      assert.deepEqual(newWindowCall.slice(targetIndex, targetIndex + 2), ['-t', '%11']);
       assert.equal(calls.some((call) => call[0] === 'split-window'), false);
     } finally {
       rmSync(cwd, { recursive: true });

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -593,25 +593,39 @@ export function launchQuestionRenderer(
 
     const sizingTarget = returnTarget || safeString(env.TMUX_PANE).trim() || undefined;
     const availableHeight = resolveAvailablePaneHeight(execTmux, sizingTarget);
+    const estimatedContentLines = estimateQuestionContentLines(readQuestionRecordForSizing(options.recordPath));
     const requestedHeight = computeAdaptiveQuestionPaneHeight(
       availableHeight,
-      estimateQuestionContentLines(readQuestionRecordForSizing(options.recordPath)),
+      estimatedContentLines,
     );
-    const rawPane = execTmux([
-      'split-window',
-      '-v',
-      '-l',
-      String(requestedHeight),
-      ...splitTarget,
-      '-P',
-      '-F',
-      '#{pane_id}',
-      '-c',
-      options.cwd,
-      ...commandArgs,
-    ]);
+    const questionNeedsFullWindow = estimatedContentLines > availableHeight;
+    const rawPane = questionNeedsFullWindow
+      ? execTmux([
+          'new-window',
+          '-n',
+          'OMX Question',
+          '-P',
+          '-F',
+          '#{pane_id}',
+          '-c',
+          options.cwd,
+          ...commandArgs,
+        ])
+      : execTmux([
+          'split-window',
+          '-v',
+          '-l',
+          String(requestedHeight),
+          ...splitTarget,
+          '-P',
+          '-F',
+          '#{pane_id}',
+          '-c',
+          options.cwd,
+          ...commandArgs,
+        ]);
     const paneId = parsePaneIdFromTmuxOutput(rawPane);
-    if (!paneId) throw new Error('Failed to create tmux split pane for omx question UI.');
+    if (!paneId) throw new Error('Failed to create tmux question renderer container.');
     sleepImpl(QUESTION_RENDERER_PANE_SETTLE_MS);
     if (!isLaunchedQuestionPaneAlive(paneId, execTmux)) {
       throw new Error(`Question UI pane ${paneId} disappeared immediately after launch.`);

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -11,6 +11,7 @@ import { getStateDir, getStatePath } from '../mcp/state-paths.js';
 import { TRACKED_WORKFLOW_MODES } from '../state/workflow-transition.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
+import { createInitialInteractiveSelectionState, createInitialQuestionWizardState, renderInteractiveQuestionFrame, renderQuestionWizardFrame } from './ui.js';
 import type { QuestionAnswer, QuestionRecord, QuestionRendererState } from './types.js';
 
 export type QuestionRendererStrategy = 'inside-tmux' | 'detached-tmux' | 'inline-tty' | 'windows-console' | 'test-noop' | 'unsupported';
@@ -98,6 +99,50 @@ function lineCount(value: string | undefined): number {
   return Math.max(1, value.split('\n').length);
 }
 
+function isCombiningMark(codePoint: number): boolean {
+  return /\p{Mark}/u.test(String.fromCodePoint(codePoint));
+}
+
+function isWideCodePoint(codePoint: number): boolean {
+  return (
+    codePoint >= 0x1100 && (
+      codePoint <= 0x115f ||
+      codePoint === 0x2329 ||
+      codePoint === 0x232a ||
+      (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) ||
+      (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+      (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+      (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+      (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+      (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+      (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+      (codePoint >= 0x1f300 && codePoint <= 0x1f64f) ||
+      (codePoint >= 0x1f900 && codePoint <= 0x1f9ff) ||
+      (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+    )
+  );
+}
+
+function displayWidth(value: string): number {
+  let width = 0;
+  for (const char of value) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    if (codePoint === 0) continue;
+    if (codePoint < 32 || (codePoint >= 0x7f && codePoint < 0xa0)) continue;
+    if (isCombiningMark(codePoint)) continue;
+    width += isWideCodePoint(codePoint) ? 2 : 1;
+  }
+  return width;
+}
+
+function wrappedDisplayLineCount(value: string | undefined, paneWidth: number): number {
+  if (!value) return 0;
+  const safeWidth = Number.isFinite(paneWidth) && paneWidth > 0 ? Math.floor(paneWidth) : 80;
+  return value
+    .split('\n')
+    .reduce((count, line) => count + Math.max(1, Math.ceil(displayWidth(line) / safeWidth)), 0);
+}
+
 export function estimateQuestionContentLines(record: QuestionRecord | null | undefined): number {
   if (!record) return 24;
   const questions = record.questions?.length
@@ -127,14 +172,6 @@ export function estimateQuestionContentLines(record: QuestionRecord | null | und
   return lines;
 }
 
-function wrappedLineCount(value: string | undefined, paneWidth: number): number {
-  if (!value) return 0;
-  const safeWidth = Number.isFinite(paneWidth) && paneWidth > 0 ? Math.floor(paneWidth) : 80;
-  return value
-    .split('\n')
-    .reduce((count, line) => count + Math.max(1, Math.ceil(line.length / safeWidth)), 0);
-}
-
 export function estimateQuestionRenderFootprint(
   record: QuestionRecord | null | undefined,
   paneWidth: number,
@@ -152,19 +189,20 @@ export function estimateQuestionRenderFootprint(
       type: record.type,
       id: 'q-1',
     }];
-  let lines = 2;
-  if (record.header) lines += wrappedLineCount(record.header, paneWidth);
-  for (const question of questions) {
-    lines += 2 + wrappedLineCount(question.question, paneWidth);
-    if (question.header && question.header !== record.header) lines += wrappedLineCount(question.header, paneWidth);
-    for (const option of question.options) {
-      lines += 1 + wrappedLineCount(option.description, paneWidth);
-    }
-    if (question.allow_other) lines += 1;
-    lines += 2;
+  if (questions.length === 1) {
+    const frame = renderInteractiveQuestionFrame(record, createInitialInteractiveSelectionState());
+    return wrappedDisplayLineCount(frame, paneWidth);
   }
-  if (questions.length > 1) lines += 3;
-  return lines;
+
+  const wizardState = createInitialQuestionWizardState(record);
+  let maxFootprint = 0;
+  for (let index = 0; index < questions.length; index += 1) {
+    const frame = renderQuestionWizardFrame(record, { ...wizardState, currentQuestionIndex: index });
+    maxFootprint = Math.max(maxFootprint, wrappedDisplayLineCount(frame, paneWidth));
+  }
+  const reviewFrame = renderQuestionWizardFrame(record, { ...wizardState, mode: 'review' });
+  maxFootprint = Math.max(maxFootprint, wrappedDisplayLineCount(reviewFrame, paneWidth));
+  return maxFootprint;
 }
 
 export function computeAdaptiveQuestionPaneHeight(availableHeight: number, estimatedContentLines: number): number {
@@ -208,15 +246,25 @@ function resolveAvailablePaneWidth(
   target: string | undefined,
 ): number {
   const format = '#{pane_width}';
-  const attempts = target ? [['display-message', '-p', '-t', target, format], ['display-message', '-p', format]] : [['display-message', '-p', format]];
-  for (const args of attempts) {
+  if (target) {
     try {
-      const parsed = Number.parseInt(execTmux(args).trim(), 10);
+      const parsed = Number.parseInt(execTmux(['display-message', '-p', '-t', target, format]).trim(), 10);
       if (Number.isFinite(parsed) && parsed > 0) return parsed;
     } catch {
-      // Try the next source, then fall back.
+      // Keep the width probe target-scoped. If the explicit target cannot be
+      // queried, fall back to the conservative default instead of measuring the
+      // current pane width for a different destination.
     }
+    return 80;
   }
+  try {
+    const parsed = Number.parseInt(execTmux(['display-message', '-p', format]).trim(), 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  } catch {
+    // Try the default tmux query, then fall back.
+  }
+  // Keep a documented fallback so renderer launches remain usable even when
+  // tmux width probing is unavailable or transiently fails.
   return 80;
 }
 

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -94,11 +94,6 @@ export function resolveQuestionRendererStrategy(
 }
 
 
-function lineCount(value: string | undefined): number {
-  if (!value) return 0;
-  return Math.max(1, value.split('\n').length);
-}
-
 function isCombiningMark(codePoint: number): boolean {
   return /\p{Mark}/u.test(String.fromCodePoint(codePoint));
 }
@@ -141,35 +136,6 @@ function wrappedDisplayLineCount(value: string | undefined, paneWidth: number): 
   return value
     .split('\n')
     .reduce((count, line) => count + Math.max(1, Math.ceil(displayWidth(line) / safeWidth)), 0);
-}
-
-export function estimateQuestionContentLines(record: QuestionRecord | null | undefined): number {
-  if (!record) return 24;
-  const questions = record.questions?.length
-    ? record.questions
-    : [{
-      header: record.header,
-      question: record.question,
-      options: record.options,
-      allow_other: record.allow_other,
-      other_label: record.other_label,
-      multi_select: record.multi_select,
-      type: record.type,
-      id: 'q-1',
-    }];
-  let lines = 2;
-  if (record.header) lines += lineCount(record.header);
-  for (const question of questions) {
-    lines += 2 + lineCount(question.question);
-    if (question.header && question.header !== record.header) lines += lineCount(question.header);
-    for (const option of question.options) {
-      lines += 1 + lineCount(option.description);
-    }
-    if (question.allow_other) lines += 1;
-    lines += 2;
-  }
-  if (questions.length > 1) lines += 3;
-  return lines;
 }
 
 export function estimateQuestionRenderFootprint(
@@ -244,28 +210,79 @@ function resolveAvailablePaneHeight(
 function resolveAvailablePaneWidth(
   execTmux: ExecTmuxSync,
   target: string | undefined,
-): number {
+): { width: number; probeFailed: boolean } {
   const format = '#{pane_width}';
   if (target) {
     try {
       const parsed = Number.parseInt(execTmux(['display-message', '-p', '-t', target, format]).trim(), 10);
-      if (Number.isFinite(parsed) && parsed > 0) return parsed;
+      if (Number.isFinite(parsed) && parsed > 0) return { width: parsed, probeFailed: false };
     } catch {
       // Keep the width probe target-scoped. If the explicit target cannot be
       // queried, fall back to the conservative default instead of measuring the
       // current pane width for a different destination.
     }
-    return 80;
+    return { width: 80, probeFailed: true };
   }
   try {
     const parsed = Number.parseInt(execTmux(['display-message', '-p', format]).trim(), 10);
-    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    if (Number.isFinite(parsed) && parsed > 0) return { width: parsed, probeFailed: false };
   } catch {
     // Try the default tmux query, then fall back.
   }
   // Keep a documented fallback so renderer launches remain usable even when
   // tmux width probing is unavailable or transiently fails.
-  return 80;
+  return { width: 80, probeFailed: false };
+}
+
+function resolveNewWindowTarget(
+  execTmux: ExecTmuxSync,
+  returnTarget: string | undefined,
+): string | undefined {
+  if (!returnTarget) return undefined;
+
+  const attempts = [
+    ['display-message', '-p', '-t', returnTarget, '#{session_id}'],
+    ['display-message', '-p', '-t', returnTarget, '#{window_id}'],
+  ] as const;
+
+  for (const args of attempts) {
+    try {
+      const resolved = execTmux([...args]).trim();
+      if (resolved) return resolved;
+    } catch {
+      // Try the next tmux target form.
+    }
+  }
+
+  return undefined;
+}
+
+function launchQuestionPane(
+  execTmux: ExecTmuxSync,
+  sleepImpl: SleepSync,
+  args: string[],
+  launchedAt: string,
+  returnTarget: string | undefined,
+): {
+  renderer: 'tmux-pane';
+  target: string;
+  launched_at: string;
+  return_target?: string;
+  return_transport?: 'tmux-send-keys';
+} {
+  const rawPane = execTmux(args);
+  const paneId = parsePaneIdFromTmuxOutput(rawPane);
+  if (!paneId) throw new Error('Failed to create tmux question renderer container.');
+  sleepImpl(QUESTION_RENDERER_PANE_SETTLE_MS);
+  if (!isLaunchedQuestionPaneAlive(paneId, execTmux)) {
+    throw new Error(`Question UI pane ${paneId} disappeared immediately after launch.`);
+  }
+  return {
+    renderer: 'tmux-pane',
+    target: paneId,
+    launched_at: launchedAt,
+    ...(returnTarget ? { return_target: returnTarget, return_transport: 'tmux-send-keys' as const } : {}),
+  };
 }
 
 function resolveQuestionUiProcessArgs(
@@ -704,55 +721,76 @@ export function launchQuestionRenderer(
     });
 
     const sizingTarget = returnTarget || safeString(env.TMUX_PANE).trim() || undefined;
+    const availableWidthInfo = resolveAvailablePaneWidth(execTmux, sizingTarget);
+    const newWindowTarget = resolveNewWindowTarget(execTmux, returnTarget);
+    const newWindowTargetArgs = newWindowTarget ? ['-t', newWindowTarget] : [];
+    if (sizingTarget && availableWidthInfo.probeFailed) {
+      return launchQuestionPane(
+        execTmux,
+        sleepImpl,
+        [
+          'new-window',
+          '-n',
+          'OMX Question',
+          ...newWindowTargetArgs,
+          '-P',
+          '-F',
+          '#{pane_id}',
+          '-c',
+          options.cwd,
+          ...commandArgs,
+        ],
+        launchedAt,
+        returnTarget,
+      );
+    }
+
     const availableHeight = resolveAvailablePaneHeight(execTmux, sizingTarget);
-    const availableWidth = resolveAvailablePaneWidth(execTmux, sizingTarget);
+    const availableWidth = availableWidthInfo.width;
     const estimatedRenderFootprint = estimateQuestionRenderFootprint(
       readQuestionRecordForSizing(options.recordPath),
       availableWidth,
+    );
+    const questionNeedsFullWindow = shouldOpenQuestionInNewWindow(
+      availableHeight,
+      estimatedRenderFootprint,
     );
     const requestedHeight = computeAdaptiveQuestionPaneHeight(
       availableHeight,
       estimatedRenderFootprint,
     );
-    const questionNeedsFullWindow = shouldOpenQuestionInNewWindow(availableHeight, estimatedRenderFootprint);
-    const rawPane = questionNeedsFullWindow
-      ? execTmux([
-          'new-window',
-          '-n',
-          'OMX Question',
-          ...splitTarget,
-          '-P',
-          '-F',
-          '#{pane_id}',
-          '-c',
-          options.cwd,
-          ...commandArgs,
-        ])
-      : execTmux([
-          'split-window',
-          '-v',
-          '-l',
-          String(requestedHeight),
-          ...splitTarget,
-          '-P',
-          '-F',
-          '#{pane_id}',
-          '-c',
-          options.cwd,
-          ...commandArgs,
-        ]);
-    const paneId = parsePaneIdFromTmuxOutput(rawPane);
-    if (!paneId) throw new Error('Failed to create tmux question renderer container.');
-    sleepImpl(QUESTION_RENDERER_PANE_SETTLE_MS);
-    if (!isLaunchedQuestionPaneAlive(paneId, execTmux)) {
-      throw new Error(`Question UI pane ${paneId} disappeared immediately after launch.`);
-    }
-    return {
-      renderer: 'tmux-pane',
-      target: paneId,
-      launched_at: launchedAt,
-      ...(returnTarget ? { return_target: returnTarget, return_transport: 'tmux-send-keys' } : {}),
-    };
+    return launchQuestionPane(
+      execTmux,
+      sleepImpl,
+      questionNeedsFullWindow
+        ? [
+            'new-window',
+            '-n',
+            'OMX Question',
+            ...newWindowTargetArgs,
+            '-P',
+            '-F',
+            '#{pane_id}',
+            '-c',
+            options.cwd,
+            ...commandArgs,
+          ]
+        : [
+            'split-window',
+            '-v',
+            '-l',
+            String(requestedHeight),
+            ...splitTarget,
+            '-P',
+            '-F',
+            '#{pane_id}',
+            '-c',
+            options.cwd,
+            ...commandArgs,
+          ],
+      launchedAt,
+      returnTarget,
+    );
   }
 
   if (strategy === 'windows-console') {

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -127,12 +127,59 @@ export function estimateQuestionContentLines(record: QuestionRecord | null | und
   return lines;
 }
 
+function wrappedLineCount(value: string | undefined, paneWidth: number): number {
+  if (!value) return 0;
+  const safeWidth = Number.isFinite(paneWidth) && paneWidth > 0 ? Math.floor(paneWidth) : 80;
+  return value
+    .split('\n')
+    .reduce((count, line) => count + Math.max(1, Math.ceil(line.length / safeWidth)), 0);
+}
+
+export function estimateQuestionRenderFootprint(
+  record: QuestionRecord | null | undefined,
+  paneWidth: number,
+): number {
+  if (!record) return 24;
+  const questions = record.questions?.length
+    ? record.questions
+    : [{
+      header: record.header,
+      question: record.question,
+      options: record.options,
+      allow_other: record.allow_other,
+      other_label: record.other_label,
+      multi_select: record.multi_select,
+      type: record.type,
+      id: 'q-1',
+    }];
+  let lines = 2;
+  if (record.header) lines += wrappedLineCount(record.header, paneWidth);
+  for (const question of questions) {
+    lines += 2 + wrappedLineCount(question.question, paneWidth);
+    if (question.header && question.header !== record.header) lines += wrappedLineCount(question.header, paneWidth);
+    for (const option of question.options) {
+      lines += 1 + wrappedLineCount(option.description, paneWidth);
+    }
+    if (question.allow_other) lines += 1;
+    lines += 2;
+  }
+  if (questions.length > 1) lines += 3;
+  return lines;
+}
+
 export function computeAdaptiveQuestionPaneHeight(availableHeight: number, estimatedContentLines: number): number {
   const safeAvailable = Number.isFinite(availableHeight) && availableHeight > 0 ? Math.floor(availableHeight) : 40;
   const maxHeight = Math.max(1, safeAvailable - 2);
   const minLarge = Math.min(Math.max(18, Math.floor(safeAvailable * 0.60)), maxHeight);
   const requested = Number.isFinite(estimatedContentLines) && estimatedContentLines > 0 ? Math.ceil(estimatedContentLines) : 24;
   return Math.min(Math.max(Math.max(requested, minLarge), Math.min(8, maxHeight)), maxHeight);
+}
+
+export function shouldOpenQuestionInNewWindow(availableHeight: number, estimatedRenderFootprint: number): boolean {
+  const safeAvailable = Number.isFinite(availableHeight) && availableHeight > 0 ? Math.floor(availableHeight) : 40;
+  const maxSplitHeight = Math.max(1, safeAvailable - 2);
+  const requested = Number.isFinite(estimatedRenderFootprint) && estimatedRenderFootprint > 0 ? Math.ceil(estimatedRenderFootprint) : 24;
+  return requested > maxSplitHeight;
 }
 
 function readQuestionRecordForSizing(recordPath: string): QuestionRecord | null {
@@ -154,6 +201,23 @@ function resolveAvailablePaneHeight(
     }
   }
   return 40;
+}
+
+function resolveAvailablePaneWidth(
+  execTmux: ExecTmuxSync,
+  target: string | undefined,
+): number {
+  const format = '#{pane_width}';
+  const attempts = target ? [['display-message', '-p', '-t', target, format], ['display-message', '-p', format]] : [['display-message', '-p', format]];
+  for (const args of attempts) {
+    try {
+      const parsed = Number.parseInt(execTmux(args).trim(), 10);
+      if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    } catch {
+      // Try the next source, then fall back.
+    }
+  }
+  return 80;
 }
 
 function resolveQuestionUiProcessArgs(
@@ -593,17 +657,22 @@ export function launchQuestionRenderer(
 
     const sizingTarget = returnTarget || safeString(env.TMUX_PANE).trim() || undefined;
     const availableHeight = resolveAvailablePaneHeight(execTmux, sizingTarget);
-    const estimatedContentLines = estimateQuestionContentLines(readQuestionRecordForSizing(options.recordPath));
+    const availableWidth = resolveAvailablePaneWidth(execTmux, sizingTarget);
+    const estimatedRenderFootprint = estimateQuestionRenderFootprint(
+      readQuestionRecordForSizing(options.recordPath),
+      availableWidth,
+    );
     const requestedHeight = computeAdaptiveQuestionPaneHeight(
       availableHeight,
-      estimatedContentLines,
+      estimatedRenderFootprint,
     );
-    const questionNeedsFullWindow = estimatedContentLines > availableHeight;
+    const questionNeedsFullWindow = shouldOpenQuestionInNewWindow(availableHeight, estimatedRenderFootprint);
     const rawPane = questionNeedsFullWindow
       ? execTmux([
           'new-window',
           '-n',
           'OMX Question',
+          ...splitTarget,
           '-P',
           '-F',
           '#{pane_id}',

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -12,7 +12,7 @@ import { TRACKED_WORKFLOW_MODES } from '../state/workflow-transition.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
 import { createInitialInteractiveSelectionState, createInitialQuestionWizardState, renderInteractiveQuestionFrame, renderQuestionWizardFrame } from './ui.js';
-import type { QuestionAnswer, QuestionRecord, QuestionRendererState } from './types.js';
+import type { NormalizedQuestionItem, QuestionAnswer, QuestionRecord, QuestionRendererState } from './types.js';
 
 export type QuestionRendererStrategy = 'inside-tmux' | 'detached-tmux' | 'inline-tty' | 'windows-console' | 'test-noop' | 'unsupported';
 
@@ -143,30 +143,19 @@ export function estimateQuestionRenderFootprint(
   paneWidth: number,
 ): number {
   if (!record) return 24;
-  const questions = record.questions?.length
-    ? record.questions
-    : [{
-      header: record.header,
-      question: record.question,
-      options: record.options,
-      allow_other: record.allow_other,
-      other_label: record.other_label,
-      multi_select: record.multi_select,
-      type: record.type,
-      id: 'q-1',
-    }];
+  const questions = recordQuestionsForSizing(record);
   if (questions.length === 1) {
     const frame = renderInteractiveQuestionFrame(record, createInitialInteractiveSelectionState());
     return wrappedDisplayLineCount(frame, paneWidth);
   }
 
-  const wizardState = createInitialQuestionWizardState(record);
+  const wizardState = buildWorstCaseReviewWizardState(record);
   let maxFootprint = 0;
   for (let index = 0; index < questions.length; index += 1) {
     const frame = renderQuestionWizardFrame(record, { ...wizardState, currentQuestionIndex: index });
     maxFootprint = Math.max(maxFootprint, wrappedDisplayLineCount(frame, paneWidth));
   }
-  const reviewFrame = renderQuestionWizardFrame(record, { ...wizardState, mode: 'review' });
+  const reviewFrame = renderQuestionWizardFrame(record, { ...wizardState, mode: 'review' as const });
   maxFootprint = Math.max(maxFootprint, wrappedDisplayLineCount(reviewFrame, paneWidth));
   return maxFootprint;
 }
@@ -188,6 +177,50 @@ export function shouldOpenQuestionInNewWindow(availableHeight: number, estimated
 
 function readQuestionRecordForSizing(recordPath: string): QuestionRecord | null {
   return readJsonFileIfExists(recordPath) as QuestionRecord | null;
+}
+
+function recordQuestionsForSizing(record: QuestionRecord): NormalizedQuestionItem[] {
+  if (record.questions?.length) return record.questions;
+  return [{
+    header: record.header,
+    question: record.question,
+    options: record.options,
+    allow_other: record.allow_other,
+    other_label: record.other_label,
+    multi_select: record.multi_select,
+    type: record.type ?? (record.multi_select ? 'multi-answerable' : 'single-answerable'),
+    id: 'q-1',
+  }];
+}
+
+function buildWorstCaseReviewWizardState(record: QuestionRecord) {
+  const questions = recordQuestionsForSizing(record);
+  const baseState = createInitialQuestionWizardState(record);
+  return {
+    ...baseState,
+    selections: questions.map((question) => {
+      if (question.multi_select || question.type === 'multi-answerable') {
+        return {
+          cursorIndex: 0,
+          selectedIndices: question.options.map((_, index) => index),
+        };
+      }
+
+      let bestIndex = 0;
+      let bestWidth = -1;
+      question.options.forEach((option, index) => {
+        const width = displayWidth(option.label);
+        if (width > bestWidth) {
+          bestWidth = width;
+          bestIndex = index;
+        }
+      });
+      return {
+        cursorIndex: bestIndex,
+        selectedIndices: [],
+      };
+    }),
+  };
 }
 
 function resolveAvailablePaneHeight(


### PR DESCRIPTION
## Summary
- Size multi-question review screens using worst-case selected answer summaries, not just empty placeholders
- Keep the existing split-vs-new-window decision grounded in rendered content
- Add regression coverage for review summaries that wrap in narrow panes

## Verification
- npm run build
- env -u OMX_ROOT -u OMX_SESSION_ID node --test dist/question/__tests__/renderer.test.js
- npx biome lint src/question/renderer.ts src/question/__tests__/renderer.test.ts

Follow-up to the closed PR #2695. Target base branch: dev.
