### PR TITLE
[codex] fix plugin Stop hook JSON fallback

### DIFF
--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -9,6 +9,7 @@ const hookDir = dirname(fileURLToPath(import.meta.url));
 const OMX_PLUGIN_HOOK_LAUNCHER_CONTRACT_MARKER = 'omx-plugin-hook-launcher:v1';
 const MAX_WRAPPER_STDIN_BYTES = 1024 * 1024;
 const RAW_EVENT_SCAN_BYTES = 64 * 1024;
+const MAX_STOP_STDOUT_BYTES = 1024 * 1024;
 const CODEX_HOOK_EVENT_NAMES = new Set([
   'SessionStart',
   'PreToolUse',
@@ -270,6 +271,19 @@ function hasActiveAutopilotStateForOversizedStop(input) {
   return shouldContinueAutopilotState(sessionState);
 }
 
+
+function parseSingleJsonObjectOutput(raw) {
+  const text = String(raw ?? '').trim();
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
 function writeJsonNoop() {
   process.stdout.write(`${JSON.stringify({})}\n`);
   process.exitCode = 0;
@@ -310,13 +324,33 @@ async function main() {
     shell: process.platform === 'win32',
   });
 
+  const stdoutChunks = [];
   let stdoutBytes = 0;
+  let bufferedStopStdoutBytes = 0;
+  let stopStdoutOversized = false;
   let childSpawnError = null;
   let childStdinError = null;
 
   child.stdout.on('data', (chunk) => {
-    stdoutBytes += Buffer.byteLength(chunk);
-    process.stdout.write(chunk);
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    stdoutBytes += buffer.byteLength;
+    if (isStop) {
+      if (!stopStdoutOversized) {
+        const remaining = MAX_STOP_STDOUT_BYTES - bufferedStopStdoutBytes;
+        if (remaining > 0) {
+          const slice = buffer.subarray(0, remaining);
+          stdoutChunks.push(slice);
+          bufferedStopStdoutBytes += slice.byteLength;
+        }
+        if (buffer.byteLength > remaining) {
+          stopStdoutOversized = true;
+          child.stdout.destroy();
+          child.kill();
+        }
+      }
+    } else {
+      process.stdout.write(chunk);
+    }
   });
   child.stderr.pipe(process.stderr);
   child.stdin.on('error', (error) => {
@@ -326,6 +360,23 @@ async function main() {
     childSpawnError = error;
   });
   child.on('close', (code, signal) => {
+    if (isStop && stopStdoutOversized) {
+      writeStopFallback('plugin_stop_hook_launcher_stdout_oversized', `codex-native-hook produced more than ${MAX_STOP_STDOUT_BYTES} bytes of Stop hook stdout`);
+      return;
+    }
+
+    if (isStop && stdoutBytes > 0) {
+      const stdoutText = Buffer.concat(stdoutChunks).toString('utf8');
+      const parsed = parseSingleJsonObjectOutput(stdoutText);
+      if (parsed) {
+        process.stdout.write(`${JSON.stringify(parsed)}\n`);
+        process.exitCode = 0;
+        return;
+      }
+      writeStopFallback('plugin_stop_hook_launcher_invalid_stdout', `codex-native-hook produced invalid Stop hook JSON stdout (${stdoutBytes} bytes)`);
+      return;
+    }
+
     if (isStop && stdoutBytes === 0) {
       if (childSpawnError) {
         writeStopFallback('plugin_stop_hook_launcher_spawn_error', `failed to launch ${command} codex-native-hook: ${childSpawnError.message}`);

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -521,7 +521,7 @@ describe('official Codex plugin layout', () => {
     });
   });
 
-  it('does not append fallback Stop JSON after partial child stdout', async () => {
+  it('replaces partial Stop child stdout with fallback Stop JSON', async () => {
     await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
       const commandPath = join(cacheRoot, process.platform === 'win32' ? 'partial.cmd' : 'partial.sh');
       if (process.platform === 'win32') {
@@ -537,9 +537,64 @@ describe('official Codex plugin layout', () => {
         { OMX_NATIVE_HOOK_COMMAND: commandPath },
       );
 
-      assert.equal(result.status, 2, result.stderr || result.stdout);
-      assert.equal(result.stdout, 'PARTIAL');
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.doesNotMatch(result.stdout, /PARTIAL/);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_launcher_invalid_stdout');
+    });
+  });
+
+  it('preserves valid Stop child JSON even when the child exits nonzero', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'valid-json-exit.cmd' : 'valid-json-exit.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, '@echo off\r\necho {"decision":"block","stopReason":"child_valid_json"}\r\nexit /b 7\r\n', 'utf-8');
+      } else {
+        await writeFile(commandPath, `#!/bin/sh
+printf '{"decision":"block","stopReason":"child_valid_json"}\n'
+exit 7
+`, 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-valid-json-exit-stop' }),
+        { OMX_NATIVE_HOOK_COMMAND: commandPath },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'child_valid_json');
       assert.doesNotMatch(result.stdout, /plugin_stop_hook_launcher/);
+    });
+  });
+
+  it('replaces oversized Stop child stdout with fallback Stop JSON', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'oversized-stop-stdout.cmd' : 'oversized-stop-stdout.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, '@echo off\r\nfor /L %%i in (1,1,1100000) do <nul set /p=x\r\n', 'utf-8');
+      } else {
+        await writeFile(commandPath, `#!/bin/sh
+head -c 1100000 /dev/zero | tr '\0' x
+`, 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-oversized-stdout-stop' }),
+        { OMX_NATIVE_HOOK_COMMAND: commandPath },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.ok(result.stdout.length < 2000, 'oversized child stdout should not leak to Stop stdout');
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_launcher_stdout_oversized');
     });
   });
 


### PR DESCRIPTION
## Summary
- Buffer plugin native hook child stdout for `Stop` events instead of streaming raw bytes directly to Codex.
- Preserve a valid single JSON object from the child, even when the child exits nonzero.
- Replace partial/invalid Stop stdout with a valid fallback block JSON response using `plugin_stop_hook_launcher_invalid_stdout`.
- Keep non-Stop stdout streaming behavior unchanged.

## Root cause
The plugin hook launcher previously treated child stdout as arbitrary transport bytes for all hook events. For `Stop`, stdout is a machine-readable Codex control channel and must be valid JSON. A child process that emitted partial output such as `PARTIAL` could therefore cause Codex to report invalid Stop hook JSON instead of receiving a structured fallback response.

## Validation
- `npm run verify:plugin-bundle`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/codex-plugin-layout.test.js` — 34/34 passed
- Code review gate: APPROVE / CLEAR
- UltraQA verifier: PASS
- Scholastic gate: PASS
