### PR TITLE
Fix hook plugin runner stdin EAGAIN (#2721)

### DIFF
--- a/src/hooks/extensibility/__tests__/plugin-runner.test.ts
+++ b/src/hooks/extensibility/__tests__/plugin-runner.test.ts
@@ -17,6 +17,12 @@ function getRunnerPath(): string {
 function runRunner(
   input: Record<string, unknown>,
 ): Promise<{ stdout: string; stderr: string; code: number | null; result: Record<string, unknown> | null }> {
+  return runRunnerWithStdin([Buffer.from(JSON.stringify(input))]);
+}
+
+function runRunnerWithStdin(
+  chunks: Array<string | Buffer | Uint8Array>,
+): Promise<{ stdout: string; stderr: string; code: number | null; result: Record<string, unknown> | null }> {
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [getRunnerPath()], {
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -42,9 +48,24 @@ function runRunner(
       resolve({ stdout, stderr, code, result });
     });
 
-    child.stdin.write(JSON.stringify(input));
+    for (const chunk of chunks) {
+      child.stdin.write(chunk);
+    }
     child.stdin.end();
   });
+}
+
+function setEuroByteOffset(payload: Record<string, unknown>, targetOffset: number): Buffer {
+  const event = payload.event as { context: { padding: string } };
+  event.context.padding = '';
+  const initial = Buffer.from(JSON.stringify(payload));
+  const initialOffset = initial.indexOf(Buffer.from('€'));
+  assert.notEqual(initialOffset, -1);
+  assert.ok(initialOffset <= targetOffset, `initial euro offset ${initialOffset} exceeded target ${targetOffset}`);
+  event.context.padding = 'a'.repeat(targetOffset - initialOffset);
+  const encoded = Buffer.from(JSON.stringify(payload));
+  assert.equal(encoded.indexOf(Buffer.from('€')), targetOffset);
+  return encoded;
 }
 
 describe('plugin-runner', () => {
@@ -58,6 +79,60 @@ describe('plugin-runner', () => {
     });
 
     assert.equal(await readStdin(stream), '{"hello":"world"}');
+  });
+
+  it('preserves multibyte UTF-8 split across input chunks', async () => {
+    const encoded = Buffer.from('{"msg":"€"}');
+    const euroOffset = encoded.indexOf(Buffer.from('€'));
+    assert.notEqual(euroOffset, -1);
+
+    const input = Readable.from([
+      encoded.subarray(0, euroOffset + 1),
+      encoded.subarray(euroOffset + 1),
+    ]);
+
+    assert.equal(await readStdin(input), '{"msg":"€"}');
+  });
+
+  it('preserves dispatcher-sized UTF-8 stdin payloads when multibyte bytes cross a stream boundary', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runner-utf8-'));
+    try {
+      const pluginPath = join(cwd, 'utf8-check.mjs');
+      await writeFile(
+        pluginPath,
+        `export function onHookEvent(event) {
+          if (event.context.msg !== '€') {
+            throw new Error('expected euro, got ' + JSON.stringify(event.context.msg));
+          }
+        }`,
+      );
+
+      const payload = {
+        cwd,
+        pluginId: 'utf8-check',
+        pluginPath,
+        event: {
+          schema_version: '1',
+          event: 'session-start',
+          timestamp: new Date().toISOString(),
+          source: 'native',
+          context: { padding: '', msg: '€' },
+        },
+      };
+      const encoded = setEuroByteOffset(payload, 65_535);
+      const euroOffset = encoded.indexOf(Buffer.from('€'));
+      const { result, code } = await runRunnerWithStdin([
+        encoded.subarray(0, euroOffset + 1),
+        encoded.subarray(euroOffset + 1),
+      ]);
+
+      assert.ok(result);
+      assert.equal(result.ok, true);
+      assert.equal(result.reason, 'ok');
+      assert.equal(code, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('emits error for empty stdin', async () => {

--- a/src/hooks/extensibility/__tests__/plugin-runner.test.ts
+++ b/src/hooks/extensibility/__tests__/plugin-runner.test.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { Readable } from 'node:stream';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
+import { readStdin } from '../plugin-runner-stdin.js';
 
 const RESULT_PREFIX = '__OMX_PLUGIN_RESULT__ ';
 
@@ -46,6 +48,18 @@ function runRunner(
 }
 
 describe('plugin-runner', () => {
+  it('reads stdin through async stream iteration without touching the fd', async () => {
+    const chunks = ['  {"hello":', Buffer.from('"world"}'), '\n'];
+    const stream = Readable.from(chunks, { encoding: 'utf-8' }) as Readable & { fd: number };
+    Object.defineProperty(stream, 'fd', {
+      get() {
+        throw Object.assign(new Error('resource temporarily unavailable'), { code: 'EAGAIN' });
+      },
+    });
+
+    assert.equal(await readStdin(stream), '{"hello":"world"}');
+  });
+
   it('emits error for empty stdin', async () => {
     const { result, code } = await new Promise<{ result: Record<string, unknown> | null; code: number | null }>((resolve) => {
       const child = spawn(process.execPath, [getRunnerPath()], {
@@ -149,6 +163,44 @@ describe('plugin-runner', () => {
       assert.equal(result.reason, 'ok');
       assert.equal(result.plugin, 'valid');
       assert.equal(code, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('handles bounded concurrent piped runner requests', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runner-concurrent-'));
+    try {
+      const pluginPath = join(cwd, 'valid-concurrent.mjs');
+      await writeFile(pluginPath, 'export async function onHookEvent() {}');
+      const runs = 60;
+      const concurrency = 20;
+      let next = 0;
+      const failures: Array<{ index: number; code: number | null; result: Record<string, unknown> | null; stderr: string }> = [];
+
+      async function worker(): Promise<void> {
+        while (next < runs) {
+          const index = next++;
+          const { result, code, stderr } = await runRunner({
+            cwd,
+            pluginId: `valid-concurrent-${index}`,
+            pluginPath,
+            event: {
+              schema_version: '1',
+              event: 'session-start',
+              timestamp: new Date().toISOString(),
+              source: 'native',
+              context: { index },
+            },
+          });
+          if (code !== 0 || result?.ok !== true || result?.reason !== 'ok') {
+            failures.push({ index, code, result, stderr });
+          }
+        }
+      }
+
+      await Promise.all(Array.from({ length: concurrency }, () => worker()));
+      assert.deepEqual(failures, []);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/extensibility/plugin-runner-stdin.ts
+++ b/src/hooks/extensibility/plugin-runner-stdin.ts
@@ -1,7 +1,19 @@
+import { TextDecoder } from 'node:util';
+
 export async function readStdin(input: AsyncIterable<string | Buffer | Uint8Array> = process.stdin): Promise<string> {
+  const decoder = new TextDecoder('utf-8');
   let raw = '';
+
   for await (const chunk of input) {
-    raw += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+    if (typeof chunk === 'string') {
+      raw += decoder.decode();
+      raw += chunk;
+      continue;
+    }
+
+    raw += decoder.decode(chunk, { stream: true });
   }
+
+  raw += decoder.decode();
   return raw.trim();
 }

--- a/src/hooks/extensibility/plugin-runner-stdin.ts
+++ b/src/hooks/extensibility/plugin-runner-stdin.ts
@@ -1,0 +1,7 @@
+export async function readStdin(input: AsyncIterable<string | Buffer | Uint8Array> = process.stdin): Promise<string> {
+  let raw = '';
+  for await (const chunk of input) {
+    raw += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+  }
+  return raw.trim();
+}

--- a/src/hooks/extensibility/plugin-runner.ts
+++ b/src/hooks/extensibility/plugin-runner.ts
@@ -1,7 +1,8 @@
+import { writeSync } from 'fs';
 import { basename } from 'path';
-import { readFileSync, writeSync } from 'fs';
 import { pathToFileURL } from 'url';
 import { createHookPluginSdk } from './sdk.js';
+import { readStdin } from './plugin-runner-stdin.js';
 import type { HookEventEnvelope, HookPluginModule } from './types.js';
 
 interface RunnerRequest {
@@ -20,10 +21,6 @@ interface RunnerResult {
 }
 
 const RESULT_PREFIX = '__OMX_PLUGIN_RESULT__ ';
-
-async function readStdin(): Promise<string> {
-  return readFileSync(process.stdin.fd, 'utf-8').trim();
-}
 
 function emitResult(result: RunnerResult): void {
   writeSync(process.stdout.fd, `${RESULT_PREFIX}${JSON.stringify(result)}\n`);


### PR DESCRIPTION
## What changed
- Replaced the hook plugin runner's synchronous `process.stdin.fd` request read with async stream-based UTF-8 stdin collection before trimming and JSON parsing.
- Added a small `readStdin` helper that is unit-testable without invoking the runner entrypoint.
- Added regression coverage for avoiding fd access/EAGAIN during stdin reads plus a bounded concurrent piped-runner test.

## Tests run
- `npm ci`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/hooks/extensibility/__tests__/plugin-runner.test.js`
- `node dist/scripts/run-test-files.js dist/hooks/extensibility/__tests__`
- `npm run lint`
- `npm run check:no-unused`
- `npm run sync:plugin:check`
- `npm run verify:native-agents`
- `npm run verify:plugin-bundle`
- `git diff --check`

Closes #2721
