### PR TITLE
Keep malformed Stop hook stdin on Stop-safe JSON

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -441,8 +441,32 @@ describe("codex native hook dispatch", () => {
     );
   });
 
-  it("emits schema-safe JSON stdout when CLI stdin is malformed", () => {
+  it("emits Stop-safe JSON stdout when CLI stdin is malformed before event detection", () => {
     const stdout = runNativeHookCli("{");
+
+    const output = parseSingleJsonStdout(stdout) as {
+      decision?: string;
+      reason?: string;
+      stopReason?: string;
+      systemMessage?: string;
+      hookSpecificOutput?: unknown;
+    };
+
+    assert.equal(output.decision, "block");
+    assert.equal(
+      output.reason,
+      "OMX native hook received malformed JSON input. Preserve runtime state, inspect the emitting hook payload yourself, and retry with valid JSON.",
+    );
+    assert.equal(output.stopReason, "native_hook_stdin_parse_error");
+    assert.equal(output.hookSpecificOutput, undefined);
+    assert.match(
+      String(output.systemMessage ?? ""),
+      /stdin JSON parsing failed inside codex-native-hook:/,
+    );
+  });
+
+  it("keeps explicit non-Stop malformed stdin on the non-Stop fail-closed schema", () => {
+    const stdout = runNativeHookCli('{"hook_event_name":"UserPromptSubmit",');
 
     const output = parseSingleJsonStdout(stdout) as {
       continue?: boolean;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4457,16 +4457,17 @@ function buildMalformedStdinHookOutput(parseError: Error, rawInput: string): Rec
     "OMX native hook received malformed JSON input. Preserve runtime state, inspect the emitting hook payload yourself, and retry with valid JSON.";
   const systemMessage =
     `${reason} stdin JSON parsing failed inside codex-native-hook: ${parseError.message}.`;
-  if (inferHookEventNameFromMalformedInput(rawInput) === "Stop") {
+  const inferredHookEventName = inferHookEventNameFromMalformedInput(rawInput);
+  if (inferredHookEventName && inferredHookEventName !== "Stop") {
     return {
-      decision: "block",
-      reason,
+      continue: false,
       stopReason: "native_hook_stdin_parse_error",
       systemMessage,
     };
   }
   return {
-    continue: false,
+    decision: "block",
+    reason,
     stopReason: "native_hook_stdin_parse_error",
     systemMessage,
   };


### PR DESCRIPTION
Closes #2727

## Summary

- default malformed native-hook stdin with no recoverable event name to Stop-safe block JSON
- preserve non-Stop fail-closed schema when an explicit non-Stop event name is recoverable
- add regression coverage for unknown malformed stdin (`{`) and explicit malformed `UserPromptSubmit`

## Verification

- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` (418 passing)
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`
