### PR TITLE
Fix plugin AGENTS merge repair

### DIFF
--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -337,6 +337,239 @@ describe('omx setup AGENTS refresh behavior', () => {
     }
   });
 
+  it('merges plugin-mode OMX-managed sections into an unmarked user AGENTS.md when explicitly requested', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-merge-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const codexAgentsPath = join(home, '.codex', 'AGENTS.md');
+    const existing = '# Personal Instructions\n\nKeep this custom user guidance.\n';
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await writeFile(codexAgentsPath, existing);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        mergeAgents: true,
+      });
+      const agentsContent = await readFile(codexAgentsPath, 'utf-8');
+
+      assert.match(output, /Merged plugin-mode OMX-managed AGENTS\.md sections into/);
+      assert.match(output, /agents_md: updated=1, unchanged=0, backed_up=1, skipped=0, removed=0/);
+      assert.match(agentsContent, /^# Personal Instructions/);
+      assert.match(agentsContent, /Keep this custom user guidance\./);
+      assert.match(agentsContent, new RegExp(OMX_MANAGED_AGENTS_START_MARKER));
+      assert.match(agentsContent, new RegExp(OMX_MANAGED_AGENTS_END_MARKER));
+      assert.match(agentsContent, /<!-- omx:generated:agents-md -->/);
+      assert.match(agentsContent, /# oh-my-codex - Intelligent Multi-Agent Orchestration/);
+      assert.equal(existsSync(join(home, '.omx', 'backups', 'setup')), true);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps plugin-mode explicit AGENTS.md merge idempotent on repeated runs', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-merge-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const codexAgentsPath = join(home, '.codex', 'AGENTS.md');
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await writeFile(codexAgentsPath, '# Personal Instructions\n\nKeep this custom user guidance.\n');
+
+      await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        mergeAgents: true,
+      });
+      const firstContent = await readFile(codexAgentsPath, 'utf-8');
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        mergeAgents: true,
+      });
+      const secondContent = await readFile(codexAgentsPath, 'utf-8');
+
+      assert.equal(secondContent, firstContent);
+      assert.match(output, /Plugin-mode AGENTS\.md already up to date in/);
+      assert.match(output, /agents_md: updated=0, unchanged=1, backed_up=0, skipped=0, removed=0/);
+      assert.equal(countOccurrences(secondContent, OMX_MANAGED_AGENTS_START_MARKER), 1);
+      assert.equal(countOccurrences(secondContent, OMX_MANAGED_AGENTS_END_MARKER), 1);
+      assert.equal(countOccurrences(secondContent, '# oh-my-codex - Intelligent Multi-Agent Orchestration'), 1);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not ask for plugin AGENTS defaults during explicit plugin-mode AGENTS.md merge', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-merge-prompt-'));
+    const restoreTty = setMockTty(true);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const codexAgentsPath = join(home, '.codex', 'AGENTS.md');
+    let promptCalls = 0;
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await writeFile(codexAgentsPath, '# Personal Instructions\n');
+
+      await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        mergeAgents: true,
+        pluginDeveloperInstructionsPrompt: async () => false,
+        pluginAgentsMdPrompt: async () => {
+          promptCalls += 1;
+          return true;
+        },
+      });
+
+      assert.equal(promptCalls, 0);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips plugin-mode explicit AGENTS.md merge for symlinked user AGENTS.md', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-symlink-merge-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const dotfilesAgentsPath = join(wd, 'dotfiles', '.codex', 'AGENTS.md');
+    const codexAgentsPath = join(home, '.codex', 'AGENTS.md');
+    const dotfilesContent = '# Dotfiles Instructions\n\nDotfiles-owned guidance.\n';
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(wd, 'dotfiles', '.codex'), { recursive: true });
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await writeFile(dotfilesAgentsPath, dotfilesContent);
+      await symlink(dotfilesAgentsPath, codexAgentsPath);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        mergeAgents: true,
+      });
+
+      assert.match(output, /Skipped plugin-mode AGENTS\.md merge for symlinked/);
+      assert.equal(await readlink(codexAgentsPath), dotfilesAgentsPath);
+      assert.equal(await readFile(dotfilesAgentsPath, 'utf-8'), dotfilesContent);
+      assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips plugin-mode explicit AGENTS.md merge for broken symlinked user AGENTS.md', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-broken-symlink-merge-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const missingAgentsPath = join(wd, 'dotfiles', '.codex', 'AGENTS.md');
+    const codexAgentsPath = join(home, '.codex', 'AGENTS.md');
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await symlink(missingAgentsPath, codexAgentsPath);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        mergeAgents: true,
+      });
+
+      assert.match(output, /Skipped plugin-mode AGENTS\.md merge for symlinked/);
+      assert.equal(await readlink(codexAgentsPath), missingAgentsPath);
+      assert.equal(existsSync(missingAgentsPath), false);
+      assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips plugin-mode AGENTS defaults for symlinked user AGENTS.md even when prompted overwrite would be accepted', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-symlink-default-'));
+    const restoreTty = setMockTty(true);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const dotfilesAgentsPath = join(wd, 'dotfiles', '.codex', 'AGENTS.md');
+    const codexAgentsPath = join(home, '.codex', 'AGENTS.md');
+    const dotfilesContent = '# Dotfiles Instructions\n\nDotfiles-owned guidance.\n';
+    let promptCalls = 0;
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(wd, 'dotfiles', '.codex'), { recursive: true });
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await writeFile(dotfilesAgentsPath, dotfilesContent);
+      await symlink(dotfilesAgentsPath, codexAgentsPath);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        pluginDeveloperInstructionsPrompt: async () => false,
+        pluginAgentsMdPrompt: async () => {
+          promptCalls += 1;
+          return true;
+        },
+        agentsOverwritePrompt: async () => true,
+      });
+
+      assert.equal(promptCalls, 0);
+      assert.match(output, /Plugin-mode AGENTS\.md defaults not selected; existing AGENTS\.md left untouched\./);
+      assert.equal(await readlink(codexAgentsPath), dotfilesAgentsPath);
+      assert.equal(await readFile(dotfilesAgentsPath, 'utf-8'), dotfilesContent);
+      assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips plugin-mode AGENTS defaults for broken symlinked user AGENTS.md', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-broken-symlink-default-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const missingAgentsPath = join(wd, 'dotfiles', '.codex', 'AGENTS.md');
+    const codexAgentsPath = join(home, '.codex', 'AGENTS.md');
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await symlink(missingAgentsPath, codexAgentsPath);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        force: true,
+        pluginDeveloperInstructionsPrompt: async () => false,
+      });
+
+      assert.match(output, /Plugin-mode AGENTS\.md defaults not selected; existing AGENTS\.md left untouched\./);
+      assert.equal(await readlink(codexAgentsPath), missingAgentsPath);
+      assert.equal(existsSync(missingAgentsPath), false);
+      assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('merges OMX-managed sections into an unmarked user-authored AGENTS.md when explicitly requested', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
     const restoreTty = setMockTty(false);
@@ -487,6 +720,85 @@ describe('omx setup AGENTS refresh behavior', () => {
       assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
       assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
       assert.equal(existsSync(join(wd, '.omx', 'backups', 'setup')), false);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips plugin-mode explicit AGENTS.md merge during an active project session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-active-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const existing = '# active plugin project file\n';
+    try {
+      const pidStartTicks = await readCurrentLinuxStartTicks();
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+      await writeFile(
+        join(wd, '.omx', 'state', 'session.json'),
+        JSON.stringify({
+          session_id: 'sess-test',
+          started_at: new Date().toISOString(),
+          cwd: wd,
+          pid: process.pid,
+          pid_start_ticks: pidStartTicks,
+        }, null, 2)
+      );
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        installMode: 'plugin',
+        mergeAgents: true,
+      });
+
+      assert.match(output, /WARNING: Active omx session detected/);
+      assert.match(output, /Skipping AGENTS\.md overwrite to avoid corrupting runtime overlay\./);
+      assert.match(output, /Stop the active session first, then re-run setup\./);
+      assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips plugin-mode AGENTS defaults during an active project session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-active-default-'));
+    const restoreTty = setMockTty(true);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const existing = '# active plugin project file\n';
+    try {
+      const pidStartTicks = await readCurrentLinuxStartTicks();
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+      await writeFile(
+        join(wd, '.omx', 'state', 'session.json'),
+        JSON.stringify({
+          session_id: 'sess-test',
+          started_at: new Date().toISOString(),
+          cwd: wd,
+          pid: process.pid,
+          pid_start_ticks: pidStartTicks,
+        }, null, 2)
+      );
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        installMode: 'plugin',
+        force: true,
+        pluginDeveloperInstructionsPrompt: async () => false,
+      });
+
+      assert.match(output, /WARNING: Active omx session detected/);
+      assert.match(output, /Skipping AGENTS\.md overwrite to avoid corrupting runtime overlay\./);
+      assert.match(output, /Stop the active session first, then re-run setup\./);
+      assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
     } finally {
       restoreHome();
       restoreTty();

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1885,15 +1885,24 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 					scopeDirs.codexConfigFile,
 				)
 		: false;
-	const pluginAgentsMdIsSymlink = existsSync(pluginAgentsMdDst)
-		? (await lstat(pluginAgentsMdDst)).isSymbolicLink()
-		: false;
+	let pluginAgentsMdPathExists = false;
+	let pluginAgentsMdIsSymlink = false;
+	try {
+		const pluginAgentsMdStat = await lstat(pluginAgentsMdDst);
+		pluginAgentsMdPathExists = true;
+		pluginAgentsMdIsSymlink = pluginAgentsMdStat.isSymbolicLink();
+	} catch {
+		pluginAgentsMdPathExists = false;
+		pluginAgentsMdIsSymlink = false;
+	}
 	const usePluginAgentsMdDefault = isPluginInstallMode
-		? force
-			? !pluginAgentsMdIsSymlink
-			: pluginAgentsMdPrompt
-				? await pluginAgentsMdPrompt(pluginAgentsMdDst)
-				: await promptForPluginAgentsMdDefault(pluginAgentsMdDst)
+		? options.mergeAgents || pluginAgentsMdIsSymlink
+			? false
+			: force
+				? true
+				: pluginAgentsMdPrompt
+					? await pluginAgentsMdPrompt(pluginAgentsMdDst)
+					: await promptForPluginAgentsMdDefault(pluginAgentsMdDst)
 		: false;
 
 	console.log("oh-my-codex setup");
@@ -2404,45 +2413,118 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 
 	// Step 6: Generate AGENTS.md
 	console.log("[6/8] Generating AGENTS.md...");
+	const activeSession =
+		resolvedScope.scope === "project"
+			? await readSessionState(projectRoot)
+			: null;
+	const sessionIsActive = activeSession && !isSessionStale(activeSession);
 	if (isPluginInstallMode) {
-		if (usePluginAgentsMdDefault) {
-			const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
-			if (existsSync(agentsMdSrc)) {
-				const content = await readFile(agentsMdSrc, "utf-8");
-				const modelTableContext = resolveAgentsModelTableContext(
-					resolvedConfig,
-					{
-						codexHomeOverride: scopeDirs.codexHomeDir,
-					},
-				);
-				const modelTableDefinitions =
-					getAgentsModelTableDefinitionsForTeamMode(resolvedTeamMode);
-				const rewritten = upsertAgentsModelTable(
-					addGeneratedAgentsMarker(
-						applyTeamModeToAgentsTemplate(
-							applyPluginModeWordingToAgentsTemplate(
-								content,
-								resolvedScope.scope,
-							),
-							resolvedTeamMode,
+		const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
+		const pluginAgentsMdExists = pluginAgentsMdPathExists;
+		if (existsSync(agentsMdSrc)) {
+			const content = await readFile(agentsMdSrc, "utf-8");
+			const modelTableContext = resolveAgentsModelTableContext(
+				resolvedConfig,
+				{
+					codexHomeOverride: scopeDirs.codexHomeDir,
+				},
+			);
+			const modelTableDefinitions =
+				getAgentsModelTableDefinitionsForTeamMode(resolvedTeamMode);
+			const rewritten = upsertAgentsModelTable(
+				addGeneratedAgentsMarker(
+					applyTeamModeToAgentsTemplate(
+						applyPluginModeWordingToAgentsTemplate(
+							content,
+							resolvedScope.scope,
 						),
+						resolvedTeamMode,
 					),
-					modelTableContext,
-					modelTableDefinitions,
-				);
-				const result = await syncManagedAgentsContent(
-					rewritten,
-					pluginAgentsMdDst,
-					summary.agentsMd,
-					backupContext,
-					{
-						agentsOverwritePrompt: options.agentsOverwritePrompt,
-						dryRun,
-						force,
-						verbose,
-					},
-				);
-				if (result === "updated") {
+				),
+				modelTableContext,
+				modelTableDefinitions,
+			);
+			if (options.mergeAgents && pluginAgentsMdExists) {
+				if (pluginAgentsMdIsSymlink) {
+					summary.agentsMd.skipped += 1;
+					console.log(
+						`  Skipped plugin-mode AGENTS.md merge for symlinked ${pluginAgentsMdDst}; existing AGENTS.md left untouched.`,
+					);
+				} else {
+					const existing = await readFile(pluginAgentsMdDst, "utf-8");
+					const mergedAgentsContent = upsertManagedAgentsBlock(existing, rewritten);
+					const canApplyManagedAgentsMerge = mergedAgentsContent !== existing;
+					if (
+						resolvedScope.scope === "project" &&
+						sessionIsActive &&
+						canApplyManagedAgentsMerge
+					) {
+						summary.agentsMd.skipped += 1;
+						console.log(
+							"  WARNING: Active omx session detected (pid " +
+								activeSession?.pid +
+								").",
+						);
+						console.log(
+							"  Skipping AGENTS.md overwrite to avoid corrupting runtime overlay.",
+						);
+						console.log("  Stop the active session first, then re-run setup.");
+					} else if (!canApplyManagedAgentsMerge) {
+						summary.agentsMd.unchanged += 1;
+						console.log(
+							resolvedScope.scope === "project"
+								? "  Plugin-mode AGENTS.md already up to date in project root."
+								: `  Plugin-mode AGENTS.md already up to date in ${scopeDirs.codexHomeDir}.`,
+						);
+					} else {
+						await syncManagedContent(
+							mergedAgentsContent,
+							pluginAgentsMdDst,
+							summary.agentsMd,
+							backupContext,
+							{ dryRun, verbose },
+							`plugin AGENTS merge ${pluginAgentsMdDst}`,
+						);
+						console.log(
+							resolvedScope.scope === "project"
+								? "  Merged plugin-mode OMX-managed AGENTS.md sections into project root."
+								: `  Merged plugin-mode OMX-managed AGENTS.md sections into ${scopeDirs.codexHomeDir}.`,
+						);
+					}
+				}
+			} else if (usePluginAgentsMdDefault) {
+				const defaultWouldChange = pluginAgentsMdExists
+					? (await readFile(pluginAgentsMdDst, "utf-8")) !== rewritten
+					: true;
+				if (
+					resolvedScope.scope === "project" &&
+					sessionIsActive &&
+					defaultWouldChange
+				) {
+					summary.agentsMd.skipped += 1;
+					console.log(
+						"  WARNING: Active omx session detected (pid " +
+							activeSession?.pid +
+							").",
+					);
+					console.log(
+						"  Skipping AGENTS.md overwrite to avoid corrupting runtime overlay.",
+					);
+					console.log("  Stop the active session first, then re-run setup.");
+				} else {
+					const result = await syncManagedAgentsContent(
+						rewritten,
+						pluginAgentsMdDst,
+						summary.agentsMd,
+						backupContext,
+						{
+							agentsOverwritePrompt: options.agentsOverwritePrompt,
+							dryRun,
+							force,
+							verbose,
+						},
+					);
+					if (result === "updated") {
 					console.log(
 						resolvedScope.scope === "project"
 							? "  Generated plugin-mode AGENTS.md defaults in project root."
@@ -2454,22 +2536,23 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 							? "  Plugin-mode AGENTS.md defaults already up to date in project root."
 							: `  Plugin-mode AGENTS.md defaults already up to date in ${scopeDirs.codexHomeDir}.`,
 					);
-				} else {
-					console.log(
-						`  Skipped plugin-mode AGENTS.md defaults for ${pluginAgentsMdDst}.`,
-					);
+					} else {
+						console.log(
+							`  Skipped plugin-mode AGENTS.md defaults for ${pluginAgentsMdDst}.`,
+						);
+					}
 				}
 			} else {
 				summary.agentsMd.skipped += 1;
-				console.log("  AGENTS.md template not found, skipping.");
+				console.log(
+					pluginAgentsMdExists
+						? "  Plugin-mode AGENTS.md defaults not selected; existing AGENTS.md left untouched.\n"
+						: "  Plugin-mode AGENTS.md defaults not selected; no AGENTS.md was generated.\n",
+				);
 			}
 		} else {
 			summary.agentsMd.skipped += 1;
-			console.log(
-				existsSync(pluginAgentsMdDst)
-					? "  Plugin-mode AGENTS.md defaults not selected; existing AGENTS.md left untouched.\n"
-					: "  Plugin-mode AGENTS.md defaults not selected; no AGENTS.md was generated.\n",
-			);
+			console.log("  AGENTS.md template not found, skipping.");
 		}
 	} else {
 		const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
@@ -2480,12 +2563,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		const agentsMdExists = existsSync(agentsMdDst);
 
 		// Guard: refuse to overwrite project-root AGENTS.md during active session
-		const activeSession =
-			resolvedScope.scope === "project"
-				? await readSessionState(projectRoot)
-				: null;
-		const sessionIsActive = activeSession && !isSessionStale(activeSession);
-
 		if (existsSync(agentsMdSrc)) {
 			const content = await readFile(agentsMdSrc, "utf-8");
 			const modelTableContext = resolveAgentsModelTableContext(resolvedConfig, {


### PR DESCRIPTION
## Summary

Follow-up to #2798 / `omx-si2`: make the doctor-recommended plugin-mode repair path actually work and keep AGENTS.md safety boundaries consistent.

- honor explicit plugin-mode `--merge-agents` as a managed-block repair path for existing AGENTS.md files
- bypass plugin AGENTS default prompts when `--merge-agents` is the operative repair mode
- skip symlinked AGENTS.md paths, including broken symlinks, for both merge repair and plugin defaults
- apply the project active-session guard before plugin AGENTS merge/default writes

## Engineering rationale

`omx doctor` can recommend `omx setup --scope <scope> --merge-agents` when a persistent plugin-mode AGENTS.md exists without OMX contract markers. Before this patch, plugin-mode setup only had two AGENTS outcomes: prompt-gated default install or no-op. That meant `--merge-agents` could be shadowed by plugin default selection and could not deterministically repair a user-authored AGENTS.md while preserving local guidance.

This patch keeps the repair ontology explicit:

- **default install** = full template generation/update, still prompt/force-driven for regular files
- **merge repair** = explicit `--merge-agents`, preserving user text and upserting only OMX-managed sections
- **symlink path** != symlink target; `lstat` detects valid and broken symlink paths without following targets
- **active session overlay** != persistent source mutation; project AGENTS.md writes are skipped during active sessions

## Acceptance checklist

- [x] Plugin-mode `--merge-agents` repairs an unmarked existing user AGENTS.md by inserting OMX-managed sections.
- [x] Existing local/user guidance is preserved during merge repair.
- [x] Repeated plugin-mode `--merge-agents` is idempotent.
- [x] Plugin-mode `--merge-agents` does not ask for plugin AGENTS defaults.
- [x] Symlinked AGENTS.md paths are skipped for explicit merge repair.
- [x] Broken symlinked AGENTS.md paths are skipped for explicit merge repair.
- [x] Symlinked AGENTS.md paths are skipped for plugin default writes, even when overwrite would be accepted.
- [x] Broken symlinked AGENTS.md paths are skipped for plugin default writes and do not create/mutate targets.
- [x] Project active-session guard skips plugin explicit merge writes.
- [x] Project active-session guard skips plugin default writes.
- [x] Final code-review gate: APPROVE.
- [x] Final Scholastic gate: PASS.

## Verification

- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/setup-agents-overwrite.test.js` → 22/22 pass
- `node dist/scripts/run-test-files.js dist/cli/__tests__/doctor-warning-copy.test.js` → 40/40 pass
- `node dist/scripts/run-test-files.js dist/cli/__tests__/setup-install-mode.test.js` → 62/62 pass
- `git diff --check`

Note: during verification, `npm run build` once emitted only CLI entry modules in `dist`; running `npx tsc --listEmittedFiles --pretty false` emitted the expected module files before rerunning the compiled tests. The source compile itself passed.
