### PR TITLE
fix: harden ralplan consensus freshness gates

### DIFF
--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -10,6 +10,228 @@ import {
 } from '../ralplan-gate.js';
 
 describe('autopilot ralplan gate', () => {
+  it('rejects invalid next-state complete consensus before falling back to older valid current state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-next-invalid-terminal-'));
+    const sessionId = 'sess-autopilot-next-invalid-terminal';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:00:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect-old': { thread_id: 'thread-architect-old', kind: 'subagent', first_seen_at: '2026-06-12T09:59:30.000Z', last_seen_at: '2026-06-12T09:59:30.000Z', completed_at: '2026-06-12T09:59:30.000Z', turn_count: 1 },
+              'thread-critic-old': { thread_id: 'thread-critic-old', kind: 'subagent', first_seen_at: '2026-06-12T10:00:00.000Z', last_seen_at: '2026-06-12T10:00:00.000Z', completed_at: '2026-06-12T10:00:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const nextState = {
+        current_phase: 'ralplan',
+        return_to_ralplan_reason: 'Code review requested a plan update.',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'iterate',
+              session_id: sessionId,
+              thread_id: 'thread-architect-new',
+              artifact_path: '.omx/artifacts/architect-new.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:01:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic-new',
+              artifact_path: '.omx/artifacts/critic-new.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+          },
+        },
+      };
+      const currentState = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-architect-old',
+              artifact_path: '.omx/artifacts/architect-old.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T09:59:30.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic-old',
+              artifact_path: '.omx/artifacts/critic-old.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:00:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, nextState, currentState });
+
+      assert.equal(decision.allowed, false);
+      assert.equal(decision.evidence?.source, 'next-autopilot-state:handoff_artifacts');
+      assert.equal(decision.evidence?.blockedReason, 'non_approving_ralplan_consensus_review');
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /architect.*verdict=iterate/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stale nested ralplan handoff consensus when parent state returned to ralplan', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-stale-nested-'));
+    const sessionId = 'sess-autopilot-stale-nested';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:00:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect-stale': { thread_id: 'thread-architect-stale', kind: 'subagent', first_seen_at: '2026-06-12T09:59:30.000Z', last_seen_at: '2026-06-12T09:59:30.000Z', completed_at: '2026-06-12T09:59:30.000Z', turn_count: 1 },
+              'thread-critic-stale': { thread_id: 'thread-critic-stale', kind: 'subagent', first_seen_at: '2026-06-12T10:00:00.000Z', last_seen_at: '2026-06-12T10:00:00.000Z', completed_at: '2026-06-12T10:00:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const nextState = {
+        current_phase: 'ralplan',
+        return_to_ralplan_reason: 'Code review requested a plan update.',
+        review_cycle: 2,
+        handoff_artifacts: {
+          ralplan: {
+            review_cycle: 2,
+            ralplanConsensusGate: {
+              complete: true,
+              sequence: ['architect-review', 'critic-review'],
+              ralplan_architect_review: {
+                agent_role: 'architect',
+                provenance_kind: 'native_subagent',
+                verdict: 'approve',
+                session_id: sessionId,
+                thread_id: 'thread-architect-stale',
+                artifact_path: '.omx/artifacts/architect-stale.md',
+                tracker_path: '.omx/state/subagent-tracking.json',
+                completed_at: '2026-06-12T09:59:30.000Z',
+              },
+              ralplan_critic_review: {
+                agent_role: 'critic',
+                provenance_kind: 'native_subagent',
+                verdict: 'approve',
+                session_id: sessionId,
+                thread_id: 'thread-critic-stale',
+                artifact_path: '.omx/artifacts/critic-stale.md',
+                tracker_path: '.omx/state/subagent-tracking.json',
+                completed_at: '2026-06-12T10:00:00.000Z',
+              },
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, nextState });
+
+      assert.equal(decision.allowed, false);
+      assert.equal(decision.evidence?.blockedReason, 'missing_sequential_architect_then_critic_approval');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stale raw handoff consensus when parent state returned to ralplan', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-stale-raw-handoff-'));
+    const sessionId = 'sess-autopilot-stale-raw-handoff';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:00:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect-stale': { thread_id: 'thread-architect-stale', kind: 'subagent', first_seen_at: '2026-06-12T09:59:30.000Z', last_seen_at: '2026-06-12T09:59:30.000Z', completed_at: '2026-06-12T09:59:30.000Z', turn_count: 1 },
+              'thread-critic-stale': { thread_id: 'thread-critic-stale', kind: 'subagent', first_seen_at: '2026-06-12T10:00:00.000Z', last_seen_at: '2026-06-12T10:00:00.000Z', completed_at: '2026-06-12T10:00:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const currentState = {
+        current_phase: 'ralplan',
+        return_to_ralplan_reason: 'Code review requested a plan update.',
+        review_cycle: 1,
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-architect-stale',
+              artifact_path: '.omx/artifacts/architect-stale.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T09:59:30.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic-stale',
+              artifact_path: '.omx/artifacts/critic-stale.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:00:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState });
+
+      assert.equal(decision.allowed, false);
+      assert.equal(decision.evidence?.blockedReason, 'missing_sequential_architect_then_critic_approval');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   for (const { lane, architectVerdict, criticVerdict } of [
     { lane: 'architect', architectVerdict: 'iterate', criticVerdict: 'approve' },
     { lane: 'critic', architectVerdict: 'approve', criticVerdict: 'iterate' },

--- a/src/autopilot/ralplan-gate.ts
+++ b/src/autopilot/ralplan-gate.ts
@@ -1,6 +1,7 @@
 import {
   buildRalplanConsensusGateFromSources,
   RALPLAN_CONSENSUS_BLOCKED_REASONS,
+  withParentReturnToRalplanContext,
   type RalplanConsensusGateEvidence,
 } from '../ralplan/consensus-gate.js';
 
@@ -46,9 +47,19 @@ function gateSources(input: AutopilotRalplanUltragoalGateInput) {
     if (!state) continue;
     sources.push({ source: label, value: state });
     const handoffs = handoffArtifacts(state);
-    if (handoffs) sources.push({ source: `${label}:handoff_artifacts`, value: handoffs });
+    if (handoffs) {
+      sources.push({
+        source: `${label}:handoff_artifacts`,
+        value: withParentReturnToRalplanContext(handoffs, state),
+      });
+    }
     const ralplan = ralplanHandoff(state);
-    if (ralplan) sources.push({ source: `${label}:handoff_artifacts.ralplan`, value: ralplan });
+    if (ralplan) {
+      sources.push({
+        source: `${label}:handoff_artifacts.ralplan`,
+        value: withParentReturnToRalplanContext(ralplan, state),
+      });
+    }
   }
   return sources;
 }

--- a/src/pipeline/__tests__/orchestrator.test.ts
+++ b/src/pipeline/__tests__/orchestrator.test.ts
@@ -233,6 +233,75 @@ describe('Pipeline Orchestrator', () => {
       assert.equal(Object.prototype.hasOwnProperty.call(ext?.handoff_artifacts ?? {}, 'review_verdict'), false);
     });
 
+    it('threads return-loop review cycle into the rerun ralplan stage context', async () => {
+      const plansDir = join(tempDir, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      await writeFile(join(plansDir, 'prd-stale.md'), '# Plan\n');
+      await writeFile(join(plansDir, 'test-spec-stale.md'), '# Test Spec\n');
+
+      let ralplanRuns = 0;
+      const structuralRalplan = createRalplanStage();
+      const staleRalplanArtifacts = {
+        ralplanConsensusGate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            verdict: 'approve',
+            completed_at: '2026-06-12T09:00:00.000Z',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            verdict: 'approve',
+            completed_at: '2026-06-12T09:05:00.000Z',
+          },
+        },
+      };
+
+      const ralplanStage: PipelineStage = {
+        name: 'ralplan',
+        async run(ctx: StageContext): Promise<StageResult> {
+          ralplanRuns += 1;
+          if (ralplanRuns === 1) {
+            return {
+              status: 'completed',
+              artifacts: staleRalplanArtifacts,
+              duration_ms: 0,
+            };
+          }
+          assert.equal(ctx.artifacts.current_phase, 'ralplan');
+          assert.equal(ctx.artifacts.return_to_ralplan_reason, 'Review requested a plan update.');
+          assert.equal(ctx.artifacts.review_cycle, 1);
+          return structuralRalplan.run(ctx);
+        },
+      };
+
+      const result = await runPipeline({
+        name: 'review-loop-stale-ralplan-test',
+        task: 'reject stale ralplan consensus after review loopback',
+        stages: [
+          ralplanStage,
+          makeStage('code-review', {
+            artifacts: {
+              review_verdict: {
+                recommendation: 'REQUEST CHANGES',
+                architectural_status: 'CLEAR',
+                clean: false,
+              },
+              return_to_ralplan_reason: 'Review requested a plan update.',
+            },
+          }),
+        ],
+        cwd: tempDir,
+        maxRalphIterations: 3,
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.equal(result.failedStage, 'ralplan');
+      assert.equal(ralplanRuns, 2);
+      assert.equal(result.stageResults.ralplan.error, 'ralplan_consensus_evidence_missing');
+    });
+
     it('returns to ralplan rather than deep-interview after default quality-gate failures', async () => {
       const order: string[] = [];
       let qaRuns = 0;

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -658,6 +658,124 @@ describe('RALPLAN Stage', () => {
     })), false);
   });
 
+  it('run rejects stale nested ralplan artifacts when parent return-to-ralplan context is present', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-my-feature.md'), '# Plan\n');
+    await writeFile(join(plansDir, 'test-spec-my-feature.md'), '# Test Spec\n');
+
+    const stage = createRalplanStage();
+    const result = await stage.run(makeCtx({
+      artifacts: {
+        return_to_ralplan_reason: 'Code review requested a plan update.',
+        review_cycle: 1,
+        ralplan: {
+          ralplanConsensusGate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'approve',
+              completed_at: '2026-06-12T09:00:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+              completed_at: '2026-06-12T09:05:00.000Z',
+            },
+          },
+        },
+      },
+    }));
+    const artifacts = result.artifacts as Record<string, unknown>;
+    const gate = artifacts.ralplanConsensusGate as { complete?: boolean; blockedReason?: string | null };
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.error, 'ralplan_consensus_evidence_missing');
+    assert.equal(gate.complete, false);
+    assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
+  });
+
+  it('run accepts nested ralplan artifacts when review_cycle explicitly advances past parent loopback', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-my-feature.md'), '# Plan\n');
+    await writeFile(join(plansDir, 'test-spec-my-feature.md'), '# Test Spec\n');
+
+    const stage = createRalplanStage();
+    const result = await stage.run(makeCtx({
+      artifacts: {
+        return_to_ralplan_reason: 'Code review requested a plan update.',
+        review_cycle: 1,
+        ralplan: {
+          review_cycle: 2,
+          ralplanConsensusGate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'approve',
+              review_cycle: 2,
+              completed_at: '2026-06-12T10:00:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+              review_cycle: 2,
+              completed_at: '2026-06-12T10:05:00.000Z',
+            },
+          },
+        },
+      },
+    }));
+    const artifacts = result.artifacts as Record<string, unknown>;
+    const gate = artifacts.ralplanConsensusGate as { complete?: boolean; blockedReason?: string | null };
+
+    assert.equal(result.status, 'completed');
+    assert.equal(result.error, undefined);
+    assert.equal(gate.complete, true);
+    assert.equal(gate.blockedReason, null);
+  });
+
+  it('run rejects nested ralplan artifacts when only the container review_cycle advances', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-my-feature.md'), '# Plan\n');
+    await writeFile(join(plansDir, 'test-spec-my-feature.md'), '# Test Spec\n');
+
+    const stage = createRalplanStage();
+    const result = await stage.run(makeCtx({
+      artifacts: {
+        return_to_ralplan_reason: 'Code review requested a plan update.',
+        review_cycle: 1,
+        ralplan: {
+          review_cycle: 2,
+          ralplanConsensusGate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'approve',
+              completed_at: '2026-06-12T10:00:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+              completed_at: '2026-06-12T10:05:00.000Z',
+            },
+          },
+        },
+      },
+    }));
+    const artifacts = result.artifacts as Record<string, unknown>;
+    const gate = artifacts.ralplanConsensusGate as { complete?: boolean; blockedReason?: string | null };
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.error, 'ralplan_consensus_evidence_missing');
+    assert.equal(gate.complete, false);
+    assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
+  });
+
   it('canSkip returns false when nested code-review artifacts are non-clean', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -190,6 +190,8 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
 
     if (shouldReturnToRalplan) {
       reviewCycle += 1;
+      artifacts.current_phase = 'ralplan';
+      artifacts.review_cycle = reviewCycle;
     }
 
     const handoffArtifacts = normalizeHandoffArtifactKeys(handoffArtifactsByStage);

--- a/src/ralplan/__tests__/consensus-gate.test.ts
+++ b/src/ralplan/__tests__/consensus-gate.test.ts
@@ -5,9 +5,101 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { getBaseStateDir } from '../../state/paths.js';
 import { subagentTrackingPath } from '../../subagents/tracker.js';
-import { buildRalplanConsensusGateForCwd } from '../consensus-gate.js';
+import { buildRalplanConsensusGateForCwd, buildRalplanConsensusGateFromSources } from '../consensus-gate.js';
 
 describe('ralplan consensus gate state roots', () => {
+
+  it('rejects invalid complete consensus even when it appears after a valid source', () => {
+    const validConsensus = {
+      ralplan_consensus_gate: {
+        complete: true,
+        sequence: ['architect-review', 'critic-review'],
+        ralplan_architect_review: {
+          agent_role: 'architect',
+          verdict: 'approve',
+          completed_at: '2026-06-12T10:00:00.000Z',
+        },
+        ralplan_critic_review: {
+          agent_role: 'critic',
+          verdict: 'approve',
+          completed_at: '2026-06-12T10:05:00.000Z',
+        },
+      },
+    };
+    const invalidConsensus = {
+      ralplan_consensus_gate: {
+        complete: true,
+        sequence: ['architect-review', 'critic-review'],
+        ralplan_architect_review: {
+          agent_role: 'architect',
+          verdict: 'iterate',
+          completed_at: '2026-06-12T10:10:00.000Z',
+        },
+        ralplan_critic_review: {
+          agent_role: 'critic',
+          verdict: 'approve',
+          completed_at: '2026-06-12T10:15:00.000Z',
+        },
+      },
+    };
+
+    const gate = buildRalplanConsensusGateFromSources([
+      { source: 'older-valid-source', value: validConsensus },
+      { source: 'later-invalid-source', value: invalidConsensus },
+    ]);
+
+    assert.equal(gate.complete, false);
+    assert.equal(gate.source, 'later-invalid-source');
+    assert.equal(gate.blockedReason, 'non_approving_ralplan_consensus_review');
+    assert.match(gate.blockedDetails?.join(' ') ?? '', /architect.*verdict=iterate/i);
+  });
+
+
+  it('rejects malformed complete consensus even when it appears after a valid source', () => {
+    const validConsensus = {
+      ralplan_consensus_gate: {
+        complete: true,
+        sequence: ['architect-review', 'critic-review'],
+        ralplan_architect_review: {
+          agent_role: 'architect',
+          verdict: 'approve',
+          completed_at: '2026-06-12T10:00:00.000Z',
+        },
+        ralplan_critic_review: {
+          agent_role: 'critic',
+          verdict: 'approve',
+          completed_at: '2026-06-12T10:05:00.000Z',
+        },
+      },
+    };
+    const malformedConsensus = {
+      ralplan_consensus_gate: {
+        complete: true,
+        sequence: ['critic-review', 'architect-review'],
+        ralplan_architect_review: {
+          agent_role: 'architect',
+          verdict: 'approve',
+          completed_at: '2026-06-12T10:10:00.000Z',
+        },
+        ralplan_critic_review: {
+          agent_role: 'critic',
+          verdict: 'approve',
+          completed_at: '2026-06-12T10:15:00.000Z',
+        },
+      },
+    };
+
+    const gate = buildRalplanConsensusGateFromSources([
+      { source: 'older-valid-source', value: validConsensus },
+      { source: 'later-malformed-source', value: malformedConsensus },
+    ]);
+
+    assert.equal(gate.complete, false);
+    assert.equal(gate.source, 'later-malformed-source');
+    assert.equal(gate.blockedReason, 'non_approving_ralplan_consensus_review');
+    assert.match(gate.blockedDetails?.join(' ') ?? '', /sequence is not architect-review then critic-review/i);
+  });
+
   it('ignores ambient root consensus unless the ambient session is bound to this cwd', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-local-'));
     const ambientRoot = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-ambient-'));
@@ -172,6 +264,275 @@ describe('ralplan consensus gate state roots', () => {
               },
             },
           },
+        },
+      });
+
+      assert.equal(gate.complete, false);
+      assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stale local ralplan state consensus during a return-to-ralplan cycle', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-stale-local-state-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            verdict: 'approve',
+            completed_at: '2026-06-11T16:00:00.000Z',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            verdict: 'approve',
+            completed_at: '2026-06-11T16:05:00.000Z',
+          },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        artifacts: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          review_cycle: 1,
+        },
+      });
+
+      assert.equal(gate.complete, false);
+      assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects local nested handoff consensus when only the local container review_cycle advances', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-local-container-only-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        current_phase: 'complete',
+        review_cycle: 2,
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'approve',
+              completed_at: '2026-06-12T10:00:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+              completed_at: '2026-06-12T10:05:00.000Z',
+            },
+          },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        artifacts: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          review_cycle: 1,
+        },
+      });
+
+      assert.equal(gate.complete, false);
+      assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts local nested handoff consensus when both reviews carry the advanced review_cycle', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-local-review-fresh-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        current_phase: 'complete',
+        review_cycle: 2,
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'approve',
+              review_cycle: 2,
+              completed_at: '2026-06-12T10:00:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+              review_cycle: 2,
+              completed_at: '2026-06-12T10:05:00.000Z',
+            },
+          },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        artifacts: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          review_cycle: 1,
+        },
+      });
+
+      assert.equal(gate.complete, true);
+      assert.equal(gate.blockedReason, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects local state.handoff_artifacts consensus when only the local container review_cycle advances', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-local-state-container-only-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        current_phase: 'complete',
+        review_cycle: 2,
+        state: {
+          handoff_artifacts: {
+            ralplan_consensus_gate: {
+              complete: true,
+              sequence: ['architect-review', 'critic-review'],
+              ralplan_architect_review: {
+                agent_role: 'architect',
+                verdict: 'approve',
+                completed_at: '2026-06-12T10:00:00.000Z',
+              },
+              ralplan_critic_review: {
+                agent_role: 'critic',
+                verdict: 'approve',
+                completed_at: '2026-06-12T10:05:00.000Z',
+              },
+            },
+          },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        artifacts: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          review_cycle: 1,
+        },
+      });
+
+      assert.equal(gate.complete, false);
+      assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts local state.handoff_artifacts consensus when nested state and both reviews carry the advanced review_cycle', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-local-state-review-fresh-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        current_phase: 'complete',
+        state: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          review_cycle: 1,
+          handoff_artifacts: {
+            review_cycle: 2,
+            ralplan_consensus_gate: {
+              complete: true,
+              sequence: ['architect-review', 'critic-review'],
+              ralplan_architect_review: {
+                agent_role: 'architect',
+                verdict: 'approve',
+                review_cycle: 2,
+                completed_at: '2026-06-12T10:00:00.000Z',
+              },
+              ralplan_critic_review: {
+                agent_role: 'critic',
+                verdict: 'approve',
+                review_cycle: 2,
+                completed_at: '2026-06-12T10:05:00.000Z',
+              },
+            },
+          },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        artifacts: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          review_cycle: 1,
+        },
+      });
+
+      assert.equal(gate.complete, true);
+      assert.equal(gate.blockedReason, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stale review history consensus during a return-to-ralplan cycle', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-stale-history-'));
+    try {
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        artifacts: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          review_history: [{
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'approve',
+              completed_at: '2026-06-11T16:00:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+              completed_at: '2026-06-11T16:05:00.000Z',
+            },
+          }],
+        },
+      });
+
+      assert.equal(gate.complete, false);
+      assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stale review array consensus during a return-to-ralplan cycle', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-stale-arrays-'));
+    try {
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        artifacts: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          architectReviews: [{
+            agent_role: 'architect',
+            verdict: 'approve',
+            completed_at: '2026-06-11T16:00:00.000Z',
+          }],
+          criticReviews: [{
+            agent_role: 'critic',
+            verdict: 'approve',
+            completed_at: '2026-06-11T16:05:00.000Z',
+          }],
         },
       });
 

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -33,11 +33,27 @@ export interface RalplanConsensusSource {
   value: unknown;
 }
 
+type ConsensusResolution = {
+  kind: 'valid';
+  ralplan_architect_review: Record<string, unknown>;
+  ralplan_critic_review: Record<string, unknown>;
+} | {
+  kind: 'invalid';
+  ralplan_architect_review: Record<string, unknown> | null;
+  ralplan_critic_review: Record<string, unknown> | null;
+  blockedDetails: string[];
+};
+
 export function buildRalplanConsensusGateFromSources(
   sources: RalplanConsensusSource[],
   options: RalplanNativeSubagentConsensusOptions = {},
 ): RalplanConsensusGateEvidence {
   let nativeBlockedEvidence: {
+    ralplan_architect_review: Record<string, unknown>;
+    ralplan_critic_review: Record<string, unknown>;
+    source: string;
+  } | null = null;
+  let validEvidence: {
     ralplan_architect_review: Record<string, unknown>;
     ralplan_critic_review: Record<string, unknown>;
     source: string;
@@ -50,8 +66,13 @@ export function buildRalplanConsensusGateFromSources(
   } | null = null;
 
   for (const candidate of sources) {
-    const evidence = extractSequentialConsensusEvidence(candidate.value);
-    if (evidence) {
+    const evidence = resolveConsensusEvidence(candidate.value);
+    if (evidence?.kind === 'invalid') {
+      invalidCompleteEvidence ??= { ...evidence, source: candidate.source };
+      continue;
+    }
+
+    if (evidence?.kind === 'valid') {
       if (
         options.requireNativeSubagents
         && !hasTrackerBackedNativeRalplanLanes(evidence, options)
@@ -59,19 +80,7 @@ export function buildRalplanConsensusGateFromSources(
         nativeBlockedEvidence ??= { ...evidence, source: candidate.source };
         continue;
       }
-      return {
-        complete: true,
-        sequence: ['architect-review', 'critic-review'],
-        ralplan_architect_review: evidence.ralplan_architect_review,
-        ralplan_critic_review: evidence.ralplan_critic_review,
-        source: candidate.source,
-        blockedReason: null,
-      };
-    }
-
-    const invalidEvidence = extractInvalidCompleteConsensusEvidence(candidate.value);
-    if (invalidEvidence) {
-      invalidCompleteEvidence ??= { ...invalidEvidence, source: candidate.source };
+      validEvidence ??= { ...evidence, source: candidate.source };
     }
   }
 
@@ -84,6 +93,17 @@ export function buildRalplanConsensusGateFromSources(
       source: invalidCompleteEvidence.source,
       blockedReason: RALPLAN_CONSENSUS_BLOCKED_REASONS.nonApprovingReview,
       blockedDetails: invalidCompleteEvidence.blockedDetails,
+    };
+  }
+
+  if (validEvidence) {
+    return {
+      complete: true,
+      sequence: ['architect-review', 'critic-review'],
+      ralplan_architect_review: validEvidence.ralplan_architect_review,
+      ralplan_critic_review: validEvidence.ralplan_critic_review,
+      source: validEvidence.source,
+      blockedReason: null,
     };
   }
 
@@ -116,12 +136,22 @@ export function buildRalplanConsensusGateForCwd(
   cwd: string,
   options: { artifacts?: Record<string, unknown>; sessionId?: string; requireNativeSubagents?: boolean } = {},
 ): RalplanConsensusGateEvidence {
+  const localStateCandidates = readLocalRalplanConsensusStateCandidates(cwd, options.sessionId)
+    .map((candidate) => ({
+      ...candidate,
+      value: options.artifacts
+        ? withParentReturnToRalplanContext(candidate.value, options.artifacts)
+        : candidate.value,
+    }));
   return buildRalplanConsensusGateFromSources([
     ...(options.artifacts ? [
       { source: 'stage-context-artifacts', value: options.artifacts },
-      { source: 'stage-context-ralplan-artifact', value: options.artifacts.ralplan },
+      {
+        source: 'stage-context-ralplan-artifact',
+        value: withParentReturnToRalplanContext(options.artifacts.ralplan, options.artifacts),
+      },
     ] : []),
-    ...readLocalRalplanConsensusStateCandidates(cwd, options.sessionId),
+    ...localStateCandidates,
   ], {
     cwd,
     sessionId: options.sessionId,
@@ -164,48 +194,42 @@ export function readLocalRalplanConsensusStateCandidates(
   });
 }
 
-function extractSequentialConsensusEvidence(value: unknown): {
-  ralplan_architect_review: Record<string, unknown>;
-  ralplan_critic_review: Record<string, unknown>;
-} | null {
+function resolveConsensusEvidence(value: unknown): ConsensusResolution | null {
   if (!value || typeof value !== 'object') return null;
   const record = value as Record<string, unknown>;
 
-  const gate = record.ralplanConsensusGate ?? record.ralplan_consensus_gate;
-  if (gate && typeof gate === 'object') {
-    const gateRecord = gate as Record<string, unknown>;
-    const architectReview = asRecord(
-      gateRecord.ralplan_architect_review ?? gateRecord.architectReview ?? gateRecord.architect_review,
-    );
-    const criticReview = asRecord(
-      gateRecord.ralplan_critic_review ?? gateRecord.criticReview ?? gateRecord.critic_review,
-    );
-    if (
-      gateRecord.complete === true
-      && hasArchitectThenCriticSequence(gateRecord)
-      && isApproveReview(architectReview, 'architect')
-      && isApproveReview(criticReview, 'critic')
-      && isCriticNotBeforeArchitect(architectReview, criticReview)
-    ) {
-      return { ralplan_architect_review: architectReview, ralplan_critic_review: criticReview };
-    }
-  }
+  const returnToRalplanCycle = isReturnToRalplanCycle(record);
+  const advancedReviewCycle = explicitFreshnessReviewCycle(record);
+  const staleReturnToRalplanCycle = returnToRalplanCycle && advancedReviewCycle === null;
+  const directGate = resolveDirectGate(record);
+  if (directGate?.kind === 'invalid') return directGate;
+  if (
+    directGate
+    && (
+      !returnToRalplanCycle
+      || (advancedReviewCycle !== null && reviewsCarryFreshnessCycle(directGate, advancedReviewCycle))
+    )
+  ) return directGate;
 
-  const handoffArtifactsAreStale = isReturnToRalplanCycle(record);
+  const handoffArtifactsAreStale = staleReturnToRalplanCycle;
   const topLevelHandoffArtifacts = handoffArtifactsAreStale ? null : asRecord(record.handoff_artifacts);
   if (topLevelHandoffArtifacts) {
-    const evidence = extractSequentialConsensusEvidence(topLevelHandoffArtifacts);
+    const evidence = resolveConsensusEvidence(withParentReturnToRalplanContext(topLevelHandoffArtifacts, record));
     if (evidence) return evidence;
   }
 
   const stateRecord = asRecord(record.state);
-  const stateHandoffArtifacts = handoffArtifactsAreStale || (stateRecord && isReturnToRalplanCycle(stateRecord))
+  const stateHasOwnReturnLoopContext = stateRecord !== null && isReturnToRalplanCycle(stateRecord);
+  const stateHandoffArtifacts = handoffArtifactsAreStale && !stateHasOwnReturnLoopContext
     ? null
     : asRecord(stateRecord?.handoff_artifacts);
   if (stateHandoffArtifacts) {
-    const evidence = extractSequentialConsensusEvidence(stateHandoffArtifacts);
+    const stateContext = stateHasOwnReturnLoopContext ? stateRecord : record;
+    const evidence = resolveConsensusEvidence(withParentReturnToRalplanContext(stateHandoffArtifacts, stateContext));
     if (evidence) return evidence;
   }
+
+  if (returnToRalplanCycle && advancedReviewCycle === null) return null;
 
   const directArchitectReview = asRecord(record.ralplan_architect_review);
   const directCriticReview = asRecord(record.ralplan_critic_review);
@@ -214,8 +238,17 @@ function extractSequentialConsensusEvidence(value: unknown): {
     && isApproveReview(directArchitectReview, 'architect')
     && isApproveReview(directCriticReview, 'critic')
     && isCriticNotBeforeArchitect(directArchitectReview, directCriticReview)
+    && (
+      !returnToRalplanCycle
+      || (advancedReviewCycle !== null && reviewPairCarriesFreshnessCycle(
+        directArchitectReview,
+        directCriticReview,
+        advancedReviewCycle,
+      ))
+    )
   ) {
     return {
+      kind: 'valid',
       ralplan_architect_review: directArchitectReview,
       ralplan_critic_review: directCriticReview,
     };
@@ -234,8 +267,16 @@ function extractSequentialConsensusEvidence(value: unknown): {
       isApproveReview(architectReview, 'architect')
       && isApproveReview(criticReview, 'critic')
       && isCriticNotBeforeArchitect(architectReview, criticReview)
+      && (
+        !returnToRalplanCycle
+        || (advancedReviewCycle !== null && reviewPairCarriesFreshnessCycle(
+          architectReview,
+          criticReview,
+          advancedReviewCycle,
+        ))
+      )
     ) {
-      return { ralplan_architect_review: architectReview, ralplan_critic_review: criticReview };
+      return { kind: 'valid', ralplan_architect_review: architectReview, ralplan_critic_review: criticReview };
     }
   }
 
@@ -248,22 +289,23 @@ function extractSequentialConsensusEvidence(value: unknown): {
       isApproveReview(architectReview, 'architect')
       && isApproveReview(criticReview, 'critic')
       && isCriticNotBeforeArchitect(architectReview, criticReview)
+      && (
+        !returnToRalplanCycle
+        || (advancedReviewCycle !== null && reviewPairCarriesFreshnessCycle(
+          architectReview,
+          criticReview,
+          advancedReviewCycle,
+        ))
+      )
     ) {
-      return { ralplan_architect_review: architectReview, ralplan_critic_review: criticReview };
+      return { kind: 'valid', ralplan_architect_review: architectReview, ralplan_critic_review: criticReview };
     }
   }
 
   return null;
 }
 
-function extractInvalidCompleteConsensusEvidence(value: unknown): {
-  ralplan_architect_review: Record<string, unknown> | null;
-  ralplan_critic_review: Record<string, unknown> | null;
-  blockedDetails: string[];
-} | null {
-  if (!value || typeof value !== 'object') return null;
-  const record = value as Record<string, unknown>;
-
+function resolveDirectGate(record: Record<string, unknown>): ConsensusResolution | null {
   const gate = record.ralplanConsensusGate ?? record.ralplan_consensus_gate;
   if (gate && typeof gate === 'object') {
     const gateRecord = gate as Record<string, unknown>;
@@ -273,16 +315,34 @@ function extractInvalidCompleteConsensusEvidence(value: unknown): {
     const criticReview = asRecord(
       gateRecord.ralplan_critic_review ?? gateRecord.criticReview ?? gateRecord.critic_review,
     );
-    if (gateRecord.complete === true && hasArchitectThenCriticSequence(gateRecord)) {
+    if (
+      gateRecord.complete === true
+      && hasArchitectThenCriticSequence(gateRecord)
+      && isApproveReview(architectReview, 'architect')
+      && isApproveReview(criticReview, 'critic')
+      && isCriticNotBeforeArchitect(architectReview, criticReview)
+    ) {
+      return {
+        kind: 'valid',
+        ralplan_architect_review: architectReview,
+        ralplan_critic_review: criticReview,
+      };
+    }
+
+    if (gateRecord.complete === true) {
       const blockedDetails = [
         ...reviewApprovalProblems(architectReview, 'architect'),
         ...reviewApprovalProblems(criticReview, 'critic'),
       ];
+      if (!hasArchitectThenCriticSequence(gateRecord)) {
+        blockedDetails.push('consensus review sequence is not architect-review then critic-review');
+      }
       if (!isCriticNotBeforeArchitect(architectReview, criticReview)) {
         blockedDetails.push('critic review is ordered before architect review');
       }
       if (blockedDetails.length > 0) {
         return {
+          kind: 'invalid',
           ralplan_architect_review: architectReview,
           ralplan_critic_review: criticReview,
           blockedDetails,
@@ -291,13 +351,69 @@ function extractInvalidCompleteConsensusEvidence(value: unknown): {
     }
   }
 
-  const stateHandoffArtifacts = asRecord(asRecord(record.state)?.handoff_artifacts);
-  if (stateHandoffArtifacts) {
-    const evidence = extractInvalidCompleteConsensusEvidence(stateHandoffArtifacts);
-    if (evidence) return evidence;
-  }
-
   return null;
+}
+
+export function withParentReturnToRalplanContext(value: unknown, parent: Record<string, unknown>): unknown {
+  const reason = parent.return_to_ralplan_reason ?? parent.returnToRalplanReason;
+  if (typeof reason !== 'string' || reason.trim() === '' || !value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  const parentReviewCycle = numericValue(
+    parent.return_to_ralplan_parent_review_cycle
+      ?? parent.returnToRalplanParentReviewCycle
+      ?? parent.review_cycle
+      ?? parent.reviewCycle,
+  );
+  const inheritedReviewCycle = record.review_cycle ?? record.reviewCycle ?? parent.review_cycle ?? parent.reviewCycle;
+  return {
+    ...record,
+    review_cycle: inheritedReviewCycle,
+    current_phase: parent.current_phase ?? parent.currentPhase ?? 'ralplan',
+    return_to_ralplan_reason: reason,
+    return_to_ralplan_parent_review_cycle: parentReviewCycle,
+  };
+}
+
+function explicitFreshnessReviewCycle(record: Record<string, unknown>): number | null {
+  const parentReviewCycle = numericValue(
+    record.return_to_ralplan_parent_review_cycle ?? record.returnToRalplanParentReviewCycle,
+  );
+  const candidateReviewCycle = numericValue(record.review_cycle ?? record.reviewCycle);
+  return parentReviewCycle !== null
+    && candidateReviewCycle !== null
+    && candidateReviewCycle > parentReviewCycle
+    ? candidateReviewCycle
+    : null;
+}
+
+function reviewsCarryFreshnessCycle(evidence: ConsensusResolution, reviewCycle: number): boolean {
+  return evidence.kind === 'valid'
+    && reviewPairCarriesFreshnessCycle(
+      evidence.ralplan_architect_review,
+      evidence.ralplan_critic_review,
+      reviewCycle,
+    );
+}
+
+function reviewPairCarriesFreshnessCycle(
+  architectReview: Record<string, unknown> | null,
+  criticReview: Record<string, unknown> | null,
+  reviewCycle: number,
+): boolean {
+  return reviewCarriesFreshnessCycle(architectReview, reviewCycle)
+    && reviewCarriesFreshnessCycle(criticReview, reviewCycle);
+}
+
+function reviewCarriesFreshnessCycle(review: Record<string, unknown> | null, reviewCycle: number): boolean {
+  const cycle = numericValue(review?.review_cycle ?? review?.reviewCycle);
+  return cycle !== null && cycle >= reviewCycle;
+}
+
+function numericValue(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary

Fixes bead `omx-bjr` by hardening RALPLAN consensus evidence handling after the PR #2808 red-team review blockers.

## What changed

- Make invalid or malformed `complete:true` RALPLAN consensus evidence terminal across all sources, regardless of source order.
- Propagate parent `return_to_ralplan_reason` / review-cycle context into nested RALPLAN artifacts and local persisted state candidates.
- Require explicit fresh `review_cycle` advancement and both Architect/Critic review artifacts carrying that cycle before reusing consensus after a return-to-ralplan loop.
- Thread `current_phase='ralplan'` and incremented `review_cycle` into pipeline rerun contexts.
- Add regression coverage for invalid-before-fallback, valid-first/invalid-later, malformed-sequence terminality, stale nested artifacts, local state fallback, and fresh nested `state.handoff_artifacts`.

## Root cause

Consensus resolution previously treated complete-looking consensus as an ordered fallback candidate. That allowed older valid evidence to mask newer invalid evidence, and allowed nested/local handoff artifacts to be parsed without enough parent return-loop freshness context.

## Validation

- `npm run build`
- `node dist/scripts/run-test-files.js dist/autopilot/__tests__/ralplan-gate.test.js dist/pipeline/__tests__/stages.test.js dist/pipeline/__tests__/orchestrator.test.js dist/ralplan/__tests__/consensus-gate.test.js dist/ralplan/__tests__/runtime.test.js dist/state/__tests__/operations.test.js`
- `npm run check:no-unused`
- `npx biome lint src/ralplan/consensus-gate.ts src/autopilot/ralplan-gate.ts src/autopilot/__tests__/ralplan-gate.test.ts src/pipeline/orchestrator.ts src/pipeline/__tests__/stages.test.ts src/pipeline/__tests__/orchestrator.test.ts src/ralplan/__tests__/consensus-gate.test.ts`
- `git diff --check`

## Review gates

- Ralplan: Architect APPROVE, Critic APPROVE; Scholastic advisory PASS.
- Code review: Architect CLEAR, Code Reviewer APPROVE; Scholastic advisory PASS.
- UltraQA: CLEAN (`.omx/reports/ultraqa-omx-bjr.md`) covering 12 hostile consensus/freshness scenarios.
