### PR TITLE
Stop team worker startup scripts from owning HUD panes

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1293,8 +1293,12 @@ describe('buildWorkerStartupCommand', () => {
     const stateRoot = join(wd, '.omx', 'state');
     const prevShell = process.env.SHELL;
     const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevHudOwner = process.env.OMX_TMUX_HUD_OWNER;
+    const prevHudLeaderPane = process.env.OMX_TMUX_HUD_LEADER_PANE;
     process.env.SHELL = '/bin/bash';
     process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.OMX_TMUX_HUD_OWNER = '1';
+    process.env.OMX_TMUX_HUD_LEADER_PANE = '%leader';
     try {
       const cmd = writeWorkerStartupScriptCommand(
         'alpha',
@@ -1304,6 +1308,8 @@ describe('buildWorkerStartupCommand', () => {
         {
           OMX_TEAM_STATE_ROOT: stateRoot,
           OMX_TEAM_LEADER_CWD: wd,
+          OMX_TMUX_HUD_OWNER: '1',
+          OMX_TMUX_HUD_LEADER_PANE: '%leader',
         },
         'gemini',
       );
@@ -1311,7 +1317,10 @@ describe('buildWorkerStartupCommand', () => {
       const script = await readFile(join(stateRoot, 'team', 'alpha', 'runtime', 'worker-1-startup.sh'), 'utf-8');
       assert.match(script, /^#!\/bin\/sh/m);
       assert.match(script, new RegExp(`cd '${wd.replace(/'/g, `'\\\\''`)}'`));
+      assert.match(script, /^unset OMX_TMUX_HUD_OWNER OMX_TMUX_HUD_LEADER_PANE$/m);
       assert.match(script, /export OMX_TEAM_STATE_ROOT=/);
+      assert.doesNotMatch(script, /^export OMX_TMUX_HUD_OWNER=/m);
+      assert.doesNotMatch(script, /^export OMX_TMUX_HUD_LEADER_PANE=/m);
       assert.match(script, /exec '\/bin\/bash' -c /);
       assert.doesNotMatch(cmd ?? '', /OMX_TEAM_STATE_ROOT=/, 'tmux command should point at script instead of inlining env');
     } finally {
@@ -1319,6 +1328,10 @@ describe('buildWorkerStartupCommand', () => {
       else delete process.env.SHELL;
       if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
       else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevHudOwner === 'string') process.env.OMX_TMUX_HUD_OWNER = prevHudOwner;
+      else delete process.env.OMX_TMUX_HUD_OWNER;
+      if (typeof prevHudLeaderPane === 'string') process.env.OMX_TMUX_HUD_LEADER_PANE = prevHudLeaderPane;
+      else delete process.env.OMX_TMUX_HUD_LEADER_PANE;
       await rm(wd, { recursive: true, force: true });
     }
   });

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1129,6 +1129,7 @@ function buildWorkerStartupScriptContent(
   return [
     '#!/bin/sh',
     'set -eu',
+    `unset ${OMX_TMUX_HUD_OWNER_ENV} ${OMX_TMUX_HUD_LEADER_PANE_ENV}`,
     `cd ${shellQuoteSingle(cwd)}`,
     envExports,
     `exec ${shellQuoteSingle(launchSpec.shell)} -c ${shellQuoteSingle(`${rcPrefix}${pathPrefix}${cliInvocation}`)}`,


### PR DESCRIPTION
## Summary

Prevent interactive team worker startup scripts from inheriting tmux HUD ownership metadata.

## Changes

- Unset `OMX_TMUX_HUD_OWNER` and `OMX_TMUX_HUD_LEADER_PANE` in generated team worker startup scripts before exporting worker env.
- Add regression coverage for inherited process env and `extraEnv` leakage.

## Relation to #2664

#2664 deduplicated legacy unowned focused HUD watcher panes during HUD reconciliation. This PR is not a duplicate of that fix: it prevents team worker panes from becoming HUD owners through their own startup scripts before HUD reconciliation runs.

## Validation

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [x] `node dist/scripts/run-test-files.js dist/team/__tests__/tmux-session.test.js`
- [x] `npm run coverage:team-critical` (Statements 86.04%, Branches 80.17%, Functions 95.48%, Lines 86.04%)
- [x] `git diff --check`
- [ ] `omx doctor` (not run; setup/config behavior was not changed)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed: not needed for this internal team worker env boundary; no user-facing command or documented option changed
- [x] Backward-compatibility impact considered: only removes HUD ownership variables from worker startup scripts

## Related

- Follow-up to #2738
- Related to #2664, which handled legacy HUD reconciliation rather than team worker startup env leakage