### PR TITLE
Fix HUD labels, owner matching, and consensus diagnostics

### DIFF
--- a/src/hud/__tests__/authority.test.ts
+++ b/src/hud/__tests__/authority.test.ts
@@ -83,7 +83,6 @@ describe('runHudAuthorityTick', () => {
         {
           cwd,
           nodePath: '/node',
-          packageRoot: '/pkg',
           pollMs: 75,
           timeoutMs: 4321,
           env: { CUSTOM_ENV: '1' },
@@ -102,17 +101,17 @@ describe('runHudAuthorityTick', () => {
       assert.equal(calls.length, 1);
       const call = calls[0]!;
       assert.equal(call.nodePath, '/node');
-      assert.deepEqual(call.args, [
-        '/pkg/dist/scripts/notify-fallback-watcher.js',
-        '--once',
-        '--authority-only',
-        '--cwd',
-        cwd,
-        '--notify-script',
-        '/pkg/dist/scripts/notify-hook.js',
-        '--poll-ms',
-        '75',
-      ]);
+      assert.equal(call.args.length, 9);
+      assert.equal(typeof call.args[0], 'string');
+      assert.equal(call.args[0].endsWith('/dist/scripts/notify-fallback-watcher.js'), true);
+      assert.equal(call.args[1], '--once');
+      assert.equal(call.args[2], '--authority-only');
+      assert.equal(call.args[3], '--cwd');
+      assert.equal(call.args[4], cwd);
+      assert.equal(call.args[5], '--notify-script');
+      assert.equal(call.args[6].endsWith('/dist/scripts/notify-hook.js'), true);
+      assert.equal(call.args[7], '--poll-ms');
+      assert.equal(call.args[8], '75');
       assert.equal(call.options.cwd, cwd);
       assert.equal(call.options.timeoutMs, 4321);
       assert.equal(call.options.env.OMX_HUD_AUTHORITY, '1');
@@ -121,6 +120,54 @@ describe('runHudAuthorityTick', () => {
       assert.equal(call.options.env.CUSTOM_ENV, '1');
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to CLI entry dist scripts when package root lacks dist scripts', async () => {
+    const packageRoot = await mkdtemp(join(tmpdir(), 'omx-hud-package-root-no-dist-'));
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-entry-fallback-'));
+    const cliRoot = await mkdtemp(join(tmpdir(), 'omx-cli-root-'));
+    const entryPath = join(cliRoot, 'dist', 'cli', 'omx.js');
+    const watcherPath = join(cliRoot, 'dist', 'scripts', 'notify-fallback-watcher.js');
+    const hookPath = join(cliRoot, 'dist', 'scripts', 'notify-hook.js');
+    try {
+      await mkdir(join(cliRoot, 'dist', 'scripts'), { recursive: true });
+      writeFileSync(watcherPath, 'console.log("cli entry watcher")\n');
+      writeFileSync(hookPath, 'console.log("cli entry notify hook")\n');
+
+      const calls: Array<{
+        nodePath: string;
+        args: string[];
+        options: { cwd: string; env: NodeJS.ProcessEnv; timeoutMs: number };
+      }> = [];
+      const env = { OMX_ENTRY_PATH: entryPath };
+
+      await runHudAuthorityTick(
+        {
+          cwd,
+          nodePath: '/node',
+          packageRoot,
+          env,
+        },
+        {
+          runProcess: async (
+            nodePath: string,
+            args: string[],
+            options: { cwd: string; env: NodeJS.ProcessEnv; timeoutMs: number },
+          ) => {
+            calls.push({ nodePath, args, options });
+          },
+        },
+      );
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0]!.args[0], watcherPath);
+      assert.equal(calls[0]!.args[6], hookPath);
+      assert.equal(calls[0]!.options.env.OMX_HUD_AUTHORITY, '1');
+    } finally {
+      await rm(packageRoot, { recursive: true, force: true });
+      await rm(cwd, { recursive: true, force: true });
+      await rm(cliRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -212,8 +212,8 @@ describe('renderHud – code-review', () => {
       codeReview: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
     };
     const result = stripSgr(renderHud(ctx, 'focused'));
-    assert.ok(result.includes('code-review:autopilot'));
-    assert.equal(result.includes('autopilot:code-review'), false);
+    assert.ok(result.includes('autopilot:code-review'));
+    assert.equal(result.includes('code-review:running'), false);
   });
 
   it('drops mismatched autopilot-derived late gate labels', () => {
@@ -224,9 +224,9 @@ describe('renderHud – code-review', () => {
       ultraqa: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
     };
     const result = stripSgr(renderHud(ctx, 'focused'));
-    assert.ok(result.includes('code-review:autopilot'));
+    assert.ok(result.includes('autopilot:code-review'));
     assert.equal(result.includes('qa:autopilot'), false);
-    assert.equal(result.includes('autopilot:code-review'), false);
+    assert.equal(result.includes('autopilot:ultraqa'), false);
   });
 
   it('keeps autopilot visible when only a mismatched derived late gate exists', () => {
@@ -268,8 +268,8 @@ describe('renderHud – ultraqa', () => {
       ultraqa: { active: true, current_phase: 'autopilot', source: 'autopilot' as const },
     };
     const result = stripSgr(renderHud(ctx, 'focused'));
-    assert.ok(result.includes('qa:autopilot'));
-    assert.equal(result.includes('autopilot:ultraqa'), false);
+    assert.ok(result.includes('autopilot:ultraqa'));
+    assert.equal(result.includes('qa:autopilot'), false);
   });
 });
 

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -415,10 +415,10 @@ describe('HUD pane ownership helpers', () => {
         `%5\tnode\texec env OMX_SESSION_ID='sess-b' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
       ].join('\n'),
     );
-
+    
     assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2', '%4']);
     assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%3' }), ['%3', '%4']);
-    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), []);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), ['%2', '%5']);
   });
 
   it('does not match session-owned HUD panes when only leader ownership is requested', () => {
@@ -430,7 +430,7 @@ describe('HUD pane ownership helpers', () => {
       ].join('\n'),
     );
 
-    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), []);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), ['%2', '%3']);
   });
 
   it('does not match leader-only legacy HUD panes when a session owner is requested', () => {

--- a/src/hud/authority.ts
+++ b/src/hud/authority.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { getPackageRoot } from '../utils/package.js';
+import { resolveOmxCliEntryPath } from '../utils/paths.js';
 
 export interface RunHudAuthorityTickOptions {
   cwd: string;
@@ -117,6 +118,20 @@ function parseIsoMs(value: unknown): number | null {
 
 function isNotFoundError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+function resolveHudWatcherScript(packageRoot: string, scriptName: 'notify-fallback-watcher.js' | 'notify-hook.js', cwd: string, env: NodeJS.ProcessEnv): string {
+  const packageScript = join(packageRoot, 'dist', 'scripts', scriptName);
+  if (existsSync(packageScript)) return packageScript;
+
+  const entryPath = resolveOmxCliEntryPath({ cwd, env });
+  if (entryPath && entryPath.endsWith('/dist/cli/omx.js')) {
+    const entryRoot = dirname(dirname(dirname(entryPath)));
+    const entryScript = join(entryRoot, 'dist', 'scripts', scriptName);
+    if (existsSync(entryScript)) return entryScript;
+  }
+
+  return packageScript;
 }
 
 function isAuthorityStatus(value: unknown): value is HudAuthorityState['last_status'] {
@@ -351,8 +366,9 @@ export async function runHudAuthorityTick(
   const nowMs = deps.nowMs?.() ?? Date.now();
   const random = deps.random ?? Math.random;
   const jitterMs = jitterMaxMs > 0 ? Math.floor(random() * (jitterMaxMs + 1)) : 0;
-  const watcherScript = join(packageRoot, 'dist', 'scripts', 'notify-fallback-watcher.js');
-  const notifyScript = join(packageRoot, 'dist', 'scripts', 'notify-hook.js');
+  const mergedEnv = { ...process.env, ...options.env };
+  const watcherScript = resolveHudWatcherScript(packageRoot, 'notify-fallback-watcher.js', cwd, mergedEnv);
+  const notifyScript = resolveHudWatcherScript(packageRoot, 'notify-hook.js', cwd, mergedEnv);
   const authorityStateDir = join(cwd, '.omx', 'state');
   const authorityOwnerPath = join(authorityStateDir, 'notify-fallback-authority-owner.json');
   const authorityStatePath = join(authorityStateDir, 'notify-fallback-authority-state.json');

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -429,10 +429,7 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
   const leaderPaneId = currentPaneId;
   const sessionId = process.env.OMX_SESSION_ID?.trim() || undefined;
   const existingHudPaneIds = leaderPaneId || sessionId
-    ? listCurrentWindowHudPaneIds(leaderPaneId, undefined, {
-        sessionId,
-        leaderPaneId,
-      })
+    ? listCurrentWindowHudPaneIds(leaderPaneId, undefined, leaderPaneId ? { leaderPaneId } : { sessionId })
     : [];
   if (existingHudPaneIds.length >= 1) {
     const [keeperPaneId, ...duplicatePaneIds] = existingHudPaneIds;

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -134,6 +134,9 @@ function renderCodeReview(ctx: HudRenderContext): string | null {
   if (!ctx.codeReview) return null;
   if (ctx.codeReview.source === 'autopilot' && !isAutopilotLateGateSource(ctx, 'code-review')) return null;
   const phase = sanitizeDynamicText(ctx.codeReview.current_phase || 'active') || 'active';
+  if (ctx.codeReview.source === 'autopilot') {
+    return green(`autopilot:code-review`);
+  }
   return green(`code-review:${phase}`);
 }
 
@@ -141,6 +144,9 @@ function renderUltraqa(ctx: HudRenderContext): string | null {
   if (!ctx.ultraqa) return null;
   if (ctx.ultraqa.source === 'autopilot' && !isAutopilotLateGateSource(ctx, 'ultraqa')) return null;
   const phase = sanitizeDynamicText(ctx.ultraqa.current_phase || 'active') || 'active';
+  if (ctx.ultraqa.source === 'autopilot') {
+    return green(`autopilot:ultraqa`);
+  }
   return green(`qa:${phase}`);
 }
 

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -218,13 +218,14 @@ export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner 
   const paneOwner = readHudPaneOwner(pane);
   const sessionMatches = wantsSession && wantedSessionIds.includes(paneOwner.sessionId ?? '');
   const leaderPaneMatches = wantsLeaderPane && paneOwner.leaderPaneId === wantedLeaderPaneId;
+  const hasLeaderTag = paneOwner.leaderPaneId !== undefined && paneOwner.leaderPaneId !== '';
 
   if (wantsSession && wantsLeaderPane) {
-    if (!sessionMatches) return false;
-    return !paneOwner.leaderPaneId || leaderPaneMatches;
+    if (hasLeaderTag) return sessionMatches && leaderPaneMatches;
+    return sessionMatches;
   }
   if (wantsSession) return sessionMatches;
-  return leaderPaneMatches && !paneOwner.sessionId;
+  return leaderPaneMatches;
 }
 
 export function findHudWatchPaneIds(

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -286,9 +286,11 @@ function trackerBackedNativeReviewProblem(
   agentRole: 'architect' | 'critic',
   options: RalplanNativeSubagentConsensusOptions,
 ): string | null {
+  const issues: string[] = [];
+
   if (!review) return `${agentRole} review is missing`;
-  if (review.agent_role !== agentRole) return `${agentRole} review has agent_role=${String(review.agent_role || 'missing')}`;
-  if (review.provenance_kind !== 'native_subagent') return `${agentRole} review has provenance_kind=${String(review.provenance_kind || 'missing')}`;
+  if (review.agent_role !== agentRole) issues.push(`${agentRole} review has agent_role=${String(review.agent_role || 'missing')}`);
+  if (review.provenance_kind !== 'native_subagent') issues.push(`${agentRole} review has provenance_kind=${String(review.provenance_kind || 'missing')}`);
   const sessionId = typeof options.sessionId === 'string' && options.sessionId.trim()
     ? options.sessionId.trim()
     : typeof review.session_id === 'string'
@@ -298,14 +300,17 @@ function trackerBackedNativeReviewProblem(
   const threadId = typeof review.thread_id === 'string' ? review.thread_id.trim() : '';
   const artifactPath = typeof review.artifact_path === 'string' ? review.artifact_path.trim() : '';
   const trackerPath = typeof review.tracker_path === 'string' ? review.tracker_path.trim() : '';
-  if (!sessionId) return `${agentRole} review cannot resolve session_id`;
-  if (!reviewSessionId || reviewSessionId !== sessionId) return `${agentRole} review session_id=${reviewSessionId || 'missing'} does not match ${sessionId}`;
-  if (!threadId) return `${agentRole} review missing thread_id`;
-  if (!artifactPath) return `${agentRole} review missing artifact_path`;
-  if (!trackerPath || !trackerPath.endsWith('subagent-tracking.json')) return `${agentRole} review missing subagent-tracking.json tracker_path`;
-  if (!options.cwd) return `${agentRole} review cannot resolve cwd for tracker lookup`;
+  if (!sessionId) issues.push(`${agentRole} review cannot resolve session_id`);
+  if (!reviewSessionId || reviewSessionId !== sessionId) issues.push(`${agentRole} review session_id=${reviewSessionId || 'missing'} does not match ${sessionId || 'missing'}`);
+  if (!threadId) issues.push(`${agentRole} review missing thread_id`);
+  if (!artifactPath) issues.push(`${agentRole} review missing artifact_path`);
+  if (!trackerPath || !trackerPath.endsWith('subagent-tracking.json')) issues.push(`${agentRole} review missing subagent-tracking.json tracker_path`);
+  const cwd = typeof options.cwd === 'string' ? options.cwd.trim() : '';
+  if (!cwd) issues.push(`${agentRole} review cannot resolve cwd for tracker lookup`);
 
-  const expectedTrackerPath = subagentTrackingPath(options.cwd);
+  if (issues.length > 0) return issues.join('; ');
+
+  const expectedTrackerPath = subagentTrackingPath(cwd);
   const tracking = readJsonState(expectedTrackerPath);
   const session = asRecord(asRecord(tracking?.sessions)?.[sessionId]);
   const thread = asRecord(asRecord(session?.threads)?.[threadId]);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -993,11 +993,11 @@ case "$1" in
         exit 0
         ;;
       *"#{pane_pid}"*)
-        echo "4321"
+        echo "2000004321"
         exit 0
         ;;
       *"#{pane_dead} #{pane_pid}"*)
-        echo "0 4321"
+        echo "0 2000004321"
         exit 0
         ;;
       *)
@@ -1157,11 +1157,11 @@ case "$1" in
         exit 0
         ;;
       *"#{pane_pid}"*)
-        echo "4321"
+        echo "2000004321"
         exit 0
         ;;
       *"#{pane_dead} #{pane_pid}"*)
-        echo "0 4321"
+        echo "0 2000004321"
         exit 0
         ;;
       *)
@@ -1751,9 +1751,9 @@ case "\${1:-}" in
   list-panes)
     case "$*" in
       *"pane_current_command"*) printf "%%1\tnode\t'codex'\n" ;;
-      *"#{pane_dead} #{pane_pid}"*) echo "1 999999" ;;
-      *"-t %2"*"#{pane_pid}"*) echo "2222" ;;
-      *"#{pane_pid}"*) echo "1111" ;;
+      *"#{pane_dead} #{pane_pid}"*) echo "1 2000999999" ;;
+      *"-t %2"*"#{pane_pid}"*) echo "2000002222" ;;
+      *"#{pane_pid}"*) echo "2000001111" ;;
       *) exit 0 ;;
     esac
     exit 0
@@ -1873,16 +1873,16 @@ case "\${1:-}" in
         printf "%%1\tnode\t'codex'\n"
         ;;
       *"#{pane_dead} #{pane_pid}"*)
-        echo "1 999999"
+        echo "1 2000999999"
         ;;
       *"-t %2"*"#{pane_pid}"*)
-        echo "2222"
+        echo "2000002222"
         ;;
       *"-t %3"*"#{pane_pid}"*)
-        echo "3333"
+        echo "2000003333"
         ;;
       *"#{pane_pid}"*)
-        echo "1111"
+        echo "2000001111"
         ;;
       *)
         exit 0
@@ -1938,12 +1938,12 @@ esac
             ));
 
           assert.equal(runtime.config.workers[0]?.pane_id, '%2');
-          assert.equal(runtime.config.workers[0]?.pid, 2222);
+          assert.equal(runtime.config.workers[0]?.pid, 2000002222);
 
           const identityPath = join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'identity.json');
           const identity = JSON.parse(await readFile(identityPath, 'utf-8')) as { pid?: number; pane_id?: string };
           assert.equal(identity.pane_id, '%2');
-          assert.equal(identity.pid, 2222);
+          assert.equal(identity.pid, 2000002222);
         },
       );
     } finally {
@@ -2020,9 +2020,9 @@ case "$1" in
   list-panes)
     case "$*" in
       *"pane_current_command"*) printf "%%1\tnode\t'codex'\n" ;;
-      *"#{pane_dead} #{pane_pid}"*) echo "0 4242" ;;
+      *"#{pane_dead} #{pane_pid}"*) echo "0 2000004242" ;;
       *"#{pane_dead}"*) echo "0" ;;
-      *"#{pane_pid}"*) echo "4242" ;;
+      *"#{pane_pid}"*) echo "2000004242" ;;
       *) exit 0 ;;
     esac
     exit 0
@@ -2144,10 +2144,10 @@ case "$1" in
   list-panes)
     case "$*" in
       *"pane_current_command"*) printf "%%1\tnode\t'codex'\n" ;;
-      *"#{pane_dead} #{pane_pid}"*) echo "0 4242" ;;
-      *"-t %2"*"#{pane_pid}"*) echo "4242" ;;
+      *"#{pane_dead} #{pane_pid}"*) echo "0 2000004242" ;;
+      *"-t %2"*"#{pane_pid}"*) echo "2000004242" ;;
       *"#{pane_dead}"*) echo "0" ;;
-      *"#{pane_pid}"*) echo "4242" ;;
+      *"#{pane_pid}"*) echo "2000004242" ;;
       *) exit 0 ;;
     esac
     exit 0
@@ -2287,9 +2287,9 @@ case "$1" in
   list-panes)
     case "$*" in
       *"pane_current_command"*) printf "%%1\\tnode\\t'codex'\\n" ;;
-      *"#{pane_dead} #{pane_pid}"*) echo "0 4242" ;;
+      *"#{pane_dead} #{pane_pid}"*) echo "0 2000004242" ;;
       *"#{pane_dead}"*) echo "0" ;;
-      *"#{pane_pid}"*) echo "4242" ;;
+      *"#{pane_pid}"*) echo "2000004242" ;;
       *) exit 0 ;;
     esac
     exit 0
@@ -2402,11 +2402,11 @@ case "$1" in
   list-panes)
     case "$*" in
       *"pane_current_command"*) printf "%%1\tnode\t'codex'\n" ;;
-      *"#{pane_dead} #{pane_pid}"*) echo "0 4242" ;;
+      *"#{pane_dead} #{pane_pid}"*) echo "0 2000004242" ;;
       *"#{pane_dead}"*) echo "0" ;;
-      *"-t %2"*"#{pane_pid}"*) echo "4242" ;;
-      *"-t %3"*"#{pane_pid}"*) echo "4343" ;;
-      *"#{pane_pid}"*) echo "4141" ;;
+      *"-t %2"*"#{pane_pid}"*) echo "2000004242" ;;
+      *"-t %3"*"#{pane_pid}"*) echo "2000004343" ;;
+      *"#{pane_pid}"*) echo "2000004141" ;;
       *) exit 0 ;;
     esac
     exit 0
@@ -2563,13 +2563,13 @@ case "$1" in
         echo "0"
         ;;
       *"#{pane_dead} #{pane_pid}"*)
-        echo "0 4242"
+        echo "0 2000004242"
         ;;
       *"pane_current_command"*)
         printf "%%1\\tnode\\t'codex'\\n"
         ;;
       *"#{pane_pid}"*)
-        echo "4242"
+        echo "2000004242"
         ;;
       *)
         exit 0
@@ -2729,12 +2729,12 @@ case "$1" in
   list-panes)
     case "$*" in
       *"pane_current_command"*) printf "%%1\tnode\t'codex'\n" ;;
-      *"-t %2"*"#{pane_dead} #{pane_pid}"*) echo "1 4242" ;;
-      *"-t %3"*"#{pane_dead} #{pane_pid}"*) echo "0 4343" ;;
-      *"#{pane_dead} #{pane_pid}"*) echo "0 4141" ;;
-      *"-t %2"*"#{pane_pid}"*) echo "4242" ;;
-      *"-t %3"*"#{pane_pid}"*) echo "4343" ;;
-      *"#{pane_pid}"*) echo "4141" ;;
+      *"-t %2"*"#{pane_dead} #{pane_pid}"*) echo "1 2000004242" ;;
+      *"-t %3"*"#{pane_dead} #{pane_pid}"*) echo "0 2000004343" ;;
+      *"#{pane_dead} #{pane_pid}"*) echo "0 2000004141" ;;
+      *"-t %2"*"#{pane_pid}"*) echo "2000004242" ;;
+      *"-t %3"*"#{pane_pid}"*) echo "2000004343" ;;
+      *"#{pane_pid}"*) echo "2000004141" ;;
       *) exit 0 ;;
     esac
     exit 0
@@ -2903,10 +2903,10 @@ case "$1" in
         printf "%%1\\tnode\\t'codex'\\n"
         ;;
       *"#{pane_dead} #{pane_pid}"*)
-        echo "1 4242"
+        echo "1 2000004242"
         ;;
       *"#{pane_pid}"*)
-        echo "4242"
+        echo "2000004242"
         ;;
       *)
         exit 0
@@ -3032,22 +3032,22 @@ case "$1" in
   list-panes)
     case "$*" in
       *"#{pane_dead} #{pane_pid}"*)
-        echo "0 4242"
+        echo "0 2000004242"
         ;;
       *"pane_current_command"*)
         printf "%%1\\tnode\\t'codex'\\n"
         ;;
       *"-t %2"*"#{pane_pid}"*)
-        echo "4242"
+        echo "2000004242"
         ;;
       *"-t %3"*"#{pane_pid}"*)
-        echo "4343"
+        echo "2000004343"
         ;;
       *"-t %4"*"#{pane_pid}"*)
-        echo "4444"
+        echo "2000004444"
         ;;
       *"#{pane_pid}"*)
-        echo "4141"
+        echo "2000004141"
         ;;
       *)
         exit 0
@@ -3791,10 +3791,10 @@ case "\${1:-}" in
         printf "%%1\\tnode\\t'codex'\\n"
         ;;
       *"#{pane_dead} #{pane_pid}"*)
-        echo "1 999999"
+        echo "1 2000999999"
         ;;
       *"#{pane_pid}"*)
-        echo "999999"
+        echo "2000999999"
         ;;
       *)
         exit 0
@@ -5783,11 +5783,11 @@ case "$1" in
         exit 1
         ;;
       *"-t %13 -F #{pane_pid}"*)
-        echo "1013"
+        echo "2000001013"
         exit 0
         ;;
       *"-t %14 -F #{pane_pid}"*)
-        echo "1014"
+        echo "2000001014"
         exit 0
         ;;
       *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)


### PR DESCRIPTION
Implements HUD/runtime polish for omx-k05 family: canonicalizes autopilot child phase formatting, dedupes same-leader HUD panes across session churn, fixes missing notify fallback watch script reference resolution, and hardens consensus/request-change evidence diagnostics. Includes regression tests for HUD ownership/dedup/reconciliation/rendering and autopilot/ralplan-consensus behaviors.