### PR TITLE
fix(best-practice-research): enforce terminal read-only boundary

### DIFF
--- a/plugins/oh-my-codex/skills/best-practice-research/SKILL.md
+++ b/plugins/oh-my-codex/skills/best-practice-research/SKILL.md
@@ -12,6 +12,10 @@ Use this skill when a task depends on current external best practices, version-a
 
 Produce a cited, reusable best-practice answer or handoff that separates current external evidence from repo-local facts and dependency-selection decisions. For pre-planning investigation, this is the ordinary first research wrapper: gather official/upstream evidence, then hand it to `$ralplan` or the caller as planning input. Do not present `$best-practice-research` as a final architecture component or as a validator-gated research loop.
 
+## Terminal By Default
+
+This skill is terminal and read-only by default. It gathers evidence and produces a cited recommendation with a handoff, then stops. Do not write or edit files, create or amend commits, run mutating commands, or otherwise modify repository state under this skill — even when the question has clear implementation implications. When implementation is warranted, stop and hand off rather than continuing: name `$ralplan` for planning and `$ultragoal`, `$team`, or `executor` for execution, and resume only after the user explicitly switches to that workflow.
+
 ## Activate When
 
 - The user asks for best practices, recommended approach, current guidance, official recommendations, standards, or version-aware external behavior.
@@ -71,7 +75,7 @@ Produce a cited, reusable best-practice answer or handoff that separates current
 <what this research does not decide>
 
 ### Handoff
-<planning/execution/test implications>
+<planning/execution/test implications; name the next workflow — `$ralplan` for planning, `$ultragoal`/`$team`/`executor` for execution — and note that this skill stops here unless the user explicitly switches workflows>
 ```
 
 ## Stop Rules
@@ -79,5 +83,6 @@ Produce a cited, reusable best-practice answer or handoff that separates current
 - Stop after a source-backed recommendation is reusable by the caller.
 - Stop and route upward if the task becomes dependency comparison, broad architecture, or implementation.
 - Do not continue researching when remaining work would only polish wording rather than change the recommendation.
+- This skill never implements. After delivering the recommendation and handoff, stop; do not modify repo files or repo state. Resume only when the user explicitly switches to a planning or implementation workflow named in the handoff.
 
 Task: {{ARGUMENTS}}

--- a/skills/best-practice-research/SKILL.md
+++ b/skills/best-practice-research/SKILL.md
@@ -12,6 +12,10 @@ Use this skill when a task depends on current external best practices, version-a
 
 Produce a cited, reusable best-practice answer or handoff that separates current external evidence from repo-local facts and dependency-selection decisions. For pre-planning investigation, this is the ordinary first research wrapper: gather official/upstream evidence, then hand it to `$ralplan` or the caller as planning input. Do not present `$best-practice-research` as a final architecture component or as a validator-gated research loop.
 
+## Terminal By Default
+
+This skill is terminal and read-only by default. It gathers evidence and produces a cited recommendation with a handoff, then stops. Do not write or edit files, create or amend commits, run mutating commands, or otherwise modify repository state under this skill — even when the question has clear implementation implications. When implementation is warranted, stop and hand off rather than continuing: name `$ralplan` for planning and `$ultragoal`, `$team`, or `executor` for execution, and resume only after the user explicitly switches to that workflow.
+
 ## Activate When
 
 - The user asks for best practices, recommended approach, current guidance, official recommendations, standards, or version-aware external behavior.
@@ -71,7 +75,7 @@ Produce a cited, reusable best-practice answer or handoff that separates current
 <what this research does not decide>
 
 ### Handoff
-<planning/execution/test implications>
+<planning/execution/test implications; name the next workflow — `$ralplan` for planning, `$ultragoal`/`$team`/`executor` for execution — and note that this skill stops here unless the user explicitly switches workflows>
 ```
 
 ## Stop Rules
@@ -79,5 +83,6 @@ Produce a cited, reusable best-practice answer or handoff that separates current
 - Stop after a source-backed recommendation is reusable by the caller.
 - Stop and route upward if the task becomes dependency comparison, broad architecture, or implementation.
 - Do not continue researching when remaining work would only polish wording rather than change the recommendation.
+- This skill never implements. After delivering the recommendation and handoff, stop; do not modify repo files or repo state. Resume only when the user explicitly switches to a planning or implementation workflow named in the handoff.
 
 Task: {{ARGUMENTS}}

--- a/src/hooks/__tests__/best-practice-research-skill.test.ts
+++ b/src/hooks/__tests__/best-practice-research-skill.test.ts
@@ -15,6 +15,20 @@ describe('best-practice-research skill contract', () => {
     assert.match(skill, /does not replace `researcher`/i);
   });
 
+  it('enforces terminal, read-only behavior by default', () => {
+    assert.match(skill, /^## Terminal By Default$/m);
+    assert.match(skill, /terminal and read-only by default/i);
+    assert.match(skill, /Do not write or edit files, create or amend commits, run mutating commands, or otherwise modify repository state/i);
+    assert.match(skill, /even when the question has clear implementation implications/i);
+    assert.match(skill, /This skill never implements/i);
+  });
+
+  it('hands off to named planning and execution workflows instead of implementing', () => {
+    assert.match(skill, /name `\$ralplan` for planning and `\$ultragoal`, `\$team`, or `executor` for execution/i);
+    assert.match(skill, /resume only after the user explicitly switches to that workflow/i);
+    assert.match(skill, /Resume only when the user explicitly switches to a planning or implementation workflow/i);
+  });
+
   it('preserves specialist routing and source quality boundaries', () => {
     assert.match(skill, /use `explore` first/i);
     assert.match(skill, /Use `researcher` for official\/upstream docs/i);


### PR DESCRIPTION
## Summary

`$best-practice-research` is intended as bounded research / planning input, but its contract did not stop it from continuing into implementation after producing recommendations. This change makes the skill **terminal and read-only by default**.

### What changed
- Added a **Terminal By Default** section to the skill contract: the skill gathers evidence, produces a cited recommendation plus handoff, then stops. It must not write/edit files, create or amend commits, run mutating commands, or modify repository state under this skill — even when the question has clear implementation implications.
- Strengthened **Stop Rules** with an explicit "this skill never implements" rule; work resumes only when the user explicitly switches to a named planning/implementation workflow.
- Updated the **Handoff** output contract to name the appropriate next workflow: `$ralplan` for planning; `$ultragoal`/`$team`/`executor` for execution.
- Mirrored the change to the plugin copy (`plugins/oh-my-codex/skills/best-practice-research/SKILL.md`), kept byte-identical to canonical.
- Added regression tests in `best-practice-research-skill.test.ts` covering the terminal/no-mutation contract and the named-workflow handoff.

### Acceptance criteria
- Invoking `$best-practice-research` for a task with implementation implications produces a cited recommendation and stops.
- The agent does not modify repo files under this skill unless the user explicitly switches workflows.
- The final handoff clearly names the appropriate next workflow for planning/execution.

### Verification
- `npm run build` (clean)
- Targeted tests pass: `best-practice-research-skill.test.js`, `research-workflow-boundaries.test.js`
- Plugin mirror verified in sync (`npm run sync:plugin:check`)

Closes #2799

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
