### PR TITLE
Let cramped tmux sessions disable automatic HUD splits

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -80,6 +80,7 @@ import {
   serializeDetachedSessionParentEnv,
   buildInsideTmuxHudHookEnv,
   registerInsideTmuxHudResizeHook,
+  isAutomaticTmuxHudPaneEnabled,
   buildDetachedHudHookEnv,
   registerDetachedHudLayoutReconcileHook,
   ensureOmxRuntimeCommandShim,
@@ -3526,6 +3527,45 @@ exit 0
       source,
       /if \(currentPaneId\) \{\s*unregisterHudResizeHook\(currentPaneId\);\s*\}/,
     );
+  });
+
+  it("runCodex honors tmux.autoPane=false before initial inside-tmux HUD creation", async () => {
+    const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf-8");
+    assert.match(source, /if \(!isAutomaticTmuxHudPaneEnabled\(cwd\)\) \{/);
+    assert.match(
+      source,
+      /if \(!isAutomaticTmuxHudPaneEnabled\(cwd\)\) \{\s*for \(const paneId of staleHudPaneIds\) \{\s*killTmuxPane\(paneId\);\s*\}\s*if \(currentPaneId\) unregisterHudResizeHook\(currentPaneId\);\s*\} else \{/,
+    );
+  });
+
+  it("isAutomaticTmuxHudPaneEnabled defaults on unless tmux.autoPane is false", async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), "omx-hud-auto-pane-"));
+    try {
+      assert.equal(isAutomaticTmuxHudPaneEnabled(tmpRoot), true);
+
+      await mkdir(join(tmpRoot, ".omx"), { recursive: true });
+      await writeFile(join(tmpRoot, ".omx", "hud-config.json"), JSON.stringify({}), "utf-8");
+      assert.equal(isAutomaticTmuxHudPaneEnabled(tmpRoot), true);
+
+      await writeFile(
+        join(tmpRoot, ".omx", "hud-config.json"),
+        JSON.stringify({ tmux: { autoPane: true } }),
+        "utf-8",
+      );
+      assert.equal(isAutomaticTmuxHudPaneEnabled(tmpRoot), true);
+
+      await writeFile(
+        join(tmpRoot, ".omx", "hud-config.json"),
+        JSON.stringify({ tmux: { autoPane: false } }),
+        "utf-8",
+      );
+      assert.equal(isAutomaticTmuxHudPaneEnabled(tmpRoot), false);
+
+      await writeFile(join(tmpRoot, ".omx", "hud-config.json"), "{", "utf-8");
+      assert.equal(isAutomaticTmuxHudPaneEnabled(tmpRoot), true);
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it("buildInsideTmuxHudHookEnv tags hook commands with session, owner, leader, and local root", () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1044,6 +1044,17 @@ export function registerInsideTmuxHudResizeHook(options: {
   );
 }
 
+export function isAutomaticTmuxHudPaneEnabled(cwd: string): boolean {
+  try {
+    const raw = JSON.parse(
+      readFileSync(join(cwd, ".omx", "hud-config.json"), "utf-8"),
+    ) as { tmux?: { autoPane?: unknown } };
+    return raw.tmux?.autoPane !== false;
+  } catch {
+    return true;
+  }
+}
+
 export function buildDetachedHudHookEnv(
   baseEnv: NodeJS.ProcessEnv,
   sessionId: string,
@@ -4480,7 +4491,7 @@ function runCodex(
   }
 
   if (launchPolicy === "inside-tmux") {
-    // Already in tmux: launch codex in current pane, HUD in bottom split
+    // Already in tmux: launch codex in current pane, HUD in bottom split unless disabled.
     const currentWindowPanes = currentPaneId ? listCurrentWindowPanes(undefined, currentPaneId) : [];
     reapDeadHudPanes(currentWindowPanes, {
       killPane: (paneId) => {
@@ -4498,41 +4509,48 @@ function runCodex(
       : [];
 
     let hudPaneId: string | null = null;
-    const [keeperHudPaneId, ...duplicateHudPaneIds] = staleHudPaneIds;
-    for (const paneId of duplicateHudPaneIds) {
-      killTmuxPane(paneId);
-    }
-
-    if (keeperHudPaneId) {
-      hudPaneId = keeperHudPaneId;
-      try {
-        resizeTmuxPane(hudPaneId, HUD_TMUX_HEIGHT_LINES);
-        registerInsideTmuxHudResizeHook({
-          hudPaneId,
-          currentPaneId,
-          cwd,
-          sessionId,
-          omxRootOverride,
-        });
-      } catch (err) {
-        logCliOperationFailure(err);
+    if (!isAutomaticTmuxHudPaneEnabled(cwd)) {
+      for (const paneId of staleHudPaneIds) {
+        killTmuxPane(paneId);
       }
+      if (currentPaneId) unregisterHudResizeHook(currentPaneId);
     } else {
-      try {
-        hudPaneId = createHudWatchPane(cwd, hudCmd, {
-          heightLines: HUD_TMUX_HEIGHT_LINES,
-          targetPaneId: currentPaneId,
-        });
-        registerInsideTmuxHudResizeHook({
-          hudPaneId,
-          currentPaneId,
-          cwd,
-          sessionId,
-          omxRootOverride,
-        });
-      } catch (err) {
-        logCliOperationFailure(err);
-        // HUD split failed, continue without it
+      const [keeperHudPaneId, ...duplicateHudPaneIds] = staleHudPaneIds;
+      for (const paneId of duplicateHudPaneIds) {
+        killTmuxPane(paneId);
+      }
+
+      if (keeperHudPaneId) {
+        hudPaneId = keeperHudPaneId;
+        try {
+          resizeTmuxPane(hudPaneId, HUD_TMUX_HEIGHT_LINES);
+          registerInsideTmuxHudResizeHook({
+            hudPaneId,
+            currentPaneId,
+            cwd,
+            sessionId,
+            omxRootOverride,
+          });
+        } catch (err) {
+          logCliOperationFailure(err);
+        }
+      } else {
+        try {
+          hudPaneId = createHudWatchPane(cwd, hudCmd, {
+            heightLines: HUD_TMUX_HEIGHT_LINES,
+            targetPaneId: currentPaneId,
+          });
+          registerInsideTmuxHudResizeHook({
+            hudPaneId,
+            currentPaneId,
+            cwd,
+            sessionId,
+            omxRootOverride,
+          });
+        } catch (err) {
+          logCliOperationFailure(err);
+          // HUD split failed, continue without it
+        }
       }
     }
 

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -100,6 +100,49 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(resized[0]?.heightLines, HUD_TMUX_HEIGHT_LINES);
   });
 
+  it('removes existing HUD panes and skips auto recreation when tmux autoPane is disabled', async () => {
+    const killed: string[] = [];
+    let created = false;
+    const unregistered: Array<string | undefined> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch --preset=focused`,
+        },
+      ],
+      createHudWatchPane: () => {
+        created = true;
+        return '%9';
+      },
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      unregisterHudResizeHook: (leaderPaneId) => {
+        unregistered.push(leaderPaneId);
+        return true;
+      },
+      readHudConfig: async () => ({
+        preset: 'focused',
+        git: { display: 'repo-branch' },
+        statusLine: { preset: 'focused' },
+        tmux: { autoPane: false },
+      }),
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'disabled');
+    assert.equal(result.paneId, null);
+    assert.equal(created, false);
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(unregistered, ['%1']);
+  });
+
   it('reaps orphaned same-session HUD panes whose leader pane was destroyed, then recreates a single HUD', async () => {
     // Regression for the "team mode leaves only stacked HUD strips" bug: the leader
     // pane (%21) was destroyed but its owner-tagged HUD panes remained, all pointing

--- a/src/hud/__tests__/types.test.ts
+++ b/src/hud/__tests__/types.test.ts
@@ -15,6 +15,10 @@ describe('DEFAULT_HUD_CONFIG', () => {
   it('defaults statusLine preset to "focused"', () => {
     assert.equal(DEFAULT_HUD_CONFIG.statusLine.preset, 'focused');
   });
+
+  it('enables automatic tmux panes by default', () => {
+    assert.equal(DEFAULT_HUD_CONFIG.tmux?.autoPane, true);
+  });
 });
 
 describe('normalizeHudConfig', () => {
@@ -28,6 +32,7 @@ describe('normalizeHudConfig', () => {
       preset: 'minimal',
       git: { display: 'repo-branch' },
       statusLine: { preset: 'focused' },
+      tmux: { autoPane: true },
     });
   });
 
@@ -46,6 +51,7 @@ describe('normalizeHudConfig', () => {
         remoteName: 'upstream',
         repoLabel: 'manual-repo',
       },
+      tmux: { autoPane: true },
       statusLine: { preset: 'focused' },
     });
   });
@@ -84,5 +90,19 @@ describe('normalizeHudConfig', () => {
     });
     assert.equal(resolved.preset, 'minimal');
     assert.equal(resolved.statusLine.preset, 'full');
+  });
+
+  it('accepts tmux auto-pane opt out', () => {
+    const resolved = normalizeHudConfig({
+      tmux: { autoPane: false },
+    });
+    assert.equal(resolved.tmux?.autoPane, false);
+  });
+
+  it('falls back to automatic tmux panes for invalid opt-out values', () => {
+    const resolved = normalizeHudConfig({
+      tmux: { autoPane: 'nope' as never },
+    });
+    assert.equal(resolved.tmux?.autoPane, true);
   });
 });

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -88,6 +88,7 @@ export interface ReconcileHudForPromptSubmitResult {
     | 'resized'
     | 'recreated'
     | 'replaced_duplicates'
+    | 'disabled'
     | 'failed';
   paneId: string | null;
   desiredHeight: number | null;
@@ -252,6 +253,19 @@ export async function reconcileHudForPromptSubmit(
   const duplicateCount = Math.max(0, hudPaneIds.length - 1);
   const readHudConfigFn = deps.readHudConfig ?? readHudConfig;
   const hudConfig = await readHudConfigFn(cwd).catch(() => null);
+  if (hudConfig?.tmux?.autoPane === false) {
+    const unregisterHook = deps.unregisterHudResizeHook ?? unregisterHudResizeHook;
+    unregisterHook(currentPaneId);
+    for (const paneId of hudPaneIds) {
+      killPane(paneId);
+    }
+    return {
+      status: 'disabled',
+      paneId: null,
+      desiredHeight: null,
+      duplicateCount,
+    };
+  }
   const readAllStateFn = deps.readAllState ?? readAllState;
   const hudState = hudConfig ? await readAllStateFn(cwd, hudConfig).catch(() => null) : null;
   const desiredHeight = hudState ? getHudRenderMaxLines(hudState) : HUD_TMUX_HEIGHT_LINES;

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -74,6 +74,9 @@ export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedH
     statusLine: {
       preset: DEFAULT_HUD_CONFIG.statusLine.preset,
     },
+    tmux: {
+      autoPane: DEFAULT_HUD_CONFIG.tmux?.autoPane ?? true,
+    },
   };
 
   if (!raw || typeof raw !== 'object') return normalized;
@@ -98,6 +101,10 @@ export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedH
     if (isValidPreset(raw.statusLine.preset)) {
       normalized.statusLine.preset = raw.statusLine.preset;
     }
+  }
+
+  if (raw.tmux && typeof raw.tmux === 'object' && typeof raw.tmux.autoPane === 'boolean') {
+    normalized.tmux = { autoPane: raw.tmux.autoPane };
   }
 
   return normalized;

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -155,11 +155,17 @@ export interface HudStatusLineConfig {
   preset?: HudPreset;
 }
 
+export interface HudTmuxConfig {
+  /** Controls automatic tmux HUD split-pane creation/reconciliation. */
+  autoPane?: boolean;
+}
+
 /** HUD configuration stored in .omx/hud-config.json */
 export interface HudConfig {
   preset?: HudPreset;
   git?: HudGitConfig;
   statusLine?: HudStatusLineConfig;
+  tmux?: HudTmuxConfig;
 }
 
 export interface ResolvedHudGitConfig {
@@ -172,10 +178,15 @@ export interface ResolvedHudStatusLineConfig {
   preset: HudPreset;
 }
 
+export interface ResolvedHudTmuxConfig {
+  autoPane: boolean;
+}
+
 export interface ResolvedHudConfig {
   preset: HudPreset;
   git: ResolvedHudGitConfig;
   statusLine: ResolvedHudStatusLineConfig;
+  tmux?: ResolvedHudTmuxConfig;
 }
 
 /** Default HUD configuration */
@@ -186,6 +197,9 @@ export const DEFAULT_HUD_CONFIG: ResolvedHudConfig = {
   },
   statusLine: {
     preset: 'focused',
+  },
+  tmux: {
+    autoPane: true,
   },
 };
 


### PR DESCRIPTION
## Summary
- add `.omx/hud-config.json` support for `tmux.autoPane`
- keep automatic tmux HUD panes enabled by default
- when `tmux.autoPane` is `false`, prompt-submit reconciliation removes owned HUD panes, unregisters the resize hook, and skips recreating the split

## Why
In cramped or frequently resized tmux sessions, the extra OMX HUD split can reduce the Codex TUI viewport and make output/composer redraw issues feel like truncated or duplicated UI. This gives users a config-level opt-out without removing the HUD default for existing workflows.

Example config:

```json
{
  "preset": "focused",
  "tmux": {
    "autoPane": false
  }
}
```

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/hud/__tests__/types.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/index.test.js dist/hud/__tests__/state.test.js dist/hud/__tests__/resource-leak-watch.test.js`
- `npm run lint`

## Notes
- This does not disable `omx hud` or explicit `omx hud --tmux` usage.
- This does not try to fix Codex CLI's own queued-message composer or terminal resize redraw behavior.
