### PR TITLE
Fix doctor plugin mode inference

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -863,6 +863,296 @@ OMX_LORE_COMMIT_GUARD = "truee"
 		}
 	});
 
+
+	it("infers plugin MCP compat mode from Codex plugin config when setup-scope is absent", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-config-compat-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await installPluginCacheFixture(codexDir);
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"plugin_hooks = true",
+					"goals = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "local"',
+					`source = ${JSON.stringify(repoRoot())}`,
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_state]',
+					"enabled = true",
+					'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_memory]',
+					"enabled = true",
+					'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_code_intel]',
+					"enabled = true",
+					'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_trace]',
+					"enabled = true",
+					'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_wiki]',
+					"enabled = true",
+					'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_hermes]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+
+			assert.equal(existsSync(join(wd, ".omx", "setup-scope.json")), false);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Resolved setup MCP mode: compat \(inferred from Codex plugin config\)/,
+			);
+			assert.match(
+				res.stdout,
+				/MCP Servers: plugin MCP compatibility enabled by setup MCP mode compat \(6\/6 first-party servers enabled\)/,
+			);
+			assert.doesNotMatch(
+				res.stdout,
+				/plugin MCP compatibility overrides are incomplete or mixed/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not infer plugin mode from a foreign local marketplace source", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-config-foreign-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"plugin_hooks = true",
+					"goals = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "local"',
+					`source = ${JSON.stringify(join(wd, "other-oh-my-codex"))}`,
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.doesNotMatch(
+				res.stdout,
+				/Resolved setup install mode: plugin \(inferred from Codex plugin config\)/,
+			);
+			assert.match(
+				res.stdout,
+				/Native hooks: expected setup-owned hooks\.json is missing at .*\.codex[\\/]+hooks\.json even though config\.toml has OMX entries; run "omx setup --force" to restore native hook coverage/,
+			);
+			assert.match(res.stdout, /Prompts: prompts directory not found/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("infers plugin mode from Codex plugin config when setup-scope is absent", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-config-infer-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			const cacheDir = await installPluginCacheFixture(codexDir);
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"plugin_hooks = true",
+					"goals = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "local"',
+					`source = ${JSON.stringify(repoRoot())}`,
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+
+			assert.equal(existsSync(join(wd, ".omx", "setup-scope.json")), false);
+			assert.equal(existsSync(join(codexDir, "hooks.json")), false);
+			assert.equal(existsSync(join(codexDir, "prompts")), false);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Resolved setup install mode: plugin \(inferred from Codex plugin config\)/,
+			);
+			assert.match(
+				res.stdout,
+				new RegExp(
+					`\\[OK\\] Native hooks: plugin-scoped hooks are enabled; setup-owned hooks\\.json is intentionally absent at .*\\.codex[\\/]+hooks\\.json, and plugin cache native hook coverage smoke passed via ${join(cacheDir, "hooks", "hooks.json").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+				),
+			);
+			assert.match(
+				res.stdout,
+				/Prompts: plugin mode intentionally omits setup-owned prompts; Codex plugin discovery supplies workflow surfaces/,
+			);
+			assert.match(
+				res.stdout,
+				/Skills: plugin marketplace oh-my-codex-local registered; OMX skills are supplied by/,
+			);
+			assert.doesNotMatch(
+				res.stdout,
+				/expected setup-owned hooks\.json is missing/,
+			);
+			assert.doesNotMatch(
+				res.stdout,
+				/plugin mode is using legacy native hook fallback/,
+			);
+			assert.doesNotMatch(
+				res.stdout,
+				/run "omx setup --force" to restore native hook coverage/,
+			);
+			assert.doesNotMatch(res.stdout, /Prompts: prompts directory not found/);
+			assert.doesNotMatch(res.stdout, /Skills: skills directory not found/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("fills missing persisted install mode from plugin config without legacy warnings", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-partial-persisted-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await mkdir(codexDir, { recursive: true });
+			await installPluginCacheFixture(codexDir);
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				`${JSON.stringify({ scope: "user" }, null, 2)}\n`,
+			);
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"plugin_hooks = true",
+					"goals = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "local"',
+					`source = ${JSON.stringify(repoRoot())}`,
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Resolved setup scope: user \(from \.omx\/setup-scope\.json\)/,
+			);
+			assert.match(
+				res.stdout,
+				/Resolved setup install mode: plugin \(from \.omx\/setup-scope\.json\)/,
+			);
+			assert.match(
+				res.stdout,
+				/Prompts: plugin mode intentionally omits setup-owned prompts; Codex plugin discovery supplies workflow surfaces/,
+			);
+			assert.doesNotMatch(
+				res.stdout,
+				/expected setup-owned hooks\.json is missing/,
+			);
+			assert.doesNotMatch(res.stdout, /Prompts: prompts directory not found/);
+			assert.doesNotMatch(res.stdout, /Skills: skills directory not found/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("infers project plugin mode from project Codex config when setup-scope is absent", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-project-plugin-config-infer-"));
+		try {
+			const home = join(wd, "home");
+			const projectCodexDir = join(wd, ".codex");
+			await mkdir(projectCodexDir, { recursive: true });
+			await installPluginCacheFixture(projectCodexDir);
+			await writeFile(
+				join(projectCodexDir, "config.toml"),
+				[
+					"plugin_hooks = true",
+					"goals = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "local"',
+					`source = ${JSON.stringify(repoRoot())}`,
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+
+			assert.equal(existsSync(join(wd, ".omx", "setup-scope.json")), false);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: join(home, ".codex"),
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Resolved setup scope: project \(inferred from Codex plugin config\)/,
+			);
+			assert.match(
+				res.stdout,
+				/Resolved setup install mode: plugin \(inferred from Codex plugin config\)/,
+			);
+			assert.match(
+				res.stdout,
+				/Prompts: plugin mode intentionally omits setup-owned prompts; Codex plugin discovery supplies workflow surfaces/,
+			);
+			assert.match(
+				res.stdout,
+				/Skills: plugin marketplace oh-my-codex-local registered; OMX skills are supplied by/,
+			);
+			assert.doesNotMatch(
+				res.stdout,
+				/expected setup-owned hooks\.json is missing/,
+			);
+			assert.doesNotMatch(res.stdout, /Prompts: prompts directory not found/);
+			assert.doesNotMatch(res.stdout, /Skills: skills directory not found/);
+			assert.doesNotMatch(res.stdout, /MCP Servers: config\.toml not found/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("accepts plugin-scoped native hooks when setup-owned hooks.json is intentionally absent", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-scoped-hooks-"));
 		try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -105,7 +105,7 @@ type DoctorSetupScope = "user" | "project";
 
 interface DoctorScopeResolution {
 	scope: DoctorSetupScope;
-	source: "persisted" | "default";
+	source: "persisted" | "config" | "default";
 	installMode?: SetupInstallMode;
 	mcpMode?: SetupMcpMode;
 }
@@ -123,15 +123,59 @@ interface DoctorPaths {
 async function resolveDoctorScope(cwd: string): Promise<DoctorScopeResolution> {
 	const persisted = await readPersistedSetupPreferences(cwd);
 	if (persisted?.scope) {
+		const inferred = await inferPluginInstallModeFromConfigForScope(cwd, persisted.scope);
 		return {
 			scope: persisted.scope,
 			source: "persisted",
-			installMode: persisted.installMode,
-			mcpMode: persisted.mcpMode ?? "none",
+			installMode: persisted.installMode ?? inferred?.installMode,
+			mcpMode: persisted.mcpMode ?? inferred?.mcpMode ?? "none",
 		};
 	}
 
+	const inferredUser = await inferPluginInstallModeFromConfigForScope(cwd, "user");
+	if (inferredUser) return inferredUser;
+
+	const inferredProject = await inferPluginInstallModeFromConfigForScope(cwd, "project");
+	if (inferredProject) return inferredProject;
+
 	return { scope: "user", source: "default" };
+}
+
+async function inferPluginInstallModeFromConfigForScope(
+	cwd: string,
+	scope: DoctorSetupScope,
+): Promise<DoctorScopeResolution | null> {
+	const configPath =
+		scope === "project" ? join(cwd, ".codex", "config.toml") : codexConfigPath();
+	if (!existsSync(configPath)) return null;
+
+	try {
+		const configContent = await readFile(configPath, "utf-8");
+		if (!configEnablesPluginScopedHooks(configContent)) return null;
+
+		const { marketplace, plugin } = getParsedPluginMarketplaceConfig(configContent);
+		if (!marketplace || marketplace.source_type !== "local") return null;
+		if (marketplace.source !== getPackageRoot()) return null;
+		if (plugin?.enabled !== true) return null;
+
+		return {
+			scope,
+			source: "config",
+			installMode: "plugin",
+			mcpMode: inferPluginMcpModeFromConfig(configContent),
+		};
+	} catch {
+		return null;
+	}
+}
+
+function inferPluginMcpModeFromConfig(configContent: string): SetupMcpMode {
+	const states = OMX_FIRST_PARTY_MCP_SERVER_NAMES.map((serverName) =>
+		pluginMcpServerEnabled(configContent, serverName),
+	);
+	return states.length > 0 && states.every((state) => state === true)
+		? "compat"
+		: "none";
 }
 
 function resolveDoctorPaths(cwd: string, scope: DoctorSetupScope): DoctorPaths {
@@ -171,6 +215,8 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	const scopeSourceMessage =
 		scopeResolution.source === "persisted"
 			? " (from .omx/setup-scope.json)"
+			: scopeResolution.source === "config"
+				? " (inferred from Codex plugin config)"
 			: "";
 
 	console.log("oh-my-codex doctor");


### PR DESCRIPTION
## Summary
- infer plugin install mode in `omx doctor` from Codex plugin config when `.omx/setup-scope.json` is absent
- backfill missing persisted install/MCP mode fields from same-scope config
- support project-scoped plugin config fallback and MCP compat inference
- add regressions for user/project inference, partial persisted state, compat MCP, and foreign marketplace source rejection

## Verification
- `git diff --check -- src/cli/doctor.ts src/cli/__tests__/doctor-warning-copy.test.ts`
- `npm run build`
- `node --test dist/cli/__tests__/doctor-warning-copy.test.js` (37/37)

## Notes
- Code review gate: APPROVE / architectural status CLEAR
- UltraQA: targeted CLI regression/smoke passed; real worktree smoke against installed user config is intentionally not representative because the config marketplace source points at the installed package root, not this worktree.

Fixes omx-s9r.
