### PR TITLE
Keep MiniMax deep-interview preflight reads unblocked

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5832,6 +5832,19 @@ exit 0
       );
       assert.equal(allowedAppendBash.outputJson, null);
 
+      const allowedReadOnlyStderrRedirect = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-readonly-stderr-redirect",
+          tool_input: { command: "find application -type d -name 'bug-tracking*' 2>/dev/null | head -20" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedReadOnlyStderrRedirect.outputJson, null);
+
       const blockedBash = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2659,22 +2659,25 @@ function readPreToolUsePathCandidates(payload: CodexHookPayload): string[] {
 
 function commandHasDeepInterviewWriteIntent(command: string): boolean {
   return /\bapply_patch\b/.test(command)
-    || /(?:^|[;&|]\s*)(?:cat|printf|echo)\b[\s\S]{0,240}>\s*[^\s&|;]+/.test(command)
-    || /\btee\s+(?:-a\s+)?[^\s&|;]+/.test(command)
+    || extractDeepInterviewCommandWriteTargets(command).length > 0
     || /\bsed\s+(?:[^\n;&|]*\s)?-i(?:\b|['"])/.test(command)
     || /\b(?:python3?|node|perl|ruby)\b[\s\S]{0,260}\b(?:writeFileSync|writeFile|write_text|open\([^)]*["']w|File\.write|Path\()/.test(command)
     || /\b(?:git\s+(?:checkout|switch|restore|reset|apply|am|merge|rebase)|npm\s+(?:install|i|ci)|pnpm\s+(?:install|i)|yarn\s+(?:install|add))\b/.test(command);
 }
 
+function isDeepInterviewIgnoredWriteTarget(target: string): boolean {
+  return target === "/dev/null" || target.toUpperCase() === "NUL";
+}
+
 function extractDeepInterviewCommandWriteTargets(command: string): string[] {
   const targets: string[] = [];
-  for (const match of command.matchAll(/(?:^|[^>])>{1,2}\s*(["']?)([^\s&|;<>]+)\1/g)) {
+  for (const match of command.matchAll(/(?:^|[\s;&|])(?:[A-Za-z_][A-Za-z0-9_]*=)?>{1,2}\s*(["']?)([^\s&|;<>]+)\1/g)) {
     const candidate = safeString(match[2]).trim();
-    if (candidate) targets.push(candidate);
+    if (candidate && !isDeepInterviewIgnoredWriteTarget(candidate)) targets.push(candidate);
   }
   for (const match of command.matchAll(/\btee\s+(?:-a\s+)?(["']?)([^\s&|;<>]+)\1/g)) {
     const candidate = safeString(match[2]).trim();
-    if (candidate) targets.push(candidate);
+    if (candidate && !isDeepInterviewIgnoredWriteTarget(candidate)) targets.push(candidate);
   }
   return targets;
 }


### PR DESCRIPTION
Closes #2726

## Summary

- make deep-interview Bash write detection target-aware for generic redirects and `tee`
- ignore fd/null-device redirection such as `2>/dev/null` during read-only preflight discovery
- keep actual implementation writes blocked while deep-interview remains in requirements/spec mode
- add a regression for the MiniMax-style read-only discovery command

## Verification

- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` (417 passing)
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`
