### PR TITLE
docs(model): clarify OMX model pinning vs Codex model-migration switching (#2748)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ These are operator/support surfaces:
 - `omx update` checks npm immediately, installs the newest global OMX build, then reruns the same interactive setup refresh path
 - launch-time update checks are throttled and prompt by default; use `OMX_AUTO_UPDATE=0` to disable them or `OMX_AUTO_UPDATE=defer` to schedule deferred updates without a prompt
 - fresh OMX-managed `gpt-5.5` config seeding now recommends `model_context_window = 250000` and `model_auto_compact_token_limit = 200000`, but only when those keys are missing
+- OMX pins your frontier model in `.codex/config.toml` and never silently downgrades it; if Codex switches your selected model (for example `gpt-5.5` to `gpt-5.4`), that is Codex CLI's own model-migration prompt — see [keeping your model stable](./docs/troubleshooting.md#codex-switched-my-model-for-example-gpt-55-to-gpt-54)
 - `.omx-config.json` model/env routing is documented in [the model/env routing reference](./docs/reference/omx-config-schema-routing.md); only edit keys supported by your installed OMX version
 - `omx doctor` verifies the install when something seems wrong; it does not prove that the active Codex profile can make an authenticated model call
 - `omx hud --watch` is a monitoring/status surface, not the primary user workflow

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -130,3 +130,24 @@ Adjust the terminal pattern if your client advertises a different terminfo name.
 - For explicit shell-native read-only evidence or `--tmux-pane` summaries, use `omx sparkshell -- <command>`.
 
 The earlier explore harness fallback boundaries (sparkshell-backend fallback and in-harness model fallback) no longer apply to a user-facing command, because the command no longer runs a harness. Internal harness-resolution helpers remain only to support `omx doctor`/native-asset diagnostics.
+
+## Codex switched my model (for example `gpt-5.5` to `gpt-5.4`)
+
+If a session that you started on one model later reports a different model, the change is almost always Codex CLI's own model-migration prompt, not OMX silently switching models on you.
+
+What OMX actually does with your model:
+
+- `omx setup` pins your frontier model in `.codex/config.toml` (the seeded default is `gpt-5.5`) and does **not** silently downgrade it. The only model line OMX rewrites is an explicit, prompted upgrade from the legacy `gpt-5.3-codex` default, and only when you accept that prompt. Non-interactive setup never changes the model on its own.
+- `omx setup` also strips Codex's transient `[tui.model_availability_nux]` counters from the config so they do not accumulate.
+
+Where the automatic switch comes from:
+
+- Codex CLI ships a per-model migration map: a model can advertise an `upgrade` target (visible in `codex debug models`). When Codex shows the model-migration prompt and the upgrade is accepted, Codex rewrites the top-level `model` in `config.toml`. OMX then preserves whatever model the file now contains, so the change persists across later launches.
+
+Keep your model stable:
+
+1. In Codex's model prompt, choose **Keep current model** instead of accepting the migration. Codex records that choice under `[tui.notice]` so it stops re-prompting for that model.
+2. Pin the model for OMX-generated surfaces with `OMX_DEFAULT_FRONTIER_MODEL=<model>` (or `models.default` in `.omx-config.json`), then re-run `omx setup` so the pinned value is written back.
+3. Confirm the resolved model with `omx doctor`, which prints the active config path and model without rewriting your config.
+
+Do not hand-add unverified Codex config keys to force this off: Codex validates known config-key types and fails closed on a type mismatch, so a wrong-shaped key can break config loading for the whole session. Use Codex's own model prompt (`/model` and **Keep current model**) and the OMX model pin above instead.


### PR DESCRIPTION
## Summary

Resolves the UX/default-behavior question in #2748 ("Auto-Promote Context" / surprise model switching, e.g. a session started on `gpt-5.5` later reporting `gpt-5.4`).

After investigation, this is **Codex CLI's own model-migration prompt**, not OMX silently switching models. The term "Auto-Promote Context" does not exist anywhere in OMX or in Codex config keys; the switch comes from Codex's per-model migration map (each model can advertise an `upgrade` target, visible via `codex debug models`). When the migration prompt is accepted, Codex rewrites the top-level `model` in `config.toml`.

### What OMX already does (verified)
- `omx setup` pins the frontier model in `.codex/config.toml` and never silently downgrades it.
- The only model line OMX rewrites is an explicit, prompted upgrade from the legacy `gpt-5.3-codex` default, and only on acceptance; non-interactive setup never changes the model on its own.
- OMX already strips Codex's transient `[tui.model_availability_nux]` counters on setup.

So OMX already satisfies the issue's first acceptance route ("preserve explicit user model choice unless promotion is explicitly enabled") for every OMX-controlled path.

### Why this is a docs fix (route 2) and not a forced Codex config toggle
Forcing Codex's migration off would require seeding an unverified top-level Codex config key. Codex validates known config-key types and **fails closed on a type mismatch** (verified: `model = 123` errors out config loading), so a wrong-shaped/unsupported key could break config loading for the whole session across Codex versions. That is too risky to seed by default. Instead this PR makes the behavior obvious and gives users a safe, supported way to keep their model stable.

### Changes
- `docs/troubleshooting.md`: new section "Codex switched my model (for example `gpt-5.5` to `gpt-5.4`)" explaining the cause, OMX's pinning behavior, and how to keep the model stable (choose **Keep current model** in Codex's prompt; pin via `OMX_DEFAULT_FRONTIER_MODEL` / `models.default` then re-run `omx setup`; verify with `omx doctor`).
- `README.md`: concise note in the setup/doctor section linking to the new troubleshooting subsection.

### Verification
- Docs-only change; no `src` behavior touched, so build/typecheck/lint (scoped to `src`) are unaffected.
- Replicated the `install-docs-contract` assertions against the edited `README.md` (all pass) and confirmed the new README anchor resolves to the new troubleshooting heading slug.

Note: dependencies are not installed in this worktree (npm cache is permission-blocked), so the suite was not run; this change does not modify any TypeScript source or test contract.

This is a maintainership question on owner-default behavior, so the issue is intentionally left open for the owner's final call.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
