### PR TITLE
fix: enforce autopilot final gates

### DIFF
--- a/src/autopilot/completion-gate.ts
+++ b/src/autopilot/completion-gate.ts
@@ -1,0 +1,166 @@
+import { deriveAutopilotChildPhase, normalizeAutopilotPhase, type AutopilotChildPhase } from './fsm.js';
+import { normalizeRunOutcome, normalizeTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
+
+type JsonObject = Record<string, unknown>;
+
+function objectRecord(value: unknown): JsonObject {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : {};
+}
+
+function nonEmptyString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function stateField(state: JsonObject, key: string): unknown {
+  if (Object.prototype.hasOwnProperty.call(state, key)) return state[key];
+  return objectRecord(state.state)[key];
+}
+
+function hasAnyStringField(value: JsonObject, keys: string[]): boolean {
+  return keys.some((key) => nonEmptyString(value[key]).length > 0);
+}
+
+function stringField(value: JsonObject, key: string): string {
+  return nonEmptyString(value[key]);
+}
+
+function isImplementationPhase(phase: AutopilotChildPhase | null): boolean {
+  return phase === 'ultragoal' || phase === 'team' || phase === 'ralph';
+}
+
+function isActiveAutopilotState(state: JsonObject): boolean {
+  return state.mode === 'autopilot' && state.active === true;
+}
+
+export function isAutopilotSuccessfulTerminalState(state: JsonObject): boolean {
+  const phase = normalizeAutopilotPhase(state.current_phase);
+  const runOutcome = normalizeRunOutcome(state.run_outcome).outcome;
+  const lifecycleOutcome = normalizeTerminalLifecycleOutcome(state.lifecycle_outcome ?? state.terminal_outcome).outcome;
+  if (phase === 'failed' || runOutcome === 'failed' || runOutcome === 'cancelled' || runOutcome === 'blocked_on_user') return false;
+  if (lifecycleOutcome === 'failed' || lifecycleOutcome === 'blocked' || lifecycleOutcome === 'userinterlude' || lifecycleOutcome === 'askuserQuestion') return false;
+  if (phase === 'complete') return true;
+  if (runOutcome === 'finish') return true;
+  if (lifecycleOutcome === 'finished') return true;
+  if (nonEmptyString(state.completed_at)) return true;
+  return state.active === false;
+}
+
+function urlLooksLikeCi(url: string): boolean {
+  return /github\.com\/[^/]+\/[^/]+\/actions\/runs\//i.test(url);
+}
+
+function evidenceText(value: JsonObject, keys: string[]): string {
+  return keys.map((key) => nonEmptyString(value[key]).toLowerCase()).filter(Boolean).join('\n');
+}
+
+function looksLikeUltraqaEvidence(value: JsonObject): boolean {
+  return /\bultraqa\b|\bqa[_-]?verdict\b|\bqa[_-]?evidence\b/.test(
+    evidenceText(value, ['source', 'artifact_path', 'url', 'review_url', 'qa_url']),
+  );
+}
+
+function looksLikeCodeReviewEvidence(value: JsonObject): boolean {
+  return /\bcode[-_]?review\b|\breview[_-]?verdict\b|\breview[_-]?evidence\b|\breviews\//.test(
+    evidenceText(value, ['source', 'artifact_path', 'url', 'review_url', 'qa_url']),
+  );
+}
+
+function hasCodeReviewLocator(value: JsonObject): boolean {
+  const artifactPath = stringField(value, 'artifact_path').toLowerCase();
+  const reviewUrl = stringField(value, 'review_url');
+  if (artifactPath) return looksLikeCodeReviewEvidence(value);
+  return reviewUrl.length > 0 || hasAnyStringField(value, ['thread_id', 'agent_id', 'tool_call_id', 'url']);
+}
+
+function hasUltraqaLocator(value: JsonObject): boolean {
+  const artifactPath = stringField(value, 'artifact_path').toLowerCase();
+  const qaUrl = stringField(value, 'qa_url');
+  const url = stringField(value, 'url');
+  if (artifactPath) return looksLikeUltraqaEvidence(value) || /\bqa\b/.test(artifactPath);
+  return qaUrl.length > 0 || urlLooksLikeCi(url) || hasAnyStringField(value, ['tool_call_id', 'thread_id']);
+}
+
+function evidenceLocatorSet(value: JsonObject): Set<string> {
+  return new Set(['artifact_path', 'url', 'review_url', 'qa_url', 'thread_id', 'tool_call_id', 'agent_id']
+    .map((key) => nonEmptyString(value[key]))
+    .filter(Boolean));
+}
+
+export function hasCleanCodeReviewEvidence(value: unknown): boolean {
+  const verdict = objectRecord(value);
+  if (verdict.clean !== true) return false;
+  if (nonEmptyString(verdict.stage) !== 'code-review') return false;
+  if (nonEmptyString(verdict.recommendation).toUpperCase() !== 'APPROVE') return false;
+  if (nonEmptyString(verdict.architectural_status).toUpperCase() !== 'CLEAR') return false;
+  if (looksLikeUltraqaEvidence(verdict)) return false;
+  const url = nonEmptyString(verdict.url);
+  if (url && urlLooksLikeCi(url)) return false;
+  return hasCodeReviewLocator(verdict);
+}
+
+export function hasCleanUltraqaEvidence(value: unknown): boolean {
+  const verdict = objectRecord(value);
+  if (verdict.clean !== true) return false;
+  if (nonEmptyString(verdict.stage) !== 'ultraqa') return false;
+  const source = nonEmptyString(verdict.source).toLowerCase();
+  if (source === 'leader' || source.includes('code-review')) return false;
+  if (looksLikeCodeReviewEvidence(verdict)) return false;
+  if (verdict.skipped === true) {
+    return (
+      nonEmptyString(verdict.reason).length > 0 || nonEmptyString(verdict.skip_reason).length > 0
+    ) && hasUltraqaLocator(verdict);
+  }
+  return hasUltraqaLocator(verdict);
+}
+
+export function hasCleanAutopilotReviewAndQaEvidence(state: JsonObject): boolean {
+  const review = objectRecord(stateField(state, 'review_verdict'));
+  const qa = objectRecord(stateField(state, 'qa_verdict'));
+  if (!hasCleanCodeReviewEvidence(review) || !hasCleanUltraqaEvidence(qa)) return false;
+  const reviewLocators = evidenceLocatorSet(review);
+  const qaLocators = evidenceLocatorSet(qa);
+  for (const locator of reviewLocators) {
+    if (qaLocators.has(locator)) return false;
+  }
+  return true;
+}
+
+export function validateAutopilotCompletionTransition(
+  currentState: JsonObject,
+  nextState: JsonObject,
+  options: { allowUnknownActivePhaseCompletion?: boolean } = {},
+): string | null {
+  const current = { ...currentState, mode: 'autopilot' };
+  const next = { ...nextState, mode: 'autopilot' };
+  const currentPhase = deriveAutopilotChildPhase(current);
+  const nextPhase = deriveAutopilotChildPhase(next);
+  const successfulTerminal = isAutopilotSuccessfulTerminalState(next);
+
+  if (
+    successfulTerminal
+    && isActiveAutopilotState(current)
+    && currentPhase === null
+    && options.allowUnknownActivePhaseCompletion !== true
+  ) {
+    return 'Cannot complete Autopilot from an unknown active phase; restore a valid Autopilot phase before terminalization.';
+  }
+  if (currentPhase === 'deep-interview' && successfulTerminal) {
+    return 'Cannot complete Autopilot before ralplan gate: deep-interview may only advance to ralplan.';
+  }
+  if (currentPhase === 'ralplan' && successfulTerminal) {
+    return 'Cannot complete Autopilot before ultragoal gate: ralplan may only advance to ultragoal.';
+  }
+  if (isImplementationPhase(currentPhase) && successfulTerminal) {
+    return `Cannot complete Autopilot before code-review gate: ${currentPhase} may only advance to code-review.`;
+  }
+  if (isImplementationPhase(currentPhase) && nextPhase === 'ultraqa') {
+    return `Cannot skip Autopilot code-review gate: ${currentPhase} may only advance to code-review.`;
+  }
+  if (currentPhase === 'code-review' && successfulTerminal) {
+    return 'Cannot complete Autopilot before ultraqa gate: code-review may only advance to ultraqa.';
+  }
+  if (currentPhase === 'ultraqa' && successfulTerminal && !hasCleanAutopilotReviewAndQaEvidence(nextState)) {
+    return 'Cannot complete Autopilot from ultraqa without clean code-review and ultraqa verdict evidence.';
+  }
+  return null;
+}

--- a/src/modes/__tests__/base-autopilot-gates.test.ts
+++ b/src/modes/__tests__/base-autopilot-gates.test.ts
@@ -1,0 +1,161 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { updateModeState } from '../base.js';
+
+async function writeAutopilotState(wd: string, state: Record<string, unknown>): Promise<void> {
+  await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+  await writeFile(join(wd, '.omx', 'state', 'autopilot-state.json'), JSON.stringify({
+    active: true,
+    mode: 'autopilot',
+    iteration: 1,
+    max_iterations: 10,
+    started_at: '2026-06-09T00:00:00.000Z',
+    ...state,
+  }, null, 2));
+}
+
+describe('modes/base Autopilot gate integration', () => {
+  it('updateModeState rejects direct deep-interview to ultragoal skips', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-deep-skip-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'deep-interview' });
+      await assert.rejects(
+        () => updateModeState('autopilot', { current_phase: 'ultragoal' }, wd),
+        /Cannot skip Autopilot ralplan gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects direct deep-interview to ultragoal skips even with user-supplied pipeline fields', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-deep-skip-pipeline-fields-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'deep-interview' });
+      await assert.rejects(
+        () => updateModeState('autopilot', {
+          current_phase: 'ultragoal',
+          pipeline_stage_index: 2,
+        }, wd),
+        /Cannot skip Autopilot ralplan gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects ralplan to code-review skips', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-skip-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'ralplan' });
+      await assert.rejects(
+        () => updateModeState('autopilot', { current_phase: 'code-review' }, wd),
+        /Cannot skip Autopilot ultragoal gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects ralplan to code-review skips even with user-supplied pipeline fields', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-skip-pipeline-fields-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'ralplan' });
+      await assert.rejects(
+        () => updateModeState('autopilot', {
+          current_phase: 'code-review',
+          pipeline_stage_results: {},
+        }, wd),
+        /Cannot skip Autopilot ultragoal gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects ralplan completion before ultragoal', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-complete-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'ralplan' });
+      await assert.rejects(
+        () => updateModeState('autopilot', { active: false, current_phase: 'complete' }, wd),
+        /Cannot complete Autopilot before ultragoal gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects ralplan to ultragoal without tracker-backed native consensus', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-no-native-'));
+    try {
+      await writeAutopilotState(wd, {
+        current_phase: 'ralplan',
+        state: {
+          handoff_artifacts: {
+            ralplan: {
+              ralplan_consensus_gate: {
+                complete: true,
+                evidence_kind: 'codex_exec',
+              },
+            },
+          },
+        },
+      });
+      await assert.rejects(
+        () => updateModeState('autopilot', { current_phase: 'ultragoal' }, wd),
+        /Cannot transition ralplan -> ultragoal/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects ralplan to ultragoal without native consensus even with user-supplied pipeline fields', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-no-native-pipeline-fields-'));
+    try {
+      await writeAutopilotState(wd, {
+        current_phase: 'ralplan',
+        state: {
+          handoff_artifacts: {
+            ralplan: {
+              ralplan_consensus_gate: {
+                complete: true,
+                evidence_kind: 'codex_exec',
+              },
+            },
+          },
+        },
+      });
+      await assert.rejects(
+        () => updateModeState('autopilot', {
+          current_phase: 'ultragoal',
+          pipeline_stage_index: 2,
+          pipeline_stage_results: {},
+        }, wd),
+        /Cannot transition ralplan -> ultragoal/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState does not persist user-supplied trustedPipelineProgress as state data', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-trusted-field-strip-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'ultraqa' });
+      await updateModeState('autopilot', {
+        current_phase: 'ultraqa',
+        trustedPipelineProgress: true,
+      }, wd);
+
+      const raw = JSON.parse(await readFile(join(wd, '.omx', 'state', 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(Object.prototype.hasOwnProperty.call(raw, 'trustedPipelineProgress'), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -15,6 +15,10 @@ import { reconcileWorkflowTransition } from '../state/workflow-transition-reconc
 import { syncCanonicalSkillStateForMode } from '../state/skill-active.js';
 import { validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
+import { validateAutopilotCompletionTransition } from '../autopilot/completion-gate.js';
+import { canAdvanceAutopilotDeepInterviewToRalplan, buildAutopilotDeepInterviewRalplanGateError } from '../autopilot/deep-interview-gate.js';
+import { canAdvanceAutopilotRalplanToUltragoal, buildAutopilotRalplanUltragoalGateError } from '../autopilot/ralplan-gate.js';
+import { deriveAutopilotChildPhase, type AutopilotChildPhase } from '../autopilot/fsm.js';
 import { syncRunStateFromModeState } from '../runtime/run-state.js';
 import {
   getAuthoritativeActiveStatePaths,
@@ -45,11 +49,47 @@ export type ModeName = 'autopilot' | 'autoresearch' | 'deep-interview' | 'ralph'
 /** @deprecated These mode names were removed in v4.6. Use the canonical modes instead. */
 export type DeprecatedModeName = 'ultrapilot' | 'pipeline' | 'ecomode';
 
+export interface UpdateModeStateOptions {
+  trustedPipelineProgress?: boolean;
+}
+
 const DEPRECATED_MODES: Record<DeprecatedModeName, string> = {
   ultrapilot: 'Use "team" instead. ultrapilot has been merged into team mode.',
   pipeline: 'Use "team" instead. pipeline has been merged into team mode.',
   ecomode: 'Use "ultrawork" instead. ecomode has been merged into ultrawork mode.',
 };
+
+const AUTOPILOT_CHILD_PHASE_ORDER: AutopilotChildPhase[] = [
+  'deep-interview',
+  'ralplan',
+  'ultragoal',
+  'team',
+  'ralph',
+  'code-review',
+  'ultraqa',
+];
+
+function autopilotPhaseOrder(phase: AutopilotChildPhase | null): number {
+  return phase ? AUTOPILOT_CHILD_PHASE_ORDER.indexOf(phase) : -1;
+}
+
+function isForwardAutopilotPhase(
+  currentPhase: AutopilotChildPhase | null,
+  nextPhase: AutopilotChildPhase | null,
+): boolean {
+  const currentOrder = autopilotPhaseOrder(currentPhase);
+  const nextOrder = autopilotPhaseOrder(nextPhase);
+  return currentOrder >= 0 && nextOrder > currentOrder;
+}
+
+function isNextAutopilotPhase(
+  currentPhase: AutopilotChildPhase | null,
+  nextPhase: AutopilotChildPhase | null,
+): boolean {
+  const currentOrder = autopilotPhaseOrder(currentPhase);
+  const nextOrder = autopilotPhaseOrder(nextPhase);
+  return currentOrder >= 0 && nextOrder === currentOrder + 1;
+}
 
 /**
  * Check if a mode name is deprecated and return a warning message if so.
@@ -236,6 +276,7 @@ export async function updateModeState(
   updates: Partial<ModeState>,
   projectRoot?: string,
   explicitSessionId?: string,
+  options: UpdateModeStateOptions = {},
 ): Promise<ModeState> {
   const scope = await resolveStateScope(projectRoot, explicitSessionId);
   const baseStateDir = getBaseStateDir(projectRoot);
@@ -252,6 +293,7 @@ export async function updateModeState(
   }
 
   const updatedBase = { ...current, ...updates };
+  delete updatedBase.trustedPipelineProgress;
   if (!Object.prototype.hasOwnProperty.call(updates, 'run_outcome')) {
     delete updatedBase.run_outcome;
   }
@@ -259,6 +301,58 @@ export async function updateModeState(
     updatedBase.owner_omx_session_id = scope.sessionId;
   }
   const normalizedBase = normalizeModeStateOrThrow(mode, updatedBase as ModeState);
+  if (mode === 'autopilot') {
+    const isPipelineOrchestratorProgressWrite = options.trustedPipelineProgress === true;
+    const currentAutopilotChildPhase = deriveAutopilotChildPhase({ ...current, mode: 'autopilot' });
+    const nextAutopilotChildPhase = deriveAutopilotChildPhase({ ...normalizedBase, mode: 'autopilot' });
+    const completionTransitionError = validateAutopilotCompletionTransition(
+      current as Record<string, unknown>,
+      normalizedBase as Record<string, unknown>,
+      { allowUnknownActivePhaseCompletion: options.trustedPipelineProgress === true },
+    );
+    if (completionTransitionError) throw new Error(completionTransitionError);
+    if (!isPipelineOrchestratorProgressWrite) {
+      if (
+        currentAutopilotChildPhase === 'deep-interview'
+        && isForwardAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+        && !isNextAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+      ) {
+        throw new Error('Cannot skip Autopilot ralplan gate: deep-interview may only advance to ralplan.');
+      }
+      if (
+        currentAutopilotChildPhase === 'deep-interview'
+        && isNextAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+      ) {
+        const gate = await canAdvanceAutopilotDeepInterviewToRalplan({
+          cwd: projectRoot ?? process.cwd(),
+          sessionId: scope.sessionId,
+          baseStateDir,
+          currentState: current as Record<string, unknown>,
+          nextState: normalizedBase as Record<string, unknown>,
+        });
+        if (!gate.allowed) throw new Error(buildAutopilotDeepInterviewRalplanGateError(gate));
+      }
+      if (
+        currentAutopilotChildPhase === 'ralplan'
+        && isForwardAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+        && !isNextAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+      ) {
+        throw new Error('Cannot skip Autopilot ultragoal gate: ralplan may only advance to ultragoal.');
+      }
+      if (
+        currentAutopilotChildPhase === 'ralplan'
+        && isNextAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+      ) {
+        const gate = canAdvanceAutopilotRalplanToUltragoal({
+          cwd: projectRoot ?? process.cwd(),
+          sessionId: scope.sessionId,
+          currentState: current as Record<string, unknown>,
+          nextState: normalizedBase as Record<string, unknown>,
+        });
+        if (!gate.allowed) throw new Error(buildAutopilotRalplanUltragoalGateError(gate));
+      }
+    }
+  }
   const updated = withModeRuntimeContext(current, normalizedBase) as ModeState;
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(updated, null, 2));
   await syncRunStateFromModeState(updated, projectRoot, scope.sessionId);

--- a/src/pipeline/__tests__/orchestrator.test.ts
+++ b/src/pipeline/__tests__/orchestrator.test.ts
@@ -188,8 +188,24 @@ describe('Pipeline Orchestrator', () => {
                   recommendation: clean ? 'APPROVE' : 'REQUEST CHANGES',
                   architectural_status: 'CLEAR',
                   clean,
+                  stage: 'code-review',
+                  artifact_path: '.omx/reviews/review-loop.json',
                 },
                 return_to_ralplan_reason: clean ? null : 'Review requested a plan update.',
+              },
+              duration_ms: 0,
+            };
+          },
+        },
+        {
+          name: 'ultraqa',
+          async run(): Promise<StageResult> {
+            order.push('ultraqa');
+            return {
+              status: 'completed',
+              artifacts: {
+                qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/1' },
+                return_to_ralplan_reason: null,
               },
               duration_ms: 0,
             };
@@ -206,7 +222,7 @@ describe('Pipeline Orchestrator', () => {
       });
 
       assert.equal(result.status, 'completed');
-      assert.deepEqual(order, ['ralplan', 'ralph', 'code-review', 'ralplan', 'ralph', 'code-review']);
+      assert.deepEqual(order, ['ralplan', 'ralph', 'code-review', 'ralplan', 'ralph', 'code-review', 'ultraqa']);
 
       const ext = await readPipelineState(tempDir);
       assert.equal(ext?.review_cycle, 1);
@@ -237,7 +253,7 @@ describe('Pipeline Orchestrator', () => {
         makeStage('ultragoal', { artifacts: { implemented: true } }),
         makeStage('code-review', {
           artifacts: {
-            review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/default-quality.json' },
             return_to_ralplan_reason: null,
           },
         }),
@@ -250,7 +266,7 @@ describe('Pipeline Orchestrator', () => {
             return {
               status: 'completed',
               artifacts: {
-                qa_verdict: { clean, skipped: false, summary: clean ? 'QA clean.' : 'QA found a regression.' },
+                qa_verdict: { stage: 'ultraqa', clean, skipped: false, summary: clean ? 'QA clean.' : 'QA found a regression.', url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/2' },
                 return_to_ralplan_reason: clean ? null : 'QA found a regression.',
               },
               duration_ms: 0,

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -129,7 +129,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
         pipeline_stage_index: i,
         pipeline_stage_results: { ...stageResults },
         handoff_artifacts: normalizeHandoffArtifactKeys(handoffArtifactsByStage),
-      } as Partial<PipelineModeStateExtension>, cwd);
+      } as Partial<PipelineModeStateExtension>, cwd, undefined, { trustedPipelineProgress: true });
 
       lastStageName = stage.name;
       previousResult = skippedResult;
@@ -141,7 +141,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       current_phase: stage.name,
       pipeline_stage_index: i,
       iteration: i + 1,
-    } as Partial<PipelineModeStateExtension>, cwd);
+    } as Partial<PipelineModeStateExtension>, cwd, undefined, { trustedPipelineProgress: true });
 
     // Execute the stage
     let result: StageResult;
@@ -210,7 +210,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       } : {}),
       pipeline_stage_index: shouldReturnToRalplan ? findStageIndex(config.stages, 'ralplan') : i,
       pipeline_stage_results: { ...stageResults },
-    } as Partial<PipelineModeStateExtension>, cwd);
+    } as Partial<PipelineModeStateExtension>, cwd, undefined, { trustedPipelineProgress: true });
 
     // Bail on failure
     if (result.status === 'failed') {
@@ -277,7 +277,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     active: false,
     current_phase: 'complete',
     completed_at: new Date().toISOString(),
-  }, cwd);
+  }, cwd, undefined, { trustedPipelineProgress: true });
 
   return {
     status: 'completed',

--- a/src/pipeline/stages/code-review.ts
+++ b/src/pipeline/stages/code-review.ts
@@ -33,7 +33,10 @@ export interface CodeReviewVerdict {
   architectural_status: 'CLEAR' | 'WATCH' | 'BLOCK';
   clean: boolean;
   summary: string;
+  stage: 'code-review';
+  artifact_path: string;
 }
+
 
 export function createCodeReviewStage(options: CodeReviewStageOptions = {}): PipelineStage {
   return {
@@ -62,6 +65,8 @@ export function createCodeReviewStage(options: CodeReviewStageOptions = {}): Pip
         summary: options.summary ?? (hasReviewEvidence
           ? (clean ? 'Review clean.' : 'Review returned findings; return to ralplan.')
           : 'Code-review evidence missing; fail closed and return to ralplan.'),
+        stage: 'code-review',
+        artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.code-review.artifacts.review_verdict',
       };
 
       return {

--- a/src/pipeline/stages/ultraqa.ts
+++ b/src/pipeline/stages/ultraqa.ts
@@ -30,7 +30,11 @@ export interface UltraqaVerdict {
   clean: boolean;
   skipped: boolean;
   summary: string;
+  stage: 'ultraqa';
+  artifact_path: string;
+  reason?: string;
 }
+
 
 export function createUltraqaStage(options: UltraqaStageOptions = {}): PipelineStage {
   return {
@@ -55,6 +59,9 @@ export function createUltraqaStage(options: UltraqaStageOptions = {}): PipelineS
         summary: options.summary ?? (hasQaEvidence
           ? (clean ? 'UltraQA gate clean.' : 'UltraQA found issues; return to ralplan.')
           : 'UltraQA evidence missing; fail closed and return to ralplan.'),
+        stage: 'ultraqa',
+        artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.ultraqa.artifacts.qa_verdict',
+        ...(skipped ? { reason: options.summary ?? 'UltraQA explicitly skipped.' } : {}),
       };
 
       return {

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -2385,6 +2385,551 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('denies Autopilot implementation-phase completion before the code-review gate', async () => {
+    for (const phase of ['ultragoal', 'team', 'ralph']) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-${phase}-complete-deny-`));
+      try {
+        await withOmxRootEnv(wd, async () => {
+          const sessionId = `sess-autopilot-${phase}-complete-deny`;
+          const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+          await mkdir(sessionDir, { recursive: true });
+          await writeFile(
+            join(sessionDir, 'autopilot-state.json'),
+            JSON.stringify({
+              active: true,
+              mode: 'autopilot',
+              current_phase: phase,
+              state: { handoff_artifacts: { ultragoal: { verification: 'passed' } } },
+            }, null, 2),
+          );
+
+          const response = await executeStateOperation('state_write', {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'autopilot',
+            active: false,
+            current_phase: 'complete',
+            state: {
+              review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+              qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/1' },
+            },
+          });
+
+          assert.equal(response.isError, true);
+          assert.match(String((response.payload as { error?: string }).error || ''), /Cannot complete Autopilot before code-review gate/i);
+          const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+          assert.equal(state.active, true);
+          assert.equal(state.current_phase, phase);
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('denies Autopilot implementation-phase skip directly to ultraqa', async () => {
+    for (const phase of ['ultragoal', 'team', 'ralph']) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-${phase}-ultraqa-skip-deny-`));
+      try {
+        await withOmxRootEnv(wd, async () => {
+          const sessionId = `sess-autopilot-${phase}-ultraqa-skip-deny`;
+          const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+          await mkdir(sessionDir, { recursive: true });
+          await writeFile(
+            join(sessionDir, 'autopilot-state.json'),
+            JSON.stringify({
+              active: true,
+              mode: 'autopilot',
+              current_phase: phase,
+              state: { handoff_artifacts: { ultragoal: { verification: 'passed' } } },
+            }, null, 2),
+          );
+
+          const response = await executeStateOperation('state_write', {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'ultraqa',
+          });
+
+          assert.equal(response.isError, true);
+          assert.match(String((response.payload as { error?: string }).error || ''), /Cannot skip Autopilot code-review gate/i);
+          const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+          assert.equal(state.active, true);
+          assert.equal(state.current_phase, phase);
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('denies Autopilot code-review completion before the ultraqa gate', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-code-review-complete-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-code-review-complete-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'code-review',
+            state: {
+              handoff_artifacts: { code_review: { source: 'native-subagent' } },
+              review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          state: {
+            review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+            qa_verdict: { clean: true, skipped: false },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /Cannot complete Autopilot before ultraqa gate/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'code-review');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot ultraqa completion without clean review and QA evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-complete-evidence-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ultraqa-complete-evidence-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'ultraqa',
+            state: {
+              review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+              qa_verdict: null,
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          state: {
+            review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /without clean code-review and ultraqa verdict evidence/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'ultraqa');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot implementation and code-review terminalization via inactive ultraqa phase', async () => {
+    for (const phase of ['ultragoal', 'team', 'ralph', 'code-review']) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-${phase}-inactive-ultraqa-deny-`));
+      try {
+        await withOmxRootEnv(wd, async () => {
+          const sessionId = `sess-autopilot-${phase}-inactive-ultraqa-deny`;
+          const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+          await mkdir(sessionDir, { recursive: true });
+          await writeFile(
+            join(sessionDir, 'autopilot-state.json'),
+            JSON.stringify({ active: true, mode: 'autopilot', current_phase: phase }, null, 2),
+          );
+
+          const response = await executeStateOperation('state_write', {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'autopilot',
+            active: false,
+            current_phase: 'ultraqa',
+            state: {
+              review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+              qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/3' },
+            },
+          });
+
+          assert.equal(response.isError, true);
+          assert.match(String((response.payload as { error?: string }).error || ''), /Cannot (complete|skip) Autopilot/i);
+          const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+          assert.equal(state.active, true);
+          assert.equal(state.current_phase, phase);
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('denies Autopilot ultraqa completion when review and QA provenance are swapped', async () => {
+    const cases = [
+      {
+        name: 'swapped-stage',
+        review_verdict: { stage: 'ultraqa', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.ultraqa.artifacts.qa_verdict' },
+        qa_verdict: { stage: 'code-review', clean: true, skipped: false, artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.code-review.artifacts.review_verdict' },
+      },
+      {
+        name: 'swapped-artifact-path',
+        review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.ultraqa.artifacts.qa_verdict' },
+        qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.code-review.artifacts.review_verdict' },
+      },
+      {
+        name: 'review-uses-ultraqa-provenance',
+        review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/ultraqa/qa-verdict.json' },
+        qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, artifact_path: '.omx/qa/qa-verdict.json' },
+      },
+      {
+        name: 'qa-uses-code-review-provenance',
+        review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+        qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, artifact_path: '.omx/reviews/code-review.json' },
+      },
+      {
+        name: 'shared-neutral-provenance',
+        review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/evidence/shared.json' },
+        qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, artifact_path: '.omx/evidence/shared.json' },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-ultraqa-${testCase.name}-deny-`));
+      try {
+        await withOmxRootEnv(wd, async () => {
+          const sessionId = `sess-autopilot-ultraqa-${testCase.name}-deny`;
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ultraqa' }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          state: {
+            review_verdict: testCase.review_verdict,
+            qa_verdict: testCase.qa_verdict,
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /without clean code-review and ultraqa verdict evidence/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'ultraqa');
+      });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('denies Autopilot ultraqa completion with self-attested clean verdicts but no durable provenance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-self-attested-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ultraqa-self-attested-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'ultraqa',
+            state: {
+              review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+              qa_verdict: { clean: true, skipped: false },
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          state: {
+            review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+            qa_verdict: { clean: true, skipped: false },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /without clean code-review and ultraqa verdict evidence/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'ultraqa');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot ultraqa skipped completion without durable QA provenance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-skipped-no-provenance-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ultraqa-skipped-no-provenance-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ultraqa' }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          state: {
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+            qa_verdict: { stage: 'ultraqa', clean: true, skipped: true, reason: 'Docs-only change; QA not applicable.' },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /without clean code-review and ultraqa verdict evidence/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'ultraqa');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot completion from an unknown active phase', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-unknown-phase-complete-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-unknown-phase-complete-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'bogus',
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          completed_at: '2026-06-09T14:40:00.000Z',
+          state: {
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+            qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/5' },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /unknown active phase/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'bogus');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot completion from an unknown active phase when persisted state omits mode', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-unknown-phase-no-mode-complete-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-unknown-phase-no-mode-complete-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            current_phase: 'bogus',
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          completed_at: '2026-06-09T14:45:00.000Z',
+          state: {
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+            qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/6' },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /unknown active phase/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'bogus');
+        assert.equal(Object.prototype.hasOwnProperty.call(state, 'mode'), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not persist user-supplied trustedPipelineProgress from Autopilot state_write', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-trusted-field-strip-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-trusted-field-strip';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            current_phase: 'ultraqa',
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: true,
+          current_phase: 'ultraqa',
+          trustedPipelineProgress: true,
+          state: {
+            trustedPipelineProgress: true,
+          },
+        });
+
+        assert.equal(response.isError, undefined);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(Object.prototype.hasOwnProperty.call(state, 'trustedPipelineProgress'), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows Autopilot ultraqa completion with clean review and QA evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-complete-allow-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ultraqa-complete-allow';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'ultraqa',
+            state: {
+              review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+              qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/1' },
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          completed_at: '2026-06-09T14:30:00.000Z',
+          state: {
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+            qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/1' },
+          },
+        });
+
+        assert.equal(response.isError, undefined);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, false);
+        assert.equal(state.current_phase, 'complete');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows Autopilot ultraqa skipped completion with reason and durable QA provenance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-skipped-allow-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ultraqa-skipped-allow';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ultraqa' }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          completed_at: '2026-06-09T14:35:00.000Z',
+          state: {
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+            qa_verdict: {
+              stage: 'ultraqa',
+              clean: true,
+              skipped: true,
+              reason: 'Docs-only change; QA not applicable.',
+              artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.ultraqa.artifacts.qa_verdict',
+            },
+          },
+        });
+
+        assert.equal(response.isError, undefined);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, false);
+        assert.equal(state.current_phase, 'complete');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('allows Autopilot ralplan to ultragoal self-write with tracker-backed native consensus evidence', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ralplan-native-allow-'));
     try {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -21,6 +21,7 @@ import { evaluateRalphCompletionAuditEvidence } from '../ralph/completion-audit.
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
+import { isAutopilotSuccessfulTerminalState, validateAutopilotCompletionTransition } from '../autopilot/completion-gate.js';
 import { readUltragoalState } from '../hud/state.js';
 import {
   SKILL_ACTIVE_STATE_MODE,
@@ -44,7 +45,6 @@ import {
 import {
   type AutopilotChildPhase,
   deriveAutopilotChildPhase,
-  normalizeAutopilotPhase,
 } from '../autopilot/fsm.js';
 import {
   buildAutopilotRalplanUltragoalGateError,
@@ -82,10 +82,6 @@ function isNextAutopilotPhase(
   const currentOrder = autopilotPhaseOrder(currentPhase);
   const nextOrder = autopilotPhaseOrder(nextPhase);
   return currentOrder >= 0 && nextOrder === currentOrder + 1;
-}
-
-function isAutopilotCompletePhase(state: Record<string, unknown>): boolean {
-  return normalizeAutopilotPhase(state.current_phase) === 'complete';
 }
 
 export const SUPPORTED_STATE_READ_MODES = [
@@ -394,6 +390,7 @@ export async function executeStateOperation(
             ...fields,
             ...((customState as Record<string, unknown>) || {}),
           } as Record<string, unknown>;
+          delete mergedRaw.trustedPipelineProgress;
           if (!hasExplicitStateField(fields, customState, 'run_outcome')) {
             delete mergedRaw.run_outcome;
           }
@@ -459,7 +456,7 @@ export async function executeStateOperation(
           if (
             mode === 'autopilot'
             && currentAutopilotChildPhase === 'deep-interview'
-            && isAutopilotCompletePhase(mergedRaw)
+            && isAutopilotSuccessfulTerminalState(mergedRaw)
           ) {
             validationError = 'Cannot complete Autopilot before ralplan gate: deep-interview may only advance to ralplan.';
             return;
@@ -468,10 +465,21 @@ export async function executeStateOperation(
           if (
             mode === 'autopilot'
             && currentAutopilotChildPhase === 'ralplan'
-            && isAutopilotCompletePhase(mergedRaw)
+            && isAutopilotSuccessfulTerminalState(mergedRaw)
           ) {
             validationError = 'Cannot complete Autopilot before ultragoal gate: ralplan may only advance to ultragoal.';
             return;
+          }
+
+          if (mode === 'autopilot') {
+            const completionTransitionError = validateAutopilotCompletionTransition(
+              existing as Record<string, unknown>,
+              mergedRaw,
+            );
+            if (completionTransitionError) {
+              validationError = completionTransitionError;
+              return;
+            }
           }
 
           if (


### PR DESCRIPTION
## Summary

Fixes `omx-7ks` by enforcing the Autopilot post-implementation lifecycle across the authoritative state-write surfaces:

- implementation phases (`ultragoal`, `team`, `ralph`) cannot terminalize or skip directly to `ultraqa`
- `code-review` cannot terminalize before `ultraqa`
- `ultraqa` completion requires clean, stage-typed, durable, non-swappable code-review + UltraQA evidence
- direct `updateModeState` calls now share Autopilot gate checks with `state_write`
- pipeline orchestrator progress writes use a non-serializable internal trust option instead of user-writable state fields
- hostile/user-supplied privileged fields are stripped before persistence

## Notable guard cases

- denies direct `deep-interview -> ultragoal`
- denies `ralplan -> code-review`
- denies `ralplan -> ultragoal` without tracker-backed native Architect/Critic consensus
- denies terminal completion from implementation/code-review phases
- denies swapped/shared/neutral review-vs-QA provenance
- denies skipped UltraQA without both a reason and durable QA locator
- denies unknown active Autopilot phase terminalization, including persisted state without embedded `mode`
- preserves generic pipeline custom-stage completion through internal `trustedPipelineProgress` options only

## Validation

Post-rebase on `origin/dev`:

- `npm run build`
- `node dist/scripts/run-test-files.js dist/state/__tests__/operations.test.js dist/modes/__tests__/base-autopilot-gates.test.js dist/pipeline/__tests__/orchestrator.test.js dist/pipeline/__tests__/stages.test.js`
  - state operations: 65/65
  - base Autopilot gates: 8/8
  - pipeline orchestrator: 31/31
  - pipeline stages: 73/73
- `npm run check:no-unused`
- `git diff --check`

## Review / QA evidence

- Code review: APPROVE/CLEAR from final focused reviewer
- Scholastic gate: APPROVE/CLEAR after forced Autopilot-context repair
- UltraQA: PASS/CLEAN after hostile serialization probes
