### PR TITLE
Fix project-local omx resume history listing

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2160,6 +2160,44 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("includes project Codex history artifacts in the runtime mirror for resume launches", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-resume-runtime-codex-home-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await mkdir(join(projectCodexHome, "sessions", "2026", "06", "03"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      await writeFile(join(projectCodexHome, "config.toml"), 'model = "gpt-5.5"\n');
+      await writeFile(join(projectCodexHome, "state_5.sqlite"), "state db placeholder");
+      await writeFile(join(projectCodexHome, "state_5.sqlite-wal"), "state db wal placeholder");
+      await writeFile(join(projectCodexHome, "logs_2.sqlite-shm"), "logs db shm placeholder");
+      await writeFile(
+        join(projectCodexHome, "sessions", "2026", "06", "03", "rollout-session-2712.jsonl"),
+        '{"type":"session_meta","payload":{"id":"session-2712"}}\n',
+      );
+
+      const prepared = await prepareCodexHomeForLaunch(wd, "session-resume", {}, {
+        includeHistoryArtifacts: true,
+      });
+      const runtimeCodexHome = runtimeCodexHomePath(wd, "session-resume");
+
+      assert.equal(prepared.codexHomeOverride, runtimeCodexHome);
+      assert.equal(prepared.sqliteHomeOverride, projectCodexHome);
+      assert.equal(existsSync(join(runtimeCodexHome, "state_5.sqlite")), true);
+      assert.equal(existsSync(join(runtimeCodexHome, "state_5.sqlite-wal")), true);
+      assert.equal(existsSync(join(runtimeCodexHome, "logs_2.sqlite-shm")), true);
+      assert.equal(
+        existsSync(join(runtimeCodexHome, "sessions", "2026", "06", "03", "rollout-session-2712.jsonl")),
+        true,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("uses a session-scoped CODEX_HOME mirror for project launch config writes", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-runtime-codex-home-"));
     try {

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -31,6 +31,58 @@ function runOmx(
 }
 
 describe('omx resume', () => {
+  it('exposes project-local Codex history artifacts to codex resume', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-project-history-'));
+    try {
+      const home = join(wd, 'home');
+      const projectCodexHome = join(wd, '.codex');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const rolloutPath = join(projectCodexHome, 'sessions', '2026', '06', '03', 'rollout-session-2712.jsonl');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await mkdir(dirname(rolloutPath), { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(join(projectCodexHome, 'config.toml'), 'model = "gpt-5.5"\n');
+      await writeFile(join(projectCodexHome, 'state_5.sqlite'), 'state db placeholder');
+      await writeFile(join(projectCodexHome, 'state_5.sqlite-wal'), 'state db wal placeholder');
+      await writeFile(rolloutPath, '{"type":"session_meta","payload":{"id":"session-2712"}}\n');
+
+      await writeFile(fakeCodexPath, `#!/bin/sh
+printf 'fake-codex:%s\n' "$*"
+printf 'codex-home:%s\n' "$CODEX_HOME"
+printf 'sqlite-home:%s\n' "$CODEX_SQLITE_HOME"
+if [ -f "$CODEX_HOME/state_5.sqlite" ]; then echo state-present=yes; else echo state-present=no; fi
+if [ -f "$CODEX_HOME/state_5.sqlite-wal" ]; then echo wal-present=yes; else echo wal-present=no; fi
+if [ -f "$CODEX_HOME/sessions/2026/06/03/rollout-session-2712.jsonl" ]; then echo rollout-present=yes; else echo rollout-present=no; fi
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:resume\b/);
+      assert.match(result.stdout, new RegExp(`sqlite-home:${projectCodexHome.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(result.stdout, /codex-home:.*\.omx\/runtime\/codex-home\//);
+      assert.match(result.stdout, /state-present=yes/);
+      assert.match(result.stdout, /wal-present=yes/);
+      assert.match(result.stdout, /rollout-present=yes/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('forwards --last to codex resume through the normal launch wrapper', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-resume-cli-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -846,10 +846,15 @@ export async function persistProjectLaunchRuntimeAuthState(
  * Launch against a session mirror so those runtime writes never dirty the
  * durable project config while preserving the project config as the launch input.
  */
+export interface PrepareRuntimeCodexHomeForProjectLaunchOptions {
+  includeHistoryArtifacts?: boolean;
+}
+
 export async function prepareRuntimeCodexHomeForProjectLaunch(
   cwd: string,
   sessionId: string,
   projectCodexHome: string,
+  options: PrepareRuntimeCodexHomeForProjectLaunchOptions = {},
 ): Promise<string> {
   const runtimeCodexHome = runtimeCodexHomePath(cwd, sessionId);
   await rm(runtimeCodexHome, { recursive: true, force: true });
@@ -858,7 +863,7 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
   if (!existsSync(projectCodexHome)) return runtimeCodexHome;
 
   for (const entry of await readdir(projectCodexHome, { withFileTypes: true })) {
-    if (isCodexSqliteArtifact(entry.name)) continue;
+    if (isCodexSqliteArtifact(entry.name) && !options.includeHistoryArtifacts) continue;
     if (PROJECT_LAUNCH_RUNTIME_SKIPPED_ENTRY_NAMES.has(entry.name)) continue;
     const source = join(projectCodexHome, entry.name);
     const destination = join(runtimeCodexHome, entry.name);
@@ -890,10 +895,15 @@ function resolveProjectSqliteHomeForLaunch(
   return projectCodexHome;
 }
 
+export interface PrepareCodexHomeForLaunchOptions {
+  includeHistoryArtifacts?: boolean;
+}
+
 export async function prepareCodexHomeForLaunch(
   cwd: string,
   sessionId: string,
   env: NodeJS.ProcessEnv = process.env,
+  options: PrepareCodexHomeForLaunchOptions = {},
 ): Promise<PreparedCodexHomeForLaunch> {
   const projectLocalCodexHomeForCleanup = resolveProjectLocalCodexHomeForLaunch(cwd, env);
   if (projectLocalCodexHomeForCleanup) {
@@ -901,6 +911,7 @@ export async function prepareCodexHomeForLaunch(
       cwd,
       sessionId,
       projectLocalCodexHomeForCleanup,
+      { includeHistoryArtifacts: options.includeHistoryArtifacts },
     );
     return {
       codexHomeOverride: runtimeCodexHome,
@@ -2356,7 +2367,9 @@ export async function launchWithHud(args: string[]): Promise<void> {
     // Non-fatal: repair failure must not block launch
   }
 
-  const preparedCodexHome = await prepareCodexHomeForLaunch(launchCwd, sessionId, process.env);
+  const preparedCodexHome = await prepareCodexHomeForLaunch(launchCwd, sessionId, process.env, {
+    includeHistoryArtifacts: normalizedArgs[0] === "resume",
+  });
   const codexHomeOverride = preparedCodexHome.codexHomeOverride;
   const sqliteHomeOverride = preparedCodexHome.sqliteHomeOverride;
   const projectLocalCodexHomeForCleanup = preparedCodexHome.projectLocalCodexHomeForCleanup;


### PR DESCRIPTION
## Summary
- Keep project-scope launch isolation intact, but opt `omx resume` into mirroring durable Codex history artifacts into the session runtime `CODEX_HOME`.
- Add a project-local regression proving the fake `codex resume` launch sees `.codex` rollout history plus `state_*.sqlite` / WAL artifacts through the runtime mirror.
- Add a unit regression for the resume-specific runtime Codex home preparation path.

## Root cause
Project-local setup stores durable Codex history/index files under `<project>/.codex`, while normal OMX launches use a session-scoped runtime mirror at `.omx/runtime/codex-home/<session>` to avoid dirtying project config. The existing mirror intentionally skipped Codex sqlite artifacts, which made `codex resume` run with a `CODEX_HOME` that could be missing the durable resume index/history data.

## Validation
- `npm ci`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/resume.test.js dist/cli/__tests__/index.test.js`
- `npm run lint`
- `npm run check:no-unused`

## Notes
- Global installs and explicit `CODEX_HOME` overrides keep the previous behavior.
- Ordinary project launches still skip sqlite artifacts; only `omx resume` opts into history artifact mirroring.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*