### PR TITLE
Route worker Stop nudges as team steering

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -9082,7 +9082,7 @@ exit 0
     }
   });
 
-  it("queues worker Stop leader nudge with Tab and submit when leader pane is busy", async () => {
+  it("steers worker Stop leader nudge directly when leader pane is busy", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-busy-leader-"));
     const prevTeamWorker = process.env.OMX_TEAM_WORKER;
     const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
@@ -9155,14 +9155,11 @@ exit 0
       assert.equal(result.outputJson, null);
       const tmuxLog = await readFile(tmuxLogPath, "utf-8");
       assert.match(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-1 native Stop allowed/);
-      assert.match(tmuxLog, /send-keys -t %42 Tab/);
-      assert.match(tmuxLog, /send-keys -t %42 C-m/);
-      assert.ok(
-        tmuxLog.indexOf("send-keys -t %42 Tab") < tmuxLog.indexOf("send-keys -t %42 C-m"),
-        "busy worker-stop nudge should press Tab before C-m",
-      );
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 Tab/);
+      const submits = tmuxLog.match(/send-keys -t %42 C-m/g) || [];
+      assert.equal(submits.length, 2, "busy worker-stop nudge should submit directly as steering, not queue via Tab");
       const nudgeState = JSON.parse(await readFile(join(workerDir, "worker-stop-nudge.json"), "utf-8"));
-      assert.equal(nudgeState.delivery, "queued");
+      assert.equal(nudgeState.delivery, "steered");
     } finally {
       if (typeof prevTeamWorker === "string") process.env.OMX_TEAM_WORKER = prevTeamWorker;
       else delete process.env.OMX_TEAM_WORKER;
@@ -9298,6 +9295,14 @@ exit 0
       });
       assert.equal(shutdownResult.result, "team_state_gone_or_shutdown");
       assert.equal(existsSync(join(stateDir, "team", "shutdown-team", "worker-stop-nudge.json")), false);
+      const deliveryLogPath = join(logsDir, `team-delivery-${new Date().toISOString().split("T")[0]}.jsonl`);
+      const deliveryEvents = (await readFile(deliveryLogPath, "utf-8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      const suppressedEvents = deliveryEvents.filter((event) => event.reason === "team_state_gone_or_shutdown");
+      assert.equal(suppressedEvents.length, 2, "late closed-team Stop nudges should be diagnostics, not queued prompts");
+      assert.equal(suppressedEvents.every((event) => event.result === "suppressed" && event.transport === "none"), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -9338,13 +9343,13 @@ exit 0
         workerContext: { teamName, workerName: "worker-2" },
       });
 
-      assert.equal(result.result, "queued");
+      assert.equal(result.result, "steered");
       const tmuxLog = await readFile(tmuxLogPath, "utf-8");
       assert.match(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-2 native Stop allowed/);
-      assert.match(tmuxLog, /send-keys -t %42 Tab/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 Tab/);
       const teamNudgeState = JSON.parse(await readFile(join(teamDir, "worker-stop-nudge.json"), "utf-8"));
       assert.equal(teamNudgeState.worker, "worker-2");
-      assert.equal(teamNudgeState.delivery, "queued");
+      assert.equal(teamNudgeState.delivery, "steered");
     } finally {
       if (typeof prevPath === "string") process.env.PATH = prevPath;
       else delete process.env.PATH;
@@ -9477,6 +9482,21 @@ exit 0
       assert.equal(existsSync(teamDir), false, "deferred worker Stop recording must not recreate removed team state");
       const tmuxLog = await readFile(tmuxLogPath, "utf-8");
       assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-1 native Stop allowed/);
+      const deliveryLogPath = join(logsDir, `team-delivery-${new Date().toISOString().split("T")[0]}.jsonl`);
+      const deliveryEvents = (await readFile(deliveryLogPath, "utf-8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      assert.equal(
+        deliveryEvents.some((event) =>
+          event.team === teamName
+          && event.result === "suppressed"
+          && event.transport === "none"
+          && event.reason === "team_state_gone_or_shutdown"
+        ),
+        true,
+        "teardown-race worker Stop nudges should be diagnostic suppression events, not queued prompts",
+      );
     } finally {
       if (typeof prevPath === "string") process.env.PATH = prevPath;
       else delete process.env.PATH;

--- a/src/scripts/notify-hook/team-worker-stop.ts
+++ b/src/scripts/notify-hook/team-worker-stop.ts
@@ -14,7 +14,7 @@ import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
 import { safeString, asNumber, isTerminalPhase } from './utils.js';
 import { readJsonIfExists } from './state-io.js';
 import { logTmuxHookEvent } from './log.js';
-import { evaluatePaneInjectionReadiness, queuePaneInput, sendPaneInput } from './team-tmux-guard.js';
+import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import { resolvePaneTarget } from './tmux-injection.js';
 import { readTeamWorkersForIdleCheck } from './team-worker.js';
 
@@ -147,6 +147,35 @@ async function resolveCanonicalLeaderPaneId(leaderPaneId) {
   return normalizedLeaderPaneId;
 }
 
+async function recordSuppressedWorkerStopNudge({
+  logsDir,
+  teamName,
+  workerName,
+  reason,
+}) {
+  const nowIso = new Date().toISOString();
+  await logTmuxHookEvent(logsDir, {
+    timestamp: nowIso,
+    type: 'worker_stop_leader_nudge_suppressed',
+    team: teamName,
+    worker: workerName,
+    to_worker: 'leader-fixed',
+    reason,
+    tmux_injection_attempted: false,
+    source_type: SOURCE_TYPE,
+  }).catch(() => {});
+  await appendTeamDeliveryLog(logsDir, {
+    event: 'nudge_triggered',
+    source: SOURCE_TYPE,
+    team: teamName,
+    from_worker: workerName,
+    to_worker: 'leader-fixed',
+    transport: 'none',
+    result: 'suppressed',
+    reason,
+  }).catch(() => {});
+}
+
 async function recordDeferred({
   stateDir,
   logsDir,
@@ -229,18 +258,34 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
   };
   let tmuxSession = '';
   let leaderPaneId = '';
+  let recordedShutdownSuppression = false;
+  const recordShutdownSuppressionOnce = async () => {
+    if (recordedShutdownSuppression) return;
+    recordedShutdownSuppression = true;
+    await recordSuppressedWorkerStopNudge({
+      logsDir,
+      teamName,
+      workerName,
+      reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
+    });
+  };
 
   if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+    await recordShutdownSuppressionOnce();
     return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
   }
 
   const lock = await acquireTeamStopNudgeLock(teamDir, nowMs, cooldownMs);
   if (!lock.acquired) {
+    if (lock.reason === TEAM_SHUTDOWN_NO_INJECTION_REASON) {
+      await recordShutdownSuppressionOnce();
+    }
     return { ok: true, result: lock.reason || TEAM_LOCK_HELD_REASON };
   }
 
   try {
     if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+      await recordShutdownSuppressionOnce();
       return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
     }
 
@@ -263,6 +308,7 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
 
   if (!tmuxTarget) {
     if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+      await recordShutdownSuppressionOnce();
       return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
     }
     await recordDeferred({
@@ -287,6 +333,7 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
   });
   if (!paneGuard.ok) {
     if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+      await recordShutdownSuppressionOnce();
       return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
     }
     await recordDeferred({
@@ -305,6 +352,7 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
   }
 
   if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+    await recordShutdownSuppressionOnce();
     return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
   }
 
@@ -314,23 +362,14 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     + DEFAULT_MARKER;
 
     const leaderHasActiveTask = paneHasActiveTask(paneGuard.paneCapture);
-    let deliveryMode = 'sent';
-    if (leaderHasActiveTask) {
-      const sendResult = await queuePaneInput({
-        paneTarget: tmuxTarget,
-        prompt,
-      });
-      if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
-      deliveryMode = 'queued';
-    } else {
-      const sendResult = await sendPaneInput({
-        paneTarget: tmuxTarget,
-        prompt,
-        submitKeyPresses: 2,
-        submitDelayMs: 100,
-      });
-      if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
-    }
+    const sendResult = await sendPaneInput({
+      paneTarget: tmuxTarget,
+      prompt,
+      submitKeyPresses: 2,
+      submitDelayMs: 100,
+    });
+    if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    const deliveryMode = leaderHasActiveTask ? 'steered' : 'sent';
 
     const deliveryState = {
       ...nextState,
@@ -376,6 +415,7 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     return { ok: true, result: deliveryMode };
   } catch (err) {
     if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
+      await recordShutdownSuppressionOnce();
       return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
     }
     // Worker Stop is already allowed before this helper runs; nudge failures are

--- a/src/team/__tests__/delivery-log.test.ts
+++ b/src/team/__tests__/delivery-log.test.ts
@@ -38,4 +38,23 @@ describe('appendTeamDeliveryLogForCwd', () => {
       await rm(box, { recursive: true, force: true });
     }
   });
+
+  it('accepts steered nudge delivery results in the shared contract', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-delivery-steered-'));
+    try {
+      await appendTeamDeliveryLogForCwd(cwd, {
+        event: 'nudge_triggered',
+        source: 'worker_stop',
+        team: 'steered-log-team',
+        transport: 'send-keys',
+        result: 'steered',
+      });
+
+      const date = new Date().toISOString().slice(0, 10);
+      const raw = await readFile(join(cwd, '.omx', 'logs', `team-delivery-${date}.jsonl`), 'utf-8');
+      assert.match(raw, /"result":"steered"/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/team/delivery-log.ts
+++ b/src/team/delivery-log.ts
@@ -24,6 +24,7 @@ export type TeamDeliveryResult =
   | 'deferred'
   | 'suppressed'
   | 'sent'
+  | 'steered'
   | 'failed';
 
 export interface TeamDeliveryLogEvent {


### PR DESCRIPTION
## Summary
- Route allowed worker Stop leader nudges as direct steering when the leader pane is already busy, avoiding the Tab/queued-follow-up path.
- Preserve existing team/worker cooldown dedupe and record closed-team late Stop nudges as suppressed diagnostics instead of prompt queue input.
- Update native hook regressions for busy leader steering, shutdown suppression diagnostics, and stale visible transcript dedupe.

Closes #2718.

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`
- `npm run check:no-unused`

---
Generated by OpenAI Codex fallback harness for issue #2718.
