### PR TITLE
fix: preserve custom developer instructions on plugin cleanup

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1946,7 +1946,7 @@ describe("omx setup install mode behavior", () => {
 						installMode: "plugin",
 						pluginDeveloperInstructionsPrompt: async () => {
 							promptCount += 1;
-							return "refresh";
+							return true;
 						},
 					});
 
@@ -1960,6 +1960,75 @@ describe("omx setup install mode behavior", () => {
 						config,
 						/You have oh-my-codex installed\\. AGENTS\\.md/,
 					);
+					assert.equal(
+						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
+						1,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves managed classic developer_instructions when plugin migration refresh is declined", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					await writeFile(
+						configPath,
+						`developer_instructions = ${JSON.stringify(OMX_DEVELOPER_INSTRUCTIONS)}\n`,
+					);
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginDeveloperInstructionsPrompt: async () => false,
+					});
+
+					const config = await readFile(configPath, "utf-8");
+					assert.match(config, /You have oh-my-codex installed\. AGENTS\.md/);
+					assert.doesNotMatch(config, /<omx version=/);
+					assert.equal(
+						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
+						1,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves edited classic developer_instructions containing the legacy phrase", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					const edited = `${OMX_DEVELOPER_INSTRUCTIONS}\nCustom local rule: keep this line.`;
+					await writeFile(
+						configPath,
+						`developer_instructions = ${JSON.stringify(edited)}\n`,
+					);
+
+					let promptCount = 0;
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginDeveloperInstructionsPrompt: async () => {
+							promptCount += 1;
+							return true;
+						},
+					});
+
+					assert.equal(promptCount, 0);
+					const config = await readFile(configPath, "utf-8");
+					assert.match(config, /You have oh-my-codex installed\. AGENTS\.md/);
+					assert.match(config, /Custom local rule: keep this line/);
+					assert.doesNotMatch(config, /<omx version=/);
 					assert.equal(
 						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
 						1,
@@ -2563,8 +2632,10 @@ describe("omx setup install mode behavior", () => {
 					assert.match(config, /^plugin_hooks = true$/m);
 					assert.doesNotMatch(
 						config,
-						/^\s*(?:notify|developer_instructions)\s*=|^\s*\[mcp_servers[.\]]/m,
+						/^\s*(?:notify)\s*=|^\s*\[mcp_servers[.\]]/m,
 					);
+					assert.match(config, /^developer_instructions\s*=/m);
+					assert.match(config, /You have oh-my-codex installed\. AGENTS\.md/);
 				});
 			});
 		} finally {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -940,12 +940,16 @@ async function askYesNoDefaultYes(question: string): Promise<boolean> {
 
 function legacyPluginDeveloperInstructionsDecision(
 	choice: boolean | "skip" | "preserve-or-add" | "refresh",
+	state: PluginDeveloperInstructionsDecision["state"] = "missing",
 ): PluginDeveloperInstructionsDecision {
-	if (choice === "refresh") {
+	if (choice === "refresh" || (choice === true && state === "historical")) {
 		return {
 			action: "update",
 			state: "historical",
-			reason: "legacy explicit refresh policy",
+			reason:
+				choice === "refresh"
+					? "legacy explicit refresh policy"
+					: "legacy boolean approval refreshed historical developer_instructions",
 		};
 	}
 	if (choice === true || choice === "preserve-or-add") {
@@ -957,7 +961,7 @@ function legacyPluginDeveloperInstructionsDecision(
 	}
 	return {
 		action: "preserve",
-		state: "custom",
+		state,
 		reason: "legacy explicit skip policy",
 	};
 }
@@ -974,6 +978,7 @@ async function resolvePluginDeveloperInstructionsDecision(
 		if (options.pluginDeveloperInstructionsPrompt) {
 			return legacyPluginDeveloperInstructionsDecision(
 				await options.pluginDeveloperInstructionsPrompt(configPath),
+				"missing",
 			);
 		}
 		const install = await askYesNoDefaultYes(
@@ -1002,13 +1007,25 @@ async function resolvePluginDeveloperInstructionsDecision(
 	}
 
 	if (state === "historical") {
-		const update = options.pluginDeveloperInstructionsPrompt
+		const updateDecision = options.pluginDeveloperInstructionsPrompt
 			? legacyPluginDeveloperInstructionsDecision(
 					await options.pluginDeveloperInstructionsPrompt(configPath),
-				).action === "update"
+					state,
+				)
 			: await askYesNoDefaultYes(
 					`Plugin mode: update OMX developer_instructions bootstrap at "${configPath}"? [Y/n]: `,
-				);
+				)
+				? {
+						action: "update",
+						state,
+						reason: "recognized historical OMX developer_instructions",
+					} satisfies PluginDeveloperInstructionsDecision
+				: {
+						action: "preserve",
+						state,
+						reason: "historical OMX developer_instructions preserved",
+					} satisfies PluginDeveloperInstructionsDecision;
+		const update = updateDecision.action === "update";
 		return update
 			? {
 					action: "update",
@@ -1495,7 +1512,18 @@ async function cleanupPluginModeLegacyPrompts(
 	return summary;
 }
 
-function stripPluginModeLegacyRootDefaults(config: string): string {
+function removeRootTomlKey(config: string, key: string): string {
+	const range = findRootTomlKeyRange(config, key);
+	if (!range) return config;
+	const before = config.slice(0, range.start);
+	const after = config.slice(range.end).replace(/^\r?\n?/, "\n");
+	return `${before}${after}`;
+}
+
+function stripPluginModeLegacyRootDefaults(
+	config: string,
+	developerInstructionsDecision: PluginDeveloperInstructionsDecision,
+): string {
 	const lines = config.split(/\r?\n/);
 	const firstTableIndex = lines.findIndex((line) => /^\s*\[/.test(line));
 	const boundary = firstTableIndex >= 0 ? firstTableIndex : lines.length;
@@ -1522,17 +1550,20 @@ function stripPluginModeLegacyRootDefaults(config: string): string {
 		) {
 			continue;
 		}
-		if (
-			index < boundary &&
-			/^\s*developer_instructions\s*=/.test(line) &&
-			line.includes("You have oh-my-codex installed.")
-		) {
-			continue;
-		}
 		result.push(line);
 	}
 
-	return result.join("\n").replace(/\n{3,}/g, "\n\n");
+	let nextConfig = result.join("\n").replace(/\n{3,}/g, "\n\n");
+	if (
+		developerInstructionsDecision.action === "update" &&
+		developerInstructionsDecision.state === "historical" &&
+		classifyPluginDeveloperInstructions(
+			readRootDeveloperInstructions(nextConfig),
+		) === "historical"
+	) {
+		nextConfig = removeRootTomlKey(nextConfig, "developer_instructions");
+	}
+	return nextConfig;
 }
 
 function rootHasTomlKey(config: string, key: string): boolean {
@@ -1868,6 +1899,7 @@ async function cleanupPluginModeLegacyConfig(
 	backupContext: SetupBackupContext,
 	options: Pick<SetupOptions, "dryRun" | "verbose"> & {
 		preserveFirstPartyMcp?: boolean;
+		developerInstructionsDecision: PluginDeveloperInstructionsDecision;
 	},
 ): Promise<boolean> {
 	if (!existsSync(configPath)) return false;
@@ -1880,7 +1912,10 @@ async function cleanupPluginModeLegacyConfig(
 	config = stripFirstPartyOmxMcpSections(config);
 	config = stripExistingOmxBlocks(config).cleaned;
 	config = stripExistingSharedMcpRegistryBlock(config).cleaned;
-	config = stripPluginModeLegacyRootDefaults(config);
+	config = stripPluginModeLegacyRootDefaults(
+		config,
+		options.developerInstructionsDecision,
+	);
 	config = stripOmxSeededBehavioralDefaults(config);
 	config = stripOmxFeatureFlags(config);
 	config = stripManagedCodexHookTrustState(config);
@@ -2361,6 +2396,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				preserveFirstPartyMcp:
 					shouldOfferFirstPartyMcpRemoval &&
 					!removeFirstPartyMcpRegistrations,
+				developerInstructionsDecision: pluginDeveloperInstructionsDecision,
 			},
 		);
 		if (configCleaned) summary.config.removed += 1;


### PR DESCRIPTION
## Summary

Follow-up to merged #2802.

This tightens plugin-mode cleanup so `developer_instructions` ownership is based on the resolved setup decision plus exact historical value classification, not substring matching.

## Root cause

The merged migration path classified edited classic `developer_instructions` as custom/preserve, but later plugin cleanup still removed any root `developer_instructions` line containing `You have oh-my-codex installed.`. That treated content similarity as ownership and could silently delete user-edited instructions.

## Changes

- Make legacy boolean approval contextual:
  - missing value + `true` => add plugin bootstrap
  - exact historical classic value + `true` => refresh/update plugin bootstrap
  - declined/no-TTY preserve remains preserve
- Pass the resolved developer-instructions decision into plugin cleanup.
- Remove the substring-based cleanup rule.
- Strip root `developer_instructions` only when the decision is `update` and the parsed root value still classifies as historical.
- Add regressions for:
  - boolean `true` refreshing exact classic managed instructions
  - declined refresh preserving exact classic instructions
  - edited phrase-containing classic instructions staying custom and unprompted
  - legacy user component plugin migration preserving `developer_instructions` when no refresh is approved

## Validation

- `npm run build`
- `git diff --check`
- `npx biome lint src/cli/setup.ts src/cli/__tests__/setup-install-mode.test.ts`
- `node --test --test-concurrency=1 --test-name-pattern='managed classic developer_instructions|edited classic developer_instructions|removes legacy user components' dist/cli/__tests__/setup-install-mode.test.js` — 4 passed, 0 failed
- Code review gate: APPROVE / CLEAR
- Scholastic gate: PASS
