### PR TITLE
fix(auth): seed subscription Codex defaults

### DIFF
--- a/src/cli/__tests__/auth.test.ts
+++ b/src/cli/__tests__/auth.test.ts
@@ -77,6 +77,40 @@ describe("omx auth CLI", () => {
     }
   });
 
+  it("sets subscription Codex defaults when auth add sees empty config", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-defaults-"));
+    try {
+      const home = join(wd, "home");
+      const codexHome = join(home, ".codex");
+      const bin = join(wd, "bin");
+      await mkdir(codexHome, { recursive: true });
+      await writeFakeCodex(bin, `#!/bin/sh\nif [ "$1" = "login" ]; then mkdir -p "$CODEX_HOME"; printf '{"access_token":"sentinel-secret"}\\n' > "$CODEX_HOME/auth.json"; exit 0; fi\necho unexpected "$@" >&2\nexit 2\n`);
+      const add = runOmx(wd, ["auth", "add", "work"], { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` });
+      assert.equal(add.status, 0, add.stderr);
+      assert.match(await readFile(join(codexHome, "config.toml"), "utf-8"), /^model = "gpt-5-codex"\n+model_provider = "openai-chatgpt"\n$/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves explicit model and provider when auth add succeeds", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-preserve-defaults-"));
+    try {
+      const home = join(wd, "home");
+      const codexHome = join(home, ".codex");
+      const bin = join(wd, "bin");
+      await mkdir(codexHome, { recursive: true });
+      const originalConfig = 'model = "gpt-custom"\nmodel_provider = "custom_provider"\n[tui]\nstatus_line = []\n';
+      await writeFile(join(codexHome, "config.toml"), originalConfig);
+      await writeFakeCodex(bin, `#!/bin/sh\nif [ "$1" = "login" ]; then mkdir -p "$CODEX_HOME"; printf '{"access_token":"sentinel-secret"}\\n' > "$CODEX_HOME/auth.json"; exit 0; fi\necho unexpected "$@" >&2\nexit 2\n`);
+      const add = runOmx(wd, ["auth", "add", "work"], { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` });
+      assert.equal(add.status, 0, add.stderr);
+      assert.equal(await readFile(join(codexHome, "config.toml"), "utf-8"), originalConfig);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 
   it("adds project-scope slots from the same CODEX_HOME used by launch", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-auth-project-add-"));

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -1,9 +1,11 @@
-import { dirname } from "path";
+import { dirname, join } from "path";
+import { mkdir, readFile, writeFile } from "fs/promises";
 import { spawnPlatformCommandSync, classifySpawnError } from "../utils/platform-command.js";
 import { readAuthConfig } from "../auth/config.js";
 import { resolveLiveAuthPath } from "../auth/paths.js";
 import { redactAuthSecrets } from "../auth/redact.js";
 import { addSlotFromAuthFile, listSlots, useSlot } from "../auth/storage.js";
+import { readTopLevelTomlString, upsertTopLevelTomlString } from "../utils/toml.js";
 
 export const AUTH_HELP = `
 Usage:
@@ -18,6 +20,9 @@ Auth slots are stored under ~/.omx/auth/<slot>.json with owner-only permissions.
 function wantsJson(args: string[]): boolean {
   return args.includes("--json");
 }
+const DEFAULT_SUBSCRIPTION_MODEL = "gpt-5-codex";
+const DEFAULT_SUBSCRIPTION_MODEL_PROVIDER = "openai-chatgpt";
+
 
 function runCodexLogin(cwd: string, env: NodeJS.ProcessEnv): void {
   const { result } = spawnPlatformCommandSync("codex", ["login"], {
@@ -37,6 +42,28 @@ function runCodexLogin(cwd: string, env: NodeJS.ProcessEnv): void {
     throw new Error(`codex login exited with code ${result.status ?? 1}`);
   }
 }
+async function ensureSubscriptionCodexDefaults(codexHome: string): Promise<void> {
+  const configPath = join(codexHome, "config.toml");
+  let existing = "";
+  try {
+    existing = await readFile(configPath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  if (
+    readTopLevelTomlString(existing, "model") !== null ||
+    readTopLevelTomlString(existing, "model_provider") !== null
+  ) {
+    return;
+  }
+
+  let updated = upsertTopLevelTomlString(existing, "model", DEFAULT_SUBSCRIPTION_MODEL);
+  updated = upsertTopLevelTomlString(updated, "model_provider", DEFAULT_SUBSCRIPTION_MODEL_PROVIDER);
+  await mkdir(codexHome, { recursive: true });
+  await writeFile(configPath, updated);
+}
+
 
 export async function authCommand(args: string[], env: NodeJS.ProcessEnv = process.env): Promise<void> {
   const command = args[0];
@@ -53,6 +80,7 @@ export async function authCommand(args: string[], env: NodeJS.ProcessEnv = proce
     const liveAuthPath = resolveLiveAuthPath(cwd, env, home);
     runCodexLogin(cwd, { ...env, CODEX_HOME: dirname(liveAuthPath) });
     const record = await addSlotFromAuthFile(slot, liveAuthPath, home);
+    await ensureSubscriptionCodexDefaults(dirname(liveAuthPath));
     console.log(`Added auth slot ${record.slot}`);
     return;
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -75,6 +75,7 @@ import {
   resolveCodexHomeForLaunch,
   resolveProjectLocalCodexHomeForLaunch,
 } from "./codex-home.js";
+import { escapeTomlString, readTopLevelTomlString, upsertTopLevelTomlString } from "../utils/toml.js";
 
 export {
   readPersistedSetupPreferences,
@@ -2789,90 +2790,7 @@ export function resolveTeamWorkerLaunchArgsEnv(
   return normalized.join(" ");
 }
 
-export function readTopLevelTomlString(
-  content: string,
-  key: string,
-): string | null {
-  let inTopLevel = true;
-  const lines = content.split(/\r?\n/);
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    if (/^\[[^[\]]+\]\s*(#.*)?$/.test(trimmed)) {
-      inTopLevel = false;
-      continue;
-    }
-    if (!inTopLevel) continue;
-    const match = line.match(/^\s*([A-Za-z0-9_.-]+)\s*=\s*(.*?)\s*(?:#.*)?$/);
-    if (!match || match[1] !== key) continue;
-    return parseTomlStringValue(match[2]);
-  }
-  return null;
-}
-
-export function upsertTopLevelTomlString(
-  content: string,
-  key: string,
-  value: string,
-): string {
-  const eol = content.includes("\r\n") ? "\r\n" : "\n";
-  const assignment = `${key} = "${escapeTomlString(value)}"`;
-
-  if (!content.trim()) {
-    return assignment + eol;
-  }
-
-  const lines = content.split(/\r?\n/);
-  let replaced = false;
-  let inTopLevel = true;
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    if (/^\[[^[\]]+\]\s*(#.*)?$/.test(trimmed)) {
-      inTopLevel = false;
-      continue;
-    }
-    if (!inTopLevel) continue;
-    const match = line.match(/^\s*([A-Za-z0-9_.-]+)\s*=/);
-    if (match && match[1] === key) {
-      lines[i] = assignment;
-      replaced = true;
-      break;
-    }
-  }
-
-  if (!replaced) {
-    const firstTableIndex = lines.findIndex((line) =>
-      /^\s*\[[^[\]]+\]\s*(#.*)?$/.test(line.trim()),
-    );
-    if (firstTableIndex >= 0) {
-      lines.splice(firstTableIndex, 0, assignment);
-    } else {
-      lines.push(assignment);
-    }
-  }
-
-  let out = lines.join(eol);
-  if (!out.endsWith(eol)) out += eol;
-  return out;
-}
-
-function parseTomlStringValue(value: string): string {
-  const trimmed = value.trim();
-  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
-    return trimmed.slice(1, -1);
-  }
-  if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
-}
-
-function escapeTomlString(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
+export { readTopLevelTomlString, upsertTopLevelTomlString } from "../utils/toml.js";
 
 function sanitizeTmuxToken(value: string): string {
   const cleaned = value

--- a/src/utils/toml.ts
+++ b/src/utils/toml.ts
@@ -1,0 +1,84 @@
+export function readTopLevelTomlString(
+  content: string,
+  key: string,
+): string | null {
+  let inTopLevel = true;
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    if (/^\[[^[\]]+\]\s*(#.*)?$/.test(trimmed)) {
+      inTopLevel = false;
+      continue;
+    }
+    if (!inTopLevel) continue;
+    const match = line.match(/^\s*([A-Za-z0-9_.-]+)\s*=\s*(.*?)\s*(?:#.*)?$/);
+    if (!match || match[1] !== key) continue;
+    return parseTomlStringValue(match[2]);
+  }
+  return null;
+}
+
+export function upsertTopLevelTomlString(
+  content: string,
+  key: string,
+  value: string,
+): string {
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const assignment = `${key} = "${escapeTomlString(value)}"`;
+
+  if (!content.trim()) {
+    return assignment + eol;
+  }
+
+  const lines = content.split(/\r?\n/);
+  let replaced = false;
+  let inTopLevel = true;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    if (/^\[[^[\]]+\]\s*(#.*)?$/.test(trimmed)) {
+      inTopLevel = false;
+      continue;
+    }
+    if (!inTopLevel) continue;
+    const match = line.match(/^\s*([A-Za-z0-9_.-]+)\s*=/);
+    if (match && match[1] === key) {
+      lines[i] = assignment;
+      replaced = true;
+      break;
+    }
+  }
+
+  if (!replaced) {
+    const firstTableIndex = lines.findIndex((line) =>
+      /^\s*\[[^[\]]+\]\s*(#.*)?$/.test(line.trim()),
+    );
+    if (firstTableIndex >= 0) {
+      lines.splice(firstTableIndex, 0, assignment);
+    } else {
+      lines.push(assignment);
+    }
+  }
+
+  let out = lines.join(eol);
+  if (!out.endsWith(eol)) out += eol;
+  return out;
+}
+
+function parseTomlStringValue(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function escapeTomlString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}


### PR DESCRIPTION
## Summary
- seed safe ChatGPT/Codex model defaults after successful `omx auth add <slot>` when live Codex config has no explicit top-level model/provider
- preserve existing explicit top-level model or model_provider values
- share existing top-level TOML string helpers with auth CLI code

## Verification
- npm run build
- node --test dist/cli/__tests__/auth.test.js