### PR TITLE
[codex] Fix ralplan consensus iterate guard

### DIFF
--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -10,6 +10,55 @@ import {
 } from '../ralplan-gate.js';
 
 describe('autopilot ralplan gate', () => {
+  for (const { lane, architectVerdict, criticVerdict } of [
+    { lane: 'architect', architectVerdict: 'iterate', criticVerdict: 'approve' },
+    { lane: 'critic', architectVerdict: 'approve', criticVerdict: 'iterate' },
+  ] as const) {
+    it(`rejects complete ralplan consensus when ${lane} review verdict is iterate`, () => {
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: architectVerdict,
+              session_id: 'sess-autopilot-iterate',
+              thread_id: 'thread-architect',
+              artifact_path: '.omx/artifacts/architect.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-05-28T18:34:51.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: criticVerdict,
+              session_id: 'sess-autopilot-iterate',
+              thread_id: 'thread-critic',
+              artifact_path: '.omx/artifacts/critic.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-05-28T18:35:10.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({
+        cwd: process.cwd(),
+        sessionId: 'sess-autopilot-iterate',
+        currentState: state,
+      });
+      assert.equal(decision.allowed, false);
+      assert.equal(decision.evidence?.blockedReason, 'non_approving_ralplan_consensus_review');
+      const error = buildAutopilotRalplanUltragoalGateError(decision);
+      assert.match(error, /non-approving architect or critic review evidence/i);
+      assert.doesNotMatch(error, /missing ralplan consensus gate/i);
+      assert.match(error, new RegExp(`${lane}.*verdict=iterate`, 'i'));
+    });
+  }
+
   it('rejects native review evidence from the session leader even when malformed tracking marks it as subagent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-leader-spoof-'));
     const sessionId = 'sess-autopilot-leader-spoof';

--- a/src/autopilot/ralplan-gate.ts
+++ b/src/autopilot/ralplan-gate.ts
@@ -1,4 +1,8 @@
-import { buildRalplanConsensusGateFromSources, type RalplanConsensusGateEvidence } from '../ralplan/consensus-gate.js';
+import {
+  buildRalplanConsensusGateFromSources,
+  RALPLAN_CONSENSUS_BLOCKED_REASONS,
+  type RalplanConsensusGateEvidence,
+} from '../ralplan/consensus-gate.js';
 
 type JsonObject = Record<string, unknown>;
 
@@ -66,11 +70,19 @@ export function canAdvanceAutopilotRalplanToUltragoal(
   }
   return {
     allowed: false,
-    reason: evidence.blockedReason === 'native_subagent_consensus_evidence_missing'
-      ? 'ralplan consensus lacks tracker-backed native architect and critic lanes'
-      : 'missing ralplan consensus gate with tracker-backed native architect and critic lanes',
+    reason: ralplanConsensusBlockedReason(evidence),
     evidence,
   };
+}
+
+function ralplanConsensusBlockedReason(evidence: RalplanConsensusGateEvidence): string {
+  if (evidence.blockedReason === RALPLAN_CONSENSUS_BLOCKED_REASONS.nativeSubagentEvidenceMissing) {
+    return 'ralplan consensus lacks tracker-backed native architect and critic lanes';
+  }
+  if (evidence.blockedReason === RALPLAN_CONSENSUS_BLOCKED_REASONS.nonApprovingReview) {
+    return 'ralplan consensus gate contains non-approving architect or critic review evidence';
+  }
+  return 'missing ralplan consensus gate with tracker-backed native architect and critic lanes';
 }
 
 export function buildAutopilotRalplanUltragoalGateError(

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -2,13 +2,22 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { subagentTrackingPath } from '../subagents/tracker.js';
 
+export const RALPLAN_CONSENSUS_BLOCKED_REASONS = {
+  nativeSubagentEvidenceMissing: 'native_subagent_consensus_evidence_missing',
+  nonApprovingReview: 'non_approving_ralplan_consensus_review',
+  missingSequentialApproval: 'missing_sequential_architect_then_critic_approval',
+} as const;
+
+export type RalplanConsensusBlockedReason =
+  typeof RALPLAN_CONSENSUS_BLOCKED_REASONS[keyof typeof RALPLAN_CONSENSUS_BLOCKED_REASONS];
+
 export interface RalplanConsensusGateEvidence {
   complete: boolean;
   sequence: ['architect-review', 'critic-review'];
   ralplan_architect_review: Record<string, unknown> | null;
   ralplan_critic_review: Record<string, unknown> | null;
   source: string | null;
-  blockedReason: string | null;
+  blockedReason: RalplanConsensusBlockedReason | null;
   blockedDetails?: string[];
 }
 
@@ -32,6 +41,12 @@ export function buildRalplanConsensusGateFromSources(
     ralplan_critic_review: Record<string, unknown>;
     source: string;
   } | null = null;
+  let invalidCompleteEvidence: {
+    ralplan_architect_review: Record<string, unknown> | null;
+    ralplan_critic_review: Record<string, unknown> | null;
+    source: string;
+    blockedDetails: string[];
+  } | null = null;
 
   for (const candidate of sources) {
     const evidence = extractSequentialConsensusEvidence(candidate.value);
@@ -52,6 +67,23 @@ export function buildRalplanConsensusGateFromSources(
         blockedReason: null,
       };
     }
+
+    const invalidEvidence = extractInvalidCompleteConsensusEvidence(candidate.value);
+    if (invalidEvidence) {
+      invalidCompleteEvidence ??= { ...invalidEvidence, source: candidate.source };
+    }
+  }
+
+  if (invalidCompleteEvidence) {
+    return {
+      complete: false,
+      sequence: ['architect-review', 'critic-review'],
+      ralplan_architect_review: invalidCompleteEvidence.ralplan_architect_review,
+      ralplan_critic_review: invalidCompleteEvidence.ralplan_critic_review,
+      source: invalidCompleteEvidence.source,
+      blockedReason: RALPLAN_CONSENSUS_BLOCKED_REASONS.nonApprovingReview,
+      blockedDetails: invalidCompleteEvidence.blockedDetails,
+    };
   }
 
   if (nativeBlockedEvidence) {
@@ -61,7 +93,7 @@ export function buildRalplanConsensusGateFromSources(
       ralplan_architect_review: nativeBlockedEvidence.ralplan_architect_review,
       ralplan_critic_review: nativeBlockedEvidence.ralplan_critic_review,
       source: nativeBlockedEvidence.source,
-      blockedReason: 'native_subagent_consensus_evidence_missing',
+      blockedReason: RALPLAN_CONSENSUS_BLOCKED_REASONS.nativeSubagentEvidenceMissing,
       blockedDetails: [
         trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_architect_review, 'architect', options),
         trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_critic_review, 'critic', options),
@@ -75,7 +107,7 @@ export function buildRalplanConsensusGateFromSources(
     ralplan_architect_review: null,
     ralplan_critic_review: null,
     source: null,
-    blockedReason: 'missing_sequential_architect_then_critic_approval',
+    blockedReason: RALPLAN_CONSENSUS_BLOCKED_REASONS.missingSequentialApproval,
   };
 }
 
@@ -208,6 +240,50 @@ function extractSequentialConsensusEvidence(value: unknown): {
   return null;
 }
 
+function extractInvalidCompleteConsensusEvidence(value: unknown): {
+  ralplan_architect_review: Record<string, unknown> | null;
+  ralplan_critic_review: Record<string, unknown> | null;
+  blockedDetails: string[];
+} | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+
+  const gate = record.ralplanConsensusGate ?? record.ralplan_consensus_gate;
+  if (gate && typeof gate === 'object') {
+    const gateRecord = gate as Record<string, unknown>;
+    const architectReview = asRecord(
+      gateRecord.ralplan_architect_review ?? gateRecord.architectReview ?? gateRecord.architect_review,
+    );
+    const criticReview = asRecord(
+      gateRecord.ralplan_critic_review ?? gateRecord.criticReview ?? gateRecord.critic_review,
+    );
+    if (gateRecord.complete === true && hasArchitectThenCriticSequence(gateRecord)) {
+      const blockedDetails = [
+        ...reviewApprovalProblems(architectReview, 'architect'),
+        ...reviewApprovalProblems(criticReview, 'critic'),
+      ];
+      if (!isCriticNotBeforeArchitect(architectReview, criticReview)) {
+        blockedDetails.push('critic review is ordered before architect review');
+      }
+      if (blockedDetails.length > 0) {
+        return {
+          ralplan_architect_review: architectReview,
+          ralplan_critic_review: criticReview,
+          blockedDetails,
+        };
+      }
+    }
+  }
+
+  const stateHandoffArtifacts = asRecord(asRecord(record.state)?.handoff_artifacts);
+  if (stateHandoffArtifacts) {
+    const evidence = extractInvalidCompleteConsensusEvidence(stateHandoffArtifacts);
+    if (evidence) return evidence;
+  }
+
+  return null;
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' ? value as Record<string, unknown> : null;
 }
@@ -215,14 +291,48 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 function isApproveReview(value: Record<string, unknown> | null, agentRole: 'architect' | 'critic'): value is Record<string, unknown> {
   if (!value || value.agent_role !== agentRole) return false;
   if (value.verdict !== undefined && value.verdict !== 'approve') return false;
-  if (value.status !== undefined && !['approve', 'approved', 'clear', 'pass', 'passed'].includes(String(value.status).toLowerCase())) {
+  if (value.status !== undefined && !isApprovedStatus(value.status)) {
     return false;
   }
-  if (value.recommendation !== undefined && !['approve', 'approved'].includes(String(value.recommendation).toLowerCase())) {
+  if (value.recommendation !== undefined && !isApproveRecommendation(value.recommendation)) {
     return false;
   }
   if (hasBlockingReviewSignal(value)) return false;
+  return hasPositiveReviewApprovalSignal(value);
+}
+
+function reviewApprovalProblems(value: Record<string, unknown> | null, agentRole: 'architect' | 'critic'): string[] {
+  const issues: string[] = [];
+  if (!value) return [`${agentRole} review is missing`];
+  if (value.agent_role !== agentRole) issues.push(`${agentRole} review has agent_role=${String(value.agent_role || 'missing')}`);
+  if (value.verdict !== undefined && value.verdict !== 'approve') {
+    issues.push(`${agentRole} review verdict=${String(value.verdict)} is not approve`);
+  }
+  if (value.status !== undefined && !isApprovedStatus(value.status)) {
+    issues.push(`${agentRole} review status=${String(value.status)} is not approve`);
+  }
+  if (value.recommendation !== undefined && !isApproveRecommendation(value.recommendation)) {
+    issues.push(`${agentRole} review recommendation=${String(value.recommendation)} is not approve`);
+  }
+  if (issues.length === 0 && hasBlockingReviewSignal(value)) {
+    issues.push(`${agentRole} review has a blocking signal`);
+  }
+  if (issues.length === 0 && !hasPositiveReviewApprovalSignal(value)) {
+    issues.push(`${agentRole} review lacks approving evidence`);
+  }
+  return issues;
+}
+
+function hasPositiveReviewApprovalSignal(value: Record<string, unknown>): boolean {
   return value.verdict === 'approve' || value.approved === true || value.clean === true;
+}
+
+function isApprovedStatus(value: unknown): boolean {
+  return ['approve', 'approved', 'clear', 'pass', 'passed'].includes(String(value).toLowerCase());
+}
+
+function isApproveRecommendation(value: unknown): boolean {
+  return ['approve', 'approved'].includes(String(value).toLowerCase());
 }
 
 function hasArchitectThenCriticSequence(value: Record<string, unknown>): boolean {

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -2256,6 +2256,61 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  for (const { lane, architectVerdict, criticVerdict } of [
+    { lane: 'architect', architectVerdict: 'iterate', criticVerdict: 'approve' },
+    { lane: 'critic', architectVerdict: 'approve', criticVerdict: 'iterate' },
+  ] as const) {
+    it(`denies Autopilot ralplan to ultragoal self-write when ${lane} verdict is iterate despite complete consensus flag`, async () => {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-ralplan-${lane}-iterate-deny-`));
+      try {
+        await withOmxRootEnv(wd, async () => {
+          const sessionId = `sess-autopilot-ralplan-${lane}-iterate-deny`;
+          const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+          await mkdir(sessionDir, { recursive: true });
+          await writeNativeSubagentTracking(wd, sessionId);
+          const consensusGate = ralplanConsensusGate(sessionId, 'native_subagent');
+          (consensusGate.ralplan_architect_review as Record<string, unknown>).verdict = architectVerdict;
+          (consensusGate.ralplan_critic_review as Record<string, unknown>).verdict = criticVerdict;
+          await writeFile(
+            join(sessionDir, 'autopilot-state.json'),
+            JSON.stringify({
+              active: true,
+              mode: 'autopilot',
+              current_phase: 'ralplan',
+              state: {
+                handoff_artifacts: {
+                  ralplan: {
+                    plan_path: '.omx/plans/prd.md',
+                    test_spec_path: '.omx/plans/test-spec.md',
+                  },
+                  ralplan_consensus_gate: consensusGate,
+                },
+              },
+            }, null, 2),
+          );
+
+          const response = await executeStateOperation('state_write', {
+            workingDirectory: wd,
+            session_id: sessionId,
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'ultragoal',
+          });
+
+          assert.equal(response.isError, true);
+          const error = String((response.payload as { error?: string }).error || '');
+          assert.match(error, new RegExp(`${lane}.*verdict=iterate`, 'i'));
+          const state = JSON.parse(
+            await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8'),
+          ) as Record<string, unknown>;
+          assert.equal(state.current_phase, 'ralplan');
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+  }
+
 
   it('explains when native ralplan reviews are not present in subagent tracking', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ralplan-native-missing-tracker-'));


### PR DESCRIPTION
## Summary
- Reject claimed-complete ralplan consensus gates when required Architect/Critic review evidence is non-approving (for example `verdict: "iterate"`).
- Add lane-specific blocked details so Autopilot reports the blocking lane and verdict instead of a generic missing-gate message.
- Centralize ralplan consensus blocked-reason constants/types and approval helper allowlists to reduce diagnostic drift.
- Add regression coverage for architect-iterate and critic-iterate cases at both the direct Autopilot gate and state-write transition layers.

## Root cause
The consensus gate already required approving review evidence for a successful extraction, but when `complete: true` was present with non-approving lane evidence, the failure collapsed into a generic missing-consensus path. That obscured which required lane blocked handoff and left room for stale/malformed complete flags to appear authoritative.

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/autopilot/__tests__/ralplan-gate.test.js dist/state/__tests__/operations.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `node dist/scripts/run-test-files.js dist/ralplan/__tests__/runtime.test.js`
- UltraQA temp harness: architect iterate, critic iterate, missing critic review, prompt-injection-like verdict text; all denied with dedicated non-approving consensus diagnostics and harness removed.

## Notes
- PR base: `dev`
- Bead: `omx-cql`
- Scholastic advisory was run separately at ralplan and code-review gates; it is not part of the durable Architect→Critic consensus gate.
