### PR TITLE
chore(catalog): add wiki skill manifest entry

### DIFF
--- a/src/catalog/__tests__/schema.test.ts
+++ b/src/catalog/__tests__/schema.test.ts
@@ -88,6 +88,14 @@ describe('catalog schema', () => {
     assert.equal(autoresearch?.status, 'active');
   });
 
+  it('includes wiki as an active utility skill', () => {
+    const parsed = validateCatalogManifest(readSourceManifest());
+    const wiki = parsed.skills.find((skill) => skill.name === 'wiki');
+
+    assert.equal(wiki?.category, 'utility');
+    assert.equal(wiki?.status, 'active');
+  });
+
   it('includes ultragoal as a core execution skill', () => {
     const parsed = validateCatalogManifest(readSourceManifest());
     const ultragoal = parsed.skills.find((skill) => skill.name === 'ultragoal');

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -2,9 +2,9 @@
   "generatedAt": "2026-05-24T12:14:18.921Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 49,
+    "skillCount": 50,
     "promptCount": 34,
-    "activeSkillCount": 27,
+    "activeSkillCount": 28,
     "activeAgentCount": 20
   },
   "coreSkills": [
@@ -268,6 +268,13 @@
     },
     {
       "name": "doctor",
+      "category": "utility",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "wiki",
       "category": "utility",
       "status": "active",
       "core": false,

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -210,6 +210,11 @@
       "status": "active"
     },
     {
+      "name": "wiki",
+      "category": "utility",
+      "status": "active"
+    },
+    {
       "name": "help",
       "category": "utility",
       "status": "deprecated",

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -260,6 +260,13 @@
       "internalRequired": false
     },
     {
+      "name": "wiki",
+      "category": "utility",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "help",
       "category": "utility",
       "status": "deprecated",


### PR DESCRIPTION
## Summary

`skills/wiki` and the plugin mirror already ship, but the catalog manifests did not expose `wiki`. The bloat/connectivity audit calls this out as Q10 / PR-3 and recommends adding the existing skill to the catalog rather than removing it.

## Changes

- Add `wiki` as an active utility skill in the source and template catalog manifests.
- Refresh the generated public catalog counts/list so `wiki` appears in the public contract.
- Add a schema assertion so the catalog keeps `wiki` covered.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `node --test dist/catalog/__tests__/schema.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js dist/hooks/__tests__/skill-catalog-hygiene.test.js dist/hooks/__tests__/wiki-docs-contract.test.js`
- [x] `npm run verify:plugin-bundle`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `GIT_CONFIG_GLOBAL=/dev/null npm test`

Local note: an initial plain `npm test` hit this machine's global `init.templateDir`, which omits `.git/info/exclude`; the two affected files passed once the global Git template was neutralized, and the full neutralized run above passed.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

Document-refresh: not-needed | generated catalog contract refreshed; no CLI/operator behavior changed

## Related

Follows `docs/audit/skills-agents-bloat-audit/connectivity-roadmap.md` Q10 / PR-3.
