### PR TITLE
Fix HUD labels, owner matching, and consensus diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -304,9 +304,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
-      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/autopilot/completion-gate.ts
+++ b/src/autopilot/completion-gate.ts
@@ -1,0 +1,166 @@
+import { deriveAutopilotChildPhase, normalizeAutopilotPhase, type AutopilotChildPhase } from './fsm.js';
+import { inferRunOutcome, inferTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
+
+type JsonObject = Record<string, unknown>;
+
+function objectRecord(value: unknown): JsonObject {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : {};
+}
+
+function nonEmptyString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function stateField(state: JsonObject, key: string): unknown {
+  if (Object.prototype.hasOwnProperty.call(state, key)) return state[key];
+  return objectRecord(state.state)[key];
+}
+
+function hasAnyStringField(value: JsonObject, keys: string[]): boolean {
+  return keys.some((key) => nonEmptyString(value[key]).length > 0);
+}
+
+function stringField(value: JsonObject, key: string): string {
+  return nonEmptyString(value[key]);
+}
+
+function isImplementationPhase(phase: AutopilotChildPhase | null): boolean {
+  return phase === 'ultragoal' || phase === 'team' || phase === 'ralph';
+}
+
+function isActiveAutopilotState(state: JsonObject): boolean {
+  return state.mode === 'autopilot' && state.active === true;
+}
+
+export function isAutopilotSuccessfulTerminalState(state: JsonObject): boolean {
+  const phase = normalizeAutopilotPhase(state.current_phase);
+  const runOutcome = inferRunOutcome(state);
+  const lifecycleOutcome = inferTerminalLifecycleOutcome(state);
+  if (phase === 'failed' || runOutcome === 'failed' || runOutcome === 'cancelled' || runOutcome === 'blocked_on_user') return false;
+  if (lifecycleOutcome === 'failed' || lifecycleOutcome === 'blocked' || lifecycleOutcome === 'userinterlude' || lifecycleOutcome === 'askuserQuestion') return false;
+  if (phase === 'complete') return true;
+  if (runOutcome === 'finish') return true;
+  if (lifecycleOutcome === 'finished') return true;
+  if (nonEmptyString(state.completed_at)) return true;
+  return state.active === false;
+}
+
+function urlLooksLikeCi(url: string): boolean {
+  return /github\.com\/[^/]+\/[^/]+\/actions\/runs\//i.test(url);
+}
+
+function evidenceText(value: JsonObject, keys: string[]): string {
+  return keys.map((key) => nonEmptyString(value[key]).toLowerCase()).filter(Boolean).join('\n');
+}
+
+function looksLikeUltraqaEvidence(value: JsonObject): boolean {
+  return /\bultraqa\b|\bqa[_-]?verdict\b|\bqa[_-]?evidence\b/.test(
+    evidenceText(value, ['source', 'artifact_path', 'url', 'review_url', 'qa_url']),
+  );
+}
+
+function looksLikeCodeReviewEvidence(value: JsonObject): boolean {
+  return /\bcode[-_]?review\b|\breview[_-]?verdict\b|\breview[_-]?evidence\b|\breviews\//.test(
+    evidenceText(value, ['source', 'artifact_path', 'url', 'review_url', 'qa_url']),
+  );
+}
+
+function hasCodeReviewLocator(value: JsonObject): boolean {
+  const artifactPath = stringField(value, 'artifact_path').toLowerCase();
+  const reviewUrl = stringField(value, 'review_url');
+  if (artifactPath) return looksLikeCodeReviewEvidence(value);
+  return reviewUrl.length > 0 || hasAnyStringField(value, ['thread_id', 'agent_id', 'tool_call_id', 'url']);
+}
+
+function hasUltraqaLocator(value: JsonObject): boolean {
+  const artifactPath = stringField(value, 'artifact_path').toLowerCase();
+  const qaUrl = stringField(value, 'qa_url');
+  const url = stringField(value, 'url');
+  if (artifactPath) return looksLikeUltraqaEvidence(value) || /\bqa\b/.test(artifactPath);
+  return qaUrl.length > 0 || urlLooksLikeCi(url) || hasAnyStringField(value, ['tool_call_id', 'thread_id']);
+}
+
+function evidenceLocatorSet(value: JsonObject): Set<string> {
+  return new Set(['artifact_path', 'url', 'review_url', 'qa_url', 'thread_id', 'tool_call_id', 'agent_id']
+    .map((key) => nonEmptyString(value[key]))
+    .filter(Boolean));
+}
+
+export function hasCleanCodeReviewEvidence(value: unknown): boolean {
+  const verdict = objectRecord(value);
+  if (verdict.clean !== true) return false;
+  if (nonEmptyString(verdict.stage) !== 'code-review') return false;
+  if (nonEmptyString(verdict.recommendation).toUpperCase() !== 'APPROVE') return false;
+  if (nonEmptyString(verdict.architectural_status).toUpperCase() !== 'CLEAR') return false;
+  if (looksLikeUltraqaEvidence(verdict)) return false;
+  const url = nonEmptyString(verdict.url);
+  if (url && urlLooksLikeCi(url)) return false;
+  return hasCodeReviewLocator(verdict);
+}
+
+export function hasCleanUltraqaEvidence(value: unknown): boolean {
+  const verdict = objectRecord(value);
+  if (verdict.clean !== true) return false;
+  if (nonEmptyString(verdict.stage) !== 'ultraqa') return false;
+  const source = nonEmptyString(verdict.source).toLowerCase();
+  if (source === 'leader' || source.includes('code-review')) return false;
+  if (looksLikeCodeReviewEvidence(verdict)) return false;
+  if (verdict.skipped === true) {
+    return (
+      nonEmptyString(verdict.reason).length > 0 || nonEmptyString(verdict.skip_reason).length > 0
+    ) && hasUltraqaLocator(verdict);
+  }
+  return hasUltraqaLocator(verdict);
+}
+
+export function hasCleanAutopilotReviewAndQaEvidence(state: JsonObject): boolean {
+  const review = objectRecord(stateField(state, 'review_verdict'));
+  const qa = objectRecord(stateField(state, 'qa_verdict'));
+  if (!hasCleanCodeReviewEvidence(review) || !hasCleanUltraqaEvidence(qa)) return false;
+  const reviewLocators = evidenceLocatorSet(review);
+  const qaLocators = evidenceLocatorSet(qa);
+  for (const locator of reviewLocators) {
+    if (qaLocators.has(locator)) return false;
+  }
+  return true;
+}
+
+export function validateAutopilotCompletionTransition(
+  currentState: JsonObject,
+  nextState: JsonObject,
+  options: { allowUnknownActivePhaseCompletion?: boolean } = {},
+): string | null {
+  const current = { ...currentState, mode: 'autopilot' };
+  const next = { ...nextState, mode: 'autopilot' };
+  const currentPhase = deriveAutopilotChildPhase(current);
+  const nextPhase = deriveAutopilotChildPhase(next);
+  const successfulTerminal = isAutopilotSuccessfulTerminalState(next);
+
+  if (
+    successfulTerminal
+    && isActiveAutopilotState(current)
+    && currentPhase === null
+    && options.allowUnknownActivePhaseCompletion !== true
+  ) {
+    return 'Cannot complete Autopilot from an unknown active phase; restore a valid Autopilot phase before terminalization.';
+  }
+  if (currentPhase === 'deep-interview' && successfulTerminal) {
+    return 'Cannot complete Autopilot before ralplan gate: deep-interview may only advance to ralplan.';
+  }
+  if (currentPhase === 'ralplan' && successfulTerminal) {
+    return 'Cannot complete Autopilot before ultragoal gate: ralplan may only advance to ultragoal.';
+  }
+  if (isImplementationPhase(currentPhase) && successfulTerminal) {
+    return `Cannot complete Autopilot before code-review gate: ${currentPhase} may only advance to code-review.`;
+  }
+  if (isImplementationPhase(currentPhase) && nextPhase === 'ultraqa') {
+    return `Cannot skip Autopilot code-review gate: ${currentPhase} may only advance to code-review.`;
+  }
+  if (currentPhase === 'code-review' && successfulTerminal) {
+    return 'Cannot complete Autopilot before ultraqa gate: code-review may only advance to ultraqa.';
+  }
+  if (currentPhase === 'ultraqa' && successfulTerminal && !hasCleanAutopilotReviewAndQaEvidence(nextState)) {
+    return 'Cannot complete Autopilot from ultraqa without clean code-review and ultraqa verdict evidence.';
+  }
+  return null;
+}

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -439,6 +439,130 @@ describe('maybeCheckAndPromptUpdate', () => {
     }
   });
 
+  it('treats a current dev install dev_base_version as the launch update baseline', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-dev-baseline-'));
+    let promptCalls = 0;
+    let updateAttempts = 0;
+
+    try {
+      await withInteractiveTty(async () => {
+        await maybeCheckAndPromptUpdate(cwd, {
+          getCurrentVersion: async () => '0.18.10',
+          fetchLatestVersion: async () => '0.18.11',
+          readUserInstallStamp: async () => ({
+            installed_version: '0.18.10',
+            setup_completed_version: '0.18.10',
+            install_channel: 'dev',
+            install_source: 'github:Yeachan-Heo/oh-my-codex#dev',
+            install_revision: '8214377e3c1d',
+            dev_base_version: '0.18.11',
+            updated_at: '2026-06-09T20:21:24.070Z',
+          }),
+          askYesNo: async () => {
+            promptCalls += 1;
+            return true;
+          },
+          runDeferredGlobalUpdate: () => {
+            updateAttempts += 1;
+            return { ok: true, stderr: '', logPath: join(cwd, '.omx', 'logs', 'update-test.log') };
+          },
+        });
+      });
+
+      assert.equal(promptCalls, 0);
+      assert.equal(updateAttempts, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not infer a dev_base_version from launch-time latest alone', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-dev-baseline-missing-'));
+    const originalCodexHome = process.env.CODEX_HOME;
+    const codexHome = join(cwd, '.codex');
+    const stampPath = join(codexHome, '.omx', 'install-state.json');
+    let promptCalls = 0;
+    let updateAttempts = 0;
+    process.env.CODEX_HOME = codexHome;
+
+    try {
+      await mkdir(join(codexHome, '.omx'), { recursive: true });
+      await writeFile(stampPath, JSON.stringify({
+        installed_version: '0.18.10',
+        setup_completed_version: '0.18.10',
+        install_channel: 'dev',
+        install_source: 'github:Yeachan-Heo/oh-my-codex#dev',
+        install_revision: '8214377e3c1d',
+        updated_at: '2026-06-09T20:21:24.070Z',
+      }, null, 2));
+
+      await withInteractiveTty(async () => {
+        await maybeCheckAndPromptUpdate(cwd, {
+          getCurrentVersion: async () => '0.18.10',
+          fetchLatestVersion: async () => '0.18.11',
+          askYesNo: async () => {
+            promptCalls += 1;
+            return false;
+          },
+          runDeferredGlobalUpdate: () => {
+            updateAttempts += 1;
+            return { ok: true, stderr: '', logPath: join(cwd, '.omx', 'logs', 'update-test.log') };
+          },
+        });
+      });
+
+      const unchangedStamp = JSON.parse(await readFile(stampPath, 'utf-8')) as { dev_base_version?: string };
+      assert.equal(promptCalls, 1);
+      assert.equal(updateAttempts, 0);
+      assert.equal(unchangedStamp.dev_base_version, undefined);
+    } finally {
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the artifact version when it is newer than the stamped dev baseline', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-dev-baseline-outrun-'));
+    let promptCalls = 0;
+    let updateAttempts = 0;
+
+    try {
+      await withInteractiveTty(async () => {
+        await maybeCheckAndPromptUpdate(cwd, {
+          getCurrentVersion: async () => '0.18.12',
+          fetchLatestVersion: async () => '0.18.13',
+          readUserInstallStamp: async () => ({
+            installed_version: '0.18.12',
+            setup_completed_version: '0.18.12',
+            install_channel: 'dev',
+            install_source: 'github:Yeachan-Heo/oh-my-codex#dev',
+            install_revision: '8214377e3c1d',
+            dev_base_version: '0.18.11',
+            updated_at: '2026-06-09T20:21:24.070Z',
+          }),
+          askYesNo: async (question) => {
+            promptCalls += 1;
+            assert.match(question, /v0\.18\.12 → v0\.18\.13/);
+            return false;
+          },
+          runDeferredGlobalUpdate: () => {
+            updateAttempts += 1;
+            return { ok: true, stderr: '', logPath: join(cwd, '.omx', 'logs', 'update-test.log') };
+          },
+        });
+      });
+
+      assert.equal(promptCalls, 1);
+      assert.equal(updateAttempts, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('respects the passive launch-time cadence before checking npm', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
     const statePath = join(cwd, '.omx', 'state', 'update-check.json');

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -823,7 +823,7 @@ describe('runImmediateUpdate', () => {
       }, { channel: 'dev' });
 
       assert.equal(result.status, 'updated');
-      assert.equal(latestCalls, 0);
+      assert.equal(latestCalls, 1);
       assert.equal(refreshCalls, 1);
       assert.deepEqual(installSources, ['github:Yeachan-Heo/oh-my-codex#dev']);
       assert.match(logs.join('\n'), /Selected update channel: dev/);
@@ -837,14 +837,56 @@ describe('runImmediateUpdate', () => {
         install_channel: string;
         install_source: string;
         install_revision: string;
+        dev_base_version: string;
       };
       assert.equal(stamp.installed_version, '0.15.0');
       assert.equal(stamp.setup_completed_version, '0.15.0');
       assert.equal(stamp.install_channel, 'dev');
       assert.equal(stamp.install_source, 'github:Yeachan-Heo/oh-my-codex#dev');
       assert.equal(stamp.install_revision, '1234567890ab');
+      assert.equal(stamp.dev_base_version, '0.15.0');
     } finally {
       console.log = originalLog;
+      if (typeof originalCodexHome === 'string') {
+        process.env.CODEX_HOME = originalCodexHome;
+      } else {
+        delete process.env.CODEX_HOME;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('records the latest release as dev display baseline when dev package.json lags behind', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-now-dev-baseline-'));
+    const stampPath = join(cwd, '.codex', '.omx', 'install-state.json');
+    const originalCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = join(cwd, '.codex');
+
+    try {
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.18.10',
+        fetchLatestVersion: async () => '0.18.11',
+        runGlobalUpdate: () => ({ ok: true, stderr: '', revision: '4dd0f6455772' }),
+        runSetupRefresh: async () => ({ ok: true, stderr: '' }),
+        getInstalledVersionAfterUpdate: async () => '0.18.10',
+        getInstalledRevisionAfterUpdate: async () => null,
+      }, { channel: 'dev' });
+
+      assert.equal(result.status, 'updated');
+      const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
+        installed_version: string;
+        setup_completed_version: string;
+        install_channel: string;
+        install_revision: string;
+        dev_base_version: string;
+      };
+      assert.equal(stamp.installed_version, '0.18.10');
+      assert.equal(stamp.setup_completed_version, '0.18.10');
+      assert.equal(stamp.install_channel, 'dev');
+      assert.equal(stamp.install_revision, '4dd0f6455772');
+      assert.equal(stamp.dev_base_version, '0.18.11');
+    } finally {
       if (typeof originalCodexHome === 'string') {
         process.env.CODEX_HOME = originalCodexHome;
       } else {

--- a/src/cli/__tests__/version-sync-contract.test.ts
+++ b/src/cli/__tests__/version-sync-contract.test.ts
@@ -17,6 +17,9 @@ interface WorkspaceMemberPackageMetadata {
 describe('version sync contract', () => {
   it('keeps package.json, workspace metadata, and Rust members aligned for releases', () => {
     const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8')) as { version: string };
+    const pluginManifest = JSON.parse(
+      readFileSync(join(process.cwd(), 'plugins', 'oh-my-codex', '.codex-plugin', 'plugin.json'), 'utf-8'),
+    ) as { version: string };
     const workspace = TOML.parse(readFileSync(join(process.cwd(), 'Cargo.toml'), 'utf-8')) as {
       workspace?: { package?: WorkspacePackageMetadata; members?: string[] };
     };
@@ -40,6 +43,7 @@ describe('version sync contract', () => {
     };
 
     assert.equal(workspace.workspace?.package?.version, pkg.version);
+    assert.equal(pluginManifest.version, pkg.version);
     assert.deepEqual(workspace.workspace?.members, [
       'crates/omx-api',
       'crates/omx-explore',

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -651,6 +651,30 @@ function doesSetupStampMatchVersion(
   return stripLeadingV(stamp?.setup_completed_version ?? '') === stripLeadingV(currentVersion);
 }
 
+function resolveUpdateCheckBaseline(
+  currentVersion: string | null,
+  stamp: UserInstallStamp | null,
+): string | null {
+  if (!currentVersion) return null;
+  const current = stripLeadingV(currentVersion);
+  const stampVersion = stripLeadingV(stamp?.setup_completed_version ?? stamp?.installed_version ?? '');
+  const devBaseVersion = stripLeadingV(stamp?.dev_base_version ?? '');
+
+  // Launch-time update checks must not synthesize dev_base_version from npm
+  // latest alone. A dev baseline is install metadata, so only a matching dev
+  // stamp written by a successful dev update can raise the comparison baseline.
+  if (
+    stamp?.install_channel === 'dev' &&
+    stampVersion === current &&
+    devBaseVersion &&
+    isNewerVersion(current, devBaseVersion)
+  ) {
+    return devBaseVersion;
+  }
+
+  return currentVersion;
+}
+
 export function resolveGlobalInstallRoot(
   spawnProcess: SpawnSyncLike = spawnSync,
   platform: NodeJS.Platform = process.platform,
@@ -803,6 +827,10 @@ async function executeUpdate(
     dependencies.getCurrentVersion(),
     channel === 'stable' || !forceInstall || channel === 'dev' ? dependencies.fetchLatestVersion() : Promise.resolve(null),
   ]);
+  const installStamp = await dependencies.readUserInstallStamp();
+  const updateCheckBaseline = !forceInstall
+    ? resolveUpdateCheckBaseline(current, installStamp)
+    : current;
 
   try {
     await dependencies.writeUpdateState(cwd, {
@@ -814,19 +842,18 @@ async function executeUpdate(
     // just because the current working directory is read-only or unavailable.
   }
 
-  if (!forceInstall && (!current || !latest)) {
+  if (!forceInstall && (!updateCheckBaseline || !latest)) {
     if (immediate) {
       console.log('[omx] Unable to determine the latest oh-my-codex version. Try again later.');
     }
     return { status: 'unavailable', currentVersion: current, latestVersion: latest };
   }
 
-  if (!forceInstall && current && latest && !isNewerVersion(current, latest)) {
+  if (!forceInstall && updateCheckBaseline && latest && !isNewerVersion(updateCheckBaseline, latest)) {
     if (immediate) {
-      const installStamp = await dependencies.readUserInstallStamp();
-      if (!doesSetupStampMatchVersion(current, installStamp)) {
+      if (current && !doesSetupStampMatchVersion(current, installStamp)) {
         console.log(
-          `[omx] oh-my-codex is already up to date (v${current}). Running setup refresh...`,
+          `[omx] oh-my-codex is already up to date (v${updateCheckBaseline}). Running setup refresh...`,
         );
         const setupRefreshResult = await dependencies.runSetupRefresh(cwd);
         if (!setupRefreshResult.ok) {
@@ -836,13 +863,13 @@ async function executeUpdate(
           return { status: 'failed', currentVersion: current, latestVersion: latest };
         }
         await writeSuccessfulInstallStamp(current);
-        console.log(`[omx] Setup refresh completed for v${current}. Restart to use current code.`);
+        console.log(`[omx] Setup refresh completed for v${updateCheckBaseline}. Restart to use current code.`);
         return { status: 'up-to-date', currentVersion: current, latestVersion: latest };
       }
     }
 
     if (immediate) {
-      console.log(`[omx] oh-my-codex is already up to date (v${current}).`);
+      console.log(`[omx] oh-my-codex is already up to date (v${updateCheckBaseline}).`);
     }
     return { status: 'up-to-date', currentVersion: current, latestVersion: latest };
   }
@@ -850,8 +877,8 @@ async function executeUpdate(
   if (prompt) {
     const approved = await dependencies.askYesNo(
       immediate
-        ? `[omx] Update available: v${current} → v${latest}. Update now? [Y/n] `
-        : `[omx] Update available: v${current} → v${latest}. Update after this session exits? [Y/n] `,
+        ? `[omx] Update available: v${updateCheckBaseline} → v${latest}. Update now? [Y/n] `
+        : `[omx] Update available: v${updateCheckBaseline} → v${latest}. Update after this session exits? [Y/n] `,
     );
     if (!approved) {
       return { status: 'declined', currentVersion: current, latestVersion: latest };
@@ -898,7 +925,9 @@ async function executeUpdate(
     ? ((await dependencies.getInstalledRevisionAfterUpdate()) ?? result.revision ?? null)
     : null;
   const devBaseVersion = channelConfig.channel === 'dev'
-    ? (latest && installedVersion && isNewerVersion(latest, installedVersion) ? installedVersion : (latest ?? installedVersion ?? current))
+    ? (latest && installedVersion
+        ? (isNewerVersion(latest, installedVersion) ? installedVersion : latest)
+        : latest)
     : null;
   const stampVersion = channelConfig.channel === 'stable'
     ? (latest ?? installedVersion ?? current)

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -27,6 +27,7 @@ export interface UserInstallStamp {
   install_channel?: UpdateChannel;
   install_source?: string;
   install_revision?: string;
+  dev_base_version?: string;
   updated_at: string;
 }
 
@@ -578,6 +579,7 @@ async function writeSuccessfulInstallStamp(
     channel?: UpdateChannel;
     source?: string;
     revision?: string | null;
+    devBaseVersion?: string | null;
   } = {},
 ): Promise<void> {
   await writeUserInstallStamp({
@@ -586,6 +588,7 @@ async function writeSuccessfulInstallStamp(
     ...(metadata.channel ? { install_channel: metadata.channel } : {}),
     ...(metadata.source ? { install_source: metadata.source } : {}),
     ...(metadata.revision ? { install_revision: metadata.revision } : {}),
+    ...(metadata.devBaseVersion ? { dev_base_version: stripLeadingV(metadata.devBaseVersion) } : {}),
     updated_at: new Date().toISOString(),
   });
 }
@@ -613,6 +616,9 @@ export async function readUserInstallStamp(
         : {}),
       ...(typeof parsed.install_revision === 'string'
         ? { install_revision: parsed.install_revision }
+        : {}),
+      ...(typeof parsed.dev_base_version === 'string'
+        ? { dev_base_version: parsed.dev_base_version }
         : {}),
       updated_at: parsed.updated_at,
     };
@@ -795,7 +801,7 @@ async function executeUpdate(
   const channelConfig = resolveUpdateChannelConfig(channel);
   const [current, latest] = await Promise.all([
     dependencies.getCurrentVersion(),
-    channel === 'stable' || !forceInstall ? dependencies.fetchLatestVersion() : Promise.resolve(null),
+    channel === 'stable' || !forceInstall || channel === 'dev' ? dependencies.fetchLatestVersion() : Promise.resolve(null),
   ]);
 
   try {
@@ -891,6 +897,9 @@ async function executeUpdate(
   const installedRevision = channelConfig.channel === 'dev'
     ? ((await dependencies.getInstalledRevisionAfterUpdate()) ?? result.revision ?? null)
     : null;
+  const devBaseVersion = channelConfig.channel === 'dev'
+    ? (latest && installedVersion && isNewerVersion(latest, installedVersion) ? installedVersion : (latest ?? installedVersion ?? current))
+    : null;
   const stampVersion = channelConfig.channel === 'stable'
     ? (latest ?? installedVersion ?? current)
     : installedVersion;
@@ -899,6 +908,7 @@ async function executeUpdate(
       channel: channelConfig.channel,
       source: channelConfig.installSource,
       revision: channelConfig.channel === 'dev' ? installedRevision : null,
+      devBaseVersion,
     });
   } else if (channelConfig.channel === 'dev') {
     console.log(

--- a/src/hud/__tests__/authority.test.ts
+++ b/src/hud/__tests__/authority.test.ts
@@ -83,7 +83,6 @@ describe('runHudAuthorityTick', () => {
         {
           cwd,
           nodePath: '/node',
-          packageRoot: '/pkg',
           pollMs: 75,
           timeoutMs: 4321,
           env: { CUSTOM_ENV: '1' },
@@ -102,17 +101,17 @@ describe('runHudAuthorityTick', () => {
       assert.equal(calls.length, 1);
       const call = calls[0]!;
       assert.equal(call.nodePath, '/node');
-      assert.deepEqual(call.args, [
-        '/pkg/dist/scripts/notify-fallback-watcher.js',
-        '--once',
-        '--authority-only',
-        '--cwd',
-        cwd,
-        '--notify-script',
-        '/pkg/dist/scripts/notify-hook.js',
-        '--poll-ms',
-        '75',
-      ]);
+      assert.equal(call.args.length, 9);
+      assert.equal(typeof call.args[0], 'string');
+      assert.equal(call.args[0].endsWith('/dist/scripts/notify-fallback-watcher.js'), true);
+      assert.equal(call.args[1], '--once');
+      assert.equal(call.args[2], '--authority-only');
+      assert.equal(call.args[3], '--cwd');
+      assert.equal(call.args[4], cwd);
+      assert.equal(call.args[5], '--notify-script');
+      assert.equal(call.args[6].endsWith('/dist/scripts/notify-hook.js'), true);
+      assert.equal(call.args[7], '--poll-ms');
+      assert.equal(call.args[8], '75');
       assert.equal(call.options.cwd, cwd);
       assert.equal(call.options.timeoutMs, 4321);
       assert.equal(call.options.env.OMX_HUD_AUTHORITY, '1');
@@ -121,6 +120,54 @@ describe('runHudAuthorityTick', () => {
       assert.equal(call.options.env.CUSTOM_ENV, '1');
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to CLI entry dist scripts when package root lacks dist scripts', async () => {
+    const packageRoot = await mkdtemp(join(tmpdir(), 'omx-hud-package-root-no-dist-'));
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-entry-fallback-'));
+    const cliRoot = await mkdtemp(join(tmpdir(), 'omx-cli-root-'));
+    const entryPath = join(cliRoot, 'dist', 'cli', 'omx.js');
+    const watcherPath = join(cliRoot, 'dist', 'scripts', 'notify-fallback-watcher.js');
+    const hookPath = join(cliRoot, 'dist', 'scripts', 'notify-hook.js');
+    try {
+      await mkdir(join(cliRoot, 'dist', 'scripts'), { recursive: true });
+      writeFileSync(watcherPath, 'console.log("cli entry watcher")\n');
+      writeFileSync(hookPath, 'console.log("cli entry notify hook")\n');
+
+      const calls: Array<{
+        nodePath: string;
+        args: string[];
+        options: { cwd: string; env: NodeJS.ProcessEnv; timeoutMs: number };
+      }> = [];
+      const env = { OMX_ENTRY_PATH: entryPath };
+
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot,
+          env,
+        },
+        {
+          runProcess: async (
+            nodePath: string,
+            args: string[],
+            options: { cwd: string; env: NodeJS.ProcessEnv; timeoutMs: number },
+          ) => {
+            calls.push({ nodePath, args, options });
+          },
+        },
+      );
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0]!.args[0], watcherPath);
+      assert.equal(calls[0]!.args[6], hookPath);
+      assert.equal(calls[0]!.options.env.OMX_HUD_AUTHORITY, '1');
+    } finally {
+      await rm(packageRoot, { recursive: true, force: true });
+      await rm(cwd, { recursive: true, force: true });
+      await rm(cliRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -177,6 +177,111 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.paneId, '%9');
   });
 
+
+  it('reaps a stale HUD pane for the same leader after the leader resumes with a new session id', async () => {
+    const killed: string[] = [];
+    const created: Array<{ options?: { targetPaneId?: string } }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%stale-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%new-hud';
+      },
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.deepEqual(killed, ['%stale-hud']);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%new-hud');
+    assert.equal(created.length, 1);
+    assert.equal(created[0]?.options?.targetPaneId, '%leader');
+  });
+
+  it('reaps a stale same-leader HUD even when a current-session HUD already exists', async () => {
+    const killed: string[] = [];
+    const created: string[] = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%current-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-new' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+        },
+        {
+          paneId: '%stale-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: () => {
+        created.push('create');
+        return '%new-hud';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.deepEqual(killed, ['%stale-hud']);
+    assert.deepEqual(created, []);
+    assert.equal(result.status, 'resized');
+    assert.equal(result.paneId, '%current-hud');
+    assert.deepEqual(resized, [{ paneId: '%current-hud', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+  });
+
+  it('does not reap a different-session HUD pane owned by a neighboring live leader', async () => {
+    const killed: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%left', OMX_SESSION_ID: 'sess-left', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%left', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%right', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%right-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-right' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%right' node omx hud --watch --preset=focused`,
+        },
+      ],
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: () => '%left-hud',
+      resizeTmuxPane: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.deepEqual(killed, []);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%left-hud');
+  });
+
   it('does not reap an orphaned HUD pane that belongs to a different session', async () => {
     // A HUD owned by another session's leader (which may live in a different tmux
     // window we cannot see here) must survive even when that leader is absent.

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -212,8 +212,8 @@ describe('renderHud – code-review', () => {
       codeReview: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
     };
     const result = stripSgr(renderHud(ctx, 'focused'));
-    assert.ok(result.includes('code-review:autopilot'));
-    assert.equal(result.includes('autopilot:code-review'), false);
+    assert.ok(result.includes('autopilot:code-review'));
+    assert.equal(result.includes('code-review:running'), false);
   });
 
   it('drops mismatched autopilot-derived late gate labels', () => {
@@ -224,9 +224,9 @@ describe('renderHud – code-review', () => {
       ultraqa: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
     };
     const result = stripSgr(renderHud(ctx, 'focused'));
-    assert.ok(result.includes('code-review:autopilot'));
+    assert.ok(result.includes('autopilot:code-review'));
     assert.equal(result.includes('qa:autopilot'), false);
-    assert.equal(result.includes('autopilot:code-review'), false);
+    assert.equal(result.includes('autopilot:ultraqa'), false);
   });
 
   it('keeps autopilot visible when only a mismatched derived late gate exists', () => {
@@ -268,8 +268,8 @@ describe('renderHud – ultraqa', () => {
       ultraqa: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
     };
     const result = stripSgr(renderHud(ctx, 'focused'));
-    assert.ok(result.includes('qa:autopilot'));
-    assert.equal(result.includes('autopilot:ultraqa'), false);
+    assert.ok(result.includes('autopilot:ultraqa'));
+    assert.equal(result.includes('qa:autopilot'), false);
   });
 });
 

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -415,10 +415,10 @@ describe('HUD pane ownership helpers', () => {
         `%5\tnode\texec env OMX_SESSION_ID='sess-b' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
       ].join('\n'),
     );
-
+    
     assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2', '%4']);
     assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%3' }), ['%3', '%4']);
-    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), []);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), ['%2', '%5']);
   });
 
   it('does not match session-owned HUD panes when only leader ownership is requested', () => {
@@ -430,7 +430,7 @@ describe('HUD pane ownership helpers', () => {
       ].join('\n'),
     );
 
-    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), []);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), ['%2', '%3']);
   });
 
   it('does not match leader-only legacy HUD panes when a session owner is requested', () => {

--- a/src/hud/authority.ts
+++ b/src/hud/authority.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { getPackageRoot } from '../utils/package.js';
+import { resolveOmxCliEntryPath } from '../utils/paths.js';
 
 export interface RunHudAuthorityTickOptions {
   cwd: string;
@@ -117,6 +118,20 @@ function parseIsoMs(value: unknown): number | null {
 
 function isNotFoundError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+function resolveHudWatcherScript(packageRoot: string, scriptName: 'notify-fallback-watcher.js' | 'notify-hook.js', cwd: string, env: NodeJS.ProcessEnv): string {
+  const packageScript = join(packageRoot, 'dist', 'scripts', scriptName);
+  if (existsSync(packageScript)) return packageScript;
+
+  const entryPath = resolveOmxCliEntryPath({ cwd, env });
+  if (entryPath && entryPath.endsWith('/dist/cli/omx.js')) {
+    const entryRoot = dirname(dirname(dirname(entryPath)));
+    const entryScript = join(entryRoot, 'dist', 'scripts', scriptName);
+    if (existsSync(entryScript)) return entryScript;
+  }
+
+  return packageScript;
 }
 
 function isAuthorityStatus(value: unknown): value is HudAuthorityState['last_status'] {
@@ -351,8 +366,9 @@ export async function runHudAuthorityTick(
   const nowMs = deps.nowMs?.() ?? Date.now();
   const random = deps.random ?? Math.random;
   const jitterMs = jitterMaxMs > 0 ? Math.floor(random() * (jitterMaxMs + 1)) : 0;
-  const watcherScript = join(packageRoot, 'dist', 'scripts', 'notify-fallback-watcher.js');
-  const notifyScript = join(packageRoot, 'dist', 'scripts', 'notify-hook.js');
+  const mergedEnv = { ...process.env, ...options.env };
+  const watcherScript = resolveHudWatcherScript(packageRoot, 'notify-fallback-watcher.js', cwd, mergedEnv);
+  const notifyScript = resolveHudWatcherScript(packageRoot, 'notify-hook.js', cwd, mergedEnv);
   const authorityStateDir = join(cwd, '.omx', 'state');
   const authorityOwnerPath = join(authorityStateDir, 'notify-fallback-authority-owner.json');
   const authorityStatePath = join(authorityStateDir, 'notify-fallback-authority-state.json');

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -429,10 +429,7 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
   const leaderPaneId = currentPaneId;
   const sessionId = process.env.OMX_SESSION_ID?.trim() || undefined;
   const existingHudPaneIds = leaderPaneId || sessionId
-    ? listCurrentWindowHudPaneIds(leaderPaneId, undefined, {
-        sessionId,
-        leaderPaneId,
-      })
+    ? listCurrentWindowHudPaneIds(leaderPaneId, undefined, leaderPaneId ? { leaderPaneId } : { sessionId })
     : [];
   if (existingHudPaneIds.length >= 1) {
     const [keeperPaneId, ...duplicatePaneIds] = existingHudPaneIds;

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -79,6 +79,36 @@ function reapOrphanedSessionHudPanes(
   return reaped;
 }
 
+function hasExplicitHudOwnerMarker(pane: TmuxPaneSnapshot): boolean {
+  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  return new RegExp(`(?:^|\\s)${OMX_TMUX_HUD_OWNER_ENV}=(?:'1'|1)(?=$|\\s)`).test(command);
+}
+
+function reapStaleCurrentLeaderHudPanes(
+  panes: TmuxPaneSnapshot[],
+  opts: {
+    sessionIds: string[];
+    currentPaneId: string | undefined;
+    killPane: (paneId: string) => boolean;
+  },
+): string[] {
+  const { currentPaneId, killPane } = opts;
+  if (!currentPaneId) return [];
+  const currentSessionIds = new Set(opts.sessionIds.map((sessionId) => sessionId.trim()).filter(Boolean));
+  if (currentSessionIds.size === 0) return [];
+
+  const reaped: string[] = [];
+  for (const pane of panes) {
+    if (!isHudWatchPane(pane)) continue;
+    const owner = readHudPaneOwner(pane);
+    if (owner.leaderPaneId !== currentPaneId) continue;
+    if (!hasExplicitHudOwnerMarker(pane)) continue;
+    if (!owner.sessionId || currentSessionIds.has(owner.sessionId)) continue;
+    if (killPane(pane.paneId)) reaped.push(pane.paneId);
+  }
+  return reaped;
+}
+
 export interface ReconcileHudForPromptSubmitResult {
   status:
     | 'skipped_not_tmux'
@@ -240,6 +270,22 @@ export async function reconcileHudForPromptSubmit(
   });
   if (reapedOrphanPaneIds.length > 0) {
     const reapedPaneIdSet = new Set(reapedOrphanPaneIds);
+    panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
+  }
+
+  // A Codex self-update can restart/resume the leader in the same tmux pane with
+  // a new OMX session id while the old HUD watcher stays alive. That stale HUD
+  // still names the current leader pane, but with the previous session id, so it
+  // does not match same-owner dedupe and the next launch would create a second HUD
+  // beside it. Reap only HUDs tied to this exact leader pane; neighboring panes'
+  // HUDs remain isolated by leaderPaneId.
+  const reapedStaleLeaderPaneIds = reapStaleCurrentLeaderHudPanes(panes, {
+    sessionIds: equivalentSessionIds,
+    currentPaneId,
+    killPane,
+  });
+  if (reapedStaleLeaderPaneIds.length > 0) {
+    const reapedPaneIdSet = new Set(reapedStaleLeaderPaneIds);
     panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
   }
 

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -134,6 +134,9 @@ function renderCodeReview(ctx: HudRenderContext): string | null {
   if (!ctx.codeReview) return null;
   if (ctx.codeReview.source === 'autopilot' && !isAutopilotLateGateSource(ctx, 'code-review')) return null;
   const phase = sanitizeDynamicText(ctx.codeReview.current_phase || 'active') || 'active';
+  if (ctx.codeReview.source === 'autopilot') {
+    return green(`autopilot:code-review`);
+  }
   return green(`code-review:${phase}`);
 }
 
@@ -141,6 +144,9 @@ function renderUltraqa(ctx: HudRenderContext): string | null {
   if (!ctx.ultraqa) return null;
   if (ctx.ultraqa.source === 'autopilot' && !isAutopilotLateGateSource(ctx, 'ultraqa')) return null;
   const phase = sanitizeDynamicText(ctx.ultraqa.current_phase || 'active') || 'active';
+  if (ctx.ultraqa.source === 'autopilot') {
+    return green(`autopilot:ultraqa`);
+  }
   return green(`qa:${phase}`);
 }
 

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -218,13 +218,14 @@ export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner 
   const paneOwner = readHudPaneOwner(pane);
   const sessionMatches = wantsSession && wantedSessionIds.includes(paneOwner.sessionId ?? '');
   const leaderPaneMatches = wantsLeaderPane && paneOwner.leaderPaneId === wantedLeaderPaneId;
+  const hasLeaderTag = paneOwner.leaderPaneId !== undefined && paneOwner.leaderPaneId !== '';
 
   if (wantsSession && wantsLeaderPane) {
-    if (!sessionMatches) return false;
-    return !paneOwner.leaderPaneId || leaderPaneMatches;
+    if (hasLeaderTag) return sessionMatches && leaderPaneMatches;
+    return sessionMatches;
   }
   if (wantsSession) return sessionMatches;
-  return leaderPaneMatches && !paneOwner.sessionId;
+  return leaderPaneMatches;
 }
 
 export function findHudWatchPaneIds(

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -16,6 +16,7 @@ import {
   shouldAutoStartMcpServer,
   shouldSelfExitForDuplicateSibling,
   shouldSelfExitForPreTrafficSiblingHardCap,
+  shouldSelfExitForPostTrafficSiblingHardCap,
   type McpServerName,
 } from '../bootstrap.js';
 import {
@@ -559,6 +560,65 @@ describe('mcp duplicate sibling detection', () => {
       shouldSelfExitForPreTrafficSiblingHardCap(oldest, null, 0),
       false,
       'zero disables the hard cap',
+    );
+  });
+
+  it('hard-caps post-traffic superseded siblings kept warm by a long-lived parent', () => {
+    const processes = [
+      { pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 102, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 103, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 104, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 105, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+    ];
+
+    const oldest = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    const secondOldest = analyzeDuplicateSiblingState(processes, 102, 55, 'state-server.js');
+
+    // Keepalive traffic at t=60_000 would forever defer the last-traffic idle
+    // window, but the oldest over-cap sibling has been superseded since t=0, so
+    // the post-traffic hard cap reaps it once the idle window elapses.
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(oldest, 60_000, 0, 60_000, 4, 60_000),
+      true,
+      'oldest over-cap sibling self-exits despite continuous keepalive traffic',
+    );
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(secondOldest, 60_000, 0, 60_000, 4, 60_000),
+      false,
+      'the newest four post-traffic contexts are always preserved',
+    );
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(oldest, 59_999, 0, 0, 4, 60_000),
+      false,
+      'must stay superseded for the full idle window before reaping',
+    );
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(oldest, 60_000, 0, null, 4, 60_000),
+      false,
+      'pre-traffic siblings are handled by the pre-traffic hard cap',
+    );
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(oldest, 60_000, 0, 60_000, 0, 60_000),
+      false,
+      'zero disables the post-traffic hard cap',
+    );
+  });
+
+  it('does not post-traffic hard-cap same-parent siblings within the retained window', () => {
+    const processes = [
+      { pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 102, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 103, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 104, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+    ];
+
+    const oldest = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    assert.equal(oldest.status, 'older_duplicate');
+    assert.equal(
+      shouldSelfExitForPostTrafficSiblingHardCap(oldest, 600_000, 0, 600_000, 4, 60_000),
+      false,
+      'at-or-below the cap, distinct client contexts are preserved',
     );
   });
 });

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -425,6 +425,35 @@ export function shouldSelfExitForPreTrafficSiblingHardCap(
   return observation.newerSiblingPids.length >= maxSiblingsPerEntrypoint;
 }
 
+export function shouldSelfExitForPostTrafficSiblingHardCap(
+  observation: DuplicateSiblingObservation,
+  nowMs: number,
+  duplicateObservedAtMs: number | null,
+  lastTrafficAtMs: number | null,
+  maxSiblingsPerEntrypoint = DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT,
+  postTrafficIdleMs = DEFAULT_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
+): boolean {
+  if (observation.status !== 'older_duplicate') return false;
+  // Pre-traffic siblings are reaped by shouldSelfExitForPreTrafficSiblingHardCap.
+  if (lastTrafficAtMs === null) return false;
+  if (!Number.isInteger(maxSiblingsPerEntrypoint) || maxSiblingsPerEntrypoint <= 0) return false;
+  if (observation.matchingPids.length <= maxSiblingsPerEntrypoint) return false;
+  // Only the oldest siblings beyond the retained window are eligible; the newest N
+  // same-parent same-entrypoint contexts are always preserved.
+  if (observation.newerSiblingPids.length < maxSiblingsPerEntrypoint) return false;
+  if (duplicateObservedAtMs === null) return false;
+  if (!Number.isFinite(nowMs) || duplicateObservedAtMs > nowMs) return false;
+  if (!Number.isFinite(lastTrafficAtMs) || lastTrafficAtMs > nowMs) return false;
+
+  // Measure the idle window from the duplicate observation rather than the last
+  // stdin byte. A long-lived Codex.app parent can keep superseded first-party
+  // siblings warm with periodic keepalive traffic, which would otherwise reset
+  // the post-traffic idle timer forever and let same-parent same-entrypoint
+  // duplicates accumulate without bound. Once a sibling has stayed superseded for
+  // the full idle window while still over the cap, reap it.
+  return nowMs - duplicateObservedAtMs >= postTrafficIdleMs;
+}
+
 export function isParentProcessAlive(
   parentPid: number,
   signalProcess: typeof process.kill = process.kill,
@@ -558,6 +587,18 @@ export function autoStartStdioMcpServer(
         lifecycleTiming.maxSiblingsPerEntrypoint,
       )) {
         void shutdown('superseded_hard_cap_pre_traffic');
+        return;
+      }
+
+      if (shouldSelfExitForPostTrafficSiblingHardCap(
+        observation,
+        Date.now(),
+        duplicateObservedAtMs,
+        lastTrafficAtMs,
+        lifecycleTiming.maxSiblingsPerEntrypoint,
+        lifecycleTiming.duplicateSiblingPostTrafficIdleMs,
+      )) {
+        void shutdown('superseded_hard_cap_post_traffic');
         return;
       }
 

--- a/src/modes/__tests__/base-autopilot-gates.test.ts
+++ b/src/modes/__tests__/base-autopilot-gates.test.ts
@@ -1,0 +1,177 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { cancelMode, updateModeState } from '../base.js';
+
+async function writeAutopilotState(wd: string, state: Record<string, unknown>): Promise<void> {
+  await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+  await writeFile(join(wd, '.omx', 'state', 'autopilot-state.json'), JSON.stringify({
+    active: true,
+    mode: 'autopilot',
+    iteration: 1,
+    max_iterations: 10,
+    started_at: '2026-06-09T00:00:00.000Z',
+    ...state,
+  }, null, 2));
+}
+
+describe('modes/base Autopilot gate integration', () => {
+  it('updateModeState rejects direct deep-interview to ultragoal skips', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-deep-skip-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'deep-interview' });
+      await assert.rejects(
+        () => updateModeState('autopilot', { current_phase: 'ultragoal' }, wd),
+        /Cannot skip Autopilot ralplan gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects direct deep-interview to ultragoal skips even with user-supplied pipeline fields', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-deep-skip-pipeline-fields-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'deep-interview' });
+      await assert.rejects(
+        () => updateModeState('autopilot', {
+          current_phase: 'ultragoal',
+          pipeline_stage_index: 2,
+        }, wd),
+        /Cannot skip Autopilot ralplan gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects ralplan to code-review skips', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-skip-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'ralplan' });
+      await assert.rejects(
+        () => updateModeState('autopilot', { current_phase: 'code-review' }, wd),
+        /Cannot skip Autopilot ultragoal gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects ralplan to code-review skips even with user-supplied pipeline fields', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-skip-pipeline-fields-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'ralplan' });
+      await assert.rejects(
+        () => updateModeState('autopilot', {
+          current_phase: 'code-review',
+          pipeline_stage_results: {},
+        }, wd),
+        /Cannot skip Autopilot ultragoal gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects ralplan completion before ultragoal', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-complete-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'ralplan' });
+      await assert.rejects(
+        () => updateModeState('autopilot', { active: false, current_phase: 'complete' }, wd),
+        /Cannot complete Autopilot before ultragoal gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects ralplan to ultragoal without tracker-backed native consensus', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-no-native-'));
+    try {
+      await writeAutopilotState(wd, {
+        current_phase: 'ralplan',
+        state: {
+          handoff_artifacts: {
+            ralplan: {
+              ralplan_consensus_gate: {
+                complete: true,
+                evidence_kind: 'codex_exec',
+              },
+            },
+          },
+        },
+      });
+      await assert.rejects(
+        () => updateModeState('autopilot', { current_phase: 'ultragoal' }, wd),
+        /Cannot transition ralplan -> ultragoal/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState rejects ralplan to ultragoal without native consensus even with user-supplied pipeline fields', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-no-native-pipeline-fields-'));
+    try {
+      await writeAutopilotState(wd, {
+        current_phase: 'ralplan',
+        state: {
+          handoff_artifacts: {
+            ralplan: {
+              ralplan_consensus_gate: {
+                complete: true,
+                evidence_kind: 'codex_exec',
+              },
+            },
+          },
+        },
+      });
+      await assert.rejects(
+        () => updateModeState('autopilot', {
+          current_phase: 'ultragoal',
+          pipeline_stage_index: 2,
+          pipeline_stage_results: {},
+        }, wd),
+        /Cannot transition ralplan -> ultragoal/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState does not persist user-supplied trustedPipelineProgress as state data', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-trusted-field-strip-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'ultraqa' });
+      await updateModeState('autopilot', {
+        current_phase: 'ultraqa',
+        trustedPipelineProgress: true,
+      }, wd);
+
+      const raw = JSON.parse(await readFile(join(wd, '.omx', 'state', 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(Object.prototype.hasOwnProperty.call(raw, 'trustedPipelineProgress'), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('cancelMode allows Autopilot cancellation from a gated implementation phase', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-cancel-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'ultragoal' });
+      await cancelMode('autopilot', wd);
+
+      const raw = JSON.parse(await readFile(join(wd, '.omx', 'state', 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(raw.active, false);
+      assert.equal(raw.current_phase, 'cancelled');
+      assert.equal(raw.run_outcome, 'cancelled');
+      assert.ok(typeof raw.completed_at === 'string' && raw.completed_at.length > 0);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -15,6 +15,10 @@ import { reconcileWorkflowTransition } from '../state/workflow-transition-reconc
 import { syncCanonicalSkillStateForMode } from '../state/skill-active.js';
 import { validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
+import { validateAutopilotCompletionTransition } from '../autopilot/completion-gate.js';
+import { canAdvanceAutopilotDeepInterviewToRalplan, buildAutopilotDeepInterviewRalplanGateError } from '../autopilot/deep-interview-gate.js';
+import { canAdvanceAutopilotRalplanToUltragoal, buildAutopilotRalplanUltragoalGateError } from '../autopilot/ralplan-gate.js';
+import { deriveAutopilotChildPhase, type AutopilotChildPhase } from '../autopilot/fsm.js';
 import { syncRunStateFromModeState } from '../runtime/run-state.js';
 import {
   getAuthoritativeActiveStatePaths,
@@ -45,11 +49,47 @@ export type ModeName = 'autopilot' | 'autoresearch' | 'deep-interview' | 'ralph'
 /** @deprecated These mode names were removed in v4.6. Use the canonical modes instead. */
 export type DeprecatedModeName = 'ultrapilot' | 'pipeline' | 'ecomode';
 
+export interface UpdateModeStateOptions {
+  trustedPipelineProgress?: boolean;
+}
+
 const DEPRECATED_MODES: Record<DeprecatedModeName, string> = {
   ultrapilot: 'Use "team" instead. ultrapilot has been merged into team mode.',
   pipeline: 'Use "team" instead. pipeline has been merged into team mode.',
   ecomode: 'Use "ultrawork" instead. ecomode has been merged into ultrawork mode.',
 };
+
+const AUTOPILOT_CHILD_PHASE_ORDER: AutopilotChildPhase[] = [
+  'deep-interview',
+  'ralplan',
+  'ultragoal',
+  'team',
+  'ralph',
+  'code-review',
+  'ultraqa',
+];
+
+function autopilotPhaseOrder(phase: AutopilotChildPhase | null): number {
+  return phase ? AUTOPILOT_CHILD_PHASE_ORDER.indexOf(phase) : -1;
+}
+
+function isForwardAutopilotPhase(
+  currentPhase: AutopilotChildPhase | null,
+  nextPhase: AutopilotChildPhase | null,
+): boolean {
+  const currentOrder = autopilotPhaseOrder(currentPhase);
+  const nextOrder = autopilotPhaseOrder(nextPhase);
+  return currentOrder >= 0 && nextOrder > currentOrder;
+}
+
+function isNextAutopilotPhase(
+  currentPhase: AutopilotChildPhase | null,
+  nextPhase: AutopilotChildPhase | null,
+): boolean {
+  const currentOrder = autopilotPhaseOrder(currentPhase);
+  const nextOrder = autopilotPhaseOrder(nextPhase);
+  return currentOrder >= 0 && nextOrder === currentOrder + 1;
+}
 
 /**
  * Check if a mode name is deprecated and return a warning message if so.
@@ -236,6 +276,7 @@ export async function updateModeState(
   updates: Partial<ModeState>,
   projectRoot?: string,
   explicitSessionId?: string,
+  options: UpdateModeStateOptions = {},
 ): Promise<ModeState> {
   const scope = await resolveStateScope(projectRoot, explicitSessionId);
   const baseStateDir = getBaseStateDir(projectRoot);
@@ -252,6 +293,7 @@ export async function updateModeState(
   }
 
   const updatedBase = { ...current, ...updates };
+  delete updatedBase.trustedPipelineProgress;
   if (!Object.prototype.hasOwnProperty.call(updates, 'run_outcome')) {
     delete updatedBase.run_outcome;
   }
@@ -259,6 +301,58 @@ export async function updateModeState(
     updatedBase.owner_omx_session_id = scope.sessionId;
   }
   const normalizedBase = normalizeModeStateOrThrow(mode, updatedBase as ModeState);
+  if (mode === 'autopilot') {
+    const isPipelineOrchestratorProgressWrite = options.trustedPipelineProgress === true;
+    const currentAutopilotChildPhase = deriveAutopilotChildPhase({ ...current, mode: 'autopilot' });
+    const nextAutopilotChildPhase = deriveAutopilotChildPhase({ ...normalizedBase, mode: 'autopilot' });
+    const completionTransitionError = validateAutopilotCompletionTransition(
+      current as Record<string, unknown>,
+      normalizedBase as Record<string, unknown>,
+      { allowUnknownActivePhaseCompletion: options.trustedPipelineProgress === true },
+    );
+    if (completionTransitionError) throw new Error(completionTransitionError);
+    if (!isPipelineOrchestratorProgressWrite) {
+      if (
+        currentAutopilotChildPhase === 'deep-interview'
+        && isForwardAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+        && !isNextAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+      ) {
+        throw new Error('Cannot skip Autopilot ralplan gate: deep-interview may only advance to ralplan.');
+      }
+      if (
+        currentAutopilotChildPhase === 'deep-interview'
+        && isNextAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+      ) {
+        const gate = await canAdvanceAutopilotDeepInterviewToRalplan({
+          cwd: projectRoot ?? process.cwd(),
+          sessionId: scope.sessionId,
+          baseStateDir,
+          currentState: current as Record<string, unknown>,
+          nextState: normalizedBase as Record<string, unknown>,
+        });
+        if (!gate.allowed) throw new Error(buildAutopilotDeepInterviewRalplanGateError(gate));
+      }
+      if (
+        currentAutopilotChildPhase === 'ralplan'
+        && isForwardAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+        && !isNextAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+      ) {
+        throw new Error('Cannot skip Autopilot ultragoal gate: ralplan may only advance to ultragoal.');
+      }
+      if (
+        currentAutopilotChildPhase === 'ralplan'
+        && isNextAutopilotPhase(currentAutopilotChildPhase, nextAutopilotChildPhase)
+      ) {
+        const gate = canAdvanceAutopilotRalplanToUltragoal({
+          cwd: projectRoot ?? process.cwd(),
+          sessionId: scope.sessionId,
+          currentState: current as Record<string, unknown>,
+          nextState: normalizedBase as Record<string, unknown>,
+        });
+        if (!gate.allowed) throw new Error(buildAutopilotRalplanUltragoalGateError(gate));
+      }
+    }
+  }
   const updated = withModeRuntimeContext(current, normalizedBase) as ModeState;
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(updated, null, 2));
   await syncRunStateFromModeState(updated, projectRoot, scope.sessionId);

--- a/src/pipeline/__tests__/orchestrator.test.ts
+++ b/src/pipeline/__tests__/orchestrator.test.ts
@@ -188,8 +188,24 @@ describe('Pipeline Orchestrator', () => {
                   recommendation: clean ? 'APPROVE' : 'REQUEST CHANGES',
                   architectural_status: 'CLEAR',
                   clean,
+                  stage: 'code-review',
+                  artifact_path: '.omx/reviews/review-loop.json',
                 },
                 return_to_ralplan_reason: clean ? null : 'Review requested a plan update.',
+              },
+              duration_ms: 0,
+            };
+          },
+        },
+        {
+          name: 'ultraqa',
+          async run(): Promise<StageResult> {
+            order.push('ultraqa');
+            return {
+              status: 'completed',
+              artifacts: {
+                qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/1' },
+                return_to_ralplan_reason: null,
               },
               duration_ms: 0,
             };
@@ -206,7 +222,7 @@ describe('Pipeline Orchestrator', () => {
       });
 
       assert.equal(result.status, 'completed');
-      assert.deepEqual(order, ['ralplan', 'ralph', 'code-review', 'ralplan', 'ralph', 'code-review']);
+      assert.deepEqual(order, ['ralplan', 'ralph', 'code-review', 'ralplan', 'ralph', 'code-review', 'ultraqa']);
 
       const ext = await readPipelineState(tempDir);
       assert.equal(ext?.review_cycle, 1);
@@ -237,7 +253,7 @@ describe('Pipeline Orchestrator', () => {
         makeStage('ultragoal', { artifacts: { implemented: true } }),
         makeStage('code-review', {
           artifacts: {
-            review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/default-quality.json' },
             return_to_ralplan_reason: null,
           },
         }),
@@ -250,7 +266,7 @@ describe('Pipeline Orchestrator', () => {
             return {
               status: 'completed',
               artifacts: {
-                qa_verdict: { clean, skipped: false, summary: clean ? 'QA clean.' : 'QA found a regression.' },
+                qa_verdict: { stage: 'ultraqa', clean, skipped: false, summary: clean ? 'QA clean.' : 'QA found a regression.', url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/2' },
                 return_to_ralplan_reason: clean ? null : 'QA found a regression.',
               },
               duration_ms: 0,

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -129,7 +129,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
         pipeline_stage_index: i,
         pipeline_stage_results: { ...stageResults },
         handoff_artifacts: normalizeHandoffArtifactKeys(handoffArtifactsByStage),
-      } as Partial<PipelineModeStateExtension>, cwd);
+      } as Partial<PipelineModeStateExtension>, cwd, undefined, { trustedPipelineProgress: true });
 
       lastStageName = stage.name;
       previousResult = skippedResult;
@@ -141,7 +141,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       current_phase: stage.name,
       pipeline_stage_index: i,
       iteration: i + 1,
-    } as Partial<PipelineModeStateExtension>, cwd);
+    } as Partial<PipelineModeStateExtension>, cwd, undefined, { trustedPipelineProgress: true });
 
     // Execute the stage
     let result: StageResult;
@@ -210,7 +210,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
       } : {}),
       pipeline_stage_index: shouldReturnToRalplan ? findStageIndex(config.stages, 'ralplan') : i,
       pipeline_stage_results: { ...stageResults },
-    } as Partial<PipelineModeStateExtension>, cwd);
+    } as Partial<PipelineModeStateExtension>, cwd, undefined, { trustedPipelineProgress: true });
 
     // Bail on failure
     if (result.status === 'failed') {
@@ -277,7 +277,7 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     active: false,
     current_phase: 'complete',
     completed_at: new Date().toISOString(),
-  }, cwd);
+  }, cwd, undefined, { trustedPipelineProgress: true });
 
   return {
     status: 'completed',

--- a/src/pipeline/stages/code-review.ts
+++ b/src/pipeline/stages/code-review.ts
@@ -33,7 +33,10 @@ export interface CodeReviewVerdict {
   architectural_status: 'CLEAR' | 'WATCH' | 'BLOCK';
   clean: boolean;
   summary: string;
+  stage: 'code-review';
+  artifact_path: string;
 }
+
 
 export function createCodeReviewStage(options: CodeReviewStageOptions = {}): PipelineStage {
   return {
@@ -62,6 +65,8 @@ export function createCodeReviewStage(options: CodeReviewStageOptions = {}): Pip
         summary: options.summary ?? (hasReviewEvidence
           ? (clean ? 'Review clean.' : 'Review returned findings; return to ralplan.')
           : 'Code-review evidence missing; fail closed and return to ralplan.'),
+        stage: 'code-review',
+        artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.code-review.artifacts.review_verdict',
       };
 
       return {

--- a/src/pipeline/stages/ultraqa.ts
+++ b/src/pipeline/stages/ultraqa.ts
@@ -30,7 +30,11 @@ export interface UltraqaVerdict {
   clean: boolean;
   skipped: boolean;
   summary: string;
+  stage: 'ultraqa';
+  artifact_path: string;
+  reason?: string;
 }
+
 
 export function createUltraqaStage(options: UltraqaStageOptions = {}): PipelineStage {
   return {
@@ -55,6 +59,9 @@ export function createUltraqaStage(options: UltraqaStageOptions = {}): PipelineS
         summary: options.summary ?? (hasQaEvidence
           ? (clean ? 'UltraQA gate clean.' : 'UltraQA found issues; return to ralplan.')
           : 'UltraQA evidence missing; fail closed and return to ralplan.'),
+        stage: 'ultraqa',
+        artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.ultraqa.artifacts.qa_verdict',
+        ...(skipped ? { reason: options.summary ?? 'UltraQA explicitly skipped.' } : {}),
       };
 
       return {

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -286,9 +286,11 @@ function trackerBackedNativeReviewProblem(
   agentRole: 'architect' | 'critic',
   options: RalplanNativeSubagentConsensusOptions,
 ): string | null {
+  const issues: string[] = [];
+
   if (!review) return `${agentRole} review is missing`;
-  if (review.agent_role !== agentRole) return `${agentRole} review has agent_role=${String(review.agent_role || 'missing')}`;
-  if (review.provenance_kind !== 'native_subagent') return `${agentRole} review has provenance_kind=${String(review.provenance_kind || 'missing')}`;
+  if (review.agent_role !== agentRole) issues.push(`${agentRole} review has agent_role=${String(review.agent_role || 'missing')}`);
+  if (review.provenance_kind !== 'native_subagent') issues.push(`${agentRole} review has provenance_kind=${String(review.provenance_kind || 'missing')}`);
   const sessionId = typeof options.sessionId === 'string' && options.sessionId.trim()
     ? options.sessionId.trim()
     : typeof review.session_id === 'string'
@@ -298,14 +300,17 @@ function trackerBackedNativeReviewProblem(
   const threadId = typeof review.thread_id === 'string' ? review.thread_id.trim() : '';
   const artifactPath = typeof review.artifact_path === 'string' ? review.artifact_path.trim() : '';
   const trackerPath = typeof review.tracker_path === 'string' ? review.tracker_path.trim() : '';
-  if (!sessionId) return `${agentRole} review cannot resolve session_id`;
-  if (!reviewSessionId || reviewSessionId !== sessionId) return `${agentRole} review session_id=${reviewSessionId || 'missing'} does not match ${sessionId}`;
-  if (!threadId) return `${agentRole} review missing thread_id`;
-  if (!artifactPath) return `${agentRole} review missing artifact_path`;
-  if (!trackerPath || !trackerPath.endsWith('subagent-tracking.json')) return `${agentRole} review missing subagent-tracking.json tracker_path`;
-  if (!options.cwd) return `${agentRole} review cannot resolve cwd for tracker lookup`;
+  if (!sessionId) issues.push(`${agentRole} review cannot resolve session_id`);
+  if (!reviewSessionId || reviewSessionId !== sessionId) issues.push(`${agentRole} review session_id=${reviewSessionId || 'missing'} does not match ${sessionId || 'missing'}`);
+  if (!threadId) issues.push(`${agentRole} review missing thread_id`);
+  if (!artifactPath) issues.push(`${agentRole} review missing artifact_path`);
+  if (!trackerPath || !trackerPath.endsWith('subagent-tracking.json')) issues.push(`${agentRole} review missing subagent-tracking.json tracker_path`);
+  const cwd = typeof options.cwd === 'string' ? options.cwd.trim() : '';
+  if (!cwd) issues.push(`${agentRole} review cannot resolve cwd for tracker lookup`);
 
-  const expectedTrackerPath = subagentTrackingPath(options.cwd);
+  if (issues.length > 0) return issues.join('; ');
+
+  const expectedTrackerPath = subagentTrackingPath(cwd);
   const tracking = readJsonState(expectedTrackerPath);
   const session = asRecord(asRecord(tracking?.sessions)?.[sessionId]);
   const thread = asRecord(asRecord(session?.threads)?.[threadId]);

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -2385,6 +2385,589 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('denies Autopilot implementation-phase completion before the code-review gate', async () => {
+    for (const phase of ['ultragoal', 'team', 'ralph']) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-${phase}-complete-deny-`));
+      try {
+        await withOmxRootEnv(wd, async () => {
+          const sessionId = `sess-autopilot-${phase}-complete-deny`;
+          const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+          await mkdir(sessionDir, { recursive: true });
+          await writeFile(
+            join(sessionDir, 'autopilot-state.json'),
+            JSON.stringify({
+              active: true,
+              mode: 'autopilot',
+              current_phase: phase,
+              state: { handoff_artifacts: { ultragoal: { verification: 'passed' } } },
+            }, null, 2),
+          );
+
+          const response = await executeStateOperation('state_write', {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'autopilot',
+            active: false,
+            current_phase: 'complete',
+            state: {
+              review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+              qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/1' },
+            },
+          });
+
+          assert.equal(response.isError, true);
+          assert.match(String((response.payload as { error?: string }).error || ''), /Cannot complete Autopilot before code-review gate/i);
+          const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+          assert.equal(state.active, true);
+          assert.equal(state.current_phase, phase);
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('denies Autopilot implementation-phase skip directly to ultraqa', async () => {
+    for (const phase of ['ultragoal', 'team', 'ralph']) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-${phase}-ultraqa-skip-deny-`));
+      try {
+        await withOmxRootEnv(wd, async () => {
+          const sessionId = `sess-autopilot-${phase}-ultraqa-skip-deny`;
+          const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+          await mkdir(sessionDir, { recursive: true });
+          await writeFile(
+            join(sessionDir, 'autopilot-state.json'),
+            JSON.stringify({
+              active: true,
+              mode: 'autopilot',
+              current_phase: phase,
+              state: { handoff_artifacts: { ultragoal: { verification: 'passed' } } },
+            }, null, 2),
+          );
+
+          const response = await executeStateOperation('state_write', {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'ultraqa',
+          });
+
+          assert.equal(response.isError, true);
+          assert.match(String((response.payload as { error?: string }).error || ''), /Cannot skip Autopilot code-review gate/i);
+          const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+          assert.equal(state.active, true);
+          assert.equal(state.current_phase, phase);
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('denies Autopilot code-review completion before the ultraqa gate', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-code-review-complete-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-code-review-complete-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'code-review',
+            state: {
+              handoff_artifacts: { code_review: { source: 'native-subagent' } },
+              review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          state: {
+            review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+            qa_verdict: { clean: true, skipped: false },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /Cannot complete Autopilot before ultraqa gate/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'code-review');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot ultraqa completion without clean review and QA evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-complete-evidence-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ultraqa-complete-evidence-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'ultraqa',
+            state: {
+              review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+              qa_verdict: null,
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          state: {
+            review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /without clean code-review and ultraqa verdict evidence/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'ultraqa');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot implementation and code-review terminalization via inactive ultraqa phase', async () => {
+    for (const phase of ['ultragoal', 'team', 'ralph', 'code-review']) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-${phase}-inactive-ultraqa-deny-`));
+      try {
+        await withOmxRootEnv(wd, async () => {
+          const sessionId = `sess-autopilot-${phase}-inactive-ultraqa-deny`;
+          const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+          await mkdir(sessionDir, { recursive: true });
+          await writeFile(
+            join(sessionDir, 'autopilot-state.json'),
+            JSON.stringify({ active: true, mode: 'autopilot', current_phase: phase }, null, 2),
+          );
+
+          const response = await executeStateOperation('state_write', {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'autopilot',
+            active: false,
+            current_phase: 'ultraqa',
+            state: {
+              review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+              qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/3' },
+            },
+          });
+
+          assert.equal(response.isError, true);
+          assert.match(String((response.payload as { error?: string }).error || ''), /Cannot (complete|skip) Autopilot/i);
+          const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+          assert.equal(state.active, true);
+          assert.equal(state.current_phase, phase);
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('denies Autopilot ultraqa completion when review and QA provenance are swapped', async () => {
+    const cases = [
+      {
+        name: 'swapped-stage',
+        review_verdict: { stage: 'ultraqa', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.ultraqa.artifacts.qa_verdict' },
+        qa_verdict: { stage: 'code-review', clean: true, skipped: false, artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.code-review.artifacts.review_verdict' },
+      },
+      {
+        name: 'swapped-artifact-path',
+        review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.ultraqa.artifacts.qa_verdict' },
+        qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.code-review.artifacts.review_verdict' },
+      },
+      {
+        name: 'review-uses-ultraqa-provenance',
+        review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/ultraqa/qa-verdict.json' },
+        qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, artifact_path: '.omx/qa/qa-verdict.json' },
+      },
+      {
+        name: 'qa-uses-code-review-provenance',
+        review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+        qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, artifact_path: '.omx/reviews/code-review.json' },
+      },
+      {
+        name: 'shared-neutral-provenance',
+        review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/evidence/shared.json' },
+        qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, artifact_path: '.omx/evidence/shared.json' },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-ultraqa-${testCase.name}-deny-`));
+      try {
+        await withOmxRootEnv(wd, async () => {
+          const sessionId = `sess-autopilot-ultraqa-${testCase.name}-deny`;
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ultraqa' }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          state: {
+            review_verdict: testCase.review_verdict,
+            qa_verdict: testCase.qa_verdict,
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /without clean code-review and ultraqa verdict evidence/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'ultraqa');
+      });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('denies Autopilot ultraqa completion with self-attested clean verdicts but no durable provenance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-self-attested-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ultraqa-self-attested-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'ultraqa',
+            state: {
+              review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+              qa_verdict: { clean: true, skipped: false },
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          state: {
+            review_verdict: { recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true },
+            qa_verdict: { clean: true, skipped: false },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /without clean code-review and ultraqa verdict evidence/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'ultraqa');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot ultraqa skipped completion without durable QA provenance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-skipped-no-provenance-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ultraqa-skipped-no-provenance-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ultraqa' }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          state: {
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+            qa_verdict: { stage: 'ultraqa', clean: true, skipped: true, reason: 'Docs-only change; QA not applicable.' },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /without clean code-review and ultraqa verdict evidence/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'ultraqa');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot completion from an unknown active phase', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-unknown-phase-complete-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-unknown-phase-complete-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'bogus',
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          completed_at: '2026-06-09T14:40:00.000Z',
+          state: {
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+            qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/5' },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /unknown active phase/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'bogus');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot completion from an unknown active phase when persisted state omits mode', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-unknown-phase-no-mode-complete-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-unknown-phase-no-mode-complete-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            current_phase: 'bogus',
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          completed_at: '2026-06-09T14:45:00.000Z',
+          state: {
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+            qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/6' },
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /unknown active phase/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'bogus');
+        assert.equal(Object.prototype.hasOwnProperty.call(state, 'mode'), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not persist user-supplied trustedPipelineProgress from Autopilot state_write', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-trusted-field-strip-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-trusted-field-strip';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            current_phase: 'ultraqa',
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: true,
+          current_phase: 'ultraqa',
+          trustedPipelineProgress: true,
+          state: {
+            trustedPipelineProgress: true,
+          },
+        });
+
+        assert.equal(response.isError, undefined);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(Object.prototype.hasOwnProperty.call(state, 'trustedPipelineProgress'), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows Autopilot state_write cancellation from gated phases without clean review and QA evidence', async () => {
+    for (const phase of ['deep-interview', 'ralplan', 'ultragoal', 'code-review']) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-${phase}-cancel-allow-`));
+      try {
+        await withOmxRootEnv(wd, async () => {
+          const sessionId = `sess-autopilot-${phase}-cancel-allow`;
+          const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+          await mkdir(sessionDir, { recursive: true });
+          await writeFile(
+            join(sessionDir, 'autopilot-state.json'),
+            JSON.stringify({
+              active: true,
+              current_phase: phase,
+            }, null, 2),
+          );
+
+          const response = await executeStateOperation('state_write', {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'autopilot',
+            active: false,
+            current_phase: 'cancelled',
+            completed_at: '2026-06-09T16:30:00.000Z',
+          });
+
+          assert.equal(response.isError, undefined);
+          const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+          assert.equal(state.active, false);
+          assert.equal(state.current_phase, 'cancelled');
+          assert.equal(state.run_outcome, 'cancelled');
+          assert.equal(state.completed_at, '2026-06-09T16:30:00.000Z');
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('allows Autopilot ultraqa completion with clean review and QA evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-complete-allow-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ultraqa-complete-allow';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'ultraqa',
+            state: {
+              review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+              qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/1' },
+            },
+          }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          completed_at: '2026-06-09T14:30:00.000Z',
+          state: {
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+            qa_verdict: { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/1' },
+          },
+        });
+
+        assert.equal(response.isError, undefined);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, false);
+        assert.equal(state.current_phase, 'complete');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows Autopilot ultraqa skipped completion with reason and durable QA provenance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-skipped-allow-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ultraqa-skipped-allow';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ultraqa' }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          completed_at: '2026-06-09T14:35:00.000Z',
+          state: {
+            review_verdict: { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review.json' },
+            qa_verdict: {
+              stage: 'ultraqa',
+              clean: true,
+              skipped: true,
+              reason: 'Docs-only change; QA not applicable.',
+              artifact_path: '.omx/state/autopilot-state.json#pipeline_stage_results.ultraqa.artifacts.qa_verdict',
+            },
+          },
+        });
+
+        assert.equal(response.isError, undefined);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, false);
+        assert.equal(state.current_phase, 'complete');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('allows Autopilot ralplan to ultragoal self-write with tracker-backed native consensus evidence', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ralplan-native-allow-'));
     try {

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -667,6 +667,72 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('does not list a mode active when terminal canonical visibility contradicts an active detail state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-terminal-canonical-wins-'));
+    try {
+      const sessionId = 'sess-terminal-visible';
+      const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'deep-interview',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: false,
+        skill: 'autopilot',
+        phase: 'complete',
+        completed_at: '2026-06-09T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+      }, null, 2));
+
+      const response = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+
+      assert.deepEqual(response.payload, { active_modes: [] });
+      const detailState = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(detailState.active, true);
+      assert.equal(detailState.current_phase, 'deep-interview');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the implicit current session canonical state when filtering list-active', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-terminal-canonical-implicit-'));
+    try {
+      const sessionId = 'sess-terminal-implicit';
+      const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'deep-interview',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: false,
+        skill: 'autopilot',
+        phase: 'complete',
+        completed_at: '2026-06-09T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+      }, null, 2));
+
+      const response = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+
+      assert.deepEqual(response.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('syncs canonical skill-active state for tracked mode writes and clears', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-canonical-'));
     try {

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -229,6 +229,96 @@ describe('skill-active state helpers', () => {
     });
   });
 
+  it('does not treat active_skills as active when the canonical state is terminal', async () => {
+    await withTempRepo('omx-skill-active-terminal-overrides-entries-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state', 'sessions', 'sess-terminal'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'sessions', 'sess-terminal', 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: false,
+        skill: 'autopilot',
+        phase: 'blocked_on_user',
+        completed_at: '2026-06-09T00:00:00.000Z',
+        session_id: 'sess-terminal',
+        active_skills: [{
+          skill: 'autopilot',
+          phase: 'deep-interview',
+          active: true,
+          session_id: 'sess-terminal',
+        }],
+      }, null, 2));
+
+      const sessionState = await readVisibleSkillActiveState(cwd, 'sess-terminal');
+
+      assert.ok(sessionState);
+      assert.equal(sessionState.active, false);
+      assert.deepEqual(listActiveSkills(sessionState), []);
+    });
+  });
+
+  it('clears stale terminal markers when a workflow is reactivated', async () => {
+    await withTempRepo('omx-skill-active-reactivate-terminal-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeSkillActiveStateCopies(cwd, {
+        active: false,
+        skill: 'autopilot',
+        phase: 'complete',
+        completed_at: '2026-06-09T00:00:00.000Z',
+        cancel_reason: 'old cancellation',
+        run_outcome: 'finish',
+        lifecycle_outcome: 'complete',
+        session_id: 'sess-reactivate',
+        active_skills: [{ skill: 'autopilot', phase: 'complete', active: true, session_id: 'sess-reactivate' }],
+      }, 'sess-reactivate');
+
+      await syncCanonicalSkillStateForMode({
+        cwd,
+        mode: 'autopilot',
+        active: true,
+        sessionId: 'sess-reactivate',
+        nowIso: '2026-06-09T00:01:00.000Z',
+      });
+
+      const sessionState = await readVisibleSkillActiveState(cwd, 'sess-reactivate');
+      assert.ok(sessionState);
+      assert.equal(sessionState.active, true);
+      assert.equal(sessionState.phase, '');
+      assert.equal(sessionState.completed_at, undefined);
+      assert.equal(sessionState.cancel_reason, undefined);
+      assert.equal(sessionState.run_outcome, undefined);
+      assert.equal(sessionState.lifecycle_outcome, undefined);
+      assert.deepEqual(listActiveSkills(sessionState).map(({ skill, phase, session_id }) => ({ skill, phase, session_id })), [
+        { skill: 'autopilot', phase: undefined, session_id: 'sess-reactivate' },
+      ]);
+    });
+  });
+
+  it('recognizes runtime terminal outcomes when suppressing stale active entries', async () => {
+    await withTempRepo('omx-skill-active-terminal-outcomes-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state', 'sessions', 'sess-terminal-outcome'), { recursive: true });
+      const cases = [
+        { run_outcome: 'blocked_on_user' },
+        { lifecycle_outcome: 'blocked' },
+        { lifecycle_outcome: 'userinterlude' },
+        { lifecycle_outcome: 'askuserQuestion' },
+        { completed_at: '2026-06-09T00:00:00.000Z' },
+        { phase: 'blocked_on_user' },
+      ];
+
+      for (const [index, terminalFields] of cases.entries()) {
+        const state = {
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          phase: 'ralplan',
+          session_id: `sess-terminal-outcome-${index}`,
+          active_skills: [{ skill: 'autopilot', phase: 'ralplan', active: true, session_id: `sess-terminal-outcome-${index}` }],
+          ...terminalFields,
+        };
+        assert.deepEqual(listActiveSkills(state), []);
+      }
+    });
+  });
+
   it('clears only the matching terminal session entry and preserves unrelated active skills', async () => {
     await withTempRepo('omx-skill-active-terminal-clear-', async (cwd) => {
       await mkdir(join(cwd, '.omx', 'state'), { recursive: true });

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -11,6 +11,7 @@ import {
   getReadScopedStatePaths,
   getStateDir,
   getStatePath,
+  resolveRuntimeStateScope,
   resolveStateScope,
   resolveWorkingDirectoryForState,
   validateSessionId,
@@ -253,12 +254,30 @@ export async function listActiveStateModes(
   explicitSessionId?: string,
 ): Promise<string[]> {
   const cwd = resolveWorkingDirectoryForState(workingDirectory);
-  const sessionId = validateSessionId(explicitSessionId);
+  const scope = await resolveRuntimeStateScope(cwd, explicitSessionId);
+  const sessionId = scope.sessionId;
   const statuses = await listStateStatuses(cwd, sessionId, undefined, {
     authoritativeActiveDecision: true,
   });
+  const canonicalState = await readVisibleSkillActiveStateForStateDir(getBaseStateDir(cwd), sessionId);
+  const canonicalActiveModes = new Set(
+    listActiveSkills(canonicalState ?? {})
+      .filter((entry) => {
+        const entrySessionId = typeof entry.session_id === 'string' ? entry.session_id.trim() : '';
+        return sessionId ? entrySessionId === sessionId : entrySessionId.length === 0;
+      })
+      .map((entry) => entry.skill),
+  );
+  const hasCanonicalVisibility = canonicalState !== null;
+
   return Object.entries(statuses)
-    .filter(([, status]) => Boolean((status as { active?: unknown }).active))
+    .filter(([mode, status]) => {
+      if (!Boolean((status as { active?: unknown }).active)) return false;
+      if (hasCanonicalVisibility && isTrackedWorkflowMode(mode)) {
+        return canonicalActiveModes.has(mode);
+      }
+      return true;
+    })
     .map(([mode]) => mode);
 }
 

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -21,6 +21,7 @@ import { evaluateRalphCompletionAuditEvidence } from '../ralph/completion-audit.
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
+import { isAutopilotSuccessfulTerminalState, validateAutopilotCompletionTransition } from '../autopilot/completion-gate.js';
 import { readUltragoalState } from '../hud/state.js';
 import {
   SKILL_ACTIVE_STATE_MODE,
@@ -44,7 +45,6 @@ import {
 import {
   type AutopilotChildPhase,
   deriveAutopilotChildPhase,
-  normalizeAutopilotPhase,
 } from '../autopilot/fsm.js';
 import {
   buildAutopilotRalplanUltragoalGateError,
@@ -82,10 +82,6 @@ function isNextAutopilotPhase(
   const currentOrder = autopilotPhaseOrder(currentPhase);
   const nextOrder = autopilotPhaseOrder(nextPhase);
   return currentOrder >= 0 && nextOrder === currentOrder + 1;
-}
-
-function isAutopilotCompletePhase(state: Record<string, unknown>): boolean {
-  return normalizeAutopilotPhase(state.current_phase) === 'complete';
 }
 
 export const SUPPORTED_STATE_READ_MODES = [
@@ -394,6 +390,7 @@ export async function executeStateOperation(
             ...fields,
             ...((customState as Record<string, unknown>) || {}),
           } as Record<string, unknown>;
+          delete mergedRaw.trustedPipelineProgress;
           if (!hasExplicitStateField(fields, customState, 'run_outcome')) {
             delete mergedRaw.run_outcome;
           }
@@ -459,7 +456,7 @@ export async function executeStateOperation(
           if (
             mode === 'autopilot'
             && currentAutopilotChildPhase === 'deep-interview'
-            && isAutopilotCompletePhase(mergedRaw)
+            && isAutopilotSuccessfulTerminalState(mergedRaw)
           ) {
             validationError = 'Cannot complete Autopilot before ralplan gate: deep-interview may only advance to ralplan.';
             return;
@@ -468,10 +465,21 @@ export async function executeStateOperation(
           if (
             mode === 'autopilot'
             && currentAutopilotChildPhase === 'ralplan'
-            && isAutopilotCompletePhase(mergedRaw)
+            && isAutopilotSuccessfulTerminalState(mergedRaw)
           ) {
             validationError = 'Cannot complete Autopilot before ultragoal gate: ralplan may only advance to ultragoal.';
             return;
+          }
+
+          if (mode === 'autopilot') {
+            const completionTransitionError = validateAutopilotCompletionTransition(
+              existing as Record<string, unknown>,
+              mergedRaw,
+            );
+            if (completionTransitionError) {
+              validationError = completionTransitionError;
+              return;
+            }
           }
 
           if (

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs';
 import { mkdir, readFile, readdir, unlink, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { omxStateDir } from '../utils/paths.js';
+import { isTerminalRunOutcome, normalizeRunOutcome, normalizeTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
 import {
   assertWorkflowTransitionAllowed,
   isTrackedWorkflowMode,
@@ -165,9 +166,40 @@ function sanitizeWriterBaseForSession(
   return inherited;
 }
 
+function isTerminalSkillActivePhase(phase: unknown): boolean {
+  const normalized = safeString(phase).trim().toLowerCase();
+  if (!normalized) return false;
+  if (normalized === 'cleared') return true;
+  const runOutcome = normalizeRunOutcome(normalized).outcome;
+  if (isTerminalRunOutcome(runOutcome)) return true;
+  return Boolean(normalizeTerminalLifecycleOutcome(normalized).outcome);
+}
+
+function isTerminalSkillActiveState(state: SkillActiveStateLike): boolean {
+  if (state.active === false) return true;
+  if (isTerminalSkillActivePhase(state.phase)) return true;
+  if (safeString(state.completed_at).trim().length > 0) return true;
+  const runOutcome = normalizeRunOutcome(state.run_outcome).outcome;
+  if (isTerminalRunOutcome(runOutcome)) return true;
+  const lifecycleOutcome = normalizeTerminalLifecycleOutcome(state.lifecycle_outcome ?? state.terminal_outcome).outcome;
+  return Boolean(lifecycleOutcome);
+}
+
+function clearTerminalSkillActiveMarkers<T extends SkillActiveStateLike>(state: T): T {
+  const next = { ...state };
+  if (isTerminalSkillActivePhase(next.phase)) delete next.phase;
+  delete next.completed_at;
+  delete next.cancel_reason;
+  delete next.run_outcome;
+  delete next.lifecycle_outcome;
+  delete next.terminal_outcome;
+  return next;
+}
+
 export function listActiveSkills(raw: unknown): SkillActiveEntry[] {
   if (!raw || typeof raw !== 'object') return [];
   const state = raw as SkillActiveStateLike;
+  if (isTerminalSkillActiveState(state)) return [];
   const deduped = new Map<string, SkillActiveEntry>();
 
   if (Array.isArray(state.active_skills)) {
@@ -374,7 +406,9 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
     fallbackMode: string,
     targetSessionId?: string,
   ): SkillActiveStateLike => {
-    const inheritedBase = sanitizeWriterBaseForSession(base, targetSessionId);
+    const inheritedBase = entries.length > 0
+      ? clearTerminalSkillActiveMarkers(sanitizeWriterBaseForSession(base, targetSessionId))
+      : sanitizeWriterBaseForSession(base, targetSessionId);
     const currentPrimary = safeString(inheritedBase.skill).trim();
     const primarySkill = pickPrimaryWorkflowMode(currentPrimary, entries.map((entry) => entry.skill), fallbackMode);
     const primaryEntry = entries.find((entry) => entry.skill === primarySkill) ?? entries[0];

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1205,7 +1205,7 @@ esac
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
           process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
-          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '100';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
           const expectedTeamName = buildInternalTeamName('team-startup-no-evidence', resolveTeamIdentityScope(process.env));
@@ -1994,6 +1994,7 @@ esac
     const previousReadyTimeout = process.env.OMX_TEAM_READY_TIMEOUT_MS;
     const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
     const previousStartupDispatchRetries = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+    const previousStartupDispatchRetryDelay = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
     const teamName = `tsd-${process.pid}-${Date.now().toString(36)}`;
 
     try {
@@ -2062,9 +2063,10 @@ esac
           process.env.TMUX_PANE = '%1';
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
-          process.env.OMX_TEAM_READY_TIMEOUT_MS = '5000';
-          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_READY_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '100';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
 
           await assert.rejects(
             withoutTeamWorkerEnv(() =>
@@ -2102,6 +2104,8 @@ esac
       else delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
       if (typeof previousStartupDispatchRetries === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = previousStartupDispatchRetries;
       else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+      if (typeof previousStartupDispatchRetryDelay === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = previousStartupDispatchRetryDelay;
+      else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -2179,8 +2183,8 @@ esac
           process.env.TMUX_PANE = '%1';
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
-          process.env.OMX_TEAM_READY_TIMEOUT_MS = '5000';
-          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_READY_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '100';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
 
           receiptNotifier = setInterval(() => {
@@ -2256,6 +2260,7 @@ esac
     const previousReadyTimeout = process.env.OMX_TEAM_READY_TIMEOUT_MS;
     const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
     const previousStartupDispatchRetries = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+    const previousStartupDispatchRetryDelay = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
     const teamName = `trt-${process.pid}-${Date.now().toString(36)}`;
     let receiptNotifier: NodeJS.Timeout | null = null;
     let runtimeTeamName: string | null = null;
@@ -2312,9 +2317,10 @@ esac
           process.env.TMUX_PANE = '%1';
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
-          process.env.OMX_TEAM_READY_TIMEOUT_MS = '5000';
-          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_READY_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '100';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
 
           receiptNotifier = setInterval(() => {
             void markPendingInboxDispatchesNotified(teamName, cwd);
@@ -2355,6 +2361,8 @@ esac
       else delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
       if (typeof previousStartupDispatchRetries === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = previousStartupDispatchRetries;
       else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+      if (typeof previousStartupDispatchRetryDelay === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = previousStartupDispatchRetryDelay;
+      else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -2368,6 +2376,7 @@ esac
     const previousReadyTimeout = process.env.OMX_TEAM_READY_TIMEOUT_MS;
     const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
     const previousStartupDispatchRetries = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+    const previousStartupDispatchRetryDelay = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
     let receiptDeliverer: NodeJS.Timeout | null = null;
     let runtimeTeamName: string | null = null;
 
@@ -2448,9 +2457,10 @@ esac
           process.env.TMUX_PANE = '%1';
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
-          process.env.OMX_TEAM_READY_TIMEOUT_MS = '2000';
+          process.env.OMX_TEAM_READY_TIMEOUT_MS = '500';
           process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '50';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
 
           receiptDeliverer = setInterval(() => {
             void (async () => {
@@ -2500,6 +2510,8 @@ esac
       else delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
       if (typeof previousStartupDispatchRetries === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = previousStartupDispatchRetries;
       else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+      if (typeof previousStartupDispatchRetryDelay === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = previousStartupDispatchRetryDelay;
+      else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -2603,7 +2615,7 @@ process.on('SIGTERM', () => process.exit(0));
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
           process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
-          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '100';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
 
@@ -2692,6 +2704,7 @@ process.on('SIGTERM', () => process.exit(0));
     const previousReadyTimeout = process.env.OMX_TEAM_READY_TIMEOUT_MS;
     const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
     const previousStartupDispatchRetries = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+    const previousStartupDispatchRetryDelay = process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
     let receiptFailer: NodeJS.Timeout | null = null;
 
     try {
@@ -2762,9 +2775,10 @@ esac
           process.env.TMUX_PANE = '%1';
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
-          process.env.OMX_TEAM_READY_TIMEOUT_MS = '5000';
-          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_READY_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '100';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
+          process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
 
           receiptFailer = setInterval(() => {
             void (async () => {
@@ -2820,6 +2834,8 @@ esac
       else delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
       if (typeof previousStartupDispatchRetries === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = previousStartupDispatchRetries;
       else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
+      if (typeof previousStartupDispatchRetryDelay === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = previousStartupDispatchRetryDelay;
+      else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -2923,8 +2939,8 @@ esac
           process.env.TMUX_PANE = '%1';
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
-          process.env.OMX_TEAM_READY_TIMEOUT_MS = '5000';
-          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_READY_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '100';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
 
@@ -3083,7 +3099,7 @@ process.on('SIGTERM', () => process.exit(0));
           process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
           process.env.OMX_TEAM_WORKER_CLI = 'codex';
           process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
-          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '100';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES = '1';
           process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = '50';
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1586,7 +1586,7 @@ function assertPromptModeWorkerCliSupported(workerCliPlan: readonly TeamWorkerCl
 function resolveWorkerReadyTimeoutMs(env: NodeJS.ProcessEnv): number {
   const raw = env.OMX_TEAM_READY_TIMEOUT_MS;
   const parsed = Number.parseInt(String(raw ?? ''), 10);
-  if (Number.isFinite(parsed) && parsed >= 5_000) return parsed;
+  if (Number.isFinite(parsed) && parsed >= 0) return Math.floor(parsed);
   return 45_000;
 }
 
@@ -1595,7 +1595,7 @@ function resolveWorkerStartupEvidenceTimeoutMs(
   workerReadyTimeoutMs: number,
 ): number {
   const raw = Number.parseInt(String(env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS ?? ''), 10);
-  if (Number.isFinite(raw) && raw >= 500) return raw;
+  if (Number.isFinite(raw) && raw >= 0) return Math.floor(raw);
   return Math.max(
     STARTUP_EVIDENCE_TIMEOUT_MS,
     Math.min(workerReadyTimeoutMs, STARTUP_EVIDENCE_LAUNCH_TIMEOUT_MS),

--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -41,6 +41,24 @@ describe('resolveOmxDisplayVersionSync', () => {
     });
   });
 
+
+
+  it('uses a dev base version from the install stamp when package.json lags the release baseline', async () => {
+    await withVersionFixture(async ({ packageRoot, stampPath }) => {
+      await writeFile(stampPath, JSON.stringify({
+        installed_version: '0.18.8',
+        setup_completed_version: '0.18.8',
+        dev_base_version: '0.18.9',
+        install_channel: 'dev',
+        install_source: 'github:Yeachan-Heo/oh-my-codex#dev',
+        install_revision: 'feedfacecafebeef',
+        updated_at: '2026-06-09T00:00:00.000Z',
+      }, null, 2));
+
+      assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.9-dev-feedfacecafe');
+    });
+  });
+
   it('does not apply stale dev stamp metadata to a different package version', async () => {
     await withVersionFixture(async ({ packageRoot, stampPath }) => {
       await writeFile(stampPath, JSON.stringify({
@@ -49,6 +67,21 @@ describe('resolveOmxDisplayVersionSync', () => {
         install_channel: 'dev',
         install_revision: 'abcdef123456',
         updated_at: '2026-06-02T00:00:00.000Z',
+      }, null, 2));
+
+      assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.8');
+    });
+  });
+
+  it('does not let stale dev_base_version metadata make a mismatched stamp current', async () => {
+    await withVersionFixture(async ({ packageRoot, stampPath }) => {
+      await writeFile(stampPath, JSON.stringify({
+        installed_version: '0.18.7',
+        setup_completed_version: '0.18.7',
+        dev_base_version: '0.18.11',
+        install_channel: 'dev',
+        install_revision: 'feedfacecafebeef',
+        updated_at: '2026-06-09T00:00:00.000Z',
       }, null, 2));
 
       assert.equal(resolveOmxDisplayVersionSync({ packageRoot, stampPath }), 'v0.18.8');

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -13,6 +13,7 @@ interface InstallVersionMetadata {
   setup_completed_version?: string;
   install_channel?: string;
   install_revision?: string;
+  dev_base_version?: string;
 }
 
 function stripLeadingV(version: string): string {
@@ -75,10 +76,15 @@ export function resolveOmxDisplayVersionSync(options: {
     : typeof stamp?.installed_version === 'string'
       ? stripLeadingV(stamp.installed_version)
       : '';
-  const isCurrentDevInstall = stamp?.install_channel === 'dev' && stampVersion === version;
+  const devBaseVersion = typeof stamp?.dev_base_version === 'string'
+    ? stripLeadingV(stamp.dev_base_version)
+    : '';
+  const isCurrentDevInstall = stamp?.install_channel === 'dev'
+    && stampVersion === version;
   if (isCurrentDevInstall) {
+    const displayVersion = devBaseVersion || version;
     const revision = shortRevision(stamp.install_revision) ?? explicitRevision ?? readGitRevision(packageRoot);
-    return revision ? `v${version}-dev-${revision}` : `v${version}-dev`;
+    return revision ? `v${displayVersion}-dev-${revision}` : `v${displayVersion}-dev`;
   }
 
   return `v${version}`;


### PR DESCRIPTION
## Scope\n- Normalize HUD autopilot late-gate labels to canonical  across render and matching tests.\n- Resolve HUD authority watcher scripts from CLI entry dist scripts when package dist scripts are missing.\n- Reconcile HUD pane ownership for same-leader same-session cleanup by matching leader/session pairs consistently.\n- Aggregate ralplan native-subagent missing-field diagnostics in one message per lane.\n\n## Validation\n- node dist/scripts/run-test-files.js dist/hud/__tests__/render.test.js dist/hud/__tests__/tmux.test.js dist/hud/__tests__/authority.test.js\n- npm test -- src/scripts/__tests__/codex-native-hook.test.ts (full suite previously run)\n\n## Open issues\n- Addresses omx-k05 child issues: omx-988, omx-t1s, omx-p3u, omx-rjr\n