### PR TITLE
Keep MiniMax deep-interview preflight reads unblocked

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5886,6 +5886,19 @@ exit 0
       );
       assert.equal(allowedAppendBash.outputJson, null);
 
+      const allowedReadOnlyStderrRedirect = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-readonly-stderr-redirect",
+          tool_input: { command: "find application -type d -name 'bug-tracking*' 2>/dev/null | head -20" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedReadOnlyStderrRedirect.outputJson, null);
+
       const blockedBash = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -5931,6 +5944,7 @@ exit 0
         "find application -type d -name 'bug-tracking*' 2>NUL | head -20",
         "find application -type d -name 'bug-tracking*' 1>/dev/null",
         "find application -type d -name 'bug-tracking*' &>/dev/null",
+        "find application -type d -name 'bug-tracking*' | tee /dev/null",
       ];
 
       for (const [index, command] of allowedCommands.entries()) {
@@ -5951,7 +5965,6 @@ exit 0
       const blockedCommands = [
         "find application -type d -name 'bug-tracking*' 2>errors.log | head -20",
         "find application -type d -name 'bug-tracking*' > /tmp/bug-tracking.txt",
-        "find application -type d -name 'bug-tracking*' | tee /dev/null",
       ];
 
       for (const [index, command] of blockedCommands.entries()) {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2673,8 +2673,7 @@ function extractDeepInterviewCommandRedirectTargets(command: string): string[] {
 
 function commandHasDeepInterviewWriteIntent(command: string): boolean {
   return /\bapply_patch\b/.test(command)
-    || extractDeepInterviewCommandRedirectTargets(command).length > 0
-    || /\btee\s+(?:-a\s+)?[^\s&|;]+/.test(command)
+    || extractDeepInterviewCommandWriteTargets(command).length > 0
     || /\bsed\s+(?:[^\n;&|]*\s)?-i(?:\b|['"])/.test(command)
     || /\b(?:python3?|node|perl|ruby)\b[\s\S]{0,260}\b(?:writeFileSync|writeFile|write_text|open\([^)]*["']w|File\.write|Path\()/.test(command)
     || /\b(?:git\s+(?:checkout|switch|restore|reset|apply|am|merge|rebase)|npm\s+(?:install|i|ci)|pnpm\s+(?:install|i)|yarn\s+(?:install|add))\b/.test(command);
@@ -2684,7 +2683,7 @@ function extractDeepInterviewCommandWriteTargets(command: string): string[] {
   const targets = extractDeepInterviewCommandRedirectTargets(command);
   for (const match of command.matchAll(/\btee\s+(?:-a\s+)?(["']?)([^\s&|;<>]+)\1/g)) {
     const candidate = safeString(match[2]).trim();
-    if (candidate) targets.push(candidate);
+    if (candidate && !isNullDeviceRedirectTarget(candidate)) targets.push(candidate);
   }
   return targets;
 }


### PR DESCRIPTION
Closes #2726
Supersedes #2728

## Summary

- recreate the MiniMax/deep-interview preflight stderr redirect fix from closed PR #2728 on the normal `dev` contribution path
- keep deep-interview Bash write detection target-aware so null-device discovery redirects such as `2>/dev/null` are not treated as implementation writes
- keep real write targets, including non-null `tee` targets, blocked while deep-interview remains in requirements/spec mode
- adapt the patch to current `dev`, which already had null-device redirect coverage, by reusing the existing null-device helper and aligning `tee /dev/null` with target-aware behavior

## Maintainer comment addressed

PR #2728 was closed because it targeted `main`. The maintainer comment stated that normal contributions for this repo must target `dev`, while the underlying issue looked like a real hook regression candidate. This replacement PR targets `dev` and keeps the scope to the original PR #2728 fix only.

## Verification

- [x] `npm run build`
- [x] `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` (419 passing)
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `git diff --check upstream/dev...HEAD`

## Scope guard

- no Stop-hook malformed-JSON fix included
- no unrelated cleanup or dependency changes
- diff is scoped to `src/scripts/codex-native-hook.ts` and `src/scripts/__tests__/codex-native-hook.test.ts`
