### PR TITLE
fix(windows): preserve Path env, emit omx.cmd shim, absolute PowerShell hook (#2780)

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3457,6 +3457,92 @@ exit 0
     }
   });
 
+  it("creates a Windows omx.cmd runtime shim with cmd batch content on win32", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-win-"));
+    try {
+      const shimDir = ensureOmxRuntimeCommandShim(
+        cwd,
+        "C:\\repo\\dist\\cli\\omx.js",
+        "C:\\Program Files\\nodejs\\node.exe",
+        "win32",
+      );
+      const shimPath = omxRuntimeCommandShimPath(cwd, "win32");
+
+      assert.equal(shimDir, dirname(shimPath));
+      assert.equal(shimPath.endsWith("omx.cmd"), true);
+      assert.equal(existsSync(shimPath), true);
+      assert.equal(await readFile(shimPath, "utf-8"), [
+        "@echo off",
+        `"C:\\Program Files\\nodejs\\node.exe" "C:\\repo\\dist\\cli\\omx.js" %*`,
+        "",
+      ].join("\r\n"));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves an inherited Windows Path key when prepending the shim dir", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-winpath-"));
+    try {
+      const env = prependOmxRuntimeCommandShimToEnv(
+        cwd,
+        { Path: "C:\\Windows\\System32;C:\\Windows" },
+        "C:\\repo\\dist\\cli\\omx.js",
+        "C:\\Program Files\\nodejs\\node.exe",
+        "win32",
+      );
+      const shimDir = dirname(omxRuntimeCommandShimPath(cwd, "win32"));
+
+      assert.equal(env.Path, `${shimDir};C:\\Windows\\System32;C:\\Windows`);
+      assert.equal(env.PATH, undefined);
+      assert.equal(env.OMX_ENTRY_PATH, "C:\\repo\\dist\\cli\\omx.js");
+      assert.equal(env.OMX_STARTUP_CWD, cwd);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("collapses duplicate Windows PATH/Path variants to a single Path key", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-windup-"));
+    try {
+      const env = prependOmxRuntimeCommandShimToEnv(
+        cwd,
+        { PATH: "", Path: "C:\\Windows\\System32" },
+        "C:\\repo\\dist\\cli\\omx.js",
+        "C:\\Program Files\\nodejs\\node.exe",
+        "win32",
+      );
+      const shimDir = dirname(omxRuntimeCommandShimPath(cwd, "win32"));
+      const pathKeys = Object.keys(env).filter(
+        (key) => key.toLowerCase() === "path",
+      );
+
+      assert.deepEqual(pathKeys, ["Path"]);
+      assert.equal(env.Path, `${shimDir};C:\\Windows\\System32`);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("seeds a Windows Path entry from the shim dir when none is inherited", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-winempty-"));
+    try {
+      const env = prependOmxRuntimeCommandShimToEnv(
+        cwd,
+        {},
+        "C:\\repo\\dist\\cli\\omx.js",
+        "C:\\Program Files\\nodejs\\node.exe",
+        "win32",
+      );
+      const shimDir = dirname(omxRuntimeCommandShimPath(cwd, "win32"));
+
+      assert.equal(env.Path, shimDir);
+      assert.equal(env.PATH, undefined);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps detached tmux bootstrap bounded when no interactive parent env file is requested", () => {
     const steps = buildDetachedSessionBootstrapSteps(
       "omx-demo",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFileSync, spawn } from "child_process";
-import { basename, delimiter, dirname, join, posix, win32 } from "path";
+import { basename, dirname, join, posix, win32 } from "path";
 import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, symlink, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
@@ -1490,8 +1490,17 @@ function runCodexBlocking(
   }
 }
 
-export function omxRuntimeCommandShimPath(cwd: string): string {
-  return join(omxRoot(cwd), "runtime", "bin", "omx");
+export function omxRuntimeCommandShimFileName(
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return platform === "win32" ? "omx.cmd" : "omx";
+}
+
+export function omxRuntimeCommandShimPath(
+  cwd: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return join(omxRoot(cwd), "runtime", "bin", omxRuntimeCommandShimFileName(platform));
 }
 
 function ensureRuntimeShimDirectory(path: string): void {
@@ -1508,7 +1517,18 @@ function ensureRuntimeShimDirectory(path: string): void {
   mkdirSync(path, { mode: 0o700 });
 }
 
-function buildOmxRuntimeCommandShim(nodePath: string, omxBin: string): string {
+function buildOmxRuntimeCommandShim(
+  nodePath: string,
+  omxBin: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return [
+      "@echo off",
+      `"${nodePath}" "${omxBin}" %*`,
+      "",
+    ].join("\r\n");
+  }
   return [
     "#!/bin/sh",
     `exec ${quoteShellArg(nodePath)} ${quoteShellArg(omxBin)} "$@"`,
@@ -1520,8 +1540,9 @@ export function ensureOmxRuntimeCommandShim(
   cwd: string,
   omxBin: string,
   nodePath: string = process.execPath,
+  platform: NodeJS.Platform = process.platform,
 ): string {
-  const shimPath = omxRuntimeCommandShimPath(cwd);
+  const shimPath = omxRuntimeCommandShimPath(cwd, platform);
   const shimDir = dirname(shimPath);
   const rootDir = omxRoot(cwd);
   const runtimeDir = dirname(shimDir);
@@ -1537,11 +1558,13 @@ export function ensureOmxRuntimeCommandShim(
       rmSync(shimPath, { force: true });
     }
   }
-  writeFileSync(shimPath, buildOmxRuntimeCommandShim(nodePath, omxBin), {
+  writeFileSync(shimPath, buildOmxRuntimeCommandShim(nodePath, omxBin, platform), {
     encoding: "utf-8",
     mode: 0o700,
   });
-  chmodSync(shimPath, 0o700);
+  if (platform !== "win32") {
+    chmodSync(shimPath, 0o700);
+  }
   return shimDir;
 }
 
@@ -1550,17 +1573,48 @@ export function prependOmxRuntimeCommandShimToEnv(
   env: NodeJS.ProcessEnv,
   omxBin: string,
   nodePath: string = process.execPath,
+  platform: NodeJS.Platform = process.platform,
 ): NodeJS.ProcessEnv {
-  const shimDir = ensureOmxRuntimeCommandShim(cwd, omxBin, nodePath);
-  const currentPath = typeof env.PATH === "string" ? env.PATH : "";
-  return {
-    ...env,
-    PATH: currentPath ? `${shimDir}${delimiter}${currentPath}` : shimDir,
-    OMX_ENTRY_PATH: omxBin,
-    OMX_STARTUP_CWD: typeof env.OMX_STARTUP_CWD === "string" && env.OMX_STARTUP_CWD.trim()
-      ? env.OMX_STARTUP_CWD
-      : cwd,
-  };
+  const shimDir = ensureOmxRuntimeCommandShim(cwd, omxBin, nodePath, platform);
+  const pathDelimiter = platform === "win32" ? win32.delimiter : posix.delimiter;
+  const result: NodeJS.ProcessEnv = { ...env };
+
+  if (platform === "win32") {
+    // Windows env var names are case-insensitive; the inherited key is usually
+    // `Path`, not `PATH`. Find every case variant, preserve the existing value,
+    // prepend the shim directory, and collapse to a single key so the child does
+    // not see an empty `PATH` shadowing the real `Path` (which drops System32,
+    // WindowsPowerShell, etc.).
+    const pathVariants = Object.keys(result).filter(
+      (key) => key.toLowerCase() === "path",
+    );
+    let pathKey = "Path";
+    let currentPath = "";
+    for (const variant of pathVariants) {
+      const value = result[variant];
+      if (typeof value === "string" && value.length > 0) {
+        pathKey = variant;
+        currentPath = value;
+        break;
+      }
+    }
+    for (const variant of pathVariants) {
+      delete result[variant];
+    }
+    result[pathKey] = currentPath
+      ? `${shimDir}${pathDelimiter}${currentPath}`
+      : shimDir;
+  } else {
+    const currentPath = typeof result.PATH === "string" ? result.PATH : "";
+    result.PATH = currentPath ? `${shimDir}${pathDelimiter}${currentPath}` : shimDir;
+  }
+
+  result.OMX_ENTRY_PATH = omxBin;
+  result.OMX_STARTUP_CWD =
+    typeof result.OMX_STARTUP_CWD === "string" && result.OMX_STARTUP_CWD.trim()
+      ? result.OMX_STARTUP_CWD
+      : cwd;
+  return result;
 }
 
 export interface DetachedSessionTmuxStep {

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -18,6 +18,7 @@ import {
   isRuntimeCodexHomeMirrorPath,
   mergeManagedCodexHooksConfig,
   removeManagedCodexHooks,
+  resolveWindowsPowerShellPath,
 } from "../codex-hooks.js";
 
 describe("codex hooks helpers", () => {
@@ -49,10 +50,14 @@ describe("codex hooks helpers", () => {
     );
   });
 
-  it("uses a PowerShell ProcessStartInfo shim for Windows managed hook commands", () => {
+  it("uses an absolute PowerShell ProcessStartInfo shim for Windows managed hook commands", () => {
     const config = buildManagedCodexHooksConfig(
       "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",
-      { platform: "win32", codexHomeDir: "C:\\Users\\Ada Lovelace\\.codex" },
+      {
+        platform: "win32",
+        codexHomeDir: "C:\\Users\\Ada Lovelace\\.codex",
+        env: { SystemRoot: "C:\\Windows" },
+      },
     );
     const command = (config.hooks.SessionStart[0] as {
       hooks?: Array<{ command?: string }>;
@@ -60,9 +65,32 @@ describe("codex hooks helpers", () => {
 
     assert.equal(
       command,
-      'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
+      '"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
     );
     assert.doesNotMatch(command ?? "", /codex-native-hook\.js/);
+  });
+
+  it("derives the PowerShell path from windir when SystemRoot is absent", () => {
+    const command = buildManagedCodexNativeHookCommand(
+      "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",
+      {
+        platform: "win32",
+        codexHomeDir: "C:\\Users\\Ada Lovelace\\.codex",
+        env: { windir: "E:\\WINNT" },
+      },
+    );
+
+    assert.equal(
+      command,
+      '"E:\\WINNT\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
+    );
+  });
+
+  it("falls back to the default Windows install root when no env hints exist", () => {
+    assert.equal(
+      resolveWindowsPowerShellPath({}),
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
   });
 
   it("keeps Windows shim paths quoted when they contain spaces", () => {
@@ -80,7 +108,11 @@ describe("codex hooks helpers", () => {
         }),
         "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",
         "C:\\Users\\Ada Lovelace\\.codex\\hooks.json",
-        { platform: "win32", codexHomeDir: "C:\\Users\\Ada Lovelace\\.codex" },
+        {
+          platform: "win32",
+          codexHomeDir: "C:\\Users\\Ada Lovelace\\.codex",
+          env: { SystemRoot: "C:\\Windows" },
+        },
       ),
     ) as { hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>> };
 
@@ -90,7 +122,7 @@ describe("codex hooks helpers", () => {
 
     assert.ok(commands.includes("echo keep-me"));
     assert.ok(commands.includes(
-      'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
+      '"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
     ));
   });
 

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -132,6 +132,31 @@ export interface ManagedCodexHookOptions {
   codexHomeDir?: string;
   nodePath?: string;
   hookScriptPath?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+const DEFAULT_WINDOWS_SYSTEM_ROOT = "C:\\Windows";
+
+/**
+ * Resolve an absolute path to Windows PowerShell. When PATH has been shortened
+ * (e.g. by a runtime shim that dropped System32), a bare `powershell.exe` fails
+ * to resolve, so prefer SystemRoot/windir and fall back to the well-known
+ * default install location.
+ */
+export function resolveWindowsPowerShellPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const systemRoot =
+    (typeof env.SystemRoot === "string" && env.SystemRoot.trim()) ||
+    (typeof env.windir === "string" && env.windir.trim()) ||
+    DEFAULT_WINDOWS_SYSTEM_ROOT;
+  return win32.join(
+    systemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
 }
 
 export function buildManagedCodexNativeHookWindowsShimPath(
@@ -189,7 +214,8 @@ export function buildManagedCodexNativeHookCommand(
   if (platform === "win32") {
     const codexHomeDir = options.codexHomeDir ?? dirname(pkgRoot);
     const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
-    return `powershell.exe -NoProfile -ExecutionPolicy Bypass -File ${quoteWindowsCommandPart(shimPath)}`;
+    const powerShellPath = resolveWindowsPowerShellPath(options.env);
+    return `${quoteWindowsCommandPart(powerShellPath)} -NoProfile -ExecutionPolicy Bypass -File ${quoteWindowsCommandPart(shimPath)}`;
   }
 
   return `${quoteCommandPart(process.execPath)} ${quoteCommandPart(hookScript)}`;


### PR DESCRIPTION
## Summary

Fixes the native-Windows regression reported in #2780. Three independent Windows defects in the runtime `omx` shim and managed hook generation are addressed:

1. **`Path` vs `PATH` env key.** `prependOmxRuntimeCommandShimToEnv` previously read and wrote only the `PATH` key. On native Windows the inherited env key is usually `Path`, so the function created a fresh empty-derived `PATH`, leaving the child with an empty path that shadowed the real `Path` and dropped `System32` / `WindowsPowerShell`. It now resolves the existing path key case-insensitively, prepends the shim directory to that key, and collapses duplicate `PATH`/`Path` variants to a single key (using the win32 `;` delimiter).
2. **Extensionless POSIX shim.** The runtime shim was always an extensionless `#!/bin/sh` script (`.omx/runtime/bin/omx`), which native Windows cannot execute. On win32 the shim is now generated as an executable `omx.cmd` batch file (`@echo off` + `"<node>" "<omx>" %*`); non-Windows keeps the POSIX `omx` shim. Shim path, content, and `chmod` are all platform-aware, and PATH still prepends the shim directory so `omx` resolves to `omx.cmd` via `PATHEXT`.
3. **Bare `powershell.exe` hook command.** The managed Codex Windows hook command used a bare `powershell.exe`, which fails when PATH is shortened. It now uses an absolute PowerShell path derived from `SystemRoot` / `windir` (default `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`).

Non-Windows behavior is unchanged: every modified function takes a `platform` parameter defaulting to `process.platform`, and the POSIX paths are untouched.

## Changed files

- `src/cli/index.ts` — platform-aware `omxRuntimeCommandShimPath` / `buildOmxRuntimeCommandShim` / `ensureOmxRuntimeCommandShim`, and `Path`-aware `prependOmxRuntimeCommandShimToEnv`.
- `src/config/codex-hooks.ts` — `resolveWindowsPowerShellPath` + absolute PowerShell in the managed Windows hook command.
- `src/cli/__tests__/index.test.ts` — Windows shim regression tests.
- `src/config/__tests__/codex-hooks.test.ts` — absolute-PowerShell hook command tests.

## Tests

- `node --test dist/cli/__tests__/index.test.js` → 277 pass
- `node --test dist/config/__tests__/codex-hooks.test.js` → 26 pass
- `npm run build` (tsc) PASS
- `npm run check:no-unused` PASS

Closes #2780

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
