### PR TITLE
Fix SessionStart project memory lookup with boxed OMX_ROOT

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1867,6 +1867,51 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("includes repo-local .omx project-memory during SessionStart when OMX_ROOT is boxed", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-boxed-memory-"));
+    const boxedRoot = await mkdtemp(join(tmpdir(), "omx-native-hook-boxed-root-"));
+    const previousOmxRoot = process.env.OMX_ROOT;
+    try {
+      process.env.OMX_ROOT = boxedRoot;
+      await writeJson(join(cwd, ".omx", "project-memory.json"), {
+        techStack: "Repo-local CLI memory",
+        conventions: "SessionStart should load CLI-written project memory",
+        directives: [
+          { directive: "Prefer repo-local .omx project memory over boxed runtime fallback.", priority: "high" },
+        ],
+      });
+      await writeJson(join(boxedRoot, ".omx", "project-memory.json"), {
+        techStack: "Boxed runtime memory should not win",
+        notes: [{ category: "runtime", content: "stale boxed runtime note", timestamp: new Date().toISOString() }],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "sess-boxed-memory-1",
+        },
+        { cwd, sessionOwnerPid: 43210 },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /\[Project memory\]/);
+      assert.match(additionalContext, /source: \.omx\/project-memory\.json/);
+      assert.match(additionalContext, /Repo-local CLI memory/);
+      assert.match(additionalContext, /SessionStart should load CLI-written project memory/);
+      assert.match(additionalContext, /Prefer repo-local \.omx project memory over boxed runtime fallback\./);
+      assert.doesNotMatch(additionalContext, /Boxed runtime memory should not win/);
+      assert.doesNotMatch(additionalContext, /stale boxed runtime note/);
+    } finally {
+      if (previousOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = previousOmxRoot;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(boxedRoot, { recursive: true, force: true });
+    }
+  });
+
   it("prefers repository project-memory.json during SessionStart while preserving legacy wiki guidance", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-root-memory-legacy-wiki-"));
     try {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -315,11 +315,24 @@ export function canonicalProjectMemoryPath(projectRoot?: string): string {
   return join(projectRoot || process.cwd(), "project-memory.json");
 }
 
-/** Project memory read order: repository-visible canonical file, then legacy OMX runtime memory. */
+/** CLI-compatible repository-local project memory file (.omx/project-memory.json). */
+export function repoLocalProjectMemoryPath(projectRoot?: string): string {
+  return join(projectRoot || process.cwd(), ".omx", "project-memory.json");
+}
+
+/**
+ * Project memory read order for startup context.
+ *
+ * Keep the repository-visible root file first for existing SessionStart compatibility,
+ * then include the CLI/MCP project-memory location before boxed OMX runtime memory.
+ */
 export function projectMemoryPathCandidates(projectRoot?: string): string[] {
-  const canonical = canonicalProjectMemoryPath(projectRoot);
-  const legacy = omxProjectMemoryPath(projectRoot);
-  return canonical === legacy ? [canonical] : [canonical, legacy];
+  const candidates = [
+    canonicalProjectMemoryPath(projectRoot),
+    repoLocalProjectMemoryPath(projectRoot),
+    omxProjectMemoryPath(projectRoot),
+  ];
+  return candidates.filter((path, index) => candidates.indexOf(path) === index);
 }
 
 /** First readable project memory path, preferring repository-visible canonical memory. */


### PR DESCRIPTION
## Summary
- Preserve `project-memory.json` as the first SessionStart project-memory candidate.
- Add repo-local `.omx/project-memory.json` before boxed runtime fallback memory.
- Cover the boxed `OMX_ROOT` SessionStart case so CLI-written repo memory is loaded.

Fixes #2707.

## Verification
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js`
- `node dist/scripts/run-test-files.js dist/utils/__tests__/paths.test.js`
- `./node_modules/.bin/biome lint src/utils/paths.ts src/scripts/__tests__/codex-native-hook.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
