### PR TITLE
Fix Windows omx update npm.cmd fallback

### DIFF
--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -9,10 +9,12 @@ import {
   maybeCheckAndPromptUpdate,
   readUserInstallStamp,
   resolveAutoUpdateMode,
+  resolveGlobalInstallRoot,
   resolveInstalledCliEntry,
   formatDeferredSetupCommand,
   resolveSetupRefreshArgs,
   runDeferredGlobalUpdate,
+  runGlobalUpdate,
   runImmediateUpdate,
   shouldCheckForUpdates,
   spawnInstalledSetupRefresh,
@@ -441,6 +443,67 @@ describe('maybeCheckAndPromptUpdate', () => {
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+});
+
+describe('direct npm spawn fallback', () => {
+  function enoentResult() {
+    const error = Object.assign(new Error('spawnSync npm ENOENT'), { code: 'ENOENT' });
+    return { status: null, signal: null, error, stdout: '', stderr: '', output: [null, '', ''], pid: 0 };
+  }
+
+  function okResult(stdout = '') {
+    return { status: 0, signal: null, error: undefined, stdout, stderr: '', output: [null, stdout, ''], pid: 0 };
+  }
+
+  it('falls back to npm.cmd for win32 global installs when direct npm spawn returns ENOENT', () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    const result = runGlobalUpdate(
+      ((command: string, args: readonly string[]) => {
+        calls.push({ command, args: args as string[] });
+        return command === 'npm' ? enoentResult() : okResult();
+      }) as unknown as typeof import('node:child_process').spawnSync,
+      'win32',
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls.map((call) => call.command), ['npm', 'npm.cmd']);
+    assert.deepEqual(calls[0].args, ['install', '-g', 'oh-my-codex@latest']);
+    assert.deepEqual(calls[1].args, ['install', '-g', 'oh-my-codex@latest']);
+  });
+
+  it('does not fall back to npm.cmd for non-Windows ENOENT failures', () => {
+    const calls: string[] = [];
+
+    const result = runGlobalUpdate(
+      ((command: string) => {
+        calls.push(command);
+        return enoentResult();
+      }) as unknown as typeof import('node:child_process').spawnSync,
+      'linux',
+    );
+
+    assert.equal(result.ok, false);
+    assert.match(result.stderr, /ENOENT/);
+    assert.deepEqual(calls, ['npm']);
+  });
+
+  it('falls back to npm.cmd for win32 global-root lookup when direct npm spawn returns ENOENT', () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    const root = resolveGlobalInstallRoot(
+      ((command: string, args: readonly string[]) => {
+        calls.push({ command, args: args as string[] });
+        return command === 'npm' ? enoentResult() : okResult('C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\r\n');
+      }) as unknown as typeof import('node:child_process').spawnSync,
+      'win32',
+    );
+
+    assert.equal(root, 'C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules');
+    assert.deepEqual(calls.map((call) => call.command), ['npm', 'npm.cmd']);
+    assert.deepEqual(calls[0].args, ['root', '-g']);
+    assert.deepEqual(calls[1].args, ['root', '-g']);
   });
 });
 

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -26,7 +26,7 @@ describe('Windows popup loop contracts', () => {
     assert.match(cliIndex, /spawnSync\(\s*process\.execPath,\s*\[watcherScript,\s*"--once",\s*"--cwd",\s*cwd,\s*"--notify-script",\s*notifyScript\],\s*\{[\s\S]*?windowsHide:\s*true/);
     assert.match(cliIndex, /spawnSync\(process\.execPath,\s*\[watcherScript,\s*"--once",\s*"--cwd",\s*cwd\],\s*\{[\s\S]*?windowsHide:\s*true/);
     assert.match(starPrompt, /spawnSyncFn\('gh',\s*\['api',[\s\S]*?windowsHide:\s*true/);
-    assert.match(updateSource, /spawnSync\('npm',\s*\['install',\s*'-g',[\s\S]*?windowsHide:\s*true/);
+    assert.match(updateSource, /spawnNpmSync\(\s*\[\s*'install',\s*'-g',[\s\S]*?windowsHide:\s*true/);
     assert.match(notifierSource, /execFileAsync\(cmd,\s*args,\s*\{\s*windowsHide:\s*true\s*\}\)/);
     assert.match(replyListenerSource, /spawn\('node',\s*\['-e',\s*daemonScript\],\s*\{[\s\S]*?windowsHide:\s*true/);
     assert.match(fallbackWatcherSource, /spawnPlatformCommandSync\('tmux', \['send-keys'/);

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -45,6 +45,7 @@ type RunGlobalUpdateResult = { ok: boolean; stderr: string };
 type RunSetupRefreshResult = { ok: boolean; stderr: string };
 type RunDeferredUpdateResult = { ok: boolean; stderr: string; logPath?: string };
 type SpawnSyncLike = typeof spawnSync;
+type SpawnSyncOptions = NonNullable<Parameters<SpawnSyncLike>[2]>;
 type SpawnLike = typeof spawn;
 export type AutoUpdateMode = 'disabled' | 'prompt' | 'defer';
 
@@ -133,19 +134,49 @@ async function getCurrentVersion(): Promise<string | null> {
   }
 }
 
-function runGlobalUpdate(): RunGlobalUpdateResult {
-  const result = spawnSync('npm', ['install', '-g', `${PACKAGE_NAME}@latest`], {
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: 120000,
-    windowsHide: true,
-  });
+function isEnoentSpawnError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT',
+  );
+}
+
+function spawnNpmSync(
+  args: string[],
+  options: SpawnSyncOptions,
+  spawnProcess: SpawnSyncLike = spawnSync,
+  platform: NodeJS.Platform = process.platform,
+): ReturnType<SpawnSyncLike> {
+  const result = spawnProcess('npm', args, options);
+  if (platform === 'win32' && isEnoentSpawnError(result.error)) {
+    return spawnProcess('npm.cmd', args, options);
+  }
+  return result;
+}
+
+export function runGlobalUpdate(
+  spawnProcess: SpawnSyncLike = spawnSync,
+  platform: NodeJS.Platform = process.platform,
+): RunGlobalUpdateResult {
+  const result = spawnNpmSync(
+    ['install', '-g', `${PACKAGE_NAME}@latest`],
+    {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 120000,
+      windowsHide: true,
+    },
+    spawnProcess,
+    platform,
+  );
 
   if (result.error) {
     return { ok: false, stderr: result.error.message };
   }
   if (result.status !== 0) {
-    return { ok: false, stderr: (result.stderr || '').trim() || `npm exited ${result.status}` };
+    return { ok: false, stderr: String(result.stderr || '').trim() || `npm exited ${result.status}` };
   }
   return { ok: true, stderr: '' };
 }
@@ -386,19 +417,27 @@ function doesSetupStampMatchVersion(
   return stripLeadingV(stamp?.setup_completed_version ?? '') === stripLeadingV(currentVersion);
 }
 
-function resolveGlobalInstallRoot(): string | null {
-  const result = spawnSync('npm', ['root', '-g'], {
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: 15000,
-    windowsHide: true,
-  });
+export function resolveGlobalInstallRoot(
+  spawnProcess: SpawnSyncLike = spawnSync,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const result = spawnNpmSync(
+    ['root', '-g'],
+    {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15000,
+      windowsHide: true,
+    },
+    spawnProcess,
+    platform,
+  );
 
   if (result.error || result.status !== 0) {
     return null;
   }
 
-  const root = (result.stdout || '').trim();
+  const root = String(result.stdout || '').trim();
   return root === '' ? null : root;
 }
 


### PR DESCRIPTION
Fixes #2705.

## Summary
- Add an updater-local npm spawn helper that retries `npm.cmd` only on Windows when direct `npm` spawning fails with ENOENT.
- Route both global self-update install and post-update npm global-root lookup through that helper.
- Add regression coverage for win32 `npm` ENOENT fallback and non-Windows no-fallback behavior.

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/update.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
