### PR TITLE
Fix ralplan consensus boxed state root lookup

### DIFF
--- a/src/ralplan/__tests__/consensus-gate.test.ts
+++ b/src/ralplan/__tests__/consensus-gate.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { getBaseStateDir } from '../../state/paths.js';
+import { subagentTrackingPath } from '../../subagents/tracker.js';
+import { buildRalplanConsensusGateForCwd } from '../consensus-gate.js';
+
+describe('ralplan consensus gate state roots', () => {
+  it('reads tracker-backed consensus evidence from OMX_STATE_ROOT instead of cwd/.omx/state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-cwd-'));
+    const boxedRoot = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-state-root-'));
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const sessionId = 'sess-boxed-consensus';
+    try {
+      delete process.env.OMX_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      process.env.OMX_STATE_ROOT = boxedRoot;
+      const baseStateDir = getBaseStateDir(cwd);
+      const sessionDir = join(baseStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(baseStateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        native_session_id: 'thread-leader',
+        cwd,
+      }, null, 2));
+      await writeFile(subagentTrackingPath(cwd), JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-11T16:30:00.000Z',
+            threads: {
+              'thread-leader': {
+                thread_id: 'thread-leader',
+                kind: 'leader',
+                first_seen_at: '2026-06-11T16:29:00.000Z',
+                last_seen_at: '2026-06-11T16:29:00.000Z',
+                turn_count: 1,
+              },
+              'thread-architect': {
+                thread_id: 'thread-architect',
+                kind: 'subagent',
+                first_seen_at: '2026-06-11T16:29:30.000Z',
+                last_seen_at: '2026-06-11T16:29:30.000Z',
+                completed_at: '2026-06-11T16:29:30.000Z',
+                turn_count: 1,
+              },
+              'thread-critic': {
+                thread_id: 'thread-critic',
+                kind: 'subagent',
+                first_seen_at: '2026-06-11T16:30:00.000Z',
+                last_seen_at: '2026-06-11T16:30:00.000Z',
+                completed_at: '2026-06-11T16:30:00.000Z',
+                turn_count: 1,
+              },
+            },
+          },
+        },
+      }, null, 2));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-architect',
+              artifact_path: '.omx/plans/architect.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-11T16:29:30.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic',
+              artifact_path: '.omx/plans/critic.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-11T16:30:00.000Z',
+            },
+          },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        sessionId,
+        requireNativeSubagents: true,
+      });
+
+      assert.equal(gate.complete, true);
+      assert.equal(gate.blockedReason, null);
+      assert.match(String(gate.source), new RegExp(`${boxedRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousOmxTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousOmxTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(boxedRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/ralplan/__tests__/consensus-gate.test.ts
+++ b/src/ralplan/__tests__/consensus-gate.test.ts
@@ -8,6 +8,43 @@ import { subagentTrackingPath } from '../../subagents/tracker.js';
 import { buildRalplanConsensusGateForCwd } from '../consensus-gate.js';
 
 describe('ralplan consensus gate state roots', () => {
+  it('ignores ambient root consensus unless the ambient session is bound to this cwd', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-local-'));
+    const ambientRoot = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-ambient-'));
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_ROOT = ambientRoot;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      const ambientStateDir = getBaseStateDir(cwd);
+      await mkdir(ambientStateDir, { recursive: true });
+      await writeFile(join(ambientStateDir, 'ralplan-state.json'), JSON.stringify({
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: { agent_role: 'architect', verdict: 'approve' },
+          ralplan_critic_review: { agent_role: 'critic', verdict: 'approve' },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd);
+
+      assert.equal(gate.complete, false);
+      assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousOmxTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousOmxTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(ambientRoot, { recursive: true, force: true });
+    }
+  });
+
   it('reads tracker-backed consensus evidence from OMX_STATE_ROOT instead of cwd/.omx/state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-cwd-'));
     const boxedRoot = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-state-root-'));
@@ -109,6 +146,39 @@ describe('ralplan consensus gate state roots', () => {
       else delete process.env.OMX_TEAM_STATE_ROOT;
       await rm(cwd, { recursive: true, force: true });
       await rm(boxedRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stale top-level handoff consensus during a return-to-ralplan cycle', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-stale-'));
+    try {
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        artifacts: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          handoff_artifacts: {
+            ralplan_consensus_gate: {
+              complete: true,
+              sequence: ['architect-review', 'critic-review'],
+              ralplan_architect_review: {
+                agent_role: 'architect',
+                verdict: 'approve',
+                completed_at: '2026-06-11T16:00:00.000Z',
+              },
+              ralplan_critic_review: {
+                agent_role: 'critic',
+                verdict: 'approve',
+                completed_at: '2026-06-11T16:05:00.000Z',
+              },
+            },
+          },
+        },
+      });
+
+      assert.equal(gate.complete, false);
+      assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
     }
   });
 });

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { subagentTrackingPath } from '../subagents/tracker.js';
-import { getBaseStateDir } from '../state/paths.js';
+import { getBaseStateDir, resolveWorkingDirectoryForState } from '../state/paths.js';
 
 export const RALPLAN_CONSENSUS_BLOCKED_REASONS = {
   nativeSubagentEvidenceMissing: 'native_subagent_consensus_evidence_missing',
@@ -142,11 +142,15 @@ export function readLocalRalplanConsensusStateCandidates(
 ): RalplanConsensusSource[] {
   const explicitSession = sessionId !== undefined;
   const sessionIdList = explicitSession ? validateLocalSessionId(sessionId) : readLocalCurrentSessionIds(cwd);
-  const baseStateDir = getBaseStateDir(cwd);
+  const scopedStateDir = getBaseStateDir(cwd);
+  const localStateDir = localBaseStateDir(cwd);
   if (explicitSession && sessionIdList.length === 0) return [];
   const stateRoots = sessionIdList.length > 0
-    ? sessionIdList.map((id) => join(baseStateDir, 'sessions', id))
-    : [baseStateDir];
+    ? uniquePaths(sessionIdList.flatMap((id) => [
+      join(scopedStateDir, 'sessions', id),
+      join(localStateDir, 'sessions', id),
+    ]))
+    : [localStateDir];
 
   const paths = stateRoots.flatMap((dir) => [
     join(dir, 'ralplan-state.json'),
@@ -187,13 +191,17 @@ function extractSequentialConsensusEvidence(value: unknown): {
     }
   }
 
-  const topLevelHandoffArtifacts = asRecord(record.handoff_artifacts);
+  const handoffArtifactsAreStale = isReturnToRalplanCycle(record);
+  const topLevelHandoffArtifacts = handoffArtifactsAreStale ? null : asRecord(record.handoff_artifacts);
   if (topLevelHandoffArtifacts) {
     const evidence = extractSequentialConsensusEvidence(topLevelHandoffArtifacts);
     if (evidence) return evidence;
   }
 
-  const stateHandoffArtifacts = asRecord(asRecord(record.state)?.handoff_artifacts);
+  const stateRecord = asRecord(record.state);
+  const stateHandoffArtifacts = handoffArtifactsAreStale || (stateRecord && isReturnToRalplanCycle(stateRecord))
+    ? null
+    : asRecord(stateRecord?.handoff_artifacts);
   if (stateHandoffArtifacts) {
     const evidence = extractSequentialConsensusEvidence(stateHandoffArtifacts);
     if (evidence) return evidence;
@@ -487,6 +495,22 @@ function readLocalCurrentSessionIds(cwd: string): string[] {
   if (typeof state?.cwd === 'string' && state.cwd !== cwd) return [];
   const sessionId = typeof state?.session_id === 'string' ? state.session_id : undefined;
   return sessionId ? validateLocalSessionId(sessionId) : [];
+}
+
+function localBaseStateDir(cwd: string): string {
+  return join(resolveWorkingDirectoryForState(cwd), '.omx', 'state');
+}
+
+function uniquePaths(paths: string[]): string[] {
+  return [...new Set(paths)];
+}
+
+function isReturnToRalplanCycle(record: Record<string, unknown>): boolean {
+  const currentPhase = String(record.current_phase ?? record.currentPhase ?? '').toLowerCase();
+  const reason = record.return_to_ralplan_reason ?? record.returnToRalplanReason;
+  return currentPhase === 'ralplan'
+    && typeof reason === 'string'
+    && reason.trim().length > 0;
 }
 
 function readJsonState(path: string): Record<string, unknown> | null {

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { subagentTrackingPath } from '../subagents/tracker.js';
+import { getBaseStateDir } from '../state/paths.js';
 
 export const RALPLAN_CONSENSUS_BLOCKED_REASONS = {
   nativeSubagentEvidenceMissing: 'native_subagent_consensus_evidence_missing',
@@ -141,10 +142,11 @@ export function readLocalRalplanConsensusStateCandidates(
 ): RalplanConsensusSource[] {
   const explicitSession = sessionId !== undefined;
   const sessionIdList = explicitSession ? validateLocalSessionId(sessionId) : readLocalCurrentSessionIds(cwd);
+  const baseStateDir = getBaseStateDir(cwd);
   if (explicitSession && sessionIdList.length === 0) return [];
   const stateRoots = sessionIdList.length > 0
-    ? sessionIdList.map((id) => join(cwd, '.omx', 'state', 'sessions', id))
-    : [join(cwd, '.omx', 'state')];
+    ? sessionIdList.map((id) => join(baseStateDir, 'sessions', id))
+    : [baseStateDir];
 
   const paths = stateRoots.flatMap((dir) => [
     join(dir, 'ralplan-state.json'),
@@ -183,6 +185,12 @@ function extractSequentialConsensusEvidence(value: unknown): {
     ) {
       return { ralplan_architect_review: architectReview, ralplan_critic_review: criticReview };
     }
+  }
+
+  const topLevelHandoffArtifacts = asRecord(record.handoff_artifacts);
+  if (topLevelHandoffArtifacts) {
+    const evidence = extractSequentialConsensusEvidence(topLevelHandoffArtifacts);
+    if (evidence) return evidence;
   }
 
   const stateHandoffArtifacts = asRecord(asRecord(record.state)?.handoff_artifacts);
@@ -438,7 +446,7 @@ function trackerBackedNativeReviewProblem(
 
 function currentSessionNativeLeaderThreadId(cwd: string | undefined): string {
   if (!cwd) return '';
-  const sessionState = readJsonState(join(cwd, '.omx', 'state', 'session.json'));
+  const sessionState = readJsonState(join(getBaseStateDir(cwd), 'session.json'));
   return typeof sessionState?.native_session_id === 'string' ? sessionState.native_session_id.trim() : '';
 }
 
@@ -475,7 +483,7 @@ function hasBlockingReviewSignal(value: Record<string, unknown>): boolean {
 }
 
 function readLocalCurrentSessionIds(cwd: string): string[] {
-  const state = readJsonState(join(cwd, '.omx', 'state', 'session.json'));
+  const state = readJsonState(join(getBaseStateDir(cwd), 'session.json'));
   if (typeof state?.cwd === 'string' && state.cwd !== cwd) return [];
   const sessionId = typeof state?.session_id === 'string' ? state.session_id : undefined;
   return sessionId ? validateLocalSessionId(sessionId) : [];


### PR DESCRIPTION
## Summary

- Fix ralplan consensus evidence lookup to honor the authoritative OMX state root (`OMX_TEAM_STATE_ROOT` / `OMX_ROOT` / `OMX_STATE_ROOT`) instead of reading `cwd/.omx/state` directly.
- Teach consensus extraction to read top-level `handoff_artifacts`, matching Autopilot state shape.
- Keep current-native-leader spoof protection aligned with the same authoritative state root.
- Add regression for boxed/run-scoped state: tracker and Autopilot state live under `OMX_STATE_ROOT`, while the repo-local `.omx/state` is stale/missing.

## Why

A live `mediagen-comfy` Autopilot run had Architect/Critic native subagent approvals recorded in the run-scoped tracker, but the lane reported `current_session_present: false` and terminal-blocked in ralplan. The root cause was split state-root handling: hooks wrote tracker state to the run root, while ralplan consensus helpers still read some durable state from `cwd/.omx/state` and did not parse top-level Autopilot `handoff_artifacts`.

## Verification

- `npm run build`
- `node dist/scripts/run-test-files.js dist/ralplan/__tests__/consensus-gate.test.js dist/autopilot/__tests__/ralplan-gate.test.js dist/state/__tests__/operations.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
