### PR TITLE
Add OMX update stable/dev channels

### DIFF
--- a/.github/scripts/dev-merge-issue-close.cjs
+++ b/.github/scripts/dev-merge-issue-close.cjs
@@ -96,7 +96,20 @@ function buildMaintainerCloseComment({ prNumber }) {
   ].join('\n');
 }
 
+function formatIssueList(issueNumbers) {
+  return issueNumbers.map((issueNumber) => `#${issueNumber}`).join(', ');
+}
+
+function buildMaintainerPrComment({ issueNumbers }) {
+  return [
+    `Closed explicitly linked issue${issueNumbers.length === 1 ? '' : 's'} after this PR was merged into \`dev\`: ${formatIssueList(issueNumbers)}.`,
+    '',
+    'A hot-fix build is available now. Issue creators can try it with `omx update --dev` and let us know whether it resolves the issue.',
+  ].join('\n');
+}
+
 module.exports = {
   buildMaintainerCloseComment,
+  buildMaintainerPrComment,
   collectLinkedLocalIssueNumbers,
 };

--- a/.github/scripts/dev-merge-issue-close.cjs
+++ b/.github/scripts/dev-merge-issue-close.cjs
@@ -89,7 +89,11 @@ function collectLinkedLocalIssueNumbers({ title = '', body = '', owner, repo }) 
 }
 
 function buildMaintainerCloseComment({ prNumber }) {
-  return `Closing automatically because PR #${prNumber} was merged into \`dev\` and explicitly referenced this issue in the PR title or body.`;
+  return [
+    `Closing automatically because PR #${prNumber} was merged into \`dev\` and explicitly referenced this issue in the PR title or body.`,
+    '',
+    'A hot-fix build is available now. Try it with `omx update --dev` and let us know whether it resolves the issue.',
+  ].join('\n');
 }
 
 module.exports = {

--- a/.github/workflows/dev-merge-issue-close.yml
+++ b/.github/workflows/dev-merge-issue-close.yml
@@ -23,6 +23,7 @@ jobs:
           script: |
             const {
               buildMaintainerCloseComment,
+              buildMaintainerPrComment,
               collectLinkedLocalIssueNumbers,
             } = require('./.github/scripts/dev-merge-issue-close.cjs');
 
@@ -84,5 +85,12 @@ jobs:
               core.notice('No open issues required closing.');
               return;
             }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequest.number,
+              body: buildMaintainerPrComment({ issueNumbers: closedIssueNumbers }),
+            });
 
             core.notice(`Closed linked issues after merge to dev: ${closedIssueNumbers.map((issueNumber) => `#${issueNumber}`).join(', ')}`);

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "verify:native-agents": "node dist/scripts/verify-native-agents.js",
     "prompt:inventory": "node dist/scripts/prompt-inventory.js",
     "build:api": "node dist/scripts/build-api.js",
-    "prepare": "npm run build"
+    "prepare": "node src/scripts/prepare-build.js"
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "verify:plugin-bundle": "node dist/scripts/sync-plugin-mirror.js --check",
     "verify:native-agents": "node dist/scripts/verify-native-agents.js",
     "prompt:inventory": "node dist/scripts/prompt-inventory.js",
-    "build:api": "node dist/scripts/build-api.js"
+    "build:api": "node dist/scripts/build-api.js",
+    "prepare": "npm run build"
   },
   "engines": {
     "node": ">=20"

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -16,6 +16,7 @@ import {
   buildWindowsPromptCommand,
   buildTmuxSessionName,
   resolveCliInvocation,
+  resolveUpdateChannelArg,
   commandOwnsLocalHelp,
   resolveCodexLaunchPolicy,
   resolveEffectiveLeaderLaunchPolicyOverride,
@@ -1721,6 +1722,20 @@ describe("resolveCliInvocation", () => {
     });
   });
 
+  it("resolves update channel flags and rejects invalid combinations", () => {
+    assert.equal(resolveUpdateChannelArg([]), "stable");
+    assert.equal(resolveUpdateChannelArg(["--stable"]), "stable");
+    assert.equal(resolveUpdateChannelArg(["--dev"]), "dev");
+    assert.throws(
+      () => resolveUpdateChannelArg(["--dev", "--stable"]),
+      /mutually exclusive/,
+    );
+    assert.throws(
+      () => resolveUpdateChannelArg(["--beta"]),
+      /Unknown omx update option: --beta/,
+    );
+  });
+
   it("resolves hooks to hooks command", () => {
     assert.deepEqual(resolveCliInvocation(["hooks"]), {
       command: "hooks",
@@ -1771,7 +1786,9 @@ describe("resolveCliInvocation", () => {
   });
 
   it("advertises the explicit update command in top-level help", () => {
-    assert.match(HELP, /omx update\s+Check npm now, update the global install immediately, then refresh setup/);
+    assert.match(HELP, /omx update\s+Install the stable channel now, then refresh setup/);
+    assert.match(HELP, /omx update --stable\s+Install\/rollback to npm stable \(oh-my-codex@latest\), then refresh setup/);
+    assert.match(HELP, /omx update --dev\s+Install the upstream dev branch, then refresh setup/);
   });
 
   it("advertises concise launch policy controls in top-level help", () => {

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -143,7 +143,9 @@ describe('package bin contract', () => {
         `${target} initialize response should include serverInfo`,
       );
     }
-    assert.match(compiledCliSource, /omx update\s+Check npm now, update the global install immediately, then refresh setup/);
+    assert.match(compiledCliSource, /omx update\s+Install the stable channel now, then refresh setup/);
+    assert.match(compiledCliSource, /omx update --stable\s+Install\/rollback to npm stable \(oh-my-codex@latest\), then refresh setup/);
+    assert.match(compiledCliSource, /omx update --dev\s+Install the upstream dev branch, then refresh setup/);
     assert.match(compiledCliSource, /case "update"/);
 
     rmSync(packagedSparkShellPath, { force: true });

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -48,7 +48,7 @@ describe('package bin contract', () => {
     assert.equal(pkg.scripts?.['verify:plugin-bundle'], 'node dist/scripts/sync-plugin-mirror.js --check');
     assert.equal(pkg.scripts?.['verify:native-agents'], 'node dist/scripts/verify-native-agents.js');
     assert.equal(pkg.scripts?.prepack, 'npm run build && npm run verify:native-agents && npm run sync:plugin && npm run verify:plugin-bundle && npm run clean:native-package-assets');
-    assert.equal(pkg.scripts?.prepare, 'npm run build');
+    assert.equal(pkg.scripts?.prepare, 'node src/scripts/prepare-build.js');
     assert.equal(pkg.scripts?.postinstall, 'node src/scripts/postinstall-bootstrap.js');
     assert.equal(pkg.scripts?.postpack, 'npm run clean:native-package-assets');
     assert.equal(pkg.scripts?.['test:explore'], 'cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js');
@@ -100,6 +100,11 @@ describe('package bin contract', () => {
 
     const binPath = join(process.cwd(), 'dist', 'cli', 'omx.js');
     const compiledCliPath = join(process.cwd(), 'dist', 'cli', 'index.js');
+
+    const prepareBuildSource = readFileSync(join(process.cwd(), 'src', 'scripts', 'prepare-build.js'), 'utf-8');
+    assert.match(prepareBuildSource, /dist.*cli.*omx\.js/s);
+    assert.match(prepareBuildSource, /dist.*scripts.*postinstall\.js/s);
+    assert.match(prepareBuildSource, /npm.*run.*build/s);
 
     const binSource = readFileSync(binPath, 'utf-8');
     const compiledCliSource = readFileSync(compiledCliPath, 'utf-8');

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -48,6 +48,7 @@ describe('package bin contract', () => {
     assert.equal(pkg.scripts?.['verify:plugin-bundle'], 'node dist/scripts/sync-plugin-mirror.js --check');
     assert.equal(pkg.scripts?.['verify:native-agents'], 'node dist/scripts/verify-native-agents.js');
     assert.equal(pkg.scripts?.prepack, 'npm run build && npm run verify:native-agents && npm run sync:plugin && npm run verify:plugin-bundle && npm run clean:native-package-assets');
+    assert.equal(pkg.scripts?.prepare, 'npm run build');
     assert.equal(pkg.scripts?.postinstall, 'node src/scripts/postinstall-bootstrap.js');
     assert.equal(pkg.scripts?.postpack, 'npm run clean:native-package-assets');
     assert.equal(pkg.scripts?.['test:explore'], 'cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js');

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -734,6 +734,7 @@ describe('runImmediateUpdate', () => {
 
   it('installs the upstream dev branch without implying npm latest', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-dev-'));
+    const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
     const originalCodexHome = process.env.CODEX_HOME;
     const originalLog = console.log;
     const logs: string[] = [];
@@ -761,6 +762,7 @@ describe('runImmediateUpdate', () => {
           refreshCalls += 1;
           return { ok: true, stderr: '' };
         },
+        getInstalledVersionAfterUpdate: async () => '0.15.0',
       }, { channel: 'dev' });
 
       assert.equal(result.status, 'updated');
@@ -771,6 +773,13 @@ describe('runImmediateUpdate', () => {
       assert.match(logs.join('\n'), /Install source: github:Yeachan-Heo\/oh-my-codex#dev/);
       assert.match(logs.join('\n'), /Running: npm install -g github:Yeachan-Heo\/oh-my-codex#dev/);
       assert.doesNotMatch(logs.join('\n'), /dev.*oh-my-codex@latest/i);
+
+      const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
+        installed_version: string;
+        setup_completed_version: string;
+      };
+      assert.equal(stamp.installed_version, '0.15.0');
+      assert.equal(stamp.setup_completed_version, '0.15.0');
     } finally {
       console.log = originalLog;
       if (typeof originalCodexHome === 'string') {

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -201,6 +201,7 @@ describe('maybeCheckAndPromptUpdate', () => {
 
   it('schedules a deferred update after a successful startup prompt', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
+    const originalMode = process.env.OMX_AUTO_UPDATE;
     const originalLog = console.log;
     const logs: string[] = [];
     let inlineUpdateCalls = 0;
@@ -209,6 +210,7 @@ describe('maybeCheckAndPromptUpdate', () => {
     console.log = (...args: unknown[]) => {
       logs.push(args.map((arg) => String(arg)).join(' '));
     };
+    delete process.env.OMX_AUTO_UPDATE;
 
     try {
       await withInteractiveTty(async () => {
@@ -240,6 +242,11 @@ describe('maybeCheckAndPromptUpdate', () => {
       assert.match(logs.join('\n'), /Update scheduled after this session exits/);
       assert.match(logs.join('\n'), /Log: .*update-test\.log/);
     } finally {
+      if (typeof originalMode === 'string') {
+        process.env.OMX_AUTO_UPDATE = originalMode;
+      } else {
+        delete process.env.OMX_AUTO_UPDATE;
+      }
       console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
     }
@@ -247,9 +254,11 @@ describe('maybeCheckAndPromptUpdate', () => {
 
   it('keeps startup update deferred so local setup is not refreshed inline', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
+    const originalMode = process.env.OMX_AUTO_UPDATE;
     const originalLog = console.log;
     const receivedCwds: string[] = [];
     console.log = () => undefined;
+    delete process.env.OMX_AUTO_UPDATE;
 
     try {
       await withInteractiveTty(async () => {
@@ -269,6 +278,11 @@ describe('maybeCheckAndPromptUpdate', () => {
 
       assert.deepEqual(receivedCwds, [cwd]);
     } finally {
+      if (typeof originalMode === 'string') {
+        process.env.OMX_AUTO_UPDATE = originalMode;
+      } else {
+        delete process.env.OMX_AUTO_UPDATE;
+      }
       console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
     }
@@ -354,6 +368,7 @@ describe('maybeCheckAndPromptUpdate', () => {
 
   it('reports scheduler diagnostics when startup deferral cannot be launched', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
+    const originalMode = process.env.OMX_AUTO_UPDATE;
     const originalLog = console.log;
     const logs: string[] = [];
     let setupRefreshCalls = 0;
@@ -361,6 +376,7 @@ describe('maybeCheckAndPromptUpdate', () => {
     console.log = (...args: unknown[]) => {
       logs.push(args.map((arg) => String(arg)).join(' '));
     };
+    delete process.env.OMX_AUTO_UPDATE;
 
     try {
       await withInteractiveTty(async () => {
@@ -381,6 +397,11 @@ describe('maybeCheckAndPromptUpdate', () => {
       assert.match(logs.join('\n'), /powershell not found/);
       assert.match(logs.join('\n'), /update-test\.log/);
     } finally {
+      if (typeof originalMode === 'string') {
+        process.env.OMX_AUTO_UPDATE = originalMode;
+      } else {
+        delete process.env.OMX_AUTO_UPDATE;
+      }
       console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
     }
@@ -517,6 +538,7 @@ describe('runImmediateUpdate', () => {
     const logs: string[] = [];
     let setupCalls = 0;
     const refreshCwds: string[] = [];
+    const installSources: string[] = [];
     let updateCalls = 0;
     let latestCalls = 0;
 
@@ -539,8 +561,9 @@ describe('runImmediateUpdate', () => {
           latestCalls += 1;
           return '0.14.1';
         },
-        runGlobalUpdate: () => {
+        runGlobalUpdate: (installSource) => {
           updateCalls += 1;
+          installSources.push(installSource);
           return { ok: true, stderr: '' };
         },
         runSetupRefresh: async (refreshCwd) => {
@@ -553,10 +576,13 @@ describe('runImmediateUpdate', () => {
       assert.equal(result.status, 'updated');
       assert.equal(latestCalls, 1);
       assert.equal(updateCalls, 1);
+      assert.deepEqual(installSources, [`${PACKAGE_NAME}@latest`]);
       assert.equal(setupCalls, 1);
       assert.deepEqual(refreshCwds, [cwd]);
+      assert.match(logs.join('\n'), /Selected update channel: stable/);
+      assert.match(logs.join('\n'), /Install source: oh-my-codex@latest/);
       assert.match(logs.join('\n'), /Running: npm install -g oh-my-codex@latest/);
-      assert.match(logs.join('\n'), /Updated to v0\.14\.1/);
+      assert.match(logs.join('\n'), /Updated stable channel to v0\.14\.1/);
 
       const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
         installed_version: string;
@@ -575,12 +601,13 @@ describe('runImmediateUpdate', () => {
     }
   });
 
-  it('reports up-to-date status for explicit update when npm is already current', async () => {
+  it('force-installs stable for explicit update even when npm is already current', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
     const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
     const originalCodexHome = process.env.CODEX_HOME;
     const originalLog = console.log;
     const logs: string[] = [];
+    const installSources: string[] = [];
     let updateCalls = 0;
     let refreshCalls = 0;
 
@@ -602,8 +629,9 @@ describe('runImmediateUpdate', () => {
       const result = await runImmediateUpdate(cwd, {
         getCurrentVersion: async () => '0.14.0',
         fetchLatestVersion: async () => '0.14.0',
-        runGlobalUpdate: () => {
+        runGlobalUpdate: (installSource) => {
           updateCalls += 1;
+          installSources.push(installSource);
           return { ok: true, stderr: '' };
         },
         runSetupRefresh: async () => {
@@ -612,10 +640,12 @@ describe('runImmediateUpdate', () => {
         },
       });
 
-      assert.equal(result.status, 'up-to-date');
-      assert.equal(updateCalls, 0);
-      assert.equal(refreshCalls, 0);
-      assert.match(logs.join('\n'), /already up to date \(v0\.14\.0\)/);
+      assert.equal(result.status, 'updated');
+      assert.equal(updateCalls, 1);
+      assert.equal(refreshCalls, 1);
+      assert.deepEqual(installSources, [`${PACKAGE_NAME}@latest`]);
+      assert.match(logs.join('\n'), /Selected update channel: stable/);
+      assert.match(logs.join('\n'), /Running: npm install -g oh-my-codex@latest/);
     } finally {
       console.log = originalLog;
       if (typeof originalCodexHome === 'string') {
@@ -627,12 +657,14 @@ describe('runImmediateUpdate', () => {
     }
   });
 
-  it('runs setup refresh for explicit update when current version matches but setup stamp is stale', async () => {
+  it('uses stable as a rollback path while preserving persisted setup preferences', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
     const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
     const originalCodexHome = process.env.CODEX_HOME;
     const originalLog = console.log;
     const logs: string[] = [];
+    const installSources: string[] = [];
+    const setupArgs = resolveSetupRefreshArgs;
     let refreshCalls = 0;
 
     console.log = (...args: unknown[]) => {
@@ -649,23 +681,39 @@ describe('runImmediateUpdate', () => {
         },
         stampPath,
       );
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(
+        join(cwd, '.omx', 'setup-scope.json'),
+        JSON.stringify({ scope: 'user', installMode: 'plugin', mcpMode: 'none', teamMode: 'disabled' }, null, 2),
+      );
 
       const result = await runImmediateUpdate(cwd, {
         getCurrentVersion: async () => '0.14.0',
         fetchLatestVersion: async () => '0.14.0',
-        runGlobalUpdate: () => {
-          throw new Error('global update should not run when already current');
+        runGlobalUpdate: (installSource) => {
+          installSources.push(installSource);
+          return { ok: true, stderr: '' };
         },
         runSetupRefresh: async () => {
           refreshCalls += 1;
+          assert.deepEqual(setupArgs(cwd), [
+            'setup',
+            '--scope',
+            'user',
+            '--plugin',
+            '--mcp',
+            'none',
+            '--disable-team',
+          ]);
           return { ok: true, stderr: '' };
         },
-      });
+      }, { channel: 'stable' });
 
-      assert.equal(result.status, 'up-to-date');
+      assert.equal(result.status, 'updated');
+      assert.deepEqual(installSources, [`${PACKAGE_NAME}@latest`]);
       assert.equal(refreshCalls, 1);
-      assert.match(logs.join('\n'), /Running setup refresh/);
-      assert.match(logs.join('\n'), /Setup refresh completed for v0\.14\.0/);
+      assert.match(logs.join('\n'), /Selected update channel: stable/);
+      assert.match(logs.join('\n'), /Install source: oh-my-codex@latest/);
 
       const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
         installed_version: string;
@@ -684,8 +732,59 @@ describe('runImmediateUpdate', () => {
     }
   });
 
+  it('installs the upstream dev branch without implying npm latest', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-dev-'));
+    const originalCodexHome = process.env.CODEX_HOME;
+    const originalLog = console.log;
+    const logs: string[] = [];
+    const installSources: string[] = [];
+    let latestCalls = 0;
+    let refreshCalls = 0;
+
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+    process.env.CODEX_HOME = join(cwd, '.codex');
+
+    try {
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.14.0',
+        fetchLatestVersion: async () => {
+          latestCalls += 1;
+          return '0.14.0';
+        },
+        runGlobalUpdate: (installSource) => {
+          installSources.push(installSource);
+          return { ok: true, stderr: '' };
+        },
+        runSetupRefresh: async () => {
+          refreshCalls += 1;
+          return { ok: true, stderr: '' };
+        },
+      }, { channel: 'dev' });
+
+      assert.equal(result.status, 'updated');
+      assert.equal(latestCalls, 0);
+      assert.equal(refreshCalls, 1);
+      assert.deepEqual(installSources, ['github:Yeachan-Heo/oh-my-codex#dev']);
+      assert.match(logs.join('\n'), /Selected update channel: dev/);
+      assert.match(logs.join('\n'), /Install source: github:Yeachan-Heo\/oh-my-codex#dev/);
+      assert.match(logs.join('\n'), /Running: npm install -g github:Yeachan-Heo\/oh-my-codex#dev/);
+      assert.doesNotMatch(logs.join('\n'), /dev.*oh-my-codex@latest/i);
+    } finally {
+      console.log = originalLog;
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('continues explicit update when update-check state cannot be written', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-'));
+    const originalCodexHome = process.env.CODEX_HOME;
     const originalLog = console.log;
     const logs: string[] = [];
     let updateCalls = 0;
@@ -694,6 +793,7 @@ describe('runImmediateUpdate', () => {
     console.log = (...args: unknown[]) => {
       logs.push(args.map((arg) => String(arg)).join(' '));
     };
+    process.env.CODEX_HOME = join(cwd, '.codex');
 
     try {
       const result = await runImmediateUpdate(cwd, {
@@ -715,9 +815,14 @@ describe('runImmediateUpdate', () => {
       assert.equal(result.status, 'updated');
       assert.equal(updateCalls, 1);
       assert.equal(refreshCalls, 1);
-      assert.match(logs.join('\n'), /Updated to v0\.14\.1/);
+      assert.match(logs.join('\n'), /Updated stable channel to v0\.14\.1/);
     } finally {
       console.log = originalLog;
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -587,6 +587,9 @@ describe('runImmediateUpdate', () => {
       const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
         installed_version: string;
         setup_completed_version: string;
+        install_channel: string;
+        install_source: string;
+        install_revision: string;
       };
       assert.equal(stamp.installed_version, '0.14.1');
       assert.equal(stamp.setup_completed_version, '0.14.1');
@@ -718,6 +721,9 @@ describe('runImmediateUpdate', () => {
       const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
         installed_version: string;
         setup_completed_version: string;
+        install_channel: string;
+        install_source: string;
+        install_revision: string;
       };
       assert.equal(stamp.installed_version, '0.14.0');
       assert.equal(stamp.setup_completed_version, '0.14.0');
@@ -763,6 +769,7 @@ describe('runImmediateUpdate', () => {
           return { ok: true, stderr: '' };
         },
         getInstalledVersionAfterUpdate: async () => '0.15.0',
+        getInstalledRevisionAfterUpdate: async () => 'abcdef123456',
       }, { channel: 'dev' });
 
       assert.equal(result.status, 'updated');
@@ -777,9 +784,15 @@ describe('runImmediateUpdate', () => {
       const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
         installed_version: string;
         setup_completed_version: string;
+        install_channel: string;
+        install_source: string;
+        install_revision: string;
       };
       assert.equal(stamp.installed_version, '0.15.0');
       assert.equal(stamp.setup_completed_version, '0.15.0');
+      assert.equal(stamp.install_channel, 'dev');
+      assert.equal(stamp.install_source, 'github:Yeachan-Heo/oh-my-codex#dev');
+      assert.equal(stamp.install_revision, 'abcdef123456');
     } finally {
       console.log = originalLog;
       if (typeof originalCodexHome === 'string') {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -93,7 +93,7 @@ import {
   type SkillActiveStateLike,
 } from "../state/skill-active.js";
 import { isTrackedWorkflowMode } from "../state/workflow-transition.js";
-import { maybeCheckAndPromptUpdate, runImmediateUpdate } from "./update.js";
+import { maybeCheckAndPromptUpdate, runImmediateUpdate, type UpdateChannel } from "./update.js";
 import { maybePromptGithubStar } from "./star-prompt.js";
 import {
   generateOverlay,
@@ -202,7 +202,11 @@ Usage:
                 Queue a Stop-hook continuation for built-in image generation turns
   omx setup     Install skills, prompts, CLI-first config, and scope-specific AGENTS.md
                 (user scope prompts for legacy vs plugin skill delivery when needed)
-  omx update    Check npm now, update the global install immediately, then refresh setup
+  omx update    Install the stable channel now, then refresh setup
+  omx update --stable
+                Install/rollback to npm stable (oh-my-codex@latest), then refresh setup
+  omx update --dev
+                Install the upstream dev branch, then refresh setup
   omx uninstall Remove OMX configuration and clean up installed artifacts
   omx doctor    Check installation health
   omx list      List packaged OMX skills and native agent prompts (--json)
@@ -626,6 +630,34 @@ export function resolveCliInvocation(args: string[]): ResolvedCliInvocation {
     return { command: "resume", launchArgs: args.slice(1) };
   }
   return { command: firstArg, launchArgs: [] };
+}
+
+export function resolveUpdateChannelArg(args: string[]): UpdateChannel {
+  let channel: UpdateChannel = 'stable';
+  let sawStable = false;
+  let sawDev = false;
+
+  for (const arg of args) {
+    if (arg === '--stable') {
+      sawStable = true;
+      channel = 'stable';
+      continue;
+    }
+    if (arg === '--dev') {
+      sawDev = true;
+      channel = 'dev';
+      continue;
+    }
+    throw new Error(
+      `Unknown omx update option: ${arg}. Expected no flags, --stable, or --dev.`,
+    );
+  }
+
+  if (sawStable && sawDev) {
+    throw new Error('omx update --dev and --stable are mutually exclusive.');
+  }
+
+  return channel;
 }
 
 export function resolveNotifyTempContract(
@@ -1896,7 +1928,7 @@ export async function main(args: string[]): Promise<void> {
         });
         break;
       case "update":
-        await runImmediateUpdate(process.cwd());
+        await runImmediateUpdate(process.cwd(), {}, { channel: resolveUpdateChannelArg(args.slice(1)) });
         break;
       case "list":
         await listCommand(args.slice(1));

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -375,6 +375,7 @@ interface UpdateDependencies {
   askYesNo: typeof askYesNo;
   fetchLatestVersion: typeof fetchLatestVersion;
   getCurrentVersion: typeof getCurrentVersion;
+  getInstalledVersionAfterUpdate: typeof getInstalledVersionAfterUpdate;
   readUserInstallStamp: typeof readUserInstallStamp;
   runGlobalUpdate: (installSource: string) => RunGlobalUpdateResult;
   runDeferredGlobalUpdate: typeof runDeferredGlobalUpdate;
@@ -386,6 +387,7 @@ const defaultUpdateDependencies: UpdateDependencies = {
   askYesNo,
   fetchLatestVersion,
   getCurrentVersion,
+  getInstalledVersionAfterUpdate,
   readUserInstallStamp,
   runGlobalUpdate,
   runDeferredGlobalUpdate,
@@ -475,6 +477,22 @@ export function resolveGlobalInstallRoot(
 
   const root = String(result.stdout || '').trim();
   return root === '' ? null : root;
+}
+
+async function getInstalledVersionAfterUpdate(): Promise<string | null> {
+  const globalInstallRoot = resolveGlobalInstallRoot();
+  if (!globalInstallRoot) return null;
+
+  try {
+    const packageJsonPath = join(globalInstallRoot, PACKAGE_NAME, 'package.json');
+    const content = await readFile(packageJsonPath, 'utf-8');
+    const pkg = JSON.parse(content) as PackageManifest;
+    return typeof pkg.version === 'string' && pkg.version.trim() !== ''
+      ? pkg.version
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 export async function resolveInstalledCliEntry(globalInstallRoot: string): Promise<string | null> {
@@ -660,9 +678,16 @@ async function executeUpdate(
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
 
-  const stampVersion = channelConfig.channel === 'stable' ? (latest ?? current) : current;
+  const installedVersion = await dependencies.getInstalledVersionAfterUpdate();
+  const stampVersion = channelConfig.channel === 'stable'
+    ? (latest ?? installedVersion ?? current)
+    : installedVersion;
   if (stampVersion) {
     await writeSuccessfulInstallStamp(stampVersion);
+  } else if (channelConfig.channel === 'dev') {
+    console.log(
+      '[omx] Dev update completed, but the installed package version could not be determined for the setup stamp.',
+    );
   }
   const versionSummary = channelConfig.channel === 'stable' && latest
     ? ` to v${latest}`

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -41,6 +41,13 @@ export interface UpdateExecutionResult {
   latestVersion: string | null;
 }
 
+export type UpdateChannel = 'stable' | 'dev';
+
+export interface UpdateChannelConfig {
+  channel: UpdateChannel;
+  installSource: string;
+}
+
 type RunGlobalUpdateResult = { ok: boolean; stderr: string };
 type RunSetupRefreshResult = { ok: boolean; stderr: string };
 type RunDeferredUpdateResult = { ok: boolean; stderr: string; logPath?: string };
@@ -51,6 +58,15 @@ export type AutoUpdateMode = 'disabled' | 'prompt' | 'defer';
 
 const PACKAGE_NAME = 'oh-my-codex';
 const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12h
+const STABLE_INSTALL_SOURCE = `${PACKAGE_NAME}@latest`;
+const DEV_INSTALL_SOURCE = 'github:Yeachan-Heo/oh-my-codex#dev';
+
+export function resolveUpdateChannelConfig(channel: UpdateChannel = 'stable'): UpdateChannelConfig {
+  if (channel === 'dev') {
+    return { channel: 'dev', installSource: DEV_INSTALL_SOURCE };
+  }
+  return { channel: 'stable', installSource: STABLE_INSTALL_SOURCE };
+}
 
 export function resolveAutoUpdateMode(value = process.env.OMX_AUTO_UPDATE): AutoUpdateMode {
   const normalized = (value ?? '').trim().toLowerCase();
@@ -157,11 +173,27 @@ function spawnNpmSync(
 }
 
 export function runGlobalUpdate(
-  spawnProcess: SpawnSyncLike = spawnSync,
+  installSourceOrSpawnProcess: string | SpawnSyncLike = STABLE_INSTALL_SOURCE,
+  spawnProcessOrPlatform: SpawnSyncLike | NodeJS.Platform = spawnSync,
   platform: NodeJS.Platform = process.platform,
 ): RunGlobalUpdateResult {
+  const legacySpawnFirst = typeof installSourceOrSpawnProcess === 'function';
+  const installSource = legacySpawnFirst ? STABLE_INSTALL_SOURCE : installSourceOrSpawnProcess;
+  const spawnProcess = legacySpawnFirst
+    ? installSourceOrSpawnProcess
+    : typeof spawnProcessOrPlatform === 'function'
+      ? spawnProcessOrPlatform
+      : spawnSync;
+  const resolvedPlatform = legacySpawnFirst
+    ? typeof spawnProcessOrPlatform === 'string'
+      ? spawnProcessOrPlatform
+      : platform
+    : typeof spawnProcessOrPlatform === 'string'
+      ? spawnProcessOrPlatform
+      : platform;
+
   const result = spawnNpmSync(
-    ['install', '-g', `${PACKAGE_NAME}@latest`],
+    ['install', '-g', installSource],
     {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -169,7 +201,7 @@ export function runGlobalUpdate(
       windowsHide: true,
     },
     spawnProcess,
-    platform,
+    resolvedPlatform,
   );
 
   if (result.error) {
@@ -314,13 +346,17 @@ function formatDeferredUpdateFailure(stderr: string, logPath?: string): string {
   ].filter((line): line is string => typeof line === 'string').join('\n');
 }
 
-function summarizeUpdateFailure(stderr: string, logPath?: string): string {
+function summarizeUpdateFailure(
+  stderr: string,
+  installSource = STABLE_INSTALL_SOURCE,
+  logPath?: string,
+): string {
   const details = stderr.trim().split(/\r?\n/).filter(Boolean).slice(0, 3).join(' | ');
   return [
-    '[omx] Update failed while running npm install -g oh-my-codex@latest.',
+    `[omx] Update failed while running npm install -g ${installSource}.`,
     details ? `[omx] npm stderr: ${details}` : undefined,
     logPath ? `[omx] Full log: ${logPath}` : undefined,
-    '[omx] You can retry manually with: npm install -g oh-my-codex@latest && omx setup',
+    `[omx] You can retry manually with: npm install -g ${installSource} && omx setup`,
   ].filter((line): line is string => typeof line === 'string').join('\n');
 }
 
@@ -340,7 +376,7 @@ interface UpdateDependencies {
   fetchLatestVersion: typeof fetchLatestVersion;
   getCurrentVersion: typeof getCurrentVersion;
   readUserInstallStamp: typeof readUserInstallStamp;
-  runGlobalUpdate: typeof runGlobalUpdate;
+  runGlobalUpdate: (installSource: string) => RunGlobalUpdateResult;
   runDeferredGlobalUpdate: typeof runDeferredGlobalUpdate;
   runSetupRefresh: (cwd: string) => Promise<RunSetupRefreshResult>;
   writeUpdateState: typeof writeUpdateState;
@@ -519,13 +555,24 @@ async function executeUpdate(
     dependencies: UpdateDependencies;
     prompt: boolean;
     immediate: boolean;
+    channel?: UpdateChannel;
+    forceInstall?: boolean;
     nowMs?: number;
   },
 ): Promise<UpdateExecutionResult> {
-  const { cwd, dependencies, prompt, immediate, nowMs = Date.now() } = options;
+  const {
+    cwd,
+    dependencies,
+    prompt,
+    immediate,
+    channel = 'stable',
+    forceInstall = false,
+    nowMs = Date.now(),
+  } = options;
+  const channelConfig = resolveUpdateChannelConfig(channel);
   const [current, latest] = await Promise.all([
     dependencies.getCurrentVersion(),
-    dependencies.fetchLatestVersion(),
+    channel === 'stable' || !forceInstall ? dependencies.fetchLatestVersion() : Promise.resolve(null),
   ]);
 
   try {
@@ -538,14 +585,14 @@ async function executeUpdate(
     // just because the current working directory is read-only or unavailable.
   }
 
-  if (!current || !latest) {
+  if (!forceInstall && (!current || !latest)) {
     if (immediate) {
       console.log('[omx] Unable to determine the latest oh-my-codex version. Try again later.');
     }
     return { status: 'unavailable', currentVersion: current, latestVersion: latest };
   }
 
-  if (!isNewerVersion(current, latest)) {
+  if (!forceInstall && current && latest && !isNewerVersion(current, latest)) {
     if (immediate) {
       const installStamp = await dependencies.readUserInstallStamp();
       if (!doesSetupStampMatchVersion(current, installStamp)) {
@@ -595,11 +642,13 @@ async function executeUpdate(
     return { status: 'scheduled', currentVersion: current, latestVersion: latest };
   }
 
-  console.log(`[omx] Running: npm install -g ${PACKAGE_NAME}@latest`);
-  const result = dependencies.runGlobalUpdate();
+  console.log(`[omx] Selected update channel: ${channelConfig.channel}`);
+  console.log(`[omx] Install source: ${channelConfig.installSource}`);
+  console.log(`[omx] Running: npm install -g ${channelConfig.installSource}`);
+  const result = dependencies.runGlobalUpdate(channelConfig.installSource);
 
   if (!result.ok) {
-    console.log(summarizeUpdateFailure(result.stderr));
+    console.log(summarizeUpdateFailure(result.stderr, channelConfig.installSource));
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
 
@@ -611,14 +660,23 @@ async function executeUpdate(
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
 
-  await writeSuccessfulInstallStamp(latest);
-  console.log(`[omx] Updated to v${latest}. Restart to use new code.`);
+  const stampVersion = channelConfig.channel === 'stable' ? (latest ?? current) : current;
+  if (stampVersion) {
+    await writeSuccessfulInstallStamp(stampVersion);
+  }
+  const versionSummary = channelConfig.channel === 'stable' && latest
+    ? ` to v${latest}`
+    : '';
+  console.log(
+    `[omx] Updated ${channelConfig.channel} channel${versionSummary}. Restart to use new code.`,
+  );
   return { status: 'updated', currentVersion: current, latestVersion: latest };
 }
 
 export async function runImmediateUpdate(
   cwd = process.cwd(),
   dependencies: Partial<UpdateDependencies> = {},
+  options: { channel?: UpdateChannel } = {},
 ): Promise<UpdateExecutionResult> {
   const updateDependencies = { ...defaultUpdateDependencies, ...dependencies };
   return executeUpdate({
@@ -626,6 +684,8 @@ export async function runImmediateUpdate(
     dependencies: updateDependencies,
     prompt: false,
     immediate: true,
+    channel: options.channel ?? 'stable',
+    forceInstall: true,
   });
 }
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -23,6 +23,9 @@ export interface UpdateState {
 export interface UserInstallStamp {
   installed_version: string;
   setup_completed_version?: string;
+  install_channel?: UpdateChannel;
+  install_source?: string;
+  install_revision?: string;
   updated_at: string;
 }
 
@@ -376,6 +379,7 @@ interface UpdateDependencies {
   fetchLatestVersion: typeof fetchLatestVersion;
   getCurrentVersion: typeof getCurrentVersion;
   getInstalledVersionAfterUpdate: typeof getInstalledVersionAfterUpdate;
+  getInstalledRevisionAfterUpdate: typeof getInstalledRevisionAfterUpdate;
   readUserInstallStamp: typeof readUserInstallStamp;
   runGlobalUpdate: (installSource: string) => RunGlobalUpdateResult;
   runDeferredGlobalUpdate: typeof runDeferredGlobalUpdate;
@@ -388,6 +392,7 @@ const defaultUpdateDependencies: UpdateDependencies = {
   fetchLatestVersion,
   getCurrentVersion,
   getInstalledVersionAfterUpdate,
+  getInstalledRevisionAfterUpdate,
   readUserInstallStamp,
   runGlobalUpdate,
   runDeferredGlobalUpdate,
@@ -401,10 +406,18 @@ function stripLeadingV(version: string): string {
 
 async function writeSuccessfulInstallStamp(
   installedVersion: string,
+  metadata: {
+    channel?: UpdateChannel;
+    source?: string;
+    revision?: string | null;
+  } = {},
 ): Promise<void> {
   await writeUserInstallStamp({
     installed_version: stripLeadingV(installedVersion),
     setup_completed_version: stripLeadingV(installedVersion),
+    ...(metadata.channel ? { install_channel: metadata.channel } : {}),
+    ...(metadata.source ? { install_source: metadata.source } : {}),
+    ...(metadata.revision ? { install_revision: metadata.revision } : {}),
     updated_at: new Date().toISOString(),
   });
 }
@@ -423,6 +436,15 @@ export async function readUserInstallStamp(
       installed_version: parsed.installed_version,
       ...(typeof parsed.setup_completed_version === 'string'
         ? { setup_completed_version: parsed.setup_completed_version }
+        : {}),
+      ...(parsed.install_channel === 'stable' || parsed.install_channel === 'dev'
+        ? { install_channel: parsed.install_channel }
+        : {}),
+      ...(typeof parsed.install_source === 'string'
+        ? { install_source: parsed.install_source }
+        : {}),
+      ...(typeof parsed.install_revision === 'string'
+        ? { install_revision: parsed.install_revision }
         : {}),
       updated_at: parsed.updated_at,
     };
@@ -490,6 +512,21 @@ async function getInstalledVersionAfterUpdate(): Promise<string | null> {
     return typeof pkg.version === 'string' && pkg.version.trim() !== ''
       ? pkg.version
       : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getInstalledRevisionAfterUpdate(): Promise<string | null> {
+  const globalInstallRoot = resolveGlobalInstallRoot();
+  if (!globalInstallRoot) return null;
+
+  try {
+    const packageJsonPath = join(globalInstallRoot, PACKAGE_NAME, 'package.json');
+    const content = await readFile(packageJsonPath, 'utf-8');
+    const pkg = JSON.parse(content) as { gitHead?: string };
+    const revision = typeof pkg.gitHead === 'string' ? pkg.gitHead.trim() : '';
+    return /^[0-9a-f]{7,40}$/i.test(revision) ? revision.slice(0, 12) : null;
   } catch {
     return null;
   }
@@ -679,11 +716,18 @@ async function executeUpdate(
   }
 
   const installedVersion = await dependencies.getInstalledVersionAfterUpdate();
+  const installedRevision = channelConfig.channel === 'dev'
+    ? await dependencies.getInstalledRevisionAfterUpdate()
+    : null;
   const stampVersion = channelConfig.channel === 'stable'
     ? (latest ?? installedVersion ?? current)
     : installedVersion;
   if (stampVersion) {
-    await writeSuccessfulInstallStamp(stampVersion);
+    await writeSuccessfulInstallStamp(stampVersion, {
+      channel: channelConfig.channel,
+      source: channelConfig.installSource,
+      revision: channelConfig.channel === 'dev' ? installedRevision : null,
+    });
   } else if (channelConfig.channel === 'dev') {
     console.log(
       '[omx] Dev update completed, but the installed package version could not be determined for the setup stamp.',

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,16 +1,12 @@
-import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { resolveOmxDisplayVersionSync } from '../utils/version.js';
 
 export function version(): void {
-  try {
-    const __filename = fileURLToPath(import.meta.url);
-    const pkgPath = join(dirname(__filename), '..', '..', 'package.json');
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    console.log(`oh-my-codex v${pkg.version}`);
+  const displayVersion = resolveOmxDisplayVersionSync();
+  if (displayVersion) {
+    console.log(`oh-my-codex ${displayVersion}`);
     console.log(`Node.js ${process.version}`);
     console.log(`Platform: ${process.platform} ${process.arch}`);
-  } catch {
+  } else {
     console.log('oh-my-codex (version unknown)');
   }
 }

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -5,11 +5,10 @@
  */
 
 import { readFile } from 'fs/promises';
-import { readFileSync } from 'fs';
 import { execFileSync } from 'child_process';
-import { join, dirname, basename } from 'path';
-import { fileURLToPath } from 'url';
+import { join, basename } from 'path';
 import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
+import { resolveOmxDisplayVersionSync } from '../utils/version.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
 import { getBaseStateDir, getStateFilePath, readCurrentSessionId, resolveRuntimeStateScope } from '../mcp/state-paths.js';
@@ -276,14 +275,7 @@ export async function readHudConfig(cwd: string): Promise<ResolvedHudConfig> {
 }
 
 export function readVersion(): string | null {
-  try {
-    const __filename = fileURLToPath(import.meta.url);
-    const pkgPath = join(dirname(__filename), '..', '..', 'package.json');
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    return `v${pkg.version}`;
-  } catch {
-    return null;
-  }
+  return resolveOmxDisplayVersionSync();
 }
 
 export type GitRunner = (cwd: string, args: string[]) => string | null;

--- a/src/scripts/prepare-build.js
+++ b/src/scripts/prepare-build.js
@@ -9,7 +9,7 @@ const requiredDistFiles = [
 ];
 
 if (requiredDistFiles.every((file) => existsSync(file))) {
-  console.log('[omx prepare] dist already present; skipping build');
+  console.log('omx prepare: dist already present; skipping build');
   process.exit(0);
 }
 
@@ -21,7 +21,7 @@ const result = spawnSync(npmBin, ['run', 'build'], {
 });
 
 if (result.error) {
-  console.error(`[omx prepare] failed to launch npm build: ${result.error.message}`);
+  console.error(`omx prepare: failed to launch npm build: ${result.error.message}`);
   process.exit(1);
 }
 

--- a/src/scripts/prepare-build.js
+++ b/src/scripts/prepare-build.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const requiredDistFiles = [
+  join(process.cwd(), 'dist', 'cli', 'omx.js'),
+  join(process.cwd(), 'dist', 'scripts', 'postinstall.js'),
+];
+
+if (requiredDistFiles.every((file) => existsSync(file))) {
+  console.log('[omx prepare] dist already present; skipping build');
+  process.exit(0);
+}
+
+const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const result = spawnSync(npmBin, ['run', 'build'], {
+  cwd: process.cwd(),
+  stdio: 'inherit',
+  env: process.env,
+});
+
+if (result.error) {
+  console.error(`[omx prepare] failed to launch npm build: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(typeof result.status === 'number' ? result.status : 1);

--- a/src/scripts/prepare-build.js
+++ b/src/scripts/prepare-build.js
@@ -9,14 +9,13 @@ const requiredDistFiles = [
 ];
 
 if (requiredDistFiles.every((file) => existsSync(file))) {
-  console.log('omx prepare: dist already present; skipping build');
   process.exit(0);
 }
 
 const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const result = spawnSync(npmBin, ['run', 'build'], {
   cwd: process.cwd(),
-  stdio: 'inherit',
+  stdio: process.env.npm_config_json === 'true' ? ['inherit', 'ignore', 'inherit'] : 'inherit',
   env: process.env,
 });
 

--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveOmxDisplayVersionSync } from '../version.js';
+
+async function withVersionFixture(
+  run: (fixture: { packageRoot: string; stampPath: string }) => Promise<void> | void,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'omx-version-fixture-'));
+  try {
+    await mkdir(join(root, 'pkg'), { recursive: true });
+    await mkdir(join(root, 'state'), { recursive: true });
+    await writeFile(join(root, 'pkg', 'package.json'), JSON.stringify({ version: '0.18.8' }, null, 2));
+    await run({ packageRoot: join(root, 'pkg'), stampPath: join(root, 'state', 'install-state.json') });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+describe('resolveOmxDisplayVersionSync', () => {
+  it('returns a plain release version when no current dev install stamp is present', async () => {
+    await withVersionFixture(({ packageRoot, stampPath }) => {
+      assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.8');
+    });
+  });
+
+  it('adds dev revision from the current dev install stamp', async () => {
+    await withVersionFixture(async ({ packageRoot, stampPath }) => {
+      await writeFile(stampPath, JSON.stringify({
+        installed_version: '0.18.8',
+        setup_completed_version: '0.18.8',
+        install_channel: 'dev',
+        install_source: 'github:Yeachan-Heo/oh-my-codex#dev',
+        install_revision: 'abcdef1234567890',
+        updated_at: '2026-06-02T00:00:00.000Z',
+      }, null, 2));
+
+      assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.8-dev-abcdef123456');
+    });
+  });
+
+  it('does not apply stale dev stamp metadata to a different package version', async () => {
+    await withVersionFixture(async ({ packageRoot, stampPath }) => {
+      await writeFile(stampPath, JSON.stringify({
+        installed_version: '0.18.7',
+        setup_completed_version: '0.18.7',
+        install_channel: 'dev',
+        install_revision: 'abcdef123456',
+        updated_at: '2026-06-02T00:00:00.000Z',
+      }, null, 2));
+
+      assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.8');
+    });
+  });
+});

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { getPackageRoot } from './package.js';
+import { omxUserInstallStampPath } from './paths.js';
+
+interface PackageVersionMetadata {
+  version?: string;
+}
+
+interface InstallVersionMetadata {
+  installed_version?: string;
+  setup_completed_version?: string;
+  install_channel?: string;
+  install_revision?: string;
+}
+
+function stripLeadingV(version: string): string {
+  return version.trim().replace(/^v/i, '');
+}
+
+function shortRevision(value: string | null | undefined): string | null {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  if (!/^[0-9a-f]{7,40}$/i.test(normalized)) return null;
+  return normalized.slice(0, 12);
+}
+
+function readJsonFile(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function readPackageVersion(packageRoot = getPackageRoot()): string | null {
+  const pkg = readJsonFile(join(packageRoot, 'package.json')) as PackageVersionMetadata | null;
+  return typeof pkg?.version === 'string' && pkg.version.trim() !== ''
+    ? stripLeadingV(pkg.version)
+    : null;
+}
+
+function readInstallVersionMetadata(stampPath = omxUserInstallStampPath()): InstallVersionMetadata | null {
+  return readJsonFile(stampPath) as InstallVersionMetadata | null;
+}
+
+function readGitRevision(packageRoot: string): string | null {
+  try {
+    return shortRevision(execFileSync('git', ['rev-parse', '--short=12', 'HEAD'], {
+      cwd: packageRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 3000,
+    }));
+  } catch {
+    return null;
+  }
+}
+
+export function resolveOmxDisplayVersionSync(options: {
+  packageRoot?: string;
+  stampPath?: string;
+  env?: NodeJS.ProcessEnv;
+} = {}): string | null {
+  const packageRoot = options.packageRoot ?? getPackageRoot();
+  const version = readPackageVersion(packageRoot);
+  if (!version) return null;
+
+  const env = options.env ?? process.env;
+  const explicitRevision = shortRevision(env.OMX_VERSION_REVISION || env.OMX_GIT_REVISION);
+  const stamp = readInstallVersionMetadata(options.stampPath);
+  const stampVersion = typeof stamp?.setup_completed_version === 'string'
+    ? stripLeadingV(stamp.setup_completed_version)
+    : typeof stamp?.installed_version === 'string'
+      ? stripLeadingV(stamp.installed_version)
+      : '';
+  const isCurrentDevInstall = stamp?.install_channel === 'dev' && stampVersion === version;
+  if (isCurrentDevInstall) {
+    const revision = shortRevision(stamp.install_revision) ?? explicitRevision ?? readGitRevision(packageRoot);
+    return revision ? `v${version}-dev-${revision}` : `v${version}-dev`;
+  }
+
+  return `v${version}`;
+}

--- a/src/verification/__tests__/dev-merge-issue-close-workflow.test.ts
+++ b/src/verification/__tests__/dev-merge-issue-close-workflow.test.ts
@@ -7,9 +7,11 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const {
   buildMaintainerCloseComment,
+  buildMaintainerPrComment,
   collectLinkedLocalIssueNumbers,
 } = require(join(process.cwd(), '.github', 'scripts', 'dev-merge-issue-close.cjs')) as {
   buildMaintainerCloseComment: ({ prNumber }: { prNumber: number }) => string;
+  buildMaintainerPrComment: ({ issueNumbers }: { issueNumbers: number[] }) => string;
   collectLinkedLocalIssueNumbers: (input: {
     title?: string;
     body?: string;
@@ -32,6 +34,9 @@ describe('dev merge issue close workflow', () => {
     assert.match(workflow, /require\('\.\/\.github\/scripts\/dev-merge-issue-close\.cjs'\)/);
     assert.match(workflow, /title:\s*pullRequest\.title/);
     assert.match(workflow, /body:\s*pullRequest\.body/);
+    assert.match(workflow, /buildMaintainerPrComment/);
+    assert.match(workflow, /issue_number:\s*pullRequest\.number/);
+    assert.match(workflow, /issueNumbers:\s*closedIssueNumbers/);
     assert.doesNotMatch(workflow, /commit/i);
     assert.doesNotMatch(workflow, /discussion/i);
   });
@@ -81,6 +86,17 @@ describe('dev merge issue close workflow', () => {
     );
     assert.match(comment, /A hot-fix build is available now\./);
     assert.match(comment, /`omx update --dev`/);
+    assert.match(comment, /let us know whether it resolves the issue/);
+  });
+
+  it('provides a matching PR summary comment after linked issues close', () => {
+    const comment = buildMaintainerPrComment({ issueNumbers: [1540, 1541] });
+    assert.match(
+      comment,
+      /Closed explicitly linked issues after this PR was merged into `dev`: #1540, #1541\./,
+    );
+    assert.match(comment, /A hot-fix build is available now\./);
+    assert.match(comment, /Issue creators can try it with `omx update --dev`/);
     assert.match(comment, /let us know whether it resolves the issue/);
   });
 });

--- a/src/verification/__tests__/dev-merge-issue-close-workflow.test.ts
+++ b/src/verification/__tests__/dev-merge-issue-close-workflow.test.ts
@@ -74,9 +74,13 @@ describe('dev merge issue close workflow', () => {
       }),
       [1540],
     );
-    assert.equal(
-      buildMaintainerCloseComment({ prNumber: 1550 }),
-      'Closing automatically because PR #1550 was merged into `dev` and explicitly referenced this issue in the PR title or body.',
+    const comment = buildMaintainerCloseComment({ prNumber: 1550 });
+    assert.match(
+      comment,
+      /Closing automatically because PR #1550 was merged into `dev` and explicitly referenced this issue in the PR title or body\./,
     );
+    assert.match(comment, /A hot-fix build is available now\./);
+    assert.match(comment, /`omx update --dev`/);
+    assert.match(comment, /let us know whether it resolves the issue/);
   });
 });


### PR DESCRIPTION
## Summary
- Adds explicit `omx update` channels:
  - `omx update` and `omx update --stable` select the stable channel and install `npm install -g oh-my-codex@latest`.
  - `omx update --dev` selects the dev channel and installs `npm install -g github:Yeachan-Heo/oh-my-codex#dev`.
- Keeps passive startup update checks stable-only, version-gated, and deferred/prompted as before.
- Runs the existing post-install setup refresh for both explicit channels, preserving persisted setup preferences (scope, plugin/legacy mode, MCP mode, team mode).
- Rejects `--dev --stable` combination and unknown `omx update` flags before install/setup can run.
- Updates the dev-merge linked issue close comment to tell users a hot-fix build is available and to try `omx update --dev`, while preserving explicit issue-link safety and close behavior.

## Verification
- Pre-rebase Autopilot verification:
  - `npm run build` ✅
  - Targeted compiled tests ✅ `308/308`
  - Help smoke ✅
  - Invalid-flag fail-fast smoke with fake npm ✅ no npm invocation
  - Code-review gate ✅ `APPROVE` / architectural status `CLEAR`
  - UltraQA gate ✅ `PASS`
- Post-rebase onto latest `origin/dev` (`2fc7d49d`):
  - `npm run build` ✅
  - `node dist/scripts/run-test-files.js dist/cli/__tests__/update.test.js dist/cli/__tests__/index.test.js dist/verification/__tests__/dev-merge-issue-close-workflow.test.js` ✅ `311/311`
    - Note: latest `dev` added direct npm spawn fallback tests, increasing the targeted count from 308 to 311.
  - `node dist/cli/omx.js --help | grep -A4 -E 'omx update'` ✅ shows stable/dev channel help
  - Fake-npm invalid flag smoke: `node dist/cli/omx.js update --beta` ✅ exit 1, clear unknown-option error, no npm invocation

## Rebase
- Rebasing onto latest `origin/dev` surfaced conflicts in pre-existing question-renderer commits that were already upstream on `dev`; resolved by keeping the newer `dev` versions.
- Feature commit conflict in `src/cli/update.ts` was resolved by preserving latest `dev` Windows `npm.cmd` fallback behavior while threading the new explicit install source through `runGlobalUpdate`.

