### PR TITLE
Fix dev version label and stale HUD cleanup

### DIFF
--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -823,7 +823,7 @@ describe('runImmediateUpdate', () => {
       }, { channel: 'dev' });
 
       assert.equal(result.status, 'updated');
-      assert.equal(latestCalls, 0);
+      assert.equal(latestCalls, 1);
       assert.equal(refreshCalls, 1);
       assert.deepEqual(installSources, ['github:Yeachan-Heo/oh-my-codex#dev']);
       assert.match(logs.join('\n'), /Selected update channel: dev/);
@@ -837,14 +837,56 @@ describe('runImmediateUpdate', () => {
         install_channel: string;
         install_source: string;
         install_revision: string;
+        dev_base_version: string;
       };
       assert.equal(stamp.installed_version, '0.15.0');
       assert.equal(stamp.setup_completed_version, '0.15.0');
       assert.equal(stamp.install_channel, 'dev');
       assert.equal(stamp.install_source, 'github:Yeachan-Heo/oh-my-codex#dev');
       assert.equal(stamp.install_revision, '1234567890ab');
+      assert.equal(stamp.dev_base_version, '0.15.0');
     } finally {
       console.log = originalLog;
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('records the latest release as dev display baseline when dev package.json lags behind', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-dev-baseline-'));
+    const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
+    const originalCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = join(cwd, '.codex');
+
+    try {
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.18.10',
+        fetchLatestVersion: async () => '0.18.11',
+        runGlobalUpdate: () => ({ ok: true, stderr: '', revision: '4dd0f6455772' }),
+        runSetupRefresh: async () => ({ ok: true, stderr: '' }),
+        getInstalledVersionAfterUpdate: async () => '0.18.10',
+        getInstalledRevisionAfterUpdate: async () => null,
+      }, { channel: 'dev' });
+
+      assert.equal(result.status, 'updated');
+      const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
+        installed_version: string;
+        setup_completed_version: string;
+        install_channel: string;
+        install_revision: string;
+        dev_base_version: string;
+      };
+      assert.equal(stamp.installed_version, '0.18.10');
+      assert.equal(stamp.setup_completed_version, '0.18.10');
+      assert.equal(stamp.install_channel, 'dev');
+      assert.equal(stamp.install_revision, '4dd0f6455772');
+      assert.equal(stamp.dev_base_version, '0.18.11');
+    } finally {
       if (typeof originalCodexHome === 'string') {
         process.env.CODEX_HOME = originalCodexHome;
       } else {

--- a/src/cli/__tests__/version-sync-contract.test.ts
+++ b/src/cli/__tests__/version-sync-contract.test.ts
@@ -17,6 +17,9 @@ interface WorkspaceMemberPackageMetadata {
 describe('version sync contract', () => {
   it('keeps package.json, workspace metadata, and Rust members aligned for releases', () => {
     const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8')) as { version: string };
+    const pluginManifest = JSON.parse(
+      readFileSync(join(process.cwd(), 'plugins', 'oh-my-codex', '.codex-plugin', 'plugin.json'), 'utf-8'),
+    ) as { version: string };
     const workspace = TOML.parse(readFileSync(join(process.cwd(), 'Cargo.toml'), 'utf-8')) as {
       workspace?: { package?: WorkspacePackageMetadata; members?: string[] };
     };
@@ -40,6 +43,7 @@ describe('version sync contract', () => {
     };
 
     assert.equal(workspace.workspace?.package?.version, pkg.version);
+    assert.equal(pluginManifest.version, pkg.version);
     assert.deepEqual(workspace.workspace?.members, [
       'crates/omx-api',
       'crates/omx-explore',

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -27,6 +27,7 @@ export interface UserInstallStamp {
   install_channel?: UpdateChannel;
   install_source?: string;
   install_revision?: string;
+  dev_base_version?: string;
   updated_at: string;
 }
 
@@ -578,6 +579,7 @@ async function writeSuccessfulInstallStamp(
     channel?: UpdateChannel;
     source?: string;
     revision?: string | null;
+    devBaseVersion?: string | null;
   } = {},
 ): Promise<void> {
   await writeUserInstallStamp({
@@ -586,6 +588,7 @@ async function writeSuccessfulInstallStamp(
     ...(metadata.channel ? { install_channel: metadata.channel } : {}),
     ...(metadata.source ? { install_source: metadata.source } : {}),
     ...(metadata.revision ? { install_revision: metadata.revision } : {}),
+    ...(metadata.devBaseVersion ? { dev_base_version: stripLeadingV(metadata.devBaseVersion) } : {}),
     updated_at: new Date().toISOString(),
   });
 }
@@ -613,6 +616,9 @@ export async function readUserInstallStamp(
         : {}),
       ...(typeof parsed.install_revision === 'string'
         ? { install_revision: parsed.install_revision }
+        : {}),
+      ...(typeof parsed.dev_base_version === 'string'
+        ? { dev_base_version: parsed.dev_base_version }
         : {}),
       updated_at: parsed.updated_at,
     };
@@ -795,7 +801,7 @@ async function executeUpdate(
   const channelConfig = resolveUpdateChannelConfig(channel);
   const [current, latest] = await Promise.all([
     dependencies.getCurrentVersion(),
-    channel === 'stable' || !forceInstall ? dependencies.fetchLatestVersion() : Promise.resolve(null),
+    channel === 'stable' || !forceInstall || channel === 'dev' ? dependencies.fetchLatestVersion() : Promise.resolve(null),
   ]);
 
   try {
@@ -891,6 +897,9 @@ async function executeUpdate(
   const installedRevision = channelConfig.channel === 'dev'
     ? ((await dependencies.getInstalledRevisionAfterUpdate()) ?? result.revision ?? null)
     : null;
+  const devBaseVersion = channelConfig.channel === 'dev'
+    ? (latest && installedVersion && isNewerVersion(latest, installedVersion) ? installedVersion : (latest ?? installedVersion ?? current))
+    : null;
   const stampVersion = channelConfig.channel === 'stable'
     ? (latest ?? installedVersion ?? current)
     : installedVersion;
@@ -899,6 +908,7 @@ async function executeUpdate(
       channel: channelConfig.channel,
       source: channelConfig.installSource,
       revision: channelConfig.channel === 'dev' ? installedRevision : null,
+      devBaseVersion,
     });
   } else if (channelConfig.channel === 'dev') {
     console.log(

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -177,6 +177,111 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.paneId, '%9');
   });
 
+
+  it('reaps a stale HUD pane for the same leader after the leader resumes with a new session id', async () => {
+    const killed: string[] = [];
+    const created: Array<{ options?: { targetPaneId?: string } }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%stale-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%new-hud';
+      },
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.deepEqual(killed, ['%stale-hud']);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%new-hud');
+    assert.equal(created.length, 1);
+    assert.equal(created[0]?.options?.targetPaneId, '%leader');
+  });
+
+  it('reaps a stale same-leader HUD even when a current-session HUD already exists', async () => {
+    const killed: string[] = [];
+    const created: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%current-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-new' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+        },
+        {
+          paneId: '%stale-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: () => {
+        created.push('create');
+        return '%new-hud';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.deepEqual(killed, ['%stale-hud']);
+    assert.deepEqual(created, []);
+    assert.equal(result.status, 'resized');
+    assert.equal(result.paneId, '%current-hud');
+    assert.deepEqual(resized, [{ paneId: '%current-hud', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+  });
+
+  it('does not reap a different-session HUD pane owned by a neighboring live leader', async () => {
+    const killed: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%left', OMX_SESSION_ID: 'sess-left', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%left', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%right', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%right-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-right' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%right' node omx hud --watch --preset=focused`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: () => '%left-hud',
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.deepEqual(killed, []);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%left-hud');
+  });
+
   it('does not reap an orphaned HUD pane that belongs to a different session', async () => {
     // A HUD owned by another session's leader (which may live in a different tmux
     // window we cannot see here) must survive even when that leader is absent.

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -79,6 +79,36 @@ function reapOrphanedSessionHudPanes(
   return reaped;
 }
 
+function hasExplicitHudOwnerMarker(pane: TmuxPaneSnapshot): boolean {
+  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  return new RegExp(`(?:^|\\s)${OMX_TMUX_HUD_OWNER_ENV}=(?:'1'|1)(?=$|\\s)`).test(command);
+}
+
+function reapStaleCurrentLeaderHudPanes(
+  panes: TmuxPaneSnapshot[],
+  opts: {
+    sessionIds: string[];
+    currentPaneId: string | undefined;
+    killPane: (paneId: string) => boolean;
+  },
+): string[] {
+  const { currentPaneId, killPane } = opts;
+  if (!currentPaneId) return [];
+  const currentSessionIds = new Set(opts.sessionIds.map((sessionId) => sessionId.trim()).filter(Boolean));
+  if (currentSessionIds.size === 0) return [];
+
+  const reaped: string[] = [];
+  for (const pane of panes) {
+    if (!isHudWatchPane(pane)) continue;
+    const owner = readHudPaneOwner(pane);
+    if (owner.leaderPaneId !== currentPaneId) continue;
+    if (!hasExplicitHudOwnerMarker(pane)) continue;
+    if (!owner.sessionId || currentSessionIds.has(owner.sessionId)) continue;
+    if (killPane(pane.paneId)) reaped.push(pane.paneId);
+  }
+  return reaped;
+}
+
 export interface ReconcileHudForPromptSubmitResult {
   status:
     | 'skipped_not_tmux'
@@ -240,6 +270,22 @@ export async function reconcileHudForPromptSubmit(
   });
   if (reapedOrphanPaneIds.length > 0) {
     const reapedPaneIdSet = new Set(reapedOrphanPaneIds);
+    panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
+  }
+
+  // A Codex self-update can restart/resume the leader in the same tmux pane with
+  // a new OMX session id while the old HUD watcher stays alive. That stale HUD
+  // still names the current leader pane, but with the previous session id, so it
+  // does not match same-owner dedupe and the next launch would create a second HUD
+  // beside it. Reap only HUDs tied to this exact leader pane; neighboring panes'
+  // HUDs remain isolated by leaderPaneId.
+  const reapedStaleLeaderPaneIds = reapStaleCurrentLeaderHudPanes(panes, {
+    sessionIds: equivalentSessionIds,
+    currentPaneId,
+    killPane,
+  });
+  if (reapedStaleLeaderPaneIds.length > 0) {
+    const reapedPaneIdSet = new Set(reapedStaleLeaderPaneIds);
     panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
   }
 

--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -41,6 +41,24 @@ describe('resolveOmxDisplayVersionSync', () => {
     });
   });
 
+
+
+  it('uses a dev base version from the install stamp when package.json lags the release baseline', async () => {
+    await withVersionFixture(async ({ packageRoot, stampPath }) => {
+      await writeFile(stampPath, JSON.stringify({
+        installed_version: '0.18.8',
+        setup_completed_version: '0.18.8',
+        dev_base_version: '0.18.9',
+        install_channel: 'dev',
+        install_source: 'github:Yeachan-Heo/oh-my-codex#dev',
+        install_revision: 'feedfacecafebeef',
+        updated_at: '2026-06-09T00:00:00.000Z',
+      }, null, 2));
+
+      assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.9-dev-feedfacecafe');
+    });
+  });
+
   it('does not apply stale dev stamp metadata to a different package version', async () => {
     await withVersionFixture(async ({ packageRoot, stampPath }) => {
       await writeFile(stampPath, JSON.stringify({
@@ -49,6 +67,21 @@ describe('resolveOmxDisplayVersionSync', () => {
         install_channel: 'dev',
         install_revision: 'abcdef123456',
         updated_at: '2026-06-02T00:00:00.000Z',
+      }, null, 2));
+
+      assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.8');
+    });
+  });
+
+  it('does not let stale dev_base_version metadata make a mismatched stamp current', async () => {
+    await withVersionFixture(async ({ packageRoot, stampPath }) => {
+      await writeFile(stampPath, JSON.stringify({
+        installed_version: '0.18.7',
+        setup_completed_version: '0.18.7',
+        dev_base_version: '0.18.11',
+        install_channel: 'dev',
+        install_revision: 'feedfacecafebeef',
+        updated_at: '2026-06-09T00:00:00.000Z',
       }, null, 2));
 
       assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.8');

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -13,6 +13,7 @@ interface InstallVersionMetadata {
   setup_completed_version?: string;
   install_channel?: string;
   install_revision?: string;
+  dev_base_version?: string;
 }
 
 function stripLeadingV(version: string): string {
@@ -75,10 +76,15 @@ export function resolveOmxDisplayVersionSync(options: {
     : typeof stamp?.installed_version === 'string'
       ? stripLeadingV(stamp.installed_version)
       : '';
-  const isCurrentDevInstall = stamp?.install_channel === 'dev' && stampVersion === version;
+  const devBaseVersion = typeof stamp?.dev_base_version === 'string'
+    ? stripLeadingV(stamp.dev_base_version)
+    : '';
+  const isCurrentDevInstall = stamp?.install_channel === 'dev'
+    && stampVersion === version;
   if (isCurrentDevInstall) {
+    const displayVersion = devBaseVersion || version;
     const revision = shortRevision(stamp.install_revision) ?? explicitRevision ?? readGitRevision(packageRoot);
-    return revision ? `v${version}-dev-${revision}` : `v${version}-dev`;
+    return revision ? `v${displayVersion}-dev-${revision}` : `v${displayVersion}-dev`;
   }
 
   return `v${version}`;


### PR DESCRIPTION
## Summary

Fixes two focused OMX issues prepared from beads `omx-p1o` and `omx-t1w`:

- dev-channel update display can now use the latest release baseline for labels like `v0.18.11-dev-<sha>` even when the dev branch `package.json` still reports `0.18.10`.
- HUD reconciliation now reaps stale same-leader HUD panes left behind after Codex update/restart, without touching neighboring active leader HUDs.
- Strengthens the version sync contract so the Codex plugin manifest version mirrors root `package.json`.

## Scholastic gate / invariants

- `package.json` remains the release-version SSOT.
- `dev_base_version` is install-stamp display metadata only; it is applied only after the stamp is already proven current for the installed package version.
- HUD ownership is scoped by the current leader pane and session ids.
- Stale HUD cleanup only targets explicit owner-tagged HUD panes for the current leader pane; neighboring active leaders are preserved.

## Validation

- `npm run build`
- `node dist/scripts/run-test-files.js dist/utils/__tests__/version.test.js dist/cli/__tests__/update.test.js dist/cli/__tests__/version-sync-contract.test.js dist/hud/__tests__/reconcile.test.js`

Results:

- `update.test`: 51 pass
- `version.test`: 5 pass
- `version-sync-contract.test`: 2 pass
- `hud reconcile.test`: 47 pass

Additional gates run locally via OMX autopilot:

- Architect: APPROVE / CLEAR
- Critic: APPROVE / CLEAR
- Code review: APPROVE / CLEAR, clean=true
- UltraQA: PASS, clean=true

## Notes

No full-suite pass is claimed; validation is scoped to the touched update/version/HUD surfaces.
