### PR TITLE
fix(windows): emit UTF-8 BOM in native-hook shim for non-ASCII install paths

### DIFF
--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -156,6 +156,23 @@ describe("codex hooks helpers", () => {
     );
   });
 
+  it("prepends a UTF-8 BOM to the Windows shim so PowerShell 5.1 reads non-ASCII paths as UTF-8", () => {
+    const content = buildManagedCodexNativeHookWindowsShimContent(
+      "C:\\Users\\정찬\\깃헙\\oh-my-codex",
+      { nodePath: "C:\\Program Files\\nodejs\\node.exe" },
+    );
+
+    assert.equal(content.charCodeAt(0), 0xfeff);
+    assert.equal(content.codePointAt(0), 0xfeff);
+    // BOM must precede the script body, not replace it.
+    assert.equal(content.slice(1).startsWith("$ErrorActionPreference = 'Stop'"), true);
+    // Non-ASCII install path is preserved verbatim in the emitted shim.
+    assert.match(content, /정찬\\깃헙\\oh-my-codex/);
+
+    const utf8 = Buffer.from(content, "utf-8");
+    assert.deepEqual([...utf8.subarray(0, 3)], [0xef, 0xbb, 0xbf]);
+  });
+
   it("forwards payload, stdout, stderr, and non-zero exit through the Windows shim when PowerShell is available", async () => {
     const shell = ["pwsh", "powershell.exe", "powershell"].find((candidate) => {
       const probe = spawnSync(candidate, ["-NoProfile", "-Command", "$PSVersionTable.PSVersion.ToString()"], {

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -174,7 +174,11 @@ export function buildManagedCodexNativeHookWindowsShimContent(
     win32.join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
   const nodePath = options.nodePath ?? process.execPath;
 
-  return [
+  // Windows PowerShell 5.1 (powershell.exe) decodes BOM-less .ps1 files using
+  // the system ANSI codepage, which mojibakes non-ASCII install paths embedded
+  // below and breaks the native hook (Node MODULE_NOT_FOUND, exit 1). Prepend a
+  // UTF-8 BOM so the script is always read as UTF-8.
+  return "\uFEFF" + [
     "$ErrorActionPreference = 'Stop'",
     "$startInfo = [System.Diagnostics.ProcessStartInfo]::new()",
     `$startInfo.FileName = ${quotePowerShellLiteral(nodePath)}`,


### PR DESCRIPTION
## Summary

Fixes #2783. On Windows, the managed native-hook shim `…\.codex\hooks\omx-native-hook-windows-shim.ps1` is generated **without a UTF-8 BOM** but launched via **`powershell.exe` (Windows PowerShell 5.1)**. WinPS 5.1 decodes a BOM-less `.ps1` using the **system ANSI code page** (e.g. 949/CP949 Korean, 936 Chinese, 932 Japanese) rather than UTF-8. The non-ASCII characters in the hard-coded node script path baked into the shim then mojibake, so `node` is launched with a garbled module path and exits 1 (`MODULE_NOT_FOUND`) → `Stop hook (failed) error: hook exited with code 1`.

This is latent: ASCII install paths never trigger it; it only surfaces for non-ASCII install / `$CODEX_HOME` paths on a localized Windows.

## Root cause

`buildManagedCodexNativeHookWindowsShimContent()` in `src/config/codex-hooks.ts` returned `[…lines…].join("\n")` with no BOM. `syncManagedContent()` writes it as default UTF-8 (no BOM), and `buildManagedCodexNativeHookCommand()` launches it with `powershell.exe`, which only treats a `.ps1` as UTF-8 when it begins with a BOM.

## Fix

Prepend a UTF-8 BOM (`\uFEFF`) to the generated Windows shim content so `powershell.exe` decodes it as UTF-8. PowerShell 7 (`pwsh`) is unaffected by the BOM. Preferred over switching the launcher to `pwsh`, since PowerShell 7 is not guaranteed installed.

The change is Windows-shim-only: no other hook content, command semantics, or non-Windows paths are touched.

## Tests

Added a regression test asserting:
- `content.charCodeAt(0) === 0xFEFF` (BOM is the first char)
- the BOM precedes the script body (`$ErrorActionPreference = 'Stop'`)
- a non-ASCII install path round-trips intact in the emitted shim
- the UTF-8 byte prefix is `EF BB BF`

Verification run locally:
- `node --test src/config/__tests__/codex-hooks.test.ts` → 27/27 pass
- `tsc --noEmit` (typecheck) clean
- `check:no-unused` clean
- `npm run build` clean
- biome lint clean on changed files

Closes #2783

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
