### PR TITLE
Fix Stop malformed stdin recovery

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -441,23 +441,77 @@ describe("codex native hook dispatch", () => {
     );
   });
 
-  it("emits schema-safe JSON stdout when CLI stdin is malformed", () => {
-    const stdout = runNativeHookCli("{");
+  it("emits Stop-schema-safe block JSON when unidentifiable malformed stdin has native Stop runtime surface", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-malformed-stop-surface-"));
+    try {
+      await mkdir(join(cwd, ".omx"), { recursive: true });
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: "{",
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
 
-    const output = parseSingleJsonStdout(stdout) as {
-      continue?: boolean;
-      stopReason?: string;
-      systemMessage?: string;
-      hookSpecificOutput?: unknown;
-    };
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stderr, "");
+      const output = parseSingleJsonStdout(result.stdout) as {
+        decision?: string;
+        continue?: boolean;
+        reason?: string;
+        stopReason?: string;
+        systemMessage?: string;
+        hookSpecificOutput?: unknown;
+      };
 
-    assert.equal(output.continue, false);
-    assert.equal(output.stopReason, "native_hook_stdin_parse_error");
-    assert.equal(output.hookSpecificOutput, undefined);
-    assert.match(
-      String(output.systemMessage ?? ""),
-      /stdin JSON parsing failed inside codex-native-hook:/,
-    );
+      assert.equal(output.decision, "block");
+      assert.equal(output.continue, undefined);
+      assert.equal(
+        output.reason,
+        "OMX native hook received malformed JSON input. Preserve runtime state, inspect the emitting hook payload yourself, and retry with valid JSON.",
+      );
+      assert.equal(output.stopReason, "native_hook_stdin_parse_error");
+      assert.equal(output.hookSpecificOutput, undefined);
+      assert.match(
+        String(output.systemMessage ?? ""),
+        /stdin JSON parsing failed inside codex-native-hook:/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves non-Stop fail-closed JSON when malformed stdin identifies a non-Stop hook", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-malformed-nonstop-"));
+    try {
+      await mkdir(join(cwd, ".omx"), { recursive: true });
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: '{hook_event_name:"PreToolUse",',
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stderr, "");
+      const output = parseSingleJsonStdout(result.stdout) as {
+        continue?: boolean;
+        decision?: string;
+        stopReason?: string;
+        systemMessage?: string;
+        hookSpecificOutput?: unknown;
+      };
+
+      assert.equal(output.continue, false);
+      assert.equal(output.decision, undefined);
+      assert.equal(output.stopReason, "native_hook_stdin_parse_error");
+      assert.equal(output.hookSpecificOutput, undefined);
+      assert.match(
+        String(output.systemMessage ?? ""),
+        /stdin JSON parsing failed inside codex-native-hook:/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it("redacts unterminated prompt-like malformed stdin fields", async () => {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4462,12 +4462,17 @@ function inferHookEventNameFromMalformedInput(raw: string): CodexHookEventName |
   return readHookEventName({ hook_event_name: value });
 }
 
-function buildMalformedStdinHookOutput(parseError: Error, rawInput: string): Record<string, unknown> {
+function buildMalformedStdinHookOutput(
+  parseError: Error,
+  rawInput: string,
+  cwd = process.cwd(),
+): Record<string, unknown> {
   const reason =
     "OMX native hook received malformed JSON input. Preserve runtime state, inspect the emitting hook payload yourself, and retry with valid JSON.";
   const systemMessage =
     `${reason} stdin JSON parsing failed inside codex-native-hook: ${parseError.message}.`;
-  if (inferHookEventNameFromMalformedInput(rawInput) === "Stop") {
+  const inferredHookEventName = inferHookEventNameFromMalformedInput(rawInput);
+  if (inferredHookEventName === "Stop" || (!inferredHookEventName && hasNativeStopRuntimeSurface(cwd))) {
     return {
       decision: "block",
       reason,
@@ -4613,7 +4618,7 @@ export async function runCodexNativeHookCli(): Promise<void> {
       {},
       buildRawInputLogFields(rawInput),
     );
-    writeNativeHookJsonStdout(buildMalformedStdinHookOutput(parseError, rawInput));
+    writeNativeHookJsonStdout(buildMalformedStdinHookOutput(parseError, rawInput, process.cwd()));
     return;
   }
 


### PR DESCRIPTION
Closes #2727.

## Summary
- emit Stop-safe `decision: "block"` JSON for malformed stdin when Stop is identifiable or the malformed payload is unidentifiable under native Stop runtime surface
- preserve non-Stop fail-closed `{ continue: false }` recovery when malformed input identifies a non-Stop hook
- add regression coverage for bare malformed Stop-surface input, explicit non-Stop malformed input, and quiet stderr recovery

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` (418 pass)
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`