### PR TITLE
ci(release): retry npm publish on Rekor outage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,24 @@ jobs:
           console.log(`[version-sync] OK package=${pkg.version} workspace=${workspace.workspace?.package?.version} tag=${tag ?? ''}`.trim());
           EOF
       - run: npm pack --dry-run
-      - run: npm publish --access public --provenance
+      - name: Publish to npm
+        shell: bash
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "::warning::Version ${VERSION} already published to npm, skipping publish"
+            exit 0
+          fi
+
+          set -o pipefail
+          if npm publish --access public --provenance 2>&1 | tee npm-publish.log; then
+            echo "Published to npm with provenance"
+          elif grep -Eiq 'TLOG_CREATE_ENTRY_ERROR|tlog|rekor|transparency log' npm-publish.log; then
+            echo "::warning::npm provenance publish failed due to Sigstore/Rekor transparency log outage; retrying without provenance"
+            npm publish --access public
+          else
+            exit 1
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Related to #2763. Bellman confirmed the `v0.18.11` release failed during npm provenance publication with `TLOG_CREATE_ENTRY_ERROR` / Rekor `ECONNRESET`, after the release build/native/smoke/package gates had already passed. This PR keeps provenance as the primary publish path and adds a narrow Rekor/TLOG fallback inline in the existing release workflow.

## Changes

- Wrap npm publish in an explicit `Publish to npm` bash step.
- Skip cleanly if the package version is already visible on npm during a rerun.
- Publish with provenance first.
- Retry `npm publish --access public` only when the captured publish log matches a Sigstore/Rekor transparency-log outage.
- Preserve non-Rekor publish failures as hard failures.

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [ ] `npm test` attempted locally; full suite currently exits 1 in existing Git local-exclude setup tests outside this workflow-only diff. PR CI test gates are green.
- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "YAML OK"'`
- [x] `sed -n '327,341p' .github/workflows/release.yml | sed 's/^          //' | bash -n`
- [x] `omx doctor` not applicable; this does not change setup/config behavior.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed; not needed for this release workflow-only change
- [x] Backward-compatibility impact considered

Document-refresh: not-needed | release workflow-only change; no runtime, prompt, CLI, or product-doc behavior changed.

## Scope note

This hardens future tag-triggered release publishes. It does not by itself make the already-created `v0.18.11` npm proof green; that still needs maintainer-controlled release action such as rerunning from an updated ref/tag or publishing manually.

## Related

Related to #2763