### PR TITLE
fix: bound native Stop hook execution

### DIFF
--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -87,6 +87,27 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('status ignores unowned root active state when a current session exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-session-root-stale-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-current' }));
+      await writeFile(join(stateDir, 'deep-interview-state.json'), JSON.stringify({
+        active: true,
+        mode: 'deep-interview',
+        current_phase: 'legacy-root-active',
+      }));
+
+      const statusResult = runOmx(wd, 'status');
+      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      assert.doesNotMatch(statusResult.stdout, /deep-interview: ACTIVE/);
+      assert.match(statusResult.stdout, /No active modes\./);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('cancels linked ultrawork when Ralph is active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-link-'));
     try {

--- a/src/hooks/extensibility/__tests__/dispatcher.test.ts
+++ b/src/hooks/extensibility/__tests__/dispatcher.test.ts
@@ -260,6 +260,44 @@ export async function onHookEvent() {}
     }
   });
 
+  it('skips remaining plugins after the aggregate dispatch deadline is exhausted', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-dispatch-deadline-'));
+    try {
+      const dir = join(cwd, '.omx', 'hooks');
+      await mkdir(dir, { recursive: true });
+      for (const name of ['a-slow.mjs', 'b-slow.mjs']) {
+        await writeFile(
+          join(dir, name),
+          `export async function onHookEvent() {
+            process.on('SIGTERM', () => {});
+            setInterval(() => {}, 60_000);
+            await new Promise(() => {});
+          }`,
+        );
+      }
+
+      const event = buildHookEvent('session-start');
+      const startedAt = Date.now();
+      const result = await dispatchHookEvent(event, {
+        cwd,
+        timeoutMs: 500,
+        deadlineMs: 80,
+        env: { ...process.env, OMX_HOOK_PLUGINS: '1' },
+      });
+      const elapsedMs = Date.now() - startedAt;
+
+      assert.equal(result.enabled, true);
+      assert.equal(result.plugin_count, 2);
+      assert.equal(result.results.length, 2);
+      assert.equal(result.results[0].status, 'timeout');
+      assert.equal(result.results[1].status, 'skipped');
+      assert.equal(result.results[1].reason, 'deadline_exceeded');
+      assert.ok(elapsedMs < 1_500, `dispatch should honor aggregate deadline promptly (elapsed=${elapsedMs}ms)`);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('dedupes repeated native lifecycle hook dispatches for the same session/turn fingerprint', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-dispatch-dedupe-'));
     try {

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -31,6 +31,37 @@ interface RunnerResult {
 const RESULT_PREFIX = "__OMX_PLUGIN_RESULT__ ";
 const RUNNER_SIGKILL_GRACE_MS = 250;
 
+function normalizeDispatchDeadlineMs(value: unknown): number | null {
+	if (typeof value !== "number" || !Number.isFinite(value)) return null;
+	const rounded = Math.floor(value);
+	return rounded > 0 ? rounded : null;
+}
+
+function remainingDispatchDeadlineMs(
+	startedAt: number,
+	deadlineMs: number | null,
+): number | null {
+	if (deadlineMs === null) return null;
+	return Math.max(0, deadlineMs - (Date.now() - startedAt));
+}
+
+function buildDeadlineSkippedPluginResult(
+	plugin: { id: string; path: string; file: string },
+): HookPluginDispatchResult {
+	return {
+		plugin: plugin.id,
+		path: plugin.path,
+		file: plugin.file,
+		plugin_id: plugin.id,
+		ok: false,
+		status: "skipped",
+		skipped: true,
+		reason: "deadline_exceeded",
+		durationMs: 0,
+		duration_ms: 0,
+	};
+}
+
 function hooksLogPath(cwd: string): string {
 	const day = new Date().toISOString().slice(0, 10);
 	return join(omxRoot(cwd), "logs", `hooks-${day}.jsonl`);
@@ -308,8 +339,10 @@ export async function dispatchHookEvent(
 	event: HookEventEnvelope,
 	options: HookDispatchOptions = {},
 ): Promise<HookDispatchResult> {
+	const startedAt = Date.now();
 	const cwd = options.cwd || process.cwd();
 	const env = options.env || process.env;
+	const deadlineMs = normalizeDispatchDeadlineMs(options.deadlineMs);
 	const runtimeHookDispatchEnabled =
 		shouldForceEnableRuntimeHookDispatch(event) || isHookPluginsEnabled(env);
 	const enabled = options.enabled ?? runtimeHookDispatchEnabled;
@@ -370,10 +403,32 @@ export async function dispatchHookEvent(
 		options.sideEffectsEnabled ?? (!inTeamWorker || allowTeamSideEffects);
 
 	for (const plugin of plugins) {
+		const remainingMs = remainingDispatchDeadlineMs(startedAt, deadlineMs);
+		if (remainingMs !== null && remainingMs <= 0) {
+			const result = buildDeadlineSkippedPluginResult(plugin);
+			summary.results.push(result);
+			await appendHooksLog(cwd, {
+				type: "hook_plugin_dispatch",
+				event: event.event,
+				source: event.source,
+				plugin: plugin.id,
+				file: plugin.file,
+				ok: result.ok,
+				status: result.status,
+				reason: result.reason,
+				duration_ms: result.duration_ms,
+			});
+			continue;
+		}
+		const pluginTimeoutMs = options.timeoutMs ?? resolveHookPluginTimeoutMs(env);
+		const effectiveTimeoutMs =
+			remainingMs === null
+				? pluginTimeoutMs
+				: Math.max(1, Math.min(pluginTimeoutMs, remainingMs));
 		const result = await runPluginRunner(
 			plugin,
 			event,
-			{ ...options, cwd, env },
+			{ ...options, cwd, env, timeoutMs: effectiveTimeoutMs },
 			sideEffectsEnabled,
 		);
 		summary.results.push(result);

--- a/src/hooks/extensibility/runtime.ts
+++ b/src/hooks/extensibility/runtime.ts
@@ -33,6 +33,7 @@ export async function dispatchHookEventRuntime(input: HookRuntimeDispatchInput):
 
   const result = await dispatchHookEvent(input.event, {
     cwd: input.cwd,
+    deadlineMs: input.deadlineMs,
     allowTeamWorkerSideEffects: input.allowTeamWorkerSideEffects,
     enabled,
   });

--- a/src/hooks/extensibility/types.ts
+++ b/src/hooks/extensibility/types.ts
@@ -206,6 +206,7 @@ export interface HookDispatchOptions {
   event?: HookEventEnvelope;
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
+  deadlineMs?: number;
   allowInTeamWorker?: boolean;
   allowTeamWorkerSideEffects?: boolean;
   sideEffectsEnabled?: boolean;
@@ -221,6 +222,7 @@ export interface HookValidateOptions {
 export interface HookRuntimeDispatchInput {
   cwd: string;
   event: HookEventEnvelope;
+  deadlineMs?: number;
   allowTeamWorkerSideEffects?: boolean;
   sideEffectsEnabled?: boolean;
 }

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -54,6 +54,26 @@ export interface ModeStateFileRef {
   scope: StateFileScope;
 }
 
+function safeStateString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function canUseRootModeStateFallback(
+  state: Record<string, unknown>,
+  sessionId?: string,
+): boolean {
+  const normalizedSessionId = safeStateString(sessionId);
+  if (!normalizedSessionId || state.active !== true) return true;
+
+  const ownerSessionId = safeStateString(
+    state.session_id
+      ?? state.owner_omx_session_id
+      ?? state.omx_session_id
+      ?? state.owner_session_id,
+  );
+  return Boolean(ownerSessionId && ownerSessionId === normalizedSessionId);
+}
+
 export function validateSessionId(sessionId: unknown): string | undefined {
   if (sessionId == null) return undefined;
   if (typeof sessionId !== 'string') {
@@ -590,14 +610,22 @@ export async function listModeStateFilesWithScopePreference(
   workingDirectory?: string,
   explicitSessionId?: string,
 ): Promise<ModeStateFileRef[]> {
+  const stateScope = await resolveStateScope(workingDirectory, explicitSessionId);
   const readDirs = await getReadScopedStateDirs(workingDirectory, explicitSessionId);
   const rootDir = getBaseStateDir(workingDirectory);
+  const sessionId = stateScope.source === 'root' ? undefined : stateScope.sessionId;
   const preferred = new Map<string, ModeStateFileRef>();
 
   // Compatibility fallback: root first, then higher-precedence scope overrides.
   for (const dir of [...readDirs].reverse()) {
     const scope: StateFileScope = dir === rootDir ? 'root' : 'session';
     for (const ref of await listModeStateFilesInDir(dir, scope)) {
+      if (scope === 'root' && sessionId) {
+        const data = await readFile(ref.path, 'utf-8')
+          .then((content) => JSON.parse(content) as Record<string, unknown>)
+          .catch(() => null);
+        if (data && !canUseRootModeStateFallback(data, sessionId)) continue;
+      }
       preferred.set(ref.mode, ref);
     }
   }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -617,6 +617,50 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("fails open before Codex timeout when Stop plugin dispatch hangs", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-deadline-"));
+    try {
+      const hooksDir = join(cwd, ".omx", "hooks");
+      await mkdir(hooksDir, { recursive: true });
+      await writeFile(
+        join(hooksDir, "hang.mjs"),
+        `export async function onHookEvent() {
+          process.on("SIGTERM", () => {});
+          setInterval(() => {}, 60_000);
+          await new Promise(() => {});
+        }`,
+      );
+
+      const startedAt = Date.now();
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: JSON.stringify({
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-deadline",
+          thread_id: "thread-stop-deadline",
+          turn_id: "turn-stop-deadline",
+        }),
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 2_000,
+        env: {
+          ...process.env,
+          OMX_HOOK_PLUGINS: "1",
+          OMX_HOOK_PLUGIN_TIMEOUT_MS: "60000",
+          OMX_NATIVE_STOP_DEADLINE_MS: "100",
+        },
+      });
+      const elapsedMs = Date.now() - startedAt;
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+      assert.ok(elapsedMs < 1_500, `Stop CLI should fail open promptly (elapsed=${elapsedMs}ms)`);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns empty JSON for oversized Stop stdin without parsing or creating inactive state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-"));
     try {
@@ -1807,6 +1851,9 @@ describe("codex native hook dispatch", () => {
     try {
       await writeFile(join(cwd, ".gitignore"), "node_modules/\n");
       execFileSync("git", ["init"], { cwd, stdio: "pipe" });
+      const emptyExcludesFile = join(cwd, "empty-excludes");
+      await writeFile(emptyExcludesFile, "");
+      execFileSync("git", ["config", "core.excludesfile", emptyExcludesFile], { cwd, stdio: "pipe" });
 
       const result = await dispatchCodexNativeHook(
         {
@@ -1836,6 +1883,9 @@ describe("codex native hook dispatch", () => {
     try {
       await writeFile(join(cwd, ".gitignore"), "node_modules/\n.omx/\n");
       execFileSync("git", ["init"], { cwd, stdio: "pipe" });
+      const emptyExcludesFile = join(cwd, "empty-excludes");
+      await writeFile(emptyExcludesFile, "");
+      execFileSync("git", ["config", "core.excludesfile", emptyExcludesFile], { cwd, stdio: "pipe" });
 
       const result = await dispatchCodexNativeHook(
         {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -131,6 +131,7 @@ type CodexHookPayload = Record<string, unknown>;
 interface NativeHookDispatchOptions {
   cwd?: string;
   sessionOwnerPid?: number;
+  stopDeadlineMs?: number;
   reconcileHudForPromptSubmitFn?: typeof reconcileHudForPromptSubmit;
 }
 
@@ -146,6 +147,11 @@ const SKILL_STOP_BLOCKERS = new Set(["ralplan"]);
 const TEAM_STOP_BLOCKING_TASK_STATUSES = new Set(["pending", "in_progress", "blocked"]);
 const TEAM_WORKER_TERMINAL_RUN_STATES = new Set(["done", "complete", "completed", "failed", "stopped", "cancelled"]);
 const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
+const NATIVE_STOP_DEADLINE_ENV = "OMX_NATIVE_STOP_DEADLINE_MS";
+const DEFAULT_NATIVE_STOP_DEADLINE_MS = 4_000;
+const MIN_NATIVE_STOP_DEADLINE_MS = 100;
+const MAX_NATIVE_STOP_DEADLINE_MS = 25_000;
+const NATIVE_STOP_DISPATCH_EXIT_GRACE_MS = 500;
 const ORDINARY_STOP_NO_PROGRESS_DEFAULT_MAX_REPEATS = 8;
 const RALPH_ORPHANED_STARTING_STALE_MS = 15 * 60_000;
 const ORDINARY_STOP_NO_PROGRESS_DEFAULT_IDLE_MS = 10 * 60_000;
@@ -3303,6 +3309,23 @@ function buildRepeatableStopSignature(
   ].join("|");
 }
 
+function readNativeStopDeadlineMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[NATIVE_STOP_DEADLINE_ENV];
+  if (typeof raw !== "string" || raw.trim() === "") return DEFAULT_NATIVE_STOP_DEADLINE_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_NATIVE_STOP_DEADLINE_MS;
+  const rounded = Math.floor(parsed);
+  return Math.min(
+    MAX_NATIVE_STOP_DEADLINE_MS,
+    Math.max(MIN_NATIVE_STOP_DEADLINE_MS, rounded),
+  );
+}
+
+function remainingNativeStopDeadlineMs(startedAt: number, deadlineMs?: number): number | undefined {
+  if (typeof deadlineMs !== "number" || !Number.isFinite(deadlineMs)) return undefined;
+  return Math.max(1, deadlineMs - NATIVE_STOP_DISPATCH_EXIT_GRACE_MS - (Date.now() - startedAt));
+}
+
 function formatStopStatePath(cwd: string, statePath: string): string {
   const relativePath = relative(cwd, statePath);
   if (!relativePath || relativePath.startsWith("..")) return statePath;
@@ -4051,6 +4074,7 @@ export async function dispatchCodexNativeHook(
   payload: CodexHookPayload,
   options: NativeHookDispatchOptions = {},
 ): Promise<NativeHookDispatchResult> {
+  const startedAt = Date.now();
   const hookEventName = readHookEventName(payload);
   const cwd = options.cwd ?? (safeString(payload.cwd).trim() || process.cwd());
   if (hookEventName === "Stop" && !hasNativeStopRuntimeSurface(cwd)) {
@@ -4309,6 +4333,9 @@ export async function dispatchCodexNativeHook(
     await dispatchHookEventRuntime({
       event,
       cwd,
+      deadlineMs: hookEventName === "Stop"
+        ? remainingNativeStopDeadlineMs(startedAt, options.stopDeadlineMs)
+        : undefined,
       allowTeamWorkerSideEffects: false,
     });
   }
@@ -4622,6 +4649,34 @@ export async function runCodexNativeHookCli(): Promise<void> {
     return;
   }
 
+  const isStopHook = readHookEventName(payload) === "Stop";
+  const stopDeadlineMs = isStopHook ? readNativeStopDeadlineMs() : undefined;
+  let stopDeadlineTimer: NodeJS.Timeout | undefined;
+  let cliOutputWritten = false;
+  const writeCliOutput = (output: Record<string, unknown>): boolean => {
+    if (cliOutputWritten) return false;
+    cliOutputWritten = true;
+    writeNativeHookJsonStdout(output);
+    return true;
+  };
+  if (isStopHook && stopDeadlineMs !== undefined) {
+    const cwd = safeString(payload.cwd).trim() || process.cwd();
+    stopDeadlineTimer = setTimeout(() => {
+      if (cliOutputWritten) return;
+      cliOutputWritten = true;
+      process.stderr.write(
+        `[omx] codex-native Stop hook exceeded internal deadline (${stopDeadlineMs}ms); failing open before Codex hook timeout.\n`,
+      );
+      void logNativeHookCliError(
+        cwd,
+        "native_stop_deadline_exceeded",
+        new Error(`native Stop exceeded ${stopDeadlineMs}ms internal deadline`),
+        payload,
+      );
+      process.stdout.write(`${JSON.stringify({})}\n`, () => process.exit(0));
+    }, stopDeadlineMs);
+  }
+
   try {
     if (isStopDispatchFailureTestTrigger(payload)) {
       throw new Error("test-induced Stop dispatch failure");
@@ -4630,20 +4685,22 @@ export async function runCodexNativeHookCli(): Promise<void> {
       throw new Error("test-induced dispatch failure");
     }
 
-    const result = await dispatchCodexNativeHook(payload);
+    const result = await dispatchCodexNativeHook(payload, { stopDeadlineMs });
     if (result.outputJson) {
-      writeNativeHookJsonStdout(result.outputJson);
+      writeCliOutput(result.outputJson);
     } else if (result.hookEventName === "Stop") {
-      writeNativeHookJsonStdout({});
+      writeCliOutput({});
     }
   } catch (error) {
     const cwd = safeString(payload.cwd).trim() || process.cwd();
     await logNativeHookCliError(cwd, "native_hook_dispatch_error", error, payload);
     if (readHookEventName(payload) === "Stop") {
-      writeNativeHookJsonStdout(buildStopDispatchFailureOutput(error));
+      writeCliOutput(buildStopDispatchFailureOutput(error));
     } else {
       process.exitCode = 1;
     }
+  } finally {
+    if (stopDeadlineTimer) clearTimeout(stopDeadlineTimer);
   }
 }
 


### PR DESCRIPTION
## Summary

- Add a native Stop hook internal deadline so Stop fails open with a single `{}` before Codex can hit its outer hook timeout.
- Carry the remaining Stop deadline into hook plugin dispatch and skip later plugins after the aggregate budget is exhausted.
- Ignore stale unowned root active mode state when a current session is known, so old root `deep-interview-state.json` files do not revive status output.
- Isolate existing SessionStart git-ignore tests from machine-global `core.excludesfile` settings.

## Root Cause

Codex native Stop hooks were allowed to run unbounded OMX work plus sequential hook plugin dispatch under Codex’s fixed hook timeout. A slow or stuck plugin could therefore make Codex report `Stop hook (failed): hook timed out after 30s` instead of receiving Stop-safe JSON.

## Validation

- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/extensibility/__tests__/dispatcher.test.js dist/cli/__tests__/session-scoped-runtime.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `npm run test:recent-bug-regressions:compiled`

## Notes

- Not live-tested inside Codex App Stop hook runner.
