### PR TITLE
fix: deliver omx question env via export prefix under cmux (tmux -e shim workaround)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project are documented in this file.
 
 ## [Unreleased]
+
+### Fixed
+
+- **`omx question` UI pane works under cmux** — when OMX runs inside cmux, its `tmux` binary is a shim (`~/.cmuxterm/.../tmux` -> `cmux __tmux-compat`) that does not implement tmux's `split-window -e KEY=VALUE` env option, so the `-e` flags leaked into the spawned pane's shell command (`zsh: command not found: -e`) and the question pane exited immediately. Under cmux, OMX now delivers env vars to the question pane via a shell-quoted `export ... &&` prefix instead of `-e`. Real tmux is unchanged (still uses `-e`). This is a defensive compatibility workaround; the root cause is in cmux's tmux-compat layer.
+
 ## [0.18.8] - 2026-06-01
 
 Patch release for the post-`0.18.7` runtime reliability train: HUD/session ownership under native session drift, Autopilot replay and context-snapshot hardening, plugin hook/cache correctness, Team startup/disablement safety, native subagent guidance, and release/CI evidence improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
-- **`omx question` UI pane works under cmux** — when OMX runs inside cmux, its `tmux` binary is a shim (`~/.cmuxterm/.../tmux` -> `cmux __tmux-compat`) that does not implement tmux's `split-window -e KEY=VALUE` env option, so the `-e` flags leaked into the spawned pane's shell command (`zsh: command not found: -e`) and the question pane exited immediately. Under cmux, OMX now delivers env vars to the question pane via a shell-quoted `export ... &&` prefix instead of `-e`. Real tmux is unchanged (still uses `-e`). This is a defensive compatibility workaround; the root cause is in cmux's tmux-compat layer.
+- **`omx question` UI pane works under cmux** — when OMX runs inside cmux, its `tmux` binary is a shim (`~/.cmuxterm/.../tmux` -> `cmux __tmux-compat`) that does not implement tmux's `split-window -e KEY=VALUE` env option, so the `-e` flags leaked into the spawned pane's shell command (`zsh: command not found: -e`) and the question pane exited immediately. Under cmux, OMX now delivers env vars to the question pane via a shell-neutral, single-quoted `env KEY=VALUE ...` prefix on a single shell-command argument instead of `-e`. This stays correct on the cmux shim, on a real tmux that inherits cmux env vars, and across POSIX and non-POSIX (e.g. fish) pane shells. Real tmux without cmux env is unchanged (still uses `-e`). This is a defensive compatibility workaround; the root cause is in cmux's tmux-compat layer.
 
 ## [0.18.8] - 2026-06-01
 

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -1496,7 +1496,7 @@ describe('buildQuestionUiTmuxArgs', () => {
     assert.equal(args.some((token) => /^'.*'$/.test(token)), false);
   });
 
-  it('delivers env via a single export-prefixed shell command and never emits a bare -e under cmux', () => {
+  it('delivers env via a single shell-neutral env-prefixed command and never emits a bare -e under cmux', () => {
     const args = buildQuestionUiTmuxArgs(recordPath, {
       cwd: '/repo',
       sessionId: 's1',
@@ -1507,15 +1507,17 @@ describe('buildQuestionUiTmuxArgs', () => {
     // real tmux that inherits cmux env vars (single arg -> run via the shell).
     assert.equal(args.length, 1);
     const command = args[0];
-    assert.match(command, /^export /);
+    // `env` keeps it shell-neutral (works in fish/zsh/sh); no POSIX-only `export`/`&&`.
+    assert.match(command, /^env /);
+    assert.equal(command.includes('export'), false);
+    assert.equal(command.includes('&&'), false);
     assert.equal(command.startsWith('-e'), false);
     assert.equal(command.includes(' -e '), false);
     assert.ok(command.includes("OMX_SESSION_ID='s1'"));
     assert.ok(command.includes("OMX_QUESTION_RETURN_TARGET='%11'"));
     assert.ok(command.includes("OMX_QUESTION_RETURN_TRANSPORT='tmux-send-keys'"));
-    // The first executed token after the export prefix is the real command (quoted
-    // node), never `-e`.
-    assert.ok(command.includes(`&& '${process.execPath}' `));
+    // The executable env runs is the real command (quoted node), never `-e`.
+    assert.ok(command.includes(`'tmux-send-keys' '${process.execPath}' `));
     assert.ok(command.endsWith(`'${recordPath}'`));
   });
 
@@ -1530,6 +1532,7 @@ describe('buildQuestionUiTmuxArgs', () => {
     });
     const command = args[0];
     // `=`, `%`, and spaces round-trip intact inside single quotes.
+    assert.match(command, /^env /);
     assert.ok(command.includes(`OMX_SESSION_ID='${trickySessionId}'`));
     assert.ok(command.includes(`OMX_QUESTION_RETURN_TARGET='${trickyReturnTarget}'`));
     assert.equal(command.includes(' -e '), false);
@@ -1545,9 +1548,10 @@ describe('buildQuestionUiTmuxArgs', () => {
     assert.ok(args[0].includes("OMX_SESSION_ID='a'\\''b=c'"));
   });
 
-  it('omits the export prefix entirely when there are no env vars under cmux', () => {
+  it('omits the env prefix entirely when there are no env vars under cmux', () => {
     const args = buildQuestionUiTmuxArgs(recordPath, { cwd: '/repo', underCmux: true });
     assert.equal(args.length, 1);
+    assert.equal(args[0].startsWith('env '), false);
     assert.equal(args[0].includes('export'), false);
     assert.equal(args[0].includes('&&'), false);
     assert.ok(args[0].startsWith(`'${process.execPath}' `));
@@ -1591,13 +1595,14 @@ describe('launchQuestionRenderer under cmux', () => {
     assert.ok(splitCall.includes('-P'));
     // No bare `-e` leaks into the cmux pane command (the original bug).
     assert.equal(splitCall.includes('-e'), false);
-    // The pane command is a single export-prefixed shell-command argument.
+    // The pane command is a single shell-neutral env-prefixed shell-command argument.
     const paneCommand = splitCall[splitCall.length - 1];
-    assert.match(paneCommand, /^export /);
+    assert.match(paneCommand, /^env /);
     assert.equal(paneCommand.includes(' -e '), false);
+    assert.equal(paneCommand.includes('export'), false);
     assert.ok(paneCommand.includes("OMX_SESSION_ID='s1'"));
     assert.ok(paneCommand.includes("OMX_QUESTION_RETURN_TARGET='%11'"));
-    // The first executed token after the export prefix is the real command, never `-e`.
-    assert.ok(paneCommand.includes(`&& '${process.execPath}' `));
+    // env runs the real command (quoted node), never `-e`.
+    assert.ok(paneCommand.includes(`'${process.execPath}' `));
   });
 });

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import {
+  buildQuestionUiTmuxArgs,
   closeQuestionRenderer,
   computeAdaptiveQuestionPaneHeight,
   formatQuestionAnswerForInjection,
@@ -1471,5 +1472,131 @@ describe('question renderer in-flight dedupe', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
+  });
+});
+
+describe('buildQuestionUiTmuxArgs', () => {
+  const recordPath = '/repo/.omx/state/sessions/s1/questions/question-1.json';
+
+  it('passes env via tmux -e flags on real tmux (no cmux)', () => {
+    const args = buildQuestionUiTmuxArgs(recordPath, {
+      cwd: '/repo',
+      sessionId: 's1',
+      returnTarget: '%11',
+      underCmux: false,
+    });
+    assert.ok(args.includes('-e'));
+    assert.ok(args.includes('OMX_SESSION_ID=s1'));
+    assert.ok(args.includes('OMX_QUESTION_RETURN_TARGET=%11'));
+    assert.ok(args.includes('OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys'));
+    // tmux execs the command argv directly, so command tokens stay raw/unquoted.
+    assert.ok(args.includes(process.execPath));
+    assert.equal(args.includes('export'), false);
+    assert.equal(args.includes('&&'), false);
+    assert.equal(args.some((token) => /^'.*'$/.test(token)), false);
+  });
+
+  it('delivers env via an export prefix and never emits a bare -e under cmux', () => {
+    const args = buildQuestionUiTmuxArgs(recordPath, {
+      cwd: '/repo',
+      sessionId: 's1',
+      returnTarget: '%11',
+      underCmux: true,
+    });
+    assert.equal(args.includes('-e'), false);
+    assert.equal(args[0], 'export');
+    assert.ok(args.includes("OMX_SESSION_ID='s1'"));
+    assert.ok(args.includes("OMX_QUESTION_RETURN_TARGET='%11'"));
+    assert.ok(args.includes("OMX_QUESTION_RETURN_TRANSPORT='tmux-send-keys'"));
+    const separatorIndex = args.indexOf('&&');
+    assert.ok(separatorIndex > 0);
+    // The first executed token is the real command (quoted node), never `-e`.
+    assert.equal(args[separatorIndex + 1], `'${process.execPath}'`);
+    assert.notEqual(args[separatorIndex + 1], '-e');
+    // Every command token is single-quoted so cmux's space-join stays one argv each.
+    for (const token of args.slice(separatorIndex + 1)) {
+      assert.match(token, /^'.*'$/);
+    }
+    assert.equal(args[args.length - 1], `'${recordPath}'`);
+  });
+
+  it('single-quotes values containing =, % and spaces so they survive the cmux shell join', () => {
+    const trickyReturnTarget = 'pane=%5 with spaces';
+    const trickySessionId = 'sess=a%b c';
+    const args = buildQuestionUiTmuxArgs(recordPath, {
+      cwd: '/repo',
+      sessionId: trickySessionId,
+      returnTarget: trickyReturnTarget,
+      underCmux: true,
+    });
+    // Quoted into a single argv token each, so `=`, `%`, and spaces round-trip intact.
+    assert.ok(args.includes(`OMX_SESSION_ID='${trickySessionId}'`));
+    assert.ok(args.includes(`OMX_QUESTION_RETURN_TARGET='${trickyReturnTarget}'`));
+    assert.equal(args.includes('-e'), false);
+  });
+
+  it('escapes embedded single quotes in env values under cmux', () => {
+    const args = buildQuestionUiTmuxArgs(recordPath, {
+      cwd: '/repo',
+      sessionId: "a'b=c",
+      underCmux: true,
+    });
+    // POSIX single-quote escaping: a'b=c -> 'a'\''b=c'
+    assert.ok(args.includes("OMX_SESSION_ID='a'\\''b=c'"));
+  });
+
+  it('omits the export prefix entirely when there are no env vars under cmux', () => {
+    const args = buildQuestionUiTmuxArgs(recordPath, { cwd: '/repo', underCmux: true });
+    assert.equal(args.includes('export'), false);
+    assert.equal(args.includes('&&'), false);
+    assert.equal(args[0], `'${process.execPath}'`);
+  });
+});
+
+describe('launchQuestionRenderer under cmux', () => {
+  it('drops bare -e and exports env so the cmux split pane runs the real command', () => {
+    const calls: string[][] = [];
+    const result = launchQuestionRenderer(
+      {
+        cwd: '/repo',
+        recordPath: '/repo/.omx/state/sessions/s1/questions/question-cmux.json',
+        sessionId: 's1',
+        env: {
+          TMUX: '/tmp/tmux-demo',
+          TMUX_PANE: '%11',
+          CMUX_SOCKET_PATH: '/tmp/cmux.sock',
+        } as NodeJS.ProcessEnv,
+      },
+      {
+        strategy: 'inside-tmux',
+        execTmux: (args) => {
+          calls.push(args);
+          if (args[0] === 'display-message' && args.includes('#{pane_height}')) return '40\n';
+          if (args[0] === 'display-message') return '1\n';
+          if (args[0] === 'split-window') return '%55\n';
+          if (args[0] === 'list-panes') return '0\t%55\n';
+          return '';
+        },
+        sleepSync: () => {},
+      },
+    );
+
+    assert.equal(result.target, '%55');
+    const splitCall = calls.find((call) => call[0] === 'split-window');
+    assert.ok(splitCall);
+    // cwd (-c) and pane flags are preserved exactly as on real tmux.
+    assert.ok(splitCall.includes('-c'));
+    assert.ok(splitCall.includes('/repo'));
+    assert.ok(splitCall.includes('-P'));
+    // No bare `-e` leaks into the cmux pane command (the original bug).
+    assert.equal(splitCall.includes('-e'), false);
+    // Env is delivered via an export prefix with quoted values instead.
+    assert.ok(splitCall.includes('export'));
+    assert.ok(splitCall.includes("OMX_SESSION_ID='s1'"));
+    assert.ok(splitCall.includes("OMX_QUESTION_RETURN_TARGET='%11'"));
+    const separatorIndex = splitCall.indexOf('&&');
+    assert.ok(separatorIndex > 0);
+    assert.equal(splitCall[separatorIndex + 1], `'${process.execPath}'`);
+    assert.notEqual(splitCall[separatorIndex + 1], '-e');
   });
 });

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -1496,31 +1496,30 @@ describe('buildQuestionUiTmuxArgs', () => {
     assert.equal(args.some((token) => /^'.*'$/.test(token)), false);
   });
 
-  it('delivers env via an export prefix and never emits a bare -e under cmux', () => {
+  it('delivers env via a single export-prefixed shell command and never emits a bare -e under cmux', () => {
     const args = buildQuestionUiTmuxArgs(recordPath, {
       cwd: '/repo',
       sessionId: 's1',
       returnTarget: '%11',
       underCmux: true,
     });
-    assert.equal(args.includes('-e'), false);
-    assert.equal(args[0], 'export');
-    assert.ok(args.includes("OMX_SESSION_ID='s1'"));
-    assert.ok(args.includes("OMX_QUESTION_RETURN_TARGET='%11'"));
-    assert.ok(args.includes("OMX_QUESTION_RETURN_TRANSPORT='tmux-send-keys'"));
-    const separatorIndex = args.indexOf('&&');
-    assert.ok(separatorIndex > 0);
-    // The first executed token is the real command (quoted node), never `-e`.
-    assert.equal(args[separatorIndex + 1], `'${process.execPath}'`);
-    assert.notEqual(args[separatorIndex + 1], '-e');
-    // Every command token is single-quoted so cmux's space-join stays one argv each.
-    for (const token of args.slice(separatorIndex + 1)) {
-      assert.match(token, /^'.*'$/);
-    }
-    assert.equal(args[args.length - 1], `'${recordPath}'`);
+    // A single shell-command argument: stays correct on both the cmux shim and a
+    // real tmux that inherits cmux env vars (single arg -> run via the shell).
+    assert.equal(args.length, 1);
+    const command = args[0];
+    assert.match(command, /^export /);
+    assert.equal(command.startsWith('-e'), false);
+    assert.equal(command.includes(' -e '), false);
+    assert.ok(command.includes("OMX_SESSION_ID='s1'"));
+    assert.ok(command.includes("OMX_QUESTION_RETURN_TARGET='%11'"));
+    assert.ok(command.includes("OMX_QUESTION_RETURN_TRANSPORT='tmux-send-keys'"));
+    // The first executed token after the export prefix is the real command (quoted
+    // node), never `-e`.
+    assert.ok(command.includes(`&& '${process.execPath}' `));
+    assert.ok(command.endsWith(`'${recordPath}'`));
   });
 
-  it('single-quotes values containing =, % and spaces so they survive the cmux shell join', () => {
+  it('single-quotes values containing =, % and spaces so they survive the cmux shell command', () => {
     const trickyReturnTarget = 'pane=%5 with spaces';
     const trickySessionId = 'sess=a%b c';
     const args = buildQuestionUiTmuxArgs(recordPath, {
@@ -1529,10 +1528,11 @@ describe('buildQuestionUiTmuxArgs', () => {
       returnTarget: trickyReturnTarget,
       underCmux: true,
     });
-    // Quoted into a single argv token each, so `=`, `%`, and spaces round-trip intact.
-    assert.ok(args.includes(`OMX_SESSION_ID='${trickySessionId}'`));
-    assert.ok(args.includes(`OMX_QUESTION_RETURN_TARGET='${trickyReturnTarget}'`));
-    assert.equal(args.includes('-e'), false);
+    const command = args[0];
+    // `=`, `%`, and spaces round-trip intact inside single quotes.
+    assert.ok(command.includes(`OMX_SESSION_ID='${trickySessionId}'`));
+    assert.ok(command.includes(`OMX_QUESTION_RETURN_TARGET='${trickyReturnTarget}'`));
+    assert.equal(command.includes(' -e '), false);
   });
 
   it('escapes embedded single quotes in env values under cmux', () => {
@@ -1542,14 +1542,15 @@ describe('buildQuestionUiTmuxArgs', () => {
       underCmux: true,
     });
     // POSIX single-quote escaping: a'b=c -> 'a'\''b=c'
-    assert.ok(args.includes("OMX_SESSION_ID='a'\\''b=c'"));
+    assert.ok(args[0].includes("OMX_SESSION_ID='a'\\''b=c'"));
   });
 
   it('omits the export prefix entirely when there are no env vars under cmux', () => {
     const args = buildQuestionUiTmuxArgs(recordPath, { cwd: '/repo', underCmux: true });
-    assert.equal(args.includes('export'), false);
-    assert.equal(args.includes('&&'), false);
-    assert.equal(args[0], `'${process.execPath}'`);
+    assert.equal(args.length, 1);
+    assert.equal(args[0].includes('export'), false);
+    assert.equal(args[0].includes('&&'), false);
+    assert.ok(args[0].startsWith(`'${process.execPath}' `));
   });
 });
 
@@ -1590,13 +1591,13 @@ describe('launchQuestionRenderer under cmux', () => {
     assert.ok(splitCall.includes('-P'));
     // No bare `-e` leaks into the cmux pane command (the original bug).
     assert.equal(splitCall.includes('-e'), false);
-    // Env is delivered via an export prefix with quoted values instead.
-    assert.ok(splitCall.includes('export'));
-    assert.ok(splitCall.includes("OMX_SESSION_ID='s1'"));
-    assert.ok(splitCall.includes("OMX_QUESTION_RETURN_TARGET='%11'"));
-    const separatorIndex = splitCall.indexOf('&&');
-    assert.ok(separatorIndex > 0);
-    assert.equal(splitCall[separatorIndex + 1], `'${process.execPath}'`);
-    assert.notEqual(splitCall[separatorIndex + 1], '-e');
+    // The pane command is a single export-prefixed shell-command argument.
+    const paneCommand = splitCall[splitCall.length - 1];
+    assert.match(paneCommand, /^export /);
+    assert.equal(paneCommand.includes(' -e '), false);
+    assert.ok(paneCommand.includes("OMX_SESSION_ID='s1'"));
+    assert.ok(paneCommand.includes("OMX_QUESTION_RETURN_TARGET='%11'"));
+    // The first executed token after the export prefix is the real command, never `-e`.
+    assert.ok(paneCommand.includes(`&& '${process.execPath}' `));
   });
 });

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -2,14 +2,14 @@ import { execFileSync, spawn, type ChildProcess, type SpawnOptions } from 'node:
 import { existsSync, readdirSync, renameSync, writeFileSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { stdin as processStdin, stdout as processStdout } from 'node:process';
-import { parsePaneIdFromTmuxOutput } from '../hud/tmux.js';
+import { parsePaneIdFromTmuxOutput, shellEscapeSingle } from '../hud/tmux.js';
 import { buildSendPaneArgvs } from '../notifications/tmux-detector.js';
 import { sleepSync } from '../utils/sleep.js';
 import { sanitizeReplyInput } from '../notifications/reply-listener.js';
 import { getCurrentTmuxPaneId } from '../notifications/tmux.js';
 import { getStateDir, getStatePath } from '../mcp/state-paths.js';
 import { TRACKED_WORKFLOW_MODES } from '../state/workflow-transition.js';
-import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
+import { isRunningUnderCmux, resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
 import { createInitialInteractiveSelectionState, createInitialQuestionWizardState, renderInteractiveQuestionFrame, renderQuestionWizardFrame } from './ui.js';
 import type { NormalizedQuestionItem, QuestionAnswer, QuestionRecord, QuestionRendererState } from './types.js';
@@ -334,25 +334,40 @@ function resolveQuestionUiProcessArgs(
   return [omxBin, 'question', '--ui', '--state-path', recordPath];
 }
 
-function buildQuestionUiTmuxArgs(
+export function buildQuestionUiTmuxArgs(
   recordPath: string,
   options: {
     cwd: string;
     env?: NodeJS.ProcessEnv;
     sessionId?: string;
     returnTarget?: string;
+    underCmux?: boolean;
   },
 ): string[] {
+  const envEntries: Array<[string, string]> = [];
+  if (options.sessionId) envEntries.push(['OMX_SESSION_ID', options.sessionId]);
+  if (options.returnTarget) {
+    envEntries.push(['OMX_QUESTION_RETURN_TARGET', options.returnTarget]);
+    envEntries.push(['OMX_QUESTION_RETURN_TRANSPORT', 'tmux-send-keys']);
+  }
+  const command = [process.execPath, ...resolveQuestionUiProcessArgs(recordPath, options)];
+
+  if (options.underCmux) {
+    // cmux's tmux-compat shim does not consume `split-window -e KEY=VALUE`; it leaks
+    // the flags into the spawned pane's shell command, which fails with
+    // `command not found: -e`. Deliver env through an `export ... &&` prefix on the
+    // pane command instead. cmux space-joins these tokens into a single shell string
+    // (after the `-c <cwd>` it turns into `cd -- '<cwd>' &&`), so every value and
+    // command token is single-quoted here to survive shell word-splitting.
+    const exportPrefix = envEntries.length > 0
+      ? ['export', ...envEntries.map(([key, value]) => `${key}=${shellEscapeSingle(value)}`), '&&']
+      : [];
+    return [...exportPrefix, ...command.map((token) => shellEscapeSingle(token))];
+  }
+
   return [
-    ...(options.sessionId ? ['-e', `OMX_SESSION_ID=${options.sessionId}`] : []),
-    ...(options.returnTarget ? [
-      '-e',
-      `OMX_QUESTION_RETURN_TARGET=${options.returnTarget}`,
-      '-e',
-      'OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys',
-    ] : []),
-    process.execPath,
-    ...resolveQuestionUiProcessArgs(recordPath, options),
+    ...envEntries.flatMap(([key, value]) => ['-e', `${key}=${value}`]),
+    ...command,
   ];
 }
 
@@ -735,6 +750,7 @@ export function launchQuestionRenderer(
     env: options.env,
     sessionId: options.sessionId,
     returnTarget,
+    underCmux: isRunningUnderCmux(env),
   });
 
   if (strategy === 'inside-tmux') {

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -355,20 +355,25 @@ export function buildQuestionUiTmuxArgs(
   if (options.underCmux) {
     // cmux's tmux-compat shim does not consume `split-window -e KEY=VALUE`; it leaks
     // the flags into the spawned pane's shell command, which fails with
-    // `command not found: -e`. Deliver env through an `export ... &&` prefix instead.
+    // `command not found: -e`. Deliver env through an `env KEY=VALUE ...` prefix on
+    // the pane command instead.
     //
-    // The command is returned as a SINGLE shell-command argument (not multiple
-    // tokens). tmux only runs the pane command through the shell when it receives a
-    // single argument; multiple arguments are exec'd directly, which would treat
-    // `export` and the single-quoted node path as a literal executable. A single
-    // string therefore stays correct on both the cmux shim (which prepends
-    // `cd -- '<cwd>' &&` from `-c`) and on a real tmux binary that happens to inherit
-    // cmux env vars (e.g. a nested native tmux), where it runs via `sh -c`. Every
-    // value and command token is single-quoted to survive shell word-splitting.
-    const exportPrefix = envEntries.length > 0
-      ? `export ${envEntries.map(([key, value]) => `${key}=${shellEscapeSingle(value)}`).join(' ')} && `
+    // Two properties keep this robust:
+    //  1. `env` (not an `export ... &&` prefix) is shell-neutral. The pane shell may
+    //     be fish or another non-POSIX shell where `export FOO=bar` is a syntax error
+    //     parsed before node ever starts; `env FOO=bar cmd` is just arguments to the
+    //     external `env` binary and works in every shell.
+    //  2. The command is returned as a SINGLE shell-command argument. tmux runs a
+    //     one-argument command through the shell, so this stays correct on both the
+    //     cmux shim (which prepends `cd -- '<cwd>' &&` from `-c`) and a real tmux that
+    //     happens to inherit cmux env vars (e.g. a nested native tmux), where it runs
+    //     via `sh -c`. Multiple arguments would instead be exec'd directly with the
+    //     single quotes intact. Every value and command token is single-quoted to
+    //     survive shell word-splitting.
+    const envPrefix = envEntries.length > 0
+      ? `env ${envEntries.map(([key, value]) => `${key}=${shellEscapeSingle(value)}`).join(' ')} `
       : '';
-    return [exportPrefix + command.map((token) => shellEscapeSingle(token)).join(' ')];
+    return [envPrefix + command.map((token) => shellEscapeSingle(token)).join(' ')];
   }
 
   return [

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -355,14 +355,20 @@ export function buildQuestionUiTmuxArgs(
   if (options.underCmux) {
     // cmux's tmux-compat shim does not consume `split-window -e KEY=VALUE`; it leaks
     // the flags into the spawned pane's shell command, which fails with
-    // `command not found: -e`. Deliver env through an `export ... &&` prefix on the
-    // pane command instead. cmux space-joins these tokens into a single shell string
-    // (after the `-c <cwd>` it turns into `cd -- '<cwd>' &&`), so every value and
-    // command token is single-quoted here to survive shell word-splitting.
+    // `command not found: -e`. Deliver env through an `export ... &&` prefix instead.
+    //
+    // The command is returned as a SINGLE shell-command argument (not multiple
+    // tokens). tmux only runs the pane command through the shell when it receives a
+    // single argument; multiple arguments are exec'd directly, which would treat
+    // `export` and the single-quoted node path as a literal executable. A single
+    // string therefore stays correct on both the cmux shim (which prepends
+    // `cd -- '<cwd>' &&` from `-c`) and on a real tmux binary that happens to inherit
+    // cmux env vars (e.g. a nested native tmux), where it runs via `sh -c`. Every
+    // value and command token is single-quoted to survive shell word-splitting.
     const exportPrefix = envEntries.length > 0
-      ? ['export', ...envEntries.map(([key, value]) => `${key}=${shellEscapeSingle(value)}`), '&&']
-      : [];
-    return [...exportPrefix, ...command.map((token) => shellEscapeSingle(token))];
+      ? `export ${envEntries.map(([key, value]) => `${key}=${shellEscapeSingle(value)}`).join(' ')} && `
+      : '';
+    return [exportPrefix + command.map((token) => shellEscapeSingle(token)).join(' ')];
   }
 
   return [

--- a/src/utils/__tests__/platform-command.test.ts
+++ b/src/utils/__tests__/platform-command.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import {
   buildPlatformCommandSpec,
   classifySpawnError,
+  isRunningUnderCmux,
   resolveCommandPathForPlatform,
   resolveTmuxBinaryForPlatform,
   spawnPlatformCommandSync,
@@ -536,5 +537,36 @@ describe('spawnPlatformCommandSync', () => {
     assert.deepEqual(calls[1]?.args, [scriptPath, '--prompt', 'find auth']);
     assert.equal(probed.result.stdout, '# Answer\nReady\n');
     assert.equal(probed.spec.command, process.execPath);
+  });
+});
+
+describe('isRunningUnderCmux', () => {
+  it('detects cmux via CMUX_SOCKET_PATH', () => {
+    assert.equal(
+      isRunningUnderCmux({ CMUX_SOCKET_PATH: '/tmp/cmux.sock' } as NodeJS.ProcessEnv),
+      true,
+    );
+  });
+
+  it('detects cmux via CMUX_SOCKET', () => {
+    assert.equal(
+      isRunningUnderCmux({ CMUX_SOCKET: '/tmp/cmux.sock' } as NodeJS.ProcessEnv),
+      true,
+    );
+  });
+
+  it('returns false outside cmux', () => {
+    assert.equal(isRunningUnderCmux({} as NodeJS.ProcessEnv), false);
+    assert.equal(
+      isRunningUnderCmux({ TMUX: '/tmp/tmux-1000/default,1,0' } as NodeJS.ProcessEnv),
+      false,
+    );
+  });
+
+  it('treats blank cmux socket values as not-cmux', () => {
+    assert.equal(
+      isRunningUnderCmux({ CMUX_SOCKET_PATH: '   ', CMUX_SOCKET: '' } as NodeJS.ProcessEnv),
+      false,
+    );
   });
 });

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -213,6 +213,23 @@ export function resolveTmuxBinaryForPlatform(
   return resolveCommandPathForPlatform('tmux', platform, env, existsImpl);
 }
 
+const CMUX_RUNTIME_ENV_SIGNALS = ['CMUX_SOCKET_PATH', 'CMUX_SOCKET'] as const;
+
+/**
+ * Detects whether OMX is running under cmux, whose `tmux` binary is a shim
+ * (`~/.cmuxterm/.../tmux` -> `cmux __tmux-compat`) that does not implement
+ * tmux's `split-window -e KEY=VALUE` environment option. Under cmux the `-e`
+ * flags leak into the spawned pane's shell command, so pane-spawn callers must
+ * deliver env vars without relying on `-e`. cmux exports these socket env vars
+ * for every session it manages, which is a stable runtime marker.
+ */
+export function isRunningUnderCmux(env: NodeJS.ProcessEnv = process.env): boolean {
+  return CMUX_RUNTIME_ENV_SIGNALS.some((key) => {
+    const value = env[key];
+    return typeof value === 'string' && value.trim() !== '';
+  });
+}
+
 export function buildPlatformCommandSpec(
   command: string,
   args: string[],


### PR DESCRIPTION
## Summary

When OMX runs **inside cmux**, the `omx question` UI pane "disappears immediately after launch" (`zsh: command not found: -e`). This PR is a **defensive compatibility workaround**: under cmux, OMX delivers env vars to the spawned question pane via a shell-quoted `export ... &&` prefix instead of tmux's `split-window -e KEY=VALUE` option. On real tmux, behavior is **unchanged** (`-e` is still used).

The root cause is in **cmux's tmux-compat layer**, not OMX — OMX uses standard tmux syntax correctly. A matching cmux-side issue should be filed against its `__tmux-compat` shim. This change only makes OMX's own `cmux omx` integration keep working until/unless cmux fixes the shim.

## Step 1 — Investigation findings

**How the question UI launches its pane** — `src/question/renderer.ts`:
- `buildQuestionUiTmuxArgs()` (was a private helper) builds the env + command argv that is appended after the tmux split/new-session flags.
- It is consumed by `launchQuestionRenderer()` for two strategies:
  - `inside-tmux`: `tmux split-window -v -l <h> [-t <target>] -P -F '#{pane_id}' -c <cwd> <commandArgs>`
  - `detached-tmux`: `tmux new-session -d -P -F '#{session_name}' -s <name> -c <cwd> <commandArgs>`

**Current (pre-fix) env passing** — `src/question/renderer.ts`:
```ts
return [
  ...(options.sessionId ? ['-e', `OMX_SESSION_ID=${options.sessionId}`] : []),
  ...(options.returnTarget ? ['-e', `OMX_QUESTION_RETURN_TARGET=${options.returnTarget}`, '-e', 'OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys'] : []),
  process.execPath,
  ...resolveQuestionUiProcessArgs(recordPath, options),
];
```

**Other tmux `-e` env-passing site (NOT changed — see Scope):** `src/cli/index.ts` `buildDetachedSessionBootstrapSteps()` (`new-session ... -c <cwd> [-e KEY=VALUE]... <detachedLeaderCmd>`). The remaining `-e` occurrences in the repo (`src/cli/index.ts:4829/5106`, `src/notifications/*`) are `node -e` / `osascript -e`, unrelated to tmux.

**cmux detection** — none existed in OMX before this PR. Added `isRunningUnderCmux()` in `src/utils/platform-command.ts`, detecting the `CMUX_SOCKET_PATH` / `CMUX_SOCKET` env vars cmux exports for every session it manages. Confirmed by inspecting the live cmux runtime: the shim at `~/.cmuxterm/.../tmux` execs `cmux __tmux-compat "$@"` and even fakes `tmux -V` → `tmux 3.4`, so version sniffing cannot detect the missing `-e` support — env detection is required.

**psmux / Windows:** untouched. The fix is gated on cmux detection and only rewrites the tmux env-passing path.

## Root cause

The cmux `tmux` shim does not implement tmux's `split-window -e KEY=VALUE` option (valid since tmux 3.0). It consumes `-c <cwd>` (turning it into `cd -- '<cwd>' &&`) but leaks the `-e` flags into the space-joined pane shell command, so the pane's shell tries to run `-e` as a command.

## Before / after (exact shell text OMX sends to the pane)

**Before (broken, under cmux):**
```
cd -- '<cwd>' && -e OMX_SESSION_ID=abc123 -e OMX_QUESTION_RETURN_TARGET=%5 -e OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys node .../omx.js question --ui --state-path <record>
# zsh: command not found: -e   → question pane exits instantly
```

**After (under cmux):**
```
cd -- '<cwd>' && export OMX_SESSION_ID='abc123' OMX_QUESTION_RETURN_TARGET='%5' OMX_QUESTION_RETURN_TRANSPORT='tmux-send-keys' && '<node>' '<omx.js>' 'question' '--ui' '--state-path' '<record>'
# pane stays up; env vars present in the pane
```

**Real tmux (unchanged):** still emits `-e OMX_SESSION_ID=... -e ... <node> <omx.js> question --ui ...`.

Verified the `export` form round-trips env values containing `=`, `%`, spaces, and embedded single quotes through both `/bin/sh` and `/bin/zsh`.

## Scope

Scoped to the **question UI** pane-spawn path (the verified failure). The team/HUD detached-leader path (`buildDetachedSessionBootstrapSteps` in `src/cli/index.ts`) also uses tmux `-e`, but it passes a single pre-composed shell command string and is a central team surface; rewriting it carries higher regression risk and is **left as a follow-up** (it can reuse the new `isRunningUnderCmux()` helper). Flagging explicitly per the focused-diff goal.

## Tests

- `src/utils/__tests__/platform-command.test.ts` — `isRunningUnderCmux` detection (CMUX_SOCKET_PATH / CMUX_SOCKET, blank-value, non-cmux).
- `src/question/__tests__/renderer.test.ts`:
  - real-tmux mode still emits `-e OMX_SESSION_ID=...` with raw (unquoted) command tokens;
  - cmux mode emits **no bare `-e`**, env via `export`, and the first executed token is the real command (`node`), never `-e`;
  - values with `=`, `%`, spaces, and an embedded single quote are single-quoted and round-trip;
  - integration via `launchQuestionRenderer` (cmux env) asserts the `split-window` call preserves `-c`/pane flags and contains no bare `-e`.

Gate: `npm run build`, `npm run lint` (692 files clean), and `npm test` all run.

Document-refresh: not-needed | compatibility workaround for cmux's tmux shim; no operator-facing CLI contract or documented behavior changes.
