### PR TITLE
fix: cancel hook-visible run-dir state

### DIFF
--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -17,6 +17,14 @@ function runOmx(cwd: string, ...args: string[]) {
   });
 }
 
+function runOmxWithEnv(cwd: string, env: NodeJS.ProcessEnv, ...args: string[]) {
+  return spawnSync(process.execPath, [omxBin, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  });
+}
+
 describe('CLI session-scoped state parity', () => {
   it('status and cancel include session-scoped states', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-session-scope-'));
@@ -84,6 +92,70 @@ describe('CLI session-scoped state parity', () => {
       assert.match(statusResult.stdout, /deep-interview: inactive \(phase: cleared\)/);
     } finally {
       await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('cancels hook-visible run-dir session state when worktree state list-active is empty', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-cancel-worktree-'));
+    const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-cancel-runs-'));
+    try {
+      const sessionId = 'sess-run-dir-cancel';
+      const runDir = join(runsRoot, 'run-20260610121751-b6c4');
+      const runStateDir = join(runDir, '.omx', 'state');
+      const runSessionDir = join(runStateDir, 'sessions', sessionId);
+      await mkdir(runSessionDir, { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(runStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(runSessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'deep-interview',
+      }, null, 2));
+      await writeFile(join(runSessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        phase: 'deep-interview',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({
+        launcher: 'omx --madmax',
+        created_at: '2026-06-10T12:17:51.000Z',
+        cwd: runDir,
+        source_cwd: wd,
+        argv: ['codex'],
+        run_dir: runDir,
+      })}\n`);
+
+      const listResult = runOmx(wd, 'state', 'list-active', '--json');
+      assert.equal(listResult.status, 0, listResult.stderr || listResult.stdout);
+      assert.deepEqual(JSON.parse(listResult.stdout), { active_modes: [] });
+
+      const cancelResult = runOmxWithEnv(wd, { OMX_RUNS_DIR: runsRoot }, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled: autopilot/);
+      assert.doesNotMatch(cancelResult.stdout, /No active modes to cancel/);
+
+      const autopilot = JSON.parse(await readFile(join(runSessionDir, 'autopilot-state.json'), 'utf-8'));
+      assert.equal(autopilot.active, false);
+      assert.equal(autopilot.current_phase, 'cancelled');
+      assert.ok(typeof autopilot.completed_at === 'string' && autopilot.completed_at.length > 0);
+
+      const skillActive = JSON.parse(await readFile(join(runSessionDir, 'skill-active-state.json'), 'utf-8'));
+      assert.equal(skillActive.active, false);
+      assert.equal(skillActive.current_phase, 'cancelled');
+      assert.equal(skillActive.phase, 'cancelled');
+      assert.deepEqual(
+        skillActive.active_skills.map((skill: { active: unknown; phase: unknown }) => ({
+          active: skill.active,
+          phase: skill.phase,
+        })),
+        [{ active: false, phase: 'cancelled' }],
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(runsRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFileSync, spawn } from "child_process";
-import { basename, dirname, join, posix, win32 } from "path";
+import { basename, dirname, join, posix, resolve, win32 } from "path";
 import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, symlink, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
@@ -67,6 +67,7 @@ import {
   getBaseStateDir,
   getStateDir,
   listModeStateFilesWithScopePreference,
+  type ModeStateFileRef,
 } from "../mcp/state-paths.js";
 import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
 import {
@@ -5826,13 +5827,104 @@ async function flushHookDerivedWatcherOnce(cwd: string): Promise<void> {
   });
 }
 
+async function listHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFileRef[]> {
+  const runsRoot = resolveMadmaxRunsRoot(process.env);
+  const registryPath = join(runsRoot, "registry.jsonl");
+  const runDirs = new Set<string>();
+  const canonicalCwd = resolve(cwd);
+  const canonicalRunsRoot = resolve(runsRoot);
+
+  const addRecord = (raw: unknown): void => {
+    if (!raw || typeof raw !== "object") return;
+    const record = raw as Record<string, unknown>;
+    const sourceCwd = typeof record.source_cwd === "string" ? record.source_cwd.trim() : "";
+    const runDir = typeof record.run_dir === "string"
+      ? record.run_dir.trim()
+      : typeof record.cwd === "string"
+        ? record.cwd.trim()
+        : "";
+    if (!sourceCwd || !runDir) return;
+
+    try {
+      if (resolve(sourceCwd) !== canonicalCwd) return;
+      const resolvedRunDir = resolve(runDir);
+      if (
+        resolvedRunDir !== canonicalRunsRoot
+        && !resolvedRunDir.startsWith(`${canonicalRunsRoot}/`)
+      ) {
+        return;
+      }
+      runDirs.add(resolvedRunDir);
+    } catch {
+      return;
+    }
+  };
+
+  try {
+    const rawRegistry = await readFile(registryPath, "utf-8");
+    for (const line of rawRegistry.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        addRecord(JSON.parse(trimmed));
+      } catch {
+        continue;
+      }
+    }
+  } catch {}
+
+  try {
+    const activeDir = join(runsRoot, MADMAX_DETACHED_ACTIVE_DIR);
+    const files = await readdir(activeDir).catch(() => [] as string[]);
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        addRecord(JSON.parse(await readFile(join(activeDir, file), "utf-8")));
+      } catch {
+        continue;
+      }
+    }
+  } catch {}
+
+  const refs: ModeStateFileRef[] = [];
+  const seenPaths = new Set<string>();
+  for (const runDir of runDirs) {
+    const stateDir = join(runDir, ".omx", "state");
+    let sessionId: string | undefined;
+    try {
+      const session = JSON.parse(await readFile(join(stateDir, "session.json"), "utf-8")) as Record<string, unknown>;
+      if (typeof session.session_id === "string" && session.session_id.trim()) {
+        sessionId = session.session_id.trim();
+      }
+    } catch {}
+
+    const candidateDirs = sessionId ? [join(stateDir, "sessions", sessionId), stateDir] : [stateDir];
+    for (const dir of candidateDirs) {
+      const files = await readdir(dir).catch(() => [] as string[]);
+      for (const file of files) {
+        if (!file.endsWith("-state.json") || file === "session.json") continue;
+        const path = join(dir, file);
+        if (seenPaths.has(path)) continue;
+        seenPaths.add(path);
+        refs.push({
+          mode: file.slice(0, -"-state.json".length),
+          path,
+          scope: dir === stateDir ? "root" : "session",
+        });
+      }
+    }
+  }
+
+  return refs.sort((a, b) => a.mode.localeCompare(b.mode));
+}
+
 async function cancelModes(): Promise<void> {
   const { writeFile, readFile } = await import("fs/promises");
   const cwd = process.cwd();
   const nowIso = new Date().toISOString();
   try {
-    const refs = await listModeStateFilesWithScopePreference(cwd);
-    const states = new Map<
+    const loadStates = async (refs: ModeStateFileRef[]) => {
+      const loaded = new Map<
       string,
       {
         path: string;
@@ -5841,20 +5933,32 @@ async function cancelModes(): Promise<void> {
       }
     >();
 
-    for (const ref of refs) {
-      const content = await readFile(ref.path, "utf-8");
-      let parsedState: Record<string, unknown>;
-      try {
-        parsedState = JSON.parse(content) as Record<string, unknown>;
-      } catch (err) {
-        logCliOperationFailure(err);
-        continue;
+      for (const ref of refs) {
+        const content = await readFile(ref.path, "utf-8");
+        let parsedState: Record<string, unknown>;
+        try {
+          parsedState = JSON.parse(content) as Record<string, unknown>;
+        } catch (err) {
+          logCliOperationFailure(err);
+          continue;
+        }
+        loaded.set(ref.mode, {
+          path: ref.path,
+          scope: ref.scope,
+          state: parsedState,
+        });
       }
-      states.set(ref.mode, {
-        path: ref.path,
-        scope: ref.scope,
-        state: parsedState,
-      });
+      return loaded;
+    };
+
+    let states = await loadStates(await listModeStateFilesWithScopePreference(cwd));
+    const hasActiveWorkflowMode = (entries: typeof states): boolean =>
+      [...entries.entries()].some(
+        ([mode, entry]) => mode !== SKILL_ACTIVE_STATE_MODE && entry.state.active === true,
+      );
+    if (!hasActiveWorkflowMode(states)) {
+      const runDirStates = await loadStates(await listHookVisibleRunDirStateRefs(cwd));
+      if (hasActiveWorkflowMode(runDirStates)) states = runDirStates;
     }
 
     const changed = new Set<string>();
@@ -5878,8 +5982,19 @@ async function cancelModes(): Promise<void> {
       entry.state.current_phase = phase;
       entry.state.completed_at = nowIso;
       entry.state.last_turn_at = nowIso;
+      if (mode === SKILL_ACTIVE_STATE_MODE) {
+        entry.state.phase = phase;
+        const activeSkills = Array.isArray(entry.state.active_skills)
+          ? entry.state.active_skills
+          : [];
+        entry.state.active_skills = activeSkills.map((skill) => (
+          skill && typeof skill === "object"
+            ? { ...(skill as Record<string, unknown>), active: false, phase }
+            : skill
+        ));
+      }
       changed.add(mode);
-      if (reportIfWasActive && wasActive) reported.add(mode);
+      if (reportIfWasActive && wasActive && mode !== SKILL_ACTIVE_STATE_MODE) reported.add(mode);
     };
 
     const ralphLinksUltrawork = (state: Record<string, unknown>): boolean =>


### PR DESCRIPTION
## Summary
- Fix `omx cancel` to fall back to hook-visible madmax/run-dir session state when the worktree-scoped state has no active workflow modes.
- Reconcile the paired `skill-active-state.json` mirror by marking it inactive/cancelled alongside the workflow state.
- Add a regression where worktree `omx state list-active --json` is empty but run-dir session Autopilot/skill state is still active.

## Stack
This is a stacked PR with base `fix/omx-y7a-ralplan-plans`.
It is stacked above #2779 (`fix/omx-supervisor-6`) and #2786 (`fix/omx-y7a-ralplan-plans`).

## Validation
Using this stack checkout, not `omx update --dev` or a remote dev-channel package:
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/session-scoped-runtime.test.js`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/state.test.js`
- `npm run lint -- src/cli/index.ts src/cli/__tests__/session-scoped-runtime.test.ts`
- `node dist/cli/omx.js state list-active --json` → `{"active_modes":[]}`

Runtime note: `which omx` in the attached runtime resolves to `/data/iqdoctor/.omx-runs/run-20260610143547-7420/.omx/runtime/bin/omx`, so validation intentionally invoked the freshly built checkout CLI via `node dist/cli/omx.js` / compiled test runner.
