### PR TITLE
Fix ralplan native subagent leader gate

### DIFF
--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -16,6 +16,10 @@ describe('autopilot ralplan gate', () => {
     const trackingPath = subagentTrackingPath(cwd);
     try {
       await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        native_session_id: 'thread-leader',
+      }, null, 2));
       await writeFile(trackingPath, JSON.stringify({
         schemaVersion: 1,
         sessions: {
@@ -23,6 +27,154 @@ describe('autopilot ralplan gate', () => {
             session_id: sessionId,
             leader_thread_id: 'thread-leader',
             updated_at: '2026-05-28T18:34:51.000Z',
+            threads: {
+              'thread-leader': {
+                thread_id: 'thread-leader',
+                kind: 'subagent',
+                first_seen_at: '2026-05-28T18:34:51.000Z',
+                last_seen_at: '2026-05-28T18:34:51.000Z',
+                turn_count: 2,
+              },
+              'thread-critic': {
+                thread_id: 'thread-critic',
+                kind: 'subagent',
+                first_seen_at: '2026-05-28T18:35:10.000Z',
+                last_seen_at: '2026-05-28T18:35:10.000Z',
+                turn_count: 1,
+              },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-leader',
+              artifact_path: '.omx/artifacts/architect.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-05-28T18:34:51.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic',
+              artifact_path: '.omx/artifacts/critic.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-05-28T18:35:10.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /architect tracker thread thread-leader is the session leader/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts fresh native review evidence when tracker leader id aliases a subagent lane', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-fresh-subagent-alias-'));
+    const sessionId = 'sess-autopilot-fresh-subagent-alias';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-architect',
+            updated_at: '2026-05-28T18:35:10.000Z',
+            threads: {
+              'thread-architect': {
+                thread_id: 'thread-architect',
+                kind: 'subagent',
+                first_seen_at: '2026-05-28T18:34:51.000Z',
+                last_seen_at: '2026-05-28T18:34:51.000Z',
+                turn_count: 1,
+                mode: 'architect',
+              },
+              'thread-critic': {
+                thread_id: 'thread-critic',
+                kind: 'subagent',
+                first_seen_at: '2026-05-28T18:35:10.000Z',
+                last_seen_at: '2026-05-28T18:35:10.000Z',
+                turn_count: 1,
+                mode: 'critic',
+              },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-architect',
+              artifact_path: '.omx/artifacts/architect.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-05-28T18:34:51.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic',
+              artifact_path: '.omx/artifacts/critic.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-05-28T18:35:10.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, true);
+      assert.equal(decision.evidence?.blockedReason, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects native review evidence from the current native session leader', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-native-leader-'));
+    const sessionId = 'sess-autopilot-native-leader';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        native_session_id: 'thread-leader',
+      }, null, 2));
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-05-28T18:35:10.000Z',
             threads: {
               'thread-leader': {
                 thread_id: 'thread-leader',

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -312,9 +312,19 @@ function trackerBackedNativeReviewProblem(
   if (!session) return `${agentRole} tracker session ${sessionId} is missing in ${expectedTrackerPath}; only reviews recorded in OMX subagent-tracking.json count as native lanes`;
   if (!thread) return `${agentRole} tracker thread ${threadId} is missing in ${expectedTrackerPath}; external/collab subagent reviews are not tracker-backed native lanes`;
   const leaderThreadId = typeof session.leader_thread_id === 'string' ? session.leader_thread_id.trim() : '';
-  if (leaderThreadId && leaderThreadId === threadId) return `${agentRole} tracker thread ${threadId} is the session leader`;
+  const currentLeaderThreadId = currentSessionNativeLeaderThreadId(options.cwd);
+  if (
+    (currentLeaderThreadId && currentLeaderThreadId === threadId)
+    || (leaderThreadId && leaderThreadId === threadId && thread.kind !== 'subagent')
+  ) return `${agentRole} tracker thread ${threadId} is the session leader`;
   if (thread.kind !== 'subagent') return `${agentRole} tracker thread ${threadId} has kind=${String(thread.kind || 'missing')}`;
   return null;
+}
+
+function currentSessionNativeLeaderThreadId(cwd: string | undefined): string {
+  if (!cwd) return '';
+  const sessionState = readJsonState(join(cwd, '.omx', 'state', 'session.json'));
+  return typeof sessionState?.native_session_id === 'string' ? sessionState.native_session_id.trim() : '';
 }
 
 function validateLocalSessionId(sessionId: string): string[] {


### PR DESCRIPTION
Closes #2734.

## Summary
- Accept tracker-backed native Architect/Critic lanes when a stale tracker `leader_thread_id` aliases a thread recorded as `kind: subagent`.
- Preserve self-review rejection by checking the current session native leader from `.omx/state/session.json` and rejecting non-subagent tracker leader entries.
- Add autopilot gate regressions for fresh native subagent alias acceptance and current native leader rejection.

## Validation
- npm run build
- node dist/scripts/run-test-files.js dist/autopilot/__tests__/ralplan-gate.test.js dist/ralplan/__tests__/runtime.test.js dist/subagents/__tests__/tracker.test.js
- npm run lint
- npm run check:no-unused
- git diff --check
- npm test (fails in unrelated existing tests: dist/cli/__tests__/codex-plugin-layout.test.js plugin MCP cache launch expected exit 0 got null; dist/cli/__tests__/team.test.js inspect_summary expectation absent from output; dist/mcp/__tests__/server-lifecycle.test.js code_intel child exited before teardown assertion)