### PR TITLE
fix(mcp): cap post-traffic same-parent first-party MCP siblings (#2759)

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -16,6 +16,7 @@ import {
   shouldAutoStartMcpServer,
   shouldSelfExitForDuplicateSibling,
   shouldSelfExitForPreTrafficSiblingHardCap,
+  shouldSelfExitForPostTrafficSiblingHardCap,
   type McpServerName,
 } from '../bootstrap.js';
 import {
@@ -559,6 +560,65 @@ describe('mcp duplicate sibling detection', () => {
       shouldSelfExitForPreTrafficSiblingHardCap(oldest, null, 0),
       false,
       'zero disables the hard cap',
+    );
+  });
+
+  it('hard-caps post-traffic superseded siblings kept warm by a long-lived parent', () => {
+    const processes = [
+      { pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 102, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 103, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 104, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 105, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+    ];
+
+    const oldest = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    const secondOldest = analyzeDuplicateSiblingState(processes, 102, 55, 'state-server.js');
+
+    // Keepalive traffic at t=60_000 would forever defer the last-traffic idle
+    // window, but the oldest over-cap sibling has been superseded since t=0, so
+    // the post-traffic hard cap reaps it once the idle window elapses.
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(oldest, 60_000, 0, 60_000, 4, 60_000),
+      true,
+      'oldest over-cap sibling self-exits despite continuous keepalive traffic',
+    );
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(secondOldest, 60_000, 0, 60_000, 4, 60_000),
+      false,
+      'the newest four post-traffic contexts are always preserved',
+    );
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(oldest, 59_999, 0, 0, 4, 60_000),
+      false,
+      'must stay superseded for the full idle window before reaping',
+    );
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(oldest, 60_000, 0, null, 4, 60_000),
+      false,
+      'pre-traffic siblings are handled by the pre-traffic hard cap',
+    );
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(oldest, 60_000, 0, 60_000, 0, 60_000),
+      false,
+      'zero disables the post-traffic hard cap',
+    );
+  });
+
+  it('does not post-traffic hard-cap same-parent siblings within the retained window', () => {
+    const processes = [
+      { pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 102, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 103, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 104, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+    ];
+
+    const oldest = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    assert.equal(oldest.status, 'older_duplicate');
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(oldest, 600_000, 0, 600_000, 4, 60_000),
+      false,
+      'at-or-below the cap, distinct client contexts are preserved',
     );
   });
 });

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -425,6 +425,35 @@ export function shouldSelfExitForPreTrafficSiblingHardCap(
   return observation.newerSiblingPids.length >= maxSiblingsPerEntrypoint;
 }
 
+export function shouldSelfExitForPostTrafficSiblingHardCap(
+  observation: DuplicateSiblingObservation,
+  nowMs: number,
+  duplicateObservedAtMs: number | null,
+  lastTrafficAtMs: number | null,
+  maxSiblingsPerEntrypoint = DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT,
+  postTrafficIdleMs = DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
+): boolean {
+  if (observation.status !== 'older_duplicate') return false;
+  // Pre-traffic siblings are reaped by shouldSelfExitForPreTrafficSiblingHardCap.
+  if (lastTrafficAtMs === null) return false;
+  if (!Number.isInteger(maxSiblingsPerEntrypoint) || maxSiblingsPerEntrypoint <= 0) return false;
+  if (observation.matchingPids.length <= maxSiblingsPerEntrypoint) return false;
+  // Only the oldest siblings beyond the retained window are eligible; the newest N
+  // same-parent same-entrypoint contexts are always preserved.
+  if (observation.newerSiblingPids.length < maxSiblingsPerEntrypoint) return false;
+  if (duplicateObservedAtMs === null) return false;
+  if (!Number.isFinite(nowMs) || duplicateObservedAtMs > nowMs) return false;
+  if (!Number.isFinite(lastTrafficAtMs) || lastTrafficAtMs > nowMs) return false;
+
+  // Measure the idle window from the duplicate observation rather than the last
+  // stdin byte. A long-lived Codex.app parent can keep superseded first-party
+  // siblings warm with periodic keepalive traffic, which would otherwise reset
+  // the post-traffic idle timer forever and let same-parent same-entrypoint
+  // duplicates accumulate without bound. Once a sibling has stayed superseded for
+  // the full idle window while still over the cap, reap it.
+  return nowMs - duplicateObservedAtMs >= postTrafficIdleMs;
+}
+
 export function isParentProcessAlive(
   parentPid: number,
   signalProcess: typeof process.kill = process.kill,
@@ -558,6 +587,18 @@ export function autoStartStdioMcpServer(
         lifecycleTiming.maxSiblingsPerEntrypoint,
       )) {
         void shutdown('superseded_hard_cap_pre_traffic');
+        return;
+      }
+
+      if (shouldSelfExitForPostTrafficSiblingHardCap(
+        observation,
+        Date.now(),
+        duplicateObservedAtMs,
+        lastTrafficAtMs,
+        lifecycleTiming.maxSiblingsPerEntrypoint,
+        lifecycleTiming.duplicateSiblingPostTrafficIdleMs,
+      )) {
+        void shutdown('superseded_hard_cap_post_traffic');
         return;
       }
 


### PR DESCRIPTION
## Summary

Fixes #2759 — same-parent OMX MCP duplicate siblings accumulating under one Codex App ppid on Windows.

### Root cause

`src/mcp/bootstrap.ts` is byte-identical between `v0.18.7` (reporter's install) and `dev`/`0.18.10`, so this is a live shape in current code, not something a version bump fixes.

The duplicate-sibling watchdog has two cleanup paths for same-parent (`ppid`), same-entrypoint, first-party OMX MCP siblings:

- **Pre-traffic hard cap** (`shouldSelfExitForPreTrafficSiblingHardCap`): bounds never-owned transports to the newest N (`OMX_MCP_MAX_SIBLINGS_PER_ENTRYPOINT`, default 4).
- **Post-traffic idle** (`shouldSelfExitForDuplicateSibling`): once a sibling has seen *any* stdin byte, it only self-exits after the idle window measured from the **last stdin byte**.

A long-lived Codex.app parent (single `ppid=30080` in the report) keeps superseded siblings warm with periodic keepalive traffic, which resets the last-traffic timer forever. There is **no upper bound** on post-traffic superseded siblings, so older duplicates pile up across sessions (reporter manually killed ~24 lingering `node` processes; disabling global MCP entries drained residual count to zero).

### Fix

Add `shouldSelfExitForPostTrafficSiblingHardCap`. For an `older_duplicate` first-party sibling that is **over** the retained window (`matchingPids.length > cap` and it is among the oldest, `newerSiblingPids.length >= cap`), reap it once it has stayed superseded for the full idle window measured from the **duplicate observation** rather than the last stdin byte. This way periodic keepalive traffic can no longer defer cleanup indefinitely.

Safety:
- Cross-parent / cross-client contexts are untouched — analysis is scoped to same `ppid` + same entrypoint, and the newest N contexts are always preserved.
- Siblings at or below the cap keep the existing conservative post-traffic idle protection.
- Pre-traffic siblings remain handled by the existing pre-traffic hard cap.
- Operators can tune via `OMX_MCP_MAX_SIBLINGS_PER_ENTRYPOINT` / `OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS`; `0` disables the cap.

### Tests

- `src/mcp/__tests__/bootstrap.test.ts`: two new cases covering the over-cap keepalive-warm reap (with idle-window and newest-N preservation assertions) and the at-cap no-op.
- `node --test dist/mcp/__tests__/bootstrap.test.js` → 33 pass.
- Full `dist/mcp/__tests__` suite → pass (incl. `server-lifecycle` runtime regression, 15 pass).
- `biome lint` on changed files → ok.
