### PR TITLE
fix: allow ralplan planning artifact writes

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5903,6 +5903,86 @@ exit 0
     }
   });
 
+  it("allows Autopilot ralplan planning artifacts while blocking implementation writes", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-autopilot-ralplan-artifact-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionDir = join(stateDir, "sessions", "sess-autopilot-ralplan-artifact");
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-autopilot-ralplan-artifact", cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        phase: "ralplan",
+        session_id: "sess-autopilot-ralplan-artifact",
+        thread_id: "thread-autopilot-ralplan-artifact",
+        active_skills: [
+          {
+            skill: "autopilot",
+            phase: "ralplan",
+            active: true,
+            session_id: "sess-autopilot-ralplan-artifact",
+            thread_id: "thread-autopilot-ralplan-artifact",
+          },
+        ],
+      });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ralplan",
+        session_id: "sess-autopilot-ralplan-artifact",
+        thread_id: "thread-autopilot-ralplan-artifact",
+      });
+
+      const allowedPlanWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-autopilot-ralplan-artifact",
+          thread_id: "thread-autopilot-ralplan-artifact",
+          tool_name: "Write",
+          tool_use_id: "tool-autopilot-ralplan-plan-write",
+          tool_input: { file_path: ".omx/plans/prd-omx-y7a.md", content: "# Plan" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedPlanWrite.outputJson, null);
+
+      const allowedSpecEdit = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-autopilot-ralplan-artifact",
+          thread_id: "thread-autopilot-ralplan-artifact",
+          tool_name: "Edit",
+          tool_use_id: "tool-autopilot-ralplan-spec-edit",
+          tool_input: { file_path: ".omx/specs/omx-y7a.md", old_string: "old", new_string: "new" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedSpecEdit.outputJson, null);
+
+      const blockedImplementationEdit = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-autopilot-ralplan-artifact",
+          thread_id: "thread-autopilot-ralplan-artifact",
+          tool_name: "Edit",
+          tool_use_id: "tool-autopilot-ralplan-src-edit",
+          tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedImplementationEdit.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedImplementationEdit.outputJson as { reason?: string } | null)?.reason ?? ""), /src\/implementation\.ts/);
+      assert.match(String((blockedImplementationEdit.outputJson as { reason?: string } | null)?.reason ?? ""), /not under allowed planning artifact paths/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("allows null-device fd redirects while deep-interview blocks real Bash writes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-deep-interview-null-redirect-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2840,12 +2840,28 @@ async function buildRalplanPreToolUseBoundaryOutput(
   const command = readPreToolUseCommand(payload);
   const pathCandidates = readPreToolUsePathCandidates(payload);
   let blocked = false;
+  let blockedDetail = "implementation/write tools are blocked until an explicit execution handoff workflow is activated";
 
   if (toolName === "Bash") {
     blocked = !isAllowedRalplanBashWrite(cwd, command);
+    if (blocked) {
+      const targets = extractDeepInterviewCommandWriteTargets(command);
+      const blockedTarget = targets.find((target) => !isAllowedRalplanArtifactPath(cwd, target));
+      blockedDetail = blockedTarget
+        ? `write target ${blockedTarget} is not under allowed planning artifact paths (${RALPLAN_ALLOWED_WRITE_PREFIXES.join(", ")})`
+        : "Bash write intent did not identify an allowed planning artifact path";
+    }
   } else if (PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES.has(toolName)) {
-    blocked = pathCandidates.length === 0
-      || !pathCandidates.every((candidate) => isAllowedRalplanArtifactPath(cwd, candidate));
+    if (pathCandidates.length === 0) {
+      blocked = true;
+      blockedDetail = `${toolName} did not include a file path; only planning artifact paths are allowed`;
+    } else {
+      const blockedPath = pathCandidates.find((candidate) => !isAllowedRalplanArtifactPath(cwd, candidate));
+      blocked = blockedPath !== undefined;
+      if (blockedPath !== undefined) {
+        blockedDetail = `path ${blockedPath} is not under allowed planning artifact paths (${RALPLAN_ALLOWED_WRITE_PREFIXES.join(", ")})`;
+      }
+    }
   }
 
   if (!blocked) return null;
@@ -2858,7 +2874,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
     : "Ralplan is consensus-planning mode";
   return {
     decision: "block",
-    reason: `${planningModeLabel} is active (phase: ${phase}); implementation/write tools are blocked until an explicit execution handoff workflow is activated.`,
+    reason: `${planningModeLabel} is active (phase: ${phase}); implementation/write tools are blocked until an explicit execution handoff workflow is activated; ${blockedDetail}.`,
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       additionalContext:


### PR DESCRIPTION
## Summary
- Allow Autopilot ralplan PreToolUse planning artifact writes under `.omx/plans/` and `.omx/specs/` while preserving implementation-file write blocking.
- Add a regression for creating a missing `.omx/plans/<file>.md` via normal `Write` tooling while Autopilot is in ralplan.
- Improve ralplan denial diagnostics with the blocked path/target and allowed planning scopes.

## Stack note
This PR is stacked above #2779 (`fix/omx-supervisor-6`) and targets `fix/omx-supervisor-6`, not `dev`. If #2779 lands first, retarget/rebase this PR onto `dev`.

## Validation
- Rebased onto `origin/fix/omx-supervisor-6` cleanly.
- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js --test-name-pattern "Autopilot ralplan planning artifacts|ralplan planning artifact writes|implementation writes while Autopilot|implementation writes while ralplan|bash implementation writes while ralplan|bash planning artifact writes while ralplan"`
  - Result: 421 tests passed, 0 failed.

## Notes
- Existing untracked local `node_modules/` was left untouched and is not part of this PR.
