### PR TITLE
fix: resolve ambient OMX entry paths against startup cwd

### DIFF
--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -603,6 +603,31 @@ describe("OMX launcher path resolution", () => {
     }
   });
 
+  it("resolves ambient OMX_ENTRY_PATH relative to the recorded startup cwd", async () => {
+    const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-env-start-"));
+    const laterCwd = await mkdtemp(join(tmpdir(), "omx-launcher-env-later-"));
+    try {
+      const launcherDir = join(startupCwd, "dist", "cli");
+      const launcherPath = join(launcherDir, "omx.js");
+      await mkdir(launcherDir, { recursive: true });
+      await writeFile(launcherPath, "#!/usr/bin/env node\n", "utf-8");
+
+      const resolved = resolveOmxEntryPath({
+        cwd: laterCwd,
+        env: {
+          ...process.env,
+          [OMX_ENTRY_PATH_ENV]: "dist/cli/omx.js",
+          [OMX_STARTUP_CWD_ENV]: startupCwd,
+        },
+      });
+
+      assert.equal(resolved, canonicalizeComparablePath(launcherPath));
+    } finally {
+      await rm(startupCwd, { recursive: true, force: true });
+      await rm(laterCwd, { recursive: true, force: true });
+    }
+  });
+
   it("replaces stale ambient OMX_ENTRY_PATH when recording an explicit launcher argv1", async () => {
     const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-explicit-record-"));
     const env: NodeJS.ProcessEnv = {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -80,7 +80,10 @@ export function resolveOmxEntryPath(
   }
 
   const fromEnv = String(env[OMX_ENTRY_PATH_ENV] ?? "").trim();
-  if (fromEnv !== "") return fromEnv;
+  if (fromEnv !== "") {
+    const startupCwd = String(env[OMX_STARTUP_CWD_ENV] ?? "").trim() || cwd;
+    return resolveLauncherPath(fromEnv, startupCwd);
+  }
 
   if (rawPath === "") return null;
 


### PR DESCRIPTION
## Summary
- Follow-up/replacement for closed PR #2777, retargeted cleanly against `dev` per maintainer guidance.
- Canonicalizes ambient `OMX_ENTRY_PATH` relative to `OMX_STARTUP_CWD` / startup cwd while preserving explicit `argv[1]` precedence.
- Keeps the regression for relative ambient `OMX_ENTRY_PATH` after cwd drift.

## Context / credit
This preserves the core patch from #2777 (`fix/ambient-entry-path-20260610`, original commit `c68e36d`) after that PR was closed because it targeted `main`. The cherry-picked commit preserves original authorship. Tracking bead: `omx-cj5`.

## Validation
- `npm run build`
- `env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_TEAM_STATE_ROOT -u OMX_SESSION_ID node --test dist/utils/__tests__/paths.test.js`

Note: running the path test with live OMX runtime env set makes unrelated path-root assertions resolve into `/data/.../.omx-runs/...`; the validation above unsets those runtime env vars so the test exercises checkout/project behavior.

## Review / dogfood order
This PR targets `dev` directly. Recommended priority relative to current OMX stabilization queue:
1. #2779 — Stop-hook JSON fallback
2. #2790 — ralplan planning artifacts
3. #2791 — cancel/status run-dir state
4. #2792 — Autopilot deep-interview write guard
5. #2789 — doctor plugin-mode/dev-update false-warning fix
6. This PR — ambient `OMX_ENTRY_PATH` canonicalization (`omx-cj5`)
