### PR TITLE
docs(model): revert #2751 — OMX issue #2748 was misattributed gajae-code #228

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,6 @@ These are operator/support surfaces:
 - `omx update` checks npm immediately, installs the newest global OMX build, then reruns the same interactive setup refresh path
 - launch-time update checks are throttled and prompt by default; use `OMX_AUTO_UPDATE=0` to disable them or `OMX_AUTO_UPDATE=defer` to schedule deferred updates without a prompt
 - fresh OMX-managed `gpt-5.5` config seeding now recommends `model_context_window = 250000` and `model_auto_compact_token_limit = 200000`, but only when those keys are missing
-- OMX pins your frontier model in `.codex/config.toml` and never silently downgrades it; if Codex switches your selected model (for example `gpt-5.5` to `gpt-5.4`), that is Codex CLI's own model-migration prompt — see [keeping your model stable](./docs/troubleshooting.md#codex-switched-my-model-for-example-gpt-55-to-gpt-54)
 - `.omx-config.json` model/env routing is documented in [the model/env routing reference](./docs/reference/omx-config-schema-routing.md); only edit keys supported by your installed OMX version
 - `omx doctor` verifies the install when something seems wrong; it does not prove that the active Codex profile can make an authenticated model call
 - `omx hud --watch` is a monitoring/status surface, not the primary user workflow

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -130,24 +130,3 @@ Adjust the terminal pattern if your client advertises a different terminfo name.
 - For explicit shell-native read-only evidence or `--tmux-pane` summaries, use `omx sparkshell -- <command>`.
 
 The earlier explore harness fallback boundaries (sparkshell-backend fallback and in-harness model fallback) no longer apply to a user-facing command, because the command no longer runs a harness. Internal harness-resolution helpers remain only to support `omx doctor`/native-asset diagnostics.
-
-## Codex switched my model (for example `gpt-5.5` to `gpt-5.4`)
-
-If a session that you started on one model later reports a different model, the change is almost always Codex CLI's own model-migration prompt, not OMX silently switching models on you.
-
-What OMX actually does with your model:
-
-- `omx setup` pins your frontier model in `.codex/config.toml` (the seeded default is `gpt-5.5`) and does **not** silently downgrade it. The only model line OMX rewrites is an explicit, prompted upgrade from the legacy `gpt-5.3-codex` default, and only when you accept that prompt. Non-interactive setup never changes the model on its own.
-- `omx setup` also strips Codex's transient `[tui.model_availability_nux]` counters from the config so they do not accumulate.
-
-Where the automatic switch comes from:
-
-- Codex CLI ships a per-model migration map: a model can advertise an `upgrade` target (visible in `codex debug models`). When Codex shows the model-migration prompt and the upgrade is accepted, Codex rewrites the top-level `model` in `config.toml`. OMX then preserves whatever model the file now contains, so the change persists across later launches.
-
-Keep your model stable:
-
-1. In Codex's model prompt, choose **Keep current model** instead of accepting the migration. Codex records that choice under `[tui.notice]` so it stops re-prompting for that model.
-2. Pin the model for OMX-generated surfaces with `OMX_DEFAULT_FRONTIER_MODEL=<model>` (or `models.default` in `.omx-config.json`), then re-run `omx setup` so the pinned value is written back.
-3. Confirm the resolved model with `omx doctor`, which prints the active config path and model without rewriting your config.
-
-Do not hand-add unverified Codex config keys to force this off: Codex validates known config-key types and fails closed on a type mismatch, so a wrong-shaped key can break config loading for the whole session. Use Codex's own model prompt (`/model` and **Keep current model**) and the OMX model pin above instead.


### PR DESCRIPTION
## Summary

Reverts the docs added in PR #2751 (commit 0d7a3899).

OMX issue #2748 ("Consider disabling Auto-Promote Context by default" — a session silently switching `gpt-5.5` → `gpt-5.4`) was **misattributed**:

- **Auto-Promote Context is a gajae-code workflow feature, not an OMX/Codex surface.** It does not exist anywhere in this codebase (`grep` for `auto.promote.context` / `promote.context` returns nothing).
- The observed model switch happened across deep-interview/ralplan/ultragoal workflow transitions. That is the **gajae-code #228** root cause (`handoff`/`newSession` not persisting model selection across transitions), already fixed via gajae-code PR #229/#231.
- PR #2751 instead documented the report as **Codex CLI's own model-migration prompt** — a different mechanism that does not match the observed behavior. The README line and `docs/troubleshooting.md` section therefore misdirect users hitting the real (gajae-code) cause.

## Change

Docs-only full revert of PR #2751:
- `README.md`: −1 line
- `docs/troubleshooting.md`: −21 lines (the "Codex switched my model" section)

No OMX bug exists, so no code change is warranted.

## Verification

- No dangling links to the removed `#codex-switched-my-model...` anchor remain.
- `git diff origin/dev`: 2 files changed, 22 deletions(-).

Closes the docs-misattribution for #2748.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*