### PR TITLE
fix(hooks): allow deep-interview apply_patch artifact writes from freeform patch text (#2809)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5903,6 +5903,121 @@ exit 0
     }
   });
 
+  it("allows deep-interview apply_patch artifact writes from freeform patch text while blocking outside paths", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-deep-interview-apply-patch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionDir = join(stateDir, "sessions", "sess-di-apply-patch");
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-di-apply-patch", cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: "sess-di-apply-patch",
+        active_skills: [{ skill: "deep-interview", phase: "planning", active: true, session_id: "sess-di-apply-patch" }],
+      });
+      await writeJson(join(sessionDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        session_id: "sess-di-apply-patch",
+      });
+
+      const allowedAddFile = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-apply-patch",
+          tool_name: "apply_patch",
+          tool_use_id: "tool-di-apply-patch-add",
+          tool_input: {
+            input: "*** Begin Patch\n*** Add File: .omx/context/findings.md\n+# Findings\n*** End Patch\n",
+          },
+        },
+        { cwd },
+      );
+      assert.equal(allowedAddFile.outputJson, null);
+
+      const allowedUpdateFile = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-apply-patch",
+          tool_name: "ApplyPatch",
+          tool_use_id: "tool-di-apply-patch-update",
+          tool_input: {
+            input: "*** Begin Patch\n*** Update File: .omx/specs/deep-interview-demo.md\n@@\n-old\n+new\n*** End Patch\n",
+          },
+        },
+        { cwd },
+      );
+      assert.equal(allowedUpdateFile.outputJson, null);
+
+      const allowedStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-apply-patch",
+          tool_name: "apply_patch",
+          tool_use_id: "tool-di-apply-patch-state",
+          tool_input: {
+            input: "*** Begin Patch\n*** Add File: .omx/state/deep-interview-notes.json\n+{}\n*** End Patch\n",
+          },
+        },
+        { cwd },
+      );
+      assert.equal(allowedStateWrite.outputJson, null);
+
+      const blockedOutsidePath = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-apply-patch",
+          tool_name: "apply_patch",
+          tool_use_id: "tool-di-apply-patch-outside",
+          tool_input: {
+            input: "*** Begin Patch\n*** Add File: src/implementation.ts\n+export const x = 1;\n*** End Patch\n",
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedOutsidePath.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedOutsidePath.outputJson as { reason?: string } | null)?.reason ?? ""), /Deep-interview is active/);
+
+      const blockedMixedPaths = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-apply-patch",
+          tool_name: "apply_patch",
+          tool_use_id: "tool-di-apply-patch-mixed",
+          tool_input: {
+            input: "*** Begin Patch\n*** Add File: .omx/context/ok.md\n+ok\n*** Add File: src/leak.ts\n+leak\n*** End Patch\n",
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedMixedPaths.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedUnparseablePatch = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-apply-patch",
+          tool_name: "apply_patch",
+          tool_use_id: "tool-di-apply-patch-empty",
+          tool_input: { input: "not a recognizable patch" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedUnparseablePatch.outputJson as { decision?: string } | null)?.decision, "block");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("allows Autopilot ralplan planning artifacts while blocking implementation writes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-autopilot-ralplan-artifact-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2708,6 +2708,44 @@ function readPreToolUsePathCandidates(payload: CodexHookPayload): string[] {
   return candidates.map((candidate) => safeString(candidate).trim()).filter(Boolean);
 }
 
+const APPLY_PATCH_TOOL_NAMES = new Set(["apply_patch", "ApplyPatch"]);
+
+function isApplyPatchToolName(toolName: string): boolean {
+  return APPLY_PATCH_TOOL_NAMES.has(toolName);
+}
+
+function readApplyPatchText(payload: CodexHookPayload): string {
+  const input = safeObject(payload.tool_input);
+  for (const key of ["input", "patch", "content", "text", "command"]) {
+    const value = safeString(input[key]).trim();
+    if (value) return value;
+  }
+  return "";
+}
+
+function extractApplyPatchTargetPaths(patchText: string): string[] {
+  if (!patchText) return [];
+  const paths: string[] = [];
+  for (const match of patchText.matchAll(/^\s*\*\*\*\s+(?:Add|Update|Delete)\s+File:\s*(.+?)\s*$/gm)) {
+    const candidate = safeString(match[1]).trim();
+    if (candidate) paths.push(candidate);
+  }
+  for (const match of patchText.matchAll(/^\s*\*\*\*\s+Move\s+to:\s*(.+?)\s*$/gm)) {
+    const candidate = safeString(match[1]).trim();
+    if (candidate) paths.push(candidate);
+  }
+  return paths;
+}
+
+function collectImplementationToolPathCandidates(
+  payload: CodexHookPayload,
+  toolName: string,
+  structuredCandidates: string[],
+): string[] {
+  if (!isApplyPatchToolName(toolName)) return structuredCandidates;
+  return [...structuredCandidates, ...extractApplyPatchTargetPaths(readApplyPatchText(payload))];
+}
+
 function isNullDeviceRedirectTarget(target: string): boolean {
   const normalized = target.trim().replace(/^['"]|['"]$/g, "").toLowerCase();
   return normalized === "/dev/null" || normalized === "nul";
@@ -2930,8 +2968,9 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
   if (toolName === "Bash") {
     blocked = !isAllowedDeepInterviewBashWrite(cwd, command);
   } else if (DEEP_INTERVIEW_IMPLEMENTATION_TOOL_NAMES.has(toolName)) {
-    blocked = pathCandidates.length === 0
-      || !pathCandidates.every((candidate) => isAllowedDeepInterviewArtifactPath(cwd, candidate));
+    const candidates = collectImplementationToolPathCandidates(payload, toolName, pathCandidates);
+    blocked = candidates.length === 0
+      || !candidates.every((candidate) => isAllowedDeepInterviewArtifactPath(cwd, candidate));
   }
 
   if (!blocked) return null;


### PR DESCRIPTION
## Summary

Closes #2809.

Deep-interview's PreToolUse boundary (`src/scripts/codex-native-hook.ts`) classified `apply_patch`/`ApplyPatch` as implementation/write tools, but extracted candidate paths only from **structured** `tool_input` keys (`file_path`, `filePath`, `path`, `target_path`, `targetPath`). Codex native `apply_patch` (Windows native/plugin mode) supplies the target **only as freeform patch text** — e.g. `*** Add File: .omx/context/foo.md`. With no structured key, the candidate list was empty, so the boundary blocked even allowed artifact writes to `.omx/context/`, `.omx/interviews/`, `.omx/specs/`, and `.omx/state/`.

## Change

- Parse `apply_patch`/`ApplyPatch` freeform patch text and extract target paths from `*** Add File:`, `*** Update File:`, `*** Delete File:`, and `*** Move to:` headers, merging them with any structured candidates.
- The write is allowed **only when every resolved target** is under an allowed deep-interview artifact prefix. Implementation writes outside those paths, mixed allowed/disallowed patches, and unparseable/ambiguous patches remain blocked.
- Path resolution reuses the existing `isAllowedDeepInterviewArtifactPath` normalizer (`resolve` + `relative` + slash normalization), so Windows path separators and CRLF line endings are handled without widening permissions.

Scope is intentionally narrow: only the deep-interview boundary's implementation-tool branch for `apply_patch` is touched; structured-key behavior for `Edit`/`Write`/etc. is unchanged.

## Verification

- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` → **423 pass / 0 fail**
- `npm run check:no-unused`
- `npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts`
- `npm run verify:plugin-bundle`

New regression test `allows deep-interview apply_patch artifact writes from freeform patch text while blocking outside paths` covers:
- allowed `Add File` to `.omx/context/` from freeform patch text (the only path source)
- allowed `Update File` to `.omx/specs/` via `ApplyPatch`
- allowed `Add File` to `.omx/state/`
- blocked `Add File` to `src/implementation.ts` (outside allowed prefixes)
- blocked patch mixing an allowed and a disallowed path
- blocked unparseable patch (ambiguous → fail-closed)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*