### PR TITLE
fix(cli): Windows-safe omx state input surface (#2811)

### DIFF
--- a/src/cli/__tests__/state.test.ts
+++ b/src/cli/__tests__/state.test.ts
@@ -1,5 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { stateCommand } from '../state.js';
 
@@ -72,6 +75,115 @@ describe('stateCommand', () => {
         stderr: () => undefined,
       }),
       /valid JSON/i,
+    );
+  });
+
+  it('maps --mode to a {mode} input object', async () => {
+    let captured: Record<string, unknown> | undefined;
+    await stateCommand(['read', '--mode', 'deep-interview', '--json'], {
+      stdout: () => undefined,
+      stderr: () => undefined,
+      execute: async (_operation, input) => {
+        captured = input;
+        return { payload: { exists: false, mode: 'deep-interview' } };
+      },
+    });
+    assert.deepEqual(captured, { mode: 'deep-interview' });
+  });
+
+  it('accepts the --mode=<value> form', async () => {
+    let captured: Record<string, unknown> | undefined;
+    await stateCommand(['clear', '--mode=ralph', '--json'], {
+      stdout: () => undefined,
+      stderr: () => undefined,
+      execute: async (_operation, input) => {
+        captured = input;
+        return { payload: { cleared: true } };
+      },
+    });
+    assert.deepEqual(captured, { mode: 'ralph' });
+  });
+
+  it('lets --mode override the mode from --input', async () => {
+    let captured: Record<string, unknown> | undefined;
+    await stateCommand(['read', '--input', '{"mode":"ralph","session_id":"abc"}', '--mode', 'team', '--json'], {
+      stdout: () => undefined,
+      stderr: () => undefined,
+      execute: async (_operation, input) => {
+        captured = input;
+        return { payload: { exists: false } };
+      },
+    });
+    assert.deepEqual(captured, { mode: 'team', session_id: 'abc' });
+  });
+
+  it('reads structured input from --input-file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omx-state-input-file-'));
+    const file = join(dir, 'payload.json');
+    await writeFile(file, JSON.stringify({ mode: 'ralph', all_sessions: true }), 'utf-8');
+    try {
+      let captured: Record<string, unknown> | undefined;
+      await stateCommand(['clear', '--input-file', file, '--json'], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+        execute: async (_operation, input) => {
+          captured = input;
+          return { payload: { cleared: true } };
+        },
+      });
+      assert.deepEqual(captured, { mode: 'ralph', all_sessions: true });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an unreadable --input-file path', async () => {
+    await assert.rejects(
+      stateCommand(['read', '--input-file', join(tmpdir(), 'omx-state-missing-does-not-exist.json')], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      }),
+      /--input-file could not be read/,
+    );
+  });
+
+  it('rejects supplying both --input and --input-file', async () => {
+    await assert.rejects(
+      stateCommand(['read', '--input', '{"mode":"ralph"}', '--input-file', 'payload.json'], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      }),
+      /either --input or --input-file/,
+    );
+  });
+
+  it('adds a Windows quote-stripping hint for quote-stripped --input JSON', async () => {
+    await assert.rejects(
+      stateCommand(['read', '--input', '{mode:deep-interview}'], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      }),
+      (error: unknown) => {
+        const message = (error as Error).message;
+        assert.match(message, /valid JSON/i);
+        assert.match(message, /Windows native shells/);
+        assert.match(message, /--mode/);
+        assert.match(message, /--input-file/);
+        return true;
+      },
+    );
+  });
+
+  it('does not add the Windows hint for ordinary malformed JSON', async () => {
+    await assert.rejects(
+      stateCommand(['read', '--input', '{"mode":"ralph"'], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      }),
+      (error: unknown) => {
+        assert.doesNotMatch((error as Error).message, /Windows native shells/);
+        return true;
+      },
     );
   });
 });

--- a/src/cli/state.ts
+++ b/src/cli/state.ts
@@ -1,6 +1,24 @@
+import { readFile } from 'node:fs/promises';
+
 import { executeStateOperation, type StateOperationName } from '../state/operations.js';
 
-const STATE_HELP = `Usage: omx state <read|write|clear|list-active|get-status> [--input <json>] [--json]\n\nExamples:\n  omx state read --input '{"mode":"ralph"}' --json\n  omx state write --input '{"mode":"ralph","active":true,"current_phase":"executing"}' --json\n  omx state clear --input '{"mode":"ralph","all_sessions":true}' --json\n  omx state list-active --json\n  omx state get-status --input '{"mode":"ralph"}' --json`;
+const STATE_HELP = `Usage: omx state <read|write|clear|list-active|get-status> [--input <json> | --input-file <path>] [--mode <mode>] [--json]
+
+Examples:
+  omx state read --input '{"mode":"ralph"}' --json
+  omx state read --mode ralph --json
+  omx state write --input '{"mode":"ralph","active":true,"current_phase":"executing"}' --json
+  omx state clear --mode ralph --json
+  omx state clear --input-file ./payload.json --json
+  omx state list-active --json
+  omx state get-status --mode ralph --json
+
+Windows note: native shells may strip the quotes from --input JSON. Use --mode for simple mode recovery or --input-file to pass JSON from a file.`;
+
+const WINDOWS_QUOTE_HINT =
+  '\nHint: on Windows native shells the quotes around --input JSON can be stripped before omx sees them. ' +
+  'Use --mode <mode> for simple recovery (e.g. `omx state read --mode ralph --json`) ' +
+  'or --input-file <path> to read JSON from a file instead.';
 
 const STATE_OPERATION_MAP: Record<string, StateOperationName> = {
   read: 'state_read',
@@ -20,16 +38,27 @@ function isHelpArg(arg: string | undefined): boolean {
   return arg === '--help' || arg === '-h' || arg === 'help';
 }
 
-function parseStateInput(input: string | undefined): Record<string, unknown> {
-  if (!input) return {};
+function looksLikeQuoteStrippedJson(raw: string): boolean {
+  const trimmed = raw.trim();
+  return trimmed.startsWith('{') && trimmed.endsWith('}') && !trimmed.includes('"');
+}
+
+function parseStateInputJson(
+  raw: string,
+  source: '--input' | '--input-file',
+): Record<string, unknown> {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(input);
+    parsed = JSON.parse(raw);
   } catch (error) {
-    throw new Error(`--input must be valid JSON: ${(error as Error).message}`);
+    let message = `${source} must be valid JSON: ${(error as Error).message}`;
+    if (source === '--input' && looksLikeQuoteStrippedJson(raw)) {
+      message += WINDOWS_QUOTE_HINT;
+    }
+    throw new Error(message);
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error('--input must decode to a JSON object');
+    throw new Error(`${source} must decode to a JSON object`);
   }
   return { ...(parsed as Record<string, unknown>) };
 }
@@ -59,6 +88,8 @@ export async function stateCommand(
   }
 
   let inputValue: string | undefined;
+  let inputFileValue: string | undefined;
+  let modeValue: string | undefined;
   let json = false;
   for (let index = 1; index < args.length; index += 1) {
     const arg = args[index];
@@ -79,10 +110,59 @@ export async function stateCommand(
       inputValue = arg.slice('--input='.length);
       continue;
     }
+    if (arg === '--input-file') {
+      const next = args[index + 1];
+      if (!next) {
+        throw new Error('Missing path value after --input-file');
+      }
+      inputFileValue = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--input-file=')) {
+      inputFileValue = arg.slice('--input-file='.length);
+      continue;
+    }
+    if (arg === '--mode') {
+      const next = args[index + 1];
+      if (!next) {
+        throw new Error('Missing value after --mode');
+      }
+      modeValue = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--mode=')) {
+      modeValue = arg.slice('--mode='.length);
+      continue;
+    }
     throw new Error(`Unknown state argument: ${arg}`);
   }
 
-  const input = parseStateInput(inputValue);
+  if (inputValue !== undefined && inputFileValue !== undefined) {
+    throw new Error('Provide either --input or --input-file, not both');
+  }
+
+  let input: Record<string, unknown> = {};
+  if (inputValue !== undefined) {
+    input = parseStateInputJson(inputValue, '--input');
+  } else if (inputFileValue !== undefined) {
+    let fileContents: string;
+    try {
+      fileContents = await readFile(inputFileValue, 'utf-8');
+    } catch (error) {
+      throw new Error(`--input-file could not be read: ${(error as Error).message}`);
+    }
+    input = parseStateInputJson(fileContents, '--input-file');
+  }
+
+  if (modeValue !== undefined) {
+    if (modeValue.length === 0) {
+      throw new Error('Missing value after --mode');
+    }
+    input = { ...input, mode: modeValue };
+  }
+
   const result = await execute(operation, input);
   const body = JSON.stringify(result.payload, null, json ? 0 : 2);
 


### PR DESCRIPTION
## Summary

Closes #2811.

On Windows native Codex/PowerShell, JSON passed to `omx state --input` can lose its double quotes before reaching Node, so the documented CLI-first state recovery path (`omx state read/clear --input '{"mode":"..."}' --json`) is unreliable on that surface. This adds quote-free ways to supply structured state input and a Windows-specific hint when quote stripping is detected.

## Changes

- `--mode <mode>` / `--mode=<mode>`: simple mode recovery without any JSON quoting (e.g. `omx state read --mode deep-interview --json`). Merges over any `mode` from `--input`.
- `--input-file <path>` / `--input-file=<path>`: read a JSON object payload from a file, sidestepping shell quoting entirely.
- Quote-stripped `--input` detection: when `--input` looks like quote-stripped JSON (e.g. `{mode:deep-interview}`), the invalid-JSON error gains a Windows-specific hint pointing at `--mode` and `--input-file`.
- `--input` and `--input-file` are mutually exclusive; both still require a JSON object.
- Help text and examples updated; existing `--input` JSON behavior preserved.

## Verification

- `npm run build`
- `node --test dist/cli/__tests__/state.test.js` — 13 pass / 0 fail.
- `npx biome lint src/cli/state.ts src/cli/__tests__/state.test.ts` — OK.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*