### PR TITLE
Fix duplicate tmux HUD ownership for team workers

### DIFF
--- a/src/cli/__tests__/auth.test.ts
+++ b/src/cli/__tests__/auth.test.ts
@@ -119,10 +119,9 @@ describe("omx auth CLI", () => {
       const bin = join(wd, "bin");
       await mkdir(join(wd, ".omx"), { recursive: true });
       await writeFile(join(wd, ".omx", "setup-scope.json"), '{"scope":"project"}\n');
-      const canonicalWd = await realpath(wd);
-      const projectCodexHome = `${canonicalWd}/.codex`;
+      const expectedCodexHome = join(await realpath(wd), ".codex");
       await writeFakeCodex(bin, `#!/bin/sh
-if [ "$1" = "login" ]; then case "$CODEX_HOME" in ${JSON.stringify(projectCodexHome)}) mkdir -p "$CODEX_HOME"; printf '{"access_token":"project-secret"}\n' > "$CODEX_HOME/auth.json"; exit 0;; *) echo "wrong CODEX_HOME=$CODEX_HOME" >&2; exit 4;; esac; fi
+if [ "$1" = "login" ]; then case "$CODEX_HOME" in ${JSON.stringify(expectedCodexHome)}) mkdir -p "$CODEX_HOME"; printf '{"access_token":"project-secret"}\n' > "$CODEX_HOME/auth.json"; exit 0;; *) echo "wrong CODEX_HOME=$CODEX_HOME" >&2; exit 4;; esac; fi
 echo unexpected "$@" >&2
 exit 2
 `);

--- a/src/cli/__tests__/codex-feature-probe.test.ts
+++ b/src/cli/__tests__/codex-feature-probe.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { spawnSync } from "node:child_process";
+import {
+  probeInstalledCodexFeatureList,
+  probeInstalledCodexVersion,
+} from "../codex-feature-probe.js";
+
+interface SpawnCall {
+  command: string;
+  args: readonly string[];
+  options: {
+    encoding?: unknown;
+    killSignal?: unknown;
+    timeout?: unknown;
+    windowsHide?: unknown;
+  };
+}
+
+describe("codex feature probe", () => {
+  it("bounds external Codex CLI probes with a timeout", () => {
+    const calls: SpawnCall[] = [];
+    const fakeSpawn = ((command: string, args: readonly string[], options: SpawnCall["options"]) => {
+      calls.push({ command, args, options });
+      return {
+        error: undefined,
+        output: [],
+        pid: 123,
+        signal: null,
+        status: 0,
+        stderr: "",
+        stdout: args.includes("--version") ? "codex-cli 0.999.0\n" : "hooks stable true\n",
+      };
+    }) as unknown as typeof spawnSync;
+
+    assert.equal(probeInstalledCodexFeatureList(fakeSpawn), "hooks stable true\n");
+    assert.equal(probeInstalledCodexVersion(fakeSpawn), "codex-cli 0.999.0\n");
+    assert.deepEqual(calls.map((call) => [call.command, call.args]), [
+      ["codex", ["features", "list"]],
+      ["codex", ["--version"]],
+    ]);
+    for (const call of calls) {
+      assert.equal(call.options.encoding, "utf-8");
+      assert.equal(call.options.killSignal, "SIGKILL");
+      assert.equal(call.options.timeout, 3_000);
+      assert.equal(call.options.windowsHide, true);
+    }
+  });
+
+  it("treats timed-out Codex CLI probes as unavailable", () => {
+    const fakeSpawn = (() => ({
+      error: Object.assign(new Error("spawnSync codex ETIMEDOUT"), { code: "ETIMEDOUT" }),
+      output: [],
+      pid: 123,
+      signal: "SIGKILL",
+      status: null,
+      stderr: "",
+      stdout: "",
+    })) as unknown as typeof spawnSync;
+
+    assert.equal(probeInstalledCodexFeatureList(fakeSpawn), null);
+    assert.equal(probeInstalledCodexVersion(fakeSpawn), null);
+  });
+});

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -594,6 +594,7 @@ enabled = true
 					HOME: home,
 					CODEX_HOME: join(home, ".codex"),
 					PATH: fakeBin,
+					OMX_EXPLORE_BIN: "",
 				});
 				if (shouldSkipForSpawnPermissions(res.error)) return;
 				assert.equal(res.status, 0, res.stderr || res.stdout);
@@ -664,6 +665,7 @@ enabled = true
 						HOME: home,
 						CODEX_HOME: join(home, ".codex"),
 						PATH: fakeBin,
+						OMX_EXPLORE_BIN: "",
 					});
 					if (shouldSkipForSpawnPermissions(res.error)) return;
 					assert.equal(res.status, 0, res.stderr || res.stdout);

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, readFileSync, utimesSync } from "node:fs";
-import { chmod, lstat, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, stat, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { delimiter, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { once } from "node:events";
@@ -82,6 +82,9 @@ import {
   registerInsideTmuxHudResizeHook,
   buildDetachedHudHookEnv,
   registerDetachedHudLayoutReconcileHook,
+  ensureOmxRuntimeCommandShim,
+  omxRuntimeCommandShimPath,
+  prependOmxRuntimeCommandShimToEnv,
   CODEX_SQLITE_HOME_ENV,
   DETACHED_TMUX_HISTORY_LIMIT,
 } from "../index.js";
@@ -3297,6 +3300,160 @@ describe("detached tmux new-session sequencing", () => {
     assert.match(envScript, /export CUSTOM_LLM_API_KEY='fake-provider-key'/);
     assert.match(envScript, /export IS_GAJAE_SLOP_GENERATOR='1'/);
     assert.doesNotMatch(envScript, /not-a-shell-name/);
+  });
+
+  it("creates a repo-local omx command shim for launched Codex sessions", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-"));
+    try {
+      const shimDir = ensureOmxRuntimeCommandShim(
+        cwd,
+        "/repo/dist/cli/omx.js",
+        "/usr/local/bin/node",
+      );
+      const shimPath = omxRuntimeCommandShimPath(cwd);
+
+      assert.equal(shimDir, dirname(shimPath));
+      assert.equal(existsSync(shimPath), true);
+      assert.equal(await readFile(shimPath, "utf-8"), [
+        "#!/bin/sh",
+        `exec '/usr/local/bin/node' '/repo/dist/cli/omx.js' "$@"`,
+        "",
+      ].join("\n"));
+      assert.equal((await stat(shimPath)).mode & 0o700, 0o700);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("prepends the repo-local omx shim before global PATH entries", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-env-"));
+    try {
+      const env = prependOmxRuntimeCommandShimToEnv(
+        cwd,
+        {
+          PATH: "/opt/homebrew/bin:/usr/bin",
+          OMX_ENTRY_PATH: "/opt/homebrew/lib/node_modules/oh-my-codex/dist/cli/omx.js",
+        },
+        "/repo/dist/cli/omx.js",
+        "/usr/local/bin/node",
+      );
+      const shimDir = dirname(omxRuntimeCommandShimPath(cwd));
+
+      assert.equal(env.PATH, `${shimDir}${delimiter}/opt/homebrew/bin:/usr/bin`);
+      assert.equal(env.OMX_ENTRY_PATH, "/repo/dist/cli/omx.js");
+      assert.equal(env.OMX_STARTUP_CWD, cwd);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("executes the repo-local omx shim before a stale global omx with misleading success output", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-exec-"));
+    try {
+      const fakeGlobalBin = join(cwd, "fake-global-bin");
+      const fakeLocalBin = join(cwd, "fake local's $() ; bin");
+      await mkdir(fakeGlobalBin);
+      await mkdir(fakeLocalBin);
+      const globalMarker = join(cwd, "GLOBAL_CALLED");
+      const localMarker = join(cwd, "LOCAL_CALLED");
+      const fakeGlobalOmx = join(fakeGlobalBin, "omx");
+      const fakeNode = join(fakeLocalBin, "node runner");
+      const localOmxEntry = join(fakeLocalBin, "omx entry's $() ;.js");
+
+      await writeFile(fakeGlobalOmx, `#!/bin/sh
+printf 'global-called\\n' > "${globalMarker}"
+printf '{"success":true,"source":"global"}\\n'
+exit 0
+`);
+      await chmod(fakeGlobalOmx, 0o755);
+      await writeFile(fakeNode, `#!/bin/sh
+printf '%s\\n' "$@" > "${localMarker}"
+printf '{"success":true,"source":"local"}\\n'
+exit 0
+`);
+      await chmod(fakeNode, 0o755);
+
+      const env = prependOmxRuntimeCommandShimToEnv(
+        cwd,
+        { PATH: `${fakeGlobalBin}${delimiter}/usr/bin:/bin` },
+        localOmxEntry,
+        fakeNode,
+      );
+      const { execFileSync } = await import("node:child_process");
+      const output = execFileSync("omx", ["team", "status", "hud-check"], {
+        cwd,
+        env,
+        encoding: "utf-8",
+      });
+
+      assert.match(output, /"source":"local"/);
+      assert.equal(existsSync(globalMarker), false);
+      assert.deepEqual((await readFile(localMarker, "utf-8")).trim().split("\n"), [
+        localOmxEntry,
+        "team",
+        "status",
+        "hud-check",
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("overwrites stale runtime shim contents and permissions", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-stale-"));
+    try {
+      const shimPath = omxRuntimeCommandShimPath(cwd);
+      await mkdir(dirname(shimPath), { recursive: true });
+      await writeFile(shimPath, "#!/bin/sh\necho stale-global\n");
+      await chmod(shimPath, 0o600);
+
+      ensureOmxRuntimeCommandShim(cwd, "/repo/dist/cli/omx.js", "/usr/local/bin/node");
+
+      assert.equal(await readFile(shimPath, "utf-8"), [
+        "#!/bin/sh",
+        `exec '/usr/local/bin/node' '/repo/dist/cli/omx.js' "$@"`,
+        "",
+      ].join("\n"));
+      assert.equal((await stat(shimPath)).mode & 0o777, 0o700);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces a stale runtime shim symlink without following it", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-symlink-"));
+    try {
+      if (process.platform === "win32") return;
+      const shimPath = omxRuntimeCommandShimPath(cwd);
+      const externalTarget = join(cwd, "outside-target");
+      await mkdir(dirname(shimPath), { recursive: true });
+      await writeFile(externalTarget, "do not overwrite\n");
+      await symlink(externalTarget, shimPath);
+
+      ensureOmxRuntimeCommandShim(cwd, "/repo/dist/cli/omx.js", "/usr/local/bin/node");
+
+      assert.equal(await readFile(externalTarget, "utf-8"), "do not overwrite\n");
+      assert.equal((await lstat(shimPath)).isSymbolicLink(), false);
+      assert.match(await readFile(shimPath, "utf-8"), /\/repo\/dist\/cli\/omx\.js/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when the runtime shim bin path is not a directory", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-file-"));
+    try {
+      const shimPath = omxRuntimeCommandShimPath(cwd);
+      await mkdir(dirname(dirname(shimPath)), { recursive: true });
+      await writeFile(dirname(shimPath), "not a directory\n");
+
+      assert.throws(
+        () => ensureOmxRuntimeCommandShim(cwd, "/repo/dist/cli/omx.js", "/usr/local/bin/node"),
+        /not a directory/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it("keeps detached tmux bootstrap bounded when no interactive parent env file is requested", () => {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -78,6 +78,10 @@ import {
   releaseTmuxExtendedKeysLease,
   withTmuxExtendedKeys,
   serializeDetachedSessionParentEnv,
+  buildInsideTmuxHudHookEnv,
+  registerInsideTmuxHudResizeHook,
+  buildDetachedHudHookEnv,
+  registerDetachedHudLayoutReconcileHook,
   CODEX_SQLITE_HOME_ENV,
   DETACHED_TMUX_HISTORY_LIMIT,
 } from "../index.js";
@@ -2954,7 +2958,19 @@ describe("tmux HUD pane helpers", () => {
       "-t",
       "%leader",
       "-F",
-      "#{pane_id}\x1f#{pane_current_command}\x1f#{pane_start_command}\x1f#{pane_current_path}",
+      [
+        "#{pane_id}",
+        "#{pane_current_command}",
+        "#{pane_left}",
+        "#{pane_top}",
+        "#{pane_width}",
+        "#{pane_height}",
+        "#{pane_bottom}",
+        "#{window_width}",
+        "#{window_height}",
+        "#{pane_start_command}",
+        "#{pane_current_path}",
+      ].join("\x1f"),
     ]);
   });
 
@@ -3347,8 +3363,151 @@ describe("detached tmux new-session sequencing", () => {
     const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
     assert.match(
       source,
-      /registerHudResizeHook\(hudPaneId,\s*currentPaneId,\s*HUD_TMUX_HEIGHT_LINES\)/,
+      /registerInsideTmuxHudResizeHook\(\{\s*hudPaneId,\s*currentPaneId,\s*cwd,\s*sessionId,\s*omxRootOverride,\s*\}\)/,
     );
+    assert.match(
+      source,
+      /if \(currentPaneId\) \{\s*unregisterHudResizeHook\(currentPaneId\);\s*\}/,
+    );
+  });
+
+  it("buildInsideTmuxHudHookEnv tags hook commands with session, owner, leader, and local root", () => {
+    const env = buildInsideTmuxHudHookEnv(
+      { PATH: "/bin" },
+      "sess-a",
+      "%leader",
+      "/repo",
+    );
+
+    assert.equal(env.PATH, "/bin");
+    assert.equal(env.OMX_SESSION_ID, "sess-a");
+    assert.equal(env.OMX_TMUX_HUD_OWNER, "1");
+    assert.equal(env.OMX_TMUX_HUD_LEADER_PANE, "%leader");
+    assert.equal(env.OMX_ROOT, "/repo");
+  });
+
+  it("registerInsideTmuxHudResizeHook forwards cwd and env to hook registration", () => {
+    const calls: Array<{
+      hudPaneId: string;
+      leaderPaneId: string | undefined;
+      heightLines: number;
+      cwd?: string;
+      env?: NodeJS.ProcessEnv;
+    }> = [];
+
+    const result = registerInsideTmuxHudResizeHook({
+      hudPaneId: "%hud",
+      currentPaneId: "%leader",
+      cwd: "/repo",
+      sessionId: "sess-a",
+      omxRootOverride: "/repo",
+      baseEnv: { PATH: "/bin" },
+      register: (hudPaneId, leaderPaneId, heightLines, options) => {
+        calls.push({ hudPaneId, leaderPaneId, heightLines, cwd: options?.cwd, env: options?.env });
+        return true;
+      },
+    });
+
+    assert.equal(result, true);
+    assert.deepEqual(calls, [{
+      hudPaneId: "%hud",
+      leaderPaneId: "%leader",
+      heightLines: HUD_TMUX_HEIGHT_LINES,
+      cwd: "/repo",
+      env: {
+        PATH: "/bin",
+        OMX_SESSION_ID: "sess-a",
+        OMX_TMUX_HUD_OWNER: "1",
+        OMX_TMUX_HUD_LEADER_PANE: "%leader",
+        OMX_ROOT: "/repo",
+      },
+    }]);
+    assert.equal(registerInsideTmuxHudResizeHook({
+      hudPaneId: null,
+      currentPaneId: "%leader",
+      cwd: "/repo",
+      sessionId: "sess-a",
+      register: () => {
+        throw new Error("should not register without a HUD pane");
+      },
+    }), false);
+  });
+
+  it("buildDetachedHudHookEnv preserves tmux targeting and local launcher identity", () => {
+    const env = buildDetachedHudHookEnv(
+      { PATH: "/bin" },
+      "sess-a",
+      "%leader",
+      "/tmp/tmux.sock,123,7",
+      "/repo/dist/cli/omx.js",
+      "/repo",
+    );
+
+    assert.equal(env.PATH, "/bin");
+    assert.equal(env.TMUX, "/tmp/tmux.sock,123,7");
+    assert.equal(env.TMUX_PANE, "%leader");
+    assert.equal(env.OMX_SESSION_ID, "sess-a");
+    assert.equal(env.OMX_TMUX_HUD_OWNER, "1");
+    assert.equal(env.OMX_ROOT, "/repo");
+    assert.equal(env.OMX_ENTRY_PATH, "/repo/dist/cli/omx.js");
+  });
+
+  it("registerDetachedHudLayoutReconcileHook reads TMUX from the detached leader pane before registering", () => {
+    const calls: Array<{
+      hudPaneId: string;
+      leaderPaneId: string | undefined;
+      heightLines: number;
+      cwd?: string;
+      env?: NodeJS.ProcessEnv;
+    }> = [];
+    const readTargets: string[] = [];
+
+    const result = registerDetachedHudLayoutReconcileHook({
+      hudPaneId: "%hud",
+      detachedLeaderPaneId: "%leader",
+      cwd: "/repo",
+      sessionId: "sess-a",
+      omxBin: "/repo/dist/cli/omx.js",
+      omxRootOverride: "/repo",
+      baseEnv: { PATH: "/bin" },
+      readTmuxEnvValue: (targetPaneId) => {
+        readTargets.push(targetPaneId);
+        return "/tmp/tmux.sock,123,7";
+      },
+      register: (hudPaneId, leaderPaneId, heightLines, options) => {
+        calls.push({ hudPaneId, leaderPaneId, heightLines, cwd: options?.cwd, env: options?.env });
+        return true;
+      },
+    });
+
+    assert.equal(result, true);
+    assert.deepEqual(readTargets, ["%leader"]);
+    assert.deepEqual(calls, [{
+      hudPaneId: "%hud",
+      leaderPaneId: "%leader",
+      heightLines: HUD_TMUX_HEIGHT_LINES,
+      cwd: "/repo",
+      env: {
+        PATH: "/bin",
+        TMUX: "/tmp/tmux.sock,123,7",
+        TMUX_PANE: "%leader",
+        OMX_SESSION_ID: "sess-a",
+        OMX_TMUX_HUD_OWNER: "1",
+        OMX_ROOT: "/repo",
+        OMX_ENTRY_PATH: "/repo/dist/cli/omx.js",
+      },
+    }]);
+    assert.equal(registerDetachedHudLayoutReconcileHook({
+      hudPaneId: "%hud",
+      detachedLeaderPaneId: "%leader",
+      cwd: "/repo",
+      sessionId: "sess-a",
+      omxBin: "/repo/dist/cli/omx.js",
+      readTmuxEnvValue: () => undefined,
+      register: () => {
+        throw new Error("should not register without TMUX");
+      },
+    }), false);
   });
 
   it("buildDetachedSessionBootstrapSteps starts native Windows detached sessions with powershell", () => {

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -9,7 +9,27 @@ import { fileURLToPath } from 'node:url';
 import { HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
 import { DETACHED_TMUX_HISTORY_LIMIT } from '../index.js';
 
-const CLI_SPAWN_TIMEOUT_MS = 15_000;
+const CLI_SPAWN_TIMEOUT_MS = 60_000;
+
+function buildRunOmxEnv(envOverrides: Record<string, string>): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (
+      key.startsWith('OMX_') ||
+      key.startsWith('CODEX_') ||
+      key === 'TMUX' ||
+      key === 'TMUX_PANE' ||
+      key === 'NODE_OPTIONS' ||
+      key === 'NODE_TEST_CONTEXT'
+    ) {
+      delete env[key];
+    }
+  }
+  return {
+    ...env,
+    ...envOverrides,
+  };
+}
 
 function runOmx(
   cwd: string,
@@ -24,10 +44,7 @@ function runOmx(
     encoding: 'utf-8',
     timeout: CLI_SPAWN_TIMEOUT_MS,
     killSignal: 'SIGKILL',
-    env: {
-      ...process.env,
-      ...envOverrides,
-    },
+    env: buildRunOmxEnv(envOverrides),
   });
   return {
     status: result.status,

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, rmSync } from 'node:fs';
-import { arch, platform } from 'node:os';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { arch, platform, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { getInstallableNativeAgentNames } from '../../agents/policy.js';
@@ -167,10 +167,22 @@ describe('package bin contract', () => {
 
     rmSync(packagedSparkShellPath, { force: true });
 
-    const packed = spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
-      cwd: process.cwd(),
-      encoding: 'utf-8',
-    });
+    const packed = (() => {
+      const npmCache = mkdtempSync(join(tmpdir(), 'omx-npm-pack-cache-'));
+      try {
+        return spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+          cwd: process.cwd(),
+          encoding: 'utf-8',
+          env: {
+            ...process.env,
+            npm_config_cache: npmCache,
+            npm_config_update_notifier: 'false',
+          },
+        });
+      } finally {
+        rmSync(npmCache, { recursive: true, force: true });
+      }
+    })();
 
     assert.equal(packed.status, 0, packed.stderr || packed.stdout);
 

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -14,6 +14,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { setup } from "../setup.js";
 
+const TEST_CODEX_PROBES = {
+  codexFeaturesProbe: () => null,
+  codexVersionProbe: () => null,
+} satisfies Parameters<typeof setup>[0];
+
 const EXPECTED_PROJECT_GITIGNORE = [
   ".omx/",
   ".codex/*",
@@ -49,7 +54,7 @@ async function runSetupWithCapturedLogs(
     logs.push(args.map((arg) => String(arg)).join(" "));
   };
   try {
-    await setup(options);
+    await setup({ ...TEST_CODEX_PROBES, ...options });
     return logs.join("\n");
   } finally {
     console.log = originalLog;
@@ -65,7 +70,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     const previousCwd = process.cwd();
     process.chdir(wd);
     try {
-      await setup(options);
+      await setup({ ...TEST_CODEX_PROBES, ...options });
     } finally {
       process.chdir(previousCwd);
     }

--- a/src/cli/__tests__/sparkshell-packaging.test.ts
+++ b/src/cli/__tests__/sparkshell-packaging.test.ts
@@ -1,9 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdtempSync } from 'node:fs';
 import { arch, platform } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 
@@ -27,8 +27,12 @@ describe('sparkshell packaging scaffold', () => {
     const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
     const binaryName = platform() === 'win32' ? 'omx-sparkshell.exe' : 'omx-sparkshell';
     const stagedRoot = mkdtempSync(join(tmpdir(), 'omx-sparkshell-stage-'));
+    const fakeBin = mkdtempSync(join(tmpdir(), 'omx-sparkshell-cargo-'));
+    const npmCache = mkdtempSync(join(tmpdir(), 'omx-sparkshell-npm-cache-'));
     const packagedBinaryRelativePath = join(`${platform()}-${arch()}`, binaryName);
     const packagedBinaryPath = join(stagedRoot, packagedBinaryRelativePath);
+    const releaseBinaryPath = join(process.cwd(), 'target', 'release', binaryName);
+    const originalReleaseBinary = existsSync(releaseBinaryPath) ? readFileSync(releaseBinaryPath) : null;
 
     assert.deepEqual(pkg.bin, { omx: 'dist/cli/omx.js' });
     assert.equal(pkg.scripts?.['build:sparkshell'], 'node dist/scripts/build-sparkshell.js');
@@ -50,6 +54,34 @@ describe('sparkshell packaging scaffold', () => {
 
     try {
       rmSync(packagedBinaryPath, { force: true });
+      rmSync(releaseBinaryPath, { force: true });
+      mkdirSync(dirname(releaseBinaryPath), { recursive: true });
+      const fakeCargoPath = join(fakeBin, platform() === 'win32' ? 'cargo.cmd' : 'cargo');
+      if (platform() === 'win32') {
+        writeFileSync(
+          fakeCargoPath,
+          [
+            '@echo off',
+            'if not exist "%OMX_FAKE_RELEASE_DIR%" mkdir "%OMX_FAKE_RELEASE_DIR%"',
+            '> "%OMX_FAKE_RELEASE_BINARY%" echo fake sparkshell',
+            'exit /b 0',
+            '',
+          ].join('\r\n'),
+        );
+      } else {
+        writeFileSync(
+          fakeCargoPath,
+          [
+            '#!/bin/sh',
+            'mkdir -p "$OMX_FAKE_RELEASE_DIR"',
+            'printf "%s\\n" "#!/bin/sh" "echo fake sparkshell" > "$OMX_FAKE_RELEASE_BINARY"',
+            'chmod +x "$OMX_FAKE_RELEASE_BINARY"',
+            '',
+          ].join('\n'),
+        );
+        chmodSync(fakeCargoPath, 0o755);
+      }
+
       const buildResult = spawnSync(process.execPath, [buildScriptPath], {
         cwd: process.cwd(),
         encoding: 'utf-8',
@@ -57,6 +89,9 @@ describe('sparkshell packaging scaffold', () => {
           ...process.env,
           OMX_SPARKSHELL_MANIFEST: join(process.cwd(), 'crates', 'omx-sparkshell', 'Cargo.toml'),
           OMX_SPARKSHELL_STAGE_DIR: stagedRoot,
+          OMX_FAKE_RELEASE_BINARY: releaseBinaryPath,
+          OMX_FAKE_RELEASE_DIR: dirname(releaseBinaryPath),
+          PATH: `${fakeBin}${delimiter}${process.env.PATH || ''}`,
         },
       });
       assert.equal(buildResult.status, 0, buildResult.stderr || buildResult.stdout);
@@ -65,6 +100,10 @@ describe('sparkshell packaging scaffold', () => {
       const packed = spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
         cwd: process.cwd(),
         encoding: 'utf-8',
+        env: {
+          ...process.env,
+          npm_config_cache: npmCache,
+        },
       });
       assert.equal(packed.status, 0, packed.stderr || packed.stdout);
 
@@ -76,6 +115,14 @@ describe('sparkshell packaging scaffold', () => {
       assert.equal(packedFiles.has(packagedBinaryRelativePath.replaceAll('\\', '/')), false);
     } finally {
       rmSync(stagedRoot, { force: true, recursive: true });
+      rmSync(fakeBin, { force: true, recursive: true });
+      rmSync(npmCache, { force: true, recursive: true });
+      if (originalReleaseBinary) {
+        writeFileSync(releaseBinaryPath, originalReleaseBinary);
+        if (platform() !== 'win32') chmodSync(releaseBinaryPath, 0o755);
+      } else {
+        rmSync(releaseBinaryPath, { force: true });
+      }
     }
   });
 });

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -166,6 +166,7 @@ async function runNodeCli(
   options: {
     cwd: string;
     env?: NodeJS.ProcessEnv;
+    timeoutMs?: number;
   },
 ): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
@@ -174,6 +175,17 @@ async function runNodeCli(
       env: options.env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    let hardKillTimer: NodeJS.Timeout | null = null;
+    const timeoutTimer = typeof options.timeoutMs === 'number' && options.timeoutMs > 0
+      ? setTimeout(() => {
+        child.kill('SIGTERM');
+        hardKillTimer = setTimeout(() => {
+          child.kill('SIGKILL');
+        }, 1_000);
+        hardKillTimer.unref();
+      }, options.timeoutMs)
+      : null;
+    timeoutTimer?.unref();
     let stdout = '';
     let stderr = '';
     child.stdout.setEncoding('utf-8');
@@ -184,8 +196,14 @@ async function runNodeCli(
     child.stderr.on('data', (chunk) => {
       stderr += chunk;
     });
-    child.on('error', reject);
+    child.on('error', (error) => {
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      if (hardKillTimer) clearTimeout(hardKillTimer);
+      reject(error);
+    });
     child.on('close', (code, signal) => {
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      if (hardKillTimer) clearTimeout(hardKillTimer);
       resolve({ code, signal, stdout, stderr });
     });
   });
@@ -1697,6 +1715,7 @@ esac
             TMUX: fixture.env.TMUX,
             TMUX_PANE: fixture.leaderPaneId,
           },
+          timeoutMs: 12_000,
         });
 
         assert.equal(result.signal, null, `shutdown CLI received signal ${result.signal ?? 'none'}\n${result.stderr}`);

--- a/src/cli/codex-feature-probe.ts
+++ b/src/cli/codex-feature-probe.ts
@@ -11,20 +11,44 @@ export interface CodexFeatureProbeOptions {
   codexVersionProbe?: () => string | null;
 }
 
-export function probeInstalledCodexFeatureList(): string | null {
-  const result = spawnSync("codex", ["features", "list"], {
+type SpawnSyncLike = typeof spawnSync;
+
+const CODEX_FEATURE_PROBE_TIMEOUT_MS = 3_000;
+
+let cachedFeatureListOutput: string | null | undefined;
+let cachedVersionOutput: string | null | undefined;
+
+function runCodexProbe(args: readonly string[], spawnImpl: SpawnSyncLike): string | null {
+  const result = spawnImpl("codex", [...args], {
     encoding: "utf-8",
+    killSignal: "SIGKILL",
+    timeout: CODEX_FEATURE_PROBE_TIMEOUT_MS,
+    windowsHide: true,
   });
   if (result.error || result.status !== 0) return null;
   return [result.stdout, result.stderr].filter(Boolean).join("\n") || null;
 }
 
-export function probeInstalledCodexVersion(): string | null {
-  const result = spawnSync("codex", ["--version"], {
-    encoding: "utf-8",
-  });
-  if (result.error || result.status !== 0) return null;
-  return [result.stdout, result.stderr].filter(Boolean).join("\n") || null;
+export function probeInstalledCodexFeatureList(
+  spawnImpl: SpawnSyncLike = spawnSync,
+): string | null {
+  if (spawnImpl === spawnSync && cachedFeatureListOutput !== undefined) {
+    return cachedFeatureListOutput;
+  }
+  const output = runCodexProbe(["features", "list"], spawnImpl);
+  if (spawnImpl === spawnSync) cachedFeatureListOutput = output;
+  return output;
+}
+
+export function probeInstalledCodexVersion(
+  spawnImpl: SpawnSyncLike = spawnSync,
+): string | null {
+  if (spawnImpl === spawnSync && cachedVersionOutput !== undefined) {
+    return cachedVersionOutput;
+  }
+  const output = runCodexProbe(["--version"], spawnImpl);
+  if (spawnImpl === spawnSync) cachedVersionOutput = output;
+  return output;
 }
 
 export interface CodexHookFeatureSupport {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,8 +4,8 @@
  */
 
 import { execFileSync, spawn } from "child_process";
-import { basename, dirname, join, posix, win32 } from "path";
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { basename, delimiter, dirname, join, posix, win32 } from "path";
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, symlink, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
 import { createHash } from "crypto";
@@ -126,7 +126,7 @@ import {
   mitigateCopyModeUnderlineArtifacts,
 } from "../team/tmux-session.js";
 import { getPackageRoot } from "../utils/package.js";
-import { codexConfigPath, omxRoot, rememberOmxLaunchContext, resolveOmxEntryPath } from "../utils/paths.js";
+import { codexConfigPath, omxRoot, rememberOmxLaunchContext, resolveOmxCliEntryPath } from "../utils/paths.js";
 import { cleanCodexModelAvailabilityNuxIfNeeded, extractSharedMcpRegistryServersFromConfig, repairConfigIfNeeded, repairProjectScopeTrustStateForLaunch, syncProjectScopeTrustStateFromRuntime } from "../config/generator.js";
 import type { UnifiedMcpRegistryServer } from "../config/mcp-registry.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
@@ -150,7 +150,7 @@ import {
 
 export { parseTmuxPaneSnapshot, isHudWatchPane, findHudWatchPaneIds } from "../hud/tmux.js";
 
-rememberOmxLaunchContext();
+rememberOmxLaunchContext({ argv1: process.argv[1], cwd: process.cwd(), env: process.env });
 import {
   classifySpawnError,
   resolveTmuxBinaryForPlatform,
@@ -1487,6 +1487,79 @@ function runCodexBlocking(
       console.error(`[omx] codex exited with code ${result.status}`);
     }
   }
+}
+
+export function omxRuntimeCommandShimPath(cwd: string): string {
+  return join(omxRoot(cwd), "runtime", "bin", "omx");
+}
+
+function ensureRuntimeShimDirectory(path: string): void {
+  if (existsSync(path)) {
+    const current = lstatSync(path);
+    if (current.isSymbolicLink()) {
+      throw new Error(`Refusing to create OMX runtime command shim through symlink directory: ${path}`);
+    }
+    if (!current.isDirectory()) {
+      throw new Error(`Refusing to create OMX runtime command shim because path is not a directory: ${path}`);
+    }
+    return;
+  }
+  mkdirSync(path, { mode: 0o700 });
+}
+
+function buildOmxRuntimeCommandShim(nodePath: string, omxBin: string): string {
+  return [
+    "#!/bin/sh",
+    `exec ${quoteShellArg(nodePath)} ${quoteShellArg(omxBin)} "$@"`,
+    "",
+  ].join("\n");
+}
+
+export function ensureOmxRuntimeCommandShim(
+  cwd: string,
+  omxBin: string,
+  nodePath: string = process.execPath,
+): string {
+  const shimPath = omxRuntimeCommandShimPath(cwd);
+  const shimDir = dirname(shimPath);
+  const rootDir = omxRoot(cwd);
+  const runtimeDir = dirname(shimDir);
+  ensureRuntimeShimDirectory(rootDir);
+  ensureRuntimeShimDirectory(runtimeDir);
+  ensureRuntimeShimDirectory(shimDir);
+  if (existsSync(shimPath)) {
+    const current = lstatSync(shimPath);
+    if (current.isDirectory()) {
+      throw new Error(`Refusing to replace OMX runtime command shim directory: ${shimPath}`);
+    }
+    if (current.isSymbolicLink()) {
+      rmSync(shimPath, { force: true });
+    }
+  }
+  writeFileSync(shimPath, buildOmxRuntimeCommandShim(nodePath, omxBin), {
+    encoding: "utf-8",
+    mode: 0o700,
+  });
+  chmodSync(shimPath, 0o700);
+  return shimDir;
+}
+
+export function prependOmxRuntimeCommandShimToEnv(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  omxBin: string,
+  nodePath: string = process.execPath,
+): NodeJS.ProcessEnv {
+  const shimDir = ensureOmxRuntimeCommandShim(cwd, omxBin, nodePath);
+  const currentPath = typeof env.PATH === "string" ? env.PATH : "";
+  return {
+    ...env,
+    PATH: currentPath ? `${shimDir}${delimiter}${currentPath}` : shimDir,
+    OMX_ENTRY_PATH: omxBin,
+    OMX_STARTUP_CWD: typeof env.OMX_STARTUP_CWD === "string" && env.OMX_STARTUP_CWD.trim()
+      ? env.OMX_STARTUP_CWD
+      : cwd,
+  };
 }
 
 export interface DetachedSessionTmuxStep {
@@ -4353,7 +4426,7 @@ function runCodex(
     sessionModelInstructionsPath(cwd, sessionId),
   );
   const nativeWindows = isNativeWindows();
-  const omxBin = resolveOmxEntryPath();
+  const omxBin = resolveOmxCliEntryPath({ argv1: process.argv[1], cwd, env: process.env });
   if (!omxBin) {
     throw new Error("Unable to resolve OMX launcher path for tmux HUD bootstrap");
   }
@@ -4375,12 +4448,16 @@ function runCodex(
     inheritLeaderFlags,
     workerDefaultModel,
   );
-  const codexBaseEnv = {
-    ...stripHermesMcpBridgeEnv(process.env),
-    ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
-    ...(sqliteHomeOverride ? { [CODEX_SQLITE_HOME_ENV]: sqliteHomeOverride } : {}),
-    ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
-  };
+  const codexBaseEnv = prependOmxRuntimeCommandShimToEnv(
+    cwd,
+    {
+      ...stripHermesMcpBridgeEnv(process.env),
+      ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
+      ...(sqliteHomeOverride ? { [CODEX_SQLITE_HOME_ENV]: sqliteHomeOverride } : {}),
+      ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
+    },
+    omxBin,
+  );
   const codexEnvWithSession = {
     ...codexBaseEnv,
     ...buildHudRuntimeEnv({ sessionId }).env,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -131,6 +131,7 @@ import { cleanCodexModelAvailabilityNuxIfNeeded, extractSharedMcpRegistryServers
 import type { UnifiedMcpRegistryServer } from "../config/mcp-registry.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
+import { OMX_TMUX_HUD_OWNER_ENV } from "../hud/reconcile.js";
 import { readUltragoalState } from "../hud/state.js";
 import {
   createHudWatchPane as createSharedHudWatchPane,
@@ -141,7 +142,10 @@ import {
   parsePaneIdFromTmuxOutput,
   reapDeadHudPanes,
   registerHudResizeHook,
+  OMX_TMUX_HUD_LEADER_PANE_ENV,
+  type RegisterHudResizeHookOptions,
   resizeTmuxPane,
+  unregisterHudResizeHook,
 } from "../hud/tmux.js";
 
 export { parseTmuxPaneSnapshot, isHudWatchPane, findHudWatchPaneIds } from "../hud/tmux.js";
@@ -976,6 +980,120 @@ function execTmuxFileSync(
     ...(options ?? {}),
     ...(process.platform === "win32" ? { windowsHide: true } : {}),
   }) as string;
+}
+
+function readTmuxEnvValueForTarget(targetPaneId: string): string | undefined {
+  if (!targetPaneId.startsWith("%")) return undefined;
+  try {
+    const raw = execTmuxFileSync(
+      ["display-message", "-p", "-t", targetPaneId, "#{socket_path},#{pid},#{session_id}"],
+      { encoding: "utf-8" },
+    ).trim();
+    return raw.replace(/,\$(\d+)$/, ",$1") || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+type HudResizeHookRegistrar = (
+  hudPaneId: string,
+  leaderPaneId: string | undefined,
+  heightLines: number,
+  options?: RegisterHudResizeHookOptions,
+) => boolean;
+
+export function buildInsideTmuxHudHookEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  sessionId: string,
+  currentPaneId: string | undefined,
+  omxRootOverride?: string,
+): NodeJS.ProcessEnv {
+  return {
+    ...baseEnv,
+    OMX_SESSION_ID: sessionId,
+    [OMX_TMUX_HUD_OWNER_ENV]: "1",
+    ...(currentPaneId ? { [OMX_TMUX_HUD_LEADER_PANE_ENV]: currentPaneId } : {}),
+    ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
+  };
+}
+
+export function registerInsideTmuxHudResizeHook(options: {
+  hudPaneId: string | null;
+  currentPaneId: string | undefined;
+  cwd: string;
+  sessionId: string;
+  omxRootOverride?: string;
+  baseEnv?: NodeJS.ProcessEnv;
+  register?: HudResizeHookRegistrar;
+}): boolean {
+  const { hudPaneId, currentPaneId } = options;
+  if (!hudPaneId || !currentPaneId) return false;
+  return (options.register ?? registerHudResizeHook)(
+    hudPaneId,
+    currentPaneId,
+    HUD_TMUX_HEIGHT_LINES,
+    {
+      cwd: options.cwd,
+      env: buildInsideTmuxHudHookEnv(
+        options.baseEnv ?? process.env,
+        options.sessionId,
+        currentPaneId,
+        options.omxRootOverride,
+      ),
+    },
+  );
+}
+
+export function buildDetachedHudHookEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  sessionId: string,
+  detachedLeaderPaneId: string,
+  tmuxEnvValue: string,
+  omxBin: string,
+  omxRootOverride?: string,
+): NodeJS.ProcessEnv {
+  return {
+    ...baseEnv,
+    TMUX: tmuxEnvValue,
+    TMUX_PANE: detachedLeaderPaneId,
+    OMX_SESSION_ID: sessionId,
+    [OMX_TMUX_HUD_OWNER_ENV]: "1",
+    ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
+    OMX_ENTRY_PATH: omxBin,
+  };
+}
+
+export function registerDetachedHudLayoutReconcileHook(options: {
+  hudPaneId: string | null;
+  detachedLeaderPaneId: string | null;
+  cwd: string;
+  sessionId: string;
+  omxBin: string;
+  omxRootOverride?: string;
+  baseEnv?: NodeJS.ProcessEnv;
+  readTmuxEnvValue?: (targetPaneId: string) => string | undefined;
+  register?: HudResizeHookRegistrar;
+}): boolean {
+  const { hudPaneId, detachedLeaderPaneId } = options;
+  if (!hudPaneId || !detachedLeaderPaneId) return false;
+  const tmuxEnvValue = (options.readTmuxEnvValue ?? readTmuxEnvValueForTarget)(detachedLeaderPaneId);
+  if (!tmuxEnvValue) return false;
+  return (options.register ?? registerHudResizeHook)(
+    hudPaneId,
+    detachedLeaderPaneId,
+    HUD_TMUX_HEIGHT_LINES,
+    {
+      cwd: options.cwd,
+      env: buildDetachedHudHookEnv(
+        options.baseEnv ?? process.env,
+        options.sessionId,
+        detachedLeaderPaneId,
+        tmuxEnvValue,
+        options.omxBin,
+        options.omxRootOverride,
+      ),
+    },
+  );
 }
 
 export const DETACHED_TMUX_HISTORY_LIMIT = 500;
@@ -4312,9 +4430,13 @@ function runCodex(
       hudPaneId = keeperHudPaneId;
       try {
         resizeTmuxPane(hudPaneId, HUD_TMUX_HEIGHT_LINES);
-        if (currentPaneId) {
-          registerHudResizeHook(hudPaneId, currentPaneId, HUD_TMUX_HEIGHT_LINES);
-        }
+        registerInsideTmuxHudResizeHook({
+          hudPaneId,
+          currentPaneId,
+          cwd,
+          sessionId,
+          omxRootOverride,
+        });
       } catch (err) {
         logCliOperationFailure(err);
       }
@@ -4324,9 +4446,13 @@ function runCodex(
           heightLines: HUD_TMUX_HEIGHT_LINES,
           targetPaneId: currentPaneId,
         });
-        if (hudPaneId && currentPaneId) {
-          registerHudResizeHook(hudPaneId, currentPaneId, HUD_TMUX_HEIGHT_LINES);
-        }
+        registerInsideTmuxHudResizeHook({
+          hudPaneId,
+          currentPaneId,
+          cwd,
+          sessionId,
+          omxRootOverride,
+        });
       } catch (err) {
         logCliOperationFailure(err);
         // HUD split failed, continue without it
@@ -4366,6 +4492,9 @@ function runCodex(
         runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
       });
     } finally {
+      if (currentPaneId) {
+        unregisterHudResizeHook(currentPaneId);
+      }
       const cleanupPaneIds = buildHudPaneCleanupTargets(
         listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId }),
         hudPaneId,
@@ -4600,6 +4729,16 @@ function runCodex(
                 clientAttachedHookName
               ) {
                 registeredClientAttachedHookName = clientAttachedHookName;
+              }
+              if (finalizeStep.name === "reconcile-hud-resize") {
+                registerDetachedHudLayoutReconcileHook({
+                  hudPaneId,
+                  detachedLeaderPaneId,
+                  cwd,
+                  sessionId,
+                  omxBin,
+                  omxRootOverride,
+                });
               }
             }
           }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -372,6 +372,9 @@ const DEFAULT_SETUP_INSTALL_MODE: SetupInstallMode = "legacy";
 const LEGACY_SETUP_MODEL = "gpt-5.3-codex";
 const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
 const OBSOLETE_NATIVE_AGENT_FIELD = ["skill", "ref"].join("_");
+const GITHUB_AUTH_STATUS_TIMEOUT_MS = 2_000;
+
+let cachedGitHubCliConfigured: boolean | undefined;
 
 function createEmptyCategorySummary(): SetupCategorySummary {
 	return {
@@ -2812,11 +2815,17 @@ async function cleanupLegacySkillPromptShims(
 }
 
 function isGitHubCliConfigured(): boolean {
+	if (cachedGitHubCliConfigured !== undefined) {
+		return cachedGitHubCliConfigured;
+	}
 	const result = spawnSync("gh", ["auth", "status"], {
+		killSignal: "SIGKILL",
 		stdio: "ignore",
+		timeout: GITHUB_AUTH_STATUS_TIMEOUT_MS,
 		windowsHide: true,
 	});
-	return result.status === 0;
+	cachedGitHubCliConfigured = result.status === 0;
+	return cachedGitHubCliConfigured;
 }
 
 async function syncManagedFileFromDisk(

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -61,6 +61,34 @@ afterEach(() => {
   process.exitCode = undefined;
 });
 
+describe('hudCommand reconcile entrypoint', () => {
+  it('runs tmux reconciliation without changing the exit code when repair succeeds', async () => {
+    let reconciledCwd: string | null = null;
+
+    await hudCommand(['--reconcile-tmux'], {
+      cwd: '/repo',
+      reconcileHudForPromptSubmit: async (cwd) => {
+        reconciledCwd = cwd;
+        return { status: 'recreated', paneId: '%9', desiredHeight: 3, duplicateCount: 0 };
+      },
+    });
+
+    assert.equal(reconciledCwd, '/repo');
+    assert.equal(process.exitCode, undefined);
+  });
+
+  it('sets a non-zero exit code when tmux reconciliation fails', async () => {
+    await hudCommand(['--reconcile-tmux'], {
+      cwd: '/repo',
+      reconcileHudForPromptSubmit: async () => (
+        { status: 'failed', paneId: null, desiredHeight: 3, duplicateCount: 0 }
+      ),
+    });
+
+    assert.equal(process.exitCode, 1);
+  });
+});
+
 describe('runWatchMode', () => {
   it('resolves a live cwd when the HUD launch path was reused by another run', () => {
     const resolved = resolveHudWatchCwd('/home/tools/calc', {
@@ -636,7 +664,10 @@ exit 0
       await hudCommand(['--tmux']);
 
       const tmuxLog = await readFile(logPath, 'utf8');
-      assert.match(tmuxLog, /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}/);
+      assert.match(
+        tmuxLog,
+        /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}(?:\x1f#\{[^}]+\})*\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}/,
+      );
       assert.match(tmuxLog, /kill-pane -t %3/);
       assert.match(tmuxLog, /resize-pane -t %2 -y \d+/);
       assert.doesNotMatch(tmuxLog, /split-window/);
@@ -701,7 +732,10 @@ exit 0
 
       const tmuxLog = await readFile(logPath, 'utf8');
       assert.match(tmuxLog, /display-message -p #\{pane_id\}/);
-      assert.match(tmuxLog, /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}/);
+      assert.match(
+        tmuxLog,
+        /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}(?:\x1f#\{[^}]+\})*\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}/,
+      );
       assert.match(tmuxLog, /resize-pane -t %2 -y \d+/);
       assert.doesNotMatch(tmuxLog, /split-window/);
       assert.ok(logs.some((line) => line.includes('Reused existing HUD pane')));

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -1191,6 +1191,268 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
   });
 
+  it('leaves an existing full-width bottom HUD pane unchanged when geometry and height are healthy', async () => {
+    const killed: string[] = [];
+    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 160, paneHeight: 50 - HUD_TMUX_HEIGHT_LINES, paneBottom: 49 - HUD_TMUX_HEIGHT_LINES, windowWidth: 160, windowHeight: 50 },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          paneLeft: 0,
+          paneTop: 50 - HUD_TMUX_HEIGHT_LINES,
+          paneWidth: 160,
+          paneHeight: HUD_TMUX_HEIGHT_LINES,
+          paneBottom: 49,
+          windowWidth: 160,
+          windowHeight: 50,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%9';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'unchanged');
+    assert.deepEqual(killed, []);
+    assert.deepEqual(created, []);
+    assert.deepEqual(resized, []);
+  });
+
+  it('recreates a single owned HUD pane when tmux layout narrows it below the window width', async () => {
+    const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+    const registered: Array<{ hudPaneId: string; currentPaneId: string | undefined; heightLines: number }> = [];
+    const unregistered: Array<string | undefined> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 80, paneHeight: 50, paneBottom: 49, windowWidth: 160, windowHeight: 50 },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          paneLeft: 80,
+          paneTop: 0,
+          paneWidth: 80,
+          paneHeight: 50,
+          paneBottom: 49,
+          windowWidth: 160,
+          windowHeight: 50,
+        },
+        { paneId: '%3', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 25, paneWidth: 80, paneHeight: 25, paneBottom: 49, windowWidth: 160, windowHeight: 50 },
+      ],
+      unregisterHudResizeHook: (currentPaneId) => {
+        unregistered.push(currentPaneId);
+        return true;
+      },
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%9';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      registerHudResizeHook: (hudPaneId, currentPaneId, heightLines) => {
+        registered.push({ hudPaneId, currentPaneId, heightLines });
+        return true;
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%9');
+    assert.equal(result.duplicateCount, 0);
+    assert.deepEqual(unregistered, ['%1']);
+    assert.deepEqual(killed, ['%2']);
+    assert.equal(created.length, 1);
+    assert.equal(created[0]?.options?.fullWidth, true);
+    assert.equal(created[0]?.options?.targetPaneId, '%1');
+    assert.equal(created[0]?.options?.heightLines, HUD_TMUX_HEIGHT_LINES);
+    assert.deepEqual(resized, [{ paneId: '%9', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+    assert.deepEqual(registered, [{ hudPaneId: '%9', currentPaneId: '%1', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+  });
+
+  it('recreates a single owned HUD pane when tmux layout moves it away from the bottom', async () => {
+    const killed: string[] = [];
+    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 3, paneWidth: 160, paneHeight: 47, paneBottom: 49, windowWidth: 160, windowHeight: 50 },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          paneLeft: 0,
+          paneTop: 0,
+          paneWidth: 160,
+          paneHeight: 3,
+          paneBottom: 2,
+          windowWidth: 160,
+          windowHeight: 50,
+        },
+        { paneId: '%3', currentCommand: 'codex', startCommand: 'codex', paneLeft: 80, paneTop: 3, paneWidth: 80, paneHeight: 47, paneBottom: 49, windowWidth: 160, windowHeight: 50 },
+      ],
+      unregisterHudResizeHook: () => true,
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%9';
+      },
+      resizeTmuxPane: () => true,
+      registerHudResizeHook: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'recreated');
+    assert.deepEqual(killed, ['%2']);
+    assert.equal(created[0]?.options?.fullWidth, true);
+    assert.equal(created[0]?.options?.targetPaneId, '%1');
+  });
+
+  it('keeps a geometrically healthy duplicate HUD pane instead of preserving a malformed first duplicate', async () => {
+    const killed: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 160, paneHeight: 47, paneBottom: 46, windowWidth: 160, windowHeight: 50 },
+        {
+          paneId: '%bad',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          paneLeft: 80,
+          paneTop: 0,
+          paneWidth: 80,
+          paneHeight: 50,
+          paneBottom: 49,
+          windowWidth: 160,
+          windowHeight: 50,
+        },
+        {
+          paneId: '%good',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          paneLeft: 0,
+          paneTop: 47,
+          paneWidth: 160,
+          paneHeight: 3,
+          paneBottom: 49,
+          windowWidth: 160,
+          windowHeight: 50,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%new';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.paneId, '%good');
+    assert.deepEqual(killed, ['%bad']);
+    assert.deepEqual(resized, [{ paneId: '%good', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+    assert.deepEqual(created, []);
+  });
+
+  it('recreates duplicate HUD panes when every duplicate has malformed topology', async () => {
+    const unregistered: Array<string | undefined> = [];
+    const killed: string[] = [];
+    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 80, paneHeight: 50, paneBottom: 49, windowWidth: 160, windowHeight: 50 },
+        {
+          paneId: '%bad-a',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          paneLeft: 80,
+          paneTop: 0,
+          paneWidth: 80,
+          paneHeight: 50,
+          paneBottom: 49,
+          windowWidth: 160,
+          windowHeight: 50,
+        },
+        {
+          paneId: '%bad-b',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          paneLeft: 0,
+          paneTop: 0,
+          paneWidth: 160,
+          paneHeight: 3,
+          paneBottom: 2,
+          windowWidth: 160,
+          windowHeight: 50,
+        },
+      ],
+      unregisterHudResizeHook: (leaderPaneId) => {
+        unregistered.push(leaderPaneId);
+        return true;
+      },
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%new';
+      },
+      resizeTmuxPane: () => true,
+      registerHudResizeHook: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.paneId, '%new');
+    assert.deepEqual(unregistered, ['%1']);
+    assert.deepEqual(killed, ['%bad-a', '%bad-b']);
+    assert.equal(created.length, 1);
+    assert.equal(created[0]?.options?.fullWidth, true);
+    assert.equal(created[0]?.options?.targetPaneId, '%1');
+  });
+
   it('registers client-resized hook scoped from the emitting pane after resizing an existing HUD pane', async () => {
     const registered: Array<{ hudPaneId: string; leaderPaneId: string | undefined; heightLines: number }> = [];
 

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -4,6 +4,9 @@ import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from '../reconcil
 import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_ULTRAGOAL_HEIGHT_LINES } from '../constants.js';
 import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../tmux.js';
 
+const noOpRegisterHudResizeHook = () => true;
+const noOpUnregisterHudResizeHook = () => true;
+
 describe('reconcileHudForPromptSubmit', () => {
   it('skips reconciliation outside tmux', async () => {
     const result = await reconcileHudForPromptSubmit('/tmp', {
@@ -55,6 +58,8 @@ describe('reconcileHudForPromptSubmit', () => {
         resized.push({ paneId, heightLines });
         return true;
       },
+      unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
@@ -255,6 +260,8 @@ describe('reconcileHudForPromptSubmit', () => {
         return '%9';
       },
       resizeTmuxPane: () => true,
+      unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
@@ -286,6 +293,8 @@ describe('reconcileHudForPromptSubmit', () => {
         return '%9';
       },
       resizeTmuxPane: () => true,
+      unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
@@ -399,6 +408,8 @@ describe('reconcileHudForPromptSubmit', () => {
         return '%hud';
       },
       resizeTmuxPane: () => true,
+      unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
@@ -708,6 +719,8 @@ describe('reconcileHudForPromptSubmit', () => {
         resized.push({ paneId, heightLines });
         return true;
       },
+      unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
@@ -918,6 +931,8 @@ describe('reconcileHudForPromptSubmit', () => {
         created.push({ cmd, options });
         return '%4';
       },
+      unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
@@ -964,6 +979,8 @@ describe('reconcileHudForPromptSubmit', () => {
       },
       createHudWatchPane: () => '%9',
       resizeTmuxPane: () => true,
+      unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
@@ -1042,6 +1059,7 @@ describe('reconcileHudForPromptSubmit', () => {
         resized.push({ paneId, heightLines });
         return true;
       },
+      registerHudResizeHook: noOpRegisterHudResizeHook,
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
@@ -1225,6 +1243,7 @@ describe('reconcileHudForPromptSubmit', () => {
         resized.push({ paneId, heightLines });
         return true;
       },
+      registerHudResizeHook: noOpRegisterHudResizeHook,
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
@@ -1490,6 +1509,7 @@ describe('reconcileHudForPromptSubmit', () => {
       ],
       createHudWatchPane: () => '%9',
       resizeTmuxPane: () => true,
+      unregisterHudResizeHook: noOpUnregisterHudResizeHook,
       registerHudResizeHook: (hudPaneId, leaderPaneId, heightLines) => {
         registered.push({ hudPaneId, leaderPaneId, heightLines });
         return true;

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  buildHudLayoutHookSlot,
   buildHudResizeHookName,
   buildHudResizeHookSlot,
   buildHudWatchCommand,
@@ -37,6 +38,15 @@ describe('HUD resize hook helpers', () => {
     assert.ok(index < 2147483647);
   });
 
+  it('builds a bounded numeric window-layout-changed slot', () => {
+    const slot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+    assert.match(slot, /^window-layout-changed\[\d+\]$/);
+
+    const index = Number.parseInt(slot.replace(/^window-layout-changed\[|\]$/g, ''), 10);
+    assert.ok(index >= 0);
+    assert.ok(index < 2147483647);
+  });
+
   it('parses hook context from tmux display-message output', () => {
     const context = parseHudResizeHookContext('$7\t@3\n', '%1');
 
@@ -46,6 +56,7 @@ describe('HUD resize hook helpers', () => {
       leaderPaneId: '%1',
       hookName: 'omx_hud_resize_7_3_1',
       hookSlot: buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
+      layoutHookSlot: buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
     });
   });
 
@@ -55,16 +66,23 @@ describe('HUD resize hook helpers', () => {
     assert.equal(parseHudResizeHookContext('$7\t@3\n', '%1; touch /tmp/owned'), null);
   });
 
-  it('registers a client-resized hook at session scope with exact HUD pane targeting', () => {
+  it('registers client-resized and layout-change hooks at session scope with exact HUD pane targeting', () => {
     const calls: string[][] = [];
 
-    const result = registerHudResizeHook('%9', '%1', 3, (args) => {
-      calls.push(args);
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      return '';
-    });
+    const result = registerHudResizeHook(
+      '%9',
+      '%1',
+      3,
+      { cwd: '/repo', env: { TMUX: '/tmp/tmux', OMX_SESSION_ID: 'sess-a' } },
+      (args) => {
+        calls.push(args);
+        if (args[0] === 'display-message') return '$7\t@3\n';
+        return '';
+      },
+    );
 
     const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
+    const layoutHookSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
     assert.equal(result, true);
     assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
     assert.equal(calls[1]?.[0], 'set-hook');
@@ -78,6 +96,43 @@ describe('HUD resize hook helpers', () => {
     assert.match(calls[1]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
     assert.match(calls[1]?.[4] ?? '', new RegExp(hookSlot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     assert.deepEqual(calls[2], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
+    assert.equal(calls[3]?.[0], 'set-hook');
+    assert.equal(calls[3]?.[1], '-t');
+    assert.equal(calls[3]?.[2], '$7');
+    assert.equal(calls[3]?.[3], layoutHookSlot);
+    assert.match(calls[3]?.[4] ?? '', /^run-shell -b /);
+    assert.match(calls[3]?.[4] ?? '', /display-message/);
+    assert.match(calls[3]?.[4] ?? '', /--reconcile-tmux/);
+    assert.match(calls[3]?.[4] ?? '', /TMUX/);
+    assert.match(calls[3]?.[4] ?? '', /TMUX_PANE/);
+    assert.match(calls[3]?.[4] ?? '', /OMX_TMUX_HUD_OWNER/);
+    assert.match(calls[3]?.[4] ?? '', /wait-for/);
+  });
+
+  it('reports partial failure but keeps the resize hook when layout-change hook install fails', () => {
+    const calls: string[][] = [];
+    const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
+    const layoutHookSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+
+    const result = registerHudResizeHook(
+      '%9',
+      '%1',
+      3,
+      { cwd: '/repo', env: { TMUX: '/tmp/tmux', OMX_SESSION_ID: 'sess-a' } },
+      (args) => {
+        calls.push(args);
+        if (args[0] === 'display-message') return '$7\t@3\n';
+        if (args[0] === 'set-hook' && args[3] === layoutHookSlot) {
+          throw new Error('layout hook rejected');
+        }
+        return '';
+      },
+    );
+
+    assert.equal(result, false);
+    assert.deepEqual(calls[1]?.slice(0, 4), ['set-hook', '-t', '$7', hookSlot]);
+    assert.deepEqual(calls[2], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
+    assert.deepEqual(calls[3]?.slice(0, 4), ['set-hook', '-t', '$7', layoutHookSlot]);
   });
 
   it('unregisters the same per-window hook slot', () => {
@@ -99,6 +154,42 @@ describe('HUD resize hook helpers', () => {
       '$7',
       buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
     ]);
+    assert.deepEqual(calls[3], [
+      'set-hook',
+      '-u',
+      '-t',
+      '$7',
+      buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
+    ]);
+  });
+
+  it('attempts to unregister the layout hook even when resize hook unregister fails', () => {
+    const calls: string[][] = [];
+
+    const result = unregisterHudResizeHook('%1', (args) => {
+      calls.push(args);
+      if (args[0] === 'display-message') return '$7\t@3\n';
+      if (args[0] === 'set-hook' && args[4] === buildHudResizeHookSlot('omx_hud_resize_7_3_1')) {
+        throw new Error('resize hook unregister rejected');
+      }
+      return '';
+    });
+
+    assert.equal(result, false);
+    assert.deepEqual(calls[2], [
+      'set-hook',
+      '-u',
+      '-t',
+      '$7',
+      buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
+    ]);
+    assert.deepEqual(calls[3], [
+      'set-hook',
+      '-u',
+      '-t',
+      '$7',
+      buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
+    ]);
   });
 
   it('uses distinct hook slots for different windows in the same session', () => {
@@ -114,7 +205,7 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%10', '%2', 3, execFor('@4')), true);
 
     const firstSlot = registered[0]?.[3];
-    const secondSlot = registered[2]?.[3];
+    const secondSlot = registered[3]?.[3];
     assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
     assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
     assert.notEqual(firstSlot, secondSlot);
@@ -132,7 +223,7 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%10', '%2', 3, execTmuxSync), true);
 
     const firstSlot = registered[0]?.[3];
-    const secondSlot = registered[2]?.[3];
+    const secondSlot = registered[3]?.[3];
     assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
     assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
     assert.notEqual(firstSlot, secondSlot);
@@ -149,7 +240,7 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
     assert.equal(registerHudResizeHook('%10', '%1', 3, execTmuxSync), true);
 
-    assert.equal(registered[0]?.[3], registered[2]?.[3]);
+    assert.equal(registered[0]?.[3], registered[3]?.[3]);
   });
 
   it('does not unregister the legacy hook when installing the leader-scoped hook fails', () => {
@@ -203,10 +294,37 @@ describe('HUD resize hook helpers', () => {
       '$7',
       buildHudResizeHookSlot('omx_hud_resize_7_3_2'),
     ]);
+    assert.deepEqual(unregistered[2], [
+      'set-hook',
+      '-u',
+      '-t',
+      '$7',
+      buildHudLayoutHookSlot('omx_hud_resize_7_3_2'),
+    ]);
   });
 });
 
 describe('HUD pane ownership helpers', () => {
+  it('parses pane geometry from tmux pane snapshots without corrupting the start command or cwd', () => {
+    const [pane] = parseTmuxPaneSnapshot(
+      `%2\tnode\t0\t47\t160\t3\t49\t160\t50\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch\t/tmp/repo`,
+    );
+
+    assert.deepEqual(pane, {
+      paneId: '%2',
+      currentCommand: 'node',
+      paneLeft: 0,
+      paneTop: 47,
+      paneWidth: 160,
+      paneHeight: 3,
+      paneBottom: 49,
+      windowWidth: 160,
+      windowHeight: 50,
+      startCommand: `exec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+      currentPath: '/tmp/repo',
+    });
+  });
+
   it('reads session and leader ownership from env-prefixed HUD commands', () => {
     const [pane] = parseTmuxPaneSnapshot(
       `%9\tnode\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
@@ -413,7 +531,23 @@ describe('HUD pane ownership helpers', () => {
 
     assert.deepEqual(listCurrentWindowHudPaneIds(undefined, execTmuxSync, { sessionId: 'sess-a' }), ['%2']);
     assert.deepEqual(calls, [
-      ['list-panes', '-F', '#{pane_id}\x1f#{pane_current_command}\x1f#{pane_start_command}\x1f#{pane_current_path}'],
+      [
+        'list-panes',
+        '-F',
+        [
+          '#{pane_id}',
+          '#{pane_current_command}',
+          '#{pane_left}',
+          '#{pane_top}',
+          '#{pane_width}',
+          '#{pane_height}',
+          '#{pane_bottom}',
+          '#{window_width}',
+          '#{window_height}',
+          '#{pane_start_command}',
+          '#{pane_current_path}',
+        ].join('\x1f'),
+      ],
     ]);
   });
 

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -7,6 +7,7 @@
  *   omx hud --json       Output raw state as JSON
  *   omx hud --preset=X   Use preset: minimal, focused, full
  *   omx hud --tmux       Open HUD in a tmux split pane (auto-detects orientation)
+ *   omx hud --reconcile-tmux
  */
 
 import { execFileSync } from 'child_process';
@@ -26,7 +27,7 @@ import {
   registerHudResizeHook,
   resizeTmuxPane,
 } from './tmux.js';
-import { OMX_TMUX_HUD_OWNER_ENV } from './reconcile.js';
+import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from './reconcile.js';
 import { buildHudRuntimeEnv } from './tmux.js';
 
 export const HUD_USAGE = [
@@ -36,6 +37,7 @@ export const HUD_USAGE = [
   '  omx hud --json       Output raw state as JSON',
   '  omx hud --preset=X   Use preset: minimal, focused, full',
   '  omx hud --tmux       Open HUD in a tmux split pane (auto-detects orientation)',
+  '  omx hud --reconcile-tmux',
 ].join('\n');
 
 type SleepFn = (ms: number, signal?: AbortSignal) => Promise<void>;
@@ -326,14 +328,28 @@ async function renderOnce(cwd: string, flags: HudFlags): Promise<void> {
   }));
 }
 
-export async function hudCommand(args: string[]): Promise<void> {
+export async function hudCommand(
+  args: string[],
+  deps: {
+    cwd?: string;
+    reconcileHudForPromptSubmit?: typeof reconcileHudForPromptSubmit;
+  } = {},
+): Promise<void> {
   if (args[0] === '--help' || args[0] === '-h') {
     console.log(HUD_USAGE);
     return;
   }
 
   const flags = parseFlags(args);
-  const cwd = process.cwd();
+  const cwd = deps.cwd ?? process.cwd();
+
+  if (args.includes('--reconcile-tmux')) {
+    const result = await (deps.reconcileHudForPromptSubmit ?? reconcileHudForPromptSubmit)(cwd);
+    if (result.status === 'failed') {
+      process.exitCode = 1;
+    }
+    return;
+  }
 
   if (flags.tmux) {
     await launchTmuxPane(cwd, flags);

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -84,6 +84,7 @@ export interface ReconcileHudForPromptSubmitResult {
     | 'skipped_no_entry'
     | 'skipped_not_omx_owned_tmux'
     | 'skipped_no_session_id'
+    | 'unchanged'
     | 'resized'
     | 'recreated'
     | 'replaced_duplicates'
@@ -101,14 +102,19 @@ export interface ReconcileHudForPromptSubmitDeps {
   createHudWatchPane?: (
     cwd: string,
     hudCmd: string,
-    options?: { heightLines?: number; targetPaneId?: string },
+    options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string },
   ) => string | null;
   killTmuxPane?: (paneId: string) => boolean;
   resizeTmuxPane?: (paneId: string, heightLines: number) => boolean;
   readHudConfig?: typeof readHudConfig;
   readAllState?: typeof readAllState;
   resolveOmxCliEntryPath?: typeof resolveOmxCliEntryPath;
-  registerHudResizeHook?: (hudPaneId: string, leaderPaneId: string | undefined, heightLines: number) => boolean;
+  registerHudResizeHook?: (
+    hudPaneId: string,
+    leaderPaneId: string | undefined,
+    heightLines: number,
+    options?: { cwd?: string; env?: NodeJS.ProcessEnv },
+  ) => boolean;
   unregisterHudResizeHook?: (leaderPaneId: string | undefined) => boolean;
 }
 
@@ -116,13 +122,38 @@ function ensureHudResizeHook(
   hudPaneId: string,
   leaderPaneId: string | undefined,
   desiredHeight: number,
+  cwd: string,
   deps: ReconcileHudForPromptSubmitDeps,
 ): void {
   try {
-    (deps.registerHudResizeHook ?? registerHudResizeHook)(hudPaneId, leaderPaneId, desiredHeight);
+    (deps.registerHudResizeHook ?? registerHudResizeHook)(hudPaneId, leaderPaneId, desiredHeight, {
+      cwd,
+      env: deps.env ?? process.env,
+    });
   } catch {
     // Non-critical — hook registration failure does not break HUD lifecycle.
   }
+}
+
+function hasCompleteGeometry(pane: TmuxPaneSnapshot): boolean {
+  return (
+    typeof pane.paneLeft === 'number'
+    && typeof pane.paneWidth === 'number'
+    && typeof pane.paneBottom === 'number'
+    && typeof pane.windowWidth === 'number'
+    && typeof pane.windowHeight === 'number'
+  );
+}
+
+function needsHudTopologyRecreate(pane: TmuxPaneSnapshot): boolean {
+  if (!hasCompleteGeometry(pane)) return false;
+  const spansWindowWidth = pane.paneLeft === 0 && pane.paneWidth === pane.windowWidth;
+  const touchesWindowBottom = pane.paneBottom === (pane.windowHeight ?? 0) - 1;
+  return !spansWindowWidth || !touchesWindowBottom;
+}
+
+function needsHudHeightResize(pane: TmuxPaneSnapshot, desiredHeight: number): boolean {
+  return typeof pane.paneHeight !== 'number' || pane.paneHeight !== desiredHeight;
 }
 
 function planOwnedHudPaneDedupe(
@@ -231,39 +262,44 @@ export async function reconcileHudForPromptSubmit(
     rootSource: env.OMX_TEAM_STATE_ROOT ? 'team-env' : env.OMX_ROOT ? 'omx-root-env' : env.OMX_STATE_ROOT ? 'omx-state-root-env' : 'cwd-default',
   });
 
-  if (hudPaneIds.length === 1) {
-    const resized = resizePane(hudPaneIds[0], desiredHeight);
-    if (resized) ensureHudResizeHook(hudPaneIds[0], currentPaneId, desiredHeight, deps);
+  const singleHudPane = hudPaneIds.length === 1
+    ? panes.find((pane) => pane.paneId === hudPaneIds[0])
+    : undefined;
+  if (singleHudPane && !needsHudTopologyRecreate(singleHudPane)) {
+    const shouldResize = needsHudHeightResize(singleHudPane, desiredHeight);
+    const resized = shouldResize ? resizePane(singleHudPane.paneId, desiredHeight) : true;
+    if (resized) ensureHudResizeHook(singleHudPane.paneId, currentPaneId, desiredHeight, cwd, deps);
     return {
-      status: resized ? 'resized' : 'failed',
-      paneId: hudPaneIds[0],
+      status: resized ? (shouldResize ? 'resized' : 'unchanged') : 'failed',
+      paneId: singleHudPane.paneId,
       desiredHeight,
       duplicateCount,
     };
   }
 
   if (hudPaneIds.length > 1) {
-    const [keeperPaneId, ...extraPaneIds] = hudPaneIds;
-    const resized = resizePane(keeperPaneId, desiredHeight);
-    for (const paneId of extraPaneIds) {
-      killPane(paneId);
-    }
-    if (!resized) {
+    const hudPanes = hudPaneIds
+      .map((paneId) => panes.find((pane) => pane.paneId === paneId))
+      .filter((pane): pane is TmuxPaneSnapshot => Boolean(pane));
+    const keeperPane = hudPanes.find((pane) => !needsHudTopologyRecreate(pane));
+
+    if (keeperPane) {
+      for (const paneId of hudPaneIds.filter((paneId) => paneId !== keeperPane.paneId)) {
+        killPane(paneId);
+      }
+      const resized = resizePane(keeperPane.paneId, desiredHeight);
+      if (resized) ensureHudResizeHook(keeperPane.paneId, currentPaneId, desiredHeight, cwd, deps);
       return {
-        status: 'failed',
-        paneId: keeperPaneId,
+        status: resized ? 'replaced_duplicates' : 'failed',
+        paneId: keeperPane.paneId,
         desiredHeight,
         duplicateCount,
       };
     }
-    ensureHudResizeHook(keeperPaneId, currentPaneId, desiredHeight, deps);
-    return {
-      status: 'replaced_duplicates',
-      paneId: keeperPaneId,
-      desiredHeight,
-      duplicateCount,
-    };
   }
+  const createFullWidth = hudPaneIds
+    .map((paneId) => panes.find((pane) => pane.paneId === paneId))
+    .some((pane) => Boolean(pane && needsHudTopologyRecreate(pane)));
 
   if (!resolvedSessionId) {
     return {
@@ -277,14 +313,17 @@ export async function reconcileHudForPromptSubmit(
   const unregisterHook = deps.unregisterHudResizeHook ?? unregisterHudResizeHook;
   unregisterHook(currentPaneId);
 
+  const removedHudPaneIds = new Set<string>();
   for (const paneId of hudPaneIds) {
-    killPane(paneId);
+    if (killPane(paneId)) removedHudPaneIds.add(paneId);
   }
 
-  const paneId = createPane(cwd, hudCmd, {
+  const createOptions: { heightLines: number; fullWidth?: boolean; targetPaneId?: string } = {
     heightLines: desiredHeight,
     targetPaneId: currentPaneId,
-  });
+  };
+  if (createFullWidth) createOptions.fullWidth = true;
+  const paneId = createPane(cwd, hudCmd, createOptions);
   if (!paneId) {
     return {
       status: 'failed',
@@ -299,15 +338,15 @@ export async function reconcileHudForPromptSubmit(
   // and collapse same-owner panes so the second creator cleans up the race
   // instead of leaving a duplicate HUD in the user window.
   const postCreate = planOwnedHudPaneDedupe(
-    listPanes(currentPaneId),
+    listPanes(currentPaneId).filter((pane) => !removedHudPaneIds.has(pane.paneId)),
     currentPaneId,
     owner,
     paneId,
   );
-  const resized = resizePane(postCreate.paneId, desiredHeight);
   for (const duplicatePaneId of postCreate.duplicatePaneIds) {
     killPane(duplicatePaneId);
   }
+  const resized = resizePane(postCreate.paneId, desiredHeight);
   if (!resized) {
     return {
       status: 'failed',
@@ -316,7 +355,7 @@ export async function reconcileHudForPromptSubmit(
       duplicateCount: postCreate.duplicatePaneIds.length,
     };
   }
-  ensureHudResizeHook(postCreate.paneId, currentPaneId, desiredHeight, deps);
+  ensureHudResizeHook(postCreate.paneId, currentPaneId, desiredHeight, cwd, deps);
 
   return {
     status: postCreate.duplicatePaneIds.length > 0 || hudPaneIds.length > 1 ? 'replaced_duplicates' : 'recreated',

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -2,12 +2,20 @@ import { execFileSync } from 'child_process';
 import { existsSync } from 'fs';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
+import { resolveOmxCliEntryPath } from '../utils/paths.js';
 
 export interface TmuxPaneSnapshot {
   paneId: string;
   currentCommand: string;
   startCommand: string;
   currentPath?: string;
+  paneLeft?: number;
+  paneTop?: number;
+  paneWidth?: number;
+  paneHeight?: number;
+  paneBottom?: number;
+  windowWidth?: number;
+  windowHeight?: number;
 }
 
 export const OMX_TMUX_HUD_LEADER_PANE_ENV = 'OMX_TMUX_HUD_LEADER_PANE';
@@ -41,6 +49,11 @@ type TmuxExecSync = (args: string[]) => string;
 /** Upper bound for tmux hook indices (signed 32-bit max). */
 const TMUX_HOOK_INDEX_MAX = 2147483647;
 
+export interface RegisterHudResizeHookOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
 function defaultExecTmuxSync(args: string[]): string {
   try {
     return execFileSync(resolveTmuxBinaryForPlatform() || 'tmux', args, {
@@ -56,6 +69,17 @@ function defaultExecTmuxSync(args: string[]): string {
   }
 }
 
+function parseNonNegativeInteger(value: string | undefined): number | null {
+  if (typeof value !== 'string' || value.trim() === '') return null;
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function parsePositiveInteger(value: string | undefined): number | null {
+  const parsed = parseNonNegativeInteger(value);
+  return parsed !== null && parsed > 0 ? parsed : null;
+}
+
 export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
   return output
     .split('\n')
@@ -69,15 +93,43 @@ export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
           : '\t';
       const parts = line.split(fieldSeparator);
       const [paneId = '', currentCommand = ''] = parts;
-      const hasCurrentPathColumn = parts.length >= 4;
-      const currentPath = hasCurrentPathColumn ? (parts.at(-1) ?? '') : '';
-      const startCommandParts = hasCurrentPathColumn ? parts.slice(2, -1) : parts.slice(2);
+      const paneLeft = parseNonNegativeInteger(parts[2]);
+      const paneTop = parseNonNegativeInteger(parts[3]);
+      const paneWidth = parsePositiveInteger(parts[4]);
+      const paneHeight = parsePositiveInteger(parts[5]);
+      const paneBottom = parseNonNegativeInteger(parts[6]);
+      const windowWidth = parsePositiveInteger(parts[7]);
+      const windowHeight = parsePositiveInteger(parts[8]);
+      const hasGeometry = (
+        paneLeft !== null
+        && paneTop !== null
+        && paneWidth !== null
+        && paneHeight !== null
+        && paneBottom !== null
+        && windowWidth !== null
+        && windowHeight !== null
+      );
+      const payloadParts = hasGeometry ? parts.slice(9) : parts.slice(2);
+      const hasCurrentPathColumn = payloadParts.length >= 2;
+      const currentPath = hasCurrentPathColumn ? (payloadParts.at(-1) ?? '') : '';
+      const startCommandParts = hasCurrentPathColumn ? payloadParts.slice(0, -1) : payloadParts;
       const trimmedCurrentPath = currentPath.trim();
       return {
         paneId: paneId.trim(),
         currentCommand: currentCommand.trim(),
         startCommand: startCommandParts.join('\t').trim(),
         ...(trimmedCurrentPath ? { currentPath: trimmedCurrentPath } : {}),
+        ...(hasGeometry
+          ? {
+              paneLeft,
+              paneTop,
+              paneWidth,
+              paneHeight,
+              paneBottom,
+              windowWidth,
+              windowHeight,
+            }
+          : {}),
       };
     })
     .filter((pane) => pane.paneId.startsWith('%'));
@@ -304,12 +356,21 @@ export function buildHudResizeHookSlot(hookName: string): string {
   return `client-resized[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
 }
 
+export function buildHudLayoutHookSlot(hookName: string): string {
+  let hash = 0;
+  for (let i = 0; i < hookName.length; i++) {
+    hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
+  }
+  return `window-layout-changed[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
+}
+
 export interface HudResizeHookContext {
   sessionId: string;
   windowId: string;
   leaderPaneId: string;
   hookName: string;
   hookSlot: string;
+  layoutHookSlot: string;
 }
 
 export function parseHudResizeHookContext(output: string, leaderPaneId: string): HudResizeHookContext | null {
@@ -326,6 +387,7 @@ export function parseHudResizeHookContext(output: string, leaderPaneId: string):
     leaderPaneId: normalizedLeaderPaneId,
     hookName,
     hookSlot: buildHudResizeHookSlot(hookName),
+    layoutHookSlot: buildHudLayoutHookSlot(hookName),
   };
 }
 
@@ -350,8 +412,9 @@ export function readHudResizeHookContext(
   }
 }
 
-function buildNestedTmuxCommand(tmuxBin: string, args: string[]): string {
-  return [tmuxBin, ...args].map((part) => shellEscapeSingle(part)).join(' ');
+function buildNestedTmuxCommand(tmuxBin: string, args: string[], tmuxEnv?: string): string {
+  const command = [tmuxBin, ...args].map((part) => shellEscapeSingle(part)).join(' ');
+  return `${buildEnvPrefix({ TMUX: tmuxEnv })}${command}`;
 }
 
 function buildHudResizeHookCommand(
@@ -359,11 +422,53 @@ function buildHudResizeHookCommand(
   hudPaneId: string,
   height: string,
   context: HudResizeHookContext,
+  tmuxEnv?: string,
 ): string {
-  const resize = buildNestedTmuxCommand(tmuxBin, ['resize-pane', '-t', hudPaneId, '-y', height]);
-  const unregister = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-t', context.sessionId, context.hookSlot]);
-  const resizeOrUnregister = `${resize} >/dev/null 2>&1 || ${unregister} >/dev/null 2>&1 || true`;
+  const resize = buildNestedTmuxCommand(tmuxBin, ['resize-pane', '-t', hudPaneId, '-y', height], tmuxEnv);
+  const unregister = buildHudHookUnregisterCommand(tmuxBin, context, tmuxEnv);
+  const resizeOrUnregister = `${resize} >/dev/null 2>&1 || (${unregister})`;
   return `${resizeOrUnregister}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeOrUnregister}`;
+}
+
+function buildHudHookUnregisterCommand(tmuxBin: string, context: HudResizeHookContext, tmuxEnv?: string): string {
+  const unregisterResize = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-t', context.sessionId, context.hookSlot], tmuxEnv);
+  const unregisterLayout = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-t', context.sessionId, context.layoutHookSlot], tmuxEnv);
+  return `${unregisterResize} >/dev/null 2>&1 || true; ${unregisterLayout} >/dev/null 2>&1 || true`;
+}
+
+function buildHudLayoutReconcileHookCommand(
+  tmuxBin: string,
+  omxBin: string,
+  leaderPaneId: string,
+  context: HudResizeHookContext,
+  options: RegisterHudResizeHookOptions = {},
+): string {
+  const env = options.env ?? process.env;
+  const cwd = options.cwd?.trim() || process.cwd();
+  const leaderAlive = buildNestedTmuxCommand(tmuxBin, ['display-message', '-p', '-t', leaderPaneId, '#{pane_id}'], env.TMUX);
+  const unregister = buildHudHookUnregisterCommand(tmuxBin, context, env.TMUX);
+  const lockName = `${context.hookName}_layout`;
+  const lock = buildNestedTmuxCommand(tmuxBin, ['wait-for', '-L', lockName], env.TMUX);
+  const unlock = buildNestedTmuxCommand(tmuxBin, ['wait-for', '-U', lockName], env.TMUX);
+  const reconcileEnv = buildEnvPrefix({
+    TMUX: env.TMUX,
+    TMUX_PANE: leaderPaneId,
+    OMX_TMUX_HUD_OWNER: '1',
+    OMX_SESSION_ID: env.OMX_SESSION_ID,
+    OMX_ROOT: env.OMX_ROOT,
+    OMX_STATE_ROOT: env.OMX_STATE_ROOT,
+    OMX_TEAM_STATE_ROOT: env.OMX_TEAM_STATE_ROOT,
+  });
+  const reconcile = [
+    'cd',
+    shellEscapeSingle(cwd),
+    '&&',
+    `${reconcileEnv}${shellEscapeSingle(process.execPath)}`,
+    shellEscapeSingle(omxBin),
+    'hud',
+    '--reconcile-tmux',
+  ].join(' ');
+  return `${leaderAlive} >/dev/null 2>&1 && (${lock} >/dev/null 2>&1; ${unregister}; ${reconcile} >/dev/null 2>&1; status=$?; ${unlock} >/dev/null 2>&1; exit $status) || (${unregister})`;
 }
 
 function unregisterLegacyHudResizeHook(
@@ -440,7 +545,19 @@ export function listCurrentWindowPanes(
         'list-panes',
         ...(currentPaneId ? ['-t', currentPaneId] : []),
         '-F',
-        `#{pane_id}${TMUX_PANE_FIELD_SEPARATOR}#{pane_current_command}${TMUX_PANE_FIELD_SEPARATOR}#{pane_start_command}${TMUX_PANE_FIELD_SEPARATOR}#{pane_current_path}`,
+        [
+          '#{pane_id}',
+          '#{pane_current_command}',
+          '#{pane_left}',
+          '#{pane_top}',
+          '#{pane_width}',
+          '#{pane_height}',
+          '#{pane_bottom}',
+          '#{window_width}',
+          '#{window_height}',
+          '#{pane_start_command}',
+          '#{pane_current_path}',
+        ].join(TMUX_PANE_FIELD_SEPARATOR),
       ]),
     );
   } catch {
@@ -558,21 +675,39 @@ export function registerHudResizeHook(
   hudPaneId: string,
   leaderPaneId: string | undefined,
   heightLines: number,
-  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+  optionsOrExecTmuxSync: RegisterHudResizeHookOptions | TmuxExecSync = {},
+  maybeExecTmuxSync?: TmuxExecSync,
 ): boolean {
+  const options = typeof optionsOrExecTmuxSync === 'function' ? {} : optionsOrExecTmuxSync;
+  const execTmuxSync = typeof optionsOrExecTmuxSync === 'function'
+    ? optionsOrExecTmuxSync
+    : (maybeExecTmuxSync ?? defaultExecTmuxSync);
   if (!hudPaneId.startsWith('%')) return false;
   const context = readHudResizeHookContext(leaderPaneId, execTmuxSync);
   if (!context) return false;
   const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
   const height = String(Math.max(1, Math.floor(heightLines)));
-  const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, context));
+  const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, context, options.env?.TMUX));
+  const omxBin = resolveOmxCliEntryPath({ cwd: options.cwd, env: options.env });
   try {
     execTmuxSync(['set-hook', '-t', context.sessionId, context.hookSlot, `run-shell -b ${resizeCmd}`]);
     unregisterLegacyHudResizeHook(context, execTmuxSync);
-    return true;
   } catch {
     return false;
   }
+  if (omxBin && leaderPaneId?.startsWith('%')) {
+    try {
+      const reconcileCmd = shellEscapeSingle(
+        buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, context, options),
+      );
+      execTmuxSync(['set-hook', '-t', context.sessionId, context.layoutHookSlot, `run-shell -b ${reconcileCmd}`]);
+    } catch {
+      // Keep the resize hook installed so older tmux builds still recover on
+      // client resize even when layout-change hook registration is unavailable.
+      return false;
+    }
+  }
+  return true;
 }
 
 export function unregisterHudResizeHook(
@@ -581,11 +716,17 @@ export function unregisterHudResizeHook(
 ): boolean {
   const context = readHudResizeHookContext(leaderPaneId, execTmuxSync);
   if (!context) return false;
+  let ok = true;
   try {
     unregisterLegacyHudResizeHook(context, execTmuxSync);
     execTmuxSync(['set-hook', '-u', '-t', context.sessionId, context.hookSlot]);
-    return true;
   } catch {
-    return false;
+    ok = false;
   }
+  try {
+    execTmuxSync(['set-hook', '-u', '-t', context.sessionId, context.layoutHookSlot]);
+  } catch {
+    ok = false;
+  }
+  return ok;
 }

--- a/src/scripts/__tests__/run-test-files.test.ts
+++ b/src/scripts/__tests__/run-test-files.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-function runCompiledRunner(root: string, envOverrides: Record<string, string> = {}, timeoutMs = 5_000) {
+function runCompiledRunner(root: string, envOverrides: Record<string, string> = {}, timeoutMs = 15_000) {
   return spawnSync(process.execPath, ['dist/scripts/run-test-files.js', root], {
     cwd: process.cwd(),
     encoding: 'utf-8',
@@ -78,7 +78,6 @@ describe('run-test-files diagnostics', () => {
       rmSync(wd, { recursive: true, force: true });
     }
   });
-
 
   it('script-level force exit terminates a completed test child that blocks process exit', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omx-run-test-files-'));
@@ -181,6 +180,33 @@ describe('run-test-files diagnostics', () => {
     }
   });
 
+  it('applies the runner timeout per test file instead of skipping later files after cumulative runtime', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omx-run-test-files-'));
+    try {
+      const testsDir = join(wd, '__tests__');
+      mkdirSync(testsDir, { recursive: true });
+      for (const name of ['a-slow-pass.test.js', 'b-slow-pass.test.js']) {
+        writeFileSync(
+          join(testsDir, name),
+          [
+            "import { test } from 'node:test';",
+            "test('passes after a short delay', async () => {",
+            "  await new Promise((resolve) => setTimeout(resolve, 450));",
+            "});",
+            '',
+          ].join('\n'),
+        );
+      }
+
+      const result = runCompiledRunner(wd, { OMX_NODE_TEST_RUNNER_TIMEOUT_MS: '750' }, 3_000);
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.doesNotMatch(result.stderr, /timeout before/);
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
   it('logs that per-test timeout is disabled by default', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omx-run-test-files-'));
     try {
@@ -199,6 +225,29 @@ describe('run-test-files diagnostics', () => {
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.match(result.stderr, /per-test timeout disabled/);
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes local test files by default to avoid runaway full-suite fan-out', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omx-run-test-files-'));
+    try {
+      const testsDir = join(wd, '__tests__');
+      mkdirSync(testsDir, { recursive: true });
+      writeFileSync(
+        join(testsDir, 'pass.test.js'),
+        [
+          "import { test } from 'node:test';",
+          "test('passes', () => {});",
+          '',
+        ].join('\n'),
+      );
+
+      const result = runCompiledRunner(wd, { CI: 'false', GITHUB_ACTIONS: 'false' });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /test concurrency 1/);
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }
@@ -250,6 +299,40 @@ describe('run-test-files diagnostics', () => {
     }
   });
 
+  it('isolates process env mutations between test files', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omx-run-test-files-'));
+    try {
+      const testsDir = join(wd, '__tests__');
+      mkdirSync(testsDir, { recursive: true });
+      writeFileSync(
+        join(testsDir, 'a-mutate-env.test.js'),
+        [
+          "import { test } from 'node:test';",
+          "test('mutates process env', () => { process.env.OMX_TEST_FILE_LEAK = 'leaked'; });",
+          '',
+        ].join('\n'),
+      );
+      writeFileSync(
+        join(testsDir, 'b-observe-env.test.js'),
+        [
+          "import { test } from 'node:test';",
+          "import assert from 'node:assert/strict';",
+          "test('does not inherit prior file env mutation', () => {",
+          "  assert.equal(process.env.OMX_TEST_FILE_LEAK, undefined);",
+          "});",
+          '',
+        ].join('\n'),
+      );
+
+      const result = runCompiledRunner(wd);
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /per-file process isolation/);
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
   it('sanitizes live OMX runtime state env from child test processes by default', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omx-run-test-files-'));
     try {
@@ -265,8 +348,16 @@ describe('run-test-files diagnostics', () => {
           "  assert.equal(process.env.OMX_STATE_ROOT, undefined);",
           "  assert.equal(process.env.OMX_TEAM_STATE_ROOT, undefined);",
           "  assert.equal(process.env.OMX_SESSION_ID, undefined);",
+          "  assert.equal(process.env.OMX_RUNS_DIR, undefined);",
+          "  assert.equal(process.env.OMXBOX_ACTIVE, undefined);",
+          "  assert.equal(process.env.OMX_MADMAX_DETACHED_CONTEXT, undefined);",
+          "  assert.equal(process.env.OMX_DEFAULT_STANDARD_MODEL, undefined);",
+          "  assert.equal(process.env.USE_OMX_EXPLORE_CMD, undefined);",
           "  assert.equal(process.env.CODEX_SESSION_ID, undefined);",
+          "  assert.equal(process.env.CODEX_HOME, undefined);",
           "  assert.equal(process.env.SESSION_ID, undefined);",
+          "  assert.equal(process.env.TMUX, undefined);",
+          "  assert.equal(process.env.TMUX_PANE, undefined);",
           "});",
           '',
         ].join('\n'),
@@ -277,8 +368,49 @@ describe('run-test-files diagnostics', () => {
         OMX_STATE_ROOT: '/tmp/live-omx-state-root',
         OMX_TEAM_STATE_ROOT: '/tmp/live-team-state-root',
         OMX_SESSION_ID: 'live-omx-session',
+        OMX_RUNS_DIR: '/tmp/live-omx-runs',
+        OMXBOX_ACTIVE: '1',
+        OMX_MADMAX_DETACHED_CONTEXT: 'live-context',
+        OMX_DEFAULT_STANDARD_MODEL: 'ambient-model',
+        USE_OMX_EXPLORE_CMD: '1',
         CODEX_SESSION_ID: 'live-codex-session',
+        CODEX_HOME: '/tmp/live-codex-home',
         SESSION_ID: 'live-shell-session',
+        TMUX: '/tmp/live-tmux,1,2',
+        TMUX_PANE: '%live',
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves explicit test-runner controls and explore harness override while scrubbing live runtime env', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omx-run-test-files-'));
+    try {
+      const testsDir = join(wd, '__tests__');
+      mkdirSync(testsDir, { recursive: true });
+      writeFileSync(
+        join(testsDir, 'env-allowlist.test.js'),
+        [
+          "import { test } from 'node:test';",
+          "import assert from 'node:assert/strict';",
+          "test('runner env allowlist is narrow', () => {",
+          "  assert.equal(process.env.OMX_EXPLORE_BIN, '/tmp/fake-explore');",
+          "  assert.equal(process.env.OMX_NODE_TEST_CONCURRENCY, '1');",
+          "  assert.equal(process.env.OMX_ROOT, undefined);",
+          "  assert.equal(process.env.CODEX_HOME, undefined);",
+          "});",
+          '',
+        ].join('\n'),
+      );
+
+      const result = runCompiledRunner(wd, {
+        OMX_EXPLORE_BIN: '/tmp/fake-explore',
+        OMX_NODE_TEST_CONCURRENCY: '1',
+        OMX_ROOT: '/tmp/live-omx-root',
+        CODEX_HOME: '/tmp/live-codex-home',
       });
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
@@ -300,6 +432,8 @@ describe('run-test-files diagnostics', () => {
           "test('runtime env is preserved', () => {",
           "  assert.equal(process.env.OMX_ROOT, '/tmp/live-omx-root');",
           "  assert.equal(process.env.OMX_SESSION_ID, 'live-omx-session');",
+          "  assert.equal(process.env.USE_OMX_EXPLORE_CMD, '1');",
+          "  assert.equal(process.env.CODEX_HOME, '/tmp/live-codex-home');",
           "});",
           '',
         ].join('\n'),
@@ -309,6 +443,8 @@ describe('run-test-files diagnostics', () => {
         OMX_NODE_TEST_PRESERVE_RUNTIME_ENV: '1',
         OMX_ROOT: '/tmp/live-omx-root',
         OMX_SESSION_ID: 'live-omx-session',
+        USE_OMX_EXPLORE_CMD: '1',
+        CODEX_HOME: '/tmp/live-codex-home',
       });
 
       assert.equal(result.status, 0, result.stderr || result.stdout);

--- a/src/scripts/run-test-files.ts
+++ b/src/scripts/run-test-files.ts
@@ -6,14 +6,24 @@ const DEFAULT_TEST_TIMEOUT_MS = 0;
 const DEFAULT_RUNNER_TIMEOUT_MS = 30 * 60 * 1_000;
 const DEFAULT_FORCE_EXIT_GRACE_MS = 30_000;
 const DEFAULT_CI_TEST_CONCURRENCY = 1;
-const RUNTIME_STATE_ENV_KEYS = [
-  'OMX_ROOT',
-  'OMX_STATE_ROOT',
-  'OMX_TEAM_STATE_ROOT',
-  'OMX_SESSION_ID',
-  'CODEX_SESSION_ID',
-  'SESSION_ID',
-] as const;
+const DEFAULT_LOCAL_TEST_CONCURRENCY = 1;
+const PRESERVED_TEST_ENV_KEYS = new Set([
+  'OMX_EXPLORE_BIN',
+  'OMX_NODE_TEST_CONCURRENCY',
+  'OMX_NODE_TEST_FORCE_EXIT',
+  'OMX_NODE_TEST_FORCE_EXIT_GRACE_MS',
+  'OMX_NODE_TEST_PRESERVE_RUNTIME_ENV',
+  'OMX_NODE_TEST_RUNNER_TIMEOUT_MS',
+  'OMX_NODE_TEST_TIMEOUT_MS',
+]);
+
+type TestRunResult = {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  errorMessage?: string;
+  timedOut: boolean;
+  abnormal: boolean;
+};
 
 function parseBooleanEnv(value: string | undefined): boolean {
   if (!value) return false;
@@ -60,7 +70,36 @@ function parseTestConcurrency(env: NodeJS.ProcessEnv): number | undefined {
     return undefined;
   }
 
-  return env.CI === 'true' || env.GITHUB_ACTIONS === 'true' ? DEFAULT_CI_TEST_CONCURRENCY : undefined;
+  return env.CI === 'true' || env.GITHUB_ACTIONS === 'true'
+    ? DEFAULT_CI_TEST_CONCURRENCY
+    : DEFAULT_LOCAL_TEST_CONCURRENCY;
+}
+
+function shouldScrubRuntimeEnvKey(key: string): boolean {
+  if (PRESERVED_TEST_ENV_KEYS.has(key)) return false;
+  return (
+    key.startsWith('OMX_') ||
+    key.startsWith('OMXBOX_') ||
+    key.startsWith('CODEX_') ||
+    key === 'USE_OMX_EXPLORE_CMD' ||
+    key === 'SESSION_ID' ||
+    key === 'TMUX' ||
+    key === 'TMUX_PANE'
+  );
+}
+
+function buildChildEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const childEnv = { ...env };
+  delete childEnv.NODE_TEST_CONTEXT;
+  if (!parseBooleanEnv(env.OMX_NODE_TEST_PRESERVE_RUNTIME_ENV)) {
+    for (const key of Object.keys(childEnv)) {
+      if (shouldScrubRuntimeEnvKey(key)) {
+        delete childEnv[key];
+      }
+    }
+  }
+  childEnv.OMX_TEST_RELAX_TMUX_TIMEOUT = '1';
+  return childEnv;
 }
 
 const roots = process.argv.slice(2);
@@ -82,41 +121,33 @@ const runnerTimeoutMs = parseTimeoutMs(process.env.OMX_NODE_TEST_RUNNER_TIMEOUT_
 const forceExitGraceMs = parseTimeoutMs(process.env.OMX_NODE_TEST_FORCE_EXIT_GRACE_MS, DEFAULT_FORCE_EXIT_GRACE_MS);
 const testConcurrency = parseTestConcurrency(process.env);
 const forceExit = parseBooleanEnv(process.env.OMX_NODE_TEST_FORCE_EXIT);
-const testArgs = ['--test'];
+const sharedTestArgs = ['--test'];
 if (testTimeoutMs > 0) {
-  testArgs.push(`--test-timeout=${testTimeoutMs}`);
+  sharedTestArgs.push(`--test-timeout=${testTimeoutMs}`);
 }
 if (testConcurrency) {
-  testArgs.push(`--test-concurrency=${testConcurrency}`);
+  sharedTestArgs.push(`--test-concurrency=${testConcurrency}`);
 }
 if (forceExit) {
-  testArgs.push('--test-force-exit', '--test-reporter=tap');
+  sharedTestArgs.push('--test-force-exit', '--test-reporter=tap');
 }
-testArgs.push(...files);
 
 console.error(
   `[run-test-files] running ${files.length} test file(s) from ${targets.join(', ')}${
     testTimeoutMs > 0 ? ` with per-test timeout ${testTimeoutMs}ms` : ' with per-test timeout disabled'
   }${testConcurrency ? `, test concurrency ${testConcurrency}` : ', default test concurrency'}${
     forceExit ? `, force exit enabled with ${forceExitGraceMs}ms completion grace` : ', force exit disabled'
-  }${runnerTimeoutMs > 0 ? `, and runner timeout ${runnerTimeoutMs}ms` : ', and runner timeout disabled'}`,
+  }${runnerTimeoutMs > 0 ? `, and runner timeout ${runnerTimeoutMs}ms` : ', and runner timeout disabled'}, with per-file process isolation`,
 );
 
-const childEnv = { ...process.env };
-delete childEnv.NODE_TEST_CONTEXT;
-childEnv.OMX_TEST_RELAX_TMUX_TIMEOUT = '1';
-if (!parseBooleanEnv(process.env.OMX_NODE_TEST_PRESERVE_RUNTIME_ENV)) {
-  for (const key of RUNTIME_STATE_ENV_KEYS) {
-    delete childEnv[key];
-  }
-}
+const childEnv = buildChildEnv(process.env);
 
-function reportAbnormalExit(signal: NodeJS.Signals | null, errorMessage?: string): void {
+function reportAbnormalExit(file: string, signal: NodeJS.Signals | null, errorMessage?: string): void {
   if (errorMessage) {
-    console.error(`[run-test-files] node --test error: ${errorMessage}`);
+    console.error(`[run-test-files] node --test error for ${file}: ${errorMessage}`);
   }
   console.error(
-    `[run-test-files] node --test did not exit normally${signal ? ` (signal: ${signal})` : ''}. `
+    `[run-test-files] node --test did not exit normally for ${file}${signal ? ` (signal: ${signal})` : ''}. `
       + `Roots: ${targets.join(', ')}. Test files: ${files.length}. `
       + `Per-test timeout: ${testTimeoutMs > 0 ? `${testTimeoutMs}ms` : 'disabled'}. `
       + `Test concurrency: ${testConcurrency ?? 'default'}. `
@@ -146,155 +177,203 @@ function terminateChild(child: ChildProcess): void {
   signalChild(child, 'SIGKILL');
 }
 
-function runWithCompletionForceExit(): void {
-  let finished = false;
-  let sawFailure = false;
-  let lastTapOk = 0;
-  let tapTests: number | undefined;
-  let tapPass: number | undefined;
-  let tapFail = 0;
-  let tapCancelled = 0;
-  let completedFromSummary = false;
-  let completionTimer: NodeJS.Timeout | undefined;
-  let runnerTimer: NodeJS.Timeout | undefined;
-  let stdoutRemainder = '';
-  let stderrRemainder = '';
+function runFileWithCompletionForceExit(file: string): Promise<TestRunResult> {
+  return new Promise((resolveRun) => {
+    let finished = false;
+    let sawFailure = false;
+    let lastTapOk = 0;
+    let tapTests: number | undefined;
+    let tapPass: number | undefined;
+    let tapFail = 0;
+    let tapCancelled = 0;
+    let completedFromSummary = false;
+    let completionTimer: NodeJS.Timeout | undefined;
+    let runnerTimer: NodeJS.Timeout | undefined;
+    let stdoutRemainder = '';
+    let stderrRemainder = '';
 
-  const child = spawn(process.execPath, testArgs, {
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: childEnv,
-    detached: !isWindows(),
-  });
+    const child = spawn(process.execPath, [...sharedTestArgs, file], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: childEnv,
+      detached: !isWindows(),
+    });
 
-  function finish(exitCode: number, reason: string): void {
-    if (finished) return;
-    finished = true;
-    if (completionTimer) clearTimeout(completionTimer);
-    if (runnerTimer) clearTimeout(runnerTimer);
-    console.error(`[run-test-files] ${reason}; exiting with status ${exitCode}`);
-    terminateChild(child);
-    child.stdout?.destroy();
-    child.stderr?.destroy();
-    child.unref();
-    process.exit(exitCode);
-  }
-
-  function markFailure(): void {
-    sawFailure = true;
-    if (completionTimer) {
-      clearTimeout(completionTimer);
-      completionTimer = undefined;
-    }
-  }
-
-  function armCompletionTimer(reason: string): void {
-    if (sawFailure) return;
-    if (completionTimer) clearTimeout(completionTimer);
-    completionTimer = setTimeout(() => {
-      if (sawFailure) return;
-      finish(0, reason);
-    }, forceExitGraceMs);
-  }
-
-  function sawCleanTapSummary(): boolean {
-    if (tapTests === undefined || tapPass === undefined) return false;
-    return tapTests === tapPass && tapFail === 0 && tapCancelled === 0;
-  }
-
-  function parseTapLine(line: string): void {
-    if (/^(?:not ok|Bail out!)/.test(line)) {
-      markFailure();
-      return;
-    }
-
-    const summary = line.match(/^# (tests|pass|fail|cancelled) (\d+)$/);
-    if (summary) {
-      const count = Number(summary[2]);
-      if (summary[1] === 'tests') tapTests = count;
-      if (summary[1] === 'pass') tapPass = count;
-      if (summary[1] === 'fail') tapFail = count;
-      if (summary[1] === 'cancelled') tapCancelled = count;
-      if ((summary[1] === 'fail' || summary[1] === 'cancelled') && count > 0) markFailure();
-      return;
-    }
-
-    const ok = line.match(/^ok (\d+)\b/);
-    if (ok) {
-      lastTapOk = Number(ok[1]);
-      if (lastTapOk >= files.length) {
-        armCompletionTimer(`force-exit completion grace elapsed after TAP ok ${lastTapOk} with no later failures`);
+    function finish(status: number | null, signal: NodeJS.Signals | null, reason: string, terminate: boolean): void {
+      if (finished) return;
+      finished = true;
+      if (completionTimer) clearTimeout(completionTimer);
+      if (runnerTimer) clearTimeout(runnerTimer);
+      console.error(`[run-test-files] ${file}: ${reason}; status ${status ?? 'unknown'}`);
+      if (terminate) {
+        terminateChild(child);
       }
-      return;
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      child.unref();
+      resolveRun({
+        status,
+        signal,
+        timedOut: reason.startsWith('runner timeout'),
+        abnormal: status === null || signal !== null || reason.startsWith('node --test failed to spawn'),
+      });
     }
 
-    const plan = line.match(/^1\.\.(\d+)$/);
-    if (plan && Number(plan[1]) === lastTapOk && !sawFailure) {
-      armCompletionTimer(`force-exit completion grace elapsed after TAP plan ${line}`);
-      return;
+    function markFailure(): void {
+      sawFailure = true;
+      if (completionTimer) {
+        clearTimeout(completionTimer);
+        completionTimer = undefined;
+      }
     }
 
-    if (/^# duration_ms /.test(line) && sawCleanTapSummary()) {
-      completedFromSummary = true;
-      armCompletionTimer('force-exit completion grace elapsed after clean TAP summary');
+    function armCompletionTimer(reason: string): void {
+      if (sawFailure) return;
+      if (completionTimer) clearTimeout(completionTimer);
+      completionTimer = setTimeout(() => {
+        if (sawFailure) return;
+        finish(0, null, reason, true);
+      }, forceExitGraceMs);
     }
-  }
 
-  function handleOutput(chunk: Buffer, stream: NodeJS.WriteStream, isStdout: boolean): void {
-    stream.write(chunk);
-    const text = chunk.toString('utf8');
-    let combined = (isStdout ? stdoutRemainder : stderrRemainder) + text;
-    const lines = combined.split(/\r?\n/);
-    combined = lines.pop() ?? '';
-    if (isStdout) {
-      stdoutRemainder = combined;
-    } else {
-      stderrRemainder = combined;
+    function sawCleanTapSummary(): boolean {
+      if (tapTests === undefined || tapPass === undefined) return false;
+      return tapTests === tapPass && tapFail === 0 && tapCancelled === 0;
     }
-    for (const line of lines) parseTapLine(line);
-  }
 
-  child.stdout?.on('data', (chunk: Buffer) => handleOutput(chunk, process.stdout, true));
-  child.stderr?.on('data', (chunk: Buffer) => handleOutput(chunk, process.stderr, false));
+    function parseTapLine(line: string): void {
+      if (/^(?:not ok|Bail out!)/.test(line)) {
+        markFailure();
+        return;
+      }
 
-  child.on('error', (error) => {
-    reportAbnormalExit(null, error.message);
-    finish(1, 'node --test failed to spawn');
+      const summary = line.match(/^# (tests|pass|fail|cancelled) (\d+)$/);
+      if (summary) {
+        const count = Number(summary[2]);
+        if (summary[1] === 'tests') tapTests = count;
+        if (summary[1] === 'pass') tapPass = count;
+        if (summary[1] === 'fail') tapFail = count;
+        if (summary[1] === 'cancelled') tapCancelled = count;
+        if ((summary[1] === 'fail' || summary[1] === 'cancelled') && count > 0) markFailure();
+        return;
+      }
+
+      const ok = line.match(/^ok (\d+)\b/);
+      if (ok) {
+        lastTapOk = Number(ok[1]);
+        if (lastTapOk >= files.length) {
+          armCompletionTimer(`force-exit completion grace elapsed after TAP ok ${lastTapOk} with no later failures`);
+        }
+        return;
+      }
+
+      const plan = line.match(/^1\.\.(\d+)$/);
+      if (plan && Number(plan[1]) === lastTapOk && !sawFailure) {
+        armCompletionTimer(`force-exit completion grace elapsed after TAP plan ${line}`);
+        return;
+      }
+
+      if (/^# duration_ms /.test(line) && sawCleanTapSummary()) {
+        completedFromSummary = true;
+        armCompletionTimer('force-exit completion grace elapsed after clean TAP summary');
+      }
+    }
+
+    function handleOutput(chunk: Buffer, stream: NodeJS.WriteStream, isStdout: boolean): void {
+      stream.write(chunk);
+      const text = chunk.toString('utf8');
+      let combined = (isStdout ? stdoutRemainder : stderrRemainder) + text;
+      const lines = combined.split(/\r?\n/);
+      combined = lines.pop() ?? '';
+      if (isStdout) {
+        stdoutRemainder = combined;
+      } else {
+        stderrRemainder = combined;
+      }
+      for (const line of lines) parseTapLine(line);
+    }
+
+    child.stdout?.on('data', (chunk: Buffer) => handleOutput(chunk, process.stdout, true));
+    child.stderr?.on('data', (chunk: Buffer) => handleOutput(chunk, process.stderr, false));
+
+    child.on('error', (error) => {
+      reportAbnormalExit(file, null, error.message);
+      finish(null, null, 'node --test failed to spawn', true);
+    });
+
+    child.on('exit', (status, signal) => {
+      if (finished) return;
+      if (stdoutRemainder) parseTapLine(stdoutRemainder);
+      if (stderrRemainder) parseTapLine(stderrRemainder);
+      if (typeof status === 'number') {
+        finish(status, null, `node --test exited normally${completedFromSummary ? ' after clean TAP summary' : ''}`, false);
+        return;
+      }
+      reportAbnormalExit(file, signal);
+      finish(null, signal, 'node --test exited without a numeric status', true);
+    });
+
+    if (runnerTimeoutMs > 0) {
+      runnerTimer = setTimeout(() => {
+        reportAbnormalExit(file, null);
+        finish(1, null, `runner timeout ${runnerTimeoutMs}ms elapsed`, true);
+      }, runnerTimeoutMs);
+    }
   });
-
-  child.on('exit', (status, signal) => {
-    if (finished) return;
-    if (stdoutRemainder) parseTapLine(stdoutRemainder);
-    if (stderrRemainder) parseTapLine(stderrRemainder);
-    if (typeof status === 'number') {
-      finish(status, `node --test exited normally${completedFromSummary ? ' after clean TAP summary' : ''}`);
-      return;
-    }
-    reportAbnormalExit(signal);
-    finish(1, 'node --test exited without a numeric status');
-  });
-
-  if (runnerTimeoutMs > 0) {
-    runnerTimer = setTimeout(() => {
-      reportAbnormalExit(null);
-      finish(1, `runner timeout ${runnerTimeoutMs}ms elapsed`);
-    }, runnerTimeoutMs);
-  }
 }
 
-if (forceExit) {
-  runWithCompletionForceExit();
-} else {
-  const result = spawnSync(process.execPath, testArgs, {
+function runFileSync(file: string): TestRunResult {
+  const result = spawnSync(process.execPath, [...sharedTestArgs, file], {
     stdio: 'inherit',
     env: childEnv,
     timeout: runnerTimeoutMs > 0 ? runnerTimeoutMs : undefined,
     killSignal: 'SIGTERM',
   });
 
-  if (typeof result.status === 'number') {
-    process.exit(result.status);
+  const timedOut = (result.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT';
+  if (result.status !== 0 && (result.error || typeof result.status !== 'number')) {
+    reportAbnormalExit(file, result.signal, result.error?.message);
   }
 
-  reportAbnormalExit(result.signal, result.error?.message);
-  process.exit(1);
+  return {
+    status: result.status,
+    signal: result.signal,
+    errorMessage: result.error?.message,
+    timedOut,
+    abnormal: Boolean(result.error || typeof result.status !== 'number'),
+  };
 }
+
+async function main(): Promise<void> {
+  const failedFiles: string[] = [];
+  let abnormalExit = false;
+  let runnerTimedOut = false;
+
+  for (const file of files) {
+    const result = forceExit ? await runFileWithCompletionForceExit(file) : runFileSync(file);
+
+    if (result.status === 0) {
+      continue;
+    }
+
+    failedFiles.push(file);
+    abnormalExit = abnormalExit || result.abnormal;
+    runnerTimedOut = runnerTimedOut || result.timedOut;
+  }
+
+  if (failedFiles.length > 0 || runnerTimedOut) {
+    const failureSummary = failedFiles.length === 0 && runnerTimedOut
+      ? `runner timed out with 0 of ${files.length} test file(s) failed`
+      : `${failedFiles.length} of ${files.length} test file(s) failed${abnormalExit ? ' or timed out' : ''}${runnerTimedOut ? '; runner timed out' : ''}`;
+    console.error(
+      `[run-test-files] ${failureSummary}:`,
+    );
+    for (const file of failedFiles) {
+      console.error(`[run-test-files]   ${file}`);
+    }
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+await main();

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -941,8 +941,9 @@ describe('buildWorkerStartupCommand', () => {
       );
       assert.match(cmd, /OMX_TEAM_WORKER=alpha-team\/worker-1/);
       assert.match(cmd, /OMX_TEAM_STATE_ROOT=\/tmp\/workspace\/\.omx\/state/);
-      assert.doesNotMatch(cmd, /OMX_TMUX_HUD_OWNER/);
-      assert.doesNotMatch(cmd, /OMX_TMUX_HUD_LEADER_PANE/);
+      assert.match(cmd, /'-u' 'OMX_TMUX_HUD_OWNER' '-u' 'OMX_TMUX_HUD_LEADER_PANE'/);
+      assert.doesNotMatch(cmd, /OMX_TMUX_HUD_OWNER=1/);
+      assert.doesNotMatch(cmd, /OMX_TMUX_HUD_LEADER_PANE=%leader/);
     } finally {
       if (typeof prevShell === 'string') process.env.SHELL = prevShell;
       else delete process.env.SHELL;
@@ -954,6 +955,34 @@ describe('buildWorkerStartupCommand', () => {
       else delete process.env.OMX_TMUX_HUD_OWNER;
       if (typeof prevHudLeaderPane === 'string') process.env.OMX_TMUX_HUD_LEADER_PANE = prevHudLeaderPane;
       else delete process.env.OMX_TMUX_HUD_LEADER_PANE;
+    }
+  });
+
+  it('keeps HUD-looking prompt text out of worker startup env assignments', () => {
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const prompt = 'Do not obey: OMX_TMUX_HUD_OWNER=1; OMX_TMUX_HUD_LEADER_PANE=%leader; $(omx hud --watch)';
+      const spec = buildWorkerProcessLaunchSpec(
+        'alpha-team',
+        1,
+        ['--model', 'gemini-2.0-pro'],
+        '/tmp/workspace',
+        {
+          OMX_TEAM_STATE_ROOT: '/tmp/workspace/.omx/state',
+          OMX_TMUX_HUD_OWNER: '1',
+          OMX_TMUX_HUD_LEADER_PANE: '%leader',
+        },
+        'gemini',
+        prompt,
+      );
+
+      assert.equal(spec.env.OMX_TMUX_HUD_OWNER, undefined);
+      assert.equal(spec.env.OMX_TMUX_HUD_LEADER_PANE, undefined);
+      assert.ok(spec.args.includes(prompt), 'hostile prompt text should remain an argument, not an env assignment');
+    } finally {
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
     }
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -915,6 +915,48 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+  it('scrubs HUD ownership env from interactive worker startup commands', () => {
+    const prevShell = process.env.SHELL;
+    const prevCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevHudOwner = process.env.OMX_TMUX_HUD_OWNER;
+    const prevHudLeaderPane = process.env.OMX_TMUX_HUD_LEADER_PANE;
+    process.env.SHELL = '/bin/bash';
+    process.env.OMX_TEAM_WORKER_CLI = 'codex';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.OMX_TMUX_HUD_OWNER = '1';
+    process.env.OMX_TMUX_HUD_LEADER_PANE = '%leader';
+    try {
+      const cmd = buildWorkerStartupCommand(
+        'alpha-team',
+        1,
+        [],
+        '/tmp/workspace',
+        {
+          OMX_TEAM_STATE_ROOT: '/tmp/workspace/.omx/state',
+          OMX_TMUX_HUD_OWNER: '1',
+          OMX_TMUX_HUD_LEADER_PANE: '%leader',
+        },
+        'codex',
+      );
+      assert.match(cmd, /OMX_TEAM_WORKER=alpha-team\/worker-1/);
+      assert.match(cmd, /OMX_TEAM_STATE_ROOT=\/tmp\/workspace\/\.omx\/state/);
+      assert.doesNotMatch(cmd, /OMX_TMUX_HUD_OWNER/);
+      assert.doesNotMatch(cmd, /OMX_TMUX_HUD_LEADER_PANE/);
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevHudOwner === 'string') process.env.OMX_TMUX_HUD_OWNER = prevHudOwner;
+      else delete process.env.OMX_TMUX_HUD_OWNER;
+      if (typeof prevHudLeaderPane === 'string') process.env.OMX_TMUX_HUD_LEADER_PANE = prevHudLeaderPane;
+      else delete process.env.OMX_TMUX_HUD_LEADER_PANE;
+    }
+  });
+
   it('auto-selects claude worker CLI from claude model', () => {
     const prevShell = process.env.SHELL;
     const prevCli = process.env.OMX_TEAM_WORKER_CLI;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -2246,6 +2246,34 @@ describe('team worker launch mode helpers', () => {
       assert.deepEqual(spec.args, ['--model', 'gpt-5.3-codex', '--dangerously-bypass-approvals-and-sandbox']);
       assert.equal(spec.env.OMX_TEAM_WORKER, 'alpha-team/worker-2');
       assert.equal(spec.env.OMX_TEAM_STATE_ROOT, '/tmp/workspace/.omx/state');
+      assert.equal(spec.env.OMX_TMUX_HUD_OWNER, undefined);
+      assert.equal(spec.env.OMX_TMUX_HUD_LEADER_PANE, undefined);
+    } finally {
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('buildWorkerProcessLaunchSpec scrubs HUD ownership env from worker launches', () => {
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const spec = buildWorkerProcessLaunchSpec(
+        'alpha-team',
+        1,
+        [],
+        '/tmp/workspace',
+        {
+          OMX_TEAM_STATE_ROOT: '/tmp/workspace/.omx/state',
+          OMX_TMUX_HUD_OWNER: '1',
+          OMX_TMUX_HUD_LEADER_PANE: '%leader',
+        },
+        'codex',
+      );
+      assert.equal(spec.env.OMX_TEAM_WORKER, 'alpha-team/worker-1');
+      assert.equal(spec.env.OMX_TEAM_STATE_ROOT, '/tmp/workspace/.omx/state');
+      assert.equal(spec.env.OMX_TMUX_HUD_OWNER, undefined);
+      assert.equal(spec.env.OMX_TMUX_HUD_LEADER_PANE, undefined);
     } finally {
       if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
       else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;

--- a/src/team/__tests__/tmux-test-fixture.test.ts
+++ b/src/team/__tests__/tmux-test-fixture.test.ts
@@ -12,6 +12,7 @@ function skipUnlessTmux(t: TestContext): void {
 function runAmbientTmux(args: string[]): string {
   return execFileSync('tmux', args, {
     encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
     env: {
       ...process.env,
       TMUX: undefined,

--- a/src/team/__tests__/tmux-test-fixture.ts
+++ b/src/team/__tests__/tmux-test-fixture.ts
@@ -3,6 +3,9 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+const TMUX_COMMAND_TIMEOUT_MS = 5_000;
+const NULL_TMUX_CONFIG = process.platform === 'win32' ? 'NUL' : '/dev/null';
+
 interface TmuxEnvSnapshot {
   TMUX?: string;
   TMUX_PANE?: string;
@@ -43,15 +46,21 @@ function applyTmuxEnv(snapshot: TmuxEnvSnapshot): void {
 
 function runTmux(
   args: string[],
-  options: { ignoreTmuxEnv?: boolean; env?: NodeJS.ProcessEnv; serverName?: string } = {},
+  options: { ignoreTmuxEnv?: boolean; env?: NodeJS.ProcessEnv; serverName?: string; configFile?: string } = {},
 ): string {
   const env = options.env
     ?? (options.ignoreTmuxEnv ? { ...process.env, TMUX: undefined, TMUX_PANE: undefined } : process.env);
-  const argv = options.serverName ? ['-L', options.serverName, ...args] : args;
+  const argv = [
+    ...(options.configFile ? ['-f', options.configFile] : []),
+    ...(options.serverName ? ['-L', options.serverName] : []),
+    ...args,
+  ];
   const result = spawnSync('tmux', argv, {
     encoding: 'utf-8',
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: TMUX_COMMAND_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (result.error) {
     throw result.error;
@@ -106,7 +115,11 @@ export async function withTempTmuxSession<T>(
   const sessionName = uniqueTmuxIdentifier('omx-test');
   const serverName = options.useAmbientServer ? '' : uniqueTmuxIdentifier('omx-fixture');
   const serverKind: TempTmuxSessionFixture['serverKind'] = options.useAmbientServer ? 'ambient' : 'synthetic';
-  const tmuxOptions = { ignoreTmuxEnv: true, serverName: serverName || undefined } as const;
+  const tmuxOptions = {
+    ignoreTmuxEnv: true,
+    serverName: serverName || undefined,
+    configFile: serverKind === 'synthetic' ? NULL_TMUX_CONFIG : undefined,
+  } as const;
 
   const created = runTmux([
     'new-session',

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3681,12 +3681,9 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       worker: 'leader-fixed',
       reason: 'force_bypass',
     }, cwd).catch(() => {});
-  }
 
-  if (force && config.worker_launch_mode === 'prompt') {
-    // Prompt-mode workers are raw CLI children, not team-runtime workers that
-    // participate in the shutdown-ack handshake. Waiting the full ack window
-    // before force-killing them only adds deterministic suite slowness.
+    // Explicit force means teardown now. Do not spend the graceful ack window
+    // waiting for interactive panes or prompt workers that will be killed below.
     skipWorkerAcks = true;
   }
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -10,6 +10,7 @@ import {
   hasCurrentTmuxClientContext,
   createTeamSession,
   buildWorkerProcessLaunchSpec,
+  scrubTeamWorkerHudOwnershipEnv,
   resolveTeamWorkerCli,
   type TeamWorkerCli,
   resolveTeamWorkerCliPlan,
@@ -2236,7 +2237,7 @@ function spawnPromptWorker(
     initialPrompt,
     workerRole,
   );
-  const childEnv = { ...process.env, ...processSpec.env };
+  const childEnv = scrubTeamWorkerHudOwnershipEnv({ ...process.env, ...processSpec.env });
   // Prompt workers are external CLI processes, not in-process runtime code.
   // Keeping c8's NODE_V8_COVERAGE in their environment makes coverage runs
   // track long-lived fake worker descendants and can keep node --test alive

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1220,7 +1220,6 @@ export function buildWorkerProcessLaunchSpec(
     OMX_TEAM_INTERNAL_WORKER: internalWorkerIdentity,
     [OMX_LEADER_NODE_PATH_ENV]: resolveLeaderNodePath(),
     [OMX_LEADER_CLI_PATH_ENV]: resolvedLauncherPath,
-    [OMX_TMUX_HUD_OWNER_ENV]: '1',
     ...(workerCli === 'codex' && workerCodexHomeOverride
       ? { CODEX_HOME: workerCodexHomeOverride }
       : {}),
@@ -1233,6 +1232,8 @@ export function buildWorkerProcessLaunchSpec(
     if (typeof value !== 'string' || value.trim() === '') continue;
     workerEnv[key] = value;
   }
+  delete workerEnv[OMX_TMUX_HUD_OWNER_ENV];
+  delete workerEnv[OMX_TMUX_HUD_LEADER_PANE_ENV];
 
   return {
     workerCli,

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -946,6 +946,13 @@ function readTmuxWorkerAmbientEnv(env: NodeJS.ProcessEnv = process.env): Record<
   return inherited;
 }
 
+function scrubTeamWorkerHudOwnershipEnv(env: Record<string, string>): Record<string, string> {
+  const scrubbed = { ...env };
+  delete scrubbed[OMX_TMUX_HUD_OWNER_ENV];
+  delete scrubbed[OMX_TMUX_HUD_LEADER_PANE_ENV];
+  return scrubbed;
+}
+
 function hasConfigOverride(args: readonly string[], key: string): boolean {
   const prefix = `${key}=`;
   for (let index = 0; index < args.length; index += 1) {
@@ -1030,10 +1037,10 @@ export function buildWorkerStartupCommand(
     initialPrompt,
     workerRole,
   );
-  const startupEnv = {
+  const startupEnv = scrubTeamWorkerHudOwnershipEnv({
     ...readTmuxWorkerAmbientEnv(process.env),
     ...processSpec.env,
-  };
+  });
   const startupArgs = [...processSpec.args];
   if (processSpec.workerCli === 'codex') {
     appendTeamWorkerMcpDisableOverrides(startupArgs, { ...process.env, ...extraEnv });
@@ -1232,14 +1239,12 @@ export function buildWorkerProcessLaunchSpec(
     if (typeof value !== 'string' || value.trim() === '') continue;
     workerEnv[key] = value;
   }
-  delete workerEnv[OMX_TMUX_HUD_OWNER_ENV];
-  delete workerEnv[OMX_TMUX_HUD_LEADER_PANE_ENV];
 
   return {
     workerCli,
     command: platformSpec.command,
     args: platformSpec.args,
-    env: workerEnv,
+    env: scrubTeamWorkerHudOwnershipEnv(workerEnv),
   };
 }
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -946,7 +946,7 @@ function readTmuxWorkerAmbientEnv(env: NodeJS.ProcessEnv = process.env): Record<
   return inherited;
 }
 
-function scrubTeamWorkerHudOwnershipEnv(env: Record<string, string>): Record<string, string> {
+export function scrubTeamWorkerHudOwnershipEnv<T extends Record<string, string | undefined>>(env: T): T {
   const scrubbed = { ...env };
   delete scrubbed[OMX_TMUX_HUD_OWNER_ENV];
   delete scrubbed[OMX_TMUX_HUD_LEADER_PANE_ENV];
@@ -1054,6 +1054,9 @@ export function buildWorkerStartupCommand(
     const pathBootstrap = leaderNodeDir
       ? `$env:PATH = ${quotePowerShellArg(`${leaderNodeDir};`)} + $env:PATH`
       : '';
+    const hudEnvUnset = [OMX_TMUX_HUD_OWNER_ENV, OMX_TMUX_HUD_LEADER_PANE_ENV]
+      .map((key) => `Remove-Item Env:${key} -ErrorAction SilentlyContinue`)
+      .join('; ');
     const envAssignments = Object.entries(startupEnv)
       .map(([key, value]) => `$env:${key} = ${quotePowerShellArg(value)}`)
       .join('; ');
@@ -1062,6 +1065,7 @@ export function buildWorkerStartupCommand(
       [
         "$ErrorActionPreference = 'Stop'",
         pathBootstrap,
+        hudEnvUnset,
         envAssignments,
         invocation,
       ].filter(Boolean).join('; '),
@@ -1085,8 +1089,9 @@ export function buildWorkerStartupCommand(
     : '';
   const inner = `${rcPrefix}${pathPrefix}${cliInvocation}`;
   const envParts = Object.entries(startupEnv).map(([key, value]) => `${key}=${value}`);
+  const unsetParts = ['-u', OMX_TMUX_HUD_OWNER_ENV, '-u', OMX_TMUX_HUD_LEADER_PANE_ENV];
 
-  return `env ${envParts.map(shellQuoteSingle).join(' ')} ${shellQuoteSingle(launchSpec.shell)} -c ${shellQuoteSingle(inner)}`;
+  return `env ${[...unsetParts, ...envParts].map(shellQuoteSingle).join(' ')} ${shellQuoteSingle(launchSpec.shell)} -c ${shellQuoteSingle(inner)}`;
 }
 
 function assertShellEnvKey(key: string): void {

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -603,6 +603,31 @@ describe("OMX launcher path resolution", () => {
     }
   });
 
+  it("replaces stale ambient OMX_ENTRY_PATH when recording an explicit launcher argv1", async () => {
+    const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-explicit-record-"));
+    const env: NodeJS.ProcessEnv = {
+      [OMX_ENTRY_PATH_ENV]: "/opt/homebrew/lib/node_modules/oh-my-codex/dist/cli/omx.js",
+      [OMX_STARTUP_CWD_ENV]: startupCwd,
+    };
+    try {
+      const launcherDir = join(startupCwd, "dist", "cli");
+      const launcherPath = join(launcherDir, "omx.js");
+      await mkdir(launcherDir, { recursive: true });
+      await writeFile(launcherPath, "#!/usr/bin/env node\n", "utf-8");
+
+      rememberOmxLaunchContext({
+        argv1: "dist/cli/omx.js",
+        cwd: startupCwd,
+        env,
+      });
+
+      assert.equal(env[OMX_ENTRY_PATH_ENV], canonicalizeComparablePath(launcherPath));
+      assert.equal(env[OMX_STARTUP_CWD_ENV], startupCwd);
+    } finally {
+      await rm(startupCwd, { recursive: true, force: true });
+    }
+  });
+
   it("records the default launcher path when called without an explicit argv1", async () => {
     const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-default-record-"));
     const originalArgv1 = process.argv[1];

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -121,9 +121,11 @@ export function rememberOmxLaunchContext(
   if (String(env[OMX_STARTUP_CWD_ENV] ?? "").trim() === "") {
     env[OMX_STARTUP_CWD_ENV] = cwd;
   }
-  if (String(env[OMX_ENTRY_PATH_ENV] ?? "").trim() !== "") return;
+  const hasExplicitArgv1 = Object.prototype.hasOwnProperty.call(options, "argv1");
+  const explicitArgv1 = typeof options.argv1 === "string" ? options.argv1.trim() : "";
+  if (String(env[OMX_ENTRY_PATH_ENV] ?? "").trim() !== "" && (!hasExplicitArgv1 || explicitArgv1 === "")) return;
 
-  const resolved = Object.prototype.hasOwnProperty.call(options, "argv1")
+  const resolved = hasExplicitArgv1
     ? resolveOmxEntryPath({
       argv1: options.argv1,
       cwd,


### PR DESCRIPTION
## Summary

Fixes tmux HUD duplication and malformed HUD pane recovery when Team workers are started or scaled in a tmux window.

Team worker panes could inherit HUD ownership context from the leader/runtime path, which allowed worker Codex panes to create additional HUD panes. Duplicate HUD reconciliation could also preserve the wrong HUD pane when the first candidate had malformed geometry.

## Changes

- Scrub HUD ownership environment from Team worker startup commands and prompt-worker process launch specs.
- Keep worker launches on the repo-local OMX runtime path so local validation matches the checked-out source.
- Recreate or select a healthy HUD pane during duplicate HUD reconciliation instead of keeping malformed topology.
- Preserve leader/HUD layout during Team scale-up and avoid targeting leader/HUD panes during scale-down or teardown.
- Harden test isolation around compiled test execution and live OMX/tmux session state.

## Validation

- [x] `npm run build` (via `npm test` and `npm run coverage:team-critical`)
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run coverage:team-critical`
- [x] Manual tmux smoke: updated `omx`, opened a new tmux window, ran Team skill, confirmed HUD stays at one pane while Team workers are active.
- [ ] `omx doctor` (not run; this change does not alter setup/config behavior)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
  - Not needed: this is internal tmux/HUD ownership and reconciliation behavior covered by regression tests.
- [x] Backward-compatibility impact considered
  - Worker panes no longer inherit HUD owner markers; leader/HUD ownership remains preserved.

## Related

Closes #
