### PR TITLE
Reap stale same-leader HUD panes

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -177,6 +177,111 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.paneId, '%9');
   });
 
+
+  it('reaps a stale HUD pane for the same leader after the leader resumes with a new session id', async () => {
+    const killed: string[] = [];
+    const created: Array<{ options?: { targetPaneId?: string } }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%stale-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%new-hud';
+      },
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.deepEqual(killed, ['%stale-hud']);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%new-hud');
+    assert.equal(created.length, 1);
+    assert.equal(created[0]?.options?.targetPaneId, '%leader');
+  });
+
+  it('reaps a stale same-leader HUD even when a current-session HUD already exists', async () => {
+    const killed: string[] = [];
+    const created: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%current-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-new' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+        },
+        {
+          paneId: '%stale-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: () => {
+        created.push('create');
+        return '%new-hud';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.deepEqual(killed, ['%stale-hud']);
+    assert.deepEqual(created, []);
+    assert.equal(result.status, 'resized');
+    assert.equal(result.paneId, '%current-hud');
+    assert.deepEqual(resized, [{ paneId: '%current-hud', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+  });
+
+  it('does not reap a different-session HUD pane owned by a neighboring live leader', async () => {
+    const killed: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%left', OMX_SESSION_ID: 'sess-left', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%left', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%right', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%right-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-right' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%right' node omx hud --watch --preset=focused`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: () => '%left-hud',
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.deepEqual(killed, []);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%left-hud');
+  });
+
   it('does not reap an orphaned HUD pane that belongs to a different session', async () => {
     // A HUD owned by another session's leader (which may live in a different tmux
     // window we cannot see here) must survive even when that leader is absent.

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -79,6 +79,36 @@ function reapOrphanedSessionHudPanes(
   return reaped;
 }
 
+function hasExplicitHudOwnerMarker(pane: TmuxPaneSnapshot): boolean {
+  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  return new RegExp(`(?:^|\\s)${OMX_TMUX_HUD_OWNER_ENV}=(?:'1'|1)(?=$|\\s)`).test(command);
+}
+
+function reapStaleCurrentLeaderHudPanes(
+  panes: TmuxPaneSnapshot[],
+  opts: {
+    sessionIds: string[];
+    currentPaneId: string | undefined;
+    killPane: (paneId: string) => boolean;
+  },
+): string[] {
+  const { currentPaneId, killPane } = opts;
+  if (!currentPaneId) return [];
+  const currentSessionIds = new Set(opts.sessionIds.map((sessionId) => sessionId.trim()).filter(Boolean));
+  if (currentSessionIds.size === 0) return [];
+
+  const reaped: string[] = [];
+  for (const pane of panes) {
+    if (!isHudWatchPane(pane)) continue;
+    const owner = readHudPaneOwner(pane);
+    if (owner.leaderPaneId !== currentPaneId) continue;
+    if (!hasExplicitHudOwnerMarker(pane)) continue;
+    if (!owner.sessionId || currentSessionIds.has(owner.sessionId)) continue;
+    if (killPane(pane.paneId)) reaped.push(pane.paneId);
+  }
+  return reaped;
+}
+
 export interface ReconcileHudForPromptSubmitResult {
   status:
     | 'skipped_not_tmux'
@@ -240,6 +270,22 @@ export async function reconcileHudForPromptSubmit(
   });
   if (reapedOrphanPaneIds.length > 0) {
     const reapedPaneIdSet = new Set(reapedOrphanPaneIds);
+    panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
+  }
+
+  // A Codex self-update can restart/resume the leader in the same tmux pane with
+  // a new OMX session id while the old HUD watcher stays alive. That stale HUD
+  // still names the current leader pane, but with the previous session id, so it
+  // does not match same-owner dedupe and the next launch would create a second HUD
+  // beside it. Reap only HUDs tied to this exact leader pane; neighboring panes'
+  // HUDs remain isolated by leaderPaneId.
+  const reapedStaleLeaderPaneIds = reapStaleCurrentLeaderHudPanes(panes, {
+    sessionIds: equivalentSessionIds,
+    currentPaneId,
+    killPane,
+  });
+  if (reapedStaleLeaderPaneIds.length > 0) {
+    const reapedPaneIdSet = new Set(reapedStaleLeaderPaneIds);
     panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
   }
 


### PR DESCRIPTION
## Summary

Split from the earlier bundled update/restart lifecycle PR. This PR only fixes the stale HUD cleanup side.

- Reap stale owner-tagged HUD panes whose recorded leader pane is the current leader but whose session id is no longer current/equivalent.
- Run the stale same-leader cleanup before normal same-owner/legacy dedupe so a current-session HUD does not suppress cleanup of the old one.
- Preserve neighboring active leader HUDs by scoping the cleanup to `OMX_TMUX_HUD_LEADER_PANE === current TMUX_PANE`.
- Preserve legacy duplicate cleanup behavior by requiring an explicit `OMX_TMUX_HUD_OWNER=1` marker for this stale-session reaper.

Issue focus: Codex update/restart can leave a stale HUD pane, and the next OMX launch can create a duplicate same-leader HUD.

## Validation

- `npm run build`
- `node dist/scripts/run-test-files.js dist/hud/__tests__/reconcile.test.js`

Results from local split validation:

- `hud reconcile.test`: 47 pass

## Notes

This intentionally does not include dev-channel version display changes; that is split into a separate PR.
