### PR TITLE
fix(agents): remove remaining omx explore mentions from global AGENTS guidance (#2749)

### DIFF
--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -86,26 +86,16 @@ describe("generateOverlay", () => {
     assert.doesNotMatch(defaultOverlay, /\*\*Orchestration Mode:\*\* team/);
   });
 
-  it("adds deprecation guidance for explore routing by default and on explicit compatibility opt-in", async () => {
+  it("adds repository-lookup routing guidance without referencing the removed explore command", async () => {
     const previous = process.env.USE_OMX_EXPLORE_CMD;
     try {
       delete process.env.USE_OMX_EXPLORE_CMD;
-      const defaultOverlay = await generateOverlay(
-        tempDir,
-        "explore-routing-default",
-      );
-      assert.match(defaultOverlay, /\*\*Explore Command Deprecated:\*\*/);
-      assert.match(defaultOverlay, /MUST NOT be recommended/i);
-      assert.match(defaultOverlay, /normal Codex repository inspection/i);
-      assert.match(defaultOverlay, /Compatibility routing is not enabled/i);
-
-      process.env.USE_OMX_EXPLORE_CMD = "1";
-      const enabledOverlay = await generateOverlay(
-        tempDir,
-        "explore-routing-enabled",
-      );
-      assert.match(enabledOverlay, /compatibility routing is explicitly enabled/i);
-      assert.match(enabledOverlay, /still prefer the replacement path/i);
+      const overlay = await generateOverlay(tempDir, "explore-routing-default");
+      assert.match(overlay, /\*\*Repository Lookup Routing:\*\*/);
+      assert.match(overlay, /normal Codex repository inspection/i);
+      assert.match(overlay, /omx sparkshell -- <command>/);
+      assert.doesNotMatch(overlay, /omx explore/i);
+      assert.doesNotMatch(overlay, /USE_OMX_EXPLORE_CMD/);
     } finally {
       if (typeof previous === "string")
         process.env.USE_OMX_EXPLORE_CMD = previous;

--- a/src/hooks/__tests__/explore-routing.test.ts
+++ b/src/hooks/__tests__/explore-routing.test.ts
@@ -34,15 +34,12 @@ describe('explore-routing', () => {
     assert.equal(isSimpleExplorationPrompt('investigate everything in this repo'), false);
   });
 
-  it('builds deprecation guidance and never recommends explore for new work', () => {
-    const guidance = buildExploreRoutingGuidance({});
-    assert.ok(guidance.startsWith('**Explore Command Deprecated:**'));
-    assert.match(guidance, /USE_OMX_EXPLORE_CMD/);
-    assert.match(guidance, /compatibility-only/i);
-    assert.match(guidance, /MUST NOT be recommended/i);
+  it('builds repository-lookup routing guidance without referencing the removed explore command', () => {
+    const guidance = buildExploreRoutingGuidance();
+    assert.ok(guidance.startsWith('**Repository Lookup Routing:**'));
     assert.match(guidance, /normal Codex repository inspection/i);
     assert.match(guidance, /omx sparkshell -- <command>/);
-    assert.match(guidance, /do not route simple lookups to `omx explore`/i);
-    assert.match(buildExploreRoutingGuidance({ USE_OMX_EXPLORE_CMD: '1' }), /explicitly enabled.*still prefer the replacement path/is);
+    assert.doesNotMatch(guidance, /omx explore/i);
+    assert.doesNotMatch(guidance, /USE_OMX_EXPLORE_CMD/);
   });
 });

--- a/src/hooks/__tests__/explore-sparkshell-guidance-contract.test.ts
+++ b/src/hooks/__tests__/explore-sparkshell-guidance-contract.test.ts
@@ -10,11 +10,8 @@ function expectPatterns(path: string, patterns: RegExp[]): void {
 }
 
 describe('explore + sparkshell guidance contract', () => {
-  it('keeps AGENTS root and template aligned on deprecated explore routing and opt-in sparkshell guidance', () => {
-    const patterns = [
-      /USE_OMX_EXPLORE_CMD/i,
-      /`omx explore` is deprecated/i,
-      /MUST NOT be recommended|does not make `omx explore` preferred/i,
+  it('keeps AGENTS root and template aligned on supported repository-lookup routing and opt-in sparkshell guidance without the removed explore command', () => {
+    const requiredPatterns = [
       /normal Codex repository inspection/i,
       /omx sparkshell --tmux-pane/i,
       /explicit opt-?in/i,
@@ -22,7 +19,10 @@ describe('explore + sparkshell guidance contract', () => {
     ];
 
     for (const surface of listTrackedAgentSurfaces()) {
-      expectPatterns(surface, patterns);
+      const content = loadSurface(surface);
+      expectPatterns(surface, requiredPatterns);
+      assert.doesNotMatch(content, /omx explore/i, `${surface} still references the removed omx explore command`);
+      assert.doesNotMatch(content, /USE_OMX_EXPLORE_CMD/i, `${surface} still references the deprecated USE_OMX_EXPLORE_CMD override`);
     }
   });
 

--- a/src/hooks/explore-routing.ts
+++ b/src/hooks/explore-routing.ts
@@ -31,14 +31,9 @@ export function isSimpleExplorationPrompt(text: string): boolean {
   return SIMPLE_EXPLORATION_PATTERNS.some((pattern) => pattern.test(trimmed));
 }
 
-export function buildExploreRoutingGuidance(env: NodeJS.ProcessEnv = process.env): string {
-  const explicitlyEnabled = isExploreCommandRoutingEnabled(env);
+export function buildExploreRoutingGuidance(): string {
   return [
-    '**Explore Command Deprecated:** `omx explore` is deprecated and MUST NOT be recommended for new repository lookup work.',
-    `- \`${OMX_EXPLORE_CMD_ENV}\` is compatibility-only; unset/default is disabled. Truthy values keep legacy callers working but do not make \`omx explore\` preferred.`,
-    '- Replacement path: use normal Codex repository inspection tools/subagents; use `omx sparkshell -- <command>` only for explicit shell-native read-only evidence or `--tmux-pane` summaries.',
-    explicitlyEnabled
-      ? '- Compatibility routing is explicitly enabled; still prefer the replacement path.'
-      : '- Compatibility routing is not enabled; do not route simple lookups to `omx explore`.',
+    '**Repository Lookup Routing:** use normal Codex repository inspection tools/subagents as the default surface for simple read-only repository lookup and implementation context.',
+    '- Use `omx sparkshell -- <command>` only for explicit shell-native read-only evidence or `--tmux-pane` summaries; it does not replace raw evidence capture.',
   ].join("\n");
 }

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -152,11 +152,10 @@ Verification loop: define the claim and success criteria, run the smallest valid
 <execution_protocols>
 Mode selection: use `$deep-interview` for unclear intent/boundaries; `$ralplan` for consensus on architecture, tradeoffs, or tests; `$team` for approved multi-lane work; `$ralph` for persistent single-owner completion/verification loops; otherwise execute directly in solo mode. Switch modes only when evidence shows the current lane is mismatched or blocked.
 
-Command routing: `omx explore` is deprecated and MUST NOT be recommended as the default surface for simple read-only repository lookup tasks. Use normal Codex repository inspection tools/subagents; use `omx sparkshell` only for explicit shell-native read-only evidence or bounded verification.
+Command routing: use normal Codex repository inspection tools/subagents as the default surface for simple read-only repository lookup tasks; use `omx sparkshell` only for explicit shell-native read-only evidence or bounded verification.
 When to use what:
 - Use normal Codex repository inspection tools/subagents for repository lookup and implementation context.
 - Use `omx sparkshell --tmux-pane` only as an explicit opt-in operator aid for shell-native tmux evidence or bounded verification; it does not replace raw evidence capture.
-- `USE_OMX_EXPLORE_CMD` is a compatibility-only override for deprecated `omx explore` routing and does not make `omx explore` preferred.
 
 Leader vs worker: leaders choose mode, delegate bounded work, integrate, and own verification; workers execute their slice and escalate blockers, scope expansion, shared-file conflicts, or mode mismatch upward. Escalate from worker to leader for blockers, scope expansion, shared ownership conflicts, or mode mismatch.
 


### PR DESCRIPTION
## Summary

Follow-up to PR #2746 (which hard-deprecated the `omx explore` command into a tombstone): deprecated `omx explore` references still surfaced in the **global / generated AGENTS guidance**. This removes them and aligns the wording with the currently supported workflow. Cleanup only — no new feature surface.

### Changes
- `templates/AGENTS.md` (global AGENTS template, `<execution_protocols>` command-routing block): dropped the `omx explore` deprecation sentence and the `USE_OMX_EXPLORE_CMD` bullet; the routing guidance now positively states the supported path (normal Codex repository inspection tools/subagents; `omx sparkshell` for explicit shell-native read-only evidence or bounded verification).
- `src/hooks/explore-routing.ts` (`buildExploreRoutingGuidance`, injected into the runtime AGENTS overlay): rewritten from an `**Explore Command Deprecated:**` block that named `omx explore` / `USE_OMX_EXPLORE_CMD` into a `**Repository Lookup Routing:**` block describing the supported workflow. The env-conditional branch (which only existed to soften the deprecation note) is gone; `OMX_EXPLORE_CMD_ENV` / `isExploreCommandRoutingEnabled` remain exported (still consumed by `doctor` and the config generator).
- Updated tests to assert the cleaned guidance and to **forbid** `omx explore` / `USE_OMX_EXPLORE_CMD` from reappearing in tracked AGENTS surfaces:
  - `src/hooks/__tests__/explore-routing.test.ts`
  - `src/hooks/__tests__/agents-overlay.test.ts`
  - `src/hooks/__tests__/explore-sparkshell-guidance-contract.test.ts`

### Scope notes
- The `explore` **subagent role** references in `templates/AGENTS.md` (model/specialist routing, agent catalog) are intentionally untouched — that role is still active.
- Per-role prompt and skill deprecation notices (`prompts/*.md`, `skills/*.md`) are intentionally left as-is, consistent with the PR #2746 precedent; this issue is scoped to global AGENTS guidance.

## Verification
- `npm run build` (tsc) — PASS.
- `npm run check:no-unused` — PASS.
- `node --test dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js dist/hooks/__tests__/agents-overlay.test.js` — PASS (54 tests, 0 fail).
- `node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-fragments.test.js dist/cli/__tests__/agents-init.test.js` — PASS (16 tests, 0 fail).
- `search 'omx explore|USE_OMX_EXPLORE_CMD'` across `templates/AGENTS.md` + overlay guidance → only the internal `OMX_EXPLORE_CMD_ENV` constant remains (infra, consumed by doctor/config), no guidance mentions.

Closes #2749

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
