### PR TITLE
docs: add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Yeachan Heo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

The project already declares MIT in several places — `package.json` (`"license": "MIT"`), `Cargo.toml` (`license = "MIT"`), and the README (the license badge and the "## License" section) — but there is no `LICENSE` file at the repository root. Because of that, GitHub reports the repository license as "None", and downstream consumers (npm tarball users, license/supply-chain scanners, corporate license audits) cannot see the actual license text, so the package can be flagged as unlicensed even though MIT is clearly the declared intent.

This PR simply adds the standard MIT license text so the repository's visible legal state matches what it already declares everywhere else. The file mirrors the `LICENSE` in the sibling project oh-my-claudecode verbatim, including the copyright line `Copyright (c) 2025 Yeachan Heo`. If you would prefer a different year or holder format, I am happy to adjust.

## Changes

- Add `LICENSE` at the repository root with the standard MIT text, copyright `(c) 2025 Yeachan Heo` (mirrors oh-my-claudecode's LICENSE verbatim).
- Nothing else touched — `package.json`, `Cargo.toml`, and `README.md` already declare MIT, so no edits are needed there.

## Validation

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [ ] `omx doctor` (when setup/config behavior changes) — N/A: license-text-only change, no setup/config behavior touched

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — README already documents MIT, so no doc edits are required
- [x] Backward-compatibility impact considered — purely additive file; no runtime, CLI, or packaging behavior changes

## Related

No existing issue covers this (I searched issues and PRs for "license" and found none). Happy to file one and link it here if issue-first is preferred.

Document-refresh: not-needed | adds the LICENSE file only; no behavior, CLI, or docs-contract change
