### PR TITLE
Fix side conversation Stop hook isolation

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -8465,6 +8465,52 @@ exit 0
     }
   });
 
+  it("suppresses parent Autopilot Stop continuation in side conversations", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-autopilot-side-conversation-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stop-autopilot-side-conversation";
+      const transcriptPath = join(cwd, "side-conversation-rollout.jsonl");
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "deep-interview",
+      });
+      await writeFile(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "message",
+          role: "user",
+          content: [
+            "Side conversation boundary.",
+            "Everything before this boundary is inherited history from the parent thread. It is reference context only. It is not your current task.",
+            "Only messages submitted after this boundary are active user instructions for this side conversation.",
+            "You are a side-conversation assistant, separate from the main thread.",
+          ].join("\n\n"),
+        })}\n`,
+        "utf-8",
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-stop-autopilot-side-conversation",
+          transcript_path: transcriptPath,
+          last_assistant_message: "Waiting for a new side-conversation question.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("requires Autopilot code review after a compact-boundary Stop exemption", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-autopilot-review-compact-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { closeSync, existsSync, openSync, readFileSync, readSync } from "fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "fs";
 import { appendFile, mkdir, readFile, readdir, stat, writeFile } from "fs/promises";
 import { extname, join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
@@ -214,6 +214,57 @@ function safeContextSnippet(value: unknown, maxLength = 300): string {
   const text = safeString(value).replace(/\s+/g, " ").trim();
   if (text.length <= maxLength) return text;
   return `${text.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+const SIDE_CONVERSATION_BOUNDARY_PATTERNS = [
+  /side conversation boundary/i,
+  /inherited history from the parent thread/i,
+  /reference context only/i,
+  /only messages submitted after this boundary are active/i,
+  /side-conversation assistant/i,
+] as const;
+
+function textHasSideConversationBoundary(text: string): boolean {
+  return SIDE_CONVERSATION_BOUNDARY_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function isLikelySideConversationStopPayload(payload: CodexHookPayload): boolean {
+  const payloadText = [
+    payload.prompt,
+    payload.user_prompt,
+    payload.userPrompt,
+    payload.input,
+    payload.last_user_message,
+    payload.lastUserMessage,
+    payload.last_assistant_message,
+    payload.lastAssistantMessage,
+  ].map(safeString).join("\n");
+  if (textHasSideConversationBoundary(payloadText)) return true;
+
+  const transcriptPath = safeString(payload.transcript_path ?? payload.transcriptPath).trim();
+  if (!transcriptPath || !existsSync(transcriptPath)) return false;
+
+  try {
+    const maxBytes = 256 * 1024;
+    const stats = statSync(transcriptPath);
+    const fd = openSync(transcriptPath, "r");
+    try {
+      const bytesToRead = Math.min(maxBytes, Math.max(0, stats.size));
+      const buffer = Buffer.alloc(bytesToRead);
+      const position = Math.max(0, stats.size - bytesToRead);
+      const bytesRead = readSync(fd, buffer, 0, bytesToRead, position);
+      return textHasSideConversationBoundary(buffer.toString("utf-8", 0, bytesRead));
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return false;
+  }
+}
+
+function shouldSuppressParentWorkflowStopForSideConversation(payload: CodexHookPayload): boolean {
+  if (safeString(payload.hook_event_name ?? payload.hookEventName).trim() !== "Stop") return false;
+  return isLikelySideConversationStopPayload(payload);
 }
 
 interface NativeSubagentSessionStartMetadata {
@@ -3745,8 +3796,12 @@ async function buildStopHookOutput(
   const sessionId = readPayloadSessionId(payload);
   const canonicalSessionId = await resolveInternalSessionIdForPayload(cwd, sessionId);
   const threadId = readPayloadThreadId(payload);
+  const suppressParentWorkflowStop = shouldSuppressParentWorkflowStopForSideConversation(payload);
   if (canonicalSessionId) {
     await reconcileStaleRootSkillActiveStateForStop(cwd, stateDir, canonicalSessionId);
+  }
+  if (suppressParentWorkflowStop) {
+    return null;
   }
   const execFollowupOutput = await buildExecFollowupStopOutput(cwd, canonicalSessionId);
   if (execFollowupOutput) return execFollowupOutput;


### PR DESCRIPTION
Fixes #2742.

## Summary
- detect the standard Codex App side-conversation boundary in Stop hook payloads/transcripts
- suppress parent workflow Stop continuation output on that side-conversation surface
- add regression coverage for active parent Autopilot deep-interview state plus a side-conversation boundary

## Verification
- npm run build
- node --test --test-name-pattern 'suppresses parent Autopilot Stop continuation in side conversations|returns Stop continuation output while Autopilot is active' dist/scripts/__tests__/codex-native-hook.test.js\n- node --test --test-name-pattern 'Stop continuation|Autopilot|deep-interview wait|side conversations' dist/scripts/__tests__/codex-native-hook.test.js\n\n—\n*[repo owner's gaebal-gajae (clawdbot) 🦞]*