### PR TITLE
fix(doctor): add Spark/model lane routing diagnostic (#2757)

### DIFF
--- a/src/cli/__tests__/doctor-spark-routing.test.ts
+++ b/src/cli/__tests__/doctor-spark-routing.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { checkSparkRouting } from '../doctor.js';
+
+const SPARK_DEFAULT = 'gpt-5.3-codex-spark';
+
+const SPARK_ENV_KEYS = [
+  'OMX_DEFAULT_SPARK_MODEL',
+  'OMX_SPARK_MODEL',
+  'OMX_DEFAULT_STANDARD_MODEL',
+  'OMX_DEFAULT_FRONTIER_MODEL',
+] as const;
+
+const saved = new Map<string, string | undefined>();
+
+function makePaths(codexHomeDir: string) {
+  const agentsDir = join(codexHomeDir, 'agents');
+  return {
+    codexHomeDir,
+    configPath: join(codexHomeDir, 'config.toml'),
+    hooksPath: join(codexHomeDir, 'hooks'),
+    promptsDir: join(codexHomeDir, 'prompts'),
+    skillsDir: join(codexHomeDir, 'skills'),
+    agentsDir,
+    stateDir: join(codexHomeDir, 'state'),
+  };
+}
+
+let workDir: string;
+
+beforeEach(() => {
+  for (const key of SPARK_ENV_KEYS) {
+    saved.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  workDir = mkdtempSync(join(tmpdir(), 'omx-doctor-spark-'));
+  mkdirSync(join(workDir, 'agents'), { recursive: true });
+});
+
+afterEach(() => {
+  for (const key of SPARK_ENV_KEYS) {
+    const value = saved.get(key);
+    if (typeof value === 'string') process.env[key] = value;
+    else delete process.env[key];
+  }
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+function writeExploreToml(body: string): void {
+  writeFileSync(join(workDir, 'agents', 'explore.toml'), body);
+}
+
+describe('checkSparkRouting', () => {
+  it('passes and names the resolved Spark model when the lane is wired correctly', () => {
+    writeExploreToml(
+      `name = "explore"\nmodel = "${SPARK_DEFAULT}"\n`,
+    );
+    const result = checkSparkRouting(makePaths(workDir));
+    assert.equal(result.status, 'pass');
+    assert.match(result.message, new RegExp(SPARK_DEFAULT));
+    assert.match(result.message, /wired/);
+    assert.match(result.message, /spark=/);
+  });
+
+  it('warns when the Spark-lane agent toml is missing', () => {
+    const result = checkSparkRouting(makePaths(workDir));
+    assert.equal(result.status, 'warn');
+    assert.match(result.message, /explore\.toml is missing/);
+    assert.match(result.message, /omx setup --force/);
+  });
+
+  it('warns when the installed model diverges from the resolved Spark model', () => {
+    writeExploreToml(`name = "explore"\nmodel = "gpt-5.4-mini"\n`);
+    const result = checkSparkRouting(makePaths(workDir));
+    assert.equal(result.status, 'warn');
+    assert.match(result.message, /gpt-5\.4-mini/);
+    assert.match(result.message, /stale install/);
+  });
+
+  it('warns when the Spark-lane agent routes through a non-default provider', () => {
+    writeExploreToml(
+      `name = "explore"\nmodel = "${SPARK_DEFAULT}"\nmodel_provider = "my-proxy"\n`,
+    );
+    const result = checkSparkRouting(makePaths(workDir));
+    assert.equal(result.status, 'warn');
+    assert.match(result.message, /non-default model_provider/);
+    assert.match(result.message, /my-proxy/);
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -69,6 +69,18 @@ import {
 	resolvePackagedOmxMarketplace,
 } from "./plugin-marketplace.js";
 import { hasOmxAgentsContract } from "../utils/agents-md.js";
+import {
+	OMX_DEFAULT_SPARK_MODEL_ENV,
+	OMX_SPARK_MODEL_ENV,
+	getCodexConfigRootModelProvider,
+	getEnvConfiguredSparkDefaultModel,
+	getMainDefaultModel,
+	getSparkDefaultModel,
+	getStandardDefaultModel,
+} from "../config/models.js";
+import { AGENT_DEFINITIONS } from "../agents/definitions.js";
+import { getInstallableNativeAgentNames } from "../agents/policy.js";
+import { readCatalogManifest } from "../catalog/reader.js";
 
 interface DoctorOptions {
 	verbose?: boolean;
@@ -240,6 +252,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 		scopeResolution.installMode,
 	);
 	if (nativeReviewerRolesCheck) checks.push(nativeReviewerRolesCheck);
+
+	// Check 6.4: Spark/model lane routing (issue #2757)
+	checks.push(checkSparkRouting(paths));
 
 	// Check 6.5: Legacy/current skill-root overlap
 	if (scopeResolution.scope === "user") {
@@ -1890,6 +1905,161 @@ function checkNativeReviewerRoles(
 		status: "pass",
 		message:
 			`required RALPLAN/Autopilot native reviewer roles are available (${REQUIRED_NATIVE_REVIEWER_ROLES.join(", ")}); advisory ${ADVISORY_NATIVE_REVIEWER_ROLES.join(", ")} role is also available`,
+	};
+}
+
+interface InstalledAgentModelInfo {
+	exists: boolean;
+	model?: string;
+	modelProvider?: string;
+}
+
+function readInstalledAgentModelInfo(tomlPath: string): InstalledAgentModelInfo {
+	if (!existsSync(tomlPath)) return { exists: false };
+	try {
+		const parsed = parseToml(readFileSync(tomlPath, "utf-8")) as {
+			model?: unknown;
+			model_provider?: unknown;
+		};
+		return {
+			exists: true,
+			model:
+				typeof parsed.model === "string" && parsed.model.trim() !== ""
+					? parsed.model.trim()
+					: undefined,
+			modelProvider:
+				typeof parsed.model_provider === "string" &&
+				parsed.model_provider.trim() !== ""
+					? parsed.model_provider.trim()
+					: undefined,
+		};
+	} catch {
+		return { exists: true };
+	}
+}
+
+function resolveSparkModelSource(codexHomeOverride?: string): string {
+	const envDefault = process.env[OMX_DEFAULT_SPARK_MODEL_ENV];
+	if (typeof envDefault === "string" && envDefault.trim() !== "") {
+		return `${OMX_DEFAULT_SPARK_MODEL_ENV} env`;
+	}
+	const envLegacy = process.env[OMX_SPARK_MODEL_ENV];
+	if (typeof envLegacy === "string" && envLegacy.trim() !== "") {
+		return `${OMX_SPARK_MODEL_ENV} env`;
+	}
+	if (getEnvConfiguredSparkDefaultModel(process.env, codexHomeOverride)) {
+		return "config.toml env";
+	}
+	return "built-in default";
+}
+
+function getInstallableSparkLaneAgentNames(): string[] {
+	try {
+		const installable = getInstallableNativeAgentNames(
+			readCatalogManifest(getPackageRoot()),
+		);
+		return Object.values(AGENT_DEFINITIONS)
+			.filter(
+				(agent) => agent.modelClass === "fast" && installable.has(agent.name),
+			)
+			.map((agent) => agent.name)
+			.sort();
+	} catch {
+		return Object.values(AGENT_DEFINITIONS)
+			.filter((agent) => agent.modelClass === "fast")
+			.map((agent) => agent.name)
+			.sort();
+	}
+}
+
+/**
+ * Surface effective Spark/model lane routing and flag the common reasons the
+ * `gpt-5.3-codex-spark` quota stays unused even though resolution is wired
+ * (issue #2757): a missing/stale installed Spark-lane agent toml, a model that
+ * diverges from the resolved Spark default, or a non-default provider that does
+ * not draw from native Spark quota.
+ */
+export function checkSparkRouting(paths: DoctorPaths): Check {
+	const name = "Spark routing";
+	const codexHomeOverride = paths.codexHomeDir;
+	const sparkModel = getSparkDefaultModel(codexHomeOverride);
+	const frontierModel = getMainDefaultModel(codexHomeOverride);
+	const standardModel = getStandardDefaultModel(codexHomeOverride);
+	const sparkSource = resolveSparkModelSource(codexHomeOverride);
+	const rootProvider = getCodexConfigRootModelProvider(codexHomeOverride);
+
+	const laneSummary =
+		`lanes: frontier=\`${frontierModel}\`, standard=\`${standardModel}\`, ` +
+		`spark=\`${sparkModel}\` (source: ${sparkSource})`;
+
+	const sparkAgents = getInstallableSparkLaneAgentNames();
+	if (sparkAgents.length === 0) {
+		return {
+			name,
+			status: "warn",
+			message:
+				`${laneSummary}; no installable Spark-eligible (fast) native agent is defined, ` +
+				`so native subagents will not consume Spark quota`,
+		};
+	}
+
+	const problems: string[] = [];
+	const wired: string[] = [];
+	for (const agentName of sparkAgents) {
+		const info = readInstalledAgentModelInfo(
+			join(paths.agentsDir, `${agentName}.toml`),
+		);
+		if (!info.exists) {
+			problems.push(
+				`${agentName}.toml is missing under ${paths.agentsDir} (run \`omx setup --force\`)`,
+			);
+			continue;
+		}
+		if (!info.model) {
+			problems.push(
+				`${agentName}.toml has no model field (stale install; run \`omx setup --force\`)`,
+			);
+			continue;
+		}
+		if (info.model !== sparkModel) {
+			problems.push(
+				`${agentName}.toml model is \`${info.model}\` but the resolved Spark model is \`${sparkModel}\` (stale install; run \`omx setup --force\`)`,
+			);
+			continue;
+		}
+		if (info.modelProvider && rootProvider && info.modelProvider !== rootProvider) {
+			problems.push(
+				`${agentName}.toml model_provider \`${info.modelProvider}\` differs from the config root provider \`${rootProvider}\` (stale install; run \`omx setup --force\`)`,
+			);
+			continue;
+		}
+		if (info.modelProvider && info.modelProvider !== "openai") {
+			problems.push(
+				`${agentName}.toml routes Spark via non-default model_provider \`${info.modelProvider}\`; native Codex Spark quota only moves when Spark is served by the default provider`,
+			);
+			continue;
+		}
+		wired.push(
+			`${agentName} -> \`${info.model}\`${
+				info.modelProvider ? ` (provider: ${info.modelProvider})` : ""
+			}`,
+		);
+	}
+
+	if (problems.length > 0) {
+		return {
+			name,
+			status: "warn",
+			message: `${laneSummary}; Spark lane issue(s): ${problems.join("; ")}`,
+		};
+	}
+
+	return {
+		name,
+		status: "pass",
+		message:
+			`${laneSummary}; Spark-lane native agent(s) wired: ${wired.join(", ")}. ` +
+			`If Spark quota is still unused, the leader may not be delegating read-only lookups to the Spark lane, or the Codex usage view may lag.`,
 	};
 }
 

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -14,6 +14,7 @@ Resolved setup scope: user
   [OK] Lore commit guard: disabled by default
   [!!] Prompts: prompts directory not found
   [!!] Skills: skills directory not found
+  [!!] Spark routing: lanes: frontier=`gpt-5.5`, standard=`gpt-5.5`, spark=`gpt-5.3-codex-spark` (source: built-in default); Spark lane issue(s): explore.toml is missing under <CODEX_HOME>/agents (run `omx setup --force`)
   [OK] Legacy skill roots: no ~/.agents/skills overlap detected
   [!!] AGENTS.md: not found in <CODEX_HOME>/AGENTS.md (run omx setup --scope user)
   [!!] State dir: <REPO_STATE_DIR> (not created yet)


### PR DESCRIPTION
## Summary

Fixes #2757 — "OMX appears to avoid Spark model routing; Spark quota remains unused."

Investigation (red-teamed) showed the Spark lane is **correctly wired** in code:
- The `explore` native subagent (`modelClass: 'fast'`, catalog `active`, not team-gated) resolves to `gpt-5.3-codex-spark` and embeds it in `~/.codex/agents/explore.toml`.
- `templates/AGENTS.md` still routes repo lookups to the `explore` subagent (#2749 only removed the deprecated `omx explore` *command*, not the subagent).
- Env precedence (`OMX_DEFAULT_SPARK_MODEL` > `OMX_SPARK_MODEL` > config > default) is correct in both TS and Rust and is tested.

So the symptom is produced by **operational/runtime conditions that OMX made invisible**, with **no diagnostic** for any of them:
- stale/missing installed `explore.toml` after an `npm` upgrade (setup not re-run with `--force`),
- an installed model that diverges from the currently-resolved Spark model,
- a non-default `model_provider` at the config root (the `gpt-5.3-codex-spark` name is sent to a non-Codex provider, so native Spark quota never moves).

`omx doctor` previously checked none of these; `omx team status --model-inspect` is tmux-only.

## Change

Adds a single additive `omx doctor` check (**"Spark routing"**) that:
1. Prints the resolved frontier/standard/spark lane models with the Spark model's source.
2. Reads the installed Spark-lane native agent toml(s) and reports the actual `model`/`model_provider`.
3. **Warns** when the Spark-lane agent is missing, model-divergent, or provider-divergent — each with remediation (`omx setup --force`, or a note that a custom provider won't consume native Spark quota).
4. **Passes** and names the resolved Spark model when the lane is wired, so users can rule out routing and look at delegation / usage-display lag instead.

No change to model-resolution behavior or defaults.

Example (correctly wired):
```
[OK] Spark routing: lanes: frontier=`gpt-5.4`, standard=`gpt-5.4`, spark=`gpt-5.3-codex-spark` (source: built-in default); Spark-lane native agent(s) wired: explore -> `gpt-5.3-codex-spark`. If Spark quota is still unused, the leader may not be delegating read-only lookups to the Spark lane, or the Codex usage view may lag.
```

## Verification
- `npm run build` — clean.
- `npx biome lint src/cli/doctor.ts src/cli/__tests__/doctor-spark-routing.test.ts` — clean.
- New unit tests `dist/cli/__tests__/doctor-spark-routing.test.js` (4 cases: wired-pass, missing-warn, model-divergent-warn, provider-divergent-warn) + existing doctor suites — 37/37 pass.
- `omx doctor` smoke run renders the new check.

## Files
- `src/cli/doctor.ts` — `checkSparkRouting` + helpers, wired into `doctor()`.
- `src/cli/__tests__/doctor-spark-routing.test.ts` — new unit tests.
