### PR TITLE
Fix dev channel version display baseline

### DIFF
--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -823,7 +823,7 @@ describe('runImmediateUpdate', () => {
       }, { channel: 'dev' });
 
       assert.equal(result.status, 'updated');
-      assert.equal(latestCalls, 0);
+      assert.equal(latestCalls, 1);
       assert.equal(refreshCalls, 1);
       assert.deepEqual(installSources, ['github:Yeachan-Heo/oh-my-codex#dev']);
       assert.match(logs.join('\n'), /Selected update channel: dev/);
@@ -837,14 +837,56 @@ describe('runImmediateUpdate', () => {
         install_channel: string;
         install_source: string;
         install_revision: string;
+        dev_base_version: string;
       };
       assert.equal(stamp.installed_version, '0.15.0');
       assert.equal(stamp.setup_completed_version, '0.15.0');
       assert.equal(stamp.install_channel, 'dev');
       assert.equal(stamp.install_source, 'github:Yeachan-Heo/oh-my-codex#dev');
       assert.equal(stamp.install_revision, '1234567890ab');
+      assert.equal(stamp.dev_base_version, '0.15.0');
     } finally {
       console.log = originalLog;
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('records the latest release as dev display baseline when dev package.json lags behind', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-dev-baseline-'));
+    const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
+    const originalCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = join(cwd, '.codex');
+
+    try {
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.18.10',
+        fetchLatestVersion: async () => '0.18.11',
+        runGlobalUpdate: () => ({ ok: true, stderr: '', revision: '4dd0f6455772' }),
+        runSetupRefresh: async () => ({ ok: true, stderr: '' }),
+        getInstalledVersionAfterUpdate: async () => '0.18.10',
+        getInstalledRevisionAfterUpdate: async () => null,
+      }, { channel: 'dev' });
+
+      assert.equal(result.status, 'updated');
+      const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
+        installed_version: string;
+        setup_completed_version: string;
+        install_channel: string;
+        install_revision: string;
+        dev_base_version: string;
+      };
+      assert.equal(stamp.installed_version, '0.18.10');
+      assert.equal(stamp.setup_completed_version, '0.18.10');
+      assert.equal(stamp.install_channel, 'dev');
+      assert.equal(stamp.install_revision, '4dd0f6455772');
+      assert.equal(stamp.dev_base_version, '0.18.11');
+    } finally {
       if (typeof originalCodexHome === 'string') {
         process.env.CODEX_HOME = originalCodexHome;
       } else {

--- a/src/cli/__tests__/version-sync-contract.test.ts
+++ b/src/cli/__tests__/version-sync-contract.test.ts
@@ -17,6 +17,9 @@ interface WorkspaceMemberPackageMetadata {
 describe('version sync contract', () => {
   it('keeps package.json, workspace metadata, and Rust members aligned for releases', () => {
     const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8')) as { version: string };
+    const pluginManifest = JSON.parse(
+      readFileSync(join(process.cwd(), 'plugins', 'oh-my-codex', '.codex-plugin', 'plugin.json'), 'utf-8'),
+    ) as { version: string };
     const workspace = TOML.parse(readFileSync(join(process.cwd(), 'Cargo.toml'), 'utf-8')) as {
       workspace?: { package?: WorkspacePackageMetadata; members?: string[] };
     };
@@ -40,6 +43,7 @@ describe('version sync contract', () => {
     };
 
     assert.equal(workspace.workspace?.package?.version, pkg.version);
+    assert.equal(pluginManifest.version, pkg.version);
     assert.deepEqual(workspace.workspace?.members, [
       'crates/omx-api',
       'crates/omx-explore',

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -27,6 +27,7 @@ export interface UserInstallStamp {
   install_channel?: UpdateChannel;
   install_source?: string;
   install_revision?: string;
+  dev_base_version?: string;
   updated_at: string;
 }
 
@@ -578,6 +579,7 @@ async function writeSuccessfulInstallStamp(
     channel?: UpdateChannel;
     source?: string;
     revision?: string | null;
+    devBaseVersion?: string | null;
   } = {},
 ): Promise<void> {
   await writeUserInstallStamp({
@@ -586,6 +588,7 @@ async function writeSuccessfulInstallStamp(
     ...(metadata.channel ? { install_channel: metadata.channel } : {}),
     ...(metadata.source ? { install_source: metadata.source } : {}),
     ...(metadata.revision ? { install_revision: metadata.revision } : {}),
+    ...(metadata.devBaseVersion ? { dev_base_version: stripLeadingV(metadata.devBaseVersion) } : {}),
     updated_at: new Date().toISOString(),
   });
 }
@@ -613,6 +616,9 @@ export async function readUserInstallStamp(
         : {}),
       ...(typeof parsed.install_revision === 'string'
         ? { install_revision: parsed.install_revision }
+        : {}),
+      ...(typeof parsed.dev_base_version === 'string'
+        ? { dev_base_version: parsed.dev_base_version }
         : {}),
       updated_at: parsed.updated_at,
     };
@@ -795,7 +801,7 @@ async function executeUpdate(
   const channelConfig = resolveUpdateChannelConfig(channel);
   const [current, latest] = await Promise.all([
     dependencies.getCurrentVersion(),
-    channel === 'stable' || !forceInstall ? dependencies.fetchLatestVersion() : Promise.resolve(null),
+    channel === 'stable' || !forceInstall || channel === 'dev' ? dependencies.fetchLatestVersion() : Promise.resolve(null),
   ]);
 
   try {
@@ -891,6 +897,9 @@ async function executeUpdate(
   const installedRevision = channelConfig.channel === 'dev'
     ? ((await dependencies.getInstalledRevisionAfterUpdate()) ?? result.revision ?? null)
     : null;
+  const devBaseVersion = channelConfig.channel === 'dev'
+    ? (latest && installedVersion && isNewerVersion(latest, installedVersion) ? installedVersion : (latest ?? installedVersion ?? current))
+    : null;
   const stampVersion = channelConfig.channel === 'stable'
     ? (latest ?? installedVersion ?? current)
     : installedVersion;
@@ -899,6 +908,7 @@ async function executeUpdate(
       channel: channelConfig.channel,
       source: channelConfig.installSource,
       revision: channelConfig.channel === 'dev' ? installedRevision : null,
+      devBaseVersion,
     });
   } else if (channelConfig.channel === 'dev') {
     console.log(

--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -41,6 +41,24 @@ describe('resolveOmxDisplayVersionSync', () => {
     });
   });
 
+
+
+  it('uses a dev base version from the install stamp when package.json lags the release baseline', async () => {
+    await withVersionFixture(async ({ packageRoot, stampPath }) => {
+      await writeFile(stampPath, JSON.stringify({
+        installed_version: '0.18.8',
+        setup_completed_version: '0.18.8',
+        dev_base_version: '0.18.9',
+        install_channel: 'dev',
+        install_source: 'github:Yeachan-Heo/oh-my-codex#dev',
+        install_revision: 'feedfacecafebeef',
+        updated_at: '2026-06-09T00:00:00.000Z',
+      }, null, 2));
+
+      assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.9-dev-feedfacecafe');
+    });
+  });
+
   it('does not apply stale dev stamp metadata to a different package version', async () => {
     await withVersionFixture(async ({ packageRoot, stampPath }) => {
       await writeFile(stampPath, JSON.stringify({
@@ -49,6 +67,21 @@ describe('resolveOmxDisplayVersionSync', () => {
         install_channel: 'dev',
         install_revision: 'abcdef123456',
         updated_at: '2026-06-02T00:00:00.000Z',
+      }, null, 2));
+
+      assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.8');
+    });
+  });
+
+  it('does not let stale dev_base_version metadata make a mismatched stamp current', async () => {
+    await withVersionFixture(async ({ packageRoot, stampPath }) => {
+      await writeFile(stampPath, JSON.stringify({
+        installed_version: '0.18.7',
+        setup_completed_version: '0.18.7',
+        dev_base_version: '0.18.11',
+        install_channel: 'dev',
+        install_revision: 'feedfacecafebeef',
+        updated_at: '2026-06-09T00:00:00.000Z',
       }, null, 2));
 
       assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.8');

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -13,6 +13,7 @@ interface InstallVersionMetadata {
   setup_completed_version?: string;
   install_channel?: string;
   install_revision?: string;
+  dev_base_version?: string;
 }
 
 function stripLeadingV(version: string): string {
@@ -75,10 +76,15 @@ export function resolveOmxDisplayVersionSync(options: {
     : typeof stamp?.installed_version === 'string'
       ? stripLeadingV(stamp.installed_version)
       : '';
-  const isCurrentDevInstall = stamp?.install_channel === 'dev' && stampVersion === version;
+  const devBaseVersion = typeof stamp?.dev_base_version === 'string'
+    ? stripLeadingV(stamp.dev_base_version)
+    : '';
+  const isCurrentDevInstall = stamp?.install_channel === 'dev'
+    && stampVersion === version;
   if (isCurrentDevInstall) {
+    const displayVersion = devBaseVersion || version;
     const revision = shortRevision(stamp.install_revision) ?? explicitRevision ?? readGitRevision(packageRoot);
-    return revision ? `v${version}-dev-${revision}` : `v${version}-dev`;
+    return revision ? `v${displayVersion}-dev-${revision}` : `v${displayVersion}-dev`;
   }
 
   return `v${version}`;


### PR DESCRIPTION
## Summary

Split from the earlier bundled update/restart lifecycle PR. This PR only fixes the dev-channel version display side.

- Keep `package.json` as the release-version SSOT.
- Persist `dev_base_version` in the install stamp for dev-channel updates when the latest release baseline is newer than the dev branch package version.
- Render `v<dev_base_version>-dev-<sha>` only after the install stamp is proven current for the installed package version.
- Add a version-sync contract check that the plugin manifest version mirrors root `package.json`.

Issue focus: dev update version label can remain at an older release baseline after a newer release exists.

## Validation

- `npm run build`
- `node dist/scripts/run-test-files.js dist/utils/__tests__/version.test.js dist/cli/__tests__/update.test.js dist/cli/__tests__/version-sync-contract.test.js`

Results from local split validation:

- `update.test`: 51 pass
- `version.test`: 5 pass
- `version-sync-contract.test`: 2 pass

## Notes

This intentionally does not include HUD pane reconciliation; that is split into a separate PR.
