### PR TITLE
fix autopilot deep-interview write guard

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -14201,6 +14201,63 @@ exit 0
     }
   });
 
+  it("blocks implementation writes while Autopilot is supervising deep-interview without a persisted phase transition", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-deep-interview-pretool-block-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-autopilot-deep-interview-pretool-block";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "deep-interview",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "deep-interview", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "deep-interview",
+        session_id: sessionId,
+        handoff_artifacts: {
+          deep_interview: null,
+          ralplan: null,
+          ultragoal: null,
+          code_review: null,
+          ultraqa: null,
+        },
+        ralplan_consensus_gate: {
+          ralplan_architect_review: null,
+          ralplan_critic_review: null,
+          complete: false,
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-autopilot-deep-interview-pretool-block",
+          tool_name: "Edit",
+          tool_input: { file_path: "src/runtime.ts", old_string: "a", new_string: "b" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Deep-interview is active .*implementation\/write tools are blocked/i);
+      assert.match(
+        String((result.outputJson?.hookSpecificOutput as { additionalContext?: string } | undefined)?.additionalContext ?? ""),
+        /To implement, first ask for or process an explicit transition/i,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks implementation writes while Autopilot is supervising ralplan without handoff", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-ralplan-pretool-block-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2753,21 +2753,46 @@ async function readActiveDeepInterviewStateForPreToolUse(
   sessionId: string,
   threadId: string,
 ): Promise<Record<string, unknown> | null> {
-  const modeState = sessionId
-    ? await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId, stateDir)
-    : await readJsonIfExists(join(stateDir, "deep-interview-state.json"));
-  if (!isActiveDeepInterviewPhase(modeState) || !modeState) return null;
-  if (!modeStateMatchesSkillStopContext(modeState, cwd, sessionId)) return null;
-
   const canonicalState = sessionId
     ? await readVisibleSkillActiveStateForStateDir(stateDir, sessionId)
     : await readSkillActiveState(join(stateDir, SKILL_ACTIVE_STATE_FILE));
   if (!canonicalState) return null;
-  const hasActiveDeepInterviewSkill = listActiveSkills(canonicalState).some((entry) => (
-    entry.skill === "deep-interview"
+
+  const modeState = sessionId
+    ? await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId, stateDir)
+    : await readJsonIfExists(join(stateDir, "deep-interview-state.json"));
+  if (isActiveDeepInterviewPhase(modeState) && modeState && modeStateMatchesSkillStopContext(modeState, cwd, sessionId)) {
+    const hasActiveDeepInterviewSkill = listActiveSkills(canonicalState).some((entry) => (
+      entry.skill === "deep-interview"
+      && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
+    ));
+    if (hasActiveDeepInterviewSkill) return modeState;
+  }
+
+  const autopilotState = sessionId
+    ? await readStopSessionPinnedState("autopilot-state.json", cwd, sessionId, stateDir)
+    : await readJsonIfExists(join(stateDir, "autopilot-state.json"));
+  if (!autopilotState || autopilotState.active !== true) return null;
+  const autopilotMode = safeString(autopilotState.mode).trim();
+  if (autopilotMode && autopilotMode !== "autopilot") return null;
+  if (!modeStateMatchesSkillStopContext(autopilotState, cwd, sessionId)) return null;
+  const terminalAutopilotRunState = await readCanonicalTerminalRunStateForStop(cwd, sessionId, "autopilot");
+  if (terminalAutopilotRunState) return null;
+
+  const autopilotStatePhase = safeString(autopilotState.current_phase ?? autopilotState.currentPhase).trim().toLowerCase();
+  const autopilotIsDeepInterview = normalizeAutopilotPhase(autopilotStatePhase) === "deep-interview";
+  const hasDeepInterviewScopedAutopilotSkill = listActiveSkills(canonicalState).some((entry) => (
+    entry.skill === "autopilot"
+    && normalizeAutopilotPhase(safeString(entry.phase).trim().toLowerCase()) === "deep-interview"
     && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
   ));
-  return hasActiveDeepInterviewSkill ? modeState : null;
+  const hasActiveAutopilotSkill = listActiveSkills(canonicalState).some((entry) => (
+    entry.skill === "autopilot"
+    && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
+  ));
+  if (!hasActiveAutopilotSkill) return null;
+  if (!autopilotIsDeepInterview && !hasDeepInterviewScopedAutopilotSkill) return null;
+  return autopilotState;
 }
 
 async function readActiveRalplanStateForPreToolUse(


### PR DESCRIPTION
## Summary

- Extend the deep-interview PreToolUse implementation/write guard to also recognize Autopilot-owned `current_phase=deep-interview` state.
- Require visible canonical Autopilot skill state before blocking, matching existing ralplan supervision behavior and avoiding stale detail-only false positives.
- Add a regression where implementation writes are blocked when transcript/work tries to enter implementation while `autopilot-state.json` still says `deep-interview` and no phase-transition / gate artifacts exist.

## Root cause

Standalone `deep-interview-state.json` writes were protected, and Autopilot `ralplan` planning writes were protected, but Autopilot supervising `deep-interview` was not checked by the deep-interview PreToolUse boundary. That left a gap where implementation tools could run while HUD/status/hook-visible Autopilot state still reported `deep-interview`.

## Stacked PR context

This PR is stacked above:

1. #2779 `fix/omx-supervisor-6` -> `dev`
2. #2786 `fix/omx-y7a-ralplan-plans` -> `fix/omx-supervisor-6`
3. #2787 `fix/omx-fd0-1-cancel-run-dir-state` -> `fix/omx-y7a-ralplan-plans`

Base for this PR: `fix/omx-fd0-1-cancel-run-dir-state`.

## Validation

- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js --test-name-pattern "Autopilot is supervising deep-interview|Autopilot is supervising ralplan"` (Node ran the full file; 422/422 passed)
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_SESSION_ID node --test dist/state/__tests__/operations.test.js dist/cli/__tests__/session-scoped-runtime.test.js` (71/71 passed)
- `node dist/cli/omx.js --version`

Note: the attached live runtime resolves `omx` from `/data/iqdoctor/.omx-runs/run-20260610144523-4219/.omx/runtime/bin/omx`; validation above used this checkout's built `node dist/cli/omx.js` and reran state tests with live OMX state env unset to avoid active-runtime leakage.
