### PR TITLE
Fix terminal skill-active visibility

### DIFF
--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -667,6 +667,72 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('does not list a mode active when terminal canonical visibility contradicts an active detail state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-terminal-canonical-wins-'));
+    try {
+      const sessionId = 'sess-terminal-visible';
+      const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'deep-interview',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: false,
+        skill: 'autopilot',
+        phase: 'complete',
+        completed_at: '2026-06-09T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+      }, null, 2));
+
+      const response = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+
+      assert.deepEqual(response.payload, { active_modes: [] });
+      const detailState = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(detailState.active, true);
+      assert.equal(detailState.current_phase, 'deep-interview');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the implicit current session canonical state when filtering list-active', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-terminal-canonical-implicit-'));
+    try {
+      const sessionId = 'sess-terminal-implicit';
+      const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'deep-interview',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: false,
+        skill: 'autopilot',
+        phase: 'complete',
+        completed_at: '2026-06-09T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+      }, null, 2));
+
+      const response = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+
+      assert.deepEqual(response.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('syncs canonical skill-active state for tracked mode writes and clears', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-canonical-'));
     try {

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -229,6 +229,96 @@ describe('skill-active state helpers', () => {
     });
   });
 
+  it('does not treat active_skills as active when the canonical state is terminal', async () => {
+    await withTempRepo('omx-skill-active-terminal-overrides-entries-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state', 'sessions', 'sess-terminal'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'sessions', 'sess-terminal', 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: false,
+        skill: 'autopilot',
+        phase: 'blocked_on_user',
+        completed_at: '2026-06-09T00:00:00.000Z',
+        session_id: 'sess-terminal',
+        active_skills: [{
+          skill: 'autopilot',
+          phase: 'deep-interview',
+          active: true,
+          session_id: 'sess-terminal',
+        }],
+      }, null, 2));
+
+      const sessionState = await readVisibleSkillActiveState(cwd, 'sess-terminal');
+
+      assert.ok(sessionState);
+      assert.equal(sessionState.active, false);
+      assert.deepEqual(listActiveSkills(sessionState), []);
+    });
+  });
+
+  it('clears stale terminal markers when a workflow is reactivated', async () => {
+    await withTempRepo('omx-skill-active-reactivate-terminal-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeSkillActiveStateCopies(cwd, {
+        active: false,
+        skill: 'autopilot',
+        phase: 'complete',
+        completed_at: '2026-06-09T00:00:00.000Z',
+        cancel_reason: 'old cancellation',
+        run_outcome: 'finish',
+        lifecycle_outcome: 'complete',
+        session_id: 'sess-reactivate',
+        active_skills: [{ skill: 'autopilot', phase: 'complete', active: true, session_id: 'sess-reactivate' }],
+      }, 'sess-reactivate');
+
+      await syncCanonicalSkillStateForMode({
+        cwd,
+        mode: 'autopilot',
+        active: true,
+        sessionId: 'sess-reactivate',
+        nowIso: '2026-06-09T00:01:00.000Z',
+      });
+
+      const sessionState = await readVisibleSkillActiveState(cwd, 'sess-reactivate');
+      assert.ok(sessionState);
+      assert.equal(sessionState.active, true);
+      assert.equal(sessionState.phase, '');
+      assert.equal(sessionState.completed_at, undefined);
+      assert.equal(sessionState.cancel_reason, undefined);
+      assert.equal(sessionState.run_outcome, undefined);
+      assert.equal(sessionState.lifecycle_outcome, undefined);
+      assert.deepEqual(listActiveSkills(sessionState).map(({ skill, phase, session_id }) => ({ skill, phase, session_id })), [
+        { skill: 'autopilot', phase: undefined, session_id: 'sess-reactivate' },
+      ]);
+    });
+  });
+
+  it('recognizes runtime terminal outcomes when suppressing stale active entries', async () => {
+    await withTempRepo('omx-skill-active-terminal-outcomes-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state', 'sessions', 'sess-terminal-outcome'), { recursive: true });
+      const cases = [
+        { run_outcome: 'blocked_on_user' },
+        { lifecycle_outcome: 'blocked' },
+        { lifecycle_outcome: 'userinterlude' },
+        { lifecycle_outcome: 'askuserQuestion' },
+        { completed_at: '2026-06-09T00:00:00.000Z' },
+        { phase: 'blocked_on_user' },
+      ];
+
+      for (const [index, terminalFields] of cases.entries()) {
+        const state = {
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          phase: 'ralplan',
+          session_id: `sess-terminal-outcome-${index}`,
+          active_skills: [{ skill: 'autopilot', phase: 'ralplan', active: true, session_id: `sess-terminal-outcome-${index}` }],
+          ...terminalFields,
+        };
+        assert.deepEqual(listActiveSkills(state), []);
+      }
+    });
+  });
+
   it('clears only the matching terminal session entry and preserves unrelated active skills', async () => {
     await withTempRepo('omx-skill-active-terminal-clear-', async (cwd) => {
       await mkdir(join(cwd, '.omx', 'state'), { recursive: true });

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -11,6 +11,7 @@ import {
   getReadScopedStatePaths,
   getStateDir,
   getStatePath,
+  resolveRuntimeStateScope,
   resolveStateScope,
   resolveWorkingDirectoryForState,
   validateSessionId,
@@ -253,12 +254,30 @@ export async function listActiveStateModes(
   explicitSessionId?: string,
 ): Promise<string[]> {
   const cwd = resolveWorkingDirectoryForState(workingDirectory);
-  const sessionId = validateSessionId(explicitSessionId);
+  const scope = await resolveRuntimeStateScope(cwd, explicitSessionId);
+  const sessionId = scope.sessionId;
   const statuses = await listStateStatuses(cwd, sessionId, undefined, {
     authoritativeActiveDecision: true,
   });
+  const canonicalState = await readVisibleSkillActiveStateForStateDir(getBaseStateDir(cwd), sessionId);
+  const canonicalActiveModes = new Set(
+    listActiveSkills(canonicalState ?? {})
+      .filter((entry) => {
+        const entrySessionId = typeof entry.session_id === 'string' ? entry.session_id.trim() : '';
+        return sessionId ? entrySessionId === sessionId : entrySessionId.length === 0;
+      })
+      .map((entry) => entry.skill),
+  );
+  const hasCanonicalVisibility = canonicalState !== null;
+
   return Object.entries(statuses)
-    .filter(([, status]) => Boolean((status as { active?: unknown }).active))
+    .filter(([mode, status]) => {
+      if (!Boolean((status as { active?: unknown }).active)) return false;
+      if (hasCanonicalVisibility && isTrackedWorkflowMode(mode)) {
+        return canonicalActiveModes.has(mode);
+      }
+      return true;
+    })
     .map(([mode]) => mode);
 }
 

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs';
 import { mkdir, readFile, readdir, unlink, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { omxStateDir } from '../utils/paths.js';
+import { isTerminalRunOutcome, normalizeRunOutcome, normalizeTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
 import {
   assertWorkflowTransitionAllowed,
   isTrackedWorkflowMode,
@@ -165,9 +166,40 @@ function sanitizeWriterBaseForSession(
   return inherited;
 }
 
+function isTerminalSkillActivePhase(phase: unknown): boolean {
+  const normalized = safeString(phase).trim().toLowerCase();
+  if (!normalized) return false;
+  if (normalized === 'cleared') return true;
+  const runOutcome = normalizeRunOutcome(normalized).outcome;
+  if (isTerminalRunOutcome(runOutcome)) return true;
+  return Boolean(normalizeTerminalLifecycleOutcome(normalized).outcome);
+}
+
+function isTerminalSkillActiveState(state: SkillActiveStateLike): boolean {
+  if (state.active === false) return true;
+  if (isTerminalSkillActivePhase(state.phase)) return true;
+  if (safeString(state.completed_at).trim().length > 0) return true;
+  const runOutcome = normalizeRunOutcome(state.run_outcome).outcome;
+  if (isTerminalRunOutcome(runOutcome)) return true;
+  const lifecycleOutcome = normalizeTerminalLifecycleOutcome(state.lifecycle_outcome ?? state.terminal_outcome).outcome;
+  return Boolean(lifecycleOutcome);
+}
+
+function clearTerminalSkillActiveMarkers<T extends SkillActiveStateLike>(state: T): T {
+  const next = { ...state };
+  if (isTerminalSkillActivePhase(next.phase)) delete next.phase;
+  delete next.completed_at;
+  delete next.cancel_reason;
+  delete next.run_outcome;
+  delete next.lifecycle_outcome;
+  delete next.terminal_outcome;
+  return next;
+}
+
 export function listActiveSkills(raw: unknown): SkillActiveEntry[] {
   if (!raw || typeof raw !== 'object') return [];
   const state = raw as SkillActiveStateLike;
+  if (isTerminalSkillActiveState(state)) return [];
   const deduped = new Map<string, SkillActiveEntry>();
 
   if (Array.isArray(state.active_skills)) {
@@ -374,7 +406,9 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
     fallbackMode: string,
     targetSessionId?: string,
   ): SkillActiveStateLike => {
-    const inheritedBase = sanitizeWriterBaseForSession(base, targetSessionId);
+    const inheritedBase = entries.length > 0
+      ? clearTerminalSkillActiveMarkers(sanitizeWriterBaseForSession(base, targetSessionId))
+      : sanitizeWriterBaseForSession(base, targetSessionId);
     const currentPrimary = safeString(inheritedBase.skill).trim();
     const primarySkill = pickPrimaryWorkflowMode(currentPrimary, entries.map((entry) => entry.skill), fallbackMode);
     const primaryEntry = entries.find((entry) => entry.skill === primarySkill) ?? entries[0];


### PR DESCRIPTION
## Summary

P0 slice for epic `omx-fd0` (Autopilot lifecycle finalization and Stop-hook state reconciliation).

This fixes terminal canonical `skill-active` visibility so stale detail workflow files cannot keep `omx state list-active` / Stop-hook visibility alive after a workflow has already reached a terminal canonical state.

## Changes

- Treat canonical skill-active terminal markers as authoritative over stale `active_skills[]` mirrors:
  - `active:false`
  - terminal phase aliases via runtime outcome classifiers
  - `completed_at`
  - terminal `run_outcome`, `lifecycle_outcome`, or `terminal_outcome`
- Clear stale terminal markers when a tracked workflow is reactivated, even when `currentPhase` is omitted.
- Make `state_list_active` resolve the effective runtime session before canonical filtering, so implicit current-session reads use the same authority as explicit `session_id` reads.
- Preserve active detail state files without mutating unrelated live detail states; this is a read/list reconciliation fix, not a destructive cleanup.

## Validation

- `npm run build`
- `node dist/scripts/run-test-files.js dist/state/__tests__/skill-active.test.js dist/state/__tests__/operations.test.js`
- `npm run check:no-unused`
- `git diff --check`

## Review gates

- Architect gate: APPROVE / CLEAR
- Critic gate: APPROVE / CLEAR
- Post-Architect Scholastic gate: APPROVE / CLEAR
- Code-reviewer gate: APPROVE / CLEAR
- Code-review Scholastic gate: APPROVE / CLEAR

## Notes

Originally stacked on `fix/dev-version-hud-reconcile`; after PR #2768 merged, this branch was rebased onto `dev`. This PR intentionally focuses on the P0 terminal-state/list-active authority slice rather than bundling the update/HUD consistency work.
