### PR TITLE
feat(config): support per-agent native model overrides

### DIFF
--- a/docs/reference/omx-config-schema-routing.md
+++ b/docs/reference/omx-config-schema-routing.md
@@ -25,6 +25,7 @@ Current code recognizes these top-level `.omx-config.json` keys:
 
 | Top-level key | Supported shape | Primary use |
 | --- | --- | --- |
+| `agentModels` | Object mapping agent names to non-empty model strings | Optional per-agent model overrides for generated native agent TOML and the generated model capability table. |
 | `agentReasoning` | Object mapping agent names to `low`, `medium`, `high`, or `xhigh` | Optional per-agent reasoning overrides for generated native agent TOML and role-based worker/Ralph staffing guidance. |
 | `env` | Object of non-empty string values | Fallback environment values for model routing and helper launch paths. Model-related supported keys are listed below. |
 | `models` | Object of non-empty string values | Mode defaults and low-complexity model aliases. Supported model-routing keys are listed below. |
@@ -51,10 +52,14 @@ Use [`docs/discord-integration.md`](../discord-integration.md) for Discord webho
 
 ## Supported model/env keys
 
-The model-routing reader supports `env`, `models`, and the role-reasoning override map `agentReasoning`.
+The model-routing reader supports `env`, `models`, the per-agent native model override map `agentModels`, and the role-reasoning override map `agentReasoning`.
 
 ```json
 {
+  "agentModels": {
+    "planner": "gpt-5.5",
+    "architect": "gpt-5.5"
+  },
   "agentReasoning": {
     "architect": "xhigh",
     "critic": "xhigh"
@@ -112,7 +117,25 @@ Supported model-routing keys:
 | `team-low-complexity` | Alias for `team_low_complexity`. |
 | `teamLowComplexity` | Alias for `team_low_complexity`. |
 
-Do not invent per-role maps such as `models.executor`, `models.architect`, or `models.roles` unless your installed version documents that exact key. Current role routing is based on agent definitions and model class, not arbitrary per-role JSON maps.
+Do not invent per-role maps such as `models.executor`, `models.architect`, or `models.roles`. Use the documented top-level `agentModels` map for generated native-agent per-role model overrides. `models` remains the mode/default routing map.
+
+### `agentModels`
+
+`agentModels` is the supported per-agent model override map for setup-managed native agent TOML files and the generated model capability table. Keys are agent names and values must be non-empty model strings.
+
+```json
+{
+  "agentModels": {
+    "planner": "gpt-5.5",
+    "architect": "gpt-5.5",
+    "explore": "gpt-5.3-codex-spark"
+  }
+}
+```
+
+These overrides do not change built-in defaults in source. They are user/project configuration that applies when OMX regenerates native agent TOML. Rerun `omx setup` after changing this map so setup-managed native agent files and the generated model capability table are refreshed. Malformed agent names, empty values, non-string values, and wrong-shaped maps are ignored.
+
+For generated native agents, `agentModels` has the highest model precedence: it wins before built-in exact-model pins and before model-class routing. This lets a user locally promote roles such as `planner`, `architect`, or `researcher` without maintaining a patch against `src/agents/definitions.ts`.
 
 ### `agentReasoning`
 
@@ -150,6 +173,19 @@ When code asks for `getModelForMode(mode)`, the mode model resolves in this orde
 
 Example: with `models.team = "gpt-5.5"` and `models.default = "gpt-5.4-mini"`, `team` uses `gpt-5.5`; a mode without its own key uses `gpt-5.4-mini`.
 
+### Generated native agents
+
+Generated native agent TOML resolves each role model in this order:
+
+1. `.omx-config.json` `agentModels[agentName]`
+2. Built-in `AgentDefinition.exactModel`, when present
+3. Existing class routing:
+   - `executor` and `frontier` roles use the active `config.toml` root `model` first, then the main/frontier fallback.
+   - `standard` roles use the standard-lane default.
+   - `fast` roles use the spark/low-complexity default.
+
+`agentModels` applies to generated native agent TOML and the generated model capability table. It is not a substitute for explicit `--model ...` launch arguments and does not redefine mode-level `models` routing.
+
 ### Standard-lane agents
 
 Standard-lane agents resolve in this order:
@@ -175,13 +211,13 @@ For team low-complexity helpers, the exact order depends on the call path: `getS
 
 ## Role/category routing examples
 
-Native agent TOML generation and team model-contract logic use agent definitions with `modelClass`, optional `exactModel`, and `reasoningEffort` metadata. Exact-model pins win before class-based routing. Native-agent generation has one important frontier-lane precedence detail: for frontier roles and the `executor` special case, it reads the active Codex `config.toml` root `model` first, then falls back to `getMainDefaultModel()` if that root model is absent. Because `getMainDefaultModel()` is only the fallback in this path, `.omx-config.json` `env.OMX_DEFAULT_FRONTIER_MODEL` does not override an explicit `config.toml` root `model` for generated native-agent TOML.
+Native agent TOML generation and team model-contract logic use agent definitions with `modelClass`, optional `exactModel`, and `reasoningEffort` metadata. For generated native agent TOML, `agentModels` wins before exact-model pins, and exact-model pins otherwise win before class-based routing. Native-agent generation has one important frontier-lane precedence detail: for frontier roles and the `executor` special case, it reads the active Codex `config.toml` root `model` first, then falls back to `getMainDefaultModel()` if that root model is absent. Because `getMainDefaultModel()` is only the fallback in this path, `.omx-config.json` `env.OMX_DEFAULT_FRONTIER_MODEL` does not override an explicit `config.toml` root `model` for generated native-agent TOML.
 
 Examples:
 
 | Role/category | Examples | Model class behavior |
 | --- | --- | --- |
-| Exact mini planning/research | `planner`, `architect`, `researcher` | Uses the exact `gpt-5.4-mini` pin before model-class routing; planner/architect keep `frontier-orchestrator` posture and high reasoning, while ralplan's `critic` remains frontier-routed for the consensus gate. |
+| Exact mini planning/research | `planner`, `architect`, `researcher` | Uses the exact `gpt-5.4-mini` pin before model-class routing unless `agentModels` overrides the role; planner/architect keep `frontier-orchestrator` posture and high reasoning, while ralplan's `critic` remains frontier-routed for the consensus gate. |
 | Frontier orchestration | `critic`, `code-reviewer`, `security-reviewer`, `team-executor`, `vision` | Native-agent generation uses active `config.toml` root `model` first, then the main/frontier default fallback. |
 | Standard worker/review | `debugger`, `quality-reviewer`, `api-reviewer`, `performance-reviewer`, `dependency-expert`, `writer` | Uses the standard-lane default, which inherits main/frontier unless `OMX_DEFAULT_STANDARD_MODEL` is set. |
 | Fast/low-complexity | `explore`, `style-reviewer` | Uses the spark/low-complexity default. |
@@ -245,6 +281,10 @@ This keeps standard agents inheriting the frontier model by omitting `OMX_DEFAUL
 
 ```json
 {
+  "agentModels": {
+    "planner": "gpt-5.5",
+    "architect": "gpt-5.5"
+  },
   "agentReasoning": {
     "architect": "xhigh",
     "critic": "xhigh"

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -133,6 +133,42 @@ describe("agents/native-config", () => {
     }
   });
 
+  it("applies per-agent model overrides before exact pins and class routing", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "omx-native-config-agent-models-"));
+    try {
+      await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({
+        agentModels: {
+          planner: "gpt-5.5",
+          debugger: "gpt-5.4-mini",
+        },
+      }));
+
+      const plannerToml = generateAgentToml(
+        AGENT_DEFINITIONS.planner,
+        "planner prompt",
+        { codexHomeOverride: codexHome },
+      );
+      assert.match(plannerToml, /model = "gpt-5\.5"/);
+      assert.match(plannerToml, /resolved_model: gpt-5\.5/);
+      assert.doesNotMatch(plannerToml, /model = "gpt-5\.4-mini"/);
+      assert.doesNotMatch(plannerToml, /exact gpt-5\.4-mini model/);
+
+      const debuggerToml = generateAgentToml(
+        AGENT_DEFINITIONS.debugger,
+        "debugger prompt",
+        {
+          codexHomeOverride: codexHome,
+          env: { OMX_DEFAULT_STANDARD_MODEL: "standard-env" } as NodeJS.ProcessEnv,
+        },
+      );
+      assert.match(debuggerToml, /model = "gpt-5\.4-mini"/);
+      assert.match(debuggerToml, /resolved_model: gpt-5\.4-mini/);
+      assert.match(debuggerToml, /exact gpt-5\.4-mini model/);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
 
   it("pins ralplan thesis/antithesis and researcher to exact gpt-5.4-mini without downgrading judgment roles", () => {
     process.env.OMX_DEFAULT_FRONTIER_MODEL = "gpt-5.5";
@@ -345,6 +381,36 @@ describe("agents/native-config", () => {
 
       const architectToml = await readFile(join(outDir, "architect.toml"), "utf8");
       assert.match(architectToml, /model_reasoning_effort = "xhigh"/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("installs native agent TOML with configured per-agent model overrides", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-config-install-agent-models-"));
+    const codexHome = join(root, ".codex");
+    const promptsDir = join(root, "prompts");
+    const outDir = join(codexHome, "agents");
+
+    try {
+      await mkdir(promptsDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({
+        agentModels: {
+          Architect: "gpt-5.5",
+        },
+      }));
+      await writeFile(join(promptsDir, "architect.md"), "architect prompt");
+
+      await installNativeAgentConfigs(root, {
+        agentsDir: outDir,
+        catalogManifest: manifestWithAgents(["architect"]),
+      });
+
+      const architectToml = await readFile(join(outDir, "architect.toml"), "utf8");
+      assert.match(architectToml, /model = "gpt-5\.5"/);
+      assert.match(architectToml, /resolved_model: gpt-5\.5/);
+      assert.doesNotMatch(architectToml, /exact gpt-5\.4-mini model/);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -11,6 +11,7 @@ import { readCatalogManifest } from "../catalog/reader.js";
 import type { CatalogManifest } from "../catalog/schema.js";
 import { getInstallableNativeAgentNames } from "./policy.js";
 import {
+  getAgentModelOverride,
   getCodexConfigRootModelProvider,
   getEnvConfiguredStandardDefaultModel,
   getAgentReasoningOverride,
@@ -174,6 +175,14 @@ function resolveAgentModel(
   agent: AgentDefinition,
   options: AgentModelResolutionOptions = {},
 ): string {
+  const configuredAgentModel = getAgentModelOverride(
+    agent.name,
+    options.codexHomeOverride,
+  );
+  if (configuredAgentModel) {
+    return configuredAgentModel;
+  }
+
   if (agent.exactModel) {
     return agent.exactModel;
   }

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_FRONTIER_MODEL,
   DEFAULT_SPARK_MODEL,
   DEFAULT_TEAM_CHILD_MODEL,
+  getAgentModelOverride,
   getAgentReasoningOverride,
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
@@ -15,6 +16,7 @@ import {
   getStandardDefaultModel,
   getTeamChildModel,
   getTeamLowComplexityModel,
+  readAgentModelOverrides,
   readAgentReasoningOverrides,
   readConfiguredEnvOverrides,
 } from '../models.js';
@@ -264,6 +266,32 @@ describe('getModelForMode', () => {
     });
     assert.equal(getAgentReasoningOverride('ARCHITECT'), 'xhigh');
     assert.equal(getAgentReasoningOverride('executor'), undefined);
+  });
+
+  it('reads normalized per-agent model overrides from .omx-config.json', async () => {
+    await writeConfig({
+      agentModels: {
+        Architect: ' gpt-5.5 ',
+        critic: 'gpt-5.4',
+        executor: 42,
+        'bad role': 'gpt-5.5',
+        empty: '   ',
+      },
+    });
+
+    assert.deepEqual(readAgentModelOverrides(), {
+      architect: 'gpt-5.5',
+      critic: 'gpt-5.4',
+    });
+    assert.equal(getAgentModelOverride('ARCHITECT'), 'gpt-5.5');
+    assert.equal(getAgentModelOverride('executor'), undefined);
+  });
+
+  it('ignores invalid per-agent model override maps', async () => {
+    await writeConfig({ agentModels: ['architect', 'gpt-5.5'] });
+
+    assert.deepEqual(readAgentModelOverrides(), {});
+    assert.equal(getAgentModelOverride('architect'), undefined);
   });
 
   it('keeps explicit low-complexity config ahead of OMX_DEFAULT_SPARK_MODEL', async () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -14,6 +14,9 @@
  *     "default": "o4-mini",
  *     "team": "gpt-4.1"
  *   },
+ *   "agentModels": {
+ *     "architect": "gpt-5.5"
+ *   },
  *   "agentReasoning": {
  *     "architect": "xhigh"
  *   }
@@ -38,6 +41,7 @@ export interface OmxConfigEnv {
 export type ConfiguredAgentReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
 
 interface OmxConfigFile {
+  agentModels?: Record<string, unknown>;
   agentReasoning?: Record<string, unknown>;
   env?: OmxConfigEnv;
   models?: ModelsConfig;
@@ -165,6 +169,29 @@ export function readAgentReasoningOverrides(
     if (role && effort) resolved[role] = effort;
   }
   return resolved;
+}
+
+export function readAgentModelOverrides(codexHomeOverride?: string): Record<string, string> {
+  const config = readOmxConfigFile(codexHomeOverride);
+  const raw = config?.agentModels;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+
+  const resolved: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const role = normalizeAgentName(key);
+    const model = normalizeConfiguredValue(value);
+    if (role && model) resolved[role] = model;
+  }
+  return resolved;
+}
+
+export function getAgentModelOverride(
+  agentName: string | undefined,
+  codexHomeOverride?: string,
+): string | undefined {
+  const normalized = normalizeAgentName(agentName);
+  if (!normalized) return undefined;
+  return readAgentModelOverrides(codexHomeOverride)[normalized];
 }
 
 export function getAgentReasoningOverride(

--- a/src/utils/__tests__/agents-model-table.test.ts
+++ b/src/utils/__tests__/agents-model-table.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   buildAgentsModelTable,
   OMX_MODELS_END_MARKER,
@@ -12,8 +15,10 @@ const originalFrontierEnv = process.env.OMX_DEFAULT_FRONTIER_MODEL;
 const originalStandardEnv = process.env.OMX_DEFAULT_STANDARD_MODEL;
 const originalSparkEnv = process.env.OMX_DEFAULT_SPARK_MODEL;
 const originalLegacySparkEnv = process.env.OMX_SPARK_MODEL;
+let tempDirs: string[] = [];
 
 beforeEach(() => {
+  tempDirs = [];
   delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
   delete process.env.OMX_DEFAULT_STANDARD_MODEL;
   delete process.env.OMX_DEFAULT_SPARK_MODEL;
@@ -41,6 +46,9 @@ afterEach(() => {
   } else {
     delete process.env.OMX_SPARK_MODEL;
   }
+  return Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))).then(
+    () => undefined,
+  );
 });
 
 describe('agents model table', () => {
@@ -55,6 +63,7 @@ describe('agents model table', () => {
       frontierModel: 'frontier-config',
       sparkModel: 'spark-env',
       subagentDefaultModel: 'standard-env',
+      agentModelOverrides: {},
     });
   });
 
@@ -65,7 +74,24 @@ describe('agents model table', () => {
       frontierModel: 'frontier-config',
       sparkModel: 'gpt-5.3-codex-spark',
       subagentDefaultModel: 'frontier-config',
+      agentModelOverrides: {},
     });
+  });
+
+  it('reads per-agent model overrides into table context', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-agents-model-table-'));
+    tempDirs.push(codexHome);
+    await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+      agentModels: {
+        Architect: 'gpt-5.5',
+      },
+    }));
+
+    const context = resolveAgentsModelTableContext('model = "frontier-config"\n', {
+      codexHomeOverride: codexHome,
+    });
+
+    assert.equal(context.agentModelOverrides?.architect, 'gpt-5.5');
   });
 
   it('builds table rows for summary roles, exact pins, and posture/modelClass-driven recommendations', () => {
@@ -73,6 +99,7 @@ describe('agents model table', () => {
       frontierModel: 'gpt-frontier',
       sparkModel: 'gpt-spark',
       subagentDefaultModel: 'gpt-standard',
+      agentModelOverrides: {},
     });
 
     assert.match(table, /\| Frontier \(leader\) \| `gpt-frontier` \| high \|/);
@@ -89,11 +116,28 @@ describe('agents model table', () => {
     assert.match(table, /\| `executor` \| `gpt-frontier` \| medium \| Code implementation, refactoring, feature work \(deep-worker, standard\) \|/);
   });
 
+  it('applies per-agent model overrides in role rows', () => {
+    const table = buildAgentsModelTable({
+      frontierModel: 'gpt-frontier',
+      sparkModel: 'gpt-spark',
+      subagentDefaultModel: 'gpt-standard',
+      agentModelOverrides: {
+        architect: 'gpt-5.5',
+        writer: 'gpt-writer',
+      },
+    });
+
+    assert.match(table, /\| `architect` \| `gpt-5\.5` \| high \|/);
+    assert.match(table, /\| `writer` \| `gpt-writer` \| high \|/);
+    assert.doesNotMatch(table, /\| `architect` \| `gpt-5\.4-mini` \|/);
+  });
+
   it('replaces existing marker-bounded content and inserts the block after team_model_resolution when missing', () => {
     const context = {
       frontierModel: 'gpt-frontier',
       sparkModel: 'gpt-spark',
       subagentDefaultModel: 'gpt-frontier',
+      agentModelOverrides: {},
     };
 
     const withMarkers = [

--- a/src/utils/agents-model-table.ts
+++ b/src/utils/agents-model-table.ts
@@ -5,6 +5,7 @@ import { getRootModelName } from '../config/generator.js';
 import {
   DEFAULT_FRONTIER_MODEL,
   DEFAULT_SPARK_MODEL,
+  readAgentModelOverrides,
   getEnvConfiguredSparkDefaultModel,
   getEnvConfiguredMainDefaultModel,
   getEnvConfiguredStandardDefaultModel,
@@ -20,6 +21,7 @@ export interface AgentsModelTableContext {
   frontierModel: string;
   sparkModel: string;
   subagentDefaultModel: string;
+  agentModelOverrides?: Record<string, string>;
 }
 
 function escapeTableCell(value: string): string {
@@ -34,6 +36,11 @@ function getAgentRecommendedModel(
   agent: AgentDefinition,
   context: AgentsModelTableContext,
 ): string {
+  const configuredModel = context.agentModelOverrides?.[agent.name];
+  if (configuredModel) {
+    return configuredModel;
+  }
+
   if (agent.exactModel) {
     return agent.exactModel;
   }
@@ -107,6 +114,7 @@ export function resolveAgentsModelTableContext(
     frontierModel,
     sparkModel,
     subagentDefaultModel,
+    agentModelOverrides: readAgentModelOverrides(codexHomeOverride),
   };
 }
 


### PR DESCRIPTION
## Summary

- Add `.omx-config.json` top-level `agentModels` for per-agent generated native model overrides.
- Apply `agentModels[agentName]` before built-in `exactModel` pins and class-based routing in native agent TOML generation.
- Keep the generated AGENTS model capability table consistent with configured per-agent model overrides.
- Document the new key, precedence, and `omx setup` regeneration flow.

## Why

Manual edits to setup-managed native agent TOML are overwritten by setup/update refreshes. This gives users a durable config surface for local/project role-specific model choices without patching `src/agents/definitions.ts` or changing upstream defaults.

## Verification

- [x] `npm run build`
- [x] `node dist/scripts/run-test-files.js dist/config/__tests__/models.test.js dist/agents/__tests__/native-config.test.js dist/utils/__tests__/agents-model-table.test.js`
- [x] `npm run verify:native-agents`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `npm run lint`
- [x] UltraQA smoke: temporary `CODEX_HOME` with `agentModels` promotes planner/architect to `gpt-5.5`, removes exact-mini guidance, and updates model table rows.

Note: full `npm test` was attempted locally. It reached unrelated existing/environment-sensitive failures in team/notification tests while all files touched by this PR and the native-agent verifier passed.
